### PR TITLE
Updates docs to mark method as deprecated

### DIFF
--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -196,6 +196,9 @@ func (s *OrganizationsService) ListTeamMembers(ctx context.Context, team int, op
 // IsTeamMember checks if a user is a member of the specified team.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/teams/#get-team-member
+//
+// Deprecated: This API has been marked as deprecated in the Github API docs,
+// OrganisationService.GetTeamMembership method should be used instead.
 func (s *OrganizationsService) IsTeamMember(ctx context.Context, team int, user string) (bool, *Response, error) {
 	u := fmt.Sprintf("teams/%v/members/%v", team, user)
 	req, err := s.client.NewRequest("GET", u, nil)

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -198,7 +198,7 @@ func (s *OrganizationsService) ListTeamMembers(ctx context.Context, team int, op
 // GitHub API docs: https://developer.github.com/v3/orgs/teams/#get-team-member
 //
 // Deprecated: This API has been marked as deprecated in the Github API docs,
-// OrganisationService.GetTeamMembership method should be used instead.
+// OrganizationsService.GetTeamMembership method should be used instead.
 func (s *OrganizationsService) IsTeamMember(ctx context.Context, team int, user string) (bool, *Response, error) {
 	u := fmt.Sprintf("teams/%v/members/%v", team, user)
 	req, err := s.client.NewRequest("GET", u, nil)


### PR DESCRIPTION
Documentation update of deprecated OrganizationsService.IsTeamMember method, as discussed in #717.