### PR TITLE
Add support for merge method and repository squash settings.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -68,6 +68,7 @@ const (
 	mediaTypeReactionsPreview = "application/vnd.github.squirrel-girl-preview"
 
 	// https://developer.github.com/changes/2016-04-01-squash-api-preview/
+	// https://developer.github.com/changes/2016-09-26-pull-request-merge-api-update/
 	mediaTypeSquashPreview = "application/vnd.github.polaris-preview+json"
 
 	// https://developer.github.com/changes/2016-04-04-git-signing-api-preview/

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -253,12 +253,16 @@ type PullRequestMergeResult struct {
 
 // PullRequestOptions lets you define how a pull request will be merged.
 type PullRequestOptions struct {
-	Squash bool
+	CommitTitle string
+
+	// The merge method to use. Possible values include: "merge", "squash", and "rebase" with the default being merge.
+	MergeMethod string
 }
 
 type pullRequestMergeRequest struct {
 	CommitMessage *string `json:"commit_message"`
-	Squash        *bool   `json:"squash,omitempty"`
+	CommitTitle   *string `json:"commit_title,omitempty"`
+	MergeMethod   *string `json:"merge_method,omitempty"`
 }
 
 // Merge a pull request (Merge Button™).
@@ -269,7 +273,8 @@ func (s *PullRequestsService) Merge(owner string, repo string, number int, commi
 
 	pullRequestBody := &pullRequestMergeRequest{CommitMessage: &commitMessage}
 	if options != nil {
-		pullRequestBody.Squash = &options.Squash
+		pullRequestBody.CommitTitle = &options.CommitTitle
+		pullRequestBody.MergeMethod = &options.MergeMethod
 	}
 	req, err := s.client.NewRequest("PUT", u, pullRequestBody)
 

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -363,7 +363,7 @@ func TestPullRequestsService_Merge(t *testing.T) {
 			}`)
 	})
 
-	options := &PullRequestOptions{Squash: true}
+	options := &PullRequestOptions{MergeMethod: "rebase"}
 	merge, _, err := client.PullRequests.Merge("o", "r", 1, "merging pull request", options)
 	if err != nil {
 		t.Errorf("PullRequests.Merge returned error: %v", err)

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -225,9 +226,10 @@ func TestRepositoriesService_Get(t *testing.T) {
 	setup()
 	defer teardown()
 
+	acceptHeader := []string{mediaTypeLicensesPreview, mediaTypeSquashPreview}
 	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeLicensesPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeader, ", "))
 		fmt.Fprint(w, `{"id":1,"name":"n","description":"d","owner":{"login":"l"},"license":{"key":"mit"}}`)
 	})
 


### PR DESCRIPTION
This PR adds merge method support and squash API options for repository get and update.

I'm unsure of what a good unit test might be, so I can update this if need be.
