### PR TITLE
Add missing ID fields to PullRequest and Issue structs

### DIFF
--- a/github/issues.go
+++ b/github/issues.go
@@ -18,6 +18,7 @@ type IssuesService service
 
 // Issue represents a GitHub issue on a repository.
 type Issue struct {
+	ID               *int              `json:"id,omitempty"`
 	Number           *int              `json:"number,omitempty"`
 	State            *string           `json:"state,omitempty"`
 	Title            *string           `json:"title,omitempty"`

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -18,6 +18,7 @@ type PullRequestsService service
 
 // PullRequest represents a GitHub pull request on a repository.
 type PullRequest struct {
+	ID           *int       `json:"id,omitempty"`
 	Number       *int       `json:"number,omitempty"`
 	State        *string    `json:"state,omitempty"`
 	Title        *string    `json:"title,omitempty"`


### PR DESCRIPTION
In [events](https://developer.github.com/v3/activity/events/types/#pullrequestevent), the `id` field is present both in the Issue and PullRequest objects.

This PR adds them.