### PR TITLE
github: add IsPullRequest helper

### DIFF
--- a/github/issues.go
+++ b/github/issues.go
@@ -21,8 +21,8 @@ type IssuesService service
 //
 // Note: As far as the GitHub API is concerned, every pull request is an issue,
 // but not every issue is a pull request. Some endpoints, events, and webhooks
-// may also return pull requests via this struct. If PullRequestLinks is nil,
-// this is an issue, and if PullRequestLinks is not nil, this is a pull request.
+// may also return pull requests via this struct. Call issue.IsPullRequest to
+// determine if the issue is a pull request.
 type Issue struct {
 	ID               *int              `json:"id,omitempty"`
 	Number           *int              `json:"number,omitempty"`
@@ -53,6 +53,13 @@ type Issue struct {
 
 func (i Issue) String() string {
 	return Stringify(i)
+}
+
+// IsPullRequest reports whether the issue is also a pull request. It uses the
+// method recommended by Github's API documentation, which is to check whether
+// PullRequestLinks is non-nil.
+func (i Issue) IsPullRequest() bool {
+	return i.PullRequestLinks != nil
 }
 
 // IssueRequest represents a request to create/edit an issue.
@@ -97,7 +104,7 @@ type IssueListOptions struct {
 }
 
 // PullRequestLinks object is added to the Issue object when it's an issue included
-// in the IssueCommentEvent webhook payload, if the webhooks is fired by a comment on a PR
+// in the IssueCommentEvent webhook payload, if the webhook is fired by a comment on a PR
 type PullRequestLinks struct {
 	URL      *string `json:"url,omitempty"`
 	HTMLURL  *string `json:"html_url,omitempty"`

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -275,3 +275,14 @@ func TestIssuesService_Unlock(t *testing.T) {
 		t.Errorf("Issues.Unlock returned error: %v", err)
 	}
 }
+
+func TestIsPullRequest(t *testing.T) {
+	i := new(Issue)
+	if i.IsPullRequest() == true {
+		t.Errorf("expected i.IsPullRequest (%v) to return false, got true", i)
+	}
+	i.PullRequestLinks = &PullRequestLinks{URL: String("http://example.com")}
+	if i.IsPullRequest() == false {
+		t.Errorf("expected i.IsPullRequest (%v) to return true, got false", i)
+	}
+}


### PR DESCRIPTION
Instead of defining a pull request in terms of a property that may
or may not be set, define it with a helper method. This way if the
definition changes, the implementation of IsPullRequest can change
without breaking user apps.