### PR TITLE
Added listing outside collaborators for an organization

### DIFF
--- a/github/orgs_outside_collaborators.go
+++ b/github/orgs_outside_collaborators.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The go-github AUTHORS. All rights reserved.
+// Copyright 2017 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
@@ -24,7 +24,7 @@ type ListOutsideCollaboratorsOptions struct {
 // Warning: The API may change without advance notice during the preview period.
 // Preview features are not supported for production use.
 //
-// GitHub API docs: https://developer.github.com/v3/orgs/outside_collaborators/
+// GitHub API docs: https://developer.github.com/v3/orgs/outside_collaborators/#list-outside-collaborators
 func (s *OrganizationsService) ListOutsideCollaborators(org string, opt *ListOutsideCollaboratorsOptions) ([]*User, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/outside_collaborators", org)
 	u, err := addOptions(u, opt)
@@ -33,7 +33,6 @@ func (s *OrganizationsService) ListOutsideCollaborators(org string, opt *ListOut
 	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
-
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/orgs_outside_collaborators.go
+++ b/github/orgs_outside_collaborators.go
@@ -46,5 +46,5 @@ func (s *OrganizationsService) ListOutsideCollaborators(org string, opt *ListOut
 		return nil, resp, err
 	}
 
-	return members, resp, err
+	return members, resp, nil
 }

--- a/github/orgs_outside_collaborators.go
+++ b/github/orgs_outside_collaborators.go
@@ -1,0 +1,51 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// ListOutsideCollaboratorsOptions specifies optional parameters to the
+// OrganizationsService.ListOutsideCollaborators method.
+type ListOutsideCollaboratorsOptions struct {
+	// Filter outside collaborators returned in the list. Possible values are:
+	// 2fa_disabled, all.  Default is "all".
+	Filter string `url:"filter,omitempty"`
+
+	ListOptions
+}
+
+// ListOutsideCollaborators lists outside collaborators of organization's repositories.
+// This will only work if the authenticated
+// user is an owner of the organization.
+//
+// Warning: The API may change without advance notice during the preview period.
+// Preview features are not supported for production use.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/outside_collaborators/
+func (s *OrganizationsService) ListOutsideCollaborators(org string, opt *ListOutsideCollaboratorsOptions) ([]*User, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/outside_collaborators", org)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeOrgMembershipPreview)
+
+	members := new([]*User)
+	resp, err := s.client.Do(req, members)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *members, resp, err
+}

--- a/github/orgs_outside_collaborators.go
+++ b/github/orgs_outside_collaborators.go
@@ -40,11 +40,11 @@ func (s *OrganizationsService) ListOutsideCollaborators(org string, opt *ListOut
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeOrgMembershipPreview)
 
-	members := new([]*User)
-	resp, err := s.client.Do(req, members)
+	var members []*User
+	resp, err := s.client.Do(req, &members)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *members, resp, err
+	return members, resp, err
 }

--- a/github/orgs_outside_collaborators_test.go
+++ b/github/orgs_outside_collaborators_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The go-github AUTHORS. All rights reserved.
+// Copyright 2017 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
@@ -22,6 +22,7 @@ func TestOrganizationsService_ListOutsideCollaborators(t *testing.T) {
 			"filter": "2fa_disabled",
 			"page":   "2",
 		})
+		testHeader(t, r, "Accept", mediaTypeOrgMembershipPreview)
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 

--- a/github/orgs_outside_collaborators_test.go
+++ b/github/orgs_outside_collaborators_test.go
@@ -1,0 +1,46 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestOrganizationsService_ListOutsideCollaborators(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/outside_collaborators", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"filter": "2fa_disabled",
+			"page":   "2",
+		})
+		fmt.Fprint(w, `[{"id":1}]`)
+	})
+
+	opt := &ListOutsideCollaboratorsOptions{
+		Filter:      "2fa_disabled",
+		ListOptions: ListOptions{Page: 2},
+	}
+	members, _, err := client.Organizations.ListOutsideCollaborators("o", opt)
+	if err != nil {
+		t.Errorf("Organizations.ListOutsideCollaborators returned error: %v", err)
+	}
+
+	want := []*User{{ID: Int(1)}}
+	if !reflect.DeepEqual(members, want) {
+		t.Errorf("Organizations.ListOutsideCollaborators returned %+v, want %+v", members, want)
+	}
+}
+
+func TestOrganizationsService_ListOutsideCollaborators_invalidOrg(t *testing.T) {
+	_, _, err := client.Organizations.ListOutsideCollaborators("%", nil)
+	testURLParseError(t, err)
+}


### PR DESCRIPTION
2fa_disabled filter is supported too.

I created a new file [orgs_outside_collaborators.go], but I'm not sure whether it wouldn't be better to rename [orgs_members.go] to something like [orgs_members_and_outside_collaborators.go] as it's not clear to me where would the function that converts a member to an outside collaborator fit best.

[orgs_outside_collaborators_test.go] contains tests that are basically recycled from [orgs_members_test.go]. 

I thought about adding an integration test, but I think that setting up a test scenario is either very hard or straight impossible right now (as we would have to be able to create an organisation and users, which I think is impossible without an Github Enterprise account). 
So I fell back to testing it a bit by hand, and those tests passed.

By the way, it's not clear to me why only the organisation's owner can list the organisation's outside collaborators (that's the response API gave me when I tried listing google's). It seems that this is inferrable by just going through all the organisation's repositories, so being a member should suffice. Or am I missing something?