### PR TITLE
Put sync.Mutex on top of variables it protects.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -88,10 +88,8 @@ const (
 
 // A Client manages communication with the GitHub API.
 type Client struct {
-	// HTTP client used to communicate with the API.
-	client *http.Client
-	// clientMu protects the client during calls that modify the CheckRedirect func.
-	clientMu sync.Mutex
+	clientMu sync.Mutex   // clientMu protects the client during calls that modify the CheckRedirect func.
+	client   *http.Client // HTTP client used to communicate with the API.
 
 	// Base URL for API requests.  Defaults to the public GitHub API, but can be
 	// set to a domain endpoint to use with GitHub Enterprise.  BaseURL should


### PR DESCRIPTION
This change makes the code more consistent with the `rateMu` below.

This is a followup to https://github.com/google/go-github/pull/390#discussion_r68863652.

I've also considered an alternative solution that kept the comments on top

```Go
// clientMu protects the client during calls that modify the CheckRedirect func.
clientMu sync.Mutex
// HTTP client used to communicate with the API.
client *http.Client
```

or

```Go
clientMu sync.Mutex // clientMu protects the client during calls that modify the CheckRedirect func.
// HTTP client used to communicate with the API.
client *http.Client
```

but decided to go with the inline version because I figured these are internal implementation details and unexported variables, so it's fine.

If there's any preference towards keeping the comments on top, I'm happy to change it back.