### PR TITLE
Add support for 'renamed' issue events.

### DIFF
--- a/github/issues_events.go
+++ b/github/issues_events.go
@@ -52,6 +52,9 @@ type IssueEvent struct {
 	//
 	//     labeled
 	//       A label was added.
+	//
+	//     renamed
+	//       The issue title was changed.
 	Event *string `json:"event,omitempty"`
 
 	// The SHA of the commit that referenced this commit, if applicable.
@@ -60,8 +63,11 @@ type IssueEvent struct {
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	Issue     *Issue     `json:"issue,omitempty"`
 
-	// Only present on 'labeled' events
+	// Only present on 'labeled' events.
 	Label *Label `json:"label,omitempty"`
+
+	// Only present on 'renamed' events.
+	Rename *Rename `json:"rename,omitempty"`
 }
 
 // ListIssueEvents lists events for the specified issue.
@@ -130,4 +136,14 @@ func (s *IssuesService) GetEvent(owner, repo string, id int) (*IssueEvent, *Resp
 	}
 
 	return event, resp, err
+}
+
+// Rename contains details for 'renamed' events.
+type Rename struct {
+	From *string `json:"from,omitempty"`
+	To   *string `json:"to,omitempty"`
+}
+
+func (r Rename) String() string {
+	return Stringify(r)
 }


### PR DESCRIPTION
Documented at https://developer.github.com/v3/issues/events/#events-1 and https://developer.github.com/v3/issues/events/#attributes.

> Event "renamed":
> 	- The issue title was changed.

> Attribute "rename":
> 	- An object containing rename details including ‘from’ and ‘to’
> 	attributes. Only provided for ‘renamed’ events.

A live example of such event can be seen here:

https://api.github.com/repos/emersion/go-js-canvas/issues/events/451244229

Relevant fields snippet:

```JSON
  ...
  "event": "renamed",
  "commit_id": null,
  "commit_url": null,
  "created_at": "2015-11-01T02:14:26Z",
  "rename": {
    "from": "Are you aware of dom package containing this already?",
    "to": "Are you aware of DOM package containing this already?"
  },
  ...
```