### PR TITLE
RepositoryContentFileOptions: specify .Content as unencoded

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -43,7 +43,7 @@ type RepositoryContentResponse struct {
 // RepositoryContentFileOptions specifies optional parameters for CreateFile, UpdateFile, and DeleteFile.
 type RepositoryContentFileOptions struct {
 	Message   *string       `json:"message,omitempty"`
-	Content   []byte        `json:"content,omitempty"`
+	Content   []byte        `json:"content,omitempty"` // unencoded
 	SHA       *string       `json:"sha,omitempty"`
 	Branch    *string       `json:"branch,omitempty"`
 	Author    *CommitAuthor `json:"author,omitempty"`


### PR DESCRIPTION
Fixes #263.

<img width="783" alt="screen shot 2016-01-23 at 12 57 06 pm" src="https://cloud.githubusercontent.com/assets/237985/12532771/dc26c7fc-c1d0-11e5-8205-a36d4430d70c.png">

/cc @willnorris 