### PR TITLE
Improve documentation of AddCollaborator method.

### DIFF
--- a/github/repos_collaborators.go
+++ b/github/repos_collaborators.go
@@ -91,7 +91,8 @@ type RepositoryAddCollaboratorOptions struct {
 	Permission string `json:"permission,omitempty"`
 }
 
-// AddCollaborator adds the specified GitHub user as collaborator to the given repo.
+// AddCollaborator sends an invitation to the specified GitHub user
+// to become a collaborator to the given repo.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator
 func (s *RepositoriesService) AddCollaborator(ctx context.Context, owner, repo, user string, opt *RepositoryAddCollaboratorOptions) (*Response, error) {


### PR DESCRIPTION
This is a cherry-pick of a minor documentation improvement for `AddCollaborator` method from https://github.com/google/go-github/pull/580#issuecomment-299608384.

It's more explicit about what the method does. It is based on wording in GitHub API docs at https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator:

> To send an invitation to a collaborator rather than directly adding them,