### PR TITLE
Changed "event" by "action" in issues events

### DIFF
--- a/github/issues_events.go
+++ b/github/issues_events.go
@@ -57,7 +57,7 @@ type IssueEvent struct {
 	//     head_ref_deleted, head_ref_restored
 	//       The pull request’s branch was deleted or restored.
 	//
-	Event *string `json:"event,omitempty"`
+	Event *string `json:"action,omitempty"`
 
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	Issue     *Issue     `json:"issue,omitempty"`


### PR DESCRIPTION
When the IssueEvent is used the event field is empty because the json payload has "action" and not "event" as key.

https://developer.github.com/v3/activity/events/types/#webhook-payload-example-8