### PR TITLE
Modify time first, round after (and strip additional precision).

### DIFF
--- a/github/github_test.go
+++ b/github/github_test.go
@@ -501,7 +501,7 @@ func TestDo_rateLimit_noNetworkCall(t *testing.T) {
 	setup()
 	defer teardown()
 
-	reset := time.Now().UTC().Round(time.Second).Add(time.Minute) // Rate reset is a minute from now, with 1 second precision.
+	reset := time.Now().UTC().Add(time.Minute).Round(time.Second).AddDate(0, 0, 0) // Rate reset is a minute from now, with 1 second precision.
 
 	mux.HandleFunc("/first", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add(headerRateLimit, "60")


### PR DESCRIPTION
**DO NOT MERGE.** Let's discuss this change first.

I've noticed that TestDo_rateLimit_noNetworkCall test fails on Go master with the following error:

	--- FAIL: TestDo_rateLimit_noNetworkCall (0.00s)
		github_test.go:549: rateLimitErr rate reset = 2017-02-25 01:49:01 +0000 UTC, want 2017-02-25 01:49:01 +0000 UTC m=+60.206993003

(Source: https://travis-ci.org/google/go-github/jobs/205180544.)

This is due to changes in Go 1.9 to perform monotonic elapsed time measurements. See https://github.com/golang/go/issues/12914 and https://golang.org/design/12914-monotonic for full details.

Make the test pass by modifying time first, round after, and strip the monotonic clock reading by using `AddDate(0, 0, 0)`. Doing that eliminates the unwanted additional monotonic precision from wanted time, making the expected time equality true.

This is also related to an open issue https://github.com/golang/go/issues/18991. Depending on the outcome there, this PR could be simplified not to need `AddDate(0, 0, 0)`.

I just wanted to get this PR created for visibility. We can discuss the potential fix, and wait on Go 1.9 to get closer to release before actually merging this, because there may be additional changes that would render this change overly complex or unnecessary.