### PR TITLE
Change ListPendingOrgInvitations method to take string org name.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	libraryVersion = "11"
+	libraryVersion = "12"
 	defaultBaseURL = "https://api.github.com/"
 	uploadBaseURL  = "https://uploads.github.com/"
 	userAgent      = "go-github/" + libraryVersion

--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -278,7 +278,7 @@ func (s *OrganizationsService) RemoveOrgMembership(ctx context.Context, user, or
 // ListPendingOrgInvitations returns a list of pending invitations.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/members/#list-pending-organization-invitations
-func (s *OrganizationsService) ListPendingOrgInvitations(ctx context.Context, org int, opt *ListOptions) ([]*Invitation, *Response, error) {
+func (s *OrganizationsService) ListPendingOrgInvitations(ctx context.Context, org string, opt *ListOptions) ([]*Invitation, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/invitations", org)
 	u, err := addOptions(u, opt)
 	if err != nil {

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -360,7 +360,7 @@ func TestOrganizationsService_ListPendingOrgInvitations(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/1/invitations", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"page": "1"})
 		fmt.Fprint(w, `[
@@ -394,7 +394,7 @@ func TestOrganizationsService_ListPendingOrgInvitations(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1}
-	invitations, _, err := client.Organizations.ListPendingOrgInvitations(context.Background(), 1, opt)
+	invitations, _, err := client.Organizations.ListPendingOrgInvitations(context.Background(), "o", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListPendingOrgInvitations returned error: %v", err)
 	}


### PR DESCRIPTION
The `/orgs/:org` GitHub API endpoint expects the string name of the organization, not its integer ID (that would be `/organizations/:id` endpoint, which we're generally not using).

Change the org parameter type from int to string to make it possible to specify the organization via its name.

This method wasn't functional before.

Fixes #730.