### PR TITLE
Return nil when there is no error 

### DIFF
--- a/github/activity_notifications.go
+++ b/github/activity_notifications.go
@@ -67,7 +67,7 @@ func (s *ActivityService) ListNotifications(opt *NotificationListOptions) ([]*No
 		return nil, resp, err
 	}
 
-	return notifications, resp, err
+	return notifications, resp, nil
 }
 
 // ListRepositoryNotifications lists all notifications in a given repository
@@ -92,7 +92,7 @@ func (s *ActivityService) ListRepositoryNotifications(owner, repo string, opt *N
 		return nil, resp, err
 	}
 
-	return notifications, resp, err
+	return notifications, resp, nil
 }
 
 type markReadOptions struct {
@@ -148,7 +148,7 @@ func (s *ActivityService) GetThread(id string) (*Notification, *Response, error)
 		return nil, resp, err
 	}
 
-	return notification, resp, err
+	return notification, resp, nil
 }
 
 // MarkThreadRead marks the specified thread as read.
@@ -183,7 +183,7 @@ func (s *ActivityService) GetThreadSubscription(id string) (*Subscription, *Resp
 		return nil, resp, err
 	}
 
-	return sub, resp, err
+	return sub, resp, nil
 }
 
 // SetThreadSubscription sets the subscription for the specified thread for the
@@ -204,7 +204,7 @@ func (s *ActivityService) SetThreadSubscription(id string, subscription *Subscri
 		return nil, resp, err
 	}
 
-	return sub, resp, err
+	return sub, resp, nil
 }
 
 // DeleteThreadSubscription deletes the subscription for the specified thread

--- a/github/activity_watching.go
+++ b/github/activity_watching.go
@@ -97,7 +97,7 @@ func (s *ActivityService) GetRepositorySubscription(owner, repo string) (*Subscr
 		return nil, resp, err
 	}
 
-	return sub, resp, err
+	return sub, resp, nil
 }
 
 // SetRepositorySubscription sets the subscription for the specified repository
@@ -122,7 +122,7 @@ func (s *ActivityService) SetRepositorySubscription(owner, repo string, subscrip
 		return nil, resp, err
 	}
 
-	return sub, resp, err
+	return sub, resp, nil
 }
 
 // DeleteRepositorySubscription deletes the subscription for the specified

--- a/github/admin.go
+++ b/github/admin.go
@@ -75,7 +75,7 @@ func (s *AdminService) UpdateUserLDAPMapping(user string, mapping *UserLDAPMappi
 		return nil, resp, err
 	}
 
-	return m, resp, err
+	return m, resp, nil
 }
 
 // UpdateTeamLDAPMapping updates the mapping between a GitHub team and an LDAP group.
@@ -94,5 +94,5 @@ func (s *AdminService) UpdateTeamLDAPMapping(team int, mapping *TeamLDAPMapping)
 		return nil, resp, err
 	}
 
-	return m, resp, err
+	return m, resp, nil
 }

--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -189,7 +189,7 @@ func (s *AuthorizationsService) Create(auth *AuthorizationRequest) (*Authorizati
 	if err != nil {
 		return nil, resp, err
 	}
-	return a, resp, err
+	return a, resp, nil
 }
 
 // GetOrCreateForApp creates a new authorization for the specified OAuth
@@ -225,7 +225,7 @@ func (s *AuthorizationsService) GetOrCreateForApp(clientID string, auth *Authori
 		return nil, resp, err
 	}
 
-	return a, resp, err
+	return a, resp, nil
 }
 
 // Edit a single authorization.
@@ -245,7 +245,7 @@ func (s *AuthorizationsService) Edit(id int, auth *AuthorizationUpdateRequest) (
 		return nil, resp, err
 	}
 
-	return a, resp, err
+	return a, resp, nil
 }
 
 // Delete a single authorization.
@@ -285,7 +285,7 @@ func (s *AuthorizationsService) Check(clientID string, token string) (*Authoriza
 		return nil, resp, err
 	}
 
-	return a, resp, err
+	return a, resp, nil
 }
 
 // Reset is used to reset a valid OAuth token without end user involvement.
@@ -313,7 +313,7 @@ func (s *AuthorizationsService) Reset(clientID string, token string) (*Authoriza
 		return nil, resp, err
 	}
 
-	return a, resp, err
+	return a, resp, nil
 }
 
 // Revoke an authorization for an application.
