### PR TITLE
change org id to int64 in OrganizationsListOptions

### DIFF
--- a/github/orgs.go
+++ b/github/orgs.go
@@ -75,7 +75,7 @@ func (p Plan) String() string {
 // OrganizationsService.ListAll method.
 type OrganizationsListOptions struct {
 	// Since filters Organizations by ID.
-	Since int `url:"since,omitempty"`
+	Since int64 `url:"since,omitempty"`
 
 	ListOptions
 }

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -18,7 +18,7 @@ func TestOrganizationsService_ListAll(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	since := 1342004
+	since := int64(1342004)
 	mux.HandleFunc("/organizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeGraphQLNodeIDPreview)


### PR DESCRIPTION
Change org ID in OrganizationsListOptions to be consistent with the [org id type](https://github.com/google/go-github/blob/master/github/orgs.go#L23)