### PR TITLE
[#605] Use more appropriate field names

### DIFF
--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -63,7 +63,7 @@ type Authorization struct {
 	App            *AuthorizationApp `json:"app,omitempty"`
 	Note           *string           `json:"note,omitempty"`
 	NoteURL        *string           `json:"note_url,omitempty"`
-	UpdateAt       *Timestamp        `json:"updated_at,omitempty"`
+	UpdatedAt      *Timestamp        `json:"updated_at,omitempty"`
 	CreatedAt      *Timestamp        `json:"created_at,omitempty"`
 	Fingerprint    *string           `json:"fingerprint,omitempty"`
 

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -100,12 +100,12 @@ func (a *Authorization) GetTokenLastEight() string {
 	return *a.TokenLastEight
 }
 
-// GetUpdateAt returns the UpdateAt field if it's non-nil, zero value otherwise.
-func (a *Authorization) GetUpdateAt() Timestamp {
-	if a == nil || a.UpdateAt == nil {
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (a *Authorization) GetUpdatedAt() Timestamp {
+	if a == nil || a.UpdatedAt == nil {
 		return Timestamp{}
 	}
-	return *a.UpdateAt
+	return *a.UpdatedAt
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1180,14 +1180,6 @@ func (d *DeploymentStatus) GetID() int {
 	return *d.ID
 }
 
-// GetPushedAt returns the PushedAt field if it's non-nil, zero value otherwise.
-func (d *DeploymentStatus) GetPushedAt() Timestamp {
-	if d == nil || d.PushedAt == nil {
-		return Timestamp{}
-	}
-	return *d.PushedAt
-}
-
 // GetRepositoryURL returns the RepositoryURL field if it's non-nil, zero value otherwise.
 func (d *DeploymentStatus) GetRepositoryURL() string {
 	if d == nil || d.RepositoryURL == nil {
@@ -1210,6 +1202,14 @@ func (d *DeploymentStatus) GetTargetURL() string {
 		return ""
 	}
 	return *d.TargetURL
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (d *DeploymentStatus) GetUpdatedAt() Timestamp {
+	if d == nil || d.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *d.UpdatedAt
 }
 
 // GetAutoInactive returns the AutoInactive field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1180,6 +1180,14 @@ func (d *DeploymentStatus) GetID() int {
 	return *d.ID
 }
 
+// GetPushedAt returns the PushedAt field if it's non-nil, zero value otherwise.
+func (d *DeploymentStatus) GetPushedAt() Timestamp {
+	if d == nil || d.PushedAt == nil {
+		return Timestamp{}
+	}
+	return *d.PushedAt
+}
+
 // GetRepositoryURL returns the RepositoryURL field if it's non-nil, zero value otherwise.
 func (d *DeploymentStatus) GetRepositoryURL() string {
 	if d == nil || d.RepositoryURL == nil {
@@ -1202,14 +1210,6 @@ func (d *DeploymentStatus) GetTargetURL() string {
 		return ""
 	}
 	return *d.TargetURL
-}
-
-// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
-func (d *DeploymentStatus) GetUpdatedAt() Timestamp {
-	if d == nil || d.UpdatedAt == nil {
-		return Timestamp{}
-	}
-	return *d.UpdatedAt
 }
 
 // GetAutoInactive returns the AutoInactive field if it's non-nil, zero value otherwise.

--- a/github/github.go
+++ b/github/github.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	libraryVersion = "10"
+	libraryVersion = "11"
 	defaultBaseURL = "https://api.github.com/"
 	uploadBaseURL  = "https://uploads.github.com/"
 	userAgent      = "go-github/" + libraryVersion

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -137,7 +137,7 @@ type DeploymentStatus struct {
 	Description   *string    `json:"description,omitempty"`
 	TargetURL     *string    `json:"target_url,omitempty"`
 	CreatedAt     *Timestamp `json:"created_at,omitempty"`
-	UpdatedAt     *Timestamp `json:"pushed_at,omitempty"`
+	PushedAt      *Timestamp `json:"pushed_at,omitempty"`
 	DeploymentURL *string    `json:"deployment_url,omitempty"`
 	RepositoryURL *string    `json:"repository_url,omitempty"`
 }

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -23,7 +23,7 @@ type Deployment struct {
 	Description   *string         `json:"description,omitempty"`
 	Creator       *User           `json:"creator,omitempty"`
 	CreatedAt     *Timestamp      `json:"created_at,omitempty"`
-	UpdatedAt     *Timestamp      `json:"pushed_at,omitempty"`
+	UpdatedAt     *Timestamp      `json:"updated_at,omitempty"`
 	StatusesURL   *string         `json:"statuses_url,omitempty"`
 	RepositoryURL *string         `json:"repository_url,omitempty"`
 }
@@ -137,7 +137,7 @@ type DeploymentStatus struct {
 	Description   *string    `json:"description,omitempty"`
 	TargetURL     *string    `json:"target_url,omitempty"`
 	CreatedAt     *Timestamp `json:"created_at,omitempty"`
-	PushedAt      *Timestamp `json:"pushed_at,omitempty"`
+	UpdatedAt     *Timestamp `json:"updated_at,omitempty"`
 	DeploymentURL *string    `json:"deployment_url,omitempty"`
 	RepositoryURL *string    `json:"repository_url,omitempty"`
 }


### PR DESCRIPTION
This PR renames two fields as per discussion in #605:
`Authorizations.UpdateAt` => `UpdatedAt`
`DeploymentStatus.UpdatedAt` => `PushedAt`

As this is a breaking API change, would it be appropriate to merge these changes as a single version bump with #706, also a breaking change?