### PR TITLE
update repos example to use RateLimits

### DIFF
--- a/examples/repos/main.go
+++ b/examples/repos/main.go
@@ -24,7 +24,7 @@ func main() {
 		fmt.Printf("%v\n\n", github.Stringify(repos))
 	}
 
-	rate, _, err := client.RateLimit()
+	rate, _, err := client.RateLimits()
 	if err != nil {
 		fmt.Printf("Error fetching rate limit: %#v\n\n", err)
 	} else {


### PR DESCRIPTION
The RateLimit() func is deprecated, and should not appear in the
official example.

Ref: http://godoc.org/github.com/google/go-github/github#Client.RateLimit