### PR TITLE
projects: Add missing fields to struct

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6140,6 +6140,14 @@ func (p *Project) GetBody() string {
 	return *p.Body
 }
 
+// GetColumnsURL returns the ColumnsURL field if it's non-nil, zero value otherwise.
+func (p *Project) GetColumnsURL() string {
+	if p == nil || p.ColumnsURL == nil {
+		return ""
+	}
+	return *p.ColumnsURL
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (p *Project) GetCreatedAt() Timestamp {
 	if p == nil || p.CreatedAt == nil {
@@ -6154,6 +6162,14 @@ func (p *Project) GetCreator() *User {
 		return nil
 	}
 	return p.Creator
+}
+
+// GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
+func (p *Project) GetHTMLURL() string {
+	if p == nil || p.HTMLURL == nil {
+		return ""
+	}
+	return *p.HTMLURL
 }
 
 // GetID returns the ID field if it's non-nil, zero value otherwise.
@@ -6194,6 +6210,14 @@ func (p *Project) GetOwnerURL() string {
 		return ""
 	}
 	return *p.OwnerURL
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (p *Project) GetState() string {
+	if p == nil || p.State == nil {
+		return ""
+	}
+	return *p.State
 }
 
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
@@ -6380,6 +6404,14 @@ func (p *ProjectCardOptions) GetArchived() bool {
 	return *p.Archived
 }
 
+// GetCardsURL returns the CardsURL field if it's non-nil, zero value otherwise.
+func (p *ProjectColumn) GetCardsURL() string {
+	if p == nil || p.CardsURL == nil {
+		return ""
+	}
+	return *p.CardsURL
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (p *ProjectColumn) GetCreatedAt() Timestamp {
 	if p == nil || p.CreatedAt == nil {
@@ -6426,6 +6458,14 @@ func (p *ProjectColumn) GetUpdatedAt() Timestamp {
 		return Timestamp{}
 	}
 	return *p.UpdatedAt
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (p *ProjectColumn) GetURL() string {
+	if p == nil || p.URL == nil {
+		return ""
+	}
+	return *p.URL
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
@@ -6546,6 +6586,46 @@ func (p *ProjectEvent) GetSender() *User {
 		return nil
 	}
 	return p.Sender
+}
+
+// GetBody returns the Body field if it's non-nil, zero value otherwise.
+func (p *ProjectOptions) GetBody() string {
+	if p == nil || p.Body == nil {
+		return ""
+	}
+	return *p.Body
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (p *ProjectOptions) GetName() string {
+	if p == nil || p.Name == nil {
+		return ""
+	}
+	return *p.Name
+}
+
+// GetOrganizationPermission returns the OrganizationPermission field if it's non-nil, zero value otherwise.
+func (p *ProjectOptions) GetOrganizationPermission() string {
+	if p == nil || p.OrganizationPermission == nil {
+		return ""
+	}
+	return *p.OrganizationPermission
+}
+
+// GetPublic returns the Public field if it's non-nil, zero value otherwise.
+func (p *ProjectOptions) GetPublic() bool {
+	if p == nil || p.Public == nil {
+		return false
+	}
+	return *p.Public
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (p *ProjectOptions) GetState() string {
+	if p == nil || p.State == nil {
+		return ""
+	}
+	return *p.State
 }
 
 // GetEnforceAdmins returns the EnforceAdmins field.

--- a/github/orgs_projects_test.go
+++ b/github/orgs_projects_test.go
@@ -41,7 +41,7 @@ func TestOrganizationsService_CreateProject(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	input := &ProjectOptions{Name: "Project Name", Body: "Project body."}
+	input := &ProjectOptions{Name: String("Project Name"), Body: String("Project body.")}
 
 	mux.HandleFunc("/orgs/o/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/github/projects.go
+++ b/github/projects.go
@@ -19,15 +19,18 @@ type ProjectsService service
 
 // Project represents a GitHub Project.
 type Project struct {
-	ID        *int64     `json:"id,omitempty"`
-	URL       *string    `json:"url,omitempty"`
-	OwnerURL  *string    `json:"owner_url,omitempty"`
-	Name      *string    `json:"name,omitempty"`
-	Body      *string    `json:"body,omitempty"`
-	Number    *int       `json:"number,omitempty"`
-	CreatedAt *Timestamp `json:"created_at,omitempty"`
-	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
-	NodeID    *string    `json:"node_id,omitempty"`
+	ID         *int64     `json:"id,omitempty"`
+	URL        *string    `json:"url,omitempty"`
+	HTMLURL    *string    `json:"html_url,omitempty"`
+	ColumnsURL *string    `json:"columns_url,omitempty"`
+	OwnerURL   *string    `json:"owner_url,omitempty"`
+	Name       *string    `json:"name,omitempty"`
+	Body       *string    `json:"body,omitempty"`
+	Number     *int       `json:"number,omitempty"`
+	State      *string    `json:"state,omitempty"`
+	CreatedAt  *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt  *Timestamp `json:"updated_at,omitempty"`
+	NodeID     *string    `json:"node_id,omitempty"`
 
 	// The User object that generated the project.
 	Creator *User `json:"creator,omitempty"`
@@ -65,15 +68,24 @@ func (s *ProjectsService) GetProject(ctx context.Context, id int64) (*Project, *
 // ProjectsService.UpdateProject methods.
 type ProjectOptions struct {
 	// The name of the project. (Required for creation; optional for update.)
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 	// The body of the project. (Optional.)
-	Body string `json:"body,omitempty"`
+	Body *string `json:"body,omitempty"`
 
 	// The following field(s) are only applicable for update.
 	// They should be left with zero values for creation.
 
 	// State of the project. Either "open" or "closed". (Optional.)
-	State string `json:"state,omitempty"`
+	State *string `json:"state,omitempty"`
+	// The permission level that all members of the project's organization
+	// will have on this project.
+	// Setting the organization permission is only available
+	// for organization projects. (Optional.)
+	OrganizationPermission *string `json:"organization_permission,omitempty"`
+	// Sets visibility of the project within the organization.
+	// Setting visibility is only available
+	// for organization projects.(Optional.)
+	Public *bool `json:"public,omitempty"`
 }
 
 // UpdateProject updates a repository project.
@@ -121,7 +133,9 @@ func (s *ProjectsService) DeleteProject(ctx context.Context, id int64) (*Respons
 type ProjectColumn struct {
 	ID         *int64     `json:"id,omitempty"`
 	Name       *string    `json:"name,omitempty"`
+	URL        *string    `json:"url,omitempty"`
 	ProjectURL *string    `json:"project_url,omitempty"`
+	CardsURL   *string    `json:"cards_url,omitempty"`
 	CreatedAt  *Timestamp `json:"created_at,omitempty"`
 	UpdatedAt  *Timestamp `json:"updated_at,omitempty"`
 	NodeID     *string    `json:"node_id,omitempty"`

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -19,7 +19,13 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	input := &ProjectOptions{Name: String("Project Name"), Body: String("Project body."), State: String("open")}
+	input := &ProjectOptions{
+		Name:  String("Project Name"),
+		Body:  String("Project body."),
+		State: String("open"),
+		OrganizationPermission: String("read"),
+		Public:                 Bool(true),
+	}
 
 	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/projects/1", func(w http.ResponseWriter, r *http.Request) {

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -19,7 +19,7 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	input := &ProjectOptions{Name: "Project Name", Body: "Project body.", State: "open"}
+	input := &ProjectOptions{Name: String("Project Name"), Body: String("Project body."), State: String("open")}
 
 	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/projects/1", func(w http.ResponseWriter, r *http.Request) {

--- a/github/repos_projects_test.go
+++ b/github/repos_projects_test.go
@@ -43,7 +43,7 @@ func TestRepositoriesService_CreateProject(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	input := &ProjectOptions{Name: "Project Name", Body: "Project body."}
+	input := &ProjectOptions{Name: String("Project Name"), Body: String("Project body.")}
 
 	acceptHeaders := []string{mediaTypeProjectsPreview, mediaTypeGraphQLNodeIDPreview}
 	mux.HandleFunc("/repos/o/r/projects", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The original motivation was to add Project's `HtmlURL` field as we need it in https://github.com/terraform-providers/terraform-provider-github/pull/111
but I took some time to look at all missing fields in both Project & ProjectColumn, just for completeness.

The PR covers only one, small part of https://github.com/google/go-github/issues/884 - there is still more work to do before #884 can actually be closed - specifically around Project Collaborators and Team Projects.