### PR TITLE
Fix incorrect URLs for milestone APIs

### DIFF
--- a/github/issues_milestones.go
+++ b/github/issues_milestones.go
@@ -49,7 +49,7 @@ type MilestoneListOptions struct {
 //
 // GitHub API docs: https://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
 func (s *IssuesService) ListMilestones(owner string, repo string, opt *MilestoneListOptions) ([]Milestone, *Response, error) {
-	u := fmt.Sprintf("/repos/%v/%v/milestones", owner, repo)
+	u := fmt.Sprintf("repos/%v/%v/milestones", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
@@ -73,7 +73,7 @@ func (s *IssuesService) ListMilestones(owner string, repo string, opt *Milestone
 //
 // GitHub API docs: https://developer.github.com/v3/issues/milestones/#get-a-single-milestone
 func (s *IssuesService) GetMilestone(owner string, repo string, number int) (*Milestone, *Response, error) {
-	u := fmt.Sprintf("/repos/%v/%v/milestones/%d", owner, repo, number)
+	u := fmt.Sprintf("repos/%v/%v/milestones/%d", owner, repo, number)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -92,7 +92,7 @@ func (s *IssuesService) GetMilestone(owner string, repo string, number int) (*Mi
 //
 // GitHub API docs: https://developer.github.com/v3/issues/milestones/#create-a-milestone
 func (s *IssuesService) CreateMilestone(owner string, repo string, milestone *Milestone) (*Milestone, *Response, error) {
-	u := fmt.Sprintf("/repos/%v/%v/milestones", owner, repo)
+	u := fmt.Sprintf("repos/%v/%v/milestones", owner, repo)
 	req, err := s.client.NewRequest("POST", u, milestone)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
API URLs starting with "/" does not play well with Github Enterprise,
whose API endpoint looks like "http(s)://hostname/api/v3/".

This fixes incorrect URLs in miletones APIs.