### PR TITLE
Add preview header for newly accessible endpoints

### DIFF
--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -198,10 +198,14 @@ func (s *ActivityService) ListEventsForRepoNetwork(ctx context.Context, owner, r
 		return nil, nil, err
 	}
 
+
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitHubAppsPreview)
 
 	var events []*Event
 	resp, err := s.client.Do(ctx, req, &events)

--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -198,7 +198,6 @@ func (s *ActivityService) ListEventsForRepoNetwork(ctx context.Context, owner, r
 		return nil, nil, err
 	}
 
-
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -231,6 +230,9 @@ func (s *ActivityService) ListEventsForOrganization(ctx context.Context, org str
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitHubAppsPreview)
+
 	var events []*Event
 	resp, err := s.client.Do(ctx, req, &events)
 	if err != nil {
@@ -260,6 +262,9 @@ func (s *ActivityService) ListEventsPerformedByUser(ctx context.Context, user st
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when endpoints are fully enabled for GitHub apps.
+	req.Header.Set("Accept", mediaTypeGitHubAppsPreview)
 
 	var events []*Event
 	resp, err := s.client.Do(ctx, req, &events)

--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -263,7 +263,7 @@ func (s *ActivityService) ListEventsPerformedByUser(ctx context.Context, user st
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when endpoints are fully enabled for GitHub apps.
+	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeGitHubAppsPreview)
 
 	var events []*Event
@@ -296,7 +296,7 @@ func (s *ActivityService) ListEventsReceivedByUser(ctx context.Context, user str
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when endpoints are fully enabled for GitHub apps.
+	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeGitHubAppsPreview)
 
 	var events []*Event

--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -296,6 +296,9 @@ func (s *ActivityService) ListEventsReceivedByUser(ctx context.Context, user str
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when endpoints are fully enabled for GitHub apps.
+	req.Header.Set("Accept", mediaTypeGitHubAppsPreview)
+
 	var events []*Event
 	resp, err := s.client.Do(ctx, req, &events)
 	if err != nil {

--- a/github/activity_events_test.go
+++ b/github/activity_events_test.go
@@ -102,7 +102,7 @@ func TestActivityService_ListEventsForRepoNetwork(t *testing.T) {
 
 	mux.HandleFunc("/networks/o/r/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r,"Accept", mediaTypeGitHubAppsPreview)
+		testHeader(t, r, "Accept", mediaTypeGitHubAppsPreview)
 		testFormValues(t, r, values{
 			"page": "2",
 		})
@@ -132,6 +132,7 @@ func TestActivityService_ListEventsForOrganization(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGitHubAppsPreview)
 		testFormValues(t, r, values{
 			"page": "2",
 		})
@@ -161,6 +162,7 @@ func TestActivityService_ListEventsPerformedByUser_all(t *testing.T) {
 
 	mux.HandleFunc("/users/u/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGitHubAppsPreview)
 		testFormValues(t, r, values{
 			"page": "2",
 		})
@@ -185,6 +187,7 @@ func TestActivityService_ListEventsPerformedByUser_publicOnly(t *testing.T) {
 
 	mux.HandleFunc("/users/u/events/public", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGitHubAppsPreview)
 		fmt.Fprint(w, `[{"id":"1"},{"id":"2"}]`)
 	})
 

--- a/github/activity_events_test.go
+++ b/github/activity_events_test.go
@@ -213,6 +213,7 @@ func TestActivityService_ListEventsReceivedByUser_all(t *testing.T) {
 
 	mux.HandleFunc("/users/u/received_events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGitHubAppsPreview)
 		testFormValues(t, r, values{
 			"page": "2",
 		})
@@ -237,6 +238,7 @@ func TestActivityService_ListEventsReceivedByUser_publicOnly(t *testing.T) {
 
 	mux.HandleFunc("/users/u/received_events/public", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGitHubAppsPreview)
 		fmt.Fprint(w, `[{"id":"1"},{"id":"2"}]`)
 	})
 

--- a/github/activity_events_test.go
+++ b/github/activity_events_test.go
@@ -102,6 +102,7 @@ func TestActivityService_ListEventsForRepoNetwork(t *testing.T) {
 
 	mux.HandleFunc("/networks/o/r/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r,"Accept", mediaTypeGitHubAppsPreview)
 		testFormValues(t, r, values{
 			"page": "2",
 		})

--- a/github/github.go
+++ b/github/github.go
@@ -102,6 +102,9 @@ const (
 
 	// https://developer.github.com/changes/2017-07-26-team-review-request-thor-preview/
 	mediaTypeTeamReviewPreview = "application/vnd.github.thor-preview+json"
+
+	// https://developer.github.com/changes/2017-09-21-additional-endpoints-for-github-apps/
+	mediaTypeGitHubAppsPreview = "application/vnd.github.machine-man-preview+json"
 )
 
 // A Client manages communication with the GitHub API.

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -107,7 +107,7 @@ func testHeader(t *testing.T, r *http.Request, header string, want string) {
 }
 
 func testHeaders(t *testing.T, r *http.Request, header string, want []string) {
-	testHeader(t, r, header, strings.Join(want, ","))
+	testHeader(t, r, header, strings.Join(want, ", "))
 }
 
 func testURLParseError(t *testing.T, err error) {

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -107,7 +107,7 @@ func testHeader(t *testing.T, r *http.Request, header string, want string) {
 }
 
 func testHeaders(t *testing.T, r *http.Request, header string, want []string) {
-	testHeader(t,r, header, strings.Join(want, ","))
+	testHeader(t, r, header, strings.Join(want, ","))
 }
 
 func testURLParseError(t *testing.T, err error) {

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -106,7 +106,7 @@ func testHeader(t *testing.T, r *http.Request, header string, want string) {
 	}
 }
 
-func testHeaders(t *testing.T, r *http.Request, header string, want []string) {
+func testHeaders(t *testing.T, r *http.Request, header string, want ...string) {
 	testHeader(t, r, header, strings.Join(want, ", "))
 }
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -106,6 +106,10 @@ func testHeader(t *testing.T, r *http.Request, header string, want string) {
 	}
 }
 
+func testHeaders(t *testing.T, r *http.Request, header string, want []string) {
+	testHeader(t,r, header, strings.Join(want, ","))
+}
+
 func testURLParseError(t *testing.T, err error) {
 	if err == nil {
 		t.Errorf("Expected error to be returned")

--- a/github/misc.go
+++ b/github/misc.go
@@ -74,6 +74,9 @@ func (c *Client) ListEmojis(ctx context.Context) (map[string]string, *Response, 
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when endpoints are fully enabled for GitHub apps.
+	req.Header.Set("Accept", mediaTypeGitHubAppsPreview)
+
 	var emoji map[string]string
 	resp, err := c.Do(ctx, req, &emoji)
 	if err != nil {

--- a/github/misc.go
+++ b/github/misc.go
@@ -74,7 +74,7 @@ func (c *Client) ListEmojis(ctx context.Context) (map[string]string, *Response, 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when endpoints are fully enabled for GitHub apps.
+	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeGitHubAppsPreview)
 
 	var emoji map[string]string

--- a/github/misc_test.go
+++ b/github/misc_test.go
@@ -53,6 +53,7 @@ func TestListEmojis(t *testing.T) {
 
 	mux.HandleFunc("/emojis", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGitHubAppsPreview)
 		fmt.Fprint(w, `{"+1": "+1.png"}`)
 	})
 

--- a/github/repos.go
+++ b/github/repos.go
@@ -836,7 +836,8 @@ func (s *RepositoriesService) GetPullRequestReviewEnforcement(ctx context.Contex
 	}
 
 	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeProtectedBranchesPreview)
+	acceptHeaders := []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ","))
 
 	r := new(PullRequestReviewsEnforcement)
 	resp, err := s.client.Do(ctx, req, r)

--- a/github/repos.go
+++ b/github/repos.go
@@ -926,8 +926,8 @@ func (s *RepositoriesService) GetAdminEnforcement(ctx context.Context, owner, re
 	}
 
 	// TODO: remove custom Accept header when this API fully launches
-	headers := strings.Join([]string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}, ", ")
-	req.Header.Set("Accept", headers)
+	acceptHeaders := []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	r := new(AdminEnforcement)
 	resp, err := s.client.Do(ctx, req, r)
@@ -950,8 +950,8 @@ func (s *RepositoriesService) AddAdminEnforcement(ctx context.Context, owner, re
 	}
 
 	// TODO: remove custom Accept header when this API fully launches
-	headers := strings.Join([]string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}, ", ")
-	req.Header.Set("Accept", headers)
+	acceptHeaders := []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	r := new(AdminEnforcement)
 	resp, err := s.client.Do(ctx, req, r)
@@ -973,8 +973,8 @@ func (s *RepositoriesService) RemoveAdminEnforcement(ctx context.Context, owner,
 	}
 
 	// TODO: remove custom Accept header when this API fully launches
-	headers := strings.Join([]string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}, ", ")
-	req.Header.Set("Accept", headers)
+	acceptHeaders := []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/repos.go
+++ b/github/repos.go
@@ -320,8 +320,9 @@ func (s *RepositoriesService) GetCodeOfConduct(ctx context.Context, owner, repo 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeCodesOfConductPreview)
+	// TODO: remove custom Accept header when this API fully launches
+	acceptHeaders := []string{mediaTypeCodesOfConductPreview, mediaTypeGitHubAppsPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ","))
 
 	coc := new(CodeOfConduct)
 	resp, err := s.client.Do(ctx, req, coc)

--- a/github/repos.go
+++ b/github/repos.go
@@ -926,7 +926,8 @@ func (s *RepositoriesService) GetAdminEnforcement(ctx context.Context, owner, re
 	}
 
 	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeProtectedBranchesPreview)
+	headers := strings.Join([]string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}, ", ")
+	req.Header.Set("Accept", headers)
 
 	r := new(AdminEnforcement)
 	resp, err := s.client.Do(ctx, req, r)
@@ -949,7 +950,8 @@ func (s *RepositoriesService) AddAdminEnforcement(ctx context.Context, owner, re
 	}
 
 	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeProtectedBranchesPreview)
+	headers := strings.Join([]string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}, ", ")
+	req.Header.Set("Accept", headers)
 
 	r := new(AdminEnforcement)
 	resp, err := s.client.Do(ctx, req, r)
@@ -971,7 +973,8 @@ func (s *RepositoriesService) RemoveAdminEnforcement(ctx context.Context, owner,
 	}
 
 	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeProtectedBranchesPreview)
+	headers := strings.Join([]string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}, ", ")
+	req.Header.Set("Accept", headers)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/repos.go
+++ b/github/repos.go
@@ -713,7 +713,8 @@ func (s *RepositoriesService) GetBranchProtection(ctx context.Context, owner, re
 	}
 
 	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeProtectedBranchesPreview)
