### PR TITLE
Add missing URL fields to CommitsComparison struct.

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -564,6 +564,38 @@ func (c *CommitsComparison) GetBehindBy() int {
 	return *c.BehindBy
 }
 
+// GetDiffURL returns the DiffURL field if it's non-nil, zero value otherwise.
+func (c *CommitsComparison) GetDiffURL() string {
+	if c == nil || c.DiffURL == nil {
+		return ""
+	}
+	return *c.DiffURL
+}
+
+// GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
+func (c *CommitsComparison) GetHTMLURL() string {
+	if c == nil || c.HTMLURL == nil {
+		return ""
+	}
+	return *c.HTMLURL
+}
+
+// GetPatchURL returns the PatchURL field if it's non-nil, zero value otherwise.
+func (c *CommitsComparison) GetPatchURL() string {
+	if c == nil || c.PatchURL == nil {
+		return ""
+	}
+	return *c.PatchURL
+}
+
+// GetPermalinkURL returns the PermalinkURL field if it's non-nil, zero value otherwise.
+func (c *CommitsComparison) GetPermalinkURL() string {
+	if c == nil || c.PermalinkURL == nil {
+		return ""
+	}
+	return *c.PermalinkURL
+}
+
 // GetStatus returns the Status field if it's non-nil, zero value otherwise.
 func (c *CommitsComparison) GetStatus() string {
 	if c == nil || c.Status == nil {
@@ -578,6 +610,14 @@ func (c *CommitsComparison) GetTotalCommits() int {
 		return 0
 	}
 	return *c.TotalCommits
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (c *CommitsComparison) GetURL() string {
+	if c == nil || c.URL == nil {
+		return ""
+	}
+	return *c.URL
 }
 
 // GetIncompleteResults returns the IncompleteResults field if it's non-nil, zero value otherwise.

--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -82,9 +82,9 @@ type CommitsComparison struct {
 
 	HTMLURL      *string `json:"html_url,omitempty"`
 	PermalinkURL *string `json:"permalink_url,omitempty"`
-	URL          *string `json:"url,omitempty"`
 	DiffURL      *string `json:"diff_url,omitempty"`
 	PatchURL     *string `json:"patch_url,omitempty"`
+	URL          *string `json:"url,omitempty"` // API URL.
 }
 
 func (c CommitsComparison) String() string {

--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -79,6 +79,12 @@ type CommitsComparison struct {
 	Commits []RepositoryCommit `json:"commits,omitempty"`
 
 	Files []CommitFile `json:"files,omitempty"`
+
+	HTMLURL      *string `json:"html_url,omitempty"`
+	PermalinkURL *string `json:"permalink_url,omitempty"`
+	URL          *string `json:"url,omitempty"`
+	DiffURL      *string `json:"diff_url,omitempty"`
+	PatchURL     *string `json:"patch_url,omitempty"`
 }
 
 func (c CommitsComparison) String() string {

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -199,11 +199,11 @@ func TestRepositoriesService_CompareCommits(t *testing.T) {
 		    }
 		  ],
 		  "files": [ { "filename": "f" } ],
-		  "html_url":      "https://github.com/o/h/compare/b...h",
-		  "permalink_url": "https://github.com/o/h/compare/o:bbcd538c8e72b8c175046e27cc8f907076331401...o:0328041d1152db8ae77652d1618a02e57f745f17",
-		  "diff_url":      "https://github.com/o/h/compare/b...h.diff",
-		  "patch_url":     "https://github.com/o/h/compare/b...h.patch",
-		  "url":           "https://api.github.com/repos/o/h/compare/b...h"
+		  "html_url":      "https://github.com/o/r/compare/b...h",
+		  "permalink_url": "https://github.com/o/r/compare/o:bbcd538c8e72b8c175046e27cc8f907076331401...o:0328041d1152db8ae77652d1618a02e57f745f17",
+		  "diff_url":      "https://github.com/o/r/compare/b...h.diff",
+		  "patch_url":     "https://github.com/o/r/compare/b...h.patch",
+		  "url":           "https://api.github.com/repos/o/r/compare/b...h"
 		}`)
 	})
 
@@ -253,11 +253,11 @@ func TestRepositoriesService_CompareCommits(t *testing.T) {
 				Filename: String("f"),
 			},
 		},
-		HTMLURL:      String("https://github.com/o/h/compare/b...h"),
-		PermalinkURL: String("https://github.com/o/h/compare/o:bbcd538c8e72b8c175046e27cc8f907076331401...o:0328041d1152db8ae77652d1618a02e57f745f17"),
-		DiffURL:      String("https://github.com/o/h/compare/b...h.diff"),
-		PatchURL:     String("https://github.com/o/h/compare/b...h.patch"),
-		URL:          String("https://api.github.com/repos/o/h/compare/b...h"),
+		HTMLURL:      String("https://github.com/o/r/compare/b...h"),
+		PermalinkURL: String("https://github.com/o/r/compare/o:bbcd538c8e72b8c175046e27cc8f907076331401...o:0328041d1152db8ae77652d1618a02e57f745f17"),
+		DiffURL:      String("https://github.com/o/r/compare/b...h.diff"),
+		PatchURL:     String("https://github.com/o/r/compare/b...h.patch"),
+		URL:          String("https://api.github.com/repos/o/r/compare/b...h"),
 	}
 
 	if !reflect.DeepEqual(got, want) {

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -198,7 +198,12 @@ func TestRepositoriesService_CompareCommits(t *testing.T) {
 		      "parents": [ { "sha": "s" } ]
 		    }
 		  ],
-		  "files": [ { "filename": "f" } ]
+		  "files": [ { "filename": "f" } ],
+		  "html_url":      "https://github.com/o/h/compare/b...h",
+		  "permalink_url": "https://github.com/o/h/compare/o:bbcd538c8e72b8c175046e27cc8f907076331401...o:0328041d1152db8ae77652d1618a02e57f745f17",
+		  "diff_url":      "https://github.com/o/h/compare/b...h.diff",
+		  "patch_url":     "https://github.com/o/h/compare/b...h.patch",
+		  "url":           "https://api.github.com/repos/o/h/compare/b...h"
 		}`)
 	})
 
