### PR TITLE
Remove RepositoryCommit.Message field.

### DIFF
--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -20,7 +20,6 @@ type RepositoryCommit struct {
 	Author      *User    `json:"author,omitempty"`
 	Committer   *User    `json:"committer,omitempty"`
 	Parents     []Commit `json:"parents,omitempty"`
-	Message     *string  `json:"message,omitempty"`
 	HTMLURL     *string  `json:"html_url,omitempty"`
 	URL         *string  `json:"url,omitempty"`
 	CommentsURL *string  `json:"comments_url,omitempty"`


### PR DESCRIPTION
This field is unused. There is no "commit message" inside of `RepositoryCommit` (higher level GitHub object), it's only inside of `Commit` (lower level git object).

It was added accidentally in #49 and not caught via test due to #491.

Followup to #49. See https://github.com/google/go-github/pull/49/files#r92034462.