### PR TITLE
Fix minor linting issue

### DIFF
--- a/github/users_gpg_keys.go
+++ b/github/users_gpg_keys.go
@@ -43,7 +43,7 @@ type GPGEmail struct {
 // ListGPGKeys lists the public GPG keys for a user. Passing the empty
 // string will fetch keys for the authenticated user. It requires authentication
 // via Basic Auth or via OAuth with at least read:gpg_key scope.
-
+//
 // GitHub API docs: https://developer.github.com/v3/users/gpg_keys/#list-gpg-keys-for-a-user
 func (s *UsersService) ListGPGKeys(ctx context.Context, user string, opt *ListOptions) ([]*GPGKey, *Response, error) {
 	var u string


### PR DESCRIPTION
`golint` does not detect the proper comment form due to an empty line.