### PR TITLE
remove addition of preview Accept headers in RepositoriesService.ListByOrg (repos.go)

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -216,10 +216,6 @@ func (s *RepositoriesService) ListByOrg(ctx context.Context, org string, opt *Re
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeCodesOfConductPreview, mediaTypeTopicsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
-
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)
 	if err != nil {

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -113,10 +113,8 @@ func TestRepositoriesService_ListByOrg(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	acceptHeaders := []string{mediaTypeCodesOfConductPreview, mediaTypeTopicsPreview}
 	mux.HandleFunc("/orgs/o/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(acceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"type": "forks",
 			"page": "2",


### PR DESCRIPTION
Fixes #930.

The change in this PR removes the mediaTypeLicensesPreview, mediaTypeCodesOfConductPreview,
and mediaTypeTopicsPreview in RepositoriesService.ListByOrg calls to prevent the GHE errors.  It's fine if you reject it in case it is too drastic or breaks other users' code, but it would be great to find a solution.