### PR TITLE
Remove redundant dereference of time.Time

### DIFF
--- a/github/timestamp.go
+++ b/github/timestamp.go
@@ -28,9 +28,9 @@ func (t *Timestamp) UnmarshalJSON(data []byte) (err error) {
 	str := string(data)
 	i, err := strconv.ParseInt(str, 10, 64)
 	if err == nil {
-		(*t).Time = time.Unix(i, 0)
+		t.Time = time.Unix(i, 0)
 	} else {
-		(*t).Time, err = time.Parse(`"`+time.RFC3339+`"`, str)
+		t.Time, err = time.Parse(`"`+time.RFC3339+`"`, str)
 	}
 	return
 }


### PR DESCRIPTION
Found by go-critic linter.
Log:
```
check-package: $GOPATH/src/github.com/google/go-github/github/timestamp.go:31:3: underef: could simplify (*t).Time to t.Time
check-package: $GOPATH/src/github.com/google/go-github/github/timestamp.go:33:3: underef: could simplify (*t).Time to t.Time
```

If next suggestions are important too, I can make another PR(or extend current).
```
check-package: $GOPATH/src/github.com/google/go-github/github/activity_notifications_test.go:37:34: namedConst: use time.January instead of 1
check-package: $GOPATH/src/github.com/google/go-github/github/activity_notifications_test.go:38:34: namedConst: use time.March instead of 3
check-package: $GOPATH/src/github.com/google/go-github/github/activity_notifications_test.go:83:88: namedConst: use time.January instead of 1
check-package: $GOPATH/src/github.com/google/go-github/github/activity_notifications_test.go:101:108: namedConst: use time.January instead of 1
check-package: $GOPATH/src/github.com/google/go-github/github/gists_test.go:341:43: namedConst: use time.January instead of 1
check-package: $GOPATH/src/github.com/google/go-github/github/gists_test.go:532:41: namedConst: use time.January instead of 1
check-package: $GOPATH/src/github.com/google/go-github/github/gists_test.go:533:41: namedConst: use time.January instead of 1
check-package: $GOPATH/src/github.com/google/go-github/github/github_test.go:514:27: namedConst: use time.July instead of 7
check-package: $GOPATH/src/github.com/google/go-github/github/github_test.go:546:27: namedConst: use time.July instead of 7
check-package: $GOPATH/src/github.com/google/go-github/github/github_test.go:585:27: namedConst: use time.July instead of 7
check-package: $GOPATH/src/github.com/google/go-github/github/github_test.go:769:42: namedConst: use time.March instead of 3
check-package: $GOPATH/src/github.com/google/go-github/github/github_test.go:870:41: namedConst: use time.July instead of 7
check-package: $GOPATH/src/github.com/google/go-github/github/github_test.go:875:41: namedConst: use time.July instead of 7
check-package: $GOPATH/src/github.com/google/go-github/github/orgs_members_test.go:416:31: namedConst: use time.January instead of 1
check-package: $GOPATH/src/github.com/google/go-github/github/orgs_teams_test.go:631:31: namedConst: use time.January instead of 1
check-package: $GOPATH/src/github.com/google/go-github/github/repos_community_health_test.go:57:31: namedConst: use time.February instead of 2
check-package: $GOPATH/src/github.com/google/go-github/github/repos_stats_test.go:57:44: namedConst: use time.May instead of 5
check-package: $GOPATH/src/github.com/google/go-github/github/repos_stats_test.go:98:38: namedConst: use time.May instead of 5
check-package: $GOPATH/src/github.com/google/go-github/github/repos_stats_test.go:123:41: namedConst: use time.April instead of 4
check-package: $GOPATH/src/github.com/google/go-github/github/strings_test.go:57:30: namedConst: use time.January instead of 1
check-package: $GOPATH/src/github.com/google/go-github/github/strings_test.go:61:31: namedConst: use time.January instead of 1
check-package: $GOPATH/src/github.com/google/go-github/github/timestamp_test.go:23:34: namedConst: use time.January instead of 1
```