### PR TITLE
Fix typos in docs.

### DIFF
--- a/github/issues.go
+++ b/github/issues.go
@@ -156,10 +156,10 @@ type IssueListByRepoOptions struct {
 	// any assigned user.
 	Assignee string `url:"assignee,omitempty"`
 
-	// Assignee filters issues based on their creator.
+	// Creator filters issues based on their creator.
 	Creator string `url:"creator,omitempty"`
 
-	// Assignee filters issues to those mentioned a specific user.
+	// Mentioned filters issues to those mentioned a specific user.
 	Mentioned string `url:"mentioned,omitempty"`
 
 	// Labels filters issues based on their label.


### PR DESCRIPTION
It was inadvertently introduced in 65fa4d43e9f1e4ba1a67b120d4cd17285c8fe013.