### PR TITLE
Document Git.CreateCommit and PullRequests.Edit arguments

### DIFF
--- a/github/git_commits.go
+++ b/github/git_commits.go
@@ -88,6 +88,7 @@ type createCommit struct {
 }
 
 // CreateCommit creates a new commit in a repository.
+// commit must not be nil.
 //
 // The commit.Committer is optional and will be filled with the commit.Author
 // data if omitted. If the commit.Author is omitted, it will be filled in with
@@ -95,22 +96,25 @@ type createCommit struct {
 //
 // GitHub API docs: https://developer.github.com/v3/git/commits/#create-a-commit
 func (s *GitService) CreateCommit(ctx context.Context, owner string, repo string, commit *Commit) (*Commit, *Response, error) {
+	if commit == nil {
+		return nil, nil, fmt.Errorf("commit must be provided")
+	}
+
 	u := fmt.Sprintf("repos/%v/%v/git/commits", owner, repo)
 
-	body := &createCommit{}
-	if commit != nil {
-		parents := make([]string, len(commit.Parents))
-		for i, parent := range commit.Parents {
-			parents[i] = *parent.SHA
-		}
+	parents := make([]string, len(commit.Parents))
+	for i, parent := range commit.Parents {
+		parents[i] = *parent.SHA
+	}
 
-		body = &createCommit{
-			Author:    commit.Author,
-			Committer: commit.Committer,
-			Message:   commit.Message,
-			Tree:      commit.Tree.SHA,
-			Parents:   parents,
-		}
+	body := &createCommit{
+		Author:    commit.Author,
+		Committer: commit.Committer,
+		Message:   commit.Message,
+		Parents:   parents,
+	}
+	if commit.Tree != nil {
+		body.Tree = commit.Tree.SHA
 	}
 
 	req, err := s.client.NewRequest("POST", u, body)

--- a/github/git_commits_test.go
+++ b/github/git_commits_test.go
@@ -79,6 +79,6 @@ func TestGitService_CreateCommit(t *testing.T) {
 }
 
 func TestGitService_CreateCommit_invalidOwner(t *testing.T) {
-	_, _, err := client.Git.CreateCommit(context.Background(), "%", "%", nil)
+	_, _, err := client.Git.CreateCommit(context.Background(), "%", "%", &Commit{})
 	testURLParseError(t, err)
 }

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -198,6 +198,7 @@ type pullRequestUpdate struct {
 }
 
 // Edit a pull request.
+// pull may be nil, in which case the requested PR is returned unmodified.
 //
 // The following fields are editable: Title, Body, State, and Base.Ref.
 // Base.Ref updates the base branch of the pull request.

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -198,23 +198,26 @@ type pullRequestUpdate struct {
 }
 
 // Edit a pull request.
-// pull may be nil, in which case the requested PR is returned unmodified.
+// pull must not be nil.
 //
 // The following fields are editable: Title, Body, State, and Base.Ref.
 // Base.Ref updates the base branch of the pull request.
 //
 // GitHub API docs: https://developer.github.com/v3/pulls/#update-a-pull-request
 func (s *PullRequestsService) Edit(ctx context.Context, owner string, repo string, number int, pull *PullRequest) (*PullRequest, *Response, error) {
+	if pull == nil {
+		return nil, nil, fmt.Errorf("pull must be provided")
+	}
+
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d", owner, repo, number)
 
-	update := new(pullRequestUpdate)
-	if pull != nil {
-		update.Title = pull.Title
-		update.Body = pull.Body
-		update.State = pull.State
-		if pull.Base != nil {
-			update.Base = pull.Base.Ref
-		}
+	update := &pullRequestUpdate{
+		Title: pull.Title,
+		Body:  pull.Body,
+		State: pull.State,
+	}
+	if pull.Base != nil {
+		update.Base = pull.Base.Ref
 	}
 
 	req, err := s.client.NewRequest("PATCH", u, update)

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -251,12 +251,6 @@ func TestPullRequestsService_Edit(t *testing.T) {
 			want:         &PullRequest{Number: Int(1)},
 		},
 		{
-			// nil request
-			sendResponse: `{}`,
-			wantUpdate:   `{}`,
-			want:         &PullRequest{},
-		},
-		{
 			// base update
 			input:        &PullRequest{Base: &PullRequestBranch{Ref: String("master")}},
 			sendResponse: `{"number":1,"base":{"ref":"master"}}`,
@@ -293,7 +287,7 @@ func TestPullRequestsService_Edit(t *testing.T) {
 }
 
 func TestPullRequestsService_Edit_invalidOwner(t *testing.T) {
-	_, _, err := client.PullRequests.Edit(context.Background(), "%", "r", 1, nil)
+	_, _, err := client.PullRequests.Edit(context.Background(), "%", "r", 1, &PullRequest{})
 	testURLParseError(t, err)
 }
 


### PR DESCRIPTION
This also changes the logic of `Git.CreateCommit` to ensure that the `commit` argument is non-nil.
I am against changing this argument to a value because it is a non-trivial struct and makes sense (to me) to be passed by reference.

Fixes #531.

Change-Id: Ifc6640db138e4ea936f3c3077c1563fe3eedd450