### PR TITLE
support 'since' pagination

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -263,8 +263,13 @@ func (r *Response) populatePageValues() {
 				continue
 			}
 			page := url.Query().Get("page")
-			if page == "" {
+			since := url.Query().Get("since")
+			if page == "" && since == "" {
 				continue
+			}
+
+			if since != "" {
+				page = since
 			}
 
 			for _, segment := range segments[1:] {


### PR DESCRIPTION
Support parsing 'since' from Link header, which enables us to actually paginate through listing Users. This is especially helpful when working with Github Enterprise.

https://developer.github.com/v3/users/#get-all-users

Also, this is kind of a hack since we're overloading the idea of a 'Page' but it does work well with code like this:

```go

opt := &github.UserListOptions{
	Since: 0,
}

// get all pages of results
var allUsers []github.User
for {
	users, resp, err := client.Users.ListAll(opt)
	if err != nil {
		return err
	}
	allUsers = append(allUsers, users...)
	if resp.NextPage == 0 {
		break
	}
	opt.Since = resp.NextPage
}
```

Also I did not add tests - if we want tests, and we want this code, I can write tests.