### PR TITLE
Remove App Engine note about rewriting context import path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,17 +215,6 @@ For complete usage of go-github, see the full [package docs][].
 [GraphQL API v4]: https://developer.github.com/v4/
 [shurcooL/githubql]: https://github.com/shurcooL/githubql
 
-### Google App Engine ###
-
-Go on App Engine Classic (which as of this writing uses Go 1.6) can not use
-the `"context"` import and still relies on `"golang.org/x/net/context"`.
-As a result, if you wish to continue to use `go-github` on App Engine Classic,
-you will need to rewrite all the `"context"` imports using the following command:
-
-	gofmt -w -r '"context" -> "golang.org/x/net/context"' *.go
-
-See `with_appengine.go` for more details.
-
 ### Integration Tests ###
 
 You can run integration tests from the `test` directory. See the integration tests [README](test/README.md).

--- a/github/doc.go
+++ b/github/doc.go
@@ -183,16 +183,5 @@ github.Response struct.
 		opt.Page = resp.NextPage
 	}
 
-Google App Engine
-
-Go on App Engine Classic (which as of this writing uses Go 1.6) can not use
-the "context" import and still relies on "golang.org/x/net/context".
-As a result, if you wish to continue to use "go-github" on App Engine Classic,
-you will need to rewrite all the "context" imports using the following command:
-
-	gofmt -w -r '"context" -> "golang.org/x/net/context"' *.go
-
-See "with_appengine.go" for more details.
-
 */
 package github

--- a/github/with_appengine.go
+++ b/github/with_appengine.go
@@ -6,11 +6,6 @@
 // +build appengine
 
 // This file provides glue for making github work on App Engine.
-// In order to get the entire github package to compile with
-// Go 1.6, you will need to rewrite all the import "context" lines.
-// Fortunately, this is easy with "gofmt":
-//
-//     gofmt -w -r '"context" -> "golang.org/x/net/context"' *.go
 
 package github
 


### PR DESCRIPTION
Google App Engine now supports Go 1.8 (up from 1.6). (They even support 1.9 beta as of today! 🎉) The `context` package in Go standard library was added in 1.7. That means we no longer have to suggest rewriting the import path. 🔥

Reference: https://cloud.google.com/appengine/docs/standard/go/release-notes#october_25_2018.

Fixes #859.

---

Note: I am not an App Engine user or expert, so it's best if this can be reviewed by someone who is. I made this PR using the information shared in #859.