### PR TITLE
Make tests catch invalid absolute URLs in methods.

### DIFF
--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -98,7 +98,7 @@ func TestRepositoriesService_DownloadContents_Success(t *testing.T) {
 		fmt.Fprint(w, `[{
 		  "type": "file",
 		  "name": "f",
-		  "download_url": "`+server.URL+`/download/f"
+		  "download_url": "`+server.URL+baseURLPath+`/download/f"
 		}]`)
 	})
 	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {

--- a/github/users.go
+++ b/github/users.go
@@ -149,7 +149,7 @@ type UserListOptions struct {
 //
 // GitHub API docs: https://developer.github.com/v3/users/#get-all-users
 func (s *UsersService) ListAll(ctx context.Context, opt *UserListOptions) ([]*User, *Response, error) {
-	u, err := addOptions("users", opt)
+	u, err := addOptions("/users", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/users.go
+++ b/github/users.go
@@ -149,7 +149,7 @@ type UserListOptions struct {
 //
 // GitHub API docs: https://developer.github.com/v3/users/#get-all-users
 func (s *UsersService) ListAll(ctx context.Context, opt *UserListOptions) ([]*User, *Response, error) {
-	u, err := addOptions("/users", opt)
+	u, err := addOptions("users", opt)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This PR consists of 4 commits, each commit has a commit message describing what was done. Please review this PR by looking at the 4 commits individually and reading their commit messages (as well as the CI result of each commit).

Fixes #752.