### PR TITLE
Add Outside Collaborators API for OrganizationsService

### DIFF
--- a/github/orgs_outside_collaborators.go
+++ b/github/orgs_outside_collaborators.go
@@ -66,6 +66,8 @@ func (s *OrganizationsService) RemoveOutsideCollaborator(ctx context.Context, or
 // ConvertMemberToOutsideCollaborator reduces the permission level of a member of the
 // organization to that of an outside collaborator. Therefore, they will only
 // have access to the repositories that their current team membership allows.
+// Responses for converting a non-member or the last owner to an outside collaborator
+// are listed in GitHub API docs.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator
 func (s *OrganizationsService) ConvertMemberToOutsideCollaborator(ctx context.Context, org string, user string) (*Response, error) {

--- a/github/orgs_outside_collaborators.go
+++ b/github/orgs_outside_collaborators.go
@@ -69,7 +69,7 @@ func (s *OrganizationsService) RemoveOutsideCollaborator(ctx context.Context, or
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator
 func (s *OrganizationsService) ConvertMemberToOutsideCollaborator(ctx context.Context, org string, user string) (*Response, error) {
-	u := fmt.Sprintf("/orgs/%v/outside_collaborators/%v", org, user)
+	u := fmt.Sprintf("orgs/%v/outside_collaborators/%v", org, user)
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/orgs_outside_collaborators.go
+++ b/github/orgs_outside_collaborators.go
@@ -48,3 +48,32 @@ func (s *OrganizationsService) ListOutsideCollaborators(ctx context.Context, org
 
 	return members, resp, nil
 }
+
+// RemoveOutsideCollaborator removes a user from the list of outside collaborators;
+// consequently, removing them from all the organization's repositories.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/outside_collaborators/#remove-outside-collaborator
+func (s *OrganizationsService) RemoveOutsideCollaborator(ctx context.Context, org string, user string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/outside_collaborators/%v", org, user)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// ConvertMemberToOutsideCollaborator reduces the permission level of a member of the
+// organization to that of an outside collaborator. Therefore, they will only
+// have access to the repositories that their current team membership allows.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator
+func (s *OrganizationsService) ConvertMemberToOutsideCollaborator(ctx context.Context, org string, user string) (*Response, error) {
+	u := fmt.Sprintf("/orgs/%v/outside_collaborators/%v", org, user)
+	req, err := s.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/orgs_outside_collaborators_test.go
+++ b/github/orgs_outside_collaborators_test.go
@@ -64,6 +64,38 @@ func TestOrganizationsService_RemoveOutsideCollaborator(t *testing.T) {
 	}
 }
 
+func TestOrganizationsService_RemoveOutsideCollaborator_NonMember(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNotFound)
+	}
+	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
+
+	_, err := client.Organizations.RemoveOutsideCollaborator(context.Background(), "o", "u")
+	if err, ok := err.(*ErrorResponse); !ok || err.Response.StatusCode != http.StatusNotFound {
+		t.Errorf("Organizations.RemoveOutsideCollaborator_NonMember returned error: %v", err)
+	}
+}
+
+func TestOrganizationsService_RemoveOutsideCollaborator_Member(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+	}
+	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
+
+	_, err := client.Organizations.RemoveOutsideCollaborator(context.Background(), "o", "u")
+	if err, ok := err.(*ErrorResponse); !ok || err.Response.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("Organizations.RemoveOutsideCollaborator_Member returned error: %v", err)
+	}
+}
+
 func TestOrganizationsService_ConvertMemberToOutsideCollaborator(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
@@ -76,5 +108,37 @@ func TestOrganizationsService_ConvertMemberToOutsideCollaborator(t *testing.T) {
 	_, err := client.Organizations.ConvertMemberToOutsideCollaborator(context.Background(), "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator returned error: %v", err)
+	}
+}
+
+func TestOrganizationsService_ConvertMemberToOutsideCollaborator_NonMember(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.WriteHeader(http.StatusForbidden)
+	}
+	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
+
+	_, err := client.Organizations.ConvertMemberToOutsideCollaborator(context.Background(), "o", "u")
+	if err, ok := err.(*ErrorResponse); !ok || err.Response.StatusCode != http.StatusForbidden {
+		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator_NonMember returned error: %v", err)
+	}
+}
+
+func TestOrganizationsService_ConvertMemberToOutsideCollaborator_LastOwner(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.WriteHeader(http.StatusForbidden)
+	}
+	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
+
+	_, err := client.Organizations.ConvertMemberToOutsideCollaborator(context.Background(), "o", "u")
+	if err, ok := err.(*ErrorResponse); !ok || err.Response.StatusCode != http.StatusForbidden {
+		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator_LastOwner returned error: %v", err)
 	}
 }

--- a/github/orgs_outside_collaborators_test.go
+++ b/github/orgs_outside_collaborators_test.go
@@ -111,7 +111,7 @@ func TestOrganizationsService_ConvertMemberToOutsideCollaborator(t *testing.T) {
 	}
 }
 
