### PR TITLE
Do URL path escape composing the URL for GetContents

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -119,6 +119,11 @@ func (s *RepositoriesService) DownloadContents(owner, repo, filepath string, opt
 	return nil, fmt.Errorf("No file named %s found in %s", filename, dir)
 }
 
+func escapeUrlPath(path string) string {
+	u := url.URL{Path: path}
+	return u.EscapedPath()
+}
+
 // GetContents can return either the metadata and content of a single file
 // (when path references a file) or the metadata of all the files and/or
 // subdirectories of a directory (when path references a directory). To make it
@@ -129,7 +134,7 @@ func (s *RepositoriesService) DownloadContents(owner, repo, filepath string, opt
 // GitHub API docs: http://developer.github.com/v3/repos/contents/#get-contents
 func (s *RepositoriesService) GetContents(owner, repo, path string, opt *RepositoryContentGetOptions) (fileContent *RepositoryContent,
 	directoryContent []*RepositoryContent, resp *Response, err error) {
-	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, path)
+	u := escapeUrlPath(fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, path))
 	u, err = addOptions(u, opt)
 	if err != nil {
 		return nil, nil, nil, err

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -119,7 +119,7 @@ func (s *RepositoriesService) DownloadContents(owner, repo, filepath string, opt
 	return nil, fmt.Errorf("No file named %s found in %s", filename, dir)
 }
 
-func escapeUrlPath(path string) string {
+func escapeURLPath(path string) string {
 	u := url.URL{Path: path}
 	return u.EscapedPath()
 }
@@ -134,7 +134,7 @@ func escapeUrlPath(path string) string {
 // GitHub API docs: http://developer.github.com/v3/repos/contents/#get-contents
 func (s *RepositoriesService) GetContents(owner, repo, path string, opt *RepositoryContentGetOptions) (fileContent *RepositoryContent,
 	directoryContent []*RepositoryContent, resp *Response, err error) {
-	u := escapeUrlPath(fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, path))
+	u := escapeURLPath(fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, path))
 	u, err = addOptions(u, opt)
 	if err != nil {
 		return nil, nil, nil, err

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html/template"
 	"io"
 	"net/http"
 	"net/url"
@@ -120,8 +121,7 @@ func (s *RepositoriesService) DownloadContents(owner, repo, filepath string, opt
 }
 
 func escapeURLPath(path string) string {
-	u := url.URL{Path: path}
-	return u.EscapedPath()
+	return template.URLQueryEscaper(path)
 }
 
 // GetContents can return either the metadata and content of a single file

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
 	"io"
 	"net/http"
 	"net/url"
@@ -121,7 +120,7 @@ func (s *RepositoriesService) DownloadContents(owner, repo, filepath string, opt
 }
 
 func escapeURLPath(path string) string {
-	return template.URLQueryEscaper(path)
+	return url.QueryEscape(path)
 }
 
 // GetContents can return either the metadata and content of a single file

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -144,7 +144,7 @@ func TestRepositoriesService_GetContents_File(t *testing.T) {
 func TestRepositoriesService_GetContents_FilenameNeedsEscape(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/repos/o/r/contents/p#e.go", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/contents/p#?%/中.go", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
 		  "type": "file",
@@ -154,7 +154,7 @@ func TestRepositoriesService_GetContents_FilenameNeedsEscape(t *testing.T) {
 		  "path": "LICENSE"
 		}`)
 	})
-	fileContents, _, _, err := client.Repositories.GetContents("o", "r", "p#e.go", &RepositoryContentGetOptions{})
+	fileContents, _, _, err := client.Repositories.GetContents("o", "r", "p#?%/中.go", &RepositoryContentGetOptions{})
 	if err != nil {
 		t.Fatalf("Repositories.GetContents returned error: %v", err)
 	}

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -141,6 +141,29 @@ func TestRepositoriesService_GetContents_File(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_GetContents_FilenameNeedsEscape(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/repos/o/r/contents/p#e.go", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+		  "type": "file",
+		  "encoding": "base64",
+		  "size": 20678,
+		  "name": "LICENSE",
+		  "path": "LICENSE"
+		}`)
+	})
+	fileContents, _, _, err := client.Repositories.GetContents("o", "r", "p#e.go", &RepositoryContentGetOptions{})
+	if err != nil {
+		t.Fatalf("Repositories.GetContents returned error: %v", err)
+	}
+	want := &RepositoryContent{Type: String("file"), Name: String("LICENSE"), Size: Int(20678), Encoding: String("base64"), Path: String("LICENSE")}
+	if !reflect.DeepEqual(fileContents, want) {
+		t.Errorf("Repositories.GetContents returned %+v, want %+v", fileContents, want)
+	}
+}
+
 func TestRepositoriesService_GetContents_Directory(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
When any of owner/repo/path contains a "#" an escaping is needed.