### PR TITLE
Fix GetBranch response

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -501,9 +501,9 @@ func (s *RepositoriesService) ListTags(owner string, repo string, opt *ListOptio
 
 // Branch represents a repository branch
 type Branch struct {
-	Name      *string `json:"name,omitempty"`
-	Commit    *Commit `json:"commit,omitempty"`
-	Protected *bool   `json:"protected,omitempty"`
+	Name      *string           `json:"name,omitempty"`
+	Commit    *RepositoryCommit `json:"commit,omitempty"`
+	Protected *bool             `json:"protected,omitempty"`
 }
 
 // Protection represents a repository branch's protection.

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -434,7 +434,7 @@ func TestRepositoriesService_ListBranches(t *testing.T) {
 		t.Errorf("Repositories.ListBranches returned error: %v", err)
 	}
 
-	want := []*Branch{{Name: String("master"), Commit: &Commit{SHA: String("a57781"), URL: String("https://api.github.com/repos/o/r/commits/a57781")}}}
+	want := []*Branch{{Name: String("master"), Commit: &RepositoryCommit{SHA: String("a57781"), URL: String("https://api.github.com/repos/o/r/commits/a57781")}}}
 	if !reflect.DeepEqual(branches, want) {
 		t.Errorf("Repositories.ListBranches returned %+v, want %+v", branches, want)
 	}
@@ -447,7 +447,7 @@ func TestRepositoriesService_GetBranch(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/branches/b", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeProtectedBranchesPreview)
-		fmt.Fprint(w, `{"name":"n", "commit":{"sha":"s"}, "protected":true}`)
+		fmt.Fprint(w, `{"name":"n", "commit":{"sha":"s","commit":{"message":"m"}}, "protected":true}`)
 	})
 
 	branch, _, err := client.Repositories.GetBranch("o", "r", "b")
@@ -456,8 +456,13 @@ func TestRepositoriesService_GetBranch(t *testing.T) {
 	}
 
 	want := &Branch{
-		Name:      String("n"),
-		Commit:    &Commit{SHA: String("s")},
+		Name: String("n"),
+		Commit: &RepositoryCommit{
+			SHA: String("s"),
+			Commit: &Commit{
+				Message: String("m"),
+			},
+		},
 		Protected: Bool(true),
 	}
 


### PR DESCRIPTION
I want to get a time of the last commit in branch. I read [Github API: Get Branch](https://developer.github.com/v3/repos/branches/#get-branch) docs and found the [RepositoriesService.GetBranch](https://github.com/google/go-github/blob/5c45bca952b96dedace6c307caff915483013003/github/repos.go#L579) method. I called it like so:

```go
client.Repositories.GetBranch(orgName, repoName, branchName)
```

But get the following data (e.g. for this repo):

```go
{
	github.Commit {
		SHA:"5c45bca952b96dedace6c307caff915483013003",
		Author:github.CommitAuthor{},
		Committer:github.CommitAuthor{},
		Parents:[
			github.Commit{
				SHA:"5c5ff1dadae3bb0b306004d480a88e7ddc1714ca",
				URL:"https://api.github.com/repos/google/go-github/commits/5c5ff1dadae3bb0b306004d480a88e7ddc1714ca"
			}
		],
		URL:"https://api.github.com/repos/google/go-github/commits/5c45bca952b96dedace6c307caff915483013003"
	}
}
```
As you see, the Author and Committer fields has no info. I tried to call the endpoint with curl:
```
curl -H 'Accept: application/vnd.github.v3+json' \
     -H "Authorization: token ${MY_GITHUB_TOKEN}" \
     "https://api.github.com/repos/google/go-github/branches/master"
```
And get data I expected:
```js
{
  "name": "master",
  "commit": {
    "sha": "5c45bca952b96dedace6c307caff915483013003",
    "commit": {
      "author": {
        "name": "Ronak Jain",
        "email": "ronakjain@outlook.in",
        "date": "2016-12-09T18:12:45Z"
      },
      "committer": {
        "name": "Glenn Lewis",
        "email": "gmlewis@google.com",
        "date": "2016-12-09T18:58:51Z"
      },
      "message": "improve docs ...",
      "tree": {
        "sha": "de558bd3716b5304a7d40e90c4871a5173ac40a2",
        "url": "https://api.github.com/repos/google/go-github/git/trees/de558bd3716b5304a7d40e90c4871a5173ac40a2"
      },
      "url": "https://api.github.com/repos/google/go-github/git/commits/5c45bca952b96dedace6c307caff915483013003",
      "comment_count": 0
    },
    ...
  }
}
```
Looks like `commit` at the root of response is a [RepositoryCommit](https://github.com/google/go-github/blob/5c45bca952b96dedace6c307caff915483013003/github/repos_commits.go#L14).