### PR TITLE
Return rate limit information immediately after `checkRateLimitBeforeDo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,10 @@ limited to 60 requests per hour, while authenticated clients can make up to
 that are not issued on behalf of a user, use the
 `UnauthenticatedRateLimitedTransport`.
 
-The `Rate` method on a client returns the rate limit information based on the most
-recent API call. This is updated on every call, but may be out of date if it's
-been some time since the last API call and other clients have made subsequent
-requests since then. You can always call `RateLimits()` directly to get the most
-up-to-date rate limit data for the client.
+The returned `Response.Rate` value contains the rate limit information
+from the most recent API call. If a recent enough response isn't
+available, you can use `RateLimits` to fetch the most up-to-date rate
+limit data for the client.
 
 To detect an API rate limit error, you can check if its type is `*github.RateLimitError`:
 

--- a/github/doc.go
+++ b/github/doc.go
@@ -71,8 +71,10 @@ limited to 60 requests per hour, while authenticated clients can make up to
 that are not issued on behalf of a user, use the
 UnauthenticatedRateLimitedTransport.
 
-You can always call RateLimits() directly to get the most up-to-date
-rate limit data for the client.
+The returned Response.Rate value contains the rate limit information
+from the most recent API call. If a recent enough response isn't
+available, you can use RateLimits to fetch the most up-to-date rate
+limit data for the client.
 
 To detect an API rate limit error, you can check if its type is *github.RateLimitError:
 

--- a/github/doc.go
+++ b/github/doc.go
@@ -71,11 +71,8 @@ limited to 60 requests per hour, while authenticated clients can make up to
 that are not issued on behalf of a user, use the
 UnauthenticatedRateLimitedTransport.
 
-The Rate method on a client returns the rate limit information based on the most
-recent API call. This is updated on every call, but may be out of date if it's
-been some time since the last API call and other clients have made subsequent
-requests since then. You can always call RateLimits() directly to get the most
-up-to-date rate limit data for the client.
+You can always call RateLimits() directly to get the most up-to-date
+rate limit data for the client.
 
 To detect an API rate limit error, you can check if its type is *github.RateLimitError:
 


### PR DESCRIPTION
Fixes #571.

Change-Id: Iefcc687d9fc56c40964d5e6f1cdbc54d020dae3c