### PR TITLE
Update `IssueEvent.Event` assign/unassign doc

### DIFF
--- a/github/issues_events.go
+++ b/github/issues_events.go
@@ -44,7 +44,7 @@ type IssueEvent struct {
 	//       Someone unspecified @mentioned the Actor [sic] in an issue comment body.
 	//
 	//     assigned, unassigned
-	//       The Actor assigned the issue to or removed the assignment from the Assignee.
+	//       The Assigner assigned the issue to or removed the assignment from the Assignee.
 	//
 	//     labeled, unlabeled
 	//       The Actor added or removed the Label from the issue.


### PR DESCRIPTION
The current phrase reads as if the "Actor" field contains the
information about the user who changed the assignment, but this
information is actually in the "Assigner" field.

Fix the description of `assigned, unassigned` event to reflect
that.

Is that clearer?