### PR TITLE
parent_team_id is an integer identifier, not a string

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2965,9 +2965,9 @@ func (n *NewTeam) GetLDAPDN() string {
 }
 
 // GetParentTeamID returns the ParentTeamID field if it's non-nil, zero value otherwise.
-func (n *NewTeam) GetParentTeamID() string {
+func (n *NewTeam) GetParentTeamID() int {
 	if n == nil || n.ParentTeamID == nil {
-		return ""
+		return 0
 	}
 	return *n.ParentTeamID
 }

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -117,7 +117,7 @@ type NewTeam struct {
 	Description  *string  `json:"description,omitempty"`
 	Maintainers  []string `json:"maintainers,omitempty"`
 	RepoNames    []string `json:"repo_names,omitempty"`
-	ParentTeamID *string  `json:"parent_team_id,omitempty"`
+	ParentTeamID *int     `json:"parent_team_id,omitempty"`
 
 	// Deprecated: Permission is deprecated when creating or editing a team in an org
 	// using the new GitHub permission model. It no longer identifies the


### PR DESCRIPTION
Using the code as written in the `NestedTeamsPreview` branch produces an error when talking to the GitHub API:

```
panic: PATCH https://api.github.com/teams/2514825: 422 Invalid request.

For 'properties/parent_team_id', "2514824" is not a number or null. []
```

The [documentation](https://developer.github.com/v3/orgs/teams/#create-team) states that this parameter is an `id` type which--for the GitHub API--appears to mean an integer, not a string.