### PR TITLE
Add StatusesURL to PushEventRepository

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -504,6 +504,7 @@ type PushEventRepository struct {
 	// The following fields are only populated by Webhook events.
 	URL          *string       `json:"url,omitempty"`
 	HTMLURL      *string       `json:"html_url,omitempty"`
+	StatusesURL  *string       `json:"statuses_url,omitempty"`
 	Installation *Installation `json:"installation,omitempty"`
 }
 

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -423,26 +423,26 @@ type PullRequestReviewCommentEvent struct {
 //
 // GitHub API docs: http://developer.github.com/v3/activity/events/types/#pushevent
 type PushEvent struct {
-	PushID       *int                 `json:"push_id,omitempty"`
-	Head         *string              `json:"head,omitempty"`
-	Ref          *string              `json:"ref,omitempty"`
-	Size         *int                 `json:"size,omitempty"`
-	Commits      []PushEventCommit    `json:"commits,omitempty"`
-	Repo         *PushEventRepository `json:"repository,omitempty"`
-	Before       *string              `json:"before,omitempty"`
-	DistinctSize *int                 `json:"distinct_size,omitempty"`
+	PushID       *int              `json:"push_id,omitempty"`
+	Head         *string           `json:"head,omitempty"`
+	Ref          *string           `json:"ref,omitempty"`
+	Size         *int              `json:"size,omitempty"`
+	Commits      []PushEventCommit `json:"commits,omitempty"`
+	Before       *string           `json:"before,omitempty"`
+	DistinctSize *int              `json:"distinct_size,omitempty"`
 
 	// The following fields are only populated by Webhook events.
-	After        *string          `json:"after,omitempty"`
-	Created      *bool            `json:"created,omitempty"`
-	Deleted      *bool            `json:"deleted,omitempty"`
-	Forced       *bool            `json:"forced,omitempty"`
-	BaseRef      *string          `json:"base_ref,omitempty"`
-	Compare      *string          `json:"compare,omitempty"`
-	HeadCommit   *PushEventCommit `json:"head_commit,omitempty"`
-	Pusher       *User            `json:"pusher,omitempty"`
-	Sender       *User            `json:"sender,omitempty"`
-	Installation *Installation    `json:"installation,omitempty"`
+	After        *string              `json:"after,omitempty"`
+	Created      *bool                `json:"created,omitempty"`
+	Deleted      *bool                `json:"deleted,omitempty"`
+	Forced       *bool                `json:"forced,omitempty"`
+	BaseRef      *string              `json:"base_ref,omitempty"`
+	Compare      *string              `json:"compare,omitempty"`
+	Repo         *PushEventRepository `json:"repository,omitempty"`
+	HeadCommit   *PushEventCommit     `json:"head_commit,omitempty"`
+	Pusher       *User                `json:"pusher,omitempty"`
+	Sender       *User                `json:"sender,omitempty"`
+	Installation *Installation        `json:"installation,omitempty"`
 }
 
 func (p PushEvent) String() string {
@@ -460,14 +460,13 @@ type PushEventCommit struct {
 	SHA *string `json:"sha,omitempty"`
 
 	// The following fields are only populated by Webhook events.
-	ID           *string       `json:"id,omitempty"`
-	TreeID       *string       `json:"tree_id,omitempty"`
-	Timestamp    *Timestamp    `json:"timestamp,omitempty"`
-	Committer    *CommitAuthor `json:"committer,omitempty"`
-	Added        []string      `json:"added,omitempty"`
-	Removed      []string      `json:"removed,omitempty"`
-	Modified     []string      `json:"modified,omitempty"`
-	Installation *Installation `json:"installation,omitempty"`
+	ID        *string       `json:"id,omitempty"`
+	TreeID    *string       `json:"tree_id,omitempty"`
+	Timestamp *Timestamp    `json:"timestamp,omitempty"`
+	Committer *CommitAuthor `json:"committer,omitempty"`
+	Added     []string      `json:"added,omitempty"`
+	Removed   []string      `json:"removed,omitempty"`
+	Modified  []string      `json:"modified,omitempty"`
 }
 
 func (p PushEventCommit) String() string {
@@ -500,12 +499,9 @@ type PushEventRepository struct {
 	DefaultBranch   *string             `json:"default_branch,omitempty"`
 	MasterBranch    *string             `json:"master_branch,omitempty"`
 	Organization    *string             `json:"organization,omitempty"`
-
-	// The following fields are only populated by Webhook events.
-	URL          *string       `json:"url,omitempty"`
-	HTMLURL      *string       `json:"html_url,omitempty"`
-	StatusesURL  *string       `json:"statuses_url,omitempty"`
-	Installation *Installation `json:"installation,omitempty"`
+	URL             *string             `json:"url,omitempty"`
+	HTMLURL         *string             `json:"html_url,omitempty"`
+	StatusesURL     *string             `json:"statuses_url,omitempty"`
 }
 
 // PushEventRepoOwner is a basic representation of user/org in a PushEvent payload.


### PR DESCRIPTION
https://developer.github.com/v3/activity/events/types/#pushevent defines the statuses_url sent with each PushEvent webhook.

There wasn't any tests around this event currently (that I could see), but I can add them if you can provide some directions/examples if you'd like.

The position in the struct is also a little strange to me, as all the fields should be populated as this struct represents a webhook event, so I don't understand the comment `The following fields are only populated by Webhook events.`, but I've added the member there as it did seem to be the most appropriate place. Happy to move around.