### PR TITLE
change DownloadReleaseAsset API to additionally return a URL

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -68,6 +68,8 @@ const (
 type Client struct {
 	// HTTP client used to communicate with the API.
 	client *http.Client
+	// clientMu protects the client during calls that modify the CheckRedirect func.
+	clientMu sync.Mutex
 
 	// Base URL for API requests.  Defaults to the public GitHub API, but can be
 	// set to a domain endpoint to use with GitHub Enterprise.  BaseURL should

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -10,8 +10,10 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // RepositoryRelease represents a GitHub release in a repository.
@@ -213,27 +215,43 @@ func (s *RepositoriesService) GetReleaseAsset(owner, repo string, id int) (*Rele
 	return asset, resp, err
 }
 
-// DownloadReleaseAsset downloads a release asset.
+// DownloadReleaseAsset downloads a release asset or returns a redirect URL.
 //
 // DownloadReleaseAsset returns an io.ReadCloser that reads the contents of the
 // specified release asset. It is the caller's responsibility to close the ReadCloser.
+// If a redirect is returned, the redirect URL will be returned as a string instead
+// of the io.ReadCloser. Exactly one of rc and redirectURL will be zero.
 //
 // GitHub API docs : http://developer.github.com/v3/repos/releases/#get-a-single-release-asset
-func (s *RepositoriesService) DownloadReleaseAsset(owner, repo string, id int) (io.ReadCloser, error) {
+func (s *RepositoriesService) DownloadReleaseAsset(owner, repo string, id int) (rc io.ReadCloser, redirectURL string, err error) {
 	u := fmt.Sprintf("repos/%s/%s/releases/assets/%d", owner, repo, id)
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	req.Header.Set("Accept", defaultMediaType)
 
+	s.client.clientMu.Lock()
+	defer s.client.clientMu.Unlock()
+
+	var loc string
+	saveRedirect := s.client.client.CheckRedirect
+	s.client.client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		loc = req.URL.String()
+		return errors.New("disable redirect")
+	}
+	defer func() { s.client.client.CheckRedirect = saveRedirect }()
+
 	resp, err := s.client.client.Do(req)
 	if err != nil {
-		return nil, err
+		if !strings.Contains(err.Error(), "disable redirect") {
+			return nil, "", err
+		}
+		return nil, loc, nil
 	}
 
-	return resp.Body, nil
+	return resp.Body, "", nil
 }
 
 // EditReleaseAsset edits a repository release asset.


### PR DESCRIPTION
If a redirect to AWS occurs, then the redirect will be canceled and
the redirect Location will be returned in the string and the
io.ReadCloser will be nil. At this point, the user would need to
perform the http.Get on the returned URL in a different http.Client
(without the GitHub authentication transport).

Fixes #246.

Change-Id: I4fe2dfc9cd0ce81934a07f11a6296e71c7dd51a0