+	acceptHeaders := []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ","))
 
 	p := new(Protection)
 	resp, err := s.client.Do(ctx, req, p)

--- a/github/repos.go
+++ b/github/repos.go
@@ -860,7 +860,8 @@ func (s *RepositoriesService) UpdatePullRequestReviewEnforcement(ctx context.Con
 	}
 
 	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeProtectedBranchesPreview)
+	acceptHeaders := []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	r := new(PullRequestReviewsEnforcement)
 	resp, err := s.client.Do(ctx, req, r)
@@ -888,7 +889,8 @@ func (s *RepositoriesService) DisableDismissalRestrictions(ctx context.Context, 
 	}
 
 	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeProtectedBranchesPreview)
+	acceptHeaders := []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	r := new(PullRequestReviewsEnforcement)
 	resp, err := s.client.Do(ctx, req, r)
@@ -910,7 +912,8 @@ func (s *RepositoriesService) RemovePullRequestReviewEnforcement(ctx context.Con
 	}
 
 	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeProtectedBranchesPreview)
+	acceptHeaders := []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/repos.go
+++ b/github/repos.go
@@ -322,7 +322,7 @@ func (s *RepositoriesService) GetCodeOfConduct(ctx context.Context, owner, repo 
 
 	// TODO: remove custom Accept header when this API fully launches
 	acceptHeaders := []string{mediaTypeCodesOfConductPreview, mediaTypeGitHubAppsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ","))
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	coc := new(CodeOfConduct)
 	resp, err := s.client.Do(ctx, req, coc)
