### PR TITLE
This adds an additional method to RepositoriesService to download a file

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -109,7 +109,7 @@ func (s *RepositoriesService) DownloadContents(owner, repo, filepath string, opt
 			if contents.DownloadURL == nil || *contents.DownloadURL == "" {
 				return nil, fmt.Errorf("No download link found for %s", filepath)
 			}
-			resp, err := http.Get(*contents.DownloadURL)
+			resp, err := s.client.client.Get(*contents.DownloadURL)
 			if err != nil {
 				return nil, err
 			}

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -104,25 +104,24 @@ func (s *RepositoriesService) GetReadme(owner, repo string, opt *RepositoryConte
 // the file.  Otherwise, it returns an error.
 func (s *RepositoriesService) DownloadContents(owner, repo, filepath string, opt *RepositoryContentGetOptions) (io.ReadCloser, error) {
 	dir := path.Dir(filepath)
-	fname := path.Base(filepath)
-	_, dcon, _, err := s.GetContents(owner, repo, dir, opt)
+	filename := path.Base(filepath)
+	_, dirContents, _, err := s.GetContents(owner, repo, dir, opt)
 	if err != nil {
 		return nil, err
 	}
-	for _, con := range dcon {
-		if *con.Name == fname {
-			if con.DownloadURL == nil || *con.DownloadURL == "" {
+	for _, contents := range dirContents {
+		if *contents.Name == filename {
+			if contents.DownloadURL == nil || *contents.DownloadURL == "" {
 				return nil, fmt.Errorf("No download link found for %s", filepath)
 			}
-			resp, err := http.Get(*con.DownloadURL)
+			resp, err := http.Get(*contents.DownloadURL)
 			if err != nil {
-				return nil, fmt.Errorf("Error downloading %s from %s: %v", filepath,
-					*con.DownloadURL, err)
+				return nil, err
 			}
 			return resp.Body, nil
 		}
 	}
-	return nil, fmt.Errorf("No file named %s found in %s", fname, dir)
+	return nil, fmt.Errorf("No file named %s found in %s", filename, dir)
 }
 
 // GetContents can return either the metadata and content of a single file

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -93,15 +93,10 @@ func (s *RepositoriesService) GetReadme(owner, repo string, opt *RepositoryConte
 	return readme, resp, err
 }
 
-// DownloadContents can be used to download files.  It circumvents the normal
-// GitHub API (which has a file size limit) and uses the `download_url` link
-// provided by the API.  That URL provides a direct link to the raw data
-// associated with that version of the file and is not subject to the same
-// limits as the GitHub API based requests.
-//
-// If path references a file or a symlink and the call succeeds, it
-// returns an instance of io.ReadCloser that provides the contents of
-// the file.  Otherwise, it returns an error.
+// DownloadContents returns an io.ReadCloser that reads the contents
+// of the specified file. This function will work with files of any
+// size, as opposed to GetContents which is limited to 1 Mb files. It
+// is the caller's responsibility to close the ReadCloser.
 func (s *RepositoriesService) DownloadContents(owner, repo, filepath string, opt *RepositoryContentGetOptions) (io.ReadCloser, error) {
 	dir := path.Dir(filepath)
 	filename := path.Base(filepath)


### PR DESCRIPTION
This is a followup to #182.  This provides a consistent way to download files regardless of whether they are over 1Mb in size.