### PR TITLE
Predict *RateLimitError, return immediately without network call (9700x speedup when rate limit exceeded).

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -320,8 +320,10 @@ func parseRate(r *http.Response) Rate {
 
 // Rate specifies the current rate limit for the client as determined by the
 // most recent API call.  If the client is used in a multi-user application,
-// this rate may not always be up-to-date.  Call RateLimits() to check the
-// current rate.
+// this rate may not always be up-to-date.
+//
+// Deprecated: Use the Response.Rate returned from most recent API call instead.
+// Call RateLimits() to check the current rate.
 func (c *Client) Rate() Rate {
 	c.rateMu.Lock()
 	rate := c.rateLimits[c.mostRecent]

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -163,6 +163,13 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+// Ensure that length of Client.rateLimits is the same as number of fields in RateLimits struct.
+func TestClient_rateLimits(t *testing.T) {
+	if got, want := len(Client{}.rateLimits), reflect.TypeOf(RateLimits{}).NumField(); got != want {
+		t.Errorf("len(Client{}.rateLimits) is %v, want %v", got, want)
+	}
+}
+
 func TestNewRequest(t *testing.T) {
 	c := NewClient(nil)
 


### PR DESCRIPTION
This (minor) optimization is possible because the client keeps track of the rate limits from previous API calls, and GitHub's rate limiting model is known in advance, and is predictable.

In situations where it's possible to predict that the network API call will result in a `*RateLimitError`, simply return it immediately instead of making the network API call to GitHub's servers. This is both faster for the client (by around 9700 times in my benchmarks) because it avoids the network round-trip latency, and better for GitHub's servers that won't need to needlessly reject network requests.

Note that this optimization only kicks in when the client is already exceeding the rate limit and it hasn't been reset yet. It has no effect during most normal usage when rate limit is not exceeded.

### Benchmarks

I wrote a small benchmark (it assumes you've already exhausted the GitHub API rate limit before you begin):

```Go
func BenchmarkClientDo_rateLimitError(b *testing.B) {
	gh := github.NewClient(nil)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_, _, err := gh.Repositories.Get("shurcooL", "vfsgen")
		if _, ok := err.(*github.RateLimitError); !ok {
			log.Println("no *github.RateLimitError error, but expected it")
		}
	}
}
```

Results before this PR (with a latency to api.github.com of around 85 ms):

```
$ go test -bench=. -benchmem
testing: warning: no tests to run
PASS
BenchmarkClientDo_rateLimitError-8	      20	  97057828 ns/op	   55922 B/op	     126 allocs/op
ok  		2.609s
```

Results after this PR:

```
go test -bench=. -benchmem
testing: warning: no tests to run
PASS
BenchmarkClientDo_rateLimitError-8	  200000	     10005 ns/op	    2763 B/op	      34 allocs/op
ok  		3.576s
```

In this limited scenario, it's a speedup by 9700 times.

Helps #152 and #153.