### PR TITLE
Change JSON encoder to not escape HTML

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -252,7 +252,9 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 	var buf io.ReadWriter
 	if body != nil {
 		buf = new(bytes.Buffer)
-		err := json.NewEncoder(buf).Encode(body)
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		err := enc.Encode(body)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The JSON encoder escapes[ > < and &](https://golang.org/pkg/encoding/json/#Encoder.SetEscapeHTML).

This is problematic because Markdown uses > for quoting. This causes > to appear as a literal character when doing, say, CreateComment, as the JSON encoder escaped it to \u003e and the Markdown processor ignores it.

This PR stops the escaping, so the Markdown processor will correctly recognize the > and quote text rather than literal printing. This is almost always what is desired. In the case it's not, the callee can use json.HTMLEscape when passing the text to the go-github service.

