### PR TITLE
Accept application/x-www-form-urlencoded webhooks

### DIFF
--- a/github/messages.go
+++ b/github/messages.go
@@ -136,9 +136,6 @@ func messageMAC(signature string) ([]byte, func() hash.Hash, error) {
 //     }
 //
 func ValidatePayload(r *http.Request, secretKey []byte) (payload []byte, err error) {
-	// payloadFormParam is the name of the form parameter that the JSON payload
-	// will be in if a webhook has its content type set to application/x-www-form-urlencoded.
-	const payloadFormParam = "payload"
 	var body []byte // Raw body that GitHub uses to calculate the signature.
 
 	switch ct := r.Header.Get("Content-Type"); ct {
@@ -148,11 +145,16 @@ func ValidatePayload(r *http.Request, secretKey []byte) (payload []byte, err err
 		if err != nil {
 			return nil, err
 		}
+
 		// If the content type is application/json,
 		// the JSON payload is just the original body.
 		payload = body
 
 	case "application/x-www-form-urlencoded":
+		// payloadFormParam is the name of the form parameter that the JSON payload
+		// will be in if a webhook has its content type set to application/x-www-form-urlencoded.
+		const payloadFormParam = "payload"
+
 		var err error
 		body, err = ioutil.ReadAll(r.Body)
 		if err != nil {

--- a/github/messages.go
+++ b/github/messages.go
@@ -141,8 +141,7 @@ func ValidatePayload(r *http.Request, secretKey []byte) (payload []byte, err err
 	switch ct := r.Header.Get("Content-Type"); ct {
 	case "application/json":
 		var err error
-		body, err = ioutil.ReadAll(r.Body)
-		if err != nil {
+		if body, err = ioutil.ReadAll(r.Body); err != nil {
 			return nil, err
 		}
 
@@ -156,8 +155,7 @@ func ValidatePayload(r *http.Request, secretKey []byte) (payload []byte, err err
 		const payloadFormParam = "payload"
 
 		var err error
-		body, err = ioutil.ReadAll(r.Body)
-		if err != nil {
+		if body, err = ioutil.ReadAll(r.Body); err != nil {
 			return nil, err
 		}
 

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -110,8 +110,7 @@ func TestValidatePayload_FormGet(t *testing.T) {
 
 	// check that if payload is invalid we get error
 	req.Header.Set(signatureHeader, "invalid signature")
-	_, err = ValidatePayload(req, nil)
-	if err == nil {
+	if _, err = ValidatePayload(req, nil); err == nil {
 		t.Error("ValidatePayload = nil, want err")
 	}
 }
@@ -141,8 +140,7 @@ func TestValidatePayload_FormPost(t *testing.T) {
 
 	// check that if payload is invalid we get error
 	req.Header.Set(signatureHeader, "invalid signature")
-	_, err = ValidatePayload(req, nil)
-	if err == nil {
+	if _, err = ValidatePayload(req, nil); err == nil {
 		t.Error("ValidatePayload = nil, want err")
 	}
 }
@@ -153,8 +151,7 @@ func TestValidatePayload_InvalidContentType(t *testing.T) {
 		t.Fatalf("NewRequest: %v", err)
 	}
 	req.Header.Set("Content-Type", "invalid content type")
-	_, err = ValidatePayload(req, nil)
-	if err == nil {
+	if _, err = ValidatePayload(req, nil); err == nil {
 		t.Error("ValidatePayload = nil, want err")
 	}
 }

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -89,13 +90,13 @@ func TestValidatePayload_FormGet(t *testing.T) {
 	signature := "sha1=3374ef144403e8035423b23b02e2c9d7a4c50368"
 	secretKey := []byte("0123456789abcdef")
 
-	req, err := http.NewRequest("GET", "http://localhost/event", nil)
-	q := req.URL.Query()
-	q.Add("payload", payload)
-	req.URL.RawQuery = q.Encode()
+	form := url.Values{}
+	form.Add("payload", payload)
+	req, err := http.NewRequest("POST", "http://localhost/event", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
+	req.PostForm = form
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set(signatureHeader, signature)
 


### PR DESCRIPTION
- Enable `ValidatePayload` to work for webhooks with Content-Type `application/x-www-form-urlencoded` in addition to `application/json`.
- Reject any Content-Type that is not `application/x-www-form-urlencoded` or `application/json`.