### PR TITLE
Remove deprecated identifiers.

### DIFF
--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -49,8 +49,6 @@ func (e *Event) Payload() (payload interface{}) {
 		payload = &IntegrationInstallationEvent{}
 	case "IntegrationInstallationRepositoriesEvent":
 		payload = &IntegrationInstallationRepositoriesEvent{}
-	case "IssueActivityEvent":
-		payload = &IssueActivityEvent{}
 	case "IssueCommentEvent":
 		payload = &IssueCommentEvent{}
 	case "IssuesEvent":

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -130,19 +130,6 @@ type GollumEvent struct {
 	Installation *Installation `json:"installation,omitempty"`
 }
 
-// IssueActivityEvent represents the payload delivered by Issue webhook.
-//
-// Deprecated: Use IssuesEvent instead.
-type IssueActivityEvent struct {
-	Action *string `json:"action,omitempty"`
-	Issue  *Issue  `json:"issue,omitempty"`
-
-	// The following fields are only populated by Webhook events.
-	Repo         *Repository   `json:"repository,omitempty"`
-	Sender       *User         `json:"sender,omitempty"`
-	Installation *Installation `json:"installation,omitempty"`
-}
-
 // EditChange represents the changes when an issue, pull request, or comment has
 // been edited.
 type EditChange struct {

--- a/github/github.go
+++ b/github/github.go
@@ -24,11 +24,6 @@ import (
 )
 
 const (
-	// StatusUnprocessableEntity is the status code returned when sending a request with invalid fields.
-	StatusUnprocessableEntity = 422
-)
-
-const (
 	libraryVersion = "3"
 	defaultBaseURL = "https://api.github.com/"
 	uploadBaseURL  = "https://uploads.github.com/"
@@ -383,19 +378,6 @@ func parseRate(r *http.Response) Rate {
 	return rate
 }
 
-// Rate specifies the current rate limit for the client as determined by the
-// most recent API call. If the client is used in a multi-user application,
-// this rate may not always be up-to-date.
-//
-// Deprecated: Use the Response.Rate returned from most recent API call instead.
-// Call RateLimits() to check the current rate.
-func (c *Client) Rate() Rate {
-	c.rateMu.Lock()
-	rate := c.rateLimits[c.mostRecent]
-	c.rateMu.Unlock()
-	return rate
-}
-
 // Do sends an API request and returns the API response. The API response is
 // JSON decoded and stored in the value pointed to by v, or returned as an
 // error if an API error has occurred. If v implements the io.Writer
@@ -728,20 +710,6 @@ func category(path string) rateLimitCategory {
 	case strings.HasPrefix(path, "/search/"):
 		return searchCategory
 	}
-}
-
-// RateLimit returns the core rate limit for the current client.
-//
-// Deprecated: RateLimit is deprecated, use RateLimits instead.
-func (c *Client) RateLimit() (*Rate, *Response, error) {
-	limits, resp, err := c.RateLimits()
-	if err != nil {
-		return nil, resp, err
-	}
-	if limits == nil {
-		return nil, resp, errors.New("RateLimits returned nil limits and error; unable to extract Core rate limit")
-	}
-	return limits.Core, resp, nil
 }
 
 // RateLimits returns the rate limits for the current client.

--- a/github/misc_test.go
+++ b/github/misc_test.go
@@ -137,7 +137,7 @@ func TestZen(t *testing.T) {
 	}
 }
 
-func TestRepositoriesService_ListServiceHooks(t *testing.T) {
+func TestListServiceHooks(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -153,9 +153,9 @@ func TestRepositoriesService_ListServiceHooks(t *testing.T) {
 		}]`)
 	})
 
-	hooks, _, err := client.Repositories.ListServiceHooks()
+	hooks, _, err := client.ListServiceHooks()
 	if err != nil {
-		t.Errorf("Repositories.ListHooks returned error: %v", err)
+		t.Errorf("ListServiceHooks returned error: %v", err)
 	}
 
 	want := []*ServiceHook{{
@@ -165,6 +165,6 @@ func TestRepositoriesService_ListServiceHooks(t *testing.T) {
 		Schema:          [][]string{{"a", "b"}},
 	}}
 	if !reflect.DeepEqual(hooks, want) {
-		t.Errorf("Repositories.ListServiceHooks returned %+v, want %+v", hooks, want)
+		t.Errorf("ListServiceHooks returned %+v, want %+v", hooks, want)
 	}
 }

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -381,7 +381,7 @@ func TestOrganizationsService_AddTeamRepo_noAccess(t *testing.T) {
 
 	mux.HandleFunc("/teams/1/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.WriteHeader(StatusUnprocessableEntity)
+		w.WriteHeader(http.StatusUnprocessableEntity)
 	})
 
 	_, err := client.Organizations.AddTeamRepo(1, "o", "r", nil)

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -11,7 +11,6 @@ package github
 import (
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -62,20 +61,6 @@ type RepositoryContentGetOptions struct {
 // String converts RepositoryContent to a string. It's primarily for testing.
 func (r RepositoryContent) String() string {
 	return Stringify(r)
-}
-
-// Decode decodes the file content if it is base64 encoded.
-//
-// Deprecated: Use GetContent instead.
-func (r *RepositoryContent) Decode() ([]byte, error) {
-	if *r.Encoding != "base64" {
-		return nil, errors.New("cannot decode non-base64")
-	}
-	o, err := base64.StdEncoding.DecodeString(*r.Content)
-	if err != nil {
-		return nil, err
-	}
-	return o, nil
 }
 
 // GetContent returns the content of r, decoding it if necessary.

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -13,41 +13,6 @@ import (
 	"testing"
 )
 
-func TestRepositoryContent_Decode(t *testing.T) {
-	tests := []struct {
-		encoding, content *string // input encoding and content
-		want              string  // desired output
-		wantErr           bool    // whether an error is expected
-	}{
-		{
-			encoding: String("base64"),
-			content:  String("aGVsbG8="),
-			want:     "hello",
-			wantErr:  false,
-		},
-		{
-			encoding: String("bad"),
-			content:  String("aGVsbG8="),
-			want:     "",
-			wantErr:  true,
-		},
-	}
-
-	for _, tt := range tests {
-		r := RepositoryContent{Encoding: tt.encoding, Content: tt.content}
-		o, err := r.Decode()
-		if err != nil && !tt.wantErr {
-			t.Errorf("RepositoryContent(%q, %q) returned unexpected error: %v", tt.encoding, tt.content, err)
-		}
-		if err == nil && tt.wantErr {
-			t.Errorf("RepositoryContent(%q, %q) did not return unexpected error", tt.encoding, tt.content)
-		}
-		if got, want := string(o), tt.want; got != want {
-			t.Errorf("RepositoryContent.Decode returned %+v, want %+v", got, want)
-		}
-	}
-}
-
 func TestRepositoryContent_GetContent(t *testing.T) {
 	tests := []struct {
 		encoding, content *string // input encoding and content

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -144,7 +144,6 @@ type DeploymentStatus struct {
 // DeploymentStatusRequest represents a deployment request
 type DeploymentStatusRequest struct {
 	State          *string `json:"state,omitempty"`
-	TargetURL      *string `json:"target_url,omitempty"` // Deprecated. Use LogURL instead.
 	LogURL         *string `json:"log_url,omitempty"`
 	Description    *string `json:"description,omitempty"`
 	EnvironmentURL *string `json:"environment_url,omitempty"`

--- a/github/repos_hooks.go
+++ b/github/repos_hooks.go
@@ -189,8 +189,3 @@ func (s *RepositoriesService) TestHook(owner, repo string, id int) (*Response, e
 	}
 	return s.client.Do(req, nil)
 }
-
-// ListServiceHooks is deprecated. Use Client.ListServiceHooks instead.
-func (s *RepositoriesService) ListServiceHooks() ([]*ServiceHook, *Response, error) {
-	return s.client.ListServiceHooks()
-}


### PR DESCRIPTION
**DO NOT MERGE:** Please note the base of this PR is currently the `require-go17-plus` branch rather than `master`. This PR is for review purposes only. Once #554 is merged, I will change base of this PR to `master` and it can be mergeable then.

This is part 2 of 3 PRs to resolve #526 (as was suggested to split PR #529 in https://github.com/google/go-github/pull/529#discussion_r101895336).

Please see commit message for change details:

> This is a breaking API change. However, it removes things that were deprecated and shouldn't be used anymore (including something that's available in standard library).
>
> Next commit will be a large breaking API change anyway, so it makes more sense to get rid of the deprecated things instead of updating their API.
>
> `http.StatusUnprocessableEntity` was added in Go 1.7, and so we can use it instead of own equivalent constant. Anyone who was previously using it should switch to using `http.StatusUnprocessableEntity` as well. Consider this commit to deprecate `StatusUnprocessableEntity` and remove it in one.

As I wrote in https://github.com/google/go-github/pull/529#issuecomment-280819989:

>  I kinda went to an extreme and removed all deprecated things, even ones that wouldn't be affected by API changes. Please see the entire change and review it carefully, and let me know your thoughts. Do we delete only the affected deprecated APIs? All of them (as currently is)? Or don't remove any?