### PR TITLE
Add support for the refs API

### DIFF
--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -31,14 +31,14 @@ func (o GitObject) String() string {
 	return Stringify(o)
 }
 
-// refCreateArgs represents the payload for creating a reference.
-type refCreateArgs struct {
+// createRefRequest represents the payload for creating a reference.
+type createRefRequest struct {
 	Ref *string `json:"ref"`
 	SHA *string `json:"sha"`
 }
 
-// refUpdateArgs represents the payload for updating a reference.
-type refUpdateArgs struct {
+// updateRefRequest represents the payload for updating a reference.
+type updateRefRequest struct {
 	SHA   *string `json:"sha"`
 	Force *bool   `json:"force"`
 }
@@ -86,7 +86,7 @@ func (s *GitService) ListRefs(owner string, repo string) ([]*Reference, *Respons
 // GitHub API docs: http://developer.github.com/v3/git/refs/#create-a-reference
 func (s *GitService) CreateRef(owner string, repo string, ref *Reference) (*Reference, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/refs", owner, repo)
-	req, err := s.client.NewRequest("POST", u, &refCreateArgs{
+	req, err := s.client.NewRequest("POST", u, &createRefRequest{
 		Ref: String("refs/" + *ref.Ref),
 		SHA: ref.Object.SHA,
 	})
@@ -108,7 +108,7 @@ func (s *GitService) CreateRef(owner string, repo string, ref *Reference) (*Refe
 // GitHub API docs: http://developer.github.com/v3/git/refs/#update-a-reference
 func (s *GitService) UpdateRef(owner string, repo string, ref *Reference, force bool) (*Reference, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/refs/%v", owner, repo, *ref.Ref)
-	req, err := s.client.NewRequest("PATCH", u, &refUpdateArgs{
+	req, err := s.client.NewRequest("PATCH", u, &updateRefRequest{
 		SHA:   ref.Object.SHA,
 		Force: &force,
 	})

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -113,13 +113,13 @@ func TestGitService_CreateRef(t *testing.T) {
 	setup()
 	defer teardown()
 
-	args := &refCreateArgs{
+	args := &createRefRequest{
 		Ref: String("refs/heads/b"),
 		SHA: String("aa218f56b14c9653891f9e74264a383fa43fefbd"),
 	}
 
 	mux.HandleFunc("/repos/o/r/git/refs", func(w http.ResponseWriter, r *http.Request) {
-		v := new(refCreateArgs)
+		v := new(createRefRequest)
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
@@ -166,13 +166,13 @@ func TestGitService_UpdateRef(t *testing.T) {
 	setup()
 	defer teardown()
 
-	args := &refUpdateArgs{
+	args := &updateRefRequest{
 		SHA:   String("aa218f56b14c9653891f9e74264a383fa43fefbd"),
 		Force: Bool(true),
 	}
 
 	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
-		v := new(refUpdateArgs)
+		v := new(updateRefRequest)
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")


### PR DESCRIPTION
This is the code to take care of issue #71 . It adds support for the [refs API](http://developer.github.com/v3/git/refs/).

Not sure how it works with adding myself to CONTRIBUTORS/AUTHORS, but I signed that Google CLA already (as Ondřej Kupka)...
