### PR TITLE
Add merge_base_commit to compare

### DIFF
--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -61,7 +61,8 @@ func (c CommitFile) String() string {
 // CommitsComparison is the result of comparing two commits.
 // See CompareCommits() for details.
 type CommitsComparison struct {
-	BaseCommit *RepositoryCommit `json:"base_commit,omitempty"`
+	BaseCommit      *RepositoryCommit `json:"base_commit,omitempty"`
+	MergeBaseCommit *RepositoryCommit `json:"merge_base_commit,omitempty"`
 
 	// Head can be 'behind' or 'ahead'
 	Status       *string `json:"status,omitempty"`


### PR DESCRIPTION
Currently the merge base commit is not accessible from the struct `CommitsComparison`, as the field is missing. I've simply added a field `MergeBaseCommit` with the proper JSON name. The response for comparing commits is documented here: https://developer.github.com/v3/repos/commits/index.html#compare-two-commits