### PR TITLE
Travis: Add Go 1.10.x and fix build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: false
 language: go
 go:
-  - 1.9.x
-  - 1.8.x
-  - 1.7.x
+  - "1.10.x"
+  - "1.9.x"
+  - "1.8.x"
+  - "1.7.x"
   - master
 matrix:
   allow_failures:

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6236,6 +6236,14 @@ func (p *PullRequestEvent) GetInstallation() *Installation {
 	return p.Installation
 }
 
+// GetLabel returns the Label field.
+func (p *PullRequestEvent) GetLabel() *Label {
+	if p == nil {
+		return nil
+	}
+	return p.Label
+}
+
 // GetNumber returns the Number field if it's non-nil, zero value otherwise.
 func (p *PullRequestEvent) GetNumber() int {
 	if p == nil || p.Number == nil {
@@ -6266,14 +6274,6 @@ func (p *PullRequestEvent) GetSender() *User {
 		return nil
 	}
 	return p.Sender
-}
-
-// GetLabel returns the Label field.
-func (p *PullRequestEvent) GetLabel() *Label {
-	if p == nil {
-		return nil
-	}
-	return p.Label
 }
 
 // GetDiffURL returns the DiffURL field if it's non-nil, zero value otherwise.


### PR DESCRIPTION
Add Go 1.10.x to .travis.yml. Add quotes to be consistent with the recommended style at https://docs.travis-ci.com/user/languages/go/#Specifying-a-Go-version-to-use.

Regenerate the package with:

	go generate github.com/google/go-github/...

That fixes the build.

Updates #868.