### PR TITLE
Add an option to automatically obey rate limits

### DIFF
--- a/github/ratelimit_test.go
+++ b/github/ratelimit_test.go
@@ -1,0 +1,71 @@
+package github
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestObeyRateLimit(t *testing.T) {
+	setup()
+	defer teardown()
+
+	limit := 60
+	s := &rateLimitServer{limit, limit, time.Now()}
+	mux.Handle("/", s)
+
+	client.wait = func(d time.Duration) {
+		t.Logf("waiting %s", d)
+		s.Remaining++
+	}
+
+	client.ObeyRateLimit = true
+	for i := 0; i < limit*2; i++ {
+		t.Logf("-- request %d", i)
+		if _, _, err := client.Octocat("foo"); err != nil {
+			t.Errorf("unexpected error: %v", err)
+			break
+		}
+	}
+
+	// Turn off automatic rate limit enforcement and make too many requests
+	// to demonstrate that the alternative is over-quota errors.
+	client.ObeyRateLimit = false
+	var err error
+	var resp *Response
+	for i := 0; i < limit*2; i++ {
+		_, resp, err = client.Octocat("foo")
+		if err != nil {
+			break
+		}
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected to be rate limited")
+	}
+}
+
+type rateLimitServer struct {
+	Limit, Remaining int
+	Reset            time.Time
+}
+
+func (rl *rateLimitServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set(headerRateLimit, fmt.Sprintf("%d", rl.Limit))
+	w.Header().Set(headerRateRemaining, fmt.Sprintf("%d", rl.Remaining))
+
+	tokensNeeded := rl.Limit - rl.Remaining
+	tokensPerSecond := rl.Limit / 60 / 60
+	timeUntilReset := time.Duration(tokensNeeded*tokensPerSecond) * time.Second
+	rl.Reset = time.Now().Add(timeUntilReset)
+	w.Header().Set(headerRateReset, fmt.Sprintf("%d", rl.Reset))
+
+	if r.URL.Path != "/rate_limit" {
+		if rl.Remaining <= 0 {
+			http.Error(w, "Over quota", http.StatusForbidden)
+		}
+		rl.Remaining--
+	}
+	io.WriteString(w, "{}")
+}


### PR DESCRIPTION
This is done by checking whether the number of remaining requests we
have according to previous rate limit header responses is >5% of the
total number of requests per hour we are allowed, and if the client is
below that number, it will wait a short amount of time until issuing the
API request.

This is not fully threadsafe and may produce surprising results if two
identically-configured clients are making requests at the same time,
consuming the same quota pool. The 5% soft threshold is intended to
alleviate some of this, but it can still be fooled by a determined user.

This is only intended as a convenience to users, not as a guarantee that
rate limits won't be hit while using this option.

This also adds a test that checks that requests against a
rate-limit-enforcing server succeed with the option on and fail with it
off.

This attempts to address #152