### PR TITLE
bugfix: pr comment field should be in_reply_to_id

### DIFF
--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -14,7 +14,7 @@ import (
 // PullRequestComment represents a comment left on a pull request.
 type PullRequestComment struct {
 	ID               *int       `json:"id,omitempty"`
-	InReplyTo        *int       `json:"in_reply_to,omitempty"`
+	InReplyTo        *int       `json:"in_reply_to_id,omitempty"`
 	Body             *string    `json:"body,omitempty"`
 	Path             *string    `json:"path,omitempty"`
 	DiffHunk         *string    `json:"diff_hunk,omitempty"`


### PR DESCRIPTION
It was previously and incorrectly `in_reply_to`.
See https://developer.github.com/v3/pulls/comments/