### PR TITLE
Remove unused Client.mostRecent.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -114,7 +114,6 @@ type Client struct {
 
 	rateMu     sync.Mutex
 	rateLimits [categories]Rate // Rate limits for the client as determined by the most recent API calls.
-	mostRecent rateLimitCategory
 
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
 
@@ -413,7 +412,6 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 
 	c.rateMu.Lock()
 	c.rateLimits[rateLimitCategory] = response.Rate
-	c.mostRecent = rateLimitCategory
 	c.rateMu.Unlock()
 
 	err = CheckResponse(resp)


### PR DESCRIPTION
This is a followup to #555. /cc @gmlewis

`mostRecent` was created specifically to support `Rate` method in #347. That method is now gone (removed in #555), so `mostRecent` is unused and can be safely removed.