### PR TITLE
Make GetArchiveLink behave the same as other calls

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -267,8 +267,12 @@ func (s *RepositoriesService) GetArchiveLink(owner, repo string, archiveformat a
 	} else {
 		resp, err = s.client.client.Transport.RoundTrip(req)
 	}
-	if err != nil || resp.StatusCode != http.StatusFound {
-		return nil, newResponse(resp), err
+	if err != nil {
+		return nil, nil, err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		return nil, newResponse(resp), fmt.Errorf("unexpected status code: %s", resp.Status)
 	}
 	parsedURL, err := url.Parse(resp.Header.Get("Location"))
 	return parsedURL, newResponse(resp), err


### PR DESCRIPTION
All available calls in the `go-github` package close the `resp.Body` before returning.

Because the `GetArchiveLink` method doesn’t use the [`Do`](https://github.com/google/go-github/blob/master/github/github.go#L381) method, we have to make sure the body is closed here as well.