### PR TITLE
search: fix url encoding

### DIFF
--- a/github/search.go
+++ b/github/search.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	qs "github.com/google/go-querystring/query"
 )
@@ -176,7 +177,13 @@ func (s *SearchService) search(ctx context.Context, searchType string, query str
 		return nil, err
 	}
 	params.Set("q", query)
-	u := fmt.Sprintf("search/%s?%s", searchType, params.Encode())
+
+	encodedParams, err := url.QueryUnescape(params.Encode())
+	if err != nil {
+		return nil, err
+	}
+
+	u := fmt.Sprintf("search/%s?%s", searchType, encodedParams)
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {


### PR DESCRIPTION
Github API uses a search syntax with colon(s), etc in the URL (as mentioned in https://developer.github.com/v3/search/).

When `params.Encode()` is used, it replaces the characters outside the ASCII set with their encoded value. Example: `:` is replaced by `%3A`.

Using `url.QueryUnescape()` will prevent this conversion.

**Example**:

- Query before this change: `q=is%3Apr%2Brepo%3Akubernetes%2Fkubernetes%2Bauthor%3Anikhita`.
    - This results in an incorrect response: https://api.github.com/search/issues?q=is%3Apr%2Brepo%3Akubernetes%2Fkubernetes%2Bauthor%3Anikhita.
- Query after this change: `q=is:pr+repo:kubernetes/kubernetes+author:nikhita`.
    - This results in a correct response: https://api.github.com/search/issues?q=is:pr+repo:kubernetes/kubernetes+author:nikhita.
