### PR TITLE
NestedTeamsPreview: Add the ListChildTeams endpoint

### DIFF
--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -211,6 +211,32 @@ type OrganizationListTeamMembersOptions struct {
 	ListOptions
 }
 
+// ListChildTeams lists child teams for a team.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/teams/#list-child-teams
+func (s *OrganizationsService) ListChildTeams(ctx context.Context, id int, opt *ListOptions) ([]*Team, *Response, error) {
+	u := fmt.Sprintf("teams/%v/teams", id)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
+
+	var teams []*Team
+	resp, err := s.client.Do(ctx, req, &teams)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return teams, resp, nil
+}
+
 // ListTeamMembers lists all of the users who are members of the specified
 // team.
 //

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -214,8 +214,8 @@ type OrganizationListTeamMembersOptions struct {
 // ListChildTeams lists child teams for a team.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/teams/#list-child-teams
-func (s *OrganizationsService) ListChildTeams(ctx context.Context, id int, opt *ListOptions) ([]*Team, *Response, error) {
-	u := fmt.Sprintf("teams/%v/teams", id)
+func (s *OrganizationsService) ListChildTeams(ctx context.Context, teamID int, opt *ListOptions) ([]*Team, *Response, error) {
+	u := fmt.Sprintf("teams/%v/teams", teamID)
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err

--- a/github/orgs_teams_test.go
+++ b/github/orgs_teams_test.go
@@ -169,6 +169,29 @@ func TestOrganizationsService_DeleteTeam(t *testing.T) {
 	}
 }
 
+func TestOrganizationsService_ListChildTeams(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/teams/1/teams", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeNestedTeamsPreview)
+		testFormValues(t, r, values{"page": "2"})
+		fmt.Fprint(w, `[{"id":2}]`)
+	})
+
+	opt := &ListOptions{Page: 2}
+	teams, _, err := client.Organizations.ListChildTeams(context.Background(), 1, opt)
+	if err != nil {
+		t.Errorf("Organizations.ListTeams returned error: %v", err)
+	}
+
+	want := []*Team{{ID: Int(2)}}
+	if !reflect.DeepEqual(teams, want) {
+		t.Errorf("Organizations.ListTeams returned %+v, want %+v", teams, want)
+	}
+}
+
 func TestOrganizationsService_ListTeamMembers(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
As per discussion in https://github.com/google/go-github/pull/747#issuecomment-336780818, this endpoint is missing.