### PR TITLE
Support preview Organization Invitation API

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2861,7 +2861,7 @@ func (i *Invitation) GetRole() string {
 }
 
 // GetTeamCount returns the TeamCount field if it's non-nil, zero value otherwise.
-func (i *Invitation) GetTeamCount() int64 {
+func (i *Invitation) GetTeamCount() int {
 	if i == nil || i.TeamCount == nil {
 		return 0
 	}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1324,6 +1324,30 @@ func (c *CreateEvent) GetSender() *User {
 	return c.Sender
 }
 
+// GetEmail returns the Email field if it's non-nil, zero value otherwise.
+func (c *CreateOrgInvitationOptions) GetEmail() string {
+	if c == nil || c.Email == nil {
+		return ""
+	}
+	return *c.Email
+}
+
+// GetInviteeID returns the InviteeID field if it's non-nil, zero value otherwise.
+func (c *CreateOrgInvitationOptions) GetInviteeID() int64 {
+	if c == nil || c.InviteeID == nil {
+		return 0
+	}
+	return *c.InviteeID
+}
+
+// GetRole returns the Role field if it's non-nil, zero value otherwise.
+func (c *CreateOrgInvitationOptions) GetRole() string {
+	if c == nil || c.Role == nil {
+		return ""
+	}
+	return *c.Role
+}
+
 // GetInstallation returns the Installation field.
 func (d *DeleteEvent) GetInstallation() *Installation {
 	if d == nil {
@@ -2804,6 +2828,14 @@ func (i *Invitation) GetID() int64 {
 	return *i.ID
 }
 
+// GetInvitationTeamURL returns the InvitationTeamURL field if it's non-nil, zero value otherwise.
+func (i *Invitation) GetInvitationTeamURL() string {
+	if i == nil || i.InvitationTeamURL == nil {
+		return ""
+	}
+	return *i.InvitationTeamURL
+}
+
 // GetInviter returns the Inviter field.
 func (i *Invitation) GetInviter() *User {
 	if i == nil {
@@ -2826,6 +2858,14 @@ func (i *Invitation) GetRole() string {
 		return ""
 	}
 	return *i.Role
+}
+
+// GetTeamCount returns the TeamCount field if it's non-nil, zero value otherwise.
+func (i *Invitation) GetTeamCount() int64 {
+	if i == nil || i.TeamCount == nil {
+		return 0
+	}
+	return *i.TeamCount
 }
 
 // GetAssignee returns the Assignee field.

--- a/github/github.go
+++ b/github/github.go
@@ -113,6 +113,9 @@ const (
 
 	// https://developer.github.com/changes/2017-12-19-graphql-node-id/
 	mediaTypeGraphQLNodeIDPreview = "application/vnd.github.jean-grey-preview+json"
+
+	// https://developer.github.com/changes/2018-01-25-organization-invitation-api-preview/
+	mediaTypeOrganizationInvitationPreview = "application/vnd.github.dazzler-preview+json"
 )
 
 // A Client manages communication with the GitHub API.

--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -297,3 +297,44 @@ func (s *OrganizationsService) ListPendingOrgInvitations(ctx context.Context, or
 	}
 	return pendingInvitations, resp, nil
 }
+
+// CreateOrgInvitationOptions specifies the parameters to the OrganizationService.Invite
+// method.
+type CreateOrgInvitationOptions struct {
+	InviteeID *int    `json:"invitee_id,omitempty"`
+	Email     *string `json:"email,omitempty"`
+	// Specify role for new member. Can be one of:
+	// * admin - Organization owners with full administrative rights to the
+	// 	 organization and complete access to all repositories and teams.
+	// * direct_member - Non-owner organization members with ability to see
+	//   other members and join teams by invitation.
+	// * billing_manager - Non-owner organization members with ability to
+	//   manage the billing settings of your organization.
+	Role   *string `json:"role"`
+	TeamID []int   `json:"team_ids"`
+}
+
+// CreateOrgInvitation Invite people to an organization by using their GitHub user ID or their email address.
+// In order to create invitations in an organization,
+// the authenticated user must be an organization owner.
+//
+// https://developer.github.com/v3/orgs/members/#create-organization-invitation
+func (s *OrganizationsService) CreateOrgInvitation(ctx context.Context, org string, opt *CreateOrgInvitationOptions) ([]*Invitation, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/invitations", org)
+
+	req, err := s.client.NewRequest("POST", u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeOrganizationInvitationPreview)
+
+	var invitations []*Invitation
+	resp, err := s.client.Do(ctx, req, &invitations)
+	if err != nil {
+		return nil, resp, err
+	}
+	return invitations, resp, nil
+
+}

--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -301,7 +301,7 @@ func (s *OrganizationsService) ListPendingOrgInvitations(ctx context.Context, or
 // CreateOrgInvitationOptions specifies the parameters to the OrganizationService.Invite
 // method.
 type CreateOrgInvitationOptions struct {
-	InviteeID *int    `json:"invitee_id,omitempty"`
+	InviteeID *int64  `json:"invitee_id,omitempty"`
 	Email     *string `json:"email,omitempty"`
 	// Specify role for new member. Can be one of:
 	// * admin - Organization owners with full administrative rights to the
@@ -311,7 +311,7 @@ type CreateOrgInvitationOptions struct {
 	// * billing_manager - Non-owner organization members with ability to
 	//   manage the billing settings of your organization.
 	Role   *string `json:"role"`
-	TeamID []int   `json:"team_ids"`
+	TeamID []int64 `json:"team_ids"`
 }
 
 // CreateOrgInvitation Invite people to an organization by using their GitHub user ID or their email address.
@@ -337,4 +337,28 @@ func (s *OrganizationsService) CreateOrgInvitation(ctx context.Context, org stri
 	}
 	return invitations, resp, nil
 
+}
+
+// ListOrgInvitationTeams List all teams associated with an invitation. In order to see invitations in an organization,
+// the authenticated user must be an organization owner.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/members/#list-organization-invitation-teams
+func (s *OrganizationsService) ListOrgInvitationTeams(ctx context.Context, org string, invitationid string, opt *ListOptions) ([]*Team, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/invitations/%v/teams", org, invitationid)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var orgInvitationTeams []*Team
+	resp, err := s.client.Do(ctx, req, &orgInvitationTeams)
+	if err != nil {
+		return nil, resp, err
+	}
+	return orgInvitationTeams, resp, nil
 }

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -400,7 +400,9 @@ func TestOrganizationsService_ListPendingOrgInvitations(t *testing.T) {
       						"received_events_url": "https://api.github.com/users/other_user/received_events/privacy",
       						"type": "User",
       						"site_admin": false
-    					}
+						},
+						"team_count": 2,
+						"invitation_team_url": "https://api.github.com/organizations/2/invitations/1/teams"	  	
   				}
 			]`)
 	})
@@ -438,6 +440,8 @@ func TestOrganizationsService_ListPendingOrgInvitations(t *testing.T) {
 				Type:              String("User"),
 				SiteAdmin:         Bool(false),
 			},
+			TeamCount:         Int64(2),
+			InvitationTeamURL: String("https://api.github.com/organizations/2/invitations/1/teams"),
 		}}
 
 	if !reflect.DeepEqual(invitations, want) {

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -444,3 +444,40 @@ func TestOrganizationsService_ListPendingOrgInvitations(t *testing.T) {
 		t.Errorf("Organizations.ListPendingOrgInvitations returned %+v, want %+v", invitations, want)
 	}
 }
+
+func TestOrganizationsService_CreateOrgInvitation(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	input := &CreateOrgInvitationOptions{
+		Email: String("octocat@github.com"),
+		Role:  String("direct_member"),
+		TeamID: []int{
+			12,
+			26,
+		},
+	}
+
+	mux.HandleFunc("/orgs/o/invitations", func(w http.ResponseWriter, r *http.Request) {
+		v := new(CreateOrgInvitationOptions)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeOrganizationInvitationPreview)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		fmt.Fprintln(w, `[{"email": "octocat@github.com"}]`)
+
+	})
+
+	invitations, _, err := client.Organizations.CreateOrgInvitation(context.Background(), "o", input)
+	if err != nil {
+		t.Errorf("Organizations.CreateOrgInvitation returned error: %v", err)
+	}
+
+	want := []*Invitation{&Invitation{Email: String("octocat@github.com")}}
+	if !reflect.DeepEqual(invitations, want) {
+		t.Errorf("Organizations.ListPendingOrgInvitations returned %+v, want %+v", invitations, want)
+	}
+}

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -480,7 +480,7 @@ func TestOrganizationsService_CreateOrgInvitation(t *testing.T) {
 		t.Errorf("Organizations.CreateOrgInvitation returned error: %v", err)
 	}
 
-	want := []*Invitation{&Invitation{Email: String("octocat@github.com")}}
+	want := []*Invitation{{Email: String("octocat@github.com")}}
 	if !reflect.DeepEqual(invitations, want) {
 		t.Errorf("Organizations.ListPendingOrgInvitations returned %+v, want %+v", invitations, want)
 	}

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -440,7 +440,7 @@ func TestOrganizationsService_ListPendingOrgInvitations(t *testing.T) {
 				Type:              String("User"),
 				SiteAdmin:         Bool(false),
 			},
-			TeamCount:         Int64(2),
+			TeamCount:         Int(2),
 			InvitationTeamURL: String("https://api.github.com/organizations/2/invitations/1/teams"),
 		}}
 

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -493,6 +493,7 @@ func TestOrganizationsService_ListOrgInvitationTeams(t *testing.T) {
 	mux.HandleFunc("/orgs/o/invitations/22/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"page": "1"})
+		testHeader(t, r, "Accept", mediaTypeOrganizationInvitationPreview)
 		fmt.Fprint(w, `[
 			{
 				"id": 1,

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -56,7 +56,7 @@ type Invitation struct {
 	Role              *string    `json:"role,omitempty"`
 	CreatedAt         *time.Time `json:"created_at,omitempty"`
 	Inviter           *User      `json:"inviter,omitempty"`
-	TeamCount         *int    `json:"team_count"`
+	TeamCount         *int       `json:"team_count"`
 	InvitationTeamURL *string    `json:"invitation_team_url"`
 }
 

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -56,7 +56,7 @@ type Invitation struct {
 	Role              *string    `json:"role,omitempty"`
 	CreatedAt         *time.Time `json:"created_at,omitempty"`
 	Inviter           *User      `json:"inviter,omitempty"`
-	TeamCount         *int64     `json:"team_count"`
+	TeamCount         *int    `json:"team_count"`
 	InvitationTeamURL *string    `json:"invitation_team_url"`
 }
 

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -56,8 +56,8 @@ type Invitation struct {
 	Role              *string    `json:"role,omitempty"`
 	CreatedAt         *time.Time `json:"created_at,omitempty"`
 	Inviter           *User      `json:"inviter,omitempty"`
-	TeamCount         *int       `json:"team_count"`
-	InvitationTeamURL *string    `json:"invitation_team_url"`
+	TeamCount         *int       `json:"team_count,omitempty"`
+	InvitationTeamURL *string    `json:"invitation_team_url,omitempty"`
 }
 
 func (i Invitation) String() string {

--- a/github/orgs_teams.go
+++ b/github/orgs_teams.go
@@ -53,9 +53,11 @@ type Invitation struct {
 	Login *string `json:"login,omitempty"`
 	Email *string `json:"email,omitempty"`
 	// Role can be one of the values - 'direct_member', 'admin', 'billing_manager', 'hiring_manager', or 'reinstate'.
-	Role      *string    `json:"role,omitempty"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
-	Inviter   *User      `json:"inviter,omitempty"`
+	Role              *string    `json:"role,omitempty"`
+	CreatedAt         *time.Time `json:"created_at,omitempty"`
+	Inviter           *User      `json:"inviter,omitempty"`
+	TeamCount         *int64     `json:"team_count"`
+	InvitationTeamURL *string    `json:"invitation_team_url"`
 }
 
 func (i Invitation) String() string {


### PR DESCRIPTION
New endpoints:
- [Create organization invitation](https://developer.github.com/v3/orgs/members/#create-organization-invitation)
- [List organization invitation teams](https://developer.github.com/v3/orgs/members/#list-organization-invitation-teams)

Changes to existing endpoints:
- [List pending organization invitations](https://developer.github.com/v3/orgs/members/#list-pending-organization-invitations) has two new fields. `team_count` and `invitation_teams_url`.

Detailed here:
- https://developer.github.com/changes/2018-01-25-organization-invitation-api-preview/

Fixes #838 