### PR TITLE
update UserListOptions docs

### DIFF
--- a/github/users.go
+++ b/github/users.go
@@ -113,7 +113,7 @@ func (s *UsersService) Edit(user *User) (*User, *Response, error) {
 	return uResp, resp, err
 }
 
-// UserListOptions specifies optional parameters to the UsersService.List
+// UserListOptions specifies optional parameters to the UsersService.ListAll
 // method.
 type UserListOptions struct {
 	// ID of the last user seen


### PR DESCRIPTION
As of [https://github.com/google/go-github/commit/fccbb9520b3a567b5438ae7a86d0ba6fd6d9a493](https://github.com/google/go-github/commit/fccbb9520b3a567b5438ae7a86d0ba6fd6d9a493), `Users.List` method was updated to `Users.ListAll`. This commit updates the documentation for `UserListOptions` to reflect that change.