### PR TITLE
#588 Handle multiple References returned by the GH refs/ endpoint.

### DIFF
--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -50,6 +50,8 @@ type updateRefRequest struct {
 // GetRef fetches a single Reference object for a given Git ref.
 // If there is no exact match, GetRef will return an error.
 //
+// Note: the GitHub API can return multiple matches, if you wish to use this functionality please use the GetRefs() method.
+//
 // GitHub API docs: https://developer.github.com/v3/git/refs/#get-a-reference
 func (s *GitService) GetRef(ctx context.Context, owner string, repo string, ref string) (*Reference, *Response, error) {
 	ref = strings.TrimPrefix(ref, "refs/")

--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -61,7 +61,6 @@ func (s *GitService) GetRef(ctx context.Context, owner string, repo string, ref 
 
 	r := new(Reference)
 	resp, err := s.client.Do(ctx, req, r)
-
 	if _, ok := err.(*json.UnmarshalTypeError); ok {
 		// Multiple refs, means there wasn't an exact match.
 		return nil, resp, nil

--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -61,7 +62,8 @@ func (s *GitService) GetRef(ctx context.Context, owner string, repo string, ref 
 	r := new(Reference)
 	resp, err := s.client.Do(ctx, req, r)
 	if _, ok := err.(*json.UnmarshalTypeError); ok {
-		return nil, resp, fmt.Errorf("No exact match found for this ref")
+		// Multiple refs, means there wasn't an exact match.
+		return nil, resp, errors.New("no exact match found for this ref")
 	} else if err != nil {
 		return nil, resp, err
 	}

--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -76,9 +76,9 @@ func (s *GitService) GetRef(ctx context.Context, owner string, repo string, ref 
 // If returned error is nil, there will be at least 1 ref returned.
 // For example:
 //
-// 	"heads/featureA"  -> ["refs/heads/featureA"]                         // Exact match, single ref is returned.
-// 	"heads/feature"   -> ["refs/heads/featureA", "refs/heads/featureB"]  // All refs that start with ref.
-// 	"heads/notexist"  -> []                                              // Returns an error.
+// 	"heads/featureA" -> ["refs/heads/featureA"]                         // Exact match, single ref is returned.
+// 	"heads/feature"  -> ["refs/heads/featureA", "refs/heads/featureB"]  // All refs that start with ref.
+// 	"heads/notexist" -> []                                              // Returns an error.
 //
 // GitHub API docs: https://developer.github.com/v3/git/refs/#get-a-reference
 func (s *GitService) GetRefs(ctx context.Context, owner string, repo string, ref string) ([]*Reference, *Response, error) {

--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -78,7 +78,7 @@ func (s *GitService) GetRef(ctx context.Context, owner string, repo string, ref 
 //
 // 	"heads/featureA"  -> ["refs/heads/featureA"]                         // Exact match, single ref is returned.
 // 	"heads/feature"   -> ["refs/heads/featureA", "refs/heads/featureB"]  // All refs that start with ref.
-// 	"heads/notexist"  -> []                                             // Returns an error.
+// 	"heads/notexist"  -> []                                              // Returns an error.
 //
 // GitHub API docs: https://developer.github.com/v3/git/refs/#get-a-reference
 func (s *GitService) GetRefs(ctx context.Context, owner string, repo string, ref string) ([]*Reference, *Response, error) {

--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -76,9 +76,9 @@ func (s *GitService) GetRef(ctx context.Context, owner string, repo string, ref 
 // If returned error is nil, there will be at least 1 ref returned.
 // For example:
 //
-// 	"heads/featureA" -> ["refs/heads/featureA"]                         // Exact match, single ref is returned.
-// 	"heads/feature"  -> ["refs/heads/featureA", "refs/heads/featureB"]  // All refs that start with ref.
-// 	"heads/feature"  -> []                                              // Returns an error.
+// 	"heads/featureA"  -> ["refs/heads/featureA"]                         // Exact match, single ref is returned.
+// 	"heads/feature"   -> ["refs/heads/featureA", "refs/heads/featureB"]  // All refs that start with ref.
+// 	"heads/notexist"  -> []                                             // Returns an error.
 //
 // GitHub API docs: https://developer.github.com/v3/git/refs/#get-a-reference
 func (s *GitService) GetRefs(ctx context.Context, owner string, repo string, ref string) ([]*Reference, *Response, error) {

--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -65,10 +65,9 @@ func (s *GitService) GetRef(ctx context.Context, owner string, repo string, ref 
 		return nil, resp, err
 	}
 
-	rbuf := bytes.NewBuffer(buf.Bytes())
 	r := new(Reference)
 
-	err = json.NewDecoder(rbuf).Decode(r)
+	err = json.NewDecoder(buf).Decode(r)
 	if _, ok := err.(*json.UnmarshalTypeError); ok {
 		// Multiple refs, means there wasn't an exact match.
 		return nil, resp, nil

--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -50,7 +50,8 @@ type updateRefRequest struct {
 // GetRef fetches a single Reference object for a given Git ref.
 // If there is no exact match, GetRef will return an error.
 //
-// Note: the GitHub API can return multiple matches, if you wish to use this functionality please use the GetRefs() method.
+// Note: The GitHub API can return multiple matches.
+// If you wish to use this functionality please use the GetRefs() method.
 //
 // GitHub API docs: https://developer.github.com/v3/git/refs/#get-a-reference
 func (s *GitService) GetRef(ctx context.Context, owner string, repo string, ref string) (*Reference, *Response, error) {

--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -47,7 +47,7 @@ type updateRefRequest struct {
 }
 
 // GetRef fetches a single Reference object for a given Git ref.
-// If there is no exact match, GetRef will return a nil Reference.
+// If there is no exact match, GetRef will return an error.
 //
 // GitHub API docs: https://developer.github.com/v3/git/refs/#get-a-reference
 func (s *GitService) GetRef(ctx context.Context, owner string, repo string, ref string) (*Reference, *Response, error) {
@@ -61,8 +61,7 @@ func (s *GitService) GetRef(ctx context.Context, owner string, repo string, ref 
 	r := new(Reference)
 	resp, err := s.client.Do(ctx, req, r)
 	if _, ok := err.(*json.UnmarshalTypeError); ok {
-		// Multiple refs, means there wasn't an exact match.
-		return nil, resp, nil
+		return nil, resp, fmt.Errorf("No exact match found for this ref")
 	} else if err != nil {
 		return nil, resp, err
 	}

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 )
 
-func TestGitService_GetRef_SingleResult(t *testing.T) {
+func TestGitService_GetRef_singleRef(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -56,7 +56,7 @@ func TestGitService_GetRef_SingleResult(t *testing.T) {
 	}
 }
 
-func TestGitService_GetRef_MultipleResult(t *testing.T) {
+func TestGitService_GetRef_multipleRefs(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -97,7 +97,7 @@ func TestGitService_GetRef_MultipleResult(t *testing.T) {
 
 }
 
-func TestGitService_GetRefs_SingleResult(t *testing.T) {
+func TestGitService_GetRefs_singleRef(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -117,7 +117,7 @@ func TestGitService_GetRefs_SingleResult(t *testing.T) {
 
 	refs, _, err := client.Git.GetRefs(context.Background(), "o", "r", "refs/heads/b")
 	if err != nil {
-		t.Fatalf("Git.GetRef returned error: %v", err)
+		t.Fatalf("Git.GetRefs returned error: %v", err)
 	}
 
 	ref := refs[0]
@@ -131,16 +131,16 @@ func TestGitService_GetRefs_SingleResult(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(ref, want) {
-		t.Errorf("Git.GetRef returned %+v, want %+v", ref, want)
+		t.Errorf("Git.GetRefs returned %+v, want %+v", ref, want)
 	}
 
 	// without 'refs/' prefix
 	if _, _, err := client.Git.GetRefs(context.Background(), "o", "r", "heads/b"); err != nil {
-		t.Errorf("Git.GetRef returned error: %v", err)
+		t.Errorf("Git.GetRefs returned error: %v", err)
 	}
 }
 
-func TestGitService_GetRefs_MultipleResult(t *testing.T) {
+func TestGitService_GetRefs_multipleRefs(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -172,7 +172,7 @@ func TestGitService_GetRefs_MultipleResult(t *testing.T) {
 
 	refs, _, err := client.Git.GetRefs(context.Background(), "o", "r", "refs/heads/b")
 	if err != nil {
-		t.Errorf("Git.GetRef returned error: %v", err)
+		t.Errorf("Git.GetRefs returned error: %v", err)
 	}
 
 	want := &Reference{
@@ -185,7 +185,7 @@ func TestGitService_GetRefs_MultipleResult(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(refs[0], want) {
-		t.Errorf("Git.GetRef returned %+v, want %+v", refs[0], want)
+		t.Errorf("Git.GetRefs returned %+v, want %+v", refs[0], want)
 	}
 }
 

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -86,13 +86,10 @@ func TestGitService_GetRef_multipleRefs(t *testing.T) {
 		`)
 	})
 
-	ref, _, err := client.Git.GetRef(context.Background(), "o", "r", "refs/heads/b")
-	if err != nil {
-		t.Errorf("Git.GetRef returned error: %v", err)
-	}
-
-	if ref != nil {
-		t.Errorf("Git.GetRef returned %+v, want nil", ref)
+	_, _, err := client.Git.GetRef(context.Background(), "o", "r", "refs/heads/b")
+	want := "No exact match found for this ref"
+	if err.Error() != want {
+		t.Errorf("Git.GetRefs returned %+v, want %+v", err, want)
 	}
 
 }

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -189,6 +189,21 @@ func TestGitService_GetRefs_multipleRefs(t *testing.T) {
 	}
 }
 
+func TestGitService_GetRefs_noRefs(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, "[]")
+	})
+
+	_, _, err := client.Git.GetRefs(context.Background(), "o", "r", "refs/heads/b")
+	if err == nil {
+		t.Errorf("Git.GetRefs did not return an error when one was expected.")
+	}
+}
+
 func TestGitService_ListRefs(t *testing.T) {
 	setup()
 	defer teardown()

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -189,6 +189,7 @@ func TestGitService_GetRefs_multipleRefs(t *testing.T) {
 	}
 }
 
+// TestGitService_GetRefs_noRefs tests for behaviour resulting from an unexpected GH response. This should never actually happen.
 func TestGitService_GetRefs_noRefs(t *testing.T) {
 	setup()
 	defer teardown()
@@ -199,9 +200,11 @@ func TestGitService_GetRefs_noRefs(t *testing.T) {
 	})
 
 	_, _, err := client.Git.GetRefs(context.Background(), "o", "r", "refs/heads/b")
-	if err == nil {
-		t.Errorf("Git.GetRefs did not return an error when one was expected.")
+	want := "unexpected response from GitHub API: an array of refs with length 0"
+	if err.Error() != want {
+		t.Errorf("Git.GetRefs returned %+v, want %+v", err, want)
 	}
+
 }
 
 func TestGitService_ListRefs(t *testing.T) {

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -87,9 +87,9 @@ func TestGitService_GetRef_multipleRefs(t *testing.T) {
 	})
 
 	_, _, err := client.Git.GetRef(context.Background(), "o", "r", "refs/heads/b")
-	want := "No exact match found for this ref"
+	want := "no exact match found for this ref"
 	if err.Error() != want {
-		t.Errorf("Git.GetRefs returned %+v, want %+v", err, want)
+		t.Errorf("Git.GetRef returned %+v, want %+v", err, want)
 	}
 
 }

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -32,12 +32,11 @@ func TestGitService_GetRef_SingleResult(t *testing.T) {
 		  }`)
 	})
 
-	refs, _, err := client.Git.GetRef(context.Background(), "o", "r", "refs/heads/b")
+	ref, _, err := client.Git.GetRef(context.Background(), "o", "r", "refs/heads/b")
 	if err != nil {
 		t.Fatalf("Git.GetRef returned error: %v", err)
 	}
 
-	ref := refs[0]
 	want := &Reference{
 		Ref: String("refs/heads/b"),
 		URL: String("https://api.github.com/repos/o/r/git/refs/heads/b"),
@@ -87,7 +86,91 @@ func TestGitService_GetRef_MultipleResult(t *testing.T) {
 		`)
 	})
 
-	refs, _, err := client.Git.GetRef(context.Background(), "o", "r", "refs/heads/b")
+	ref, _, err := client.Git.GetRef(context.Background(), "o", "r", "refs/heads/b")
+	if err != nil {
+		t.Errorf("Git.GetRef returned error: %v", err)
+	}
+
+	if ref != nil {
+		t.Errorf("Git.GetRef returned %+v, want nil", ref)
+	}
+
+}
+
+func TestGitService_GetRefs_SingleResult(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `
+		  {
+		    "ref": "refs/heads/b",
+		    "url": "https://api.github.com/repos/o/r/git/refs/heads/b",
+		    "object": {
+		      "type": "commit",
+		      "sha": "aa218f56b14c9653891f9e74264a383fa43fefbd",
+		      "url": "https://api.github.com/repos/o/r/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"
+		    }
+		  }`)
+	})
+
+	refs, _, err := client.Git.GetRefs(context.Background(), "o", "r", "refs/heads/b")
+	if err != nil {
+		t.Fatalf("Git.GetRef returned error: %v", err)
+	}
+
+	ref := refs[0]
+	want := &Reference{
+		Ref: String("refs/heads/b"),
+		URL: String("https://api.github.com/repos/o/r/git/refs/heads/b"),
+		Object: &GitObject{
+			Type: String("commit"),
+			SHA:  String("aa218f56b14c9653891f9e74264a383fa43fefbd"),
+			URL:  String("https://api.github.com/repos/o/r/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"),
+		},
+	}
+	if !reflect.DeepEqual(ref, want) {
+		t.Errorf("Git.GetRef returned %+v, want %+v", ref, want)
+	}
+
+	// without 'refs/' prefix
+	if _, _, err := client.Git.GetRefs(context.Background(), "o", "r", "heads/b"); err != nil {
+		t.Errorf("Git.GetRef returned error: %v", err)
+	}
+}
+
+func TestGitService_GetRefs_MultipleResult(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `
+		  [
+		    {
+			    "ref": "refs/heads/booger",
+			    "url": "https://api.github.com/repos/o/r/git/refs/heads/booger",
+			    "object": {
+			      "type": "commit",
+			      "sha": "aa218f56b14c9653891f9e74264a383fa43fefbd",
+			      "url": "https://api.github.com/repos/o/r/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"
+			    }
+		  	},
+		    {
+		      "ref": "refs/heads/bandsaw",
+		      "url": "https://api.github.com/repos/o/r/git/refs/heads/bandsaw",
+		      "object": {
+		        "type": "commit",
+		        "sha": "612077ae6dffb4d2fbd8ce0cccaa58893b07b5ac",
+		        "url": "https://api.github.com/repos/o/r/git/commits/612077ae6dffb4d2fbd8ce0cccaa58893b07b5ac"
+		      }
+		    }
+		  ]
+		`)
+	})
+
+	refs, _, err := client.Git.GetRefs(context.Background(), "o", "r", "refs/heads/b")
 	if err != nil {
 		t.Errorf("Git.GetRef returned error: %v", err)
 	}
@@ -103,11 +186,6 @@ func TestGitService_GetRef_MultipleResult(t *testing.T) {
 	}
 	if !reflect.DeepEqual(refs[0], want) {
 		t.Errorf("Git.GetRef returned %+v, want %+v", refs[0], want)
-	}
-
-	// without 'refs/' prefix
-	if _, _, err := client.Git.GetRef(context.Background(), "o", "r", "heads/b"); err != nil {
-		t.Errorf("Git.GetRef returned error: %v", err)
 	}
 }
 

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -164,7 +164,7 @@ func (s *RepositoriesService) GetContents(ctx context.Context, owner, repo, path
 	if directoryUnmarshalError == nil {
 		return nil, directoryContent, resp, directoryUnmarshalError
 	}
-	return nil, nil, resp, fmt.Errorf("unmarshalling failed for both file and directory content: %s and %s ", fileUnmarshalError, directoryUnmarshalError)
+	return nil, nil, resp, fmt.Errorf("unmarshalling failed for both file and directory content: %s and %s", fileUnmarshalError, directoryUnmarshalError)
 }
 
 // CreateFile creates a new file in a repository at the given path and returns


### PR DESCRIPTION
This (breaking) change alters the api of GetRef() to return a slice of
References instead of a single Reference, in order to account for the
fact that GH will return an array of references in the event that
there is not a precise match to the queried reference.

This is accomplished by passing a buffer to client.Do(), and making a
second attempt at unmarshalling in the event that the single-object
case fails.

Addresses issue #588 