### PR TITLE
Correctly handle API errors when downloading Release Assets

### DIFF
--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -251,6 +251,11 @@ func (s *RepositoriesService) DownloadReleaseAsset(owner, repo string, id int) (
 		return nil, loc, nil
 	}
 
+	if err := CheckResponse(resp); err != nil {
+		resp.Body.Close()
+		return nil, "", err
+	}
+
 	return resp.Body, "", nil
 }
 

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -253,6 +253,32 @@ func TestRepositoriesService_DownloadReleaseAsset_Redirect(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_DownloadReleaseAsset_APIError(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", defaultMediaType)
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"message":"Not Found","documentation_url":"https://developer.github.com/v3"}`)
+	})
+
+	resp, loc, err := client.Repositories.DownloadReleaseAsset("o", "r", 1)
+	if err == nil {
+		t.Error("Repositories.DownloadReleaseAsset did not return an error")
+	}
+
+	if resp != nil {
+		resp.Close()
+		t.Error("Repositories.DownloadReleaseAsset returned stream, want nil")
+	}
+
+	if loc != "" {
+		t.Error(`Repositories.DownloadReleaseAsset returned "%s", want empty ""`, loc)
+	}
+}
+
 func TestRepositoriesService_EditReleaseAsset(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
If `RepositoriesService.DownloadReleaseAsset` encounters an error from the GitHub API (e.g., 404 Not Found), The error would not be returned by the method and instead the error payload would be delivered as the `io.ReadCloser`. This patch resolves this with `CheckResponse`.

Fixes #343

/cc @willnorris (thanks for the help!)