### PR TITLE
Remove preview header for traffic API

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -85,9 +85,6 @@ const (
 	// https://developer.github.com/changes/2016-07-06-github-pages-preiew-api/
 	mediaTypePagesPreview = "application/vnd.github.mister-fantastic-preview+json"
 
-	// https://developer.github.com/v3/repos/traffic/
-	mediaTypeTrafficPreview = "application/vnd.github.spiderman-preview+json"
-
 	// https://developer.github.com/changes/2016-09-14-projects-api/
 	mediaTypeProjectsPreview = "application/vnd.github.inertia-preview+json"
 

--- a/github/repos_traffic.go
+++ b/github/repos_traffic.go
@@ -60,9 +60,6 @@ func (s *RepositoriesService) ListTrafficReferrers(owner, repo string) ([]*Traff
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeTrafficPreview)
-
 	trafficReferrers := new([]*TrafficReferrer)
 	resp, err := s.client.Do(req, &trafficReferrers)
 	if err != nil {
@@ -82,9 +79,6 @@ func (s *RepositoriesService) ListTrafficPaths(owner, repo string) ([]*TrafficPa
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeTrafficPreview)
 
 	var paths = new([]*TrafficPath)
 	resp, err := s.client.Do(req, &paths)
@@ -110,9 +104,6 @@ func (s *RepositoriesService) ListTrafficViews(owner, repo string, opt *TrafficB
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeTrafficPreview)
-
 	trafficViews := new(TrafficViews)
 	resp, err := s.client.Do(req, &trafficViews)
 	if err != nil {
@@ -136,9 +127,6 @@ func (s *RepositoriesService) ListTrafficClones(owner, repo string, opt *Traffic
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeTrafficPreview)
 
 	trafficClones := new(TrafficClones)
 	resp, err := s.client.Do(req, &trafficClones)

--- a/github/repos_traffic_test.go
+++ b/github/repos_traffic_test.go
@@ -19,7 +19,6 @@ func TestRepositoriesService_ListTrafficReferrers(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/traffic/popular/referrers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeTrafficPreview)
 		fmt.Fprintf(w, `[{
 			"referrer": "Google",
 			"count": 4,
@@ -48,7 +47,6 @@ func TestRepositoriesService_ListTrafficPaths(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/traffic/popular/paths", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeTrafficPreview)
 		fmt.Fprintf(w, `[{
 			"path": "/github/hubot",
 			"title": "github/hubot: A customizable life embetterment robot.",
@@ -79,7 +77,6 @@ func TestRepositoriesService_ListTrafficViews(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/traffic/views", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeTrafficPreview)
 		fmt.Fprintf(w, `{"count": 7,
 			"uniques": 6,
 			"views": [{
@@ -116,7 +113,6 @@ func TestRepositoriesService_ListTrafficClones(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/traffic/clones", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeTrafficPreview)
 		fmt.Fprintf(w, `{"count": 7,
 			"uniques": 6,
 			"clones": [{


### PR DESCRIPTION
The traffic API is now formally released and a preview header is no longer required.

https://developer.github.com/changes/2016-12-28-end-traffic-api-preview/