### PR TITLE
Add MirrorURL field to Repository

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -31,6 +31,7 @@ type Repository struct {
 	HTMLURL         *string    `json:"html_url,omitempty"`
 	CloneURL        *string    `json:"clone_url,omitempty"`
 	GitURL          *string    `json:"git_url,omitempty"`
+	MirrorURL       *string    `json:"mirror_url,omitempty"`
 	SSHURL          *string    `json:"ssh_url,omitempty"`
 	SVNURL          *string    `json:"svn_url,omitempty"`
 	Language        *string    `json:"language,omitempty"`


### PR DESCRIPTION
The `mirror_url` field on repository objects is the clone URL of the mirror's origin repository, or `null` if the repository is not a mirror. To see an example JSON response for a mirror repository, run `curl https://api.github.com/repos/apache/avro`.

The `mirror_url` field is currently immutable (according to [this post](https://issues.apache.org/jira/browse/INFRA-6130)) and determined upon repository creation. (I mention this only because I don't think it'd be possible to set the `mirror_url` field to `null` with the current struct field-pointer scheme. As long as it's immutable, this is not an issue.)

BTW, I was unable to create a mirror repository with my user account (POSTing a repository with `mirror_url` set just created a normal repository with `mirror_url: null`), so it's possible that it requires special privileges. Can anyone confirm this?
