### PR TITLE
Fix RequestCheckSuite

### DIFF
--- a/github/checks.go
+++ b/github/checks.go
@@ -411,12 +411,8 @@ type RequestCheckSuiteOptions struct {
 // GitHub API docs: https://developer.github.com/v3/checks/suites/#request-check-suites
 func (s *ChecksService) RequestCheckSuite(ctx context.Context, owner, repo string, opt RequestCheckSuiteOptions) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/check-suite-requests", owner, repo)
-	u, err := addOptions(u, opt)
-	if err != nil {
-		return nil, err
-	}
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest("POST", u, opt)
 	if err != nil {
 		return nil, err
 	}

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -467,7 +467,7 @@ func TestChecksService_RequestCheckSuite(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/check-suite-requests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
-		testBody(t, r, "{\"head_sha\":\"deadbeef\"}"+"\n")
+		testBody(t, r, `{"head_sha":"deadbeef"}`+"\n")
 	})
 	opt := RequestCheckSuiteOptions{
 		HeadSHA: "deadbeef",

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -467,6 +467,7 @@ func TestChecksService_RequestCheckSuite(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/check-suite-requests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
+		testBody(t, r, "{\"head_sha\":\"deadbeef\"}"+"\n")
 	})
 	opt := RequestCheckSuiteOptions{
 		HeadSHA: "deadbeef",


### PR DESCRIPTION
Previously, `RequestCheckSuite` appended the contents of the `ops RequestCheckSuiteOptions` parameter as query string parameters, resulting in requests like `https://api.github.com/repos/$owner/$repo/check-suite-requests?HeadSHA=$sha`. These sorts of requests result in `422 Invalid request` errors from the GitHub API.

This PR passes the contents of the `ops RequestCheckSuiteOptions` parameter through to `(c *Client) NewRequest` as the body instead, resulting in requests that GitHub's API accepts.