### PR TITLE
Don't use Header.Add where Header.Set is sufficient.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -220,9 +220,9 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 		return nil, err
 	}
 
-	req.Header.Add("Accept", mediaTypeV3)
+	req.Header.Set("Accept", mediaTypeV3)
 	if c.UserAgent != "" {
-		req.Header.Add("User-Agent", c.UserAgent)
+		req.Header.Set("User-Agent", c.UserAgent)
 	}
 	return req, nil
 }
@@ -246,9 +246,9 @@ func (c *Client) NewUploadRequest(urlStr string, reader io.Reader, size int64, m
 	if len(mediaType) == 0 {
 		mediaType = defaultMediaType
 	}
-	req.Header.Add("Content-Type", mediaType)
-	req.Header.Add("Accept", mediaTypeV3)
-	req.Header.Add("User-Agent", c.UserAgent)
+	req.Header.Set("Content-Type", mediaType)
+	req.Header.Set("Accept", mediaTypeV3)
+	req.Header.Set("User-Agent", c.UserAgent)
 	return req, nil
 }
 
@@ -756,7 +756,7 @@ func (t *BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error
 	req = cloneRequest(req) // per RoundTrip contract
 	req.SetBasicAuth(t.Username, t.Password)
 	if t.OTP != "" {
-		req.Header.Add(headerOTP, t.OTP)
+		req.Header.Set(headerOTP, t.OTP)
 	}
 	return t.transport().RoundTrip(req)
 }


### PR DESCRIPTION
This is largely a style change. In the case of `NewRequest` and `NewUploadRequest`, it is completely a noop given current code (since a new request is created, and each header is added only one time). For `BasicAuthTransport`, it's a noop as long as incoming request doesn't already have "X-GitHub-OTP" header set (and if it did, then this is a better behavior to change its value rather than add a new one).

Even though these changes are largely noops, `Header.Set` is a simpler primitive to reason about, and it's more representative of the intended action. For "Content-Type", "Accept", and "User-Agent" headers, multiple such headers do not make sense, so it's better to use `Header.Set` than `Header.Add`.