### PR TITLE
Add pull_request_review_id field to PullRequestComment (Fixes #897)

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6309,7 +6309,7 @@ func (p *PullRequestComment) GetPosition() int {
 }
 
 // GetPullRequestReviewID returns the PullRequestReviewID field if it's non-nil, zero value otherwise.
-func (p *PullRequestComment) GetPullRequestReviewID() int {
+func (p *PullRequestComment) GetPullRequestReviewID() int64 {
 	if p == nil || p.PullRequestReviewID == nil {
 		return 0
 	}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6308,6 +6308,14 @@ func (p *PullRequestComment) GetPosition() int {
 	return *p.Position
 }
 
+// GetPullRequestReviewID returns the PullRequestReviewID field if it's non-nil, zero value otherwise.
+func (p *PullRequestComment) GetPullRequestReviewID() int {
+	if p == nil || p.PullRequestReviewID == nil {
+		return 0
+	}
+	return *p.PullRequestReviewID
+}
+
 // GetPullRequestURL returns the PullRequestURL field if it's non-nil, zero value otherwise.
 func (p *PullRequestComment) GetPullRequestURL() string {
 	if p == nil || p.PullRequestURL == nil {

--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -13,19 +13,20 @@ import (
 
 // PullRequestComment represents a comment left on a pull request.
 type PullRequestComment struct {
-	ID               *int64     `json:"id,omitempty"`
-	InReplyTo        *int64     `json:"in_reply_to,omitempty"`
-	Body             *string    `json:"body,omitempty"`
-	Path             *string    `json:"path,omitempty"`
-	DiffHunk         *string    `json:"diff_hunk,omitempty"`
-	Position         *int       `json:"position,omitempty"`
-	OriginalPosition *int       `json:"original_position,omitempty"`
-	CommitID         *string    `json:"commit_id,omitempty"`
-	OriginalCommitID *string    `json:"original_commit_id,omitempty"`
-	User             *User      `json:"user,omitempty"`
-	Reactions        *Reactions `json:"reactions,omitempty"`
-	CreatedAt        *time.Time `json:"created_at,omitempty"`
-	UpdatedAt        *time.Time `json:"updated_at,omitempty"`
+	ID                  *int64     `json:"id,omitempty"`
+	InReplyTo           *int64     `json:"in_reply_to,omitempty"`
+	Body                *string    `json:"body,omitempty"`
+	Path                *string    `json:"path,omitempty"`
+	DiffHunk            *string    `json:"diff_hunk,omitempty"`
+	PullRequestReviewID *int       `json:"pull_request_review_id,omitempty"`
+	Position            *int       `json:"position,omitempty"`
+	OriginalPosition    *int       `json:"original_position,omitempty"`
+	CommitID            *string    `json:"commit_id,omitempty"`
+	OriginalCommitID    *string    `json:"original_commit_id,omitempty"`
+	User                *User      `json:"user,omitempty"`
+	Reactions           *Reactions `json:"reactions,omitempty"`
+	CreatedAt           *time.Time `json:"created_at,omitempty"`
+	UpdatedAt           *time.Time `json:"updated_at,omitempty"`
 	// AuthorAssociation is the comment author's relationship to the pull request's repository.
 	// Possible values are "COLLABORATOR", "CONTRIBUTOR", "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "MEMBER", "OWNER", or "NONE".
 	AuthorAssociation *string `json:"author_association,omitempty"`

--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -18,7 +18,7 @@ type PullRequestComment struct {
 	Body                *string    `json:"body,omitempty"`
 	Path                *string    `json:"path,omitempty"`
 	DiffHunk            *string    `json:"diff_hunk,omitempty"`
-	PullRequestReviewID *int       `json:"pull_request_review_id,omitempty"`
+	PullRequestReviewID *int64     `json:"pull_request_review_id,omitempty"`
 	Position            *int       `json:"position,omitempty"`
 	OriginalPosition    *int       `json:"original_position,omitempty"`
 	CommitID            *string    `json:"commit_id,omitempty"`

--- a/github/pulls_comments_test.go
+++ b/github/pulls_comments_test.go
@@ -55,7 +55,7 @@ func TestPullRequestsService_ListComments_specificPull(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/pulls/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
-		fmt.Fprint(w, `[{"id":1, "pull_request_review_id": 42}]`)
+		fmt.Fprint(w, `[{"id":1, "pull_request_review_id":42}]`)
 	})
 
 	pulls, _, err := client.PullRequests.ListComments(context.Background(), "o", "r", 1, nil)

--- a/github/pulls_comments_test.go
+++ b/github/pulls_comments_test.go
@@ -63,7 +63,7 @@ func TestPullRequestsService_ListComments_specificPull(t *testing.T) {
 		t.Errorf("PullRequests.ListComments returned error: %v", err)
 	}
 
-	want := []*PullRequestComment{{ID: Int64(1), PullRequestReviewID: Int(42)}}
+	want := []*PullRequestComment{{ID: Int64(1), PullRequestReviewID: Int64(42)}}
 	if !reflect.DeepEqual(pulls, want) {
 		t.Errorf("PullRequests.ListComments returned %+v, want %+v", pulls, want)
 	}

--- a/github/pulls_comments_test.go
+++ b/github/pulls_comments_test.go
@@ -55,7 +55,7 @@ func TestPullRequestsService_ListComments_specificPull(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/pulls/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
-		fmt.Fprint(w, `[{"id":1}]`)
+		fmt.Fprint(w, `[{"id":1, "pull_request_review_id": 42}]`)
 	})
 
 	pulls, _, err := client.PullRequests.ListComments(context.Background(), "o", "r", 1, nil)
@@ -63,7 +63,7 @@ func TestPullRequestsService_ListComments_specificPull(t *testing.T) {
 		t.Errorf("PullRequests.ListComments returned error: %v", err)
 	}
 
-	want := []*PullRequestComment{{ID: Int64(1)}}
+	want := []*PullRequestComment{{ID: Int64(1), PullRequestReviewID: Int(42)}}
 	if !reflect.DeepEqual(pulls, want) {
 		t.Errorf("PullRequests.ListComments returned %+v, want %+v", pulls, want)
 	}


### PR DESCRIPTION
Closes: #897
This PR adds the  'pull_request_review_id' field to PullRequestComment as requested in #897 