### PR TITLE
orgs: Fixup ListPendingOrgInvitations.

### DIFF
--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -278,7 +278,7 @@ func (s *OrganizationsService) RemoveOrgMembership(ctx context.Context, user, or
 // ListPendingOrgInvitations returns a list of pending invitations.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/members/#list-pending-organization-invitations
-func (s *OrganizationsService) ListPendingOrgInvitations(ctx context.Context, org int, opt *ListOptions) ([]*Invitation, *Response, error) {
+func (s *OrganizationsService) ListPendingOrgInvitations(ctx context.Context, org string, opt *ListOptions) ([]*Invitation, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/invitations", org)
 	u, err := addOptions(u, opt)
 	if err != nil {

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -360,7 +360,7 @@ func TestOrganizationsService_ListPendingOrgInvitations(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/1/invitations", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/one/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"page": "1"})
 		fmt.Fprint(w, `[
@@ -394,7 +394,7 @@ func TestOrganizationsService_ListPendingOrgInvitations(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1}
-	invitations, _, err := client.Organizations.ListPendingOrgInvitations(context.Background(), 1, opt)
+	invitations, _, err := client.Organizations.ListPendingOrgInvitations(context.Background(), "one", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListPendingOrgInvitations returned error: %v", err)
 	}


### PR DESCRIPTION
The API doesn't take an organization ID, but rather the name.

This is obviously a breaking change to the API -- and I'm unsure how to handle that,
given that it doesn't function as is, compare:

```
curl -vvv -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/orgs/<id>/invitations
curl -vvv -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/orgs/<name>/invitations
```