### PR TITLE
Add the ability to read a label from labeled events

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -495,6 +495,7 @@ type PullRequestEvent struct {
 	Repo               *Repository   `json:"repository,omitempty"`
 	Sender             *User         `json:"sender,omitempty"`
 	Installation       *Installation `json:"installation,omitempty"`
+	Label              *Label        `json:"label,omitempty"` // Populated in "labeled" event deliveries.
 }
 
 // PullRequestReviewEvent is triggered when a review is submitted on a pull


### PR DESCRIPTION
This PR adds the ability to read labels from 'labeled' pull request events. This isn't present in any other event, hence the comment.