### PR TITLE
Fix PullRequests.Merge incorrectly sending empty optional values.

### DIFF
--- a/github/pulls.go
+++ b/github/pulls.go
@@ -301,7 +301,7 @@ type pullRequestMergeRequest struct {
 func (s *PullRequestsService) Merge(owner string, repo string, number int, commitMessage string, options *PullRequestOptions) (*PullRequestMergeResult, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/merge", owner, repo, number)
 
-	pullRequestBody := pullRequestMergeRequest{CommitMessage: commitMessage}
+	pullRequestBody := &pullRequestMergeRequest{CommitMessage: commitMessage}
 	if options != nil {
 		pullRequestBody.CommitTitle = options.CommitTitle
 		pullRequestBody.MergeMethod = options.MergeMethod

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -288,10 +288,10 @@ type PullRequestOptions struct {
 }
 
 type pullRequestMergeRequest struct {
-	CommitMessage *string `json:"commit_message"`
-	CommitTitle   *string `json:"commit_title,omitempty"`
-	MergeMethod   *string `json:"merge_method,omitempty"`
-	SHA           *string `json:"sha,omitempty"`
+	CommitMessage string `json:"commit_message"`
+	CommitTitle   string `json:"commit_title,omitempty"`
+	MergeMethod   string `json:"merge_method,omitempty"`
+	SHA           string `json:"sha,omitempty"`
 }
 
 // Merge a pull request (Merge Button™).
@@ -301,11 +301,11 @@ type pullRequestMergeRequest struct {
 func (s *PullRequestsService) Merge(owner string, repo string, number int, commitMessage string, options *PullRequestOptions) (*PullRequestMergeResult, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/merge", owner, repo, number)
 
-	pullRequestBody := &pullRequestMergeRequest{CommitMessage: &commitMessage}
+	pullRequestBody := pullRequestMergeRequest{CommitMessage: commitMessage}
 	if options != nil {
-		pullRequestBody.CommitTitle = &options.CommitTitle
-		pullRequestBody.MergeMethod = &options.MergeMethod
-		pullRequestBody.SHA = &options.SHA
+		pullRequestBody.CommitTitle = options.CommitTitle
+		pullRequestBody.MergeMethod = options.MergeMethod
+		pullRequestBody.SHA = options.SHA
 	}
 	req, err := s.client.NewRequest("PUT", u, pullRequestBody)
 	if err != nil {

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -307,12 +307,12 @@ func (s *PullRequestsService) Merge(owner string, repo string, number int, commi
 		pullRequestBody.SHA = &options.SHA
 	}
 	req, err := s.client.NewRequest("PUT", u, pullRequestBody)
-
-	// TODO: This header will be unnecessary when the API is no longer in preview.
-	req.Header.Set("Accept", mediaTypeSquashPreview)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: This header will be unnecessary when the API is no longer in preview.
+	req.Header.Set("Accept", mediaTypeSquashPreview)
 
 	mergeResult := new(PullRequestMergeResult)
 	resp, err := s.client.Do(req, mergeResult)

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -280,10 +280,10 @@ type PullRequestMergeResult struct {
 
 // PullRequestOptions lets you define how a pull request will be merged.
 type PullRequestOptions struct {
-	CommitTitle string
+	CommitTitle string // Extra detail to append to automatic commit message. (Optional.)
 	SHA         string // SHA that pull request head must match to allow merge. (Optional.)
 
-	// The merge method to use. Possible values include: "merge", "squash", and "rebase" with the default being merge.
+	// The merge method to use. Possible values include: "merge", "squash", and "rebase" with the default being merge. (Optional.)
 	MergeMethod string
 }
 
@@ -295,6 +295,7 @@ type pullRequestMergeRequest struct {
 }
 
 // Merge a pull request (Merge Button™).
+// commitMessage is the title for the automatic commit message.
 //
 // GitHub API docs: https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade
 func (s *PullRequestsService) Merge(owner string, repo string, number int, commitMessage string, options *PullRequestOptions) (*PullRequestMergeResult, *Response, error) {

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -471,18 +471,16 @@ func TestPullRequestsService_Merge_options(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		t.Run(fmt.Sprintf("Test%d/%#v", i, test.options), func(t *testing.T) {
-			madeRequest := false
-			mux.HandleFunc(fmt.Sprintf("/repos/o/r/pulls/%d/merge", i), func(w http.ResponseWriter, r *http.Request) {
-				testMethod(t, r, "PUT")
-				testHeader(t, r, "Accept", mediaTypeSquashPreview)
-				testBody(t, r, test.wantBody+"\n")
-				madeRequest = true
-			})
-			_, _, _ = client.PullRequests.Merge("o", "r", i, "merging pull request", test.options)
-			if !madeRequest {
-				t.Error("expected request was not made")
-			}
+		madeRequest := false
+		mux.HandleFunc(fmt.Sprintf("/repos/o/r/pulls/%d/merge", i), func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "PUT")
+			testHeader(t, r, "Accept", mediaTypeSquashPreview)
+			testBody(t, r, test.wantBody+"\n")
+			madeRequest = true
 		})
+		_, _, _ = client.PullRequests.Merge("o", "r", i, "merging pull request", test.options)
+		if !madeRequest {
+			t.Errorf("%d: PullRequests.Merge(%#v): expected request was not made", i, test.options)
+		}
 	}
 }


### PR DESCRIPTION
Resolves #500.

This PR consists of 4 _logical_ commits, please review by looking at each commit individually and read its commit message for description.

First commit is unrelated but got in my way, sorry.