### PR TITLE
gen-accessors: add support for named structs

### DIFF
--- a/github/gen-accessors.go
+++ b/github/gen-accessors.go
@@ -155,7 +155,7 @@ func (t *templateData) dump() error {
 	return ioutil.WriteFile(t.filename, clean, 0644)
 }
 
-func newGetter(receiverType, fieldName, fieldType, zeroValue string) *getter {
+func newGetter(receiverType, fieldName, fieldType, zeroValue string, namedStruct bool) *getter {
 	return &getter{
 		sortVal:      strings.ToLower(receiverType) + "." + strings.ToLower(fieldName),
 		ReceiverVar:  strings.ToLower(receiverType[:1]),
@@ -163,6 +163,7 @@ func newGetter(receiverType, fieldName, fieldType, zeroValue string) *getter {
 		FieldName:    fieldName,
 		FieldType:    fieldType,
 		ZeroValue:    zeroValue,
+		NamedStruct:  namedStruct,
 	}
 }
 
@@ -176,11 +177,12 @@ func (t *templateData) addArrayType(x *ast.ArrayType, receiverType, fieldName st
 		return
 	}
 
-	t.Getters = append(t.Getters, newGetter(receiverType, fieldName, "[]"+eltType, "nil"))
+	t.Getters = append(t.Getters, newGetter(receiverType, fieldName, "[]"+eltType, "nil", false))
 }
 
 func (t *templateData) addIdent(x *ast.Ident, receiverType, fieldName string) {
 	var zeroValue string
+	var namedStruct = false
 	switch x.String() {
 	case "int":
 		zeroValue = "0"
@@ -190,11 +192,12 @@ func (t *templateData) addIdent(x *ast.Ident, receiverType, fieldName string) {
 		zeroValue = "false"
 	case "Timestamp":
 		zeroValue = "Timestamp{}"
-	default: // other structs handled by their receivers directly.
-		return
+	default:
+		zeroValue = `nil`
+		namedStruct = true
 	}
 
-	t.Getters = append(t.Getters, newGetter(receiverType, fieldName, x.String(), zeroValue))
+	t.Getters = append(t.Getters, newGetter(receiverType, fieldName, x.String(), zeroValue, namedStruct))
 }
 
 func (t *templateData) addMapType(x *ast.MapType, receiverType, fieldName string) {
@@ -218,7 +221,7 @@ func (t *templateData) addMapType(x *ast.MapType, receiverType, fieldName string
 
 	fieldType := fmt.Sprintf("map[%v]%v", keyType, valueType)
 	zeroValue := fmt.Sprintf("map[%v]%v{}", keyType, valueType)
-	t.Getters = append(t.Getters, newGetter(receiverType, fieldName, fieldType, zeroValue))
+	t.Getters = append(t.Getters, newGetter(receiverType, fieldName, fieldType, zeroValue, false))
 }
 
 func (t *templateData) addSelectorExpr(x *ast.SelectorExpr, receiverType, fieldName string) {
@@ -243,7 +246,7 @@ func (t *templateData) addSelectorExpr(x *ast.SelectorExpr, receiverType, fieldN
 		if xX == "time" && x.Sel.Name == "Duration" {
 			zeroValue = "0"
 		}
-		t.Getters = append(t.Getters, newGetter(receiverType, fieldName, fieldType, zeroValue))
+		t.Getters = append(t.Getters, newGetter(receiverType, fieldName, fieldType, zeroValue, false))
 	default:
 		logf("addSelectorExpr: xX %q, type %q, field %q: unknown x=%+v; skipping.", xX, receiverType, fieldName, x)
 	}
@@ -264,6 +267,7 @@ type getter struct {
 	FieldName    string
 	FieldType    string
 	ZeroValue    string
+	NamedStruct  bool // getter for named struct
 }
 
 type byName []*getter
@@ -288,6 +292,15 @@ import (
 )
 {{end}}
 {{range .Getters}}
+{{if .NamedStruct}}
+// Get{{.FieldName}} returns the {{.FieldName}} field.
+func ({{.ReceiverVar}} *{{.ReceiverType}}) Get{{.FieldName}}() *{{.FieldType}} {
+  if {{.ReceiverVar}} == nil {
+    return {{.ZeroValue}}
+  }
+  return {{.ReceiverVar}}.{{.FieldName}}
+}
+{{else}}
 // Get{{.FieldName}} returns the {{.FieldName}} field if it's non-nil, zero value otherwise.
 func ({{.ReceiverVar}} *{{.ReceiverType}}) Get{{.FieldName}}() {{.FieldType}} {
   if {{.ReceiverVar}} == nil || {{.ReceiverVar}}.{{.FieldName}} == nil {
@@ -295,5 +308,6 @@ func ({{.ReceiverVar}} *{{.ReceiverType}}) Get{{.FieldName}}() {{.FieldType}} {
   }
   return *{{.ReceiverVar}}.{{.FieldName}}
 }
+{{end}}
 {{end}}
 `

--- a/github/gen-accessors.go
+++ b/github/gen-accessors.go
@@ -193,7 +193,7 @@ func (t *templateData) addIdent(x *ast.Ident, receiverType, fieldName string) {
 	case "Timestamp":
 		zeroValue = "Timestamp{}"
 	default:
-		zeroValue = `nil`
+		zeroValue = "nil"
 		namedStruct = true
 	}
 

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -28,6 +28,86 @@ func (a *AdminEnforcement) GetURL() string {
 	return *a.URL
 }
 
+// GetComments returns the Comments field.
+func (a *AdminStats) GetComments() *CommentStats {
+	if a == nil {
+		return nil
+	}
+	return a.Comments
+}
+
+// GetGists returns the Gists field.
+func (a *AdminStats) GetGists() *GistStats {
+	if a == nil {
+		return nil
+	}
+	return a.Gists
+}
+
+// GetHooks returns the Hooks field.
+func (a *AdminStats) GetHooks() *HookStats {
+	if a == nil {
+		return nil
+	}
+	return a.Hooks
+}
+
+// GetIssues returns the Issues field.
+func (a *AdminStats) GetIssues() *IssueStats {
+	if a == nil {
+		return nil
+	}
+	return a.Issues
+}
+
+// GetMilestones returns the Milestones field.
+func (a *AdminStats) GetMilestones() *MilestoneStats {
+	if a == nil {
+		return nil
+	}
+	return a.Milestones
+}
+
+// GetOrgs returns the Orgs field.
+func (a *AdminStats) GetOrgs() *OrgStats {
+	if a == nil {
+		return nil
+	}
+	return a.Orgs
+}
+
+// GetPages returns the Pages field.
+func (a *AdminStats) GetPages() *PageStats {
+	if a == nil {
+		return nil
+	}
+	return a.Pages
+}
+
+// GetPulls returns the Pulls field.
+func (a *AdminStats) GetPulls() *PullStats {
+	if a == nil {
+		return nil
+	}
+	return a.Pulls
+}
+
+// GetRepos returns the Repos field.
+func (a *AdminStats) GetRepos() *RepoStats {
+	if a == nil {
+		return nil
+	}
+	return a.Repos
+}
+
+// GetUsers returns the Users field.
+func (a *AdminStats) GetUsers() *UserStats {
+	if a == nil {
+		return nil
+	}
+	return a.Users
+}
+
 // GetVerifiablePasswordAuthentication returns the VerifiablePasswordAuthentication field if it's non-nil, zero value otherwise.
 func (a *APIMeta) GetVerifiablePasswordAuthentication() bool {
 	if a == nil || a.VerifiablePasswordAuthentication == nil {
@@ -2276,6 +2356,14 @@ func (g *GistFork) GetURL() string {
 	return *g.URL
 }
 
+// GetUser returns the User field.
+func (g *GistFork) GetUser() *User {
+	if g == nil {
+		return nil
+	}
+	return g.User
+}
+
 // GetPrivateGists returns the PrivateGists field if it's non-nil, zero value otherwise.
 func (g *GistStats) GetPrivateGists() int {
 	if g == nil || g.PrivateGists == nil {
@@ -2298,14 +2386,6 @@ func (g *GistStats) GetTotalGists() int {
 		return 0
 	}
 	return *g.TotalGists
-}
-
-// GetUser returns the User field.
-func (g *GistFork) GetUser() *User {
-	if g == nil {
-		return nil
-	}
-	return g.User
 }
 
 // GetName returns the Name field if it's non-nil, zero value otherwise.
@@ -4132,30 +4212,6 @@ func (m *MilestoneEvent) GetAction() string {
 	return *m.Action
 }
 
-// GetClosedMilestones returns the ClosedMilestones field if it's non-nil, zero value otherwise.
-func (m *MilestoneStats) GetClosedMilestones() int {
-	if m == nil || m.ClosedMilestones == nil {
-		return 0
-	}
-	return *m.ClosedMilestones
-}
-
-// GetOpenMilestones returns the OpenMilestones field if it's non-nil, zero value otherwise.
-func (m *MilestoneStats) GetOpenMilestones() int {
-	if m == nil || m.OpenMilestones == nil {
-		return 0
-	}
-	return *m.OpenMilestones
-}
-
-// GetTotalMilestones returns the TotalMilestones field if it's non-nil, zero value otherwise.
-func (m *MilestoneStats) GetTotalMilestones() int {
-	if m == nil || m.TotalMilestones == nil {
-		return 0
-	}
-	return *m.TotalMilestones
-}
-
 // GetChanges returns the Changes field.
 func (m *MilestoneEvent) GetChanges() *EditChange {
 	if m == nil {
@@ -4202,6 +4258,30 @@ func (m *MilestoneEvent) GetSender() *User {
 		return nil
 	}
 	return m.Sender
+}
+
+// GetClosedMilestones returns the ClosedMilestones field if it's non-nil, zero value otherwise.
+func (m *MilestoneStats) GetClosedMilestones() int {
+	if m == nil || m.ClosedMilestones == nil {
+		return 0
+	}
+	return *m.ClosedMilestones
+}
+
+// GetOpenMilestones returns the OpenMilestones field if it's non-nil, zero value otherwise.
+func (m *MilestoneStats) GetOpenMilestones() int {
+	if m == nil || m.OpenMilestones == nil {
+		return 0
+	}
+	return *m.OpenMilestones
+}
+
+// GetTotalMilestones returns the TotalMilestones field if it's non-nil, zero value otherwise.
+func (m *MilestoneStats) GetTotalMilestones() int {
+	if m == nil || m.TotalMilestones == nil {
+		return 0
+	}
+	return *m.TotalMilestones
 }
 
 // GetBase returns the Base field if it's non-nil, zero value otherwise.
@@ -4692,38 +4772,6 @@ func (o *OrgBlockEvent) GetAction() string {
 	return *o.Action
 }
 
-// GetDisabledOrgs returns the DisabledOrgs field if it's non-nil, zero value otherwise.
-func (o *OrgStats) GetDisabledOrgs() int {
-	if o == nil || o.DisabledOrgs == nil {
-		return 0
-	}
-	return *o.DisabledOrgs
-}
-
-// GetTotalOrgs returns the TotalOrgs field if it's non-nil, zero value otherwise.
-func (o *OrgStats) GetTotalOrgs() int {
-	if o == nil || o.TotalOrgs == nil {
-		return 0
-	}
-	return *o.TotalOrgs
-}
-
-// GetTotalTeamMembers returns the TotalTeamMembers field if it's non-nil, zero value otherwise.
-func (o *OrgStats) GetTotalTeamMembers() int {
-	if o == nil || o.TotalTeamMembers == nil {
-		return 0
-	}
-	return *o.TotalTeamMembers
-}
-
-// GetTotalTeams returns the TotalTeams field if it's non-nil, zero value otherwise.
-func (o *OrgStats) GetTotalTeams() int {
-	if o == nil || o.TotalTeams == nil {
-		return 0
-	}
-	return *o.TotalTeams
-}
-
 // GetBlockedUser returns the BlockedUser field.
 func (o *OrgBlockEvent) GetBlockedUser() *User {
 	if o == nil {
@@ -4754,6 +4802,38 @@ func (o *OrgBlockEvent) GetSender() *User {
 		return nil
 	}
 	return o.Sender
+}
+
+// GetDisabledOrgs returns the DisabledOrgs field if it's non-nil, zero value otherwise.
+func (o *OrgStats) GetDisabledOrgs() int {
+	if o == nil || o.DisabledOrgs == nil {
+		return 0
+	}
+	return *o.DisabledOrgs
+}
+
+// GetTotalOrgs returns the TotalOrgs field if it's non-nil, zero value otherwise.
+func (o *OrgStats) GetTotalOrgs() int {
+	if o == nil || o.TotalOrgs == nil {
+		return 0
+	}
+	return *o.TotalOrgs
+}
+
+// GetTotalTeamMembers returns the TotalTeamMembers field if it's non-nil, zero value otherwise.
+func (o *OrgStats) GetTotalTeamMembers() int {
+	if o == nil || o.TotalTeamMembers == nil {
+		return 0
+	}
+	return *o.TotalTeamMembers
+}
+
+// GetTotalTeams returns the TotalTeams field if it's non-nil, zero value otherwise.
+func (o *OrgStats) GetTotalTeams() int {
+	if o == nil || o.TotalTeams == nil {
+		return 0
+	}
+	return *o.TotalTeams
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -84,12 +84,28 @@ func (a *App) GetName() string {
 	return *a.Name
 }
 
+// GetOwner returns the Owner field.
+func (a *App) GetOwner() *User {
+	if a == nil {
+		return nil
+	}
+	return a.Owner
+}
+
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (a *App) GetUpdatedAt() time.Time {
 	if a == nil || a.UpdatedAt == nil {
 		return time.Time{}
 	}
 	return *a.UpdatedAt
+}
+
+// GetApp returns the App field.
+func (a *Authorization) GetApp() *AuthorizationApp {
+	if a == nil {
+		return nil
+	}
+	return a.App
 }
 
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
@@ -170,6 +186,14 @@ func (a *Authorization) GetURL() string {
 		return ""
 	}
 	return *a.URL
+}
+
+// GetUser returns the User field.
+func (a *Authorization) GetUser() *User {
+	if a == nil {
+		return nil
+	}
+	return a.User
 }
 
 // GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
@@ -300,6 +324,14 @@ func (b *Blob) GetURL() string {
 	return *b.URL
 }
 
+// GetCommit returns the Commit field.
+func (b *Branch) GetCommit() *RepositoryCommit {
+	if b == nil {
+		return nil
+	}
+	return b.Commit
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (b *Branch) GetName() string {
 	if b == nil || b.Name == nil {
@@ -314,6 +346,142 @@ func (b *Branch) GetProtected() bool {
 		return false
 	}
 	return *b.Protected
+}
+
+// GetActivity returns the Activity field.
+func (c *Client) GetActivity() *ActivityService {
+	if c == nil {
+		return nil
+	}
+	return c.Activity
+}
+
+// GetAdmin returns the Admin field.
+func (c *Client) GetAdmin() *AdminService {
+	if c == nil {
+		return nil
+	}
+	return c.Admin
+}
+
+// GetApps returns the Apps field.
+func (c *Client) GetApps() *AppsService {
+	if c == nil {
+		return nil
+	}
+	return c.Apps
+}
+
+// GetAuthorizations returns the Authorizations field.
+func (c *Client) GetAuthorizations() *AuthorizationsService {
+	if c == nil {
+		return nil
+	}
+	return c.Authorizations
+}
+
+// GetGists returns the Gists field.
+func (c *Client) GetGists() *GistsService {
+	if c == nil {
+		return nil
+	}
+	return c.Gists
+}
+
+// GetGit returns the Git field.
+func (c *Client) GetGit() *GitService {
+	if c == nil {
+		return nil
+	}
+	return c.Git
+}
+
+// GetGitignores returns the Gitignores field.
+func (c *Client) GetGitignores() *GitignoresService {
+	if c == nil {
+		return nil
+	}
+	return c.Gitignores
+}
+
+// GetIssues returns the Issues field.
+func (c *Client) GetIssues() *IssuesService {
+	if c == nil {
+		return nil
+	}
+	return c.Issues
+}
+
+// GetLicenses returns the Licenses field.
+func (c *Client) GetLicenses() *LicensesService {
+	if c == nil {
+		return nil
+	}
+	return c.Licenses
+}
+
+// GetMigrations returns the Migrations field.
+func (c *Client) GetMigrations() *MigrationService {
+	if c == nil {
+		return nil
+	}
+	return c.Migrations
+}
+
+// GetOrganizations returns the Organizations field.
+func (c *Client) GetOrganizations() *OrganizationsService {
+	if c == nil {
+		return nil
+	}
+	return c.Organizations
+}
+
+// GetProjects returns the Projects field.
+func (c *Client) GetProjects() *ProjectsService {
+	if c == nil {
+		return nil
+	}
+	return c.Projects
+}
+
+// GetPullRequests returns the PullRequests field.
+func (c *Client) GetPullRequests() *PullRequestsService {
+	if c == nil {
+		return nil
+	}
+	return c.PullRequests
+}
+
+// GetReactions returns the Reactions field.
+func (c *Client) GetReactions() *ReactionsService {
+	if c == nil {
+		return nil
+	}
+	return c.Reactions
+}
+
+// GetRepositories returns the Repositories field.
+func (c *Client) GetRepositories() *RepositoriesService {
+	if c == nil {
+		return nil
+	}
+	return c.Repositories
+}
+
+// GetSearch returns the Search field.
+func (c *Client) GetSearch() *SearchService {
+	if c == nil {
+		return nil
+	}
+	return c.Search
+}
+
+// GetUsers returns the Users field.
+func (c *Client) GetUsers() *UsersService {
+	if c == nil {
+		return nil
+	}
+	return c.Users
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
@@ -370,6 +538,14 @@ func (c *CodeResult) GetPath() string {
 		return ""
 	}
 	return *c.Path
+}
+
+// GetRepository returns the Repository field.
+func (c *CodeResult) GetRepository() *Repository {
+	if c == nil {
+		return nil
+	}
+	return c.Repository
 }
 
 // GetSHA returns the SHA field if it's non-nil, zero value otherwise.
@@ -476,12 +652,28 @@ func (c *CommentStats) GetTotalPullRequestComments() int {
 	return *c.TotalPullRequestComments
 }
 
+// GetAuthor returns the Author field.
+func (c *Commit) GetAuthor() *CommitAuthor {
+	if c == nil {
+		return nil
+	}
+	return c.Author
+}
+
 // GetCommentCount returns the CommentCount field if it's non-nil, zero value otherwise.
 func (c *Commit) GetCommentCount() int {
 	if c == nil || c.CommentCount == nil {
 		return 0
 	}
 	return *c.CommentCount
+}
+
+// GetCommitter returns the Committer field.
+func (c *Commit) GetCommitter() *CommitAuthor {
+	if c == nil {
+		return nil
+	}
+	return c.Committer
 }
 
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
@@ -508,12 +700,36 @@ func (c *Commit) GetSHA() string {
 	return *c.SHA
 }
 
+// GetStats returns the Stats field.
+func (c *Commit) GetStats() *CommitStats {
+	if c == nil {
+		return nil
+	}
+	return c.Stats
+}
+
+// GetTree returns the Tree field.
+func (c *Commit) GetTree() *Tree {
+	if c == nil {
+		return nil
+	}
+	return c.Tree
+}
+
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
 func (c *Commit) GetURL() string {
 	if c == nil || c.URL == nil {
 		return ""
 	}
 	return *c.URL
+}
+
+// GetVerification returns the Verification field.
+func (c *Commit) GetVerification() *SignatureVerification {
+	if c == nil {
+		return nil
+	}
+	return c.Verification
 }
 
 // GetDate returns the Date field if it's non-nil, zero value otherwise.
@@ -554,6 +770,38 @@ func (c *CommitCommentEvent) GetAction() string {
 		return ""
 	}
 	return *c.Action
+}
+
+// GetComment returns the Comment field.
+func (c *CommitCommentEvent) GetComment() *RepositoryComment {
+	if c == nil {
+		return nil
+	}
+	return c.Comment
+}
+
+// GetInstallation returns the Installation field.
+func (c *CommitCommentEvent) GetInstallation() *Installation {
+	if c == nil {
+		return nil
+	}
+	return c.Installation
+}
+
+// GetRepo returns the Repo field.
+func (c *CommitCommentEvent) GetRepo() *Repository {
+	if c == nil {
+		return nil
+	}
+	return c.Repo
+}
+
+// GetSender returns the Sender field.
+func (c *CommitCommentEvent) GetSender() *User {
+	if c == nil {
+		return nil
+	}
+	return c.Sender
 }
 
 // GetAdditions returns the Additions field if it's non-nil, zero value otherwise.
@@ -636,6 +884,14 @@ func (c *CommitFile) GetStatus() string {
 	return *c.Status
 }
 
+// GetAuthor returns the Author field.
+func (c *CommitResult) GetAuthor() *User {
+	if c == nil {
+		return nil
+	}
+	return c.Author
+}
+
 // GetCommentsURL returns the CommentsURL field if it's non-nil, zero value otherwise.
 func (c *CommitResult) GetCommentsURL() string {
 	if c == nil || c.CommentsURL == nil {
@@ -644,12 +900,44 @@ func (c *CommitResult) GetCommentsURL() string {
 	return *c.CommentsURL
 }
 
+// GetCommit returns the Commit field.
+func (c *CommitResult) GetCommit() *Commit {
+	if c == nil {
+		return nil
+	}
+	return c.Commit
+}
+
+// GetCommitter returns the Committer field.
+func (c *CommitResult) GetCommitter() *User {
+	if c == nil {
+		return nil
+	}
+	return c.Committer
+}
+
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
 func (c *CommitResult) GetHTMLURL() string {
 	if c == nil || c.HTMLURL == nil {
 		return ""
 	}
 	return *c.HTMLURL
+}
+
+// GetRepository returns the Repository field.
+func (c *CommitResult) GetRepository() *Repository {
+	if c == nil {
+		return nil
+	}
+	return c.Repository
+}
+
+// GetScore returns the Score field.
+func (c *CommitResult) GetScore() *float64 {
+	if c == nil {
+		return nil
+	}
+	return c.Score
 }
 
 // GetSHA returns the SHA field if it's non-nil, zero value otherwise.
@@ -676,6 +964,14 @@ func (c *CommitsComparison) GetAheadBy() int {
 	return *c.AheadBy
 }
 
+// GetBaseCommit returns the BaseCommit field.
+func (c *CommitsComparison) GetBaseCommit() *RepositoryCommit {
+	if c == nil {
+		return nil
+	}
+	return c.BaseCommit
+}
+
 // GetBehindBy returns the BehindBy field if it's non-nil, zero value otherwise.
 func (c *CommitsComparison) GetBehindBy() int {
 	if c == nil || c.BehindBy == nil {
@@ -698,6 +994,14 @@ func (c *CommitsComparison) GetHTMLURL() string {
 		return ""
 	}
 	return *c.HTMLURL
+}
+
+// GetMergeBaseCommit returns the MergeBaseCommit field.
+func (c *CommitsComparison) GetMergeBaseCommit() *RepositoryCommit {
+	if c == nil {
+		return nil
+	}
+	return c.MergeBaseCommit
 }
 
 // GetPatchURL returns the PatchURL field if it's non-nil, zero value otherwise.
@@ -778,6 +1082,46 @@ func (c *CommitStats) GetTotal() int {
 		return 0
 	}
 	return *c.Total
+}
+
+// GetCodeOfConduct returns the CodeOfConduct field.
+func (c *CommunityHealthFiles) GetCodeOfConduct() *Metric {
+	if c == nil {
+		return nil
+	}
+	return c.CodeOfConduct
+}
+
+// GetContributing returns the Contributing field.
+func (c *CommunityHealthFiles) GetContributing() *Metric {
+	if c == nil {
+		return nil
+	}
+	return c.Contributing
+}
+
+// GetLicense returns the License field.
+func (c *CommunityHealthFiles) GetLicense() *Metric {
+	if c == nil {
+		return nil
+	}
+	return c.License
+}
+
+// GetReadme returns the Readme field.
+func (c *CommunityHealthFiles) GetReadme() *Metric {
+	if c == nil {
+		return nil
+	}
+	return c.Readme
+}
+
+// GetFiles returns the Files field.
+func (c *CommunityHealthMetrics) GetFiles() *CommunityHealthFiles {
+	if c == nil {
+		return nil
+	}
+	return c.Files
 }
 
 // GetHealthPercentage returns the HealthPercentage field if it's non-nil, zero value otherwise.
@@ -940,12 +1284,36 @@ func (c *Contributor) GetURL() string {
 	return *c.URL
 }
 
+// GetAuthor returns the Author field.
+func (c *ContributorStats) GetAuthor() *Contributor {
+	if c == nil {
+		return nil
+	}
+	return c.Author
+}
+
 // GetTotal returns the Total field if it's non-nil, zero value otherwise.
 func (c *ContributorStats) GetTotal() int {
 	if c == nil || c.Total == nil {
 		return 0
 	}
 	return *c.Total
+}
+
+// GetAuthor returns the Author field.
+func (c *createCommit) GetAuthor() *CommitAuthor {
+	if c == nil {
+		return nil
+	}
+	return c.Author
+}
+
+// GetCommitter returns the Committer field.
+func (c *createCommit) GetCommitter() *CommitAuthor {
+	if c == nil {
+		return nil
+	}
+	return c.Committer
 }
 
 // GetMessage returns the Message field if it's non-nil, zero value otherwise.
@@ -970,6 +1338,14 @@ func (c *CreateEvent) GetDescription() string {
 		return ""
 	}
 	return *c.Description
+}
+
+// GetInstallation returns the Installation field.
+func (c *CreateEvent) GetInstallation() *Installation {
+	if c == nil {
+		return nil
+	}
+	return c.Installation
 }
 
 // GetMasterBranch returns the MasterBranch field if it's non-nil, zero value otherwise.
@@ -1002,6 +1378,22 @@ func (c *CreateEvent) GetRefType() string {
 		return ""
 	}
 	return *c.RefType
+}
+
+// GetRepo returns the Repo field.
+func (c *CreateEvent) GetRepo() *Repository {
+	if c == nil {
+		return nil
+	}
+	return c.Repo
+}
+
+// GetSender returns the Sender field.
+func (c *CreateEvent) GetSender() *User {
+	if c == nil {
+		return nil
+	}
+	return c.Sender
 }
 
 // GetRef returns the Ref field if it's non-nil, zero value otherwise.
@@ -1044,12 +1436,28 @@ func (c *createTagRequest) GetTag() string {
 	return *c.Tag
 }
 
+// GetTagger returns the Tagger field.
+func (c *createTagRequest) GetTagger() *CommitAuthor {
+	if c == nil {
+		return nil
+	}
+	return c.Tagger
+}
+
 // GetType returns the Type field if it's non-nil, zero value otherwise.
 func (c *createTagRequest) GetType() string {
 	if c == nil || c.Type == nil {
 		return ""
 	}
 	return *c.Type
+}
+
+// GetInstallation returns the Installation field.
+func (d *DeleteEvent) GetInstallation() *Installation {
+	if d == nil {
+		return nil
+	}
+	return d.Installation
 }
 
 // GetPusherType returns the PusherType field if it's non-nil, zero value otherwise.
@@ -1076,12 +1484,36 @@ func (d *DeleteEvent) GetRefType() string {
 	return *d.RefType
 }
 
+// GetRepo returns the Repo field.
+func (d *DeleteEvent) GetRepo() *Repository {
+	if d == nil {
+		return nil
+	}
+	return d.Repo
+}
+
+// GetSender returns the Sender field.
+func (d *DeleteEvent) GetSender() *User {
+	if d == nil {
+		return nil
+	}
+	return d.Sender
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (d *Deployment) GetCreatedAt() Timestamp {
 	if d == nil || d.CreatedAt == nil {
 		return Timestamp{}
 	}
 	return *d.CreatedAt
+}
+
+// GetCreator returns the Creator field.
+func (d *Deployment) GetCreator() *User {
+	if d == nil {
+		return nil
+	}
+	return d.Creator
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
@@ -1164,6 +1596,38 @@ func (d *Deployment) GetURL() string {
 	return *d.URL
 }
 
+// GetDeployment returns the Deployment field.
+func (d *DeploymentEvent) GetDeployment() *Deployment {
+	if d == nil {
+		return nil
+	}
+	return d.Deployment
+}
+
+// GetInstallation returns the Installation field.
+func (d *DeploymentEvent) GetInstallation() *Installation {
+	if d == nil {
+		return nil
+	}
+	return d.Installation
+}
+
+// GetRepo returns the Repo field.
+func (d *DeploymentEvent) GetRepo() *Repository {
+	if d == nil {
+		return nil
+	}
+	return d.Repo
+}
+
+// GetSender returns the Sender field.
+func (d *DeploymentEvent) GetSender() *User {
+	if d == nil {
+		return nil
+	}
+	return d.Sender
+}
+
 // GetAutoMerge returns the AutoMerge field if it's non-nil, zero value otherwise.
 func (d *DeploymentRequest) GetAutoMerge() bool {
 	if d == nil || d.AutoMerge == nil {
@@ -1244,6 +1708,14 @@ func (d *DeploymentStatus) GetCreatedAt() Timestamp {
 	return *d.CreatedAt
 }
 
+// GetCreator returns the Creator field.
+func (d *DeploymentStatus) GetCreator() *User {
+	if d == nil {
+		return nil
+	}
+	return d.Creator
+}
+
 // GetDeploymentURL returns the DeploymentURL field if it's non-nil, zero value otherwise.
 func (d *DeploymentStatus) GetDeploymentURL() string {
 	if d == nil || d.DeploymentURL == nil {
@@ -1298,6 +1770,46 @@ func (d *DeploymentStatus) GetUpdatedAt() Timestamp {
 		return Timestamp{}
 	}
 	return *d.UpdatedAt
+}
+
+// GetDeployment returns the Deployment field.
+func (d *DeploymentStatusEvent) GetDeployment() *Deployment {
+	if d == nil {
+		return nil
+	}
+	return d.Deployment
+}
+
+// GetDeploymentStatus returns the DeploymentStatus field.
+func (d *DeploymentStatusEvent) GetDeploymentStatus() *DeploymentStatus {
+	if d == nil {
+		return nil
+	}
+	return d.DeploymentStatus
+}
+
+// GetInstallation returns the Installation field.
+func (d *DeploymentStatusEvent) GetInstallation() *Installation {
+	if d == nil {
+		return nil
+	}
+	return d.Installation
+}
+
+// GetRepo returns the Repo field.
+func (d *DeploymentStatusEvent) GetRepo() *Repository {
+	if d == nil {
+		return nil
+	}
+	return d.Repo
+}
+
+// GetSender returns the Sender field.
+func (d *DeploymentStatusEvent) GetSender() *User {
+	if d == nil {
+		return nil
+	}
+	return d.Sender
 }
 
 // GetAutoInactive returns the AutoInactive field if it's non-nil, zero value otherwise.
@@ -1364,6 +1876,14 @@ func (d *DraftReviewComment) GetPosition() int {
 	return *d.Position
 }
 
+// GetActor returns the Actor field.
+func (e *Event) GetActor() *User {
+	if e == nil {
+		return nil
+	}
+	return e.Actor
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (e *Event) GetCreatedAt() time.Time {
 	if e == nil || e.CreatedAt == nil {
@@ -1380,6 +1900,14 @@ func (e *Event) GetID() string {
 	return *e.ID
 }
 
+// GetOrg returns the Org field.
+func (e *Event) GetOrg() *Organization {
+	if e == nil {
+		return nil
+	}
+	return e.Org
+}
+
 // GetPublic returns the Public field if it's non-nil, zero value otherwise.
 func (e *Event) GetPublic() bool {
 	if e == nil || e.Public == nil {
@@ -1394,6 +1922,14 @@ func (e *Event) GetRawPayload() json.RawMessage {
 		return json.RawMessage{}
 	}
 	return *e.RawPayload
+}
+
+// GetRepo returns the Repo field.
+func (e *Event) GetRepo() *Repository {
+	if e == nil {
+		return nil
+	}
+	return e.Repo
 }
 
 // GetType returns the Type field if it's non-nil, zero value otherwise.
@@ -1468,6 +2004,38 @@ func (f *Feeds) GetUserURL() string {
 	return *f.UserURL
 }
 
+// GetForkee returns the Forkee field.
+func (f *ForkEvent) GetForkee() *Repository {
+	if f == nil {
+		return nil
+	}
+	return f.Forkee
+}
+
+// GetInstallation returns the Installation field.
+func (f *ForkEvent) GetInstallation() *Installation {
+	if f == nil {
+		return nil
+	}
+	return f.Installation
+}
+
+// GetRepo returns the Repo field.
+func (f *ForkEvent) GetRepo() *Repository {
+	if f == nil {
+		return nil
+	}
+	return f.Repo
+}
+
+// GetSender returns the Sender field.
+func (f *ForkEvent) GetSender() *User {
+	if f == nil {
+		return nil
+	}
+	return f.Sender
+}
+
 // GetComments returns the Comments field if it's non-nil, zero value otherwise.
 func (g *Gist) GetComments() int {
 	if g == nil || g.Comments == nil {
@@ -1524,6 +2092,14 @@ func (g *Gist) GetID() string {
 	return *g.ID
 }
 
+// GetOwner returns the Owner field.
+func (g *Gist) GetOwner() *User {
+	if g == nil {
+		return nil
+	}
+	return g.Owner
+}
+
 // GetPublic returns the Public field if it's non-nil, zero value otherwise.
 func (g *Gist) GetPublic() bool {
 	if g == nil || g.Public == nil {
@@ -1572,6 +2148,22 @@ func (g *GistComment) GetURL() string {
 	return *g.URL
 }
 
+// GetUser returns the User field.
+func (g *GistComment) GetUser() *User {
+	if g == nil {
+		return nil
+	}
+	return g.User
+}
+
+// GetChangeStatus returns the ChangeStatus field.
+func (g *GistCommit) GetChangeStatus() *CommitStats {
+	if g == nil {
+		return nil
+	}
+	return g.ChangeStatus
+}
+
 // GetCommittedAt returns the CommittedAt field if it's non-nil, zero value otherwise.
 func (g *GistCommit) GetCommittedAt() Timestamp {
 	if g == nil || g.CommittedAt == nil {
@@ -1586,6 +2178,14 @@ func (g *GistCommit) GetURL() string {
 		return ""
 	}
 	return *g.URL
+}
+
+// GetUser returns the User field.
+func (g *GistCommit) GetUser() *User {
+	if g == nil {
+		return nil
+	}
+	return g.User
 }
 
 // GetVersion returns the Version field if it's non-nil, zero value otherwise.
@@ -1700,6 +2300,14 @@ func (g *GistStats) GetTotalGists() int {
 	return *g.TotalGists
 }
 
+// GetUser returns the User field.
+func (g *GistFork) GetUser() *User {
+	if g == nil {
+		return nil
+	}
+	return g.User
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (g *Gitignore) GetName() string {
 	if g == nil || g.Name == nil {
@@ -1738,6 +2346,30 @@ func (g *GitObject) GetURL() string {
 		return ""
 	}
 	return *g.URL
+}
+
+// GetInstallation returns the Installation field.
+func (g *GollumEvent) GetInstallation() *Installation {
+	if g == nil {
+		return nil
+	}
+	return g.Installation
+}
+
+// GetRepo returns the Repo field.
+func (g *GollumEvent) GetRepo() *Repository {
+	if g == nil {
+		return nil
+	}
+	return g.Repo
+}
+
+// GetSender returns the Sender field.
+func (g *GollumEvent) GetSender() *User {
+	if g == nil {
+		return nil
+	}
+	return g.Sender
 }
 
 // GetEmail returns the Email field if it's non-nil, zero value otherwise.
@@ -1834,6 +2466,14 @@ func (g *GPGKey) GetPublicKey() string {
 		return ""
 	}
 	return *g.PublicKey
+}
+
+// GetApp returns the App field.
+func (g *Grant) GetApp() *AuthorizationApp {
+	if g == nil {
+		return nil
+	}
+	return g.App
 }
 
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
@@ -2124,6 +2764,14 @@ func (i *Installation) GetAccessTokensURL() string {
 	return *i.AccessTokensURL
 }
 
+// GetAccount returns the Account field.
+func (i *Installation) GetAccount() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Account
+}
+
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
 func (i *Installation) GetHTMLURL() string {
 	if i == nil || i.HTMLURL == nil {
@@ -2156,6 +2804,22 @@ func (i *InstallationEvent) GetAction() string {
 	return *i.Action
 }
 
+// GetInstallation returns the Installation field.
+func (i *InstallationEvent) GetInstallation() *Installation {
+	if i == nil {
+		return nil
+	}
+	return i.Installation
+}
+
+// GetSender returns the Sender field.
+func (i *InstallationEvent) GetSender() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Sender
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (i *InstallationRepositoriesEvent) GetAction() string {
 	if i == nil || i.Action == nil {
@@ -2164,12 +2828,28 @@ func (i *InstallationRepositoriesEvent) GetAction() string {
 	return *i.Action
 }
 
+// GetInstallation returns the Installation field.
+func (i *InstallationRepositoriesEvent) GetInstallation() *Installation {
+	if i == nil {
+		return nil
+	}
+	return i.Installation
+}
+
 // GetRepositorySelection returns the RepositorySelection field if it's non-nil, zero value otherwise.
 func (i *InstallationRepositoriesEvent) GetRepositorySelection() string {
 	if i == nil || i.RepositorySelection == nil {
 		return ""
 	}
 	return *i.RepositorySelection
+}
+
+// GetSender returns the Sender field.
+func (i *InstallationRepositoriesEvent) GetSender() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Sender
 }
 
 // GetExpiresAt returns the ExpiresAt field if it's non-nil, zero value otherwise.
@@ -2212,6 +2892,14 @@ func (i *Invitation) GetID() int {
 	return *i.ID
 }
 
+// GetInviter returns the Inviter field.
+func (i *Invitation) GetInviter() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Inviter
+}
+
 // GetLogin returns the Login field if it's non-nil, zero value otherwise.
 func (i *Invitation) GetLogin() string {
 	if i == nil || i.Login == nil {
@@ -2228,6 +2916,14 @@ func (i *Invitation) GetRole() string {
 	return *i.Role
 }
 
+// GetAssignee returns the Assignee field.
+func (i *Issue) GetAssignee() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Assignee
+}
+
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
 func (i *Issue) GetBody() string {
 	if i == nil || i.Body == nil {
@@ -2242,6 +2938,14 @@ func (i *Issue) GetClosedAt() time.Time {
 		return time.Time{}
 	}
 	return *i.ClosedAt
+}
+
+// GetClosedBy returns the ClosedBy field.
+func (i *Issue) GetClosedBy() *User {
+	if i == nil {
+		return nil
+	}
+	return i.ClosedBy
 }
 
 // GetComments returns the Comments field if it's non-nil, zero value otherwise.
@@ -2308,12 +3012,44 @@ func (i *Issue) GetLocked() bool {
 	return *i.Locked
 }
 
+// GetMilestone returns the Milestone field.
+func (i *Issue) GetMilestone() *Milestone {
+	if i == nil {
+		return nil
+	}
+	return i.Milestone
+}
+
 // GetNumber returns the Number field if it's non-nil, zero value otherwise.
 func (i *Issue) GetNumber() int {
 	if i == nil || i.Number == nil {
 		return 0
 	}
 	return *i.Number
+}
+
+// GetPullRequestLinks returns the PullRequestLinks field.
+func (i *Issue) GetPullRequestLinks() *PullRequestLinks {
+	if i == nil {
+		return nil
+	}
+	return i.PullRequestLinks
+}
+
+// GetReactions returns the Reactions field.
+func (i *Issue) GetReactions() *Reactions {
+	if i == nil {
+		return nil
+	}
+	return i.Reactions
+}
+
+// GetRepository returns the Repository field.
+func (i *Issue) GetRepository() *Repository {
+	if i == nil {
+		return nil
+	}
+	return i.Repository
 }
 
 // GetRepositoryURL returns the RepositoryURL field if it's non-nil, zero value otherwise.
@@ -2356,6 +3092,14 @@ func (i *Issue) GetURL() string {
 	return *i.URL
 }
 
+// GetUser returns the User field.
+func (i *Issue) GetUser() *User {
+	if i == nil {
+		return nil
+	}
+	return i.User
+}
+
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
 func (i *IssueComment) GetBody() string {
 	if i == nil || i.Body == nil {
@@ -2396,6 +3140,14 @@ func (i *IssueComment) GetIssueURL() string {
 	return *i.IssueURL
 }
 
+// GetReactions returns the Reactions field.
+func (i *IssueComment) GetReactions() *Reactions {
+	if i == nil {
+		return nil
+	}
+	return i.Reactions
+}
+
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (i *IssueComment) GetUpdatedAt() time.Time {
 	if i == nil || i.UpdatedAt == nil {
@@ -2412,12 +3164,92 @@ func (i *IssueComment) GetURL() string {
 	return *i.URL
 }
 
+// GetUser returns the User field.
+func (i *IssueComment) GetUser() *User {
+	if i == nil {
+		return nil
+	}
+	return i.User
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (i *IssueCommentEvent) GetAction() string {
 	if i == nil || i.Action == nil {
 		return ""
 	}
 	return *i.Action
+}
+
+// GetChanges returns the Changes field.
+func (i *IssueCommentEvent) GetChanges() *EditChange {
+	if i == nil {
+		return nil
+	}
+	return i.Changes
+}
+
+// GetComment returns the Comment field.
+func (i *IssueCommentEvent) GetComment() *IssueComment {
+	if i == nil {
+		return nil
+	}
+	return i.Comment
+}
+
+// GetInstallation returns the Installation field.
+func (i *IssueCommentEvent) GetInstallation() *Installation {
+	if i == nil {
+		return nil
+	}
+	return i.Installation
+}
+
+// GetIssue returns the Issue field.
+func (i *IssueCommentEvent) GetIssue() *Issue {
+	if i == nil {
+		return nil
+	}
+	return i.Issue
+}
+
+// GetRepo returns the Repo field.
+func (i *IssueCommentEvent) GetRepo() *Repository {
+	if i == nil {
+		return nil
+	}
+	return i.Repo
+}
+
+// GetSender returns the Sender field.
+func (i *IssueCommentEvent) GetSender() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Sender
+}
+
+// GetActor returns the Actor field.
+func (i *IssueEvent) GetActor() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Actor
+}
+
+// GetAssignee returns the Assignee field.
+func (i *IssueEvent) GetAssignee() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Assignee
+}
+
+// GetAssigner returns the Assigner field.
+func (i *IssueEvent) GetAssigner() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Assigner
 }
 
 // GetCommitID returns the CommitID field if it's non-nil, zero value otherwise.
@@ -2450,6 +3282,38 @@ func (i *IssueEvent) GetID() int {
 		return 0
 	}
 	return *i.ID
+}
+
+// GetIssue returns the Issue field.
+func (i *IssueEvent) GetIssue() *Issue {
+	if i == nil {
+		return nil
+	}
+	return i.Issue
+}
+
+// GetLabel returns the Label field.
+func (i *IssueEvent) GetLabel() *Label {
+	if i == nil {
+		return nil
+	}
+	return i.Label
+}
+
+// GetMilestone returns the Milestone field.
+func (i *IssueEvent) GetMilestone() *Milestone {
+	if i == nil {
+		return nil
+	}
+	return i.Milestone
+}
+
+// GetRename returns the Rename field.
+func (i *IssueEvent) GetRename() *Rename {
+	if i == nil {
+		return nil
+	}
+	return i.Rename
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
@@ -2522,6 +3386,62 @@ func (i *IssuesEvent) GetAction() string {
 		return ""
 	}
 	return *i.Action
+}
+
+// GetAssignee returns the Assignee field.
+func (i *IssuesEvent) GetAssignee() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Assignee
+}
+
+// GetChanges returns the Changes field.
+func (i *IssuesEvent) GetChanges() *EditChange {
+	if i == nil {
+		return nil
+	}
+	return i.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (i *IssuesEvent) GetInstallation() *Installation {
+	if i == nil {
+		return nil
+	}
+	return i.Installation
+}
+
+// GetIssue returns the Issue field.
+func (i *IssuesEvent) GetIssue() *Issue {
+	if i == nil {
+		return nil
+	}
+	return i.Issue
+}
+
+// GetLabel returns the Label field.
+func (i *IssuesEvent) GetLabel() *Label {
+	if i == nil {
+		return nil
+	}
+	return i.Label
+}
+
+// GetRepo returns the Repo field.
+func (i *IssuesEvent) GetRepo() *Repository {
+	if i == nil {
+		return nil
+	}
+	return i.Repo
+}
+
+// GetSender returns the Sender field.
+func (i *IssuesEvent) GetSender() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Sender
 }
 
 // GetIncompleteResults returns the IncompleteResults field if it's non-nil, zero value otherwise.
@@ -2642,6 +3562,46 @@ func (l *LabelEvent) GetAction() string {
 		return ""
 	}
 	return *l.Action
+}
+
+// GetChanges returns the Changes field.
+func (l *LabelEvent) GetChanges() *EditChange {
+	if l == nil {
+		return nil
+	}
+	return l.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (l *LabelEvent) GetInstallation() *Installation {
+	if l == nil {
+		return nil
+	}
+	return l.Installation
+}
+
+// GetLabel returns the Label field.
+func (l *LabelEvent) GetLabel() *Label {
+	if l == nil {
+		return nil
+	}
+	return l.Label
+}
+
+// GetOrg returns the Org field.
+func (l *LabelEvent) GetOrg() *Organization {
+	if l == nil {
+		return nil
+	}
+	return l.Org
+}
+
+// GetRepo returns the Repo field.
+func (l *LabelEvent) GetRepo() *Repository {
+	if l == nil {
+		return nil
+	}
+	return l.Repo
 }
 
 // GetOID returns the OID field if it's non-nil, zero value otherwise.
@@ -2812,6 +3772,46 @@ func (m *MemberEvent) GetAction() string {
 	return *m.Action
 }
 
+// GetInstallation returns the Installation field.
+func (m *MemberEvent) GetInstallation() *Installation {
+	if m == nil {
+		return nil
+	}
+	return m.Installation
+}
+
+// GetMember returns the Member field.
+func (m *MemberEvent) GetMember() *User {
+	if m == nil {
+		return nil
+	}
+	return m.Member
+}
+
+// GetRepo returns the Repo field.
+func (m *MemberEvent) GetRepo() *Repository {
+	if m == nil {
+		return nil
+	}
+	return m.Repo
+}
+
+// GetSender returns the Sender field.
+func (m *MemberEvent) GetSender() *User {
+	if m == nil {
+		return nil
+	}
+	return m.Sender
+}
+
+// GetOrganization returns the Organization field.
+func (m *Membership) GetOrganization() *Organization {
+	if m == nil {
+		return nil
+	}
+	return m.Organization
+}
+
 // GetOrganizationURL returns the OrganizationURL field if it's non-nil, zero value otherwise.
 func (m *Membership) GetOrganizationURL() string {
 	if m == nil || m.OrganizationURL == nil {
@@ -2844,6 +3844,14 @@ func (m *Membership) GetURL() string {
 	return *m.URL
 }
 
+// GetUser returns the User field.
+func (m *Membership) GetUser() *User {
+	if m == nil {
+		return nil
+	}
+	return m.User
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (m *MembershipEvent) GetAction() string {
 	if m == nil || m.Action == nil {
@@ -2852,12 +3860,52 @@ func (m *MembershipEvent) GetAction() string {
 	return *m.Action
 }
 
+// GetInstallation returns the Installation field.
+func (m *MembershipEvent) GetInstallation() *Installation {
+	if m == nil {
+		return nil
+	}
+	return m.Installation
+}
+
+// GetMember returns the Member field.
+func (m *MembershipEvent) GetMember() *User {
+	if m == nil {
+		return nil
+	}
+	return m.Member
+}
+
+// GetOrg returns the Org field.
+func (m *MembershipEvent) GetOrg() *Organization {
+	if m == nil {
+		return nil
+	}
+	return m.Org
+}
+
 // GetScope returns the Scope field if it's non-nil, zero value otherwise.
 func (m *MembershipEvent) GetScope() string {
 	if m == nil || m.Scope == nil {
 		return ""
 	}
 	return *m.Scope
+}
+
+// GetSender returns the Sender field.
+func (m *MembershipEvent) GetSender() *User {
+	if m == nil {
+		return nil
+	}
+	return m.Sender
+}
+
+// GetTeam returns the Team field.
+func (m *MembershipEvent) GetTeam() *Team {
+	if m == nil {
+		return nil
+	}
+	return m.Team
 }
 
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
@@ -2980,6 +4028,14 @@ func (m *Milestone) GetCreatedAt() time.Time {
 	return *m.CreatedAt
 }
 
+// GetCreator returns the Creator field.
+func (m *Milestone) GetCreator() *User {
+	if m == nil {
+		return nil
+	}
+	return m.Creator
+}
+
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
 func (m *Milestone) GetDescription() string {
 	if m == nil || m.Description == nil {
@@ -3100,6 +4156,54 @@ func (m *MilestoneStats) GetTotalMilestones() int {
 	return *m.TotalMilestones
 }
 
+// GetChanges returns the Changes field.
+func (m *MilestoneEvent) GetChanges() *EditChange {
+	if m == nil {
+		return nil
+	}
+	return m.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (m *MilestoneEvent) GetInstallation() *Installation {
+	if m == nil {
+		return nil
+	}
+	return m.Installation
+}
+
+// GetMilestone returns the Milestone field.
+func (m *MilestoneEvent) GetMilestone() *Milestone {
+	if m == nil {
+		return nil
+	}
+	return m.Milestone
+}
+
+// GetOrg returns the Org field.
+func (m *MilestoneEvent) GetOrg() *Organization {
+	if m == nil {
+		return nil
+	}
+	return m.Org
+}
+
+// GetRepo returns the Repo field.
+func (m *MilestoneEvent) GetRepo() *Repository {
+	if m == nil {
+		return nil
+	}
+	return m.Repo
+}
+
+// GetSender returns the Sender field.
+func (m *MilestoneEvent) GetSender() *User {
+	if m == nil {
+		return nil
+	}
+	return m.Sender
+}
+
 // GetBase returns the Base field if it's non-nil, zero value otherwise.
 func (n *NewPullRequest) GetBase() string {
 	if n == nil || n.Base == nil {
@@ -3210,6 +4314,22 @@ func (n *Notification) GetReason() string {
 		return ""
 	}
 	return *n.Reason
+}
+
+// GetRepository returns the Repository field.
+func (n *Notification) GetRepository() *Repository {
+	if n == nil {
+		return nil
+	}
+	return n.Repository
+}
+
+// GetSubject returns the Subject field.
+func (n *Notification) GetSubject() *NotificationSubject {
+	if n == nil {
+		return nil
+	}
+	return n.Subject
 }
 
 // GetUnread returns the Unread field if it's non-nil, zero value otherwise.
@@ -3436,6 +4556,14 @@ func (o *Organization) GetOwnedPrivateRepos() int {
 	return *o.OwnedPrivateRepos
 }
 
+// GetPlan returns the Plan field.
+func (o *Organization) GetPlan() *Plan {
+	if o == nil {
+		return nil
+	}
+	return o.Plan
+}
+
 // GetPrivateGists returns the PrivateGists field if it's non-nil, zero value otherwise.
 func (o *Organization) GetPrivateGists() int {
 	if o == nil || o.PrivateGists == nil {
@@ -3516,6 +4644,46 @@ func (o *OrganizationEvent) GetAction() string {
 	return *o.Action
 }
 
+// GetInstallation returns the Installation field.
+func (o *OrganizationEvent) GetInstallation() *Installation {
+	if o == nil {
+		return nil
+	}
+	return o.Installation
+}
+
+// GetInvitation returns the Invitation field.
+func (o *OrganizationEvent) GetInvitation() *Invitation {
+	if o == nil {
+		return nil
+	}
+	return o.Invitation
+}
+
+// GetMembership returns the Membership field.
+func (o *OrganizationEvent) GetMembership() *Membership {
+	if o == nil {
+		return nil
+	}
+	return o.Membership
+}
+
+// GetOrganization returns the Organization field.
+func (o *OrganizationEvent) GetOrganization() *Organization {
+	if o == nil {
+		return nil
+	}
+	return o.Organization
+}
+
+// GetSender returns the Sender field.
+func (o *OrganizationEvent) GetSender() *User {
+	if o == nil {
+		return nil
+	}
+	return o.Sender
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (o *OrgBlockEvent) GetAction() string {
 	if o == nil || o.Action == nil {
@@ -3554,6 +4722,38 @@ func (o *OrgStats) GetTotalTeams() int {
 		return 0
 	}
 	return *o.TotalTeams
+}
+
+// GetBlockedUser returns the BlockedUser field.
+func (o *OrgBlockEvent) GetBlockedUser() *User {
+	if o == nil {
+		return nil
+	}
+	return o.BlockedUser
+}
+
+// GetInstallation returns the Installation field.
+func (o *OrgBlockEvent) GetInstallation() *Installation {
+	if o == nil {
+		return nil
+	}
+	return o.Installation
+}
+
+// GetOrganization returns the Organization field.
+func (o *OrgBlockEvent) GetOrganization() *Organization {
+	if o == nil {
+		return nil
+	}
+	return o.Organization
+}
+
+// GetSender returns the Sender field.
+func (o *OrgBlockEvent) GetSender() *User {
+	if o == nil {
+		return nil
+	}
+	return o.Sender
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
@@ -3604,12 +4804,44 @@ func (p *Page) GetTitle() string {
 	return *p.Title
 }
 
+// GetBuild returns the Build field.
+func (p *PageBuildEvent) GetBuild() *PagesBuild {
+	if p == nil {
+		return nil
+	}
+	return p.Build
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (p *PageBuildEvent) GetID() int {
 	if p == nil || p.ID == nil {
 		return 0
 	}
 	return *p.ID
+}
+
+// GetInstallation returns the Installation field.
+func (p *PageBuildEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetRepo returns the Repo field.
+func (p *PageBuildEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *PageBuildEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
 }
 
 // GetCNAME returns the CNAME field if it's non-nil, zero value otherwise.
@@ -3676,6 +4908,22 @@ func (p *PagesBuild) GetDuration() int {
 	return *p.Duration
 }
 
+// GetError returns the Error field.
+func (p *PagesBuild) GetError() *PagesError {
+	if p == nil {
+		return nil
+	}
+	return p.Error
+}
+
+// GetPusher returns the Pusher field.
+func (p *PagesBuild) GetPusher() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Pusher
+}
+
 // GetStatus returns the Status field if it's non-nil, zero value otherwise.
 func (p *PagesBuild) GetStatus() string {
 	if p == nil || p.Status == nil {
@@ -3716,12 +4964,28 @@ func (p *PageStats) GetTotalPages() int {
 	return *p.TotalPages
 }
 
+// GetHook returns the Hook field.
+func (p *PingEvent) GetHook() *Hook {
+	if p == nil {
+		return nil
+	}
+	return p.Hook
+}
+
 // GetHookID returns the HookID field if it's non-nil, zero value otherwise.
 func (p *PingEvent) GetHookID() int {
 	if p == nil || p.HookID == nil {
 		return 0
 	}
 	return *p.HookID
+}
+
+// GetInstallation returns the Installation field.
+func (p *PingEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
 }
 
 // GetZen returns the Zen field if it's non-nil, zero value otherwise.
@@ -3778,6 +5042,14 @@ func (p *Project) GetCreatedAt() Timestamp {
 		return Timestamp{}
 	}
 	return *p.CreatedAt
+}
+
+// GetCreator returns the Creator field.
+func (p *Project) GetCreator() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Creator
 }
 
 // GetID returns the ID field if it's non-nil, zero value otherwise.
@@ -3860,6 +5132,14 @@ func (p *ProjectCard) GetCreatedAt() Timestamp {
 	return *p.CreatedAt
 }
 
+// GetCreator returns the Creator field.
+func (p *ProjectCard) GetCreator() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Creator
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (p *ProjectCard) GetID() int {
 	if p == nil || p.ID == nil {
@@ -3906,6 +5186,54 @@ func (p *ProjectCardEvent) GetAfterID() int {
 		return 0
 	}
 	return *p.AfterID
+}
+
+// GetChanges returns the Changes field.
+func (p *ProjectCardEvent) GetChanges() *ProjectCardChange {
+	if p == nil {
+		return nil
+	}
+	return p.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (p *ProjectCardEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetOrg returns the Org field.
+func (p *ProjectCardEvent) GetOrg() *Organization {
+	if p == nil {
+		return nil
+	}
+	return p.Org
+}
+
+// GetProjectCard returns the ProjectCard field.
+func (p *ProjectCardEvent) GetProjectCard() *ProjectCard {
+	if p == nil {
+		return nil
+	}
+	return p.ProjectCard
+}
+
+// GetRepo returns the Repo field.
+func (p *ProjectCardEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *ProjectCardEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
 }
 
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
@@ -3964,6 +5292,54 @@ func (p *ProjectColumnEvent) GetAfterID() int {
 	return *p.AfterID
 }
 
+// GetChanges returns the Changes field.
+func (p *ProjectColumnEvent) GetChanges() *ProjectColumnChange {
+	if p == nil {
+		return nil
+	}
+	return p.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (p *ProjectColumnEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetOrg returns the Org field.
+func (p *ProjectColumnEvent) GetOrg() *Organization {
+	if p == nil {
+		return nil
+	}
+	return p.Org
+}
+
+// GetProjectColumn returns the ProjectColumn field.
+func (p *ProjectColumnEvent) GetProjectColumn() *ProjectColumn {
+	if p == nil {
+		return nil
+	}
+	return p.ProjectColumn
+}
+
+// GetRepo returns the Repo field.
+func (p *ProjectColumnEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *ProjectColumnEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (p *ProjectEvent) GetAction() string {
 	if p == nil || p.Action == nil {
@@ -3972,12 +5348,156 @@ func (p *ProjectEvent) GetAction() string {
 	return *p.Action
 }
 
+// GetChanges returns the Changes field.
+func (p *ProjectEvent) GetChanges() *ProjectChange {
+	if p == nil {
+		return nil
+	}
+	return p.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (p *ProjectEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetOrg returns the Org field.
+func (p *ProjectEvent) GetOrg() *Organization {
+	if p == nil {
+		return nil
+	}
+	return p.Org
+}
+
+// GetProject returns the Project field.
+func (p *ProjectEvent) GetProject() *Project {
+	if p == nil {
+		return nil
+	}
+	return p.Project
+}
+
+// GetRepo returns the Repo field.
+func (p *ProjectEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *ProjectEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
+}
+
+// GetEnforceAdmins returns the EnforceAdmins field.
+func (p *Protection) GetEnforceAdmins() *AdminEnforcement {
+	if p == nil {
+		return nil
+	}
+	return p.EnforceAdmins
+}
+
+// GetRequiredPullRequestReviews returns the RequiredPullRequestReviews field.
+func (p *Protection) GetRequiredPullRequestReviews() *PullRequestReviewsEnforcement {
+	if p == nil {
+		return nil
+	}
+	return p.RequiredPullRequestReviews
+}
+
+// GetRequiredStatusChecks returns the RequiredStatusChecks field.
+func (p *Protection) GetRequiredStatusChecks() *RequiredStatusChecks {
+	if p == nil {
+		return nil
+	}
+	return p.RequiredStatusChecks
+}
+
+// GetRestrictions returns the Restrictions field.
+func (p *Protection) GetRestrictions() *BranchRestrictions {
+	if p == nil {
+		return nil
+	}
+	return p.Restrictions
+}
+
+// GetRequiredPullRequestReviews returns the RequiredPullRequestReviews field.
+func (p *ProtectionRequest) GetRequiredPullRequestReviews() *PullRequestReviewsEnforcementRequest {
+	if p == nil {
+		return nil
+	}
+	return p.RequiredPullRequestReviews
+}
+
+// GetRequiredStatusChecks returns the RequiredStatusChecks field.
+func (p *ProtectionRequest) GetRequiredStatusChecks() *RequiredStatusChecks {
+	if p == nil {
+		return nil
+	}
+	return p.RequiredStatusChecks
+}
+
+// GetRestrictions returns the Restrictions field.
+func (p *ProtectionRequest) GetRestrictions() *BranchRestrictionsRequest {
+	if p == nil {
+		return nil
+	}
+	return p.Restrictions
+}
+
+// GetInstallation returns the Installation field.
+func (p *PublicEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetRepo returns the Repo field.
+func (p *PublicEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *PublicEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
+}
+
 // GetAdditions returns the Additions field if it's non-nil, zero value otherwise.
 func (p *PullRequest) GetAdditions() int {
 	if p == nil || p.Additions == nil {
 		return 0
 	}
 	return *p.Additions
+}
+
+// GetAssignee returns the Assignee field.
+func (p *PullRequest) GetAssignee() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Assignee
+}
+
+// GetBase returns the Base field.
+func (p *PullRequest) GetBase() *PullRequestBranch {
+	if p == nil {
+		return nil
+	}
+	return p.Base
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
@@ -4044,6 +5564,14 @@ func (p *PullRequest) GetDiffURL() string {
 	return *p.DiffURL
 }
 
+// GetHead returns the Head field.
+func (p *PullRequest) GetHead() *PullRequestBranch {
+	if p == nil {
+		return nil
+	}
+	return p.Head
+}
+
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
 func (p *PullRequest) GetHTMLURL() string {
 	if p == nil || p.HTMLURL == nil {
@@ -4106,6 +5634,22 @@ func (p *PullRequest) GetMergedAt() time.Time {
 		return time.Time{}
 	}
 	return *p.MergedAt
+}
+
+// GetMergedBy returns the MergedBy field.
+func (p *PullRequest) GetMergedBy() *User {
+	if p == nil {
+		return nil
+	}
+	return p.MergedBy
+}
+
+// GetMilestone returns the Milestone field.
+func (p *PullRequest) GetMilestone() *Milestone {
+	if p == nil {
+		return nil
+	}
+	return p.Milestone
 }
 
 // GetNumber returns the Number field if it's non-nil, zero value otherwise.
@@ -4180,6 +5724,14 @@ func (p *PullRequest) GetURL() string {
 	return *p.URL
 }
 
+// GetUser returns the User field.
+func (p *PullRequest) GetUser() *User {
+	if p == nil {
+		return nil
+	}
+	return p.User
+}
+
 // GetLabel returns the Label field if it's non-nil, zero value otherwise.
 func (p *PullRequestBranch) GetLabel() string {
 	if p == nil || p.Label == nil {
@@ -4196,12 +5748,28 @@ func (p *PullRequestBranch) GetRef() string {
 	return *p.Ref
 }
 
+// GetRepo returns the Repo field.
+func (p *PullRequestBranch) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
 // GetSHA returns the SHA field if it's non-nil, zero value otherwise.
 func (p *PullRequestBranch) GetSHA() string {
 	if p == nil || p.SHA == nil {
 		return ""
 	}
 	return *p.SHA
+}
+
+// GetUser returns the User field.
+func (p *PullRequestBranch) GetUser() *User {
+	if p == nil {
+		return nil
+	}
+	return p.User
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
@@ -4300,6 +5868,14 @@ func (p *PullRequestComment) GetPullRequestURL() string {
 	return *p.PullRequestURL
 }
 
+// GetReactions returns the Reactions field.
+func (p *PullRequestComment) GetReactions() *Reactions {
+	if p == nil {
+		return nil
+	}
+	return p.Reactions
+}
+
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (p *PullRequestComment) GetUpdatedAt() time.Time {
 	if p == nil || p.UpdatedAt == nil {
@@ -4316,6 +5892,14 @@ func (p *PullRequestComment) GetURL() string {
 	return *p.URL
 }
 
+// GetUser returns the User field.
+func (p *PullRequestComment) GetUser() *User {
+	if p == nil {
+		return nil
+	}
+	return p.User
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (p *PullRequestEvent) GetAction() string {
 	if p == nil || p.Action == nil {
@@ -4324,12 +5908,52 @@ func (p *PullRequestEvent) GetAction() string {
 	return *p.Action
 }
 
+// GetChanges returns the Changes field.
+func (p *PullRequestEvent) GetChanges() *EditChange {
+	if p == nil {
+		return nil
+	}
+	return p.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (p *PullRequestEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
 // GetNumber returns the Number field if it's non-nil, zero value otherwise.
 func (p *PullRequestEvent) GetNumber() int {
 	if p == nil || p.Number == nil {
 		return 0
 	}
 	return *p.Number
+}
+
+// GetPullRequest returns the PullRequest field.
+func (p *PullRequestEvent) GetPullRequest() *PullRequest {
+	if p == nil {
+		return nil
+	}
+	return p.PullRequest
+}
+
+// GetRepo returns the Repo field.
+func (p *PullRequestEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *PullRequestEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
 }
 
 // GetDiffURL returns the DiffURL field if it's non-nil, zero value otherwise.
@@ -4444,12 +6068,68 @@ func (p *PullRequestReview) GetSubmittedAt() time.Time {
 	return *p.SubmittedAt
 }
 
+// GetUser returns the User field.
+func (p *PullRequestReview) GetUser() *User {
+	if p == nil {
+		return nil
+	}
+	return p.User
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (p *PullRequestReviewCommentEvent) GetAction() string {
 	if p == nil || p.Action == nil {
 		return ""
 	}
 	return *p.Action
+}
+
+// GetChanges returns the Changes field.
+func (p *PullRequestReviewCommentEvent) GetChanges() *EditChange {
+	if p == nil {
+		return nil
+	}
+	return p.Changes
+}
+
+// GetComment returns the Comment field.
+func (p *PullRequestReviewCommentEvent) GetComment() *PullRequestComment {
+	if p == nil {
+		return nil
+	}
+	return p.Comment
+}
+
+// GetInstallation returns the Installation field.
+func (p *PullRequestReviewCommentEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetPullRequest returns the PullRequest field.
+func (p *PullRequestReviewCommentEvent) GetPullRequest() *PullRequest {
+	if p == nil {
+		return nil
+	}
+	return p.PullRequest
+}
+
+// GetRepo returns the Repo field.
+func (p *PullRequestReviewCommentEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *PullRequestReviewCommentEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
 }
 
 // GetMessage returns the Message field if it's non-nil, zero value otherwise.
@@ -4466,6 +6146,54 @@ func (p *PullRequestReviewEvent) GetAction() string {
 		return ""
 	}
 	return *p.Action
+}
+
+// GetInstallation returns the Installation field.
+func (p *PullRequestReviewEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetOrganization returns the Organization field.
+func (p *PullRequestReviewEvent) GetOrganization() *Organization {
+	if p == nil {
+		return nil
+	}
+	return p.Organization
+}
+
+// GetPullRequest returns the PullRequest field.
+func (p *PullRequestReviewEvent) GetPullRequest() *PullRequest {
+	if p == nil {
+		return nil
+	}
+	return p.PullRequest
+}
+
+// GetRepo returns the Repo field.
+func (p *PullRequestReviewEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetReview returns the Review field.
+func (p *PullRequestReviewEvent) GetReview() *PullRequestReview {
+	if p == nil {
+		return nil
+	}
+	return p.Review
+}
+
+// GetSender returns the Sender field.
+func (p *PullRequestReviewEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
@@ -4490,6 +6218,22 @@ func (p *PullRequestReviewRequest) GetEvent() string {
 		return ""
 	}
 	return *p.Event
+}
+
+// GetDismissalRestrictionsRequest returns the DismissalRestrictionsRequest field.
+func (p *PullRequestReviewsEnforcementRequest) GetDismissalRestrictionsRequest() *DismissalRestrictionsRequest {
+	if p == nil {
+		return nil
+	}
+	return p.DismissalRestrictionsRequest
+}
+
+// GetDismissalRestrictionsRequest returns the DismissalRestrictionsRequest field.
+func (p *PullRequestReviewsEnforcementUpdate) GetDismissalRestrictionsRequest() *DismissalRestrictionsRequest {
+	if p == nil {
+		return nil
+	}
+	return p.DismissalRestrictionsRequest
 }
 
 // GetDismissStaleReviews returns the DismissStaleReviews field if it's non-nil, zero value otherwise.
@@ -4668,6 +6412,30 @@ func (p *PushEvent) GetHead() string {
 	return *p.Head
 }
 
+// GetHeadCommit returns the HeadCommit field.
+func (p *PushEvent) GetHeadCommit() *PushEventCommit {
+	if p == nil {
+		return nil
+	}
+	return p.HeadCommit
+}
+
+// GetInstallation returns the Installation field.
+func (p *PushEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetPusher returns the Pusher field.
+func (p *PushEvent) GetPusher() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Pusher
+}
+
 // GetPushID returns the PushID field if it's non-nil, zero value otherwise.
 func (p *PushEvent) GetPushID() int {
 	if p == nil || p.PushID == nil {
@@ -4684,12 +6452,44 @@ func (p *PushEvent) GetRef() string {
 	return *p.Ref
 }
 
+// GetRepo returns the Repo field.
+func (p *PushEvent) GetRepo() *PushEventRepository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *PushEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
+}
+
 // GetSize returns the Size field if it's non-nil, zero value otherwise.
 func (p *PushEvent) GetSize() int {
 	if p == nil || p.Size == nil {
 		return 0
 	}
 	return *p.Size
+}
+
+// GetAuthor returns the Author field.
+func (p *PushEventCommit) GetAuthor() *CommitAuthor {
+	if p == nil {
+		return nil
+	}
+	return p.Author
+}
+
+// GetCommitter returns the Committer field.
+func (p *PushEventCommit) GetCommitter() *CommitAuthor {
+	if p == nil {
+		return nil
+	}
+	return p.Committer
 }
 
 // GetDistinct returns the Distinct field if it's non-nil, zero value otherwise.
@@ -4932,6 +6732,14 @@ func (p *PushEventRepository) GetOrganization() string {
 	return *p.Organization
 }
 
+// GetOwner returns the Owner field.
+func (p *PushEventRepository) GetOwner() *PushEventRepoOwner {
+	if p == nil {
+		return nil
+	}
+	return p.Owner
+}
+
 // GetPrivate returns the Private field if it's non-nil, zero value otherwise.
 func (p *PushEventRepository) GetPrivate() bool {
 	if p == nil || p.Private == nil {
@@ -5012,6 +6820,22 @@ func (p *PushEventRepository) GetWatchersCount() int {
 	return *p.WatchersCount
 }
 
+// GetCore returns the Core field.
+func (r *RateLimits) GetCore() *Rate {
+	if r == nil {
+		return nil
+	}
+	return r.Core
+}
+
+// GetSearch returns the Search field.
+func (r *RateLimits) GetSearch() *Rate {
+	if r == nil {
+		return nil
+	}
+	return r.Search
+}
+
 // GetContent returns the Content field if it's non-nil, zero value otherwise.
 func (r *Reaction) GetContent() string {
 	if r == nil || r.Content == nil {
@@ -5026,6 +6850,14 @@ func (r *Reaction) GetID() int {
 		return 0
 	}
 	return *r.ID
+}
+
+// GetUser returns the User field.
+func (r *Reaction) GetUser() *User {
+	if r == nil {
+		return nil
+	}
+	return r.User
 }
 
 // GetConfused returns the Confused field if it's non-nil, zero value otherwise.
@@ -5090,6 +6922,14 @@ func (r *Reactions) GetURL() string {
 		return ""
 	}
 	return *r.URL
+}
+
+// GetObject returns the Object field.
+func (r *Reference) GetObject() *GitObject {
+	if r == nil {
+		return nil
+	}
+	return r.Object
 }
 
 // GetRef returns the Ref field if it's non-nil, zero value otherwise.
@@ -5188,6 +7028,14 @@ func (r *ReleaseAsset) GetUpdatedAt() Timestamp {
 	return *r.UpdatedAt
 }
 
+// GetUploader returns the Uploader field.
+func (r *ReleaseAsset) GetUploader() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Uploader
+}
+
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
 func (r *ReleaseAsset) GetURL() string {
 	if r == nil || r.URL == nil {
@@ -5202,6 +7050,38 @@ func (r *ReleaseEvent) GetAction() string {
 		return ""
 	}
 	return *r.Action
+}
+
+// GetInstallation returns the Installation field.
+func (r *ReleaseEvent) GetInstallation() *Installation {
+	if r == nil {
+		return nil
+	}
+	return r.Installation
+}
+
+// GetRelease returns the Release field.
+func (r *ReleaseEvent) GetRelease() *RepositoryRelease {
+	if r == nil {
+		return nil
+	}
+	return r.Release
+}
+
+// GetRepo returns the Repo field.
+func (r *ReleaseEvent) GetRepo() *Repository {
+	if r == nil {
+		return nil
+	}
+	return r.Repo
+}
+
+// GetSender returns the Sender field.
+func (r *ReleaseEvent) GetSender() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Sender
 }
 
 // GetFrom returns the From field if it's non-nil, zero value otherwise.
@@ -5306,6 +7186,14 @@ func (r *Repository) GetCloneURL() string {
 		return ""
 	}
 	return *r.CloneURL
+}
+
+// GetCodeOfConduct returns the CodeOfConduct field.
+func (r *Repository) GetCodeOfConduct() *CodeOfConduct {
+	if r == nil {
+		return nil
+	}
+	return r.CodeOfConduct
 }
 
 // GetCollaboratorsURL returns the CollaboratorsURL field if it's non-nil, zero value otherwise.
@@ -5596,6 +7484,14 @@ func (r *Repository) GetLanguagesURL() string {
 	return *r.LanguagesURL
 }
 
+// GetLicense returns the License field.
+func (r *Repository) GetLicense() *License {
+	if r == nil {
+		return nil
+	}
+	return r.License
+}
+
 // GetLicenseTemplate returns the LicenseTemplate field if it's non-nil, zero value otherwise.
 func (r *Repository) GetLicenseTemplate() string {
 	if r == nil || r.LicenseTemplate == nil {
@@ -5668,6 +7564,30 @@ func (r *Repository) GetOpenIssuesCount() int {
 	return *r.OpenIssuesCount
 }
 
+// GetOrganization returns the Organization field.
+func (r *Repository) GetOrganization() *Organization {
+	if r == nil {
+		return nil
+	}
+	return r.Organization
+}
+
+// GetOwner returns the Owner field.
+func (r *Repository) GetOwner() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Owner
+}
+
+// GetParent returns the Parent field.
+func (r *Repository) GetParent() *Repository {
+	if r == nil {
+		return nil
+	}
+	return r.Parent
+}
+
 // GetPermissions returns the Permissions field if it's non-nil, zero value otherwise.
 func (r *Repository) GetPermissions() map[string]bool {
 	if r == nil || r.Permissions == nil {
@@ -5714,6 +7634,14 @@ func (r *Repository) GetSize() int {
 		return 0
 	}
 	return *r.Size
+}
+
+// GetSource returns the Source field.
+func (r *Repository) GetSource() *Repository {
+	if r == nil {
+		return nil
+	}
+	return r.Source
 }
 
 // GetSSHURL returns the SSHURL field if it's non-nil, zero value otherwise.
@@ -5892,6 +7820,14 @@ func (r *RepositoryComment) GetPosition() int {
 	return *r.Position
 }
 
+// GetReactions returns the Reactions field.
+func (r *RepositoryComment) GetReactions() *Reactions {
+	if r == nil {
+		return nil
+	}
+	return r.Reactions
+}
+
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (r *RepositoryComment) GetUpdatedAt() time.Time {
 	if r == nil || r.UpdatedAt == nil {
@@ -5908,12 +7844,44 @@ func (r *RepositoryComment) GetURL() string {
 	return *r.URL
 }
 
+// GetUser returns the User field.
+func (r *RepositoryComment) GetUser() *User {
+	if r == nil {
+		return nil
+	}
+	return r.User
+}
+
+// GetAuthor returns the Author field.
+func (r *RepositoryCommit) GetAuthor() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Author
+}
+
 // GetCommentsURL returns the CommentsURL field if it's non-nil, zero value otherwise.
 func (r *RepositoryCommit) GetCommentsURL() string {
 	if r == nil || r.CommentsURL == nil {
 		return ""
 	}
 	return *r.CommentsURL
+}
+
+// GetCommit returns the Commit field.
+func (r *RepositoryCommit) GetCommit() *Commit {
+	if r == nil {
+		return nil
+	}
+	return r.Commit
+}
+
+// GetCommitter returns the Committer field.
+func (r *RepositoryCommit) GetCommitter() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Committer
 }
 
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
@@ -5930,6 +7898,14 @@ func (r *RepositoryCommit) GetSHA() string {
 		return ""
 	}
 	return *r.SHA
+}
+
+// GetStats returns the Stats field.
+func (r *RepositoryCommit) GetStats() *CommitStats {
+	if r == nil {
+		return nil
+	}
+	return r.Stats
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
@@ -6020,12 +7996,28 @@ func (r *RepositoryContent) GetURL() string {
 	return *r.URL
 }
 
+// GetAuthor returns the Author field.
+func (r *RepositoryContentFileOptions) GetAuthor() *CommitAuthor {
+	if r == nil {
+		return nil
+	}
+	return r.Author
+}
+
 // GetBranch returns the Branch field if it's non-nil, zero value otherwise.
 func (r *RepositoryContentFileOptions) GetBranch() string {
 	if r == nil || r.Branch == nil {
 		return ""
 	}
 	return *r.Branch
+}
+
+// GetCommitter returns the Committer field.
+func (r *RepositoryContentFileOptions) GetCommitter() *CommitAuthor {
+	if r == nil {
+		return nil
+	}
+	return r.Committer
 }
 
 // GetMessage returns the Message field if it's non-nil, zero value otherwise.
@@ -6044,12 +8036,52 @@ func (r *RepositoryContentFileOptions) GetSHA() string {
 	return *r.SHA
 }
 
+// GetContent returns the Content field.
+func (r *RepositoryContentResponse) GetContent() *RepositoryContent {
+	if r == nil {
+		return nil
+	}
+	return r.Content
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (r *RepositoryEvent) GetAction() string {
 	if r == nil || r.Action == nil {
 		return ""
 	}
 	return *r.Action
+}
+
+// GetInstallation returns the Installation field.
+func (r *RepositoryEvent) GetInstallation() *Installation {
+	if r == nil {
+		return nil
+	}
+	return r.Installation
+}
+
+// GetOrg returns the Org field.
+func (r *RepositoryEvent) GetOrg() *Organization {
+	if r == nil {
+		return nil
+	}
+	return r.Org
+}
+
+// GetRepo returns the Repo field.
+func (r *RepositoryEvent) GetRepo() *Repository {
+	if r == nil {
+		return nil
+	}
+	return r.Repo
+}
+
+// GetSender returns the Sender field.
+func (r *RepositoryEvent) GetSender() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Sender
 }
 
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
@@ -6076,12 +8108,36 @@ func (r *RepositoryInvitation) GetID() int {
 	return *r.ID
 }
 
+// GetInvitee returns the Invitee field.
+func (r *RepositoryInvitation) GetInvitee() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Invitee
+}
+
+// GetInviter returns the Inviter field.
+func (r *RepositoryInvitation) GetInviter() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Inviter
+}
+
 // GetPermissions returns the Permissions field if it's non-nil, zero value otherwise.
 func (r *RepositoryInvitation) GetPermissions() string {
 	if r == nil || r.Permissions == nil {
 		return ""
 	}
 	return *r.Permissions
+}
+
+// GetRepo returns the Repo field.
+func (r *RepositoryInvitation) GetRepo() *Repository {
+	if r == nil {
+		return nil
+	}
+	return r.Repo
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
@@ -6130,6 +8186,14 @@ func (r *RepositoryLicense) GetHTMLURL() string {
 		return ""
 	}
 	return *r.HTMLURL
+}
+
+// GetLicense returns the License field.
+func (r *RepositoryLicense) GetLicense() *License {
+	if r == nil {
+		return nil
+	}
+	return r.License
 }
 
 // GetName returns the Name field if it's non-nil, zero value otherwise.
@@ -6212,12 +8276,28 @@ func (r *RepositoryPermissionLevel) GetPermission() string {
 	return *r.Permission
 }
 
+// GetUser returns the User field.
+func (r *RepositoryPermissionLevel) GetUser() *User {
+	if r == nil {
+		return nil
+	}
+	return r.User
+}
+
 // GetAssetsURL returns the AssetsURL field if it's non-nil, zero value otherwise.
 func (r *RepositoryRelease) GetAssetsURL() string {
 	if r == nil || r.AssetsURL == nil {
 		return ""
 	}
 	return *r.AssetsURL
+}
+
+// GetAuthor returns the Author field.
+func (r *RepositoryRelease) GetAuthor() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Author
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
@@ -6332,6 +8412,14 @@ func (r *RepositoryRelease) GetZipballURL() string {
 	return *r.ZipballURL
 }
 
+// GetCommit returns the Commit field.
+func (r *RepositoryTag) GetCommit() *Commit {
+	if r == nil {
+		return nil
+	}
+	return r.Commit
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (r *RepositoryTag) GetName() string {
 	if r == nil || r.Name == nil {
@@ -6420,6 +8508,14 @@ func (r *RepoStatus) GetCreatedAt() time.Time {
 	return *r.CreatedAt
 }
 
+// GetCreator returns the Creator field.
+func (r *RepoStatus) GetCreator() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Creator
+}
+
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
 func (r *RepoStatus) GetDescription() string {
 	if r == nil || r.Description == nil {
@@ -6468,6 +8564,14 @@ func (r *RepoStatus) GetURL() string {
 	return *r.URL
 }
 
+// Getclient returns the client field.
+func (s *service) Getclient() *Client {
+	if s == nil {
+		return nil
+	}
+	return s.client
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (s *ServiceHook) GetName() string {
 	if s == nil || s.Name == nil {
@@ -6506,6 +8610,14 @@ func (s *SignatureVerification) GetVerified() bool {
 		return false
 	}
 	return *s.Verified
+}
+
+// GetActor returns the Actor field.
+func (s *Source) GetActor() *User {
+	if s == nil {
+		return nil
+	}
+	return s.Actor
 }
 
 // GetID returns the ID field if it's non-nil, zero value otherwise.
@@ -6588,6 +8700,22 @@ func (s *Stargazer) GetStarredAt() Timestamp {
 	return *s.StarredAt
 }
 
+// GetUser returns the User field.
+func (s *Stargazer) GetUser() *User {
+	if s == nil {
+		return nil
+	}
+	return s.User
+}
+
+// GetRepository returns the Repository field.
+func (s *StarredRepository) GetRepository() *Repository {
+	if s == nil {
+		return nil
+	}
+	return s.Repository
+}
+
 // GetStarredAt returns the StarredAt field if it's non-nil, zero value otherwise.
 func (s *StarredRepository) GetStarredAt() Timestamp {
 	if s == nil || s.StarredAt == nil {
@@ -6610,6 +8738,14 @@ func (s *startMigration) GetLockRepositories() bool {
 		return false
 	}
 	return *s.LockRepositories
+}
+
+// GetCommit returns the Commit field.
+func (s *StatusEvent) GetCommit() *RepositoryCommit {
+	if s == nil {
+		return nil
+	}
+	return s.Commit
 }
 
 // GetContext returns the Context field if it's non-nil, zero value otherwise.
@@ -6644,12 +8780,36 @@ func (s *StatusEvent) GetID() int {
 	return *s.ID
 }
 
+// GetInstallation returns the Installation field.
+func (s *StatusEvent) GetInstallation() *Installation {
+	if s == nil {
+		return nil
+	}
+	return s.Installation
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (s *StatusEvent) GetName() string {
 	if s == nil || s.Name == nil {
 		return ""
 	}
 	return *s.Name
+}
+
+// GetRepo returns the Repo field.
+func (s *StatusEvent) GetRepo() *Repository {
+	if s == nil {
+		return nil
+	}
+	return s.Repo
+}
+
+// GetSender returns the Sender field.
+func (s *StatusEvent) GetSender() *User {
+	if s == nil {
+		return nil
+	}
+	return s.Sender
 }
 
 // GetSHA returns the SHA field if it's non-nil, zero value otherwise.
@@ -6748,6 +8908,14 @@ func (t *Tag) GetMessage() string {
 	return *t.Message
 }
 
+// GetObject returns the Object field.
+func (t *Tag) GetObject() *GitObject {
+	if t == nil {
+		return nil
+	}
+	return t.Object
+}
+
 // GetSHA returns the SHA field if it's non-nil, zero value otherwise.
 func (t *Tag) GetSHA() string {
 	if t == nil || t.SHA == nil {
@@ -6764,12 +8932,28 @@ func (t *Tag) GetTag() string {
 	return *t.Tag
 }
 
+// GetTagger returns the Tagger field.
+func (t *Tag) GetTagger() *CommitAuthor {
+	if t == nil {
+		return nil
+	}
+	return t.Tagger
+}
+
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
 func (t *Tag) GetURL() string {
 	if t == nil || t.URL == nil {
 		return ""
 	}
 	return *t.URL
+}
+
+// GetVerification returns the Verification field.
+func (t *Tag) GetVerification() *SignatureVerification {
+	if t == nil {
+		return nil
+	}
+	return t.Verification
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
@@ -6820,6 +9004,22 @@ func (t *Team) GetName() string {
 	return *t.Name
 }
 
+// GetOrganization returns the Organization field.
+func (t *Team) GetOrganization() *Organization {
+	if t == nil {
+		return nil
+	}
+	return t.Organization
+}
+
+// GetParent returns the Parent field.
+func (t *Team) GetParent() *Team {
+	if t == nil {
+		return nil
+	}
+	return t.Parent
+}
+
 // GetPermission returns the Permission field if it's non-nil, zero value otherwise.
 func (t *Team) GetPermission() string {
 	if t == nil || t.Permission == nil {
@@ -6868,12 +9068,100 @@ func (t *Team) GetURL() string {
 	return *t.URL
 }
 
+// GetInstallation returns the Installation field.
+func (t *TeamAddEvent) GetInstallation() *Installation {
+	if t == nil {
+		return nil
+	}
+	return t.Installation
+}
+
+// GetOrg returns the Org field.
+func (t *TeamAddEvent) GetOrg() *Organization {
+	if t == nil {
+		return nil
+	}
+	return t.Org
+}
+
+// GetRepo returns the Repo field.
+func (t *TeamAddEvent) GetRepo() *Repository {
+	if t == nil {
+		return nil
+	}
+	return t.Repo
+}
+
+// GetSender returns the Sender field.
+func (t *TeamAddEvent) GetSender() *User {
+	if t == nil {
+		return nil
+	}
+	return t.Sender
+}
+
+// GetTeam returns the Team field.
+func (t *TeamAddEvent) GetTeam() *Team {
+	if t == nil {
+		return nil
+	}
+	return t.Team
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (t *TeamEvent) GetAction() string {
 	if t == nil || t.Action == nil {
 		return ""
 	}
 	return *t.Action
+}
+
+// GetChanges returns the Changes field.
+func (t *TeamEvent) GetChanges() *TeamChange {
+	if t == nil {
+		return nil
+	}
+	return t.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (t *TeamEvent) GetInstallation() *Installation {
+	if t == nil {
+		return nil
+	}
+	return t.Installation
+}
+
+// GetOrg returns the Org field.
+func (t *TeamEvent) GetOrg() *Organization {
+	if t == nil {
+		return nil
+	}
+	return t.Org
+}
+
+// GetRepo returns the Repo field.
+func (t *TeamEvent) GetRepo() *Repository {
+	if t == nil {
+		return nil
+	}
+	return t.Repo
+}
+
+// GetSender returns the Sender field.
+func (t *TeamEvent) GetSender() *User {
+	if t == nil {
+		return nil
+	}
+	return t.Sender
+}
+
+// GetTeam returns the Team field.
+func (t *TeamEvent) GetTeam() *Team {
+	if t == nil {
+		return nil
+	}
+	return t.Team
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
@@ -6988,6 +9276,22 @@ func (t *TextMatch) GetProperty() string {
 	return *t.Property
 }
 
+// GetActor returns the Actor field.
+func (t *Timeline) GetActor() *User {
+	if t == nil {
+		return nil
+	}
+	return t.Actor
+}
+
+// GetAssignee returns the Assignee field.
+func (t *Timeline) GetAssignee() *User {
+	if t == nil {
+		return nil
+	}
+	return t.Assignee
+}
+
 // GetCommitID returns the CommitID field if it's non-nil, zero value otherwise.
 func (t *Timeline) GetCommitID() string {
 	if t == nil || t.CommitID == nil {
@@ -7026,6 +9330,38 @@ func (t *Timeline) GetID() int {
 		return 0
 	}
 	return *t.ID
+}
+
+// GetLabel returns the Label field.
+func (t *Timeline) GetLabel() *Label {
+	if t == nil {
+		return nil
+	}
+	return t.Label
+}
+
+// GetMilestone returns the Milestone field.
+func (t *Timeline) GetMilestone() *Milestone {
+	if t == nil {
+		return nil
+	}
+	return t.Milestone
+}
+
+// GetRename returns the Rename field.
+func (t *Timeline) GetRename() *Rename {
+	if t == nil {
+		return nil
+	}
+	return t.Rename
+}
+
+// GetSource returns the Source field.
+func (t *Timeline) GetSource() *Source {
+	if t == nil {
+		return nil
+	}
+	return t.Source
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
@@ -7420,6 +9756,14 @@ func (u *User) GetPermissions() map[string]bool {
 	return *u.Permissions
 }
 
+// GetPlan returns the Plan field.
+func (u *User) GetPlan() *Plan {
+	if u == nil {
+		return nil
+	}
+	return u.Plan
+}
+
 // GetPrivateGists returns the PrivateGists field if it's non-nil, zero value otherwise.
 func (u *User) GetPrivateGists() int {
 	if u == nil || u.PrivateGists == nil {
@@ -7732,6 +10076,30 @@ func (w *WatchEvent) GetAction() string {
 	return *w.Action
 }
 
+// GetInstallation returns the Installation field.
+func (w *WatchEvent) GetInstallation() *Installation {
+	if w == nil {
+		return nil
+	}
+	return w.Installation
+}
+
+// GetRepo returns the Repo field.
+func (w *WatchEvent) GetRepo() *Repository {
+	if w == nil {
+		return nil
+	}
+	return w.Repo
+}
+
+// GetSender returns the Sender field.
+func (w *WatchEvent) GetSender() *User {
+	if w == nil {
+		return nil
+	}
+	return w.Sender
+}
+
 // GetEmail returns the Email field if it's non-nil, zero value otherwise.
 func (w *WebHookAuthor) GetEmail() string {
 	if w == nil || w.Email == nil {
@@ -7754,6 +10122,22 @@ func (w *WebHookAuthor) GetUsername() string {
 		return ""
 	}
 	return *w.Username
+}
+
+// GetAuthor returns the Author field.
+func (w *WebHookCommit) GetAuthor() *WebHookAuthor {
+	if w == nil {
+		return nil
+	}
+	return w.Author
+}
+
+// GetCommitter returns the Committer field.
+func (w *WebHookCommit) GetCommitter() *WebHookAuthor {
+	if w == nil {
+		return nil
+	}
+	return w.Committer
 }
 
 // GetDistinct returns the Distinct field if it's non-nil, zero value otherwise.
@@ -7836,12 +10220,44 @@ func (w *WebHookPayload) GetForced() bool {
 	return *w.Forced
 }
 
+// GetHeadCommit returns the HeadCommit field.
+func (w *WebHookPayload) GetHeadCommit() *WebHookCommit {
+	if w == nil {
+		return nil
+	}
+	return w.HeadCommit
+}
+
+// GetPusher returns the Pusher field.
+func (w *WebHookPayload) GetPusher() *User {
+	if w == nil {
+		return nil
+	}
+	return w.Pusher
+}
+
 // GetRef returns the Ref field if it's non-nil, zero value otherwise.
 func (w *WebHookPayload) GetRef() string {
 	if w == nil || w.Ref == nil {
 		return ""
 	}
 	return *w.Ref
+}
+
+// GetRepo returns the Repo field.
+func (w *WebHookPayload) GetRepo() *Repository {
+	if w == nil {
+		return nil
+	}
+	return w.Repo
+}
+
+// GetSender returns the Sender field.
+func (w *WebHookPayload) GetSender() *User {
+	if w == nil {
+		return nil
+	}
+	return w.Sender
 }
 
 // GetTotal returns the Total field if it's non-nil, zero value otherwise.

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1055,7 +1055,7 @@ func TestFormatRateReset(t *testing.T) {
 	}
 }
 
-func TestNamedStructAccessor_noPanic(t *testing.T) {
+func TestNestedStructAccessorNoPanic(t *testing.T) {
 	issue := &Issue{User: nil}
 	got := issue.GetUser().GetPlan().GetName()
 	want := ""

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1054,3 +1054,12 @@ func TestFormatRateReset(t *testing.T) {
 		t.Errorf("Format is wrong. got: %v, want: %v", got, want)
 	}
 }
+
+func TestNamedStructAccessor_noPanic(t *testing.T) {
+	issue := &Issue{User: nil}
+	got := issue.GetUser().GetPlan().GetName()
+	want := ""
+	if got != want {
+		t.Errorf("Issues.Get.GetUser().GetPlan().GetName() returned %+v, want %+v", got, want)
+	}
+}


### PR DESCRIPTION
Add support for automatically adding accessor methods for named structs
in github-accessors.go. Add a new flag to struct type Getter - NamedStruct
which is a flag to decide if this getter is for a named struct or not.
If it's a named struct, we make some changes in the way its
accessor method looks like finally in github-accessors.go.

Another thing to note here is that named structs are always going to end
up of type *ast.Ident from AST point of view so we don't need to check
for named structs for any other cases (like array/map/selector expression).

Fixes #587 
/cc @gmlewis 