### PR TITLE
Accepted mime type fixes

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -32,8 +32,7 @@ const (
 	headerRateRemaining = "X-RateLimit-Remaining"
 	headerRateReset     = "X-RateLimit-Reset"
 
-	mimePreview        = "application/vnd.github.preview"
-	mimeReleasePreview = "application/vnd.github.manifold-preview"
+	mimeType = "application/vnd.github.v3+json"
 )
 
 // A Client manages communication with the GitHub API.
@@ -159,11 +158,12 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 		return nil, err
 	}
 
+	req.Header.Add("Accept", mimeType)
 	req.Header.Add("User-Agent", c.UserAgent)
 	return req, nil
 }
 
-// NewUploadRequest creates an upload request. A relative URL can be provided in 
+// NewUploadRequest creates an upload request. A relative URL can be provided in
 // urlStr, in which case it is resolved relative to the UploadURL of the Client.
 // Relative URLs should always be specified without a preceding slash.
 func (c *Client) NewUploadRequest(urlStr string, reader io.Reader, contentType string) (*http.Request, error) {
@@ -178,6 +178,7 @@ func (c *Client) NewUploadRequest(urlStr string, reader io.Reader, contentType s
 		return nil, err
 	}
 
+	req.Header.Add("Accept", mimeType)
 	req.Header.Add("Content-Type", contentType)
 	req.Header.Add("User-Agent", c.UserAgent)
 	return req, nil

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -59,7 +59,6 @@ func (s *RepositoriesService) ListReleases(owner, repo string) ([]RepositoryRele
 	if err != nil {
 		return nil, nil, err
 	}
-	req.Header.Add("Accept", mimeReleasePreview)
 
 	releases := new([]RepositoryRelease)
 	resp, err := s.client.Do(req, releases)
@@ -79,7 +78,6 @@ func (s *RepositoriesService) GetRelease(owner, repo string, id int) (*Repositor
 	if err != nil {
 		return nil, nil, err
 	}
-	req.Header.Add("Accept", mimeReleasePreview)
 
 	release := new(RepositoryRelease)
 	resp, err := s.client.Do(req, release)
@@ -99,7 +97,6 @@ func (s *RepositoriesService) CreateRelease(owner, repo string, release *Reposit
 	if err != nil {
 		return nil, nil, err
 	}
-	req.Header.Add("Accept", mimeReleasePreview)
 
 	r := new(RepositoryRelease)
 	resp, err := s.client.Do(req, r)
@@ -119,7 +116,6 @@ func (s *RepositoriesService) EditRelease(owner, repo string, id int, release *R
 	if err != nil {
 		return nil, nil, err
 	}
-	req.Header.Add("Accept", mimeReleasePreview)
 
 	r := new(RepositoryRelease)
 	resp, err := s.client.Do(req, r)
@@ -139,7 +135,6 @@ func (s *RepositoriesService) DeleteRelease(owner, repo string, id int) (*Respon
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Accept", mimeReleasePreview)
 	return s.client.Do(req, nil)
 }
 
@@ -153,7 +148,6 @@ func (s *RepositoriesService) ListReleaseAssets(owner, repo string, id int) ([]R
 	if err != nil {
 		return nil, nil, err
 	}
-	req.Header.Add("Accept", mimeReleasePreview)
 
 	assets := new([]ReleaseAsset)
 	resp, err := s.client.Do(req, assets)
@@ -173,7 +167,6 @@ func (s *RepositoriesService) GetReleaseAsset(owner, repo string, id int) (*Rele
 	if err != nil {
 		return nil, nil, err
 	}
-	req.Header.Add("Accept", mimeReleasePreview)
 
 	asset := new(ReleaseAsset)
 	resp, err := s.client.Do(req, asset)
@@ -193,7 +186,6 @@ func (s *RepositoriesService) EditReleaseAsset(owner, repo string, id int, relea
 	if err != nil {
 		return nil, nil, err
 	}
-	req.Header.Add("Accept", mimeReleasePreview)
 
 	asset := new(ReleaseAsset)
 	resp, err := s.client.Do(req, asset)
@@ -213,7 +205,6 @@ func (s *RepositoriesService) DeleteReleaseAsset(owner, repo string, id int) (*R
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Accept", mimeReleasePreview)
 	return s.client.Do(req, nil)
 }
 
@@ -231,7 +222,6 @@ func (s *RepositoriesService) UploadReleaseAsset(owner, repo string, id int, opt
 	if err != nil {
 		return nil, nil, err
 	}
-	req.Header.Add("Accept", mimeReleasePreview)
 
 	asset := new(ReleaseAsset)
 	resp, err := s.client.Do(req, asset)

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -20,7 +20,6 @@ func TestRepositoriesService_ListReleases(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/releases", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mimeReleasePreview)
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
@@ -40,7 +39,6 @@ func TestRepositoriesService_GetRelease(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/releases/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mimeReleasePreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -66,7 +64,6 @@ func TestRepositoriesService_CreateRelease(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mimeReleasePreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -95,7 +92,6 @@ func TestRepositoriesService_EditRelease(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", mimeReleasePreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -118,7 +114,6 @@ func TestRepositoriesService_DeleteRelease(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/releases/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mimeReleasePreview)
 	})
 
 	_, err := client.Repositories.DeleteRelease("o", "r", 1)
@@ -133,7 +128,6 @@ func TestRepositoriesService_ListReleaseAssets(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/releases/1/assets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mimeReleasePreview)
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
@@ -153,7 +147,6 @@ func TestRepositoriesService_GetReleaseAsset(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mimeReleasePreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -178,7 +171,6 @@ func TestRepositoriesService_EditReleaseAsset(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", mimeReleasePreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -201,7 +193,6 @@ func TestRepositoriesService_DeleteReleaseAsset(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mimeReleasePreview)
 	})
 
 	_, err := client.Repositories.DeleteReleaseAsset("o", "r", 1)
@@ -216,7 +207,6 @@ func TestRepositoriesService_UploadReleaseAsset(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/releases/1/assets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mimeReleasePreview)
 		testHeader(t, r, "Content-Type", "application/zip")
 		testFormValues(t, r, values{"name": "n"})
 

--- a/github/search.go
+++ b/github/search.go
@@ -124,7 +124,6 @@ func (s *SearchService) search(searchType string, query string, opt *SearchOptio
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Accept", mimePreview)
 
 	return s.client.Do(req, result)
 }

--- a/github/search_test.go
+++ b/github/search_test.go
@@ -14,7 +14,6 @@ func TestSearchService_Repositories(t *testing.T) {
 
 	mux.HandleFunc("/search/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mimePreview)
 		testFormValues(t, r, values{
 			"q":        "blah",
 			"sort":     "forks",
@@ -47,7 +46,6 @@ func TestSearchService_Issues(t *testing.T) {
 
 	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mimePreview)
 		testFormValues(t, r, values{
 			"q":        "blah",
 			"sort":     "forks",
@@ -80,7 +78,6 @@ func TestSearchService_Users(t *testing.T) {
 
 	mux.HandleFunc("/search/users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mimePreview)
 		testFormValues(t, r, values{
 			"q":        "blah",
 			"sort":     "forks",
@@ -113,7 +110,6 @@ func TestSearchService_Code(t *testing.T) {
 
 	mux.HandleFunc("/search/code", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mimePreview)
 		testFormValues(t, r, values{
 			"q":        "blah",
 			"sort":     "forks",


### PR DESCRIPTION
According to various blog posts of the official github developer
website [1] [2], the mime preview for Releases and Search are no longer
needed.
Moreover, they recommend to use `application/vnd.github.v3+json` for
every requests.

[1]
http://developer.github.com/changes/2013-11-04-releases-api-is-official/
[2]
http://developer.github.com/changes/2013-10-29-search-api-becomes-an-official-part-of-github-api-v3/
