### PR TITLE
Add "SuspendedAt" field to User struct.

### DIFF
--- a/github/users.go
+++ b/github/users.go
@@ -35,6 +35,7 @@ type User struct {
 	Following         *int       `json:"following,omitempty"`
 	CreatedAt         *Timestamp `json:"created_at,omitempty"`
 	UpdatedAt         *Timestamp `json:"updated_at,omitempty"`
+	SuspendedAt       *Timestamp `json:"suspended_at,omitempty"`
 	Type              *string    `json:"type,omitempty"`
 	SiteAdmin         *bool      `json:"site_admin,omitempty"`
 	TotalPrivateRepos *int       `json:"total_private_repos,omitempty"`

--- a/github/users_test.go
+++ b/github/users_test.go
@@ -32,6 +32,7 @@ func TestUser_marshall(t *testing.T) {
 		Followers:   Int(1),
 		Following:   Int(1),
 		CreatedAt:   &Timestamp{referenceTime},
+		SuspendedAt: &Timestamp{referenceTime},
 	}
 	want := `{
 		"login": "l",
@@ -48,6 +49,7 @@ func TestUser_marshall(t *testing.T) {
 		"followers": 1,
 		"following": 1,
 		"created_at": ` + referenceTimeStr + `,
+		"suspended_at": ` + referenceTimeStr + `,
 		"url": "u"
 	}`
 	testJSONMarshal(t, u, want)


### PR DESCRIPTION
There is "suspended_at" key in "/users/:username" response  when I use GitHub Enterprise. so I added "SuspendedAt" field to User struct same as `CreatedAt` & `UpdatedAt`.