### PR TITLE
tests/integration: Point to a better place for more information.

### DIFF
--- a/tests/integration/doc.go
+++ b/tests/integration/doc.go
@@ -6,6 +6,6 @@
 // Package tests contains integration tests.
 //
 // These tests call the live GitHub API, and therefore require a little more
-// setup to run.  See https://github.com/google/go-github/tree/master/tests/integration
+// setup to run.  See https://github.com/google/go-github/tree/master/tests#integration
 // for more information.
 package tests


### PR DESCRIPTION
Point to the README, section on integration tests, instead of an empty directory.