### PR TITLE
NewEnterpriseClient method with custom urls

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -243,8 +243,8 @@ func NewClient(httpClient *http.Client) *Client {
 // Note that NewEnterpriseClient is a convenience helper only;
 // its behavior is equivalent to using NewClient, followed by setting
 // the BaseURL and UploadURL fields.
-func NewEnterpriseClient(baseEndpointStr, uploadEndpointStr string, httpClient *http.Client) (*Client, error) {
-	baseEndpoint, err := url.Parse(baseEndpointStr)
+func NewEnterpriseClient(baseURL, uploadURL string, httpClient *http.Client) (*Client, error) {
+	baseEndpoint, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func NewEnterpriseClient(baseEndpointStr, uploadEndpointStr string, httpClient *
 		baseEndpoint.Path += "/"
 	}
 
-	uploadEndpoint, err := url.Parse(uploadEndpointStr)
+	uploadEndpoint, err := url.Parse(uploadURL)
 	if err != nil {
 		return nil, err
 	}

--- a/github/github.go
+++ b/github/github.go
@@ -235,6 +235,23 @@ func NewClient(httpClient *http.Client) *Client {
 	return c
 }
 
+// NewEnterpriseClient returns a new GitHub API client (same as NewClient),
+// except it allows injection of custom base and upload urls. These urls might
+// be the same, but for flexibility both can be set separately.
+func NewEnterpriseClient(httpClient *http.Client, baseURL string, uploadURL string) *Client {
+	if !strings.HasSuffix(baseURL, "/") {
+		baseURL = baseURL + "/"
+	}
+	if !strings.HasSuffix(uploadURL, "/") {
+		uploadURL = uploadURL + "/"
+	}
+
+	c := NewClient(httpClient)
+	c.BaseURL, _ = url.Parse(baseURL)
+	c.UploadURL, _ = url.Parse(uploadURL)
+	return c
+}
+
 // NewRequest creates an API request. A relative URL can be provided in urlStr,
 // in which case it is resolved relative to the BaseURL of the Client.
 // Relative URLs should always be specified without a preceding slash. If

--- a/github/github.go
+++ b/github/github.go
@@ -243,26 +243,26 @@ func NewClient(httpClient *http.Client) *Client {
 // Note that NewEnterpriseClient is a convenience helper only;
 // its behavior is equivalent to using NewClient, followed by setting
 // the BaseURL and UploadURL fields.
-func NewEnterpriseClient(httpClient *http.Client, baseEndpointStr string, uploadEndpointStr string) (*Client, error) {
-	baseURL, err := url.Parse(baseEndpointStr)
+func NewEnterpriseClient(baseEndpointStr, uploadEndpointStr string, httpClient *http.Client) (*Client, error) {
+	baseEndpoint, err := url.Parse(baseEndpointStr)
 	if err != nil {
 		return nil, err
 	}
-	if !strings.HasSuffix(baseURL.Path, "/") {
-		baseURL.Path += "/"
+	if !strings.HasSuffix(baseEndpoint.Path, "/") {
+		baseEndpoint.Path += "/"
 	}
 
-	uploadURL, err := url.Parse(uploadEndpointStr)
+	uploadEndpoint, err := url.Parse(uploadEndpointStr)
 	if err != nil {
 		return nil, err
 	}
-	if !strings.HasSuffix(uploadURL.Path, "/") {
-		uploadURL.Path += "/"
+	if !strings.HasSuffix(uploadEndpoint.Path, "/") {
+		uploadEndpoint.Path += "/"
 	}
 
 	c := NewClient(httpClient)
-	c.BaseURL = baseURL
-	c.UploadURL = uploadURL
+	c.BaseURL = baseEndpoint
+	c.UploadURL = uploadEndpoint
 	return c, nil
 }
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -189,7 +189,7 @@ func TestNewClient(t *testing.T) {
 func TestNewEnterpriseClient(t *testing.T) {
 	baseURL := "https://custom-url/"
 	uploadURL := "https://custom-upload-url/"
-	c := NewEnterpriseClient(nil, baseURL, uploadURL)
+	c, _ := NewEnterpriseClient(nil, baseURL, uploadURL)
 	if got, want := c.BaseURL.String(), baseURL; got != want {
 		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
 	}
@@ -204,7 +204,7 @@ func TestNewEnterpriseClient_addsTrailingSlashToURLs(t *testing.T) {
 	formattedBaseURL := baseURL + "/"
 	formattedUploadURL := uploadURL + "/"
 
-	c := NewEnterpriseClient(nil, baseURL, uploadURL)
+	c, _ := NewEnterpriseClient(nil, baseURL, uploadURL)
 
 	if got, want := c.BaseURL.String(), formattedBaseURL; got != want {
 		t.Errorf("NewClient BaseURL is %v, want %v", got, want)

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -186,6 +186,34 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewEnterpriseClient(t *testing.T) {
+	baseURL := "https://custom-url/"
+	uploadURL := "https://custom-upload-url/"
+	c := NewEnterpriseClient(nil, baseURL, uploadURL)
+	if got, want := c.BaseURL.String(), baseURL; got != want {
+		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
+	}
+	if got, want := c.UploadURL.String(), uploadURL; got != want {
+		t.Errorf("NewClient UploadURL is %v, want %v", got, want)
+	}
+}
+
+func TestNewEnterpriseClient_adssTrailingSlashToURLs(t *testing.T) {
+	baseURL := "https://custom-url"
+	uploadURL := "https://custom-upload-url"
+	formattedBaseURL := baseURL + "/"
+	formattedUploadURL := uploadURL + "/"
+
+	c := NewEnterpriseClient(nil, baseURL, uploadURL)
+
+	if got, want := c.BaseURL.String(), formattedBaseURL; got != want {
+		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
+	}
+	if got, want := c.UploadURL.String(), formattedUploadURL; got != want {
+		t.Errorf("NewClient UploadURL is %v, want %v", got, want)
+	}
+}
+
 // Ensure that length of Client.rateLimits is the same as number of fields in RateLimits struct.
 func TestClient_rateLimits(t *testing.T) {
 	if got, want := len(Client{}.rateLimits), reflect.TypeOf(RateLimits{}).NumField(); got != want {

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -198,7 +198,7 @@ func TestNewEnterpriseClient(t *testing.T) {
 	}
 }
 
-func TestNewEnterpriseClient_adssTrailingSlashToURLs(t *testing.T) {
+func TestNewEnterpriseClient_addsTrailingSlashToURLs(t *testing.T) {
 	baseURL := "https://custom-url"
 	uploadURL := "https://custom-upload-url"
 	formattedBaseURL := baseURL + "/"

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -189,7 +189,7 @@ func TestNewClient(t *testing.T) {
 func TestNewEnterpriseClient(t *testing.T) {
 	baseURL := "https://custom-url/"
 	uploadURL := "https://custom-upload-url/"
-	c, _ := NewEnterpriseClient(nil, baseURL, uploadURL)
+	c, _ := NewEnterpriseClient(baseURL, uploadURL, nil)
 	if got, want := c.BaseURL.String(), baseURL; got != want {
 		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
 	}
@@ -204,7 +204,7 @@ func TestNewEnterpriseClient_addsTrailingSlashToURLs(t *testing.T) {
 	formattedBaseURL := baseURL + "/"
 	formattedUploadURL := uploadURL + "/"
 
-	c, _ := NewEnterpriseClient(nil, baseURL, uploadURL)
+	c, _ := NewEnterpriseClient(baseURL, uploadURL, nil)
 
 	if got, want := c.BaseURL.String(), formattedBaseURL; got != want {
 		t.Errorf("NewClient BaseURL is %v, want %v", got, want)

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -189,7 +189,11 @@ func TestNewClient(t *testing.T) {
 func TestNewEnterpriseClient(t *testing.T) {
 	baseURL := "https://custom-url/"
 	uploadURL := "https://custom-upload-url/"
-	c, _ := NewEnterpriseClient(baseURL, uploadURL, nil)
+	c, err := NewEnterpriseClient(baseURL, uploadURL, nil)
+	if err != nil {
+		t.Fatalf("NewEnterpriseClient returned unexpected error: %v", err)
+	}
+
 	if got, want := c.BaseURL.String(), baseURL; got != want {
 		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
 	}
@@ -204,7 +208,10 @@ func TestNewEnterpriseClient_addsTrailingSlashToURLs(t *testing.T) {
 	formattedBaseURL := baseURL + "/"
 	formattedUploadURL := uploadURL + "/"
 
-	c, _ := NewEnterpriseClient(baseURL, uploadURL, nil)
+	c, err := NewEnterpriseClient(baseURL, uploadURL, nil)
+	if err != nil {
+		t.Fatalf("NewEnterpriseClient returned unexpected error: %v", err)
+	}
 
 	if got, want := c.BaseURL.String(), formattedBaseURL; got != want {
 		t.Errorf("NewClient BaseURL is %v, want %v", got, want)


### PR DESCRIPTION
With this PR I have completed the following, addressing the issues discussed in #756:

- Introduced new func to create a new enterprise client
- Ensured base and upload urls are formatted with a trailing slash
- Added appropriate comment documentation
- Extended test cases to cover this new creation method

Did I cover everything? :)