### PR TITLE
Add link to GitHub Apps authentication package in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,26 @@ See the [oauth2 docs][] for complete instructions on using that library.
 For API methods that require HTTP Basic Authentication, use the
 [`BasicAuthTransport`](https://godoc.org/github.com/google/go-github/github#BasicAuthTransport).
 
+GitHub Apps authentication can be provided by the [ghinstallation](https://github.com/bradleyfalzon/ghinstallation)
+package.
+
+```go
+import "github.com/bradleyfalzon/ghinstallation"
+
+func main() {
+  // Wrap the shared transport for use with the integration ID 1 authenticating with installation ID 99.
+  itr, err := ghinstallation.NewKeyFromFile(http.DefaultTransport, 1, 99, "2016-10-19.private-key.pem")
+  if err != nil {
+    // Handle error.
+  }
+
+  // Use installation transport with client.
+  client := github.NewClient(&http.Client{Transport: itr})
+
+  // Use client...
+}
+```
+
 ### Rate Limiting ###
 
 GitHub imposes a rate limit on all API clients. Unauthenticated clients are

--- a/github/doc.go
+++ b/github/doc.go
@@ -63,6 +63,24 @@ See the oauth2 docs for complete instructions on using that library.
 For API methods that require HTTP Basic Authentication, use the
 BasicAuthTransport.
 
+GitHub Apps authentication can be provided by the
+https://github.com/bradleyfalzon/ghinstallation package.
+
+	import "github.com/bradleyfalzon/ghinstallation"
+
+	func main() {
+		// Wrap the shared transport for use with the integration ID 1 authenticating with installation ID 99.
+		itr, err := ghinstallation.NewKeyFromFile(http.DefaultTransport, 1, 99, "2016-10-19.private-key.pem")
+		if err != nil {
+			// Handle error.
+		}
+
+		// Use installation transport with client
+		client := github.NewClient(&http.Client{Transport: itr})
+
+		// Use client...
+	}
+
 Rate Limiting
 
 GitHub imposes a rate limit on all API clients. Unauthenticated clients are


### PR DESCRIPTION
As discussed in #627 I have a package which provides the GitHub Apps Authentication as an Installation `http.RoundTripper` that I use with this GitHub library successfully. I'm happy to keep maintaining it in an external repository, but a link from this library may assist others in finding the package.

Relates to #455.