### PR TITLE
Bug fix PUT /repos/:owner/:repo/branches/:branch/protection

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -583,11 +583,11 @@ type PullRequestReviewsEnforcementRequest struct {
 func (req PullRequestReviewsEnforcementRequest) MarshalJSON() ([]byte, error) {
 	if req.DismissalRestrictionsRequest == nil {
 		newReq := struct {
-			R []interface{} `json:"dismissal_restrictions"`
-			D bool          `json:"dismiss_stale_reviews"`
-			O bool          `json:"require_code_owner_reviews"`
+			R map[string]string `json:"dismissal_restrictions"`
+			D bool              `json:"dismiss_stale_reviews"`
+			O bool              `json:"require_code_owner_reviews"`
 		}{
-			R: []interface{}{},
+			R: make(map[string]string),
 			D: req.DismissStaleReviews,
 			O: req.RequireCodeOwnerReviews,
 		}

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -929,7 +929,7 @@ func TestPullRequestReviewsEnforcementRequest_MarshalJSON_nilDismissalRestirctio
 		t.Errorf("PullRequestReviewsEnforcementRequest.MarshalJSON returned error: %v", err)
 	}
 
-	want := `{"dismissal_restrictions":[],"dismiss_stale_reviews":false,"require_code_owner_reviews":false}`
+	want := `{"dismissal_restrictions":{},"dismiss_stale_reviews":false,"require_code_owner_reviews":false}`
 	if want != string(json) {
 		t.Errorf("PullRequestReviewsEnforcementRequest.MarshalJSON returned %+v, want %+v", string(json), want)
 	}


### PR DESCRIPTION
Empty dismissal restrictions should be a JSON object not a JSON array. See https://developer.github.com/v3/repos/branches/#update-branch-protection. I think this is pretty straightforward? Providing a JSON array for the 'dismissal_restrictions' the GitHub API returns an error response.