### PR TITLE
Document that Issue struct can represent PRs too.

### DIFF
--- a/github/issues.go
+++ b/github/issues.go
@@ -17,6 +17,11 @@ import (
 type IssuesService service
 
 // Issue represents a GitHub issue on a repository.
+//
+// Note: As far as the GitHub API is concerned, every pull request is an issue,
+// but not every issue is a pull request. Some endpoints, events, and webhooks
+// may also return pull requests via this struct. If PullRequestLinks is nil,
+// this is an issue, and if PullRequestLinks is not nil, this is a pull request.
 type Issue struct {
 	ID               *int              `json:"id,omitempty"`
 	Number           *int              `json:"number,omitempty"`


### PR DESCRIPTION
GitHub API documentation says:

> If an issue is a pull request, the object will include a pull_request key.

Source: https://developer.github.com/v3/issues/#list-issues