### PR TITLE
Add OrganizationService.GetByID method.

### DIFF
--- a/github/orgs.go
+++ b/github/orgs.go
@@ -154,6 +154,25 @@ func (s *OrganizationsService) Get(ctx context.Context, org string) (*Organizati
 	return organization, resp, nil
 }
 
+// GetByID fetches an organization.
+//
+// Note: GetByID uses the undocumented GitHub API endpoint /organizations/:id.
+func (s *OrganizationsService) GetByID(ctx context.Context, id int) (*Organization, *Response, error) {
+	u := fmt.Sprintf("organizations/%d", id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	organization := new(Organization)
+	resp, err := s.client.Do(ctx, req, organization)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return organization, resp, nil
+}
+
 // Edit an organization.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/#edit-an-organization

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -120,7 +120,7 @@ func TestOrganizationsService_GetByID(t *testing.T) {
 
 	org, _, err := client.Organizations.GetByID(context.Background(), 1)
 	if err != nil {
-		t.Errorf("Organizations.GetByID returned error: %v", err)
+		t.Fatalf("Organizations.GetByID returned error: %v", err)
 	}
 
 	want := &Organization{ID: Int(1), Login: String("l"), URL: String("u"), AvatarURL: String("a"), Location: String("l")}

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -109,6 +109,26 @@ func TestOrganizationsService_Get_invalidOrg(t *testing.T) {
 	testURLParseError(t, err)
 }
 
+func TestOrganizationsService_GetByID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/organizations/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":1, "login":"l", "url":"u", "avatar_url": "a", "location":"l"}`)
+	})
+
+	org, _, err := client.Organizations.GetByID(context.Background(), 1)
+	if err != nil {
+		t.Errorf("Organizations.GetByID returned error: %v", err)
+	}
+
+	want := &Organization{ID: Int(1), Login: String("l"), URL: String("u"), AvatarURL: String("a"), Location: String("l")}
+	if !reflect.DeepEqual(org, want) {
+		t.Errorf("Organizations.GetByID returned %+v, want %+v", org, want)
+	}
+}
+
 func TestOrganizationsService_Edit(t *testing.T) {
 	setup()
 	defer teardown()

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -289,7 +289,7 @@ func TestRepositoriesService_GetByID(t *testing.T) {
 
 	repo, _, err := client.Repositories.GetByID(context.Background(), 1)
 	if err != nil {
-		t.Errorf("Repositories.GetByID returned error: %v", err)
+		t.Fatalf("Repositories.GetByID returned error: %v", err)
 	}
 
 	want := &Repository{ID: Int(1), Name: String("n"), Description: String("d"), Owner: &User{Login: String("l")}, License: &License{Key: String("mit")}}

--- a/github/users_test.go
+++ b/github/users_test.go
@@ -112,7 +112,7 @@ func TestUsersService_GetByID(t *testing.T) {
 
 	user, _, err := client.Users.GetByID(context.Background(), 1)
 	if err != nil {
-		t.Errorf("Users.GetByID returned error: %v", err)
+		t.Fatalf("Users.GetByID returned error: %v", err)
 	}
 
 	want := &User{ID: Int(1)}


### PR DESCRIPTION
This pull request adds the `GetByID` method to `OrganizationsService` in the same fashion as is done for `UsersService`  in #333 and `RepositoriesService` in #332.

I've not created a separate issue as this method was added in the same spirit as described in #329.