### PR TITLE
(#715) Add test for anomalous timestamp format from Projects API.

### DIFF
--- a/github/timestamp_test.go
+++ b/github/timestamp_test.go
@@ -15,6 +15,7 @@ import (
 const (
 	emptyTimeStr         = `"0001-01-01T00:00:00Z"`
 	referenceTimeStr     = `"2006-01-02T15:04:05Z"`
+	referenceTimeStrFractional = `"2006-01-02T15:04:05.000Z"` // This format was returned by the Projects API before October 1, 2017.
 	referenceUnixTimeStr = `1136214245`
 )
 
@@ -58,6 +59,7 @@ func TestTimestamp_Unmarshal(t *testing.T) {
 	}{
 		{"Reference", referenceTimeStr, Timestamp{referenceTime}, false, true},
 		{"ReferenceUnix", `1136214245`, Timestamp{referenceTime}, false, true},
+		{"ReferenceFractional", referenceTimeStrFractional, Timestamp{referenceTime}, false, true},
 		{"Empty", emptyTimeStr, Timestamp{}, false, true},
 		{"UnixStart", `0`, Timestamp{unixOrigin}, false, true},
 		{"Mismatch", referenceTimeStr, Timestamp{}, false, false},

--- a/github/timestamp_test.go
+++ b/github/timestamp_test.go
@@ -13,10 +13,10 @@ import (
 )
 
 const (
-	emptyTimeStr         = `"0001-01-01T00:00:00Z"`
-	referenceTimeStr     = `"2006-01-02T15:04:05Z"`
+	emptyTimeStr               = `"0001-01-01T00:00:00Z"`
+	referenceTimeStr           = `"2006-01-02T15:04:05Z"`
 	referenceTimeStrFractional = `"2006-01-02T15:04:05.000Z"` // This format was returned by the Projects API before October 1, 2017.
-	referenceUnixTimeStr = `1136214245`
+	referenceUnixTimeStr       = `1136214245`
 )
 
 var (


### PR DESCRIPTION
This PR adds test logic verifying that timestamp strings in the `"2006-01-02T15:04:05.000Z"`  format are converted properly into `Timestamps` by JSON unmarshalling.
Fixes #715.