### PR TITLE
Simplify pagination example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ for {
 	if resp.NextPage == 0 {
 		break
 	}
-	opt.ListOptions.Page = resp.NextPage
+	opt.Page = resp.NextPage
 }
 ```
 

--- a/github/doc.go
+++ b/github/doc.go
@@ -153,7 +153,7 @@ github.Response struct.
 		if resp.NextPage == 0 {
 			break
 		}
-		opt.ListOptions.Page = resp.NextPage
+		opt.Page = resp.NextPage
 	}
 
 Google App Engine


### PR DESCRIPTION
In [`RepositoryListByOrgOptions`](https://godoc.org/github.com/google/go-github/github#RepositoryListByOrgOptions) struct, [`ListOptions`](https://godoc.org/github.com/google/go-github/github#ListOptions) struct is an [embedded field](https://golang.org/ref/spec#Struct_types), so it's possible to dereference `Page` without explicitly going through `ListOptions`.

This is shorter, simpler and readable.