### PR TITLE
Retains ability to add users directly as collaborators

### DIFF
--- a/github/repos_collaborators.go
+++ b/github/repos_collaborators.go
@@ -94,7 +94,7 @@ type RepositoryAddCollaboratorOptions struct {
 	Permission string `json:"permission,omitempty"`
 }
 
-// AddCollaborator adds the specified GitHub user as collaborator to the given repo.
+// AddCollaborator invites the specified GitHub user as a collaborator to the given repo.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator
 func (s *RepositoriesService) AddCollaborator(ctx context.Context, owner, repo, user string, opt *RepositoryAddCollaboratorOptions) (*Response, error) {
@@ -106,6 +106,19 @@ func (s *RepositoriesService) AddCollaborator(ctx context.Context, owner, repo, 
 
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeRepositoryInvitationsPreview)
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// AddCollaboratorDirectly adds the specified GitHub user as a collaborator to the given repo.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator
+func (s *RepositoriesService) AddCollaboratorDirectly(ctx context.Context, owner, repo, user string, opt *RepositoryAddCollaboratorOptions) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/collaborators/%v", owner, repo, user)
+	req, err := s.client.NewRequest("PUT", u, opt)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/repos_collaborators_test.go
+++ b/github/repos_collaborators_test.go
@@ -141,6 +141,31 @@ func TestRepositoriesService_AddCollaborator_invalidUser(t *testing.T) {
 	testURLParseError(t, err)
 }
 
+func TestRepositoriesService_AddCollaboratorDirectly(t *testing.T) {
+	setup()
+	defer teardown()
+
+	opt := &RepositoryAddCollaboratorOptions{Permission: "admin"}
+
+	mux.HandleFunc("/repos/o/r/collaborators/u", func(w http.ResponseWriter, r *http.Request) {
+		v := new(RepositoryAddCollaboratorOptions)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Accept", mediaTypeV3)
+		if !reflect.DeepEqual(v, opt) {
+			t.Errorf("Request body = %+v, want %+v", v, opt)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	_, err := client.Repositories.AddCollaboratorDirectly(context.Background(), "o", "r", "u", opt)
+	if err != nil {
+		t.Errorf("Repositories.AddCollaborator returned error: %v", err)
+	}
+}
+
 func TestRepositoriesService_RemoveCollaborator(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
GitHub is previewing a media type that [sends invitations instead of directly adding collaborators](https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator).

Currently `go-github` always sends the preview header, but I think we should retain the ability to add a collaborator directly because this header is a fundamental behavior change--rather than a typical preview which enables new functionality or sends back additional information.

Concretely, the change to always use the preview header is affecting my ability to upgrade `go-github` in the [terraform](https://github.com/hashicorp/terraform) project without changing the behavior of the `github_repository_collaborator` resource. In the version that's currently vendored, the preview header is not sent, meaning the user is added directly. If I upgrade go-github to get access to new (unrelated) functionality, I fundamentally change how an unrelated resource works.

I think eventually programs like terraform will need to switch to using invitations, but I propose the old functionality continue to be exposed in `go-github` since, in fact, the GitHub API itself still supports it.