### PR TITLE
Travis: Add Go 1.9.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: go
 go:
+  - 1.9.x
   - 1.8.x
   - 1.7.x
   - master


### PR DESCRIPTION
Go 1.9 is out by now, and it's different from `master`.