### PR TITLE
Replace `int` id with `int64` in OrganizationsService

### DIFF
--- a/github/issues_comments.go
+++ b/github/issues_comments.go
@@ -79,7 +79,7 @@ func (s *IssuesService) ListComments(ctx context.Context, owner string, repo str
 // GetComment fetches the specified issue comment.
 //
 // GitHub API docs: https://developer.github.com/v3/issues/comments/#get-a-single-comment
-func (s *IssuesService) GetComment(ctx context.Context, owner string, repo string, id int) (*IssueComment, *Response, error) {
+func (s *IssuesService) GetComment(ctx context.Context, owner string, repo string, id int64) (*IssueComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/comments/%d", owner, repo, id)
 
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -120,7 +120,7 @@ func (s *IssuesService) CreateComment(ctx context.Context, owner string, repo st
 // EditComment updates an issue comment.
 //
 // GitHub API docs: https://developer.github.com/v3/issues/comments/#edit-a-comment
-func (s *IssuesService) EditComment(ctx context.Context, owner string, repo string, id int, comment *IssueComment) (*IssueComment, *Response, error) {
+func (s *IssuesService) EditComment(ctx context.Context, owner string, repo string, id int64, comment *IssueComment) (*IssueComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/comments/%d", owner, repo, id)
 	req, err := s.client.NewRequest("PATCH", u, comment)
 	if err != nil {
@@ -138,7 +138,7 @@ func (s *IssuesService) EditComment(ctx context.Context, owner string, repo stri
 // DeleteComment deletes an issue comment.
 //
 // GitHub API docs: https://developer.github.com/v3/issues/comments/#delete-a-comment
-func (s *IssuesService) DeleteComment(ctx context.Context, owner string, repo string, id int) (*Response, error) {
+func (s *IssuesService) DeleteComment(ctx context.Context, owner string, repo string, id int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/comments/%d", owner, repo, id)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/orgs_hooks.go
+++ b/github/orgs_hooks.go
@@ -37,7 +37,7 @@ func (s *OrganizationsService) ListHooks(ctx context.Context, org string, opt *L
 // GetHook returns a single specified Hook.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/hooks/#get-single-hook
-func (s *OrganizationsService) GetHook(ctx context.Context, org string, id int) (*Hook, *Response, error) {
+func (s *OrganizationsService) GetHook(ctx context.Context, org string, id int64) (*Hook, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/hooks/%d", org, id)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -71,7 +71,7 @@ func (s *OrganizationsService) CreateHook(ctx context.Context, org string, hook 
 // EditHook updates a specified Hook.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/hooks/#edit-a-hook
-func (s *OrganizationsService) EditHook(ctx context.Context, org string, id int, hook *Hook) (*Hook, *Response, error) {
+func (s *OrganizationsService) EditHook(ctx context.Context, org string, id int64, hook *Hook) (*Hook, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/hooks/%d", org, id)
 	req, err := s.client.NewRequest("PATCH", u, hook)
 	if err != nil {
@@ -85,7 +85,7 @@ func (s *OrganizationsService) EditHook(ctx context.Context, org string, id int,
 // PingHook triggers a 'ping' event to be sent to the Hook.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/hooks/#ping-a-hook
-func (s *OrganizationsService) PingHook(ctx context.Context, org string, id int) (*Response, error) {
+func (s *OrganizationsService) PingHook(ctx context.Context, org string, id int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/hooks/%d/pings", org, id)
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -97,7 +97,7 @@ func (s *OrganizationsService) PingHook(ctx context.Context, org string, id int)
 // DeleteHook deletes a specified Hook.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/hooks/#delete-a-hook
-func (s *OrganizationsService) DeleteHook(ctx context.Context, org string, id int) (*Response, error) {
+func (s *OrganizationsService) DeleteHook(ctx context.Context, org string, id int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/hooks/%d", org, id)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/repos_keys.go
+++ b/github/repos_keys.go
@@ -79,7 +79,7 @@ func (s *RepositoriesService) CreateKey(ctx context.Context, owner string, repo 
 // EditKey edits a deploy key.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/keys/#edit
-func (s *RepositoriesService) EditKey(ctx context.Context, owner string, repo string, id int, key *Key) (*Key, *Response, error) {
+func (s *RepositoriesService) EditKey(ctx context.Context, owner string, repo string, id int64, key *Key) (*Key, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/keys/%v", owner, repo, id)
 
 	req, err := s.client.NewRequest("PATCH", u, key)
@@ -99,7 +99,7 @@ func (s *RepositoriesService) EditKey(ctx context.Context, owner string, repo st
 // DeleteKey deletes a deploy key.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/keys/#delete
-func (s *RepositoriesService) DeleteKey(ctx context.Context, owner string, repo string, id int) (*Response, error) {
+func (s *RepositoriesService) DeleteKey(ctx context.Context, owner string, repo string, id int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/keys/%v", owner, repo, id)
 
 	req, err := s.client.NewRequest("DELETE", u, nil)


### PR DESCRIPTION
I think the OrganizationsService didn't get converted in the int -> int64 id migration.

Updates #597.