### PR TITLE
add PushEvent file stats

### DIFF
--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -46,14 +46,12 @@ func (e *Event) Payload() (payload interface{}) {
 //
 // GitHub API docs: http://developer.github.com/v3/activity/events/types/#pushevent
 type PushEvent struct {
-	PushID   *int              `json:"push_id,omitempty"`
-	Head     *string           `json:"head,omitempty"`
-	Ref      *string           `json:"ref,omitempty"`
-	Size     *int              `json:"ref,omitempty"`
-	Commits  []PushEventCommit `json:"commits,omitempty"`
-	Added    []*string         `json:"added"`
-	Removed  []*string         `json:"removed"`
-	Modified []*string         `json:"modified"`
+	PushID  *int              `json:"push_id,omitempty"`
+	Head    *string           `json:"head,omitempty"`
+	Ref     *string           `json:"ref,omitempty"`
+	Size    *int              `json:"ref,omitempty"`
+	Commits []PushEventCommit `json:"commits,omitempty"`
+	Repo    *Repository       `json:"repository,omitempty"`
 }
 
 func (p PushEvent) String() string {
@@ -67,6 +65,9 @@ type PushEventCommit struct {
 	Author   *CommitAuthor `json:"author,omitempty"`
 	URL      *string       `json:"url,omitempty"`
 	Distinct *bool         `json:"distinct"`
+	Added    []*string     `json:"added"`
+	Removed  []*string     `json:"removed"`
+	Modified []*string     `json:"modified"`
 }
 
 func (p PushEventCommit) String() string {


### PR DESCRIPTION
Turns out that the payload for PushEvent provides some undocumented but useful data.
GitHub support people claim it should be considered as a stable addition that is not going to disappear any time soon.
