### PR TITLE
Add remaining `app` fields

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -35,6 +35,34 @@ type InstallationToken struct {
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
 
+// InstallationPermissions lists the permissions for metadata, contents, issues and single file for an installation.
+type InstallationPermissions struct {
+	Metadata   *string `json:"metadata,omitempty"`
+	Contents   *string `json:"contents,omitempty"`
+	Issues     *string `json:"issues,omitempty"`
+	SingleFile *string `json:"single_file,omitempty"`
+}
+
+// Installation represents a GitHub Apps installation.
+type Installation struct {
+	ID                  *int64                   `json:"id,omitempty"`
+	AppID               *int64                   `json:"app_id,omitempty"`
+	TargetID            *int64                   `json:"target_id,omitempty"`
+	Account             *User                    `json:"account,omitempty"`
+	AccessTokensURL     *string                  `json:"access_tokens_url,omitempty"`
+	RepositoriesURL     *string                  `json:"repositories_url,omitempty"`
+	HTMLURL             *string                  `json:"html_url,omitempty"`
+	TargetType          *string                  `json:"target_type,omitempty"`
+	SingleFileName      *string                  `json:"single_file_name,omitempty"`
+	RepositorySelection *string                  `json:"repository_selection,omitempty"`
+	Events              []string                 `json:"events,omitempty"`
+	Permissions         *InstallationPermissions `json:"permissions,omitempty"`
+}
+
+func (i Installation) String() string {
+	return Stringify(i)
+}
+
 // Get a single GitHub App. Passing the empty string will get
 // the authenticated GitHub App.
 //

--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -12,14 +12,16 @@ import (
 
 // Installation represents a GitHub Apps installation.
 type Installation struct {
-	ID              *int64  `json:"id,omitempty"`
-	AppID           *int64  `json:"app_id,omitempty"`
-	TargetID        *int64  `json:"target_id,omitempty"`
-	Account         *User   `json:"account,omitempty"`
-	AccessTokensURL *string `json:"access_tokens_url,omitempty"`
-	RepositoriesURL *string `json:"repositories_url,omitempty"`
-	HTMLURL         *string `json:"html_url,omitempty"`
-	TargetType      *string `json:"target_type,omitempty"`
+	ID                  *int64  `json:"id,omitempty"`
+	AppID               *int64  `json:"app_id,omitempty"`
+	TargetID            *int64  `json:"target_id,omitempty"`
+	Account             *User   `json:"account,omitempty"`
+	AccessTokensURL     *string `json:"access_tokens_url,omitempty"`
+	RepositoriesURL     *string `json:"repositories_url,omitempty"`
+	HTMLURL             *string `json:"html_url,omitempty"`
+	TargetType          *string `json:"target_type,omitempty"`
+	SingleFileName      *string `json:"single_file,omitempty"`
+	RepositorySelection *string `json:"repository_selection,omitempty"`
 }
 
 func (i Installation) String() string {

--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -10,9 +10,9 @@ import (
 	"fmt"
 )
 
-// InstallationPermissions Lists the permissions for metadata, contents, issues and single file for an installation.
+// InstallationPermissions lists the permissions for metadata, contents, issues and single file for an installation.
 type InstallationPermissions struct {
-	MetaData   *string `json:"metadata,omitempty"`
+	Metadata   *string `json:"metadata,omitempty"`
 	Contents   *string `json:"contents,omitempty"`
 	Issues     *string `json:"issues,omitempty"`
 	SingleFile *string `json:"single_file,omitempty"`
@@ -30,7 +30,7 @@ type Installation struct {
 	TargetType          *string                  `json:"target_type,omitempty"`
 	SingleFileName      *string                  `json:"single_file_name,omitempty"`
 	RepositorySelection *string                  `json:"repository_selection,omitempty"`
-	Events              *[]string                `json:"events,omitempty"`
+	Events              []string                 `json:"events,omitempty"`
 	Permissions         *InstallationPermissions `json:"permissions,omitempty"`
 }
 

--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -10,34 +10,6 @@ import (
 	"fmt"
 )
 
-// InstallationPermissions lists the permissions for metadata, contents, issues and single file for an installation.
-type InstallationPermissions struct {
-	Metadata   *string `json:"metadata,omitempty"`
-	Contents   *string `json:"contents,omitempty"`
-	Issues     *string `json:"issues,omitempty"`
-	SingleFile *string `json:"single_file,omitempty"`
-}
-
-// Installation represents a GitHub Apps installation.
-type Installation struct {
-	ID                  *int64                   `json:"id,omitempty"`
-	AppID               *int64                   `json:"app_id,omitempty"`
-	TargetID            *int64                   `json:"target_id,omitempty"`
-	Account             *User                    `json:"account,omitempty"`
-	AccessTokensURL     *string                  `json:"access_tokens_url,omitempty"`
-	RepositoriesURL     *string                  `json:"repositories_url,omitempty"`
-	HTMLURL             *string                  `json:"html_url,omitempty"`
-	TargetType          *string                  `json:"target_type,omitempty"`
-	SingleFileName      *string                  `json:"single_file_name,omitempty"`
-	RepositorySelection *string                  `json:"repository_selection,omitempty"`
-	Events              []string                 `json:"events,omitempty"`
-	Permissions         *InstallationPermissions `json:"permissions,omitempty"`
-}
-
-func (i Installation) String() string {
-	return Stringify(i)
-}
-
 // ListRepos lists the repositories that are accessible to the authenticated installation.
 //
 // GitHub API docs: https://developer.github.com/v3/apps/installations/#list-repositories

--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -10,18 +10,28 @@ import (
 	"fmt"
 )
 
+// InstallationPermissions Lists the permissions for metadata, contents, issues and single file for an installation.
+type InstallationPermissions struct {
+	MetaData   *string `json:"metadata,omitempty"`
+	Contents   *string `json:"contents,omitempty"`
+	Issues     *string `json:"issues,omitempty"`
+	SingleFile *string `json:"single_file,omitempty"`
+}
+
 // Installation represents a GitHub Apps installation.
 type Installation struct {
-	ID                  *int64  `json:"id,omitempty"`
-	AppID               *int64  `json:"app_id,omitempty"`
-	TargetID            *int64  `json:"target_id,omitempty"`
-	Account             *User   `json:"account,omitempty"`
-	AccessTokensURL     *string `json:"access_tokens_url,omitempty"`
-	RepositoriesURL     *string `json:"repositories_url,omitempty"`
-	HTMLURL             *string `json:"html_url,omitempty"`
-	TargetType          *string `json:"target_type,omitempty"`
-	SingleFileName      *string `json:"single_file,omitempty"`
-	RepositorySelection *string `json:"repository_selection,omitempty"`
+	ID                  *int64                   `json:"id,omitempty"`
+	AppID               *int64                   `json:"app_id,omitempty"`
+	TargetID            *int64                   `json:"target_id,omitempty"`
+	Account             *User                    `json:"account,omitempty"`
+	AccessTokensURL     *string                  `json:"access_tokens_url,omitempty"`
+	RepositoriesURL     *string                  `json:"repositories_url,omitempty"`
+	HTMLURL             *string                  `json:"html_url,omitempty"`
+	TargetType          *string                  `json:"target_type,omitempty"`
+	SingleFileName      *string                  `json:"single_file_name,omitempty"`
+	RepositorySelection *string                  `json:"repository_selection,omitempty"`
+	Events              *[]string                `json:"events,omitempty"`
+	Permissions         *InstallationPermissions `json:"permissions,omitempty"`
 }
 
 func (i Installation) String() string {

--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -19,6 +19,7 @@ type Installation struct {
 	AccessTokensURL *string `json:"access_tokens_url,omitempty"`
 	RepositoriesURL *string `json:"repositories_url,omitempty"`
 	HTMLURL         *string `json:"html_url,omitempty"`
+	TargetType      *string `json:"target_type,omitempty"`
 }
 
 func (i Installation) String() string {

--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -14,6 +14,7 @@ import (
 type Installation struct {
 	ID              *int64  `json:"id,omitempty"`
 	AppID           *int64  `json:"app_id,omitempty"`
+	TargetID        *int64  `json:"target_id,omitempty"`
 	Account         *User   `json:"account,omitempty"`
 	AccessTokensURL *string `json:"access_tokens_url,omitempty"`
 	RepositoriesURL *string `json:"repositories_url,omitempty"`

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -100,11 +100,11 @@ func TestAppsService_ListInstallations(t *testing.T) {
 		SingleFileName:      String("config.yml"),
 		RepositorySelection: String("selected"),
 		Permissions: &InstallationPermissions{
-			MetaData:   String("read"),
+			Metadata:   String("read"),
 			Contents:   String("read"),
 			Issues:     String("write"),
 			SingleFile: String("write")},
-		Events: &[]string{"push", "pull_request"},
+		Events: []string{"push", "pull_request"},
 	}}
 	if !reflect.DeepEqual(installations, want) {
 		t.Errorf("Apps.ListInstallations returned %+v, want %+v", installations, want)

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -66,7 +66,7 @@ func TestAppsService_ListInstallations(t *testing.T) {
 			"page":     "1",
 			"per_page": "2",
 		})
-		fmt.Fprint(w, `[{"id":1, "app_id":1, "target_id":1}]`)
+		fmt.Fprint(w, `[{"id":1, "app_id":1, "target_id":1, "target_type": "Organization"}]`)
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
@@ -75,7 +75,7 @@ func TestAppsService_ListInstallations(t *testing.T) {
 		t.Errorf("Apps.ListInstallations returned error: %v", err)
 	}
 
-	want := []*Installation{{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1)}}
+	want := []*Installation{{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1), TargetType: String("Organization")}}
 	if !reflect.DeepEqual(installations, want) {
 		t.Errorf("Apps.ListInstallations returned %+v, want %+v", installations, want)
 	}
@@ -88,7 +88,7 @@ func TestAppsService_GetInstallation(t *testing.T) {
 	mux.HandleFunc("/app/installations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeIntegrationPreview)
-		fmt.Fprint(w, `{"id":1, "app_id":1, "target_id":1}`)
+		fmt.Fprint(w, `{"id":1, "app_id":1, "target_id":1, "target_type": "Organization"}`)
 	})
 
 	installation, _, err := client.Apps.GetInstallation(context.Background(), 1)
@@ -96,7 +96,7 @@ func TestAppsService_GetInstallation(t *testing.T) {
 		t.Errorf("Apps.GetInstallation returned error: %v", err)
 	}
 
-	want := &Installation{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1)}
+	want := &Installation{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1), TargetType: String("Organization")}
 	if !reflect.DeepEqual(installation, want) {
 		t.Errorf("Apps.GetInstallation returned %+v, want %+v", installation, want)
 	}
@@ -113,7 +113,7 @@ func TestAppsService_ListUserInstallations(t *testing.T) {
 			"page":     "1",
 			"per_page": "2",
 		})
-		fmt.Fprint(w, `{"installations":[{"id":1, "app_id":1, "target_id":1}]}`)
+		fmt.Fprint(w, `{"installations":[{"id":1, "app_id":1, "target_id":1, "target_type": "Organization"}]}`)
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
@@ -122,7 +122,7 @@ func TestAppsService_ListUserInstallations(t *testing.T) {
 		t.Errorf("Apps.ListUserInstallations returned error: %v", err)
 	}
 
-	want := []*Installation{{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1)}}
+	want := []*Installation{{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1), TargetType: String("Organization")}}
 	if !reflect.DeepEqual(installations, want) {
 		t.Errorf("Apps.ListUserInstallations returned %+v, want %+v", installations, want)
 	}

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -66,7 +66,7 @@ func TestAppsService_ListInstallations(t *testing.T) {
 			"page":     "1",
 			"per_page": "2",
 		})
