### PR TITLE
Make use of testMethod consistent

### DIFF
--- a/github/git_trees_test.go
+++ b/github/git_trees_test.go
@@ -19,9 +19,7 @@ func TestGitService_GetTree(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/repos/o/r/git/trees/s", func(w http.ResponseWriter, r *http.Request) {
-		if m := "GET"; m != r.Method {
-			t.Errorf("Request method = %v, want %v", r.Method, m)
-		}
+		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
 			  "sha": "s",
 			  "tree": [ { "type": "blob" } ]
@@ -71,9 +69,7 @@ func TestGitService_CreateTree(t *testing.T) {
 		v := new(createTree)
 		json.NewDecoder(r.Body).Decode(v)
 
-		if m := "POST"; m != r.Method {
-			t.Errorf("Request method = %v, want %v", r.Method, m)
-		}
+		testMethod(t, r, "POST")
 
 		want := &createTree{
 			BaseTree: "b",
@@ -136,9 +132,7 @@ func TestGitService_CreateTree_Content(t *testing.T) {
 		v := new(createTree)
 		json.NewDecoder(r.Body).Decode(v)
 
-		if m := "POST"; m != r.Method {
-			t.Errorf("Request method = %v, want %v", r.Method, m)
-		}
+		testMethod(t, r, "POST")
 
 		want := &createTree{
 			BaseTree: "b",

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -413,9 +413,7 @@ func TestDo(t *testing.T) {
 	}
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if m := "GET"; m != r.Method {
-			t.Errorf("Request method = %v, want %v", r.Method, m)
-		}
+		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"A":"a"}`)
 	})
 
@@ -853,9 +851,7 @@ func TestRateLimits(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/rate_limit", func(w http.ResponseWriter, r *http.Request) {
-		if m := "GET"; m != r.Method {
-			t.Errorf("Request method = %v, want %v", r.Method, m)
-		}
+		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"resources":{
 			"core": {"limit":2,"remaining":1,"reset":1372700873},
 			"search": {"limit":3,"remaining":2,"reset":1372700874}


### PR DESCRIPTION
Use testMethod to test the request method instead of manually comparing
it and testing. This change is to make things consistent through out the
code base.

Fixes #829