### PR TITLE
Redact secret in error from HTTP client Do.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -550,7 +550,7 @@ func (r *AbuseRateLimitError) Error() string {
 }
 
 // sanitizeURL redacts the client_secret parameter from the URL which may be
-// exposed to the user, specifically in the ErrorResponse error message.
+// exposed to the user.
 func sanitizeURL(uri *url.URL) *url.URL {
 	if uri == nil {
 		return nil

--- a/github/github.go
+++ b/github/github.go
@@ -406,6 +406,12 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 
 	resp, err := c.client.Do(req)
 	if err != nil {
+		if e, ok := err.(*url.Error); ok {
+			if url, err := url.Parse(e.URL); err == nil {
+				e.URL = sanitizeURL(url).String()
+				return nil, e
+			}
+		}
 		return nil, err
 	}
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -392,8 +392,7 @@ func TestDo_sanitizeURL(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error to be returned.")
 	}
-	if !strings.Contains(err.Error(), "client_secret=REDACTED") ||
-		strings.Contains(err.Error(), "client_secret=secret") {
+	if strings.Contains(err.Error(), "client_secret=secret") {
 		t.Errorf("Do error contains secret, should be redacted:\n%q", err)
 	}
 }


### PR DESCRIPTION
Fixes #522. See that issue and commit messages for explanation.

I see that CI succeeds on Go 1.7 and newer, but fails on 1.6 and older. I'm going to think about how to best address that, and update this PR.