### PR TITLE
Added missing fields to repo struct

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -21,15 +21,31 @@ type RepositoriesService struct {
 
 // Repository represents a GitHub repository.
 type Repository struct {
-	ID            *int       `json:"id,omitempty"`
-	Owner         *User      `json:"owner,omitempty"`
-	Name          *string    `json:"name,omitempty"`
-	Description   *string    `json:"description,omitempty"`
-	Homepage      *string    `json:"homepage,omitempty"`
-	DefaultBranch *string    `json:"default_branch,omitempty"`
-	CreatedAt     *Timestamp `json:"created_at,omitempty"`
-	PushedAt      *Timestamp `json:"pushed_at,omitempty"`
-	UpdatedAt     *Timestamp `json:"updated_at,omitempty"`
+	ID              *int       `json:"id,omitempty"`
+	Owner           *User      `json:"owner,omitempty"`
+	Name            *string    `json:"name,omitempty"`
+	Description     *string    `json:"description,omitempty"`
+	Homepage        *string    `json:"homepage,omitempty"`
+	DefaultBranch   *string    `json:"default_branch,omitempty"`
+	MasterBranch    *string    `json:"master_branch,omitempty"`
+	CreatedAt       *Timestamp `json:"created_at,omitempty"`
+	PushedAt        *Timestamp `json:"pushed_at,omitempty"`
+	UpdatedAt       *Timestamp `json:"updated_at,omitempty"`
+	URL             *string    `json:"url,omitempty"`
+	HTMLURL         *string    `json:"html_url,omitempty"`
+	CloneURL        *string    `json:"clone_url,omitempty"`
+	GitURL          *string    `json:"git_url,omitempty"`
+	SSHURL          *string    `json:"ssh_url,omitempty"`
+	SVNURL          *string    `json:"svn_url,omitempty"`
+	Language        *string    `json:"language,omitempty"`
+	Fork            *bool      `json:"fork"`
+	Forks           *int       `json:"forks,omitempty"`
+	ForksCount      *int       `json:"forks_count,omitempty"`
+	Watchers        *int       `json:"watchers,omitempty"`
+	WatchersCount   *int       `json:"watchers_count,omitempty"`
+	OpenIssues      *int       `json:"open_issues,omitempty"`
+	OpenIssuesCount *int       `json:"open_issues_count,omitempty"`
+	Size            *int       `json:"size,omitempty"`
 
 	// Additional mutable fields when creating and editing a repository
 	Private   *bool `json:"private"`


### PR DESCRIPTION
Similar to issue #38, there were a lot of missing fields from the repository struct. This should add most of them in.
