### PR TITLE
Fix default comment for Direction in issue lists

### DIFF
--- a/github/issues.go
+++ b/github/issues.go
@@ -76,7 +76,7 @@ type IssueListOptions struct {
 	Sort string `url:"sort,omitempty"`
 
 	// Direction in which to sort issues.  Possible values are: asc, desc.
-	// Default is "asc".
+	// Default is "desc".
 	Direction string `url:"direction,omitempty"`
 
 	// Since filters issues by time.
@@ -170,7 +170,7 @@ type IssueListByRepoOptions struct {
 	Sort string `url:"sort,omitempty"`
 
 	// Direction in which to sort issues.  Possible values are: asc, desc.
-	// Default is "asc".
+	// Default is "desc".
 	Direction string `url:"direction,omitempty"`
 
 	// Since filters issues by time.


### PR DESCRIPTION
Both:
https://developer.github.com/v3/issues/#list-issues
https://developer.github.com/v3/issues/#list-issues-for-a-repository

State that the default is `desc` for direction. (As does my results). So
update the comment.