### PR TITLE
avoid stale responses

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Justin Abrahms <justin@abrah.ms>
 Konrad Malawski <konrad.malawski@project13.pl>
 Krzysztof Kowalczyk <kkowalczyk@gmail.com>
 Maksim Zhylinski <uzzable@gmail.com>
+Matt Landis <landis.matt@gmail.com>
 Ondrej Kupka <ondra.cap@gmail.com>
 Piotr Zurek <p.zurek@gmail.com>
 Quinn Slack <qslack@qslack.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,6 +32,7 @@ Konrad Malawski <konrad.malawski@project13.pl>
 Krzysztof Kowalczyk <kkowalczyk@gmail.com>
 Kyle Kelley <kyle.kelley@rackspace.com>
 Maksim Zhylinski <uzzable@gmail.com>
+Matt Landis <landis.matt@gmail.com>
 Ondrej Kupka <ondra.cap@gmail.com>
 Piotr Zurek <p.zurek@gmail.com>
 Quinn Slack <qslack@qslack.com>

--- a/github/github.go
+++ b/github/github.go
@@ -161,6 +161,7 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 
 	req.Header.Add("Accept", mediaTypeV3)
 	req.Header.Add("User-Agent", c.UserAgent)
+	req.Header.Set("Cache-Control", "must-revalidate")
 	return req, nil
 }
 

--- a/github/repos.go
+++ b/github/repos.go
@@ -43,6 +43,7 @@ type Repository struct {
 	SubscribersCount *int             `json:"subscribers_count,omitempty"`
 	WatchersCount    *int             `json:"watchers_count,omitempty"`
 	Size             *int             `json:"size,omitempty"`
+	AutoInit         *bool            `json:"auto_init,omitempty"`
 	Parent           *Repository      `json:"parent,omitempty"`
 	Source           *Repository      `json:"source,omitempty"`
 	Organization     *Organization    `json:"organization,omitempty"`

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -36,16 +36,18 @@ func (r RepositoryRelease) String() string {
 
 // ReleaseAsset represents a Github release asset in a repository.
 type ReleaseAsset struct {
-	ID            *int       `json:"id,omitempty"`
-	URL           *string    `json:"url,omitempty"`
-	Name          *string    `json:"name,omitempty"`
-	Label         *string    `json:"label,omitempty"`
-	State         *string    `json:"state,omitempty"`
-	ContentType   *string    `json:"content_type,omitempty"`
-	Size          *int       `json:"size,omitempty"`
-	DownloadCount *int       `json:"download_count,omitempty"`
-	CreatedAt     *Timestamp `json:"created_at,omitempty"`
-	UpdatedAt     *Timestamp `json:"updated_at,omitempty"`
+	ID                 *int       `json:"id,omitempty"`
+	URL                *string    `json:"url,omitempty"`
+	Name               *string    `json:"name,omitempty"`
+	Label              *string    `json:"label,omitempty"`
+	State              *string    `json:"state,omitempty"`
+	ContentType        *string    `json:"content_type,omitempty"`
+	Size               *int       `json:"size,omitempty"`
+	DownloadCount      *int       `json:"download_count,omitempty"`
+	CreatedAt          *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt          *Timestamp `json:"updated_at,omitempty"`
+	BrowserDownloadUrl *string    `json:"browser_download_url,omitempty"`
+	Uploader           *User      `json:"uploader,omitempty"`
 }
 
 func (r ReleaseAsset) String() string {


### PR DESCRIPTION
currently if you push/delete tags from a repo and then query the list of refs, github returns stale data. setting the cache-control header to "must-revalidate" alleviates this. [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) is a list of other values we could set if we'd prefer no caching or something.