### PR TITLE
Correct path escaping

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -130,8 +130,8 @@ func (s *RepositoriesService) DownloadContents(owner, repo, filepath string, opt
 func (s *RepositoriesService) GetContents(owner, repo, path string, opt *RepositoryContentGetOptions) (fileContent *RepositoryContent, directoryContent []*RepositoryContent, resp *Response, err error) {
 	// escape characters not allowed in URL path.  This actually escapes a
 	// lot more, but seems to be harmless.
-	urlPath := url.URL{Path: path}
-	escapedPath := urlPath.EscapedPath()
+	tmpURL := url.URL{Path: path}
+	escapedPath := tmpURL.EscapedPath()
 	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, escapedPath)
 	u, err = addOptions(u, opt)
 	if err != nil {

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -130,7 +130,8 @@ func (s *RepositoriesService) DownloadContents(owner, repo, filepath string, opt
 func (s *RepositoriesService) GetContents(owner, repo, path string, opt *RepositoryContentGetOptions) (fileContent *RepositoryContent, directoryContent []*RepositoryContent, resp *Response, err error) {
 	// escape characters not allowed in URL path.  This actually escapes a
 	// lot more, but seems to be harmless.
-	escapedPath := url.QueryEscape(path)
+	urlPath := url.URL{Path: path}
+	escapedPath := urlPath.EscapedPath()
 	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, escapedPath)
 	u, err = addOptions(u, opt)
 	if err != nil {

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -128,8 +128,7 @@ func (s *RepositoriesService) DownloadContents(owner, repo, filepath string, opt
 //
 // GitHub API docs: http://developer.github.com/v3/repos/contents/#get-contents
 func (s *RepositoriesService) GetContents(owner, repo, path string, opt *RepositoryContentGetOptions) (fileContent *RepositoryContent, directoryContent []*RepositoryContent, resp *Response, err error) {
-	tmpURL := url.URL{Path: path}
-	escapedPath := tmpURL.String()
+	escapedPath := (&url.URL{Path: path}).String()
 	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, escapedPath)
 	u, err = addOptions(u, opt)
 	if err != nil {

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -128,10 +128,8 @@ func (s *RepositoriesService) DownloadContents(owner, repo, filepath string, opt
 //
 // GitHub API docs: http://developer.github.com/v3/repos/contents/#get-contents
 func (s *RepositoriesService) GetContents(owner, repo, path string, opt *RepositoryContentGetOptions) (fileContent *RepositoryContent, directoryContent []*RepositoryContent, resp *Response, err error) {
-	// escape characters not allowed in URL path.  This actually escapes a
-	// lot more, but seems to be harmless.
 	tmpURL := url.URL{Path: path}
-	escapedPath := tmpURL.EscapedPath()
+	escapedPath := tmpURL.String()
 	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, escapedPath)
 	u, err = addOptions(u, opt)
 	if err != nil {

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -154,6 +154,19 @@ func TestRepositoriesService_GetContents_FilenameNeedsEscape(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_GetContents_DirectoryWithSpaces(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/repos/o/r/contents/some directory/file.go", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{}`)
+	})
+	_, _, _, err := client.Repositories.GetContents("o", "r", "some directory/file.go", &RepositoryContentGetOptions{})
+	if err != nil {
+		t.Fatalf("Repositories.GetContents returned error: %v", err)
+	}
+}
+
 func TestRepositoriesService_GetContents_Directory(t *testing.T) {
 	setup()
 	defer teardown()

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -170,11 +170,11 @@ func TestRepositoriesService_GetContents_DirectoryWithSpaces(t *testing.T) {
 func TestRepositoriesService_GetContents_DirectoryWithPlusChars(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/repos/o/r/contents/some directory/file.go", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/contents/some directory+name/file.go", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{}`)
 	})
-	_, _, _, err := client.Repositories.GetContents("o", "r", "some+directory/file.go", &RepositoryContentGetOptions{})
+	_, _, _, err := client.Repositories.GetContents("o", "r", "some directory+name/file.go", &RepositoryContentGetOptions{})
 	if err != nil {
 		t.Fatalf("Repositories.GetContents returned error: %v", err)
 	}

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -167,6 +167,19 @@ func TestRepositoriesService_GetContents_DirectoryWithSpaces(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_GetContents_DirectoryWithPlusChars(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/repos/o/r/contents/some directory/file.go", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{}`)
+	})
+	_, _, _, err := client.Repositories.GetContents("o", "r", "some+directory/file.go", &RepositoryContentGetOptions{})
+	if err != nil {
+		t.Fatalf("Repositories.GetContents returned error: %v", err)
+	}
+}
+
 func TestRepositoriesService_GetContents_Directory(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Use the correct method to escape the url path.
Fixes #308.