### PR TITLE
Document required branch protection fields.

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -522,18 +522,18 @@ type ProtectionRequest struct {
 
 // RequiredStatusChecks represents the protection status of a individual branch.
 type RequiredStatusChecks struct {
-	// Enforce required status checks for repository administrators.
+	// Enforce required status checks for repository administrators. (Required.)
 	IncludeAdmins bool `json:"include_admins"`
-	// Require branches to be up to date before merging.
+	// Require branches to be up to date before merging. (Required.)
 	Strict bool `json:"strict"`
 	// The list of status checks to require in order to merge into this
-	// branch.
+	// branch. (Required; use []string{} instead of nil for empty list.)
 	Contexts []string `json:"contexts"`
 }
 
 // RequiredPullRequestReviews represents the protection configuration for pull requests.
 type RequiredPullRequestReviews struct {
-	// Enforce pull request reviews for repository administrators.
+	// Enforce pull request reviews for repository administrators. (Required.)
 	IncludeAdmins bool `json:"include_admins"`
 }
 
@@ -551,9 +551,9 @@ type BranchRestrictions struct {
 // separate from BranchRestrictions above because the request structure is
 // different from the response structure.
 type BranchRestrictionsRequest struct {
-	// The list of user logins with push access.
+	// The list of user logins with push access. (Required; use []string{} instead of nil for empty list.)
 	Users []string `json:"users"`
-	// The list of team slugs with push access.
+	// The list of team slugs with push access. (Required; use []string{} instead of nil for empty list.)
 	Teams []string `json:"teams"`
 }
 


### PR DESCRIPTION
All of those fields are documented as required at https://developer.github.com/v3/repos/branches/#update-branch-protection.

In #512, we changed the API to better reflect that. However, it should still be documented that the fields are required. This is consistent with the other required fields that are also documented as required.

Additionally, note that empty slices must be non-`nil`. From running integration tests, I've seen that passing `nil` slices (which get encoded as `null` via `encoding/json`) resulted in invalid request errors such as:

	No subschema in "anyOf" matched.
	For 'properties/users', nil is not an array.
	For 'properties/teams', nil is not an array.
	Not all subschemas of "allOf" matched.
	For 'anyOf/1', {"users"=>nil, "teams"=>nil} is not a null. []

Follows #512.

/cc @alindeman since you worked on #512 where we discussed this.