### PR TITLE
GitHub requires 'reviewers' and 'team_reviewers' to be sent, even if empty

### DIFF
--- a/github/pulls_reviewers.go
+++ b/github/pulls_reviewers.go
@@ -12,7 +12,7 @@ import (
 
 // ReviewersRequest specifies users and teams for a pull request review request.
 type ReviewersRequest struct {
-	Reviewers     []string `json:"reviewers,omitempty"`
+	Reviewers     []string `json:"reviewers"`
 	TeamReviewers []string `json:"team_reviewers,omitempty"`
 }
 


### PR DESCRIPTION
Otherwise an error is returned. Extracted from our logs:

```
level=error msg="POST https://X/api/v3/repos/X/Y/pulls/2234/requested_reviewers: 422 Invalid request.\n\n\"reviewers\" wasn't supplied. []" 
```