### PR TITLE
Add initial support for protected branches

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -48,6 +48,9 @@ const (
 	// https://developer.github.com/changes/2015-06-24-api-enhancements-for-working-with-organization-permissions/
 	mediaTypeOrgPermissionPreview     = "application/vnd.github.ironman-preview+json"
 	mediaTypeOrgPermissionRepoPreview = "application/vnd.github.ironman-preview.repository+json"
+
+	// https://developer.github.com/changes/2015-11-11-protected-branches-api/
+	mediaTypeProtectedBranchesPreview = "application/vnd.github.loki-preview+json"
 )
 
 // A Client manages communication with the GitHub API.

--- a/github/repos.go
+++ b/github/repos.go
@@ -448,8 +448,27 @@ func (s *RepositoriesService) ListTags(owner string, repo string, opt *ListOptio
 
 // Branch represents a repository branch
 type Branch struct {
-	Name   *string `json:"name,omitempty"`
-	Commit *Commit `json:"commit,omitempty"`
+	Name       *string     `json:"name,omitempty"`
+	Commit     *Commit     `json:"commit,omitempty"`
+	Protection *Protection `json:"protection,omitempty"`
+}
+
+// Protection represents a repository branch's protection
+type Protection struct {
+	Enabled              *bool                 `json:"enabled,omitempty"`
+	RequiredStatusChecks *RequiredStatusChecks `json:"required_status_checks,omitempty"`
+}
+
+// RequiredStatusChecks represents the protection status of a individual branch
+type RequiredStatusChecks struct {
+	// Who required status checks apply to.
+	// Possible values are:
+	//     off
+	//     non_admins
+	//     everyone
+	EnforcementLevel *string   `json:"enforcement_level,omitempty"`
+	// The list of status checks which are required
+	Contexts         *[]string `json:"contexts,omitempty"`
 }
 
 // ListBranches lists branches for the specified repository.
@@ -485,6 +504,8 @@ func (s *RepositoriesService) GetBranch(owner, repo, branch string) (*Branch, *R
 	if err != nil {
 		return nil, nil, err
 	}
+
+	req.Header.Set("Accept", mediaTypeProtectedBranchesPreview)
 
 	b := new(Branch)
 	resp, err := s.client.Do(req, b)

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -389,7 +389,8 @@ func TestRepositoriesService_GetBranch(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"name":"n", "commit":{"sha":"s"}}`)
+		testHeader(t, r, "Accept", mediaTypeProtectedBranchesPreview)
+		fmt.Fprint(w, `{"name":"n", "commit":{"sha":"s"}, "protection": {"enabled": true, "required_status_checks": {"enforcement_level": "everyone","contexts": []}}}`)
 	})
 
 	branch, _, err := client.Repositories.GetBranch("o", "r", "b")
@@ -397,7 +398,18 @@ func TestRepositoriesService_GetBranch(t *testing.T) {
 		t.Errorf("Repositories.GetBranch returned error: %v", err)
 	}
 
-	want := &Branch{Name: String("n"), Commit: &Commit{SHA: String("s")}}
+	want := &Branch{
+		Name:   String("n"),
+		Commit: &Commit{SHA: String("s")},
+		Protection: &Protection{
+			Enabled: Bool(true),
+			RequiredStatusChecks: &RequiredStatusChecks{
+				EnforcementLevel: String("everyone"),
+				Contexts:         &[]string{},
+			},
+		},
+	}
+
 	if !reflect.DeepEqual(branch, want) {
 		t.Errorf("Repositories.GetBranch returned %+v, want %+v", branch, want)
 	}


### PR DESCRIPTION
For more information about the preview see here:
https://developer.github.com/changes/2015-11-11-protected-branches-api/

This adds only retrieving the information and not setting it. Setting
will come in a later commit (if that one here is okay).

I tried to follow the naming guidelines as much as possible and
hopefully I made it right the first time. :-)