### PR TITLE
Update the transfer repository request to use the correct json name

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -1018,7 +1018,7 @@ func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo 
 // TransferRequest represents a request to transfer a repository.
 type TransferRequest struct {
 	NewOwner string  `json:"new_owner"`
-	TeamID   []int64 `json:"team_id,omitempty"`
+	TeamID   []int64 `json:"team_ids,omitempty"`
 }
 
 // Transfer transfers a repository from one account or organization to another.


### PR DESCRIPTION
...for team IDs.

I didn't change the variable name to keep consistent with the [create org invitation options](https://github.com/google/go-github/blob/74e913d8de3209e490c76b099d574e033bdcf717/github/orgs_members.go#L318).

Fixes #946