### PR TITLE
Additional Clone related URLs to PushEventRepository

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -502,6 +502,10 @@ type PushEventRepository struct {
 	URL             *string             `json:"url,omitempty"`
 	HTMLURL         *string             `json:"html_url,omitempty"`
 	StatusesURL     *string             `json:"statuses_url,omitempty"`
+	GitURL          *string             `json:"git_url,omitempty"`
+	SSHURL          *string             `json:"ssh_url,omitempty"`
+	CloneURL        *string             `json:"clone_url,omitempty"`
+	SVNURL          *string             `json:"svn_url,omitempty"`
 }
 
 // PushEventRepoOwner is a basic representation of user/org in a PushEvent payload.


### PR DESCRIPTION
As defined in https://developer.github.com/v3/activity/events/types/#pushevent

Sorry, these should've been merged in with #533 at the time, and have the same conditions applied, that they're only defined in the webhook payload which contains `PushEventRepository` which is commented to only exist during a webhook. So I think it should be a simple addition.

Let me know if you'd like changes.