### PR TITLE
Require Go 1.7 and newer.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,12 @@
 sudo: false
 language: go
 go:
-  - 1.5.4
-  - 1.6.3
-  - 1.7
-  - tip
+  - 1.7.x
+  - 1.8.x
+  - master
 matrix:
-  include:
-    - go: 1.4.3
-      script:
-        - go get -t -v ./...
-        - go test -v -race ./...
   allow_failures:
-    - go: tip
+    - go: master
   fast_finish: true
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ go-github is a Go client library for accessing the [GitHub API][].
 **Build Status:** [![Build Status](https://travis-ci.org/google/go-github.svg?branch=master)](https://travis-ci.org/google/go-github)  
 **Test Coverage:** [![Test Coverage](https://coveralls.io/repos/google/go-github/badge.svg?branch=master)](https://coveralls.io/r/google/go-github?branch=master) ([gocov report](https://drone.io/github.com/google/go-github/files/coverage.html))
 
-go-github requires Go version 1.4 or greater.
+go-github requires Go version 1.7 or greater.
 
 ## Usage ##
 

--- a/github/github.go
+++ b/github/github.go
@@ -29,7 +29,7 @@ const (
 )
 
 const (
-	libraryVersion = "2"
+	libraryVersion = "3"
 	defaultBaseURL = "https://api.github.com/"
 	uploadBaseURL  = "https://uploads.github.com/"
 	userAgent      = "go-github/" + libraryVersion


### PR DESCRIPTION
This is part 1 of 3 PRs to resolve #526 (as was suggested to split PR #529 in https://github.com/google/go-github/pull/529#discussion_r101895336).

Please see commit message for change details:

> We need to do this in order to be able to resolve #526 without unreasonable compromises.
> 
> That's the minimum version that has context package in standard library, and built-in support for it inside net/http package. Now that Go 1.8 is out, this "current version, plus one back".
> 
> Bump up the library version in anticipation of breaking API changes in following commits. It makes sense to bump it now because this commit drops support for Go versions 1.4, 1.5 and 1.6, so we can say that version 2 is the latest supported by older Go versions.
> 
> Helps #526.