### PR TITLE
Add support for Commit Search endpoint

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -93,6 +93,9 @@ const (
 
 	// https://developer.github.com/changes/2016-11-28-preview-org-membership/
 	mediaTypeOrgMembershipPreview = "application/vnd.github.korra-preview+json"
+
+	// https://developer.github.com/changes/2017-01-05-commit-search-api/
+	mediaTypeCommitSearchPreview = "application/vnd.github.cloak-preview+json"
 )
 
 // A Client manages communication with the GitHub API.

--- a/github/search.go
+++ b/github/search.go
@@ -183,13 +183,14 @@ func (s *SearchService) search(searchType string, query string, opt *SearchOptio
 	}
 
 	switch {
+	case searchType == "commits":
+		// Accept header for search commits preview endpoint
+		// TODO: remove custom Accept header when this API fully launches.
+		req.Header.Set("Accept", mediaTypeCommitSearchPreview)
 	case opt != nil && opt.TextMatch:
 		// Accept header defaults to "application/vnd.github.v3+json"
 		// We change it here to fetch back text-match metadata
 		req.Header.Set("Accept", "application/vnd.github.v3.text-match+json")
-	case searchType == "commits":
-		// Accept header for search commits preview endpoint
-		req.Header.Set("Accept", mediaTypeCommitSearchPreview)
 	}
 
 	return s.client.Do(req, result)

--- a/github/search.go
+++ b/github/search.go
@@ -55,6 +55,7 @@ func (s *SearchService) Repositories(query string, opt *SearchOptions) (*Reposit
 	return result, resp, err
 }
 
