### PR TITLE
Add support for the Gitignore API.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -56,6 +56,7 @@ type Client struct {
 	Activity      *ActivityService
 	Gists         *GistsService
 	Git           *GitService
+	Gitignores    *GitignoresService
 	Issues        *IssuesService
 	Organizations *OrganizationsService
 	PullRequests  *PullRequestsService
@@ -110,6 +111,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Activity = &ActivityService{client: c}
 	c.Gists = &GistsService{client: c}
 	c.Git = &GitService{client: c}
+	c.Gitignores = &GitignoresService{client: c}
 	c.Issues = &IssuesService{client: c}
 	c.Organizations = &OrganizationsService{client: c}
 	c.PullRequests = &PullRequestsService{client: c}

--- a/github/gitignore.go
+++ b/github/gitignore.go
@@ -1,0 +1,65 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+)
+
+// GitignoresService provides access to the gitignore related functions in the
+// GitHub API.
+//
+// GitHub API docs: http://developer.github.com/v3/gitignore/
+type GitignoresService struct {
+	client *Client
+}
+
+// Represents a .gitignore file as returned by the GitHub API.
+type Gitignore struct {
+	Name   *string `json:"name,omitempty"`
+	Source *string `json:"source,omitempty"`
+}
+
+func (g Gitignore) String() string {
+	return Stringify(g)
+}
+
+// Fetches a list of all available Gitignore templates.
+//
+// http://developer.github.com/v3/gitignore/#listing-available-templates
+func (s GitignoresService) List() (*[]string, *Response, error) {
+	req, err := s.client.NewRequest("GET", "gitignore/templates", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	availableTemplates := new([]string)
+	resp, err := s.client.Do(req, availableTemplates)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return availableTemplates, resp, err
+}
+
+// Fetches a Gitignore by name.
+//
+// http://developer.github.com/v3/gitignore/#get-a-single-template
+func (s GitignoresService) Get(name string) (*Gitignore, *Response, error) {
+	u := fmt.Sprintf("gitignore/templates/%v", name)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gitignore := new(Gitignore)
+	resp, err := s.client.Do(req, gitignore)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gitignore, resp, err
+}

--- a/github/gitignore_test.go
+++ b/github/gitignore_test.go
@@ -1,0 +1,58 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestGitignoresService_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/gitignore/templates", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `["C", "Go"]`)
+	})
+
+	available, _, err := client.Gitignores.List()
+	if err != nil {
+		t.Errorf("Gitignores.List returned error: %v", err)
+	}
+
+	want := &[]string{"C", "Go"}
+	if !reflect.DeepEqual(available, want) {
+		t.Errorf("Gitignores.List returned %+v, want %+v", available, want)
+	}
+}
+
+func TestGitignoresService_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/gitignore/templates/name", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"name":"Name","source":"template source"}`)
+	})
+
+	gitignore, _, err := client.Gitignores.Get("name")
+	if err != nil {
+		t.Errorf("Gitignores.List returned error: %v", err)
+	}
+
+	want := &Gitignore{Name: String("Name"), Source: String("template source")}
+	if !reflect.DeepEqual(gitignore, want) {
+		t.Errorf("Gitignores.Get returned %+v, want %+v", gitignore, want)
+	}
+}
+
+func TestGitignoresService_Get_invalidTemplate(t *testing.T) {
+	_, _, err := client.Gitignores.Get("%")
+	testURLParseError(t, err)
+}


### PR DESCRIPTION
This pull request adds support for the [Gitignore API](http://developer.github.com/v3/gitignore/).

The `GitignoresService` can be accessed with `client.Gitignores`. There are two functions available, `Gitignores.List` and `Gitignores.Get`. Everything is fully documented and tested.

Example usage:

``` go
package main

import (
    "fmt"
    "github.com/zachlatta/go-github/github"
)

func main() {
    client := github.NewClient(nil)

    // List all available .gitignore templates.
    availableTemplates, _, err := client.Gitignores.List()
    if err != nil {
        fmt.Println(err)
    } else {
        fmt.Println(availableTemplates)
    }

    // Retrieve and print a specific template's source.
    template, _, err := client.Gitignores.Get("Go")
    if err != nil {
        fmt.Println(err)
    } else {
        fmt.Println(*template.Source)
    }
}
```
