### PR TITLE
Implementation of Feeds API

### DIFF
--- a/github/feeds.go
+++ b/github/feeds.go
@@ -1,0 +1,61 @@
+package github
+
+//FeedsService handles communication with the feeds related
+//methods of the GitHub API.
+//Note. client should provide basic basic auth.
+//
+//Github API docs: https://developer.github.com/v3/activity/feeds/
+type FeedsService struct {
+	client *Client
+}
+
+//Feeds represents the all the feeds available to the authenticated user
+type Feeds struct {
+	TimeLineURL                 *string      `json:"timeline_url,omitempty"`
+	User                        *string      `json:"user_url,omitempty"`
+	PublicURL                   *string      `json:"current_user_public_url,omitempty"`
+	URL                         *string      `json:"current_user_url,omitempty"`
+	CurrentUserActorURL         *string      `json:"current_user_actor_url,omitempty"`
+	CurrentUserOrgannizationURL *string      `json:"current_user_organization_url,omitempty"`
+	CurrentUserOrganizationList []string     `json:"current_user_organization_urls,omitempty"`
+	Links                       *LinkService `json:"_links,omitempty"`
+}
+
+func (r Feeds) String() string {
+	return Stringify(r)
+}
+
+
+//LinkService represents list of available links
+type LinkService struct {
+	Timeline                 *LinkData   `json:"timeline,omitempty"`
+	User                     *LinkData   `json:"user,omitempty"`
+	CurrentUserPublic        *LinkData   `json:"current_user_public,omitempty"`
+	CurrentUser              *LinkData   `json:"current_user,omitempty"`
+	CurrentUserActor         *LinkData   `json:"current_user_actor,omitempty"`
+	CurrentUserOrganizations []*LinkData `json:"current_user_organizations,omitempty"`
+}
+
+//LinkData represents information from each link
+type LinkData struct {
+	Href string `json:"href, omitempty"`
+	Type string `json:"type, omitempty"`
+}
+
+//ListFeeds Get feeds available to the authenticated user
+//
+//Github API Docs: https://developer.github.com/v3/activity/feeds/#list-feeds
+func (s *FeedsService) ListFeeds() (*Feeds, *Response, error) {
+	req, err := s.client.NewRequest("GET", "https://api.github.com/feeds", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	feeds := &Feeds{}
+	resp, err := s.client.Do(req, feeds)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return feeds, resp, err
+}

--- a/github/feeds_test.go
+++ b/github/feeds_test.go
@@ -1,0 +1,39 @@
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+)
+
+type Transport struct {
+	Username string
+	Password string
+}
+
+func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.SetBasicAuth(t.Username, t.Password)
+	return http.DefaultTransport.RoundTrip(r)
+}
+
+func TestListFeeds(t *testing.T) {
+	username := os.Getenv("GITHUB_USERNAME")
+	password := os.Getenv("GITHUB_PASSWORD")
+	if username != "" && password != "" {
+		mux.HandleFunc("/feeds", func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "GET")
+
+		})
+		client := &http.Client{Transport: &Transport{username, password}}
+		cl := NewClient(client)
+		res, _, err := cl.Feeds.ListFeeds()
+		if err != nil {
+			t.Errorf("Feeds.ListFeeds returned error: %v", err)
+		}
+		item := fmt.Sprintf("https://github.com/%s", username)
+		if *res.PublicURL != item {
+			t.Errorf("Feeds.ListFeeds returned %+v want %s", *res.PublicURL, item)
+		}
+	}
+}

--- a/github/github.go
+++ b/github/github.go
@@ -81,6 +81,7 @@ type Client struct {
 	Search        *SearchService
 	Users         *UsersService
 	Licenses      *LicensesService
+	Feeds         *FeedsService
 }
 
 // ListOptions specifies the optional parameters to various List methods that
@@ -143,6 +144,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Search = &SearchService{client: c}
 	c.Users = &UsersService{client: c}
 	c.Licenses = &LicensesService{client: c}
+	c.Feeds = &FeedsService{client: c}
 	return c
 }
 


### PR DESCRIPTION
Hi!
I found that [Feeds API](https://developer.github.com/v3/activity/feeds/) is missing and just implemented it. The main problem was, what to do with basic auth and at the end, i decided to do as with oauth2 example, i.e make client outside go-github.
```go
type Transport struct {
	Username string
	Password string
}
func(t* Transport) RoundTrip(r *http.Request)(*http.Response, error) {
	r.SetBasicAuth(t.Username, t.Password)
	return http.DefaultTransport.RoundTrip(r)
}

func main() {
  client := &http.Client{Transport: &Transport{"username", "password"}}
  cl := github.NewClient(client)
  res, _, _ := cl.Feeds.ListFeeds()
}

```
I don't know, probably this is not best solution, but i don't see any reasons to put basic auth to go-github.
What do you think?