### PR TITLE
Fix type of RepositoryRelease Author field.

### DIFF
--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -34,7 +34,7 @@ type RepositoryRelease struct {
 	UploadURL       *string        `json:"upload_url,omitempty"`
 	ZipballURL      *string        `json:"zipball_url,omitempty"`
 	TarballURL      *string        `json:"tarball_url,omitempty"`
-	Author          *CommitAuthor  `json:"author,omitempty"`
+	Author          *User          `json:"author,omitempty"`
 }
 
 func (r RepositoryRelease) String() string {

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -44,7 +44,7 @@ func TestRepositoriesService_GetRelease(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/releases/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"id":1}`)
+		fmt.Fprint(w, `{"id":1,"author":{"login":"l"}}`)
 	})
 
 	release, resp, err := client.Repositories.GetRelease("o", "r", 1)
@@ -52,7 +52,7 @@ func TestRepositoriesService_GetRelease(t *testing.T) {
 		t.Errorf("Repositories.GetRelease returned error: %v\n%v", err, resp.Body)
 	}
 
-	want := &RepositoryRelease{ID: Int(1)}
+	want := &RepositoryRelease{ID: Int(1), Author: &User{Login: String("l")}}
 	if !reflect.DeepEqual(release, want) {
 		t.Errorf("Repositories.GetRelease returned %+v, want %+v", release, want)
 	}


### PR DESCRIPTION
The author JSON is in [the format of a user](https://developer.github.com/v3/repos/releases/#get-a-single-release), not a commit author, and so the fields for the author returned in all the release fetching methods were nil.

There wasn't a test specifically for the decoding of the user, so I added a simple one in the fashion of [a similar test in the commit fetching code](https://github.com/google/go-github/blob/master/github/git_commits_test.go#L16-L35). The unit tests pass locally and this seems to work for me in some code that is using the library and was seeing a nil author for a release where the GitHub API is correctly returning one. I did not run the integration tests because they don't appear to cover releases anyway, and I need my token to not be exhausted right now.

Thanks for this library, it works great!