### PR TITLE
Fail the build if "go generate" fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: go
+go_import_path: github.com/google/go-github
 go:
   - 1.7.x
   - 1.8.x
@@ -8,10 +9,15 @@ matrix:
   allow_failures:
     - go: master
   fast_finish: true
+before_script:
+    - mkdir -p $HOME/bin
+    - curl --silent --location https://github.com/kevinburke/differ/releases/download/0.4/differ-linux-amd64 > $HOME/bin/differ
+    - chmod 755 $HOME/bin/differ
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
 script:
   - go get -t -v ./...
-  - diff -u <(echo -n) <(gofmt -d -s .)
+  - differ gofmt -s .
+  - differ go generate ./...
   - go tool vet .
   - go test -v -race ./...


### PR DESCRIPTION
I wrote a little binary that will run a command and error if any files
tracked by Git are modified: github.com/kevinburke/differ.

I used it here to check whether "go generate" generates any changes,
and also to simplify the gofmt command invocation. I tested that they
worked by forking from the commit that didn't run "go generate."

I also updated the .travis.yml file with a go_import_path so
forks work correctly - Travis can run into problems building e.g.
github.com/kevinburke/go-github since the import paths for subprojects
all mention github.com/google/go-github.