### PR TITLE
Changed repositories.UpdateComment to use a struct.

### DIFF
--- a/github/repos_comments.go
+++ b/github/repos_comments.go
@@ -21,7 +21,8 @@ type RepositoryComment struct {
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// User-mutable fields
-	Body     *string `json:"body"`
+	Body *string `json:"body"`
+	// User-initialized fields
 	Path     *string `json:"path,omitempty"`
 	Position *int    `json:"position,omitempty"`
 }
@@ -90,10 +91,9 @@ func (s *RepositoriesService) GetComment(owner, repo string, id int) (*Repositor
 // UpdateComment updates the body of a single comment.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/comments/#update-a-commit-comment
-func (s *RepositoriesService) UpdateComment(owner, repo string, id int, body string) (*RepositoryComment, *Response, error) {
+func (s *RepositoriesService) UpdateComment(owner, repo string, id int, comment *RepositoryComment) (*RepositoryComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, id)
-	comment := RepositoryComment{Body: String(body)}
-	req, err := s.client.NewRequest("PATCH", u, &comment)
+	req, err := s.client.NewRequest("PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/repos_comments_test.go
+++ b/github/repos_comments_test.go
@@ -120,7 +120,7 @@ func TestRepositoriesService_UpdateComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	comment, _, err := client.Repositories.UpdateComment("o", "r", 1, "b")
+	comment, _, err := client.Repositories.UpdateComment("o", "r", 1, &RepositoryComment{Body: String("b")})
 	if err != nil {
 		t.Errorf("Repositories.UpdateComment returned error: %v", err)
 	}


### PR DESCRIPTION
In response to [a discussion](https://github.com/google/go-github/pull/41#discussion_r5877562) with @willnorris in issue #41

UpdateComment now takes in a RepositoryComment instead of a string for a
parameter. This makes it easier to support more data types if/when the API
changes.
