### PR TITLE
Invitation methods take :owner/:repo

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	libraryVersion = "3"
+	libraryVersion = "4"
 	defaultBaseURL = "https://api.github.com/"
 	uploadBaseURL  = "https://uploads.github.com/"
 	userAgent      = "go-github/" + libraryVersion

--- a/github/repos_invitations.go
+++ b/github/repos_invitations.go
@@ -28,8 +28,8 @@ type RepositoryInvitation struct {
 // ListInvitations lists all currently-open repository invitations.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository
-func (s *RepositoriesService) ListInvitations(ctx context.Context, repoID int, opt *ListOptions) ([]*RepositoryInvitation, *Response, error) {
-	u := fmt.Sprintf("repositories/%v/invitations", repoID)
+func (s *RepositoriesService) ListInvitations(ctx context.Context, owner, repo string, opt *ListOptions) ([]*RepositoryInvitation, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/invitations", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
@@ -55,8 +55,8 @@ func (s *RepositoriesService) ListInvitations(ctx context.Context, repoID int, o
 // DeleteInvitation deletes a repository invitation.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/invitations/#delete-a-repository-invitation
-func (s *RepositoriesService) DeleteInvitation(ctx context.Context, repoID, invitationID int) (*Response, error) {
-	u := fmt.Sprintf("repositories/%v/invitations/%v", repoID, invitationID)
+func (s *RepositoriesService) DeleteInvitation(ctx context.Context, owner, repo string, invitationID int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/invitations/%v", owner, repo, invitationID)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -75,11 +75,11 @@ func (s *RepositoriesService) DeleteInvitation(ctx context.Context, repoID, invi
 // on the repository. Possible values are: "read", "write", "admin".
 //
 // GitHub API docs: https://developer.github.com/v3/repos/invitations/#update-a-repository-invitation
-func (s *RepositoriesService) UpdateInvitation(ctx context.Context, repoID, invitationID int, permissions string) (*RepositoryInvitation, *Response, error) {
+func (s *RepositoriesService) UpdateInvitation(ctx context.Context, owner, repo string, invitationID int, permissions string) (*RepositoryInvitation, *Response, error) {
 	opts := &struct {
 		Permissions string `json:"permissions"`
 	}{Permissions: permissions}
-	u := fmt.Sprintf("repositories/%v/invitations/%v", repoID, invitationID)
+	u := fmt.Sprintf("repos/%v/%v/invitations/%v", owner, repo, invitationID)
 	req, err := s.client.NewRequest("PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err

--- a/github/repos_invitations_test.go
+++ b/github/repos_invitations_test.go
@@ -17,7 +17,7 @@ func TestRepositoriesService_ListInvitations(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/repositories/1/invitations", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeRepositoryInvitationsPreview)
 		testFormValues(t, r, values{"page": "2"})
@@ -25,7 +25,7 @@ func TestRepositoriesService_ListInvitations(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	got, _, err := client.Repositories.ListInvitations(context.Background(), 1, opt)
+	got, _, err := client.Repositories.ListInvitations(context.Background(), "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListInvitations returned error: %v", err)
 	}
@@ -40,13 +40,13 @@ func TestRepositoriesService_DeleteInvitation(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/repositories/1/invitations/2", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/invitations/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		testHeader(t, r, "Accept", mediaTypeRepositoryInvitationsPreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Repositories.DeleteInvitation(context.Background(), 1, 2)
+	_, err := client.Repositories.DeleteInvitation(context.Background(), "o", "r", 2)
 	if err != nil {
 		t.Errorf("Repositories.DeleteInvitation returned error: %v", err)
 	}
@@ -56,13 +56,13 @@ func TestRepositoriesService_UpdateInvitation(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/repositories/1/invitations/2", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/invitations/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
 		testHeader(t, r, "Accept", mediaTypeRepositoryInvitationsPreview)
 		fmt.Fprintf(w, `{"id":1}`)
 	})
 
-	got, _, err := client.Repositories.UpdateInvitation(context.Background(), 1, 2, "write")
+	got, _, err := client.Repositories.UpdateInvitation(context.Background(), "o", "r", 2, "write")
 	if err != nil {
 		t.Errorf("Repositories.UpdateInvitation returned error: %v", err)
 	}


### PR DESCRIPTION
All repository routes on the GitHub API can accessed via /repositories/:id _and_ /repos/:owner/:repo. For whatever reason, the documentation for the invitation routes only references the former, but both work correctly.

Repository invitations are the only functions in google/go-github to use the :id style routes, so I'd propose we change them to use :owner/:repo as that will likely be much more convenient for users of this library.