### PR TITLE
Support for custom media types for Repository contents

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -43,6 +43,9 @@ const (
 	mediaTypeV3Diff            = "application/vnd.github.v3.diff"
 	mediaTypeV3Patch           = "application/vnd.github.v3.patch"
 	mediaTypeOrgPermissionRepo = "application/vnd.github.v3.repository+json"
+	mediaTypeV3Raw             = "application/vnd.github.v3.raw"
+	mediaTypeV3HTML            = "application/vnd.github.v3.html"
+	mediaTypeV3Object          = "application/vnd.github.v3.object"
 
 	// Media Type values to access preview APIs
 

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -90,6 +90,48 @@ func TestRepositoriesService_GetReadme(t *testing.T) {
 	}
 }
 
+func TestResositoriesService_GetReadmeCustom_html(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	const htmlStr = `<p>go-github is a Go client library for accessing the <a href="https://developer.github.com/v3/">GitHub API v3</a>.`
+	mux.HandleFunc("/repos/o/r/readme", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeV3HTML)
+		fmt.Fprint(w, htmlStr)
+	})
+
+	got, _, err := client.Repositories.GetReadmeCustom(context.Background(), "o", "r", &RepositoryContentGetOptions{}, RepositoryContentMediaType(2))
+	if err != nil {
+		t.Errorf("Repositories.GetReadmeCustom returned error: %v", err)
+	}
+	want := htmlStr
+	if got != want {
+		t.Errorf("Repositories.GetReadmeCustom returned %+v, want %+v", got, want)
+	}
+}
+
+func TestResositoriesService_GetReadmeCustom_raw(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	const rawStr = `#\n\ngo-github is a Go client library for accessing the [GitHub API v3][].`
+	mux.HandleFunc("/repos/o/r/readme", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeV3Raw)
+		fmt.Fprint(w, rawStr)
+	})
+
+	got, _, err := client.Repositories.GetReadmeCustom(context.Background(), "o", "r", &RepositoryContentGetOptions{}, RepositoryContentMediaType(1))
+	if err != nil {
+		t.Errorf("Repositories.GetReadmeCustom returned error: %v", err)
+	}
+	want := rawStr
+	if got != want {
+		t.Errorf("Repositories.GetReadmeCustom returned %+v, want %+v", got, want)
+	}
+}
+
 func TestRepositoriesService_DownloadContents_Success(t *testing.T) {
 	client, mux, serverURL, teardown := setup()
 	defer teardown()

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -101,7 +101,7 @@ func TestResositoriesService_GetReadmeCustom_html(t *testing.T) {
 		fmt.Fprint(w, htmlStr)
 	})
 
-	got, _, err := client.Repositories.GetReadmeCustom(context.Background(), "o", "r", &RepositoryContentGetOptions{}, RepositoryContentMediaType(2))
+	got, _, err := client.Repositories.GetReadmeCustom(context.Background(), "o", "r", &RepositoryContentGetOptions{MediaType: HTML})
 	if err != nil {
 		t.Errorf("Repositories.GetReadmeCustom returned error: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestResositoriesService_GetReadmeCustom_raw(t *testing.T) {
 		fmt.Fprint(w, rawStr)
 	})
 
-	got, _, err := client.Repositories.GetReadmeCustom(context.Background(), "o", "r", &RepositoryContentGetOptions{}, RepositoryContentMediaType(1))
+	got, _, err := client.Repositories.GetReadmeCustom(context.Background(), "o", "r", &RepositoryContentGetOptions{MediaType: Raw})
 	if err != nil {
 		t.Errorf("Repositories.GetReadmeCustom returned error: %v", err)
 	}
@@ -406,7 +406,7 @@ func TestRepositoriesService_GetArchiveLink(t *testing.T) {
 		testMethod(t, r, "GET")
 		http.Redirect(w, r, "http://github.com/a", http.StatusFound)
 	})
-	url, resp, err := client.Repositories.GetArchiveLink(context.Background(), "o", "r", Tarball, &RepositoryContentGetOptions{})
+	url, resp, err := client.Repositories.GetArchiveLink(context.Background(), "o", "r", Tarball, &RepositoryContentParameters{})
 	if err != nil {
 		t.Errorf("Repositories.GetArchiveLink returned error: %v", err)
 	}


### PR DESCRIPTION
This is a proof-of-concept of how we can extend support for custom mime types across all services.
Reviews, suggestions, and discussions on the implementation are welcome. 

- [x] `GetReadme` supports `html`, `raw` and `object`(default) media types
- [ ] `GetContents` supports custom media types
- [ ] `DownloadContents` supports custom media types
- [x] `GetArchiveLink` should support only the `ref` parameter.

Fixes #727 

**NOTE:** This change breaks the backward compatibility of `GetArchiveLink` as the new `opt` is of type `RepositoryContentsGetParameters` instead of `RepositoryContentsGetOptions`. One way to overcome this issue is to revert the naming change and rename the new `RepositoryContentsGetOptions` to something else.

Ping @gmlewis @sahildua2305 