### PR TITLE
Add Request a Page Build API

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -81,6 +81,9 @@ const (
 
 	// https://developer.github.com/changes/2016-04-21-oauth-authorizations-grants-api-preview/
 	mediaTypeOAuthGrantAuthorizationsPreview = "application/vnd.github.damage-preview+json"
+
+	// https://developer.github.com/changes/2016-07-06-github-pages-preiew-api/
+	mediaTypePagesPreview = "application/vnd.github.mister-fantastic-preview+json"
 )
 
 // A Client manages communication with the GitHub API.

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -13,6 +13,7 @@ type Pages struct {
 	Status    *string `json:"status,omitempty"`
 	CNAME     *string `json:"cname,omitempty"`
 	Custom404 *bool   `json:"custom_404,omitempty"`
+	HTMLURL   *string `json:"html_url,omitempty"`
 }
 
 // PagesError represents a build error for a GitHub Pages site.
@@ -41,6 +42,9 @@ func (s *RepositoriesService) GetPagesInfo(owner string, repo string) (*Pages, *
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypePagesPreview)
 
 	site := new(Pages)
 	resp, err := s.client.Do(req, site)
@@ -79,6 +83,28 @@ func (s *RepositoriesService) GetLatestPagesBuild(owner string, repo string) (*P
 	if err != nil {
 		return nil, nil, err
 	}
+
+	build := new(PagesBuild)
+	resp, err := s.client.Do(req, build)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return build, resp, err
+}
+
+// RequestPageBuild requests a build of a GitHub Pages site without needing to push new commit.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/pages/#request-a-page-build
+func (s *RepositoriesService) RequestPageBuild(owner string, repo string) (*PagesBuild, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pages/builds", owner, repo)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypePagesPreview)
 
 	build := new(PagesBuild)
 	resp, err := s.client.Do(req, build)

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -18,7 +18,8 @@ func TestRepositoriesService_GetPagesInfo(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"url":"u","status":"s","cname":"c","custom_404":false}`)
+		testHeader(t, r, "Accept", mediaTypePagesPreview)
+		fmt.Fprint(w, `{"url":"u","status":"s","cname":"c","custom_404":false,"html_url":"h"}`)
 	})
 
 	page, _, err := client.Repositories.GetPagesInfo("o", "r")
@@ -26,7 +27,7 @@ func TestRepositoriesService_GetPagesInfo(t *testing.T) {
 		t.Errorf("Repositories.GetPagesInfo returned error: %v", err)
 	}
 
-	want := &Pages{URL: String("u"), Status: String("s"), CNAME: String("c"), Custom404: Bool(false)}
+	want := &Pages{URL: String("u"), Status: String("s"), CNAME: String("c"), Custom404: Bool(false), HTMLURL: String("h")}
 	if !reflect.DeepEqual(page, want) {
 		t.Errorf("Repositories.GetPagesInfo returned %+v, want %+v", page, want)
 	}
@@ -69,5 +70,26 @@ func TestRepositoriesService_GetLatestPagesBuild(t *testing.T) {
 	want := &PagesBuild{URL: String("u"), Status: String("s"), Commit: String("c")}
 	if !reflect.DeepEqual(build, want) {
 		t.Errorf("Repositories.GetLatestPagesBuild returned %+v, want %+v", build, want)
+	}
+}
+
+func TestRepositoriesService_RequestPageBuild(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/pages/builds", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypePagesPreview)
+		fmt.Fprint(w, `{"url":"u","status":"s"}`)
+	})
+
+	build, _, err := client.Repositories.RequestPageBuild("o", "r")
+	if err != nil {
+		t.Errorf("Repositories.RequestPageBuild returned error: %v", err)
+	}
+
+	want := &PagesBuild{URL: String("u"), Status: String("s")}
+	if !reflect.DeepEqual(build, want) {
+		t.Errorf("Repositories.RequestPageBuild returned %+v, want %+v", build, want)
 	}
 }


### PR DESCRIPTION
Add new Request a Page Build API for GitHub Pages API.

Fixes #394 

The new API documented at this URL: https://developer.github.com/v3/repos/pages/#request-a-page-build