### PR TITLE
Update API inside documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ func main() {
   ts := oauth2.StaticTokenSource(
     &oauth2.Token{AccessToken: "... your access token ..."},
   )
-  tc := oauth2.NewClient(oauth2.NoContext, ts)
+  tc := oauth2.NewClient(context.Background(), ts)
 
   client := github.NewClient(tc)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ access different parts of the GitHub API. For example:
 client := github.NewClient(nil)
 
 // list all organizations for user "willnorris"
-orgs, _, err := client.Organizations.List("willnorris", nil)
+orgs, _, err := client.Organizations.List(ctx, "willnorris", nil)
 ```
 
 Some API methods have optional parameters that can be passed. For example:
@@ -32,7 +32,7 @@ client := github.NewClient(nil)
 
 // list public repositories for org "github"
 opt := &github.RepositoryListByOrgOptions{Type: "public"}
-repos, _, err := client.Repositories.ListByOrg("github", opt)
+repos, _, err := client.Repositories.ListByOrg(ctx, "github", opt)
 ```
 
 The services of a client divide the API into logical chunks and correspond to
@@ -60,7 +60,7 @@ func main() {
   client := github.NewClient(tc)
 
   // list all repositories for the authenticated user
-  repos, _, err := client.Repositories.List("", nil)
+  repos, _, err := client.Repositories.List(ctx, "", nil)
 }
 ```
 
@@ -90,7 +90,7 @@ up-to-date rate limit data for the client.
 To detect an API rate limit error, you can check if its type is `*github.RateLimitError`:
 
 ```go
-repos, _, err := client.Repositories.List("", nil)
+repos, _, err := client.Repositories.List(ctx, "", nil)
 if _, ok := err.(*github.RateLimitError); ok {
 	log.Println("hit rate limit")
 }
@@ -110,7 +110,7 @@ To detect this condition of error, you can check if its type is
 `*github.AcceptedError`:
 
 ```go
-stats, _, err := client.Repositories.ListContributorsStats(org, repo)
+stats, _, err := client.Repositories.ListContributorsStats(ctx, org, repo)
 if _, ok := err.(*github.AcceptedError); ok {
 	log.Println("scheduled on GitHub side")
 }
@@ -140,7 +140,7 @@ repo := &github.Repository{
 	Name:    github.String("foo"),
 	Private: github.Bool(true),
 }
-client.Repositories.Create("", repo)
+client.Repositories.Create(ctx, "", repo)
 ```
 
 Users who have worked with protocol buffers should find this pattern familiar.
@@ -163,7 +163,7 @@ opt := &github.RepositoryListByOrgOptions{
 // get all pages of results
 var allRepos []*github.Repository
 for {
-	repos, resp, err := client.Repositories.ListByOrg("github", opt)
+	repos, resp, err := client.Repositories.ListByOrg(ctx, "github", opt)
 	if err != nil {
 		return err
 	}

--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ API token][]), you can use it with the oauth2 library using:
 import "golang.org/x/oauth2"
 
 func main() {
+  ctx := context.Background()
   ts := oauth2.StaticTokenSource(
     &oauth2.Token{AccessToken: "... your access token ..."},
   )
-  tc := oauth2.NewClient(context.Background(), ts)
+  tc := oauth2.NewClient(ctx, ts)
 
   client := github.NewClient(tc)
 

--- a/github/doc.go
+++ b/github/doc.go
@@ -16,7 +16,7 @@ access different parts of the GitHub API. For example:
 	client := github.NewClient(nil)
 
 	// list all organizations for user "willnorris"
-	orgs, _, err := client.Organizations.List("willnorris", nil)
+	orgs, _, err := client.Organizations.List(ctx, "willnorris", nil)
 
 Some API methods have optional parameters that can be passed. For example:
 
@@ -24,7 +24,7 @@ Some API methods have optional parameters that can be passed. For example:
 
 	// list public repositories for org "github"
 	opt := &github.RepositoryListByOrgOptions{Type: "public"}
-	repos, _, err := client.Repositories.ListByOrg("github", opt)
+	repos, _, err := client.Repositories.ListByOrg(ctx, "github", opt)
 
 The services of a client divide the API into logical chunks and correspond to
 the structure of the GitHub API documentation at
@@ -50,7 +50,7 @@ use it with the oauth2 library using:
 		client := github.NewClient(tc)
 
 		// list all repositories for the authenticated user
-		repos, _, err := client.Repositories.List("", nil)
+		repos, _, err := client.Repositories.List(ctx, "", nil)
 	}
 
 Note that when using an authenticated Client, all calls made by the client will
@@ -78,7 +78,7 @@ up-to-date rate limit data for the client.
 
 To detect an API rate limit error, you can check if its type is *github.RateLimitError:
 
-	repos, _, err := client.Repositories.List("", nil)
+	repos, _, err := client.Repositories.List(ctx, "", nil)
 	if _, ok := err.(*github.RateLimitError); ok {
 		log.Println("hit rate limit")
 	}
@@ -96,7 +96,7 @@ this behavior.
 To detect this condition of error, you can check if its type is
 *github.AcceptedError:
 
-	stats, _, err := client.Repositories.ListContributorsStats(org, repo)
+	stats, _, err := client.Repositories.ListContributorsStats(ctx, org, repo)
 	if _, ok := err.(*github.AcceptedError); ok {
 		log.Println("scheduled on GitHub side")
 	}
@@ -124,7 +124,7 @@ bool, and int values. For example:
 		Name:    github.String("foo"),
 		Private: github.Bool(true),
 	}
-	client.Repositories.Create("", repo)
+	client.Repositories.Create(ctx, "", repo)
 
 Users who have worked with protocol buffers should find this pattern familiar.
 
@@ -145,7 +145,7 @@ github.Response struct.
 	// get all pages of results
 	var allRepos []*github.Repository
 	for {
-		repos, resp, err := client.Repositories.ListByOrg("github", opt)
+		repos, resp, err := client.Repositories.ListByOrg(ctx, "github", opt)
 		if err != nil {
 			return err
 		}

--- a/github/doc.go
+++ b/github/doc.go
@@ -45,7 +45,7 @@ use it with the oauth2 library using:
 		ts := oauth2.StaticTokenSource(
 			&oauth2.Token{AccessToken: "... your access token ..."},
 		)
-		tc := oauth2.NewClient(oauth2.NoContext, ts)
+		tc := oauth2.NewClient(context.Background(), ts)
 
 		client := github.NewClient(tc)
 

--- a/github/doc.go
+++ b/github/doc.go
@@ -42,10 +42,11 @@ use it with the oauth2 library using:
 	import "golang.org/x/oauth2"
 
 	func main() {
+		ctx := context.Background()
 		ts := oauth2.StaticTokenSource(
 			&oauth2.Token{AccessToken: "... your access token ..."},
 		)
-		tc := oauth2.NewClient(context.Background(), ts)
+		tc := oauth2.NewClient(ctx, ts)
 
 		client := github.NewClient(tc)
 

--- a/tests/integration/github_test.go
+++ b/tests/integration/github_test.go
@@ -8,6 +8,7 @@
 package tests
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -31,7 +32,7 @@ func init() {
 		print("!!! No OAuth token. Some tests won't run. !!!\n\n")
 		client = github.NewClient(nil)
 	} else {
-		tc := oauth2.NewClient(oauth2.NoContext, oauth2.StaticTokenSource(
+		tc := oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
 			&oauth2.Token{AccessToken: token},
 		))
 		client = github.NewClient(tc)


### PR DESCRIPTION
- Update documentation with new context parameter.
- Update remaining uses of oauth2.NoContext.

This is a followup to #529.