### PR TITLE
Add RateLimitError type, detect and return it when appropriate.

### DIFF
--- a/github/doc.go
+++ b/github/doc.go
@@ -65,6 +65,13 @@ been some time since the last API call and other clients have made subsequent
 requests since then.  You can always call RateLimit() directly to get the most
 up-to-date rate limit data for the client.
 
+To detect an API rate limit error, you can check if its type is *github.RateLimitError:
+
+	repos, _, err := client.Repositories.List("", nil)
+	if _, ok := err.(*github.RateLimitError); ok {
+		log.Println("hit rate limit")
+	}
+
 Learn more about GitHub rate limiting at
 http://developer.github.com/v3/#rate-limiting.
 

--- a/github/github.go
+++ b/github/github.go
@@ -434,6 +434,9 @@ func (e *Error) Error() string {
 // the 200 range.  API error responses are expected to have either no response
 // body, or a JSON response body that maps to ErrorResponse.  Any other
 // response body will be silently ignored.
+//
+// The error type will be *RateLimitError for rate limit exceeded errors,
+// and *TwoFactorAuthError for two-factor authentication errors.
 func CheckResponse(r *http.Response) error {
 	if c := r.StatusCode; 200 <= c && c <= 299 {
 		return nil

--- a/github/github.go
+++ b/github/github.go
@@ -236,7 +236,7 @@ type Response struct {
 func newResponse(r *http.Response) *Response {
 	response := &Response{Response: r}
 	response.populatePageValues()
-	response.populateRate()
+	response.Rate = parseRate(r)
 	return response
 }
 
@@ -284,19 +284,21 @@ func (r *Response) populatePageValues() {
 	}
 }
 
-// populateRate parses the rate related headers and populates the response Rate.
-func (r *Response) populateRate() {
+// parseRate parses the rate related headers.
+func parseRate(r *http.Response) Rate {
+	var rate Rate
 	if limit := r.Header.Get(headerRateLimit); limit != "" {
-		r.Rate.Limit, _ = strconv.Atoi(limit)
+		rate.Limit, _ = strconv.Atoi(limit)
 	}
 	if remaining := r.Header.Get(headerRateRemaining); remaining != "" {
-		r.Rate.Remaining, _ = strconv.Atoi(remaining)
+		rate.Remaining, _ = strconv.Atoi(remaining)
 	}
 	if reset := r.Header.Get(headerRateReset); reset != "" {
 		if v, _ := strconv.ParseInt(reset, 10, 64); v != 0 {
-			r.Rate.Reset = Timestamp{time.Unix(v, 0)}
+			rate.Reset = Timestamp{time.Unix(v, 0)}
 		}
 	}
+	return rate
 }
 
 // Rate specifies the current rate limit for the client as determined by the
@@ -373,6 +375,20 @@ type TwoFactorAuthError ErrorResponse
 
 func (r *TwoFactorAuthError) Error() string { return (*ErrorResponse)(r).Error() }
 
+// RateLimitError occurs when GitHub returns 403 Forbidden response with a rate limit
+// remaining value of 0, and error message starts with "API rate limit exceeded for ".
+type RateLimitError struct {
+	Rate     Rate           // Rate specifies last known rate limit for the client
+	Response *http.Response // HTTP response that caused this error
+	Message  string         `json:"message"` // error message
+}
+
+func (r *RateLimitError) Error() string {
+	return fmt.Sprintf("%v %v: %d %v; rate reset in %v",
+		r.Response.Request.Method, sanitizeURL(r.Response.Request.URL),
+		r.Response.StatusCode, r.Message, r.Rate.Reset.Time.Sub(time.Now()))
+}
+
 // sanitizeURL redacts the client_secret parameter from the URL which may be
 // exposed to the user, specifically in the ErrorResponse error message.
 func sanitizeURL(uri *url.URL) *url.URL {
@@ -427,10 +443,18 @@ func CheckResponse(r *http.Response) error {
 	if err == nil && data != nil {
 		json.Unmarshal(data, errorResponse)
 	}
-	if r.StatusCode == http.StatusUnauthorized && strings.HasPrefix(r.Header.Get(headerOTP), "required") {
+	switch {
+	case r.StatusCode == http.StatusUnauthorized && strings.HasPrefix(r.Header.Get(headerOTP), "required"):
 		return (*TwoFactorAuthError)(errorResponse)
+	case r.StatusCode == http.StatusForbidden && r.Header.Get(headerRateRemaining) == "0" && strings.HasPrefix(errorResponse.Message, "API rate limit exceeded for "):
+		return &RateLimitError{
+			Rate:     parseRate(r),
+			Response: errorResponse.Response,
+			Message:  errorResponse.Message,
+		}
+	default:
+		return errorResponse
 	}
-	return errorResponse
 }
 
 // parseBoolResponse determines the boolean result from a GitHub API response.


### PR DESCRIPTION
Fixes #152.

Add tests for `RateLimitError`.

Refactor `populateRate` into a more general `parseRate`.

Here's a sample error returned when hitting the rate limit:

```
GET https://api.github.com/users/shurcooL: 403 API rate limit exceeded for xxx.xxx.xxx.xxx. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.); rate reset in 15m8.193650147s
```