### PR TITLE
pulls: Support updating base branch

### DIFF
--- a/github/pulls.go
+++ b/github/pulls.go
@@ -198,6 +198,9 @@ type pullRequestUpdate struct {
 
 // Edit a pull request.
 //
+// The following fields are editable: Title, Body, State, and Base.Ref.
+// Base.Ref updates the base branch of the pull request.
+//
 // GitHub API docs: https://developer.github.com/v3/pulls/#update-a-pull-request
 func (s *PullRequestsService) Edit(owner string, repo string, number int, pull *PullRequest) (*PullRequest, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d", owner, repo, number)

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -189,12 +189,30 @@ func (s *PullRequestsService) Create(owner string, repo string, pull *NewPullReq
 	return p, resp, err
 }
 
+type pullRequestUpdate struct {
+	Title *string `json:"title,omitempty"`
+	Body  *string `json:"body,omitempty"`
+	State *string `json:"state,omitempty"`
+	Base  *string `json:"base,omitempty"`
+}
+
 // Edit a pull request.
 //
 // GitHub API docs: https://developer.github.com/v3/pulls/#update-a-pull-request
 func (s *PullRequestsService) Edit(owner string, repo string, number int, pull *PullRequest) (*PullRequest, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d", owner, repo, number)
-	req, err := s.client.NewRequest("PATCH", u, pull)
+
+	update := new(pullRequestUpdate)
+	if pull != nil {
+		update.Title = pull.Title
+		update.Body = pull.Body
+		update.State = pull.State
+		if pull.Base != nil {
+			update.Base = pull.Base.Ref
+		}
+	}
+
+	req, err := s.client.NewRequest("PATCH", u, update)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -240,27 +240,27 @@ func TestPullRequestsService_Edit(t *testing.T) {
 		input        *PullRequest
 		sendResponse string
 
-		wantUpdate   string
-		wantResponse *PullRequest
+		wantUpdate string
+		want       *PullRequest
 	}{
 		{
 			input:        &PullRequest{Title: String("t")},
 			sendResponse: `{"number":1}`,
 			wantUpdate:   `{"title":"t"}`,
-			wantResponse: &PullRequest{Number: Int(1)},
+			want:         &PullRequest{Number: Int(1)},
 		},
 		{
 			// nil request
 			sendResponse: `{}`,
 			wantUpdate:   `{}`,
-			wantResponse: &PullRequest{},
+			want:         &PullRequest{},
 		},
 		{
 			// base update
 			input:        &PullRequest{Base: &PullRequestBranch{Ref: String("master")}},
 			sendResponse: `{"number":1,"base":{"ref":"master"}}`,
 			wantUpdate:   `{"base":"master"}`,
-			wantResponse: &PullRequest{
+			want: &PullRequest{
 				Number: Int(1),
 				Base:   &PullRequestBranch{Ref: String("master")},
 			},
@@ -281,8 +281,8 @@ func TestPullRequestsService_Edit(t *testing.T) {
 			t.Errorf("%d: PullRequests.Edit returned error: %v", i, err)
 		}
 
-		if !reflect.DeepEqual(pull, tt.wantResponse) {
-			t.Errorf("%d: PullRequests.Edit returned %+v, want %+v", i, pull, tt.wantResponse)
+		if !reflect.DeepEqual(pull, tt.want) {
+			t.Errorf("%d: PullRequests.Edit returned %+v, want %+v", i, pull, tt.want)
 		}
 
 		if !madeRequest {


### PR DESCRIPTION
This adds support for changing the base branch of a PR.

As per the discussion in #421, the `PullRequest` is converted into an
unexported type `pullRequestUpdate` which matches the shape expected by the
pulls PATCH endpoint.

Resolves issue #421.