### PR TITLE
Update orgs_members.go

### DIFF
--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -59,7 +59,7 @@ type ListMembersOptions struct {
 	// Possible values are:
 	//     all - all members of the organization, regardless of role
 	//     admin - organization owners
-	//     member - non-organization members
+	//     member - non-owner members
 	//
 	// Default is "all".
 	Role string `url:"role,omitempty"`

--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -59,7 +59,7 @@ type ListMembersOptions struct {
 	// Possible values are:
 	//     all - all members of the organization, regardless of role
 	//     admin - organization owners
-	//     member - non-owner members
+	//     member - non-owner organization members
 	//
 	// Default is "all".
 	Role string `url:"role,omitempty"`


### PR DESCRIPTION
role filter 'member' means return only users that are not owners