### PR TITLE
Change number int to commentID int64 in PRsService comment methods.

### DIFF
--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -87,8 +87,8 @@ func (s *PullRequestsService) ListComments(ctx context.Context, owner string, re
 // GetComment fetches the specified pull request comment.
 //
 // GitHub API docs: https://developer.github.com/v3/pulls/comments/#get-a-single-comment
-func (s *PullRequestsService) GetComment(ctx context.Context, owner string, repo string, number int) (*PullRequestComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%d", owner, repo, number)
+func (s *PullRequestsService) GetComment(ctx context.Context, owner string, repo string, commentID int64) (*PullRequestComment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%d", owner, repo, commentID)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -126,10 +126,11 @@ func (s *PullRequestsService) CreateComment(ctx context.Context, owner string, r
 }
 
 // EditComment updates a pull request comment.
+// A non-nil comment.Body must be provided. Other comment fields should be left nil.
 //
 // GitHub API docs: https://developer.github.com/v3/pulls/comments/#edit-a-comment
-func (s *PullRequestsService) EditComment(ctx context.Context, owner string, repo string, number int, comment *PullRequestComment) (*PullRequestComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%d", owner, repo, number)
+func (s *PullRequestsService) EditComment(ctx context.Context, owner string, repo string, commentID int64, comment *PullRequestComment) (*PullRequestComment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%d", owner, repo, commentID)
 	req, err := s.client.NewRequest("PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -147,8 +148,8 @@ func (s *PullRequestsService) EditComment(ctx context.Context, owner string, rep
 // DeleteComment deletes a pull request comment.
 //
 // GitHub API docs: https://developer.github.com/v3/pulls/comments/#delete-a-comment
-func (s *PullRequestsService) DeleteComment(ctx context.Context, owner string, repo string, number int) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%d", owner, repo, number)
+func (s *PullRequestsService) DeleteComment(ctx context.Context, owner string, repo string, commentID int64) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%d", owner, repo, commentID)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**This is a breaking API change that is a part of issue #597.** It should've been applied earlier, but we missed it because the parameter was misleadingly named `number` rather than `id` or `commentID`.

Rename the parameter to `commentID` to make it more clear that it's the comment ID and not the PR ID nor PR number. This should help improve clarity of the API, and reduce the chance to mix up the IDs.

Also document which `PullRequestComment` fields need to be set in `EditComment` method.

Similar to #886.
Updates #885.
Updates #597.