-func TestOrganizationsService_ConvertMemberToOutsideCollaborator_NonMember(t *testing.T) {
+func TestOrganizationsService_ConvertMemberToOutsideCollaborator_NonMemberOrLastOwner(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -124,21 +124,5 @@ func TestOrganizationsService_ConvertMemberToOutsideCollaborator_NonMember(t *te
 	_, err := client.Organizations.ConvertMemberToOutsideCollaborator(context.Background(), "o", "u")
 	if err, ok := err.(*ErrorResponse); !ok || err.Response.StatusCode != http.StatusForbidden {
 		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator_NonMember returned error: %v", err)
-	}
-}
-
-func TestOrganizationsService_ConvertMemberToOutsideCollaborator_LastOwner(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-		w.WriteHeader(http.StatusForbidden)
-	}
-	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
-
-	_, err := client.Organizations.ConvertMemberToOutsideCollaborator(context.Background(), "o", "u")
-	if err, ok := err.(*ErrorResponse); !ok || err.Response.StatusCode != http.StatusForbidden {
-		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator_LastOwner returned error: %v", err)
 	}
 }

--- a/github/orgs_outside_collaborators_test.go
+++ b/github/orgs_outside_collaborators_test.go
@@ -75,8 +75,10 @@ func TestOrganizationsService_RemoveOutsideCollaborator_NonMember(t *testing.T) 
 	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
 
 	_, err := client.Organizations.RemoveOutsideCollaborator(context.Background(), "o", "u")
-	if err, ok := err.(*ErrorResponse); !ok || err.Response.StatusCode != http.StatusNotFound {
-		t.Errorf("Organizations.RemoveOutsideCollaborator_NonMember returned error: %v", err)
+	if err, ok := err.(*ErrorResponse); !ok {
+		t.Errorf("Organizations.RemoveOutsideCollaborator did not return an error")
+	} else if err.Response.StatusCode != http.StatusNotFound {
+		t.Errorf("Organizations.RemoveOutsideCollaborator did not return 404 status code")
 	}
 }
 
@@ -91,8 +93,10 @@ func TestOrganizationsService_RemoveOutsideCollaborator_Member(t *testing.T) {
 	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
 
 	_, err := client.Organizations.RemoveOutsideCollaborator(context.Background(), "o", "u")
-	if err, ok := err.(*ErrorResponse); !ok || err.Response.StatusCode != http.StatusUnprocessableEntity {
-		t.Errorf("Organizations.RemoveOutsideCollaborator_Member returned error: %v", err)
+	if err, ok := err.(*ErrorResponse); !ok {
+		t.Errorf("Organizations.RemoveOutsideCollaborator did not return an error")
+	} else if err.Response.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("Organizations.RemoveOutsideCollaborator did not return 422 status code")
 	}
 }
 
@@ -122,7 +126,9 @@ func TestOrganizationsService_ConvertMemberToOutsideCollaborator_NonMemberOrLast
 	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
 
 	_, err := client.Organizations.ConvertMemberToOutsideCollaborator(context.Background(), "o", "u")
-	if err, ok := err.(*ErrorResponse); !ok || err.Response.StatusCode != http.StatusForbidden {
-		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator_NonMember returned error: %v", err)
+	if err, ok := err.(*ErrorResponse); !ok {
+		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator did not return an error")
+	} else if err.Response.StatusCode != http.StatusForbidden {
+		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator did not return 403 Status code")
 	}
 }

--- a/github/orgs_outside_collaborators_test.go
+++ b/github/orgs_outside_collaborators_test.go
@@ -48,3 +48,33 @@ func TestOrganizationsService_ListOutsideCollaborators_invalidOrg(t *testing.T) 
 	_, _, err := client.Organizations.ListOutsideCollaborators(context.Background(), "%", nil)
 	testURLParseError(t, err)
 }
+
+func TestOrganizationsService_RemoveOutsideCollaborator(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	}
+	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
+
+	_, err := client.Organizations.RemoveOutsideCollaborator(context.Background(), "o", "u")
+	if err != nil {
+		t.Errorf("Organizations.RemoveOutsideCollaborator returned error: %v", err)
+	}
+}
+
+func TestOrganizationsService_ConvertMemberToOutsideCollaborator(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+	}
+	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
+
+	_, err := client.Organizations.ConvertMemberToOutsideCollaborator(context.Background(), "o", "u")
+	if err != nil {
+		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator returned error: %v", err)
+	}
+}

--- a/github/orgs_outside_collaborators_test.go
+++ b/github/orgs_outside_collaborators_test.go
@@ -129,6 +129,6 @@ func TestOrganizationsService_ConvertMemberToOutsideCollaborator_NonMemberOrLast
 	if err, ok := err.(*ErrorResponse); !ok {
 		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator did not return an error")
 	} else if err.Response.StatusCode != http.StatusForbidden {
-		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator did not return 403 Status code")
+		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator did not return 403 status code")
 	}
 }


### PR DESCRIPTION
I have implemented the two methods on `OrganizationsService` corresponding to missing
endpoints of the Outside Collaborators API, namely:
1. [`RemoveOutsideCollaborator`](https://developer.github.com/v3/orgs/outside_collaborators/#remove-outside-collaborator)
2. [`ConvertMemberToOutsideCollaborator`](https://developer.github.com/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator)

### TODO
- [x] Add unit tests

This was my first attempt at wrapping endpoints so it is likely that the code can be improved upon.
Meanwhile, I will work on adding unit tests for these endpoints.

Refer #524 