### PR TITLE
Add comment location fields to the PullRequestComment struct.

### DIFF
--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -19,7 +19,7 @@ type PullRequestComment struct {
 	Position         *int       `json:"position,omitempty"`
 	OriginalPosition *int       `json:"original_position,omitempty"`
 	CommitID         *string    `json:"commit_id,omitempty"`
-	OriginalCommitId *string    `json:"original_commit_id,omitempty"`
+	OriginalCommitID *string    `json:"original_commit_id,omitempty"`
 	User             *User      `json:"user,omitempty"`
 	CreatedAt        *time.Time `json:"created_at,omitempty"`
 	UpdatedAt        *time.Time `json:"updated_at,omitempty"`

--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -12,14 +12,17 @@ import (
 
 // PullRequestComment represents a comment left on a pull request.
 type PullRequestComment struct {
-	ID        *int       `json:"id,omitempty"`
-	Body      *string    `json:"body,omitempty"`
-	Path      *string    `json:"path,omitempty"`
-	Position  *int       `json:"position,omitempty"`
-	CommitID  *string    `json:"commit_id,omitempty"`
-	User      *User      `json:"user,omitempty"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	ID               *int       `json:"id,omitempty"`
+	Body             *string    `json:"body,omitempty"`
+	Path             *string    `json:"path,omitempty"`
+	DiffHunk         *string    `json:"diff_hunk,omitempty"`
+	Position         *int       `json:"position,omitempty"`
+	OriginalPosition *int       `json:"original_position,omitempty"`
+	CommitID         *string    `json:"commit_id,omitempty"`
+	OriginalCommitId *string    `json:"original_commit_id,omitempty"`
+	User             *User      `json:"user,omitempty"`
+	CreatedAt        *time.Time `json:"created_at,omitempty"`
+	UpdatedAt        *time.Time `json:"updated_at,omitempty"`
 }
 
 func (p PullRequestComment) String() string {


### PR DESCRIPTION
This change adds the fields "DiffHunk", "OriginalPosition", and "OriginalCommitId" to the PullRequestComment struct. These fields provide important information about the location of a comment.

See issue #232 for more details.