### PR TITLE
orgs_teams: remove AddTeamMember and RemoveTeamMember

### DIFF
--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -158,32 +158,6 @@ func (s *OrganizationsService) IsTeamMember(team int, user string) (bool, *Respo
 	return member, resp, err
 }
 
-// AddTeamMember adds a user to a team.
-//
-// GitHub API docs: http://developer.github.com/v3/orgs/teams/#add-team-member
-func (s *OrganizationsService) AddTeamMember(team int, user string) (*Response, error) {
-	u := fmt.Sprintf("teams/%v/members/%v", team, user)
-	req, err := s.client.NewRequest("PUT", u, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.client.Do(req, nil)
-}
-
-// RemoveTeamMember removes a user from a team.
-//
-// GitHub API docs: http://developer.github.com/v3/orgs/teams/#remove-team-member
-func (s *OrganizationsService) RemoveTeamMember(team int, user string) (*Response, error) {
-	u := fmt.Sprintf("teams/%v/members/%v", team, user)
-	req, err := s.client.NewRequest("DELETE", u, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.client.Do(req, nil)
-}
-
 // ListTeamRepos lists the repositories that the specified team has access to.
 //
 // GitHub API docs: http://developer.github.com/v3/orgs/teams/#list-team-repos

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -220,46 +220,6 @@ func TestOrganizationsService_IsTeamMember_invalidUser(t *testing.T) {
 	testURLParseError(t, err)
 }
 
-func TestOrganizationsService_AddTeamMember(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/teams/1/members/u", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	_, err := client.Organizations.AddTeamMember(1, "u")
-	if err != nil {
-		t.Errorf("Organizations.AddTeamMember returned error: %v", err)
-	}
-}
-
-func TestOrganizationsService_AddTeamMember_invalidUser(t *testing.T) {
-	_, err := client.Organizations.AddTeamMember(1, "%")
-	testURLParseError(t, err)
-}
-
-func TestOrganizationsService_RemoveTeamMember(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/teams/1/members/u", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	_, err := client.Organizations.RemoveTeamMember(1, "u")
-	if err != nil {
-		t.Errorf("Organizations.RemoveTeamMember returned error: %v", err)
-	}
-}
-
-func TestOrganizationsService_RemoveTeamMember_invalidUser(t *testing.T) {
-	_, err := client.Organizations.RemoveTeamMember(1, "%")
-	testURLParseError(t, err)
-}
-
 func TestOrganizationsService_PublicizeMembership(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Both have been deprecated.

Fixes #190.

- AddTeamMember: https://developer.github.com/v3/orgs/teams/#add-team-member
- RemoveTeamMember: https://developer.github.com/v3/orgs/teams/#remove-team-member

/cc @willnorris 