### PR TITLE
Fix broken test TestRepositoriesService_CompareCommits.

### DIFF
--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -231,7 +231,7 @@ func TestRepositoriesService_CompareCommits(t *testing.T) {
 		},
 	}
 
-	if reflect.DeepEqual(got, want) {
+	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Repositories.CompareCommits returned \n%+v, want \n%+v", got, want)
 	}
 }

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -180,7 +180,7 @@ func TestRepositoriesService_CompareCommits(t *testing.T) {
 		      "message": "m",
 		      "tree": { "sha": "t" }
 		    },
-		    "author": { "login": "n" },
+		    "author": { "login": "l" },
 		    "committer": { "login": "l" },
 		    "parents": [ { "sha": "s" } ]
 		  },
@@ -207,21 +207,39 @@ func TestRepositoriesService_CompareCommits(t *testing.T) {
 	}
 
 	want := &CommitsComparison{
+		BaseCommit: &RepositoryCommit{
+			SHA: String("s"),
+			Commit: &Commit{
+				Author:    &CommitAuthor{Name: String("n")},
+				Committer: &CommitAuthor{Name: String("n")},
+				Message:   String("m"),
+				Tree:      &Tree{SHA: String("t")},
+			},
+			Author:    &User{Login: String("l")},
+			Committer: &User{Login: String("l")},
+			Parents: []Commit{
+				{
+					SHA: String("s"),
+				},
+			},
+		},
 		Status:       String("s"),
 		AheadBy:      Int(1),
 		BehindBy:     Int(2),
 		TotalCommits: Int(1),
-		BaseCommit: &RepositoryCommit{
-			Commit: &Commit{
-				Author: &CommitAuthor{Name: String("n")},
-			},
-			Author:    &User{Login: String("l")},
-			Committer: &User{Login: String("l")},
-			Message:   String("m"),
-		},
 		Commits: []RepositoryCommit{
 			{
 				SHA: String("s"),
+				Commit: &Commit{
+					Author: &CommitAuthor{Name: String("n")},
+				},
+				Author:    &User{Login: String("l")},
+				Committer: &User{Login: String("l")},
+				Parents: []Commit{
+					{
+						SHA: String("s"),
+					},
+				},
 			},
 		},
 		Files: []CommitFile{


### PR DESCRIPTION
Previously, the test would pass if `got` and `want` were different, and fail if they were equal.

Update expected data in `TestRepositoriesService_CompareCommits`. This makes the test pass, by matching the mock JSON data that the test handler returns.

Re-arrange fields in want to match order in the JSON data.

Followup to #49.