### PR TITLE
Add pagination option to PullRequests.ListReviews.

### DIFF
--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -343,8 +343,13 @@ func (s *AuthorizationsService) Revoke(ctx context.Context, clientID string, tok
 // tokens an application has generated for the user.
 //
 // GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#list-your-grants
-func (s *AuthorizationsService) ListGrants(ctx context.Context) ([]*Grant, *Response, error) {
-	req, err := s.client.NewRequest("GET", "applications/grants", nil)
+func (s *AuthorizationsService) ListGrants(ctx context.Context, opt *ListOptions) ([]*Grant, *Response, error) {
+	u, err := addOptions("applications/grants", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/authorizations_test.go
+++ b/github/authorizations_test.go
@@ -260,7 +260,7 @@ func TestListGrants(t *testing.T) {
 		fmt.Fprint(w, `[{"id": 1}]`)
 	})
 
-	got, _, err := client.Authorizations.ListGrants(context.Background())
+	got, _, err := client.Authorizations.ListGrants(context.Background(), nil)
 	if err != nil {
 		t.Errorf("OAuthAuthorizations.ListGrants returned error: %v", err)
 	}
@@ -268,6 +268,24 @@ func TestListGrants(t *testing.T) {
 	want := []*Grant{{ID: Int(1)}}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("OAuthAuthorizations.ListGrants = %+v, want %+v", got, want)
+	}
+}
+
+func TestListGrants_withOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/applications/grants", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"page": "2",
+		})
+		fmt.Fprint(w, `[{"id": 1}]`)
+	})
+
+	_, _, err := client.Authorizations.ListGrants(context.Background(), &ListOptions{Page: 2})
+	if err != nil {
+		t.Errorf("OAuthAuthorizations.ListGrants returned error: %v", err)
 	}
 }
 

