### PR TITLE
Add AuthorAssociation field in struct PullRequest

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -5812,6 +5812,14 @@ func (p *PullRequest) GetAssignee() *User {
 	return p.Assignee
 }
 
+// GetAuthorAssociation returns the AuthorAssociation field if it's non-nil, zero value otherwise.
+func (p *PullRequest) GetAuthorAssociation() string {
+	if p == nil || p.AuthorAssociation == nil {
+		return ""
+	}
+	return *p.AuthorAssociation
+}
+
 // GetBase returns the Base field.
 func (p *PullRequest) GetBase() *PullRequestBranch {
 	if p == nil {

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -51,6 +51,7 @@ type PullRequest struct {
 	Assignees           []*User    `json:"assignees,omitempty"`
 	Milestone           *Milestone `json:"milestone,omitempty"`
 	MaintainerCanModify *bool      `json:"maintainer_can_modify,omitempty"`
+	AuthorAssociation   *string    `json:"author_association,omitempty"`
 
 	Head *PullRequestBranch `json:"head,omitempty"`
 	Base *PullRequestBranch `json:"base,omitempty"`


### PR DESCRIPTION
I see that when a user contributes to a repo at his first time, the github will show this contributor is the-first-time-contributor. And I contact with developers in github about how to get this field in API.
And they said they design a new Field `AuthorAssociation` in pullrequest struct. Although this is not documented in github API docs.

I think it is important, so I try to add this field.