### PR TITLE
Installation: Use *Timestamp instead of *time.Time for the benefit of InstallationEvent

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -57,8 +57,8 @@ type Installation struct {
 	RepositorySelection *string                  `json:"repository_selection,omitempty"`
 	Events              []string                 `json:"events,omitempty"`
 	Permissions         *InstallationPermissions `json:"permissions,omitempty"`
-	CreatedAt           *time.Time               `json:"created_at,omitempty"`
-	UpdatedAt           *time.Time               `json:"updated_at,omitempty"`
+	CreatedAt           *Timestamp               `json:"created_at,omitempty"`
+	UpdatedAt           *Timestamp               `json:"updated_at,omitempty"`
 }
 
 func (i Installation) String() string {

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -95,7 +95,7 @@ func TestAppsService_ListInstallations(t *testing.T) {
 		t.Errorf("Apps.ListInstallations returned error: %v", err)
 	}
 
-	date := time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC)
+	date := Timestamp{Time: time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC)}
 	want := []*Installation{{
 		ID:                  Int64(1),
 		AppID:               Int64(1),

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -3357,9 +3357,9 @@ func (i *Installation) GetAppID() int64 {
 }
 
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
-func (i *Installation) GetCreatedAt() time.Time {
+func (i *Installation) GetCreatedAt() Timestamp {
 	if i == nil || i.CreatedAt == nil {
-		return time.Time{}
+		return Timestamp{}
 	}
 	return *i.CreatedAt
 }
@@ -3429,9 +3429,9 @@ func (i *Installation) GetTargetType() string {
 }
 
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
-func (i *Installation) GetUpdatedAt() time.Time {
+func (i *Installation) GetUpdatedAt() Timestamp {
 	if i == nil || i.UpdatedAt == nil {
-		return time.Time{}
+		return Timestamp{}
 	}
 	return *i.UpdatedAt
 }


### PR DESCRIPTION
According to https://developer.github.com/v3/activity/events/types/#installationevent the `created_at` and `updated_at` timestamps in the event payloads are unix-formatted, while the CRUD APIs use RFC3339. Using `*Timestamp` handles the unfortunate fact that the API is inconsistent. Without this change, my application emits the following error
```
failed to unmarshal PullRequestEvent: parsing time "1533435666" as ""2006-01-02T15:04:05Z07:00"": cannot parse "1533435666" as """
```

I understand this might be a breaking change to the public API, so I'm open to feedback if there are alternative ways to proceed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/go-github/965)
<!-- Reviewable:end -->
