### PR TITLE
Add OnRequest + OnResponse hooks

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -99,6 +99,9 @@ const (
 	mediaTypeBlockUsersPreview = "application/vnd.github.giant-sentry-fist-preview+json"
 )
 
+type onRequestFunc func(r *http.Request)
+type onResponseFunc func(r *http.Response)
+
 // A Client manages communication with the GitHub API.
 type Client struct {
 	clientMu sync.Mutex   // clientMu protects the client during calls that modify the CheckRedirect func.
@@ -119,6 +122,11 @@ type Client struct {
 	rateLimits [categories]Rate // Rate limits for the client as determined by the most recent API calls.
 
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
+
+	// A function to call prior to sending a request
+	OnRequest onRequestFunc
+	// A function to call right after receiving a response
+	OnResponse onResponseFunc
 
 	// Services used for talking to different parts of the GitHub API.
 	Activity       *ActivityService
@@ -390,6 +398,10 @@ func parseRate(r *http.Response) Rate {
 // The provided ctx must be non-nil. If it is canceled or times out,
 // ctx.Err() will be returned.
 func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Response, error) {
+	if c.OnRequest != nil {
+		c.OnRequest(req)
+	}
+
 	ctx, req = withContext(ctx, req)
 
 	rateLimitCategory := category(req.URL.Path)
@@ -421,6 +433,10 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 		}
 
 		return nil, err
+	}
+
+	if c.OnResponse != nil {
+		c.OnResponse(resp)
 	}
 
 	defer func() {


### PR DESCRIPTION
I was unable to find a way to debug the communication between Github and the client and server, which is something we'd find extremely useful in [Terraform](https://github.com/hashicorp/terraform), especially when our nightly acceptance tests fail because of what appears to be eventual consistency.

The only way to debug such issues without this patch from my point of view is either:

1. tcpdump + some kind of MITM proxy (because all traffic is encrypted), or
2. capture _every single_ request and response from each call, e.g. from `activitySvc.ListFeeds(ctx)` which would involve a lot of duplicated logic in many places (esp. in the case of Terraform) assuming we want to capture all requests and responses.

We've been able to debug various issues with a very similar pattern that is already part of AWS Go SDK, but I'm open to alternative solutions/suggestions to solve that problem.