### PR TITLE
Local check for comments which are too long

### DIFF
--- a/github/issues.go
+++ b/github/issues.go
@@ -236,8 +236,14 @@ func (s *IssuesService) Get(owner string, repo string, number int) (*Issue, *Res
 
 // Create a new issue on the specified repository.
 //
+// Issues with a body longer than 65536 will return an error.
+//
 // GitHub API docs: http://developer.github.com/v3/issues/#create-an-issue
 func (s *IssuesService) Create(owner string, repo string, issue *IssueRequest) (*Issue, *Response, error) {
+	if issue != nil && issue.Body != nil && len(*issue.Body) > maxCommentLen {
+		return nil, nil, fmt.Errorf("body is too long (maximum is %d characters)", maxCommentLen)
+	}
+
 	u := fmt.Sprintf("repos/%v/%v/issues", owner, repo)
 	req, err := s.client.NewRequest("POST", u, issue)
 	if err != nil {

--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -107,8 +107,14 @@ func (s *PullRequestsService) GetComment(owner string, repo string, number int) 
 
 // CreateComment creates a new comment on the specified pull request.
 //
+// Comments longer than 65536 will return an error.
+//
 // GitHub API docs: https://developer.github.com/v3/pulls/comments/#create-a-comment
 func (s *PullRequestsService) CreateComment(owner string, repo string, number int, comment *PullRequestComment) (*PullRequestComment, *Response, error) {
+	if comment != nil && comment.Body != nil && len(*comment.Body) > maxCommentLen {
+		return nil, nil, fmt.Errorf("body is too long (maximum is %d characters)", maxCommentLen)
+	}
+
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/comments", owner, repo, number)
 	req, err := s.client.NewRequest("POST", u, comment)
 	if err != nil {


### PR DESCRIPTION
If a comment exceeds 64k github will reject it:

POST https://api.github.com/repos/kubernetes/kubernetes/issues/33381/comments: 422 Validation Failed [{Resource:IssueComment Field:body Code:custom Message:body is too long (maximum is 65536 characters)}]

Do a local check and error in the library instead.
