### PR TITLE
Add ReadOnly boolean field to deploy keys

### DIFF
--- a/github/users_keys.go
+++ b/github/users_keys.go
@@ -9,10 +9,11 @@ import "fmt"
 
 // Key represents a public SSH key used to authenticate a user or deploy script.
 type Key struct {
-	ID    *int    `json:"id,omitempty"`
-	Key   *string `json:"key,omitempty"`
-	URL   *string `json:"url,omitempty"`
-	Title *string `json:"title,omitempty"`
+	ID       *int    `json:"id,omitempty"`
+	Key      *string `json:"key,omitempty"`
+	URL      *string `json:"url,omitempty"`
+	Title    *string `json:"title,omitempty"`
+	ReadOnly *bool   `json:"read_only,omitempty"`
 }
 
 func (k Key) String() string {


### PR DESCRIPTION
Hi there,

I just added the `ReadOnly` field (json: "read_only") to the Key structure (github/user_keys.go) so that we can specify with `true` or `false` if we want to make the deploy key read-only or not.

Here is the github API documentation which shows an example of read-only boolean:
https://developer.github.com/v3/repos/keys/#add-a-new-deploy-key
