### PR TITLE
Fix incorrect marshalling of DismissalRestrictionsRequest field.

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -585,11 +585,11 @@ type PullRequestReviewsEnforcementRequest struct {
 func (req PullRequestReviewsEnforcementRequest) MarshalJSON() ([]byte, error) {
 	if req.DismissalRestrictionsRequest == nil {
 		newReq := struct {
-			R []interface{} `json:"dismissal_restrictions"`
-			D bool          `json:"dismiss_stale_reviews"`
-			O bool          `json:"require_code_owner_reviews"`
+			R struct{} `json:"dismissal_restrictions"`
+			D bool     `json:"dismiss_stale_reviews"`
+			O bool     `json:"require_code_owner_reviews"`
 		}{
-			R: []interface{}{},
+			R: struct{}{},
 			D: req.DismissStaleReviews,
 			O: req.RequireCodeOwnerReviews,
 		}

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -947,7 +947,7 @@ func TestPullRequestReviewsEnforcementRequest_MarshalJSON_nilDismissalRestirctio
 		t.Errorf("PullRequestReviewsEnforcementRequest.MarshalJSON returned error: %v", err)
 	}
 
-	want := `{"dismissal_restrictions":[],"dismiss_stale_reviews":false,"require_code_owner_reviews":false}`
+	want := `{"dismissal_restrictions":{},"dismiss_stale_reviews":false,"require_code_owner_reviews":false}`
 	if want != string(json) {
 		t.Errorf("PullRequestReviewsEnforcementRequest.MarshalJSON returned %+v, want %+v", string(json), want)
 	}


### PR DESCRIPTION
Previously, an empty DismissalRestrictionsRequest was being marshalled
to an empty array [] instead of an empty object {}. This is an invalid
api call according to github's documentation, and caused github to
respond with a 422.

Fixes #664