### PR TITLE
add support for /markdown endpoint

### DIFF
--- a/examples/markdown.go
+++ b/examples/markdown.go
@@ -1,0 +1,24 @@
+// Copyright 2014 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/google/go-github/github"
+)
+
+func main() {
+	client := github.NewClient(nil)
+
+	input := "# heading #\nLink to issue #1\n"
+	md, _, err := client.Markdown(input, &github.MarkdownOptions{Mode: "gfm", Context: "google/go-github"})
+	if err != nil {
+		fmt.Printf("error: %v\n\n", err)
+	}
+
+	fmt.Printf("converted mardown:\n%v\n", md)
+}

--- a/github/misc.go
+++ b/github/misc.go
@@ -1,0 +1,63 @@
+// Copyright 2014 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"bytes"
+)
+
+// MarkdownOptions specifies optional parameters to the Markdown method.
+type MarkdownOptions struct {
+	// Mode identifies the rendering mode.  Possible values are:
+	//   markdown - render a document as plain Markdown, just like
+	//   README files are rendered.
+	//
+	//   gfm - to render a document as user-content, e.g. like user
+	//   comments or issues are rendered. In GFM mode, hard line breaks are
+	//   always taken into account, and issue and user mentions are linked
+	//   accordingly.
+	//
+	// Default is "markdown".
+	Mode string
+
+	// Context identifies the repository context.  Only taken into account
+	// when rendering as "gfm".
+	Context string
+}
+
+type markdownRequest struct {
+	Text    *string `json:"text,omitempty"`
+	Mode    *string `json:"mode,omitempty"`
+	Context *string `json:"context,omitempty"`
+}
+
+// Markdown renders an arbitrary Markdown document.
+//
+// GitHub API docs: https://developer.github.com/v3/markdown/
+func (c *Client) Markdown(text string, opt *MarkdownOptions) (string, *Response, error) {
+	request := &markdownRequest{Text: String(text)}
+	if opt != nil {
+		if opt.Mode != "" {
+			request.Mode = String(opt.Mode)
+		}
+		if opt.Context != "" {
+			request.Context = String(opt.Context)
+		}
+	}
+
+	req, err := c.NewRequest("POST", "/markdown", request)
+	if err != nil {
+		return "", nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	resp, err := c.Do(req, buf)
+	if err != nil {
+		return "", resp, nil
+	}
+
+	return buf.String(), resp, nil
+}

--- a/github/misc_test.go
+++ b/github/misc_test.go
@@ -1,0 +1,47 @@
+// Copyright 2014 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestMarkdown(t *testing.T) {
+	setup()
+	defer teardown()
+
+	input := &markdownRequest{
+		Text:    String("# text #"),
+		Mode:    String("gfm"),
+		Context: String("google/go-github"),
+	}
+	mux.HandleFunc("/markdown", func(w http.ResponseWriter, r *http.Request) {
+		v := new(markdownRequest)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "POST")
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		fmt.Fprint(w, `<h1>text</h1>`)
+	})
+
+	md, _, err := client.Markdown("# text #", &MarkdownOptions{
+		Mode:    "gfm",
+		Context: "google/go-github",
+	})
+	if err != nil {
+		t.Errorf("Markdown returned error: %v", err)
+	}
+
+	if want := "<h1>text</h1>"; want != md {
+		t.Errorf("Markdown returned %+v, want %+v", md, want)
+	}
+}


### PR DESCRIPTION
notably, this also updates client.Do() to handle non-JSON response bodies by passing an io.Writer as the final argument, v.

---

I'm not 100% sure where this should go.  For Gitignore, we created a dedicated gitignore.go, along with a `GitignoresService`, though looking at it now I'm thinking we probably should not have.  The GitHub docs list this under "Miscellaneous", which is why I've added it to misc.go, but I've stopped short of creating a `MiscService` and instead am putting this directly on the `Client` struct, similar to how `RateLimit` is done.  All these miscellaneous methods should probably all be consistent, but I'm open to suggestions on what that should be.
