### PR TITLE
Omit base_tree if empty

### DIFF
--- a/github/git_trees.go
+++ b/github/git_trees.go
@@ -58,7 +58,7 @@ func (s *GitService) GetTree(owner string, repo string, sha string, recursive bo
 
 // createTree represents the body of a CreateTree request.
 type createTree struct {
-	BaseTree string      `json:"base_tree"`
+	BaseTree string      `json:"base_tree,omitempty"`
 	Entries  []TreeEntry `json:"tree"`
 }
 


### PR DESCRIPTION
A recent update to the GitHub API changed some undocumented behavior. Previously
a nonexistent base_tree and an empty string base_tree were treated the same, but
now the empty string case will fail with "422 base_tree is not a valid oid".
