### PR TITLE
Documentation update for 'OrganizationsListOptions' and 'UserListOptions' (#900)

### DIFF
--- a/github/orgs.go
+++ b/github/orgs.go
@@ -77,6 +77,9 @@ type OrganizationsListOptions struct {
 	// Since filters Organizations by ID.
 	Since int64 `url:"since,omitempty"`
 
+	// Note: Pagination is powered exclusively by the Since parameter,
+	// ListOptions.Page has no effect.
+	// ListOptions.PerPage controls an undocumented GitHub API parameter.
 	ListOptions
 }
 

--- a/github/users.go
+++ b/github/users.go
@@ -140,6 +140,9 @@ type UserListOptions struct {
 	// ID of the last user seen
 	Since int64 `url:"since,omitempty"`
 
+	// Note: Pagination is powered exclusively by the Since parameter,
+	// ListOptions.Page has no effect.
+	// ListOptions.PerPage controls an undocumented GitHub API parameter.
 	ListOptions
 }
 


### PR DESCRIPTION
This PR adds the following note:

- Pagination is powered exclusively by the Since parameter,
- ListOptions.Page has no effect.
- ListOptions.PerPage controls an undocumented GitHub API parameter.

Fix bug #900