### PR TITLE
Fix type in team event fields

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -179,9 +179,9 @@ type TeamChange struct {
 	Repository *struct {
 		Permissions *struct {
 			From *struct {
-				Admin *string `json:"admin,omitempty"`
-				Pull  *string `json:"pull,omitempty"`
-				Push  *string `json:"push,omitempty"`
+				Admin *bool `json:"admin,omitempty"`
+				Pull  *bool `json:"pull,omitempty"`
+				Push  *bool `json:"push,omitempty"`
 			} `json:"from,omitempty"`
 		} `json:"permissions,omitempty"`
 	} `json:"repository,omitempty"`


### PR DESCRIPTION
I made these strings by accident in #653. The documentation in
https://developer.github.com/v3/activity/events/types/#teamevent
clearly states that they're boolean.

My apologies for missing that the first time around 🌷 