### PR TITLE
Support preview Team Discussions API

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1764,6 +1764,102 @@ func (d *DeploymentStatusRequest) GetState() string {
 	return *d.State
 }
 
+// GetAuthor returns the Author field.
+func (d *DiscussionComment) GetAuthor() *User {
+	if d == nil {
+		return nil
+	}
+	return d.Author
+}
+
+// GetBody returns the Body field if it's non-nil, zero value otherwise.
+func (d *DiscussionComment) GetBody() string {
+	if d == nil || d.Body == nil {
+		return ""
+	}
+	return *d.Body
+}
+
+// GetBodyHTML returns the BodyHTML field if it's non-nil, zero value otherwise.
+func (d *DiscussionComment) GetBodyHTML() string {
+	if d == nil || d.BodyHTML == nil {
+		return ""
+	}
+	return *d.BodyHTML
+}
+
+// GetBodyVersion returns the BodyVersion field if it's non-nil, zero value otherwise.
+func (d *DiscussionComment) GetBodyVersion() string {
+	if d == nil || d.BodyVersion == nil {
+		return ""
+	}
+	return *d.BodyVersion
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (d *DiscussionComment) GetCreatedAt() Timestamp {
+	if d == nil || d.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *d.CreatedAt
+}
+
+// GetDiscussionURL returns the DiscussionURL field if it's non-nil, zero value otherwise.
+func (d *DiscussionComment) GetDiscussionURL() string {
+	if d == nil || d.DiscussionURL == nil {
+		return ""
+	}
+	return *d.DiscussionURL
+}
+
+// GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
+func (d *DiscussionComment) GetHTMLURL() string {
+	if d == nil || d.HTMLURL == nil {
+		return ""
+	}
+	return *d.HTMLURL
+}
+
+// GetLastEditedAt returns the LastEditedAt field if it's non-nil, zero value otherwise.
+func (d *DiscussionComment) GetLastEditedAt() Timestamp {
+	if d == nil || d.LastEditedAt == nil {
+		return Timestamp{}
+	}
+	return *d.LastEditedAt
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (d *DiscussionComment) GetNodeID() string {
+	if d == nil || d.NodeID == nil {
+		return ""
+	}
+	return *d.NodeID
+}
+
+// GetNumber returns the Number field if it's non-nil, zero value otherwise.
+func (d *DiscussionComment) GetNumber() int64 {
+	if d == nil || d.Number == nil {
+		return 0
+	}
+	return *d.Number
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (d *DiscussionComment) GetUpdatedAt() Timestamp {
+	if d == nil || d.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *d.UpdatedAt
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (d *DiscussionComment) GetURL() string {
+	if d == nil || d.URL == nil {
+		return ""
+	}
+	return *d.URL
+}
+
 // GetTeams returns the Teams field if it's non-nil, zero value otherwise.
 func (d *DismissalRestrictionsRequest) GetTeams() []string {
 	if d == nil || d.Teams == nil {
@@ -9458,6 +9554,142 @@ func (t *TeamAddEvent) GetTeam() *Team {
 		return nil
 	}
 	return t.Team
+}
+
+// GetAuthor returns the Author field.
+func (t *TeamDiscussion) GetAuthor() *User {
+	if t == nil {
+		return nil
+	}
+	return t.Author
+}
+
+// GetBody returns the Body field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetBody() string {
+	if t == nil || t.Body == nil {
+		return ""
+	}
+	return *t.Body
+}
+
+// GetBodyHTML returns the BodyHTML field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetBodyHTML() string {
+	if t == nil || t.BodyHTML == nil {
+		return ""
+	}
+	return *t.BodyHTML
+}
+
+// GetBodyVersion returns the BodyVersion field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetBodyVersion() string {
+	if t == nil || t.BodyVersion == nil {
+		return ""
+	}
+	return *t.BodyVersion
+}
+
+// GetCommentsCount returns the CommentsCount field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetCommentsCount() int64 {
+	if t == nil || t.CommentsCount == nil {
+		return 0
+	}
+	return *t.CommentsCount
+}
+
+// GetCommentsURL returns the CommentsURL field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetCommentsURL() string {
+	if t == nil || t.CommentsURL == nil {
+		return ""
+	}
+	return *t.CommentsURL
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetCreatedAt() Timestamp {
+	if t == nil || t.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *t.CreatedAt
+}
+
+// GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetHTMLURL() string {
+	if t == nil || t.HTMLURL == nil {
+		return ""
+	}
+	return *t.HTMLURL
+}
+
+// GetLastEditedAt returns the LastEditedAt field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetLastEditedAt() Timestamp {
+	if t == nil || t.LastEditedAt == nil {
+		return Timestamp{}
+	}
+	return *t.LastEditedAt
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetNodeID() string {
+	if t == nil || t.NodeID == nil {
+		return ""
+	}
+	return *t.NodeID
+}
+
+// GetNumber returns the Number field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetNumber() int64 {
+	if t == nil || t.Number == nil {
+		return 0
+	}
+	return *t.Number
+}
+
+// GetPinned returns the Pinned field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetPinned() bool {
+	if t == nil || t.Pinned == nil {
+		return false
+	}
+	return *t.Pinned
+}
+
+// GetPrivate returns the Private field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetPrivate() bool {
+	if t == nil || t.Private == nil {
+		return false
+	}
+	return *t.Private
+}
+
+// GetTeamURL returns the TeamURL field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetTeamURL() string {
+	if t == nil || t.TeamURL == nil {
+		return ""
+	}
+	return *t.TeamURL
+}
+
+// GetTitle returns the Title field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetTitle() string {
+	if t == nil || t.Title == nil {
+		return ""
+	}
+	return *t.Title
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetUpdatedAt() Timestamp {
+	if t == nil || t.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *t.UpdatedAt
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (t *TeamDiscussion) GetURL() string {
+	if t == nil || t.URL == nil {
+		return ""
+	}
+	return *t.URL
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.

--- a/github/github.go
+++ b/github/github.go
@@ -113,6 +113,9 @@ const (
 
 	// https://developer.github.com/changes/2018-01-25-organization-invitation-api-preview/
 	mediaTypeOrganizationInvitationPreview = "application/vnd.github.dazzler-preview+json"
+
+	// https://developer.github.com/changes/2018-02-07-team-discussions-api/
+	mediaTypeTeamDiscussionsPreview = "application/vnd.github.echo-preview+json"
 )
 
 // A Client manages communication with the GitHub API.
@@ -154,6 +157,7 @@ type Client struct {
 	Reactions      *ReactionsService
 	Repositories   *RepositoriesService
 	Search         *SearchService
+	Teams          *TeamsService
 	Users          *UsersService
 }
 
@@ -244,6 +248,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Reactions = (*ReactionsService)(&c.common)
 	c.Repositories = (*RepositoriesService)(&c.common)
 	c.Search = (*SearchService)(&c.common)
+	c.Teams = (*TeamsService)(&c.common)
 	c.Users = (*UsersService)(&c.common)
 	return c
 }

--- a/github/teams.go
+++ b/github/teams.go
@@ -1,0 +1,7 @@
+package github
+
+// TeamsService provides access to the team related functions
+// in the GitHub API.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/
+type TeamsService service

--- a/github/teams.go
+++ b/github/teams.go
@@ -1,6 +1,6 @@
 package github
 
-// TeamsService provides access to the team related functions
+// TeamsService provides access to the team-related functions
 // in the GitHub API.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/

--- a/github/teams_discussion_comments.go
+++ b/github/teams_discussion_comments.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"errors"
 	"fmt"
 )
 
