### PR TITLE
add tokentype=basic to example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ import "golang.org/x/oauth2"
 func main() {
   ctx := context.Background()
   ts := oauth2.StaticTokenSource(
-    &oauth2.Token{AccessToken: "... your access token ..."},
+    &oauth2.Token{TokenType: "Basic", AccessToken: "... your access token ..."},
   )
   tc := oauth2.NewClient(ctx, ts)
 


### PR DESCRIPTION
If users obtain a github API Token (as suggested in the example), they need to add `TokenType: "Basic"` to the client definition, or they get `401 Unauthorized`.

Apparently, the default value is something else.