### PR TITLE
Add parent team id param

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2924,22 +2924,6 @@ func (n *NewTeam) GetDescription() string {
 	return *n.Description
 }
 
-// GetID returns the ID field if it's non-nil, zero value otherwise.
-func (n *NewTeam) GetID() int {
-	if n == nil || n.ID == nil {
-		return 0
-	}
-	return *n.ID
-}
-
-// GetName returns the Name field if it's non-nil, zero value otherwise.
-func (n *NewTeam) GetName() string {
-	if n == nil || n.Name == nil {
-		return ""
-	}
-	return *n.Name
-}
-
 // GetParentTeamID returns the ParentTeamID field if it's non-nil, zero value otherwise.
 func (n *NewTeam) GetParentTeamID() string {
 	if n == nil || n.ParentTeamID == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2924,6 +2924,14 @@ func (n *NewTeam) GetDescription() string {
 	return *n.Description
 }
 
+// GetLDAPDN returns the LDAPDN field if it's non-nil, zero value otherwise.
+func (n *NewTeam) GetLDAPDN() string {
+	if n == nil || n.LDAPDN == nil {
+		return ""
+	}
+	return *n.LDAPDN
+}
+
 // GetParentTeamID returns the ParentTeamID field if it's non-nil, zero value otherwise.
 func (n *NewTeam) GetParentTeamID() string {
 	if n == nil || n.ParentTeamID == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2916,6 +2916,54 @@ func (n *NewPullRequest) GetTitle() string {
 	return *n.Title
 }
 
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (n *NewTeam) GetDescription() string {
+	if n == nil || n.Description == nil {
+		return ""
+	}
+	return *n.Description
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (n *NewTeam) GetID() int {
+	if n == nil || n.ID == nil {
+		return 0
+	}
+	return *n.ID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (n *NewTeam) GetName() string {
+	if n == nil || n.Name == nil {
+		return ""
+	}
+	return *n.Name
+}
+
+// GetParentTeamID returns the ParentTeamID field if it's non-nil, zero value otherwise.
+func (n *NewTeam) GetParentTeamID() string {
+	if n == nil || n.ParentTeamID == nil {
+		return ""
+	}
+	return *n.ParentTeamID
+}
+
+// GetPermission returns the Permission field if it's non-nil, zero value otherwise.
+func (n *NewTeam) GetPermission() string {
+	if n == nil || n.Permission == nil {
+		return ""
+	}
+	return *n.Permission
+}
+
+// GetPrivacy returns the Privacy field if it's non-nil, zero value otherwise.
+func (n *NewTeam) GetPrivacy() string {
+	if n == nil || n.Privacy == nil {
+		return ""
+	}
+	return *n.Privacy
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (n *Notification) GetID() string {
 	if n == nil || n.ID == nil {

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -114,10 +114,39 @@ func (s *OrganizationsService) GetTeam(ctx context.Context, team int) (*Team, *R
 	return t, resp, nil
 }
 
+// NewTeam represents a team to be created or modified.
+type NewTeam struct {
+	ID           *int      `json:"id,omitempty"`
+	Name         *string   `json:"name,omitempty"`
+	Description  *string   `json:"description,omitempty"`
+	Maintainers  []*string `json:"maintainers,omitempty"`
+	RepoNames    []*string `json:"repo_names,omitempty"`
+	ParentTeamID *string   `json:"parent_team_id,omitempty"`
+
+	// Permission is deprecated when creating or editing a team in an org
+	// using the new GitHub permission model. It no longer identifies the
+	// permission a team has on its repos, but only specifies the default
+	// permission a repo is initially added with. Avoid confusion by
+	// specifying a permission value when calling AddTeamRepo.
+	Permission *string `json:"permission,omitempty"`
+
+	// Privacy identifies the level of privacy this team should have.
+	// Possible values are:
+	//     secret - only visible to organization owners and members of this team
+	//     closed - visible to all members of this organization
+	// Default is "secret".
+	Privacy *string `json:"privacy,omitempty"`
+
+	// TODO: decide whether to delete
+	// LDAPDN is only available in GitHub Enterprise and when the team
+	// membership is synchronized with LDAP.
+	LDAPDN *string `json:"ldap_dn,omitempty"`
+}
+
 // CreateTeam creates a new team within an organization.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/teams/#create-team
-func (s *OrganizationsService) CreateTeam(ctx context.Context, org string, team *Team) (*Team, *Response, error) {
+func (s *OrganizationsService) CreateTeam(ctx context.Context, org string, parent_team_id int, team *Team) (*Team, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams", org)
 	req, err := s.client.NewRequest("POST", u, team)
 	if err != nil {
@@ -139,7 +168,7 @@ func (s *OrganizationsService) CreateTeam(ctx context.Context, org string, team 
 // EditTeam edits a team.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/teams/#edit-team
-func (s *OrganizationsService) EditTeam(ctx context.Context, id int, team *Team) (*Team, *Response, error) {
+func (s *OrganizationsService) EditTeam(ctx context.Context, id, parent_team_id int, team *Team) (*Team, *Response, error) {
 	u := fmt.Sprintf("teams/%v", id)
 	req, err := s.client.NewRequest("PATCH", u, team)
 	if err != nil {

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -136,11 +136,6 @@ type NewTeam struct {
 	//     closed - visible to all members of this organization
 	// Default is "secret".
 	Privacy *string `json:"privacy,omitempty"`
-
-	// TODO: decide whether to delete
-	// LDAPDN is only available in GitHub Enterprise and when the team
-	// membership is synchronized with LDAP.
-	LDAPDN *string `json:"ldap_dn,omitempty"`
 }
 
 // CreateTeam creates a new team within an organization.

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -119,8 +119,8 @@ type NewTeam struct {
 	ID           *int      `json:"id,omitempty"`
 	Name         *string   `json:"name,omitempty"`
 	Description  *string   `json:"description,omitempty"`
-	Maintainers  []*string `json:"maintainers,omitempty"`
-	RepoNames    []*string `json:"repo_names,omitempty"`
+	Maintainers  []string `json:"maintainers,omitempty"`
+	RepoNames    []string `json:"repo_names,omitempty"`
 	ParentTeamID *string   `json:"parent_team_id,omitempty"`
 
 	// Permission is deprecated when creating or editing a team in an org

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -146,7 +146,7 @@ type NewTeam struct {
 // CreateTeam creates a new team within an organization.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/teams/#create-team
-func (s *OrganizationsService) CreateTeam(ctx context.Context, org string, parent_team_id int, team *Team) (*Team, *Response, error) {
+func (s *OrganizationsService) CreateTeam(ctx context.Context, org string, team *NewTeam) (*Team, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams", org)
 	req, err := s.client.NewRequest("POST", u, team)
 	if err != nil {
@@ -168,7 +168,7 @@ func (s *OrganizationsService) CreateTeam(ctx context.Context, org string, paren
 // EditTeam edits a team.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/teams/#edit-team
-func (s *OrganizationsService) EditTeam(ctx context.Context, id, parent_team_id int, team *Team) (*Team, *Response, error) {
+func (s *OrganizationsService) EditTeam(ctx context.Context, id int, team *NewTeam) (*Team, *Response, error) {
 	u := fmt.Sprintf("teams/%v", id)
 	req, err := s.client.NewRequest("PATCH", u, team)
 	if err != nil {

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -116,12 +116,13 @@ func (s *OrganizationsService) GetTeam(ctx context.Context, team int) (*Team, *R
 
 // NewTeam represents a team to be created or modified.
 type NewTeam struct {
-	ID           *int      `json:"id,omitempty"`
-	Name         *string   `json:"name,omitempty"`
-	Description  *string   `json:"description,omitempty"`
+
+	// The name of the team (Required.)
+	Name         string   `json:"name"`
+	Description  *string  `json:"description,omitempty"`
 	Maintainers  []string `json:"maintainers,omitempty"`
 	RepoNames    []string `json:"repo_names,omitempty"`
-	ParentTeamID *string   `json:"parent_team_id,omitempty"`
+	ParentTeamID *string  `json:"parent_team_id,omitempty"`
 
 	// Permission is deprecated when creating or editing a team in an org
 	// using the new GitHub permission model. It no longer identifies the

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -116,9 +116,7 @@ func (s *OrganizationsService) GetTeam(ctx context.Context, team int) (*Team, *R
 
 // NewTeam represents a team to be created or modified.
 type NewTeam struct {
-
-	// The name of the team (Required.)
-	Name         string   `json:"name"`
+	Name         string   `json:"name"` // Name of the team (Required.)
 	Description  *string  `json:"description,omitempty"`
 	Maintainers  []string `json:"maintainers,omitempty"`
 	RepoNames    []string `json:"repo_names,omitempty"`

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -137,6 +137,10 @@ type NewTeam struct {
 	//     closed - visible to all members of this organization
 	// Default is "secret".
 	Privacy *string `json:"privacy,omitempty"`
+
+	// LDAPDN may be used in GitHub Enterprise when the team membership
+	// is synchronized with LDAP.
+	LDAPDN *string `json:"ldap_dn,omitempty"`
 }
 
 // CreateTeam creates a new team within an organization.

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -20,11 +20,7 @@ type Team struct {
 	URL         *string `json:"url,omitempty"`
 	Slug        *string `json:"slug,omitempty"`
 
-	// Permission is deprecated when creating or editing a team in an org
-	// using the new GitHub permission model. It no longer identifies the
-	// permission a team has on its repos, but only specifies the default
-	// permission a repo is initially added with. Avoid confusion by
-	// specifying a permission value when calling AddTeamRepo.
+	// Permission specifies the default permission for repositories owned by the team.
 	Permission *string `json:"permission,omitempty"`
 
 	// Privacy identifies the level of privacy this team should have.
@@ -116,13 +112,13 @@ func (s *OrganizationsService) GetTeam(ctx context.Context, team int) (*Team, *R
 
 // NewTeam represents a team to be created or modified.
 type NewTeam struct {
-	Name         string   `json:"name"` // Name of the team (Required.)
+	Name         string   `json:"name"` // Name of the team. (Required.)
 	Description  *string  `json:"description,omitempty"`
 	Maintainers  []string `json:"maintainers,omitempty"`
 	RepoNames    []string `json:"repo_names,omitempty"`
 	ParentTeamID *string  `json:"parent_team_id,omitempty"`
 
-	// Permission is deprecated when creating or editing a team in an org
+	// Deprecated: Permission is deprecated when creating or editing a team in an org
 	// using the new GitHub permission model. It no longer identifies the
 	// permission a team has on its repos, but only specifies the default
 	// permission a repo is initially added with. Avoid confusion by

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -137,6 +137,10 @@ type NewTeam struct {
 	LDAPDN *string `json:"ldap_dn,omitempty"`
 }
 
+func (s NewTeam) String() string {
+	return Stringify(s)
+}
+
 // CreateTeam creates a new team within an organization.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/teams/#create-team

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -92,8 +92,7 @@ func TestOrganizationsService_CreateTeam(t *testing.T) {
 	setup()
 	defer teardown()
 
-	r := "r"
-	input := &NewTeam{Name: String("n"), Privacy: String("closed"), RepoNames: []*string{&r}}
+	input := &NewTeam{Name: String("n"), Privacy: String("closed"), RepoNames: []string{"r"}}
 
 	mux.HandleFunc("/orgs/o/teams", func(w http.ResponseWriter, r *http.Request) {
 		v := new(NewTeam)

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -73,7 +73,6 @@ func TestOrganizationService_GetTeam_nestedTeams(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeNestedTeamsPreview)
 		fmt.Fprint(w, `{"id":1, "name":"n", "description": "d", "url":"u", "slug": "s", "permission":"p",
 		"parent": {"id":2, "name":"n", "description": "d", "parent": null}}`)
-
 	})
 
 	team, _, err := client.Organizations.GetTeam(context.Background(), 1)

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -73,6 +73,7 @@ func TestOrganizationService_GetTeam_nestedTeams(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeNestedTeamsPreview)
 		fmt.Fprint(w, `{"id":1, "name":"n", "description": "d", "url":"u", "slug": "s", "permission":"p",
 		"parent": {"id":2, "name":"n", "description": "d", "parent": null}}`)
+
 	})
 
 	team, _, err := client.Organizations.GetTeam(context.Background(), 1)
@@ -92,9 +93,11 @@ func TestOrganizationsService_CreateTeam(t *testing.T) {
 	setup()
 	defer teardown()
 
-	input := &Team{Name: String("n"), Privacy: String("closed")}
+	r := "r"
+	input := &NewTeam{Name: String("n"), Privacy: String("closed"), RepoNames: []*string{&r}}
+
 	mux.HandleFunc("/orgs/o/teams", func(w http.ResponseWriter, r *http.Request) {
-		v := new(Team)
+		v := new(NewTeam)
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
@@ -126,10 +129,10 @@ func TestOrganizationsService_EditTeam(t *testing.T) {
 	setup()
 	defer teardown()
 
-	input := &Team{Name: String("n"), Privacy: String("closed")}
+	input := &NewTeam{Name: String("n"), Privacy: String("closed")}
 
 	mux.HandleFunc("/teams/1", func(w http.ResponseWriter, r *http.Request) {
-		v := new(Team)
+		v := new(NewTeam)
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -92,7 +92,7 @@ func TestOrganizationsService_CreateTeam(t *testing.T) {
 	setup()
 	defer teardown()
 
-	input := &NewTeam{Name: String("n"), Privacy: String("closed"), RepoNames: []string{"r"}}
+	input := &NewTeam{Name: "n", Privacy: String("closed"), RepoNames: []string{"r"}}
 
 	mux.HandleFunc("/orgs/o/teams", func(w http.ResponseWriter, r *http.Request) {
 		v := new(NewTeam)
@@ -127,7 +127,7 @@ func TestOrganizationsService_EditTeam(t *testing.T) {
 	setup()
 	defer teardown()
 
-	input := &NewTeam{Name: String("n"), Privacy: String("closed")}
+	input := &NewTeam{Name: "n", Privacy: String("closed")}
 
 	mux.HandleFunc("/teams/1", func(w http.ResponseWriter, r *http.Request) {
 		v := new(NewTeam)

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -133,6 +133,7 @@ func TestOrganizationsService_EditTeam(t *testing.T) {
 		v := new(NewTeam)
 		json.NewDecoder(r.Body).Decode(v)
 
+		testHeader(t, r, "Accept", mediaTypeNestedTeamsPreview)
 		testMethod(t, r, "PATCH")
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)


### PR DESCRIPTION
This replaces `Team` with `NewTeam` in function that accept a team for creating or editing a team.
The `NewTeam` struct is similar to the existing `NewPullRequest` for creating pull requests.

We need a new struct because the set of parameters for creating or editing a team contains some parameters that are not in the parameter for teams, and most properties of teams cannot be used for editing.

The specific change is that Teams are returned with a `parent` field, but are created/edited with a `parent_id` field.

<!-- TODO: enumerate all removed fields -->



