### PR TITLE
README: add rate limit info for search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ func main() {
 
 GitHub imposes a rate limit on all API clients. Unauthenticated clients are
 limited to 60 requests per hour, while authenticated clients can make up to
-5,000 requests per hour. To receive the higher rate limit when making calls
-that are not issued on behalf of a user, use the
-`UnauthenticatedRateLimitedTransport`.
+5,000 requests per hour. The Search API has a custom rate limit. Unauthenticated
+clients are limited to 10 requests per minute, while authenticated clients
+can make up to 30 requests per minute. To receive the higher rate limit when
+making calls that are not issued on behalf of a user,
+use `UnauthenticatedRateLimitedTransport`.
 
 The returned `Response.Rate` value contains the rate limit information
 from the most recent API call. If a recent enough response isn't

--- a/github/doc.go
+++ b/github/doc.go
@@ -85,9 +85,11 @@ Rate Limiting
 
 GitHub imposes a rate limit on all API clients. Unauthenticated clients are
 limited to 60 requests per hour, while authenticated clients can make up to
-5,000 requests per hour. To receive the higher rate limit when making calls
-that are not issued on behalf of a user, use the
-UnauthenticatedRateLimitedTransport.
+5,000 requests per hour. The Search API has a custom rate limit. Unauthenticated
+clients are limited to 10 requests per minute, while authenticated clients
+can make up to 30 requests per minute. To receive the higher rate limit when
+making calls that are not issued on behalf of a user,
+use UnauthenticatedRateLimitedTransport.
 
 The returned Response.Rate value contains the rate limit information
 from the most recent API call. If a recent enough response isn't


### PR DESCRIPTION
The Search API has a separate rate limit. This is not mentioned in the README and could be misleading.

Link to the Github API docs: https://developer.github.com/v3/search/#rate-limit.