### PR TITLE
Change markdown example to be an Example (with expected output).

### DIFF
--- a/examples/markdown/main_test.go
+++ b/examples/markdown/main_test.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package main
+package main_test
 
 import (
 	"fmt"
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-github/github"
 )
 
-func main() {
+func ExampleMarkdown() {
 	client := github.NewClient(nil)
 
 	input := "# heading #\nLink to issue #1\n"
@@ -21,4 +21,10 @@ func main() {
 	}
 
 	fmt.Printf("converted markdown:\n%v\n", md)
+
+	// Output:
+	//converted markdown:
+	//<h1>heading</h1>
+	//
+	//<p>Link to issue <a href="https://github.com/google/go-github/issues/1" class="issue-link" title="Add support for parsing post-receive webhooks">#1</a></p>
 }


### PR DESCRIPTION
This way, the output of this example program can be seen simply by looking at its source code. This is convenient for users who haven't downloaded the library yet, or don't have a Go installation at hand,
and simply want to see what the output would be.

It also makes it into a test. I imagine it should be fairly stable and not break over time, but it is possible if GitHub changes their rendering. The test would have to be updated in that case.

Finally, the test may or may not pass the Travis tests. We shall find out soon. If not, it can be disabled by adding a build tag. **_Update:**_ Actually, I don't think the current Travis script will run tests in ./examples/ folder.
