### PR TITLE
Update RateLimits comment

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -611,8 +611,8 @@ type RateLimits struct {
 	Core *Rate `json:"core"`
 
 	// The rate limit for search API requests.  Unauthenticated requests
-	// are limited to 5 requests per minutes.  Authenticated requests are
-	// limited to 20 per minute.
+	// are limited to 10 requests per minutes.  Authenticated requests are
+	// limited to 30 per minute.
 	//
 	// GitHub API docs: https://developer.github.com/v3/search/#rate-limit
 	Search *Rate `json:"search"`


### PR DESCRIPTION
GitHub search API ratelimits are changed recently.
Reference: https://developer.github.com/v3/search/#rate-limit

Rate limit for unauthenticated requests change from 5 to 10 per minute.
And, rate limit for authenticated requests change from 20 to 30 per minute.