### PR TITLE
Removing omitifempty on topics.Names to be able to remove all topics

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -991,7 +991,7 @@ type Topics struct {
 // ListAllTopics lists topics for a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/#list-all-topics-for-a-repository
-func (s *RepositoriesService) ListAllTopics(ctx context.Context, owner, repo string) (*Topics, *Response, error) {
+func (s *RepositoriesService) ListAllTopics(ctx context.Context, owner, repo string) ([]string, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/topics", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -1007,15 +1007,19 @@ func (s *RepositoriesService) ListAllTopics(ctx context.Context, owner, repo str
 		return nil, resp, err
 	}
 
-	return topics, resp, nil
+	return topics.Names, resp, nil
 }
 
 // ReplaceAllTopics replaces topics for a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/#replace-all-topics-for-a-repository
-func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo string, topics *Topics) (*Topics, *Response, error) {
+func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo string, topics []string) ([]string, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/topics", owner, repo)
-	req, err := s.client.NewRequest("PUT", u, topics)
+	t := new(Topics)
+	if t.Names = topics; topics == nil {
+		t.Names = []string{}
+	}
+	req, err := s.client.NewRequest("PUT", u, t)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1023,11 +1027,11 @@ func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo 
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeTopicsPreview)
 
-	t := new(Topics)
+	t = new(Topics)
 	resp, err := s.client.Do(ctx, req, t)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return t, resp, nil
+	return t.Names, resp, nil
 }

--- a/github/repos.go
+++ b/github/repos.go
@@ -985,7 +985,7 @@ func (s *RepositoriesService) RemoveAdminEnforcement(ctx context.Context, owner,
 
 // Topics represents a collection of repository topics.
 type Topics struct {
-	Names []string `json:"names,omitempty"`
+	Names []string `json:"names"`
 }
 
 // ListAllTopics lists topics for a repository.

--- a/github/repos.go
+++ b/github/repos.go
@@ -1015,8 +1015,10 @@ func (s *RepositoriesService) ListAllTopics(ctx context.Context, owner, repo str
 // GitHub API docs: https://developer.github.com/v3/repos/#replace-all-topics-for-a-repository
 func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo string, topics []string) ([]string, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/topics", owner, repo)
-	t := new(Topics)
-	if t.Names = topics; topics == nil {
+	t := &Topics{
+		Names: topics,
+	}
+	if t.Names == nil {
 		t.Names = []string{}
 	}
 	req, err := s.client.NewRequest("PUT", u, t)

--- a/github/repos.go
+++ b/github/repos.go
@@ -983,8 +983,8 @@ func (s *RepositoriesService) RemoveAdminEnforcement(ctx context.Context, owner,
 	return s.client.Do(ctx, req, nil)
 }
 
-// Topics represents a collection of repository topics.
-type Topics struct {
+// repositoryTopics represents a collection of repository topics.
+type repositoryTopics struct {
 	Names []string `json:"names"`
 }
 
@@ -1001,7 +1001,7 @@ func (s *RepositoriesService) ListAllTopics(ctx context.Context, owner, repo str
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeTopicsPreview)
 
-	topics := new(Topics)
+	topics := new(repositoryTopics)
 	resp, err := s.client.Do(ctx, req, topics)
 	if err != nil {
 		return nil, resp, err
@@ -1015,7 +1015,7 @@ func (s *RepositoriesService) ListAllTopics(ctx context.Context, owner, repo str
 // GitHub API docs: https://developer.github.com/v3/repos/#replace-all-topics-for-a-repository
 func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo string, topics []string) ([]string, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/topics", owner, repo)
-	t := &Topics{
+	t := &repositoryTopics{
 		Names: topics,
 	}
 	if t.Names == nil {
@@ -1029,7 +1029,7 @@ func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo 
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeTopicsPreview)
 
-	t = new(Topics)
+	t = new(repositoryTopics)
 	resp, err := s.client.Do(ctx, req, t)
 	if err != nil {
 		return nil, resp, err

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -950,7 +950,28 @@ func TestRepositoriesService_ListAllTopics(t *testing.T) {
 		t.Fatalf("Repositories.ListAllTopics returned error: %v", err)
 	}
 
-	want := &Topics{Names: []string{"go", "go-github", "github"}}
+	want := []string{"go", "go-github", "github"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Repositories.ListAllTopics returned %+v, want %+v", got, want)
+	}
+}
+
+func TestRepositoriesService_ListAllTopics_emptyTopics(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/topics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeTopicsPreview)
+		fmt.Fprint(w, `{"names":[]}`)
+	})
+
+	got, _, err := client.Repositories.ListAllTopics(context.Background(), "o", "r")
+	if err != nil {
+		t.Fatalf("Repositories.ListAllTopics returned error: %v", err)
+	}
+
+	want := []string{}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Repositories.ListAllTopics returned %+v, want %+v", got, want)
 	}
@@ -966,12 +987,56 @@ func TestRepositoriesService_ReplaceAllTopics(t *testing.T) {
 		fmt.Fprint(w, `{"names":["go", "go-github", "github"]}`)
 	})
 
-	got, _, err := client.Repositories.ReplaceAllTopics(context.Background(), "o", "r", &Topics{Names: []string{"go", "go-github", "github"}})
+	got, _, err := client.Repositories.ReplaceAllTopics(context.Background(), "o", "r", []string{"go", "go-github", "github"})
 	if err != nil {
 		t.Fatalf("Repositories.ReplaceAllTopics returned error: %v", err)
 	}
 
-	want := &Topics{Names: []string{"go", "go-github", "github"}}
+	want := []string{"go", "go-github", "github"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Repositories.ReplaceAllTopics returned %+v, want %+v", got, want)
+	}
+}
+
+func TestRepositoriesService_ReplaceAllTopics_nilSlice(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/topics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Accept", mediaTypeTopicsPreview)
+		testBody(t, r, `{"names":[]}`+"\n")
+		fmt.Fprint(w, `{"names":[]}`)
+	})
+
+	got, _, err := client.Repositories.ReplaceAllTopics(context.Background(), "o", "r", nil)
+	if err != nil {
+		t.Fatalf("Repositories.ReplaceAllTopics returned error: %v", err)
+	}
+
+	want := []string{}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Repositories.ReplaceAllTopics returned %+v, want %+v", got, want)
+	}
+}
+
+func TestRepositoriesService_ReplaceAllTopics_emptySlice(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/topics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Accept", mediaTypeTopicsPreview)
+		testBody(t, r, `{"names":[]}`+"\n")
+		fmt.Fprint(w, `{"names":[]}`)
+	})
+
+	got, _, err := client.Repositories.ReplaceAllTopics(context.Background(), "o", "r", []string{})
+	if err != nil {
+		t.Fatalf("Repositories.ReplaceAllTopics returned error: %v", err)
+	}
+
+	want := []string{}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Repositories.ReplaceAllTopics returned %+v, want %+v", got, want)
 	}


### PR DESCRIPTION
Based on GitHub documentation:

> Required. An array of topics to add to the repository. Pass one or more topics to replace the set of existing topics. Send an empty array ([]) to clear all topics from the repository.

https://developer.github.com/v3/repos/#replace-all-topics-for-a-repository 

right now if passing an empty array, the Names attribute is omitted resulting in API validation error on GitHub side.