### PR TITLE
Add "assignee" field in pull request

### DIFF
--- a/github/pulls.go
+++ b/github/pulls.go
@@ -43,6 +43,7 @@ type PullRequest struct {
 	StatusesURL  *string    `json:"statuses_url,omitempty"`
 	DiffURL      *string    `json:"diff_url,omitempty"`
 	PatchURL     *string    `json:"patch_url,omitempty"`
+	Assignee     *User      `json:"assignee,omitempty"` // probably only in webhooks
 
 	Head *PullRequestBranch `json:"head,omitempty"`
 	Base *PullRequestBranch `json:"base,omitempty"`


### PR DESCRIPTION
On webhooks, when the PR is assigned you get
```
{
  "action": "assigned",
  "number": 73,
  "pull_request": {
    "url":
...
    "body": "",
    "created_at": "2016-04-13T13:51:23Z",
    "updated_at": "2016-04-13T13:51:37Z",
    "closed_at": null,
    "merged_at": null,
    "merge_commit_sha": "333a18e2215ec59bfd09fefd730f71492a52f983",
    "assignee": {
      "login": "someuser",
      "id": ...
```