### PR TITLE
Return nil explicitly when there is no error.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -739,7 +739,7 @@ func (c *Client) RateLimit() (*Rate, *Response, error) {
 		return nil, resp, err
 	}
 	if limits == nil {
-		return nil, resp, fmt.Errorf("RateLimits returned nil limits and error; unable to extract Core rate limit")
+		return nil, resp, errors.New("RateLimits returned nil limits and error; unable to extract Core rate limit")
 	}
 	return limits.Core, resp, nil
 }

--- a/github/github.go
+++ b/github/github.go
@@ -739,7 +739,7 @@ func (c *Client) RateLimit() (*Rate, *Response, error) {
 		return nil, nil, err
 	}
 
-	return limits.Core, resp, err
+	return limits.Core, resp, nil
 }
 
 // RateLimits returns the rate limits for the current client.

--- a/github/github.go
+++ b/github/github.go
@@ -741,7 +741,6 @@ func (c *Client) RateLimit() (*Rate, *Response, error) {
 	if limits == nil {
 		return nil, resp, fmt.Errorf("RateLimits returned nil limits and error; unable to extract Core rate limit")
 	}
-
 	return limits.Core, resp, nil
 }
 

--- a/github/github.go
+++ b/github/github.go
@@ -736,10 +736,10 @@ func category(path string) rateLimitCategory {
 func (c *Client) RateLimit() (*Rate, *Response, error) {
 	limits, resp, err := c.RateLimits()
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	if limits == nil {
-		return nil, nil, fmt.Errorf("RateLimits returned nil limits and error. Unable to extract Core rate limit")
+		return nil, resp, fmt.Errorf("RateLimits returned nil limits and error; unable to extract Core rate limit")
 	}
 
 	return limits.Core, resp, nil

--- a/github/github.go
+++ b/github/github.go
@@ -735,8 +735,11 @@ func category(path string) rateLimitCategory {
 // Deprecated: RateLimit is deprecated, use RateLimits instead.
 func (c *Client) RateLimit() (*Rate, *Response, error) {
 	limits, resp, err := c.RateLimits()
-	if limits == nil {
+	if err != nil {
 		return nil, nil, err
+	}
+	if limits == nil {
+		return nil, nil, fmt.Errorf("RateLimits returned nil limits and error. Unable to extract Core rate limit")
 	}
 
 	return limits.Core, resp, nil

--- a/github/issues_events.go
+++ b/github/issues_events.go
@@ -91,7 +91,7 @@ func (s *IssuesService) ListIssueEvents(owner, repo string, number int, opt *Lis
 		return nil, resp, err
 	}
 
-	return events, resp, err
+	return events, resp, nil
 }
 
 // ListRepositoryEvents lists events for the specified repository.
@@ -115,7 +115,7 @@ func (s *IssuesService) ListRepositoryEvents(owner, repo string, opt *ListOption
 		return nil, resp, err
 	}
 
-	return events, resp, err
+	return events, resp, nil
 }
 
 // GetEvent returns the specified issue event.
@@ -135,7 +135,7 @@ func (s *IssuesService) GetEvent(owner, repo string, id int) (*IssueEvent, *Resp
 		return nil, resp, err
 	}
 
-	return event, resp, err
+	return event, resp, nil
 }
 
 // Rename contains details for 'renamed' events.

--- a/github/repos_comments.go
+++ b/github/repos_comments.go
@@ -103,7 +103,7 @@ func (s *RepositoriesService) CreateComment(owner, repo, sha string, comment *Re
 		return nil, resp, err
 	}
 
-	return c, resp, err
+	return c, resp, nil
 }
 
 // GetComment gets a single comment from a repository.
@@ -125,7 +125,7 @@ func (s *RepositoriesService) GetComment(owner, repo string, id int) (*Repositor
 		return nil, resp, err
 	}
 
-	return c, resp, err
+	return c, resp, nil
 }
 
 // UpdateComment updates the body of a single comment.
@@ -144,7 +144,7 @@ func (s *RepositoriesService) UpdateComment(owner, repo string, id int, comment 
 		return nil, resp, err
 	}
 
-	return c, resp, err
+	return c, resp, nil
 }
 
 // DeleteComment deletes a single comment from a repository.


### PR DESCRIPTION
Resolves #536. Explicitly return nil when there is no error. Hopefully, this should address outstanding instances of the following pattern: 

```go
if err != nil {
  return ..., err
}
return ..., err
```