### PR TITLE
readme: add section on versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ straightforward.
 In general, go-github follows [semver](http://semver.org/) as closely as we can
 for tagging releases of the package. For self-contained libraries, the
 application of semantic versioning is relatively straightforward and generally
-understood.  But because go-github is a client library for the GitHub API,
+understood. But because go-github is a client library for the GitHub API,
 which itself changes behavior, and because we are typically pretty aggressive
 about implementing preview features of the GitHub API, we've adopted the
 following versioning policy:
@@ -258,9 +258,8 @@ following versioning policy:
 * We increment the **patch version** with any backwards-compatible bug fixes.
 
 Preview functionality may take the form of entire methods or simply additional
-data returned from an otherwise non-preview method.  We do our best to call out
-which portions of a method's behavior and/or data are part of a GitHub Preview
-in the appropriate Go doc.
+data returned from an otherwise non-preview method. Refer to the GitHub API
+documentation for details on preview functionality.
 
 ## License ##
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,30 @@ straightforward.
 [roadmap]: https://docs.google.com/spreadsheet/ccc?key=0ApoVX4GOiXr-dGNKN1pObFh6ek1DR2FKUjBNZ1FmaEE&usp=sharing
 [contributing]: CONTRIBUTING.md
 
+## Versioning ##
+
+In general, go-github follows [semver](http://semver.org/) as closely as we can
+for tagging releases of the package. For self-contained libraries, the
+application of semantic versioning is relatively straightforward and generally
+understood.  But because go-github is a client library for the GitHub API,
+which itself changes behavior, and because we are typically pretty aggressive
+about implementing preview features of the GitHub API, we've adopted the
+following versioning policy:
+
+* We increment the **major version** with any incompatible change to
+	non-preview functionality, including changes to the exported Go API surface
+	or behavior of the API.
+* We increment the **minor version** with any backwards-compatible changes to
+	functionality, as well as any changes to preview functionality in the GitHub
+	API. GitHub makes no guarantee about the stability of preview functionality,
+	so neither do we consider it a stable part of the go-github API.
+* We increment the **patch version** with any backwards-compatible bug fixes.
+
+Preview functionality may take the form of entire methods or simply additional
+data returned from an otherwise non-preview method.  We do our best to call out
+which portions of a method's behavior and/or data are part of a GitHub Preview
+in the appropriate Go doc.
+
 ## License ##
 
 This library is distributed under the BSD-style license found in the [LICENSE](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -240,13 +240,13 @@ straightforward.
 
 ## Versioning ##
 
-In general, go-github follows [semver](http://semver.org/) as closely as we can
-for tagging releases of the package. For self-contained libraries, the
+In general, go-github follows [semver](https://semver.org/) as closely as we
+can for tagging releases of the package. For self-contained libraries, the
 application of semantic versioning is relatively straightforward and generally
-understood. But because go-github is a client library for the GitHub API,
-which itself changes behavior, and because we are typically pretty aggressive
-about implementing preview features of the GitHub API, we've adopted the
-following versioning policy:
+understood. But because go-github is a client library for the GitHub API, which
+itself changes behavior, and because we are typically pretty aggressive about
+implementing preview features of the GitHub API, we've adopted the following
+versioning policy:
 
 * We increment the **major version** with any incompatible change to
 	non-preview functionality, including changes to the exported Go API surface

--- a/github/github.go
+++ b/github/github.go
@@ -27,10 +27,9 @@ import (
 )
 
 const (
-	libraryVersion = "15"
 	defaultBaseURL = "https://api.github.com/"
 	uploadBaseURL  = "https://uploads.github.com/"
-	userAgent      = "go-github/" + libraryVersion
+	userAgent      = "go-github"
 
 	headerRateLimit     = "X-RateLimit-Limit"
 	headerRateRemaining = "X-RateLimit-Remaining"


### PR DESCRIPTION
This does not yet address some of the additional workflows and policies we'll need to adopt as a result.  For example, when do we cut new releases, do we attempt to maintain a formal changelog, or at least release notes when we cut a new release, etc.  This also requires that we update go docs to call out which methods are exposing preview functionality from the GitHub API.

Fixes #376 