### PR TITLE
Request parent team when endpoints return a team

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -102,6 +102,9 @@ const (
 
 	// https://developer.github.com/changes/2017-07-26-team-review-request-thor-preview/
 	mediaTypeTeamReviewPreview = "application/vnd.github.thor-preview+json"
+
+	// https://developer.github.com/changes/2017-08-30-preview-nested-teams/
+	mediaTypeNestedTeamsPreview = "application/vnd.github.hellcat-preview+json"
 )
 
 // A Client manages communication with the GitHub API.

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -39,6 +39,7 @@ type Team struct {
 	Organization    *Organization `json:"organization,omitempty"`
 	MembersURL      *string       `json:"members_url,omitempty"`
 	RepositoriesURL *string       `json:"repositories_url,omitempty"`
+	Parent          *Team         `json:"parent,omitempty"`
 
 	// LDAPDN is only available in GitHub Enterprise and when the team
 	// membership is synchronized with LDAP.
@@ -79,6 +80,9 @@ func (s *OrganizationsService) ListTeams(ctx context.Context, org string, opt *L
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
+
 	var teams []*Team
 	resp, err := s.client.Do(ctx, req, &teams)
 	if err != nil {
@@ -97,6 +101,9 @@ func (s *OrganizationsService) GetTeam(ctx context.Context, team int) (*Team, *R
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
 
 	t := new(Team)
 	resp, err := s.client.Do(ctx, req, t)
@@ -117,6 +124,9 @@ func (s *OrganizationsService) CreateTeam(ctx context.Context, org string, team 
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
+
 	t := new(Team)
 	resp, err := s.client.Do(ctx, req, t)
 	if err != nil {
@@ -135,6 +145,9 @@ func (s *OrganizationsService) EditTeam(ctx context.Context, id int, team *Team)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
 
 	t := new(Team)
 	resp, err := s.client.Do(ctx, req, t)
@@ -184,6 +197,9 @@ func (s *OrganizationsService) ListTeamMembers(ctx context.Context, team int, op
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
+
 	var members []*User
 	resp, err := s.client.Do(ctx, req, &members)
 	if err != nil {
@@ -202,6 +218,9 @@ func (s *OrganizationsService) IsTeamMember(ctx context.Context, team int, user 
 	if err != nil {
 		return false, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
 
 	resp, err := s.client.Do(ctx, req, nil)
 	member, err := parseBoolResponse(err)
@@ -315,6 +334,9 @@ func (s *OrganizationsService) ListUserTeams(ctx context.Context, opt *ListOptio
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
+
 	var teams []*Team
 	resp, err := s.client.Do(ctx, req, &teams)
 	if err != nil {
@@ -333,6 +355,9 @@ func (s *OrganizationsService) GetTeamMembership(ctx context.Context, team int, 
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
 
 	t := new(Membership)
 	resp, err := s.client.Do(ctx, req, t)

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -197,9 +197,6 @@ func (s *OrganizationsService) ListTeamMembers(ctx context.Context, team int, op
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
-
 	var members []*User
 	resp, err := s.client.Do(ctx, req, &members)
 	if err != nil {
@@ -352,9 +349,6 @@ func (s *OrganizationsService) GetTeamMembership(ctx context.Context, team int, 
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
 
 	t := new(Membership)
 	resp, err := s.client.Do(ctx, req, t)

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -219,9 +219,6 @@ func (s *OrganizationsService) IsTeamMember(ctx context.Context, team int, user 
 		return false, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
-
 	resp, err := s.client.Do(ctx, req, nil)
 	member, err := parseBoolResponse(err)
 	return member, resp, err

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -48,7 +48,8 @@ func TestOrganizationsService_GetTeam(t *testing.T) {
 
 	mux.HandleFunc("/teams/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"id":1, "name":"n", "description": "d", "url":"u", "slug": "s", "permission":"p", "ldap_dn":"cn=n,ou=groups,dc=example,dc=com"}`)
+		fmt.Fprint(w, `{"id":1, "name":"n", "description": "d", "url":"u", "slug": "s", "permission":"p", "ldap_dn":"cn=n,ou=groups,dc=example,dc=com", "parent":null}`)
+
 	})
 
 	team, _, err := client.Organizations.GetTeam(context.Background(), 1)

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -63,6 +63,30 @@ func TestOrganizationsService_GetTeam(t *testing.T) {
 	}
 }
 
+func TestOrganizationService_GetTeam_nestedTeams(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/teams/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":1, "name":"n", "description": "d", "url":"u", "slug": "s", "permission":"p",
+		"parent": {"id":2, "name":"n", "description": "d", "parent": null}}`)
+
+	})
+
+	team, _, err := client.Organizations.GetTeam(context.Background(), 1)
+	if err != nil {
+		t.Errorf("Organizations.GetTeam returned error: %v", err)
+	}
+
+	want := &Team{ID: Int(1), Name: String("n"), Description: String("d"), URL: String("u"), Slug: String("s"), Permission: String("p"),
+		Parent: &Team{ID: Int(2), Name: String("n"), Description: String("d")},
+	}
+	if !reflect.DeepEqual(team, want) {
+		t.Errorf("Organizations.GetTeam returned %+v, want %+v", team, want)
+	}
+}
+
 func TestOrganizationsService_CreateTeam(t *testing.T) {
 	setup()
 	defer teardown()

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -21,6 +21,7 @@ func TestOrganizationsService_ListTeams(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeNestedTeamsPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -48,8 +49,8 @@ func TestOrganizationsService_GetTeam(t *testing.T) {
 
 	mux.HandleFunc("/teams/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeNestedTeamsPreview)
 		fmt.Fprint(w, `{"id":1, "name":"n", "description": "d", "url":"u", "slug": "s", "permission":"p", "ldap_dn":"cn=n,ou=groups,dc=example,dc=com", "parent":null}`)
-
 	})
 
 	team, _, err := client.Organizations.GetTeam(context.Background(), 1)
@@ -69,6 +70,7 @@ func TestOrganizationService_GetTeam_nestedTeams(t *testing.T) {
 
 	mux.HandleFunc("/teams/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeNestedTeamsPreview)
 		fmt.Fprint(w, `{"id":1, "name":"n", "description": "d", "url":"u", "slug": "s", "permission":"p",
 		"parent": {"id":2, "name":"n", "description": "d", "parent": null}}`)
 
@@ -98,6 +100,7 @@ func TestOrganizationsService_CreateTeam(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeNestedTeamsPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -512,6 +515,7 @@ func TestOrganizationsService_ListUserTeams(t *testing.T) {
 
 	mux.HandleFunc("/user/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeNestedTeamsPreview)
 		testFormValues(t, r, values{"page": "1"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -73,7 +73,6 @@ func TestOrganizationService_GetTeam_nestedTeams(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeNestedTeamsPreview)
 		fmt.Fprint(w, `{"id":1, "name":"n", "description": "d", "url":"u", "slug": "s", "permission":"p",
 		"parent": {"id":2, "name":"n", "description": "d", "parent": null}}`)
-
 	})
 
 	team, _, err := client.Organizations.GetTeam(context.Background(), 1)
@@ -94,7 +93,6 @@ func TestOrganizationsService_CreateTeam(t *testing.T) {
 	defer teardown()
 
 	input := &Team{Name: String("n"), Privacy: String("closed")}
-
 	mux.HandleFunc("/orgs/o/teams", func(w http.ResponseWriter, r *http.Request) {
 		v := new(Team)
 		json.NewDecoder(r.Body).Decode(v)


### PR DESCRIPTION
Re-submit of #718.

This PR address part of #714 by
1. Adding a parent field to the Team struct.
2. Requesting this field to be populated from each endpoint that returns a team, by adding the API preview header to the request.