### PR TITLE
Use nested commit for StatusEvent

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -459,17 +459,14 @@ type StatusEvent struct {
 	Branches    []*Branch `json:"branches,omitempty"`
 
 	// The following fields are only populated by Webhook events.
-	ID      *int    `json:"id,omitempty"`
-	Name    *string `json:"name,omitempty"`
-	Context *string `json:"context,omitempty"`
-	Commit  *struct {
-		SHA    *string          `json:"sha,omitempty"`
-		Commit *PushEventCommit `json:"commit,omitempty"`
-	}
-	CreatedAt *Timestamp  `json:"created_at,omitempty"`
-	UpdatedAt *Timestamp  `json:"updated_at,omitempty"`
-	Repo      *Repository `json:"repository,omitempty"`
-	Sender    *User       `json:"sender,omitempty"`
+	ID        *int              `json:"id,omitempty"`
+	Name      *string           `json:"name,omitempty"`
+	Context   *string           `json:"context,omitempty"`
+	Commit    *RepositoryCommit `json:"commit,omitempty"`
+	CreatedAt *Timestamp        `json:"created_at,omitempty"`
+	UpdatedAt *Timestamp        `json:"updated_at,omitempty"`
+	Repo      *Repository       `json:"repository,omitempty"`
+	Sender    *User             `json:"sender,omitempty"`
 }
 
 // TeamAddEvent is triggered when a repository is added to a team.

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -459,14 +459,17 @@ type StatusEvent struct {
 	Branches    []*Branch `json:"branches,omitempty"`
 
 	// The following fields are only populated by Webhook events.
-	ID        *int             `json:"id,omitempty"`
-	Name      *string          `json:"name,omitempty"`
-	Context   *string          `json:"context,omitempty"`
-	Commit    *PushEventCommit `json:"commit,omitempty"`
-	CreatedAt *Timestamp       `json:"created_at,omitempty"`
-	UpdatedAt *Timestamp       `json:"updated_at,omitempty"`
-	Repo      *Repository      `json:"repository,omitempty"`
-	Sender    *User            `json:"sender,omitempty"`
+	ID      *int    `json:"id,omitempty"`
+	Name    *string `json:"name,omitempty"`
+	Context *string `json:"context,omitempty"`
+	Commit  *struct {
+		SHA    *string          `json:"sha,omitempty"`
+		Commit *PushEventCommit `json:"commit,omitempty"`
+	}
+	CreatedAt *Timestamp  `json:"created_at,omitempty"`
+	UpdatedAt *Timestamp  `json:"updated_at,omitempty"`
+	Repo      *Repository `json:"repository,omitempty"`
+	Sender    *User       `json:"sender,omitempty"`
 }
 
 // TeamAddEvent is triggered when a repository is added to a team.

--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -27,6 +27,10 @@ type RepositoryCommit struct {
 	Stats *CommitStats `json:"stats,omitempty"`
 	// Details about which files, and how this commit touched. Only filled in during GetCommit!
 	Files []CommitFile `json:"files,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	URL         *string `json:"url,omitempty"`
+	CommentsURL *string `json:"comments_url,omitempty"`
 }
 
 func (r RepositoryCommit) String() string {

--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -15,22 +15,20 @@ import (
 // Note that it's wrapping a Commit, so author/committer information is in two places,
 // but contain different details about them: in RepositoryCommit "github details", in Commit - "git details".
 type RepositoryCommit struct {
-	SHA       *string  `json:"sha,omitempty"`
-	Commit    *Commit  `json:"commit,omitempty"`
-	Author    *User    `json:"author,omitempty"`
-	Committer *User    `json:"committer,omitempty"`
-	Parents   []Commit `json:"parents,omitempty"`
-	Message   *string  `json:"message,omitempty"`
-	HTMLURL   *string  `json:"html_url,omitempty"`
+	SHA         *string  `json:"sha,omitempty"`
+	Commit      *Commit  `json:"commit,omitempty"`
+	Author      *User    `json:"author,omitempty"`
+	Committer   *User    `json:"committer,omitempty"`
+	Parents     []Commit `json:"parents,omitempty"`
+	Message     *string  `json:"message,omitempty"`
+	HTMLURL     *string  `json:"html_url,omitempty"`
+	URL         *string  `json:"url,omitempty"`
+	CommentsURL *string  `json:"comments_url,omitempty"`
 
 	// Details about how many changes were made in this commit. Only filled in during GetCommit!
 	Stats *CommitStats `json:"stats,omitempty"`
 	// Details about which files, and how this commit touched. Only filled in during GetCommit!
 	Files []CommitFile `json:"files,omitempty"`
-
-	// The following fields are only populated by Webhook events.
-	URL         *string `json:"url,omitempty"`
-	CommentsURL *string `json:"comments_url,omitempty"`
 }
 
 func (r RepositoryCommit) String() string {


### PR DESCRIPTION
Full documentation of StatusEvent webhook here:
https://developer.github.com/v3/activity/events/types/#statusevent

Closes #448

---

- [ ] I used an unnamed type for the nested `Commit`, but could use `statusCommit` or something similar. 
- [ ] `PushEventCommit` also doesn't 100% match the correct structure of a nested `commit` in the statusEvent. I can create an additional `StatusEventCommit` type.

Let me know if you'd like me to make the above changes in this PR. I was going to do it initially, but wasn't sure about how I should name the structs.  