### PR TITLE
change PingEvent.HookID to be int, not string

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -302,7 +302,7 @@ type PingEvent struct {
 	// Random string of GitHub zen.
 	Zen *string `json:"zen,omitempty"`
 	// The ID of the webhook that triggered the ping.
-	HookID *string `json:"hook_id,omitempty"`
+	HookID *int `json:"hook_id,omitempty"`
 	// The webhook configuration.
 	Hook *Hook `json:"hook,omitempty"`
 }


### PR DESCRIPTION
See Hook type struct: 

type Hook struct {
	CreatedAt *time.Time             `json:"created_at,omitempty"`
	UpdatedAt *time.Time             `json:"updated_at,omitempty"`
	Name      *string                `json:"name,omitempty"`
	URL       *string                `json:"url,omitempty"`
	Events    []string               `json:"events,omitempty"`
	Active    *bool                  `json:"active,omitempty"`
	Config    map[string]interface{} `json:"config,omitempty"`
	_**ID        *int                   `json:"id,omitempty"`**_
}
