### PR TITLE
Add app_id to the Installation struct

### DIFF
--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -13,6 +13,7 @@ import (
 // Installation represents a GitHub Apps installation.
 type Installation struct {
 	ID              *int64  `json:"id,omitempty"`
+	AppID           *int64  `json:"app_id,omitempty"`
 	Account         *User   `json:"account,omitempty"`
 	AccessTokensURL *string `json:"access_tokens_url,omitempty"`
 	RepositoriesURL *string `json:"repositories_url,omitempty"`

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -66,7 +66,7 @@ func TestAppsService_ListInstallations(t *testing.T) {
 			"page":     "1",
 			"per_page": "2",
 		})
-		fmt.Fprint(w, `[{"id":1}]`)
+		fmt.Fprint(w, `[{"id":1, "app_id":1}]`)
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
@@ -75,7 +75,7 @@ func TestAppsService_ListInstallations(t *testing.T) {
 		t.Errorf("Apps.ListInstallations returned error: %v", err)
 	}
 
-	want := []*Installation{{ID: Int64(1)}}
+	want := []*Installation{{ID: Int64(1), AppID: Int64(1)}}
 	if !reflect.DeepEqual(installations, want) {
 		t.Errorf("Apps.ListInstallations returned %+v, want %+v", installations, want)
 	}
@@ -88,7 +88,7 @@ func TestAppsService_GetInstallation(t *testing.T) {
 	mux.HandleFunc("/app/installations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeIntegrationPreview)
-		fmt.Fprint(w, `{"id":1}`)
+		fmt.Fprint(w, `{"id":1, "app_id":1}`)
 	})
 
 	installation, _, err := client.Apps.GetInstallation(context.Background(), 1)
@@ -96,7 +96,7 @@ func TestAppsService_GetInstallation(t *testing.T) {
 		t.Errorf("Apps.GetInstallation returned error: %v", err)
 	}
 
-	want := &Installation{ID: Int64(1)}
+	want := &Installation{ID: Int64(1), AppID: Int64(1)}
 	if !reflect.DeepEqual(installation, want) {
 		t.Errorf("Apps.GetInstallation returned %+v, want %+v", installation, want)
 	}
@@ -113,7 +113,7 @@ func TestAppsService_ListUserInstallations(t *testing.T) {
 			"page":     "1",
 			"per_page": "2",
 		})
-		fmt.Fprint(w, `{"installations":[{"id":1}]}`)
+		fmt.Fprint(w, `{"installations":[{"id":1, "app_id":1}]}`)
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
@@ -122,7 +122,7 @@ func TestAppsService_ListUserInstallations(t *testing.T) {
 		t.Errorf("Apps.ListUserInstallations returned error: %v", err)
 	}
 
-	want := []*Installation{{ID: Int64(1)}}
+	want := []*Installation{{ID: Int64(1), AppID: Int64(1)}}
 	if !reflect.DeepEqual(installations, want) {
 		t.Errorf("Apps.ListUserInstallations returned %+v, want %+v", installations, want)
 	}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2684,6 +2684,14 @@ func (i *Installation) GetAccount() *User {
 	return i.Account
 }
 
+// GetAppID returns the AppID field if it's non-nil, zero value otherwise.
+func (i *Installation) GetAppID() int64 {
+	if i == nil || i.AppID == nil {
+		return 0
+	}
+	return *i.AppID
+}
+
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
 func (i *Installation) GetHTMLURL() string {
 	if i == nil || i.HTMLURL == nil {


### PR DESCRIPTION
Implements https://github.com/google/go-github/issues/851

An InstallationID is different from an AppID. This PR adds an additional field
so that we can query the GitHub application ID given its installation ID.

The `app_id` field is returned during installation and creation events.
It is also returned in the https://developer.github.com/v3/apps/#get-a-single-installation endpoint.