### PR TITLE
typo missing space

### DIFF
--- a/github/admin_stats.go
+++ b/github/admin_stats.go
@@ -108,7 +108,7 @@ func (s UserStats) String() string {
 	return Stringify(s)
 }
 
-//GistStats represents the number of total, private and public gists.
+// GistStats represents the number of total, private and public gists.
 type GistStats struct {
 	TotalGists   *int `json:"total_gists,omitempty"`
 	PrivateGists *int `json:"private_gists,omitempty"`


### PR DESCRIPTION
It's just for consistency with the other comments in the code.