### PR TITLE
Return nil error explicitly in RepositoriesService.GetContents.

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -158,11 +158,11 @@ func (s *RepositoriesService) GetContents(ctx context.Context, owner, repo, path
 	}
 	fileUnmarshalError := json.Unmarshal(rawJSON, &fileContent)
 	if fileUnmarshalError == nil {
-		return fileContent, nil, resp, fileUnmarshalError
+		return fileContent, nil, resp, nil
 	}
 	directoryUnmarshalError := json.Unmarshal(rawJSON, &directoryContent)
 	if directoryUnmarshalError == nil {
-		return nil, directoryContent, resp, directoryUnmarshalError
+		return nil, directoryContent, resp, nil
 	}
 	return nil, nil, resp, fmt.Errorf("unmarshalling failed for both file and directory content: %s and %s ", fileUnmarshalError, directoryUnmarshalError)
 }


### PR DESCRIPTION
This is simpler and more readable.

Helps #536.