@@ -714,7 +714,7 @@ func (s *RepositoriesService) GetBranchProtection(ctx context.Context, owner, re
 
 	// TODO: remove custom Accept header when this API fully launches
 	acceptHeaders := []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ","))
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	p := new(Protection)
 	resp, err := s.client.Do(ctx, req, p)
@@ -837,7 +837,7 @@ func (s *RepositoriesService) GetPullRequestReviewEnforcement(ctx context.Contex
 
 	// TODO: remove custom Accept header when this API fully launches
 	acceptHeaders := []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ","))
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	r := new(PullRequestReviewsEnforcement)
 	resp, err := s.client.Do(ctx, req, r)

--- a/github/repos_community_health.go
+++ b/github/repos_community_health.go
@@ -8,8 +8,8 @@ package github
 import (
 	"context"
 	"fmt"
-	"time"
 	"strings"
+	"time"
 )
 
 // Metric represents the different fields for one file in community health files.

--- a/github/repos_community_health.go
+++ b/github/repos_community_health.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"time"
+	"strings"
 )
 
 // Metric represents the different fields for one file in community health files.
@@ -45,7 +46,8 @@ func (s *RepositoriesService) GetCommunityHealthMetrics(ctx context.Context, own
 	}
 
 	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeRepositoryCommunityHealthMetricsPreview)
