### PR TITLE
fix unit tests for go1.7 release

### DIFF
--- a/github/github_test.go
+++ b/github/github_test.go
@@ -198,7 +198,7 @@ func TestNewRequest_invalidJSON(t *testing.T) {
 	c := NewClient(nil)
 
 	type T struct {
-		A map[int]interface{}
+		A map[interface{}]interface{}
 	}
 	_, err := c.NewRequest("GET", "/", &T{})
 


### PR DESCRIPTION
An upcoming change to Go 1.7 allows the json package to be able to encode maps
with the integer keys. Thus, this is no longer a good way to generate intentional
JSON failures.

Reference: https://github.com/golang/go/commit/f05c3aa24d815cd3869153750c9875e35fc48a6e