### PR TITLE
Add PullRequest branch fields Base and Head

### DIFF
--- a/github/pulls.go
+++ b/github/pulls.go
@@ -42,11 +42,21 @@ type PullRequest struct {
 	IssueURL     *string    `json:"issue_url,omitempty"`
 	StatusesURL  *string    `json:"statuses_url,omitempty"`
 
-	// TODO(willnorris): add head and base once we have a Commit struct defined somewhere
+	Head *PullRequestBranch `json:"head,omitempty"`
+	Base *PullRequestBranch `json:"base,omitempty"`
 }
 
 func (p PullRequest) String() string {
 	return Stringify(p)
+}
+
+// PullRequestBranch represents a base or head branch in a GitHub pull request.
+type PullRequestBranch struct {
+	Label *string     `json:"label,omitempty"`
+	Ref   *string     `json:"ref,omitempty"`
+	SHA   *string     `json:"sha,omitempty"`
+	Repo  *Repository `json:"repo,omitempty"`
+	User  *User       `json:"user,omitempty"`
 }
 
 // PullRequestListOptions specifies the optional parameters to the
@@ -109,10 +119,19 @@ func (s *PullRequestsService) Get(owner string, repo string, number int) (*PullR
 	return pull, resp, err
 }
 
+// NewPullRequest represents a new pull request to be created.
+type NewPullRequest struct {
+	Title *string `json:"title,omitempty"`
+	Head  *string `json:"head,omitempty"`
+	Base  *string `json:"base,omitempty"`
+	Body  *string `json:"body,omitempty"`
+	Issue *int    `json:"issue,omitempty"`
+}
+
 // Create a new pull request on the specified repository.
 //
 // GitHub API docs: https://developer.github.com/v3/pulls/#create-a-pull-request
-func (s *PullRequestsService) Create(owner string, repo string, pull *PullRequest) (*PullRequest, *Response, error) {
+func (s *PullRequestsService) Create(owner string, repo string, pull *NewPullRequest) (*PullRequest, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls", owner, repo)
 	req, err := s.client.NewRequest("POST", u, pull)
 	if err != nil {

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -67,6 +67,37 @@ func TestPullRequestsService_Get(t *testing.T) {
 	}
 }
 
+func TestPullRequestsService_Get_headAndBase(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/pulls/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"number":1,"head":{"ref":"r2","repo":{"id":2}},"base":{"ref":"r1","repo":{"id":1}}}`)
+	})
+
+	pull, _, err := client.PullRequests.Get("o", "r", 1)
+
+	if err != nil {
+		t.Errorf("PullRequests.Get returned error: %v", err)
+	}
+
+	want := &PullRequest{
+		Number: Int(1),
+		Head: &PullRequestBranch{
+			Ref:  String("r2"),
+			Repo: &Repository{ID: Int(2)},
+		},
+		Base: &PullRequestBranch{
+			Ref:  String("r1"),
+			Repo: &Repository{ID: Int(1)},
+		},
+	}
+	if !reflect.DeepEqual(pull, want) {
+		t.Errorf("PullRequests.Get returned %+v, want %+v", pull, want)
+	}
+}
+
 func TestPullRequestsService_Get_invalidOwner(t *testing.T) {
 	_, _, err := client.PullRequests.Get("%", "r", 1)
 	testURLParseError(t, err)
@@ -76,10 +107,10 @@ func TestPullRequestsService_Create(t *testing.T) {
 	setup()
 	defer teardown()
 
-	input := &PullRequest{Title: String("t")}
+	input := &NewPullRequest{Title: String("t")}
 
 	mux.HandleFunc("/repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
-		v := new(PullRequest)
+		v := new(NewPullRequest)
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")


### PR DESCRIPTION
This PR adds `base` and `head` fields to the `PullRequest` struct.

Note: When [creating a PR](https://developer.github.com/v3/pulls/#create-a-pull-request), `head` and `base` are strings. But when [listing or getting a PR](https://developer.github.com/v3/pulls/#list-pull-requests), `head` and `base` are objects. So, creating and listing/getting need to use different Go types. My solution was to create a separate type for creating PRs, since that accepts only a limited set of fields. (It does not appear possible to edit a PR's head or base from the API; see [Update a pull request](https://developer.github.com/v3/pulls/#update-a-pull-request), which lacks those fields).
