### PR TITLE
Add preview Topics support to more methods

### DIFF
--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -223,6 +223,9 @@ func (s *OrganizationsService) ListTeamRepos(ctx context.Context, team int, opt 
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when topics API fully launches.
+	req.Header.Set("Accept", mediaTypeTopicsPreview)
+
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)
 	if err != nil {

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -268,6 +268,7 @@ func TestOrganizationsService_ListTeamRepos(t *testing.T) {
 
 	mux.HandleFunc("/teams/1/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeTopicsPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})

--- a/github/repos.go
+++ b/github/repos.go
@@ -177,9 +177,8 @@ func (s *RepositoriesService) List(ctx context.Context, user string, opt *Reposi
 	}
 
 	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeader := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
-
-	req.Header.Set("Accept", strings.Join(acceptHeader, ", "))
+	acceptHeaders := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)
@@ -216,9 +215,9 @@ func (s *RepositoriesService) ListByOrg(ctx context.Context, org string, opt *Re
 	}
 
 	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeader := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
+	acceptHeaders := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
-	req.Header.Set("Accept", strings.Join(acceptHeader, ", "))
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)
 	if err != nil {

--- a/github/repos.go
+++ b/github/repos.go
@@ -176,8 +176,10 @@ func (s *RepositoriesService) List(ctx context.Context, user string, opt *Reposi
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when license support fully launches
-	req.Header.Set("Accept", mediaTypeLicensesPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeader := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
+
+	req.Header.Set("Accept", strings.Join(acceptHeader, ", "))
 
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)
@@ -213,9 +215,10 @@ func (s *RepositoriesService) ListByOrg(ctx context.Context, org string, opt *Re
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when license support fully launches
-	req.Header.Set("Accept", mediaTypeLicensesPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeader := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
 
+	req.Header.Set("Accept", strings.Join(acceptHeader, ", "))
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)
 	if err != nil {

--- a/github/repos_forks.go
+++ b/github/repos_forks.go
@@ -35,6 +35,9 @@ func (s *RepositoriesService) ListForks(ctx context.Context, owner, repo string,
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when topics API fully launches.
+	req.Header.Set("Accept", mediaTypeTopicsPreview)
+
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)
 	if err != nil {

--- a/github/repos_forks_test.go
+++ b/github/repos_forks_test.go
@@ -19,6 +19,7 @@ func TestRepositoriesService_ListForks(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/forks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeTopicsPreview)
 		testFormValues(t, r, values{
 			"sort": "newest",
 			"page": "3",

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -19,10 +19,10 @@ func TestRepositoriesService_List_authenticatedUser(t *testing.T) {
 	setup()
 	defer teardown()
 
-	acceptHeader := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
+	acceptHeaders := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
 	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(acceptHeader, ", "))
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
@@ -41,10 +41,10 @@ func TestRepositoriesService_List_specifiedUser(t *testing.T) {
 	setup()
 	defer teardown()
 
-	acceptHeader := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
+	acceptHeaders := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
 	mux.HandleFunc("/users/u/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(acceptHeader, ", "))
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"visibility":  "public",
 			"affiliation": "owner,collaborator",
@@ -77,10 +77,10 @@ func TestRepositoriesService_List_specifiedUser_type(t *testing.T) {
 	setup()
 	defer teardown()
 
-	acceptHeader := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
+	acceptHeaders := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
 	mux.HandleFunc("/users/u/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(acceptHeader, ", "))
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"type": "owner",
 		})
@@ -110,10 +110,10 @@ func TestRepositoriesService_ListByOrg(t *testing.T) {
 	setup()
 	defer teardown()
 
-	acceptHeader := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
+	acceptHeaders := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
 	mux.HandleFunc("/orgs/o/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(acceptHeader, ", "))
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"type": "forks",
 			"page": "2",
@@ -231,10 +231,10 @@ func TestRepositoriesService_Get(t *testing.T) {
 	setup()
 	defer teardown()
 
-	acceptHeader := []string{mediaTypeLicensesPreview, mediaTypeSquashPreview, mediaTypeCodesOfConductPreview, mediaTypeTopicsPreview}
+	acceptHeaders := []string{mediaTypeLicensesPreview, mediaTypeSquashPreview, mediaTypeCodesOfConductPreview, mediaTypeTopicsPreview}
 	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(acceptHeader, ", "))
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		fmt.Fprint(w, `{"id":1,"name":"n","description":"d","owner":{"login":"l"},"license":{"key":"mit"}}`)
 	})
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -19,9 +19,10 @@ func TestRepositoriesService_List_authenticatedUser(t *testing.T) {
 	setup()
 	defer teardown()
 
+	acceptHeader := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
 	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeLicensesPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeader, ", "))
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
@@ -40,9 +41,10 @@ func TestRepositoriesService_List_specifiedUser(t *testing.T) {
 	setup()
 	defer teardown()
 
+	acceptHeader := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
 	mux.HandleFunc("/users/u/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeLicensesPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeader, ", "))
 		testFormValues(t, r, values{
 			"visibility":  "public",
 			"affiliation": "owner,collaborator",
@@ -75,9 +77,10 @@ func TestRepositoriesService_List_specifiedUser_type(t *testing.T) {
 	setup()
 	defer teardown()
 
+	acceptHeader := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
 	mux.HandleFunc("/users/u/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeLicensesPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeader, ", "))
 		testFormValues(t, r, values{
 			"type": "owner",
 		})
@@ -107,9 +110,10 @@ func TestRepositoriesService_ListByOrg(t *testing.T) {
 	setup()
 	defer teardown()
 
+	acceptHeader := []string{mediaTypeLicensesPreview, mediaTypeTopicsPreview}
 	mux.HandleFunc("/orgs/o/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeLicensesPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeader, ", "))
 		testFormValues(t, r, values{
 			"type": "forks",
 			"page": "2",


### PR DESCRIPTION
Add topics preview header to more RepositoriesService methods. 
Fixes https://github.com/google/go-github/issues/675 