@@ -352,7 +352,7 @@ func (s *AuthorizationsService) ListGrants() ([]*Grant, *Response, error) {
 		return nil, resp, err
 	}
 
-	return grants, resp, err
+	return grants, resp, nil
 }
 
 // GetGrant gets a single OAuth application grant.
@@ -371,7 +371,7 @@ func (s *AuthorizationsService) GetGrant(id int) (*Grant, *Response, error) {
 		return nil, resp, err
 	}
 
-	return grant, resp, err
+	return grant, resp, nil
 }
 
 // DeleteGrant deletes an OAuth application grant. Deleting an application's
@@ -408,7 +408,8 @@ func (s *AuthorizationsService) CreateImpersonation(username string, authReq *Au
 	if err != nil {
 		return nil, resp, err
 	}
-	return a, resp, err
+	
+	return a, resp, nil
 }
 
 // DeleteImpersonation deletes an impersonation OAuth token.

--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -170,7 +170,7 @@ func (s *AuthorizationsService) Get(id int) (*Authorization, *Response, error) {
 	if err != nil {
 		return nil, resp, err
 	}
-	return a, resp, err
+	return a, resp, nil
 }
 
 // Create a new authorization for the specified OAuth application.
@@ -408,7 +408,6 @@ func (s *AuthorizationsService) CreateImpersonation(username string, authReq *Au
 	if err != nil {
 		return nil, resp, err
 	}
-	
 	return a, resp, nil
 }
 

--- a/github/gists.go
+++ b/github/gists.go
@@ -180,7 +180,7 @@ func (s *GistsService) Get(id string) (*Gist, *Response, error) {
 		return nil, resp, err
 	}
 
-	return gist, resp, err
+	return gist, resp, nil
 }
 
 // GetRevision gets a specific revision of a gist.
@@ -198,7 +198,7 @@ func (s *GistsService) GetRevision(id, sha string) (*Gist, *Response, error) {
 		return nil, resp, err
 	}
 
-	return gist, resp, err
+	return gist, resp, nil
 }
 
 // Create a gist for authenticated user.
@@ -216,7 +216,7 @@ func (s *GistsService) Create(gist *Gist) (*Gist, *Response, error) {
 		return nil, resp, err
 	}
 
-	return g, resp, err
+	return g, resp, nil
 }
 
 // Edit a gist.
@@ -234,7 +234,7 @@ func (s *GistsService) Edit(id string, gist *Gist) (*Gist, *Response, error) {
 		return nil, resp, err
 	}
 
-	return g, resp, err
+	return g, resp, nil
 }
 
 // ListCommits lists commits of a gist.
@@ -322,7 +322,7 @@ func (s *GistsService) Fork(id string) (*Gist, *Response, error) {
 		return nil, resp, err
 	}
 
-	return g, resp, err
+	return g, resp, nil
 }
 
 // ListForks lists forks of a gist.

--- a/github/gists_comments.go
+++ b/github/gists_comments.go
@@ -63,7 +63,7 @@ func (s *GistsService) GetComment(gistID string, commentID int) (*GistComment, *
 		return nil, resp, err
 	}
 
-	return c, resp, err
+	return c, resp, nil
 }
 
 // CreateComment creates a comment for a gist.
@@ -82,7 +82,7 @@ func (s *GistsService) CreateComment(gistID string, comment *GistComment) (*Gist
 		return nil, resp, err
 	}
 
-	return c, resp, err
+	return c, resp, nil
 }
 
 // EditComment edits an existing gist comment.
@@ -101,7 +101,7 @@ func (s *GistsService) EditComment(gistID string, commentID int, comment *GistCo
 		return nil, resp, err
 	}
 
-	return c, resp, err
+	return c, resp, nil
 }
 
 // DeleteComment deletes a gist comment.

--- a/github/git_commits.go
+++ b/github/git_commits.go
@@ -74,7 +74,7 @@ func (s *GitService) GetCommit(owner string, repo string, sha string) (*Commit, 
 		return nil, resp, err
 	}
 
-	return c, resp, err
+	return c, resp, nil
 }
 
 // createCommit represents the body of a CreateCommit request.
@@ -123,5 +123,5 @@ func (s *GitService) CreateCommit(owner string, repo string, commit *Commit) (*C
 		return nil, resp, err
 	}
 
-	return c, resp, err
+	return c, resp, nil
 }

