### PR TITLE
Add UsersService.GetByID method.

### DIFF
--- a/github/users.go
+++ b/github/users.go
@@ -95,6 +95,25 @@ func (s *UsersService) Get(user string) (*User, *Response, error) {
 	return uResp, resp, err
 }
 
+// GetByID fetches a user.
+//
+// Note: GetByID uses the undocumented GitHub API endpoint /user/:id.
+func (s *UsersService) GetByID(id int) (*User, *Response, error) {
+	u := fmt.Sprintf("user/%d", id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	user := new(User)
+	resp, err := s.client.Do(req, user)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return user, resp, err
+}
+
 // Edit the authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/users/#update-the-authenticated-user

--- a/github/users_test.go
+++ b/github/users_test.go
@@ -100,6 +100,26 @@ func TestUsersService_Get_invalidUser(t *testing.T) {
 	testURLParseError(t, err)
 }
 
+func TestUsersService_GetByID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":1}`)
+	})
+
+	user, _, err := client.Users.GetByID(1)
+	if err != nil {
+		t.Errorf("Users.GetByID returned error: %v", err)
+	}
+
+	want := &User{ID: Int(1)}
+	if !reflect.DeepEqual(user, want) {
+		t.Errorf("Users.GetByID returned %+v, want %+v", user, want)
+	}
+}
+
 func TestUsersService_Edit(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Note: GetByID uses the undocumented GitHub API endpoint `/user/:id`.

Resolves #329 (assuming #332 is also merged).

This commit is based on sourcegraph@e4f201ff9b2966d65e34b342d19a386d5c35624f which has been tested in production. It has been amended by me to add details to the commit message only.

@sqs, can you please confirm you're okay with this commit being contributed to Google?