### PR TITLE
Remove issue locking/unlocking preview media type.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -55,9 +55,6 @@ const (
 	// https://developer.github.com/changes/2015-11-11-protected-branches-api/
 	mediaTypeProtectedBranchesPreview = "application/vnd.github.loki-preview+json"
 
-	// https://developer.github.com/changes/2016-02-11-issue-locking-api/
-	mediaTypeIssueLockingPreview = "application/vnd.github.the-key-preview+json"
-
 	// https://help.github.com/enterprise/2.4/admin/guides/migrations/exporting-the-github-com-organization-s-repositories/
 	mediaTypeMigrationsPreview = "application/vnd.github.wyandotte-preview+json"
 

--- a/github/issues.go
+++ b/github/issues.go
@@ -289,9 +289,6 @@ func (s *IssuesService) Lock(owner string, repo string, number int) (*Response, 
 		return nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeIssueLockingPreview)
-
 	return s.client.Do(req, nil)
 }
 
@@ -304,9 +301,6 @@ func (s *IssuesService) Unlock(owner string, repo string, number int) (*Response
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeIssueLockingPreview)
 
 	return s.client.Do(req, nil)
 }

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -253,7 +253,6 @@ func TestIssuesService_Lock(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/1/lock", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeIssueLockingPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -269,7 +268,6 @@ func TestIssuesService_Unlock(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/1/lock", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeIssueLockingPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})


### PR DESCRIPTION
These changes are now official, so the custom media type is no longer needed.

Fixes #381.
Updates #279.