### PR TITLE
Feature add get issue by url

### DIFF
--- a/github/issues.go
+++ b/github/issues.go
@@ -208,7 +208,15 @@ func (s *IssuesService) ListByRepo(owner string, repo string, opt *IssueListByRe
 // GitHub API docs: http://developer.github.com/v3/issues/#get-a-single-issue
 func (s *IssuesService) Get(owner string, repo string, number int) (*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%d", owner, repo, number)
-	req, err := s.client.NewRequest("GET", u, nil)
+
+	return s.GetByURL(u)
+}
+
+// Get a single issue by its API url.
+//
+// Intended for following hypermedia links exposed in the API.
+func (s *IssuesService) GetByURL(url string) (*Issue, *Response, error) {
+	req, err := s.client.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/issues.go
+++ b/github/issues.go
@@ -214,7 +214,7 @@ func (s *IssuesService) Get(owner string, repo string, number int) (*Issue, *Res
 
 // Get a single issue by its API url.
 //
-// Intended for following hypermedia links exposed in the API.
+// Intended to be used for following hypermedia links exposed in the API.
 func (s *IssuesService) GetByURL(url string) (*Issue, *Response, error) {
 	req, err := s.client.NewRequest("GET", url, nil)
 	if err != nil {

--- a/github/issues_comments.go
+++ b/github/issues_comments.go
@@ -52,7 +52,15 @@ func (s *IssuesService) ListComments(owner string, repo string, number int, opt 
 	} else {
 		u = fmt.Sprintf("repos/%v/%v/issues/%d/comments", owner, repo, number)
 	}
-	u, err := addOptions(u, opt)
+
+	return s.ListCommentsByURL(u, opt)
+}
+
+// ListCommentsByURL lists all issue comments at the specified URL.
+//
+// Intended to be used for following hypermedia links in the API.
+func (s *IssuesService) ListCommentsByURL(url string, opt *IssueListCommentsOptions) ([]IssueComment, *Response, error) {
+	u, err := addOptions(url, opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -81,7 +89,7 @@ func (s *IssuesService) GetComment(owner string, repo string, id int) (*IssueCom
 
 // Get an issue comment by its URL
 //
-// Intended for following hypermedia links in the API.
+// Intended to be used for following hypermedia links in the API.
 func (s *IssuesService) GetCommentByURL(url string) (*IssueComment, *Response, error) {
 	req, err := s.client.NewRequest("GET", url, nil)
 	if err != nil {

--- a/github/issues_comments.go
+++ b/github/issues_comments.go
@@ -76,7 +76,14 @@ func (s *IssuesService) ListComments(owner string, repo string, number int, opt 
 func (s *IssuesService) GetComment(owner string, repo string, id int) (*IssueComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/comments/%d", owner, repo, id)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	return s.GetCommentByURL(u)
+}
+
+// Get an issue comment by its URL
+//
+// Intended for following hypermedia links in the API.
+func (s *IssuesService) GetCommentByURL(url string) (*IssueComment, *Response, error) {
+	req, err := s.client.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tests/integration/issues_test.go
+++ b/tests/integration/issues_test.go
@@ -5,7 +5,11 @@
 
 package tests
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/go-github/github"
+)
 
 func TestIssueEvents(t *testing.T) {
 	events, _, err := client.Issues.ListRepositoryEvents("google", "go-github", nil)
@@ -57,5 +61,17 @@ func TestGetIssueCommentByURL(t *testing.T) {
 
 	if *c.ID != 19136005 {
 		t.Errorf("expected Issues.GetCommentByURL to return a representation of the specified comment")
+	}
+}
+
+func TestListIssueCommentsByURL(t *testing.T) {
+	c, _, err := client.Issues.ListCommentsByURL("https://api.github.com/repos/google/go-github/issues/2/comments", &github.IssueListCommentsOptions{})
+
+	if err != nil {
+		t.Fatalf("Issues.ListIssueCommentsByURL returned error: %v", err)
+	}
+
+	if len(c) == 0 {
+		t.Errorf("expected Issues.ListIssueCommentsByURL to return at least one comment from issue")
 	}
 }

--- a/tests/integration/issues_test.go
+++ b/tests/integration/issues_test.go
@@ -35,3 +35,15 @@ func TestIssueEvents(t *testing.T) {
 		t.Fatalf("Issues.GetEvent returned event URL: %v, want %v", *event.URL, *events[0].URL)
 	}
 }
+
+func TestGetIssueByURL(t *testing.T) {
+	i, _, err := client.Issues.GetByURL("https://api.github.com/repos/google/go-github/issues/1")
+
+	if err != nil {
+		t.Fatalf("Issues.GetByURL returned error: %v", err)
+	}
+
+	if *i.Number != 1 {
+		t.Errorf("expected Issues.GetByURL to return a representation of the issue")
+	}
+}

--- a/tests/integration/issues_test.go
+++ b/tests/integration/issues_test.go
@@ -47,3 +47,15 @@ func TestGetIssueByURL(t *testing.T) {
 		t.Errorf("expected Issues.GetByURL to return a representation of the issue")
 	}
 }
+
+func TestGetIssueCommentByURL(t *testing.T) {
+	c, _, err := client.Issues.GetCommentByURL("https://api.github.com/repos/google/go-github/issues/comments/19136005")
+
+	if err != nil {
+		t.Fatalf("Issues.GetCommentByURL returned error: %v", err)
+	}
+
+	if *c.ID != 19136005 {
+		t.Errorf("expected Issues.GetCommentByURL to return a representation of the specified comment")
+	}
+}


### PR DESCRIPTION
Several parts of the Github API expose hypermedia links to other API resources. Webhook payloads also make heavy use of URLs to link to to resources affected by the webhook's event.

This PR refactors a few methods to allow consumers to fetch issues and their comments by URL (mainly because I need these specific methods for a project I'm working on). If you'd like this done consistently across the project I'd be happy to help out, but I'm not sure whether it's best to have one mega PR that is hard to grok, or several smaller ones.

I've filled out a CLA.