### PR TITLE
fix: RemoveReviewers json unmarshall error

### DIFF
--- a/github/pulls_reviewers.go
+++ b/github/pulls_reviewers.go
@@ -84,5 +84,5 @@ func (s *PullRequestsService) RemoveReviewers(ctx context.Context, owner, repo s
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeTeamReviewPreview)
 
-	return s.client.Do(ctx, req, reviewers)
+	return s.client.Do(ctx, req, nil)
 }


### PR DESCRIPTION
Use a pointer when execute the request.

```
error: json: Unmarshal(non-pointer github.ReviewersRequest)
```

I think the best way is to change method signature to use a pointer but it's breaking.
```go
func (s *PullRequestsService) RequestReviewers(ctx context.Context, owner, repo string, number int, reviewers *ReviewersRequest) (*PullRequest, *Response, error) {
```