### PR TITLE
Explicitly drop unused variables

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -248,7 +248,7 @@ func (s *RepositoriesService) GetArchiveLink(ctx context.Context, owner, repo st
 	}
 	var resp *http.Response
 	// Use http.DefaultTransport if no custom Transport is configured
-	ctx, req = withContext(ctx, req)
+	_, req = withContext(ctx, req)
 	if s.client.client.Transport == nil {
 		resp, err = http.DefaultTransport.RoundTrip(req)
 	} else {

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -244,7 +244,7 @@ func (s *RepositoriesService) DownloadReleaseAsset(ctx context.Context, owner, r
 	}
 	defer func() { s.client.client.CheckRedirect = saveRedirect }()
 
-	ctx, req = withContext(ctx, req)
+	_, req = withContext(ctx, req)
 	resp, err := s.client.client.Do(req)
 	if err != nil {
 		if !strings.Contains(err.Error(), "disable redirect") {


### PR DESCRIPTION
I found a couple of places where variables were being set but silently swallowed. This explicitly assigns to '_'.