### PR TITLE
Add error for no trailing slash

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -242,7 +242,7 @@ func NewClient(httpClient *http.Client) *Client {
 // request body.
 func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Request, error) {
 	if c.BaseURL.Path != "" && !strings.HasSuffix(c.BaseURL.Path, "/") {
-		return nil, fmt.Errorf("BaseURL must have a trailing slash, but %q does not", c.BaseURL.String())
+		return nil, fmt.Errorf("BaseURL must have a trailing slash, but %q does not", c.BaseURL)
 	}
 	u, err := c.BaseURL.Parse(urlStr)
 	if err != nil {
@@ -278,7 +278,7 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 // Relative URLs should always be specified without a preceding slash.
 func (c *Client) NewUploadRequest(urlStr string, reader io.Reader, size int64, mediaType string) (*http.Request, error) {
 	if c.UploadURL.Path != "" && !strings.HasSuffix(c.UploadURL.Path, "/") {
-		return nil, fmt.Errorf("UploadURL must have a trailing slash, but %q does not", c.UploadURL.String())
+		return nil, fmt.Errorf("UploadURL must have a trailing slash, but %q does not", c.UploadURL)
 	}
 	u, err := c.UploadURL.Parse(urlStr)
 	if err != nil {

--- a/github/github.go
+++ b/github/github.go
@@ -241,7 +241,7 @@ func NewClient(httpClient *http.Client) *Client {
 // specified, the value pointed to by body is JSON encoded and included as the
 // request body.
 func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Request, error) {
-	if c.BaseURL.Path != "" && !strings.HasSuffix(c.BaseURL.Path, "/") {
+	if !strings.HasSuffix(c.BaseURL.Path, "/") {
 		return nil, fmt.Errorf("BaseURL must have a trailing slash, but %q does not", c.BaseURL)
 	}
 	u, err := c.BaseURL.Parse(urlStr)
@@ -277,7 +277,7 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 // urlStr, in which case it is resolved relative to the UploadURL of the Client.
 // Relative URLs should always be specified without a preceding slash.
 func (c *Client) NewUploadRequest(urlStr string, reader io.Reader, size int64, mediaType string) (*http.Request, error) {
-	if c.UploadURL.Path != "" && !strings.HasSuffix(c.UploadURL.Path, "/") {
+	if !strings.HasSuffix(c.UploadURL.Path, "/") {
 		return nil, fmt.Errorf("UploadURL must have a trailing slash, but %q does not", c.UploadURL)
 	}
 	u, err := c.UploadURL.Parse(urlStr)

--- a/github/github.go
+++ b/github/github.go
@@ -241,12 +241,13 @@ func NewClient(httpClient *http.Client) *Client {
 // specified, the value pointed to by body is JSON encoded and included as the
 // request body.
 func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Request, error) {
-	rel, err := url.Parse(urlStr)
+	if c.BaseURL.Path != "" && !strings.HasSuffix(c.BaseURL.Path, "/") {
+		return nil, fmt.Errorf("BaseURL must have a trailing slash, but %q does not", c.BaseURL.String())
+	}
+	u, err := c.BaseURL.Parse(urlStr)
 	if err != nil {
 		return nil, err
 	}
-
-	u := c.BaseURL.ResolveReference(rel)
 
 	var buf io.ReadWriter
 	if body != nil {
@@ -276,12 +277,14 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 // urlStr, in which case it is resolved relative to the UploadURL of the Client.
 // Relative URLs should always be specified without a preceding slash.
 func (c *Client) NewUploadRequest(urlStr string, reader io.Reader, size int64, mediaType string) (*http.Request, error) {
-	rel, err := url.Parse(urlStr)
+	if c.UploadURL.Path != "" && !strings.HasSuffix(c.UploadURL.Path, "/") {
+		return nil, fmt.Errorf("UploadURL must have a trailing slash, but %q does not", c.UploadURL.String())
+	}
+	u, err := c.UploadURL.Parse(urlStr)
 	if err != nil {
 		return nil, err
 	}
 
-	u := c.UploadURL.ResolveReference(rel)
 	req, err := http.NewRequest("POST", u.String(), reader)
 	if err != nil {
 		return nil, err

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -250,11 +250,11 @@ func TestNewRequest_emptyBody(t *testing.T) {
 
 func TestNewRequest_errorForNoTrailingSlash(t *testing.T) {
 	tests := []struct {
-		rawurl  string
-		isError bool
+		rawurl    string
+		wantError bool
 	}{
-		{"https://example.com/api/v3", true},
-		{"https://example.com/api/v3/", false},
+		{rawurl: "https://example.com/api/v3", wantError: true},
+		{rawurl: "https://example.com/api/v3/", wantError: false},
 	}
 	c := NewClient(nil)
 	for _, test := range tests {
@@ -263,9 +263,9 @@ func TestNewRequest_errorForNoTrailingSlash(t *testing.T) {
 			t.Fatalf("url.Parse returned unexpected error: %v.", err)
 		}
 		c.BaseURL = u
-		if _, err := c.NewRequest(http.MethodGet, "test", nil); test.isError && err == nil {
+		if _, err := c.NewRequest(http.MethodGet, "test", nil); test.wantError && err == nil {
 			t.Fatalf("Expected error to be returned.")
-		} else if !test.isError && err != nil {
+		} else if !test.wantError && err != nil {
 			t.Fatalf("NewRequest returned unexpected error: %v.", err)
 		}
 	}
@@ -273,11 +273,11 @@ func TestNewRequest_errorForNoTrailingSlash(t *testing.T) {
 
 func TestNewUploadRequest_errorForNoTrailingSlash(t *testing.T) {
 	tests := []struct {
-		rawurl  string
-		isError bool
+		rawurl    string
+		wantError bool
 	}{
-		{"https://example.com/api/v3", true},
-		{"https://example.com/api/v3/", false},
+		{rawurl: "https://example.com/api/v3", wantError: true},
+		{rawurl: "https://example.com/api/v3/", wantError: false},
 	}
 	c := NewClient(nil)
 	for _, test := range tests {
@@ -286,9 +286,9 @@ func TestNewUploadRequest_errorForNoTrailingSlash(t *testing.T) {
 			t.Fatalf("url.Parse returned unexpected error: %v.", err)
 		}
 		c.UploadURL = u
-		if _, err = c.NewUploadRequest("test", nil, 0, ""); test.isError && err == nil {
+		if _, err = c.NewUploadRequest("test", nil, 0, ""); test.wantError && err == nil {
 			t.Fatalf("Expected error to be returned.")
-		} else if !test.isError && err != nil {
+		} else if !test.wantError && err != nil {
 			t.Fatalf("NewUploadRequest returned unexpected error: %v.", err)
 		}
 	}

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -248,6 +248,52 @@ func TestNewRequest_emptyBody(t *testing.T) {
 	}
 }
 
+func TestNewRequest_errorForNoTrailingSlash(t *testing.T) {
+	tests := []struct {
+		rawurl  string
+		isError bool
+	}{
+		{"https://example.com/api/v3", true},
+		{"https://example.com/api/v3/", false},
+	}
+	c := NewClient(nil)
+	for _, test := range tests {
+		u, err := url.Parse(test.rawurl)
+		if err != nil {
+			t.Fatalf("url.Parse returned unexpected error: %v.", err)
+		}
+		c.BaseURL = u
+		if _, err := c.NewRequest(http.MethodGet, "test", nil); test.isError && err == nil {
+			t.Fatalf("Expected error to be returned.")
+		} else if !test.isError && err != nil {
+			t.Fatalf("NewRequest returned unexpected error: %v.", err)
+		}
+	}
+}
+
+func TestNewUploadRequest_errorForNoTrailingSlash(t *testing.T) {
+	tests := []struct {
+		rawurl  string
+		isError bool
+	}{
+		{"https://example.com/api/v3", true},
+		{"https://example.com/api/v3/", false},
+	}
+	c := NewClient(nil)
+	for _, test := range tests {
+		u, err := url.Parse(test.rawurl)
+		if err != nil {
+			t.Fatalf("url.Parse returned unexpected error: %v.", err)
+		}
+		c.UploadURL = u
+		if _, err = c.NewUploadRequest("test", nil, 0, ""); test.isError && err == nil {
+			t.Fatalf("Expected error to be returned.")
+		} else if !test.isError && err != nil {
+			t.Fatalf("NewUploadRequest returned unexpected error: %v.", err)
+		}
+	}
+}
+
 func TestResponse_populatePageValues(t *testing.T) {
 	r := http.Response{
 		Header: http.Header{

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -43,7 +43,7 @@ func setup() {
 
 	// github client configured to use test server
 	client = NewClient(nil)
-	url, _ := url.Parse(server.URL)
+	url, _ := url.Parse(server.URL + "/")
 	client.BaseURL = url
 	client.UploadURL = url
 }

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -276,8 +276,8 @@ func TestNewUploadRequest_errorForNoTrailingSlash(t *testing.T) {
 		rawurl    string
 		wantError bool
 	}{
-		{rawurl: "https://example.com/api/v3", wantError: true},
-		{rawurl: "https://example.com/api/v3/", wantError: false},
+		{rawurl: "https://example.com/api/uploads", wantError: true},
+		{rawurl: "https://example.com/api/uploads/", wantError: false},
 	}
 	c := NewClient(nil)
 	for _, test := range tests {


### PR DESCRIPTION
This pull request provides logic to return an error if there is no slash at the end of `BaseURL` or `UploadURL`.

Related comment:
https://github.com/google/go-github/pull/690#issuecomment-321879628