### PR TITLE
Remove mediaTypeGraphQLNodeIDPreview accept header from DownloadReleaseAsset.

### DIFF
--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -251,8 +251,6 @@ func (s *RepositoriesService) DownloadReleaseAsset(ctx context.Context, owner, r
 	if err != nil {
 		return nil, "", err
 	}
-
-	// TODO: remove custom Accept header when APIs fully launch.
 	req.Header.Set("Accept", defaultMediaType)
 
 	s.client.clientMu.Lock()

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -253,8 +253,7 @@ func (s *RepositoriesService) DownloadReleaseAsset(ctx context.Context, owner, r
 	}
 
 	// TODO: remove custom Accept header when APIs fully launch.
-	acceptHeaders := []string{defaultMediaType, mediaTypeGraphQLNodeIDPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
+	req.Header.Set("Accept", defaultMediaType)
 
 	s.client.clientMu.Lock()
 	defer s.client.clientMu.Unlock()

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -220,10 +220,9 @@ func TestRepositoriesService_DownloadReleaseAsset_Stream(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	acceptHeaders := []string{defaultMediaType, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
+		testHeader(t, r, "Accept", defaultMediaType)
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.Header().Set("Content-Disposition", "attachment; filename=hello-world.txt")
 		fmt.Fprint(w, "Hello World")
@@ -247,10 +246,9 @@ func TestRepositoriesService_DownloadReleaseAsset_Redirect(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	acceptHeaders := []string{defaultMediaType, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
+		testHeader(t, r, "Accept", defaultMediaType)
 		http.Redirect(w, r, "/yo", http.StatusFound)
 	})
 
@@ -268,10 +266,9 @@ func TestRepositoriesService_DownloadReleaseAsset_APIError(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	acceptHeaders := []string{defaultMediaType, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
+		testHeader(t, r, "Accept", defaultMediaType)
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprint(w, `{"message":"Not Found","documentation_url":"https://developer.github.com/v3"}`)
 	})


### PR DESCRIPTION
As I commented at https://github.com/google/go-github/issues/870#issuecomment-375071816, a downloaded binary file with `DownloadReleaseAsset()` is broken due to the additional accept header. I'm facing this problem on [go-github-selfupdate](https://github.com/rhysd/go-github-selfupdate) library.

https://travis-ci.org/rhysd/go-github-selfupdate/jobs/356272200#L218

I confirmed that this fix solved the problem on my local machine (macOS 10.12, Go 1.10).

Fixes #870.