### PR TITLE
Enables creation of a client with a custom enterprise url

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -207,11 +207,22 @@ func addOptions(s string, opt interface{}) (string, error) {
 // authentication, provide an http.Client that will perform the authentication
 // for you (such as that provided by the golang.org/x/oauth2 library).
 func NewClient(httpClient *http.Client) *Client {
+	return newClient(httpClient, defaultBaseURL, uploadBaseURL)
+}
+
+// NewEnterpriseClient returns a new GitHub API client (same as NewClient), except
+// it allows injection of an enterprise URL.
+func NewEnterpriseClient(httpClient *http.Client, enterpriseUrl string) *Client {
+	return newClient(httpClient, enterpriseUrl, enterpriseUrl)
+}
+
+func newClient(httpClient *http.Client, baseUrl string, uploadUrl string) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	baseURL, _ := url.Parse(defaultBaseURL)
-	uploadURL, _ := url.Parse(uploadBaseURL)
+
+	baseURL, _ := url.Parse(baseUrl)
+	uploadURL, _ := url.Parse(uploadUrl)
 
 	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent, UploadURL: uploadURL}
 	c.common.client = c

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -186,6 +186,17 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewEnterpriseClient(t *testing.T) {
+	enterpriseUrl := "custom-url"
+	c := NewEnterpriseClient(nil, enterpriseUrl)
+	if got, want := c.BaseURL.String(), enterpriseUrl; got != want {
+		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
+	}
+	if got, want := c.UploadURL.String(), enterpriseUrl; got != want {
+		t.Errorf("NewClient UploadURL is %v, want %v", got, want)
+	}
+}
+
 // Ensure that length of Client.rateLimits is the same as number of fields in RateLimits struct.
 func TestClient_rateLimits(t *testing.T) {
 	if got, want := len(Client{}.rateLimits), reflect.TypeOf(RateLimits{}).NumField(); got != want {


### PR DESCRIPTION
- Added ability to create a new client and pass in an enterprise base URL
- Used this base URL for both the "base" and "upload" URLs (documentation found [https://developer.github.com/v3/enterprise/](here), said this would be the only URL endpoint required)
- Added test cases for this

Related ticket: https://github.com/google/go-github/issues/756