### PR TITLE
CheckResponse: Allow reuse of response body

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -698,6 +698,9 @@ func CheckResponse(r *http.Response) error {
 	if err == nil && data != nil {
 		json.Unmarshal(data, errorResponse)
 	}
+
+	r.Body = ioutil.NopCloser(bytes.NewReader(data))
+
 	switch {
 	case r.StatusCode == http.StatusUnauthorized && strings.HasPrefix(r.Header.Get(headerOTP), "required"):
 		return (*TwoFactorAuthError)(errorResponse)

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -858,6 +858,29 @@ func TestCheckResponse_errorBody(t *testing.T) {
 	}
 }
 
+func TestGetRepository_errorBody(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/test/test", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintln(w, `{
+  "message": "Not Found",
+  "documentation_url": "https://developer.github.com/v3/repos/#get"
+}`)
+	})
+
+	_, res, err := client.Repositories.Get(context.Background(), "test", "test")
+	if err == nil {
+		t.Fatal("Expected error, given nil")
+	}
+
+	_, rErr := httputil.DumpResponse(res.Response, true)
+	if rErr != nil {
+		t.Errorf("Failed to dump response: %s", rErr)
+	}
+}
+
 func TestParseBooleanResponse_true(t *testing.T) {
 	result, err := parseBoolResponse(nil)
 	if err != nil {


### PR DESCRIPTION
I tried using `CheckResponse` in a custom transport to identify certain errors and implement conditional retries and I kept bumping into a weird error

```
http: ContentLength=157 with Body length 0
```

from another transport I use to log all HTTP requests & responses (incl. bodies).

I noticed (after some debugging) that `ioutil.ReadAll` is in use, which closes the stream and prevents other readers from reading the body.

Attached is a test reproducing described behaviour.