### PR TITLE
Upgrade RepoStatus.ID from int to int64

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -8564,12 +8564,12 @@ func (r *RepoStatus) GetDescription() string {
 	return *r.Description
 }
 
-// GetID returns the ID field if it's non-nil, zero value otherwise.
-func (r *RepoStatus) GetID() int64 {
-	if r == nil || r.ID == nil {
-		return 0
+// GetID returns the ID field.
+func (r *RepoStatus) GetID() *int64 {
+	if r == nil {
+		return nil
 	}
-	return *r.ID
+	return r.ID
 }
 
 // GetState returns the State field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -8565,7 +8565,7 @@ func (r *RepoStatus) GetDescription() string {
 }
 
 // GetID returns the ID field if it's non-nil, zero value otherwise.
-func (r *RepoStatus) GetID() int {
+func (r *RepoStatus) GetID() int64 {
 	if r == nil || r.ID == nil {
 		return 0
 	}

--- a/github/github.go
+++ b/github/github.go
@@ -963,6 +963,10 @@ func Bool(v bool) *bool { return &v }
 // to store v and returns a pointer to it.
 func Int(v int) *int { return &v }
 
+// Int64 is a helper routine that allocates a new int64 value
+// to store v and returns a pointer to it.
+func Int64(v int64) *int64 { return &v }
+
 // String is a helper routine that allocates a new string value
 // to store v and returns a pointer to it.
 func String(v string) *string { return &v }

--- a/github/repos_statuses.go
+++ b/github/repos_statuses.go
@@ -13,7 +13,7 @@ import (
 
 // RepoStatus represents the status of a repository at a particular reference.
 type RepoStatus struct {
-	ID  *int    `json:"id,omitempty"`
+	ID  *int64  `json:"id,omitempty"`
 	URL *string `json:"url,omitempty"`
 
 	// State is the current state of the repository. Possible values are:

--- a/github/repos_statuses_test.go
+++ b/github/repos_statuses_test.go
@@ -30,7 +30,7 @@ func TestRepositoriesService_ListStatuses(t *testing.T) {
 		t.Errorf("Repositories.ListStatuses returned error: %v", err)
 	}
 
-	want := []*RepoStatus{{ID: Int(1)}}
+	want := []*RepoStatus{{ID: Int64(1)}}
 	if !reflect.DeepEqual(statuses, want) {
 		t.Errorf("Repositories.ListStatuses returned %+v, want %+v", statuses, want)
 	}
@@ -66,7 +66,7 @@ func TestRepositoriesService_CreateStatus(t *testing.T) {
 		t.Errorf("Repositories.CreateStatus returned error: %v", err)
 	}
 
-	want := &RepoStatus{ID: Int(1)}
+	want := &RepoStatus{ID: Int64(1)}
 	if !reflect.DeepEqual(status, want) {
 		t.Errorf("Repositories.CreateStatus returned %+v, want %+v", status, want)
 	}
@@ -96,7 +96,7 @@ func TestRepositoriesService_GetCombinedStatus(t *testing.T) {
 		t.Errorf("Repositories.GetCombinedStatus returned error: %v", err)
 	}
 
-	want := &CombinedStatus{State: String("success"), Statuses: []RepoStatus{{ID: Int(1)}}}
+	want := &CombinedStatus{State: String("success"), Statuses: []RepoStatus{{ID: Int64(1)}}}
 	if !reflect.DeepEqual(status, want) {
 		t.Errorf("Repositories.GetCombinedStatus returned %+v, want %+v", status, want)
 	}

--- a/github/strings_test.go
+++ b/github/strings_test.go
@@ -117,7 +117,7 @@ func TestString(t *testing.T) {
 		{PushEvent{PushID: Int(1)}, `github.PushEvent{PushID:1}`},
 		{Reference{Ref: String("r")}, `github.Reference{Ref:"r"}`},
 		{ReleaseAsset{ID: Int(1)}, `github.ReleaseAsset{ID:1}`},
-		{RepoStatus{ID: Int(1)}, `github.RepoStatus{ID:1}`},
+		{RepoStatus{ID: Int64(1)}, `github.RepoStatus{ID:1}`},
 		{RepositoryComment{ID: Int(1)}, `github.RepositoryComment{ID:1}`},
 		{RepositoryCommit{SHA: String("s")}, `github.RepositoryCommit{SHA:"s"}`},
 		{RepositoryContent{Name: String("n")}, `github.RepositoryContent{Name:"n"}`},


### PR DESCRIPTION
This is needed on 32 bits platforms. Right now it is impossible to call
CreateStatus() on 32 bits executable because the ID returned by Github
overflows.

This is an API breaking change.

Fixes #806