### PR TITLE
Set Content-Type to "application/json" for request bodies.

### DIFF
--- a/github/activity_notifications_test.go
+++ b/github/activity_notifications_test.go
@@ -73,6 +73,7 @@ func TestActivityService_MarkNotificationsRead(t *testing.T) {
 
 	mux.HandleFunc("/notifications", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
+		testHeader(t, r, "Content-Type", "application/json")
 		testBody(t, r, `{"last_read_at":"2006-01-02T15:04:05Z"}`+"\n")
 
 		w.WriteHeader(http.StatusResetContent)
@@ -90,6 +91,7 @@ func TestActivityService_MarkRepositoryNotificationsRead(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/notifications", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
+		testHeader(t, r, "Content-Type", "application/json")
 		testBody(t, r, `{"last_read_at":"2006-01-02T15:04:05Z"}`+"\n")
 
 		w.WriteHeader(http.StatusResetContent)

--- a/github/github.go
+++ b/github/github.go
@@ -220,6 +220,9 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 		return nil, err
 	}
 
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	req.Header.Set("Accept", mediaTypeV3)
 	if c.UserAgent != "" {
 		req.Header.Set("User-Agent", c.UserAgent)

--- a/github/github.go
+++ b/github/github.go
@@ -246,7 +246,7 @@ func (c *Client) NewUploadRequest(urlStr string, reader io.Reader, size int64, m
 	}
 	req.ContentLength = size
 
-	if len(mediaType) == 0 {
+	if mediaType == "" {
 		mediaType = defaultMediaType
 	}
 	req.Header.Set("Content-Type", mediaType)

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -101,7 +101,7 @@ func testFormValues(t *testing.T, r *http.Request, values values) {
 
 func testHeader(t *testing.T, r *http.Request, header string, want string) {
 	if got := r.Header.Get(header); got != want {
-		t.Errorf("Header.Get(%q) returned %s, want %s", header, got, want)
+		t.Errorf("Header.Get(%q) returned %q, want %q", header, got, want)
 	}
 }
 


### PR DESCRIPTION
According to https://developer.github.com/v3/#parameters:

> For POST, PATCH, PUT, and DELETE requests, parameters not included in the URL should be encoded as JSON with a Content-Type of 'application/json'

I'm not completely sure that we should merge this, but after I read what the GitHub API documentation said above, it seems like we should do it. Any thoughts?