### PR TITLE
Remove leading slash from ReactionsService.DeleteReaction URL.

### DIFF
--- a/github/reactions.go
+++ b/github/reactions.go
@@ -258,7 +258,7 @@ func (s ReactionsService) CreatePullRequestCommentReaction(owner, repo string, i
 //
 // GitHub API docs: https://developer.github.com/v3/reaction/reactions/#delete-a-reaction-archive
 func (s *ReactionsService) DeleteReaction(id int) (*Response, error) {
-	u := fmt.Sprintf("/reactions/%v", id)
+	u := fmt.Sprintf("reactions/%v", id)
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {


### PR DESCRIPTION
It's harmless, but inconsistent. All other such URLs in this package do not use a leading slash.

See https://github.com/google/go-github/commit/09a37d57ac99a8938444e44375db8660c2184696#commitcomment-17927607.