### PR TITLE
fix: abuse rate limits handling

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -601,7 +601,7 @@ func (*AcceptedError) Error() string {
 }
 
 // AbuseRateLimitError occurs when GitHub returns 403 Forbidden response with the
-// "documentation_url" field value equal to "https://developer.github.com/v3#abuse-rate-limits".
+// "documentation_url" field value equal to "https://developer.github.com/v3/#abuse-rate-limits".
 type AbuseRateLimitError struct {
 	Response *http.Response // HTTP response that caused this error
 	Message  string         `json:"message"` // error message
@@ -693,7 +693,7 @@ func CheckResponse(r *http.Response) error {
 			Response: errorResponse.Response,
 			Message:  errorResponse.Message,
 		}
-	case r.StatusCode == http.StatusForbidden && errorResponse.DocumentationURL == "https://developer.github.com/v3#abuse-rate-limits":
+	case r.StatusCode == http.StatusForbidden && errorResponse.DocumentationURL == "https://developer.github.com/v3/#abuse-rate-limits":
 		abuseRateLimitError := &AbuseRateLimitError{
 			Response: errorResponse.Response,
 			Message:  errorResponse.Message,

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -657,7 +657,7 @@ func TestDo_rateLimit_abuseRateLimitError(t *testing.T) {
 		// there is no "Retry-After" header.
 		fmt.Fprintln(w, `{
    "message": "You have triggered an abuse detection mechanism and have been temporarily blocked from content creation. Please retry your request again later.",
-   "documentation_url": "https://developer.github.com/v3#abuse-rate-limits"
+   "documentation_url": "https://developer.github.com/v3/#abuse-rate-limits"
 }`)
 	})
 
@@ -687,7 +687,7 @@ func TestDo_rateLimit_abuseRateLimitError_retryAfter(t *testing.T) {
 		w.WriteHeader(http.StatusForbidden)
 		fmt.Fprintln(w, `{
    "message": "You have triggered an abuse detection mechanism ...",
-   "documentation_url": "https://developer.github.com/v3#abuse-rate-limits"
+   "documentation_url": "https://developer.github.com/v3/#abuse-rate-limits"
 }`)
 	})
 


### PR DESCRIPTION
Seems like the URL changed, docs were not updated though:

https://developer.github.com/v3/#abuse-rate-limits

Will also send an email to github support to check wether this is intended or not.