### PR TITLE
Add RepositoriesService method GetByID for fetching a repository by its numeric ID

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -210,6 +210,25 @@ func (s *RepositoriesService) Get(owner, repo string) (*Repository, *Response, e
 	return repository, resp, err
 }
 
+// GetByID fetches a repository by its numeric ID.
+//
+// Note: GetByID uses the undocumented GitHub API endpoint /repositories/:id.
+func (s *RepositoriesService) GetByID(id int) (*Repository, *Response, error) {
+	u := fmt.Sprintf("repositories/%d", id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	repository := new(Repository)
+	resp, err := s.client.Do(req, repository)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return repository, resp, err
+}
+
 // Edit updates a repository.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/#edit

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -205,6 +205,26 @@ func TestRepositoriesService_Get(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_GetByID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repositories/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":1,"name":"n","description":"d","owner":{"login":"l"}}`)
+	})
+
+	repo, _, err := client.Repositories.GetByID(1)
+	if err != nil {
+		t.Errorf("Repositories.GetByID returned error: %v", err)
+	}
+
+	want := &Repository{ID: Int(1), Name: String("n"), Description: String("d"), Owner: &User{Login: String("l")}}
+	if !reflect.DeepEqual(repo, want) {
+		t.Errorf("Repositories.GetByID returned %+v, want %+v", repo, want)
+	}
+}
+
 func TestRepositoriesService_Edit(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
This PR adds a `GetByID(id int)` method to `RepositoriesService` that fetches a GitHub repository by its numeric ID from the undocumented `/repositories/:id` endpoint.

Being able to fetch a repository by its ID is useful for tracking it when its name changes. The API does not redirect from the old name to the new name (and even if it did, if you created a 2nd repo with the old name, the redirect would have to be removed). The numeric ID is also useful because it takes up less space than the (owner, name) tuple.

Users should use this method with caution :warning: because it uses an undocumented API endpoint. @willnorris, if you think it's a bad idea to merge this method in, I would understand.
