### PR TITLE
Add function for PullRequestService to download raw content of pull r…

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -42,6 +42,8 @@ const (
 	mediaTypeV3                = "application/vnd.github.v3+json"
 	defaultMediaType           = "application/octet-stream"
 	mediaTypeV3SHA             = "application/vnd.github.v3.sha"
+	mediaTypeV3Diff            = "application/vnd.github.v3.diff"
+	mediaTypeV3Patch           = "application/vnd.github.v3.patch"
 	mediaTypeOrgPermissionRepo = "application/vnd.github.v3.repository+json"
 
 	// Media Type values to access preview APIs
@@ -152,6 +154,20 @@ type ListOptions struct {
 // UploadOptions specifies the parameters to methods that support uploads.
 type UploadOptions struct {
 	Name string `url:"name,omitempty"`
+}
+
+// RawType represents type of raw format of a request instead of JSON.
+type RawType uint8
+
+const (
+	Diff RawType = 1 + iota
+	Patch
+)
+
+// RawOptions specifies parameters when user wants to get raw format of
+// a response instead of JSON.
+type RawOptions struct {
+	Type RawType
 }
 
 // addOptions adds the parameters in opt as URL query parameters to s.  opt


### PR DESCRIPTION
…equest

We already has an issue here https://github.com/google/go-github/issues/6
And as @willnorris said it's better to use Contents API to download, but Contents API seems to support blob or file content which is a part of a repository git tree only. (not include pull request)

I want to support patch/diff media type in pull request also (which may not be supported even in future release).
So i added method `GetRaw` to `PullRequestService` separate from original `Get` method (to maintain backward compatibility)