### PR TITLE
Add NestedTeamsPreview header to remaining endpoints

### DIFF
--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -242,8 +242,8 @@ func (s *OrganizationsService) ListTeamRepos(ctx context.Context, team int, opt 
 	}
 
 	// TODO: remove custom Accept header when topics API fully launches.
-	headers := strings.Join([]string{mediaTypeTopicsPreview, mediaTypeNestedTeamsPreview}, ", ")
-	req.Header.Set("Accept", headers)
+	headers := []string{mediaTypeTopicsPreview, mediaTypeNestedTeamsPreview}
+	req.Header.Set("Accept", strings.Join(headers, ", "))
 
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -168,6 +169,8 @@ func (s *OrganizationsService) DeleteTeam(ctx context.Context, team int) (*Respo
 		return nil, err
 	}
 
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
+
 	return s.client.Do(ctx, req, nil)
 }
 
@@ -196,6 +199,8 @@ func (s *OrganizationsService) ListTeamMembers(ctx context.Context, team int, op
 	if err != nil {
 		return nil, nil, err
 	}
+
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
 
 	var members []*User
 	resp, err := s.client.Do(ctx, req, &members)
@@ -237,7 +242,8 @@ func (s *OrganizationsService) ListTeamRepos(ctx context.Context, team int, opt 
 	}
 
 	// TODO: remove custom Accept header when topics API fully launches.
-	req.Header.Set("Accept", mediaTypeTopicsPreview)
+	headers := strings.Join([]string{mediaTypeTopicsPreview, mediaTypeNestedTeamsPreview}, ", ")
+	req.Header.Set("Accept", headers)
 
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)
@@ -260,7 +266,8 @@ func (s *OrganizationsService) IsTeamRepo(ctx context.Context, team int, owner s
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeOrgPermissionRepo)
+	headers := []string{mediaTypeOrgPermissionRepo, mediaTypeNestedTeamsPreview}
+	req.Header.Set("Accept", strings.Join(headers, ", "))
 
 	repository := new(Repository)
 	resp, err := s.client.Do(ctx, req, repository)
@@ -349,6 +356,8 @@ func (s *OrganizationsService) GetTeamMembership(ctx context.Context, team int, 
 	if err != nil {
 		return nil, nil, err
 	}
+
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
 
 	t := new(Membership)
 	resp, err := s.client.Do(ctx, req, t)

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -157,6 +158,7 @@ func TestOrganizationsService_DeleteTeam(t *testing.T) {
 
 	mux.HandleFunc("/teams/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
+		testHeader(t, r, "Accept", mediaTypeNestedTeamsPreview)
 	})
 
 	_, err := client.Organizations.DeleteTeam(context.Background(), 1)
@@ -171,6 +173,7 @@ func TestOrganizationsService_ListTeamMembers(t *testing.T) {
 
 	mux.HandleFunc("/teams/1/members", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeNestedTeamsPreview)
 		testFormValues(t, r, values{"role": "member", "page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -294,7 +297,8 @@ func TestOrganizationsService_ListTeamRepos(t *testing.T) {
 
 	mux.HandleFunc("/teams/1/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeTopicsPreview)
+		acceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeNestedTeamsPreview}
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -317,7 +321,8 @@ func TestOrganizationsService_IsTeamRepo_true(t *testing.T) {
 
 	mux.HandleFunc("/teams/1/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeOrgPermissionRepo)
+		acceptHeaders := []string{mediaTypeOrgPermissionRepo, mediaTypeNestedTeamsPreview}
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -449,6 +454,7 @@ func TestOrganizationsService_GetTeamMembership(t *testing.T) {
 
 	mux.HandleFunc("/teams/1/memberships/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeNestedTeamsPreview)
 		fmt.Fprint(w, `{"url":"u", "state":"active"}`)
 	})
 

--- a/github/repos.go
+++ b/github/repos.go
@@ -483,6 +483,8 @@ func (s *RepositoriesService) ListTeams(ctx context.Context, owner string, repo 
 		return nil, nil, err
 	}
 
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
+
 	var teams []*Team
 	resp, err := s.client.Do(ctx, req, &teams)
 	if err != nil {

--- a/github/repos_collaborators.go
+++ b/github/repos_collaborators.go
@@ -41,6 +41,8 @@ func (s *RepositoriesService) ListCollaborators(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
+
 	var users []*User
 	resp, err := s.client.Do(ctx, req, &users)
 	if err != nil {

--- a/github/repos_collaborators_test.go
+++ b/github/repos_collaborators_test.go
@@ -20,6 +20,7 @@ func TestRepositoriesService_ListCollaborators(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/collaborators", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeNestedTeamsPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprintf(w, `[{"id":1}, {"id":2}]`)
 	})

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -406,6 +406,7 @@ func TestRepositoriesService_ListTeams(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeNestedTeamsPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})


### PR DESCRIPTION
This adds the preview header to the rest of the endpoints mentioned in https://developer.github.com/changes/2017-08-30-preview-nested-teams/.

In summary, supporting the preview API required adding a parameter for `CreateTeam` and `EditTeam`, creating the `NewPullRequest` struct, and adding the preview header to every header involving a team (this PR).

This should finish up support for the API.