### PR TITLE
Add a GetLabel() accessor for the PullRequestLabel

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -495,6 +495,7 @@ type PullRequestEvent struct {
 	Repo               *Repository   `json:"repository,omitempty"`
 	Sender             *User         `json:"sender,omitempty"`
 	Installation       *Installation `json:"installation,omitempty"`
+	Label              *Label        `json:"label,omitempty"` // Populated in "labeled" event deliveries.
 }
 
 // PullRequestReviewEvent is triggered when a review is submitted on a pull

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6268,6 +6268,14 @@ func (p *PullRequestEvent) GetSender() *User {
 	return p.Sender
 }
 
+// GetLabel returns the Label field.
+func (p *PullRequestEvent) GetLabel() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Label
+}
+
 // GetDiffURL returns the DiffURL field if it's non-nil, zero value otherwise.
 func (p *PullRequestLinks) GetDiffURL() string {
 	if p == nil || p.DiffURL == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6269,7 +6269,7 @@ func (p *PullRequestEvent) GetSender() *User {
 }
 
 // GetLabel returns the Label field.
-func (p *PullRequestEvent) GetLabel() *User {
+func (p *PullRequestEvent) GetLabel() *Label {
 	if p == nil {
 		return nil
 	}


### PR DESCRIPTION
PR #867 added a Label field to the PullRequestEvent, but I forgot to add the corresponding accessor. This fixes this oversight.