### PR TITLE
Added node id to other API's

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -5212,6 +5212,14 @@ func (p *Project) GetName() string {
 	return *p.Name
 }
 
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (p *Project) GetNodeID() string {
+	if p == nil || p.NodeID == nil {
+		return ""
+	}
+	return *p.NodeID
+}
+
 // GetNumber returns the Number field if it's non-nil, zero value otherwise.
 func (p *Project) GetNumber() int {
 	if p == nil || p.Number == nil {
@@ -5290,6 +5298,14 @@ func (p *ProjectCard) GetID() int64 {
 		return 0
 	}
 	return *p.ID
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (p *ProjectCard) GetNodeID() string {
+	if p == nil || p.NodeID == nil {
+		return ""
+	}
+	return *p.NodeID
 }
 
 // GetNote returns the Note field if it's non-nil, zero value otherwise.
@@ -5402,6 +5418,14 @@ func (p *ProjectColumn) GetName() string {
 		return ""
 	}
 	return *p.Name
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (p *ProjectColumn) GetNodeID() string {
+	if p == nil || p.NodeID == nil {
+		return ""
+	}
+	return *p.NodeID
 }
 
 // GetProjectURL returns the ProjectURL field if it's non-nil, zero value otherwise.
@@ -6980,6 +7004,14 @@ func (r *Reaction) GetID() int64 {
 	return *r.ID
 }
 
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (r *Reaction) GetNodeID() string {
+	if r == nil || r.NodeID == nil {
+		return ""
+	}
+	return *r.NodeID
+}
+
 // GetUser returns the User field.
 func (r *Reaction) GetUser() *User {
 	if r == nil {
@@ -7138,6 +7170,14 @@ func (r *ReleaseAsset) GetName() string {
 		return ""
 	}
 	return *r.Name
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (r *ReleaseAsset) GetNodeID() string {
+	if r == nil || r.NodeID == nil {
+		return ""
+	}
+	return *r.NodeID
 }
 
 // GetSize returns the Size field if it's non-nil, zero value otherwise.
@@ -8498,6 +8538,14 @@ func (r *RepositoryRelease) GetName() string {
 		return ""
 	}
 	return *r.Name
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (r *RepositoryRelease) GetNodeID() string {
+	if r == nil || r.NodeID == nil {
+		return ""
+	}
+	return *r.NodeID
 }
 
 // GetPrerelease returns the Prerelease field if it's non-nil, zero value otherwise.

--- a/github/projects.go
+++ b/github/projects.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 // ProjectsService provides access to the projects functions in the
@@ -26,6 +27,7 @@ type Project struct {
 	Number    *int       `json:"number,omitempty"`
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
+	NodeID    *string    `json:"node_id,omitempty"`
 
 	// The User object that generated the project.
 	Creator *User `json:"creator,omitempty"`
@@ -45,8 +47,9 @@ func (s *ProjectsService) GetProject(ctx context.Context, id int64) (*Project, *
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	project := &Project{}
 	resp, err := s.client.Do(ctx, req, project)
@@ -83,8 +86,9 @@ func (s *ProjectsService) UpdateProject(ctx context.Context, id int64, opt *Proj
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	project := &Project{}
 	resp, err := s.client.Do(ctx, req, project)
@@ -120,6 +124,7 @@ type ProjectColumn struct {
 	ProjectURL *string    `json:"project_url,omitempty"`
 	CreatedAt  *Timestamp `json:"created_at,omitempty"`
 	UpdatedAt  *Timestamp `json:"updated_at,omitempty"`
+	NodeID     *string    `json:"node_id,omitempty"`
 }
 
 // ListProjectColumns lists the columns of a GitHub Project for a repo.
@@ -137,8 +142,9 @@ func (s *ProjectsService) ListProjectColumns(ctx context.Context, projectID int6
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	columns := []*ProjectColumn{}
 	resp, err := s.client.Do(ctx, req, &columns)
@@ -159,8 +165,9 @@ func (s *ProjectsService) GetProjectColumn(ctx context.Context, id int64) (*Proj
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	column := &ProjectColumn{}
 	resp, err := s.client.Do(ctx, req, column)
@@ -189,8 +196,9 @@ func (s *ProjectsService) CreateProjectColumn(ctx context.Context, projectID int
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	column := &ProjectColumn{}
 	resp, err := s.client.Do(ctx, req, column)
@@ -211,8 +219,9 @@ func (s *ProjectsService) UpdateProjectColumn(ctx context.Context, columnID int6
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	column := &ProjectColumn{}
 	resp, err := s.client.Do(ctx, req, column)
@@ -275,6 +284,7 @@ type ProjectCard struct {
 	Creator    *User      `json:"creator,omitempty"`
 	CreatedAt  *Timestamp `json:"created_at,omitempty"`
 	UpdatedAt  *Timestamp `json:"updated_at,omitempty"`
+	NodeID     *string    `json:"node_id,omitempty"`
 
 	// The following fields are only populated by Webhook events.
 	ColumnID *int64 `json:"column_id,omitempty"`
@@ -295,8 +305,9 @@ func (s *ProjectsService) ListProjectCards(ctx context.Context, columnID int64, 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	cards := []*ProjectCard{}
 	resp, err := s.client.Do(ctx, req, &cards)
@@ -317,8 +328,9 @@ func (s *ProjectsService) GetProjectCard(ctx context.Context, columnID int64) (*
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	card := &ProjectCard{}
 	resp, err := s.client.Do(ctx, req, card)
@@ -352,8 +364,9 @@ func (s *ProjectsService) CreateProjectCard(ctx context.Context, columnID int64,
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	card := &ProjectCard{}
 	resp, err := s.client.Do(ctx, req, card)
@@ -374,8 +387,9 @@ func (s *ProjectsService) UpdateProjectCard(ctx context.Context, cardID int64, o
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	card := &ProjectCard{}
 	resp, err := s.client.Do(ctx, req, card)

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -20,9 +21,10 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 
 	input := &ProjectOptions{Name: "Project Name", Body: "Project body.", State: "open"}
 
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 
 		v := &ProjectOptions{}
 		json.NewDecoder(r.Body).Decode(v)
@@ -48,9 +50,10 @@ func TestProjectsService_GetProject(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -84,9 +87,10 @@ func TestProjectsService_ListProjectColumns(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/projects/1/columns", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -107,9 +111,10 @@ func TestProjectsService_GetProjectColumn(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/projects/columns/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -130,9 +135,10 @@ func TestProjectsService_CreateProjectColumn(t *testing.T) {
 
 	input := &ProjectColumnOptions{Name: "Column Name"}
 
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/projects/1/columns", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 
 		v := &ProjectColumnOptions{}
 		json.NewDecoder(r.Body).Decode(v)
@@ -160,9 +166,10 @@ func TestProjectsService_UpdateProjectColumn(t *testing.T) {
 
 	input := &ProjectColumnOptions{Name: "Column Name"}
 
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/projects/columns/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 
 		v := &ProjectColumnOptions{}
 		json.NewDecoder(r.Body).Decode(v)
@@ -226,9 +233,10 @@ func TestProjectsService_ListProjectCards(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/projects/columns/1/cards", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -249,9 +257,10 @@ func TestProjectsService_GetProjectCard(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/projects/columns/cards/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -275,9 +284,10 @@ func TestProjectsService_CreateProjectCard(t *testing.T) {
 		ContentType: "Issue",
 	}
 
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/projects/columns/1/cards", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 
 		v := &ProjectCardOptions{}
 		json.NewDecoder(r.Body).Decode(v)
@@ -308,9 +318,10 @@ func TestProjectsService_UpdateProjectCard(t *testing.T) {
 		ContentType: "Issue",
 	}
 
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/projects/columns/cards/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 
 		v := &ProjectCardOptions{}
 		json.NewDecoder(r.Body).Decode(v)

--- a/github/reactions.go
+++ b/github/reactions.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 // ReactionsService provides access to the reactions-related functions in the
@@ -19,8 +20,9 @@ type ReactionsService service
 // Reaction represents a GitHub reaction.
 type Reaction struct {
 	// ID is the Reaction ID.
-	ID   *int64 `json:"id,omitempty"`
-	User *User  `json:"user,omitempty"`
+	ID     *int64  `json:"id,omitempty"`
+	User   *User   `json:"user,omitempty"`
+	NodeID *string `json:"node_id,omitempty"`
 	// Content is the type of reaction.
 	// Possible values are:
 	//     "+1", "-1", "laugh", "confused", "heart", "hooray".
@@ -58,8 +60,9 @@ func (s *ReactionsService) ListCommentReactions(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
@@ -84,8 +87,9 @@ func (s ReactionsService) CreateCommentReaction(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -111,8 +115,9 @@ func (s *ReactionsService) ListIssueReactions(ctx context.Context, owner, repo s
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
@@ -137,8 +142,9 @@ func (s ReactionsService) CreateIssueReaction(ctx context.Context, owner, repo s
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -164,8 +170,9 @@ func (s *ReactionsService) ListIssueCommentReactions(ctx context.Context, owner,
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
@@ -190,8 +197,9 @@ func (s ReactionsService) CreateIssueCommentReaction(ctx context.Context, owner,
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -217,8 +225,9 @@ func (s *ReactionsService) ListPullRequestCommentReactions(ctx context.Context, 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
@@ -243,8 +252,9 @@ func (s ReactionsService) CreatePullRequestCommentReaction(ctx context.Context, 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)

--- a/github/reactions_test.go
+++ b/github/reactions_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -16,9 +17,10 @@ func TestReactionsService_ListCommentReactions(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
@@ -37,9 +39,10 @@ func TestReactionsService_CreateCommentReaction(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
@@ -59,9 +62,10 @@ func TestReactionsService_ListIssueReactions(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/issues/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
@@ -80,9 +84,10 @@ func TestReactionsService_CreateIssueReaction(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/issues/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
@@ -102,9 +107,10 @@ func TestReactionsService_ListIssueCommentReactions(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/issues/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
@@ -123,9 +129,10 @@ func TestReactionsService_CreateIssueCommentReaction(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/issues/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
@@ -145,9 +152,10 @@ func TestReactionsService_ListPullRequestCommentReactions(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/pulls/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
@@ -166,9 +174,10 @@ func TestReactionsService_CreatePullRequestCommentReaction(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/pulls/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))

--- a/github/repos_projects.go
+++ b/github/repos_projects.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 // ProjectListOptions specifies the optional parameters to the
@@ -34,8 +35,9 @@ func (s *RepositoriesService) ListProjects(ctx context.Context, owner, repo stri
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var projects []*Project
 	resp, err := s.client.Do(ctx, req, &projects)
@@ -56,8 +58,9 @@ func (s *RepositoriesService) CreateProject(ctx context.Context, owner, repo str
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	project := &Project{}
 	resp, err := s.client.Do(ctx, req, project)

--- a/github/repos_projects_test.go
+++ b/github/repos_projects_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -18,9 +19,10 @@ func TestRepositoriesService_ListProjects(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -43,9 +45,10 @@ func TestRepositoriesService_CreateProject(t *testing.T) {
 
 	input := &ProjectOptions{Name: "Project Name", Body: "Project body."}
 
+	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 
 		v := &ProjectOptions{}
 		json.NewDecoder(r.Body).Decode(v)

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -36,6 +36,7 @@ type RepositoryRelease struct {
 	ZipballURL      *string        `json:"zipball_url,omitempty"`
 	TarballURL      *string        `json:"tarball_url,omitempty"`
 	Author          *User          `json:"author,omitempty"`
+	NodeID          *string        `json:"node_id,omitempty"`
 }
 
 func (r RepositoryRelease) String() string {
@@ -56,6 +57,7 @@ type ReleaseAsset struct {
 	UpdatedAt          *Timestamp `json:"updated_at,omitempty"`
 	BrowserDownloadURL *string    `json:"browser_download_url,omitempty"`
 	Uploader           *User      `json:"uploader,omitempty"`
+	NodeID             *string    `json:"node_id,omitempty"`
 }
 
 func (r ReleaseAsset) String() string {
@@ -76,6 +78,9 @@ func (s *RepositoriesService) ListReleases(ctx context.Context, owner, repo stri
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	var releases []*RepositoryRelease
 	resp, err := s.client.Do(ctx, req, &releases)
@@ -115,6 +120,9 @@ func (s *RepositoriesService) getSingleRelease(ctx context.Context, url string) 
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	release := new(RepositoryRelease)
 	resp, err := s.client.Do(ctx, req, release)
 	if err != nil {
@@ -134,6 +142,9 @@ func (s *RepositoriesService) CreateRelease(ctx context.Context, owner, repo str
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	r := new(RepositoryRelease)
 	resp, err := s.client.Do(ctx, req, r)
 	if err != nil {
@@ -152,6 +163,9 @@ func (s *RepositoriesService) EditRelease(ctx context.Context, owner, repo strin
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	r := new(RepositoryRelease)
 	resp, err := s.client.Do(ctx, req, r)
@@ -189,6 +203,9 @@ func (s *RepositoriesService) ListReleaseAssets(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
+
 	var assets []*ReleaseAsset
 	resp, err := s.client.Do(ctx, req, &assets)
 	if err != nil {
@@ -207,6 +224,9 @@ func (s *RepositoriesService) GetReleaseAsset(ctx context.Context, owner, repo s
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	asset := new(ReleaseAsset)
 	resp, err := s.client.Do(ctx, req, asset)
@@ -231,7 +251,10 @@ func (s *RepositoriesService) DownloadReleaseAsset(ctx context.Context, owner, r
 	if err != nil {
 		return nil, "", err
 	}
-	req.Header.Set("Accept", defaultMediaType)
+
+	// TODO: remove custom Accept header when APIs fully launch.
+	acceptHeaders := []string{defaultMediaType, mediaTypeGraphQLNodeIDPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	s.client.clientMu.Lock()
 	defer s.client.clientMu.Unlock()
@@ -271,6 +294,9 @@ func (s *RepositoriesService) EditReleaseAsset(ctx context.Context, owner, repo 
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	asset := new(ReleaseAsset)
 	resp, err := s.client.Do(ctx, req, asset)
@@ -317,6 +343,9 @@ func (s *RepositoriesService) UploadReleaseAsset(ctx context.Context, owner, rep
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGraphQLNodeIDPreview)
 
 	asset := new(ReleaseAsset)
 	resp, err := s.client.Do(ctx, req, asset)

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -24,6 +24,7 @@ func TestRepositoriesService_ListReleases(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/releases", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -45,6 +46,7 @@ func TestRepositoriesService_GetRelease(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/releases/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `{"id":1,"author":{"login":"l"}}`)
 	})
 
@@ -65,6 +67,7 @@ func TestRepositoriesService_GetLatestRelease(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/releases/latest", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `{"id":3}`)
 	})
 
@@ -85,6 +88,7 @@ func TestRepositoriesService_GetReleaseByTag(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/releases/tags/foo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `{"id":13}`)
 	})
 
@@ -110,6 +114,7 @@ func TestRepositoriesService_CreateRelease(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -138,6 +143,7 @@ func TestRepositoriesService_EditRelease(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -174,6 +180,7 @@ func TestRepositoriesService_ListReleaseAssets(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/releases/1/assets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -195,6 +202,7 @@ func TestRepositoriesService_GetReleaseAsset(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -212,9 +220,10 @@ func TestRepositoriesService_DownloadReleaseAsset_Stream(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{defaultMediaType, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", defaultMediaType)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.Header().Set("Content-Disposition", "attachment; filename=hello-world.txt")
 		fmt.Fprint(w, "Hello World")
@@ -238,9 +247,10 @@ func TestRepositoriesService_DownloadReleaseAsset_Redirect(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{defaultMediaType, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", defaultMediaType)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		http.Redirect(w, r, "/yo", http.StatusFound)
 	})
 
@@ -258,9 +268,10 @@ func TestRepositoriesService_DownloadReleaseAsset_APIError(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	acceptHeaders := []string{defaultMediaType, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", defaultMediaType)
+		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprint(w, `{"message":"Not Found","documentation_url":"https://developer.github.com/v3"}`)
 	})
@@ -291,6 +302,7 @@ func TestRepositoriesService_EditReleaseAsset(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -329,6 +341,7 @@ func TestRepositoriesService_UploadReleaseAsset(t *testing.T) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Content-Type", "text/plain; charset=utf-8")
 		testHeader(t, r, "Content-Length", "12")
+		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)
 		testFormValues(t, r, values{"name": "n"})
 		testBody(t, r, "Upload me !\n")
 


### PR DESCRIPTION
Helps #814 .
The current pull request includes the GraphQL node ID in the response for the following REST API v3 resources:

* Projects
* Reactions
* Releases