### PR TITLE
Fix InReplyToID JSON tag for PullRequestComment

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6364,12 +6364,12 @@ func (p *PullRequestComment) GetID() int64 {
 	return *p.ID
 }
 
-// GetInReplyToID returns the InReplyToID field if it's non-nil, zero value otherwise.
-func (p *PullRequestComment) GetInReplyToID() int64 {
-	if p == nil || p.InReplyToID == nil {
+// GetInReplyTo returns the InReplyTo field if it's non-nil, zero value otherwise.
+func (p *PullRequestComment) GetInReplyTo() int64 {
+	if p == nil || p.InReplyTo == nil {
 		return 0
 	}
-	return *p.InReplyToID
+	return *p.InReplyTo
 }
 
 // GetOriginalCommitID returns the OriginalCommitID field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6364,12 +6364,12 @@ func (p *PullRequestComment) GetID() int64 {
 	return *p.ID
 }
 
-// GetInReplyTo returns the InReplyTo field if it's non-nil, zero value otherwise.
-func (p *PullRequestComment) GetInReplyTo() int64 {
-	if p == nil || p.InReplyTo == nil {
+// GetInReplyToID returns the InReplyToID field if it's non-nil, zero value otherwise.
+func (p *PullRequestComment) GetInReplyToID() int64 {
+	if p == nil || p.InReplyToID == nil {
 		return 0
 	}
-	return *p.InReplyTo
+	return *p.InReplyToID
 }
 
 // GetOriginalCommitID returns the OriginalCommitID field if it's non-nil, zero value otherwise.

--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -14,7 +14,7 @@ import (
 // PullRequestComment represents a comment left on a pull request.
 type PullRequestComment struct {
 	ID                  *int64     `json:"id,omitempty"`
-	InReplyToID         *int64     `json:"in_reply_to_id,omitempty"`
+	InReplyTo           *int64     `json:"in_reply_to_id,omitempty"`
 	Body                *string    `json:"body,omitempty"`
 	Path                *string    `json:"path,omitempty"`
 	DiffHunk            *string    `json:"diff_hunk,omitempty"`
@@ -115,37 +115,33 @@ func (s *PullRequestsService) GetComment(ctx context.Context, owner string, repo
 // GitHub API docs: https://developer.github.com/v3/pulls/comments/#create-a-comment
 func (s *PullRequestsService) CreateComment(ctx context.Context, owner string, repo string, number int, comment *PullRequestComment) (*PullRequestComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/comments", owner, repo, number)
-
-	// pullRequestCreateComment is an alias to PullRequestComment that corrects the InReplyToID field tag from `in_reply_to_id` to `in_reply_to`.
-	type pullRequestCreateComment struct {
-		ID                  *int64     `json:"id,omitempty"`
-		InReplyToID         *int64     `json:"in_reply_to,omitempty"`
-		Body                *string    `json:"body,omitempty"`
-		Path                *string    `json:"path,omitempty"`
-		DiffHunk            *string    `json:"diff_hunk,omitempty"`
-		PullRequestReviewID *int64     `json:"pull_request_review_id,omitempty"`
-		Position            *int       `json:"position,omitempty"`
-		OriginalPosition    *int       `json:"original_position,omitempty"`
-		CommitID            *string    `json:"commit_id,omitempty"`
-		OriginalCommitID    *string    `json:"original_commit_id,omitempty"`
-		User                *User      `json:"user,omitempty"`
-		Reactions           *Reactions `json:"reactions,omitempty"`
-		CreatedAt           *time.Time `json:"created_at,omitempty"`
-		UpdatedAt           *time.Time `json:"updated_at,omitempty"`
-		// AuthorAssociation is the comment author's relationship to the pull request's repository.
-		// Possible values are "COLLABORATOR", "CONTRIBUTOR", "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "MEMBER", "OWNER", or "NONE".
-		AuthorAssociation *string `json:"author_association,omitempty"`
-		URL               *string `json:"url,omitempty"`
-		HTMLURL           *string `json:"html_url,omitempty"`
-		PullRequestURL    *string `json:"pull_request_url,omitempty"`
-	}
-	var alias *pullRequestCreateComment
-	if comment != nil {
-		a := pullRequestCreateComment(*comment)
-		alias = &a
+	req, err := s.client.NewRequest("POST", u, comment)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("POST", u, alias)
+	c := new(PullRequestComment)
+	resp, err := s.client.Do(ctx, req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, nil
+}
+
+// CreateCommentInReplyTo creates a new comment as a reply to an existing pull request comment.
+//
+// GitHub API docs: https://developer.github.com/v3/pulls/comments/#alternative-input
+func (s *PullRequestsService) CreateCommentInReplyTo(ctx context.Context, owner string, repo string, number int, body string, commentID int64) (*PullRequestComment, *Response, error) {
+	comment := &struct {
+		Body      string `json:"body,omitempty"`
+		InReplyTo int64  `json:"in_reply_to,omitempty"`
+	}{
+		Body:      body,
+		InReplyTo: commentID,
+	}
+	u := fmt.Sprintf("repos/%v/%v/pulls/%d/comments", owner, repo, number)
+	req, err := s.client.NewRequest("POST", u, comment)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -14,7 +14,7 @@ import (
 // PullRequestComment represents a comment left on a pull request.
 type PullRequestComment struct {
 	ID                  *int64     `json:"id,omitempty"`
-	InReplyTo           *int64     `json:"in_reply_to,omitempty"`
+	InReplyToID         *int64     `json:"in_reply_to_id,omitempty"`
 	Body                *string    `json:"body,omitempty"`
 	Path                *string    `json:"path,omitempty"`
 	DiffHunk            *string    `json:"diff_hunk,omitempty"`
@@ -115,7 +115,37 @@ func (s *PullRequestsService) GetComment(ctx context.Context, owner string, repo
 // GitHub API docs: https://developer.github.com/v3/pulls/comments/#create-a-comment
 func (s *PullRequestsService) CreateComment(ctx context.Context, owner string, repo string, number int, comment *PullRequestComment) (*PullRequestComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/comments", owner, repo, number)
-	req, err := s.client.NewRequest("POST", u, comment)
+
+	// pullRequestCreateComment is an alias to PullRequestComment that corrects the InReplyToID field tag from `in_reply_to_id` to `in_reply_to`.
+	type pullRequestCreateComment struct {
+		ID                  *int64     `json:"id,omitempty"`
+		InReplyToID         *int64     `json:"in_reply_to,omitempty"`
+		Body                *string    `json:"body,omitempty"`
+		Path                *string    `json:"path,omitempty"`
+		DiffHunk            *string    `json:"diff_hunk,omitempty"`
+		PullRequestReviewID *int64     `json:"pull_request_review_id,omitempty"`
+		Position            *int       `json:"position,omitempty"`
+		OriginalPosition    *int       `json:"original_position,omitempty"`
+		CommitID            *string    `json:"commit_id,omitempty"`
+		OriginalCommitID    *string    `json:"original_commit_id,omitempty"`
+		User                *User      `json:"user,omitempty"`
+		Reactions           *Reactions `json:"reactions,omitempty"`
+		CreatedAt           *time.Time `json:"created_at,omitempty"`
+		UpdatedAt           *time.Time `json:"updated_at,omitempty"`
+		// AuthorAssociation is the comment author's relationship to the pull request's repository.
+		// Possible values are "COLLABORATOR", "CONTRIBUTOR", "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "MEMBER", "OWNER", or "NONE".
+		AuthorAssociation *string `json:"author_association,omitempty"`
+		URL               *string `json:"url,omitempty"`
+		HTMLURL           *string `json:"html_url,omitempty"`
+		PullRequestURL    *string `json:"pull_request_url,omitempty"`
+	}
+	var alias *pullRequestCreateComment
+	if comment != nil {
+		a := pullRequestCreateComment(*comment)
+		alias = &a
+	}
+
+	req, err := s.client.NewRequest("POST", u, alias)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Fixes #948.

The JSON tag mismatches the one returned from the API, so the value is always encoded as nil.

Relevant docs: https://developer.github.com/v3/pulls/comments/#get-a-single-comment

Also have to use an alias since the JSON tag is different between getting a comment and creating a comment.

I'd be keen to see if there's a more elegant way to do this.