+// SingleCommitResult represents a commit object as returned in commit search endpoint response.
 type SingleCommitResult struct {
 	Hash           *string     `json:"hash,omitempty"`
 	Message        *string     `json:"message,omitempty"`

--- a/github/search.go
+++ b/github/search.go
@@ -58,11 +58,11 @@ func (s *SearchService) Repositories(query string, opt *SearchOptions) (*Reposit
 type SingleCommitResult struct {
 	Hash           *string     `json:"hash,omitempty"`
 	Message        *string     `json:"message,omitempty"`
-	AuthorID       int         `json:"author_id,omitempty"`
+	AuthorID       *int        `json:"author_id,omitempty"`
 	AuthorName     *string     `json:"author_name,omitempty"`
 	AuthorEmail    *string     `json:"author_email,omitempty"`
 	AuthorDate     *string     `json:"author_date,omitempty"`
-	CommitterID    int         `json:"committer_id,omitempty"`
+	CommitterID    *int        `json:"committer_id,omitempty"`
 	CommitterName  *string     `json:"committer_name,omitempty"`
 	CommitterEmail *string     `json:"committer_email,omitempty"`
 	CommitterDate  *string     `json:"committer_date,omitempty"`

--- a/github/search.go
+++ b/github/search.go
@@ -57,9 +57,9 @@ func (s *SearchService) Repositories(query string, opt *SearchOptions) (*Reposit
 
 // CommitsSearchResult represents the result of a commits search.
 type CommitsSearchResult struct {
-	Total             *int           `json:"total_count,omitempty"`
-	IncompleteResults *bool          `json:"incomplete_results,omitempty"`
-	Commits           []CommitResult `json:"items,omitempty"`
+	Total             *int            `json:"total_count,omitempty"`
+	IncompleteResults *bool           `json:"incomplete_results,omitempty"`
+	Commits           []*CommitResult `json:"items,omitempty"`
 }
 
 // CommitResult represents a commit object as returned in commit search endpoint response.

--- a/github/search.go
+++ b/github/search.go
@@ -21,6 +21,7 @@ type SearchService service
 type SearchOptions struct {
 	// How to sort the search results.  Possible values are:
 	//   - for repositories: stars, fork, updated
+	//   - for commits: author-date, committer-date
 	//   - for code: indexed
 	//   - for issues: comments, created, updated
 	//   - for users: followers, repositories, joined
@@ -51,6 +52,36 @@ type RepositoriesSearchResult struct {
 func (s *SearchService) Repositories(query string, opt *SearchOptions) (*RepositoriesSearchResult, *Response, error) {
 	result := new(RepositoriesSearchResult)
 	resp, err := s.search("repositories", query, opt, result)
+	return result, resp, err
+}
+
+type SingleCommitResult struct {
+	Hash           *string     `json:"hash,omitempty"`
+	Message        *string     `json:"message,omitempty"`
+	AuthorID       int         `json:"author_id,omitempty"`
+	AuthorName     *string     `json:"author_name,omitempty"`
+	AuthorEmail    *string     `json:"author_email,omitempty"`
+	AuthorDate     *string     `json:"author_date,omitempty"`
+	CommitterID    int         `json:"committer_id,omitempty"`
+	CommitterName  *string     `json:"committer_name,omitempty"`
+	CommitterEmail *string     `json:"committer_email,omitempty"`
+	CommitterDate  *string     `json:"committer_date,omitempty"`
+	Repository     *Repository `json:"repository,omitempty"`
+}
+
+// CommitsSearchResult represents the result of a commits search.
+type CommitsSearchResult struct {
+	Total             *int                 `json:"total_count,omitempty"`
+	IncompleteResults *bool                `json:"incomplete_results,omitempty"`
+	Commits           []SingleCommitResult `json:"items,omitempty"`
+}
+
+// Commits searches commits via various criteria.
+//
+// GitHub API Docs: https://developer.github.com/v3/search/#search-commits
+func (s *SearchService) Commits(query string, opt *SearchOptions) (*CommitsSearchResult, *Response, error) {
+	result := new(CommitsSearchResult)
+	resp, err := s.search("commits", query, opt, result)
 	return result, resp, err
 }
 
@@ -148,6 +179,11 @@ func (s *SearchService) search(searchType string, query string, opt *SearchOptio
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if searchType == "commits" {
+		// Accept header for search commits preview endpoint
+		req.Header.Set("Accept", mediaTypeCommitSearchPreview)
 	}
 
 	if opt != nil && opt.TextMatch {

--- a/github/search.go
+++ b/github/search.go
@@ -77,7 +77,6 @@ type CommitResult struct {
 	Repository     *Repository `json:"repository,omitempty"`
 }
 
-
 // Commits searches commits via various criteria.
 //
 // GitHub API Docs: https://developer.github.com/v3/search/#search-commits
@@ -184,13 +183,13 @@ func (s *SearchService) search(searchType string, query string, opt *SearchOptio
 	}
 
 	switch {
-		case opt != nil && opt.TextMatch:
-			// Accept header defaults to "application/vnd.github.v3+json"
-			// We change it here to fetch back text-match metadata
-			req.Header.Set("Accept", "application/vnd.github.v3.text-match+json")
-		case searchType == "commits":
-			// Accept header for search commits preview endpoint
-			req.Header.Set("Accept", mediaTypeCommitSearchPreview)
+	case opt != nil && opt.TextMatch:
+		// Accept header defaults to "application/vnd.github.v3+json"
+		// We change it here to fetch back text-match metadata
+		req.Header.Set("Accept", "application/vnd.github.v3.text-match+json")
+	case searchType == "commits":
+		// Accept header for search commits preview endpoint
+		req.Header.Set("Accept", mediaTypeCommitSearchPreview)
 	}
 
 	return s.client.Do(req, result)

--- a/github/search_test.go
+++ b/github/search_test.go
@@ -46,6 +46,37 @@ func TestSearchService_Repositories(t *testing.T) {
 	}
 }
 
+func TestSearchService_Commits(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/search/commits", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"q":        "blah",
+			"sort":     "author-date",
+			"order":    "desc",
+		})
+
+		fmt.Fprint(w, `{"total_count": 4, "incomplete_results": false, "items": [{"hash":"random_hash1"},{"hash":"random_hash2"}]}`)
+	})
+
+	opts := &SearchOptions{Sort: "author-date", Order: "desc"}
+	result, _, err := client.Search.Commits("blah", opts)
+	if err != nil {
+		t.Errorf("Search.Commits returned error: %v", err)
+	}
+
+	want := &CommitsSearchResult{
+		Total:             Int(4),
+		IncompleteResults: Bool(false),
+		Commits:           []SingleCommitResult{{Hash: String("random_hash1")}, {Hash: String("random_hash2")}},
+	}
+	if !reflect.DeepEqual(result, want) {
+		t.Errorf("Search.Commits returned %+v, want %+v", result, want)
+	}
+}
+
 func TestSearchService_Issues(t *testing.T) {
 	setup()
 	defer teardown()

--- a/github/search_test.go
+++ b/github/search_test.go
@@ -53,9 +53,9 @@ func TestSearchService_Commits(t *testing.T) {
 	mux.HandleFunc("/search/commits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{
-			"q":        "blah",
-			"sort":     "author-date",
-			"order":    "desc",
+			"q":     "blah",
+			"sort":  "author-date",
+			"order": "desc",
 		})
 
 		fmt.Fprint(w, `{"total_count": 4, "incomplete_results": false, "items": [{"hash":"random_hash1"},{"hash":"random_hash2"}]}`)

--- a/github/search_test.go
+++ b/github/search_test.go
@@ -70,7 +70,7 @@ func TestSearchService_Commits(t *testing.T) {
 	want := &CommitsSearchResult{
 		Total:             Int(4),
 		IncompleteResults: Bool(false),
-		Commits:           []CommitResult{{Hash: String("random_hash1")}, {Hash: String("random_hash2")}},
+		Commits:           []*CommitResult{{Hash: String("random_hash1")}, {Hash: String("random_hash2")}},
 	}
 	if !reflect.DeepEqual(result, want) {
 		t.Errorf("Search.Commits returned %+v, want %+v", result, want)

--- a/github/search_test.go
+++ b/github/search_test.go
@@ -70,7 +70,7 @@ func TestSearchService_Commits(t *testing.T) {
 	want := &CommitsSearchResult{
 		Total:             Int(4),
 		IncompleteResults: Bool(false),
-		Commits:           []SingleCommitResult{{Hash: String("random_hash1")}, {Hash: String("random_hash2")}},
+		Commits:           []CommitResult{{Hash: String("random_hash1")}, {Hash: String("random_hash2")}},
 	}
 	if !reflect.DeepEqual(result, want) {
 		t.Errorf("Search.Commits returned %+v, want %+v", result, want)


### PR DESCRIPTION
Added support for this new preview endpoint which lets users
search for commits based on various conditions.

GitHub announcement -
https://developer.github.com/changes/2017-01-05-commit-search-api/
Docs - https://developer.github.com/v3/search/#search-commits

Fixes #508.

\cc @shurcooL @gmlewis 