### PR TITLE
Remove unnecessary force close body for conn reuse

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -478,12 +478,6 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 		return nil, err
 	}
 
-	defer func() {
-		// Drain up to 512 bytes and close the body to let the Transport reuse the connection
-		io.CopyN(ioutil.Discard, resp.Body, 512)
-		resp.Body.Close()
-	}()
-
 	response := newResponse(resp)
 
 	c.rateMu.Lock()


### PR DESCRIPTION
The behavior on connection reuse is introduced in golang/go@18072ad.

Fixes #843

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/go-github/846)
<!-- Reviewable:end -->
