### PR TITLE
Prefer setting over adding, where setting is sufficient and better fits intention.

### DIFF
--- a/github/github_test.go
+++ b/github/github_test.go
@@ -403,9 +403,9 @@ func TestDo_rateLimit(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add(headerRateLimit, "60")
-		w.Header().Add(headerRateRemaining, "59")
-		w.Header().Add(headerRateReset, "1372700873")
+		w.Header().Set(headerRateLimit, "60")
+		w.Header().Set(headerRateRemaining, "59")
+		w.Header().Set(headerRateReset, "1372700873")
 	})
 
 	req, _ := client.NewRequest("GET", "/", nil)
@@ -431,9 +431,9 @@ func TestDo_rateLimit_errorResponse(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add(headerRateLimit, "60")
-		w.Header().Add(headerRateRemaining, "59")
-		w.Header().Add(headerRateReset, "1372700873")
+		w.Header().Set(headerRateLimit, "60")
+		w.Header().Set(headerRateRemaining, "59")
+		w.Header().Set(headerRateReset, "1372700873")
 		http.Error(w, "Bad Request", 400)
 	})
 
@@ -463,9 +463,9 @@ func TestDo_rateLimit_rateLimitError(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add(headerRateLimit, "60")
-		w.Header().Add(headerRateRemaining, "0")
-		w.Header().Add(headerRateReset, "1372700873")
+		w.Header().Set(headerRateLimit, "60")
+		w.Header().Set(headerRateRemaining, "0")
+		w.Header().Set(headerRateReset, "1372700873")
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusForbidden)
 		fmt.Fprintln(w, `{
@@ -504,9 +504,9 @@ func TestDo_rateLimit_noNetworkCall(t *testing.T) {
 	reset := time.Now().UTC().Round(time.Second).Add(time.Minute) // Rate reset is a minute from now, with 1 second precision.
 
 	mux.HandleFunc("/first", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add(headerRateLimit, "60")
-		w.Header().Add(headerRateRemaining, "0")
-		w.Header().Add(headerRateReset, fmt.Sprint(reset.Unix()))
+		w.Header().Set(headerRateLimit, "60")
+		w.Header().Set(headerRateRemaining, "0")
+		w.Header().Set(headerRateReset, fmt.Sprint(reset.Unix()))
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusForbidden)
 		fmt.Fprintln(w, `{

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -91,7 +91,7 @@ type values map[string]string
 func testFormValues(t *testing.T, r *http.Request, values values) {
 	want := url.Values{}
 	for k, v := range values {
-		want.Add(k, v)
+		want.Set(k, v)
 	}
 
 	r.ParseForm()

--- a/github/repos.go
+++ b/github/repos.go
@@ -339,7 +339,7 @@ func (s *RepositoriesService) Edit(ctx context.Context, owner, repo string, repo
 	}
 
 	// TODO: Remove this preview header after API is fully vetted.
-	req.Header.Add("Accept", mediaTypeSquashPreview)
+	req.Header.Set("Accept", mediaTypeSquashPreview)
 
 	r := new(Repository)
 	resp, err := s.client.Do(ctx, req, r)

--- a/github/search.go
+++ b/github/search.go
@@ -175,7 +175,7 @@ func (s *SearchService) search(ctx context.Context, searchType string, query str
 	if err != nil {
 		return nil, err
 	}
-	params.Add("q", query)
+	params.Set("q", query)
 	u := fmt.Sprintf("search/%s?%s", searchType, params.Encode())
 
 	req, err := s.client.NewRequest("GET", u, nil)


### PR DESCRIPTION
The common theme of this cleanup PR is to prefer setting things, instead of adding, in places where setting is sufficient (i.e., the current adding behavior is provably never done more than once for the same key), and it's a better fit for the intended behavior.

The motivation to do so is because set communicates the underlying intended action better, and it's simpler to reason about, more readable. Readers can see that there will not be multiple entries of the same key without having to verify that by reading additional code. It also fixes inconsistencies in the code in some places.

The PR consists of 4 commits, see commit message of each commit for details and rationale of each distinct change.