@@ -248,6 +253,11 @@ func TestRepositoriesService_CompareCommits(t *testing.T) {
 				Filename: String("f"),
 			},
 		},
+		HTMLURL:      String("https://github.com/o/h/compare/b...h"),
+		PermalinkURL: String("https://github.com/o/h/compare/o:bbcd538c8e72b8c175046e27cc8f907076331401...o:0328041d1152db8ae77652d1618a02e57f745f17"),
+		DiffURL:      String("https://github.com/o/h/compare/b...h.diff"),
+		PatchURL:     String("https://github.com/o/h/compare/b...h.patch"),
+		URL:          String("https://api.github.com/repos/o/h/compare/b...h"),
 	}
 
 	if !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
They are documented in the sample response at https://developer.github.com/v3/repos/commits/#compare-two-commits. I also confirmed the fields are present in a real GitHub API response:

<details>

```
GET https://api.github.com/repos/robpike/ivy/compare/dev...master

{
  "url": "https://api.github.com/repos/robpike/ivy/compare/dev...master",
  "html_url": "https://github.com/robpike/ivy/compare/dev...master",
  "permalink_url": "https://github.com/robpike/ivy/compare/robpike:5bded9c...robpike:37dab08",
  "diff_url": "https://github.com/robpike/ivy/compare/dev...master.diff",
  "patch_url": "https://github.com/robpike/ivy/compare/dev...master.patch",
  "base_commit": {
    "sha": "5bded9c912dced5a0e13acaea6169c77608ac22e",
    "commit": {
      "author": {
        "name": "Rob Pike",
        "email": "r@golang.org",
        "date": "2017-03-31T02:43:14Z"
      },
      "committer": {
        "name": "Rob Pike",
        "email": "r@golang.org",
        "date": "2017-03-31T02:43:14Z"
      },
      "message": "value: make assignment-as-expression work everywhere\n\nIn an earlier CL we introduced an Assignment type in the parser that\nwraps an expression created by assignment. This serves to suppress\nprinting of such values, but it causes problems in a number of places\nthat do type switches to see what they are holding.\n\nResolve this by introducing a trivial new method to Value: Inner,\nwhich just returns the value. But for the embedded Value in an\nAssignment, it pokes through to the inner true value, giving the\nright type for the expression.\n\nWhile we're here, tidy up a few things and implement an odd detail\nof APL that allows an assignment to a vector element make the\nvariable available anywhere else in the vector:\n\n\t(x=3) x\n\t\t3 3\n\ty (y=4)\n\t\t4 4",
      "tree": {
        "sha": "cdca36649eda834af43a78ca11e019972c43701c",
        "url": "https://api.github.com/repos/robpike/ivy/git/trees/cdca36649eda834af43a78ca11e019972c43701c"
      },
      "url": "https://api.github.com/repos/robpike/ivy/git/commits/5bded9c912dced5a0e13acaea6169c77608ac22e",
      "comment_count": 0
    },
    "url": "https://api.github.com/repos/robpike/ivy/commits/5bded9c912dced5a0e13acaea6169c77608ac22e",
    "html_url": "https://github.com/robpike/ivy/commit/5bded9c912dced5a0e13acaea6169c77608ac22e",
    "comments_url": "https://api.github.com/repos/robpike/ivy/commits/5bded9c912dced5a0e13acaea6169c77608ac22e/comments",
    "author": {
      "login": "robpike",
      "id": 4324516,
      "avatar_url": "https://avatars3.githubusercontent.com/u/4324516?v=3",
      "gravatar_id": "",
      "url": "https://api.github.com/users/robpike",
      "html_url": "https://github.com/robpike",
      "followers_url": "https://api.github.com/users/robpike/followers",
      "following_url": "https://api.github.com/users/robpike/following{/other_user}",
      "gists_url": "https://api.github.com/users/robpike/gists{/gist_id}",
      "starred_url": "https://api.github.com/users/robpike/starred{/owner}{/repo}",
      "subscriptions_url": "https://api.github.com/users/robpike/subscriptions",
      "organizations_url": "https://api.github.com/users/robpike/orgs",
      "repos_url": "https://api.github.com/users/robpike/repos",
      "events_url": "https://api.github.com/users/robpike/events{/privacy}",
      "received_events_url": "https://api.github.com/users/robpike/received_events",
      "type": "User",
      "site_admin": false
    },
    "committer": {
      "login": "robpike",
      "id": 4324516,
      "avatar_url": "https://avatars3.githubusercontent.com/u/4324516?v=3",
      "gravatar_id": "",
      "url": "https://api.github.com/users/robpike",
      "html_url": "https://github.com/robpike",
      "followers_url": "https://api.github.com/users/robpike/followers",
      "following_url": "https://api.github.com/users/robpike/following{/other_user}",
      "gists_url": "https://api.github.com/users/robpike/gists{/gist_id}",
      "starred_url": "https://api.github.com/users/robpike/starred{/owner}{/repo}",
      "subscriptions_url": "https://api.github.com/users/robpike/subscriptions",
      "organizations_url": "https://api.github.com/users/robpike/orgs",
      "repos_url": "https://api.github.com/users/robpike/repos",
      "events_url": "https://api.github.com/users/robpike/events{/privacy}",
      "received_events_url": "https://api.github.com/users/robpike/received_events",
      "type": "User",
      "site_admin": false
    },
    "parents": [
      {
        "sha": "3432b2213cef4daf636841ba3cbb3bcc886fdb86",
        "url": "https://api.github.com/repos/robpike/ivy/commits/3432b2213cef4daf636841ba3cbb3bcc886fdb86",
        "html_url": "https://github.com/robpike/ivy/commit/3432b2213cef4daf636841ba3cbb3bcc886fdb86"
      }
    ]
  },
  "merge_base_commit": {
    "sha": "e696326a83948dfec322b01146752cdd9f62b598",
    "commit": {
      "author": {
        "name": "Rob Pike",
        "email": "r@golang.org",
        "date": "2016-07-30T23:22:40Z"
      },
      "committer": {
        "name": "Rob Pike",
        "email": "r@golang.org",
        "date": "2016-07-30T23:22:40Z"
      },
      "message": "parse: more simplifications",
      "tree": {
        "sha": "9f8188957d06b4051e157bf0aeb3af15ab2820ac",
        "url": "https://api.github.com/repos/robpike/ivy/git/trees/9f8188957d06b4051e157bf0aeb3af15ab2820ac"
      },
      "url": "https://api.github.com/repos/robpike/ivy/git/commits/e696326a83948dfec322b01146752cdd9f62b598",
      "comment_count": 0
    },
    "url": "https://api.github.com/repos/robpike/ivy/commits/e696326a83948dfec322b01146752cdd9f62b598",
    "html_url": "https://github.com/robpike/ivy/commit/e696326a83948dfec322b01146752cdd9f62b598",
    "comments_url": "https://api.github.com/repos/robpike/ivy/commits/e696326a83948dfec322b01146752cdd9f62b598/comments",
    "author": {
      "login": "robpike",
      "id": 4324516,
      "avatar_url": "https://avatars3.githubusercontent.com/u/4324516?v=3",
      "gravatar_id": "",
      "url": "https://api.github.com/users/robpike",
      "html_url": "https://github.com/robpike",
      "followers_url": "https://api.github.com/users/robpike/followers",
      "following_url": "https://api.github.com/users/robpike/following{/other_user}",
      "gists_url": "https://api.github.com/users/robpike/gists{/gist_id}",
      "starred_url": "https://api.github.com/users/robpike/starred{/owner}{/repo}",
      "subscriptions_url": "https://api.github.com/users/robpike/subscriptions",
      "organizations_url": "https://api.github.com/users/robpike/orgs",
      "repos_url": "https://api.github.com/users/robpike/repos",
      "events_url": "https://api.github.com/users/robpike/events{/privacy}",
      "received_events_url": "https://api.github.com/users/robpike/received_events",
      "type": "User",
      "site_admin": false
    },
    "committer": {
      "login": "robpike",
      "id": 4324516,
      "avatar_url": "https://avatars3.githubusercontent.com/u/4324516?v=3",
      "gravatar_id": "",
      "url": "https://api.github.com/users/robpike",
      "html_url": "https://github.com/robpike",
      "followers_url": "https://api.github.com/users/robpike/followers",
      "following_url": "https://api.github.com/users/robpike/following{/other_user}",
      "gists_url": "https://api.github.com/users/robpike/gists{/gist_id}",
      "starred_url": "https://api.github.com/users/robpike/starred{/owner}{/repo}",
      "subscriptions_url": "https://api.github.com/users/robpike/subscriptions",
      "organizations_url": "https://api.github.com/users/robpike/orgs",
      "repos_url": "https://api.github.com/users/robpike/repos",
      "events_url": "https://api.github.com/users/robpike/events{/privacy}",
      "received_events_url": "https://api.github.com/users/robpike/received_events",
      "type": "User",
      "site_admin": false
    },
    "parents": [
      {
        "sha": "18a72e7203454e989cf82927d17b9054654d0093",
        "url": "https://api.github.com/repos/robpike/ivy/commits/18a72e7203454e989cf82927d17b9054654d0093",
        "html_url": "https://github.com/robpike/ivy/commit/18a72e7203454e989cf82927d17b9054654d0093"
      }
    ]
  },
  "status": "diverged",
  "ahead_by": 2,
  "behind_by": 19,
  "total_commits": 2,
  "commits": [
    {
      "sha": "123a01c425422ead6aef6af6f9e78692d361487f",
      "commit": {
        "author": {
          "name": "Radu Berinde",
          "email": "radu@cockroachlabs.com",
          "date": "2017-02-03T23:19:24Z"
        },
        "committer": {
          "name": "Radu Berinde",
          "email": "radu@cockroachlabs.com",
          "date": "2017-02-05T13:58:40Z"
        },
        "message": "better loop termination condition\n\nReplace the questionable \"previous delta equals current delta\" condition with a\ncondition that checks if delta is small (as small than the last bit of\nprecision).\n\nFixes #31.",
        "tree": {
          "sha": "1873ddeecaa2b71f20f6b2b6514b4adb3e29a5ab",
          "url": "https://api.github.com/repos/robpike/ivy/git/trees/1873ddeecaa2b71f20f6b2b6514b4adb3e29a5ab"
        },
        "url": "https://api.github.com/repos/robpike/ivy/git/commits/123a01c425422ead6aef6af6f9e78692d361487f",
        "comment_count": 0
      },
      "url": "https://api.github.com/repos/robpike/ivy/commits/123a01c425422ead6aef6af6f9e78692d361487f",
      "html_url": "https://github.com/robpike/ivy/commit/123a01c425422ead6aef6af6f9e78692d361487f",
      "comments_url": "https://api.github.com/repos/robpike/ivy/commits/123a01c425422ead6aef6af6f9e78692d361487f/comments",
      "author": {
        "login": "RaduBerinde",
        "id": 16544120,
        "avatar_url": "https://avatars2.githubusercontent.com/u/16544120?v=3",
        "gravatar_id": "",
        "url": "https://api.github.com/users/RaduBerinde",
        "html_url": "https://github.com/RaduBerinde",
        "followers_url": "https://api.github.com/users/RaduBerinde/followers",
        "following_url": "https://api.github.com/users/RaduBerinde/following{/other_user}",
        "gists_url": "https://api.github.com/users/RaduBerinde/gists{/gist_id}",
        "starred_url": "https://api.github.com/users/RaduBerinde/starred{/owner}{/repo}",
        "subscriptions_url": "https://api.github.com/users/RaduBerinde/subscriptions",
        "organizations_url": "https://api.github.com/users/RaduBerinde/orgs",
        "repos_url": "https://api.github.com/users/RaduBerinde/repos",
        "events_url": "https://api.github.com/users/RaduBerinde/events{/privacy}",
        "received_events_url": "https://api.github.com/users/RaduBerinde/received_events",
        "type": "User",
        "site_admin": false
      },
      "committer": {
        "login": "RaduBerinde",
        "id": 16544120,
        "avatar_url": "https://avatars2.githubusercontent.com/u/16544120?v=3",
        "gravatar_id": "",
        "url": "https://api.github.com/users/RaduBerinde",
        "html_url": "https://github.com/RaduBerinde",
        "followers_url": "https://api.github.com/users/RaduBerinde/followers",
        "following_url": "https://api.github.com/users/RaduBerinde/following{/other_user}",
        "gists_url": "https://api.github.com/users/RaduBerinde/gists{/gist_id}",
        "starred_url": "https://api.github.com/users/RaduBerinde/starred{/owner}{/repo}",
        "subscriptions_url": "https://api.github.com/users/RaduBerinde/subscriptions",
        "organizations_url": "https://api.github.com/users/RaduBerinde/orgs",
        "repos_url": "https://api.github.com/users/RaduBerinde/repos",
        "events_url": "https://api.github.com/users/RaduBerinde/events{/privacy}",
        "received_events_url": "https://api.github.com/users/RaduBerinde/received_events",
        "type": "User",
        "site_admin": false
      },
      "parents": [
        {
          "sha": "e696326a83948dfec322b01146752cdd9f62b598",
          "url": "https://api.github.com/repos/robpike/ivy/commits/e696326a83948dfec322b01146752cdd9f62b598",
          "html_url": "https://github.com/robpike/ivy/commit/e696326a83948dfec322b01146752cdd9f62b598"
        }
      ]
    },
    {
      "sha": "37dab0894d040e516fb3c2e2c332df39eeb5aab7",
      "commit": {
        "author": {
          "name": "Rob Pike",
          "email": "r@golang.org",
          "date": "2017-02-05T16:24:45Z"
        },
        "committer": {
          "name": "GitHub",
          "email": "noreply@github.com",
          "date": "2017-02-05T16:24:45Z"
        },
        "message": "Merge pull request #32 from RaduBerinde/loop-termination\n\nbetter loop termination condition",
        "tree": {
          "sha": "1873ddeecaa2b71f20f6b2b6514b4adb3e29a5ab",
          "url": "https://api.github.com/repos/robpike/ivy/git/trees/1873ddeecaa2b71f20f6b2b6514b4adb3e29a5ab"
        },
        "url": "https://api.github.com/repos/robpike/ivy/git/commits/37dab0894d040e516fb3c2e2c332df39eeb5aab7",
        "comment_count": 0
      },
      "url": "https://api.github.com/repos/robpike/ivy/commits/37dab0894d040e516fb3c2e2c332df39eeb5aab7",
      "html_url": "https://github.com/robpike/ivy/commit/37dab0894d040e516fb3c2e2c332df39eeb5aab7",
      "comments_url": "https://api.github.com/repos/robpike/ivy/commits/37dab0894d040e516fb3c2e2c332df39eeb5aab7/comments",
      "author": {
        "login": "robpike",
        "id": 4324516,
        "avatar_url": "https://avatars3.githubusercontent.com/u/4324516?v=3",
        "gravatar_id": "",
        "url": "https://api.github.com/users/robpike",
        "html_url": "https://github.com/robpike",
        "followers_url": "https://api.github.com/users/robpike/followers",
        "following_url": "https://api.github.com/users/robpike/following{/other_user}",
        "gists_url": "https://api.github.com/users/robpike/gists{/gist_id}",
        "starred_url": "https://api.github.com/users/robpike/starred{/owner}{/repo}",
        "subscriptions_url": "https://api.github.com/users/robpike/subscriptions",
        "organizations_url": "https://api.github.com/users/robpike/orgs",
        "repos_url": "https://api.github.com/users/robpike/repos",
        "events_url": "https://api.github.com/users/robpike/events{/privacy}",
        "received_events_url": "https://api.github.com/users/robpike/received_events",
        "type": "User",
        "site_admin": false
      },
      "committer": {
        "login": "web-flow",
        "id": 19864447,
        "avatar_url": "https://avatars0.githubusercontent.com/u/19864447?v=3",
        "gravatar_id": "",
        "url": "https://api.github.com/users/web-flow",
        "html_url": "https://github.com/web-flow",
        "followers_url": "https://api.github.com/users/web-flow/followers",
        "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
        "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
        "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
        "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
        "organizations_url": "https://api.github.com/users/web-flow/orgs",
        "repos_url": "https://api.github.com/users/web-flow/repos",
        "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
        "received_events_url": "https://api.github.com/users/web-flow/received_events",
        "type": "User",
        "site_admin": false
      },
      "parents": [
        {
          "sha": "e696326a83948dfec322b01146752cdd9f62b598",
          "url": "https://api.github.com/repos/robpike/ivy/commits/e696326a83948dfec322b01146752cdd9f62b598",
          "html_url": "https://github.com/robpike/ivy/commit/e696326a83948dfec322b01146752cdd9f62b598"
        },
        {
          "sha": "123a01c425422ead6aef6af6f9e78692d361487f",
          "url": "https://api.github.com/repos/robpike/ivy/commits/123a01c425422ead6aef6af6f9e78692d361487f",
          "html_url": "https://github.com/robpike/ivy/commit/123a01c425422ead6aef6af6f9e78692d361487f"
        }
      ]
    }
  ],
  "files": [
    {
      "sha": "21b8e3b4b844d931ba3b06d89665e5350057c919",
      "filename": "demo/demo.out",
      "status": "modified",
      "additions": 1,
      "deletions": 1,
      "changes": 2,
      "blob_url": "https://github.com/robpike/ivy/blob/37dab0894d040e516fb3c2e2c332df39eeb5aab7/demo/demo.out",
      "raw_url": "https://github.com/robpike/ivy/raw/37dab0894d040e516fb3c2e2c332df39eeb5aab7/demo/demo.out",
      "contents_url": "https://api.github.com/repos/robpike/ivy/contents/demo/demo.out?ref=37dab0894d040e516fb3c2e2c332df39eeb5aab7",
      "patch": "@@ -293,7 +293,7 @@ obase\t10\n 2302585.09299\n 1\n 1 0.707106781187 7.70893799599e-78 -0.707106781187 -1 -0.707106781187 2.38604460223e-76 0.707106781187 1\n-6.90893484408e-77 0.69314718056 1.09861228867 1.38629436112 1.60943791243 1.79175946923\n+7.77255169959e-77 0.69314718056 1.09861228867 1.38629436112 1.60943791243 1.79175946923\n 2.5937424601 2.70481382942 2.71692393224 2.71814592683 2.71826823717 2.71828046932 2.71828169254 2.71828181487 2.7182818271\n 2.71828182846\n 2.718281828459045235360287471352662497757247093699959574966967627724076630353547594571382178525166427427466391932003059921817413596629043572900334295260595630738132328627943490763233829880753195251019011573834187930702154089149934884167509244761460668082264800168477411853742345442437107539077744992069551702761838606261331384583000752044933826560297606737113200709328709127443747047230696977209310141692836819025515108657463772111252389784425056953696770785449969967946864454905987931636889230098793127736178215424999229576351482208269895193668033182528869398496465105820939239829488793320362509443117301238197068416140397019837679320683282376464804295311802328782509819455815301756717361332069811250996181881593041690351598888519345807273866738589422879228499892086805825749279610484198444363463244968487560233624827041978623209002160990235304369941849146314093431738143640546253152096183690888707016768396424378140592714563549061303107208510383750510115747704171898610687396965521267154688957035035"
    },
    {
      "sha": "1ff444d41fd2c86efb018f75af935adf46b32ae8",
      "filename": "value/loop.go",
      "status": "modified",
      "additions": 9,
      "deletions": 23,
      "changes": 32,
      "blob_url": "https://github.com/robpike/ivy/blob/37dab0894d040e516fb3c2e2c332df39eeb5aab7/value/loop.go",
      "raw_url": "https://github.com/robpike/ivy/raw/37dab0894d040e516fb3c2e2c332df39eeb5aab7/value/loop.go",
      "contents_url": "https://api.github.com/repos/robpike/ivy/contents/value/loop.go?ref=37dab0894d040e516fb3c2e2c332df39eeb5aab7",
      "patch": "@@ -14,11 +14,9 @@ type loop struct {\n \tname          string     // The name of the function we are evaluating.\n \ti             uint64     // Loop count.\n \tmaxIterations uint64     // When to give up.\n-\tstallCount    int        // Iterations since |delta| changed.\n \targ           *big.Float // original argument to function; only used for diagnostic.\n \tprevZ         *big.Float // Result from the previous iteration.\n \tdelta         *big.Float // |Change| from previous iteration.\n-\tprevDelta     *big.Float // Delta from the previous iteration.\n }\n \n // newLoop returns a new loop checker. The arguments are the name\n@@ -33,44 +31,32 @@ func newLoop(conf *config.Config, name string, x *big.Float, itersPerBit uint) *\n \t\tmaxIterations: 10 + uint64(itersPerBit*conf.FloatPrec()),\n \t\tprevZ:         newF(conf),\n \t\tdelta:         newF(conf),\n-\t\tprevDelta:     newF(conf),\n \t}\n }\n \n // done reports whether the loop is done. If it does not converge\n // after the maximum number of iterations, it errors out.\n func (l *loop) done(z *big.Float) bool {\n \tl.delta.Sub(l.prevZ, z)\n-\tif l.delta.Sign() == 0 {\n+\tsign := l.delta.Sign()\n+\tif sign == 0 {\n \t\treturn true\n \t}\n-\tif l.delta.Sign() < 0 {\n-\t\t// Convergence can oscillate when the calculation is nearly\n-\t\t// done and we're running out of bits. This stops that.\n-\t\t// See next comment.\n+\tif sign < 0 {\n \t\tl.delta.Neg(l.delta)\n \t}\n-\tif l.delta.Cmp(l.prevDelta) == 0 {\n-\t\t// In freaky cases (like e**3) we can hit the same large positive\n-\t\t// and then  large negative value (4.5, -4.5) so we count a few times\n-\t\t// to see that it really has stalled. Avoids having to do hard math,\n-\t\t// but it means we may iterate a few extra times. Usually, though,\n-\t\t// iteration is stopped by the zero check above, so this is fine.\n-\t\tl.stallCount++\n-\t\tif l.stallCount > 3 {\n-\t\t\t// Convergence has stopped.\n-\t\t\treturn true\n-\t\t}\n-\t} else {\n-\t\tl.stallCount = 0\n+\t// Check if delta is no bigger than the smallest change in z that can be\n+\t// represented with the given precision.\n+\tvar eps big.Float\n+\teps.SetMantExp(eps.SetUint64(1), z.MantExp(nil)-int(z.Prec()))\n+\tif l.delta.Cmp(&eps) <= 0 {\n+\t\treturn true\n \t}\n \tl.i++\n \tif l.i == l.maxIterations {\n \t\t// Users should never see this.\n \t\tErrorf(\"%s %s: did not converge after %d iterations; prev,last result %s,%s delta %s\", l.name, l.arg, l.maxIterations, BigFloat{z}, BigFloat{l.prevZ}, BigFloat{l.delta})\n \t}\n-\tl.prevDelta.Set(l.delta)\n \tl.prevZ.Set(z)\n \treturn false\n-\n }"
    }
  ]
}
```

</details><br>

Fixes #643.