### PR TITLE
Add RepositoriesService.GetByID method.

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -277,6 +277,29 @@ func (s *RepositoriesService) Get(owner, repo string) (*Repository, *Response, e
 	return repository, resp, err
 }
 
+// GetByID fetches a repository.
+//
+// Note: GetByID uses the undocumented GitHub API endpoint /repositories/:id.
+func (s *RepositoriesService) GetByID(id int) (*Repository, *Response, error) {
+	u := fmt.Sprintf("repositories/%d", id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when the license support fully launches
+	// https://developer.github.com/v3/licenses/#get-a-repositorys-license
+	req.Header.Set("Accept", mediaTypeLicensesPreview)
+
+	repository := new(Repository)
+	resp, err := s.client.Do(req, repository)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return repository, resp, err
+}
+
 // Edit updates a repository.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/#edit

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -222,6 +222,27 @@ func TestRepositoriesService_Get(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_GetByID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repositories/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeLicensesPreview)
+		fmt.Fprint(w, `{"id":1,"name":"n","description":"d","owner":{"login":"l"},"license":{"key":"mit"}}`)
+	})
+
+	repo, _, err := client.Repositories.GetByID(1)
+	if err != nil {
+		t.Errorf("Repositories.GetByID returned error: %v", err)
+	}
+
+	want := &Repository{ID: Int(1), Name: String("n"), Description: String("d"), Owner: &User{Login: String("l")}, License: &License{Key: String("mit")}}
+	if !reflect.DeepEqual(repo, want) {
+		t.Errorf("Repositories.GetByID returned %+v, want %+v", repo, want)
+	}
+}
+
 func TestRepositoriesService_Edit(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Note: GetByID uses the undocumented GitHub API endpoint `/repositories/:id`.

Include license preview Accept header.

Helps #329.

This commit is based on https://github.com/sourcegraph/go-github/commit/da394ef1f53de34e9c3e5782ca27589df32b426c which has been tested in production. It has been amended by me to include [Licences API](https://developer.github.com/changes/2015-03-09-licenses-api/) header, improved documentation and commit message, with appropriate updates to the test.

I've tested it locally with the Licences API header to make sure it works, and I've confirmed that it did.