### PR TITLE
Don't panic when processing event payload

### DIFF
--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -28,9 +28,9 @@ func (e Event) String() string {
 	return Stringify(e)
 }
 
-// Payload returns the parsed event payload. For recognized event types,
+// ParsePayload parses the event payload. For recognized event types,
 // a value of the corresponding struct type will be returned.
-func (e *Event) Payload() (payload interface{}) {
+func (e *Event) ParsePayload() (payload interface{}, err error) {
 	switch *e.Type {
 	case "CommitCommentEvent":
 		payload = &CommitCommentEvent{}
@@ -89,8 +89,20 @@ func (e *Event) Payload() (payload interface{}) {
 	case "WatchEvent":
 		payload = &WatchEvent{}
 	}
-	if err := json.Unmarshal(*e.RawPayload, &payload); err != nil {
-		panic(err.Error())
+	err = json.Unmarshal(*e.RawPayload, &payload)
+	return payload, err
+}
+
+// Payload returns the parsed event payload. For recognized event types,
+// a value of the corresponding struct type will be returned.
+//
+// Deprecated: Use ParsePayload instead, which returns an error
+// rather than panics if JSON unmarshaling raw payload fails.
+func (e *Event) Payload() (payload interface{}) {
+	var err error
+	payload, err = e.ParsePayload()
+	if err != nil {
+		panic(err)
 	}
 	return payload
 }

--- a/github/activity_events_test.go
+++ b/github/activity_events_test.go
@@ -276,7 +276,7 @@ func TestActivityService_ListUserEventsForOrganization(t *testing.T) {
 	}
 }
 
-func TestActivityService_EventPayload_typed(t *testing.T) {
+func TestActivityService_EventParsePayload_typed(t *testing.T) {
 	raw := []byte(`{"type": "PushEvent","payload":{"push_id": 1}}`)
 	var event *Event
 	if err := json.Unmarshal(raw, &event); err != nil {
@@ -284,15 +284,19 @@ func TestActivityService_EventPayload_typed(t *testing.T) {
 	}
 
 	want := &PushEvent{PushID: Int(1)}
-	if !reflect.DeepEqual(event.Payload(), want) {
-		t.Errorf("Event Payload returned %+v, want %+v", event.Payload(), want)
+	got, err := event.ParsePayload()
+	if err != nil {
+		t.Fatalf("ParsePayload returned unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Event.ParsePayload returned %+v, want %+v", got, want)
 	}
 }
 
 // TestEvent_Payload_untyped checks that unrecognized events are parsed to an
 // interface{} value (instead of being discarded or throwing an error), for
 // forward compatibility with new event types.
-func TestActivityService_EventPayload_untyped(t *testing.T) {
+func TestActivityService_EventParsePayload_untyped(t *testing.T) {
 	raw := []byte(`{"type": "UnrecognizedEvent","payload":{"field": "val"}}`)
 	var event *Event
 	if err := json.Unmarshal(raw, &event); err != nil {
@@ -300,12 +304,16 @@ func TestActivityService_EventPayload_untyped(t *testing.T) {
 	}
 
 	want := map[string]interface{}{"field": "val"}
-	if !reflect.DeepEqual(event.Payload(), want) {
-		t.Errorf("Event Payload returned %+v, want %+v", event.Payload(), want)
+	got, err := event.ParsePayload()
+	if err != nil {
+		t.Fatalf("ParsePayload returned unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Event.ParsePayload returned %+v, want %+v", got, want)
 	}
 }
 
-func TestActivityService_EventPayload_installation(t *testing.T) {
+func TestActivityService_EventParsePayload_installation(t *testing.T) {
 	raw := []byte(`{"type": "PullRequestEvent","payload":{"installation":{"id":1}}}`)
 	var event *Event
 	if err := json.Unmarshal(raw, &event); err != nil {
@@ -313,7 +321,11 @@ func TestActivityService_EventPayload_installation(t *testing.T) {
 	}
 
 	want := &PullRequestEvent{Installation: &Installation{ID: Int(1)}}
-	if !reflect.DeepEqual(event.Payload(), want) {
-		t.Errorf("Event Payload returned %+v, want %+v", event.Payload(), want)
+	got, err := event.ParsePayload()
+	if err != nil {
+		t.Fatalf("ParsePayload returned unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Event.ParsePayload returned %+v, want %+v", got, want)
 	}
 }

--- a/github/messages.go
+++ b/github/messages.go
@@ -162,7 +162,7 @@ func WebHookType(r *http.Request) string {
 
 // ParseWebHook parses the event payload. For recognized event types, a
 // value of the corresponding struct type will be returned (as returned
-// by Event.Payload()). An error will be returned for unrecognized event
+// by Event.ParsePayload()). An error will be returned for unrecognized event
 // types.
 //
 // Example usage:
@@ -191,5 +191,5 @@ func ParseWebHook(messageType string, payload []byte) (interface{}, error) {
 		Type:       &eventType,
 		RawPayload: (*json.RawMessage)(&payload),
 	}
-	return event.Payload(), nil
+	return event.ParsePayload()
 }


### PR DESCRIPTION
The `Event.Payload` function can fail in instances when it receives invalid
json. (example: when parsing a webhook that is set to application/x-www-form-urlencoded)
If this happens, we shouldn't panic but instead return an error to let the
caller know about the failure.

Added in a new function, `Event.ParsePayload` to take its place a depreciated
the old function.

Also, it looks like this is the only place where we are panicing in this library. https://github.com/google/go-github/search?q=panic&type=Code&utf8=%E2%9C%93