### PR TITLE
Fix PagesBuild.UpdatedAt field tag.

### DIFF
--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -30,7 +30,7 @@ type PagesBuild struct {
 	Commit    *string     `json:"commit,omitempty"`
 	Duration  *int        `json:"duration,omitempty"`
 	CreatedAt *Timestamp  `json:"created_at,omitempty"`
-	UpdatedAt *Timestamp  `json:"created_at,omitempty"`
+	UpdatedAt *Timestamp  `json:"updated_at,omitempty"`
 }
 
 // GetPagesInfo fetches information about a GitHub Pages site.


### PR DESCRIPTION
This was originally fixed in #469, but it regressed in 905f04725b7bcad81e475ce48474b87561ecc723 (although it was not a part of the PR #467 that commit was based on).

I spotted it [once again](https://github.com/google/go-github/pull/469#issuecomment-258648061) via Travis CI running with the improved `go vet` that comes in 1.8. See https://travis-ci.org/google/go-github/jobs/183406963.