### PR TITLE
Switches to the new traffic API format

### DIFF
--- a/github/repos_traffic.go
+++ b/github/repos_traffic.go
@@ -5,11 +5,7 @@
 
 package github
 
-import (
-	"fmt"
-	"strconv"
-	"time"
-)
+import "fmt"
 
 // TrafficReferrer represent information about traffic from a referrer .
 type TrafficReferrer struct {
@@ -26,30 +22,11 @@ type TrafficPath struct {
 	Uniques *int    `json:"uniques,omitempty"`
 }
 
-// TimestampMS represents a timestamp as used in datapoint.
-//
-// It's only used to parse the result given by the API which are unix timestamp in milliseonds.
-type TimestampMS struct {
-	time.Time
-}
-
-// UnmarshalJSON parse unix timestamp.
-func (t *TimestampMS) UnmarshalJSON(b []byte) error {
-	s := string(b)
-	i, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		return err
-	}
-	// We can drop the reaminder as returned values are days and it will always be 0
-	*t = TimestampMS{time.Unix(i/1000, 0)}
-	return nil
-}
-
 // TrafficData represent information about a specific timestamp in views or clones list.
 type TrafficData struct {
-	Timestamp *TimestampMS `json:"timestamp,omitempty"`
-	Count     *int         `json:"count,omitempty"`
-	Uniques   *int         `json:"uniques,omitempty"`
+	Timestamp *Timestamp `json:"timestamp,omitempty"`
+	Count     *int       `json:"count,omitempty"`
+	Uniques   *int       `json:"uniques,omitempty"`
 }
 
 // TrafficViews represent information about the number of views in the last 14 days.

--- a/github/repos_traffic_test.go
+++ b/github/repos_traffic_test.go
@@ -83,7 +83,7 @@ func TestRepositoriesService_ListTrafficViews(t *testing.T) {
 		fmt.Fprintf(w, `{"count": 7,
 			"uniques": 6,
 			"views": [{
-				"timestamp": 1464710400000,
+				"timestamp": "2016-05-31T16:00:00.000Z",
 				"count": 7,
 				"uniques": 6
 		}]}`)
@@ -96,7 +96,7 @@ func TestRepositoriesService_ListTrafficViews(t *testing.T) {
 
 	want := &TrafficViews{
 		Views: []*TrafficData{{
-			Timestamp: &TimestampMS{time.Unix(1464710400, 0)},
+			Timestamp: &Timestamp{time.Date(2016, time.May, 31, 16, 0, 0, 0, time.UTC)},
 			Count:     Int(7),
 			Uniques:   Int(6),
 		}},
@@ -120,7 +120,7 @@ func TestRepositoriesService_ListTrafficClones(t *testing.T) {
 		fmt.Fprintf(w, `{"count": 7,
 			"uniques": 6,
 			"clones": [{
-				"timestamp": 1464710400000,
+				"timestamp": "2016-05-31T16:00:00.00Z",
 				"count": 7,
 				"uniques": 6
 		}]}`)
@@ -133,7 +133,7 @@ func TestRepositoriesService_ListTrafficClones(t *testing.T) {
 
 	want := &TrafficClones{
 		Clones: []*TrafficData{{
-			Timestamp: &TimestampMS{time.Unix(1464710400, 0)},
+			Timestamp: &Timestamp{time.Date(2016, time.May, 31, 16, 0, 0, 0, time.UTC)},
 			Count:     Int(7),
 			Uniques:   Int(6),
 		}},


### PR DESCRIPTION
I just removed the old `timestampMS` type, and used the common `timestamp`.
I also made the test clearer by defining the `timestamp` using `time.Date`.

Should fix #458 .