### PR TITLE
RoundTrip: avoid modifying the original request

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -859,10 +859,8 @@ func (t *UnauthenticatedRateLimitedTransport) RoundTrip(req *http.Request) (*htt
 	//
 	// Since we are going to modify only req.URL here, we only need a deep copy
 	// of req.URL.
-	// shallow copy of request
 	req2 := new(http.Request)
 	*req2 = *req
-	// deep copy of request URL
 	req2.URL = new(url.URL)
 	*req2.URL = *req.URL
 
@@ -910,10 +908,8 @@ func (t *BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error
 	//
 	// Since we are going to modify only req.Header here, we only need a deep copy
 	// of req.Header.
-	// shallow copy of the struct
 	req2 := new(http.Request)
 	*req2 = *req
-	// deep copy of the Header
 	req2.Header = make(http.Header, len(req.Header))
 	for k, s := range req.Header {
 		req2.Header[k] = append([]string(nil), s...)

--- a/github/github.go
+++ b/github/github.go
@@ -912,7 +912,7 @@ func (t *BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error
 	*req2 = *req
 	req2.Header = make(http.Header, len(req.Header))
 	for k, s := range req.Header {
-		req2.Header[k] = append([]string{}, s...)
+		req2.Header[k] = append([]string(nil), s...)
 	}
 
 	req2.SetBasicAuth(t.Username, t.Password)

--- a/github/github.go
+++ b/github/github.go
@@ -856,14 +856,23 @@ func (t *UnauthenticatedRateLimitedTransport) RoundTrip(req *http.Request) (*htt
 	// To set extra querystring params, we must make a copy of the Request so
 	// that we don't modify the Request we were given. This is required by the
 	// specification of http.RoundTripper.
-	req = cloneRequest(req)
-	q := req.URL.Query()
+	//
+	// Since we are going to modify only req.URL here, we only need a deep copy
+	// of req.URL.
+	// shallow copy of request
+	req2 := new(http.Request)
+	*req2 = *req
+	// deep copy of request URL
+	req2.URL = new(url.URL)
+	*req2.URL = *req.URL
+
+	q := req2.URL.Query()
 	q.Set("client_id", t.ClientID)
 	q.Set("client_secret", t.ClientSecret)
-	req.URL.RawQuery = q.Encode()
+	req2.URL.RawQuery = q.Encode()
 
 	// Make the HTTP request.
-	return t.transport().RoundTrip(req)
+	return t.transport().RoundTrip(req2)
 }
 
 // Client returns an *http.Client that makes requests which are subject to the
@@ -895,12 +904,26 @@ type BasicAuthTransport struct {
 
 // RoundTrip implements the RoundTripper interface.
 func (t *BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req = cloneRequest(req) // per RoundTrip contract
-	req.SetBasicAuth(t.Username, t.Password)
-	if t.OTP != "" {
-		req.Header.Set(headerOTP, t.OTP)
+	// To set extra headers, we must make a copy of the Request so
+	// that we don't modify the Request we were given. This is required by the
+	// specification of http.RoundTripper.
+	//
+	// Since we are going to modify only req.Header here, we only need a deep copy
+	// of req.Header.
+	// shallow copy of the struct
+	req2 := new(http.Request)
+	*req2 = *req
+	// deep copy of the Header
+	req2.Header = make(http.Header, len(req.Header))
+	for k, s := range req.Header {
+		req2.Header[k] = append([]string(nil), s...)
 	}
-	return t.transport().RoundTrip(req)
+
+	req2.SetBasicAuth(t.Username, t.Password)
+	if t.OTP != "" {
+		req2.Header.Set(headerOTP, t.OTP)
+	}
+	return t.transport().RoundTrip(req2)
 }
 
 // Client returns an *http.Client that makes requests that are authenticated
@@ -914,20 +937,6 @@ func (t *BasicAuthTransport) transport() http.RoundTripper {
 		return t.Transport
 	}
 	return http.DefaultTransport
-}
-
-// cloneRequest returns a clone of the provided *http.Request. The clone is a
-// shallow copy of the struct and its Header map.
-func cloneRequest(r *http.Request) *http.Request {
-	// shallow copy of the struct
-	r2 := new(http.Request)
-	*r2 = *r
-	// deep copy of the Header
-	r2.Header = make(http.Header, len(r.Header))
-	for k, s := range r.Header {
-		r2.Header[k] = append([]string(nil), s...)
-	}
-	return r2
 }
 
 // formatRateReset formats d to look like "[rate reset in 2s]" or

--- a/github/github.go
+++ b/github/github.go
@@ -912,7 +912,7 @@ func (t *BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error
 	*req2 = *req
 	req2.Header = make(http.Header, len(req.Header))
 	for k, s := range req.Header {
-		req2.Header[k] = append([]string(nil), s...)
+		req2.Header[k] = append([]string{}, s...)
 	}
 
 	req2.SetBasicAuth(t.Username, t.Password)


### PR DESCRIPTION
Avoid modifying the original request as per http.RoundTripper contract.
In UnauthenticatedRateLimitedTransport.RoundTrip, we need to modify the
URL of the request only, while in BasicAuthTransport.RoundTrip, we need
to modify only the headers.

Hence, we get rid of cloneRequest method which wasn't working good for
the needs of UnauthenticatedRateLimitedTransport.RoundTrip. Instead, now
we have the implementation of cloneRequest inline in both the RoundTrip
interfaces.

We decided to make the cloneRequest implementation inline because of its
use at only these two places and we think we won't gain much by making a
generic implementation of cloneRequest as a function. To follow the
discussion on this, check the GitHub issue - https://github.com/google/go-github/issues/556.

Fixes #556