### PR TITLE
README: Update for githubql package rename.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ go-github is a Go client library for accessing the [GitHub API v3][].
 go-github requires Go version 1.7 or greater.
 
 If you're interested in using the [GraphQL API v4][], the recommended library is
-[shurcooL/githubql][].
+[shurcooL/githubv4][].
 
 ## Usage ##
 
@@ -213,7 +213,7 @@ For complete usage of go-github, see the full [package docs][].
 [personal API token]: https://github.com/blog/1509-personal-api-tokens
 [package docs]: https://godoc.org/github.com/google/go-github/github
 [GraphQL API v4]: https://developer.github.com/v4/
-[shurcooL/githubql]: https://github.com/shurcooL/githubql
+[shurcooL/githubv4]: https://github.com/shurcooL/githubv4
 
 ### Integration Tests ###
 


### PR DESCRIPTION
Follows https://github.com/shurcooL/githubv4/commit/19298c78142b5fe80c2cdaa2091bc51cbc3a94fc.

Updates shurcooL/githubv4#35.