### PR TITLE
Fix MilestoneListOptions docs.

### DIFF
--- a/github/issues_milestones.go
+++ b/github/issues_milestones.go
@@ -38,11 +38,11 @@ func (m Milestone) String() string {
 // IssuesService.ListMilestones method.
 type MilestoneListOptions struct {
 	// State filters milestones based on their state. Possible values are:
-	// open, closed. Default is "open".
+	// open, closed, all. Default is "open".
 	State string `url:"state,omitempty"`
 
-	// Sort specifies how to sort milestones. Possible values are: due_date, completeness.
-	// Default value is "due_date".
+	// Sort specifies how to sort milestones. Possible values are: due_on, completeness.
+	// Default value is "due_on".
 	Sort string `url:"sort,omitempty"`
 
 	// Direction in which to sort milestones. Possible values are: asc, desc.


### PR DESCRIPTION
The state field was missing "all".

The sort field listed "due_date" instead of "due_on" (but had due_on
correctly elsewhere).

See https://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository