### PR TITLE
Adds support for GET /repos/:owner/:repo/collaborators/:username/permission

### DIFF
--- a/github/repos_collaborators.go
+++ b/github/repos_collaborators.go
@@ -75,7 +75,7 @@ func (s *RepositoriesService) GetPermissionLevel(owner, repo, user string) (*Rep
 	if err != nil {
 		return nil, resp, err
 	}
-	return rpl, resp, err
+	return rpl, resp, nil
 }
 
 // RepositoryAddCollaboratorOptions specifies the optional parameters to the

--- a/github/repos_collaborators.go
+++ b/github/repos_collaborators.go
@@ -49,6 +49,35 @@ func (s *RepositoriesService) IsCollaborator(owner, repo, user string) (bool, *R
 	return isCollab, resp, err
 }
 
+// RepositoryPermissionLevel represents the permission level an organization
+// member has for a given repository.
+type RepositoryPermissionLevel struct {
+	// Possible values: "admin", "write", "read", "none"
+	Permission *string `json:"permission,omitempty"`
+
+	User *User `json:"user,omitempty"`
+}
+
+// GetPermissionLevel retrieves the specific permission level a collaborator has for a given repository.
+// GitHub API docs: https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level
+func (s *RepositoriesService) GetPermissionLevel(owner, repo, user string) (*RepositoryPermissionLevel, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/collaborators/%v/permission", owner, repo, user)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeOrgMembershipPreview)
+
+	rpl := new(RepositoryPermissionLevel)
+	resp, err := s.client.Do(req, rpl)
+	if err != nil {
+		return nil, resp, err
+	}
+	return rpl, resp, err
+}
+
 // RepositoryAddCollaboratorOptions specifies the optional parameters to the
 // RepositoriesService.AddCollaborator method.
 type RepositoryAddCollaboratorOptions struct {

--- a/github/repos_collaborators_test.go
+++ b/github/repos_collaborators_test.go
@@ -83,6 +83,33 @@ func TestRepositoriesService_IsCollaborator_invalidUser(t *testing.T) {
 	testURLParseError(t, err)
 }
 
+func TestRepositoryService_GetPermissionLevel(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/collaborators/u/permission", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeOrgMembershipPreview)
+		fmt.Fprintf(w, `{"permission":"admin","user":{"login":"u"}}`)
+	})
+
+	rpl, _, err := client.Repositories.GetPermissionLevel("o", "r", "u")
+	if err != nil {
+		t.Errorf("Repositories.GetPermissionLevel returned error: %v", err)
+	}
+
+	want := &RepositoryPermissionLevel{
+		Permission: String("admin"),
+		User: &User{
+			Login: String("u"),
+		},
+	}
+
+	if !reflect.DeepEqual(rpl, want) {
+		t.Errorf("Repositories.GetPermissionLevel returned %+v, want %+v", rpl, want)
+	}
+}
+
 func TestRepositoriesService_AddCollaborator(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
GitHub API docs: https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level