### PR TITLE
StarredRepository.repository has been renamed to .repo.

### DIFF
--- a/github/activity_star.go
+++ b/github/activity_star.go
@@ -10,7 +10,7 @@ import "fmt"
 // StarredRepository is returned by ListStarred.
 type StarredRepository struct {
 	StarredAt  *Timestamp  `json:"starred_at,omitempty"`
-	Repository *Repository `json:"repository,omitempty"`
+	Repository *Repository `json:"repo,omitempty"`
 }
 
 // ListStargazers lists people who have starred the specified repo.

--- a/github/activity_star_test.go
+++ b/github/activity_star_test.go
@@ -44,7 +44,7 @@ func TestActivityService_ListStarred_authenticatedUser(t *testing.T) {
 	mux.HandleFunc("/user/starred", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeStarringPreview)
-		fmt.Fprint(w, `[{"starred_at":"2002-02-10T15:30:00Z","repository":{"id":1}}]`)
+		fmt.Fprint(w, `[{"starred_at":"2002-02-10T15:30:00Z","repo":{"id":1}}]`)
 	})
 
 	repos, _, err := client.Activity.ListStarred("", nil)
@@ -70,7 +70,7 @@ func TestActivityService_ListStarred_specifiedUser(t *testing.T) {
 			"direction": "asc",
 			"page":      "2",
 		})
-		fmt.Fprint(w, `[{"starred_at":"2002-02-10T15:30:00Z","repository":{"id":2}}]`)
+		fmt.Fprint(w, `[{"starred_at":"2002-02-10T15:30:00Z","repo":{"id":2}}]`)
 	})
 
 	opt := &ActivityListStarredOptions{"created", "asc", ListOptions{Page: 2}}


### PR DESCRIPTION
According to [github docs](https://developer.github.com/v3/activity/starring/#list-repositories-being-starred), it appears that the repository attribute on the StarredRepository object is just 'repo'.