-		fmt.Fprint(w, `[{"id":1, "app_id":1}]`)
+		fmt.Fprint(w, `[{"id":1, "app_id":1, "target_id":1}]`)
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
@@ -75,7 +75,7 @@ func TestAppsService_ListInstallations(t *testing.T) {
 		t.Errorf("Apps.ListInstallations returned error: %v", err)
 	}
 
-	want := []*Installation{{ID: Int64(1), AppID: Int64(1)}}
+	want := []*Installation{{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1)}}
 	if !reflect.DeepEqual(installations, want) {
 		t.Errorf("Apps.ListInstallations returned %+v, want %+v", installations, want)
 	}
@@ -88,7 +88,7 @@ func TestAppsService_GetInstallation(t *testing.T) {
 	mux.HandleFunc("/app/installations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeIntegrationPreview)
-		fmt.Fprint(w, `{"id":1, "app_id":1}`)
+		fmt.Fprint(w, `{"id":1, "app_id":1, "target_id":1}`)
 	})
 
 	installation, _, err := client.Apps.GetInstallation(context.Background(), 1)
@@ -96,7 +96,7 @@ func TestAppsService_GetInstallation(t *testing.T) {
 		t.Errorf("Apps.GetInstallation returned error: %v", err)
 	}
 
-	want := &Installation{ID: Int64(1), AppID: Int64(1)}
+	want := &Installation{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1)}
 	if !reflect.DeepEqual(installation, want) {
 		t.Errorf("Apps.GetInstallation returned %+v, want %+v", installation, want)
 	}
