### PR TITLE
Add support for 'team' events

### DIFF
--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -92,6 +92,8 @@ func (e *Event) ParsePayload() (payload interface{}, err error) {
 		payload = &RepositoryEvent{}
 	case "StatusEvent":
 		payload = &StatusEvent{}
+	case "TeamEvent":
+		payload = &TeamEvent{}
 	case "TeamAddEvent":
 		payload = &TeamAddEvent{}
 	case "WatchEvent":

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -165,6 +165,28 @@ type ProjectColumnChange struct {
 	} `json:"name,omitempty"`
 }
 
+// TeamChange represents the changes when a team has been edited.
+type TeamChange struct {
+	Description *struct {
+		From *string `json:"from,omitempty"`
+	} `json:"description,omitempty"`
+	Name *struct {
+		From *string `json:"from,omitempty"`
+	} `json:"name,omitempty"`
+	Privacy *struct {
+		From *string `json:"from,omitempty"`
+	} `json:"privacy,omitempty"`
+	Repository *struct {
+		Permissions *struct {
+			From *struct {
+				Admin *string `json:"admin,omitempty"`
+				Pull  *string `json:"pull,omitempty"`
+				Push  *string `json:"push,omitempty"`
+			} `json:"from,omitempty"`
+		} `json:"permissions,omitempty"`
+	} `json:"repository,omitempty"`
+}
+
 // IntegrationInstallationEvent is triggered when an integration is created or deleted.
 // The Webhook event name is "integration_installation".
 //
@@ -651,6 +673,25 @@ type StatusEvent struct {
 	Repo         *Repository       `json:"repository,omitempty"`
 	Sender       *User             `json:"sender,omitempty"`
 	Installation *Installation     `json:"installation,omitempty"`
+}
+
+// TeamEvent is triggered when an organization's team is created, modified or deleted.
+// The Webhook event name is "team".
+//
+// Events of this type are not visible in timelines. These events are only used
+// to trigger hooks.
+//
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#teamevent
+type TeamEvent struct {
+	Action  *string     `json:"action,omitempty"`
+	Team    *Team       `json:"team,omitempty"`
+	Changes *TeamChange `json:"changes,omitempty"`
+	Repo    *Repository `json:"repository,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Org          *Organization `json:"organization,omitempty"`
+	Sender       *User         `json:"sender,omitempty"`
+	Installation *Installation `json:"installation,omitempty"`
 }
 
 // TeamAddEvent is triggered when a repository is added to a team.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6404,6 +6404,14 @@ func (t *Team) GetURL() string {
 	return *t.URL
 }
 
+// GetAction returns the Action field if it's non-nil, zero value otherwise.
+func (t *TeamEvent) GetAction() string {
+	if t == nil || t.Action == nil {
+		return ""
+	}
+	return *t.Action
+}
+
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
 func (t *TeamLDAPMapping) GetDescription() string {
 	if t == nil || t.Description == nil {

--- a/github/messages.go
+++ b/github/messages.go
@@ -70,6 +70,7 @@ var (
 		"repository":                            "RepositoryEvent",
 		"release":                               "ReleaseEvent",
 		"status":                                "StatusEvent",
+		"team":                                  "TeamEvent",
 		"team_add":                              "TeamAddEvent",
 		"watch":                                 "WatchEvent",
 	}

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -201,6 +201,10 @@ func TestParseWebHook(t *testing.T) {
 			messageType: "status",
 		},
 		{
+			payload:     &TeamEvent{},
+			messageType: "team",
+		},
+		{
 			payload:     &TeamAddEvent{},
 			messageType: "team_add",
 		},


### PR DESCRIPTION
The team event was announced in this post:
https://developer.github.com/changes/2016-11-29-user-management-webhooks/

The API documentation is at:
https://developer.github.com/v3/activity/events/types/#teamevent

The "Changes" object in the response is not illustrated in
the example payload, but it is documented in the table of fields.

Closes #652.