+	acceptHeaders := []string{mediaTypeRepositoryCommunityHealthMetricsPreview, mediaTypeGitHubAppsPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ","))
 
 	metrics := &CommunityHealthMetrics{}
 	resp, err := s.client.Do(ctx, req, metrics)

--- a/github/repos_community_health.go
+++ b/github/repos_community_health.go
@@ -47,7 +47,7 @@ func (s *RepositoriesService) GetCommunityHealthMetrics(ctx context.Context, own
 
 	// TODO: remove custom Accept header when this API fully launches.
 	acceptHeaders := []string{mediaTypeRepositoryCommunityHealthMetricsPreview, mediaTypeGitHubAppsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ","))
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	metrics := &CommunityHealthMetrics{}
 	resp, err := s.client.Do(ctx, req, metrics)

--- a/github/repos_community_health_test.go
+++ b/github/repos_community_health_test.go
@@ -20,7 +20,7 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/community/profile", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeaders(t, r, "Accept", []string{mediaTypeRepositoryCommunityHealthMetricsPreview, mediaTypeGitHubAppsPreview})
+		testHeaders(t, r, "Accept", mediaTypeRepositoryCommunityHealthMetricsPreview, mediaTypeGitHubAppsPreview)
 		fmt.Fprintf(w, `{
 				"health_percentage": 100,
 				"files": {

--- a/github/repos_community_health_test.go
+++ b/github/repos_community_health_test.go
@@ -20,7 +20,7 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/community/profile", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeRepositoryCommunityHealthMetricsPreview)
+		testHeaders(t, r, "Accept", []string{mediaTypeRepositoryCommunityHealthMetricsPreview, mediaTypeGitHubAppsPreview})
 		fmt.Fprintf(w, `{
 				"health_percentage": 100,
 				"files": {

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -858,7 +858,7 @@ func TestRepositoriesService_GetAdminEnforcement(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/enforce_admins", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProtectedBranchesPreview)
+		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
 		fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/enforce_admins","enabled":true}`)
 	})
 
@@ -883,7 +883,7 @@ func TestRepositoriesService_AddAdminEnforcement(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/enforce_admins", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeProtectedBranchesPreview)
+		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
 		fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/enforce_admins","enabled":true}`)
 	})
 
@@ -907,7 +907,7 @@ func TestRepositoriesService_RemoveAdminEnforcement(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/enforce_admins", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeProtectedBranchesPreview)
+		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
 		w.WriteHeader(http.StatusNoContent)
 	})
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -255,7 +255,7 @@ func TestRepositoriesService_GetCodeOfConduct(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/community/code_of_conduct", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeCodesOfConductPreview)
+		testHeaders(t, r, "Accept", []string{mediaTypeCodesOfConductPreview, mediaTypeGitHubAppsPreview})
 		fmt.Fprint(w, `{
 						"key": "key",
 						"name": "name",

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -517,7 +517,7 @@ func TestRepositoriesService_GetBranchProtection(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProtectedBranchesPreview)
+		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
 		fmt.Fprintf(w, `{"required_status_checks":{"strict":true,"contexts":["continuous-integration"]},"required_pull_request_reviews":{"dismissal_restrictions":{"users":[{"id":3,"login":"u"}],"teams":[{"id":4,"slug":"t"}]},"dismiss_stale_reviews":true},"enforce_admins":{"url":"/repos/o/r/branches/b/protection/enforce_admins","enabled":true},"restrictions":{"users":[{"id":1,"login":"u"}],"teams":[{"id":2,"slug":"t"}]}}`)
 	})
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -783,7 +783,7 @@ func TestRepositoriesService_UpdatePullRequestReviewEnforcement(t *testing.T) {
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		testHeader(t, r, "Accept", mediaTypeProtectedBranchesPreview)
+		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
 		fmt.Fprintf(w, `{"dismissal_restrictions":{"users":[{"id":1,"login":"u"}],"teams":[{"id":2,"slug":"t"}]},"dismiss_stale_reviews":true}`)
 	})
 
@@ -814,7 +814,7 @@ func TestRepositoriesService_DisableDismissalRestrictions(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/required_pull_request_reviews", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", mediaTypeProtectedBranchesPreview)
+		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
 		testBody(t, r, `{"dismissal_restrictions":[]}`+"\n")
 		fmt.Fprintf(w, `{"dismissal_restrictions":{"users":[],"teams":[]},"dismiss_stale_reviews":true}`)
 	})
@@ -842,7 +842,7 @@ func TestRepositoriesService_RemovePullRequestReviewEnforcement(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/required_pull_request_reviews", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeProtectedBranchesPreview)
+		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
 		w.WriteHeader(http.StatusNoContent)
 	})
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -738,7 +738,7 @@ func TestRepositoriesService_GetPullRequestReviewEnforcement(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/required_pull_request_reviews", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProtectedBranchesPreview)
+		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
 		fmt.Fprintf(w, `{"dismissal_restrictions":{"users":[{"id":1,"login":"u"}],"teams":[{"id":2,"slug":"t"}]},"dismiss_stale_reviews":true}`)
 	})
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -255,7 +255,7 @@ func TestRepositoriesService_GetCodeOfConduct(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/community/code_of_conduct", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeaders(t, r, "Accept", []string{mediaTypeCodesOfConductPreview, mediaTypeGitHubAppsPreview})
+		testHeaders(t, r, "Accept", mediaTypeCodesOfConductPreview, mediaTypeGitHubAppsPreview)
 		fmt.Fprint(w, `{
 						"key": "key",
 						"name": "name",
@@ -517,7 +517,7 @@ func TestRepositoriesService_GetBranchProtection(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "GET")
-		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
+		testHeaders(t, r, "Accept", mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview)
 		fmt.Fprintf(w, `{"required_status_checks":{"strict":true,"contexts":["continuous-integration"]},"required_pull_request_reviews":{"dismissal_restrictions":{"users":[{"id":3,"login":"u"}],"teams":[{"id":4,"slug":"t"}]},"dismiss_stale_reviews":true},"enforce_admins":{"url":"/repos/o/r/branches/b/protection/enforce_admins","enabled":true},"restrictions":{"users":[{"id":1,"login":"u"}],"teams":[{"id":2,"slug":"t"}]}}`)
 	})
 
@@ -738,7 +738,7 @@ func TestRepositoriesService_GetPullRequestReviewEnforcement(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/required_pull_request_reviews", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
+		testHeaders(t, r, "Accept", mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview)
 		fmt.Fprintf(w, `{"dismissal_restrictions":{"users":[{"id":1,"login":"u"}],"teams":[{"id":2,"slug":"t"}]},"dismiss_stale_reviews":true}`)
 	})
 