@@ -113,7 +113,7 @@ func TestAppsService_ListUserInstallations(t *testing.T) {
 			"page":     "1",
 			"per_page": "2",
 		})
-		fmt.Fprint(w, `{"installations":[{"id":1, "app_id":1}]}`)
+		fmt.Fprint(w, `{"installations":[{"id":1, "app_id":1, "target_id":1}]}`)
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
@@ -122,7 +122,7 @@ func TestAppsService_ListUserInstallations(t *testing.T) {
 		t.Errorf("Apps.ListUserInstallations returned error: %v", err)
 	}
 
-	want := []*Installation{{ID: Int64(1), AppID: Int64(1)}}
+	want := []*Installation{{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1)}}
 	if !reflect.DeepEqual(installations, want) {
 		t.Errorf("Apps.ListUserInstallations returned %+v, want %+v", installations, want)
 	}

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -66,7 +66,24 @@ func TestAppsService_ListInstallations(t *testing.T) {
 			"page":     "1",
 			"per_page": "2",
 		})
-		fmt.Fprint(w, `[{"id":1, "app_id":1, "target_id":1, "target_type": "Organization"}]`)
+		fmt.Fprint(w, `[{
+                                   "id":1,
+                                   "app_id":1,
+                                   "target_id":1,
+                                   "target_type": "Organization",
+                                   "permissions": {
+                                       "metadata": "read",
+                                       "contents": "read",
+                                       "issues": "write",
+                                       "single_file": "write"
+                                   },
+                                  "events": [
+                                      "push",
+                                      "pull_request"
+                                  ],
+                                 "single_file_name": "config.yml",
+                                 "repository_selection": "selected"}]`,
+		)
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
@@ -75,7 +92,20 @@ func TestAppsService_ListInstallations(t *testing.T) {
 		t.Errorf("Apps.ListInstallations returned error: %v", err)
 	}
 
