### PR TITLE
Add Gists.GetRevision()

### DIFF
--- a/github/gists.go
+++ b/github/gists.go
@@ -157,6 +157,24 @@ func (s *GistsService) Get(id string) (*Gist, *Response, error) {
 	return gist, resp, err
 }
 
+// Get a specific revision of a gist.
+//
+// GitHub API docs: https://developer.github.com/v3/gists/#get-a-specific-revision-of-a-gist
+func (s *GistsService) GetRevision(id, sha string) (*Gist, *Response, error) {
+	u := fmt.Sprintf("gists/%v/%v", id, sha)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	gist := new(Gist)
+	resp, err := s.client.Do(req, gist)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gist, resp, err
+}
+
 // Create a gist for authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/gists/#create-a-gist

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -146,6 +146,32 @@ func TestGistsService_Get_invalidID(t *testing.T) {
 	testURLParseError(t, err)
 }
 
+func TestGistsService_GetRevision(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/gists/1/s", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id": "1"}`)
+	})
+
+	gist, _, err := client.Gists.GetRevision("1", "s")
+
+	if err != nil {
+		t.Errorf("Gists.Get returned error: %v", err)
+	}
+
+	want := &Gist{ID: String("1")}
+	if !reflect.DeepEqual(gist, want) {
+		t.Errorf("Gists.Get returned %+v, want %+v", gist, want)
+	}
+}
+
+func TestGistsService_GetRevision_invalidID(t *testing.T) {
+	_, _, err := client.Gists.GetRevision("%", "%")
+	testURLParseError(t, err)
+}
+
 func TestGistsService_Create(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Added in a function for https://developer.github.com/v3/gists/#get-a-specific-revision-of-a-gist. This endpoint was not in the Github API spreadsheet, but should have been (after row 42).