### PR TITLE
Adds state to project options per github's docs

### DIFF
--- a/github/projects.go
+++ b/github/projects.go
@@ -65,7 +65,11 @@ type ProjectOptions struct {
 	Name string `json:"name,omitempty"`
 	// The body of the project. (Optional.)
 	Body string `json:"body,omitempty"`
-	// State of the project. Either open or closed
+
+	// The following field(s) are only applicable for update.
+	// They should be left with zero values for creation.
+
+	// State of the project. Either "open" or "closed". (Optional.)
 	State string `json:"state,omitempty"`
 }
 

--- a/github/projects.go
+++ b/github/projects.go
@@ -65,6 +65,8 @@ type ProjectOptions struct {
 	Name string `json:"name,omitempty"`
 	// The body of the project. (Optional.)
 	Body string `json:"body,omitempty"`
+	// State of the project. Either open or closed
+	State string `json:"state,omitempty"`
 }
 
 // UpdateProject updates a repository project.

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -18,7 +18,7 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 	setup()
 	defer teardown()
 
-	input := &ProjectOptions{Name: "Project Name", Body: "Project body."}
+	input := &ProjectOptions{Name: "Project Name", Body: "Project body.", State: "open"}
 
 	mux.HandleFunc("/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")


### PR DESCRIPTION
State was missing, useful for updating projects per:
https://developer.github.com/v3/projects/#update-a-project

Adds the ability to `open`/`close` projects based on `ProjectOptions` with `ProjectUpdate`