### PR TITLE
Introduce go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: go
 go:
+  - "1.11.x"
   - "1.10.x"
   - "1.9.x"
   - "1.8.x"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ go:
   - "1.11.x"
   - "1.10.x"
   - "1.9.x"
-  - "1.8.x"
-  - master
+  - tip
+env:
+  global:
+    - GO111MODULE=on
 matrix:
   allow_failures:
-    - go: master
+    - go: tip
   fast_finish: true
 env:
   secure: "IrnPmy/rkIP6Nrbqji+u7MCAibQlA6WvPLEllmDQ2yZP/uIe3wLwwYbTu9BOkgzoLA+f8PA6u3pp/RhY/rtaM4NzHAO2nVfGIv9UHUQ3NGq0DYS6rODjVKhq7vkhELoagRewyqFVN4rE0LnExkknRMgjQfRke6/DA7u7Xm8JyhY=" # COVERALLS_TOKEN

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you're interested in using the [GraphQL API v4][], the recommended library is
 ## Usage ##
 
 ```go
-import "github.com/google/go-github/github"
+import "github.com/google/go-github/github/v17"
 ```
 
 Construct a new GitHub client, then use the various services on the client to

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 go-github is a Go client library for accessing the [GitHub API v3][].
 
-go-github requires Go version 1.8 or greater.
+go-github requires Go version 1.9 or greater.
 
 If you're interested in using the [GraphQL API v4][], the recommended library is
 [shurcooL/githubv4][].

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you're interested in using the [GraphQL API v4][], the recommended library is
 ## Usage ##
 
 ```go
-import "github.com/google/go-github/github/v17"
+import "github.com/google/go-github/github/v18"
 ```
 
 Construct a new GitHub client, then use the various services on the client to

--- a/example/appengine/app.go
+++ b/example/appengine/app.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v17/github"
 	"golang.org/x/oauth2"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/log"

--- a/example/appengine/app.go
+++ b/example/appengine/app.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/google/go-github/v17/github"
+	"github.com/google/go-github/v18/github"
 	"golang.org/x/oauth2"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/log"

--- a/example/basicauth/main.go
+++ b/example/basicauth/main.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/google/go-github/v17/github"
+	"github.com/google/go-github/v18/github"
 	"golang.org/x/crypto/ssh/terminal"
 )
 

--- a/example/basicauth/main.go
+++ b/example/basicauth/main.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v17/github"
 	"golang.org/x/crypto/ssh/terminal"
 )
 

--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -31,7 +31,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v17/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -31,7 +31,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v17/github"
+	"github.com/google/go-github/v18/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/migrations/main.go
+++ b/example/migrations/main.go
@@ -11,7 +11,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v17/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/migrations/main.go
+++ b/example/migrations/main.go
@@ -11,7 +11,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v17/github"
+	"github.com/google/go-github/v18/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/newrepo/main.go
+++ b/example/newrepo/main.go
@@ -16,7 +16,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v17/github"
+	"github.com/google/go-github/v18/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/newrepo/main.go
+++ b/example/newrepo/main.go
@@ -16,7 +16,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v17/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v17/github"
 )
 
 // Fetch all the public organizations' membership of a user.

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v17/github"
+	"github.com/google/go-github/v18/github"
 )
 
 // Fetch all the public organizations' membership of a user.

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v17/github"
+	"github.com/google/go-github/v18/github"
 )
 
 func ExampleClient_Markdown() {

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v17/github"
 )
 
 func ExampleClient_Markdown() {

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -20,9 +20,9 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 	defer teardown()
 
 	input := &ProjectOptions{
-		Name:  String("Project Name"),
-		Body:  String("Project body."),
-		State: String("open"),
+		Name:                   String("Project Name"),
+		Body:                   String("Project body."),
+		State:                  String("open"),
 		OrganizationPermission: String("read"),
 		Public:                 Bool(true),
 	}

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -20,11 +20,12 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 	defer teardown()
 
 	input := &ProjectOptions{
-		Name:                   String("Project Name"),
-		Body:                   String("Project body."),
-		State:                  String("open"),
+		Name:   String("Project Name"),
+		Body:   String("Project body."),
+		State:  String("open"),
+		Public: Bool(true),
+
 		OrganizationPermission: String("read"),
-		Public:                 Bool(true),
 	}
 
 	mux.HandleFunc("/projects/1", func(w http.ResponseWriter, r *http.Request) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v17
+module github.com/google/go-github/v18
 
 require (
 	github.com/golang/protobuf v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/google/go-github/v17
+
+require (
+	github.com/golang/protobuf v1.2.0 // indirect
+	github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135
+	golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac
+	golang.org/x/net v0.0.0-20180826012351-8a410e7b638d // indirect
+	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
+	golang.org/x/sys v0.0.0-20180824143301-4910a1d54f87 // indirect
+	google.golang.org/appengine v1.1.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135 h1:zLTLjkaOFEFIOxY5BWLFLwh+cL8vOBW4XJ2aqLE/Tf0=
+github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac h1:7d7lG9fHOLdL6jZPtnV4LpI41SbohIJ1Atq7U991dMg=
+golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/net v0.0.0-20180826012351-8a410e7b638d h1:g9qWBGx4puODJTMVyoPrpoxPFgVGd+z1DZwjfRu4d0I=
+golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/sys v0.0.0-20180824143301-4910a1d54f87 h1:GqwDwfvIpC33dK9bA1fD+JiDUNsuAiQiEkpHqUKze4o=
+golang.org/x/sys v0.0.0-20180824143301-4910a1d54f87/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
+google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/test/fields/fields.go
+++ b/test/fields/fields.go
@@ -25,7 +25,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/google/go-github/v17/github"
+	"github.com/google/go-github/v18/github"
 	"golang.org/x/oauth2"
 )
 

--- a/test/fields/fields.go
+++ b/test/fields/fields.go
@@ -25,7 +25,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v17/github"
 	"golang.org/x/oauth2"
 )
 


### PR DESCRIPTION
This PR is generated by a [tool I wrote](https://github.com/marwan-at-work/mod) that helps migrate Go packages that are tagged +2 to Semantic Import Versioning. 

Note that this change should be backwards compatible and can still be imported without the `/vX` suffix when Go Modules is off. 