### PR TITLE
Switch ListByRepo() to use addOptions().

### DIFF
--- a/github/issues.go
+++ b/github/issues.go
@@ -159,11 +159,7 @@ type IssueListByRepoOptions struct {
 	// Since filters issues by time.
 	Since time.Time `url:"since,omitempty"`
 
-	// For paginated result sets, page of results to retrieve.
-	Page int `url:"page,omitempty"`
-
-	// For paginated result sets, number of results per page to retrieve.
-	PerPage int `url:"per_page,omitempty"`
+	ListOptions
 }
 
 // ListByRepo lists the issues for the specified repository.

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -116,7 +116,8 @@ func TestIssuesService_ListByRepo(t *testing.T) {
 
 	opt := &IssueListByRepoOptions{
 		"*", "closed", "a", "c", "m", []string{"a", "b"}, "updated", "asc",
-		time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC), 0, 0,
+		time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC),
+		ListOptions{0, 0},
 	}
 	issues, _, err := client.Issues.ListByRepo("o", "r", opt)
 	if err != nil {


### PR DESCRIPTION
`ListByRepo()` was pretty much unusable without this change, as the GitHub API rejected the empty query parameters.

This also adds support for pagination.
