### PR TITLE
deployments: remove cannonball Accept header

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -39,9 +39,6 @@ const (
 
 	// https://developer.github.com/changes/2014-08-05-team-memberships-api/
 	mediaTypeMembershipPreview = "application/vnd.github.the-wasp-preview+json"
-
-	// https://developer.github.com/changes/2014-01-09-preview-the-new-deployments-api/
-	mediaTypeDeploymentPreview = "application/vnd.github.cannonball-preview+json"
 )
 
 // A Client manages communication with the GitHub API.

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -69,9 +69,6 @@ func (s *RepositoriesService) ListDeployments(owner, repo string, opt *Deploymen
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeDeploymentPreview)
-
 	deployments := new([]Deployment)
 	resp, err := s.client.Do(req, deployments)
 	if err != nil {
@@ -91,9 +88,6 @@ func (s *RepositoriesService) CreateDeployment(owner, repo string, request *Depl
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeDeploymentPreview)
 
 	d := new(Deployment)
 	resp, err := s.client.Do(req, d)
@@ -138,9 +132,6 @@ func (s *RepositoriesService) ListDeploymentStatuses(owner, repo string, deploym
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeDeploymentPreview)
-
 	statuses := new([]DeploymentStatus)
 	resp, err := s.client.Do(req, statuses)
 	if err != nil {
@@ -160,9 +151,6 @@ func (s *RepositoriesService) CreateDeploymentStatus(owner, repo string, deploym
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeDeploymentPreview)
 
 	d := new(DeploymentStatus)
 	resp, err := s.client.Do(req, d)


### PR DESCRIPTION
Deployments API is now official.

https://developer.github.com/changes/2014-11-25-the-deployments-api-is-official/

Fixes #189.

/cc @willnorris 