### PR TITLE
Adds DiffURL and PatchURL to CommitsComparison

### DIFF
--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -76,6 +76,9 @@ type CommitsComparison struct {
 	BehindBy     *int    `json:"behind_by,omitempty"`
 	TotalCommits *int    `json:"total_commits,omitempty"`
 
+	DiffURL  *string `json:"diff_url,omitempty"`
+	PatchURL *string `json:"patch_url,omitempty"`
+
 	Commits []RepositoryCommit `json:"commits,omitempty"`
 
 	Files []CommitFile `json:"files,omitempty"`


### PR DESCRIPTION
These fields are documented in
https://developer.github.com/v3/repos/commits/#compare-two-commits

