### PR TITLE
Use single space after period.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
 # How to contribute #
 
-We'd love to accept your patches and contributions to this project.  There are
+We'd love to accept your patches and contributions to this project. There are
 a just a few small guidelines you need to follow.
 
 
 ## Contributor License Agreement ##
 
 Contributions to any Google project must be accompanied by a Contributor
-License Agreement.  This is not a copyright **assignment**, it simply gives
+License Agreement. This is not a copyright **assignment**, it simply gives
 Google permission to use and redistribute your contributions as part of the
-project.  Head over to <https://cla.developers.google.com/> to see your current
+project. Head over to <https://cla.developers.google.com/> to see your current
 agreements on file or to sign a new one.
 
 You generally only need to submit a CLA once, so if you've already submitted one
@@ -20,25 +20,25 @@ again.
 ## Submitting a patch ##
 
   1. It's generally best to start by opening a new issue describing the bug or
-     feature you're intending to fix.  Even if you think it's relatively minor,
-     it's helpful to know what people are working on.  Mention in the initial
+     feature you're intending to fix. Even if you think it's relatively minor,
+     it's helpful to know what people are working on. Mention in the initial
      issue that you are planning to work on that bug or feature so that it can
      be assigned to you.
 
   1. Follow the normal process of [forking][] the project, and setup a new
-     branch to work in.  It's important that each group of changes be done in
+     branch to work in. It's important that each group of changes be done in
      separate branches in order to ensure that a pull request only includes the
      commits related to that bug or feature.
 
   1. Go makes it very simple to ensure properly formatted code, so always run
-     `go fmt` on your code before committing it.  You should also run
-     [golint][] over your code.  As noted in the [golint readme][], it's not
+     `go fmt` on your code before committing it. You should also run
+     [golint][] over your code. As noted in the [golint readme][], it's not
      strictly necessary that your code be completely "lint-free", but this will
      help you find common style issues.
 
-  1. Any significant changes should almost always be accompanied by tests.  The
+  1. Any significant changes should almost always be accompanied by tests. The
      project already has good test coverage, so look at some of the existing
-     tests if you're unsure how to go about it.  [gocov][] and [gocov-html][]
+     tests if you're unsure how to go about it. [gocov][] and [gocov-html][]
      are invaluable tools for seeing which parts of your code aren't being
      exercised by your tests.
 
@@ -61,12 +61,12 @@ again.
 ## Other notes on code organization ##
 
 Currently, everything is defined in the main `github` package, with API methods
-broken into separate service objects.  These services map directly to how
+broken into separate service objects. These services map directly to how
 the [GitHub API documentation][] is organized, so use that as your guide for
 where to put new methods.
 
 Code is organized in files also based pretty closely on the GitHub API
-documentation, following the format `{service}_{api}.go`.  For example, methods
+documentation, following the format `{service}_{api}.go`. For example, methods
 defined at <https://developer.github.com/v3/repos/hooks/> live in
 [repos_hooks.go][].
 
@@ -88,18 +88,18 @@ exceptions, running `git log` should not show a bunch of branching and merging.
 
 Never use the GitHub "merge" button, since it always creates a merge commit.
 Instead, check out the pull request locally ([these git aliases
-help][git-aliases]), then cherry-pick or rebase them onto master.  If there are
+help][git-aliases]), then cherry-pick or rebase them onto master. If there are
 small cleanup commits, especially as a result of addressing code review
-comments, these should almost always be squashed down to a single commit.  Don't
-bother squashing commits that really deserve to be separate though.  If needed,
+comments, these should almost always be squashed down to a single commit. Don't
+bother squashing commits that really deserve to be separate though. If needed,
 feel free to amend additional small changes to the code or commit message that
 aren't worth going through code review for.
 
 If you made any changes like squashing commits, rebasing onto master, etc, then
 GitHub won't recognize that this is the same commit in order to mark the pull
-request as "merged".  So instead, amend the commit message to include a line
-"Fixes #0", referencing the pull request number.  This would be in addition to
-any other "Fixes" lines for closing related issues.  If you forget to do this,
+request as "merged". So instead, amend the commit message to include a line
+"Fixes #0", referencing the pull request number. This would be in addition to
+any other "Fixes" lines for closing related issues. If you forget to do this,
 you can also leave a comment on the pull request [like this][rebase-comment].
 If you made any other changes, it's worth noting that as well, [like
 this][modified-comment].

--- a/LICENSE
+++ b/LICENSE
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Some documentation is taken from the GitHub Developer site
 <http://developer.github.com/>, which is available under the following Creative
-Commons Attribution 3.0 License.  This applies only to the go-github source
+Commons Attribution 3.0 License. This applies only to the go-github source
 code and would not apply to any compiled binaries.
 
 THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE

--- a/examples/basicauth/main.go
+++ b/examples/basicauth/main.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 
 // The basicauth command demonstrates using the github.BasicAuthTransport,
-// including handling two-factor authentication.  This won't currently work for
+// including handling two-factor authentication. This won't currently work for
 // accounts that use SMS to receive one-time passwords.
 package main
 