-	want := []*Installation{{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1), TargetType: String("Organization")}}
+	want := []*Installation{{
+		ID:                  Int64(1),
+		AppID:               Int64(1),
+		TargetID:            Int64(1),
+		TargetType:          String("Organization"),
+		SingleFileName:      String("config.yml"),
+		RepositorySelection: String("selected"),
+		Permissions: &InstallationPermissions{
+			MetaData:   String("read"),
+			Contents:   String("read"),
+			Issues:     String("write"),
+			SingleFile: String("write")},
+		Events: &[]string{"push", "pull_request"},
+	}}
 	if !reflect.DeepEqual(installations, want) {
 		t.Errorf("Apps.ListInstallations returned %+v, want %+v", installations, want)
 	}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2716,14 +2716,6 @@ func (i *Installation) GetAppID() int64 {
 	return *i.AppID
 }
 
-// GetEvents returns the Events field if it's non-nil, zero value otherwise.
-func (i *Installation) GetEvents() []string {
-	if i == nil || i.Events == nil {
-		return nil
-	}
-	return *i.Events
-}
-
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
 func (i *Installation) GetHTMLURL() string {
 	if i == nil || i.HTMLURL == nil {
@@ -2828,12 +2820,12 @@ func (i *InstallationPermissions) GetIssues() string {
 	return *i.Issues
 }
 
-// GetMetaData returns the MetaData field if it's non-nil, zero value otherwise.
-func (i *InstallationPermissions) GetMetaData() string {
-	if i == nil || i.MetaData == nil {
+// GetMetadata returns the Metadata field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetMetadata() string {
+	if i == nil || i.Metadata == nil {
 		return ""
 	}
-	return *i.MetaData
+	return *i.Metadata
 }
 
 // GetSingleFile returns the SingleFile field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2740,6 +2740,14 @@ func (i *Installation) GetRepositoriesURL() string {
 	return *i.RepositoriesURL
 }
 
+// GetTargetID returns the TargetID field if it's non-nil, zero value otherwise.
+func (i *Installation) GetTargetID() int64 {
+	if i == nil || i.TargetID == nil {
+		return 0
+	}
+	return *i.TargetID
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (i *InstallationEvent) GetAction() string {
 	if i == nil || i.Action == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2716,6 +2716,14 @@ func (i *Installation) GetAppID() int64 {
 	return *i.AppID
 }
 
+// GetEvents returns the Events field if it's non-nil, zero value otherwise.
+func (i *Installation) GetEvents() []string {
+	if i == nil || i.Events == nil {
+		return nil
+	}
+	return *i.Events
+}
+
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
 func (i *Installation) GetHTMLURL() string {
 	if i == nil || i.HTMLURL == nil {
@@ -2730,6 +2738,14 @@ func (i *Installation) GetID() int64 {
 		return 0
 	}
 	return *i.ID
+}
+
+// GetPermissions returns the Permissions field.
+func (i *Installation) GetPermissions() *InstallationPermissions {
+	if i == nil {
+		return nil
+	}
+	return i.Permissions
 }
 
 // GetRepositoriesURL returns the RepositoriesURL field if it's non-nil, zero value otherwise.
@@ -2794,6 +2810,38 @@ func (i *InstallationEvent) GetSender() *User {
 		return nil
 	}
 	return i.Sender
+}
+
+// GetContents returns the Contents field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetContents() string {
+	if i == nil || i.Contents == nil {
+		return ""
+	}
+	return *i.Contents
+}
+
+// GetIssues returns the Issues field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetIssues() string {
+	if i == nil || i.Issues == nil {
+		return ""
+	}
+	return *i.Issues
+}
+
+// GetMetaData returns the MetaData field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetMetaData() string {
+	if i == nil || i.MetaData == nil {
+		return ""
+	}
+	return *i.MetaData
+}
+
+// GetSingleFile returns the SingleFile field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetSingleFile() string {
+	if i == nil || i.SingleFile == nil {
+		return ""
+	}
+	return *i.SingleFile
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2748,6 +2748,14 @@ func (i *Installation) GetTargetID() int64 {
 	return *i.TargetID
 }
 
+// GetTargetType returns the TargetType field if it's non-nil, zero value otherwise.
+func (i *Installation) GetTargetType() string {
+	if i == nil || i.TargetType == nil {
+		return ""
+	}
+	return *i.TargetType
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (i *InstallationEvent) GetAction() string {
 	if i == nil || i.Action == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2740,6 +2740,22 @@ func (i *Installation) GetRepositoriesURL() string {
 	return *i.RepositoriesURL
 }
 
+// GetRepositorySelection returns the RepositorySelection field if it's non-nil, zero value otherwise.
+func (i *Installation) GetRepositorySelection() string {
+	if i == nil || i.RepositorySelection == nil {
+		return ""
+	}
+	return *i.RepositorySelection
+}
+
+// GetSingleFileName returns the SingleFileName field if it's non-nil, zero value otherwise.
+func (i *Installation) GetSingleFileName() string {
+	if i == nil || i.SingleFileName == nil {
+		return ""
+	}
+	return *i.SingleFileName
+}
+
 // GetTargetID returns the TargetID field if it's non-nil, zero value otherwise.
 func (i *Installation) GetTargetID() int64 {
 	if i == nil || i.TargetID == nil {


### PR DESCRIPTION
This is the companion PR for adding the remaining fields of the `app` response. 
context: https://github.com/google/go-github/issues/851

This PR adds the remaining fields for the `app` endpoints, specifically adding support for 
`target`
`target_type`
`repository_selection`
`single_file_name`
`permissions`
`events`

### Tests
* I've added unit tests for `target`(s) field for all the tests
* Added a more detailed response test for `ListInstallations` only (would like feedback if I can follow the same pattern for the remaining tests).

/cc @kshitij10496 @gmlewis 