### PR TITLE
Support preview GraphQL API v4 Node IDs

### DIFF
--- a/github/gists.go
+++ b/github/gists.go
@@ -209,7 +209,7 @@ func (s *GistsService) GetRevision(ctx context.Context, id, sha string) (*Gist, 
 	if err != nil {
 		return nil, nil, err
 	}
-	
+
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 

--- a/github/gists.go
+++ b/github/gists.go
@@ -30,7 +30,7 @@ type Gist struct {
 	GitPushURL  *string                   `json:"git_push_url,omitempty"`
 	CreatedAt   *time.Time                `json:"created_at,omitempty"`
 	UpdatedAt   *time.Time                `json:"updated_at,omitempty"`
-	NodeID	    *string		  `json:"node_id,omitempty"`
+	NodeID      *string                   `json:"node_id,omitempty"`
 }
 
 func (g Gist) String() string {
@@ -61,7 +61,7 @@ type GistCommit struct {
 	User         *User        `json:"user,omitempty"`
 	ChangeStatus *CommitStats `json:"change_status,omitempty"`
 	CommittedAt  *Timestamp   `json:"committed_at,omitempty"`
-	NodeID	   *string		  `json:"node_id,omitempty"`
+	NodeID       *string      `json:"node_id,omitempty"`
 }
 
 func (gc GistCommit) String() string {
@@ -75,7 +75,7 @@ type GistFork struct {
 	ID        *string    `json:"id,omitempty"`
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
-    NodeID	   *string	 `json:"node_id,omitempty"`
+	NodeID    *string    `json:"node_id,omitempty"`
 }
 
 func (gf GistFork) String() string {
@@ -209,6 +209,7 @@ func (s *GistsService) GetRevision(ctx context.Context, id, sha string) (*Gist, 
 	if err != nil {
 		return nil, nil, err
 	}
+	
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 

--- a/github/gists.go
+++ b/github/gists.go
@@ -30,6 +30,7 @@ type Gist struct {
 	GitPushURL  *string                   `json:"git_push_url,omitempty"`
 	CreatedAt   *time.Time                `json:"created_at,omitempty"`
 	UpdatedAt   *time.Time                `json:"updated_at,omitempty"`
+	NodeID	    *string		  `json:"node_id,omitempty"`
 }
 
 func (g Gist) String() string {
@@ -60,6 +61,7 @@ type GistCommit struct {
 	User         *User        `json:"user,omitempty"`
 	ChangeStatus *CommitStats `json:"change_status,omitempty"`
 	CommittedAt  *Timestamp   `json:"committed_at,omitempty"`
+	NodeID	   *string		  `json:"node_id,omitempty"`
 }
 
 func (gc GistCommit) String() string {
@@ -73,6 +75,7 @@ type GistFork struct {
 	ID        *string    `json:"id,omitempty"`
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
+    NodeID	   *string	 `json:"node_id,omitempty"`
 }
 
 func (gf GistFork) String() string {
@@ -111,6 +114,9 @@ func (s *GistsService) List(ctx context.Context, user string, opt *GistListOptio
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	var gists []*Gist
 	resp, err := s.client.Do(ctx, req, &gists)
 	if err != nil {
@@ -133,6 +139,9 @@ func (s *GistsService) ListAll(ctx context.Context, opt *GistListOptions) ([]*Gi
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	var gists []*Gist
 	resp, err := s.client.Do(ctx, req, &gists)
@@ -157,6 +166,9 @@ func (s *GistsService) ListStarred(ctx context.Context, opt *GistListOptions) ([
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	var gists []*Gist
 	resp, err := s.client.Do(ctx, req, &gists)
 	if err != nil {
@@ -175,6 +187,10 @@ func (s *GistsService) Get(ctx context.Context, id string) (*Gist, *Response, er
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	gist := new(Gist)
 	resp, err := s.client.Do(ctx, req, gist)
 	if err != nil {
@@ -193,6 +209,9 @@ func (s *GistsService) GetRevision(ctx context.Context, id, sha string) (*Gist, 
 	if err != nil {
 		return nil, nil, err
 	}
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	gist := new(Gist)
 	resp, err := s.client.Do(ctx, req, gist)
 	if err != nil {
@@ -211,6 +230,10 @@ func (s *GistsService) Create(ctx context.Context, gist *Gist) (*Gist, *Response
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	g := new(Gist)
 	resp, err := s.client.Do(ctx, req, g)
 	if err != nil {
@@ -229,6 +252,10 @@ func (s *GistsService) Edit(ctx context.Context, id string, gist *Gist) (*Gist, 
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	g := new(Gist)
 	resp, err := s.client.Do(ctx, req, g)
 	if err != nil {
@@ -252,6 +279,9 @@ func (s *GistsService) ListCommits(ctx context.Context, id string, opt *ListOpti
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	var gistCommits []*GistCommit
 	resp, err := s.client.Do(ctx, req, &gistCommits)
@@ -322,6 +352,9 @@ func (s *GistsService) Fork(ctx context.Context, id string) (*Gist, *Response, e
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	g := new(Gist)
 	resp, err := s.client.Do(ctx, req, g)
 	if err != nil {
@@ -340,6 +373,9 @@ func (s *GistsService) ListForks(ctx context.Context, id string) ([]*GistFork, *
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	var gistForks []*GistFork
 	resp, err := s.client.Do(ctx, req, &gistForks)

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -23,6 +23,7 @@ func TestGistsService_List_specifiedUser(t *testing.T) {
 
 	mux.HandleFunc("/users/u/gists", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{
 			"since": since,
 		})
@@ -47,6 +48,7 @@ func TestGistsService_List_authenticatedUser(t *testing.T) {
 
 	mux.HandleFunc("/gists", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `[{"id": "1"}]`)
 	})
 
@@ -77,6 +79,7 @@ func TestGistsService_ListAll(t *testing.T) {
 
 	mux.HandleFunc("/gists/public", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{
 			"since": since,
 		})
@@ -103,6 +106,7 @@ func TestGistsService_ListStarred(t *testing.T) {
 
 	mux.HandleFunc("/gists/starred", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{
 			"since": since,
 		})
@@ -127,6 +131,7 @@ func TestGistsService_Get(t *testing.T) {
 
 	mux.HandleFunc("/gists/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `{"id": "1"}`)
 	})
 
@@ -155,6 +160,7 @@ func TestGistsService_GetRevision(t *testing.T) {
 
 	mux.HandleFunc("/gists/1/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `{"id": "1"}`)
 	})
 
@@ -194,6 +200,7 @@ func TestGistsService_Create(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -246,6 +253,7 @@ func TestGistsService_Edit(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -300,6 +308,7 @@ func TestGistsService_ListCommits(t *testing.T) {
 
 	mux.HandleFunc("/gists/1/commits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, nil)
 		fmt.Fprint(w, `
 		  [
@@ -347,6 +356,7 @@ func TestGistsService_ListCommits_withOptions(t *testing.T) {
 
 	mux.HandleFunc("/gists/1/commits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{
 			"page": "2",
 		})
@@ -475,6 +485,7 @@ func TestGistsService_Fork(t *testing.T) {
 
 	mux.HandleFunc("/gists/1/forks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `{"id": "2"}`)
 	})
 
@@ -495,6 +506,7 @@ func TestGistsService_ListForks(t *testing.T) {
 
 	mux.HandleFunc("/gists/1/forks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, nil)
 		fmt.Fprint(w, `
 		  [

--- a/github/git_blobs.go
+++ b/github/git_blobs.go
@@ -17,7 +17,7 @@ type Blob struct {
 	SHA      *string `json:"sha,omitempty"`
 	Size     *int    `json:"size,omitempty"`
 	URL      *string `json:"url,omitempty"`
-	NodeID	    *string		  `json:"node_id,omitempty"`
+	NodeID   *string `json:"node_id,omitempty"`
 }
 
 // GetBlob fetchs a blob from a repo given a SHA.
@@ -50,7 +50,7 @@ func (s *GitService) CreateBlob(ctx context.Context, owner string, repo string, 
 
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
-	
+
 	t := new(Blob)
 	resp, err := s.client.Do(ctx, req, t)
 	return t, resp, err

--- a/github/git_blobs.go
+++ b/github/git_blobs.go
@@ -17,6 +17,7 @@ type Blob struct {
 	SHA      *string `json:"sha,omitempty"`
 	Size     *int    `json:"size,omitempty"`
 	URL      *string `json:"url,omitempty"`
+	NodeID	    *string		  `json:"node_id,omitempty"`
 }
 
 // GetBlob fetchs a blob from a repo given a SHA.
@@ -28,6 +29,9 @@ func (s *GitService) GetBlob(ctx context.Context, owner string, repo string, sha
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	blob := new(Blob)
 	resp, err := s.client.Do(ctx, req, blob)
@@ -44,6 +48,9 @@ func (s *GitService) CreateBlob(ctx context.Context, owner string, repo string, 
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+	
 	t := new(Blob)
 	resp, err := s.client.Do(ctx, req, t)
 	return t, resp, err

--- a/github/git_blobs_test.go
+++ b/github/git_blobs_test.go
@@ -78,7 +78,7 @@ func TestGitService_CreateBlob(t *testing.T) {
 		if m := mediaTypeGraphQLNodeIDPreview; m != r.Header.Get("Accept") {
 			t.Errorf("Request accept header = %v, want %v", r.Header.Get("Accept"), m)
 		}
-		
+
 		want := input
 		if !reflect.DeepEqual(v, want) {
 			t.Errorf("Git.CreateBlob request body: %+v, want %+v", v, want)

--- a/github/git_blobs_test.go
+++ b/github/git_blobs_test.go
@@ -22,6 +22,11 @@ func TestGitService_GetBlob(t *testing.T) {
 		if m := "GET"; m != r.Method {
 			t.Errorf("Request method = %v, want %v", r.Method, m)
 		}
+
+		if m := mediaTypeGraphQLNodeIDPreview; m != r.Header.Get("Accept") {
+			t.Errorf("Request accept header = %v, want %v", r.Header.Get("Accept"), m)
+		}
+
 		fmt.Fprint(w, `{
 			  "sha": "s",
 			  "content": "blob content"
@@ -70,6 +75,10 @@ func TestGitService_CreateBlob(t *testing.T) {
 			t.Errorf("Request method = %v, want %v", r.Method, m)
 		}
 
+		if m := mediaTypeGraphQLNodeIDPreview; m != r.Header.Get("Accept") {
+			t.Errorf("Request accept header = %v, want %v", r.Header.Get("Accept"), m)
+		}
+		
 		want := input
 		if !reflect.DeepEqual(v, want) {
 			t.Errorf("Git.CreateBlob request body: %+v, want %+v", v, want)

--- a/github/git_blobs_test.go
+++ b/github/git_blobs_test.go
@@ -19,13 +19,8 @@ func TestGitService_GetBlob(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/repos/o/r/git/blobs/s", func(w http.ResponseWriter, r *http.Request) {
-		if m := "GET"; m != r.Method {
-			t.Errorf("Request method = %v, want %v", r.Method, m)
-		}
-
-		if m := mediaTypeGraphQLNodeIDPreview; m != r.Header.Get("Accept") {
-			t.Errorf("Request accept header = %v, want %v", r.Header.Get("Accept"), m)
-		}
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 
 		fmt.Fprint(w, `{
 			  "sha": "s",
@@ -71,13 +66,8 @@ func TestGitService_CreateBlob(t *testing.T) {
 		v := new(Blob)
 		json.NewDecoder(r.Body).Decode(v)
 
-		if m := "POST"; m != r.Method {
-			t.Errorf("Request method = %v, want %v", r.Method, m)
-		}
-
-		if m := mediaTypeGraphQLNodeIDPreview; m != r.Header.Get("Accept") {
-			t.Errorf("Request accept header = %v, want %v", r.Header.Get("Accept"), m)
-		}
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 
 		want := input
 		if !reflect.DeepEqual(v, want) {

--- a/github/git_commits.go
+++ b/github/git_commits.go
@@ -32,12 +32,12 @@ type Commit struct {
 	HTMLURL      *string                `json:"html_url,omitempty"`
 	URL          *string                `json:"url,omitempty"`
 	Verification *SignatureVerification `json:"verification,omitempty"`
+	NodeID       *string                `json:"node_id,omitempty"`
 
 	// CommentCount is the number of GitHub comments on the commit. This
 	// is only populated for requests that fetch GitHub data like
 	// Pulls.ListCommits, Repositories.ListCommits, etc.
-	CommentCount *int    `json:"comment_count,omitempty"`
-	NodeID       *string `json:"node_id,omitempty"`
+	CommentCount *int `json:"comment_count,omitempty"`
 }
 
 func (c Commit) String() string {

--- a/github/git_commits.go
+++ b/github/git_commits.go
@@ -36,6 +36,7 @@ type Commit struct {
 	// is only populated for requests that fetch GitHub data like
 	// Pulls.ListCommits, Repositories.ListCommits, etc.
 	CommentCount *int `json:"comment_count,omitempty"`
+	NodeID	    *string		  `json:"node_id,omitempty"`
 }
 
 func (c Commit) String() string {
@@ -67,8 +68,9 @@ func (s *GitService) GetCommit(ctx context.Context, owner string, repo string, s
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeGitSigningPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeGitSigningPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	c := new(Commit)
 	resp, err := s.client.Do(ctx, req, c)
@@ -123,6 +125,9 @@ func (s *GitService) CreateCommit(ctx context.Context, owner string, repo string
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+	
 	c := new(Commit)
 	resp, err := s.client.Do(ctx, req, c)
 	if err != nil {

--- a/github/git_commits.go
+++ b/github/git_commits.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -35,8 +36,8 @@ type Commit struct {
 	// CommentCount is the number of GitHub comments on the commit. This
 	// is only populated for requests that fetch GitHub data like
 	// Pulls.ListCommits, Repositories.ListCommits, etc.
-	CommentCount *int `json:"comment_count,omitempty"`
-	NodeID	    *string		  `json:"node_id,omitempty"`
+	CommentCount *int    `json:"comment_count,omitempty"`
+	NodeID       *string `json:"node_id,omitempty"`
 }
 
 func (c Commit) String() string {
@@ -127,7 +128,7 @@ func (s *GitService) CreateCommit(ctx context.Context, owner string, repo string
 
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
-	
+
 	c := new(Commit)
 	resp, err := s.client.Do(ctx, req, c)
 	if err != nil {

--- a/github/git_commits_test.go
+++ b/github/git_commits_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -60,7 +61,7 @@ func TestGitService_CreateCommit(t *testing.T) {
 
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
-		
+
 		want := &createCommit{
 			Message: input.Message,
 			Tree:    String("t"),

--- a/github/git_commits_test.go
+++ b/github/git_commits_test.go
@@ -18,9 +18,10 @@ func TestGitService_GetCommit(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeGitSigningPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/git/commits/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeGitSigningPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		fmt.Fprint(w, `{"sha":"s","message":"m","author":{"name":"n"}}`)
 	})
 
@@ -58,7 +59,8 @@ func TestGitService_CreateCommit(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
+		
 		want := &createCommit{
 			Message: input.Message,
 			Tree:    String("t"),

--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -18,6 +18,7 @@ type Reference struct {
 	Ref    *string    `json:"ref"`
 	URL    *string    `json:"url"`
 	Object *GitObject `json:"object"`
+	NodeID *string	  `json:"node_id,omitempty"`
 }
 
 func (r Reference) String() string {
@@ -62,6 +63,9 @@ func (s *GitService) GetRef(ctx context.Context, owner string, repo string, ref 
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	r := new(Reference)
 	resp, err := s.client.Do(ctx, req, r)
 	if _, ok := err.(*json.UnmarshalTypeError); ok {
@@ -92,6 +96,9 @@ func (s *GitService) GetRefs(ctx context.Context, owner string, repo string, ref
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	var rawJSON json.RawMessage
 	resp, err := s.client.Do(ctx, req, &rawJSON)
@@ -147,6 +154,9 @@ func (s *GitService) ListRefs(ctx context.Context, owner, repo string, opt *Refe
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	var rs []*Reference
 	resp, err := s.client.Do(ctx, req, &rs)
 	if err != nil {
@@ -169,6 +179,9 @@ func (s *GitService) CreateRef(ctx context.Context, owner string, repo string, r
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	r := new(Reference)
 	resp, err := s.client.Do(ctx, req, r)
@@ -193,6 +206,9 @@ func (s *GitService) UpdateRef(ctx context.Context, owner string, repo string, r
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+	
 	r := new(Reference)
 	resp, err := s.client.Do(ctx, req, r)
 	if err != nil {

--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -18,7 +18,7 @@ type Reference struct {
 	Ref    *string    `json:"ref"`
 	URL    *string    `json:"url"`
 	Object *GitObject `json:"object"`
-	NodeID *string	  `json:"node_id,omitempty"`
+	NodeID *string    `json:"node_id,omitempty"`
 }
 
 func (r Reference) String() string {
@@ -208,7 +208,7 @@ func (s *GitService) UpdateRef(ctx context.Context, owner string, repo string, r
 
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
-	
+
 	r := new(Reference)
 	resp, err := s.client.Do(ctx, req, r)
 	if err != nil {

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -20,6 +20,7 @@ func TestGitService_GetRef_singleRef(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `
 		  {
 		    "ref": "refs/heads/b",
@@ -62,6 +63,7 @@ func TestGitService_GetRef_multipleRefs(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `
 		  [
 		    {
@@ -100,6 +102,7 @@ func TestGitService_GetRefs_singleRef(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `
 		  {
 		    "ref": "refs/heads/b",
@@ -143,6 +146,7 @@ func TestGitService_GetRefs_multipleRefs(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `
 		  [
 		    {
@@ -193,6 +197,7 @@ func TestGitService_GetRefs_noRefs(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, "[]")
 	})
 
@@ -210,6 +215,7 @@ func TestGitService_ListRefs(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/git/refs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `
 		  [
 		    {
@@ -269,6 +275,7 @@ func TestGitService_ListRefs_options(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/git/refs/t", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"ref": "r"}]`)
 	})
@@ -299,6 +306,7 @@ func TestGitService_CreateRef(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, args) {
 			t.Errorf("Request body = %+v, want %+v", v, args)
 		}
@@ -363,6 +371,7 @@ func TestGitService_UpdateRef(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, args) {
 			t.Errorf("Request body = %+v, want %+v", v, args)
 		}

--- a/github/git_tags.go
+++ b/github/git_tags.go
@@ -19,6 +19,7 @@ type Tag struct {
 	Tagger       *CommitAuthor          `json:"tagger,omitempty"`
 	Object       *GitObject             `json:"object,omitempty"`
 	Verification *SignatureVerification `json:"verification,omitempty"`
+	NodeID	   *string		  `json:"node_id,omitempty"`
 }
 
 // createTagRequest represents the body of a CreateTag request. This is mostly
@@ -42,8 +43,9 @@ func (s *GitService) GetTag(ctx context.Context, owner string, repo string, sha 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeGitSigningPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeGitSigningPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	tag := new(Tag)
 	resp, err := s.client.Do(ctx, req, tag)
@@ -72,6 +74,9 @@ func (s *GitService) CreateTag(ctx context.Context, owner string, repo string, t
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+	
 	t := new(Tag)
 	resp, err := s.client.Do(ctx, req, t)
 	return t, resp, err

--- a/github/git_tags.go
+++ b/github/git_tags.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 // Tag represents a tag object.
@@ -19,7 +20,7 @@ type Tag struct {
 	Tagger       *CommitAuthor          `json:"tagger,omitempty"`
 	Object       *GitObject             `json:"object,omitempty"`
 	Verification *SignatureVerification `json:"verification,omitempty"`
-	NodeID	   *string		  `json:"node_id,omitempty"`
+	NodeID       *string                `json:"node_id,omitempty"`
 }
 
 // createTagRequest represents the body of a CreateTag request. This is mostly
@@ -76,7 +77,7 @@ func (s *GitService) CreateTag(ctx context.Context, owner string, repo string, t
 
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
-	
+
 	t := new(Tag)
 	resp, err := s.client.Do(ctx, req, t)
 	return t, resp, err

--- a/github/git_tags_test.go
+++ b/github/git_tags_test.go
@@ -18,9 +18,10 @@ func TestGitService_GetTag(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeGitSigningPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/git/tags/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeGitSigningPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 
 		fmt.Fprint(w, `{"tag": "t"}`)
 	})
@@ -47,6 +48,7 @@ func TestGitService_CreateTag(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}

--- a/github/git_tags_test.go
+++ b/github/git_tags_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -380,6 +380,14 @@ func (b *Blob) GetEncoding() string {
 	return *b.Encoding
 }
 
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (b *Blob) GetNodeID() string {
+	if b == nil || b.NodeID == nil {
+		return ""
+	}
+	return *b.NodeID
+}
+
 // GetSHA returns the SHA field if it's non-nil, zero value otherwise.
 func (b *Blob) GetSHA() string {
 	if b == nil || b.SHA == nil {
@@ -634,6 +642,14 @@ func (c *Commit) GetMessage() string {
 		return ""
 	}
 	return *c.Message
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (c *Commit) GetNodeID() string {
+	if c == nil || c.NodeID == nil {
+		return ""
+	}
+	return *c.NodeID
 }
 
 // GetSHA returns the SHA field if it's non-nil, zero value otherwise.
@@ -1396,6 +1412,14 @@ func (d *Deployment) GetID() int {
 	return *d.ID
 }
 
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (d *Deployment) GetNodeID() string {
+	if d == nil || d.NodeID == nil {
+		return ""
+	}
+	return *d.NodeID
+}
+
 // GetRef returns the Ref field if it's non-nil, zero value otherwise.
 func (d *Deployment) GetRef() string {
 	if d == nil || d.Ref == nil {
@@ -1594,6 +1618,14 @@ func (d *DeploymentStatus) GetID() int {
 		return 0
 	}
 	return *d.ID
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (d *DeploymentStatus) GetNodeID() string {
+	if d == nil || d.NodeID == nil {
+		return ""
+	}
+	return *d.NodeID
 }
 
 // GetRepositoryURL returns the RepositoryURL field if it's non-nil, zero value otherwise.
@@ -1948,6 +1980,14 @@ func (g *Gist) GetID() string {
 	return *g.ID
 }
 
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (g *Gist) GetNodeID() string {
+	if g == nil || g.NodeID == nil {
+		return ""
+	}
+	return *g.NodeID
+}
+
 // GetOwner returns the Owner field.
 func (g *Gist) GetOwner() *User {
 	if g == nil {
@@ -2026,6 +2066,14 @@ func (g *GistCommit) GetCommittedAt() Timestamp {
 		return Timestamp{}
 	}
 	return *g.CommittedAt
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (g *GistCommit) GetNodeID() string {
+	if g == nil || g.NodeID == nil {
+		return ""
+	}
+	return *g.NodeID
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
@@ -2114,6 +2162,14 @@ func (g *GistFork) GetID() string {
 		return ""
 	}
 	return *g.ID
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (g *GistFork) GetNodeID() string {
+	if g == nil || g.NodeID == nil {
+		return ""
+	}
+	return *g.NodeID
 }
 
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
@@ -2876,6 +2932,14 @@ func (i *Issue) GetMilestone() *Milestone {
 	return i.Milestone
 }
 
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (i *Issue) GetNodeID() string {
+	if i == nil || i.NodeID == nil {
+		return ""
+	}
+	return *i.NodeID
+}
+
 // GetNumber returns the Number field if it's non-nil, zero value otherwise.
 func (i *Issue) GetNumber() int {
 	if i == nil || i.Number == nil {
@@ -3402,6 +3466,14 @@ func (l *Label) GetName() string {
 		return ""
 	}
 	return *l.Name
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (l *Label) GetNodeID() string {
+	if l == nil || l.NodeID == nil {
+		return ""
+	}
+	return *l.NodeID
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
@@ -4132,6 +4204,14 @@ func (m *Milestone) GetLabelsURL() string {
 	return *m.LabelsURL
 }
 
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (m *Milestone) GetNodeID() string {
+	if m == nil || m.NodeID == nil {
+		return ""
+	}
+	return *m.NodeID
+}
+
 // GetNumber returns the Number field if it's non-nil, zero value otherwise.
 func (m *Milestone) GetNumber() int {
 	if m == nil || m.Number == nil {
@@ -4602,6 +4682,14 @@ func (o *Organization) GetName() string {
 		return ""
 	}
 	return *o.Name
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (o *Organization) GetNodeID() string {
+	if o == nil || o.NodeID == nil {
+		return ""
+	}
+	return *o.NodeID
 }
 
 // GetOwnedPrivateRepos returns the OwnedPrivateRepos field if it's non-nil, zero value otherwise.
@@ -6956,6 +7044,14 @@ func (r *Reactions) GetURL() string {
 	return *r.URL
 }
 
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (r *Reference) GetNodeID() string {
+	if r == nil || r.NodeID == nil {
+		return ""
+	}
+	return *r.NodeID
+}
+
 // GetObject returns the Object field.
 func (r *Reference) GetObject() *GitObject {
 	if r == nil {
@@ -8930,6 +9026,14 @@ func (t *Tag) GetMessage() string {
 		return ""
 	}
 	return *t.Message
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (t *Tag) GetNodeID() string {
+	if t == nil || t.NodeID == nil {
+		return ""
+	}
+	return *t.NodeID
 }
 
 // GetObject returns the Object field.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The go-github AUTHORS. All rights reserved.
+// Copyright 2018 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The go-github AUTHORS. All rights reserved.
+// Copyright 2017 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/github/github.go
+++ b/github/github.go
@@ -111,6 +111,9 @@ const (
 
 	// https://developer.github.com/changes/2017-11-09-repository-transfer-api-preview/
 	mediaTypeRepositoryTransferPreview = "application/vnd.github.nightshade-preview+json"
+
+	// https://developer.github.com/changes/2017-12-19-graphql-node-id/
+	mediaTypeGraphQLNodeIDPreview = "application/vnd.github.jean-grey-preview+json"
 )
 
 // A Client manages communication with the GitHub API.

--- a/github/issues.go
+++ b/github/issues.go
@@ -54,6 +54,7 @@ type Issue struct {
 	// TextMatches is only populated from search results that request text matches
 	// See: search.go and https://developer.github.com/v3/search/#text-match-metadata
 	TextMatches []TextMatch `json:"text_matches,omitempty"`
+	NodeID	   *string		  `json:"node_id,omitempty"`
 }
 
 func (i Issue) String() string {
@@ -153,8 +154,9 @@ func (s *IssuesService) listIssues(ctx context.Context, u string, opt *IssueList
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var issues []*Issue
 	resp, err := s.client.Do(ctx, req, &issues)
@@ -220,8 +222,9 @@ func (s *IssuesService) ListByRepo(ctx context.Context, owner string, repo strin
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var issues []*Issue
 	resp, err := s.client.Do(ctx, req, &issues)
@@ -242,8 +245,9 @@ func (s *IssuesService) Get(ctx context.Context, owner string, repo string, numb
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	issue := new(Issue)
 	resp, err := s.client.Do(ctx, req, issue)
@@ -264,6 +268,9 @@ func (s *IssuesService) Create(ctx context.Context, owner string, repo string, i
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	i := new(Issue)
 	resp, err := s.client.Do(ctx, req, i)
 	if err != nil {
@@ -283,6 +290,9 @@ func (s *IssuesService) Edit(ctx context.Context, owner string, repo string, num
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+	
 	i := new(Issue)
 	resp, err := s.client.Do(ctx, req, i)
 	if err != nil {

--- a/github/issues.go
+++ b/github/issues.go
@@ -51,11 +51,11 @@ type Issue struct {
 	Repository       *Repository       `json:"repository,omitempty"`
 	Reactions        *Reactions        `json:"reactions,omitempty"`
 	Assignees        []*User           `json:"assignees,omitempty"`
+	NodeID           *string           `json:"node_id,omitempty"`
 
 	// TextMatches is only populated from search results that request text matches
 	// See: search.go and https://developer.github.com/v3/search/#text-match-metadata
 	TextMatches []TextMatch `json:"text_matches,omitempty"`
-	NodeID      *string     `json:"node_id,omitempty"`
 }
 
 func (i Issue) String() string {

--- a/github/issues.go
+++ b/github/issues.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -54,7 +55,7 @@ type Issue struct {
 	// TextMatches is only populated from search results that request text matches
 	// See: search.go and https://developer.github.com/v3/search/#text-match-metadata
 	TextMatches []TextMatch `json:"text_matches,omitempty"`
-	NodeID	   *string		  `json:"node_id,omitempty"`
+	NodeID      *string     `json:"node_id,omitempty"`
 }
 
 func (i Issue) String() string {
@@ -292,7 +293,7 @@ func (s *IssuesService) Edit(ctx context.Context, owner string, repo string, num
 
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
-	
+
 	i := new(Issue)
 	resp, err := s.client.Do(ctx, req, i)
 	if err != nil {

--- a/github/issues_labels.go
+++ b/github/issues_labels.go
@@ -16,6 +16,7 @@ type Label struct {
 	URL   *string `json:"url,omitempty"`
 	Name  *string `json:"name,omitempty"`
 	Color *string `json:"color,omitempty"`
+	NodeID	 *string `json:"node_id,omitempty"`
 }
 
 func (l Label) String() string {
@@ -37,6 +38,9 @@ func (s *IssuesService) ListLabels(ctx context.Context, owner string, repo strin
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	var labels []*Label
 	resp, err := s.client.Do(ctx, req, &labels)
 	if err != nil {
@@ -55,6 +59,9 @@ func (s *IssuesService) GetLabel(ctx context.Context, owner string, repo string,
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	label := new(Label)
 	resp, err := s.client.Do(ctx, req, label)
@@ -94,6 +101,9 @@ func (s *IssuesService) EditLabel(ctx context.Context, owner string, repo string
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	l := new(Label)
 	resp, err := s.client.Do(ctx, req, l)
 	if err != nil {
@@ -130,6 +140,9 @@ func (s *IssuesService) ListLabelsByIssue(ctx context.Context, owner string, rep
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	var labels []*Label
 	resp, err := s.client.Do(ctx, req, &labels)
 	if err != nil {
@@ -148,6 +161,9 @@ func (s *IssuesService) AddLabelsToIssue(ctx context.Context, owner string, repo
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	var l []*Label
 	resp, err := s.client.Do(ctx, req, &l)
@@ -179,6 +195,9 @@ func (s *IssuesService) ReplaceLabelsForIssue(ctx context.Context, owner string,
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	var l []*Label
 	resp, err := s.client.Do(ctx, req, &l)
@@ -216,6 +235,9 @@ func (s *IssuesService) ListLabelsForMilestone(ctx context.Context, owner string
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+	
 	var labels []*Label
 	resp, err := s.client.Do(ctx, req, &labels)
 	if err != nil {

--- a/github/issues_labels.go
+++ b/github/issues_labels.go
@@ -12,11 +12,11 @@ import (
 
 // Label represents a GitHub label on an Issue
 type Label struct {
-	ID    *int    `json:"id,omitempty"`
-	URL   *string `json:"url,omitempty"`
-	Name  *string `json:"name,omitempty"`
-	Color *string `json:"color,omitempty"`
-	NodeID	 *string `json:"node_id,omitempty"`
+	ID     *int    `json:"id,omitempty"`
+	URL    *string `json:"url,omitempty"`
+	Name   *string `json:"name,omitempty"`
+	Color  *string `json:"color,omitempty"`
+	NodeID *string `json:"node_id,omitempty"`
 }
 
 func (l Label) String() string {
@@ -237,7 +237,7 @@ func (s *IssuesService) ListLabelsForMilestone(ctx context.Context, owner string
 
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
-	
+
 	var labels []*Label
 	resp, err := s.client.Do(ctx, req, &labels)
 	if err != nil {

--- a/github/issues_labels.go
+++ b/github/issues_labels.go
@@ -82,6 +82,9 @@ func (s *IssuesService) CreateLabel(ctx context.Context, owner string, repo stri
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	l := new(Label)
 	resp, err := s.client.Do(ctx, req, l)
 	if err != nil {

--- a/github/issues_labels_test.go
+++ b/github/issues_labels_test.go
@@ -20,6 +20,7 @@ func TestIssuesService_ListLabels(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"name": "a"},{"name": "b"}]`)
 	})
@@ -50,6 +51,7 @@ func TestIssuesService_GetLabel(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/labels/n", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `{"url":"u", "name": "n", "color": "c"}`)
 	})
 
@@ -83,6 +85,7 @@ func TestIssuesService_CreateLabel(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -120,6 +123,7 @@ func TestIssuesService_EditLabel(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -174,6 +178,7 @@ func TestIssuesService_ListLabelsByIssue(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"name":"a","id":1},{"name":"b","id":2}]`)
 	})
@@ -212,6 +217,7 @@ func TestIssuesService_AddLabelsToIssue(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -271,6 +277,7 @@ func TestIssuesService_ReplaceLabelsForIssue(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "PUT")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -325,6 +332,7 @@ func TestIssuesService_ListLabelsForMilestone(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/milestones/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"name": "a"},{"name": "b"}]`)
 	})

--- a/github/issues_milestones.go
+++ b/github/issues_milestones.go
@@ -28,7 +28,7 @@ type Milestone struct {
 	UpdatedAt    *time.Time `json:"updated_at,omitempty"`
 	ClosedAt     *time.Time `json:"closed_at,omitempty"`
 	DueOn        *time.Time `json:"due_on,omitempty"`
-	NodeID	     *string	`json:"node_id,omitempty"`
+	NodeID       *string    `json:"node_id,omitempty"`
 }
 
 func (m Milestone) String() string {
@@ -136,7 +136,7 @@ func (s *IssuesService) EditMilestone(ctx context.Context, owner string, repo st
 
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
-	
+
 	m := new(Milestone)
 	resp, err := s.client.Do(ctx, req, m)
 	if err != nil {

--- a/github/issues_milestones.go
+++ b/github/issues_milestones.go
@@ -28,6 +28,7 @@ type Milestone struct {
 	UpdatedAt    *time.Time `json:"updated_at,omitempty"`
 	ClosedAt     *time.Time `json:"closed_at,omitempty"`
 	DueOn        *time.Time `json:"due_on,omitempty"`
+	NodeID	     *string	`json:"node_id,omitempty"`
 }
 
 func (m Milestone) String() string {
@@ -67,6 +68,9 @@ func (s *IssuesService) ListMilestones(ctx context.Context, owner string, repo s
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	var milestones []*Milestone
 	resp, err := s.client.Do(ctx, req, &milestones)
 	if err != nil {
@@ -85,6 +89,9 @@ func (s *IssuesService) GetMilestone(ctx context.Context, owner string, repo str
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	milestone := new(Milestone)
 	resp, err := s.client.Do(ctx, req, milestone)
@@ -105,6 +112,9 @@ func (s *IssuesService) CreateMilestone(ctx context.Context, owner string, repo 
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	m := new(Milestone)
 	resp, err := s.client.Do(ctx, req, m)
 	if err != nil {
@@ -124,6 +134,9 @@ func (s *IssuesService) EditMilestone(ctx context.Context, owner string, repo st
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+	
 	m := new(Milestone)
 	resp, err := s.client.Do(ctx, req, m)
 	if err != nil {

--- a/github/issues_milestones_test.go
+++ b/github/issues_milestones_test.go
@@ -20,7 +20,7 @@ func TestIssuesService_ListMilestones(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/milestones", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-    	testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{
 			"state":     "closed",
 			"sort":      "due_date",

--- a/github/issues_milestones_test.go
+++ b/github/issues_milestones_test.go
@@ -20,6 +20,7 @@ func TestIssuesService_ListMilestones(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/milestones", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+    	testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{
 			"state":     "closed",
 			"sort":      "due_date",
@@ -55,6 +56,7 @@ func TestIssuesService_GetMilestone(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/milestones/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
@@ -88,6 +90,7 @@ func TestIssuesService_CreateMilestone(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -125,6 +128,7 @@ func TestIssuesService_EditMilestone(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -19,9 +19,10 @@ func TestIssuesService_List_all(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"filter":    "all",
 			"state":     "closed",
@@ -55,9 +56,10 @@ func TestIssuesService_List_owned(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/user/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		fmt.Fprint(w, `[{"number":1}]`)
 	})
 
@@ -76,9 +78,10 @@ func TestIssuesService_ListByOrg(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/orgs/o/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		fmt.Fprint(w, `[{"number":1}]`)
 	})
 
@@ -105,9 +108,10 @@ func TestIssuesService_ListByRepo(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"milestone": "*",
 			"state":     "closed",
@@ -150,9 +154,10 @@ func TestIssuesService_Get(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		fmt.Fprint(w, `{"number":1, "labels": [{"url": "u", "name": "n", "color": "c"}]}`)
 	})
 
@@ -198,6 +203,7 @@ func TestIssuesService_Create(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -235,6 +241,7 @@ func TestIssuesService_Edit(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -43,6 +43,7 @@ type Organization struct {
 	BillingEmail      *string    `json:"billing_email,omitempty"`
 	Type              *string    `json:"type,omitempty"`
 	Plan              *Plan      `json:"plan,omitempty"`
+	NodeID            *string    `json:"node_id,omitempty"`
 
 	// API URLs
 	URL              *string `json:"url,omitempty"`
@@ -97,6 +98,9 @@ func (s *OrganizationsService) ListAll(ctx context.Context, opt *OrganizationsLi
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	orgs := []*Organization{}
 	resp, err := s.client.Do(ctx, req, &orgs)
 	if err != nil {
@@ -126,6 +130,9 @@ func (s *OrganizationsService) List(ctx context.Context, user string, opt *ListO
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	var orgs []*Organization
 	resp, err := s.client.Do(ctx, req, &orgs)
 	if err != nil {
@@ -144,6 +151,9 @@ func (s *OrganizationsService) Get(ctx context.Context, org string) (*Organizati
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	organization := new(Organization)
 	resp, err := s.client.Do(ctx, req, organization)
@@ -164,6 +174,9 @@ func (s *OrganizationsService) GetByID(ctx context.Context, id int) (*Organizati
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	organization := new(Organization)
 	resp, err := s.client.Do(ctx, req, organization)
 	if err != nil {
@@ -182,6 +195,9 @@ func (s *OrganizationsService) Edit(ctx context.Context, name string, org *Organ
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	o := new(Organization)
 	resp, err := s.client.Do(ctx, req, o)

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -21,6 +21,7 @@ func TestOrganizationsService_ListAll(t *testing.T) {
 	since := 1342004
 	mux.HandleFunc("/organizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{"since": "1342004"})
 		fmt.Fprint(w, `[{"id":4314092}]`)
 	})
@@ -43,6 +44,7 @@ func TestOrganizationsService_List_authenticatedUser(t *testing.T) {
 
 	mux.HandleFunc("/user/orgs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
@@ -63,6 +65,7 @@ func TestOrganizationsService_List_specifiedUser(t *testing.T) {
 
 	mux.HandleFunc("/users/u/orgs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
@@ -93,6 +96,7 @@ func TestOrganizationsService_Get(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `{"id":1, "login":"l", "url":"u", "avatar_url": "a", "location":"l"}`)
 	})
 
@@ -121,6 +125,7 @@ func TestOrganizationsService_GetByID(t *testing.T) {
 
 	mux.HandleFunc("/organizations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `{"id":1, "login":"l", "url":"u", "avatar_url": "a", "location":"l"}`)
 	})
 
@@ -146,6 +151,7 @@ func TestOrganizationsService_Edit(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -26,6 +26,7 @@ type Deployment struct {
 	UpdatedAt     *Timestamp      `json:"updated_at,omitempty"`
 	StatusesURL   *string         `json:"statuses_url,omitempty"`
 	RepositoryURL *string         `json:"repository_url,omitempty"`
+	NodeID	   *string		  `json:"node_id,omitempty"`
 }
 
 // DeploymentRequest represents a deployment request
@@ -74,6 +75,9 @@ func (s *RepositoriesService) ListDeployments(ctx context.Context, owner, repo s
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	var deployments []*Deployment
 	resp, err := s.client.Do(ctx, req, &deployments)
 	if err != nil {
@@ -93,6 +97,9 @@ func (s *RepositoriesService) GetDeployment(ctx context.Context, owner, repo str
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	deployment := new(Deployment)
 	resp, err := s.client.Do(ctx, req, deployment)
@@ -114,8 +121,9 @@ func (s *RepositoriesService) CreateDeployment(ctx context.Context, owner, repo 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when deployment support fully launches
-	req.Header.Set("Accept", mediaTypeDeploymentStatusPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	d := new(Deployment)
 	resp, err := s.client.Do(ctx, req, d)
@@ -140,6 +148,7 @@ type DeploymentStatus struct {
 	UpdatedAt     *Timestamp `json:"updated_at,omitempty"`
 	DeploymentURL *string    `json:"deployment_url,omitempty"`
 	RepositoryURL *string    `json:"repository_url,omitempty"`
+	NodeID	   *string	 `json:"node_id,omitempty"`
 }
 
 // DeploymentStatusRequest represents a deployment request
@@ -166,6 +175,9 @@ func (s *RepositoriesService) ListDeploymentStatuses(ctx context.Context, owner,
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	var statuses []*DeploymentStatus
 	resp, err := s.client.Do(ctx, req, &statuses)
 	if err != nil {
@@ -186,8 +198,9 @@ func (s *RepositoriesService) GetDeploymentStatus(ctx context.Context, owner, re
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when deployment support fully launches
-	req.Header.Set("Accept", mediaTypeDeploymentStatusPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	d := new(DeploymentStatus)
 	resp, err := s.client.Do(ctx, req, d)
@@ -209,8 +222,9 @@ func (s *RepositoriesService) CreateDeploymentStatus(ctx context.Context, owner,
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when deployment support fully launches
-	req.Header.Set("Accept", mediaTypeDeploymentStatusPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	d := new(DeploymentStatus)
 	resp, err := s.client.Do(ctx, req, d)

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // Deployment represents a deployment in a repo
@@ -26,7 +27,7 @@ type Deployment struct {
 	UpdatedAt     *Timestamp      `json:"updated_at,omitempty"`
 	StatusesURL   *string         `json:"statuses_url,omitempty"`
 	RepositoryURL *string         `json:"repository_url,omitempty"`
-	NodeID	   *string		  `json:"node_id,omitempty"`
+	NodeID        *string         `json:"node_id,omitempty"`
 }
 
 // DeploymentRequest represents a deployment request
@@ -148,7 +149,7 @@ type DeploymentStatus struct {
 	UpdatedAt     *Timestamp `json:"updated_at,omitempty"`
 	DeploymentURL *string    `json:"deployment_url,omitempty"`
 	RepositoryURL *string    `json:"repository_url,omitempty"`
-	NodeID	   *string	 `json:"node_id,omitempty"`
+	NodeID        *string    `json:"node_id,omitempty"`
 }
 
 // DeploymentStatusRequest represents a deployment request

--- a/github/repos_deployments_test.go
+++ b/github/repos_deployments_test.go
@@ -20,6 +20,7 @@ func TestRepositoriesService_ListDeployments(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/deployments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{"environment": "test"})
 		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
@@ -42,6 +43,7 @@ func TestRepositoriesService_GetDeployment(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/deployments/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `{"id":3}`)
 	})
 
@@ -63,12 +65,13 @@ func TestRepositoriesService_CreateDeployment(t *testing.T) {
 
 	input := &DeploymentRequest{Ref: String("1111"), Task: String("deploy"), TransientEnvironment: Bool(true)}
 
+	acceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/deployments", func(w http.ResponseWriter, r *http.Request) {
 		v := new(DeploymentRequest)
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeDeploymentStatusPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -93,6 +96,7 @@ func TestRepositoriesService_ListDeploymentStatuses(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/deployments/1/statuses", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
@@ -113,9 +117,10 @@ func TestRepositoriesService_GetDeploymentStatus(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/deployments/3/statuses/4", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeDeploymentStatusPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		fmt.Fprint(w, `{"id":4}`)
 	})
 
@@ -136,12 +141,13 @@ func TestRepositoriesService_CreateDeploymentStatus(t *testing.T) {
 
 	input := &DeploymentStatusRequest{State: String("inactive"), Description: String("deploy"), AutoInactive: Bool(false)}
 
+	acceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/deployments/1/statuses", func(w http.ResponseWriter, r *http.Request) {
 		v := new(DeploymentStatusRequest)
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeDeploymentStatusPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}

--- a/github/repos_deployments_test.go
+++ b/github/repos_deployments_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 


### PR DESCRIPTION
Helps #814 .
The current pull request includes the GraphQL node ID in the response for the following REST API v3 resources:

- Deployments
- Gists
- Git Blobs
- Git Commits
- Git References
- Git Tags
- Issues
- Labels
- Milestones
- Organizations