### PR TITLE
Document search api

### DIFF
--- a/github/search.go
+++ b/github/search.go
@@ -15,12 +15,13 @@ import (
 // SearchService provides access to the search related functions
 // in the GitHub API.
 //
-// Each method takes a query string defining the search keywords and any search qualifiers. For example,
-// when searching issues, the query "gopher is:issue language:go" will search for issues containing the word "gopher"
-// in go repositories. The method call
+// Each method takes a query string defining the search keywords and any search qualifiers.
+// For example, when searching issues, the query "gopher is:issue language:go" will search
+// for issues containing the word "gopher" in Go repositories. The method call
 //   opts :=  &github.SearchOptions{Sort: "created", Order: "asc"}
-//   cl.Search.Issues(ctx, "gopher is:issue label:bug language:go", opts)
-// will search for such issues, sorting by creation date in ascending order (i.e., oldest first).
+//   cl.Search.Issues(ctx, "gopher is:issue language:go", opts)
+// will search for such issues, sorting by creation date in ascending order
+// (i.e., oldest first).
 //
 // GitHub API docs: https://developer.github.com/v3/search/
 type SearchService service

--- a/github/search.go
+++ b/github/search.go
@@ -15,6 +15,13 @@ import (
 // SearchService provides access to the search related functions
 // in the GitHub API.
 //
+// Each method takes a query string defining the search keywords and any search qualifiers. For example,
+// when searching issues, the query "gopher is:issue language:go" will search for issues containing the word "gopher"
+// in go repositories. The method call
+//   opts :=  &github.SearchOptions{Sort: "created", Order: "asc"}
+//   cl.Search.Issues(ctx, "gopher is:issue label:bug language:go", opts)
+// will search for such issues, sorting by creation date in ascending order (i.e., oldest first).
+//
 // GitHub API docs: https://developer.github.com/v3/search/
 type SearchService service
 

--- a/github/search_test.go
+++ b/github/search_test.go
@@ -111,6 +111,35 @@ func TestSearchService_Issues(t *testing.T) {
 	}
 }
 
+func TestSearchService_Issues_withQualifiers(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"q": "gopher is:issue label:bug language:go",
+		})
+
+		fmt.Fprint(w, `{"total_count": 4, "incomplete_results": true, "items": [{"number":1},{"number":2}]}`)
+	})
+
+	opts := &SearchOptions{}
+	result, _, err := client.Search.Issues(context.Background(), "gopher is:issue label:bug language:go", opts)
+	if err != nil {
+		t.Errorf("Search.Issues returned error: %v", err)
+	}
+
+	want := &IssuesSearchResult{
+		Total:             Int(4),
+		IncompleteResults: Bool(true),
+		Issues:            []Issue{{Number: Int(1)}, {Number: Int(2)}},
+	}
+	if !reflect.DeepEqual(result, want) {
+		t.Errorf("Search.Issues returned %+v, want %+v", result, want)
+	}
+}
+
 func TestSearchService_Users(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
This PR addresses #707 by adding some example documentation on search queries and a unit test for what GitHub terms "search qualifiers", e.g., `"is:issue"`. 