### PR TITLE
Add Community Health metrics endpoint

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -620,6 +620,14 @@ func (c *CommitStats) GetTotal() int {
 	return *c.Total
 }
 
+// GetHealthPercentage returns the HealthPercentage field if it's non-nil, zero value otherwise.
+func (c *CommunityHealthMetrics) GetHealthPercentage() int {
+	if c == nil || c.HealthPercentage == nil {
+		return 0
+	}
+	return *c.HealthPercentage
+}
+
 // GetAvatarURL returns the AvatarURL field if it's non-nil, zero value otherwise.
 func (c *Contributor) GetAvatarURL() string {
 	if c == nil || c.AvatarURL == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2572,6 +2572,38 @@ func (m *MembershipEvent) GetScope() string {
 	return *m.Scope
 }
 
+// GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
+func (m *Metric) GetHTMLURL() string {
+	if m == nil || m.HTMLURL == nil {
+		return ""
+	}
+	return *m.HTMLURL
+}
+
+// GetKey returns the Key field if it's non-nil, zero value otherwise.
+func (m *Metric) GetKey() string {
+	if m == nil || m.Key == nil {
+		return ""
+	}
+	return *m.Key
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (m *Metric) GetName() string {
+	if m == nil || m.Name == nil {
+		return ""
+	}
+	return *m.Name
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (m *Metric) GetURL() string {
+	if m == nil || m.URL == nil {
+		return ""
+	}
+	return *m.URL
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (m *Migration) GetCreatedAt() string {
 	if m == nil || m.CreatedAt == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -628,6 +628,14 @@ func (c *CommunityHealthMetrics) GetHealthPercentage() int {
 	return *c.HealthPercentage
 }
 
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (c *CommunityHealthMetrics) GetUpdatedAt() time.Time {
+	if c == nil || c.UpdatedAt == nil {
+		return time.Time{}
+	}
+	return *c.UpdatedAt
+}
+
 // GetAvatarURL returns the AvatarURL field if it's non-nil, zero value otherwise.
 func (c *Contributor) GetAvatarURL() string {
 	if c == nil || c.AvatarURL == nil {

--- a/github/github.go
+++ b/github/github.go
@@ -97,6 +97,9 @@ const (
 
 	// https://developer.github.com/changes/2017-02-28-user-blocking-apis-and-webhook/
 	mediaTypeBlockUsersPreview = "application/vnd.github.giant-sentry-fist-preview+json"
+
+	// https://developer.github.com/changes/2017-02-09-community-health/
+	mediaTypeRepositoryCommunityHealthMetricsPreview = "application/vnd.github.black-panther-preview"
 )
 
 // A Client manages communication with the GitHub API.

--- a/github/github.go
+++ b/github/github.go
@@ -99,7 +99,7 @@ const (
 	mediaTypeBlockUsersPreview = "application/vnd.github.giant-sentry-fist-preview+json"
 
 	// https://developer.github.com/changes/2017-02-09-community-health/
-	mediaTypeRepositoryCommunityHealthMetricsPreview = "application/vnd.github.black-panther-preview"
+	mediaTypeRepositoryCommunityHealthMetricsPreview = "application/vnd.github.black-panther-preview+json"
 )
 
 // A Client manages communication with the GitHub API.

--- a/github/repos_community_health.go
+++ b/github/repos_community_health.go
@@ -43,7 +43,7 @@ type CommunityHealthMetrics struct {
 //
 // GitHub API docs: https://developer.github.com/v3/repos/community/#retrieve-community-health-metrics
 func (s *RepositoriesService) GetCommunityHealthMetrics(ctx context.Context, owner, repo string) (*CommunityHealthMetrics, *Response, error) {
-	u := fmt.Sprintf("repositories/%v/%v/community/profile", owner, repo)
+	u := fmt.Sprintf("repos/%v/%v/community/profile", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -54,5 +54,9 @@ func (s *RepositoriesService) GetCommunityHealthMetrics(ctx context.Context, own
 
 	metrics := &CommunityHealthMetrics{}
 	resp, err := s.client.Do(ctx, req, metrics)
-	return metrics, resp, err
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return metrics, resp, nil
 }

--- a/github/repos_community_health.go
+++ b/github/repos_community_health.go
@@ -21,7 +21,7 @@ type Metric struct {
 
 // CommunityHealthFiles represents the different files in the community health metrics response.
 type CommunityHealthFiles struct {
-	CodeOfConduct *Metric `json:"code_conduct"`
+	CodeOfConduct *Metric `json:"code_of_conduct"`
 	Contributing  *Metric `json:"contributing"`
 	License       *Metric `json:"license"`
 	Readme        *Metric `json:"readme"`

--- a/github/repos_community_health.go
+++ b/github/repos_community_health.go
@@ -1,0 +1,58 @@
+// Copyright 2017 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// CommunityHealthMetrics represents a response containing the community metrics of a repository.
+type CommunityHealthMetrics struct {
+	HealthPercentage *int `json:"health_percentage"`
+	Files            struct {
+		CodeOfConduct struct {
+			Name    *string `json:"name"`
+			Key     *string `json:"key"`
+			URL     *string `json:"url"`
+			HTMLURL *string `json:"html_url"`
+		} `json:"code_of_conduct"`
+		Contributing struct {
+			URL     *string `json:"url"`
+			HTMLURL *string `json:"html_url"`
+		} `json:"contributing"`
+		License struct {
+			Name    *string `json:"name"`
+			Key     *string `json:"key"`
+			URL     *string `json:"url"`
+			HTMLURL *string `json:"html_url"`
+		} `json:"license"`
+		Readme struct {
+			URL     *string `json:"url"`
+			HTMLURL *string `json:"html_url"`
+		} `json:"readme"`
+	} `json:"files"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// GetCommunityHealthMetrics retrieves all the community health  metrics for a  repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/community/#retrieve-community-health-metrics
+func (s *RepositoriesService) GetCommunityHealthMetrics(ctx context.Context, owner, repo string) (*CommunityHealthMetrics, *Response, error) {
+	u := fmt.Sprintf("repositories/%v/%v/community/profile", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeRepositoryCommunityHealthMetricsPreview)
+
+	metrics := &CommunityHealthMetrics{}
+	resp, err := s.client.Do(ctx, req, metrics)
+	return metrics, resp, err
+}

--- a/github/repos_community_health.go
+++ b/github/repos_community_health.go
@@ -36,7 +36,7 @@ type CommunityHealthMetrics struct {
 			HTMLURL *string `json:"html_url"`
 		} `json:"readme"`
 	} `json:"files"`
-	UpdatedAt time.Time `json:"updated_at"`
+	UpdatedAt *time.Time `json:"updated_at"`
 }
 
 // GetCommunityHealthMetrics retrieves all the community health  metrics for a  repository.

--- a/github/repos_community_health.go
+++ b/github/repos_community_health.go
@@ -11,6 +11,7 @@ import (
 	"time"
 )
 
+// Metric represents the different fields for one file in community health files.
 type Metric struct {
 	Name    *string `json:"name"`
 	Key     *string `json:"key"`
@@ -18,6 +19,7 @@ type Metric struct {
 	HTMLURL *string `json:"html_url"`
 }
 
+// CommunityHealthFiles represents the different files in the community health metrics response.
 type CommunityHealthFiles struct {
 	CodeOfConduct *Metric `json:"code_conduct"`
 	Contributing  *Metric `json:"contributing"`

--- a/github/repos_community_health.go
+++ b/github/repos_community_health.go
@@ -11,32 +11,25 @@ import (
 	"time"
 )
 
+type Metric struct {
+	Name    *string `json:"name"`
+	Key     *string `json:"key"`
+	URL     *string `json:"url"`
+	HTMLURL *string `json:"html_url"`
+}
+
+type CommunityHealthFiles struct {
+	CodeOfConduct *Metric `json:"code_conduct"`
+	Contributing  *Metric `json:"contributing"`
+	License       *Metric `json:"license"`
+	Readme        *Metric `json:"readme"`
+}
+
 // CommunityHealthMetrics represents a response containing the community metrics of a repository.
 type CommunityHealthMetrics struct {
-	HealthPercentage *int `json:"health_percentage"`
-	Files            struct {
-		CodeOfConduct struct {
-			Name    *string `json:"name"`
-			Key     *string `json:"key"`
-			URL     *string `json:"url"`
-			HTMLURL *string `json:"html_url"`
-		} `json:"code_of_conduct"`
-		Contributing struct {
-			URL     *string `json:"url"`
-			HTMLURL *string `json:"html_url"`
-		} `json:"contributing"`
-		License struct {
-			Name    *string `json:"name"`
-			Key     *string `json:"key"`
-			URL     *string `json:"url"`
-			HTMLURL *string `json:"html_url"`
-		} `json:"license"`
-		Readme struct {
-			URL     *string `json:"url"`
-			HTMLURL *string `json:"html_url"`
-		} `json:"readme"`
-	} `json:"files"`
-	UpdatedAt *time.Time `json:"updated_at"`
+	HealthPercentage *int                  `json:"health_percentage"`
+	Files            *CommunityHealthFiles `json:"files"`
+	UpdatedAt        *time.Time            `json:"updated_at"`
 }
 
 // GetCommunityHealthMetrics retrieves all the community health  metrics for a  repository.

--- a/github/repos_community_health_test.go
+++ b/github/repos_community_health_test.go
@@ -56,25 +56,25 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 	updatedAt := time.Date(2017, 02, 28, 0, 0, 0, 0, time.UTC)
 	want := &CommunityHealthMetrics{
 		HealthPercentage: Int(100),
-		UpdatedAt: &updatedAt,
+		UpdatedAt:        &updatedAt,
 		Files: &CommunityHealthFiles{
 			CodeOfConduct: &Metric{
-				Name: String("Contributor Covenant"),
-				Key: String("contributor_covenant"),
+				Name:    String("Contributor Covenant"),
+				Key:     String("contributor_covenant"),
 				HTMLURL: String("https://github.com/octocat/Hello-World/blob/master/CODE_OF_CONDUCT.md"),
 			},
 			Contributing: &Metric{
-				URL: String("https://api.github.com/repos/octocat/Hello-World/contents/CONTRIBUTING"),
+				URL:     String("https://api.github.com/repos/octocat/Hello-World/contents/CONTRIBUTING"),
 				HTMLURL: String("https://github.com/octocat/Hello-World/blob/master/CONTRIBUTING"),
 			},
 			License: &Metric{
-				Name: String("MIT License"),
-				Key: String("mit"),
-				URL: String("https://api.github.com/licenses/mit"),
+				Name:    String("MIT License"),
+				Key:     String("mit"),
+				URL:     String("https://api.github.com/licenses/mit"),
 				HTMLURL: String("https://github.com/octocat/Hello-World/blob/master/LICENSE"),
 			},
 			Readme: &Metric{
-				URL: String("https://api.github.com/repos/octocat/Hello-World/contents/README.md"),
+				URL:     String("https://api.github.com/repos/octocat/Hello-World/contents/README.md"),
 				HTMLURL: String("https://github.com/octocat/Hello-World/blob/master/README.md"),
 			},
 		},

--- a/github/repos_community_health_test.go
+++ b/github/repos_community_health_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
@@ -20,7 +21,31 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/community/profile", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeRepositoryCommunityHealthMetricsPreview)
-		fmt.Fprintf(w, `{"health_percentage":75}`)
+		fmt.Fprintf(w, `{
+				"health_percentage": 100,
+				"files": {
+					"code_of_conduct": {
+						"name": "Contributor Covenant",
+						"key": "contributor_covenant",
+						"html_url": "https://github.com/octocat/Hello-World/blob/master/CODE_OF_CONDUCT.md"
+					},
+					"contributing": {
+						"url": "https://api.github.com/repos/octocat/Hello-World/contents/CONTRIBUTING",
+						"html_url": "https://github.com/octocat/Hello-World/blob/master/CONTRIBUTING"
+					},
+					"license": {
+						"name": "MIT License",
+						"key": "mit",
+						"url": "https://api.github.com/licenses/mit",
+						"html_url": "https://github.com/octocat/Hello-World/blob/master/LICENSE"
+					},
+					"readme": {
+						"url": "https://api.github.com/repos/octocat/Hello-World/contents/README.md",
+						"html_url": "https://github.com/octocat/Hello-World/blob/master/README.md"
+					}
+				},
+				"updated_at": "2017-02-28T00:00:00Z"
+			}`)
 	})
 
 	got, _, err := client.Repositories.GetCommunityHealthMetrics(context.Background(), "o", "r")
@@ -28,7 +53,32 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 		t.Errorf("Repositories.GetCommunityHealthMetrics returned error: %v", err)
 	}
 
-	want := &CommunityHealthMetrics{HealthPercentage: Int(75)}
+	updatedAt := time.Date(2017, 02, 28, 0, 0, 0, 0, time.UTC)
+	want := &CommunityHealthMetrics{
+		HealthPercentage: Int(100),
+		UpdatedAt: &updatedAt,
+		Files: &CommunityHealthFiles{
+			CodeOfConduct: &Metric{
+				Name: String("Contributor Covenant"),
+				Key: String("contributor_covenant"),
+				HTMLURL: String("https://github.com/octocat/Hello-World`/blob/master/CODE_OF_CONDUCT.md"),
+			},
+			Contributing: &Metric{
+				URL: String("https://api.github.com/repos/octocat/Hello-World/contents/CONTRIBUTING"),
+				HTMLURL: String("https://github.com/octocat/Hello-World/blob/master/CONTRIBUTING"),
+			},
+			License: &Metric{
+				Name: String("MIT License"),
+				Key: String("mit"),
+				URL: String("https://api.github.com/licenses/mit"),
+				HTMLURL: String("https://github.com/octocat/Hello-World/blob/master/LICENSE"),
+			},
+			Readme: &Metric{
+				URL: String("https://api.github.com/repos/octocat/Hello-World/contents/README.md"),
+				HTMLURL: String("https://github.com/octocat/Hello-World/blob/master/README.md"),
+			},
+		},
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Repositories.GetCommunityHealthMetrics = %+v, want %+v", got, want)
 	}

--- a/github/repos_community_health_test.go
+++ b/github/repos_community_health_test.go
@@ -1,0 +1,35 @@
+// Copyright 2017 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repositories/o/r/community/profile", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeRepositoryCommunityHealthMetricsPreview)
+		fmt.Fprintf(w, `{"health_percentage":75}`)
+	})
+
+	got, _, err := client.Repositories.GetCommunityHealthMetrics(context.Background(), "o", "r")
+	if err != nil {
+		t.Errorf("Repositories.GetCommunityHealthMetrics returned error: %v", err)
+	}
+
+	want := &CommunityHealthMetrics{HealthPercentage: Int(75)}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Repositories.GetCommunityHealthMetrics = %+v, want %+v", got, want)
+	}
+}

--- a/github/repos_community_health_test.go
+++ b/github/repos_community_health_test.go
@@ -27,6 +27,7 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 					"code_of_conduct": {
 						"name": "Contributor Covenant",
 						"key": "contributor_covenant",
+						"url": null,
 						"html_url": "https://github.com/octocat/Hello-World/blob/master/CODE_OF_CONDUCT.md"
 					},
 					"contributing": {

--- a/github/repos_community_health_test.go
+++ b/github/repos_community_health_test.go
@@ -61,7 +61,7 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 			CodeOfConduct: &Metric{
 				Name: String("Contributor Covenant"),
 				Key: String("contributor_covenant"),
-				HTMLURL: String("https://github.com/octocat/Hello-World`/blob/master/CODE_OF_CONDUCT.md"),
+				HTMLURL: String("https://github.com/octocat/Hello-World/blob/master/CODE_OF_CONDUCT.md"),
 			},
 			Contributing: &Metric{
 				URL: String("https://api.github.com/repos/octocat/Hello-World/contents/CONTRIBUTING"),
@@ -80,6 +80,6 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Repositories.GetCommunityHealthMetrics = %+v, want %+v", got, want)
+		t.Errorf("Repositories.GetCommunityHealthMetrics:\ngot:\n%v\nwant:\n%v", Stringify(got), Stringify(want))
 	}
 }

--- a/github/repos_community_health_test.go
+++ b/github/repos_community_health_test.go
@@ -17,7 +17,7 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/repositories/o/r/community/profile", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/community/profile", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeRepositoryCommunityHealthMetricsPreview)
 		fmt.Fprintf(w, `{"health_percentage":75}`)


### PR DESCRIPTION
This is a new API released by GitHub and is currently available as a
preview only.
Link - https://developer.github.com/v3/repos/community/#retrieve-community-health-metrics

Fixes: #553