### PR TITLE
Single deployment status

### DIFF
--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -84,8 +84,7 @@ func (s *RepositoriesService) ListDeployments(owner, repo string, opt *Deploymen
 
 // GetDeployment returns a single deployment of a repository.
 //
-// GitHub API docs: https://developer.github.com/v3/repos/deployments/
-// Note: GetDeployment uses the undocumented GitHub API endpoint /repos/:owner/:repo/deployments/:id.
+// GitHub API docs: https://developer.github.com/v3/repos/deployments/#get-a-single-deployment
 func (s *RepositoriesService) GetDeployment(owner, repo string, deploymentID int) (*Deployment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/deployments/%v", owner, repo, deploymentID)
 

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -175,6 +175,29 @@ func (s *RepositoriesService) ListDeploymentStatuses(owner, repo string, deploym
 	return *statuses, resp, err
 }
 
+// GetDeploymentStatus returns a single deployment status of a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/deployments/#get-a-single-deployment-status
+func (s *RepositoriesService) GetDeploymentStatus(owner, repo string, deploymentID, deploymentStatusID int) (*DeploymentStatus, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/deployments/%v/statuses/%v", owner, repo, deploymentID, deploymentStatusID)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when deployment support fully launches
+	req.Header.Set("Accept", mediaTypeDeploymentStatusPreview)
+
+	d := new(DeploymentStatus)
+	resp, err := s.client.Do(req, d)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return d, resp, err
+}
+
 // CreateDeploymentStatus creates a new status for a deployment.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/deployments/#create-a-deployment-status

--- a/github/repos_deployments_test.go
+++ b/github/repos_deployments_test.go
@@ -108,6 +108,27 @@ func TestRepositoriesService_ListDeploymentStatuses(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_GetDeploymentStatus(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/deployments/3/statuses/4", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeDeploymentStatusPreview)
+		fmt.Fprint(w, `{"id":4}`)
+	})
+
+	deploymentStatus, _, err := client.Repositories.GetDeploymentStatus("o", "r", 3, 4)
+	if err != nil {
+		t.Errorf("Repositories.GetDeploymentStatus returned error: %v", err)
+	}
+
+	want := &DeploymentStatus{ID: Int(4)}
+	if !reflect.DeepEqual(deploymentStatus, want) {
+		t.Errorf("Repositories.GetDeploymentStatus returned %+v, want %+v", deploymentStatus, want)
+	}
+}
+
 func TestRepositoriesService_CreateDeploymentStatus(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
This adds support for the get-single-deployment-status endpoint, which is newly documented - plus the link to the newly documented get-single-deployment endpoint.

Fixes #482 