### PR TITLE
Add Truncated field to Tree

### DIFF
--- a/github/git_trees.go
+++ b/github/git_trees.go
@@ -14,6 +14,12 @@ import (
 type Tree struct {
 	SHA     *string     `json:"sha,omitempty"`
 	Entries []TreeEntry `json:"tree,omitempty"`
+
+	// Truncated is true if the number of items in the tree
+	// exceeded GitHub's maximum limit and the Entries were truncated
+	// in the response. Only populated for requests that fetch
+	// trees like Git.GetTree.
+	Truncated *bool `json:"truncated,omitempty"`
 }
 
 func (t Tree) String() string {

--- a/github/git_trees_test.go
+++ b/github/git_trees_test.go
@@ -22,7 +22,8 @@ func TestGitService_GetTree(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
 			  "sha": "s",
-			  "tree": [ { "type": "blob" } ]
+			  "tree": [ { "type": "blob" } ],
+			  "truncated": true
 			}`)
 	})
 
@@ -38,6 +39,7 @@ func TestGitService_GetTree(t *testing.T) {
 				Type: String("blob"),
 			},
 		},
+		Truncated: Bool(true),
 	}
 	if !reflect.DeepEqual(*tree, want) {
 		t.Errorf("Tree.Get returned %+v, want %+v", *tree, want)
@@ -109,6 +111,7 @@ func TestGitService_CreateTree(t *testing.T) {
 				SHA:  String("7c258a9869f33c1e1e1f74fbb32f07c86cb5a75b"),
 			},
 		},
+		nil,
 	}
 
 	if !reflect.DeepEqual(*tree, want) {
@@ -175,6 +178,7 @@ func TestGitService_CreateTree_Content(t *testing.T) {
 				URL:  String("https://api.github.com/repos/o/r/git/blobs/aad8feacf6f8063150476a7b2bd9770f2794c08b"),
 			},
 		},
+		nil,
 	}
 
 	if !reflect.DeepEqual(*tree, want) {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -10188,6 +10188,14 @@ func (t *Tree) GetSHA() string {
 	return *t.SHA
 }
 
+// GetTruncated returns the Truncated field if it's non-nil, zero value otherwise.
+func (t *Tree) GetTruncated() bool {
+	if t == nil || t.Truncated == nil {
+		return false
+	}
+	return *t.Truncated
+}
+
 // GetContent returns the Content field if it's non-nil, zero value otherwise.
 func (t *TreeEntry) GetContent() string {
 	if t == nil || t.Content == nil {


### PR DESCRIPTION
Makes it so that the "Truncated" field provided by the response
to the GetTree call is properly populated.

Fixes #922