### PR TITLE
Ability to list organization repos

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -42,6 +42,9 @@ const (
 
 	// https://developer.github.com/changes/2014-12-09-new-attributes-for-stars-api/
 	mediaTypeStarringPreview = "application/vnd.github.v3.star+json"
+
+	// https://developer.github.com/changes/2014-12-08-organization-permissions-api-preview/
+	mediaTypeOrganizationsPreview = "application/vnd.github.moondragon+json"
 )
 
 // A Client manages communication with the GitHub API.

--- a/github/repos.go
+++ b/github/repos.go
@@ -122,6 +122,11 @@ type RepositoryListOptions struct {
 	// Default is "asc" when sort is "full_name", otherwise default is "desc".
 	Direction string `url:"direction,omitempty"`
 
+	// Include orginization repositories the user has access to.
+	// This will become the default behavior in the future, but is opt-in for now.
+	// See https://developer.github.com/changes/2015-01-07-prepare-for-organization-permissions-changes/
+	IncludeOrg bool `url:"-"`
+
 	ListOptions
 }
 
@@ -144,6 +149,10 @@ func (s *RepositoriesService) List(user string, opt *RepositoryListOptions) ([]R
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if opt != nil && opt.IncludeOrg {
+		req.Header.Set("Accept", mediaTypeOrganizationsPreview)
 	}
 
 	repos := new([]Repository)

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -45,11 +45,11 @@ func TestRepositoriesService_List_specifiedUser(t *testing.T) {
 			"direction": "asc",
 			"page":      "2",
 		})
-
+		testHeader(t, r, "Accept", mediaTypeOrganizationsPreview)
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	opt := &RepositoryListOptions{"owner", "created", "asc", ListOptions{Page: 2}}
+	opt := &RepositoryListOptions{"owner", "created", "asc", true, ListOptions{Page: 2}}
 	repos, _, err := client.Repositories.List("u", opt)
 	if err != nil {
 		t.Errorf("Repositories.List returned error: %v", err)


### PR DESCRIPTION
With recent changes to github api it is possible to list organization and user repos in the same list. A special header is required to activate this until the feature is fully rolled out.

https://developer.github.com/changes/2015-01-07-prepare-for-organization-permissions-changes/

This PR allows users to opt-in to this functionality during the migration period.