@@ -43,8 +42,8 @@ type DiscussionCommentListOptions struct {
 // Authenticated user must grant read:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#list-comments
-func (s *TeamsService) ListComments(ctx context.Context, team, discussion int64, options *DiscussionCommentListOptions) ([]*DiscussionComment, *Response, error) {
-	u := fmt.Sprintf("teams/%v/discussions/%v/comments", team, discussion)
+func (s *TeamsService) ListComments(ctx context.Context, teamID int64, discussionNumber int, options *DiscussionCommentListOptions) ([]*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v/comments", teamID, discussionNumber)
 	u, err := addOptions(u, options)
 	if err != nil {
 		return nil, nil, err
@@ -71,8 +70,8 @@ func (s *TeamsService) ListComments(ctx context.Context, team, discussion int64,
 // Authenticated user must grant read:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#get-a-single-comment
-func (s *TeamsService) GetComment(ctx context.Context, team, discussion, id int64) (*DiscussionComment, *Response, error) {
-	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v", team, discussion, id)
+func (s *TeamsService) GetComment(ctx context.Context, teamID int64, discussionNumber, commentNumber int) (*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v", teamID, discussionNumber, commentNumber)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -94,12 +93,8 @@ func (s *TeamsService) GetComment(ctx context.Context, team, discussion, id int6
 // Authenticated user must grant write:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#create-a-comment
-func (s *TeamsService) CreateComment(ctx context.Context, team, discussion int64, comment *DiscussionComment) (*DiscussionComment, *Response, error) {
-	if comment == nil {
-		return nil, nil, errors.New("comment must be provided")
-	}
-
-	u := fmt.Sprintf("teams/%v/discussions/%v/comments", team, discussion)
+func (s *TeamsService) CreateComment(ctx context.Context, teamID int64, discsusionNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v/comments", teamID, discsusionNumber)
 	req, err := s.client.NewRequest("POST", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -122,12 +117,8 @@ func (s *TeamsService) CreateComment(ctx context.Context, team, discussion int64
 // User is allowed to edit body of a comment only.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#edit-a-comment
-func (s *TeamsService) EditComment(ctx context.Context, team, discussion, id int64, comment *DiscussionComment) (*DiscussionComment, *Response, error) {
-	if comment == nil {
-		return nil, nil, errors.New("comment must be provided")
-	}
-
-	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v", team, discussion, id)
+func (s *TeamsService) EditComment(ctx context.Context, teamID int64, discussionNumber, commentNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v", teamID, discussionNumber, commentNumber)
 	req, err := s.client.NewRequest("PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -149,8 +140,8 @@ func (s *TeamsService) EditComment(ctx context.Context, team, discussion, id int
 // Authenticated user must grant write:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#delete-a-comment
-func (s *TeamsService) DeleteComment(ctx context.Context, team, discussion, id int64) (*Response, error) {
-	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v", team, discussion, id)
+func (s *TeamsService) DeleteComment(ctx context.Context, teamID int64, discussionNumber, commentNumber int) (*Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v", teamID, discussionNumber, commentNumber)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/teams_discussion_comments.go
+++ b/github/teams_discussion_comments.go
@@ -7,10 +7,11 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
-// DiscussionComment represents a GitHub dicussion in a team
+// DiscussionComment represents a GitHub dicussion in a team.
 type DiscussionComment struct {
 	Author        *User      `json:"author,omitempty"`
 	Body          *string    `json:"body,omitempty"`
@@ -31,7 +32,7 @@ func (c DiscussionComment) String() string {
 }
 
 // DiscussionCommentListOptions specifies optional parameters to the
-// TeamServices.ListComments method
+// TeamServices.ListComments method.
 type DiscussionCommentListOptions struct {
 	// Sorts the discussion comments by the date they were created.
 	// Accepted values are asc and desc. Default is desc.
@@ -94,6 +95,10 @@ func (s *TeamsService) GetComment(ctx context.Context, team, discussion, id int6
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#create-a-comment
 func (s *TeamsService) CreateComment(ctx context.Context, team, discussion int64, comment *DiscussionComment) (*DiscussionComment, *Response, error) {
+	if comment == nil {
+		return nil, nil, errors.New("comment must be provided")
+	}
+
 	u := fmt.Sprintf("teams/%v/discussions/%v/comments", team, discussion)
 	req, err := s.client.NewRequest("POST", u, comment)
 	if err != nil {
@@ -118,6 +123,10 @@ func (s *TeamsService) CreateComment(ctx context.Context, team, discussion int64
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#edit-a-comment
 func (s *TeamsService) EditComment(ctx context.Context, team, discussion, id int64, comment *DiscussionComment) (*DiscussionComment, *Response, error) {
+	if comment == nil {
+		return nil, nil, errors.New("comment must be provided")
+	}
+
 	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v", team, discussion, id)
 	req, err := s.client.NewRequest("PATCH", u, comment)
 	if err != nil {

--- a/github/teams_discussion_comments.go
+++ b/github/teams_discussion_comments.go
@@ -1,0 +1,154 @@
+// Copyright 2018 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// DiscussionComment represents a GitHub dicussion in a team
+type DiscussionComment struct {
+	Author        *User      `json:"author,omitempty"`
+	Body          *string    `json:"body,omitempty"`
+	BodyHTML      *string    `json:"body_html,omitempty"`
+	BodyVersion   *string    `json:"body_version,omitempty"`
+	CreatedAt     *Timestamp `json:"created_at,omitempty"`
+	LastEditedAt  *Timestamp `json:"last_edited_at,omitempty"`
+	DiscussionURL *string    `json:"discussion_url,omitempty"`
+	HTMLURL       *string    `json:"html_url,omitempty"`
+	NodeID        *string    `json:"node_id,omitempty"`
+	Number        *int64     `json:"number,omitempty"`
+	UpdatedAt     *Timestamp `json:"updated_at,omitempty"`
+	URL           *string    `json:"url,omitempty"`
+}
+
+func (c DiscussionComment) String() string {
+	return Stringify(c)
+}
+
+// DiscussionCommentListOptions specifies optional parameters to the
+// TeamServices.ListComments method
+type DiscussionCommentListOptions struct {
+	// Sorts the discussion comments by the date they were created.
+	// Accepted values are asc and desc. Default is desc.
+	Direction string `url:"direction,omitempty"`
+}
+
+// ListComments lists all comments on a team discussion.
+// Authenticated user must grant read:discussion scope.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#list-comments
+func (s *TeamsService) ListComments(ctx context.Context, team, discussion int64, options *DiscussionCommentListOptions) ([]*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v/comments", team, discussion)
+	u, err := addOptions(u, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeTeamDiscussionsPreview)
+
+	var comments []*DiscussionComment
+	resp, err := s.client.Do(ctx, req, &comments)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return comments, resp, nil
+}
+
+// GetComment gets a specific comment on a team discussion.
+// Authenticated user must grant read:discussion scope.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#get-a-single-comment
+func (s *TeamsService) GetComment(ctx context.Context, team, discussion, id int64) (*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v", team, discussion, id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeTeamDiscussionsPreview)
+
+	discussionComment := &DiscussionComment{}
+	resp, err := s.client.Do(ctx, req, discussionComment)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return discussionComment, resp, nil
+}
+
+// CreateComment creates a new discussion post on a team discussion.
+// Authenticated user must grant write:discussion scope.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#create-a-comment
+func (s *TeamsService) CreateComment(ctx context.Context, team, discussion int64, comment *DiscussionComment) (*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v/comments", team, discussion)
+	req, err := s.client.NewRequest("POST", u, comment)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeTeamDiscussionsPreview)
+
+	discussionComment := &DiscussionComment{}
+	resp, err := s.client.Do(ctx, req, discussionComment)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return discussionComment, resp, nil
+}
+
+// EditComment edits the body text of a discussion comment.
+// Authenticated user must grant write:discussion scope.
+// User is allowed to edit body of a comment only.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#edit-a-comment
+func (s *TeamsService) EditComment(ctx context.Context, team, discussion, id int64, comment *DiscussionComment) (*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v", team, discussion, id)
+	req, err := s.client.NewRequest("PATCH", u, comment)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeTeamDiscussionsPreview)
+
+	discussionComment := &DiscussionComment{}
+	resp, err := s.client.Do(ctx, req, discussionComment)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return discussionComment, resp, nil
+}
+
+// DeleteComment deletes a comment on a team discussion.
+// Authenticated user must grant write:discussion scope.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#delete-a-comment
+func (s *TeamsService) DeleteComment(ctx context.Context, team, discussion, id int64) (*Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v", team, discussion, id)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeTeamDiscussionsPreview)
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/teams_discussion_comments_test.go
+++ b/github/teams_discussion_comments_test.go
@@ -131,7 +131,7 @@ func TestTeamsService_CreateComment(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	input := &DiscussionComment{Body: String("c")}
+	input := DiscussionComment{Body: String("c")}
 
 	mux.HandleFunc("/teams/2/discussions/3/comments", func(w http.ResponseWriter, r *http.Request) {
 		v := new(DiscussionComment)
@@ -139,7 +139,7 @@ func TestTeamsService_CreateComment(t *testing.T) {
 
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", mediaTypeTeamDiscussionsPreview)
-		if !reflect.DeepEqual(v, input) {
+		if !reflect.DeepEqual(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -157,21 +157,11 @@ func TestTeamsService_CreateComment(t *testing.T) {
 	}
 }
 
-func TestTeamsService_CreateCommentWithNilComment(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	_, _, err := client.Teams.CreateComment(context.Background(), 2, 3, nil)
-	if err == nil {
-		t.Errorf("Teams.CreateComment must return error with nil DiscussionComment")
-	}
-}
-
 func TestTeamsService_EditComment(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	input := &DiscussionComment{Body: String("e")}
+	input := DiscussionComment{Body: String("e")}
 
 	mux.HandleFunc("/teams/2/discussions/3/comments/4", func(w http.ResponseWriter, r *http.Request) {
 		v := new(DiscussionComment)
@@ -179,7 +169,7 @@ func TestTeamsService_EditComment(t *testing.T) {
 
 		testMethod(t, r, "PATCH")
 		testHeader(t, r, "Accept", mediaTypeTeamDiscussionsPreview)
-		if !reflect.DeepEqual(v, input) {
+		if !reflect.DeepEqual(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -194,16 +184,6 @@ func TestTeamsService_EditComment(t *testing.T) {
 	want := &DiscussionComment{Number: Int64(4)}
 	if !reflect.DeepEqual(comment, want) {
 		t.Errorf("Teams.EditComment returned %+v, want %+v", comment, want)
-	}
-}
-
-func TestTeamsService_EditCommentWithNilComment(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	_, _, err := client.Teams.EditComment(context.Background(), 2, 3, 4, nil)
-	if err == nil {
-		t.Errorf("Teams.EditComment must return error with nil DiscussionComment")
 	}
 }
 

--- a/github/teams_discussion_comments_test.go
+++ b/github/teams_discussion_comments_test.go
@@ -157,6 +157,16 @@ func TestTeamsService_CreateComment(t *testing.T) {
 	}
 }
 
+func TestTeamsService_CreateCommentWithNilComment(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, _, err := client.Teams.CreateComment(context.Background(), 2, 3, nil)
+	if err == nil {
+		t.Errorf("Teams.CreateComment must return error with nil DiscussionComment")
+	}
+}
+
 func TestTeamsService_EditComment(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
@@ -184,6 +194,16 @@ func TestTeamsService_EditComment(t *testing.T) {
 	want := &DiscussionComment{Number: Int64(4)}
 	if !reflect.DeepEqual(comment, want) {
 		t.Errorf("Teams.EditComment returned %+v, want %+v", comment, want)
+	}
+}
+
+func TestTeamsService_EditCommentWithNilComment(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, _, err := client.Teams.EditComment(context.Background(), 2, 3, 4, nil)
+	if err == nil {
+		t.Errorf("Teams.EditComment must return error with nil DiscussionComment")
 	}
 }
 

--- a/github/teams_discussion_comments_test.go
+++ b/github/teams_discussion_comments_test.go
@@ -1,0 +1,203 @@
+// Copyright 2018 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestTeamsService_ListComments(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/teams/2/discussions/3/comments", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeTeamDiscussionsPreview)
+		testFormValues(t, r, values{
+			"direction": "desc",
+		})
+		fmt.Fprintf(w,
+			`[
+				{
+					"author": {
+						"login": "author",
+						"id": 0,
+						"avatar_url": "https://avatars1.githubusercontent.com/u/0?v=4",
+						"gravatar_id": "",
+						"url": "https://api.github.com/users/author",
+						"html_url": "https://github.com/author",
+						"followers_url": "https://api.github.com/users/author/followers",
+						"following_url": "https://api.github.com/users/author/following{/other_user}",
+						"gists_url": "https://api.github.com/users/author/gists{/gist_id}",
+						"starred_url": "https://api.github.com/users/author/starred{/owner}{/repo}",
+						"subscriptions_url": "https://api.github.com/users/author/subscriptions",
+						"organizations_url": "https://api.github.com/users/author/orgs",
+						"repos_url": "https://api.github.com/users/author/repos",
+						"events_url": "https://api.github.com/users/author/events{/privacy}",
+						"received_events_url": "https://api.github.com/users/author/received_events",
+						"type": "User",
+						"site_admin": false
+					},
+					"body": "comment",
+					"body_html": "<p>comment</p>",
+					"body_version": "version",
+					"created_at": "2018-01-01T00:00:00Z",
+					"last_edited_at": null,
+					"discussion_url": "https://api.github.com/teams/2/discussions/3",
+					"html_url": "https://github.com/orgs/1/teams/2/discussions/3/comments/4",
+					"node_id": "node",
+					"number": 4,
+					"updated_at": "2018-01-01T00:00:00Z",
+					"url": "https://api.github.com/teams/2/discussions/3/comments/4"
+				}
+			]`)
+	})
+
+	comments, _, err := client.Teams.ListComments(context.Background(), 2, 3, &DiscussionCommentListOptions{"desc"})
+	if err != nil {
+		t.Errorf("Teams.ListComments returned error: %v", err)
+	}
+
+	want := []*DiscussionComment{
+		{
+			Author: &User{
+				Login:             String("author"),
+				ID:                Int64(0),
+				AvatarURL:         String("https://avatars1.githubusercontent.com/u/0?v=4"),
+				GravatarID:        String(""),
+				URL:               String("https://api.github.com/users/author"),
+				HTMLURL:           String("https://github.com/author"),
+				FollowersURL:      String("https://api.github.com/users/author/followers"),
+				FollowingURL:      String("https://api.github.com/users/author/following{/other_user}"),
+				GistsURL:          String("https://api.github.com/users/author/gists{/gist_id}"),
+				StarredURL:        String("https://api.github.com/users/author/starred{/owner}{/repo}"),
+				SubscriptionsURL:  String("https://api.github.com/users/author/subscriptions"),
+				OrganizationsURL:  String("https://api.github.com/users/author/orgs"),
+				ReposURL:          String("https://api.github.com/users/author/repos"),
+				EventsURL:         String("https://api.github.com/users/author/events{/privacy}"),
+				ReceivedEventsURL: String("https://api.github.com/users/author/received_events"),
+				Type:              String("User"),
+				SiteAdmin:         Bool(false),
+			},
+			Body:          String("comment"),
+			BodyHTML:      String("<p>comment</p>"),
+			BodyVersion:   String("version"),
+			CreatedAt:     &Timestamp{time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
+			LastEditedAt:  nil,
+			DiscussionURL: String("https://api.github.com/teams/2/discussions/3"),
+			HTMLURL:       String("https://github.com/orgs/1/teams/2/discussions/3/comments/4"),
+			NodeID:        String("node"),
+			Number:        Int64(4),
+			UpdatedAt:     &Timestamp{time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
+			URL:           String("https://api.github.com/teams/2/discussions/3/comments/4"),
+		},
+	}
+	if !reflect.DeepEqual(comments, want) {
+		t.Errorf("Teams.ListComments returned %+v, want %+v", comments, want)
+	}
+}
+
+func TestTeamsService_GetComment(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/teams/2/discussions/3/comments/4", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeTeamDiscussionsPreview)
+		fmt.Fprint(w, `{"number":4}`)
+	})
+
+	comment, _, err := client.Teams.GetComment(context.Background(), 2, 3, 4)
+	if err != nil {
+		t.Errorf("Teams.GetComment returned error: %v", err)
+	}
+
+	want := &DiscussionComment{Number: Int64(4)}
+	if !reflect.DeepEqual(comment, want) {
+		t.Errorf("Teams.GetComment returned %+v, want %+v", comment, want)
+	}
+}
+
+func TestTeamsService_CreateComment(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &DiscussionComment{Body: String("c")}
+
+	mux.HandleFunc("/teams/2/discussions/3/comments", func(w http.ResponseWriter, r *http.Request) {
+		v := new(DiscussionComment)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeTeamDiscussionsPreview)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		fmt.Fprint(w, `{"number":4}`)
+	})
+
+	comment, _, err := client.Teams.CreateComment(context.Background(), 2, 3, input)
+	if err != nil {
+		t.Errorf("Teams.CreateComment returned error: %v", err)
+	}
+
+	want := &DiscussionComment{Number: Int64(4)}
+	if !reflect.DeepEqual(comment, want) {
+		t.Errorf("Teams.CreateComment returned %+v, want %+v", comment, want)
+	}
+}
+
+func TestTeamsService_EditComment(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &DiscussionComment{Body: String("e")}
+
+	mux.HandleFunc("/teams/2/discussions/3/comments/4", func(w http.ResponseWriter, r *http.Request) {
+		v := new(DiscussionComment)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "PATCH")
+		testHeader(t, r, "Accept", mediaTypeTeamDiscussionsPreview)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		fmt.Fprint(w, `{"number":4}`)
+	})
+
+	comment, _, err := client.Teams.EditComment(context.Background(), 2, 3, 4, input)
+	if err != nil {
+		t.Errorf("Teams.EditComment returned error: %v", err)
+	}
+
+	want := &DiscussionComment{Number: Int64(4)}
+	if !reflect.DeepEqual(comment, want) {
+		t.Errorf("Teams.EditComment returned %+v, want %+v", comment, want)
+	}
+}
+
+func TestTeamsService_DeleteComment(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/teams/2/discussions/3/comments/4", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testHeader(t, r, "Accept", mediaTypeTeamDiscussionsPreview)
+	})
+
+	_, err := client.Teams.DeleteComment(context.Background(), 2, 3, 4)
+	if err != nil {
+		t.Errorf("Teams.DeleteComment returned error: %v", err)
+	}
+}

--- a/github/teams_discussions.go
+++ b/github/teams_discussions.go
@@ -1,0 +1,159 @@
+// Copyright 2018 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// TeamDiscussion represents a GitHub dicussion in a team
+type TeamDiscussion struct {
+	Author        *User      `json:"author,omitempty"`
+	Body          *string    `json:"body,omitempty"`
+	BodyHTML      *string    `json:"body_html,omitempty"`
+	BodyVersion   *string    `json:"body_version,omitempty"`
+	CommentsCount *int64     `json:"comments_count,omitempty"`
+	CommentsURL   *string    `json:"comments_url,omitempty"`
+	CreatedAt     *Timestamp `json:"created_at,omitempty"`
+	LastEditedAt  *Timestamp `json:"last_edited_at,omitempty"`
+	HTMLURL       *string    `json:"html_url,omitempty"`
+	NodeID        *string    `json:"node_id,omitempty"`
+	Number        *int64     `json:"number,omitempty"`
+	Pinned        *bool      `json:"pinned,omitempty"`
+	Private       *bool      `json:"private,omitempty"`
+	TeamURL       *string    `json:"team_url,omitempty"`
+	Title         *string    `json:"title,omitempty"`
+	UpdatedAt     *Timestamp `json:"updated_at,omitempty"`
+	URL           *string    `json:"url,omitempty"`
+}
+
+func (d TeamDiscussion) String() string {
+	return Stringify(d)
+}
+
+// DiscussionListOptions specifies optional parameters to the
+// TeamServices.ListDiscussions method
+type DiscussionListOptions struct {
+	// Sorts the discussion by the date they were created.
+	// Accepted values are asc and desc. Default is desc.
+	Direction string `url:"direction,omitempty"`
+}
+
+// ListDiscussions lists all discussions on team's page.
+// Authenticated user must grant read:discussion scope.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/discussions/#list-discussions
+func (s *TeamsService) ListDiscussions(ctx context.Context, team int64, options *DiscussionListOptions) ([]*TeamDiscussion, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions", team)
+	u, err := addOptions(u, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeTeamDiscussionsPreview)
+
+	var teamDiscussions []*TeamDiscussion
+	resp, err := s.client.Do(ctx, req, &teamDiscussions)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return teamDiscussions, resp, nil
+}
+
+// GetDiscussion gets a specific discussion on a team's page.
+// Authenticated user must grant read:discussion scope.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/discussions/#get-a-single-discussion
+func (s *TeamsService) GetDiscussion(ctx context.Context, team, id int64) (*TeamDiscussion, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v", team, id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeTeamDiscussionsPreview)
+
+	teamDiscussion := &TeamDiscussion{}
+	resp, err := s.client.Do(ctx, req, teamDiscussion)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return teamDiscussion, resp, nil
+}
+
+// CreateDiscussion creates a new discussion post on a team's page.
+// Authenticated user must grant write:discussion scope.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/discussions/#create-a-discussion
+func (s *TeamsService) CreateDiscussion(ctx context.Context, team int64, discussion *TeamDiscussion) (*TeamDiscussion, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions", team)
+	req, err := s.client.NewRequest("POST", u, discussion)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeTeamDiscussionsPreview)
+
+	teamDiscussion := &TeamDiscussion{}
+	resp, err := s.client.Do(ctx, req, teamDiscussion)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return teamDiscussion, resp, nil
+}
+
+// EditDiscussion edits the title and body text of a discussion post.
+// Authenticated user must grant write:discussion scope.
+// User is allowed to change Title and Body of a discussion only.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/discussions/#edit-a-discussion
+func (s *TeamsService) EditDiscussion(ctx context.Context, team, id int64, discussion *TeamDiscussion) (*TeamDiscussion, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v", team, id)
+	req, err := s.client.NewRequest("PATCH", u, discussion)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeTeamDiscussionsPreview)
+
+	teamDiscussion := &TeamDiscussion{}
+	resp, err := s.client.Do(ctx, req, teamDiscussion)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return teamDiscussion, resp, nil
+}
+
+// DeleteDiscussion deletes a discussion from team's page.
+// Authenticated user must grant write:discussion scope.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/discussions/#delete-a-discussion
+func (s *TeamsService) DeleteDiscussion(ctx context.Context, team, id int64) (*Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v", team, id)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeTeamDiscussionsPreview)
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/teams_discussions.go
+++ b/github/teams_discussions.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"errors"
 	"fmt"
 )
 
@@ -48,8 +47,8 @@ type DiscussionListOptions struct {
 // Authenticated user must grant read:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussions/#list-discussions
-func (s *TeamsService) ListDiscussions(ctx context.Context, team int64, options *DiscussionListOptions) ([]*TeamDiscussion, *Response, error) {
-	u := fmt.Sprintf("teams/%v/discussions", team)
+func (s *TeamsService) ListDiscussions(ctx context.Context, teamID int64, options *DiscussionListOptions) ([]*TeamDiscussion, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions", teamID)
 	u, err := addOptions(u, options)
 	if err != nil {
 		return nil, nil, err
@@ -76,8 +75,8 @@ func (s *TeamsService) ListDiscussions(ctx context.Context, team int64, options 
 // Authenticated user must grant read:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussions/#get-a-single-discussion
-func (s *TeamsService) GetDiscussion(ctx context.Context, team, id int64) (*TeamDiscussion, *Response, error) {
-	u := fmt.Sprintf("teams/%v/discussions/%v", team, id)
+func (s *TeamsService) GetDiscussion(ctx context.Context, teamID int64, discussionNumber int) (*TeamDiscussion, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v", teamID, discussionNumber)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -99,12 +98,8 @@ func (s *TeamsService) GetDiscussion(ctx context.Context, team, id int64) (*Team
 // Authenticated user must grant write:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussions/#create-a-discussion
-func (s *TeamsService) CreateDiscussion(ctx context.Context, team int64, discussion *TeamDiscussion) (*TeamDiscussion, *Response, error) {
-	if discussion == nil {
-		return nil, nil, errors.New("discussion must be provided")
-	}
-
-	u := fmt.Sprintf("teams/%v/discussions", team)
+func (s *TeamsService) CreateDiscussion(ctx context.Context, teamID int64, discussion TeamDiscussion) (*TeamDiscussion, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions", teamID)
 	req, err := s.client.NewRequest("POST", u, discussion)
 	if err != nil {
 		return nil, nil, err
@@ -127,12 +122,8 @@ func (s *TeamsService) CreateDiscussion(ctx context.Context, team int64, discuss
 // User is allowed to change Title and Body of a discussion only.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussions/#edit-a-discussion
-func (s *TeamsService) EditDiscussion(ctx context.Context, team, id int64, discussion *TeamDiscussion) (*TeamDiscussion, *Response, error) {
-	if discussion == nil {
-		return nil, nil, errors.New("discussion must be provided")
-	}
-
-	u := fmt.Sprintf("teams/%v/discussions/%v", team, id)
+func (s *TeamsService) EditDiscussion(ctx context.Context, teamID int64, discussionNumber int, discussion TeamDiscussion) (*TeamDiscussion, *Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v", teamID, discussionNumber)
 	req, err := s.client.NewRequest("PATCH", u, discussion)
 	if err != nil {
 		return nil, nil, err
@@ -154,8 +145,8 @@ func (s *TeamsService) EditDiscussion(ctx context.Context, team, id int64, discu
 // Authenticated user must grant write:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussions/#delete-a-discussion
-func (s *TeamsService) DeleteDiscussion(ctx context.Context, team, id int64) (*Response, error) {
-	u := fmt.Sprintf("teams/%v/discussions/%v", team, id)
+func (s *TeamsService) DeleteDiscussion(ctx context.Context, teamID int64, discussionNumber int) (*Response, error) {
+	u := fmt.Sprintf("teams/%v/discussions/%v", teamID, discussionNumber)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/teams_discussions.go
+++ b/github/teams_discussions.go
@@ -7,10 +7,11 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
-// TeamDiscussion represents a GitHub dicussion in a team
+// TeamDiscussion represents a GitHub dicussion in a team.
 type TeamDiscussion struct {
 	Author        *User      `json:"author,omitempty"`
 	Body          *string    `json:"body,omitempty"`
@@ -36,7 +37,7 @@ func (d TeamDiscussion) String() string {
 }
 
 // DiscussionListOptions specifies optional parameters to the
-// TeamServices.ListDiscussions method
+// TeamServices.ListDiscussions method.
 type DiscussionListOptions struct {
 	// Sorts the discussion by the date they were created.
 	// Accepted values are asc and desc. Default is desc.
@@ -99,6 +100,10 @@ func (s *TeamsService) GetDiscussion(ctx context.Context, team, id int64) (*Team
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussions/#create-a-discussion
 func (s *TeamsService) CreateDiscussion(ctx context.Context, team int64, discussion *TeamDiscussion) (*TeamDiscussion, *Response, error) {
+	if discussion == nil {
+		return nil, nil, errors.New("discussion must be provided")
+	}
+
 	u := fmt.Sprintf("teams/%v/discussions", team)
 	req, err := s.client.NewRequest("POST", u, discussion)
 	if err != nil {
@@ -123,6 +128,10 @@ func (s *TeamsService) CreateDiscussion(ctx context.Context, team int64, discuss
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussions/#edit-a-discussion
 func (s *TeamsService) EditDiscussion(ctx context.Context, team, id int64, discussion *TeamDiscussion) (*TeamDiscussion, *Response, error) {
+	if discussion == nil {
+		return nil, nil, errors.New("discussion must be provided")
+	}
+
 	u := fmt.Sprintf("teams/%v/discussions/%v", team, id)
 	req, err := s.client.NewRequest("PATCH", u, discussion)
 	if err != nil {

--- a/github/teams_discussions_test.go
+++ b/github/teams_discussions_test.go
@@ -140,7 +140,7 @@ func TestTeamsService_CreateDiscussion(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	input := &TeamDiscussion{Title: String("c_t"), Body: String("c_b")}
+	input := TeamDiscussion{Title: String("c_t"), Body: String("c_b")}
 
 	mux.HandleFunc("/teams/2/discussions", func(w http.ResponseWriter, r *http.Request) {
 		v := new(TeamDiscussion)
@@ -148,7 +148,7 @@ func TestTeamsService_CreateDiscussion(t *testing.T) {
 
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", mediaTypeTeamDiscussionsPreview)
-		if !reflect.DeepEqual(v, input) {
+		if !reflect.DeepEqual(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -166,21 +166,11 @@ func TestTeamsService_CreateDiscussion(t *testing.T) {
 	}
 }
 
-func TestTeamsService_CreateDiscussionWithNilDiscussion(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	_, _, err := client.Teams.CreateDiscussion(context.Background(), 2, nil)
-	if err == nil {
-		t.Errorf("Teams.CreateDiscussion must return error with nil Discussion")
-	}
-}
-
 func TestTeamsService_EditDiscussion(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	input := &TeamDiscussion{Title: String("e_t"), Body: String("e_b")}
+	input := TeamDiscussion{Title: String("e_t"), Body: String("e_b")}
 
 	mux.HandleFunc("/teams/2/discussions/3", func(w http.ResponseWriter, r *http.Request) {
 		v := new(TeamDiscussion)
@@ -188,7 +178,7 @@ func TestTeamsService_EditDiscussion(t *testing.T) {
 
 		testMethod(t, r, "PATCH")
 		testHeader(t, r, "Accept", mediaTypeTeamDiscussionsPreview)
-		if !reflect.DeepEqual(v, input) {
+		if !reflect.DeepEqual(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -203,16 +193,6 @@ func TestTeamsService_EditDiscussion(t *testing.T) {
 	want := &TeamDiscussion{Number: Int64(3)}
 	if !reflect.DeepEqual(comment, want) {
 		t.Errorf("Teams.EditDiscussion returned %+v, want %+v", comment, want)
-	}
-}
-
-func TestTeamsService_EditDiscussionWithNilDiscussion(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	_, _, err := client.Teams.EditDiscussion(context.Background(), 2, 3, nil)
-	if err == nil {
-		t.Errorf("Teams.EditDiscussion must return error with nil Discussion")
 	}
 }
 

--- a/github/teams_discussions_test.go
+++ b/github/teams_discussions_test.go
@@ -1,0 +1,212 @@
+// Copyright 2018 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestTeamsService_ListDiscussions(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/teams/2/discussions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeTeamDiscussionsPreview)
+		testFormValues(t, r, values{
+			"direction": "desc",
+		})
+		fmt.Fprintf(w,
+			`[
+				{
+					"author": {
+						"login": "author",
+						"id": 0,
+						"avatar_url": "https://avatars1.githubusercontent.com/u/0?v=4",
+						"gravatar_id": "",
+						"url": "https://api.github.com/users/author",
+						"html_url": "https://github.com/author",
+						"followers_url": "https://api.github.com/users/author/followers",
+						"following_url": "https://api.github.com/users/author/following{/other_user}",
+						"gists_url": "https://api.github.com/users/author/gists{/gist_id}",
+						"starred_url": "https://api.github.com/users/author/starred{/owner}{/repo}",
+						"subscriptions_url": "https://api.github.com/users/author/subscriptions",
+						"organizations_url": "https://api.github.com/users/author/orgs",
+						"repos_url": "https://api.github.com/users/author/repos",
+						"events_url": "https://api.github.com/users/author/events{/privacy}",
+						"received_events_url": "https://api.github.com/users/author/received_events",
+						"type": "User",
+						"site_admin": false
+					},
+					"body": "test",
+					"body_html": "<p>test</p>",
+					"body_version": "version",
+					"comments_count": 1,
+					"comments_url": "https://api.github.com/teams/2/discussions/3/comments",
+					"created_at": "2018-01-01T00:00:00Z",
+					"last_edited_at": null,
+					"html_url": "https://github.com/orgs/1/teams/2/discussions/3",
+					"node_id": "node",
+					"number": 3,
+					"pinned": false,
+					"private": false,
+					"team_url": "https://api.github.com/teams/2",
+					"title": "test",
+					"updated_at": "2018-01-01T00:00:00Z",
+					"url": "https://api.github.com/teams/2/discussions/3"
+				}
+			]`)
+	})
+	discussions, _, err := client.Teams.ListDiscussions(context.Background(), 2, &DiscussionListOptions{"desc"})
+	if err != nil {
+		t.Errorf("Teams.ListDiscussions returned error: %v", err)
+	}
+
+	want := []*TeamDiscussion{
+		{
+			Author: &User{
+				Login:             String("author"),
+				ID:                Int64(0),
+				AvatarURL:         String("https://avatars1.githubusercontent.com/u/0?v=4"),
+				GravatarID:        String(""),
+				URL:               String("https://api.github.com/users/author"),
+				HTMLURL:           String("https://github.com/author"),
+				FollowersURL:      String("https://api.github.com/users/author/followers"),
+				FollowingURL:      String("https://api.github.com/users/author/following{/other_user}"),
+				GistsURL:          String("https://api.github.com/users/author/gists{/gist_id}"),
+				StarredURL:        String("https://api.github.com/users/author/starred{/owner}{/repo}"),
+				SubscriptionsURL:  String("https://api.github.com/users/author/subscriptions"),
+				OrganizationsURL:  String("https://api.github.com/users/author/orgs"),
+				ReposURL:          String("https://api.github.com/users/author/repos"),
+				EventsURL:         String("https://api.github.com/users/author/events{/privacy}"),
+				ReceivedEventsURL: String("https://api.github.com/users/author/received_events"),
+				Type:              String("User"),
+				SiteAdmin:         Bool(false),
+			},
+			Body:          String("test"),
+			BodyHTML:      String("<p>test</p>"),
+			BodyVersion:   String("version"),
+			CommentsCount: Int64(1),
+			CommentsURL:   String("https://api.github.com/teams/2/discussions/3/comments"),
+			CreatedAt:     &Timestamp{time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
+			LastEditedAt:  nil,
+			HTMLURL:       String("https://github.com/orgs/1/teams/2/discussions/3"),
+			NodeID:        String("node"),
+			Number:        Int64(3),
+			Pinned:        Bool(false),
+			Private:       Bool(false),
+			TeamURL:       String("https://api.github.com/teams/2"),
+			Title:         String("test"),
+			UpdatedAt:     &Timestamp{time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
+			URL:           String("https://api.github.com/teams/2/discussions/3"),
+		},
+	}
+	if !reflect.DeepEqual(discussions, want) {
+		t.Errorf("Teams.ListDiscussions returned %+v, want %+v", discussions, want)
+	}
+}
+
+func TestTeamsService_GetDiscussion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/teams/2/discussions/3", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeTeamDiscussionsPreview)
+		fmt.Fprint(w, `{"number":3}`)
+	})
+
+	discussion, _, err := client.Teams.GetDiscussion(context.Background(), 2, 3)
+	if err != nil {
+		t.Errorf("Teams.GetDiscussion returned error: %v", err)
+	}
+
+	want := &TeamDiscussion{Number: Int64(3)}
+	if !reflect.DeepEqual(discussion, want) {
+		t.Errorf("Teams.GetDiscussion returned %+v, want %+v", discussion, want)
+	}
+}
+
+func TestTeamsService_CreateDiscussion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &TeamDiscussion{Title: String("c_t"), Body: String("c_b")}
+
+	mux.HandleFunc("/teams/2/discussions", func(w http.ResponseWriter, r *http.Request) {
+		v := new(TeamDiscussion)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeTeamDiscussionsPreview)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		fmt.Fprint(w, `{"number":3}`)
+	})
+
+	comment, _, err := client.Teams.CreateDiscussion(context.Background(), 2, input)
+	if err != nil {
+		t.Errorf("Teams.CreateDiscussion returned error: %v", err)
+	}
+
+	want := &TeamDiscussion{Number: Int64(3)}
+	if !reflect.DeepEqual(comment, want) {
+		t.Errorf("Teams.CreateDiscussion returned %+v, want %+v", comment, want)
+	}
+}
+
+func TestTeamsService_EditDiscussion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &TeamDiscussion{Title: String("e_t"), Body: String("e_b")}
+
+	mux.HandleFunc("/teams/2/discussions/3", func(w http.ResponseWriter, r *http.Request) {
+		v := new(TeamDiscussion)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "PATCH")
+		testHeader(t, r, "Accept", mediaTypeTeamDiscussionsPreview)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		fmt.Fprint(w, `{"number":3}`)
+	})
+
+	comment, _, err := client.Teams.EditDiscussion(context.Background(), 2, 3, input)
+	if err != nil {
+		t.Errorf("Teams.EditDiscussion returned error: %v", err)
+	}
+
+	want := &TeamDiscussion{Number: Int64(3)}
+	if !reflect.DeepEqual(comment, want) {
+		t.Errorf("Teams.EditDiscussion returned %+v, want %+v", comment, want)
+	}
+}
+
+func TestTeamsService_DeleteDiscussion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/teams/2/discussions/3", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testHeader(t, r, "Accept", mediaTypeTeamDiscussionsPreview)
+	})
+
+	_, err := client.Teams.DeleteDiscussion(context.Background(), 2, 3)
+	if err != nil {
+		t.Errorf("Teams.DeleteDiscussion returned error: %v", err)
+	}
+}

--- a/github/teams_discussions_test.go
+++ b/github/teams_discussions_test.go
@@ -166,6 +166,16 @@ func TestTeamsService_CreateDiscussion(t *testing.T) {
 	}
 }
 
+func TestTeamsService_CreateDiscussionWithNilDiscussion(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, _, err := client.Teams.CreateDiscussion(context.Background(), 2, nil)
+	if err == nil {
+		t.Errorf("Teams.CreateDiscussion must return error with nil Discussion")
+	}
+}
+
 func TestTeamsService_EditDiscussion(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
@@ -193,6 +203,16 @@ func TestTeamsService_EditDiscussion(t *testing.T) {
 	want := &TeamDiscussion{Number: Int64(3)}
 	if !reflect.DeepEqual(comment, want) {
 		t.Errorf("Teams.EditDiscussion returned %+v, want %+v", comment, want)
+	}
+}
+
+func TestTeamsService_EditDiscussionWithNilDiscussion(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, _, err := client.Teams.EditDiscussion(context.Background(), 2, 3, nil)
+	if err == nil {
+		t.Errorf("Teams.EditDiscussion must return error with nil Discussion")
 	}
 }
 


### PR DESCRIPTION
- Add a new service TeamsService to support API related to Organization Teams https://developer.github.com/v3/teams/
- Add methods to support new preview API for team discussions https://developer.github.com/v3/teams/discussions/
- Add methods to support new preview API for team discussion comments https://developer.github.com/v3/teams/discussion_comments/

Fixes #849 
https://developer.github.com/changes/2018-02-07-team-discussions-api/#new-rest-api-endpoints

Second part of the change https://developer.github.com/changes/2018-02-07-team-discussions-api/#updates-to-the-teams-api-documentation will be done in a separate PR, once this PR is merged.