### PR TITLE
Changed boolean checks to a Is*() naming convention.

### DIFF
--- a/github/gists.go
+++ b/github/gists.go
@@ -206,10 +206,10 @@ func (s *GistsService) Unstar(id string) (*Response, error) {
 	return s.client.Do(req, nil)
 }
 
-// Starred checks if a gist is starred by authenticated user.
+// IsStarred checks if a gist is starred by authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/gists/#check-if-a-gist-is-starred
-func (s *GistsService) Starred(id string) (bool, *Response, error) {
+func (s *GistsService) IsStarred(id string) (bool, *Response, error) {
 	u := fmt.Sprintf("gists/%v/star", id)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -287,7 +287,7 @@ func TestGistsService_Unstar(t *testing.T) {
 	}
 }
 
-func TestGistsService_Starred_hasStar(t *testing.T) {
+func TestGistsService_IsStarred_hasStar(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -296,7 +296,7 @@ func TestGistsService_Starred_hasStar(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	star, _, err := client.Gists.Starred("1")
+	star, _, err := client.Gists.IsStarred("1")
 	if err != nil {
 		t.Errorf("Gists.Starred returned error: %v", err)
 	}
@@ -305,7 +305,7 @@ func TestGistsService_Starred_hasStar(t *testing.T) {
 	}
 }
 
-func TestGistsService_Starred_noStar(t *testing.T) {
+func TestGistsService_IsStarred_noStar(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -314,7 +314,7 @@ func TestGistsService_Starred_noStar(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	star, _, err := client.Gists.Starred("1")
+	star, _, err := client.Gists.IsStarred("1")
 	if err != nil {
 		t.Errorf("Gists.Starred returned error: %v", err)
 	}

--- a/github/issues_assignees.go
+++ b/github/issues_assignees.go
@@ -22,10 +22,10 @@ func (s *IssuesService) ListAssignees(owner string, repo string) ([]User, *Respo
 	return *assignees, resp, err
 }
 
-// CheckAssignee checks if a user is an assignee for the specified repository.
+// IsAssignee checks if a user is an assignee for the specified repository.
 //
 // GitHub API docs: http://developer.github.com/v3/issues/assignees/#check-assignee
-func (s *IssuesService) CheckAssignee(owner string, repo string, user string) (bool, *Response, error) {
+func (s *IssuesService) IsAssignee(owner string, repo string, user string) (bool, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/assignees/%v", owner, repo, user)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/issues_assignees_test.go
+++ b/github/issues_assignees_test.go
@@ -37,7 +37,7 @@ func TestIssuesService_ListAssignees_invalidOwner(t *testing.T) {
 	testURLParseError(t, err)
 }
 
-func TestIssuesService_CheckAssignee_true(t *testing.T) {
+func TestIssuesService_IsAssignee_true(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -45,16 +45,16 @@ func TestIssuesService_CheckAssignee_true(t *testing.T) {
 		testMethod(t, r, "GET")
 	})
 
-	assignee, _, err := client.Issues.CheckAssignee("o", "r", "u")
+	assignee, _, err := client.Issues.IsAssignee("o", "r", "u")
 	if err != nil {
-		t.Errorf("Issues.CheckAssignee returned error: %v", err)
+		t.Errorf("Issues.IsAssignee returned error: %v", err)
 	}
 	if want := true; assignee != want {
-		t.Errorf("Issues.CheckAssignee returned %+v, want %+v", assignee, want)
+		t.Errorf("Issues.IsAssignee returned %+v, want %+v", assignee, want)
 	}
 }
 
-func TestIssuesService_CheckAssignee_false(t *testing.T) {
+func TestIssuesService_IsAssignee_false(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -63,16 +63,16 @@ func TestIssuesService_CheckAssignee_false(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	assignee, _, err := client.Issues.CheckAssignee("o", "r", "u")
+	assignee, _, err := client.Issues.IsAssignee("o", "r", "u")
 	if err != nil {
-		t.Errorf("Issues.CheckAssignee returned error: %v", err)
+		t.Errorf("Issues.IsAssignee returned error: %v", err)
 	}
 	if want := false; assignee != want {
-		t.Errorf("Issues.CheckAssignee returned %+v, want %+v", assignee, want)
+		t.Errorf("Issues.IsAssignee returned %+v, want %+v", assignee, want)
 	}
 }
 
-func TestIssuesService_CheckAssignee_error(t *testing.T) {
+func TestIssuesService_IsAssignee_error(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -81,16 +81,16 @@ func TestIssuesService_CheckAssignee_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	assignee, _, err := client.Issues.CheckAssignee("o", "r", "u")
+	assignee, _, err := client.Issues.IsAssignee("o", "r", "u")
 	if err == nil {
 		t.Errorf("Expected HTTP 400 response")
 	}
 	if want := false; assignee != want {
-		t.Errorf("Issues.CheckAssignee returned %+v, want %+v", assignee, want)
+		t.Errorf("Issues.IsAssignee returned %+v, want %+v", assignee, want)
 	}
 }
 
-func TestIssuesService_CheckAssignee_invalidOwner(t *testing.T) {
-	_, _, err := client.Issues.CheckAssignee("%", "r", "u")
+func TestIssuesService_IsAssignee_invalidOwner(t *testing.T) {
+	_, _, err := client.Issues.IsAssignee("%", "r", "u")
 	testURLParseError(t, err)
 }

--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -39,10 +39,10 @@ func (s *OrganizationsService) ListPublicMembers(org string) ([]User, *Response,
 	return *members, resp, err
 }
 
-// CheckMembership checks if a user is a member of an organization.
+// IsMember checks if a user is a member of an organization.
 //
 // GitHub API docs: http://developer.github.com/v3/orgs/members/#check-membership
-func (s *OrganizationsService) CheckMembership(org, user string) (bool, *Response, error) {
+func (s *OrganizationsService) IsMember(org, user string) (bool, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/members/%v", org, user)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -54,10 +54,10 @@ func (s *OrganizationsService) CheckMembership(org, user string) (bool, *Respons
 	return member, resp, err
 }
 
-// CheckPublicMembership checks if a user is a public member of an organization.
+// IsPublicMember checks if a user is a public member of an organization.
 //
 // GitHub API docs: http://developer.github.com/v3/orgs/members/#check-public-membership
-func (s *OrganizationsService) CheckPublicMembership(org, user string) (bool, *Response, error) {
+func (s *OrganizationsService) IsPublicMember(org, user string) (bool, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/public_members/%v", org, user)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -62,7 +62,7 @@ func TestOrganizationsService_ListPublicMembers_invalidOrg(t *testing.T) {
 	testURLParseError(t, err)
 }
 
-func TestOrganizationsService_CheckMembership(t *testing.T) {
+func TestOrganizationsService_IsMember(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -71,17 +71,17 @@ func TestOrganizationsService_CheckMembership(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	member, _, err := client.Organizations.CheckMembership("o", "u")
+	member, _, err := client.Organizations.IsMember("o", "u")
 	if err != nil {
-		t.Errorf("Organizations.CheckMembership returned error: %v", err)
+		t.Errorf("Organizations.IsMember returned error: %v", err)
 	}
 	if want := true; member != want {
-		t.Errorf("Organizations.CheckMembership returned %+v, want %+v", member, want)
+		t.Errorf("Organizations.IsMember returned %+v, want %+v", member, want)
 	}
 }
 
 // ensure that a 404 response is interpreted as "false" and not an error
-func TestOrganizationsService_CheckMembership_notMember(t *testing.T) {
+func TestOrganizationsService_IsMember_notMember(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -90,18 +90,18 @@ func TestOrganizationsService_CheckMembership_notMember(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	member, _, err := client.Organizations.CheckMembership("o", "u")
+	member, _, err := client.Organizations.IsMember("o", "u")
 	if err != nil {
-		t.Errorf("Organizations.CheckMembership returned error: %+v", err)
+		t.Errorf("Organizations.IsMember returned error: %+v", err)
 	}
 	if want := false; member != want {
-		t.Errorf("Organizations.CheckMembership returned %+v, want %+v", member, want)
+		t.Errorf("Organizations.IsMember returned %+v, want %+v", member, want)
 	}
 }
 
 // ensure that a 400 response is interpreted as an actual error, and not simply
 // as "false" like the above case of a 404
-func TestOrganizationsService_CheckMembership_error(t *testing.T) {
+func TestOrganizationsService_IsMember_error(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -110,21 +110,21 @@ func TestOrganizationsService_CheckMembership_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	member, _, err := client.Organizations.CheckMembership("o", "u")
+	member, _, err := client.Organizations.IsMember("o", "u")
 	if err == nil {
 		t.Errorf("Expected HTTP 400 response")
 	}
 	if want := false; member != want {
-		t.Errorf("Organizations.CheckMembership returned %+v, want %+v", member, want)
+		t.Errorf("Organizations.IsMember returned %+v, want %+v", member, want)
 	}
 }
 
-func TestOrganizationsService_CheckMembership_invalidOrg(t *testing.T) {
-	_, _, err := client.Organizations.CheckMembership("%", "u")
+func TestOrganizationsService_IsMember_invalidOrg(t *testing.T) {
+	_, _, err := client.Organizations.IsMember("%", "u")
 	testURLParseError(t, err)
 }
 
-func TestOrganizationsService_CheckPublicMembership(t *testing.T) {
+func TestOrganizationsService_IsPublicMember(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -133,17 +133,17 @@ func TestOrganizationsService_CheckPublicMembership(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	member, _, err := client.Organizations.CheckPublicMembership("o", "u")
+	member, _, err := client.Organizations.IsPublicMember("o", "u")
 	if err != nil {
-		t.Errorf("Organizations.CheckPublicMembership returned error: %v", err)
+		t.Errorf("Organizations.IsPublicMember returned error: %v", err)
 	}
 	if want := true; member != want {
-		t.Errorf("Organizations.CheckPublicMembership returned %+v, want %+v", member, want)
+		t.Errorf("Organizations.IsPublicMember returned %+v, want %+v", member, want)
 	}
 }
 
 // ensure that a 404 response is interpreted as "false" and not an error
-func TestOrganizationsService_CheckPublicMembership_notMember(t *testing.T) {
+func TestOrganizationsService_IsPublicMember_notMember(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -152,18 +152,18 @@ func TestOrganizationsService_CheckPublicMembership_notMember(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	member, _, err := client.Organizations.CheckPublicMembership("o", "u")
+	member, _, err := client.Organizations.IsPublicMember("o", "u")
 	if err != nil {
-		t.Errorf("Organizations.CheckPublicMembership returned error: %v", err)
+		t.Errorf("Organizations.IsPublicMember returned error: %v", err)
 	}
 	if want := false; member != want {
-		t.Errorf("Organizations.CheckPublicMembership returned %+v, want %+v", member, want)
+		t.Errorf("Organizations.IsPublicMember returned %+v, want %+v", member, want)
 	}
 }
 
 // ensure that a 400 response is interpreted as an actual error, and not simply
 // as "false" like the above case of a 404
-func TestOrganizationsService_CheckPublicMembership_error(t *testing.T) {
+func TestOrganizationsService_IsPublicMember_error(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -172,17 +172,17 @@ func TestOrganizationsService_CheckPublicMembership_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	member, _, err := client.Organizations.CheckPublicMembership("o", "u")
+	member, _, err := client.Organizations.IsPublicMember("o", "u")
 	if err == nil {
 		t.Errorf("Expected HTTP 400 response")
 	}
 	if want := false; member != want {
-		t.Errorf("Organizations.CheckPublicMembership returned %+v, want %+v", member, want)
+		t.Errorf("Organizations.IsPublicMember returned %+v, want %+v", member, want)
 	}
 }
 
-func TestOrganizationsService_CheckPublicMembership_invalidOrg(t *testing.T) {
-	_, _, err := client.Organizations.CheckPublicMembership("%", "u")
+func TestOrganizationsService_IsPublicMember_invalidOrg(t *testing.T) {
+	_, _, err := client.Organizations.IsPublicMember("%", "u")
 	testURLParseError(t, err)
 }
 

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -108,10 +108,10 @@ func (s *OrganizationsService) ListTeamMembers(team int) ([]User, *Response, err
 	return *members, resp, err
 }
 
-// CheckTeamMembership checks if a user is a member of the specified team.
+// IsTeamMember checks if a user is a member of the specified team.
 //
 // GitHub API docs: http://developer.github.com/v3/orgs/teams/#get-team-member
-func (s *OrganizationsService) CheckTeamMembership(team int, user string) (bool, *Response, error) {
+func (s *OrganizationsService) IsTeamMember(team int, user string) (bool, *Response, error) {
 	u := fmt.Sprintf("teams/%v/members/%v", team, user)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -164,10 +164,10 @@ func (s *OrganizationsService) ListTeamRepos(team int) ([]Repository, *Response,
 	return *repos, resp, err
 }
 
-// CheckTeamRepo checks if a team manages the specified repository.
+// IsTeamRepo checks if a team manages the specified repository.
 //
 // GitHub API docs: http://developer.github.com/v3/orgs/teams/#get-team-repo
-func (s *OrganizationsService) CheckTeamRepo(team int, owner string, repo string) (bool, *Response, error) {
+func (s *OrganizationsService) IsTeamRepo(team int, owner string, repo string) (bool, *Response, error) {
 	u := fmt.Sprintf("teams/%v/repos/%v/%v", team, owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -155,7 +155,7 @@ func TestOrganizationsService_ListTeamMembers(t *testing.T) {
 	}
 }
 
-func TestOrganizationsService_CheckTeamMembership_true(t *testing.T) {
+func TestOrganizationsService_IsTeamMember_true(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -163,17 +163,17 @@ func TestOrganizationsService_CheckTeamMembership_true(t *testing.T) {
 		testMethod(t, r, "GET")
 	})
 
-	member, _, err := client.Organizations.CheckTeamMembership(1, "u")
+	member, _, err := client.Organizations.IsTeamMember(1, "u")
 	if err != nil {
-		t.Errorf("Organizations.CheckTeamMembership returned error: %v", err)
+		t.Errorf("Organizations.IsTeamMember returned error: %v", err)
 	}
 	if want := true; member != want {
-		t.Errorf("Organizations.CheckTeamMembership returned %+v, want %+v", member, want)
+		t.Errorf("Organizations.IsTeamMember returned %+v, want %+v", member, want)
 	}
 }
 
 // ensure that a 404 response is interpreted as "false" and not an error
-func TestOrganizationsService_CheckTeamMembership_false(t *testing.T) {
+func TestOrganizationsService_IsTeamMember_false(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -182,18 +182,18 @@ func TestOrganizationsService_CheckTeamMembership_false(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	member, _, err := client.Organizations.CheckTeamMembership(1, "u")
+	member, _, err := client.Organizations.IsTeamMember(1, "u")
 	if err != nil {
-		t.Errorf("Organizations.CheckTeamMembership returned error: %+v", err)
+		t.Errorf("Organizations.IsTeamMember returned error: %+v", err)
 	}
 	if want := false; member != want {
-		t.Errorf("Organizations.CheckTeamMembership returned %+v, want %+v", member, want)
+		t.Errorf("Organizations.IsTeamMember returned %+v, want %+v", member, want)
 	}
 }
 
 // ensure that a 400 response is interpreted as an actual error, and not simply
 // as "false" like the above case of a 404
-func TestOrganizationsService_CheckTeamMembership_error(t *testing.T) {
+func TestOrganizationsService_IsTeamMember_error(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -202,17 +202,17 @@ func TestOrganizationsService_CheckTeamMembership_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	member, _, err := client.Organizations.CheckTeamMembership(1, "u")
+	member, _, err := client.Organizations.IsTeamMember(1, "u")
 	if err == nil {
 		t.Errorf("Expected HTTP 400 response")
 	}
 	if want := false; member != want {
-		t.Errorf("Organizations.CheckTeamMembership returned %+v, want %+v", member, want)
+		t.Errorf("Organizations.IsTeamMember returned %+v, want %+v", member, want)
 	}
 }
 
-func TestOrganizationsService_CheckMembership_invalidUser(t *testing.T) {
-	_, _, err := client.Organizations.CheckTeamMembership(1, "%")
+func TestOrganizationsService_IsTeamMember_invalidUser(t *testing.T) {
+	_, _, err := client.Organizations.IsTeamMember(1, "%")
 	testURLParseError(t, err)
 }
 
@@ -316,7 +316,7 @@ func TestOrganizationsService_ListTeamRepos(t *testing.T) {
 	}
 }
 
-func TestOrganizationsService_CheckTeamRepo_true(t *testing.T) {
+func TestOrganizationsService_IsTeamRepo_true(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -325,16 +325,16 @@ func TestOrganizationsService_CheckTeamRepo_true(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	managed, _, err := client.Organizations.CheckTeamRepo(1, "o", "r")
+	managed, _, err := client.Organizations.IsTeamRepo(1, "o", "r")
 	if err != nil {
-		t.Errorf("Organizations.CheckTeamRepo returned error: %v", err)
+		t.Errorf("Organizations.IsTeamRepo returned error: %v", err)
 	}
 	if want := true; managed != want {
-		t.Errorf("Organizations.CheckTeamRepo returned %+v, want %+v", managed, want)
+		t.Errorf("Organizations.IsTeamRepo returned %+v, want %+v", managed, want)
 	}
 }
 
-func TestOrganizationsService_CheckTeamRepo_false(t *testing.T) {
+func TestOrganizationsService_IsTeamRepo_false(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -343,16 +343,16 @@ func TestOrganizationsService_CheckTeamRepo_false(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	managed, _, err := client.Organizations.CheckTeamRepo(1, "o", "r")
+	managed, _, err := client.Organizations.IsTeamRepo(1, "o", "r")
 	if err != nil {
-		t.Errorf("Organizations.CheckTeamRepo returned error: %v", err)
+		t.Errorf("Organizations.IsTeamRepo returned error: %v", err)
 	}
 	if want := false; managed != want {
-		t.Errorf("Organizations.CheckTeamRepo returned %+v, want %+v", managed, want)
+		t.Errorf("Organizations.IsTeamRepo returned %+v, want %+v", managed, want)
 	}
 }
 
-func TestOrganizationsService_CheckTeamRepo_error(t *testing.T) {
+func TestOrganizationsService_IsTeamRepo_error(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -361,17 +361,17 @@ func TestOrganizationsService_CheckTeamRepo_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	managed, _, err := client.Organizations.CheckTeamRepo(1, "o", "r")
+	managed, _, err := client.Organizations.IsTeamRepo(1, "o", "r")
 	if err == nil {
 		t.Errorf("Expected HTTP 400 response")
 	}
 	if want := false; managed != want {
-		t.Errorf("Organizations.CheckTeamRepo returned %+v, want %+v", managed, want)
+		t.Errorf("Organizations.IsTeamRepo returned %+v, want %+v", managed, want)
 	}
 }
 
-func TestOrganizationsService_CheckTeamRepo_invalidOwner(t *testing.T) {
-	_, _, err := client.Organizations.CheckTeamRepo(1, "%", "r")
+func TestOrganizationsService_IsTeamRepo_invalidOwner(t *testing.T) {
+	_, _, err := client.Organizations.IsTeamRepo(1, "%", "r")
 	testURLParseError(t, err)
 }
 


### PR DESCRIPTION
Issue #35

This changes the boolean Check_() functions to the Is_() convention that is more common in the standard go libs.

[CheckResponse()](https://github.com/google/go-github/blob/master/github/github.go#L326) was not changed since this is not a function that returns a boolean value. I'm fine with leaving it this way, but I'm open to discussion to change it.
