### PR TITLE
examples/basicauth: Simplify comma-ok type assertion in if statement.

### DIFF
--- a/examples/basicauth/main.go
+++ b/examples/basicauth/main.go
@@ -37,7 +37,7 @@ func main() {
 	user, _, err := client.Users.Get("")
 
 	// Is this a two-factor auth error? If so, prompt for OTP and try again.
-	if _, ok := err.(*github.TwoFactorAuthError); err != nil && ok {
+	if _, ok := err.(*github.TwoFactorAuthError); ok {
 		fmt.Print("\nGitHub OTP: ")
 		otp, _ := r.ReadString('\n')
 		tp.OTP = strings.TrimSpace(otp)


### PR DESCRIPTION
According to https://golang.org/ref/spec#Type_assertions:

> For an expression `x` of interface type and a type `T`, the primary expression
>
>     x.(T)
>
> asserts that `x` is not nil and that the value stored in `x` is of type `T`. [...] The value of `ok` is `true` if the assertion holds.

Therefore, this if statement can be simplified without changing behavior.

I also made a proposal for this check in https://github.com/dominikh/go-tools/issues/34.