### PR TITLE
Adds LDAPDN field to Team

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6212,6 +6212,14 @@ func (t *Team) GetID() int {
 	return *t.ID
 }
 
+// GetLDAPDN returns the LDAPDN field if it's non-nil, zero value otherwise.
+func (t *Team) GetLDAPDN() string {
+	if t == nil || t.LDAPDN == nil {
+		return ""
+	}
+	return *t.LDAPDN
+}
+
 // GetMembersCount returns the MembersCount field if it's non-nil, zero value otherwise.
 func (t *Team) GetMembersCount() int {
 	if t == nil || t.MembersCount == nil {

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -39,6 +39,10 @@ type Team struct {
 	Organization    *Organization `json:"organization,omitempty"`
 	MembersURL      *string       `json:"members_url,omitempty"`
 	RepositoriesURL *string       `json:"repositories_url,omitempty"`
+
+	// LDAPDN is only available in GitHub Enterprise and when the team
+	// membership is synchronized with LDAP.
+	LDAPDN *string `json:"ldap_dn,omitempty"`
 }
 
 func (t Team) String() string {

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -48,7 +48,7 @@ func TestOrganizationsService_GetTeam(t *testing.T) {
 
 	mux.HandleFunc("/teams/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"id":1, "name":"n", "description": "d", "url":"u", "slug": "s", "permission":"p"}`)
+		fmt.Fprint(w, `{"id":1, "name":"n", "description": "d", "url":"u", "slug": "s", "permission":"p", "ldap_dn":"cn=n,ou=groups,dc=example,dc=com"}`)
 	})
 
 	team, _, err := client.Organizations.GetTeam(context.Background(), 1)
@@ -56,7 +56,7 @@ func TestOrganizationsService_GetTeam(t *testing.T) {
 		t.Errorf("Organizations.GetTeam returned error: %v", err)
 	}
 
-	want := &Team{ID: Int(1), Name: String("n"), Description: String("d"), URL: String("u"), Slug: String("s"), Permission: String("p")}
+	want := &Team{ID: Int(1), Name: String("n"), Description: String("d"), URL: String("u"), Slug: String("s"), Permission: String("p"), LDAPDN: String("cn=n,ou=groups,dc=example,dc=com")}
 	if !reflect.DeepEqual(team, want) {
 		t.Errorf("Organizations.GetTeam returned %+v, want %+v", team, want)
 	}


### PR DESCRIPTION
In GitHub Enterprise, the teams API routes include `ldap_dn` if the team is being synchronized with LDAP.