### PR TITLE
Fix #664. Docs for empty DismissalRestrictions were incorrect.  [] -> {}

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -20,14 +20,6 @@ func (a *AbuseRateLimitError) GetRetryAfter() time.Duration {
 	return *a.RetryAfter
 }
 
-// GetURL returns the URL field if it's non-nil, zero value otherwise.
-func (a *AdminEnforcement) GetURL() string {
-	if a == nil || a.URL == nil {
-		return ""
-	}
-	return *a.URL
-}
-
 // GetVerifiablePasswordAuthentication returns the VerifiablePasswordAuthentication field if it's non-nil, zero value otherwise.
 func (a *APIMeta) GetVerifiablePasswordAuthentication() bool {
 	if a == nil || a.VerifiablePasswordAuthentication == nil {

--- a/github/repos.go
+++ b/github/repos.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -559,9 +558,11 @@ type RequiredStatusChecks struct {
 // PullRequestReviewsEnforcement represents the pull request reviews enforcement of a protected branch.
 type PullRequestReviewsEnforcement struct {
 	// Specifies which users and teams can dismiss pull requets reviews.
-	DismissalRestrictions DismissalRestrictions `json:"dismissal_restrictions"`
+	DismissalRestrictions DismissalRestrictions `json:"dismissal_restrictions,omitempty"`
 	// Specifies if approved reviews are dismissed automatically, when a new commit is pushed.
-	DismissStaleReviews bool `json:"dismiss_stale_reviews"`
+	DismissStaleReviews bool `json:"dismiss_stale_reviews,omitempty"`
+	// Specifies if review by the code owner is required
+	RequireCodeOwnerReviews bool `json:"require_code_owner_reviews,omitempty"`
 }
 
 // PullRequestReviewsEnforcementRequest represents request to set the pull request review
@@ -569,32 +570,11 @@ type PullRequestReviewsEnforcement struct {
 // because the request structure is different from the response structure.
 type PullRequestReviewsEnforcementRequest struct {
 	// Specifies which users and teams should be allowed to dismiss pull requets reviews. Can be nil to disable the restrictions.
-	DismissalRestrictionsRequest *DismissalRestrictionsRequest `json:"dismissal_restrictions"`
+	DismissalRestrictionsRequest *DismissalRestrictionsRequest `json:"dismissal_restrictions,omitempty"`
 	// Specifies if approved reviews can be dismissed automatically, when a new commit is pushed. (Required)
-	DismissStaleReviews bool `json:"dismiss_stale_reviews"`
-}
-
-// MarshalJSON implements the json.Marshaler interface.
-// Converts nil value of PullRequestReviewsEnforcementRequest.DismissalRestrictionsRequest to empty array
-func (req PullRequestReviewsEnforcementRequest) MarshalJSON() ([]byte, error) {
-	if req.DismissalRestrictionsRequest == nil {
-		newReq := struct {
-			R []interface{} `json:"dismissal_restrictions"`
-			D bool          `json:"dismiss_stale_reviews"`
-		}{
-			R: []interface{}{},
-			D: req.DismissStaleReviews,
-		}
-		return json.Marshal(newReq)
-	}
-	newReq := struct {
-		R *DismissalRestrictionsRequest `json:"dismissal_restrictions"`
-		D bool                          `json:"dismiss_stale_reviews"`
-	}{
-		R: req.DismissalRestrictionsRequest,
-		D: req.DismissStaleReviews,
-	}
-	return json.Marshal(newReq)
+	DismissStaleReviews bool `json:"dismiss_stale_reviews,omitempty"`
+	// Specifies if review by the code owner is required
+	RequireCodeOwnerReviews bool `json:"require_code_owner_reviews,omitempty"`
 }
 
 // PullRequestReviewsEnforcementUpdate represents request to patch the pull request review
@@ -609,8 +589,7 @@ type PullRequestReviewsEnforcementUpdate struct {
 
 // AdminEnforcement represents the configuration to enforce required status checks for repository administrators.
 type AdminEnforcement struct {
-	URL     *string `json:"url,omitempty"`
-	Enabled bool    `json:"enabled"`
+	Enabled bool `json:"enabled"`
 }
 
 // BranchRestrictions represents the restriction that only certain users or

--- a/github/repos.go
+++ b/github/repos.go
@@ -569,7 +569,9 @@ type PullRequestReviewsEnforcement struct {
 // enforcement of a protected branch. It is separate from PullRequestReviewsEnforcement above
 // because the request structure is different from the response structure.
 type PullRequestReviewsEnforcementRequest struct {
-	// Specifies which users and teams should be allowed to dismiss pull requets reviews. Can be nil to disable the restrictions.
+	// Specifies which users and teams should be allowed to dismiss pull requets reviews.
+	// MUST be nil for non-organization repositories, may be empty on an organization repo
+	// to remove existing restrictions
 	DismissalRestrictionsRequest *DismissalRestrictionsRequest `json:"dismissal_restrictions,omitempty"`
 	// Specifies if approved reviews can be dismissed automatically, when a new commit is pushed. (Required)
 	DismissStaleReviews bool `json:"dismiss_stale_reviews,omitempty"`
@@ -626,9 +628,11 @@ type DismissalRestrictions struct {
 // different from the response structure.
 type DismissalRestrictionsRequest struct {
 	// The list of user logins who can dismiss pull request reviews. (Required; use []string{} instead of nil for empty list.)
-	Users []string `json:"users"`
+	// If both are nil, then this will be an empty object which is what we want to pass for
+	// no restrictions.
+	Users []string `json:"users,omitempty"`
 	// The list of team slugs which can dismiss pull request reviews. (Required; use []string{} instead of nil for empty list.)
-	Teams []string `json:"teams"`
+	Teams []string `json:"teams,omitempty"`
 }
 
 // ListBranches lists branches for the specified repository.

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -543,7 +543,6 @@ func TestRepositoriesService_GetBranchProtection(t *testing.T) {
 			},
 		},
 		EnforceAdmins: &AdminEnforcement{
-			URL:     String("/repos/o/r/branches/b/protection/enforce_admins"),
 			Enabled: true,
 		},
 		Restrictions: &BranchRestrictions{
@@ -868,7 +867,6 @@ func TestRepositoriesService_GetAdminEnforcement(t *testing.T) {
 	}
 
 	want := &AdminEnforcement{
-		URL:     String("/repos/o/r/branches/b/protection/enforce_admins"),
 		Enabled: true,
 	}
 
@@ -893,7 +891,6 @@ func TestRepositoriesService_AddAdminEnforcement(t *testing.T) {
 	}
 
 	want := &AdminEnforcement{
-		URL:     String("/repos/o/r/branches/b/protection/enforce_admins"),
 		Enabled: true,
 	}
 	if !reflect.DeepEqual(enforcement, want) {
@@ -914,20 +911,6 @@ func TestRepositoriesService_RemoveAdminEnforcement(t *testing.T) {
 	_, err := client.Repositories.RemoveAdminEnforcement(context.Background(), "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.RemoveAdminEnforcement returned error: %v", err)
-	}
-}
-
-func TestPullRequestReviewsEnforcementRequest_MarshalJSON_nilDismissalRestirctions(t *testing.T) {
-	req := PullRequestReviewsEnforcementRequest{}
-
-	json, err := json.Marshal(req)
-	if err != nil {
-		t.Errorf("PullRequestReviewsEnforcementRequest.MarshalJSON returned error: %v", err)
-	}
-
-	want := `{"dismissal_restrictions":[],"dismiss_stale_reviews":false}`
-	if want != string(json) {
-		t.Errorf("PullRequestReviewsEnforcementRequest.MarshalJSON returned %+v, want %+v", string(json), want)
 	}
 }
 

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -13,7 +13,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-github/github"
 )
 
@@ -151,9 +150,7 @@ func TestRepositories_EditBranches(t *testing.T) {
 		Restrictions: nil,
 	}
 	if !reflect.DeepEqual(protection, want) {
-		// Using spew helped me see that we were comparing an unwanted URL as part of
-		// AdminEnforcement structure.  Maybe add to other %+v tests?
-		t.Error(spew.Sprintf("Repositories.UpdateBranchProtection() returned %+v, want %+v", protection, want))
+		t.Errorf("Repositories.UpdateBranchProtection() returned %+v, want %+v", protection, want)
 	}
 
 	_, err = client.Repositories.Delete(context.Background(), *repo.Owner.Login, *repo.Name)

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -114,10 +114,10 @@ func TestRepositories_EditBranches(t *testing.T) {
 			Contexts: []string{"continuous-integration"},
 		},
 		RequiredPullRequestReviews: &github.PullRequestReviewsEnforcementRequest{
-			// 422 Error comes from trying to use team/user permissions
-			// on a non-organization repo.
-			DismissStaleReviews:     true,
-			RequireCodeOwnerReviews: true,
+			// Nil is perfectly acceptable here now and it proves the test.
+			DismissalRestrictionsRequest: nil,
+			DismissStaleReviews:          true,
+			RequireCodeOwnerReviews:      true,
 		},
 		EnforceAdmins: true,
 		// TODO: Only organization repositories can have users and team restrictions.
@@ -150,7 +150,7 @@ func TestRepositories_EditBranches(t *testing.T) {
 		Restrictions: nil,
 	}
 	if !reflect.DeepEqual(protection, want) {
-		t.Errorf("Repositories.UpdateBranchProtection() returned %+v, want %+v", protection, want)
+		t.Errorf("Repositories.UpdateBranchProtection() returned %s, want %s", github.Stringify(protection), github.Stringify(want))
 	}
 
 	_, err = client.Repositories.Delete(context.Background(), *repo.Owner.Login, *repo.Name)

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -114,7 +114,9 @@ func TestRepositories_EditBranches(t *testing.T) {
 			Contexts: []string{"continuous-integration"},
 		},
 		RequiredPullRequestReviews: &github.PullRequestReviewsEnforcementRequest{
-			// Nil is perfectly acceptable here now and it proves the test.
+			// The way to disable the setting is to send: &github.DismissalRestrictionsRequest{},
+			// but that yields a 422 error if you are operating on a non-org repo.
+			// Leaving the field out allows the test to function on a non-org repo.
 			DismissalRestrictionsRequest: nil,
 			DismissStaleReviews:          true,
 			RequireCodeOwnerReviews:      true,
@@ -125,7 +127,6 @@ func TestRepositories_EditBranches(t *testing.T) {
 		//       for creating temporary organization repositories.
 		Restrictions: nil,
 	}
-
 	protection, _, err := client.Repositories.UpdateBranchProtection(context.Background(), *repo.Owner.Login, *repo.Name, "master", protectionRequest)
 	if err != nil {
 		t.Fatalf("Repositories.UpdateBranchProtection() returned error: %v", err)


### PR DESCRIPTION
I've driveby added the require owner commit attribute as an omitmissing as it
was missing from the API.  Because it is omitmissing it is not a breaking change.

Added spew library which helped me discover that we were comparing returned URLs from the
AdminEnforcement object.  None of the other objects in the API care about their URLs so
I just removed that.