### PR TITLE
Bug fix PUT /repos/:owner/:repo/branches/:branch/protection

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1940,6 +1940,22 @@ func (d *DeploymentStatusRequest) GetState() string {
 	return *d.State
 }
 
+// GetTeams returns the Teams field if it's non-nil, zero value otherwise.
+func (d *DismissalRestrictionsRequest) GetTeams() []string {
+	if d == nil || d.Teams == nil {
+		return nil
+	}
+	return *d.Teams
+}
+
+// GetUsers returns the Users field if it's non-nil, zero value otherwise.
+func (d *DismissalRestrictionsRequest) GetUsers() []string {
+	if d == nil || d.Users == nil {
+		return nil
+	}
+	return *d.Users
+}
+
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
 func (d *DraftReviewComment) GetBody() string {
 	if d == nil || d.Body == nil {

--- a/github/repos.go
+++ b/github/repos.go
@@ -571,7 +571,9 @@ type PullRequestReviewsEnforcement struct {
 // enforcement of a protected branch. It is separate from PullRequestReviewsEnforcement above
 // because the request structure is different from the response structure.
 type PullRequestReviewsEnforcementRequest struct {
-	// Specifies which users and teams should be allowed to dismiss pull request reviews. Can be nil to disable the restrictions.
+	// Specifies which users and teams should be allowed to dismiss pull request reviews.
+	// User and team dismissal restrictions are only available for
+	// organization-owned repositories. Must be nil for personal repositories.
 	DismissalRestrictionsRequest *DismissalRestrictionsRequest `json:"dismissal_restrictions,omitempty"`
 	// Specifies if approved reviews can be dismissed automatically, when a new commit is pushed. (Required)
 	DismissStaleReviews bool `json:"dismiss_stale_reviews"`
@@ -629,10 +631,11 @@ type DismissalRestrictions struct {
 // restriction to allows only specific users or teams to dimiss pull request reviews. It is
 // separate from DismissalRestrictions above because the request structure is
 // different from the response structure.
+// Note: Both Users and Teams must be nil, or both must be non-nil.
 type DismissalRestrictionsRequest struct {
-	// The list of user logins who can dismiss pull request reviews. (Required; use nil to disable dismissal_restrictions or []string{} otherwise.)
+	// The list of user logins who can dismiss pull request reviews. (Required; use nil to disable dismissal_restrictions or &[]string{} otherwise.)
 	Users *[]string `json:"users,omitempty"`
-	// The list of team slugs which can dismiss pull request reviews. (Required; use nil to disable dismissal_restrictions or []string{} otherwise.)
+	// The list of team slugs which can dismiss pull request reviews. (Required; use nil to disable dismissal_restrictions or &[]string{} otherwise.)
 	Teams *[]string `json:"teams,omitempty"`
 }
 

--- a/github/repos.go
+++ b/github/repos.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -573,38 +572,11 @@ type PullRequestReviewsEnforcement struct {
 // because the request structure is different from the response structure.
 type PullRequestReviewsEnforcementRequest struct {
 	// Specifies which users and teams should be allowed to dismiss pull request reviews. Can be nil to disable the restrictions.
-	DismissalRestrictionsRequest *DismissalRestrictionsRequest `json:"dismissal_restrictions"`
+	DismissalRestrictionsRequest *DismissalRestrictionsRequest `json:"dismissal_restrictions,omitempty"`
 	// Specifies if approved reviews can be dismissed automatically, when a new commit is pushed. (Required)
 	DismissStaleReviews bool `json:"dismiss_stale_reviews"`
 	// RequireCodeOwnerReviews specifies if an approved review is required in pull requests including files with a designated code owner.
 	RequireCodeOwnerReviews bool `json:"require_code_owner_reviews"`
-}
-
-// MarshalJSON implements the json.Marshaler interface.
-// Converts nil value of PullRequestReviewsEnforcementRequest.DismissalRestrictionsRequest to empty array
-func (req PullRequestReviewsEnforcementRequest) MarshalJSON() ([]byte, error) {
-	if req.DismissalRestrictionsRequest == nil {
-		newReq := struct {
-			R []interface{} `json:"dismissal_restrictions"`
-			D bool          `json:"dismiss_stale_reviews"`
-			O bool          `json:"require_code_owner_reviews"`
-		}{
-			R: []interface{}{},
-			D: req.DismissStaleReviews,
-			O: req.RequireCodeOwnerReviews,
-		}
-		return json.Marshal(newReq)
-	}
-	newReq := struct {
-		R *DismissalRestrictionsRequest `json:"dismissal_restrictions"`
-		D bool                          `json:"dismiss_stale_reviews"`
-		O bool                          `json:"require_code_owner_reviews"`
-	}{
-		R: req.DismissalRestrictionsRequest,
-		D: req.DismissStaleReviews,
-		O: req.RequireCodeOwnerReviews,
-	}
-	return json.Marshal(newReq)
 }
 
 // PullRequestReviewsEnforcementUpdate represents request to patch the pull request review
@@ -658,10 +630,10 @@ type DismissalRestrictions struct {
 // separate from DismissalRestrictions above because the request structure is
 // different from the response structure.
 type DismissalRestrictionsRequest struct {
-	// The list of user logins who can dismiss pull request reviews. (Required; use []string{} instead of nil for empty list.)
-	Users []string `json:"users"`
-	// The list of team slugs which can dismiss pull request reviews. (Required; use []string{} instead of nil for empty list.)
-	Teams []string `json:"teams"`
+	// The list of user logins who can dismiss pull request reviews. (Required; use nil to disable dismissal_restrictions or []string{} otherwise.)
+	Users *[]string `json:"users,omitempty"`
+	// The list of team slugs which can dismiss pull request reviews. (Required; use nil to disable dismissal_restrictions or []string{} otherwise.)
+	Teams *[]string `json:"teams,omitempty"`
 }
 
 // ListBranches lists branches for the specified repository.

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -572,8 +572,8 @@ func TestRepositoriesService_UpdateBranchProtection(t *testing.T) {
 		RequiredPullRequestReviews: &PullRequestReviewsEnforcementRequest{
 			DismissStaleReviews: true,
 			DismissalRestrictionsRequest: &DismissalRestrictionsRequest{
-				Users: []string{"uu"},
-				Teams: []string{"tt"},
+				Users: &[]string{"uu"},
+				Teams: &[]string{"tt"},
 			},
 		},
 		Restrictions: &BranchRestrictionsRequest{
@@ -772,8 +772,8 @@ func TestRepositoriesService_UpdatePullRequestReviewEnforcement(t *testing.T) {
 
 	input := &PullRequestReviewsEnforcementUpdate{
 		DismissalRestrictionsRequest: &DismissalRestrictionsRequest{
-			Users: []string{"u"},
-			Teams: []string{"t"},
+			Users: &[]string{"u"},
+			Teams: &[]string{"t"},
 		},
 	}
 
@@ -924,14 +924,45 @@ func TestRepositoriesService_RemoveAdminEnforcement(t *testing.T) {
 func TestPullRequestReviewsEnforcementRequest_MarshalJSON_nilDismissalRestirctions(t *testing.T) {
 	req := PullRequestReviewsEnforcementRequest{}
 
-	json, err := json.Marshal(req)
+	got, err := json.Marshal(req)
 	if err != nil {
 		t.Errorf("PullRequestReviewsEnforcementRequest.MarshalJSON returned error: %v", err)
 	}
 
-	want := `{"dismissal_restrictions":[],"dismiss_stale_reviews":false,"require_code_owner_reviews":false}`
-	if want != string(json) {
-		t.Errorf("PullRequestReviewsEnforcementRequest.MarshalJSON returned %+v, want %+v", string(json), want)
+	want := `{"dismiss_stale_reviews":false,"require_code_owner_reviews":false}`
+	if want != string(got) {
+		t.Errorf("PullRequestReviewsEnforcementRequest.MarshalJSON returned %+v, want %+v", string(got), want)
+	}
+
+	req = PullRequestReviewsEnforcementRequest{
+		DismissalRestrictionsRequest: &DismissalRestrictionsRequest{},
+	}
+
+	got, err = json.Marshal(req)
+	if err != nil {
+		t.Errorf("PullRequestReviewsEnforcementRequest.MarshalJSON returned error: %v", err)
+	}
+
+	want = `{"dismissal_restrictions":{},"dismiss_stale_reviews":false,"require_code_owner_reviews":false}`
+	if want != string(got) {
+		t.Errorf("PullRequestReviewsEnforcementRequest.MarshalJSON returned %+v, want %+v", string(got), want)
+	}
+
+	req = PullRequestReviewsEnforcementRequest{
+		DismissalRestrictionsRequest: &DismissalRestrictionsRequest{
+			Users: &[]string{},
+			Teams: &[]string{},
+		},
+	}
+
+	got, err = json.Marshal(req)
+	if err != nil {
+		t.Errorf("PullRequestReviewsEnforcementRequest.MarshalJSON returned error: %v", err)
+	}
+
+	want = `{"dismissal_restrictions":{"users":[],"teams":[]},"dismiss_stale_reviews":false,"require_code_owner_reviews":false}`
+	if want != string(got) {
+		t.Errorf("PullRequestReviewsEnforcementRequest.MarshalJSON returned %+v, want %+v", string(got), want)
 	}
 }
 

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -128,7 +128,6 @@ func TestRepositories_EditBranches(t *testing.T) {
 		t.Fatalf("Repositories.UpdateBranchProtection() returned error: %v", err)
 	}
 
-	enforcementURL := "https://api.github.com/repos/" + *repo.Owner.Login + "/" + *repo.Name + "/branches/master/protection/enforce_admins"
 	want := &github.Protection{
 		RequiredStatusChecks: &github.RequiredStatusChecks{
 			Strict:   true,
@@ -138,7 +137,7 @@ func TestRepositories_EditBranches(t *testing.T) {
 			DismissStaleReviews: true,
 		},
 		EnforceAdmins: &github.AdminEnforcement{
-			URL:     github.String(enforcementURL),
+			URL:     github.String("https://api.github.com/repos/" + *repo.Owner.Login + "/" + *repo.Name + "/branches/master/protection/enforce_admins"),
 			Enabled: true,
 		},
 		Restrictions: nil,

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -108,9 +108,6 @@ func TestRepositories_EditBranches(t *testing.T) {
 		t.Fatalf("Branch %v of repo %v is already protected", "master", *repo.Name)
 	}
 
-	// TODO: This test fails with 422 Validation Failed [{Resource: Field: Code: Message:}].
-	//       Someone familiar with protection requests needs to come up with
-	//       a valid protection request that doesn't give 422 error.
 	protectionRequest := &github.ProtectionRequest{
 		RequiredStatusChecks: &github.RequiredStatusChecks{
 			Strict:   true,
@@ -141,7 +138,7 @@ func TestRepositories_EditBranches(t *testing.T) {
 			DismissStaleReviews: true,
 		},
 		EnforceAdmins: &github.AdminEnforcement{
-			URL:     &enforcementURL,
+			URL:     github.String(enforcementURL),
 			Enabled: true,
 		},
 		Restrictions: nil,

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -118,8 +118,8 @@ func TestRepositories_EditBranches(t *testing.T) {
 		},
 		RequiredPullRequestReviews: &github.PullRequestReviewsEnforcementRequest{
 			DismissalRestrictionsRequest: &github.DismissalRestrictionsRequest{
-				Users: []string{},
-				Teams: []string{},
+				Users: &[]string{},
+				Teams: &[]string{},
 			},
 			DismissStaleReviews: true,
 		},

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -117,10 +117,6 @@ func TestRepositories_EditBranches(t *testing.T) {
 			Contexts: []string{"continuous-integration"},
 		},
 		RequiredPullRequestReviews: &github.PullRequestReviewsEnforcementRequest{
-			DismissalRestrictionsRequest: &github.DismissalRestrictionsRequest{
-				Users: &[]string{},
-				Teams: &[]string{},
-			},
 			DismissStaleReviews: true,
 		},
 		EnforceAdmins: true,
@@ -135,19 +131,17 @@ func TestRepositories_EditBranches(t *testing.T) {
 		t.Fatalf("Repositories.UpdateBranchProtection() returned error: %v", err)
 	}
 
+	enforcementURL := "https://api.github.com/repos/" + *repo.Owner.Login + "/" + *repo.Name + "/branches/master/protection/enforce_admins"
 	want := &github.Protection{
 		RequiredStatusChecks: &github.RequiredStatusChecks{
 			Strict:   true,
 			Contexts: []string{"continuous-integration"},
 		},
 		RequiredPullRequestReviews: &github.PullRequestReviewsEnforcement{
-			DismissalRestrictions: github.DismissalRestrictions{
-				Users: []*github.User{},
-				Teams: []*github.Team{},
-			},
 			DismissStaleReviews: true,
 		},
 		EnforceAdmins: &github.AdminEnforcement{
+			URL:     &enforcementURL,
 			Enabled: true,
 		},
 		Restrictions: nil,


### PR DESCRIPTION
The 'dismissal_restrictions' key in the 'required_pull_request_reviews' object must either be omitted (for the case of personal repositories), an empty JSON object, or a JSON object with exactly two keys 'users' and 'teams'. See https://developer.github.com/v3/repos/branches/#update-branch-protection. Closes #664