@@ -36,7 +36,7 @@ func main() {
 	client := github.NewClient(tp.Client())
 	user, _, err := client.Users.Get("")
 
-	// Is this a two-factor auth error?  If so, prompt for OTP and try again.
+	// Is this a two-factor auth error? If so, prompt for OTP and try again.
 	if _, ok := err.(*github.TwoFactorAuthError); err != nil && ok {
 		fmt.Print("\nGitHub OTP: ")
 		otp, _ := r.ReadString('\n')

--- a/github/activity_star.go
+++ b/github/activity_star.go
@@ -49,18 +49,18 @@ func (s *ActivityService) ListStargazers(owner, repo string, opt *ListOptions) (
 // ActivityListStarredOptions specifies the optional parameters to the
 // ActivityService.ListStarred method.
 type ActivityListStarredOptions struct {
-	// How to sort the repository list.  Possible values are: created, updated,
-	// pushed, full_name.  Default is "full_name".
+	// How to sort the repository list. Possible values are: created, updated,
+	// pushed, full_name. Default is "full_name".
 	Sort string `url:"sort,omitempty"`
 
-	// Direction in which to sort repositories.  Possible values are: asc, desc.
+	// Direction in which to sort repositories. Possible values are: asc, desc.
 	// Default is "asc" when sort is "full_name", otherwise default is "desc".
 	Direction string `url:"direction,omitempty"`
 
 	ListOptions
 }
 
-// ListStarred lists all the repos starred by a user.  Passing the empty string
+// ListStarred lists all the repos starred by a user. Passing the empty string
 // will list the starred repositories for the authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/activity/starring/#list-repositories-being-starred

--- a/github/activity_watching.go
+++ b/github/activity_watching.go
@@ -46,7 +46,7 @@ func (s *ActivityService) ListWatchers(owner, repo string, opt *ListOptions) ([]
 	return watchers, resp, nil
 }
 
-// ListWatched lists the repositories the specified user is watching.  Passing
+// ListWatched lists the repositories the specified user is watching. Passing
 // the empty string will fetch watched repos for the authenticated user.
 //
 // GitHub API Docs: https://developer.github.com/v3/activity/watching/#list-repositories-being-watched
@@ -77,7 +77,7 @@ func (s *ActivityService) ListWatched(user string, opt *ListOptions) ([]*Reposit
 }
 
 // GetRepositorySubscription returns the subscription for the specified
-// repository for the authenticated user.  If the authenticated user is not
+// repository for the authenticated user. If the authenticated user is not
 // watching the repository, a nil Subscription is returned.
 //
 // GitHub API Docs: https://developer.github.com/v3/activity/watching/#get-a-repository-subscription

--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -114,7 +114,7 @@ func (a AuthorizationRequest) String() string {
 // AuthorizationUpdateRequest represents a request to update an authorization.
 //
 // Note that for any one update, you must only provide one of the "scopes"
-// fields.  That is, you may provide only one of "Scopes", or "AddScopes", or
+// fields. That is, you may provide only one of "Scopes", or "AddScopes", or
 // "RemoveScopes".
 //
 // GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#update-an-existing-authorization

--- a/github/git_commits.go
+++ b/github/git_commits.go
@@ -30,7 +30,7 @@ type Commit struct {
 	URL          *string                `json:"url,omitempty"`
 	Verification *SignatureVerification `json:"verification,omitempty"`
 
-	// CommentCount is the number of GitHub comments on the commit.  This
+	// CommentCount is the number of GitHub comments on the commit. This
 	// is only populated for requests that fetch GitHub data like
 	// Pulls.ListCommits, Repositories.ListCommits, etc.
 	CommentCount *int `json:"comment_count,omitempty"`
@@ -40,7 +40,7 @@ func (c Commit) String() string {
 	return Stringify(c)
 }
 
-// CommitAuthor represents the author or committer of a commit.  The commit
+// CommitAuthor represents the author or committer of a commit. The commit
 // author may not correspond to a GitHub User.
 type CommitAuthor struct {
 	Date  *time.Time `json:"date,omitempty"`

--- a/github/git_tags.go
+++ b/github/git_tags.go
@@ -20,7 +20,7 @@ type Tag struct {
 	Verification *SignatureVerification `json:"verification,omitempty"`
 }
 
-// createTagRequest represents the body of a CreateTag request.  This is mostly
+// createTagRequest represents the body of a CreateTag request. This is mostly
 // identical to Tag with the exception that the object SHA and Type are
 // top-level fields, rather than being nested inside a JSON object.
 type createTagRequest struct {

--- a/github/git_trees.go
+++ b/github/git_trees.go
@@ -17,7 +17,7 @@ func (t Tree) String() string {
 	return Stringify(t)
 }
 
-// TreeEntry represents the contents of a tree structure.  TreeEntry can
+// TreeEntry represents the contents of a tree structure. TreeEntry can
 // represent either a blob, a commit (in the case of a submodule), or another
 // tree.
 type TreeEntry struct {
@@ -62,7 +62,7 @@ type createTree struct {
 	Entries  []TreeEntry `json:"tree"`
 }
 
-// CreateTree creates a new tree in a repository.  If both a tree and a nested
+// CreateTree creates a new tree in a repository. If both a tree and a nested
 // path modifying that tree are specified, it will overwrite the contents of
 // that tree with the new path contents and write a new tree out.
 //

--- a/github/github.go
+++ b/github/github.go
@@ -106,8 +106,8 @@ type Client struct {
 	clientMu sync.Mutex   // clientMu protects the client during calls that modify the CheckRedirect func.
 	client   *http.Client // HTTP client used to communicate with the API.
 
-	// Base URL for API requests.  Defaults to the public GitHub API, but can be
-	// set to a domain endpoint to use with GitHub Enterprise.  BaseURL should
+	// Base URL for API requests. Defaults to the public GitHub API, but can be
+	// set to a domain endpoint to use with GitHub Enterprise. BaseURL should
 	// always be specified with a trailing slash.
 	BaseURL *url.URL
 
@@ -178,7 +178,7 @@ type RawOptions struct {
 	Type RawType
 }
 
-// addOptions adds the parameters in opt as URL query parameters to s.  opt
+// addOptions adds the parameters in opt as URL query parameters to s. opt
 // must be a struct whose fields may contain "url" tags.
 func addOptions(s string, opt interface{}) (string, error) {
 	v := reflect.ValueOf(opt)
@@ -200,8 +200,8 @@ func addOptions(s string, opt interface{}) (string, error) {
 	return u.String(), nil
 }
 
-// NewClient returns a new GitHub API client.  If a nil httpClient is
-// provided, http.DefaultClient will be used.  To use API methods which require
+// NewClient returns a new GitHub API client. If a nil httpClient is
+// provided, http.DefaultClient will be used. To use API methods which require
 // authentication, provide an http.Client that will perform the authentication
 // for you (such as that provided by the golang.org/x/oauth2 library).
 func NewClient(httpClient *http.Client) *Client {
@@ -235,7 +235,7 @@ func NewClient(httpClient *http.Client) *Client {
 
 // NewRequest creates an API request. A relative URL can be provided in urlStr,
 // in which case it is resolved relative to the BaseURL of the Client.
-// Relative URLs should always be specified without a preceding slash.  If
+// Relative URLs should always be specified without a preceding slash. If
 // specified, the value pointed to by body is JSON encoded and included as the
 // request body.
 func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Request, error) {
@@ -295,14 +295,14 @@ func (c *Client) NewUploadRequest(urlStr string, reader io.Reader, size int64, m
 	return req, nil
 }
 
-// Response is a GitHub API response.  This wraps the standard http.Response
+// Response is a GitHub API response. This wraps the standard http.Response
 // returned from GitHub and provides convenient access to things like
 // pagination links.
 type Response struct {
 	*http.Response
 
 	// These fields provide the page values for paginating through a set of
-	// results.  Any or all of these may be set to the zero value for
+	// results. Any or all of these may be set to the zero value for
 	// responses that are not part of a paginated set, or for which there
 	// are no additional pages.
 
@@ -384,7 +384,7 @@ func parseRate(r *http.Response) Rate {
 }
 
 // Rate specifies the current rate limit for the client as determined by the
-// most recent API call.  If the client is used in a multi-user application,
+// most recent API call. If the client is used in a multi-user application,
 // this rate may not always be up-to-date.
 //
 // Deprecated: Use the Response.Rate returned from most recent API call instead.
@@ -396,11 +396,11 @@ func (c *Client) Rate() Rate {
 	return rate
 }
 
-// Do sends an API request and returns the API response.  The API response is
+// Do sends an API request and returns the API response. The API response is
 // JSON decoded and stored in the value pointed to by v, or returned as an
-// error if an API error has occurred.  If v implements the io.Writer
+// error if an API error has occurred. If v implements the io.Writer
 // interface, the raw response body will be written to v, without attempting to
-// first decode it.  If rate limit is exceeded and reset time is in the future,
+// first decode it. If rate limit is exceeded and reset time is in the future,
 // Do returns *RateLimitError immediately without making a network API call.
 func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 	rateLimitCategory := category(req.URL.Path)
@@ -511,7 +511,7 @@ func (r *ErrorResponse) Error() string {
 }
 
 // TwoFactorAuthError occurs when using HTTP Basic Authentication for a user
-// that has two-factor authentication enabled.  The request can be reattempted
+// that has two-factor authentication enabled. The request can be reattempted
 // by providing a one-time password in the request.
 type TwoFactorAuthError ErrorResponse
 
@@ -609,7 +609,7 @@ func (e *Error) Error() string {
 // present. A response is considered an error if it has a status code outside
 // the 200 range or equal to 202 Accepted.
 // API error responses are expected to have either no response
-// body, or a JSON response body that maps to ErrorResponse.  Any other
+// body, or a JSON response body that maps to ErrorResponse. Any other
 // response body will be silently ignored.
 //
 // The error type will be *RateLimitError for rate limit exceeded errors,
@@ -658,15 +658,15 @@ func CheckResponse(r *http.Response) error {
 // parseBoolResponse determines the boolean result from a GitHub API response.
 // Several GitHub API methods return boolean responses indicated by the HTTP
 // status code in the response (true indicated by a 204, false indicated by a
-// 404).  This helper function will determine that result and hide the 404
-// error if present.  Any other error will be returned through as-is.
+// 404). This helper function will determine that result and hide the 404
+// error if present. Any other error will be returned through as-is.
 func parseBoolResponse(err error) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
 
 	if err, ok := err.(*ErrorResponse); ok && err.Response.StatusCode == http.StatusNotFound {
-		// Simply false.  In this one case, we do not pass the error through.
+		// Simply false. In this one case, we do not pass the error through.
 		return false, nil
 	}
 
@@ -692,15 +692,15 @@ func (r Rate) String() string {
 
 // RateLimits represents the rate limits for the current client.
 type RateLimits struct {
-	// The rate limit for non-search API requests.  Unauthenticated
-	// requests are limited to 60 per hour.  Authenticated requests are
+	// The rate limit for non-search API requests. Unauthenticated
+	// requests are limited to 60 per hour. Authenticated requests are
 	// limited to 5,000 per hour.
 	//
 	// GitHub API docs: https://developer.github.com/v3/#rate-limiting
 	Core *Rate `json:"core"`
 
-	// The rate limit for search API requests.  Unauthenticated requests
-	// are limited to 10 requests per minutes.  Authenticated requests are
+	// The rate limit for search API requests. Unauthenticated requests
+	// are limited to 10 requests per minutes. Authenticated requests are
 	// limited to 30 per minute.
 	//
 	// GitHub API docs: https://developer.github.com/v3/search/#rate-limit
@@ -838,7 +838,7 @@ func (t *UnauthenticatedRateLimitedTransport) transport() http.RoundTripper {
 }
 
 // BasicAuthTransport is an http.RoundTripper that authenticates all requests
-// using HTTP Basic Authentication with the provided username and password.  It
+// using HTTP Basic Authentication with the provided username and password. It
 // additionally supports users who have two-factor authentication enabled on
 // their GitHub account.
 type BasicAuthTransport struct {

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -33,7 +33,7 @@ var (
 )
 
 // setup sets up a test HTTP server along with a github.Client that is
-// configured to talk to that test server.  Tests should register handlers on
+// configured to talk to that test server. Tests should register handlers on
 // mux which provide mock responses for the API method being tested.
 func setup() {
 	// test server
@@ -54,7 +54,7 @@ func teardown() {
 
 // openTestFile creates a new file with the given name and content for testing.
 // In order to ensure the exact file name, this function will create a new temp
-// directory, and create the file in that directory.  It is the caller's
+// directory, and create the file in that directory. It is the caller's
 // responsibility to remove the directory and its contents when no longer needed.
 func openTestFile(name, content string) (file *os.File, dir string, err error) {
 	dir, err = ioutil.TempDir("", "go-github")
@@ -231,9 +231,9 @@ func TestNewRequest_emptyUserAgent(t *testing.T) {
 }
 
 // If a nil body is passed to github.NewRequest, make sure that nil is also
-// passed to http.NewRequest.  In most cases, passing an io.Reader that returns
+// passed to http.NewRequest. In most cases, passing an io.Reader that returns
 // no content is fine, since there is no difference between an HTTP request
-// body that is an empty string versus one that is not set at all.  However in
+// body that is an empty string versus one that is not set at all. However in
 // certain cases, intermediate systems may treat these differently resulting in
 // subtle errors.
 func TestNewRequest_emptyBody(t *testing.T) {
@@ -354,7 +354,7 @@ func TestDo_httpError(t *testing.T) {
 }
 
 // Test handling of an error caused by the internal http client's Do()
-// function.  A redirect loop is pretty unlikely to occur within the GitHub
+// function. A redirect loop is pretty unlikely to occur within the GitHub
 // API, but does allow us to exercise the right code path.
 func TestDo_redirectLoop(t *testing.T) {
 	setup()

--- a/github/issues.go
+++ b/github/issues.go
@@ -68,22 +68,22 @@ type IssueRequest struct {
 // IssueListOptions specifies the optional parameters to the IssuesService.List
 // and IssuesService.ListByOrg methods.
 type IssueListOptions struct {
-	// Filter specifies which issues to list.  Possible values are: assigned,
-	// created, mentioned, subscribed, all.  Default is "assigned".
+	// Filter specifies which issues to list. Possible values are: assigned,
+	// created, mentioned, subscribed, all. Default is "assigned".
 	Filter string `url:"filter,omitempty"`
 
-	// State filters issues based on their state.  Possible values are: open,
-	// closed, all.  Default is "open".
+	// State filters issues based on their state. Possible values are: open,
+	// closed, all. Default is "open".
 	State string `url:"state,omitempty"`
 
 	// Labels filters issues based on their label.
 	Labels []string `url:"labels,comma,omitempty"`
 
-	// Sort specifies how to sort issues.  Possible values are: created, updated,
-	// and comments.  Default value is "created".
+	// Sort specifies how to sort issues. Possible values are: created, updated,
+	// and comments. Default value is "created".
 	Sort string `url:"sort,omitempty"`
 
-	// Direction in which to sort issues.  Possible values are: asc, desc.
+	// Direction in which to sort issues. Possible values are: asc, desc.
 	// Default is "desc".
 	Direction string `url:"direction,omitempty"`
 
@@ -102,7 +102,7 @@ type PullRequestLinks struct {
 	PatchURL *string `json:"patch_url,omitempty"`
 }
 
-// List the issues for the authenticated user.  If all is true, list issues
+// List the issues for the authenticated user. If all is true, list issues
 // across all the user's visible repositories including owned, member, and
 // organization repositories; if false, list only owned and member
 // repositories.
@@ -153,16 +153,16 @@ func (s *IssuesService) listIssues(u string, opt *IssueListOptions) ([]*Issue, *
 // IssueListByRepoOptions specifies the optional parameters to the
 // IssuesService.ListByRepo method.
 type IssueListByRepoOptions struct {
-	// Milestone limits issues for the specified milestone.  Possible values are
+	// Milestone limits issues for the specified milestone. Possible values are
 	// a milestone number, "none" for issues with no milestone, "*" for issues
 	// with any milestone.
 	Milestone string `url:"milestone,omitempty"`
 
-	// State filters issues based on their state.  Possible values are: open,
-	// closed, all.  Default is "open".
+	// State filters issues based on their state. Possible values are: open,
+	// closed, all. Default is "open".
 	State string `url:"state,omitempty"`
 
-	// Assignee filters issues based on their assignee.  Possible values are a
+	// Assignee filters issues based on their assignee. Possible values are a
 	// user name, "none" for issues that are not assigned, "*" for issues with
 	// any assigned user.
 	Assignee string `url:"assignee,omitempty"`
@@ -176,11 +176,11 @@ type IssueListByRepoOptions struct {
 	// Labels filters issues based on their label.
 	Labels []string `url:"labels,omitempty,comma"`
 
-	// Sort specifies how to sort issues.  Possible values are: created, updated,
-	// and comments.  Default value is "created".
+	// Sort specifies how to sort issues. Possible values are: created, updated,
+	// and comments. Default value is "created".
 	Sort string `url:"sort,omitempty"`
 
-	// Direction in which to sort issues.  Possible values are: asc, desc.
+	// Direction in which to sort issues. Possible values are: asc, desc.
 	// Default is "desc".
 	Direction string `url:"direction,omitempty"`
 

--- a/github/issues_comments.go
+++ b/github/issues_comments.go
@@ -30,10 +30,10 @@ func (i IssueComment) String() string {
 // IssueListCommentsOptions specifies the optional parameters to the
 // IssuesService.ListComments method.
 type IssueListCommentsOptions struct {
-	// Sort specifies how to sort comments.  Possible values are: created, updated.
+	// Sort specifies how to sort comments. Possible values are: created, updated.
 	Sort string `url:"sort,omitempty"`
 
-	// Direction in which to sort comments.  Possible values are: asc, desc.
+	// Direction in which to sort comments. Possible values are: asc, desc.
 	Direction string `url:"direction,omitempty"`
 
 	// Since filters comments by time.
@@ -42,7 +42,7 @@ type IssueListCommentsOptions struct {
 	ListOptions
 }
 
-// ListComments lists all comments on the specified issue.  Specifying an issue
+// ListComments lists all comments on the specified issue. Specifying an issue
 // number of 0 will return all comments on all issues for the repository.
 //
 // GitHub API docs: http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue

--- a/github/issues_events.go
+++ b/github/issues_events.go
@@ -18,7 +18,7 @@ type IssueEvent struct {
 	// The User that generated this event.
 	Actor *User `json:"actor,omitempty"`
 
-	// Event identifies the actual type of Event that occurred.  Possible
+	// Event identifies the actual type of Event that occurred. Possible
 	// values are:
 	//
 	//     closed

--- a/github/migrations_source_import.go
+++ b/github/migrations_source_import.go
@@ -39,7 +39,7 @@ type Import struct {
 	// repository. To see a list of these files, call LargeFiles.
 	LargeFilesCount *int `json:"large_files_count,omitempty"`
 
-	// Identifies the current status of an import.  An import that does not
+	// Identifies the current status of an import. An import that does not
 	// have errors will progress through these steps:
 	//
 	//     detecting - the "detection" step of the import is in progress
@@ -101,7 +101,7 @@ type Import struct {
 	HumanName *string `json:"human_name,omitempty"`
 
 	// When the importer finds several projects or repositories at the
-	// provided URLs, this will identify the available choices.  Call
+	// provided URLs, this will identify the available choices. Call
 	// UpdateImport with the selected Import value.
 	ProjectChoices []Import `json:"project_choices,omitempty"`
 }
@@ -264,7 +264,7 @@ func (s *MigrationService) MapCommitAuthor(owner, repo string, id int, author *S
 }
 
 // SetLFSPreference sets whether imported repositories should use Git LFS for
-// files larger than 100MB.  Only the UseLFS field on the provided Import is
+// files larger than 100MB. Only the UseLFS field on the provided Import is
 // used.
 //
 // GitHub API docs: https://developer.github.com/v3/migration/source_imports/#set-git-lfs-preference

--- a/github/misc.go
+++ b/github/misc.go
@@ -13,7 +13,7 @@ import (
 
 // MarkdownOptions specifies optional parameters to the Markdown method.
 type MarkdownOptions struct {
-	// Mode identifies the rendering mode.  Possible values are:
+	// Mode identifies the rendering mode. Possible values are:
 	//   markdown - render a document as plain Markdown, just like
 	//   README files are rendered.
 	//
@@ -25,7 +25,7 @@ type MarkdownOptions struct {
 	// Default is "markdown".
 	Mode string
 
-	// Context identifies the repository context.  Only taken into account
+	// Context identifies the repository context. Only taken into account
 	// when rendering as "gfm".
 	Context string
 }
@@ -125,7 +125,7 @@ func (c *Client) APIMeta() (*APIMeta, *Response, error) {
 }
 
 // Octocat returns an ASCII art octocat with the specified message in a speech
-// bubble.  If message is empty, a random zen phrase is used.
+// bubble. If message is empty, a random zen phrase is used.
 func (c *Client) Octocat(message string) (string, *Response, error) {
 	u := "octocat"
 	if message != "" {

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -57,7 +57,7 @@ func (o Organization) String() string {
 	return Stringify(o)
 }
 
-// Plan represents the payment plan for an account.  See plans at https://github.com/plans.
+// Plan represents the payment plan for an account. See plans at https://github.com/plans.
 type Plan struct {
 	Name          *string `json:"name,omitempty"`
 	Space         *int    `json:"space,omitempty"`
@@ -104,7 +104,7 @@ func (s *OrganizationsService) ListAll(opt *OrganizationsListOptions) ([]*Organi
 	return orgs, resp, nil
 }
 
-// List the organizations for a user.  Passing the empty string will list
+// List the organizations for a user. Passing the empty string will list
 // organizations for the authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/orgs/#list-user-organizations

--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -48,8 +48,8 @@ type ListMembersOptions struct {
 	// organization), list only publicly visible members.
 	PublicOnly bool `url:"-"`
 
-	// Filter members returned in the list.  Possible values are:
-	// 2fa_disabled, all.  Default is "all".
+	// Filter members returned in the list. Possible values are:
+	// 2fa_disabled, all. Default is "all".
 	Filter string `url:"filter,omitempty"`
 
 	// Role filters members returned by their role in the organization.
@@ -64,7 +64,7 @@ type ListMembersOptions struct {
 	ListOptions
 }
 
-// ListMembers lists the members for an organization.  If the authenticated
+// ListMembers lists the members for an organization. If the authenticated
 // user is an owner of the organization, this will return both concealed and
 // public members, otherwise it will only return public members.
 //
@@ -257,7 +257,7 @@ func (s *OrganizationsService) EditOrgMembership(user, org string, membership *M
 	return m, resp, nil
 }
 
-// RemoveOrgMembership removes user from the specified organization.  If the
+// RemoveOrgMembership removes user from the specified organization. If the
 // user has been invited to the organization, this will cancel their invitation.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/members/#remove-organization-membership

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-// Team represents a team within a GitHub organization.  Teams are used to
+// Team represents a team within a GitHub organization. Teams are used to
 // manage access to an organization's repositories.
 type Team struct {
 	ID          *int    `json:"id,omitempty"`
@@ -20,9 +20,9 @@ type Team struct {
 	Slug        *string `json:"slug,omitempty"`
 
 	// Permission is deprecated when creating or editing a team in an org
-	// using the new GitHub permission model.  It no longer identifies the
+	// using the new GitHub permission model. It no longer identifies the
 	// permission a team has on its repos, but only specifies the default
-	// permission a repo is initially added with.  Avoid confusion by
+	// permission a repo is initially added with. Avoid confusion by
 	// specifying a permission value when calling AddTeamRepo.
 	Permission *string `json:"permission,omitempty"`
 
@@ -156,8 +156,8 @@ func (s *OrganizationsService) DeleteTeam(team int) (*Response, error) {
 // OrganizationListTeamMembersOptions specifies the optional parameters to the
 // OrganizationsService.ListTeamMembers method.
 type OrganizationListTeamMembersOptions struct {
-	// Role filters members returned by their role in the team.  Possible
-	// values are "all", "member", "maintainer".  Default is "all".
+	// Role filters members returned by their role in the team. Possible
+	// values are "all", "member", "maintainer". Default is "all".
 	Role string `url:"role,omitempty"`
 
 	ListOptions
@@ -227,7 +227,7 @@ func (s *OrganizationsService) ListTeamRepos(team int, opt *ListOptions) ([]*Rep
 	return repos, resp, nil
 }
 
-// IsTeamRepo checks if a team manages the specified repository.  If the
+// IsTeamRepo checks if a team manages the specified repository. If the
 // repository is managed by team, a Repository is returned which includes the
 // permissions team has for that repo.
 //
@@ -263,7 +263,7 @@ type OrganizationAddTeamRepoOptions struct {
 	Permission string `json:"permission,omitempty"`
 }
 
-// AddTeamRepo adds a repository to be managed by the specified team.  The
+// AddTeamRepo adds a repository to be managed by the specified team. The
 // specified repository must be owned by the organization to which the team
 // belongs, or a direct fork of a repository owned by the organization.
 //
@@ -279,7 +279,7 @@ func (s *OrganizationsService) AddTeamRepo(team int, owner string, repo string, 
 }
 
 // RemoveTeamRepo removes a repository from being managed by the specified
-// team.  Note that this does not delete the repository, it just removes it
+// team. Note that this does not delete the repository, it just removes it
 // from the team.
 //
 // GitHub API docs: http://developer.github.com/v3/orgs/teams/#remove-team-repo
@@ -338,7 +338,7 @@ func (s *OrganizationsService) GetTeamMembership(team int, user string) (*Member
 // OrganizationAddTeamMembershipOptions does stuff specifies the optional
 // parameters to the OrganizationsService.AddTeamMembership method.
 type OrganizationAddTeamMembershipOptions struct {
-	// Role specifies the role the user should have in the team.  Possible
+	// Role specifies the role the user should have in the team. Possible
 	// values are:
 	//     member - a normal member of the team
 	//     maintainer - a team maintainer. Able to add/remove other team

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -69,8 +69,8 @@ type PullRequestBranch struct {
 // PullRequestListOptions specifies the optional parameters to the
 // PullRequestsService.List method.
 type PullRequestListOptions struct {
-	// State filters pull requests based on their state.  Possible values are:
-	// open, closed.  Default is "open".
+	// State filters pull requests based on their state. Possible values are:
+	// open, closed. Default is "open".
 	State string `url:"state,omitempty"`
 
 	// Head filters pull requests by head user and branch name in the format of:

--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -37,10 +37,10 @@ func (p PullRequestComment) String() string {
 // PullRequestListCommentsOptions specifies the optional parameters to the
 // PullRequestsService.ListComments method.
 type PullRequestListCommentsOptions struct {
-	// Sort specifies how to sort comments.  Possible values are: created, updated.
+	// Sort specifies how to sort comments. Possible values are: created, updated.
 	Sort string `url:"sort,omitempty"`
 
-	// Direction in which to sort comments.  Possible values are: asc, desc.
+	// Direction in which to sort comments. Possible values are: asc, desc.
 	Direction string `url:"direction,omitempty"`
 
 	// Since filters comments by time.
@@ -49,7 +49,7 @@ type PullRequestListCommentsOptions struct {
 	ListOptions
 }
 
-// ListComments lists all comments on the specified pull request.  Specifying a
+// ListComments lists all comments on the specified pull request. Specifying a
 // pull request number of 0 will return all comments on all pull requests for
 // the repository.
 //

--- a/github/repos.go
+++ b/github/repos.go
@@ -151,7 +151,7 @@ type RepositoryListOptions struct {
 	ListOptions
 }
 
-// List the repositories for a user.  Passing the empty string will list
+// List the repositories for a user. Passing the empty string will list
 // repositories for the authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/#list-user-repositories
@@ -187,8 +187,8 @@ func (s *RepositoriesService) List(user string, opt *RepositoryListOptions) ([]*
 // RepositoryListByOrgOptions specifies the optional parameters to the
 // RepositoriesService.ListByOrg method.
 type RepositoryListByOrgOptions struct {
-	// Type of repositories to list.  Possible values are: all, public, private,
-	// forks, sources, member.  Default is "all".
+	// Type of repositories to list. Possible values are: all, public, private,
+	// forks, sources, member. Default is "all".
 	Type string `url:"type,omitempty"`
 
 	ListOptions
@@ -253,8 +253,8 @@ func (s *RepositoriesService) ListAll(opt *RepositoryListAllOptions) ([]*Reposit
 	return repos, resp, nil
 }
 
-// Create a new repository.  If an organization is specified, the new
-// repository will be created under that org.  If the empty string is
+// Create a new repository. If an organization is specified, the new
+// repository will be created under that org. If the empty string is
 // specified, it will be created for the authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/#create

--- a/github/repos_collaborators.go
+++ b/github/repos_collaborators.go
@@ -87,7 +87,7 @@ type RepositoryAddCollaboratorOptions struct {
 	//     push - team members can pull and push, but not administer this repository
 	//     admin - team members can pull, push and administer this repository
 	//
-	// Default value is "push".  This option is only valid for organization-owned repositories.
+	// Default value is "push". This option is only valid for organization-owned repositories.
 	Permission string `json:"permission,omitempty"`
 }
 

--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -154,7 +154,7 @@ func (s *RepositoriesService) GetCommit(owner, repo, sha string) (*RepositoryCom
 	return commit, resp, nil
 }
 
-// GetCommitSHA1 gets the SHA-1 of a commit reference.  If a last-known SHA1 is
+// GetCommitSHA1 gets the SHA-1 of a commit reference. If a last-known SHA1 is
 // supplied and no new commits have occurred, a 304 Unmodified response is returned.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference

--- a/github/repos_forks.go
+++ b/github/repos_forks.go
@@ -10,8 +10,8 @@ import "fmt"
 // RepositoryListForksOptions specifies the optional parameters to the
 // RepositoriesService.ListForks method.
 type RepositoryListForksOptions struct {
-	// How to sort the forks list.  Possible values are: newest, oldest,
-	// watchers.  Default is "newest".
+	// How to sort the forks list. Possible values are: newest, oldest,
+	// watchers. Default is "newest".
 	Sort string `url:"sort,omitempty"`
 
 	ListOptions

--- a/github/repos_hooks.go
+++ b/github/repos_hooks.go
@@ -11,9 +11,9 @@ import (
 )
 
 // WebHookPayload represents the data that is received from GitHub when a push
-// event hook is triggered.  The format of these payloads pre-date most of the
+// event hook is triggered. The format of these payloads pre-date most of the
 // GitHub v3 API, so there are lots of minor incompatibilities with the types
-// defined in the rest of the API.  Therefore, several types are duplicated
+// defined in the rest of the API. Therefore, several types are duplicated
 // here to account for these differences.
 //
 // GitHub API docs: https://help.github.com/articles/post-receive-hooks
@@ -55,7 +55,7 @@ func (w WebHookCommit) String() string {
 }
 
 // WebHookAuthor represents the author or committer of a commit, as specified
-// in a WebHookCommit.  The commit author may not correspond to a GitHub User.
+// in a WebHookCommit. The commit author may not correspond to a GitHub User.
 type WebHookAuthor struct {
 	Email    *string `json:"email,omitempty"`
 	Name     *string `json:"name,omitempty"`
@@ -190,7 +190,7 @@ func (s *RepositoriesService) TestHook(owner, repo string, id int) (*Response, e
 	return s.client.Do(req, nil)
 }
 
-// ListServiceHooks is deprecated.  Use Client.ListServiceHooks instead.
+// ListServiceHooks is deprecated. Use Client.ListServiceHooks instead.
 func (s *RepositoriesService) ListServiceHooks() ([]*ServiceHook, *Response, error) {
 	return s.client.ListServiceHooks()
 }

--- a/github/repos_stats.go
+++ b/github/repos_stats.go
@@ -101,7 +101,7 @@ func (s *RepositoriesService) ListCommitActivity(owner, repo string) ([]*WeeklyC
 }
 
 // ListCodeFrequency returns a weekly aggregate of the number of additions and
-// deletions pushed to a repository.  Returned WeeklyStats will contain
+// deletions pushed to a repository. Returned WeeklyStats will contain
 // additions and deletions, but not total commits.
 //
 // If this is the first time these statistics are requested for the given

--- a/github/repos_statuses.go
+++ b/github/repos_statuses.go
@@ -15,11 +15,11 @@ type RepoStatus struct {
 	ID  *int    `json:"id,omitempty"`
 	URL *string `json:"url,omitempty"`
 
-	// State is the current state of the repository.  Possible values are:
+	// State is the current state of the repository. Possible values are:
 	// pending, success, error, or failure.
 	State *string `json:"state,omitempty"`
 
-	// TargetURL is the URL of the page representing this status.  It will be
+	// TargetURL is the URL of the page representing this status. It will be
 	// linked from the GitHub UI to allow users to see the source of the status.
 	TargetURL *string `json:"target_url,omitempty"`
 
@@ -39,7 +39,7 @@ func (r RepoStatus) String() string {
 }
 
 // ListStatuses lists the statuses of a repository at the specified
-// reference.  ref can be a SHA, a branch name, or a tag name.
+// reference. ref can be a SHA, a branch name, or a tag name.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
 func (s *RepositoriesService) ListStatuses(owner, repo, ref string, opt *ListOptions) ([]*RepoStatus, *Response, error) {
@@ -64,7 +64,7 @@ func (s *RepositoriesService) ListStatuses(owner, repo, ref string, opt *ListOpt
 }
 
 // CreateStatus creates a new status for a repository at the specified
-// reference.  Ref can be a SHA, a branch name, or a tag name.
+// reference. Ref can be a SHA, a branch name, or a tag name.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/statuses/#create-a-status
 func (s *RepositoriesService) CreateStatus(owner, repo, ref string, status *RepoStatus) (*RepoStatus, *Response, error) {
@@ -85,7 +85,7 @@ func (s *RepositoriesService) CreateStatus(owner, repo, ref string, status *Repo
 
 // CombinedStatus represents the combined status of a repository at a particular reference.
 type CombinedStatus struct {
-	// State is the combined state of the repository.  Possible values are:
+	// State is the combined state of the repository. Possible values are:
 	// failure, pending, or success.
 	State *string `json:"state,omitempty"`
 
@@ -103,7 +103,7 @@ func (s CombinedStatus) String() string {
 }
 
 // GetCombinedStatus returns the combined status of a repository at the specified
-// reference.  ref can be a SHA, a branch name, or a tag name.
+// reference. ref can be a SHA, a branch name, or a tag name.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
 func (s *RepositoriesService) GetCombinedStatus(owner, repo, ref string, opt *ListOptions) (*CombinedStatus, *Response, error) {

--- a/github/search.go
+++ b/github/search.go
@@ -19,7 +19,7 @@ type SearchService service
 
 // SearchOptions specifies optional parameters to the SearchService methods.
 type SearchOptions struct {
-	// How to sort the search results.  Possible values are:
+	// How to sort the search results. Possible values are:
 	//   - for repositories: stars, fork, updated
 	//   - for commits: author-date, committer-date
 	//   - for code: indexed

--- a/github/strings.go
+++ b/github/strings.go
@@ -16,7 +16,7 @@ import (
 var timestampType = reflect.TypeOf(Timestamp{})
 
 // Stringify attempts to create a reasonable string representation of types in
-// the GitHub library.  It does things like resolve pointers to their values
+// the GitHub library. It does things like resolve pointers to their values
 // and omits struct fields with nil values.
 func Stringify(message interface{}) string {
 	var buf bytes.Buffer

--- a/github/strings_test.go
+++ b/github/strings_test.go
@@ -79,9 +79,9 @@ func TestStringify(t *testing.T) {
 	}
 }
 
-// Directly test the String() methods on various GitHub types.  We don't do an
+// Directly test the String() methods on various GitHub types. We don't do an
 // exaustive test of all the various field types, since TestStringify() above
-// takes care of that.  Rather, we just make sure that Stringify() is being
+// takes care of that. Rather, we just make sure that Stringify() is being
 // used to build the strings, which we do by verifying that pointers are
 // stringified as their underlying value.
 func TestString(t *testing.T) {

--- a/github/users.go
+++ b/github/users.go
@@ -68,7 +68,7 @@ func (u User) String() string {
 	return Stringify(u)
 }
 
-// Get fetches a user.  Passing the empty string will fetch the authenticated
+// Get fetches a user. Passing the empty string will fetch the authenticated
 // user.
 //
 // GitHub API docs: http://developer.github.com/v3/users/#get-a-single-user

--- a/github/users_followers.go
+++ b/github/users_followers.go
@@ -7,7 +7,7 @@ package github
 
 import "fmt"
 
-// ListFollowers lists the followers for a user.  Passing the empty string will
+// ListFollowers lists the followers for a user. Passing the empty string will
 // fetch followers for the authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/users/followers/#list-followers-of-a-user
@@ -37,7 +37,7 @@ func (s *UsersService) ListFollowers(user string, opt *ListOptions) ([]*User, *R
 	return users, resp, nil
 }
 
-// ListFollowing lists the people that a user is following.  Passing the empty
+// ListFollowing lists the people that a user is following. Passing the empty
 // string will list people the authenticated user is following.
 //
 // GitHub API docs: http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user
@@ -67,7 +67,7 @@ func (s *UsersService) ListFollowing(user string, opt *ListOptions) ([]*User, *R
 	return users, resp, nil
 }
 
-// IsFollowing checks if "user" is following "target".  Passing the empty
+// IsFollowing checks if "user" is following "target". Passing the empty
 // string for "user" will check if the authenticated user is following "target".
 //
 // GitHub API docs: http://developer.github.com/v3/users/followers/#check-if-you-are-following-a-user

--- a/github/users_keys.go
+++ b/github/users_keys.go
@@ -20,7 +20,7 @@ func (k Key) String() string {
 	return Stringify(k)
 }
 
-// ListKeys lists the verified public keys for a user.  Passing the empty
+// ListKeys lists the verified public keys for a user. Passing the empty
 // string will fetch keys for the authenticated user.
 //
 // GitHub API docs: http://developer.github.com/v3/users/keys/#list-public-keys-for-a-user

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,7 +2,7 @@ go-github tests
 ===============
 
 This directory contains additional test suites beyond the unit tests already in
-[../github](../github).  Whereas the unit tests run very quickly (since they
+[../github](../github). Whereas the unit tests run very quickly (since they
 don't make any network calls) and are run by Travis on every commit, the tests
 in this directory are only run manually.
 
@@ -12,7 +12,7 @@ integration
 -----------
 
 This will exercise the entire go-github library (or at least as much as is
-practical) against the live GitHub API.  These tests will verify that the
+practical) against the live GitHub API. These tests will verify that the
 library is properly coded against the actual behavior of the API, and will
 (hopefully) fail upon any incompatible change in the API.
 
@@ -23,7 +23,7 @@ data having been changed, etc.
 These tests send real network traffic to the GitHub API and will exhaust the
 default unregistered rate limit (60 requests per hour) very quickly.
 Additionally, in order to test the methods that modify data, a real OAuth token
-will need to be present.  While the tests will try to be well-behaved in terms
+will need to be present. While the tests will try to be well-behaved in terms
 of what data they modify, it is **strongly** recommended that these tests only
 be run using a dedicated test account.
 
@@ -46,13 +46,13 @@ fields
 ------
 
 This will identify the fields being returned by the live GitHub API that are
-not currently being mapped into the relevant Go data type.  Sometimes fields
+not currently being mapped into the relevant Go data type. Sometimes fields
 are deliberately not mapped, so the results of this tool should just be taken
 as a hint.
 
 This test sends real network traffic to the GitHub API and will exhaust the
 default unregistered rate limit (60 requests per hour) very quickly.
-Additionally, some data is only returned for authenticated API calls.  Unlike
+Additionally, some data is only returned for authenticated API calls. Unlike
 the integration tests above, these tests only read data, so it's less
 imperitive that these be run using a dedicated test account (though you still
 really should).

--- a/tests/fields/fields.go
+++ b/tests/fields/fields.go
@@ -3,9 +3,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// This tool tests for the JSON mappings in the go-github data types.  It will
+// This tool tests for the JSON mappings in the go-github data types. It will
 // identify fields that are returned by the live GitHub API, but that are not
-// currently mapped into a struct field of the relevant go-github type.  This
+// currently mapped into a struct field of the relevant go-github type. This
 // helps to ensure that all relevant data returned by the API is being made
 // accessible, particularly new fields that are periodically (and sometimes
 // quietly) added to the API over time.
@@ -43,7 +43,7 @@ func main() {
 
 	token := os.Getenv("GITHUB_AUTH_TOKEN")
 	if token == "" {
-		print("!!! No OAuth token.  Some tests won't run. !!!\n\n")
+		print("!!! No OAuth token. Some tests won't run. !!!\n\n")
 		client = github.NewClient(nil)
 	} else {
 		tc := oauth2.NewClient(oauth2.NoContext, oauth2.StaticTokenSource(

--- a/tests/integration/activity_test.go
+++ b/tests/integration/activity_test.go
@@ -39,7 +39,7 @@ func TestActivity_Starring(t *testing.T) {
 		t.Fatalf("Activity.IsStarred returned error: %v", err)
 	}
 	if star {
-		t.Fatalf("Already starring %v/%v.  Please manually unstar it first.", owner, repo)
+		t.Fatalf("Already starring %v/%v. Please manually unstar it first.", owner, repo)
 	}
 
 	// star the target repository

--- a/tests/integration/doc.go
+++ b/tests/integration/doc.go
@@ -6,6 +6,6 @@
 // Package tests contains integration tests.
 //
 // These tests call the live GitHub API, and therefore require a little more
-// setup to run.  See https://github.com/google/go-github/tree/master/tests#integration
+// setup to run. See https://github.com/google/go-github/tree/master/tests#integration
 // for more information.
 package tests

--- a/tests/integration/github_test.go
+++ b/tests/integration/github_test.go
@@ -28,7 +28,7 @@ var (
 func init() {
 	token := os.Getenv("GITHUB_AUTH_TOKEN")
 	if token == "" {
-		print("!!! No OAuth token.  Some tests won't run. !!!\n\n")
+		print("!!! No OAuth token. Some tests won't run. !!!\n\n")
 		client = github.NewClient(nil)
 	} else {
 		tc := oauth2.NewClient(oauth2.NoContext, oauth2.StaticTokenSource(

--- a/tests/integration/users_test.go
+++ b/tests/integration/users_test.go
@@ -183,7 +183,7 @@ func TestUsers_Keys(t *testing.T) {
 	key := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCy/RIqaMFj2wjkOEjx9EAU0ReLAIhodga82/feo5nnT9UUkHLbL9xrIavfdLHx28lD3xYgPfAoSicUMaAeNwuQhmuerr2c2LFGxzrdXP8pVsQ+Ol7y7OdmFPfe0KrzoZaLJs9aSiZ4VKyY4z5Se/k2UgcJTdgQVlLfw/P96aqCx8yUu94BiWqkDqYEvgWKRNHrTiIo1EXeVBCCcfgNZe1suFfNJUJSUU2T3EG2bpwBbSOCjE3FyH8+Lz3K3BOGzm3df8E7Regj9j4YIcD8cWJYO86jLJoGgQ0L5MSOq+ishNaHQXech22Ix03D1lVMjCvDT7S/C94Z1LzhI2lhvyff"
 	for _, k := range keys {
 		if k.Key != nil && *k.Key == key {
-			t.Fatalf("Test key already exists for user.  Please manually remove it first.")
+			t.Fatalf("Test key already exists for user. Please manually remove it first.")
 		}
 	}
 


### PR DESCRIPTION
This PR was largely generated by:

```
perl -i -npe 's,^(\s*// .+[a-z]\.)  +([A-Z]),$1 $2,' $(git grep -l -E '^\s*//(.+\.)  +([A-Z])')
```

With additional manual followups to catch the few remaining missed cases, such as inside non-go files, spaces after question marks, etc.

Fixes #548.