### PR TITLE
Add Assigner field to issues_events

### DIFF
--- a/github/issues_events.go
+++ b/github/issues_events.go
@@ -65,6 +65,7 @@ type IssueEvent struct {
 
 	// Only present on certain events; see above.
 	Assignee  *User      `json:"assignee,omitempty"`
+	Assigner  *User      `json:"assigner,omitempty"`
 	CommitID  *string    `json:"commit_id,omitempty"`
 	Milestone *Milestone `json:"milestone,omitempty"`
 	Label     *Label     `json:"label,omitempty"`


### PR DESCRIPTION
I've not updated the comment:

>        //     assigned, unassigned                                                                         
>        //       The Actor assigned the issue to or removed the assignment from the Assignee.               

to keep it consistent with [Github documentation](https://developer.github.com/v3/issues/events/) even though it is clearly incorrect.