### PR TITLE
Add support for integration service

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -172,14 +172,6 @@ type IntegrationInstallationRepositoriesEvent struct {
 	Sender              *User         `json:"sender,omitempty"`
 }
 
-// Installation represents a GitHub integration installation.
-type Installation struct {
-	ID              *int    `json:"id,omitempty"`
-	Account         *User   `json:"account,omitempty"`
-	AccessTokensURL *string `json:"access_tokens_url,omitempty"`
-	RepositoriesURL *string `json:"repositories_url,omitempty"`
-}
-
 // IssueCommentEvent is triggered when an issue comment is created on an issue
 // or pull request.
 // The Webhook event name is "issue_comment".

--- a/github/github.go
+++ b/github/github.go
@@ -90,6 +90,9 @@ const (
 
 	// https://developer.github.com/changes/2016-09-14-projects-api/
 	mediaTypeProjectsPreview = "application/vnd.github.inertia-preview+json"
+
+	// https://developer.github.com/v3/integrations/
+	mediaTypeIntegrationPreview = "application/vnd.github.machine-man-preview+json"
 )
 
 // A Client manages communication with the GitHub API.
@@ -120,6 +123,7 @@ type Client struct {
 	Gists          *GistsService
 	Git            *GitService
 	Gitignores     *GitignoresService
+	Integrations   *IntegrationsService
 	Issues         *IssuesService
 	Organizations  *OrganizationsService
 	PullRequests   *PullRequestsService
@@ -190,6 +194,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Gists = (*GistsService)(&c.common)
 	c.Git = (*GitService)(&c.common)
 	c.Gitignores = (*GitignoresService)(&c.common)
+	c.Integrations = (*IntegrationsService)(&c.common)
 	c.Issues = (*IssuesService)(&c.common)
 	c.Licenses = (*LicensesService)(&c.common)
 	c.Migrations = (*MigrationService)(&c.common)

--- a/github/integration.go
+++ b/github/integration.go
@@ -1,0 +1,37 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+// IntegrationsService provides access to the installation related functions
+// in the GitHub API.
+//
+// GitHub API docs: https://developer.github.com/v3/integrations/
+type IntegrationsService service
+
+// ListInstallations lists the installations that the current integration has.
+//
+// GitHub API docs: https://developer.github.com/v3/integrations/#find-installations
+func (s *IntegrationsService) ListInstallations(opt *ListOptions) ([]*Installation, *Response, error) {
+	u, err := addOptions("integration/installations", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.Header.Set("Accept", mediaTypeIntegrationPreview)
+
+	i := new([]*Installation)
+	resp, err := s.client.Do(req, &i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *i, resp, err
+}

--- a/github/integration.go
+++ b/github/integration.go
@@ -25,6 +25,7 @@ func (s *IntegrationsService) ListInstallations(opt *ListOptions) ([]*Installati
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeIntegrationPreview)
 
 	i := new([]*Installation)

--- a/github/integration_installation.go
+++ b/github/integration_installation.go
@@ -1,0 +1,45 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+// Installation represents a GitHub integration installation.
+type Installation struct {
+	ID              *int    `json:"id,omitempty"`
+	Account         *User   `json:"account,omitempty"`
+	AccessTokensURL *string `json:"access_tokens_url,omitempty"`
+	RepositoriesURL *string `json:"repositories_url,omitempty"`
+}
+
+func (i Installation) String() string {
+	return Stringify(i)
+}
+
+// ListRepos lists the repositories that the current installation has access to.
+//
+// GitHub API docs: https://developer.github.com/v3/integrations/installations/#list-repositories
+func (s *IntegrationsService) ListRepos(opt *ListOptions) ([]*Repository, *Response, error) {
+	u, err := addOptions("installation/repositories", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.Header.Set("Accept", mediaTypeIntegrationPreview)
+
+	var r struct {
+		Repositories []*Repository `json:"repositories"`
+	}
+	resp, err := s.client.Do(req, &r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r.Repositories, resp, err
+}

--- a/github/integration_installation.go
+++ b/github/integration_installation.go
@@ -31,6 +31,7 @@ func (s *IntegrationsService) ListRepos(opt *ListOptions) ([]*Repository, *Respo
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeIntegrationPreview)
 
 	var r struct {

--- a/github/integration_installation_test.go
+++ b/github/integration_installation_test.go
@@ -1,0 +1,39 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestIntegrationService_ListRepos(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/installation/repositories", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeIntegrationPreview)
+		testFormValues(t, r, values{
+			"page":     "1",
+			"per_page": "2",
+		})
+		fmt.Fprint(w, `{"repositories": [{"id":1}]}`)
+	})
+
+	opt := &ListOptions{Page: 1, PerPage: 2}
+	repositories, _, err := client.Integrations.ListRepos(opt)
+	if err != nil {
+		t.Errorf("Integration.ListRepos returned error: %v", err)
+	}
+
+	want := []*Repository{{ID: Int(1)}}
+	if !reflect.DeepEqual(repositories, want) {
+		t.Errorf("Integration.ListRepos returned %+v, want %+v", repositories, want)
+	}
+}

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -1,0 +1,39 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestIntegrationService_ListInstallations(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/integration/installations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeIntegrationPreview)
+		testFormValues(t, r, values{
+			"page":     "1",
+			"per_page": "2",
+		})
+		fmt.Fprint(w, `[{"id":1}]`)
+	})
+
+	opt := &ListOptions{Page: 1, PerPage: 2}
+	installations, _, err := client.Integrations.ListInstallations(opt)
+	if err != nil {
+		t.Errorf("Integration.ListInstallations returned error: %v", err)
+	}
+
+	want := []*Installation{{ID: Int(1)}}
+	if !reflect.DeepEqual(installations, want) {
+		t.Errorf("Integration.ListInstallations returned %+v, want %+v", installations, want)
+	}
+}


### PR DESCRIPTION
Installations do have an one endpoint that list the repository they have access to. 

Sadly, it's fairly undocumented for now, the only mention of it can be found the webhooks documentation, see: https://developer.github.com/early-access/integrations/webhooks/#integrationinstallationevent
