### PR TITLE
check options for nil

### DIFF
--- a/github/search.go
+++ b/github/search.go
@@ -148,7 +148,7 @@ func (s *SearchService) search(searchType string, query string, opt *SearchOptio
 		return nil, err
 	}
 
-	if opt.TextMatch {
+	if opt != nil && opt.TextMatch {
 		// Accept header defaults to "application/vnd.github.v3+json"
 		// We change it here to fetch back text-match metadata
 		req.Header.Set("Accept", "application/vnd.github.v3.text-match+json")


### PR DESCRIPTION
Hi. Does it make sense to check for nil here?
I think I should be able to send nil in search params (if I don't really care)

`query := "repo:" + repo.Organization + "/" + repo.Project + " label:" + label`
`  prs, _, err := repo.Client.Search.Issues(query, nil)`

