### PR TITLE
Add get pending invitation API and OrganizationEvent type structure

### DIFF
--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -63,6 +63,8 @@ func (e *Event) Payload() (payload interface{}) {
 		payload = &MembershipEvent{}
 	case "MilestoneEvent":
 		payload = &MilestoneEvent{}
+	case "OrganizationEvent":
+		payload = &OrganizationEvent{}
 	case "PageBuildEvent":
 		payload = &PageBuildEvent{}
 	case "PublicEvent":

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -276,6 +276,27 @@ type MilestoneEvent struct {
 	Org     *Organization `json:"organization,omitempty"`
 }
 
+// OrganizationEvent is Triggered when a user is added, removed, or invited to an Organization.
+// Events of this type are not visible in timelines. These events are only used to trigger organization hooks.
+// Webhook event name is "organization"
+//
+// Github docs: https://developer.github.com/v3/activity/events/types/#organizationevent
+type OrganizationEvent struct {
+	// Action is the action that was performed.
+	// Can be one of "member_added", "member_removed", or "member_invited"
+	Action *string `json:"action,omitempty"`
+
+	// Invitaion is the invitation for the user or email if the action is "member_invited"
+	Invitation *Invitation `json:"invitation,omitempty"`
+
+	// Membership is the membership between the user and the organization.
+	// Not present when the action is "member_invited"
+	Membership *Membership `json:"membership,omitempty"`
+
+	Organization *Organization `json:"organization,omitempty"`
+	Sender       *User         `json:"sender,omitempty"`
+}
+
 // PageBuildEvent represents an attempted build of a GitHub Pages site, whether
 // successful or not.
 // The Webhook event name is "page_build".
@@ -450,7 +471,7 @@ type PushEventRepository struct {
 	HTMLURL *string `json:"html_url,omitempty"`
 }
 
-// PushEventRepoOwner is a basic reporesntation of user/org in a PushEvent payload
+// PushEventRepoOwner is a basic representation of user/org in a PushEvent payload
 type PushEventRepoOwner struct {
 	Name  *string `json:"name,omitempty"`
 	Email *string `json:"email,omitempty"`

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -283,14 +283,14 @@ type MilestoneEvent struct {
 // Github docs: https://developer.github.com/v3/activity/events/types/#organizationevent
 type OrganizationEvent struct {
 	// Action is the action that was performed.
-	// Can be one of "member_added", "member_removed", or "member_invited"
+	// Can be one of "member_added", "member_removed", or "member_invited".
 	Action *string `json:"action,omitempty"`
 
-	// Invitaion is the invitation for the user or email if the action is "member_invited"
+	// Invitaion is the invitation for the user or email if the action is "member_invited".
 	Invitation *Invitation `json:"invitation,omitempty"`
 
 	// Membership is the membership between the user and the organization.
-	// Not present when the action is "member_invited"
+	// Not present when the action is "member_invited".
 	Membership *Membership `json:"membership,omitempty"`
 
 	Organization *Organization `json:"organization,omitempty"`
@@ -439,7 +439,7 @@ func (p PushEventCommit) String() string {
 	return Stringify(p)
 }
 
-// PushEventRepository represents the repo object in a PushEvent payload
+// PushEventRepository represents the repo object in a PushEvent payload.
 type PushEventRepository struct {
 	ID              *int                `json:"id,omitempty"`
 	Name            *string             `json:"name,omitempty"`
@@ -471,7 +471,7 @@ type PushEventRepository struct {
 	HTMLURL *string `json:"html_url,omitempty"`
 }
 
-// PushEventRepoOwner is a basic representation of user/org in a PushEvent payload
+// PushEventRepoOwner is a basic representation of user/org in a PushEvent payload.
 type PushEventRepoOwner struct {
 	Name  *string `json:"name,omitempty"`
 	Email *string `json:"email,omitempty"`

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -276,9 +276,9 @@ type MilestoneEvent struct {
 	Org     *Organization `json:"organization,omitempty"`
 }
 
-// OrganizationEvent is Triggered when a user is added, removed, or invited to an Organization.
+// OrganizationEvent is triggered when a user is added, removed, or invited to an organization.
 // Events of this type are not visible in timelines. These events are only used to trigger organization hooks.
-// Webhook event name is "organization"
+// Webhook event name is "organization".
 //
 // Github docs: https://developer.github.com/v3/activity/events/types/#organizationevent
 type OrganizationEvent struct {

--- a/github/github.go
+++ b/github/github.go
@@ -93,6 +93,9 @@ const (
 
 	// https://developer.github.com/changes/2016-09-14-Integrations-Early-Access/
 	mediaTypeIntegrationPreview = "application/vnd.github.machine-man-preview+json"
+
+	// https://developer.github.com/changes/2016-11-28-preview-org-membership/
+	mediaTypeOrgMembershipPreview = "application/vnd.github.korra-preview+json"
 )
 
 // A Client manages communication with the GitHub API.

--- a/github/messages.go
+++ b/github/messages.go
@@ -53,6 +53,7 @@ var (
 		"member":                                "MemberEvent",
 		"membership":                            "MembershipEvent",
 		"milestone":                             "MilestoneEvent",
+		"organization":                          "OrganizationEvent",
 		"page_build":                            "PageBuildEvent",
 		"public":                                "PublicEvent",
 		"pull_request_review":                   "PullRequestReviewEvent",

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -141,6 +141,10 @@ func TestParseWebHook(t *testing.T) {
 			messageType: "milestone",
 		},
 		{
+			payload:     &OrganizationEvent{},
+			messageType: "organization",
+		},
+		{
 			payload:     &PageBuildEvent{},
 			messageType: "page_build",
 		},

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -411,7 +411,7 @@ func (s *OrganizationsService) ListPendingTeamInvitations(team int, opt *ListOpt
 		return nil, nil, err
 	}
 
-	// TODO: remove custom accept header when this API fully launches.
+	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeOrgMembershipPreview)
 
 	pendingInvitations := new([]*Invitation)

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -5,7 +5,10 @@
 
 package github
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // Team represents a team within a GitHub organization.  Teams are used to
 // manage access to an organization's repositories.
@@ -37,8 +40,21 @@ type Team struct {
 	RepositoriesURL *string       `json:"repositories_url,omitempty"`
 }
 
+// Invitation represents a team member's inviation status
+type Invitation struct {
+	ID        *int       `json:"id,omitempty"`
+	Login     *string    `json:"login,omitempty"`
+	Email     *string    `json:"email,omitempty"`
+	Role      *string    `json:"role,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+}
+
 func (t Team) String() string {
 	return Stringify(t)
+}
+
+func (i Invitation) String() string {
+	return Stringify(i)
 }
 
 // ListTeams lists all of the teams for an organization.
@@ -376,4 +392,29 @@ func (s *OrganizationsService) RemoveTeamMembership(team int, user string) (*Res
 	}
 
 	return s.client.Do(req, nil)
+}
+
+// ListPendingTeamInvitations get pending invitaion list in team.
+// Warning: The API may change without advance notice during the preview period.
+// Preview features are not supported for production use.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/teams/#list-pending-team-invitations
+func (s *OrganizationsService) ListPendingTeamInvitations(team int, opt *ListOptions) ([]*Invitation, *Response, error) {
+	u := fmt.Sprintf("teams/%v/invitations", team)
+	u, err := addOptions(u, opt)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.Header.Set("Accept", mediaTypeOrgMembershipPreview)
+
+	pendingInvitations := new([]*Invitation)
+	resp, err := s.client.Do(req, pendingInvitations)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *pendingInvitations, resp, err
 }

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -40,6 +40,10 @@ type Team struct {
 	RepositoriesURL *string       `json:"repositories_url,omitempty"`
 }
 
+func (t Team) String() string {
+	return Stringify(t)
+}
+
 // Invitation represents a team member's inviation status
 type Invitation struct {
 	ID        *int       `json:"id,omitempty"`
@@ -47,10 +51,6 @@ type Invitation struct {
 	Email     *string    `json:"email,omitempty"`
 	Role      *string    `json:"role,omitempty"`
 	CreatedAt *time.Time `json:"created_at,omitempty"`
-}
-
-func (t Team) String() string {
-	return Stringify(t)
 }
 
 func (i Invitation) String() string {
@@ -402,12 +402,16 @@ func (s *OrganizationsService) RemoveTeamMembership(team int, user string) (*Res
 func (s *OrganizationsService) ListPendingTeamInvitations(team int, opt *ListOptions) ([]*Invitation, *Response, error) {
 	u := fmt.Sprintf("teams/%v/invitations", team)
 	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// TODO: remove custom accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeOrgMembershipPreview)
 
 	pendingInvitations := new([]*Invitation)

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -499,3 +499,25 @@ func TestOrganizationsService_ListUserTeams(t *testing.T) {
 		t.Errorf("Organizations.ListUserTeams returned %+v, want %+v", teams, want)
 	}
 }
+
+func TestOrganizationsService_ListPendingTeamInvitations(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/teams/1/invitations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"page": "1"})
+		fmt.Fprint(w, `[{"id":1}]`)
+	})
+
+	opt := &ListOptions{Page: 1}
+	invitations, _, err := client.Organizations.ListPendingTeamInvitations(1, opt)
+	if err != nil {
+		t.Errorf("Organizations.ListPendingTeamInvitations returned error: %v", err)
+	}
+
+	want := []*Invitation{{ID: Int(1)}}
+	if !reflect.DeepEqual(invitations, want) {
+		t.Errorf("Organizations.ListPendingTeamInvitations returned %+v, want %+v", invitations, want)
+	}
+}

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -507,6 +507,7 @@ func TestOrganizationsService_ListPendingTeamInvitations(t *testing.T) {
 	mux.HandleFunc("/teams/1/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"page": "1"})
+		testHeader(t, r, "Accept", mediaTypeOrgMembershipPreview)
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 


### PR DESCRIPTION
I added team pending invitation API and OrganizationEvent type structures.

Team pending invitation API : https://developer.github.com/v3/orgs/teams/#list-pending-team-invitations

Organization Event Type : https://developer.github.com/v3/activity/events/types/#organizationevent