### PR TITLE
Add missing ListOptions to various structs

### DIFF
--- a/github/activity_notifications.go
+++ b/github/activity_notifications.go
@@ -42,6 +42,8 @@ type NotificationListOptions struct {
 	Participating bool      `url:"participating,omitempty"`
 	Since         time.Time `url:"since,omitempty"`
 	Before        time.Time `url:"before,omitempty"`
+
+	ListOptions
 }
 
 // ListNotifications lists all notifications for the authenticated user.

--- a/github/issues_milestones.go
+++ b/github/issues_milestones.go
@@ -47,6 +47,8 @@ type MilestoneListOptions struct {
 	// Direction in which to sort milestones. Possible values are: asc, desc.
 	// Default is "asc".
 	Direction string `url:"direction,omitempty"`
+
+	ListOptions
 }
 
 // ListMilestones lists all milestones for a repository.

--- a/github/issues_milestones_test.go
+++ b/github/issues_milestones_test.go
@@ -23,11 +23,12 @@ func TestIssuesService_ListMilestones(t *testing.T) {
 			"state":     "closed",
 			"sort":      "due_date",
 			"direction": "asc",
+			"page":      "2",
 		})
 		fmt.Fprint(w, `[{"number":1}]`)
 	})
 
-	opt := &MilestoneListOptions{"closed", "due_date", "asc"}
+	opt := &MilestoneListOptions{"closed", "due_date", "asc", ListOptions{Page: 2}}
 	milestones, _, err := client.Issues.ListMilestones("o", "r", opt)
 	if err != nil {
 		t.Errorf("IssuesService.ListMilestones returned error: %v", err)

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -73,6 +73,8 @@ func (p Plan) String() string {
 type OrganizationsListOptions struct {
 	// Since filters Organizations by ID.
 	Since int `url:"since,omitempty"`
+
+	ListOptions
 }
 
 // ListAll lists all organizations, in the order that they were created on GitHub.

--- a/github/users.go
+++ b/github/users.go
@@ -138,6 +138,8 @@ func (s *UsersService) Edit(user *User) (*User, *Response, error) {
 type UserListOptions struct {
 	// ID of the last user seen
 	Since int `url:"since,omitempty"`
+
+	ListOptions
 }
 
 // ListAll lists all GitHub users.

--- a/github/users_test.go
+++ b/github/users_test.go
@@ -155,11 +155,11 @@ func TestUsersService_ListAll(t *testing.T) {
 
 	mux.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testFormValues(t, r, values{"since": "1"})
+		testFormValues(t, r, values{"since": "1", "page": "2"})
 		fmt.Fprint(w, `[{"id":2}]`)
 	})
 
-	opt := &UserListOptions{1}
+	opt := &UserListOptions{1, ListOptions{Page: 2}}
 	users, _, err := client.Users.ListAll(opt)
 	if err != nil {
 		t.Errorf("Users.Get returned error: %v", err)


### PR DESCRIPTION
Make it possible for callers of IssuesService.ListMilestones() and
similar to step through pages of results.

Fixes #354