### PR TITLE
New release endpoints

### DIFF
--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -85,18 +85,7 @@ func (s *RepositoriesService) ListReleases(owner, repo string, opt *ListOptions)
 // GitHub API docs: http://developer.github.com/v3/repos/releases/#get-a-single-release
 func (s *RepositoriesService) GetRelease(owner, repo string, id int) (*RepositoryRelease, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/releases/%d", owner, repo, id)
-
-	req, err := s.client.NewRequest("GET", u, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	release := new(RepositoryRelease)
-	resp, err := s.client.Do(req, release)
-	if err != nil {
-		return nil, resp, err
-	}
-	return release, resp, err
+	return s.getSingleRelease(u)
 }
 
 // GetLatestRelease fetches the latest published release for the repository.
@@ -104,8 +93,19 @@ func (s *RepositoriesService) GetRelease(owner, repo string, id int) (*Repositor
 // GitHub API docs: https://developer.github.com/v3/repos/releases/#get-the-latest-release
 func (s *RepositoriesService) GetLatestRelease(owner, repo string) (*RepositoryRelease, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/releases/latest", owner, repo)
+	return s.getSingleRelease(u)
+}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+// GetLatestReleaseByTag fetches a release with the specified tag.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name
+func (s *RepositoriesService) GetReleaseByTag(owner, repo, tag string) (*RepositoryRelease, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/releases/tags/%s", owner, repo, tag)
+	return s.getSingleRelease(u)
+}
+
+func (s *RepositoriesService) getSingleRelease(url string) (*RepositoryRelease, *Response, error) {
+	req, err := s.client.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -99,6 +99,25 @@ func (s *RepositoriesService) GetRelease(owner, repo string, id int) (*Repositor
 	return release, resp, err
 }
 
+// GetLatestRelease fetches the latest published release for the repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/releases/#get-the-latest-release
+func (s *RepositoriesService) GetLatestRelease(owner, repo string) (*RepositoryRelease, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/releases/latest", owner, repo)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	release := new(RepositoryRelease)
+	resp, err := s.client.Do(req, release)
+	if err != nil {
+		return nil, resp, err
+	}
+	return release, resp, err
+}
+
 // CreateRelease adds a new release for a repository.
 //
 // GitHub API docs : http://developer.github.com/v3/repos/releases/#create-a-release

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -55,6 +55,26 @@ func TestRepositoriesService_GetRelease(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_GetLatestRelease(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":3}`)
+	})
+
+	release, resp, err := client.Repositories.GetLatestRelease("o", "r")
+	if err != nil {
+		t.Errorf("Repositories.GetLatestRelease returned error: %v\n%v", err, resp.Body)
+	}
+
+	want := &RepositoryRelease{ID: Int(3)}
+	if !reflect.DeepEqual(release, want) {
+		t.Errorf("Repositories.GetLatestRelease returned %+v, want %+v", release, want)
+	}
+}
+
 func TestRepositoriesService_CreateRelease(t *testing.T) {
 	setup()
 	defer teardown()

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -75,6 +75,26 @@ func TestRepositoriesService_GetLatestRelease(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_GetReleaseByTag(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/releases/tags/foo", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":13}`)
+	})
+
+	release, resp, err := client.Repositories.GetReleaseByTag("o", "r", "foo")
+	if err != nil {
+		t.Errorf("Repositories.GetReleaseByTag returned error: %v\n%v", err, resp.Body)
+	}
+
+	want := &RepositoryRelease{ID: Int(13)}
+	if !reflect.DeepEqual(release, want) {
+		t.Errorf("Repositories.GetReleaseByTag returned %+v, want %+v", release, want)
+	}
+}
+
 func TestRepositoriesService_CreateRelease(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Fixes #186 
Adds `GetLatestRelease` and `GetReleaseByTag` to RepositoriesService.