### PR TITLE
Add InReplyTo to PullRequestComment struct

### DIFF
--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -13,6 +13,7 @@ import (
 // PullRequestComment represents a comment left on a pull request.
 type PullRequestComment struct {
 	ID               *int       `json:"id,omitempty"`
+	InReplyTo        *int       `json:"in_reply_to,omitempty"`
 	Body             *string    `json:"body,omitempty"`
 	Path             *string    `json:"path,omitempty"`
 	DiffHunk         *string    `json:"diff_hunk,omitempty"`


### PR DESCRIPTION
In V3 of the GitHub API, pull request comments are created in two ways. The first way is to create a comment on a specific line of a file in a commit with the following parameters:

| Name      | Type    | Description                                            |
|-----------|---------|--------------------------------------------------------|
| body      | string  | Required. The text of the comment                      |
| commit_id | string  | Required. The SHA of the commit to comment on.         |
| path      | string  | Required. The relative path of the file to comment on. |
| position  | integer | Required. The line index in the diff to comment on.    |

And the second way is through a reply to an existing comment with the following parameters:

| Name        | Type    | Description                           |
|-------------|---------|---------------------------------------|
| body        | string  | Required. The text of the comment     |
| in_reply_to | integer | Required. The comment id to reply to. |

This commit adds support for the second (or "Alternative Input" according to the GitHub [docs](https://developer.github.com/v3/pulls/comments/#alternative-input)) way.