### PR TITLE
Improve consistency of "GitHub API docs" strings in comments.

### DIFF
--- a/github/activity_notifications.go
+++ b/github/activity_notifications.go
@@ -19,7 +19,7 @@ type Notification struct {
 
 	// Reason identifies the event that triggered the notification.
 	//
-	// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#notification-reasons
+	// GitHub API docs: https://developer.github.com/v3/activity/notifications/#notification-reasons
 	Reason *string `json:"reason,omitempty"`
 
 	Unread     *bool      `json:"unread,omitempty"`
@@ -49,7 +49,7 @@ type NotificationListOptions struct {
 
 // ListNotifications lists all notifications for the authenticated user.
 //
-// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#list-your-notifications
+// GitHub API docs: https://developer.github.com/v3/activity/notifications/#list-your-notifications
 func (s *ActivityService) ListNotifications(ctx context.Context, opt *NotificationListOptions) ([]*Notification, *Response, error) {
 	u := fmt.Sprintf("notifications")
 	u, err := addOptions(u, opt)
@@ -74,7 +74,7 @@ func (s *ActivityService) ListNotifications(ctx context.Context, opt *Notificati
 // ListRepositoryNotifications lists all notifications in a given repository
 // for the authenticated user.
 //
-// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#list-your-notifications-in-a-repository
+// GitHub API docs: https://developer.github.com/v3/activity/notifications/#list-your-notifications-in-a-repository
 func (s *ActivityService) ListRepositoryNotifications(ctx context.Context, owner, repo string, opt *NotificationListOptions) ([]*Notification, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/notifications", owner, repo)
 	u, err := addOptions(u, opt)
@@ -102,7 +102,7 @@ type markReadOptions struct {
 
 // MarkNotificationsRead marks all notifications up to lastRead as read.
 //
-// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#mark-as-read
+// GitHub API docs: https://developer.github.com/v3/activity/notifications/#mark-as-read
 func (s *ActivityService) MarkNotificationsRead(ctx context.Context, lastRead time.Time) (*Response, error) {
 	opts := &markReadOptions{
 		LastReadAt: lastRead,
@@ -118,7 +118,7 @@ func (s *ActivityService) MarkNotificationsRead(ctx context.Context, lastRead ti
 // MarkRepositoryNotificationsRead marks all notifications up to lastRead in
 // the specified repository as read.
 //
-// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository
+// GitHub API docs: https://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository
 func (s *ActivityService) MarkRepositoryNotificationsRead(ctx context.Context, owner, repo string, lastRead time.Time) (*Response, error) {
 	opts := &markReadOptions{
 		LastReadAt: lastRead,
@@ -134,7 +134,7 @@ func (s *ActivityService) MarkRepositoryNotificationsRead(ctx context.Context, o
 
 // GetThread gets the specified notification thread.
 //
-// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#view-a-single-thread
+// GitHub API docs: https://developer.github.com/v3/activity/notifications/#view-a-single-thread
 func (s *ActivityService) GetThread(ctx context.Context, id string) (*Notification, *Response, error) {
 	u := fmt.Sprintf("notifications/threads/%v", id)
 
@@ -154,7 +154,7 @@ func (s *ActivityService) GetThread(ctx context.Context, id string) (*Notificati
 
 // MarkThreadRead marks the specified thread as read.
 //
-// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read
+// GitHub API docs: https://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read
 func (s *ActivityService) MarkThreadRead(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("notifications/threads/%v", id)
 
@@ -169,7 +169,7 @@ func (s *ActivityService) MarkThreadRead(ctx context.Context, id string) (*Respo
 // GetThreadSubscription checks to see if the authenticated user is subscribed
 // to a thread.
 //
-// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#get-a-thread-subscription
+// GitHub API docs: https://developer.github.com/v3/activity/notifications/#get-a-thread-subscription
 func (s *ActivityService) GetThreadSubscription(ctx context.Context, id string) (*Subscription, *Response, error) {
 	u := fmt.Sprintf("notifications/threads/%v/subscription", id)
 
@@ -190,7 +190,7 @@ func (s *ActivityService) GetThreadSubscription(ctx context.Context, id string) 
 // SetThreadSubscription sets the subscription for the specified thread for the
 // authenticated user.
 //
-// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#set-a-thread-subscription
+// GitHub API docs: https://developer.github.com/v3/activity/notifications/#set-a-thread-subscription
 func (s *ActivityService) SetThreadSubscription(ctx context.Context, id string, subscription *Subscription) (*Subscription, *Response, error) {
 	u := fmt.Sprintf("notifications/threads/%v/subscription", id)
 
@@ -211,7 +211,7 @@ func (s *ActivityService) SetThreadSubscription(ctx context.Context, id string, 
 // DeleteThreadSubscription deletes the subscription for the specified thread
 // for the authenticated user.
 //
-// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription
+// GitHub API docs: https://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription
 func (s *ActivityService) DeleteThreadSubscription(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("notifications/threads/%v/subscription", id)
 	req, err := s.client.NewRequest("DELETE", u, nil)

--- a/github/activity_star.go
+++ b/github/activity_star.go
@@ -24,7 +24,7 @@ type Stargazer struct {
 
 // ListStargazers lists people who have starred the specified repo.
 //
-// GitHub API Docs: https://developer.github.com/v3/activity/starring/#list-stargazers
+// GitHub API docs: https://developer.github.com/v3/activity/starring/#list-stargazers
 func (s *ActivityService) ListStargazers(ctx context.Context, owner, repo string, opt *ListOptions) ([]*Stargazer, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/stargazers", owner, repo)
 	u, err := addOptions(u, opt)

--- a/github/activity_watching.go
+++ b/github/activity_watching.go
@@ -27,7 +27,7 @@ type Subscription struct {
 
 // ListWatchers lists watchers of a particular repo.
 //
-// GitHub API Docs: https://developer.github.com/v3/activity/watching/#list-watchers
+// GitHub API docs: https://developer.github.com/v3/activity/watching/#list-watchers
 func (s *ActivityService) ListWatchers(ctx context.Context, owner, repo string, opt *ListOptions) ([]*User, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/subscribers", owner, repo)
 	u, err := addOptions(u, opt)
@@ -52,7 +52,7 @@ func (s *ActivityService) ListWatchers(ctx context.Context, owner, repo string, 
 // ListWatched lists the repositories the specified user is watching. Passing
 // the empty string will fetch watched repos for the authenticated user.
 //
-// GitHub API Docs: https://developer.github.com/v3/activity/watching/#list-repositories-being-watched
+// GitHub API docs: https://developer.github.com/v3/activity/watching/#list-repositories-being-watched
 func (s *ActivityService) ListWatched(ctx context.Context, user string, opt *ListOptions) ([]*Repository, *Response, error) {
 	var u string
 	if user != "" {
@@ -83,7 +83,7 @@ func (s *ActivityService) ListWatched(ctx context.Context, user string, opt *Lis
 // repository for the authenticated user. If the authenticated user is not
 // watching the repository, a nil Subscription is returned.
 //
-// GitHub API Docs: https://developer.github.com/v3/activity/watching/#get-a-repository-subscription
+// GitHub API docs: https://developer.github.com/v3/activity/watching/#get-a-repository-subscription
 func (s *ActivityService) GetRepositorySubscription(ctx context.Context, owner, repo string) (*Subscription, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/subscription", owner, repo)
 
@@ -110,7 +110,7 @@ func (s *ActivityService) GetRepositorySubscription(ctx context.Context, owner, 
 // To ignore notifications made within a repository, set subscription.Ignored to true.
 // To stop watching a repository, use DeleteRepositorySubscription.
 //
-// GitHub API Docs: https://developer.github.com/v3/activity/watching/#set-a-repository-subscription
+// GitHub API docs: https://developer.github.com/v3/activity/watching/#set-a-repository-subscription
 func (s *ActivityService) SetRepositorySubscription(ctx context.Context, owner, repo string, subscription *Subscription) (*Subscription, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/subscription", owner, repo)
 
@@ -134,7 +134,7 @@ func (s *ActivityService) SetRepositorySubscription(ctx context.Context, owner, 
 // This is used to stop watching a repository. To control whether or not to
 // receive notifications from a repository, use SetRepositorySubscription.
 //
-// GitHub API Docs: https://developer.github.com/v3/activity/watching/#delete-a-repository-subscription
+// GitHub API docs: https://developer.github.com/v3/activity/watching/#delete-a-repository-subscription
 func (s *ActivityService) DeleteRepositorySubscription(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/subscription", owner, repo)
 	req, err := s.client.NewRequest("DELETE", u, nil)

--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -12,7 +12,7 @@ import (
 
 // Scope models a GitHub authorization scope.
 //
-// GitHub API docs:https://developer.github.com/v3/oauth/#scopes
+// GitHub API docs: https://developer.github.com/v3/oauth/#scopes
 type Scope string
 
 // This is the set of scopes for GitHub API V3
@@ -207,8 +207,8 @@ func (s *AuthorizationsService) Create(ctx context.Context, auth *AuthorizationR
 // clientID is the OAuth Client ID with which to create the token.
 //
 // GitHub API docs:
-// - https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app
-// - https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint
+// https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app
+// https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint
 func (s *AuthorizationsService) GetOrCreateForApp(ctx context.Context, clientID string, auth *AuthorizationRequest) (*Authorization, *Response, error) {
 	var u string
 	if auth.Fingerprint == nil || *auth.Fingerprint == "" {

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -10,7 +10,7 @@ package github
 // CommitCommentEvent is triggered when a commit comment is created.
 // The Webhook event name is "commit_comment".
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#commitcommentevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#commitcommentevent
 type CommitCommentEvent struct {
 	Comment *RepositoryComment `json:"comment,omitempty"`
 
@@ -28,7 +28,7 @@ type CommitCommentEvent struct {
 // Additionally, webhooks will not receive this event for tags if more
 // than three tags are pushed at once.
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#createevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#createevent
 type CreateEvent struct {
 	Ref *string `json:"ref,omitempty"`
 	// RefType is the object that was created. Possible values are: "repository", "branch", "tag".
@@ -49,7 +49,7 @@ type CreateEvent struct {
 // Note: webhooks will not receive this event for tags if more than three tags
 // are deleted at once.
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#deleteevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#deleteevent
 type DeleteEvent struct {
 	Ref *string `json:"ref,omitempty"`
 	// RefType is the object that was deleted. Possible values are: "branch", "tag".
@@ -67,7 +67,7 @@ type DeleteEvent struct {
 //
 // Events of this type are not visible in timelines, they are only used to trigger hooks.
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#deploymentevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#deploymentevent
 type DeploymentEvent struct {
 	Deployment *Deployment `json:"deployment,omitempty"`
 	Repo       *Repository `json:"repository,omitempty"`
@@ -82,7 +82,7 @@ type DeploymentEvent struct {
 //
 // Events of this type are not visible in timelines, they are only used to trigger hooks.
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#deploymentstatusevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#deploymentstatusevent
 type DeploymentStatusEvent struct {
 	Deployment       *Deployment       `json:"deployment,omitempty"`
 	DeploymentStatus *DeploymentStatus `json:"deployment_status,omitempty"`
@@ -96,7 +96,7 @@ type DeploymentStatusEvent struct {
 // ForkEvent is triggered when a user forks a repository.
 // The Webhook event name is "fork".
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#forkevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#forkevent
 type ForkEvent struct {
 	// Forkee is the created repository.
 	Forkee *Repository `json:"forkee,omitempty"`
@@ -120,7 +120,7 @@ type Page struct {
 // GollumEvent is triggered when a Wiki page is created or updated.
 // The Webhook event name is "gollum".
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#gollumevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#gollumevent
 type GollumEvent struct {
 	Pages []*Page `json:"pages,omitempty"`
 
@@ -144,7 +144,7 @@ type EditChange struct {
 // IntegrationInstallationEvent is triggered when an integration is created or deleted.
 // The Webhook event name is "integration_installation".
 //
-// GitHub docs: https://developer.github.com/early-access/integrations/webhooks/#integrationinstallationevent
+// GitHub API docs: https://developer.github.com/early-access/integrations/webhooks/#integrationinstallationevent
 type IntegrationInstallationEvent struct {
 	// The action that was performed. Possible values for an "integration_installation"
 	// event are: "created", "deleted".
@@ -156,7 +156,7 @@ type IntegrationInstallationEvent struct {
 // IntegrationInstallationRepositoriesEvent is triggered when an integration repository
 // is added or removed. The Webhook event name is "integration_installation_repositories".
 //
-// GitHub docs: https://developer.github.com/early-access/integrations/webhooks/#integrationinstallationrepositoriesevent
+// GitHub API docs: https://developer.github.com/early-access/integrations/webhooks/#integrationinstallationrepositoriesevent
 type IntegrationInstallationRepositoriesEvent struct {
 	// The action that was performed. Possible values for an "integration_installation_repositories"
 	// event are: "added", "removed".
@@ -171,7 +171,7 @@ type IntegrationInstallationRepositoriesEvent struct {
 // or pull request.
 // The Webhook event name is "issue_comment".
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#issuecommentevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#issuecommentevent
 type IssueCommentEvent struct {
 	// Action is the action that was performed on the comment.
 	// Possible values are: "created", "edited", "deleted".
@@ -190,7 +190,7 @@ type IssueCommentEvent struct {
 // unlabeled, opened, closed, or reopened.
 // The Webhook event name is "issues".
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#issuesevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#issuesevent
 type IssuesEvent struct {
 	// Action is the action that was performed. Possible values are: "assigned",
 	// "unassigned", "labeled", "unlabeled", "opened", "closed", "reopened", "edited".
@@ -209,7 +209,7 @@ type IssuesEvent struct {
 // LabelEvent is triggered when a repository's label is created, edited, or deleted.
 // The Webhook event name is "label"
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#labelevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#labelevent
 type LabelEvent struct {
 	// Action is the action that was performed. Possible values are:
 	// "created", "edited", "deleted"
@@ -226,7 +226,7 @@ type LabelEvent struct {
 // MemberEvent is triggered when a user is added as a collaborator to a repository.
 // The Webhook event name is "member".
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#memberevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#memberevent
 type MemberEvent struct {
 	// Action is the action that was performed. Possible value is: "added".
 	Action *string `json:"action,omitempty"`
@@ -244,7 +244,7 @@ type MemberEvent struct {
 // Events of this type are not visible in timelines, they are only used to
 // trigger organization webhooks.
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#membershipevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#membershipevent
 type MembershipEvent struct {
 	// Action is the action that was performed. Possible values are: "added", "removed".
 	Action *string `json:"action,omitempty"`
@@ -262,7 +262,7 @@ type MembershipEvent struct {
 // MilestoneEvent is triggered when a milestone is created, closed, opened, edited, or deleted.
 // The Webhook event name is "milestone".
 //
-// Github docs: https://developer.github.com/v3/activity/events/types/#milestoneevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#milestoneevent
 type MilestoneEvent struct {
 	// Action is the action that was performed. Possible values are:
 	// "created", "closed", "opened", "edited", "deleted"
@@ -281,7 +281,7 @@ type MilestoneEvent struct {
 // Events of this type are not visible in timelines. These events are only used to trigger organization hooks.
 // Webhook event name is "organization".
 //
-// Github docs: https://developer.github.com/v3/activity/events/types/#organizationevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#organizationevent
 type OrganizationEvent struct {
 	// Action is the action that was performed.
 	// Can be one of "member_added", "member_removed", or "member_invited".
@@ -308,7 +308,7 @@ type OrganizationEvent struct {
 //
 // Events of this type are not visible in timelines, they are only used to trigger hooks.
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#pagebuildevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#pagebuildevent
 type PageBuildEvent struct {
 	Build *PagesBuild `json:"build,omitempty"`
 
@@ -321,7 +321,7 @@ type PageBuildEvent struct {
 
 // PingEvent is triggered when a Webhook is added to GitHub.
 //
-// GitHub docs: https://developer.github.com/webhooks/#ping-event
+// GitHub API docs: https://developer.github.com/webhooks/#ping-event
 type PingEvent struct {
 	// Random string of GitHub zen.
 	Zen *string `json:"zen,omitempty"`
@@ -336,7 +336,7 @@ type PingEvent struct {
 // According to GitHub: "Without a doubt: the best GitHub event."
 // The Webhook event name is "public".
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#publicevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#publicevent
 type PublicEvent struct {
 	// The following fields are only populated by Webhook events.
 	Repo         *Repository   `json:"repository,omitempty"`
@@ -348,7 +348,7 @@ type PublicEvent struct {
 // labeled, unlabeled, opened, closed, reopened, or synchronized.
 // The Webhook event name is "pull_request".
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#pullrequestevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#pullrequestevent
 type PullRequestEvent struct {
 	// Action is the action that was performed. Possible values are: "assigned",
 	// "unassigned", "labeled", "unlabeled", "opened", "closed", or "reopened",
@@ -370,7 +370,7 @@ type PullRequestEvent struct {
 // request.
 // The Webhook event name is "pull_request_review".
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent
 type PullRequestReviewEvent struct {
 	// Action is always "submitted".
 	Action      *string            `json:"action,omitempty"`
@@ -391,7 +391,7 @@ type PullRequestReviewEvent struct {
 // portion of the unified diff of a pull request.
 // The Webhook event name is "pull_request_review_comment".
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#pullrequestreviewcommentevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#pullrequestreviewcommentevent
 type PullRequestReviewCommentEvent struct {
 	// Action is the action that was performed on the comment.
 	// Possible values are: "created", "edited", "deleted".
@@ -504,7 +504,7 @@ type PushEventRepoOwner struct {
 // ReleaseEvent is triggered when a release is published.
 // The Webhook event name is "release".
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#releaseevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#releaseevent
 type ReleaseEvent struct {
 	// Action is the action that was performed. Possible value is: "published".
 	Action  *string            `json:"action,omitempty"`
@@ -522,7 +522,7 @@ type ReleaseEvent struct {
 // Events of this type are not visible in timelines, they are only used to
 // trigger organization webhooks.
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#repositoryevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#repositoryevent
 type RepositoryEvent struct {
 	// Action is the action that was performed. Possible values are: "created", "deleted",
 	// "publicized", "privatized".
@@ -541,7 +541,7 @@ type RepositoryEvent struct {
 // Events of this type are not visible in timelines, they are only used to
 // trigger hooks.
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#statusevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#statusevent
 type StatusEvent struct {
 	SHA *string `json:"sha,omitempty"`
 	// State is the new state. Possible values are: "pending", "success", "failure", "error".
@@ -568,7 +568,7 @@ type StatusEvent struct {
 // Events of this type are not visible in timelines. These events are only used
 // to trigger hooks.
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#teamaddevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#teamaddevent
 type TeamAddEvent struct {
 	Team *Team       `json:"team,omitempty"`
 	Repo *Repository `json:"repository,omitempty"`
@@ -585,7 +585,7 @@ type TeamAddEvent struct {
 // The event’s actor is the user who starred a repository, and the event’s
 // repository is the repository that was starred.
 //
-// GitHub docs: https://developer.github.com/v3/activity/events/types/#watchevent
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#watchevent
 type WatchEvent struct {
 	// Action is the action that was performed. Possible value is: "started".
 	Action *string `json:"action,omitempty"`

--- a/github/gists.go
+++ b/github/gists.go
@@ -240,7 +240,7 @@ func (s *GistsService) Edit(ctx context.Context, id string, gist *Gist) (*Gist, 
 
 // ListCommits lists commits of a gist.
 //
-// Github API docs: https://developer.github.com/v3/gists/#list-gist-commits
+// GitHub API docs: https://developer.github.com/v3/gists/#list-gist-commits
 func (s *GistsService) ListCommits(ctx context.Context, id string) ([]*GistCommit, *Response, error) {
 	u := fmt.Sprintf("gists/%v/commits", id)
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -283,7 +283,7 @@ func (s *GistsService) Star(ctx context.Context, id string) (*Response, error) {
 
 // Unstar a gist on a behalf of authenticated user.
 //
-// Github API docs: https://developer.github.com/v3/gists/#unstar-a-gist
+// GitHub API docs: https://developer.github.com/v3/gists/#unstar-a-gist
 func (s *GistsService) Unstar(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("gists/%v/star", id)
 	req, err := s.client.NewRequest("DELETE", u, nil)
@@ -328,7 +328,7 @@ func (s *GistsService) Fork(ctx context.Context, id string) (*Gist, *Response, e
 
 // ListForks lists forks of a gist.
 //
-// Github API docs: https://developer.github.com/v3/gists/#list-gist-forks
+// GitHub API docs: https://developer.github.com/v3/gists/#list-gist-forks
 func (s *GistsService) ListForks(ctx context.Context, id string) ([]*GistFork, *Response, error) {
 	u := fmt.Sprintf("gists/%v/forks", id)
 	req, err := s.client.NewRequest("GET", u, nil)

--- a/github/gitignore.go
+++ b/github/gitignore.go
@@ -28,7 +28,7 @@ func (g Gitignore) String() string {
 
 // List all available Gitignore templates.
 //
-// https://developer.github.com/v3/gitignore/#listing-available-templates
+// GitHub API docs: https://developer.github.com/v3/gitignore/#listing-available-templates
 func (s GitignoresService) List(ctx context.Context) ([]string, *Response, error) {
 	req, err := s.client.NewRequest("GET", "gitignore/templates", nil)
 	if err != nil {
@@ -46,7 +46,7 @@ func (s GitignoresService) List(ctx context.Context) ([]string, *Response, error
 
 // Get a Gitignore by name.
 //
-// https://developer.github.com/v3/gitignore/#get-a-single-template
+// GitHub API docs: https://developer.github.com/v3/gitignore/#get-a-single-template
 func (s GitignoresService) Get(ctx context.Context, name string) (*Gitignore, *Response, error) {
 	u := fmt.Sprintf("gitignore/templates/%v", name)
 	req, err := s.client.NewRequest("GET", u, nil)

--- a/github/issues_milestones.go
+++ b/github/issues_milestones.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-// Milestone represents a Github repository milestone.
+// Milestone represents a GitHub repository milestone.
 type Milestone struct {
 	URL          *string    `json:"url,omitempty"`
 	HTMLURL      *string    `json:"html_url,omitempty"`

--- a/github/messages.go
+++ b/github/messages.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 
 // This file provides functions for validating payloads from GitHub Webhooks.
-// GitHub docs: https://developer.github.com/webhooks/securing/#validating-payloads-from-github
+// GitHub API docs: https://developer.github.com/webhooks/securing/#validating-payloads-from-github
 
 package github
 
@@ -31,7 +31,7 @@ const (
 	sha512Prefix = "sha512"
 	// signatureHeader is the GitHub header key used to pass the HMAC hexdigest.
 	signatureHeader = "X-Hub-Signature"
-	// eventTypeHeader is the Github header key used to pass the event type.
+	// eventTypeHeader is the GitHub header key used to pass the event type.
 	eventTypeHeader = "X-Github-Event"
 )
 
@@ -143,7 +143,7 @@ func ValidatePayload(r *http.Request, secretKey []byte) (payload []byte, err err
 // payload is the JSON payload sent by GitHub Webhooks.
 // secretKey is the GitHub Webhook secret message.
 //
-// GitHub docs: https://developer.github.com/webhooks/securing/#validating-payloads-from-github
+// GitHub API docs: https://developer.github.com/webhooks/securing/#validating-payloads-from-github
 func validateSignature(signature string, payload, secretKey []byte) error {
 	messageMAC, hashFunc, err := messageMAC(signature)
 	if err != nil {

--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -206,8 +206,9 @@ func (s *OrganizationsService) ListOrgMemberships(ctx context.Context, opt *List
 // Passing an empty string for user will get the membership for the
 // authenticated user.
 //
-// GitHub API docs: https://developer.github.com/v3/orgs/members/#get-organization-membership
-// GitHub API docs: https://developer.github.com/v3/orgs/members/#get-your-organization-membership
+// GitHub API docs:
+// https://developer.github.com/v3/orgs/members/#get-organization-membership
+// https://developer.github.com/v3/orgs/members/#get-your-organization-membership
 func (s *OrganizationsService) GetOrgMembership(ctx context.Context, user, org string) (*Membership, *Response, error) {
 	var u string
 	if user != "" {

--- a/github/repos.go
+++ b/github/repos.go
@@ -427,7 +427,7 @@ func (s *RepositoriesService) ListContributors(ctx context.Context, owner string
 //       "Python": 7769
 //     }
 //
-// GitHub API Docs: https://developer.github.com/v3/repos/#list-languages
+// GitHub API docs: https://developer.github.com/v3/repos/#list-languages
 func (s *RepositoriesService) ListLanguages(ctx context.Context, owner string, repo string) (map[string]int, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/languages", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)

--- a/github/repos_collaborators.go
+++ b/github/repos_collaborators.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 )
 
-// ListCollaborators lists the Github users that have access to the repository.
+// ListCollaborators lists the GitHub users that have access to the repository.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/collaborators/#list
 func (s *RepositoriesService) ListCollaborators(ctx context.Context, owner, repo string, opt *ListOptions) ([]*User, *Response, error) {
@@ -34,7 +34,7 @@ func (s *RepositoriesService) ListCollaborators(ctx context.Context, owner, repo
 	return users, resp, nil
 }
 
-// IsCollaborator checks whether the specified Github user has collaborator
+// IsCollaborator checks whether the specified GitHub user has collaborator
 // access to the given repo.
 // Note: This will return false if the user is not a collaborator OR the user
 // is not a GitHub user.
@@ -94,7 +94,7 @@ type RepositoryAddCollaboratorOptions struct {
 	Permission string `json:"permission,omitempty"`
 }
 
-// AddCollaborator adds the specified Github user as collaborator to the given repo.
+// AddCollaborator adds the specified GitHub user as collaborator to the given repo.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator
 func (s *RepositoriesService) AddCollaborator(ctx context.Context, owner, repo, user string, opt *RepositoryAddCollaboratorOptions) (*Response, error) {
@@ -110,7 +110,7 @@ func (s *RepositoriesService) AddCollaborator(ctx context.Context, owner, repo, 
 	return s.client.Do(ctx, req, nil)
 }
 
-// RemoveCollaborator removes the specified Github user as collaborator from the given repo.
+// RemoveCollaborator removes the specified GitHub user as collaborator from the given repo.
 // Note: Does not return error if a valid user that is not a collaborator is removed.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/collaborators/#remove-collaborator

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 
 // Repository contents API methods.
-// https://developer.github.com/v3/repos/contents/
+// GitHub API docs: https://developer.github.com/v3/repos/contents/
 
 package github
 

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -42,7 +42,7 @@ func (r RepositoryRelease) String() string {
 	return Stringify(r)
 }
 
-// ReleaseAsset represents a Github release asset in a repository.
+// ReleaseAsset represents a GitHub release asset in a repository.
 type ReleaseAsset struct {
 	ID                 *int       `json:"id,omitempty"`
 	URL                *string    `json:"url,omitempty"`
@@ -125,7 +125,7 @@ func (s *RepositoriesService) getSingleRelease(ctx context.Context, url string) 
 
 // CreateRelease adds a new release for a repository.
 //
-// GitHub API docs : https://developer.github.com/v3/repos/releases/#create-a-release
+// GitHub API docs: https://developer.github.com/v3/repos/releases/#create-a-release
 func (s *RepositoriesService) CreateRelease(ctx context.Context, owner, repo string, release *RepositoryRelease) (*RepositoryRelease, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/releases", owner, repo)
 
@@ -144,7 +144,7 @@ func (s *RepositoriesService) CreateRelease(ctx context.Context, owner, repo str
 
 // EditRelease edits a repository release.
 //
-// GitHub API docs : https://developer.github.com/v3/repos/releases/#edit-a-release
+// GitHub API docs: https://developer.github.com/v3/repos/releases/#edit-a-release
 func (s *RepositoriesService) EditRelease(ctx context.Context, owner, repo string, id int, release *RepositoryRelease) (*RepositoryRelease, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/releases/%d", owner, repo, id)
 
@@ -163,7 +163,7 @@ func (s *RepositoriesService) EditRelease(ctx context.Context, owner, repo strin
 
 // DeleteRelease delete a single release from a repository.
 //
-// GitHub API docs : https://developer.github.com/v3/repos/releases/#delete-a-release
+// GitHub API docs: https://developer.github.com/v3/repos/releases/#delete-a-release
 func (s *RepositoriesService) DeleteRelease(ctx context.Context, owner, repo string, id int) (*Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/releases/%d", owner, repo, id)
 
@@ -176,7 +176,7 @@ func (s *RepositoriesService) DeleteRelease(ctx context.Context, owner, repo str
 
 // ListReleaseAssets lists the release's assets.
 //
-// GitHub API docs : https://developer.github.com/v3/repos/releases/#list-assets-for-a-release
+// GitHub API docs: https://developer.github.com/v3/repos/releases/#list-assets-for-a-release
 func (s *RepositoriesService) ListReleaseAssets(ctx context.Context, owner, repo string, id int, opt *ListOptions) ([]*ReleaseAsset, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/releases/%d/assets", owner, repo, id)
 	u, err := addOptions(u, opt)
@@ -199,7 +199,7 @@ func (s *RepositoriesService) ListReleaseAssets(ctx context.Context, owner, repo
 
 // GetReleaseAsset fetches a single release asset.
 //
-// GitHub API docs : https://developer.github.com/v3/repos/releases/#get-a-single-release-asset
+// GitHub API docs: https://developer.github.com/v3/repos/releases/#get-a-single-release-asset
 func (s *RepositoriesService) GetReleaseAsset(ctx context.Context, owner, repo string, id int) (*ReleaseAsset, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/releases/assets/%d", owner, repo, id)
 
@@ -223,7 +223,7 @@ func (s *RepositoriesService) GetReleaseAsset(ctx context.Context, owner, repo s
 // If a redirect is returned, the redirect URL will be returned as a string instead
 // of the io.ReadCloser. Exactly one of rc and redirectURL will be zero.
 //
-// GitHub API docs : https://developer.github.com/v3/repos/releases/#get-a-single-release-asset
+// GitHub API docs: https://developer.github.com/v3/repos/releases/#get-a-single-release-asset
 func (s *RepositoriesService) DownloadReleaseAsset(ctx context.Context, owner, repo string, id int) (rc io.ReadCloser, redirectURL string, err error) {
 	u := fmt.Sprintf("repos/%s/%s/releases/assets/%d", owner, repo, id)
 
@@ -262,7 +262,7 @@ func (s *RepositoriesService) DownloadReleaseAsset(ctx context.Context, owner, r
 
 // EditReleaseAsset edits a repository release asset.
 //
-// GitHub API docs : https://developer.github.com/v3/repos/releases/#edit-a-release-asset
+// GitHub API docs: https://developer.github.com/v3/repos/releases/#edit-a-release-asset
 func (s *RepositoriesService) EditReleaseAsset(ctx context.Context, owner, repo string, id int, release *ReleaseAsset) (*ReleaseAsset, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/releases/assets/%d", owner, repo, id)
 
@@ -281,7 +281,7 @@ func (s *RepositoriesService) EditReleaseAsset(ctx context.Context, owner, repo 
 
 // DeleteReleaseAsset delete a single release asset from a repository.
 //
-// GitHub API docs : https://developer.github.com/v3/repos/releases/#delete-a-release-asset
+// GitHub API docs: https://developer.github.com/v3/repos/releases/#delete-a-release-asset
 func (s *RepositoriesService) DeleteReleaseAsset(ctx context.Context, owner, repo string, id int) (*Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/releases/assets/%d", owner, repo, id)
 
@@ -295,7 +295,7 @@ func (s *RepositoriesService) DeleteReleaseAsset(ctx context.Context, owner, rep
 // UploadReleaseAsset creates an asset by uploading a file into a release repository.
 // To upload assets that cannot be represented by an os.File, call NewUploadRequest directly.
 //
-// GitHub API docs : https://developer.github.com/v3/repos/releases/#upload-a-release-asset
+// GitHub API docs: https://developer.github.com/v3/repos/releases/#upload-a-release-asset
 func (s *RepositoriesService) UploadReleaseAsset(ctx context.Context, owner, repo string, id int, opt *UploadOptions, file *os.File) (*ReleaseAsset, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/releases/%d/assets", owner, repo, id)
 	u, err := addOptions(u, opt)

--- a/github/repos_stats.go
+++ b/github/repos_stats.go
@@ -45,7 +45,7 @@ func (w WeeklyStats) String() string {
 // it is now computing the requested statistics. A follow up request, after a
 // delay of a second or so, should result in a successful request.
 //
-// GitHub API Docs: https://developer.github.com/v3/repos/statistics/#contributors
+// GitHub API docs: https://developer.github.com/v3/repos/statistics/#contributors
 func (s *RepositoriesService) ListContributorsStats(ctx context.Context, owner, repo string) ([]*ContributorStats, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/stats/contributors", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -84,7 +84,7 @@ func (w WeeklyCommitActivity) String() string {
 // it is now computing the requested statistics. A follow up request, after a
 // delay of a second or so, should result in a successful request.
 //
-// GitHub API Docs: https://developer.github.com/v3/repos/statistics/#commit-activity
+// GitHub API docs: https://developer.github.com/v3/repos/statistics/#commit-activity
 func (s *RepositoriesService) ListCommitActivity(ctx context.Context, owner, repo string) ([]*WeeklyCommitActivity, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/stats/commit_activity", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -111,7 +111,7 @@ func (s *RepositoriesService) ListCommitActivity(ctx context.Context, owner, rep
 // it is now computing the requested statistics. A follow up request, after a
 // delay of a second or so, should result in a successful request.
 //
-// GitHub API Docs: https://developer.github.com/v3/repos/statistics/#code-frequency
+// GitHub API docs: https://developer.github.com/v3/repos/statistics/#code-frequency
 func (s *RepositoriesService) ListCodeFrequency(ctx context.Context, owner, repo string) ([]*WeeklyStats, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/stats/code_frequency", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -164,7 +164,7 @@ func (r RepositoryParticipation) String() string {
 // it is now computing the requested statistics. A follow up request, after a
 // delay of a second or so, should result in a successful request.
 //
-// GitHub API Docs: https://developer.github.com/v3/repos/statistics/#participation
+// GitHub API docs: https://developer.github.com/v3/repos/statistics/#participation
 func (s *RepositoriesService) ListParticipation(ctx context.Context, owner, repo string) (*RepositoryParticipation, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/stats/participation", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -197,7 +197,7 @@ type PunchCard struct {
 // it is now computing the requested statistics. A follow up request, after a
 // delay of a second or so, should result in a successful request.
 //
-// GitHub API Docs: https://developer.github.com/v3/repos/statistics/#punch-card
+// GitHub API docs: https://developer.github.com/v3/repos/statistics/#punch-card
 func (s *RepositoriesService) ListPunchCard(ctx context.Context, owner, repo string) ([]*PunchCard, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/stats/punch_card", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)

--- a/github/search.go
+++ b/github/search.go
@@ -80,7 +80,7 @@ type CommitResult struct {
 
 // Commits searches commits via various criteria.
 //
-// GitHub API Docs: https://developer.github.com/v3/search/#search-commits
+// GitHub API docs: https://developer.github.com/v3/search/#search-commits
 func (s *SearchService) Commits(ctx context.Context, query string, opt *SearchOptions) (*CommitsSearchResult, *Response, error) {
 	result := new(CommitsSearchResult)
 	resp, err := s.search(ctx, "commits", query, opt, result)


### PR DESCRIPTION
While reviewing #551, I noticed that there were various slight variations in the phrasing of comments with the form:

	// GitHub API docs: https://developer.github.com/v3/...

This change makes them all consistent.

Also fix "GitHub" misspelled as "Github" in a few places.

Followup to #551. /cc @kevinburke