### PR TITLE
use *[]string for DeploymentRequest.RequiredContexts

### DIFF
--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -27,13 +27,13 @@ type Deployment struct {
 
 // DeploymentRequest represents a deployment request
 type DeploymentRequest struct {
-	Ref              *string  `json:"ref,omitempty"`
-	Task             *string  `json:"task,omitempty"`
-	AutoMerge        *bool    `json:"auto_merge,omitempty"`
-	RequiredContexts []string `json:"required_contexts,omitempty"`
-	Payload          *string  `json:"payload,omitempty"`
-	Environment      *string  `json:"environment,omitempty"`
-	Description      *string  `json:"description,omitempty"`
+	Ref              *string   `json:"ref,omitempty"`
+	Task             *string   `json:"task,omitempty"`
+	AutoMerge        *bool     `json:"auto_merge,omitempty"`
+	RequiredContexts *[]string `json:"required_contexts,omitempty"`
+	Payload          *string   `json:"payload,omitempty"`
+	Environment      *string   `json:"environment,omitempty"`
+	Description      *string   `json:"description,omitempty"`
 }
 
 // DeploymentsListOptions specifies the optional parameters to the


### PR DESCRIPTION
There's no way of serializing/requesting an empty required_contexts that
is needed for bypassing the commit status checks for the ref.

It's a breaking change but will allow to serialize an empty array and
omit empty value as expected.

Example: http://play.golang.org/p/6Jsh8L7AfO