### PR TITLE
Add ListContributorsStats and ListCommitActivity for RepositoriesService

### DIFF
--- a/github/repos_stats.go
+++ b/github/repos_stats.go
@@ -1,0 +1,82 @@
+// Copyright 2014 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// ContributorStats represents a contributor to a repository and their
+// weekly contributions to a given repo.
+type ContributorStats struct {
+	Author *Contributor `json:"author,omitempty"`
+	Total  *int         `json:"total,omitempty"`
+	Weeks  []WeeklyHash `json:"weeks,omitempty"`
+}
+
+// WeeklyHash represents the number of additions, deletions and commits
+// a Contributor made in a given week.
+type WeeklyHash struct {
+	Week      *int `json:"w,omitempty"`
+	Additions *int `json:"a,omitempty"`
+	Deletions *int `json:"d,omitempty"`
+	Commits   *int `json:"c,omitempty"`
+}
+
+// ListContributorsStats gets a repo's contributor list with additions, deletions and commit counts.
+// If this is the first time these statistics are requested for the given repository, this will method
+// will return a non-nil error and a status code of 202. This is because this is the status that github
+// returns to signify that it is now computing the requested statistics. A follow up request, after
+// a delay of a second or so, should result in a successful request.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/statistics/#contributors
+func (s *RepositoriesService) ListContributorsStats(owner, repo string) (*[]ContributorStats, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/stats/contributors", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	contributorStats := new([]ContributorStats)
+	resp, err := s.client.Do(req, contributorStats)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return contributorStats, resp, err
+}
+
+// WeeklyCommitActivity represents the weekly commit activity for a repository.
+// The days array is a group of commits per day, starting on Sunday.
+type WeeklyCommitActivity struct {
+	Days  []int `json:"days,omitempty"`
+	Total *int  `json:"total,omitempty"`
+	Week  *int  `json:"week,omitempty"`
+}
+
+// ListLastYearCommitActivity returns the last year of commit activity
+// grouped by week. The days array is a group of commits per day,
+// starting on Sunday. If this is the first time these statistics are
+// requested for the given repository, this will method will return a
+// non-nil error and a status code of 202. This is because this is the
+// status that github returns to signify that it is now computing the
+// requested statistics. A follow up request, after a delay of a second
+// or so, should result in a successful request.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/statistics/#commit-activity
+func (s *RepositoriesService) ListCommitActivity(owner, repo string) (*[]WeeklyCommitActivity, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/stats/commit_activity", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	weeklyCommitActivity := new([]WeeklyCommitActivity)
+	resp, err := s.client.Do(req, weeklyCommitActivity)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return weeklyCommitActivity, resp, err
+}

--- a/github/repos_stats_test.go
+++ b/github/repos_stats_test.go
@@ -1,0 +1,103 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestRepositoriesService_ListContributorsStats(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/stats/contributors", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+
+		fmt.Fprint(w, `
+[
+  {
+    "author": {
+      "id": 1
+    },
+    "total": 135,
+    "weeks": [
+      {
+        "w": 1367712000,
+        "a": 6898,
+        "d": 77,
+        "c": 10
+      }
+    ]
+  }
+]
+`)
+	})
+
+	stats, _, err := client.Repositories.ListContributorsStats("o", "r")
+	if err != nil {
+		t.Errorf("RepositoriesService.ListContributorsStats returned error: %v", err)
+	}
+
+	want := &[]ContributorStats{
+		ContributorStats{
+			Author: &Contributor{
+				ID: Int(1),
+			},
+			Total: Int(135),
+			Weeks: []WeeklyHash{
+				WeeklyHash{
+					Week:      Int(1367712000),
+					Additions: Int(6898),
+					Deletions: Int(77),
+					Commits:   Int(10),
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(stats, want) {
+		t.Errorf("RepositoriesService.ListContributorsStats returned %+v, want %+v", stats, want)
+	}
+}
+
+func TestRepositoriesService_ListCommitActivity(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/stats/commit_activity", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+
+		fmt.Fprint(w, `
+[
+  {
+    "days": [0, 3, 26, 20, 39, 1, 0],
+    "total": 89,
+    "week": 1336280400
+  }
+]
+`)
+	})
+
+	activity, _, err := client.Repositories.ListCommitActivity("o", "r")
+	if err != nil {
+		t.Errorf("RepositoriesService.ListCommitActivity returned error: %v", err)
+	}
+
+	want := &[]WeeklyCommitActivity{
+		WeeklyCommitActivity{
+			Days:  []int{0, 3, 26, 20, 39, 1, 0},
+			Total: Int(89),
+			Week:  Int(1336280400),
+		},
+	}
+
+	if !reflect.DeepEqual(activity, want) {
+		t.Errorf("RepositoriesService.ListCommitActivity returned %+v, want %+v", activity, want)
+	}
+}


### PR DESCRIPTION
When you make a request for stats, you often get a 202 back at first (meaning the stats haven't been computed but now will be computed). I didn't do any extra work because I figured the user would rather be the one handling this (once you receive a 202, waiting ~1 second and then making the request again results in a 200).
