### PR TITLE
Two bug fixes and one enhancement

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -19,16 +19,17 @@ import (
 
 // RepositoryContent represents a file or directory in a github repository.
 type RepositoryContent struct {
-	Type     *string `json:"type,omitempty"`
-	Encoding *string `json:"encoding,omitempty"`
-	Size     *int    `json:"size,omitempty"`
-	Name     *string `json:"name,omitempty"`
-	Path     *string `json:"path,omitempty"`
-	Content  *string `json:"content,omitempty"`
-	SHA      *string `json:"sha,omitempty"`
-	URL      *string `json:"url,omitempty"`
-	GitURL   *string `json:"git_url,omitempty"`
-	HTMLURL  *string `json:"html_url,omitempty"`
+	Type        *string `json:"type,omitempty"`
+	Encoding    *string `json:"encoding,omitempty"`
+	Size        *int    `json:"size,omitempty"`
+	Name        *string `json:"name,omitempty"`
+	Path        *string `json:"path,omitempty"`
+	Content     *string `json:"content,omitempty"`
+	SHA         *string `json:"sha,omitempty"`
+	URL         *string `json:"url,omitempty"`
+	GitURL      *string `json:"git_url,omitempty"`
+	HTMLURL     *string `json:"html_url,omitempty"`
+	DownloadURL *string `json:"download_url,omitempty"`
 }
 
 // RepositoryContentResponse holds the parsed response from CreateFile, UpdateFile, and DeleteFile.

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -27,8 +27,8 @@ type RepositoryContent struct {
 	Content  *string `json:"content,omitempty"`
 	SHA      *string `json:"sha,omitempty"`
 	URL      *string `json:"url,omitempty"`
-	GitURL   *string `json:"giturl,omitempty"`
-	HTMLURL  *string `json:"htmlurl,omitempty"`
+	GitURL   *string `json:"git_url,omitempty"`
+	HTMLURL  *string `json:"html_url,omitempty"`
 }
 
 // RepositoryContentResponse holds the parsed response from CreateFile, UpdateFile, and DeleteFile.


### PR DESCRIPTION
The `git_url` and `html_url` tags in the `RepositoryContent` struct were wrong.  I've fixed tha
and added one additional field that is in the API but wasn't provided here, `download_url`.  The
`download_url` link is important because it is not subject to the same download limitations
that access through the API is.  So it provides a way to get at large files.