--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -61,7 +61,7 @@ func (s *GitService) GetRef(owner string, repo string, ref string) (*Reference, 
 		return nil, resp, err
 	}
 
-	return r, resp, err
+	return r, resp, nil
 }
 
 // ReferenceListOptions specifies optional parameters to the
@@ -98,7 +98,7 @@ func (s *GitService) ListRefs(owner, repo string, opt *ReferenceListOptions) ([]
 		return nil, resp, err
 	}
 
-	return rs, resp, err
+	return rs, resp, nil
 }
 
 // CreateRef creates a new ref in a repository.
@@ -121,7 +121,7 @@ func (s *GitService) CreateRef(owner string, repo string, ref *Reference) (*Refe
 		return nil, resp, err
 	}
 
-	return r, resp, err
+	return r, resp, nil
 }
 
 // UpdateRef updates an existing ref in a repository.
@@ -144,7 +144,7 @@ func (s *GitService) UpdateRef(owner string, repo string, ref *Reference, force 
 		return nil, resp, err
 	}
 
-	return r, resp, err
+	return r, resp, nil
 }
 
 // DeleteRef deletes a ref from a repository.

--- a/github/git_trees.go
+++ b/github/git_trees.go
@@ -53,7 +53,7 @@ func (s *GitService) GetTree(owner string, repo string, sha string, recursive bo
 		return nil, resp, err
 	}
 
-	return t, resp, err
+	return t, resp, nil
 }
 
 // createTree represents the body of a CreateTree request.
@@ -85,5 +85,5 @@ func (s *GitService) CreateTree(owner string, repo string, baseTree string, entr
 		return nil, resp, err
 	}
 
-	return t, resp, err
+	return t, resp, nil
 }

--- a/github/github.go
+++ b/github/github.go
@@ -768,7 +768,7 @@ func (c *Client) RateLimits() (*RateLimits, *Response, error) {
 		c.rateMu.Unlock()
 	}
 
