### PR TITLE
change custom accept header for support of commit reference SHA-1 API

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -41,6 +41,7 @@ const (
 
 	mediaTypeV3      = "application/vnd.github.v3+json"
 	defaultMediaType = "application/octet-stream"
+	mediaTypeV3SHA   = "application/vnd.github.v3.sha"
 
 	// Media Type values to access preview APIs
 
@@ -59,9 +60,6 @@ const (
 
 	// https://developer.github.com/changes/2016-02-11-issue-locking-api/
 	mediaTypeIssueLockingPreview = "application/vnd.github.the-key-preview+json"
-
-	// https://developer.github.com/changes/2016-02-24-commit-reference-sha-api/
-	mediaTypeCommitReferenceSHAPreview = "application/vnd.github.chitauri-preview+sha"
 
 	// https://help.github.com/enterprise/2.4/admin/guides/migrations/exporting-the-github-com-organization-s-repositories/
 	mediaTypeMigrationsPreview = "application/vnd.github.wyandotte-preview+json"

--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -162,8 +162,7 @@ func (s *RepositoriesService) GetCommitSHA1(owner, repo, ref, lastSHA string) (s
 		req.Header.Set("If-None-Match", `"`+lastSHA+`"`)
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeCommitReferenceSHAPreview)
+	req.Header.Set("Accept", mediaTypeV3SHA)
 
 	var buf bytes.Buffer
 	resp, err := s.client.Do(req, &buf)

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -126,7 +126,7 @@ func TestRepositoriesService_GetCommitSHA1(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/commits/master", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeCommitReferenceSHAPreview)
+		testHeader(t, r, "Accept", mediaTypeV3SHA)
 
 		fmt.Fprintf(w, sha1)
 	})
@@ -143,7 +143,7 @@ func TestRepositoriesService_GetCommitSHA1(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/commits/tag", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeCommitReferenceSHAPreview)
+		testHeader(t, r, "Accept", mediaTypeV3SHA)
 		testHeader(t, r, "If-None-Match", `"`+sha1+`"`)
 
 		w.WriteHeader(http.StatusNotModified)


### PR DESCRIPTION
See: https://developer.github.com/changes/2016-04-12-commit-reference-sha-api-is-now-official/

Fixes #297.

Change-Id: I9cc3c4a2e143c6b3ca4677d8d27ea7af96341dd9