### PR TITLE
replace []Issue with []*Issue and for other large structs as well

### DIFF
--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -85,7 +85,7 @@ func (e *Event) Payload() (payload interface{}) {
 // ListEvents drinks from the firehose of all public events across GitHub.
 //
 // GitHub API docs: http://developer.github.com/v3/activity/events/#list-public-events
-func (s *ActivityService) ListEvents(opt *ListOptions) ([]Event, *Response, error) {
+func (s *ActivityService) ListEvents(opt *ListOptions) ([]*Event, *Response, error) {
 	u, err := addOptions("events", opt)
 	if err != nil {
 		return nil, nil, err
@@ -96,7 +96,7 @@ func (s *ActivityService) ListEvents(opt *ListOptions) ([]Event, *Response, erro
 		return nil, nil, err
 	}
 
-	events := new([]Event)
+	events := new([]*Event)
 	resp, err := s.client.Do(req, events)
 	if err != nil {
 		return nil, resp, err
@@ -108,7 +108,7 @@ func (s *ActivityService) ListEvents(opt *ListOptions) ([]Event, *Response, erro
 // ListRepositoryEvents lists events for a repository.
 //
 // GitHub API docs: http://developer.github.com/v3/activity/events/#list-repository-events
-func (s *ActivityService) ListRepositoryEvents(owner, repo string, opt *ListOptions) ([]Event, *Response, error) {
+func (s *ActivityService) ListRepositoryEvents(owner, repo string, opt *ListOptions) ([]*Event, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/events", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -120,7 +120,7 @@ func (s *ActivityService) ListRepositoryEvents(owner, repo string, opt *ListOpti
 		return nil, nil, err
 	}
 
-	events := new([]Event)
+	events := new([]*Event)
 	resp, err := s.client.Do(req, events)
 	if err != nil {
 		return nil, resp, err
@@ -132,7 +132,7 @@ func (s *ActivityService) ListRepositoryEvents(owner, repo string, opt *ListOpti
 // ListIssueEventsForRepository lists issue events for a repository.
 //
 // GitHub API docs: http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
-func (s *ActivityService) ListIssueEventsForRepository(owner, repo string, opt *ListOptions) ([]Event, *Response, error) {
+func (s *ActivityService) ListIssueEventsForRepository(owner, repo string, opt *ListOptions) ([]*Event, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/events", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -144,7 +144,7 @@ func (s *ActivityService) ListIssueEventsForRepository(owner, repo string, opt *
 		return nil, nil, err
 	}
 
-	events := new([]Event)
+	events := new([]*Event)
 	resp, err := s.client.Do(req, events)
 	if err != nil {
 		return nil, resp, err
@@ -156,7 +156,7 @@ func (s *ActivityService) ListIssueEventsForRepository(owner, repo string, opt *
 // ListEventsForRepoNetwork lists public events for a network of repositories.
 //
 // GitHub API docs: http://developer.github.com/v3/activity/events/#list-public-events-for-a-network-of-repositories
-func (s *ActivityService) ListEventsForRepoNetwork(owner, repo string, opt *ListOptions) ([]Event, *Response, error) {
+func (s *ActivityService) ListEventsForRepoNetwork(owner, repo string, opt *ListOptions) ([]*Event, *Response, error) {
 	u := fmt.Sprintf("networks/%v/%v/events", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -168,7 +168,7 @@ func (s *ActivityService) ListEventsForRepoNetwork(owner, repo string, opt *List
 		return nil, nil, err
 	}
 
-	events := new([]Event)
+	events := new([]*Event)
 	resp, err := s.client.Do(req, events)
 	if err != nil {
 		return nil, resp, err
@@ -180,7 +180,7 @@ func (s *ActivityService) ListEventsForRepoNetwork(owner, repo string, opt *List
 // ListEventsForOrganization lists public events for an organization.
 //
 // GitHub API docs: http://developer.github.com/v3/activity/events/#list-public-events-for-an-organization
-func (s *ActivityService) ListEventsForOrganization(org string, opt *ListOptions) ([]Event, *Response, error) {
+func (s *ActivityService) ListEventsForOrganization(org string, opt *ListOptions) ([]*Event, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/events", org)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -192,7 +192,7 @@ func (s *ActivityService) ListEventsForOrganization(org string, opt *ListOptions
 		return nil, nil, err
 	}
 
-	events := new([]Event)
+	events := new([]*Event)
 	resp, err := s.client.Do(req, events)
 	if err != nil {
 		return nil, resp, err
@@ -205,7 +205,7 @@ func (s *ActivityService) ListEventsForOrganization(org string, opt *ListOptions
 // true, only public events will be returned.
 //
 // GitHub API docs: http://developer.github.com/v3/activity/events/#list-events-performed-by-a-user
-func (s *ActivityService) ListEventsPerformedByUser(user string, publicOnly bool, opt *ListOptions) ([]Event, *Response, error) {
+func (s *ActivityService) ListEventsPerformedByUser(user string, publicOnly bool, opt *ListOptions) ([]*Event, *Response, error) {
 	var u string
 	if publicOnly {
 		u = fmt.Sprintf("users/%v/events/public", user)
@@ -222,7 +222,7 @@ func (s *ActivityService) ListEventsPerformedByUser(user string, publicOnly bool
 		return nil, nil, err
 	}
 
-	events := new([]Event)
+	events := new([]*Event)
 	resp, err := s.client.Do(req, events)
 	if err != nil {
 		return nil, resp, err
@@ -235,7 +235,7 @@ func (s *ActivityService) ListEventsPerformedByUser(user string, publicOnly bool
 // true, only public events will be returned.
 //
 // GitHub API docs: http://developer.github.com/v3/activity/events/#list-events-that-a-user-has-received
-func (s *ActivityService) ListEventsReceivedByUser(user string, publicOnly bool, opt *ListOptions) ([]Event, *Response, error) {
+func (s *ActivityService) ListEventsReceivedByUser(user string, publicOnly bool, opt *ListOptions) ([]*Event, *Response, error) {
 	var u string
 	if publicOnly {
 		u = fmt.Sprintf("users/%v/received_events/public", user)
@@ -252,7 +252,7 @@ func (s *ActivityService) ListEventsReceivedByUser(user string, publicOnly bool,
 		return nil, nil, err
 	}
 
-	events := new([]Event)
+	events := new([]*Event)
 	resp, err := s.client.Do(req, events)
 	if err != nil {
 		return nil, resp, err
@@ -265,7 +265,7 @@ func (s *ActivityService) ListEventsReceivedByUser(user string, publicOnly bool,
 // must be authenticated as the user to view this.
 //
 // GitHub API docs: http://developer.github.com/v3/activity/events/#list-events-for-an-organization
-func (s *ActivityService) ListUserEventsForOrganization(org, user string, opt *ListOptions) ([]Event, *Response, error) {
+func (s *ActivityService) ListUserEventsForOrganization(org, user string, opt *ListOptions) ([]*Event, *Response, error) {
 	u := fmt.Sprintf("users/%v/events/orgs/%v", user, org)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -277,7 +277,7 @@ func (s *ActivityService) ListUserEventsForOrganization(org, user string, opt *L
 		return nil, nil, err
 	}
 
-	events := new([]Event)
+	events := new([]*Event)
 	resp, err := s.client.Do(req, events)
 	if err != nil {
 		return nil, resp, err

--- a/github/activity_events_test.go
+++ b/github/activity_events_test.go
@@ -31,7 +31,7 @@ func TestActivityService_ListEvents(t *testing.T) {
 		t.Errorf("Activities.ListEvents returned error: %v", err)
 	}
 
-	want := []Event{{ID: String("1")}, {ID: String("2")}}
+	want := []*Event{{ID: String("1")}, {ID: String("2")}}
 	if !reflect.DeepEqual(events, want) {
 		t.Errorf("Activities.ListEvents returned %+v, want %+v", events, want)
 	}
@@ -55,7 +55,7 @@ func TestActivityService_ListRepositoryEvents(t *testing.T) {
 		t.Errorf("Activities.ListRepositoryEvents returned error: %v", err)
 	}
 
-	want := []Event{{ID: String("1")}, {ID: String("2")}}
+	want := []*Event{{ID: String("1")}, {ID: String("2")}}
 	if !reflect.DeepEqual(events, want) {
 		t.Errorf("Activities.ListRepositoryEvents returned %+v, want %+v", events, want)
 	}
@@ -84,7 +84,7 @@ func TestActivityService_ListIssueEventsForRepository(t *testing.T) {
 		t.Errorf("Activities.ListIssueEventsForRepository returned error: %v", err)
 	}
 
-	want := []Event{{ID: String("1")}, {ID: String("2")}}
+	want := []*Event{{ID: String("1")}, {ID: String("2")}}
 	if !reflect.DeepEqual(events, want) {
 		t.Errorf("Activities.ListIssueEventsForRepository returned %+v, want %+v", events, want)
 	}
@@ -113,7 +113,7 @@ func TestActivityService_ListEventsForRepoNetwork(t *testing.T) {
 		t.Errorf("Activities.ListEventsForRepoNetwork returned error: %v", err)
 	}
 
-	want := []Event{{ID: String("1")}, {ID: String("2")}}
+	want := []*Event{{ID: String("1")}, {ID: String("2")}}
 	if !reflect.DeepEqual(events, want) {
 		t.Errorf("Activities.ListEventsForRepoNetwork returned %+v, want %+v", events, want)
 	}
@@ -142,7 +142,7 @@ func TestActivityService_ListEventsForOrganization(t *testing.T) {
 		t.Errorf("Activities.ListEventsForOrganization returned error: %v", err)
 	}
 
-	want := []Event{{ID: String("1")}, {ID: String("2")}}
+	want := []*Event{{ID: String("1")}, {ID: String("2")}}
 	if !reflect.DeepEqual(events, want) {
 		t.Errorf("Activities.ListEventsForOrganization returned %+v, want %+v", events, want)
 	}
@@ -171,7 +171,7 @@ func TestActivityService_ListEventsPerformedByUser_all(t *testing.T) {
 		t.Errorf("Events.ListPerformedByUser returned error: %v", err)
 	}
 
-	want := []Event{{ID: String("1")}, {ID: String("2")}}
+	want := []*Event{{ID: String("1")}, {ID: String("2")}}
 	if !reflect.DeepEqual(events, want) {
 		t.Errorf("Events.ListPerformedByUser returned %+v, want %+v", events, want)
 	}
@@ -191,7 +191,7 @@ func TestActivityService_ListEventsPerformedByUser_publicOnly(t *testing.T) {
 		t.Errorf("Events.ListPerformedByUser returned error: %v", err)
 	}
 
-	want := []Event{{ID: String("1")}, {ID: String("2")}}
+	want := []*Event{{ID: String("1")}, {ID: String("2")}}
 	if !reflect.DeepEqual(events, want) {
 		t.Errorf("Events.ListPerformedByUser returned %+v, want %+v", events, want)
 	}
@@ -220,7 +220,7 @@ func TestActivityService_ListEventsReceivedByUser_all(t *testing.T) {
 		t.Errorf("Events.ListReceivedByUser returned error: %v", err)
 	}
 
-	want := []Event{{ID: String("1")}, {ID: String("2")}}
+	want := []*Event{{ID: String("1")}, {ID: String("2")}}
 	if !reflect.DeepEqual(events, want) {
 		t.Errorf("Events.ListReceivedUser returned %+v, want %+v", events, want)
 	}
@@ -240,7 +240,7 @@ func TestActivityService_ListEventsReceivedByUser_publicOnly(t *testing.T) {
 		t.Errorf("Events.ListReceivedByUser returned error: %v", err)
 	}
 
-	want := []Event{{ID: String("1")}, {ID: String("2")}}
+	want := []*Event{{ID: String("1")}, {ID: String("2")}}
 	if !reflect.DeepEqual(events, want) {
 		t.Errorf("Events.ListReceivedByUser returned %+v, want %+v", events, want)
 	}
@@ -269,7 +269,7 @@ func TestActivityService_ListUserEventsForOrganization(t *testing.T) {
 		t.Errorf("Activities.ListUserEventsForOrganization returned error: %v", err)
 	}
 
-	want := []Event{{ID: String("1")}, {ID: String("2")}}
+	want := []*Event{{ID: String("1")}, {ID: String("2")}}
 	if !reflect.DeepEqual(events, want) {
 		t.Errorf("Activities.ListUserEventsForOrganization returned %+v, want %+v", events, want)
 	}

--- a/github/activity_notifications.go
+++ b/github/activity_notifications.go
@@ -49,7 +49,7 @@ type NotificationListOptions struct {
 // ListNotifications lists all notifications for the authenticated user.
 //
 // GitHub API Docs: https://developer.github.com/v3/activity/notifications/#list-your-notifications
-func (s *ActivityService) ListNotifications(opt *NotificationListOptions) ([]Notification, *Response, error) {
+func (s *ActivityService) ListNotifications(opt *NotificationListOptions) ([]*Notification, *Response, error) {
 	u := fmt.Sprintf("notifications")
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -61,7 +61,7 @@ func (s *ActivityService) ListNotifications(opt *NotificationListOptions) ([]Not
 		return nil, nil, err
 	}
 
-	var notifications []Notification
+	var notifications []*Notification
 	resp, err := s.client.Do(req, &notifications)
 	if err != nil {
 		return nil, resp, err
@@ -74,7 +74,7 @@ func (s *ActivityService) ListNotifications(opt *NotificationListOptions) ([]Not
 // for the authenticated user.
 //
 // GitHub API Docs: https://developer.github.com/v3/activity/notifications/#list-your-notifications-in-a-repository
-func (s *ActivityService) ListRepositoryNotifications(owner, repo string, opt *NotificationListOptions) ([]Notification, *Response, error) {
+func (s *ActivityService) ListRepositoryNotifications(owner, repo string, opt *NotificationListOptions) ([]*Notification, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/notifications", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -86,7 +86,7 @@ func (s *ActivityService) ListRepositoryNotifications(owner, repo string, opt *N
 		return nil, nil, err
 	}
 
-	var notifications []Notification
+	var notifications []*Notification
 	resp, err := s.client.Do(req, &notifications)
 	if err != nil {
 		return nil, resp, err

--- a/github/activity_notifications_test.go
+++ b/github/activity_notifications_test.go
@@ -41,7 +41,7 @@ func TestActivityService_ListNotification(t *testing.T) {
 		t.Errorf("Activity.ListNotifications returned error: %v", err)
 	}
 
-	want := []Notification{{ID: String("1"), Subject: &NotificationSubject{Title: String("t")}}}
+	want := []*Notification{{ID: String("1"), Subject: &NotificationSubject{Title: String("t")}}}
 	if !reflect.DeepEqual(notifications, want) {
 		t.Errorf("Activity.ListNotifications returned %+v, want %+v", notifications, want)
 	}
@@ -61,7 +61,7 @@ func TestActivityService_ListRepositoryNotification(t *testing.T) {
 		t.Errorf("Activity.ListRepositoryNotifications returned error: %v", err)
 	}
 
-	want := []Notification{{ID: String("1")}}
+	want := []*Notification{{ID: String("1")}}
 	if !reflect.DeepEqual(notifications, want) {
 		t.Errorf("Activity.ListRepositoryNotifications returned %+v, want %+v", notifications, want)
 	}

--- a/github/activity_star.go
+++ b/github/activity_star.go
@@ -22,7 +22,7 @@ type Stargazer struct {
 // ListStargazers lists people who have starred the specified repo.
 //
 // GitHub API Docs: https://developer.github.com/v3/activity/starring/#list-stargazers
-func (s *ActivityService) ListStargazers(owner, repo string, opt *ListOptions) ([]Stargazer, *Response, error) {
+func (s *ActivityService) ListStargazers(owner, repo string, opt *ListOptions) ([]*Stargazer, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/stargazers", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -37,7 +37,7 @@ func (s *ActivityService) ListStargazers(owner, repo string, opt *ListOptions) (
 	// TODO: remove custom Accept header when this API fully launches
 	req.Header.Set("Accept", mediaTypeStarringPreview)
 
-	stargazers := new([]Stargazer)
+	stargazers := new([]*Stargazer)
 	resp, err := s.client.Do(req, stargazers)
 	if err != nil {
 		return nil, resp, err
@@ -64,7 +64,7 @@ type ActivityListStarredOptions struct {
 // will list the starred repositories for the authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/activity/starring/#list-repositories-being-starred
-func (s *ActivityService) ListStarred(user string, opt *ActivityListStarredOptions) ([]StarredRepository, *Response, error) {
+func (s *ActivityService) ListStarred(user string, opt *ActivityListStarredOptions) ([]*StarredRepository, *Response, error) {
 	var u string
 	if user != "" {
 		u = fmt.Sprintf("users/%v/starred", user)
@@ -84,7 +84,7 @@ func (s *ActivityService) ListStarred(user string, opt *ActivityListStarredOptio
 	// TODO: remove custom Accept header when this API fully launches
 	req.Header.Set("Accept", mediaTypeStarringPreview)
 
-	repos := new([]StarredRepository)
+	repos := new([]*StarredRepository)
 	resp, err := s.client.Do(req, repos)
 	if err != nil {
 		return nil, resp, err

--- a/github/activity_star_test.go
+++ b/github/activity_star_test.go
@@ -32,7 +32,7 @@ func TestActivityService_ListStargazers(t *testing.T) {
 		t.Errorf("Activity.ListStargazers returned error: %v", err)
 	}
 
-	want := []Stargazer{{StarredAt: &Timestamp{time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC)}, User: &User{ID: Int(1)}}}
+	want := []*Stargazer{{StarredAt: &Timestamp{time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC)}, User: &User{ID: Int(1)}}}
 	if !reflect.DeepEqual(stargazers, want) {
 		t.Errorf("Activity.ListStargazers returned %+v, want %+v", stargazers, want)
 	}
@@ -53,7 +53,7 @@ func TestActivityService_ListStarred_authenticatedUser(t *testing.T) {
 		t.Errorf("Activity.ListStarred returned error: %v", err)
 	}
 
-	want := []StarredRepository{{StarredAt: &Timestamp{time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC)}, Repository: &Repository{ID: Int(1)}}}
+	want := []*StarredRepository{{StarredAt: &Timestamp{time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC)}, Repository: &Repository{ID: Int(1)}}}
 	if !reflect.DeepEqual(repos, want) {
 		t.Errorf("Activity.ListStarred returned %+v, want %+v", repos, want)
 	}
@@ -80,7 +80,7 @@ func TestActivityService_ListStarred_specifiedUser(t *testing.T) {
 		t.Errorf("Activity.ListStarred returned error: %v", err)
 	}
 
-	want := []StarredRepository{{StarredAt: &Timestamp{time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC)}, Repository: &Repository{ID: Int(2)}}}
+	want := []*StarredRepository{{StarredAt: &Timestamp{time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC)}, Repository: &Repository{ID: Int(2)}}}
 	if !reflect.DeepEqual(repos, want) {
 		t.Errorf("Activity.ListStarred returned %+v, want %+v", repos, want)
 	}

--- a/github/activity_watching.go
+++ b/github/activity_watching.go
@@ -25,7 +25,7 @@ type Subscription struct {
 // ListWatchers lists watchers of a particular repo.
 //
 // GitHub API Docs: http://developer.github.com/v3/activity/watching/#list-watchers
-func (s *ActivityService) ListWatchers(owner, repo string, opt *ListOptions) ([]User, *Response, error) {
+func (s *ActivityService) ListWatchers(owner, repo string, opt *ListOptions) ([]*User, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/subscribers", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -37,7 +37,7 @@ func (s *ActivityService) ListWatchers(owner, repo string, opt *ListOptions) ([]
 		return nil, nil, err
 	}
 
-	watchers := new([]User)
+	watchers := new([]*User)
 	resp, err := s.client.Do(req, watchers)
 	if err != nil {
 		return nil, resp, err
@@ -50,7 +50,7 @@ func (s *ActivityService) ListWatchers(owner, repo string, opt *ListOptions) ([]
 // the empty string will fetch watched repos for the authenticated user.
 //
 // GitHub API Docs: https://developer.github.com/v3/activity/watching/#list-repositories-being-watched
-func (s *ActivityService) ListWatched(user string, opt *ListOptions) ([]Repository, *Response, error) {
+func (s *ActivityService) ListWatched(user string, opt *ListOptions) ([]*Repository, *Response, error) {
 	var u string
 	if user != "" {
 		u = fmt.Sprintf("users/%v/subscriptions", user)
@@ -67,7 +67,7 @@ func (s *ActivityService) ListWatched(user string, opt *ListOptions) ([]Reposito
 		return nil, nil, err
 	}
 
-	watched := new([]Repository)
+	watched := new([]*Repository)
 	resp, err := s.client.Do(req, watched)
 	if err != nil {
 		return nil, resp, err

--- a/github/activity_watching_test.go
+++ b/github/activity_watching_test.go
@@ -31,7 +31,7 @@ func TestActivityService_ListWatchers(t *testing.T) {
 		t.Errorf("Activity.ListWatchers returned error: %v", err)
 	}
 
-	want := []User{{ID: Int(1)}}
+	want := []*User{{ID: Int(1)}}
 	if !reflect.DeepEqual(watchers, want) {
 		t.Errorf("Activity.ListWatchers returned %+v, want %+v", watchers, want)
 	}
@@ -54,7 +54,7 @@ func TestActivityService_ListWatched_authenticatedUser(t *testing.T) {
 		t.Errorf("Activity.ListWatched returned error: %v", err)
 	}
 
-	want := []Repository{{ID: Int(1)}}
+	want := []*Repository{{ID: Int(1)}}
 	if !reflect.DeepEqual(watched, want) {
 		t.Errorf("Activity.ListWatched returned %+v, want %+v", watched, want)
 	}
@@ -77,7 +77,7 @@ func TestActivityService_ListWatched_specifiedUser(t *testing.T) {
 		t.Errorf("Activity.ListWatched returned error: %v", err)
 	}
 
-	want := []Repository{{ID: Int(1)}}
+	want := []*Repository{{ID: Int(1)}}
 	if !reflect.DeepEqual(watched, want) {
 		t.Errorf("Activity.ListWatched returned %+v, want %+v", watched, want)
 	}

--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -122,7 +122,7 @@ func (a AuthorizationUpdateRequest) String() string {
 // List the authorizations for the authenticated user.
 //
 // GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations
-func (s *AuthorizationsService) List(opt *ListOptions) ([]Authorization, *Response, error) {
+func (s *AuthorizationsService) List(opt *ListOptions) ([]*Authorization, *Response, error) {
 	u := "authorizations"
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -134,7 +134,7 @@ func (s *AuthorizationsService) List(opt *ListOptions) ([]Authorization, *Respon
 		return nil, nil, err
 	}
 
-	auths := new([]Authorization)
+	auths := new([]*Authorization)
 	resp, err := s.client.Do(req, auths)
 	if err != nil {
 		return nil, resp, err

--- a/github/authorizations_test.go
+++ b/github/authorizations_test.go
@@ -29,7 +29,7 @@ func TestAuthorizationsService_List(t *testing.T) {
 		t.Errorf("Authorizations.List returned error: %v", err)
 	}
 
-	want := []Authorization{{ID: Int(1)}}
+	want := []*Authorization{{ID: Int(1)}}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Authorizations.List returned %+v, want %+v", *got[0].ID, *want[0].ID)
 	}

--- a/github/doc.go
+++ b/github/doc.go
@@ -116,7 +116,7 @@ PullRequestListOptions).  Pages information is available via Response struct.
 		ListOptions: github.ListOptions{PerPage: 10},
 	}
 	// get all pages of results
-	var allRepos []github.Repository
+	var allRepos []*github.Repository
 	for {
 		repos, resp, err := client.Repositories.ListByOrg("github", opt)
 		if err != nil {

--- a/github/gists.go
+++ b/github/gists.go
@@ -67,7 +67,7 @@ type GistListOptions struct {
 // user.
 //
 // GitHub API docs: http://developer.github.com/v3/gists/#list-gists
-func (s *GistsService) List(user string, opt *GistListOptions) ([]Gist, *Response, error) {
+func (s *GistsService) List(user string, opt *GistListOptions) ([]*Gist, *Response, error) {
 	var u string
 	if user != "" {
 		u = fmt.Sprintf("users/%v/gists", user)
@@ -84,7 +84,7 @@ func (s *GistsService) List(user string, opt *GistListOptions) ([]Gist, *Respons
 		return nil, nil, err
 	}
 
-	gists := new([]Gist)
+	gists := new([]*Gist)
 	resp, err := s.client.Do(req, gists)
 	if err != nil {
 		return nil, resp, err
@@ -96,7 +96,7 @@ func (s *GistsService) List(user string, opt *GistListOptions) ([]Gist, *Respons
 // ListAll lists all public gists.
 //
 // GitHub API docs: http://developer.github.com/v3/gists/#list-gists
-func (s *GistsService) ListAll(opt *GistListOptions) ([]Gist, *Response, error) {
+func (s *GistsService) ListAll(opt *GistListOptions) ([]*Gist, *Response, error) {
 	u, err := addOptions("gists/public", opt)
 	if err != nil {
 		return nil, nil, err
@@ -107,7 +107,7 @@ func (s *GistsService) ListAll(opt *GistListOptions) ([]Gist, *Response, error) 
 		return nil, nil, err
 	}
 
-	gists := new([]Gist)
+	gists := new([]*Gist)
 	resp, err := s.client.Do(req, gists)
 	if err != nil {
 		return nil, resp, err
@@ -119,7 +119,7 @@ func (s *GistsService) ListAll(opt *GistListOptions) ([]Gist, *Response, error) 
 // ListStarred lists starred gists of authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/gists/#list-gists
-func (s *GistsService) ListStarred(opt *GistListOptions) ([]Gist, *Response, error) {
+func (s *GistsService) ListStarred(opt *GistListOptions) ([]*Gist, *Response, error) {
 	u, err := addOptions("gists/starred", opt)
 	if err != nil {
 		return nil, nil, err
@@ -130,7 +130,7 @@ func (s *GistsService) ListStarred(opt *GistListOptions) ([]Gist, *Response, err
 		return nil, nil, err
 	}
 
-	gists := new([]Gist)
+	gists := new([]*Gist)
 	resp, err := s.client.Do(req, gists)
 	if err != nil {
 		return nil, resp, err

--- a/github/gists_comments.go
+++ b/github/gists_comments.go
@@ -26,7 +26,7 @@ func (g GistComment) String() string {
 // ListComments lists all comments for a gist.
 //
 // GitHub API docs: http://developer.github.com/v3/gists/comments/#list-comments-on-a-gist
-func (s *GistsService) ListComments(gistID string, opt *ListOptions) ([]GistComment, *Response, error) {
+func (s *GistsService) ListComments(gistID string, opt *ListOptions) ([]*GistComment, *Response, error) {
 	u := fmt.Sprintf("gists/%v/comments", gistID)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -38,7 +38,7 @@ func (s *GistsService) ListComments(gistID string, opt *ListOptions) ([]GistComm
 		return nil, nil, err
 	}
 
-	comments := new([]GistComment)
+	comments := new([]*GistComment)
 	resp, err := s.client.Do(req, comments)
 	if err != nil {
 		return nil, resp, err

--- a/github/gists_comments_test.go
+++ b/github/gists_comments_test.go
@@ -29,7 +29,7 @@ func TestGistsService_ListComments(t *testing.T) {
 		t.Errorf("Gists.Comments returned error: %v", err)
 	}
 
-	want := []GistComment{{ID: Int(1)}}
+	want := []*GistComment{{ID: Int(1)}}
 	if !reflect.DeepEqual(comments, want) {
 		t.Errorf("Gists.ListComments returned %+v, want %+v", comments, want)
 	}

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -34,7 +34,7 @@ func TestGistsService_List_specifiedUser(t *testing.T) {
 		t.Errorf("Gists.List returned error: %v", err)
 	}
 
-	want := []Gist{{ID: String("1")}}
+	want := []*Gist{{ID: String("1")}}
 	if !reflect.DeepEqual(gists, want) {
 		t.Errorf("Gists.List returned %+v, want %+v", gists, want)
 	}
@@ -54,7 +54,7 @@ func TestGistsService_List_authenticatedUser(t *testing.T) {
 		t.Errorf("Gists.List returned error: %v", err)
 	}
 
-	want := []Gist{{ID: String("1")}}
+	want := []*Gist{{ID: String("1")}}
 	if !reflect.DeepEqual(gists, want) {
 		t.Errorf("Gists.List returned %+v, want %+v", gists, want)
 	}
@@ -85,7 +85,7 @@ func TestGistsService_ListAll(t *testing.T) {
 		t.Errorf("Gists.ListAll returned error: %v", err)
 	}
 
-	want := []Gist{{ID: String("1")}}
+	want := []*Gist{{ID: String("1")}}
 	if !reflect.DeepEqual(gists, want) {
 		t.Errorf("Gists.ListAll returned %+v, want %+v", gists, want)
 	}
@@ -111,7 +111,7 @@ func TestGistsService_ListStarred(t *testing.T) {
 		t.Errorf("Gists.ListStarred returned error: %v", err)
 	}
 
-	want := []Gist{{ID: String("1")}}
+	want := []*Gist{{ID: String("1")}}
 	if !reflect.DeepEqual(gists, want) {
 		t.Errorf("Gists.ListStarred returned %+v, want %+v", gists, want)
 	}

--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -75,7 +75,7 @@ type ReferenceListOptions struct {
 // ListRefs lists all refs in a repository.
 //
 // GitHub API docs: http://developer.github.com/v3/git/refs/#get-all-references
-func (s *GitService) ListRefs(owner, repo string, opt *ReferenceListOptions) ([]Reference, *Response, error) {
+func (s *GitService) ListRefs(owner, repo string, opt *ReferenceListOptions) ([]*Reference, *Response, error) {
 	var u string
 	if opt != nil && opt.Type != "" {
 		u = fmt.Sprintf("repos/%v/%v/git/refs/%v", owner, repo, opt.Type)
@@ -92,7 +92,7 @@ func (s *GitService) ListRefs(owner, repo string, opt *ReferenceListOptions) ([]
 		return nil, nil, err
 	}
 
-	var rs []Reference
+	var rs []*Reference
 	resp, err := s.client.Do(req, &rs)
 	if err != nil {
 		return nil, resp, err

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -89,7 +89,7 @@ func TestGitService_ListRefs(t *testing.T) {
 		t.Errorf("Git.ListRefs returned error: %v", err)
 	}
 
-	want := []Reference{
+	want := []*Reference{
 		{
 			Ref: String("refs/heads/branchA"),
 			URL: String("https://api.github.com/repos/o/r/git/refs/heads/branchA"),
@@ -130,7 +130,7 @@ func TestGitService_ListRefs_options(t *testing.T) {
 		t.Errorf("Git.ListRefs returned error: %v", err)
 	}
 
-	want := []Reference{{Ref: String("r")}}
+	want := []*Reference{{Ref: String("r")}}
 	if !reflect.DeepEqual(refs, want) {
 		t.Errorf("Git.ListRefs returned %+v, want %+v", refs, want)
 	}

--- a/github/github.go
+++ b/github/github.go
@@ -29,7 +29,7 @@ const (
 )
 
 const (
-	libraryVersion = "0.1"
+	libraryVersion = "2"
 	defaultBaseURL = "https://api.github.com/"
 	uploadBaseURL  = "https://uploads.github.com/"
 	userAgent      = "go-github/" + libraryVersion

--- a/github/issues.go
+++ b/github/issues.go
@@ -104,7 +104,7 @@ type PullRequestLinks struct {
 // repositories.
 //
 // GitHub API docs: http://developer.github.com/v3/issues/#list-issues
-func (s *IssuesService) List(all bool, opt *IssueListOptions) ([]Issue, *Response, error) {
+func (s *IssuesService) List(all bool, opt *IssueListOptions) ([]*Issue, *Response, error) {
 	var u string
 	if all {
 		u = "issues"
@@ -118,12 +118,12 @@ func (s *IssuesService) List(all bool, opt *IssueListOptions) ([]Issue, *Respons
 // authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/issues/#list-issues
-func (s *IssuesService) ListByOrg(org string, opt *IssueListOptions) ([]Issue, *Response, error) {
+func (s *IssuesService) ListByOrg(org string, opt *IssueListOptions) ([]*Issue, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/issues", org)
 	return s.listIssues(u, opt)
 }
 
-func (s *IssuesService) listIssues(u string, opt *IssueListOptions) ([]Issue, *Response, error) {
+func (s *IssuesService) listIssues(u string, opt *IssueListOptions) ([]*Issue, *Response, error) {
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
@@ -137,7 +137,7 @@ func (s *IssuesService) listIssues(u string, opt *IssueListOptions) ([]Issue, *R
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
-	issues := new([]Issue)
+	issues := new([]*Issue)
 	resp, err := s.client.Do(req, issues)
 	if err != nil {
 		return nil, resp, err
@@ -189,7 +189,7 @@ type IssueListByRepoOptions struct {
 // ListByRepo lists the issues for the specified repository.
 //
 // GitHub API docs: http://developer.github.com/v3/issues/#list-issues-for-a-repository
-func (s *IssuesService) ListByRepo(owner string, repo string, opt *IssueListByRepoOptions) ([]Issue, *Response, error) {
+func (s *IssuesService) ListByRepo(owner string, repo string, opt *IssueListByRepoOptions) ([]*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -204,7 +204,7 @@ func (s *IssuesService) ListByRepo(owner string, repo string, opt *IssueListByRe
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
-	issues := new([]Issue)
+	issues := new([]*Issue)
 	resp, err := s.client.Do(req, issues)
 	if err != nil {
 		return nil, resp, err

--- a/github/issues_assignees.go
+++ b/github/issues_assignees.go
@@ -11,7 +11,7 @@ import "fmt"
 // which issues may be assigned.
 //
 // GitHub API docs: http://developer.github.com/v3/issues/assignees/#list-assignees
-func (s *IssuesService) ListAssignees(owner, repo string, opt *ListOptions) ([]User, *Response, error) {
+func (s *IssuesService) ListAssignees(owner, repo string, opt *ListOptions) ([]*User, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/assignees", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -22,7 +22,7 @@ func (s *IssuesService) ListAssignees(owner, repo string, opt *ListOptions) ([]U
 	if err != nil {
 		return nil, nil, err
 	}
-	assignees := new([]User)
+	assignees := new([]*User)
 	resp, err := s.client.Do(req, assignees)
 	if err != nil {
 		return nil, resp, err

--- a/github/issues_assignees_test.go
+++ b/github/issues_assignees_test.go
@@ -29,7 +29,7 @@ func TestIssuesService_ListAssignees(t *testing.T) {
 		t.Errorf("Issues.ListAssignees returned error: %v", err)
 	}
 
-	want := []User{{ID: Int(1)}}
+	want := []*User{{ID: Int(1)}}
 	if !reflect.DeepEqual(assignees, want) {
 		t.Errorf("Issues.ListAssignees returned %+v, want %+v", assignees, want)
 	}

--- a/github/issues_comments.go
+++ b/github/issues_comments.go
@@ -46,7 +46,7 @@ type IssueListCommentsOptions struct {
 // number of 0 will return all comments on all issues for the repository.
 //
 // GitHub API docs: http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue
-func (s *IssuesService) ListComments(owner string, repo string, number int, opt *IssueListCommentsOptions) ([]IssueComment, *Response, error) {
+func (s *IssuesService) ListComments(owner string, repo string, number int, opt *IssueListCommentsOptions) ([]*IssueComment, *Response, error) {
 	var u string
 	if number == 0 {
 		u = fmt.Sprintf("repos/%v/%v/issues/comments", owner, repo)
@@ -66,7 +66,7 @@ func (s *IssuesService) ListComments(owner string, repo string, number int, opt 
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
-	comments := new([]IssueComment)
+	comments := new([]*IssueComment)
 	resp, err := s.client.Do(req, comments)
 	if err != nil {
 		return nil, resp, err

--- a/github/issues_comments_test.go
+++ b/github/issues_comments_test.go
@@ -41,7 +41,7 @@ func TestIssuesService_ListComments_allIssues(t *testing.T) {
 		t.Errorf("Issues.ListComments returned error: %v", err)
 	}
 
-	want := []IssueComment{{ID: Int(1)}}
+	want := []*IssueComment{{ID: Int(1)}}
 	if !reflect.DeepEqual(comments, want) {
 		t.Errorf("Issues.ListComments returned %+v, want %+v", comments, want)
 	}
@@ -62,7 +62,7 @@ func TestIssuesService_ListComments_specificIssue(t *testing.T) {
 		t.Errorf("Issues.ListComments returned error: %v", err)
 	}
 
-	want := []IssueComment{{ID: Int(1)}}
+	want := []*IssueComment{{ID: Int(1)}}
 	if !reflect.DeepEqual(comments, want) {
 		t.Errorf("Issues.ListComments returned %+v, want %+v", comments, want)
 	}

--- a/github/issues_events.go
+++ b/github/issues_events.go
@@ -73,7 +73,7 @@ type IssueEvent struct {
 // ListIssueEvents lists events for the specified issue.
 //
 // GitHub API docs: https://developer.github.com/v3/issues/events/#list-events-for-an-issue
-func (s *IssuesService) ListIssueEvents(owner, repo string, number int, opt *ListOptions) ([]IssueEvent, *Response, error) {
+func (s *IssuesService) ListIssueEvents(owner, repo string, number int, opt *ListOptions) ([]*IssueEvent, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v/events", owner, repo, number)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -85,7 +85,7 @@ func (s *IssuesService) ListIssueEvents(owner, repo string, number int, opt *Lis
 		return nil, nil, err
 	}
 
-	var events []IssueEvent
+	var events []*IssueEvent
 	resp, err := s.client.Do(req, &events)
 	if err != nil {
 		return nil, resp, err
@@ -97,7 +97,7 @@ func (s *IssuesService) ListIssueEvents(owner, repo string, number int, opt *Lis
 // ListRepositoryEvents lists events for the specified repository.
 //
 // GitHub API docs: https://developer.github.com/v3/issues/events/#list-events-for-a-repository
-func (s *IssuesService) ListRepositoryEvents(owner, repo string, opt *ListOptions) ([]IssueEvent, *Response, error) {
+func (s *IssuesService) ListRepositoryEvents(owner, repo string, opt *ListOptions) ([]*IssueEvent, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/events", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -109,7 +109,7 @@ func (s *IssuesService) ListRepositoryEvents(owner, repo string, opt *ListOption
 		return nil, nil, err
 	}
 
-	var events []IssueEvent
+	var events []*IssueEvent
 	resp, err := s.client.Do(req, &events)
 	if err != nil {
 		return nil, resp, err

--- a/github/issues_events_test.go
+++ b/github/issues_events_test.go
@@ -31,7 +31,7 @@ func TestIssuesService_ListIssueEvents(t *testing.T) {
 		t.Errorf("Issues.ListIssueEvents returned error: %v", err)
 	}
 
-	want := []IssueEvent{{ID: Int(1)}}
+	want := []*IssueEvent{{ID: Int(1)}}
 	if !reflect.DeepEqual(events, want) {
 		t.Errorf("Issues.ListIssueEvents returned %+v, want %+v", events, want)
 	}
@@ -56,7 +56,7 @@ func TestIssuesService_ListRepositoryEvents(t *testing.T) {
 		t.Errorf("Issues.ListRepositoryEvents returned error: %v", err)
 	}
 
-	want := []IssueEvent{{ID: Int(1)}}
+	want := []*IssueEvent{{ID: Int(1)}}
 	if !reflect.DeepEqual(events, want) {
 		t.Errorf("Issues.ListRepositoryEvents returned %+v, want %+v", events, want)
 	}

--- a/github/issues_labels.go
+++ b/github/issues_labels.go
@@ -21,7 +21,7 @@ func (l Label) String() string {
 // ListLabels lists all labels for a repository.
 //
 // GitHub API docs: http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository
-func (s *IssuesService) ListLabels(owner string, repo string, opt *ListOptions) ([]Label, *Response, error) {
+func (s *IssuesService) ListLabels(owner string, repo string, opt *ListOptions) ([]*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/labels", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -33,7 +33,7 @@ func (s *IssuesService) ListLabels(owner string, repo string, opt *ListOptions) 
 		return nil, nil, err
 	}
 
-	labels := new([]Label)
+	labels := new([]*Label)
 	resp, err := s.client.Do(req, labels)
 	if err != nil {
 		return nil, resp, err
@@ -114,7 +114,7 @@ func (s *IssuesService) DeleteLabel(owner string, repo string, name string) (*Re
 // ListLabelsByIssue lists all labels for an issue.
 //
 // GitHub API docs: http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository
-func (s *IssuesService) ListLabelsByIssue(owner string, repo string, number int, opt *ListOptions) ([]Label, *Response, error) {
+func (s *IssuesService) ListLabelsByIssue(owner string, repo string, number int, opt *ListOptions) ([]*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels", owner, repo, number)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -126,7 +126,7 @@ func (s *IssuesService) ListLabelsByIssue(owner string, repo string, number int,
 		return nil, nil, err
 	}
 
-	labels := new([]Label)
+	labels := new([]*Label)
 	resp, err := s.client.Do(req, labels)
 	if err != nil {
 		return nil, resp, err
@@ -138,14 +138,14 @@ func (s *IssuesService) ListLabelsByIssue(owner string, repo string, number int,
 // AddLabelsToIssue adds labels to an issue.
 //
 // GitHub API docs: http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository
-func (s *IssuesService) AddLabelsToIssue(owner string, repo string, number int, labels []string) ([]Label, *Response, error) {
+func (s *IssuesService) AddLabelsToIssue(owner string, repo string, number int, labels []string) ([]*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels", owner, repo, number)
 	req, err := s.client.NewRequest("POST", u, labels)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	l := new([]Label)
+	l := new([]*Label)
 	resp, err := s.client.Do(req, l)
 	if err != nil {
 		return nil, resp, err
@@ -169,14 +169,14 @@ func (s *IssuesService) RemoveLabelForIssue(owner string, repo string, number in
 // ReplaceLabelsForIssue replaces all labels for an issue.
 //
 // GitHub API docs: http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue
-func (s *IssuesService) ReplaceLabelsForIssue(owner string, repo string, number int, labels []string) ([]Label, *Response, error) {
+func (s *IssuesService) ReplaceLabelsForIssue(owner string, repo string, number int, labels []string) ([]*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels", owner, repo, number)
 	req, err := s.client.NewRequest("PUT", u, labels)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	l := new([]Label)
+	l := new([]*Label)
 	resp, err := s.client.Do(req, l)
 	if err != nil {
 		return nil, resp, err
@@ -200,7 +200,7 @@ func (s *IssuesService) RemoveLabelsForIssue(owner string, repo string, number i
 // ListLabelsForMilestone lists labels for every issue in a milestone.
 //
 // GitHub API docs: http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone
-func (s *IssuesService) ListLabelsForMilestone(owner string, repo string, number int, opt *ListOptions) ([]Label, *Response, error) {
+func (s *IssuesService) ListLabelsForMilestone(owner string, repo string, number int, opt *ListOptions) ([]*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/milestones/%d/labels", owner, repo, number)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -212,7 +212,7 @@ func (s *IssuesService) ListLabelsForMilestone(owner string, repo string, number
 		return nil, nil, err
 	}
 
-	labels := new([]Label)
+	labels := new([]*Label)
 	resp, err := s.client.Do(req, labels)
 	if err != nil {
 		return nil, resp, err

--- a/github/issues_labels_test.go
+++ b/github/issues_labels_test.go
@@ -29,7 +29,7 @@ func TestIssuesService_ListLabels(t *testing.T) {
 		t.Errorf("Issues.ListLabels returned error: %v", err)
 	}
 
-	want := []Label{{Name: String("a")}, {Name: String("b")}}
+	want := []*Label{{Name: String("a")}, {Name: String("b")}}
 	if !reflect.DeepEqual(labels, want) {
 		t.Errorf("Issues.ListLabels returned %+v, want %+v", labels, want)
 	}
@@ -168,7 +168,7 @@ func TestIssuesService_ListLabelsByIssue(t *testing.T) {
 		t.Errorf("Issues.ListLabelsByIssue returned error: %v", err)
 	}
 
-	want := []Label{{Name: String("a")}, {Name: String("b")}}
+	want := []*Label{{Name: String("a")}, {Name: String("b")}}
 	if !reflect.DeepEqual(labels, want) {
 		t.Errorf("Issues.ListLabelsByIssue returned %+v, want %+v", labels, want)
 	}
@@ -202,7 +202,7 @@ func TestIssuesService_AddLabelsToIssue(t *testing.T) {
 		t.Errorf("Issues.AddLabelsToIssue returned error: %v", err)
 	}
 
-	want := []Label{{URL: String("u")}}
+	want := []*Label{{URL: String("u")}}
 	if !reflect.DeepEqual(labels, want) {
 		t.Errorf("Issues.AddLabelsToIssue returned %+v, want %+v", labels, want)
 	}
@@ -255,7 +255,7 @@ func TestIssuesService_ReplaceLabelsForIssue(t *testing.T) {
 		t.Errorf("Issues.ReplaceLabelsForIssue returned error: %v", err)
 	}
 
-	want := []Label{{URL: String("u")}}
+	want := []*Label{{URL: String("u")}}
 	if !reflect.DeepEqual(labels, want) {
 		t.Errorf("Issues.ReplaceLabelsForIssue returned %+v, want %+v", labels, want)
 	}
@@ -301,7 +301,7 @@ func TestIssuesService_ListLabelsForMilestone(t *testing.T) {
 		t.Errorf("Issues.ListLabelsForMilestone returned error: %v", err)
 	}
 
-	want := []Label{{Name: String("a")}, {Name: String("b")}}
+	want := []*Label{{Name: String("a")}, {Name: String("b")}}
 	if !reflect.DeepEqual(labels, want) {
 		t.Errorf("Issues.ListLabelsForMilestone returned %+v, want %+v", labels, want)
 	}

--- a/github/issues_milestones.go
+++ b/github/issues_milestones.go
@@ -54,7 +54,7 @@ type MilestoneListOptions struct {
 // ListMilestones lists all milestones for a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
-func (s *IssuesService) ListMilestones(owner string, repo string, opt *MilestoneListOptions) ([]Milestone, *Response, error) {
+func (s *IssuesService) ListMilestones(owner string, repo string, opt *MilestoneListOptions) ([]*Milestone, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/milestones", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -66,7 +66,7 @@ func (s *IssuesService) ListMilestones(owner string, repo string, opt *Milestone
 		return nil, nil, err
 	}
 
-	milestones := new([]Milestone)
+	milestones := new([]*Milestone)
 	resp, err := s.client.Do(req, milestones)
 	if err != nil {
 		return nil, resp, err

--- a/github/issues_milestones_test.go
+++ b/github/issues_milestones_test.go
@@ -34,7 +34,7 @@ func TestIssuesService_ListMilestones(t *testing.T) {
 		t.Errorf("IssuesService.ListMilestones returned error: %v", err)
 	}
 
-	want := []Milestone{{Number: Int(1)}}
+	want := []*Milestone{{Number: Int(1)}}
 	if !reflect.DeepEqual(milestones, want) {
 		t.Errorf("IssuesService.ListMilestones returned %+v, want %+v", milestones, want)
 	}

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -44,7 +44,7 @@ func TestIssuesService_List_all(t *testing.T) {
 		t.Errorf("Issues.List returned error: %v", err)
 	}
 
-	want := []Issue{{Number: Int(1)}}
+	want := []*Issue{{Number: Int(1)}}
 	if !reflect.DeepEqual(issues, want) {
 		t.Errorf("Issues.List returned %+v, want %+v", issues, want)
 	}
@@ -65,7 +65,7 @@ func TestIssuesService_List_owned(t *testing.T) {
 		t.Errorf("Issues.List returned error: %v", err)
 	}
 
-	want := []Issue{{Number: Int(1)}}
+	want := []*Issue{{Number: Int(1)}}
 	if !reflect.DeepEqual(issues, want) {
 		t.Errorf("Issues.List returned %+v, want %+v", issues, want)
 	}
@@ -86,7 +86,7 @@ func TestIssuesService_ListByOrg(t *testing.T) {
 		t.Errorf("Issues.ListByOrg returned error: %v", err)
 	}
 
-	want := []Issue{{Number: Int(1)}}
+	want := []*Issue{{Number: Int(1)}}
 	if !reflect.DeepEqual(issues, want) {
 		t.Errorf("Issues.List returned %+v, want %+v", issues, want)
 	}
@@ -128,7 +128,7 @@ func TestIssuesService_ListByRepo(t *testing.T) {
 		t.Errorf("Issues.ListByOrg returned error: %v", err)
 	}
 
-	want := []Issue{{Number: Int(1)}}
+	want := []*Issue{{Number: Int(1)}}
 	if !reflect.DeepEqual(issues, want) {
 		t.Errorf("Issues.List returned %+v, want %+v", issues, want)
 	}

--- a/github/licenses.go
+++ b/github/licenses.go
@@ -39,7 +39,7 @@ func (l License) String() string {
 // List popular open source licenses.
 //
 // GitHub API docs: https://developer.github.com/v3/licenses/#list-all-licenses
-func (s *LicensesService) List() ([]License, *Response, error) {
+func (s *LicensesService) List() ([]*License, *Response, error) {
 	req, err := s.client.NewRequest("GET", "licenses", nil)
 	if err != nil {
 		return nil, nil, err
@@ -48,7 +48,7 @@ func (s *LicensesService) List() ([]License, *Response, error) {
 	// TODO: remove custom Accept header when this API fully launches
 	req.Header.Set("Accept", mediaTypeLicensesPreview)
 
-	licenses := new([]License)
+	licenses := new([]*License)
 	resp, err := s.client.Do(req, licenses)
 	if err != nil {
 		return nil, resp, err

--- a/github/licenses_test.go
+++ b/github/licenses_test.go
@@ -27,7 +27,7 @@ func TestLicensesService_List(t *testing.T) {
 		t.Errorf("Licenses.List returned error: %v", err)
 	}
 
-	want := []License{{
+	want := []*License{{
 		Key:  String("mit"),
 		Name: String("MIT"),
 		URL:  String("https://api.github.com/licenses/mit"),

--- a/github/migrations_source_import.go
+++ b/github/migrations_source_import.go
@@ -220,7 +220,7 @@ func (s *MigrationService) UpdateImport(owner, repo string, in *Import) (*Import
 // information.
 //
 // GitHub API docs: https://developer.github.com/v3/migration/source_imports/#get-commit-authors
-func (s *MigrationService) CommitAuthors(owner, repo string) ([]SourceImportAuthor, *Response, error) {
+func (s *MigrationService) CommitAuthors(owner, repo string) ([]*SourceImportAuthor, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/import/authors", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -230,7 +230,7 @@ func (s *MigrationService) CommitAuthors(owner, repo string) ([]SourceImportAuth
 	// TODO: remove custom Accept header when this API fully launches
 	req.Header.Set("Accept", mediaTypeImportPreview)
 
-	authors := new([]SourceImportAuthor)
+	authors := new([]*SourceImportAuthor)
 	resp, err := s.client.Do(req, authors)
 	if err != nil {
 		return nil, resp, err
@@ -290,7 +290,7 @@ func (s *MigrationService) SetLFSPreference(owner, repo string, in *Import) (*Im
 // LargeFiles lists files larger than 100MB found during the import.
 //
 // GitHub API docs: https://developer.github.com/v3/migration/source_imports/#get-large-files
-func (s *MigrationService) LargeFiles(owner, repo string) ([]LargeFile, *Response, error) {
+func (s *MigrationService) LargeFiles(owner, repo string) ([]*LargeFile, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/import/large_files", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -300,7 +300,7 @@ func (s *MigrationService) LargeFiles(owner, repo string) ([]LargeFile, *Respons
 	// TODO: remove custom Accept header when this API fully launches
 	req.Header.Set("Accept", mediaTypeImportPreview)
 
-	files := new([]LargeFile)
+	files := new([]*LargeFile)
 	resp, err := s.client.Do(req, files)
 	if err != nil {
 		return nil, resp, err

--- a/github/migrations_source_import_test.go
+++ b/github/migrations_source_import_test.go
@@ -117,7 +117,7 @@ func TestMigrationService_CommitAuthors(t *testing.T) {
 	if err != nil {
 		t.Errorf("CommitAuthors returned error: %v", err)
 	}
-	want := []SourceImportAuthor{
+	want := []*SourceImportAuthor{
 		{ID: Int(1), Name: String("a")},
 		{ID: Int(2), Name: String("b")},
 	}
@@ -199,7 +199,7 @@ func TestMigrationService_LargeFiles(t *testing.T) {
 	if err != nil {
 		t.Errorf("LargeFiles returned error: %v", err)
 	}
-	want := []LargeFile{
+	want := []*LargeFile{
 		{OID: String("a")},
 		{OID: String("b")},
 	}

--- a/github/misc.go
+++ b/github/misc.go
@@ -180,14 +180,14 @@ func (s *ServiceHook) String() string {
 // ListServiceHooks lists all of the available service hooks.
 //
 // GitHub API docs: https://developer.github.com/webhooks/#services
-func (c *Client) ListServiceHooks() ([]ServiceHook, *Response, error) {
+func (c *Client) ListServiceHooks() ([]*ServiceHook, *Response, error) {
 	u := "hooks"
 	req, err := c.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	hooks := new([]ServiceHook)
+	hooks := new([]*ServiceHook)
 	resp, err := c.Do(req, hooks)
 	if err != nil {
 		return nil, resp, err

--- a/github/misc_test.go
+++ b/github/misc_test.go
@@ -158,7 +158,7 @@ func TestRepositoriesService_ListServiceHooks(t *testing.T) {
 		t.Errorf("Repositories.ListHooks returned error: %v", err)
 	}
 
-	want := []ServiceHook{{
+	want := []*ServiceHook{{
 		Name:            String("n"),
 		Events:          []string{"e"},
 		SupportedEvents: []string{"s"},

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -84,7 +84,7 @@ type OrganizationsListOptions struct {
 // as the opts.Since parameter for the next call.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/#list-all-organizations
-func (s *OrganizationsService) ListAll(opt *OrganizationsListOptions) ([]Organization, *Response, error) {
+func (s *OrganizationsService) ListAll(opt *OrganizationsListOptions) ([]*Organization, *Response, error) {
 	u, err := addOptions("organizations", opt)
 	if err != nil {
 		return nil, nil, err
@@ -95,7 +95,7 @@ func (s *OrganizationsService) ListAll(opt *OrganizationsListOptions) ([]Organiz
 		return nil, nil, err
 	}
 
-	orgs := []Organization{}
+	orgs := []*Organization{}
 	resp, err := s.client.Do(req, &orgs)
 	if err != nil {
 		return nil, resp, err
@@ -107,7 +107,7 @@ func (s *OrganizationsService) ListAll(opt *OrganizationsListOptions) ([]Organiz
 // organizations for the authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/orgs/#list-user-organizations
-func (s *OrganizationsService) List(user string, opt *ListOptions) ([]Organization, *Response, error) {
+func (s *OrganizationsService) List(user string, opt *ListOptions) ([]*Organization, *Response, error) {
 	var u string
 	if user != "" {
 		u = fmt.Sprintf("users/%v/orgs", user)
@@ -124,7 +124,7 @@ func (s *OrganizationsService) List(user string, opt *ListOptions) ([]Organizati
 		return nil, nil, err
 	}
 
-	orgs := new([]Organization)
+	orgs := new([]*Organization)
 	resp, err := s.client.Do(req, orgs)
 	if err != nil {
 		return nil, resp, err

--- a/github/orgs_hooks.go
+++ b/github/orgs_hooks.go
@@ -10,7 +10,7 @@ import "fmt"
 // ListHooks lists all Hooks for the specified organization.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/hooks/#list-hooks
-func (s *OrganizationsService) ListHooks(org string, opt *ListOptions) ([]Hook, *Response, error) {
+func (s *OrganizationsService) ListHooks(org string, opt *ListOptions) ([]*Hook, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/hooks", org)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -22,7 +22,7 @@ func (s *OrganizationsService) ListHooks(org string, opt *ListOptions) ([]Hook, 
 		return nil, nil, err
 	}
 
-	hooks := new([]Hook)
+	hooks := new([]*Hook)
 	resp, err := s.client.Do(req, hooks)
 	if err != nil {
 		return nil, resp, err

--- a/github/orgs_hooks_test.go
+++ b/github/orgs_hooks_test.go
@@ -30,7 +30,7 @@ func TestOrganizationsService_ListHooks(t *testing.T) {
 		t.Errorf("Organizations.ListHooks returned error: %v", err)
 	}
 
-	want := []Hook{{ID: Int(1)}, {ID: Int(2)}}
+	want := []*Hook{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(hooks, want) {
 		t.Errorf("Organizations.ListHooks returned %+v, want %+v", hooks, want)
 	}

--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -69,7 +69,7 @@ type ListMembersOptions struct {
 // public members, otherwise it will only return public members.
 //
 // GitHub API docs: http://developer.github.com/v3/orgs/members/#members-list
-func (s *OrganizationsService) ListMembers(org string, opt *ListMembersOptions) ([]User, *Response, error) {
+func (s *OrganizationsService) ListMembers(org string, opt *ListMembersOptions) ([]*User, *Response, error) {
 	var u string
 	if opt != nil && opt.PublicOnly {
 		u = fmt.Sprintf("orgs/%v/public_members", org)
@@ -86,7 +86,7 @@ func (s *OrganizationsService) ListMembers(org string, opt *ListMembersOptions) 
 		return nil, nil, err
 	}
 
-	members := new([]User)
+	members := new([]*User)
 	resp, err := s.client.Do(req, members)
 	if err != nil {
 		return nil, resp, err
@@ -178,7 +178,7 @@ type ListOrgMembershipsOptions struct {
 // ListOrgMemberships lists the organization memberships for the authenticated user.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/members/#list-your-organization-memberships
-func (s *OrganizationsService) ListOrgMemberships(opt *ListOrgMembershipsOptions) ([]Membership, *Response, error) {
+func (s *OrganizationsService) ListOrgMemberships(opt *ListOrgMembershipsOptions) ([]*Membership, *Response, error) {
 	u := "user/memberships/orgs"
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -190,7 +190,7 @@ func (s *OrganizationsService) ListOrgMemberships(opt *ListOrgMembershipsOptions
 		return nil, nil, err
 	}
 
-	var memberships []Membership
+	var memberships []*Membership
 	resp, err := s.client.Do(req, &memberships)
 	if err != nil {
 		return nil, resp, err

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -38,7 +38,7 @@ func TestOrganizationsService_ListMembers(t *testing.T) {
 		t.Errorf("Organizations.ListMembers returned error: %v", err)
 	}
 
-	want := []User{{ID: Int(1)}}
+	want := []*User{{ID: Int(1)}}
 	if !reflect.DeepEqual(members, want) {
 		t.Errorf("Organizations.ListMembers returned %+v, want %+v", members, want)
 	}
@@ -64,7 +64,7 @@ func TestOrganizationsService_ListMembers_public(t *testing.T) {
 		t.Errorf("Organizations.ListMembers returned error: %v", err)
 	}
 
-	want := []User{{ID: Int(1)}}
+	want := []*User{{ID: Int(1)}}
 	if !reflect.DeepEqual(members, want) {
 		t.Errorf("Organizations.ListMembers returned %+v, want %+v", members, want)
 	}
@@ -235,7 +235,7 @@ func TestOrganizationsService_ListOrgMemberships(t *testing.T) {
 		t.Errorf("Organizations.ListOrgMemberships returned error: %v", err)
 	}
 
-	want := []Membership{{URL: String("u")}}
+	want := []*Membership{{URL: String("u")}}
 	if !reflect.DeepEqual(memberships, want) {
 		t.Errorf("Organizations.ListOrgMemberships returned %+v, want %+v", memberships, want)
 	}

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -44,7 +44,7 @@ func (t Team) String() string {
 // ListTeams lists all of the teams for an organization.
 //
 // GitHub API docs: http://developer.github.com/v3/orgs/teams/#list-teams
-func (s *OrganizationsService) ListTeams(org string, opt *ListOptions) ([]Team, *Response, error) {
+func (s *OrganizationsService) ListTeams(org string, opt *ListOptions) ([]*Team, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams", org)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -56,7 +56,7 @@ func (s *OrganizationsService) ListTeams(org string, opt *ListOptions) ([]Team, 
 		return nil, nil, err
 	}
 
-	teams := new([]Team)
+	teams := new([]*Team)
 	resp, err := s.client.Do(req, teams)
 	if err != nil {
 		return nil, resp, err
@@ -149,7 +149,7 @@ type OrganizationListTeamMembersOptions struct {
 // team.
 //
 // GitHub API docs: http://developer.github.com/v3/orgs/teams/#list-team-members
-func (s *OrganizationsService) ListTeamMembers(team int, opt *OrganizationListTeamMembersOptions) ([]User, *Response, error) {
+func (s *OrganizationsService) ListTeamMembers(team int, opt *OrganizationListTeamMembersOptions) ([]*User, *Response, error) {
 	u := fmt.Sprintf("teams/%v/members", team)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -161,7 +161,7 @@ func (s *OrganizationsService) ListTeamMembers(team int, opt *OrganizationListTe
 		return nil, nil, err
 	}
 
-	members := new([]User)
+	members := new([]*User)
 	resp, err := s.client.Do(req, members)
 	if err != nil {
 		return nil, resp, err
@@ -188,7 +188,7 @@ func (s *OrganizationsService) IsTeamMember(team int, user string) (bool, *Respo
 // ListTeamRepos lists the repositories that the specified team has access to.
 //
 // GitHub API docs: http://developer.github.com/v3/orgs/teams/#list-team-repos
-func (s *OrganizationsService) ListTeamRepos(team int, opt *ListOptions) ([]Repository, *Response, error) {
+func (s *OrganizationsService) ListTeamRepos(team int, opt *ListOptions) ([]*Repository, *Response, error) {
 	u := fmt.Sprintf("teams/%v/repos", team)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -200,7 +200,7 @@ func (s *OrganizationsService) ListTeamRepos(team int, opt *ListOptions) ([]Repo
 		return nil, nil, err
 	}
 
-	repos := new([]Repository)
+	repos := new([]*Repository)
 	resp, err := s.client.Do(req, repos)
 	if err != nil {
 		return nil, resp, err
@@ -277,7 +277,7 @@ func (s *OrganizationsService) RemoveTeamRepo(team int, owner string, repo strin
 
 // ListUserTeams lists a user's teams
 // GitHub API docs: https://developer.github.com/v3/orgs/teams/#list-user-teams
-func (s *OrganizationsService) ListUserTeams(opt *ListOptions) ([]Team, *Response, error) {
+func (s *OrganizationsService) ListUserTeams(opt *ListOptions) ([]*Team, *Response, error) {
 	u := "user/teams"
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -289,7 +289,7 @@ func (s *OrganizationsService) ListUserTeams(opt *ListOptions) ([]Team, *Respons
 		return nil, nil, err
 	}
 
-	teams := new([]Team)
+	teams := new([]*Team)
 	resp, err := s.client.Do(req, teams)
 	if err != nil {
 		return nil, resp, err

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -29,7 +29,7 @@ func TestOrganizationsService_ListTeams(t *testing.T) {
 		t.Errorf("Organizations.ListTeams returned error: %v", err)
 	}
 
-	want := []Team{{ID: Int(1)}}
+	want := []*Team{{ID: Int(1)}}
 	if !reflect.DeepEqual(teams, want) {
 		t.Errorf("Organizations.ListTeams returned %+v, want %+v", teams, want)
 	}
@@ -153,7 +153,7 @@ func TestOrganizationsService_ListTeamMembers(t *testing.T) {
 		t.Errorf("Organizations.ListTeamMembers returned error: %v", err)
 	}
 
-	want := []User{{ID: Int(1)}}
+	want := []*User{{ID: Int(1)}}
 	if !reflect.DeepEqual(members, want) {
 		t.Errorf("Organizations.ListTeamMembers returned %+v, want %+v", members, want)
 	}
@@ -276,7 +276,7 @@ func TestOrganizationsService_ListTeamRepos(t *testing.T) {
 		t.Errorf("Organizations.ListTeamRepos returned error: %v", err)
 	}
 
-	want := []Repository{{ID: Int(1)}}
+	want := []*Repository{{ID: Int(1)}}
 	if !reflect.DeepEqual(members, want) {
 		t.Errorf("Organizations.ListTeamRepos returned %+v, want %+v", members, want)
 	}
@@ -494,7 +494,7 @@ func TestOrganizationsService_ListUserTeams(t *testing.T) {
 		t.Errorf("Organizations.ListUserTeams returned error: %v", err)
 	}
 
-	want := []Team{{ID: Int(1)}}
+	want := []*Team{{ID: Int(1)}}
 	if !reflect.DeepEqual(teams, want) {
 		t.Errorf("Organizations.ListUserTeams returned %+v, want %+v", teams, want)
 	}

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -30,7 +30,7 @@ func TestOrganizationsService_ListAll(t *testing.T) {
 		t.Errorf("Organizations.ListAll returned error: %v", err)
 	}
 
-	want := []Organization{{ID: Int(4314092)}}
+	want := []*Organization{{ID: Int(4314092)}}
 	if !reflect.DeepEqual(orgs, want) {
 		t.Errorf("Organizations.ListAll returned %+v, want %+v", orgs, want)
 	}
@@ -50,7 +50,7 @@ func TestOrganizationsService_List_authenticatedUser(t *testing.T) {
 		t.Errorf("Organizations.List returned error: %v", err)
 	}
 
-	want := []Organization{{ID: Int(1)}, {ID: Int(2)}}
+	want := []*Organization{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(orgs, want) {
 		t.Errorf("Organizations.List returned %+v, want %+v", orgs, want)
 	}
@@ -72,7 +72,7 @@ func TestOrganizationsService_List_specifiedUser(t *testing.T) {
 		t.Errorf("Organizations.List returned error: %v", err)
 	}
 
-	want := []Organization{{ID: Int(1)}, {ID: Int(2)}}
+	want := []*Organization{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(orgs, want) {
 		t.Errorf("Organizations.List returned %+v, want %+v", orgs, want)
 	}

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -91,7 +91,7 @@ type PullRequestListOptions struct {
 // List the pull requests for the specified repository.
 //
 // GitHub API docs: http://developer.github.com/v3/pulls/#list-pull-requests
-func (s *PullRequestsService) List(owner string, repo string, opt *PullRequestListOptions) ([]PullRequest, *Response, error) {
+func (s *PullRequestsService) List(owner string, repo string, opt *PullRequestListOptions) ([]*PullRequest, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -103,7 +103,7 @@ func (s *PullRequestsService) List(owner string, repo string, opt *PullRequestLi
 		return nil, nil, err
 	}
 
-	pulls := new([]PullRequest)
+	pulls := new([]*PullRequest)
 	resp, err := s.client.Do(req, pulls)
 	if err != nil {
 		return nil, resp, err
@@ -181,7 +181,7 @@ func (s *PullRequestsService) Edit(owner string, repo string, number int, pull *
 // ListCommits lists the commits in a pull request.
 //
 // GitHub API docs: https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request
-func (s *PullRequestsService) ListCommits(owner string, repo string, number int, opt *ListOptions) ([]RepositoryCommit, *Response, error) {
+func (s *PullRequestsService) ListCommits(owner string, repo string, number int, opt *ListOptions) ([]*RepositoryCommit, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/commits", owner, repo, number)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -193,7 +193,7 @@ func (s *PullRequestsService) ListCommits(owner string, repo string, number int,
 		return nil, nil, err
 	}
 
-	commits := new([]RepositoryCommit)
+	commits := new([]*RepositoryCommit)
 	resp, err := s.client.Do(req, commits)
 	if err != nil {
 		return nil, resp, err
@@ -205,7 +205,7 @@ func (s *PullRequestsService) ListCommits(owner string, repo string, number int,
 // ListFiles lists the files in a pull request.
 //
 // GitHub API docs: https://developer.github.com/v3/pulls/#list-pull-requests-files
-func (s *PullRequestsService) ListFiles(owner string, repo string, number int, opt *ListOptions) ([]CommitFile, *Response, error) {
+func (s *PullRequestsService) ListFiles(owner string, repo string, number int, opt *ListOptions) ([]*CommitFile, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/files", owner, repo, number)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -217,7 +217,7 @@ func (s *PullRequestsService) ListFiles(owner string, repo string, number int, o
 		return nil, nil, err
 	}
 
-	commitFiles := new([]CommitFile)
+	commitFiles := new([]*CommitFile)
 	resp, err := s.client.Do(req, commitFiles)
 	if err != nil {
 		return nil, resp, err

--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -54,7 +54,7 @@ type PullRequestListCommentsOptions struct {
 // the repository.
 //
 // GitHub API docs: https://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request
-func (s *PullRequestsService) ListComments(owner string, repo string, number int, opt *PullRequestListCommentsOptions) ([]PullRequestComment, *Response, error) {
+func (s *PullRequestsService) ListComments(owner string, repo string, number int, opt *PullRequestListCommentsOptions) ([]*PullRequestComment, *Response, error) {
 	var u string
 	if number == 0 {
 		u = fmt.Sprintf("repos/%v/%v/pulls/comments", owner, repo)
@@ -74,7 +74,7 @@ func (s *PullRequestsService) ListComments(owner string, repo string, number int
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
-	comments := new([]PullRequestComment)
+	comments := new([]*PullRequestComment)
 	resp, err := s.client.Do(req, comments)
 	if err != nil {
 		return nil, resp, err

--- a/github/pulls_comments_test.go
+++ b/github/pulls_comments_test.go
@@ -41,7 +41,7 @@ func TestPullRequestsService_ListComments_allPulls(t *testing.T) {
 		t.Errorf("PullRequests.ListComments returned error: %v", err)
 	}
 
-	want := []PullRequestComment{{ID: Int(1)}}
+	want := []*PullRequestComment{{ID: Int(1)}}
 	if !reflect.DeepEqual(pulls, want) {
 		t.Errorf("PullRequests.ListComments returned %+v, want %+v", pulls, want)
 	}
@@ -62,7 +62,7 @@ func TestPullRequestsService_ListComments_specificPull(t *testing.T) {
 		t.Errorf("PullRequests.ListComments returned error: %v", err)
 	}
 
-	want := []PullRequestComment{{ID: Int(1)}}
+	want := []*PullRequestComment{{ID: Int(1)}}
 	if !reflect.DeepEqual(pulls, want) {
 		t.Errorf("PullRequests.ListComments returned %+v, want %+v", pulls, want)
 	}

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -36,7 +36,7 @@ func TestPullRequestsService_List(t *testing.T) {
 		t.Errorf("PullRequests.List returned error: %v", err)
 	}
 
-	want := []PullRequest{{Number: Int(1)}}
+	want := []*PullRequest{{Number: Int(1)}}
 	if !reflect.DeepEqual(pulls, want) {
 		t.Errorf("PullRequests.List returned %+v, want %+v", pulls, want)
 	}
@@ -226,7 +226,7 @@ func TestPullRequestsService_ListCommits(t *testing.T) {
 		t.Errorf("PullRequests.ListCommits returned error: %v", err)
 	}
 
-	want := []RepositoryCommit{
+	want := []*RepositoryCommit{
 		{
 			SHA: String("3"),
 			Parents: []Commit{
@@ -285,7 +285,7 @@ func TestPullRequestsService_ListFiles(t *testing.T) {
 		t.Errorf("PullRequests.ListFiles returned error: %v", err)
 	}
 
-	want := []CommitFile{
+	want := []*CommitFile{
 		{
 			SHA:       String("6dcb09b5b57875f334f61aebed695e2e4193db5e"),
 			Filename:  String("file1.txt"),

--- a/github/repos.go
+++ b/github/repos.go
@@ -129,7 +129,7 @@ type RepositoryListOptions struct {
 // repositories for the authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/#list-user-repositories
-func (s *RepositoriesService) List(user string, opt *RepositoryListOptions) ([]Repository, *Response, error) {
+func (s *RepositoriesService) List(user string, opt *RepositoryListOptions) ([]*Repository, *Response, error) {
 	var u string
 	if user != "" {
 		u = fmt.Sprintf("users/%v/repos", user)
@@ -149,7 +149,7 @@ func (s *RepositoriesService) List(user string, opt *RepositoryListOptions) ([]R
 	// TODO: remove custom Accept header when license support fully launches
 	req.Header.Set("Accept", mediaTypeLicensesPreview)
 
-	repos := new([]Repository)
+	repos := new([]*Repository)
 	resp, err := s.client.Do(req, repos)
 	if err != nil {
 		return nil, resp, err
@@ -171,7 +171,7 @@ type RepositoryListByOrgOptions struct {
 // ListByOrg lists the repositories for an organization.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/#list-organization-repositories
-func (s *RepositoriesService) ListByOrg(org string, opt *RepositoryListByOrgOptions) ([]Repository, *Response, error) {
+func (s *RepositoriesService) ListByOrg(org string, opt *RepositoryListByOrgOptions) ([]*Repository, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/repos", org)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -186,7 +186,7 @@ func (s *RepositoriesService) ListByOrg(org string, opt *RepositoryListByOrgOpti
 	// TODO: remove custom Accept header when license support fully launches
 	req.Header.Set("Accept", mediaTypeLicensesPreview)
 
-	repos := new([]Repository)
+	repos := new([]*Repository)
 	resp, err := s.client.Do(req, repos)
 	if err != nil {
 		return nil, resp, err
@@ -207,7 +207,7 @@ type RepositoryListAllOptions struct {
 // ListAll lists all GitHub repositories in the order that they were created.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/#list-all-public-repositories
-func (s *RepositoriesService) ListAll(opt *RepositoryListAllOptions) ([]Repository, *Response, error) {
+func (s *RepositoriesService) ListAll(opt *RepositoryListAllOptions) ([]*Repository, *Response, error) {
 	u, err := addOptions("repositories", opt)
 	if err != nil {
 		return nil, nil, err
@@ -218,7 +218,7 @@ func (s *RepositoriesService) ListAll(opt *RepositoryListAllOptions) ([]Reposito
 		return nil, nil, err
 	}
 
-	repos := new([]Repository)
+	repos := new([]*Repository)
 	resp, err := s.client.Do(req, repos)
 	if err != nil {
 		return nil, resp, err
@@ -366,7 +366,7 @@ type ListContributorsOptions struct {
 // ListContributors lists contributors for a repository.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/#list-contributors
-func (s *RepositoriesService) ListContributors(owner string, repository string, opt *ListContributorsOptions) ([]Contributor, *Response, error) {
+func (s *RepositoriesService) ListContributors(owner string, repository string, opt *ListContributorsOptions) ([]*Contributor, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/contributors", owner, repository)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -378,7 +378,7 @@ func (s *RepositoriesService) ListContributors(owner string, repository string, 
 		return nil, nil, err
 	}
 
-	contributor := new([]Contributor)
+	contributor := new([]*Contributor)
 	resp, err := s.client.Do(req, contributor)
 	if err != nil {
 		return nil, nil, err
@@ -416,7 +416,7 @@ func (s *RepositoriesService) ListLanguages(owner string, repo string) (map[stri
 // ListTeams lists the teams for the specified repository.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/#list-teams
-func (s *RepositoriesService) ListTeams(owner string, repo string, opt *ListOptions) ([]Team, *Response, error) {
+func (s *RepositoriesService) ListTeams(owner string, repo string, opt *ListOptions) ([]*Team, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/teams", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -428,7 +428,7 @@ func (s *RepositoriesService) ListTeams(owner string, repo string, opt *ListOpti
 		return nil, nil, err
 	}
 
-	teams := new([]Team)
+	teams := new([]*Team)
 	resp, err := s.client.Do(req, teams)
 	if err != nil {
 		return nil, resp, err
@@ -448,7 +448,7 @@ type RepositoryTag struct {
 // ListTags lists tags for the specified repository.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/#list-tags
-func (s *RepositoriesService) ListTags(owner string, repo string, opt *ListOptions) ([]RepositoryTag, *Response, error) {
+func (s *RepositoriesService) ListTags(owner string, repo string, opt *ListOptions) ([]*RepositoryTag, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/tags", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -460,7 +460,7 @@ func (s *RepositoriesService) ListTags(owner string, repo string, opt *ListOptio
 		return nil, nil, err
 	}
 
-	tags := new([]RepositoryTag)
+	tags := new([]*RepositoryTag)
 	resp, err := s.client.Do(req, tags)
 	if err != nil {
 		return nil, resp, err
@@ -497,7 +497,7 @@ type RequiredStatusChecks struct {
 // ListBranches lists branches for the specified repository.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/#list-branches
-func (s *RepositoriesService) ListBranches(owner string, repo string, opt *ListOptions) ([]Branch, *Response, error) {
+func (s *RepositoriesService) ListBranches(owner string, repo string, opt *ListOptions) ([]*Branch, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -511,7 +511,7 @@ func (s *RepositoriesService) ListBranches(owner string, repo string, opt *ListO
 
 	req.Header.Set("Accept", mediaTypeProtectedBranchesPreview)
 
-	branches := new([]Branch)
+	branches := new([]*Branch)
 	resp, err := s.client.Do(req, branches)
 	if err != nil {
 		return nil, resp, err

--- a/github/repos_collaborators.go
+++ b/github/repos_collaborators.go
@@ -10,7 +10,7 @@ import "fmt"
 // ListCollaborators lists the Github users that have access to the repository.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/collaborators/#list
-func (s *RepositoriesService) ListCollaborators(owner, repo string, opt *ListOptions) ([]User, *Response, error) {
+func (s *RepositoriesService) ListCollaborators(owner, repo string, opt *ListOptions) ([]*User, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/collaborators", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -22,7 +22,7 @@ func (s *RepositoriesService) ListCollaborators(owner, repo string, opt *ListOpt
 		return nil, nil, err
 	}
 
-	users := new([]User)
+	users := new([]*User)
 	resp, err := s.client.Do(req, users)
 	if err != nil {
 		return nil, resp, err

--- a/github/repos_collaborators_test.go
+++ b/github/repos_collaborators_test.go
@@ -29,7 +29,7 @@ func TestRepositoriesService_ListCollaborators(t *testing.T) {
 		t.Errorf("Repositories.ListCollaborators returned error: %v", err)
 	}
 
-	want := []User{{ID: Int(1)}, {ID: Int(2)}}
+	want := []*User{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(users, want) {
 		t.Errorf("Repositories.ListCollaborators returned %+v, want %+v", users, want)
 	}

--- a/github/repos_comments.go
+++ b/github/repos_comments.go
@@ -35,7 +35,7 @@ func (r RepositoryComment) String() string {
 // ListComments lists all the comments for the repository.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository
-func (s *RepositoriesService) ListComments(owner, repo string, opt *ListOptions) ([]RepositoryComment, *Response, error) {
+func (s *RepositoriesService) ListComments(owner, repo string, opt *ListOptions) ([]*RepositoryComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/comments", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -50,7 +50,7 @@ func (s *RepositoriesService) ListComments(owner, repo string, opt *ListOptions)
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
-	comments := new([]RepositoryComment)
+	comments := new([]*RepositoryComment)
 	resp, err := s.client.Do(req, comments)
 	if err != nil {
 		return nil, resp, err
@@ -62,7 +62,7 @@ func (s *RepositoriesService) ListComments(owner, repo string, opt *ListOptions)
 // ListCommitComments lists all the comments for a given commit SHA.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit
-func (s *RepositoriesService) ListCommitComments(owner, repo, sha string, opt *ListOptions) ([]RepositoryComment, *Response, error) {
+func (s *RepositoriesService) ListCommitComments(owner, repo, sha string, opt *ListOptions) ([]*RepositoryComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/commits/%v/comments", owner, repo, sha)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -77,7 +77,7 @@ func (s *RepositoriesService) ListCommitComments(owner, repo, sha string, opt *L
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
-	comments := new([]RepositoryComment)
+	comments := new([]*RepositoryComment)
 	resp, err := s.client.Do(req, comments)
 	if err != nil {
 		return nil, resp, err

--- a/github/repos_comments_test.go
+++ b/github/repos_comments_test.go
@@ -30,7 +30,7 @@ func TestRepositoriesService_ListComments(t *testing.T) {
 		t.Errorf("Repositories.ListComments returned error: %v", err)
 	}
 
-	want := []RepositoryComment{{ID: Int(1)}, {ID: Int(2)}}
+	want := []*RepositoryComment{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(comments, want) {
 		t.Errorf("Repositories.ListComments returned %+v, want %+v", comments, want)
 	}
@@ -58,7 +58,7 @@ func TestRepositoriesService_ListCommitComments(t *testing.T) {
 		t.Errorf("Repositories.ListCommitComments returned error: %v", err)
 	}
 
-	want := []RepositoryComment{{ID: Int(1)}, {ID: Int(2)}}
+	want := []*RepositoryComment{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(comments, want) {
 		t.Errorf("Repositories.ListCommitComments returned %+v, want %+v", comments, want)
 	}

--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -104,7 +104,7 @@ type CommitsListOptions struct {
 // ListCommits lists the commits of a repository.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/commits/#list
-func (s *RepositoriesService) ListCommits(owner, repo string, opt *CommitsListOptions) ([]RepositoryCommit, *Response, error) {
+func (s *RepositoriesService) ListCommits(owner, repo string, opt *CommitsListOptions) ([]*RepositoryCommit, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/commits", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -116,7 +116,7 @@ func (s *RepositoriesService) ListCommits(owner, repo string, opt *CommitsListOp
 		return nil, nil, err
 	}
 
-	commits := new([]RepositoryCommit)
+	commits := new([]*RepositoryCommit)
 	resp, err := s.client.Do(req, commits)
 	if err != nil {
 		return nil, resp, err

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -43,7 +43,7 @@ func TestRepositoriesService_ListCommits(t *testing.T) {
 		t.Errorf("Repositories.ListCommits returned error: %v", err)
 	}
 
-	want := []RepositoryCommit{{SHA: String("s")}}
+	want := []*RepositoryCommit{{SHA: String("s")}}
 	if !reflect.DeepEqual(commits, want) {
 		t.Errorf("Repositories.ListCommits returned %+v, want %+v", commits, want)
 	}

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -61,7 +61,7 @@ type DeploymentsListOptions struct {
 // ListDeployments lists the deployments of a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/deployments/#list-deployments
-func (s *RepositoriesService) ListDeployments(owner, repo string, opt *DeploymentsListOptions) ([]Deployment, *Response, error) {
+func (s *RepositoriesService) ListDeployments(owner, repo string, opt *DeploymentsListOptions) ([]*Deployment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/deployments", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -73,7 +73,7 @@ func (s *RepositoriesService) ListDeployments(owner, repo string, opt *Deploymen
 		return nil, nil, err
 	}
 
-	deployments := new([]Deployment)
+	deployments := new([]*Deployment)
 	resp, err := s.client.Do(req, deployments)
 	if err != nil {
 		return nil, resp, err
@@ -134,7 +134,7 @@ type DeploymentStatusRequest struct {
 // ListDeploymentStatuses lists the statuses of a given deployment of a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/deployments/#list-deployment-statuses
-func (s *RepositoriesService) ListDeploymentStatuses(owner, repo string, deployment int, opt *ListOptions) ([]DeploymentStatus, *Response, error) {
+func (s *RepositoriesService) ListDeploymentStatuses(owner, repo string, deployment int, opt *ListOptions) ([]*DeploymentStatus, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/deployments/%v/statuses", owner, repo, deployment)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -146,7 +146,7 @@ func (s *RepositoriesService) ListDeploymentStatuses(owner, repo string, deploym
 		return nil, nil, err
 	}
 
-	statuses := new([]DeploymentStatus)
+	statuses := new([]*DeploymentStatus)
 	resp, err := s.client.Do(req, statuses)
 	if err != nil {
 		return nil, resp, err

--- a/github/repos_deployments_test.go
+++ b/github/repos_deployments_test.go
@@ -29,7 +29,7 @@ func TestRepositoriesService_ListDeployments(t *testing.T) {
 		t.Errorf("Repositories.ListDeployments returned error: %v", err)
 	}
 
-	want := []Deployment{{ID: Int(1)}, {ID: Int(2)}}
+	want := []*Deployment{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(deployments, want) {
 		t.Errorf("Repositories.ListDeployments returned %+v, want %+v", deployments, want)
 	}
@@ -81,7 +81,7 @@ func TestRepositoriesService_ListDeploymentStatuses(t *testing.T) {
 		t.Errorf("Repositories.ListDeploymentStatuses returned error: %v", err)
 	}
 
-	want := []DeploymentStatus{{ID: Int(1)}, {ID: Int(2)}}
+	want := []*DeploymentStatus{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(statutses, want) {
 		t.Errorf("Repositories.ListDeploymentStatuses returned %+v, want %+v", statutses, want)
 	}

--- a/github/repos_forks.go
+++ b/github/repos_forks.go
@@ -20,7 +20,7 @@ type RepositoryListForksOptions struct {
 // ListForks lists the forks of the specified repository.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/forks/#list-forks
-func (s *RepositoriesService) ListForks(owner, repo string, opt *RepositoryListForksOptions) ([]Repository, *Response, error) {
+func (s *RepositoriesService) ListForks(owner, repo string, opt *RepositoryListForksOptions) ([]*Repository, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/forks", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -32,7 +32,7 @@ func (s *RepositoriesService) ListForks(owner, repo string, opt *RepositoryListF
 		return nil, nil, err
 	}
 
-	repos := new([]Repository)
+	repos := new([]*Repository)
 	resp, err := s.client.Do(req, repos)
 	if err != nil {
 		return nil, resp, err

--- a/github/repos_forks_test.go
+++ b/github/repos_forks_test.go
@@ -34,7 +34,7 @@ func TestRepositoriesService_ListForks(t *testing.T) {
 		t.Errorf("Repositories.ListForks returned error: %v", err)
 	}
 
-	want := []Repository{{ID: Int(1)}, {ID: Int(2)}}
+	want := []*Repository{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(repos, want) {
 		t.Errorf("Repositories.ListForks returned %+v, want %+v", repos, want)
 	}

--- a/github/repos_hooks.go
+++ b/github/repos_hooks.go
@@ -105,7 +105,7 @@ func (s *RepositoriesService) CreateHook(owner, repo string, hook *Hook) (*Hook,
 // ListHooks lists all Hooks for the specified repository.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/hooks/#list
-func (s *RepositoriesService) ListHooks(owner, repo string, opt *ListOptions) ([]Hook, *Response, error) {
+func (s *RepositoriesService) ListHooks(owner, repo string, opt *ListOptions) ([]*Hook, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/hooks", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -117,7 +117,7 @@ func (s *RepositoriesService) ListHooks(owner, repo string, opt *ListOptions) ([
 		return nil, nil, err
 	}
 
-	hooks := new([]Hook)
+	hooks := new([]*Hook)
 	resp, err := s.client.Do(req, hooks)
 	if err != nil {
 		return nil, resp, err
@@ -191,6 +191,6 @@ func (s *RepositoriesService) TestHook(owner, repo string, id int) (*Response, e
 }
 
 // ListServiceHooks is deprecated.  Use Client.ListServiceHooks instead.
-func (s *RepositoriesService) ListServiceHooks() ([]ServiceHook, *Response, error) {
+func (s *RepositoriesService) ListServiceHooks() ([]*ServiceHook, *Response, error) {
 	return s.client.ListServiceHooks()
 }

--- a/github/repos_hooks_test.go
+++ b/github/repos_hooks_test.go
@@ -64,7 +64,7 @@ func TestRepositoriesService_ListHooks(t *testing.T) {
 		t.Errorf("Repositories.ListHooks returned error: %v", err)
 	}
 
-	want := []Hook{{ID: Int(1)}, {ID: Int(2)}}
+	want := []*Hook{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(hooks, want) {
 		t.Errorf("Repositories.ListHooks returned %+v, want %+v", hooks, want)
 	}

--- a/github/repos_keys.go
+++ b/github/repos_keys.go
@@ -12,7 +12,7 @@ import "fmt"
 // ListKeys lists the deploy keys for a repository.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/keys/#list
-func (s *RepositoriesService) ListKeys(owner string, repo string, opt *ListOptions) ([]Key, *Response, error) {
+func (s *RepositoriesService) ListKeys(owner string, repo string, opt *ListOptions) ([]*Key, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/keys", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -24,7 +24,7 @@ func (s *RepositoriesService) ListKeys(owner string, repo string, opt *ListOptio
 		return nil, nil, err
 	}
 
-	keys := new([]Key)
+	keys := new([]*Key)
 	resp, err := s.client.Do(req, keys)
 	if err != nil {
 		return nil, resp, err

--- a/github/repos_keys_test.go
+++ b/github/repos_keys_test.go
@@ -29,7 +29,7 @@ func TestRepositoriesService_ListKeys(t *testing.T) {
 		t.Errorf("Repositories.ListKeys returned error: %v", err)
 	}
 
-	want := []Key{{ID: Int(1)}}
+	want := []*Key{{ID: Int(1)}}
 	if !reflect.DeepEqual(keys, want) {
 		t.Errorf("Repositories.ListKeys returned %+v, want %+v", keys, want)
 	}

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -54,14 +54,14 @@ func (s *RepositoriesService) GetPagesInfo(owner string, repo string) (*Pages, *
 // ListPagesBuilds lists the builds for a GitHub Pages site.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/pages/#list-pages-builds
-func (s *RepositoriesService) ListPagesBuilds(owner string, repo string) ([]PagesBuild, *Response, error) {
+func (s *RepositoriesService) ListPagesBuilds(owner string, repo string) ([]*PagesBuild, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pages/builds", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var pages []PagesBuild
+	var pages []*PagesBuild
 	resp, err := s.client.Do(req, &pages)
 	if err != nil {
 		return nil, resp, err

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -46,7 +46,7 @@ func TestRepositoriesService_ListPagesBuilds(t *testing.T) {
 		t.Errorf("Repositories.ListPagesBuilds returned error: %v", err)
 	}
 
-	want := []PagesBuild{{URL: String("u"), Status: String("s"), Commit: String("c")}}
+	want := []*PagesBuild{{URL: String("u"), Status: String("s"), Commit: String("c")}}
 	if !reflect.DeepEqual(pages, want) {
 		t.Errorf("Repositories.ListPagesBuilds returned %+v, want %+v", pages, want)
 	}

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -64,7 +64,7 @@ func (r ReleaseAsset) String() string {
 // ListReleases lists the releases for a repository.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/releases/#list-releases-for-a-repository
-func (s *RepositoriesService) ListReleases(owner, repo string, opt *ListOptions) ([]RepositoryRelease, *Response, error) {
+func (s *RepositoriesService) ListReleases(owner, repo string, opt *ListOptions) ([]*RepositoryRelease, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/releases", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -76,7 +76,7 @@ func (s *RepositoriesService) ListReleases(owner, repo string, opt *ListOptions)
 		return nil, nil, err
 	}
 
-	releases := new([]RepositoryRelease)
+	releases := new([]*RepositoryRelease)
 	resp, err := s.client.Do(req, releases)
 	if err != nil {
 		return nil, resp, err
@@ -176,7 +176,7 @@ func (s *RepositoriesService) DeleteRelease(owner, repo string, id int) (*Respon
 // ListReleaseAssets lists the release's assets.
 //
 // GitHub API docs : http://developer.github.com/v3/repos/releases/#list-assets-for-a-release
-func (s *RepositoriesService) ListReleaseAssets(owner, repo string, id int, opt *ListOptions) ([]ReleaseAsset, *Response, error) {
+func (s *RepositoriesService) ListReleaseAssets(owner, repo string, id int, opt *ListOptions) ([]*ReleaseAsset, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/releases/%d/assets", owner, repo, id)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -188,7 +188,7 @@ func (s *RepositoriesService) ListReleaseAssets(owner, repo string, id int, opt 
 		return nil, nil, err
 	}
 
-	assets := new([]ReleaseAsset)
+	assets := new([]*ReleaseAsset)
 	resp, err := s.client.Do(req, assets)
 	if err != nil {
 		return nil, resp, nil

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -32,7 +32,7 @@ func TestRepositoriesService_ListReleases(t *testing.T) {
 	if err != nil {
 		t.Errorf("Repositories.ListReleases returned error: %v", err)
 	}
-	want := []RepositoryRelease{{ID: Int(1)}}
+	want := []*RepositoryRelease{{ID: Int(1)}}
 	if !reflect.DeepEqual(releases, want) {
 		t.Errorf("Repositories.ListReleases returned %+v, want %+v", releases, want)
 	}
@@ -182,7 +182,7 @@ func TestRepositoriesService_ListReleaseAssets(t *testing.T) {
 	if err != nil {
 		t.Errorf("Repositories.ListReleaseAssets returned error: %v", err)
 	}
-	want := []ReleaseAsset{{ID: Int(1)}}
+	want := []*ReleaseAsset{{ID: Int(1)}}
 	if !reflect.DeepEqual(assets, want) {
 		t.Errorf("Repositories.ListReleaseAssets returned %+v, want %+v", assets, want)
 	}

--- a/github/repos_stats.go
+++ b/github/repos_stats.go
@@ -45,14 +45,14 @@ func (w WeeklyStats) String() string {
 // delay of a second or so, should result in a successful request.
 //
 // GitHub API Docs: https://developer.github.com/v3/repos/statistics/#contributors
-func (s *RepositoriesService) ListContributorsStats(owner, repo string) ([]ContributorStats, *Response, error) {
+func (s *RepositoriesService) ListContributorsStats(owner, repo string) ([]*ContributorStats, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/stats/contributors", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var contributorStats []ContributorStats
+	var contributorStats []*ContributorStats
 	resp, err := s.client.Do(req, &contributorStats)
 	if err != nil {
 		return nil, resp, err
@@ -84,14 +84,14 @@ func (w WeeklyCommitActivity) String() string {
 // delay of a second or so, should result in a successful request.
 //
 // GitHub API Docs: https://developer.github.com/v3/repos/statistics/#commit-activity
-func (s *RepositoriesService) ListCommitActivity(owner, repo string) ([]WeeklyCommitActivity, *Response, error) {
+func (s *RepositoriesService) ListCommitActivity(owner, repo string) ([]*WeeklyCommitActivity, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/stats/commit_activity", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var weeklyCommitActivity []WeeklyCommitActivity
+	var weeklyCommitActivity []*WeeklyCommitActivity
 	resp, err := s.client.Do(req, &weeklyCommitActivity)
 	if err != nil {
 		return nil, resp, err
@@ -105,7 +105,7 @@ func (s *RepositoriesService) ListCommitActivity(owner, repo string) ([]WeeklyCo
 // additions and deletions, but not total commits.
 //
 // GitHub API Docs: https://developer.github.com/v3/repos/statistics/#code-frequency
-func (s *RepositoriesService) ListCodeFrequency(owner, repo string) ([]WeeklyStats, *Response, error) {
+func (s *RepositoriesService) ListCodeFrequency(owner, repo string) ([]*WeeklyStats, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/stats/code_frequency", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -116,12 +116,12 @@ func (s *RepositoriesService) ListCodeFrequency(owner, repo string) ([]WeeklySta
 	resp, err := s.client.Do(req, &weeks)
 
 	// convert int slices into WeeklyStats
-	var stats []WeeklyStats
+	var stats []*WeeklyStats
 	for _, week := range weeks {
 		if len(week) != 3 {
 			continue
 		}
-		stat := WeeklyStats{
+		stat := &WeeklyStats{
 			Week:      &Timestamp{time.Unix(int64(week[0]), 0)},
 			Additions: Int(week[1]),
 			Deletions: Int(week[2]),
@@ -186,7 +186,7 @@ type PunchCard struct {
 // ListPunchCard returns the number of commits per hour in each day.
 //
 // GitHub API Docs: https://developer.github.com/v3/repos/statistics/#punch-card
-func (s *RepositoriesService) ListPunchCard(owner, repo string) ([]PunchCard, *Response, error) {
+func (s *RepositoriesService) ListPunchCard(owner, repo string) ([]*PunchCard, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/stats/punch_card", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -197,12 +197,12 @@ func (s *RepositoriesService) ListPunchCard(owner, repo string) ([]PunchCard, *R
 	resp, err := s.client.Do(req, &results)
 
 	// convert int slices into Punchcards
-	var cards []PunchCard
+	var cards []*PunchCard
 	for _, result := range results {
 		if len(result) != 3 {
 			continue
 		}
-		card := PunchCard{
+		card := &PunchCard{
 			Day:     Int(result[0]),
 			Hour:    Int(result[1]),
 			Commits: Int(result[2]),

--- a/github/repos_stats_test.go
+++ b/github/repos_stats_test.go
@@ -45,7 +45,7 @@ func TestRepositoriesService_ListContributorsStats(t *testing.T) {
 		t.Errorf("RepositoriesService.ListContributorsStats returned error: %v", err)
 	}
 
-	want := []ContributorStats{
+	want := []*ContributorStats{
 		{
 			Author: &Contributor{
 				ID: Int(1),
@@ -90,7 +90,7 @@ func TestRepositoriesService_ListCommitActivity(t *testing.T) {
 		t.Errorf("RepositoriesService.ListCommitActivity returned error: %v", err)
 	}
 
-	want := []WeeklyCommitActivity{
+	want := []*WeeklyCommitActivity{
 		{
 			Days:  []int{0, 3, 26, 20, 39, 1, 0},
 			Total: Int(89),
@@ -118,7 +118,7 @@ func TestRepositoriesService_ListCodeFrequency(t *testing.T) {
 		t.Errorf("RepositoriesService.ListCodeFrequency returned error: %v", err)
 	}
 
-	want := []WeeklyStats{{
+	want := []*WeeklyStats{{
 		Week:      &Timestamp{time.Date(2011, 04, 17, 00, 00, 00, 0, time.UTC).Local()},
 		Additions: Int(1124),
 		Deletions: Int(-435),
@@ -198,7 +198,7 @@ func TestRepositoriesService_ListPunchCard(t *testing.T) {
 		t.Errorf("RepositoriesService.ListPunchCard returned error: %v", err)
 	}
 
-	want := []PunchCard{
+	want := []*PunchCard{
 		{Day: Int(0), Hour: Int(0), Commits: Int(5)},
 		{Day: Int(0), Hour: Int(1), Commits: Int(43)},
 		{Day: Int(0), Hour: Int(2), Commits: Int(21)},

--- a/github/repos_statuses.go
+++ b/github/repos_statuses.go
@@ -42,7 +42,7 @@ func (r RepoStatus) String() string {
 // reference.  ref can be a SHA, a branch name, or a tag name.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
-func (s *RepositoriesService) ListStatuses(owner, repo, ref string, opt *ListOptions) ([]RepoStatus, *Response, error) {
+func (s *RepositoriesService) ListStatuses(owner, repo, ref string, opt *ListOptions) ([]*RepoStatus, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/commits/%v/statuses", owner, repo, ref)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -54,7 +54,7 @@ func (s *RepositoriesService) ListStatuses(owner, repo, ref string, opt *ListOpt
 		return nil, nil, err
 	}
 
-	statuses := new([]RepoStatus)
+	statuses := new([]*RepoStatus)
 	resp, err := s.client.Do(req, statuses)
 	if err != nil {
 		return nil, resp, err

--- a/github/repos_statuses_test.go
+++ b/github/repos_statuses_test.go
@@ -29,7 +29,7 @@ func TestRepositoriesService_ListStatuses(t *testing.T) {
 		t.Errorf("Repositories.ListStatuses returned error: %v", err)
 	}
 
-	want := []RepoStatus{{ID: Int(1)}}
+	want := []*RepoStatus{{ID: Int(1)}}
 	if !reflect.DeepEqual(statuses, want) {
 		t.Errorf("Repositories.ListStatuses returned %+v, want %+v", statuses, want)
 	}

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -28,7 +28,7 @@ func TestRepositoriesService_List_authenticatedUser(t *testing.T) {
 		t.Errorf("Repositories.List returned error: %v", err)
 	}
 
-	want := []Repository{{ID: Int(1)}, {ID: Int(2)}}
+	want := []*Repository{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(repos, want) {
 		t.Errorf("Repositories.List returned %+v, want %+v", repos, want)
 	}
@@ -56,7 +56,7 @@ func TestRepositoriesService_List_specifiedUser(t *testing.T) {
 		t.Errorf("Repositories.List returned error: %v", err)
 	}
 
-	want := []Repository{{ID: Int(1)}}
+	want := []*Repository{{ID: Int(1)}}
 	if !reflect.DeepEqual(repos, want) {
 		t.Errorf("Repositories.List returned %+v, want %+v", repos, want)
 	}
@@ -87,7 +87,7 @@ func TestRepositoriesService_ListByOrg(t *testing.T) {
 		t.Errorf("Repositories.ListByOrg returned error: %v", err)
 	}
 
-	want := []Repository{{ID: Int(1)}}
+	want := []*Repository{{ID: Int(1)}}
 	if !reflect.DeepEqual(repos, want) {
 		t.Errorf("Repositories.ListByOrg returned %+v, want %+v", repos, want)
 	}
@@ -118,7 +118,7 @@ func TestRepositoriesService_ListAll(t *testing.T) {
 		t.Errorf("Repositories.ListAll returned error: %v", err)
 	}
 
-	want := []Repository{{ID: Int(1)}}
+	want := []*Repository{{ID: Int(1)}}
 	if !reflect.DeepEqual(repos, want) {
 		t.Errorf("Repositories.ListAll returned %+v, want %+v", repos, want)
 	}
@@ -301,7 +301,7 @@ func TestRepositoriesService_ListContributors(t *testing.T) {
 		t.Errorf("Repositories.ListContributors returned error: %v", err)
 	}
 
-	want := []Contributor{{Contributions: Int(42)}}
+	want := []*Contributor{{Contributions: Int(42)}}
 	if !reflect.DeepEqual(contributors, want) {
 		t.Errorf("Repositories.ListContributors returned %+v, want %+v", contributors, want)
 	}
@@ -343,7 +343,7 @@ func TestRepositoriesService_ListTeams(t *testing.T) {
 		t.Errorf("Repositories.ListTeams returned error: %v", err)
 	}
 
-	want := []Team{{ID: Int(1)}}
+	want := []*Team{{ID: Int(1)}}
 	if !reflect.DeepEqual(teams, want) {
 		t.Errorf("Repositories.ListTeams returned %+v, want %+v", teams, want)
 	}
@@ -365,7 +365,7 @@ func TestRepositoriesService_ListTags(t *testing.T) {
 		t.Errorf("Repositories.ListTags returned error: %v", err)
 	}
 
-	want := []RepositoryTag{
+	want := []*RepositoryTag{
 		{
 			Name: String("n"),
 			Commit: &Commit{
@@ -398,7 +398,7 @@ func TestRepositoriesService_ListBranches(t *testing.T) {
 		t.Errorf("Repositories.ListBranches returned error: %v", err)
 	}
 
-	want := []Branch{{Name: String("master"), Commit: &Commit{SHA: String("a57781"), URL: String("https://api.github.com/repos/o/r/commits/a57781")}}}
+	want := []*Branch{{Name: String("master"), Commit: &Commit{SHA: String("a57781"), URL: String("https://api.github.com/repos/o/r/commits/a57781")}}}
 	if !reflect.DeepEqual(branches, want) {
 		t.Errorf("Repositories.ListBranches returned %+v, want %+v", branches, want)
 	}

--- a/github/users.go
+++ b/github/users.go
@@ -147,7 +147,7 @@ type UserListOptions struct {
 // To paginate through all users, populate 'Since' with the ID of the last user.
 //
 // GitHub API docs: http://developer.github.com/v3/users/#get-all-users
-func (s *UsersService) ListAll(opt *UserListOptions) ([]User, *Response, error) {
+func (s *UsersService) ListAll(opt *UserListOptions) ([]*User, *Response, error) {
 	u, err := addOptions("users", opt)
 	if err != nil {
 		return nil, nil, err
@@ -158,7 +158,7 @@ func (s *UsersService) ListAll(opt *UserListOptions) ([]User, *Response, error) 
 		return nil, nil, err
 	}
 
-	users := new([]User)
+	users := new([]*User)
 	resp, err := s.client.Do(req, users)
 	if err != nil {
 		return nil, resp, err

--- a/github/users_emails.go
+++ b/github/users_emails.go
@@ -15,7 +15,7 @@ type UserEmail struct {
 // ListEmails lists all email addresses for the authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user
-func (s *UsersService) ListEmails(opt *ListOptions) ([]UserEmail, *Response, error) {
+func (s *UsersService) ListEmails(opt *ListOptions) ([]*UserEmail, *Response, error) {
 	u := "user/emails"
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *UsersService) ListEmails(opt *ListOptions) ([]UserEmail, *Response, err
 		return nil, nil, err
 	}
 
-	emails := new([]UserEmail)
+	emails := new([]*UserEmail)
 	resp, err := s.client.Do(req, emails)
 	if err != nil {
 		return nil, resp, err
@@ -39,14 +39,14 @@ func (s *UsersService) ListEmails(opt *ListOptions) ([]UserEmail, *Response, err
 // AddEmails adds email addresses of the authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/users/emails/#add-email-addresses
-func (s *UsersService) AddEmails(emails []string) ([]UserEmail, *Response, error) {
+func (s *UsersService) AddEmails(emails []string) ([]*UserEmail, *Response, error) {
 	u := "user/emails"
 	req, err := s.client.NewRequest("POST", u, emails)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	e := new([]UserEmail)
+	e := new([]*UserEmail)
 	resp, err := s.client.Do(req, e)
 	if err != nil {
 		return nil, resp, err

--- a/github/users_emails_test.go
+++ b/github/users_emails_test.go
@@ -33,7 +33,7 @@ func TestUsersService_ListEmails(t *testing.T) {
 		t.Errorf("Users.ListEmails returned error: %v", err)
 	}
 
-	want := []UserEmail{{Email: String("user@example.com"), Verified: Bool(false), Primary: Bool(true)}}
+	want := []*UserEmail{{Email: String("user@example.com"), Verified: Bool(false), Primary: Bool(true)}}
 	if !reflect.DeepEqual(emails, want) {
 		t.Errorf("Users.ListEmails returned %+v, want %+v", emails, want)
 	}
@@ -62,7 +62,7 @@ func TestUsersService_AddEmails(t *testing.T) {
 		t.Errorf("Users.AddEmails returned error: %v", err)
 	}
 
-	want := []UserEmail{
+	want := []*UserEmail{
 		{Email: String("old@example.com")},
 		{Email: String("new@example.com")},
 	}

--- a/github/users_followers.go
+++ b/github/users_followers.go
@@ -11,7 +11,7 @@ import "fmt"
 // fetch followers for the authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/users/followers/#list-followers-of-a-user
-func (s *UsersService) ListFollowers(user string, opt *ListOptions) ([]User, *Response, error) {
+func (s *UsersService) ListFollowers(user string, opt *ListOptions) ([]*User, *Response, error) {
 	var u string
 	if user != "" {
 		u = fmt.Sprintf("users/%v/followers", user)
@@ -28,7 +28,7 @@ func (s *UsersService) ListFollowers(user string, opt *ListOptions) ([]User, *Re
 		return nil, nil, err
 	}
 
-	users := new([]User)
+	users := new([]*User)
 	resp, err := s.client.Do(req, users)
 	if err != nil {
 		return nil, resp, err
@@ -41,7 +41,7 @@ func (s *UsersService) ListFollowers(user string, opt *ListOptions) ([]User, *Re
 // string will list people the authenticated user is following.
 //
 // GitHub API docs: http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user
-func (s *UsersService) ListFollowing(user string, opt *ListOptions) ([]User, *Response, error) {
+func (s *UsersService) ListFollowing(user string, opt *ListOptions) ([]*User, *Response, error) {
 	var u string
 	if user != "" {
 		u = fmt.Sprintf("users/%v/following", user)
@@ -58,7 +58,7 @@ func (s *UsersService) ListFollowing(user string, opt *ListOptions) ([]User, *Re
 		return nil, nil, err
 	}
 
-	users := new([]User)
+	users := new([]*User)
 	resp, err := s.client.Do(req, users)
 	if err != nil {
 		return nil, resp, err

--- a/github/users_followers_test.go
+++ b/github/users_followers_test.go
@@ -28,7 +28,7 @@ func TestUsersService_ListFollowers_authenticatedUser(t *testing.T) {
 		t.Errorf("Users.ListFollowers returned error: %v", err)
 	}
 
-	want := []User{{ID: Int(1)}}
+	want := []*User{{ID: Int(1)}}
 	if !reflect.DeepEqual(users, want) {
 		t.Errorf("Users.ListFollowers returned %+v, want %+v", users, want)
 	}
@@ -48,7 +48,7 @@ func TestUsersService_ListFollowers_specifiedUser(t *testing.T) {
 		t.Errorf("Users.ListFollowers returned error: %v", err)
 	}
 
-	want := []User{{ID: Int(1)}}
+	want := []*User{{ID: Int(1)}}
 	if !reflect.DeepEqual(users, want) {
 		t.Errorf("Users.ListFollowers returned %+v, want %+v", users, want)
 	}
@@ -75,7 +75,7 @@ func TestUsersService_ListFollowing_authenticatedUser(t *testing.T) {
 		t.Errorf("Users.ListFollowing returned error: %v", err)
 	}
 
-	want := []User{{ID: Int(1)}}
+	want := []*User{{ID: Int(1)}}
 	if !reflect.DeepEqual(users, want) {
 		t.Errorf("Users.ListFollowing returned %+v, want %+v", users, want)
 	}
@@ -95,7 +95,7 @@ func TestUsersService_ListFollowing_specifiedUser(t *testing.T) {
 		t.Errorf("Users.ListFollowing returned error: %v", err)
 	}
 
-	want := []User{{ID: Int(1)}}
+	want := []*User{{ID: Int(1)}}
 	if !reflect.DeepEqual(users, want) {
 		t.Errorf("Users.ListFollowing returned %+v, want %+v", users, want)
 	}

--- a/github/users_gpg_keys.go
+++ b/github/users_gpg_keys.go
@@ -43,7 +43,7 @@ type GPGEmail struct {
 // via Basic Auth or via OAuth with at least read:gpg_key scope.
 //
 // GitHub API docs: https://developer.github.com/v3/users/gpg_keys/#list-your-gpg-keys
-func (s *UsersService) ListGPGKeys() ([]GPGKey, *Response, error) {
+func (s *UsersService) ListGPGKeys() ([]*GPGKey, *Response, error) {
 	req, err := s.client.NewRequest("GET", "user/gpg_keys", nil)
 	if err != nil {
 		return nil, nil, err
@@ -52,7 +52,7 @@ func (s *UsersService) ListGPGKeys() ([]GPGKey, *Response, error) {
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeGitSigningPreview)
 
-	var keys []GPGKey
+	var keys []*GPGKey
 	resp, err := s.client.Do(req, &keys)
 	if err != nil {
 		return nil, resp, err

--- a/github/users_gpg_keys_test.go
+++ b/github/users_gpg_keys_test.go
@@ -28,7 +28,7 @@ func TestUsersService_ListGPGKeys(t *testing.T) {
 		t.Errorf("Users.ListGPGKeys returned error: %v", err)
 	}
 
-	want := []GPGKey{{ID: Int(1), PrimaryKeyID: Int(2)}}
+	want := []*GPGKey{{ID: Int(1), PrimaryKeyID: Int(2)}}
 	if !reflect.DeepEqual(keys, want) {
 		t.Errorf("Users.ListGPGKeys = %+v, want %+v", keys, want)
 	}

--- a/github/users_keys.go
+++ b/github/users_keys.go
@@ -23,7 +23,7 @@ func (k Key) String() string {
 // string will fetch keys for the authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
-func (s *UsersService) ListKeys(user string, opt *ListOptions) ([]Key, *Response, error) {
+func (s *UsersService) ListKeys(user string, opt *ListOptions) ([]*Key, *Response, error) {
 	var u string
 	if user != "" {
 		u = fmt.Sprintf("users/%v/keys", user)
@@ -40,7 +40,7 @@ func (s *UsersService) ListKeys(user string, opt *ListOptions) ([]Key, *Response
 		return nil, nil, err
 	}
 
-	keys := new([]Key)
+	keys := new([]*Key)
 	resp, err := s.client.Do(req, keys)
 	if err != nil {
 		return nil, resp, err

--- a/github/users_keys_test.go
+++ b/github/users_keys_test.go
@@ -29,7 +29,7 @@ func TestUsersService_ListKeys_authenticatedUser(t *testing.T) {
 		t.Errorf("Users.ListKeys returned error: %v", err)
 	}
 
-	want := []Key{{ID: Int(1)}}
+	want := []*Key{{ID: Int(1)}}
 	if !reflect.DeepEqual(keys, want) {
 		t.Errorf("Users.ListKeys returned %+v, want %+v", keys, want)
 	}
@@ -49,7 +49,7 @@ func TestUsersService_ListKeys_specifiedUser(t *testing.T) {
 		t.Errorf("Users.ListKeys returned error: %v", err)
 	}
 
-	want := []Key{{ID: Int(1)}}
+	want := []*Key{{ID: Int(1)}}
 	if !reflect.DeepEqual(keys, want) {
 		t.Errorf("Users.ListKeys returned %+v, want %+v", keys, want)
 	}

--- a/github/users_test.go
+++ b/github/users_test.go
@@ -165,7 +165,7 @@ func TestUsersService_ListAll(t *testing.T) {
 		t.Errorf("Users.Get returned error: %v", err)
 	}
 
-	want := []User{{ID: Int(2)}}
+	want := []*User{{ID: Int(2)}}
 	if !reflect.DeepEqual(users, want) {
 		t.Errorf("Users.ListAll returned %+v, want %+v", users, want)
 	}


### PR DESCRIPTION
Note that this is an API-breaking change but should have minimal
impact on users of this package due to the nice inference
properties of the Go programming language.

Bumped `libraryVersion` to `2` due to API-breaking change as
discussed in #376.

Fixes #180.

Change-Id: Ib386135e6b8f306d1f54278968c576f3ceccc4e7