### PR TITLE
Remove unnecessary index.html from a #compare-two-commits url

### DIFF
--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -218,7 +218,7 @@ func (s *RepositoriesService) GetCommitSHA1(ctx context.Context, owner, repo, re
 // CompareCommits compares a range of commits with each other.
 // todo: support media formats - https://github.com/google/go-github/issues/6
 //
-// GitHub API docs: https://developer.github.com/v3/repos/commits/index.html#compare-two-commits
+// GitHub API docs: https://developer.github.com/v3/repos/commits/#compare-two-commits
 func (s *RepositoriesService) CompareCommits(ctx context.Context, owner, repo string, base, head string) (*CommitsComparison, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/compare/%v...%v", owner, repo, base, head)
 


### PR DESCRIPTION
I always try finding the right go-github method by searching the url of a compatible GitHub API Document URL. When I searched `https://developer.github.com/v3/repos/commits/#compare-two-commits`, I found the same URL is specified as `https://developer.github.com/v3/repos/commits/index.html#compare-two-commits` in go-github GoDoc.

I personally think the former one would be better than later one since the url people normally encounter on GitHub API Document is the former one. So I changed it! Thanks! 👍 

