### PR TITLE
Do not try to unmarshall response when http response code is 204

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -316,7 +316,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 		return response, err
 	}
 
-	if v != nil {
+	if v != nil && resp.StatusCode != http.StatusNoContent {
 		if w, ok := v.(io.Writer); ok {
 			io.Copy(w, resp.Body)
 		} else {

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -430,6 +430,24 @@ func TestDo_rateLimit_errorResponse(t *testing.T) {
 	}
 }
 
+func TestDo_noContent(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "No Content", 204)
+	})
+
+	var body map[interface{}]interface{}
+
+	req, _ := client.NewRequest("GET", "/", nil)
+	_, err := client.Do(req, &body)
+
+	if err != nil {
+		t.Fatalf("Do returned unexpected error: %v", err)
+	}
+}
+
 func TestSanitizeURL(t *testing.T) {
 	tests := []struct {
 		in, want string
@@ -453,7 +471,7 @@ func TestCheckResponse(t *testing.T) {
 	res := &http.Response{
 		Request:    &http.Request{},
 		StatusCode: http.StatusBadRequest,
-		Body: ioutil.NopCloser(strings.NewReader(`{"message":"m", 
+		Body: ioutil.NopCloser(strings.NewReader(`{"message":"m",
 			"errors": [{"resource": "r", "field": "f", "code": "c"}]}`)),
 	}
 	err := CheckResponse(res).(*ErrorResponse)


### PR DESCRIPTION
I'm not completely sure if it's correct semantics in my PR, but I had such bug: some GH API endpoints (contributors collection endpoint in my case) returns 204 No Content when there's no content, which leads to an EOF error. Probably it would be better to not to try unmarshall data to avoid error. 

Code to reproduce:

```go
package main

import (
	"fmt"

	"github.com/google/go-github/github"
)

func main() {
	client := github.NewClient(nil)
	_, _, err := client.Repositories.ListContributors("cloudfoundry", "em-posix-spawn", nil)
	if err != nil {
		fmt.Println("An error has occured:", err.Error())
	}
}
```

```
$ go run reproduce.go
An error has occured: EOF
```