### PR TITLE
fix go vet error with go1.11

### DIFF
--- a/github/misc_test.go
+++ b/github/misc_test.go
@@ -147,6 +147,7 @@ func TestAPIMeta(t *testing.T) {
 		Git:      []string{"g"},
 		Pages:    []string{"p"},
 		Importer: []string{"i"},
+
 		VerifiablePasswordAuthentication: Bool(true),
 	}
 	if !reflect.DeepEqual(want, meta) {

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -56,15 +56,26 @@ func TestRepositoryContent_GetContent(t *testing.T) {
 		r := RepositoryContent{Encoding: tt.encoding, Content: tt.content}
 		got, err := r.GetContent()
 		if err != nil && !tt.wantErr {
-			t.Errorf("RepositoryContent(%q, %q) returned unexpected error: %v", tt.encoding, tt.content, err)
+			t.Errorf("RepositoryContent(%s, %s) returned unexpected error: %v",
+				stringOrNil(tt.encoding), stringOrNil(tt.content), err)
 		}
 		if err == nil && tt.wantErr {
-			t.Errorf("RepositoryContent(%q, %q) did not return unexpected error", tt.encoding, tt.content)
+			t.Errorf("RepositoryContent(%s, %s) did not return unexpected error",
+				stringOrNil(tt.encoding), stringOrNil(tt.content))
 		}
 		if want := tt.want; got != want {
 			t.Errorf("RepositoryContent.GetContent returned %+v, want %+v", got, want)
 		}
 	}
+}
+
+// stringOrNil converts a potentially null string pointer to string.
+// For non-nil input pointer, the returned string is enclosed in double-quotes.
+func stringOrNil(s *string) string {
+	if s == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%q", *s)
 }
 
 func TestRepositoriesService_GetReadme(t *testing.T) {


### PR DESCRIPTION
currently builds of the package with go1.11 fail due to using `%q` qualifier with `*string` type in github/repos_contents_test.go:
```
$ go1.11beta2 tool vet .
github/repos_contents_test.go:59: T.Errorf format %q has arg tt.encoding of wrong type *string
github/repos_contents_test.go:62: T.Errorf format %q has arg tt.encoding of wrong type *string
```

In Travis, a number of PR builds fail with `Go:master` ("Allowed failures"), ex. https://travis-ci.org/google/go-github/builds/406237120

PR fixes the issue by treating the cases where tt.enconding and tt.content are nil or not nil separately and adding extra varaibles (`encoding` and `content`) for printing in error messages.  It also adds a workaround for gofmt difference between go1.10 and go1.11  (as in https://github.com/golang/go/issues/26228, Go commit: https://github.com/golang/go/commit/542ea5ad91367d2b40589942cc5757a4d5f43f97) by adding an empty line.