### PR TITLE
Add support for "content" attribute at tree creation

### DIFF
--- a/github/git_trees.go
+++ b/github/git_trees.go
@@ -21,11 +21,12 @@ func (t Tree) String() string {
 // represent either a blob, a commit (in the case of a submodule), or another
 // tree.
 type TreeEntry struct {
-	SHA  *string `json:"sha,omitempty"`
-	Path *string `json:"path,omitempty"`
-	Mode *string `json:"mode,omitempty"`
-	Type *string `json:"type,omitempty"`
-	Size *int    `json:"size,omitempty"`
+	SHA     *string `json:"sha,omitempty"`
+	Path    *string `json:"path,omitempty"`
+	Mode    *string `json:"mode,omitempty"`
+	Type    *string `json:"type,omitempty"`
+	Size    *int    `json:"size,omitempty"`
+	Content *string `json:"content,omitempty"`
 }
 
 func (t TreeEntry) String() string {


### PR DESCRIPTION
The GitHub API supports a "content" attribute when creating a new tree
[1](https://developer.github.com/v3/git/trees/#create-a-tree), which allows to skip additional requests to create blobs first.
