### PR TITLE
add preview header to list branches request

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -486,6 +486,8 @@ func (s *RepositoriesService) ListBranches(owner string, repo string, opt *ListO
 		return nil, nil, err
 	}
 
+	req.Header.Set("Accept", mediaTypeProtectedBranchesPreview)
+
 	branches := new([]Branch)
 	resp, err := s.client.Do(req, branches)
 	if err != nil {

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -367,6 +367,7 @@ func TestRepositoriesService_ListBranches(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeProtectedBranchesPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"name":"master", "commit" : {"sha" : "a57781", "url" : "https://api.github.com/repos/o/r/commits/a57781"}}]`)
 	})


### PR DESCRIPTION
This adds the Branch Protection to the ListBranches method which previously always responded with nil