### PR TITLE
fix misspelling in GistCommit struct

### DIFF
--- a/github/gists.go
+++ b/github/gists.go
@@ -59,7 +59,7 @@ type GistCommit struct {
 	Version      *string      `json:"version,omitempty"`
 	User         *User        `json:"user,omitempty"`
 	ChangeStatus *CommitStats `json:"change_status,omitempty"`
-	CommitedAt   *Timestamp   `json:"commited_at,omitempty"`
+	CommittedAt  *Timestamp   `json:"committed_at,omitempty"`
 }
 
 func (gc GistCommit) String() string {

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -302,7 +302,7 @@ func TestGistsService_ListCommits(t *testing.T) {
 		        "additions": 180,
 		        "total": 180
 		      },
-		      "commited_at": "2010-01-01T00:00:00Z"
+		      "committed_at": "2010-01-01T00:00:00Z"
 		    }
 		  ]
 		`)
@@ -314,10 +314,10 @@ func TestGistsService_ListCommits(t *testing.T) {
 	}
 
 	want := []*GistCommit{{
-		URL:        String("https://api.github.com/gists/1/1"),
-		Version:    String("1"),
-		User:       &User{ID: Int(1)},
-		CommitedAt: &Timestamp{time.Date(2010, 1, 1, 00, 00, 00, 0, time.UTC)},
+		URL:         String("https://api.github.com/gists/1/1"),
+		Version:     String("1"),
+		User:        &User{ID: Int(1)},
+		CommittedAt: &Timestamp{time.Date(2010, 1, 1, 00, 00, 00, 0, time.UTC)},
 		ChangeStatus: &CommitStats{
 			Additions: Int(180),
 			Deletions: Int(0),

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1428,12 +1428,12 @@ func (g *GistComment) GetURL() string {
 	return *g.URL
 }
 
-// GetCommitedAt returns the CommitedAt field if it's non-nil, zero value otherwise.
-func (g *GistCommit) GetCommitedAt() Timestamp {
-	if g == nil || g.CommitedAt == nil {
+// GetCommittedAt returns the CommittedAt field if it's non-nil, zero value otherwise.
+func (g *GistCommit) GetCommittedAt() Timestamp {
+	if g == nil || g.CommittedAt == nil {
 		return Timestamp{}
 	}
-	return *g.CommitedAt
+	return *g.CommittedAt
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.


### PR DESCRIPTION
Found on [Go Report Card](https://goreportcard.com/report/github.com/google/go-github)