### PR TITLE
IssueRequest struct for create/edit. Fixes #75.

### DIFF
--- a/github/issues.go
+++ b/github/issues.go
@@ -39,6 +39,18 @@ func (i Issue) String() string {
 	return Stringify(i)
 }
 
+// IssueRequest represents a request to create/edit an issue.
+// It is separate from Issue above because otherwise Labels
+// and Assignee fail to serialize to the correct JSON.
+type IssueRequest struct {
+	Title    *string  `json:"title,omitempty"`
+	Body     *string  `json:"body,omitempty"`
+	Labels   []string `json:"labels,omitempty"`
+	Assignee *string  `json:"assignee,omitempty"`
+
+	// TODO(willnorris): milestone here too!
+}
+
 // IssueListOptions specifies the optional parameters to the IssuesService.List
 // and IssuesService.ListByOrg methods.
 type IssueListOptions struct {
@@ -198,7 +210,7 @@ func (s *IssuesService) Get(owner string, repo string, number int) (*Issue, *Res
 // Create a new issue on the specified repository.
 //
 // GitHub API docs: http://developer.github.com/v3/issues/#create-an-issue
-func (s *IssuesService) Create(owner string, repo string, issue *Issue) (*Issue, *Response, error) {
+func (s *IssuesService) Create(owner string, repo string, issue *IssueRequest) (*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues", owner, repo)
 	req, err := s.client.NewRequest("POST", u, issue)
 	if err != nil {
@@ -217,7 +229,7 @@ func (s *IssuesService) Create(owner string, repo string, issue *Issue) (*Issue,
 // Edit an issue.
 //
 // GitHub API docs: http://developer.github.com/v3/issues/#edit-an-issue
-func (s *IssuesService) Edit(owner string, repo string, number int, issue *Issue) (*Issue, *Response, error) {
+func (s *IssuesService) Edit(owner string, repo string, number int, issue *IssueRequest) (*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%d", owner, repo, number)
 	req, err := s.client.NewRequest("PATCH", u, issue)
 	if err != nil {

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -172,10 +172,15 @@ func TestIssuesService_Create(t *testing.T) {
 	setup()
 	defer teardown()
 
-	input := &Issue{Title: String("t")}
+	input := &IssueRequest{
+		Title:    String("t"),
+		Body:     String("b"),
+		Assignee: String("a"),
+		Labels:   []string{"l1", "l2"},
+	}
 
 	mux.HandleFunc("/repos/o/r/issues", func(w http.ResponseWriter, r *http.Request) {
-		v := new(Issue)
+		v := new(IssueRequest)
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
@@ -206,10 +211,10 @@ func TestIssuesService_Edit(t *testing.T) {
 	setup()
 	defer teardown()
 
-	input := &Issue{Title: String("t")}
+	input := &IssueRequest{Title: String("t")}
 
 	mux.HandleFunc("/repos/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
-		v := new(Issue)
+		v := new(IssueRequest)
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")


### PR DESCRIPTION
Using an *Issue in IssuesService.{Create,Edit} means that the Labels
and Assignee fields do not serialize to the correct JSON representation
for the GitHub API. This change introduces an IssueRequest struct to
use instead, allowing labels and assignees to be set on create or edit.