@@ -783,7 +783,7 @@ func TestRepositoriesService_UpdatePullRequestReviewEnforcement(t *testing.T) {
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
+		testHeaders(t, r, "Accept", mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview)
 		fmt.Fprintf(w, `{"dismissal_restrictions":{"users":[{"id":1,"login":"u"}],"teams":[{"id":2,"slug":"t"}]},"dismiss_stale_reviews":true}`)
 	})
 
@@ -814,7 +814,7 @@ func TestRepositoriesService_DisableDismissalRestrictions(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/required_pull_request_reviews", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
+		testHeaders(t, r, "Accept", mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview)
 		testBody(t, r, `{"dismissal_restrictions":[]}`+"\n")
 		fmt.Fprintf(w, `{"dismissal_restrictions":{"users":[],"teams":[]},"dismiss_stale_reviews":true}`)
 	})
@@ -842,7 +842,7 @@ func TestRepositoriesService_RemovePullRequestReviewEnforcement(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/required_pull_request_reviews", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
+		testHeaders(t, r, "Accept", mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -858,7 +858,7 @@ func TestRepositoriesService_GetAdminEnforcement(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/enforce_admins", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
+		testHeaders(t, r, "Accept", mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview)
 		fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/enforce_admins","enabled":true}`)
 	})
 
@@ -883,7 +883,7 @@ func TestRepositoriesService_AddAdminEnforcement(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/enforce_admins", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
+		testHeaders(t, r, "Accept", mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview)
 		fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/enforce_admins","enabled":true}`)
 	})
 
@@ -907,7 +907,7 @@ func TestRepositoriesService_RemoveAdminEnforcement(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/enforce_admins", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeaders(t, r, "Accept", []string{mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview})
+		testHeaders(t, r, "Accept", mediaTypeProtectedBranchesPreview, mediaTypeGitHubAppsPreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 


### PR DESCRIPTION
Fixes #722. This will add the preview header for the endpoints newly accessible to GitHub apps.