### PR TITLE
Use referenceUnixTimeStr const in tests.

### DIFF
--- a/github/timestamp_test.go
+++ b/github/timestamp_test.go
@@ -58,7 +58,7 @@ func TestTimestamp_Unmarshal(t *testing.T) {
 		equal   bool
 	}{
 		{"Reference", referenceTimeStr, Timestamp{referenceTime}, false, true},
-		{"ReferenceUnix", `1136214245`, Timestamp{referenceTime}, false, true},
+		{"ReferenceUnix", referenceUnixTimeStr, Timestamp{referenceTime}, false, true},
 		{"ReferenceFractional", referenceTimeStrFractional, Timestamp{referenceTime}, false, true},
 		{"Empty", emptyTimeStr, Timestamp{}, false, true},
 		{"UnixStart", `0`, Timestamp{unixOrigin}, false, true},


### PR DESCRIPTION
It's already declared and used elsewhere; no reason not to use it here.

This is a minor code simplification opportunity I spotted while reviewing #716. /cc @e-beach