### PR TITLE
TrimSpace around the link 

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -189,7 +189,7 @@ func newResponse(r *http.Response) *Response {
 func (r *Response) populatePageValues() {
 	if links, ok := r.Response.Header["Link"]; ok && len(links) > 0 {
 		for _, link := range strings.Split(links[0], ",") {
-			segments := strings.Split(link, ";")
+			segments := strings.Split(strings.TrimSpace(link), ";")
 
 			// link must at least have href and rel
 			if len(segments) < 2 {

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -134,9 +134,9 @@ func TestResponse_populatePageValues(t *testing.T) {
 	r := http.Response{
 		Header: http.Header{
 			"Link": {`<https://api.github.com/?page=1>; rel="first",` +
-				`<https://api.github.com/?page=2>; rel="prev",` +
-				`<https://api.github.com/?page=4>; rel="next",` +
-				`<https://api.github.com/?page=5>; rel="last"`,
+				` <https://api.github.com/?page=2>; rel="prev",` +
+				` <https://api.github.com/?page=4>; rel="next",` +
+				` <https://api.github.com/?page=5>; rel="last"`,
 			},
 		},
 	}


### PR DESCRIPTION
ref #22. 
While testing the new API I noticed that `response.NextPage` was always 0. We need to TrimSpace on the link in `response.PopulatePageValues` because there is some.

Thanks
