### PR TITLE
misc: add GitHub Pages IP addresses

### DIFF
--- a/github/misc.go
+++ b/github/misc.go
@@ -98,6 +98,10 @@ type APIMeta struct {
 	// username and password, sudo mode, and two-factor authentication are
 	// not supported on these servers.)
 	VerifiablePasswordAuthentication *bool `json:"verifiable_password_authentication,omitempty"`
+
+	// An array of IP addresses in CIDR format specifying the addresses
+	// which serve GitHub Pages websites.
+	Pages []string `json:"pages,omitempty"`
 }
 
 // APIMeta returns information about GitHub.com, the service. Or, if you access

--- a/github/misc_test.go
+++ b/github/misc_test.go
@@ -72,7 +72,7 @@ func TestAPIMeta(t *testing.T) {
 
 	mux.HandleFunc("/meta", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"hooks":["h"], "git":["g"], "verifiable_password_authentication": true}`)
+		fmt.Fprint(w, `{"hooks":["h"], "git":["g"], "pages":["p"], "verifiable_password_authentication": true}`)
 	})
 
 	meta, _, err := client.APIMeta()
@@ -83,6 +83,7 @@ func TestAPIMeta(t *testing.T) {
 	want := &APIMeta{
 		Hooks: []string{"h"},
 		Git:   []string{"g"},
+		Pages: []string{"p"},
 		VerifiablePasswordAuthentication: Bool(true),
 	}
 	if !reflect.DeepEqual(want, meta) {


### PR DESCRIPTION
GitHub occasionally changes the IP addresses from which GitHub Pages
websites are served. For users of the service, they must upgrade any A
records to these IP addresses to continue using the service. This patch
provides this data in the `APIMeta` struct as the property `Pages` and
populates from the /meta endpoint.

Release Announcement:
https://developer.github.com/changes/2015-06-11-pages-a-records/

Fixes #212.

/cc @willnorris 