### PR TITLE
Support for updated starring API

### DIFF
--- a/github/activity_star.go
+++ b/github/activity_star.go
@@ -7,6 +7,12 @@ package github
 
 import "fmt"
 
+// StarredRepository is returned by ListStarred.
+type StarredRepository struct {
+	StarredAt  *Timestamp  `json:"starred_at,omitempty"`
+	Repository *Repository `json:"repository,omitempty"`
+}
+
 // ListStargazers lists people who have starred the specified repo.
 //
 // GitHub API Docs: https://developer.github.com/v3/activity/starring/#list-stargazers
@@ -49,7 +55,7 @@ type ActivityListStarredOptions struct {
 // will list the starred repositories for the authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/activity/starring/#list-repositories-being-starred
-func (s *ActivityService) ListStarred(user string, opt *ActivityListStarredOptions) ([]Repository, *Response, error) {
+func (s *ActivityService) ListStarred(user string, opt *ActivityListStarredOptions) ([]StarredRepository, *Response, error) {
 	var u string
 	if user != "" {
 		u = fmt.Sprintf("users/%v/starred", user)
@@ -66,7 +72,10 @@ func (s *ActivityService) ListStarred(user string, opt *ActivityListStarredOptio
 		return nil, nil, err
 	}
 
-	repos := new([]Repository)
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeStarringPreview)
+
+	repos := new([]StarredRepository)
 	resp, err := s.client.Do(req, repos)
 	if err != nil {
 		return nil, resp, err

--- a/github/activity_star_test.go
+++ b/github/activity_star_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestActivityService_ListStargazers(t *testing.T) {
@@ -42,7 +43,8 @@ func TestActivityService_ListStarred_authenticatedUser(t *testing.T) {
 
 	mux.HandleFunc("/user/starred", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{"id":1}]`)
+		testHeader(t, r, "Accept", mediaTypeStarringPreview)
+		fmt.Fprint(w, `[{"starred_at":"2002-02-10T15:30:00Z","repository":{"id":1}}]`)
 	})
 
 	repos, _, err := client.Activity.ListStarred("", nil)
@@ -50,7 +52,7 @@ func TestActivityService_ListStarred_authenticatedUser(t *testing.T) {
 		t.Errorf("Activity.ListStarred returned error: %v", err)
 	}
 
-	want := []Repository{{ID: Int(1)}}
+	want := []StarredRepository{{StarredAt: &Timestamp{time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC)}, Repository: &Repository{ID: Int(1)}}}
 	if !reflect.DeepEqual(repos, want) {
 		t.Errorf("Activity.ListStarred returned %+v, want %+v", repos, want)
 	}
@@ -62,12 +64,13 @@ func TestActivityService_ListStarred_specifiedUser(t *testing.T) {
 
 	mux.HandleFunc("/users/u/starred", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeStarringPreview)
 		testFormValues(t, r, values{
 			"sort":      "created",
 			"direction": "asc",
 			"page":      "2",
 		})
-		fmt.Fprint(w, `[{"id":2}]`)
+		fmt.Fprint(w, `[{"starred_at":"2002-02-10T15:30:00Z","repository":{"id":2}}]`)
 	})
 
 	opt := &ActivityListStarredOptions{"created", "asc", ListOptions{Page: 2}}
@@ -76,7 +79,7 @@ func TestActivityService_ListStarred_specifiedUser(t *testing.T) {
 		t.Errorf("Activity.ListStarred returned error: %v", err)
 	}
 
-	want := []Repository{{ID: Int(2)}}
+	want := []StarredRepository{{StarredAt: &Timestamp{time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC)}, Repository: &Repository{ID: Int(2)}}}
 	if !reflect.DeepEqual(repos, want) {
 		t.Errorf("Activity.ListStarred returned %+v, want %+v", repos, want)
 	}

--- a/github/github.go
+++ b/github/github.go
@@ -39,6 +39,9 @@ const (
 
 	// https://developer.github.com/changes/2015-03-09-licenses-api/
 	mediaTypeLicensesPreview = "application/vnd.github.drax-preview+json"
+
+	// https://developer.github.com/changes/2014-12-09-new-attributes-for-stars-api/
+	mediaTypeStarringPreview = "application/vnd.github.v3.star+json"
 )
 
 // A Client manages communication with the GitHub API.


### PR DESCRIPTION
Supports the updated starring API as mentioned in issue #188.

There is now a new struct called StarredRepository which holds a pointer to a Repository and the new `starred_at` timestamp. This was the cleanest way I found to go about this

For now there is a special media type to request the new API. I've added a TODO for it to be deleted when the new API fully launches.