### PR TITLE
Fix type for Event.ID field

### DIFF
--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -20,7 +20,7 @@ type Event struct {
 	Actor      *User            `json:"actor,omitempty"`
 	Org        *Organization    `json:"org,omitempty"`
 	CreatedAt  *time.Time       `json:"created_at,omitempty"`
-	ID         *string          `json:"id,omitempty"`
+	ID         *int             `json:"id,omitempty"`
 }
 
 func (e Event) String() string {


### PR DESCRIPTION
ID is an int, not a string, per:

https://developer.github.com/v3/issues/events/#get-a-single-event

Fixes https://github.com/google/go-github/issues/176