### PR TITLE
Return IssueEvent in ListIssueEventsForRepository

### DIFF
--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -140,7 +140,7 @@ func (s *ActivityService) ListRepositoryEvents(owner, repo string, opt *ListOpti
 // ListIssueEventsForRepository lists issue events for a repository.
 //
 // GitHub API docs: http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
-func (s *ActivityService) ListIssueEventsForRepository(owner, repo string, opt *ListOptions) ([]*Event, *Response, error) {
+func (s *ActivityService) ListIssueEventsForRepository(owner, repo string, opt *ListOptions) ([]*IssueEvent, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/events", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -152,7 +152,7 @@ func (s *ActivityService) ListIssueEventsForRepository(owner, repo string, opt *
 		return nil, nil, err
 	}
 
-	events := new([]*Event)
+	events := new([]*IssueEvent)
 	resp, err := s.client.Do(req, events)
 	if err != nil {
 		return nil, resp, err

--- a/github/activity_events_test.go
+++ b/github/activity_events_test.go
@@ -75,7 +75,7 @@ func TestActivityService_ListIssueEventsForRepository(t *testing.T) {
 		testFormValues(t, r, values{
 			"page": "2",
 		})
-		fmt.Fprint(w, `[{"id":"1"},{"id":"2"}]`)
+		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
 	opt := &ListOptions{Page: 2}
@@ -84,7 +84,7 @@ func TestActivityService_ListIssueEventsForRepository(t *testing.T) {
 		t.Errorf("Activities.ListIssueEventsForRepository returned error: %v", err)
 	}
 
-	want := []*Event{{ID: String("1")}, {ID: String("2")}}
+	want := []*IssueEvent{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(events, want) {
 		t.Errorf("Activities.ListIssueEventsForRepository returned %+v, want %+v", events, want)
 	}


### PR DESCRIPTION
Supersedes https://github.com/google/go-github/pull/474, fixes #176.