### PR TITLE
go-github: add DeploymentStatusEvent

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -106,3 +106,15 @@ type IssueCommentEvent struct {
 	Repo   *Repository `json:"repository,omitempty"`
 	Sender *User       `json:"sender,omitempty"`
 }
+
+// DeploymentStatusEvent represents the payload delivered by DeploymentStatus webhook.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#deploymentstatusevent
+type DeploymentStatusEvent struct {
+	Deployment       *Deployment       `json:"deployment,omitempty"`
+	DeploymentStatus *DeploymentStatus `json:"deployment_status,omitempty"`
+	Repo             *Repository       `json:"repository,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Sender *User `json:"sender,omitempty"`
+}

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -101,13 +101,16 @@ func (s *RepositoriesService) CreateDeployment(owner, repo string, request *Depl
 // DeploymentStatus represents the status of a
 // particular deployment.
 type DeploymentStatus struct {
-	ID          *int       `json:"id,omitempty"`
-	State       *string    `json:"state,omitempty"`
-	Creator     *User      `json:"creator,omitempty"`
-	Description *string    `json:"description,omitempty"`
-	TargetURL   *string    `json:"target_url,omitempty"`
-	CreatedAt   *Timestamp `json:"created_at,omitempty"`
-	UpdatedAt   *Timestamp `json:"pushed_at,omitempty"`
+	URL           *string    `json:"url,omitempty"`
+	ID            *int       `json:"id,omitempty"`
+	State         *string    `json:"state,omitempty"`
+	Creator       *User      `json:"creator,omitempty"`
+	Description   *string    `json:"description,omitempty"`
+	TargetURL     *string    `json:"target_url,omitempty"`
+	CreatedAt     *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt     *Timestamp `json:"pushed_at,omitempty"`
+	DeploymentURL *string    `json:"deployment_url,omitempty"`
+	RepositoryURL *string    `json:"repository_url,omitempty"`
 }
 
 // DeploymentStatusRequest represents a deployment request


### PR DESCRIPTION
Note that two new fields were added to the DeploymentStatus struct:
DeploymentURL and
RepositoryURL

documented here:
https://developer.github.com/v3/repos/deployments/#list-deployment-statuses

Change-Id: I9736c5143fc93ced2f154becad1c7de90337ef5d