--- a/github/gists.go
+++ b/github/gists.go
@@ -241,8 +241,13 @@ func (s *GistsService) Edit(ctx context.Context, id string, gist *Gist) (*Gist, 
 // ListCommits lists commits of a gist.
 //
 // GitHub API docs: https://developer.github.com/v3/gists/#list-gist-commits
-func (s *GistsService) ListCommits(ctx context.Context, id string) ([]*GistCommit, *Response, error) {
+func (s *GistsService) ListCommits(ctx context.Context, id string, opt *ListOptions) ([]*GistCommit, *Response, error) {
 	u := fmt.Sprintf("gists/%v/commits", id)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -308,7 +308,7 @@ func TestGistsService_ListCommits(t *testing.T) {
 		`)
 	})
 
-	gistCommits, _, err := client.Gists.ListCommits(context.Background(), "1")
+	gistCommits, _, err := client.Gists.ListCommits(context.Background(), "1", nil)
 	if err != nil {
 		t.Errorf("Gists.ListCommits returned error: %v", err)
 	}
@@ -326,6 +326,24 @@ func TestGistsService_ListCommits(t *testing.T) {
 
 	if !reflect.DeepEqual(gistCommits, want) {
 		t.Errorf("Gists.ListCommits returned %+v, want %+v", gistCommits, want)
+	}
+}
+
+func TestGistsService_ListCommits_withOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/gists/1/commits", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"page": "2",
+		})
+		fmt.Fprint(w, `[]`)
+	})
+
+	_, _, err := client.Gists.ListCommits(context.Background(), "1", &ListOptions{Page: 2})
+	if err != nil {
+		t.Errorf("Gists.ListCommits returned error: %v", err)
 	}
 }
 

--- a/github/github.go
+++ b/github/github.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	libraryVersion = "6"
+	libraryVersion = "7"
 	defaultBaseURL = "https://api.github.com/"
 	uploadBaseURL  = "https://uploads.github.com/"
 	userAgent      = "go-github/" + libraryVersion

--- a/github/pulls_reviewers.go
+++ b/github/pulls_reviewers.go
@@ -41,8 +41,12 @@ func (s *PullRequestsService) RequestReviewers(ctx context.Context, owner, repo 
 // ListReviewers lists users whose reviews have been requested on the specified pull request.
 //
 // GitHub API docs: https://developer.github.com/v3/pulls/review_requests/#list-review-requests
-func (s *PullRequestsService) ListReviewers(ctx context.Context, owner, repo string, number int) ([]*User, *Response, error) {
+func (s *PullRequestsService) ListReviewers(ctx context.Context, owner, repo string, number int, opt *ListOptions) ([]*User, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/requested_reviewers", owner, repo, number)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/pulls_reviewers_test.go
+++ b/github/pulls_reviewers_test.go
@@ -61,7 +61,7 @@ func TestListReviewers(t *testing.T) {
 		fmt.Fprint(w, `[{"login":"octocat","id":1}]`)
 	})
 
-	reviewers, _, err := client.PullRequests.ListReviewers(context.Background(), "o", "r", 1)
+	reviewers, _, err := client.PullRequests.ListReviewers(context.Background(), "o", "r", 1, nil)
 	if err != nil {
 		t.Errorf("PullRequests.ListReviewers returned error: %v", err)
 	}
@@ -74,5 +74,24 @@ func TestListReviewers(t *testing.T) {
 	}
 	if !reflect.DeepEqual(reviewers, want) {
 		t.Errorf("PullRequests.ListReviewers returned %+v, want %+v", reviewers, want)
+	}
+}
+
+func TestListReviewers_withOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/pulls/1/requested_reviewers", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"page": "2",
+		})
+		testHeader(t, r, "Accept", mediaTypePullRequestReviewsPreview)
+		fmt.Fprint(w, `[]`)
+	})
+
+	_, _, err := client.PullRequests.ListReviewers(context.Background(), "o", "r", 1, &ListOptions{Page: 2})
+	if err != nil {
+		t.Errorf("PullRequests.ListReviewers returned error: %v", err)
 	}
 }

--- a/github/pulls_reviews.go
+++ b/github/pulls_reviews.go
@@ -149,9 +149,13 @@ func (s *PullRequestsService) DeletePendingReview(ctx context.Context, owner, re
 // returned error format and remove this comment once it's fixed.
 // Read more about it here - https://github.com/google/go-github/issues/540
 //
-// GitHub API docs: https://developer.github.com/v3/pulls/reviews/#get-a-single-reviews-comments
-func (s *PullRequestsService) ListReviewComments(ctx context.Context, owner, repo string, number, reviewID int) ([]*PullRequestComment, *Response, error) {
+// GitHub API docs: https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review
+func (s *PullRequestsService) ListReviewComments(ctx context.Context, owner, repo string, number, reviewID int, opt *ListOptions) ([]*PullRequestComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/reviews/%d/comments", owner, repo, number, reviewID)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/pulls_reviews.go
+++ b/github/pulls_reviews.go
@@ -65,8 +65,12 @@ func (r PullRequestReviewDismissalRequest) String() string {
 // Read more about it here - https://github.com/google/go-github/issues/540
 //
 // GitHub API docs: https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request
-func (s *PullRequestsService) ListReviews(ctx context.Context, owner, repo string, number int) ([]*PullRequestReview, *Response, error) {
+func (s *PullRequestsService) ListReviews(ctx context.Context, owner, repo string, number int, opt *ListOptions) ([]*PullRequestReview, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/reviews", owner, repo, number)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/pulls_reviews_test.go
+++ b/github/pulls_reviews_test.go
@@ -20,11 +20,15 @@ func TestPullRequestsService_ListReviews(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pulls/1/reviews", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"page": "2",
+		})
 		testHeader(t, r, "Accept", mediaTypePullRequestReviewsPreview)
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	reviews, _, err := client.PullRequests.ListReviews(context.Background(), "o", "r", 1)
+	opt := &ListOptions{Page: 2}
+	reviews, _, err := client.PullRequests.ListReviews(context.Background(), "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("PullRequests.ListReviews returned error: %v", err)
 	}
@@ -39,7 +43,7 @@ func TestPullRequestsService_ListReviews(t *testing.T) {
 }
 
 func TestPullRequestsService_ListReviews_invalidOwner(t *testing.T) {
-	_, _, err := client.PullRequests.ListReviews(context.Background(), "%", "r", 1)
+	_, _, err := client.PullRequests.ListReviews(context.Background(), "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
 

--- a/github/pulls_reviews_test.go
+++ b/github/pulls_reviews_test.go
@@ -109,7 +109,7 @@ func TestPullRequestsService_ListReviewComments(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	comments, _, err := client.PullRequests.ListReviewComments(context.Background(), "o", "r", 1, 1)
+	comments, _, err := client.PullRequests.ListReviewComments(context.Background(), "o", "r", 1, 1, nil)
 	if err != nil {
 		t.Errorf("PullRequests.ListReviewComments returned error: %v", err)
 	}
@@ -123,8 +123,27 @@ func TestPullRequestsService_ListReviewComments(t *testing.T) {
 	}
 }
 
+func TestPullRequestsService_ListReviewComments_withOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/pulls/1/reviews/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"page": "2",
+		})
+		testHeader(t, r, "Accept", mediaTypePullRequestReviewsPreview)
+		fmt.Fprint(w, `[]`)
+	})
+
+	_, _, err := client.PullRequests.ListReviewComments(context.Background(), "o", "r", 1, 1, &ListOptions{Page: 2})
+	if err != nil {
+		t.Errorf("PullRequests.ListReviewComments returned error: %v", err)
+	}
+}
+
 func TestPullRequestsService_ListReviewComments_invalidOwner(t *testing.T) {
-	_, _, err := client.PullRequests.ListReviewComments(context.Background(), "%", "r", 1, 1)
+	_, _, err := client.PullRequests.ListReviewComments(context.Background(), "%", "r", 1, 1, nil)
 	testURLParseError(t, err)
 }
 

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -61,8 +61,13 @@ func (s *RepositoriesService) GetPagesInfo(ctx context.Context, owner, repo stri
 // ListPagesBuilds lists the builds for a GitHub Pages site.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/pages/#list-pages-builds
-func (s *RepositoriesService) ListPagesBuilds(ctx context.Context, owner, repo string) ([]*PagesBuild, *Response, error) {
+func (s *RepositoriesService) ListPagesBuilds(ctx context.Context, owner, repo string, opt *ListOptions) ([]*PagesBuild, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pages/builds", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -43,7 +43,7 @@ func TestRepositoriesService_ListPagesBuilds(t *testing.T) {
 		fmt.Fprint(w, `[{"url":"u","status":"s","commit":"c"}]`)
 	})
 
-	pages, _, err := client.Repositories.ListPagesBuilds(context.Background(), "o", "r")
+	pages, _, err := client.Repositories.ListPagesBuilds(context.Background(), "o", "r", nil)
 	if err != nil {
 		t.Errorf("Repositories.ListPagesBuilds returned error: %v", err)
 	}
@@ -51,6 +51,24 @@ func TestRepositoriesService_ListPagesBuilds(t *testing.T) {
 	want := []*PagesBuild{{URL: String("u"), Status: String("s"), Commit: String("c")}}
 	if !reflect.DeepEqual(pages, want) {
 		t.Errorf("Repositories.ListPagesBuilds returned %+v, want %+v", pages, want)
+	}
+}
+
+func TestRepositoriesService_ListPagesBuilds_withOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/pages/builds", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"page": "2",
+		})
+		fmt.Fprint(w, `[]`)
+	})
+
+	_, _, err := client.Repositories.ListPagesBuilds(context.Background(), "o", "r", &ListOptions{Page: 2})
+	if err != nil {
+		t.Errorf("Repositories.ListPagesBuilds returned error: %v", err)
 	}
 }
 

--- a/github/users.go
+++ b/github/users.go
@@ -172,8 +172,13 @@ func (s *UsersService) ListAll(ctx context.Context, opt *UserListOptions) ([]*Us
 // authenticated user.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/invitations/#list-a-users-repository-invitations
-func (s *UsersService) ListInvitations(ctx context.Context) ([]*RepositoryInvitation, *Response, error) {
-	req, err := s.client.NewRequest("GET", "user/repository_invitations", nil)
+func (s *UsersService) ListInvitations(ctx context.Context, opt *ListOptions) ([]*RepositoryInvitation, *Response, error) {
+	u, err := addOptions("user/repository_invitations", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/users_test.go
+++ b/github/users_test.go
@@ -182,7 +182,7 @@ func TestUsersService_ListInvitations(t *testing.T) {
 		fmt.Fprintf(w, `[{"id":1}, {"id":2}]`)
 	})
 
-	got, _, err := client.Users.ListInvitations(context.Background())
+	got, _, err := client.Users.ListInvitations(context.Background(), nil)
 	if err != nil {
 		t.Errorf("Users.ListInvitations returned error: %v", err)
 	}
@@ -193,6 +193,24 @@ func TestUsersService_ListInvitations(t *testing.T) {
 	}
 }
 
+func TestUsersService_ListInvitations_withOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/repository_invitations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"page": "2",
+		})
+		testHeader(t, r, "Accept", mediaTypeRepositoryInvitationsPreview)
+		fmt.Fprintf(w, `[{"id":1}, {"id":2}]`)
+	})
+
+	_, _, err := client.Users.ListInvitations(context.Background(), &ListOptions{Page: 2})
+	if err != nil {
+		t.Errorf("Users.ListInvitations returned error: %v", err)
+	}
+}
 func TestUsersService_AcceptInvitation(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
This adds a ListOptions argument to ListReviews, so that pagination is
able to be supported. Without this it’s not possible to fetch the
2nd page of reviews, from what I can see.

Note that this does break the API, but I’ve added support for a nil
value in the argument, to minimise upgrade pain.