-	return response.Resources, resp, err
+	return response.Resources, resp, nil
 }
 
 /*

--- a/github/gitignore.go
+++ b/github/gitignore.go
@@ -57,5 +57,5 @@ func (s GitignoresService) Get(name string) (*Gitignore, *Response, error) {
 		return nil, resp, err
 	}
 
-	return gitignore, resp, err
+	return gitignore, resp, nil
 }

--- a/github/integration_installation.go
+++ b/github/integration_installation.go
@@ -42,5 +42,5 @@ func (s *IntegrationsService) ListRepos(opt *ListOptions) ([]*Repository, *Respo
 		return nil, resp, err
 	}
 
-	return r.Repositories, resp, err
+	return r.Repositories, resp, nil
 }

--- a/github/licenses.go
+++ b/github/licenses.go
@@ -96,5 +96,5 @@ func (s *LicensesService) Get(licenseName string) (*License, *Response, error) {
 		return nil, resp, err
 	}
 
-	return license, resp, err
+	return license, resp, nil
 }

--- a/github/migrations_source_import.go
+++ b/github/migrations_source_import.go
@@ -160,7 +160,7 @@ func (s *MigrationService) StartImport(owner, repo string, in *Import) (*Import,
 		return nil, resp, err
 	}
 
-	return out, resp, err
+	return out, resp, nil
 }
 
 // ImportProgress queries for the status and progress of an ongoing repository import.
@@ -182,7 +182,7 @@ func (s *MigrationService) ImportProgress(owner, repo string) (*Import, *Respons
 		return nil, resp, err
 	}
 
-	return out, resp, err
+	return out, resp, nil
 }
 
 // UpdateImport initiates a repository import.
@@ -204,7 +204,7 @@ func (s *MigrationService) UpdateImport(owner, repo string, in *Import) (*Import
 		return nil, resp, err
 	}
 
-	return out, resp, err
+	return out, resp, nil
 }
 
 // CommitAuthors gets the authors mapped from the original repository.
@@ -260,7 +260,7 @@ func (s *MigrationService) MapCommitAuthor(owner, repo string, id int, author *S
 		return nil, resp, err
 	}
 
-	return out, resp, err
+	return out, resp, nil
 }
 
 // SetLFSPreference sets whether imported repositories should use Git LFS for
@@ -284,7 +284,7 @@ func (s *MigrationService) SetLFSPreference(owner, repo string, in *Import) (*Im
 		return nil, resp, err
 	}
 
-	return out, resp, err
+	return out, resp, nil
 }
 
 // LargeFiles lists files larger than 100MB found during the import.

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -101,7 +101,7 @@ func (s *OrganizationsService) ListAll(opt *OrganizationsListOptions) ([]*Organi
 	if err != nil {
 		return nil, resp, err
 	}
-	return orgs, resp, err
+	return orgs, resp, nil
 }
 
 // List the organizations for a user.  Passing the empty string will list
@@ -150,7 +150,7 @@ func (s *OrganizationsService) Get(org string) (*Organization, *Response, error)
 		return nil, resp, err
 	}
 
-	return organization, resp, err
+	return organization, resp, nil
 }
 
 // Edit an organization.
@@ -169,5 +169,5 @@ func (s *OrganizationsService) Edit(name string, org *Organization) (*Organizati
 		return nil, resp, err
 	}
 
-	return o, resp, err
+	return o, resp, nil
 }

--- a/github/orgs_hooks.go
+++ b/github/orgs_hooks.go
@@ -62,7 +62,7 @@ func (s *OrganizationsService) CreateHook(org string, hook *Hook) (*Hook, *Respo
 		return nil, resp, err
 	}
 
-	return h, resp, err
+	return h, resp, nil
 }
 
 // EditHook updates a specified Hook.

--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -196,7 +196,7 @@ func (s *OrganizationsService) ListOrgMemberships(opt *ListOrgMembershipsOptions
 		return nil, resp, err
 	}
 
-	return memberships, resp, err
+	return memberships, resp, nil
 }
 
 // GetOrgMembership gets the membership for a user in a specified organization.
@@ -224,7 +224,7 @@ func (s *OrganizationsService) GetOrgMembership(user, org string) (*Membership, 
 		return nil, resp, err
 	}
 
-	return membership, resp, err
+	return membership, resp, nil
 }
 
 // EditOrgMembership edits the membership for user in specified organization.
@@ -254,7 +254,7 @@ func (s *OrganizationsService) EditOrgMembership(user, org string, membership *M
 		return nil, resp, err
 	}
 
-	return m, resp, err
+	return m, resp, nil
 }
 
 // RemoveOrgMembership removes user from the specified organization.  If the

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -99,7 +99,7 @@ func (s *OrganizationsService) GetTeam(team int) (*Team, *Response, error) {
 		return nil, resp, err
 	}
 
-	return t, resp, err
+	return t, resp, nil
 }
 
 // CreateTeam creates a new team within an organization.
@@ -118,7 +118,7 @@ func (s *OrganizationsService) CreateTeam(org string, team *Team) (*Team, *Respo
 		return nil, resp, err
 	}
 
-	return t, resp, err
+	return t, resp, nil
 }
 
 // EditTeam edits a team.
@@ -137,7 +137,7 @@ func (s *OrganizationsService) EditTeam(id int, team *Team) (*Team, *Response, e
 		return nil, resp, err
 	}
 
-	return t, resp, err
+	return t, resp, nil
 }
 
 // DeleteTeam deletes a team.
@@ -247,7 +247,7 @@ func (s *OrganizationsService) IsTeamRepo(team int, owner string, repo string) (
 		return nil, resp, err
 	}
 
-	return repository, resp, err
+	return repository, resp, nil
 }
 
 // OrganizationAddTeamRepoOptions specifies the optional parameters to the
@@ -332,7 +332,7 @@ func (s *OrganizationsService) GetTeamMembership(team int, user string) (*Member
 		return nil, resp, err
 	}
 
-	return t, resp, err
+	return t, resp, nil
 }
 
 // OrganizationAddTeamMembershipOptions does stuff specifies the optional
@@ -380,7 +380,7 @@ func (s *OrganizationsService) AddTeamMembership(team int, user string, opt *Org
 		return nil, resp, err
 	}
 
-	return t, resp, err
+	return t, resp, nil
 }
 
 // RemoveTeamMembership removes a user from a team.

--- a/github/projects.go
+++ b/github/projects.go
@@ -51,7 +51,7 @@ func (s *ProjectsService) GetProject(id int) (*Project, *Response, error) {
 		return nil, resp, err
 	}
 
-	return project, resp, err
+	return project, resp, nil
 }
 
 // ProjectOptions specifies the parameters to the
@@ -83,7 +83,7 @@ func (s *ProjectsService) UpdateProject(id int, opt *ProjectOptions) (*Project, 
 		return nil, resp, err
 	}
 
-	return project, resp, err
+	return project, resp, nil
 }
 
 // DeleteProject deletes a GitHub Project from a repository.
@@ -137,7 +137,7 @@ func (s *ProjectsService) ListProjectColumns(projectID int, opt *ListOptions) ([
 		return nil, resp, err
 	}
 
-	return columns, resp, err
+	return columns, resp, nil
 }
 
 // GetProjectColumn gets a column of a GitHub Project for a repo.
@@ -159,7 +159,7 @@ func (s *ProjectsService) GetProjectColumn(id int) (*ProjectColumn, *Response, e
 		return nil, resp, err
 	}
 
-	return column, resp, err
+	return column, resp, nil
 }
 
 // ProjectColumnOptions specifies the parameters to the
@@ -189,7 +189,7 @@ func (s *ProjectsService) CreateProjectColumn(projectID int, opt *ProjectColumnO
 		return nil, resp, err
 	}
 
-	return column, resp, err
+	return column, resp, nil
 }
 
 // UpdateProjectColumn updates a column of a GitHub Project.
@@ -211,7 +211,7 @@ func (s *ProjectsService) UpdateProjectColumn(columnID int, opt *ProjectColumnOp
 		return nil, resp, err
 	}
 
-	return column, resp, err
+	return column, resp, nil
 }
 
 // DeleteProjectColumn deletes a column from a GitHub Project.
@@ -290,7 +290,7 @@ func (s *ProjectsService) ListProjectCards(columnID int, opt *ListOptions) ([]*P
 		return nil, resp, err
 	}
 
-	return cards, resp, err
+	return cards, resp, nil
 }
 
 // GetProjectCard gets a card in a column of a GitHub Project.
@@ -312,7 +312,7 @@ func (s *ProjectsService) GetProjectCard(columnID int) (*ProjectCard, *Response,
 		return nil, resp, err
 	}
 
-	return card, resp, err
+	return card, resp, nil
 }
 
 // ProjectCardOptions specifies the parameters to the
@@ -347,7 +347,7 @@ func (s *ProjectsService) CreateProjectCard(columnID int, opt *ProjectCardOption
 		return nil, resp, err
 	}
 
-	return card, resp, err
+	return card, resp, nil
 }
 
 // UpdateProjectCard updates a card of a GitHub Project.
@@ -369,7 +369,7 @@ func (s *ProjectsService) UpdateProjectCard(cardID int, opt *ProjectCardOptions)
 		return nil, resp, err
 	}
 
-	return card, resp, err
+	return card, resp, nil
 }
 
 // DeleteProjectCard deletes a card from a GitHub Project.

--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -151,7 +151,7 @@ func (s *RepositoriesService) GetCommit(owner, repo, sha string) (*RepositoryCom
 		return nil, resp, err
 	}
 
-	return commit, resp, err
+	return commit, resp, nil
 }
 
 // GetCommitSHA1 gets the SHA-1 of a commit reference.  If a last-known SHA1 is
@@ -177,7 +177,7 @@ func (s *RepositoriesService) GetCommitSHA1(owner, repo, ref, lastSHA string) (s
 		return "", resp, err
 	}
 
-	return buf.String(), resp, err
+	return buf.String(), resp, nil
 }
 
 // CompareCommits compares a range of commits with each other.
@@ -198,5 +198,5 @@ func (s *RepositoriesService) CompareCommits(owner, repo string, base, head stri
 		return nil, resp, err
 	}
 
-	return comp, resp, err
+	return comp, resp, nil
 }

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -117,7 +117,7 @@ func (s *RepositoriesService) GetReadme(owner, repo string, opt *RepositoryConte
 	if err != nil {
 		return nil, resp, err
 	}
-	return readme, resp, err
+	return readme, resp, nil
 }
 
 // DownloadContents returns an io.ReadCloser that reads the contents of the
@@ -196,7 +196,7 @@ func (s *RepositoriesService) CreateFile(owner, repo, path string, opt *Reposito
 	if err != nil {
 		return nil, resp, err
 	}
-	return createResponse, resp, err
+	return createResponse, resp, nil
 }
 
 // UpdateFile updates a file in a repository at the given path and returns the
@@ -214,7 +214,7 @@ func (s *RepositoriesService) UpdateFile(owner, repo, path string, opt *Reposito
 	if err != nil {
 		return nil, resp, err
 	}
-	return updateResponse, resp, err
+	return updateResponse, resp, nil
 }
 
 // DeleteFile deletes a file from a repository and returns the commit.
@@ -232,7 +232,7 @@ func (s *RepositoriesService) DeleteFile(owner, repo, path string, opt *Reposito
 	if err != nil {
 		return nil, resp, err
 	}
-	return deleteResponse, resp, err
+	return deleteResponse, resp, nil
 }
 
 // archiveFormat is used to define the archive type when calling GetArchiveLink.

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -99,7 +99,7 @@ func (s *RepositoriesService) GetDeployment(owner, repo string, deploymentID int
 		return nil, resp, err
 	}
 
-	return deployment, resp, err
+	return deployment, resp, nil
 }
 
 // CreateDeployment creates a new deployment for a repository.
@@ -122,7 +122,7 @@ func (s *RepositoriesService) CreateDeployment(owner, repo string, request *Depl
 		return nil, resp, err
 	}
 
-	return d, resp, err
+	return d, resp, nil
 }
 
 // DeploymentStatus represents the status of a
@@ -195,7 +195,7 @@ func (s *RepositoriesService) GetDeploymentStatus(owner, repo string, deployment
 		return nil, resp, err
 	}
 
-	return d, resp, err
+	return d, resp, nil
 }
 
 // CreateDeploymentStatus creates a new status for a deployment.
@@ -218,5 +218,5 @@ func (s *RepositoriesService) CreateDeploymentStatus(owner, repo string, deploym
 		return nil, resp, err
 	}
 
-	return d, resp, err
+	return d, resp, nil
 }

--- a/github/repos_forks.go
+++ b/github/repos_forks.go
@@ -75,5 +75,5 @@ func (s *RepositoriesService) CreateFork(owner, repo string, opt *RepositoryCrea
 		return nil, resp, err
 	}
 
-	return fork, resp, err
+	return fork, resp, nil
 }

--- a/github/repos_hooks.go
+++ b/github/repos_hooks.go
@@ -99,7 +99,7 @@ func (s *RepositoriesService) CreateHook(owner, repo string, hook *Hook) (*Hook,
 		return nil, resp, err
 	}
 
-	return h, resp, err
+	return h, resp, nil
 }
 
 // ListHooks lists all Hooks for the specified repository.

--- a/github/repos_invitations.go
+++ b/github/repos_invitations.go
@@ -46,7 +46,7 @@ func (s *RepositoriesService) ListInvitations(repoID int, opt *ListOptions) ([]*
 		return nil, resp, err
 	}
 
-	return invites, resp, err
+	return invites, resp, nil
 }
 
 // DeleteInvitation deletes a repository invitation.

--- a/github/repos_keys.go
+++ b/github/repos_keys.go
@@ -50,7 +50,7 @@ func (s *RepositoriesService) GetKey(owner string, repo string, id int) (*Key, *
 		return nil, resp, err
 	}
 
-	return key, resp, err
+	return key, resp, nil
 }
 
 // CreateKey adds a deploy key for a repository.
@@ -70,7 +70,7 @@ func (s *RepositoriesService) CreateKey(owner string, repo string, key *Key) (*K
 		return nil, resp, err
 	}
 
-	return k, resp, err
+	return k, resp, nil
 }
 
 // EditKey edits a deploy key.
@@ -90,7 +90,7 @@ func (s *RepositoriesService) EditKey(owner string, repo string, id int, key *Ke
 		return nil, resp, err
 	}
 
-	return k, resp, err
+	return k, resp, nil
 }
 
 // DeleteKey deletes a deploy key.

--- a/github/repos_merging.go
+++ b/github/repos_merging.go
@@ -33,5 +33,5 @@ func (s *RepositoriesService) Merge(owner, repo string, request *RepositoryMerge
 		return nil, resp, err
 	}
 
-	return commit, resp, err
+	return commit, resp, nil
 }

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -52,7 +52,7 @@ func (s *RepositoriesService) GetPagesInfo(owner, repo string) (*Pages, *Respons
 		return nil, resp, err
 	}
 
-	return site, resp, err
+	return site, resp, nil
 }
 
 // ListPagesBuilds lists the builds for a GitHub Pages site.
@@ -71,7 +71,7 @@ func (s *RepositoriesService) ListPagesBuilds(owner, repo string) ([]*PagesBuild
 		return nil, resp, err
 	}
 
-	return pages, resp, err
+	return pages, resp, nil
 }
 
 // GetLatestPagesBuild fetches the latest build information for a GitHub pages site.
@@ -90,7 +90,7 @@ func (s *RepositoriesService) GetLatestPagesBuild(owner, repo string) (*PagesBui
 		return nil, resp, err
 	}
 
-	return build, resp, err
+	return build, resp, nil
 }
 
 // GetPageBuild fetches the specific build information for a GitHub pages site.
@@ -109,7 +109,7 @@ func (s *RepositoriesService) GetPageBuild(owner, repo string, id int) (*PagesBu
 		return nil, resp, err
 	}
 
-	return build, resp, err
+	return build, resp, nil
 }
 
 // RequestPageBuild requests a build of a GitHub Pages site without needing to push new commit.
@@ -131,5 +131,5 @@ func (s *RepositoriesService) RequestPageBuild(owner, repo string) (*PagesBuild,
 		return nil, resp, err
 	}
 
-	return build, resp, err
+	return build, resp, nil
 }

--- a/github/repos_projects.go
+++ b/github/repos_projects.go
@@ -31,7 +31,7 @@ func (s *RepositoriesService) ListProjects(owner, repo string, opt *ListOptions)
 		return nil, resp, err
 	}
 
-	return projects, resp, err
+	return projects, resp, nil
 }
 
 // CreateProject creates a GitHub Project for the specified repository.
@@ -53,5 +53,5 @@ func (s *RepositoriesService) CreateProject(owner, repo string, opt *ProjectOpti
 		return nil, resp, err
 	}
 
-	return project, resp, err
+	return project, resp, nil
 }

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -119,7 +119,7 @@ func (s *RepositoriesService) getSingleRelease(url string) (*RepositoryRelease, 
 	if err != nil {
 		return nil, resp, err
 	}
-	return release, resp, err
+	return release, resp, nil
 }
 
 // CreateRelease adds a new release for a repository.
@@ -138,7 +138,7 @@ func (s *RepositoriesService) CreateRelease(owner, repo string, release *Reposit
 	if err != nil {
 		return nil, resp, err
 	}
-	return r, resp, err
+	return r, resp, nil
 }
 
 // EditRelease edits a repository release.
@@ -157,7 +157,7 @@ func (s *RepositoriesService) EditRelease(owner, repo string, id int, release *R
 	if err != nil {
 		return nil, resp, err
 	}
-	return r, resp, err
+	return r, resp, nil
 }
 
 // DeleteRelease delete a single release from a repository.
@@ -212,7 +212,7 @@ func (s *RepositoriesService) GetReleaseAsset(owner, repo string, id int) (*Rele
 	if err != nil {
 		return nil, resp, err
 	}
-	return asset, resp, err
+	return asset, resp, nil
 }
 
 // DownloadReleaseAsset downloads a release asset or returns a redirect URL.
@@ -275,7 +275,7 @@ func (s *RepositoriesService) EditReleaseAsset(owner, repo string, id int, relea
 	if err != nil {
 		return nil, resp, err
 	}
-	return asset, resp, err
+	return asset, resp, nil
 }
 
 // DeleteReleaseAsset delete a single release asset from a repository.
@@ -321,5 +321,5 @@ func (s *RepositoriesService) UploadReleaseAsset(owner, repo string, id int, opt
 	if err != nil {
 		return nil, resp, err
 	}
-	return asset, resp, err
+	return asset, resp, nil
 }

--- a/github/repos_stats.go
+++ b/github/repos_stats.go
@@ -58,7 +58,7 @@ func (s *RepositoriesService) ListContributorsStats(owner, repo string) ([]*Cont
 		return nil, resp, err
 	}
 
-	return contributorStats, resp, err
+	return contributorStats, resp, nil
 }
 
 // WeeklyCommitActivity represents the weekly commit activity for a repository.
@@ -97,7 +97,7 @@ func (s *RepositoriesService) ListCommitActivity(owner, repo string) ([]*WeeklyC
 		return nil, resp, err
 	}
 
-	return weeklyCommitActivity, resp, err
+	return weeklyCommitActivity, resp, nil
 }
 
 // ListCodeFrequency returns a weekly aggregate of the number of additions and
@@ -177,7 +177,7 @@ func (s *RepositoriesService) ListParticipation(owner, repo string) (*Repository
 		return nil, resp, err
 	}
 
-	return participation, resp, err
+	return participation, resp, nil
 }
 
 // PunchCard represents the number of commits made during a given hour of a

--- a/github/repos_statuses.go
+++ b/github/repos_statuses.go
@@ -80,7 +80,7 @@ func (s *RepositoriesService) CreateStatus(owner, repo, ref string, status *Repo
 		return nil, resp, err
 	}
 
-	return repoStatus, resp, err
+	return repoStatus, resp, nil
 }
 
 // CombinedStatus represents the combined status of a repository at a particular reference.
@@ -124,5 +124,5 @@ func (s *RepositoriesService) GetCombinedStatus(owner, repo, ref string, opt *Li
 		return nil, resp, err
 	}
 
-	return status, resp, err
+	return status, resp, nil
 }

--- a/github/repos_traffic.go
+++ b/github/repos_traffic.go
@@ -110,7 +110,7 @@ func (s *RepositoriesService) ListTrafficViews(owner, repo string, opt *TrafficB
 		return nil, resp, err
 	}
 
-	return trafficViews, resp, err
+	return trafficViews, resp, nil
 }
 
 // ListTrafficClones get total number of clones for the last 14 days and breaks it down either per day or week for the last 14 days.
@@ -134,5 +134,5 @@ func (s *RepositoriesService) ListTrafficClones(owner, repo string, opt *Traffic
 		return nil, resp, err
 	}
 
-	return trafficClones, resp, err
+	return trafficClones, resp, nil
 }

--- a/github/users.go
+++ b/github/users.go
@@ -90,7 +90,7 @@ func (s *UsersService) Get(user string) (*User, *Response, error) {
 		return nil, resp, err
 	}
 
-	return uResp, resp, err
+	return uResp, resp, nil
 }
 
 // GetByID fetches a user.
@@ -109,7 +109,7 @@ func (s *UsersService) GetByID(id int) (*User, *Response, error) {
 		return nil, resp, err
 	}
 
-	return user, resp, err
+	return user, resp, nil
 }
 
 // Edit the authenticated user.
@@ -128,7 +128,7 @@ func (s *UsersService) Edit(user *User) (*User, *Response, error) {
 		return nil, resp, err
 	}
 
-	return uResp, resp, err
+	return uResp, resp, nil
 }
 
 // UserListOptions specifies optional parameters to the UsersService.ListAll
@@ -184,7 +184,7 @@ func (s *UsersService) ListInvitations() ([]*RepositoryInvitation, *Response, er
 		return nil, resp, err
 	}
 
-	return invites, resp, err
+	return invites, resp, nil
 }
 
 // AcceptInvitation accepts the currently-open repository invitation for the

--- a/github/users_gpg_keys.go
+++ b/github/users_gpg_keys.go
@@ -58,7 +58,7 @@ func (s *UsersService) ListGPGKeys() ([]*GPGKey, *Response, error) {
 		return nil, resp, err
 	}
 
-	return keys, resp, err
+	return keys, resp, nil
 }
 
 // GetGPGKey gets extended details for a single GPG key. It requires authentication
@@ -81,7 +81,7 @@ func (s *UsersService) GetGPGKey(id int) (*GPGKey, *Response, error) {
 		return nil, resp, err
 	}
 
-	return key, resp, err
+	return key, resp, nil
 }
 
 // CreateGPGKey creates a GPG key. It requires authenticatation via Basic Auth
@@ -106,7 +106,7 @@ func (s *UsersService) CreateGPGKey(armoredPublicKey string) (*GPGKey, *Response
 		return nil, resp, err
 	}
 
-	return key, resp, err
+	return key, resp, nil
 }
 
 // DeleteGPGKey deletes a GPG key. It requires authentication via Basic Auth or

--- a/github/users_keys.go
+++ b/github/users_keys.go
@@ -67,7 +67,7 @@ func (s *UsersService) GetKey(id int) (*Key, *Response, error) {
 		return nil, resp, err
 	}
 
-	return key, resp, err
+	return key, resp, nil
 }
 
 // CreateKey adds a public key for the authenticated user.
@@ -87,7 +87,7 @@ func (s *UsersService) CreateKey(key *Key) (*Key, *Response, error) {
 		return nil, resp, err
 	}
 
-	return k, resp, err
+	return k, resp, nil
 }
 
 // DeleteKey deletes a public key.


### PR DESCRIPTION
Return nil explicitly when there is no error code to aid readability (and consistency). 

Fixes #536