### PR TITLE
Travis: Run gofmt -s, go vet, go test -race, add Go 1.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,22 @@
+sudo: false
 language: go
 go:
- - 1.4
- - 1.5
- - tip
-install: go get -v ./github
-script: go test -v ./github
+  - 1.5.4
+  - 1.6.2
+  - tip
+matrix:
+  include:
+    - go: 1.4.3
+      script:
+        - go get -t -v ./...
+        - go test -v -race ./...
+  allow_failures:
+    - go: tip
+  fast_finish: true
+install:
+  - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d -s .)
+  - go tool vet .
+  - go test -v -race ./...

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -275,7 +275,7 @@ func TestRepositoriesService_DownloadReleaseAsset_APIError(t *testing.T) {
 	}
 
 	if loc != "" {
-		t.Error(`Repositories.DownloadReleaseAsset returned "%s", want empty ""`, loc)
+		t.Errorf(`Repositories.DownloadReleaseAsset returned "%s", want empty ""`, loc)
 	}
 }
 

--- a/tests/integration/authorizations_test.go
+++ b/tests/integration/authorizations_test.go
@@ -3,6 +3,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build integration
+
 package tests
 
 import (

--- a/tests/integration/authorizations_test.go
+++ b/tests/integration/authorizations_test.go
@@ -52,7 +52,7 @@ func TestAuthorizationsBasicOperations(t *testing.T) {
 	failIfNotStatusCode(t, resp, 200)
 
 	if len(auths) != initialAuthCount+1 {
-		t.Fatalf("The number of Authorizations should have increased. Expected [%v], was [%v]", (initialAuthCount + 1), len(auths))
+		t.Fatalf("The number of Authorizations should have increased. Expected [%v], was [%v]", initialAuthCount+1, len(auths))
 	}
 
 	// Test updating the authorization
@@ -94,7 +94,7 @@ func TestAuthorizationsBasicOperations(t *testing.T) {
 	failIfNotStatusCode(t, resp, 200)
 
 	if len(auths) != initialAuthCount {
-		t.Fatal("The number of Authorizations should match the initial count Expected [%v], got [%v]", (initialAuthCount), len(auths))
+		t.Fatalf("The number of Authorizations should match the initial count Expected [%v], got [%v]", initialAuthCount, len(auths))
 	}
 
 }

--- a/tests/integration/doc.go
+++ b/tests/integration/doc.go
@@ -1,0 +1,6 @@
+// Package tests contains integration tests.
+//
+// These tests call the live GitHub API, and therefore require a little more
+// setup to run.  See https://github.com/google/go-github/tree/master/tests/integration
+// for more information.
+package tests

--- a/tests/integration/github_test.go
+++ b/tests/integration/github_test.go
@@ -3,9 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// These tests call the live GitHub API, and therefore require a little more
-// setup to run.  See https://github.com/google/go-github/tree/master/tests/integration
-// for more information
+// +build integration
 
 package tests
 


### PR DESCRIPTION
Also make tip a fast-finish allowed failure. That way, if CI fails on tip due to a temporary issue with tip, it will not break build status. However, it's still possible to see tip build status by looking at CI details page.

Expect CI to fail on this PR because there are known go vet issues, those will be fixed in next commit.