### PR TITLE
Add CommentCount to Commit.

### DIFF
--- a/github/git_commits.go
+++ b/github/git_commits.go
@@ -12,14 +12,15 @@ import (
 
 // Commit represents a GitHub commit.
 type Commit struct {
-	SHA       *string       `json:"sha,omitempty"`
-	Author    *CommitAuthor `json:"author,omitempty"`
-	Committer *CommitAuthor `json:"committer,omitempty"`
-	Message   *string       `json:"message,omitempty"`
-	Tree      *Tree         `json:"tree,omitempty"`
-	Parents   []Commit      `json:"parents,omitempty"`
-	Stats     *CommitStats  `json:"stats,omitempty"`
-	URL       *string       `json:"url,omitempty"`
+	SHA          *string       `json:"sha,omitempty"`
+	Author       *CommitAuthor `json:"author,omitempty"`
+	Committer    *CommitAuthor `json:"committer,omitempty"`
+	Message      *string       `json:"message,omitempty"`
+	Tree         *Tree         `json:"tree,omitempty"`
+	Parents      []Commit      `json:"parents,omitempty"`
+	Stats        *CommitStats  `json:"stats,omitempty"`
+	URL          *string       `json:"url,omitempty"`
+	CommentCount *int          `json:"comment_count,omitempty"`
 }
 
 func (c Commit) String() string {


### PR DESCRIPTION
This integer exposes the number of comments that have been posted for that commit on GitHub.

It is documented at https://developer.github.com/v3/repos/commits/.

This is needed for https://github.com/shurcooL/Go-Package-Store/pull/30.

P.S. I think @GitHub messed up the API a little by putting this field inside of what we refer to as [`Commit`](http://godoc.org/github.com/google/go-github/github#Commit) in this package, rather than [`RepositoryCommit`](http://godoc.org/github.com/google/go-github/github#RepositoryCommit), since technically comments are a property of github commits rather than git commits. But what can I do. :/ I've carefully tested to ensure this works.