### PR TITLE
deal with 202 Accepted status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 go-github is a Go client library for accessing the [GitHub API][].
 
-**Documentation:** [![GoDoc](https://godoc.org/github.com/google/go-github/github?status.svg)](https://godoc.org/github.com/google/go-github/github)
-**Mailing List:** [go-github@googlegroups.com](https://groups.google.com/group/go-github)
-**Build Status:** [![Build Status](https://travis-ci.org/google/go-github.svg?branch=master)](https://travis-ci.org/google/go-github)
-**Test Coverage:** [![Test Coverage](https://coveralls.io/repos/google/go-github/badge.svg?branch=master)](https://coveralls.io/r/google/go-github?branch=master) ([gocov report](https://drone.io/github.com/google/go-github/files/coverage.html))
+**Documentation:** [![GoDoc](https://godoc.org/github.com/google/go-github/github?status.svg)](https://godoc.org/github.com/google/go-github/github)  
+**Mailing List:** [go-github@googlegroups.com](https://groups.google.com/group/go-github)  
+**Build Status:** [![Build Status](https://travis-ci.org/google/go-github.svg?branch=master)](https://travis-ci.org/google/go-github)  
+**Test Coverage:** [![Test Coverage](https://coveralls.io/repos/google/go-github/badge.svg?branch=master)](https://coveralls.io/r/google/go-github?branch=master) ([gocov report](https://drone.io/github.com/google/go-github/files/coverage.html))  
 
 go-github requires Go version 1.4 or greater.
 

--- a/README.md
+++ b/README.md
@@ -99,20 +99,20 @@ if _, ok := err.(*github.RateLimitError); ok {
 Learn more about GitHub rate limiting at
 http://developer.github.com/v3/#rate-limiting.
 
-### Accepted status ###
+### Accepted Status ###
 
 Some endpoints may return a 202 Accepted status code, meaning that the
-information required is not yet ready and was scheduled to be gather in
-GitHub side. Methods know to behave like this are documented specifying
+information required is not yet ready and was scheduled to be gathered on
+GitHub side. Methods known to behave like this are documented specifying
 this behavior.
 
 To detect this condition of error, you can check if its type is
 `*github.AcceptedError`:
 
 ```go
-repos, _, err := client.Repositories.ListContributorsStats(org, repo)
+stats, _, err := client.Repositories.ListContributorsStats(org, repo)
 if _, ok := err.(*github.AcceptedError); ok {
-  log.Println("scheduled on github side")
+	log.Println("scheduled on github side")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ go-github is a Go client library for accessing the [GitHub API][].
 **Documentation:** [![GoDoc](https://godoc.org/github.com/google/go-github/github?status.svg)](https://godoc.org/github.com/google/go-github/github)  
 **Mailing List:** [go-github@googlegroups.com](https://groups.google.com/group/go-github)  
 **Build Status:** [![Build Status](https://travis-ci.org/google/go-github.svg?branch=master)](https://travis-ci.org/google/go-github)  
-**Test Coverage:** [![Test Coverage](https://coveralls.io/repos/google/go-github/badge.svg?branch=master)](https://coveralls.io/r/google/go-github?branch=master) ([gocov report](https://drone.io/github.com/google/go-github/files/coverage.html))  
+**Test Coverage:** [![Test Coverage](https://coveralls.io/repos/google/go-github/badge.svg?branch=master)](https://coveralls.io/r/google/go-github?branch=master) ([gocov report](https://drone.io/github.com/google/go-github/files/coverage.html))
 
 go-github requires Go version 1.4 or greater.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 go-github is a Go client library for accessing the [GitHub API][].
 
-**Documentation:** [![GoDoc](https://godoc.org/github.com/google/go-github/github?status.svg)](https://godoc.org/github.com/google/go-github/github)  
-**Mailing List:** [go-github@googlegroups.com](https://groups.google.com/group/go-github)  
-**Build Status:** [![Build Status](https://travis-ci.org/google/go-github.svg?branch=master)](https://travis-ci.org/google/go-github)  
+**Documentation:** [![GoDoc](https://godoc.org/github.com/google/go-github/github?status.svg)](https://godoc.org/github.com/google/go-github/github)
+**Mailing List:** [go-github@googlegroups.com](https://groups.google.com/group/go-github)
+**Build Status:** [![Build Status](https://travis-ci.org/google/go-github.svg?branch=master)](https://travis-ci.org/google/go-github)
 **Test Coverage:** [![Test Coverage](https://coveralls.io/repos/google/go-github/badge.svg?branch=master)](https://coveralls.io/r/google/go-github?branch=master) ([gocov report](https://drone.io/github.com/google/go-github/files/coverage.html))
 
 go-github requires Go version 1.4 or greater.
@@ -98,6 +98,23 @@ if _, ok := err.(*github.RateLimitError); ok {
 
 Learn more about GitHub rate limiting at
 http://developer.github.com/v3/#rate-limiting.
+
+### Accepted status ###
+
+Some endpoints may return a 202 Accepted status code, meaning that the
+information required is not yet ready and was scheduled to be gather in
+GitHub side. Methods know to behave like this are documented specifying
+this behavior.
+
+To detect this condition of error, you can check if its type is
+`*github.AcceptedError`:
+
+```go
+repos, _, err := client.Repositories.ListContributorsStats(org, repo)
+if _, ok := err.(*github.AcceptedError); ok {
+  log.Println("scheduled on github side")
+}
+```
 
 ### Conditional Requests ###
 

--- a/github/doc.go
+++ b/github/doc.go
@@ -86,17 +86,17 @@ To detect an API rate limit error, you can check if its type is *github.RateLimi
 Learn more about GitHub rate limiting at
 http://developer.github.com/v3/#rate-limiting.
 
-Accepted status
+Accepted Status
 
 Some endpoints may return a 202 Accepted status code, meaning that the
-information required is not yet ready and was scheduled to be gather in
-GitHub side. Methods know to behave like this are documented specifying
+information required is not yet ready and was scheduled to be gathered on
+GitHub side. Methods known to behave like this are documented specifying
 this behavior.
 
 To detect this condition of error, you can check if its type is
 *github.AcceptedError:
 
-	repos, _, err := client.Repositories.ListContributorsStats(org, repo)
+	stats, _, err := client.Repositories.ListContributorsStats(org, repo)
 	if _, ok := err.(*github.AcceptedError); ok {
 		log.Println("scheduled on github side")
 	}

--- a/github/doc.go
+++ b/github/doc.go
@@ -86,6 +86,21 @@ To detect an API rate limit error, you can check if its type is *github.RateLimi
 Learn more about GitHub rate limiting at
 http://developer.github.com/v3/#rate-limiting.
 
+Accepted status
+
+Some endpoints may return a 202 Accepted status code, meaning that the
+information required is not yet ready and was scheduled to be gather in
+GitHub side. Methods know to behave like this are documented specifying
+this behavior.
+
+To detect this condition of error, you can check if its type is
+*github.AcceptedError:
+
+	repos, _, err := client.Repositories.ListContributorsStats(org, repo)
+	if _, ok := err.(*github.AcceptedError); ok {
+		log.Println("scheduled on github side")
+	}
+
 Conditional Requests
 
 The GitHub API has good support for conditional requests which will help

--- a/github/github.go
+++ b/github/github.go
@@ -509,7 +509,7 @@ func (r *RateLimitError) Error() string {
 // The request can be repeated after some time.
 type AcceptedError struct{}
 
-func (AcceptedError) Error() string {
+func (*AcceptedError) Error() string {
 	return "job scheduled on github side, try again later"
 }
 
@@ -583,10 +583,11 @@ func (e *Error) Error() string {
 // response body will be silently ignored.
 //
 // The error type will be *RateLimitError for rate limit exceeded errors,
+// *AcceptedError for 202 Accepted status codes,
 // and *TwoFactorAuthError for two-factor authentication errors.
 func CheckResponse(r *http.Response) error {
 	if r.StatusCode == http.StatusAccepted {
-		return AcceptedError{}
+		return &AcceptedError{}
 	}
 	if c := r.StatusCode; 200 <= c && c <= 299 {
 		return nil

--- a/github/repos_forks.go
+++ b/github/repos_forks.go
@@ -50,6 +50,12 @@ type RepositoryCreateForkOptions struct {
 
 // CreateFork creates a fork of the specified repository.
 //
+// This method might return an *AcceptedError and a status code of
+// 202. This is because this is the status that github returns to signify that
+// it is now computing creating the fork in a background task.
+// A follow up request, after a delay of a second or so, should result
+// in a successful request.
+//
 // GitHub API docs: https://developer.github.com/v3/repos/forks/#create-a-fork
 func (s *RepositoriesService) CreateFork(owner, repo string, opt *RepositoryCreateForkOptions) (*Repository, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/forks", owner, repo)

--- a/github/repos_stats.go
+++ b/github/repos_stats.go
@@ -39,7 +39,7 @@ func (w WeeklyStats) String() string {
 // deletions and commit counts.
 //
 // If this is the first time these statistics are requested for the given
-// repository, this method will return a non-nil error and a status code of
+// repository, this method will return an *AcceptedError and a status code of
 // 202. This is because this is the status that github returns to signify that
 // it is now computing the requested statistics. A follow up request, after a
 // delay of a second or so, should result in a successful request.
@@ -78,7 +78,7 @@ func (w WeeklyCommitActivity) String() string {
 // starting on Sunday.
 //
 // If this is the first time these statistics are requested for the given
-// repository, this method will return a non-nil error and a status code of
+// repository, this method will return an *AcceptedError and a status code of
 // 202. This is because this is the status that github returns to signify that
 // it is now computing the requested statistics. A follow up request, after a
 // delay of a second or so, should result in a successful request.
@@ -103,6 +103,12 @@ func (s *RepositoriesService) ListCommitActivity(owner, repo string) ([]*WeeklyC
 // ListCodeFrequency returns a weekly aggregate of the number of additions and
 // deletions pushed to a repository.  Returned WeeklyStats will contain
 // additions and deletions, but not total commits.
+//
+// If this is the first time these statistics are requested for the given
+// repository, this method will return an *AcceptedError and a status code of
+// 202. This is because this is the status that github returns to signify that
+// it is now computing the requested statistics. A follow up request, after a
+// delay of a second or so, should result in a successful request.
 //
 // GitHub API Docs: https://developer.github.com/v3/repos/statistics/#code-frequency
 func (s *RepositoriesService) ListCodeFrequency(owner, repo string) ([]*WeeklyStats, *Response, error) {
@@ -152,7 +158,7 @@ func (r RepositoryParticipation) String() string {
 // The array order is oldest week (index 0) to most recent week.
 //
 // If this is the first time these statistics are requested for the given
-// repository, this method will return a non-nil error and a status code
+// repository, this method will return an *AcceptedError and a status code
 // of 202. This is because this is the status that github returns to
 // signify that it is now computing the requested statistics. A follow
 // up request, after a delay of a second or so, should result in a
@@ -184,6 +190,12 @@ type PunchCard struct {
 }
 
 // ListPunchCard returns the number of commits per hour in each day.
+//
+// If this is the first time these statistics are requested for the given
+// repository, this method will return an *AcceptedError and a status code of
+// 202. This is because this is the status that github returns to signify that
+// it is now computing the requested statistics. A follow up request, after a
+// delay of a second or so, should result in a successful request.
 //
 // GitHub API Docs: https://developer.github.com/v3/repos/statistics/#punch-card
 func (s *RepositoriesService) ListPunchCard(owner, repo string) ([]*PunchCard, *Response, error) {

--- a/github/repos_stats.go
+++ b/github/repos_stats.go
@@ -158,11 +158,10 @@ func (r RepositoryParticipation) String() string {
 // The array order is oldest week (index 0) to most recent week.
 //
 // If this is the first time these statistics are requested for the given
-// repository, this method will return an *AcceptedError and a status code
-// of 202. This is because this is the status that github returns to
-// signify that it is now computing the requested statistics. A follow
-// up request, after a delay of a second or so, should result in a
-// successful request.
+// repository, this method will return an *AcceptedError and a status code of
+// 202. This is because this is the status that github returns to signify that
+// it is now computing the requested statistics. A follow up request, after a
+// delay of a second or so, should result in a successful request.
 //
 // GitHub API Docs: https://developer.github.com/v3/repos/statistics/#participation
 func (s *RepositoriesService) ListParticipation(owner, repo string) (*RepositoryParticipation, *Response, error) {


### PR DESCRIPTION
When github returns a 202, it means that they don't have the data you asked, and it is considered a rater heavy operation to get it, so they schedule a background job to fetch and cache it, and subsequent calls to it might work.

go-github was failing to deal with that, because in some places it was trying to parse the body to a list of some object, and github actually returns a `{}`.

With this change we would be able to do the same as we do with rate limiting issues, e.g.:

```go
stats, _, err := client.Repositories.ListContributorsStats(org, repo)
if err != nil {
	if _, ok := err.(*github.AcceptedError); ok {
		// handle accepted error, likely by trying again later
	}
	// handle other errors
}
```

fixes https://github.com/google/go-github/issues/486