### PR TITLE
Change Label.String behavior to use Stringify like all others.

### DIFF
--- a/github/issues_labels.go
+++ b/github/issues_labels.go
@@ -19,7 +19,7 @@ type Label struct {
 }
 
 func (l Label) String() string {
-	return fmt.Sprint(*l.Name)
+	return Stringify(l)
 }
 
 // ListLabels lists all labels for a repository.

--- a/github/strings_test.go
+++ b/github/strings_test.go
@@ -105,7 +105,7 @@ func TestString(t *testing.T) {
 		{IssueComment{ID: Int(1)}, `github.IssueComment{ID:1}`},
 		{Issue{Number: Int(1)}, `github.Issue{Number:1}`},
 		{Key{ID: Int(1)}, `github.Key{ID:1}`},
-		{Label{Name: String("l")}, "l"},
+		{Label{ID: Int(1), Name: String("l")}, `github.Label{ID:1, Name:"l"}`},
 		{Organization{ID: Int(1)}, `github.Organization{ID:1}`},
 		{PullRequestComment{ID: Int(1)}, `github.PullRequestComment{ID:1}`},
 		{PullRequest{Number: Int(1)}, `github.PullRequest{Number:1}`},


### PR DESCRIPTION
The previous behavior was inconsistent, and not documented, so no one could actually rely on it. If custom printing behavior is needed, it should be done in a helper func or a wrapper type that implements desired printing behavior, and documents it.

There was agreement in #595 that this is the best thing to do.

Fixes #595.

/cc @yml FYI, since you might be relying on this behavior.