### PR TITLE
Add FindRepositoryInstallationByID to AppsService

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -197,6 +197,13 @@ func (s *AppsService) FindRepositoryInstallation(ctx context.Context, owner, rep
 	return s.getInstallation(ctx, fmt.Sprintf("repos/%v/%v/installation", owner, repo))
 }
 
+// FindRepositoryInstallationByID finds the repository's installation information.
+//
+// Note: FindRepositoryInstallationByID uses the undocumented GitHub API endpoint /repositories/:id/installation.
+func (s *AppsService) FindRepositoryInstallationByID(ctx context.Context, id int64) (*Installation, *Response, error) {
+	return s.getInstallation(ctx, fmt.Sprintf("repositories/%d/installation", id))
+}
+
 // FindUserInstallation finds the user's installation information.
 //
 // GitHub API docs: https://developer.github.com/v3/apps/#find-repository-installation

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -227,6 +227,27 @@ func TestAppsService_FindRepositoryInstallation(t *testing.T) {
 	}
 }
 
+func TestAppsService_FindRepositoryInstallationByID(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repositories/1/installation", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeIntegrationPreview)
+		fmt.Fprint(w, `{"id":1, "app_id":1, "target_id":1, "target_type": "Organization"}`)
+	})
+
+	installation, _, err := client.Apps.FindRepositoryInstallationByID(context.Background(), 1)
+	if err != nil {
+		t.Errorf("Apps.FindRepositoryInstallationByID returned error: %v", err)
+	}
+
+	want := &Installation{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1), TargetType: String("Organization")}
+	if !reflect.DeepEqual(installation, want) {
+		t.Errorf("Apps.FindRepositoryInstallationByID returned %+v, want %+v", installation, want)
+	}
+}
+
 func TestAppsService_FindUserInstallation(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
With a GitHub App that I'm building, I am only ever persisting IDs rather than `owner` and `name` for repositories. For the most part I am using the GraphQL API, but I need to create an installation access token, which I'm using `go-github` for.

This change adds a `FindRepositoryInstallationByID` endpoint which mirrors how `RepositoryService#GetByID` works.