### PR TITLE
memberships: remove custom wasp Accept header

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -37,9 +37,6 @@ const (
 
 	// Media Type values to access preview APIs
 
-	// https://developer.github.com/changes/2014-08-05-team-memberships-api/
-	mediaTypeMembershipPreview = "application/vnd.github.the-wasp-preview+json"
-
 	// https://developer.github.com/changes/2014-01-09-preview-the-new-deployments-api/
 	mediaTypeDeploymentPreview = "application/vnd.github.cannonball-preview+json"
 )

--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -171,9 +171,6 @@ func (s *OrganizationsService) ListOrgMemberships(opt *ListOrgMembershipsOptions
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeMembershipPreview)
-
 	var memberships []Membership
 	resp, err := s.client.Do(req, &memberships)
 	if err != nil {
@@ -194,9 +191,6 @@ func (s *OrganizationsService) GetOrgMembership(org string) (*Membership, *Respo
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeMembershipPreview)
-
 	membership := new(Membership)
 	resp, err := s.client.Do(req, membership)
 	if err != nil {
@@ -216,9 +210,6 @@ func (s *OrganizationsService) EditOrgMembership(org string, membership *Members
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeMembershipPreview)
 
 	m := new(Membership)
 	resp, err := s.client.Do(req, m)

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -217,7 +217,6 @@ func TestOrganizationsService_ListOrgMemberships(t *testing.T) {
 
 	mux.HandleFunc("/user/memberships/orgs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeMembershipPreview)
 		testFormValues(t, r, values{
 			"state": "active",
 			"page":  "2",
@@ -246,7 +245,6 @@ func TestOrganizationsService_GetOrgMembership(t *testing.T) {
 
 	mux.HandleFunc("/user/memberships/orgs/o", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeMembershipPreview)
 		fmt.Fprint(w, `{"url":"u"}`)
 	})
 
@@ -272,7 +270,6 @@ func TestOrganizationsService_EditOrgMembership(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", mediaTypeMembershipPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -286,9 +286,6 @@ func (s *OrganizationsService) GetTeamMembership(team int, user string) (*Member
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeMembershipPreview)
-
 	t := new(Membership)
 	resp, err := s.client.Do(req, t)
 	if err != nil {
@@ -323,9 +320,6 @@ func (s *OrganizationsService) AddTeamMembership(team int, user string) (*Member
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeMembershipPreview)
-
 	t := new(Membership)
 	resp, err := s.client.Do(req, t)
 	if err != nil {
@@ -344,9 +338,6 @@ func (s *OrganizationsService) RemoveTeamMembership(team int, user string) (*Res
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeMembershipPreview)
 
 	return s.client.Do(req, nil)
 }

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -442,7 +442,6 @@ func TestOrganizationsService_GetTeamMembership(t *testing.T) {
 
 	mux.HandleFunc("/teams/1/memberships/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeMembershipPreview)
 		fmt.Fprint(w, `{"url":"u", "state":"active"}`)
 	})
 
@@ -463,7 +462,6 @@ func TestOrganizationsService_AddTeamMembership(t *testing.T) {
 
 	mux.HandleFunc("/teams/1/memberships/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeMembershipPreview)
 		fmt.Fprint(w, `{"url":"u", "state":"pending"}`)
 	})
 
@@ -484,7 +482,6 @@ func TestOrganizationsService_RemoveTeamMembership(t *testing.T) {
 
 	mux.HandleFunc("/teams/1/memberships/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeMembershipPreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 


### PR DESCRIPTION
Memberships API is now official.

https://developer.github.com/changes/2014-09-16-finalizing-the-organization-and-team-membership-apis/

Fixes #192

/cc @willnorris 