### PR TITLE
Add TeamID to Repository for creating organization repos.

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -53,6 +53,8 @@ type Repository struct {
 	HasIssues    *bool `json:"has_issues"`
 	HasWiki      *bool `json:"has_wiki"`
 	HasDownloads *bool `json:"has_downloads"`
+	// Creating an organization repository. Required for non-owners.
+	TeamID *int `json:"team_id"`
 
 	// API URLs
 	URL              *string `json:"url,omitempty"`


### PR DESCRIPTION
This is required for non-owners to create organization repos on github.

This fixes issue #126.

(Submitted CLA earlier today).
