### PR TITLE
Fix Mark{,Repository}NotificationsRead methods.

### DIFF
--- a/github/activity_notifications.go
+++ b/github/activity_notifications.go
@@ -96,20 +96,17 @@ func (s *ActivityService) ListRepositoryNotifications(owner, repo string, opt *N
 }
 
 type markReadOptions struct {
-	LastReadAt time.Time `url:"last_read_at,omitempty"`
+	LastReadAt time.Time `json:"last_read_at,omitempty"`
 }
 
 // MarkNotificationsRead marks all notifications up to lastRead as read.
 //
 // GitHub API Docs: https://developer.github.com/v3/activity/notifications/#mark-as-read
 func (s *ActivityService) MarkNotificationsRead(lastRead time.Time) (*Response, error) {
-	u := fmt.Sprintf("notifications")
-	u, err := addOptions(u, markReadOptions{lastRead})
-	if err != nil {
-		return nil, err
+	opts := &markReadOptions{
+		LastReadAt: lastRead,
 	}
-
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest("PUT", "notifications", opts)
 	if err != nil {
 		return nil, err
 	}
@@ -122,13 +119,11 @@ func (s *ActivityService) MarkNotificationsRead(lastRead time.Time) (*Response, 
 //
 // GitHub API Docs: https://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository
 func (s *ActivityService) MarkRepositoryNotificationsRead(owner, repo string, lastRead time.Time) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/notifications", owner, repo)
-	u, err := addOptions(u, markReadOptions{lastRead})
-	if err != nil {
-		return nil, err
+	opts := &markReadOptions{
+		LastReadAt: lastRead,
 	}
-
-	req, err := s.client.NewRequest("PUT", u, nil)
+	u := fmt.Sprintf("repos/%v/%v/notifications", owner, repo)
+	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/github/activity_notifications_test.go
+++ b/github/activity_notifications_test.go
@@ -73,9 +73,7 @@ func TestActivityService_MarkNotificationsRead(t *testing.T) {
 
 	mux.HandleFunc("/notifications", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testFormValues(t, r, values{
-			"last_read_at": "2006-01-02T15:04:05Z",
-		})
+		testBody(t, r, `{"last_read_at":"2006-01-02T15:04:05Z"}`+"\n")
 
 		w.WriteHeader(http.StatusResetContent)
 	})
@@ -92,9 +90,7 @@ func TestActivityService_MarkRepositoryNotificationsRead(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/notifications", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testFormValues(t, r, values{
-			"last_read_at": "2006-01-02T15:04:05Z",
-		})
+		testBody(t, r, `{"last_read_at":"2006-01-02T15:04:05Z"}`+"\n")
 
 		w.WriteHeader(http.StatusResetContent)
 	})


### PR DESCRIPTION
Both of those endpoints use PUT method, which means they must send the parameters as a JSON encoded body rather than query parameters.

Source: https://developer.github.com/v3/#parameters

Fixes #402.