### PR TITLE
Remove preview media type for Team Review Requests

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -99,9 +99,6 @@ const (
 	// https://developer.github.com/changes/2017-07-17-update-topics-on-repositories/
 	mediaTypeTopicsPreview = "application/vnd.github.mercy-preview+json"
 
-	// https://developer.github.com/changes/2017-07-26-team-review-request-thor-preview/
-	mediaTypeTeamReviewPreview = "application/vnd.github.thor-preview+json"
-
 	// https://developer.github.com/v3/apps/marketplace/
 	mediaTypeMarketplacePreview = "application/vnd.github.valkyrie-preview+json"
 

--- a/github/pulls_reviewers.go
+++ b/github/pulls_reviewers.go
@@ -32,9 +32,6 @@ func (s *PullRequestsService) RequestReviewers(ctx context.Context, owner, repo 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeTeamReviewPreview)
-
 	r := new(PullRequest)
 	resp, err := s.client.Do(ctx, req, r)
 	if err != nil {
@@ -59,9 +56,6 @@ func (s *PullRequestsService) ListReviewers(ctx context.Context, owner, repo str
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeTeamReviewPreview)
-
 	reviewers := new(Reviewers)
 	resp, err := s.client.Do(ctx, req, reviewers)
 	if err != nil {
@@ -80,9 +74,6 @@ func (s *PullRequestsService) RemoveReviewers(ctx context.Context, owner, repo s
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeTeamReviewPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/pulls_reviewers_test.go
+++ b/github/pulls_reviewers_test.go
@@ -20,7 +20,6 @@ func TestRequestReviewers(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/pulls/1/requested_reviewers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testBody(t, r, `{"reviewers":["octocat","googlebot"],"team_reviewers":["justice-league","injustice-league"]}`+"\n")
-		testHeader(t, r, "Accept", mediaTypeTeamReviewPreview)
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
@@ -41,7 +40,6 @@ func TestRemoveReviewers(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pulls/1/requested_reviewers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeTeamReviewPreview)
 		testBody(t, r, `{"reviewers":["octocat","googlebot"],"team_reviewers":["justice-league"]}`+"\n")
 	})
 
@@ -57,7 +55,6 @@ func TestListReviewers(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pulls/1/requested_reviewers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeTeamReviewPreview)
 		fmt.Fprint(w, `{"users":[{"login":"octocat","id":1}],"teams":[{"id":1,"name":"Justice League"}]}`)
 	})
 


### PR DESCRIPTION
As the Team Review Requests API is fully supported by GitHub API v3, we
have removed the preview(custom) media type: `thor-preview`.

Fixes #835 

-------------

1. How should we proceed here given that some GitHub enterprise versions may not yet support the Team Review Requests API?
2. According to the new versioning guideline, under which category should be removing preview functionality in favor of GitHub API support fall?

Ping @willnorris @gmlewis @sahildua2305 