### PR TITLE
Refactor test to first Add(time.Minute), then Round(time.Second).

### DIFF
--- a/github/github_test.go
+++ b/github/github_test.go
@@ -501,7 +501,7 @@ func TestDo_rateLimit_noNetworkCall(t *testing.T) {
 	setup()
 	defer teardown()
 
-	reset := time.Now().UTC().Round(time.Second).Add(time.Minute) // Rate reset is a minute from now, with 1 second precision.
+	reset := time.Now().UTC().Add(time.Minute).Round(time.Second) // Rate reset is a minute from now, with 1 second precision.
 
 	mux.HandleFunc("/first", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(headerRateLimit, "60")


### PR DESCRIPTION
This is a minor refactor that is a noop. Do it because the new order seems more readable and logical. It's also more consistent with the comment.

This tiny refactor is extracted from #568.