### PR TITLE
Update repos_stats.go: fix a typo in file repos_repos

### DIFF
--- a/github/repos_stats.go
+++ b/github/repos_stats.go
@@ -182,7 +182,7 @@ func (s *RepositoriesService) ListParticipation(ctx context.Context, owner, repo
 }
 
 // PunchCard represents the number of commits made during a given hour of a
-// day of thew eek.
+// day of the week.
 type PunchCard struct {
 	Day     *int // Day of the week (0-6: =Sunday - Saturday).
 	Hour    *int // Hour of day (0-23).


### PR DESCRIPTION
fix a typo in file repos_repos

I think `thew eek` should be `the week`.