### PR TITLE
go-github: add ForkEvent

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -106,3 +106,14 @@ type IssueCommentEvent struct {
 	Repo   *Repository `json:"repository,omitempty"`
 	Sender *User       `json:"sender,omitempty"`
 }
+
+// ForkEvent represents the payload delivered by Fork webhook.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#forkevent
+type ForkEvent struct {
+	Forkee *Repository `json:"forkee,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}


### PR DESCRIPTION
Note that a `Forkee` is a `Repository` with one extra field: `Public: *bool`...
as documented here:
https://developer.github.com/v3/activity/events/types/#forkevent

But since the `Repository` struct already has a `Private` field (which is its negated value), I didn't think it was worth adding the extra `Public` field to the `Repository` struct... nor is it worthwhile to make a completely new struct for a `Forkee`.

Change-Id: Iddf2ea1bdde8d200f84bc075e330fa9c88dd0ee4