### PR TITLE
Add HTMLURL field to RepositoryCommit.

### DIFF
--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -20,6 +20,7 @@ type RepositoryCommit struct {
 	Committer *User    `json:"committer,omitempty"`
 	Parents   []Commit `json:"parents,omitempty"`
 	Message   *string  `json:"message,omitempty"`
+	HTMLURL   *string  `json:"html_url,omitempty"`
 
 	// Details about how many changes were made in this commit. Only filled in during GetCommit!
 	Stats *CommitStats `json:"stats,omitempty"`


### PR DESCRIPTION
This field is a part of the GitHub API. It's already present in some other structs in `go-github`, but not `RepositoryCommit`. It contains the url of the html on GitHub page for the given commit.

https://developer.github.com/v3/repos/commits/

This is needed for shurcooL/Go-Package-Store#21.
