### PR TITLE
go-github: add DeploymentEvent

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -106,3 +106,14 @@ type IssueCommentEvent struct {
 	Repo   *Repository `json:"repository,omitempty"`
 	Sender *User       `json:"sender,omitempty"`
 }
+
+// DeploymentEvent represents the payload delivered by Deployment webhook.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#deploymentevent
+type DeploymentEvent struct {
+	Deployment *Deployment `json:"deployment,omitempty"`
+	Repo       *Repository `json:"repository,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Sender *User `json:"sender,omitempty"`
+}

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -12,17 +12,19 @@ import (
 
 // Deployment represents a deployment in a repo
 type Deployment struct {
-	URL         *string         `json:"url,omitempty"`
-	ID          *int            `json:"id,omitempty"`
-	SHA         *string         `json:"sha,omitempty"`
-	Ref         *string         `json:"ref,omitempty"`
-	Task        *string         `json:"task,omitempty"`
-	Payload     json.RawMessage `json:"payload,omitempty"`
-	Environment *string         `json:"environment,omitempty"`
-	Description *string         `json:"description,omitempty"`
-	Creator     *User           `json:"creator,omitempty"`
-	CreatedAt   *Timestamp      `json:"created_at,omitempty"`
-	UpdatedAt   *Timestamp      `json:"pushed_at,omitempty"`
+	URL           *string         `json:"url,omitempty"`
+	ID            *int            `json:"id,omitempty"`
+	SHA           *string         `json:"sha,omitempty"`
+	Ref           *string         `json:"ref,omitempty"`
+	Task          *string         `json:"task,omitempty"`
+	Payload       json.RawMessage `json:"payload,omitempty"`
+	Environment   *string         `json:"environment,omitempty"`
+	Description   *string         `json:"description,omitempty"`
+	Creator       *User           `json:"creator,omitempty"`
+	CreatedAt     *Timestamp      `json:"created_at,omitempty"`
+	UpdatedAt     *Timestamp      `json:"pushed_at,omitempty"`
+	StatusesURL   *string         `json:"statuses_url,omitempty"`
+	RepositoryURL *string         `json:"repository_url,omitempty"`
 }
 
 // DeploymentRequest represents a deployment request


### PR DESCRIPTION
Note that two new fields were added to the Deployment struct:
StatusesURL and
RepositoryURL

documented here:
https://developer.github.com/v3/repos/deployments/#list-deployments

Change-Id: I0a2f653d3cdc969860217ceb9c55f913fda48a65