### PR TITLE
licenses: add support for the OSS licenses API provided by GitHub.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -37,6 +37,8 @@ const (
 
 	// Media Type values to access preview APIs
 
+	// https://developer.github.com/changes/2015-03-09-licenses-api/
+	mediaTypeLicensesPreview = "application/vnd.github.drax-preview+json"
 )
 
 // A Client manages communication with the GitHub API.
@@ -72,6 +74,7 @@ type Client struct {
 	Repositories  *RepositoriesService
 	Search        *SearchService
 	Users         *UsersService
+	Licenses      *LicensesService
 }
 
 // ListOptions specifies the optional parameters to various List methods that
@@ -133,6 +136,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Repositories = &RepositoriesService{client: c}
 	c.Search = &SearchService{client: c}
 	c.Users = &UsersService{client: c}
+	c.Licenses = &LicensesService{client: c}
 	return c
 }
 

--- a/github/licenses.go
+++ b/github/licenses.go
@@ -1,0 +1,81 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// LicensesService handles communication with the license related
+// methods of the GitHub API.
+//
+// GitHub API docs: http://developer.github.com/v3/pulls/
+type LicensesService struct {
+	client *Client
+}
+
+// License represents an open source license.
+type License struct {
+	Key  *string `json:"key,omitempty"`
+	Name *string `json:"name,omitempty"`
+	URL  *string `json:"url,omitempty"`
+
+	HTMLURL        *string   `json:"html_url",omitempty`
+	Featured       *bool     `json:"featured,omitempty"`
+	Description    *string   `json:"description,omitempty"`
+	Category       *string   `json:"category,omitempty"`
+	Implementation *string   `json:"implementation,omitempty"`
+	Required       *[]string `json:"required,omitempty"`
+	Permitted      *[]string `json:"permitted,omitempty"`
+	Forbidden      *[]string `json:"forbidden,omitempty"`
+	Body           *string   `json:"body,omitempty"`
+}
+
+func (l License) String() string {
+	return Stringify(l)
+}
+
+// List popular open source licenses.
+//
+// GitHub API docs: https://developer.github.com/v3/licenses/#list-all-licenses
+func (s *LicensesService) List() ([]License, *Response, error) {
+	req, err := s.client.NewRequest("GET", "licenses", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeLicensesPreview)
+
+	licenses := new([]License)
+	resp, err := s.client.Do(req, licenses)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *licenses, resp, err
+}
+
+// Fetch extended metadata for one license.
+//
+// GitHub API docs: https://developer.github.com/v3/licenses/#get-an-individual-license
+func (s *LicensesService) Get(licenseName string) (*License, *Response, error) {
+	u := fmt.Sprintf("licenses/%s", licenseName)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeLicensesPreview)
+
+	license := new(License)
+	resp, err := s.client.Do(req, license)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return license, resp, err
+}

--- a/github/licenses_test.go
+++ b/github/licenses_test.go
@@ -1,0 +1,64 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestLicensesService_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/licenses", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeLicensesPreview)
+		fmt.Fprint(w, `[{"key":"mit","name":"MIT","url":"https://api.github.com/licenses/mit"}]`)
+	})
+
+	licenses, _, err := client.Licenses.List()
+	if err != nil {
+		t.Errorf("Licenses.List returned error: %v", err)
+	}
+
+	want := []License{License{
+		Key:  String("mit"),
+		Name: String("MIT"),
+		URL:  String("https://api.github.com/licenses/mit"),
+	}}
+	if !reflect.DeepEqual(licenses, want) {
+		t.Errorf("Licenses.List returned %+v, want %+v", licenses, want)
+	}
+}
+
+func TestLicensesService_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/licenses/mit", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeLicensesPreview)
+		fmt.Fprint(w, `{"key":"mit","name":"MIT"}`)
+	})
+
+	license, _, err := client.Licenses.Get("mit")
+	if err != nil {
+		t.Errorf("Licenses.Get returned error: %v", err)
+	}
+
+	want := &License{Key: String("mit"), Name: String("MIT")}
+	if !reflect.DeepEqual(license, want) {
+		t.Errorf("Licenses.Get returned %+v, want %+v", license, want)
+	}
+}
+
+func TestLicensesService_Get_invalidTemplate(t *testing.T) {
+	_, _, err := client.Licenses.Get("%")
+	testURLParseError(t, err)
+}

--- a/github/repos.go
+++ b/github/repos.go
@@ -49,6 +49,9 @@ type Repository struct {
 	Organization     *Organization    `json:"organization,omitempty"`
 	Permissions      *map[string]bool `json:"permissions,omitempty"`
 
+	// Only provided when using RepositoriesService.Get while in preview
+	License *License `json:"license,omitempty"`
+
 	// Additional mutable fields when creating and editing a repository
 	Private      *bool `json:"private"`
 	HasIssues    *bool `json:"has_issues"`
@@ -254,6 +257,10 @@ func (s *RepositoriesService) Get(owner, repo string) (*Repository, *Response, e
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when the license support fully launches
+	// https://developer.github.com/v3/licenses/#get-a-repositorys-license
+	req.Header.Set("Accept", mediaTypeLicensesPreview)
 
 	repository := new(Repository)
 	resp, err := s.client.Do(req, repository)

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -191,7 +191,8 @@ func TestRepositoriesService_Get(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"id":1,"name":"n","description":"d","owner":{"login":"l"}}`)
+		testHeader(t, r, "Accept", mediaTypeLicensesPreview)
+		fmt.Fprint(w, `{"id":1,"name":"n","description":"d","owner":{"login":"l"},"license":{"key":"mit"}}`)
 	})
 
 	repo, _, err := client.Repositories.Get("o", "r")
@@ -199,7 +200,7 @@ func TestRepositoriesService_Get(t *testing.T) {
 		t.Errorf("Repositories.Get returned error: %v", err)
 	}
 
-	want := &Repository{ID: Int(1), Name: String("n"), Description: String("d"), Owner: &User{Login: String("l")}}
+	want := &Repository{ID: Int(1), Name: String("n"), Description: String("d"), Owner: &User{Login: String("l")}, License: &License{Key: String("mit")}}
 	if !reflect.DeepEqual(repo, want) {
 		t.Errorf("Repositories.Get returned %+v, want %+v", repo, want)
 	}


### PR DESCRIPTION
Fixes #185.

- [x] Implement & test `IssuesService.List`
- [x] Implement & test `IssuesService.Get`
- [x] Ensure the preview header is being used and has TODO comments.
- [x] Implement for `Repository` & `Repositories.Get`

/cc @willnorris 