### PR TITLE
Document that newResponse expects non-nil input.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -315,6 +315,7 @@ type Response struct {
 }
 
 // newResponse creates a new Response for the provided http.Response.
+// r must not be nil.
 func newResponse(r *http.Response) *Response {
 	response := &Response{Response: r}
 	response.populatePageValues()


### PR DESCRIPTION
The current behavior of `newResponse` is that it expects non-nil `r`, and always returns non-nil `*github.Response`. This behavior is relied on by all callers of `newResponse`.

This change improves the documentation of `newResponse` to reflect that.

Closes #660.