### PR TITLE
Support changes to the Checks REST API

### DIFF
--- a/github/checks.go
+++ b/github/checks.go
@@ -47,7 +47,7 @@ type CheckRunOutput struct {
 
 // CheckRunAnnotation represents an annotation object for a CheckRun output.
 type CheckRunAnnotation struct {
-	FileName     *string `json:"filename,omitempty"`
+	Path         *string `json:"path,omitempty"`
 	BlobHRef     *string `json:"blob_href,omitempty"`
 	StartLine    *int    `json:"start_line,omitempty"`
 	EndLine      *int    `json:"end_line,omitempty"`

--- a/github/checks.go
+++ b/github/checks.go
@@ -400,25 +400,3 @@ func (s *ChecksService) CreateCheckSuite(ctx context.Context, owner, repo string
 
 	return checkSuite, resp, nil
 }
-
-// RequestCheckSuiteOptions sets up the parameters for a request check suite endpoint.
-type RequestCheckSuiteOptions struct {
-	HeadSHA string `json:"head_sha"` // The sha of the head commit. (Required.)
-}
-
-// RequestCheckSuite triggers GitHub to create a new check suite, without pushing new code to a repository.
-//
-// GitHub API docs: https://developer.github.com/v3/checks/suites/#request-check-suites
-func (s *ChecksService) RequestCheckSuite(ctx context.Context, owner, repo string, opt RequestCheckSuiteOptions) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/check-suite-requests", owner, repo)
-
-	req, err := s.client.NewRequest("POST", u, opt)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
-
-	resp, err := s.client.Do(ctx, req, nil)
-	return resp, err
-}

--- a/github/checks.go
+++ b/github/checks.go
@@ -404,8 +404,8 @@ func (s *ChecksService) CreateCheckSuite(ctx context.Context, owner, repo string
 // ReRequestCheckSuite triggers GitHub to rerequest an existing check suite, without pushing new code to a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/checks/suites/#rerequest-check-suite
-func (s *ChecksService) ReRequestCheckSuite(ctx context.Context, owner, repo string, CheckSuiteID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/check-suites/%v/rerequest", owner, repo, CheckSuiteID)
+func (s *ChecksService) ReRequestCheckSuite(ctx context.Context, owner, repo string, checkSuiteID int64) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/check-suites/%v/rerequest", owner, repo, checkSuiteID)
 
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {

--- a/github/checks.go
+++ b/github/checks.go
@@ -400,3 +400,20 @@ func (s *ChecksService) CreateCheckSuite(ctx context.Context, owner, repo string
 
 	return checkSuite, resp, nil
 }
+
+// ReRequestCheckSuite triggers GitHub to rerequest an existing check suite, without pushing new code to a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/checks/suites/#rerequest-check-suite
+func (s *ChecksService) ReRequestCheckSuite(ctx context.Context, owner, repo string, CheckSuiteID int64) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/check-suites/%v/rerequest", owner, repo, CheckSuiteID)
+
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+
+	resp, err := s.client.Do(ctx, req, nil)
+	return resp, err
+}

--- a/github/checks.go
+++ b/github/checks.go
@@ -47,14 +47,14 @@ type CheckRunOutput struct {
 
 // CheckRunAnnotation represents an annotation object for a CheckRun output.
 type CheckRunAnnotation struct {
-	Path         *string `json:"path,omitempty"`
-	BlobHRef     *string `json:"blob_href,omitempty"`
-	StartLine    *int    `json:"start_line,omitempty"`
-	EndLine      *int    `json:"end_line,omitempty"`
-	WarningLevel *string `json:"warning_level,omitempty"`
-	Message      *string `json:"message,omitempty"`
-	Title        *string `json:"title,omitempty"`
-	RawDetails   *string `json:"raw_details,omitempty"`
+	Path            *string `json:"path,omitempty"`
+	BlobHRef        *string `json:"blob_href,omitempty"`
+	StartLine       *int    `json:"start_line,omitempty"`
+	EndLine         *int    `json:"end_line,omitempty"`
+	AnnotationLevel *string `json:"annotation_level,omitempty"`
+	Message         *string `json:"message,omitempty"`
+	Title           *string `json:"title,omitempty"`
+	RawDetails      *string `json:"raw_details,omitempty"`
 }
 
 // CheckRunImage represents an image object for a CheckRun output.

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -147,7 +147,7 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 			"page": "1",
 		})
 		fmt.Fprint(w, `[{
-		                           "filename": "README.md",
+		                           "path": "README.md",
 		                           "blob_href": "https://github.com/octocat/Hello-World/blob/837db83be4137ca555d9a5598d0a1ea2987ecfee/README.md",
 		                           "start_line": 2,
 		                           "end_line": 2,
@@ -164,7 +164,7 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 	}
 
 	want := []*CheckRunAnnotation{{
-		FileName:     String("README.md"),
+		Path:         String("README.md"),
 		BlobHRef:     String("https://github.com/octocat/Hello-World/blob/837db83be4137ca555d9a5598d0a1ea2987ecfee/README.md"),
 		StartLine:    Int(2),
 		EndLine:      Int(2),

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -459,3 +459,21 @@ func TestChecksService_CreateCheckSuite(t *testing.T) {
 		t.Errorf("Checks.CreateCheckSuite return %+v, want %+v", checkSuite, want)
 	}
 }
+
+func TestChecksService_ReRequestCheckSuite(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/check-suites/1/rerequest", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
+		w.WriteHeader(http.StatusCreated)
+	})
+	resp, err := client.Checks.ReRequestCheckSuite(context.Background(), "o", "r", 1)
+	if err != nil {
+		t.Errorf("Checks.ReRequestCheckSuite return error: %v", err)
+	}
+	if resp.StatusCode != 201 {
+		t.Errorf("Checks.ReRequestCheckSuite return %+v, want 201", resp.StatusCode)
+	}
+}

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -459,24 +459,3 @@ func TestChecksService_CreateCheckSuite(t *testing.T) {
 		t.Errorf("Checks.CreateCheckSuite return %+v, want %+v", checkSuite, want)
 	}
 }
-
-func TestChecksService_RequestCheckSuite(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/repos/o/r/check-suite-requests", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
-		testBody(t, r, `{"head_sha":"deadbeef"}`+"\n")
-	})
-	opt := RequestCheckSuiteOptions{
-		HeadSHA: "deadbeef",
-	}
-	resp, err := client.Checks.RequestCheckSuite(context.Background(), "o", "r", opt)
-	if err != nil {
-		t.Errorf("Checks.RequestCheckSuite return error: %v", err)
-	}
-	if resp.StatusCode != 200 {
-		t.Errorf("Checks.RequestCheckSuite return %+v, want 200", resp.StatusCode)
-	}
-}

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -151,7 +151,7 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 		                           "blob_href": "https://github.com/octocat/Hello-World/blob/837db83be4137ca555d9a5598d0a1ea2987ecfee/README.md",
 		                           "start_line": 2,
 		                           "end_line": 2,
-		                           "warning_level": "warning",
+		                           "annotation_level": "warning",
 		                           "message": "Check your spelling for 'banaas'.",
                                            "title": "Spell check",
 		                           "raw_details": "Do you mean 'bananas' or 'banana'?"}]`,
@@ -164,14 +164,14 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 	}
 
 	want := []*CheckRunAnnotation{{
-		Path:         String("README.md"),
-		BlobHRef:     String("https://github.com/octocat/Hello-World/blob/837db83be4137ca555d9a5598d0a1ea2987ecfee/README.md"),
-		StartLine:    Int(2),
-		EndLine:      Int(2),
-		WarningLevel: String("warning"),
-		Message:      String("Check your spelling for 'banaas'."),
-		RawDetails:   String("Do you mean 'bananas' or 'banana'?"),
-		Title:        String("Spell check"),
+		Path:            String("README.md"),
+		BlobHRef:        String("https://github.com/octocat/Hello-World/blob/837db83be4137ca555d9a5598d0a1ea2987ecfee/README.md"),
+		StartLine:       Int(2),
+		EndLine:         Int(2),
+		AnnotationLevel: String("warning"),
+		Message:         String("Check your spelling for 'banaas'."),
+		RawDetails:      String("Do you mean 'bananas' or 'banana'?"),
+		Title:           String("Spell check"),
 	}}
 
 	if !reflect.DeepEqual(checkRunAnnotations, want) {

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -473,7 +473,7 @@ func TestChecksService_ReRequestCheckSuite(t *testing.T) {
 	if err != nil {
 		t.Errorf("Checks.ReRequestCheckSuite return error: %v", err)
 	}
-	if resp.StatusCode != 201 {
-		t.Errorf("Checks.ReRequestCheckSuite return %+v, want 201", resp.StatusCode)
+	if got, want := resp.StatusCode, http.StatusCreated; got != want {
+		t.Errorf("Checks.ReRequestCheckSuite = %v, want %v", got, want)
 	}
 }

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -564,6 +564,14 @@ func (c *CheckRun) GetURL() string {
 	return *c.URL
 }
 
+// GetAnnotationLevel returns the AnnotationLevel field if it's non-nil, zero value otherwise.
+func (c *CheckRunAnnotation) GetAnnotationLevel() string {
+	if c == nil || c.AnnotationLevel == nil {
+		return ""
+	}
+	return *c.AnnotationLevel
+}
+
 // GetBlobHRef returns the BlobHRef field if it's non-nil, zero value otherwise.
 func (c *CheckRunAnnotation) GetBlobHRef() string {
 	if c == nil || c.BlobHRef == nil {
@@ -618,14 +626,6 @@ func (c *CheckRunAnnotation) GetTitle() string {
 		return ""
 	}
 	return *c.Title
-}
-
-// GetWarningLevel returns the WarningLevel field if it's non-nil, zero value otherwise.
-func (c *CheckRunAnnotation) GetWarningLevel() string {
-	if c == nil || c.WarningLevel == nil {
-		return ""
-	}
-	return *c.WarningLevel
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -580,20 +580,20 @@ func (c *CheckRunAnnotation) GetEndLine() int {
 	return *c.EndLine
 }
 
-// GetFileName returns the FileName field if it's non-nil, zero value otherwise.
-func (c *CheckRunAnnotation) GetFileName() string {
-	if c == nil || c.FileName == nil {
-		return ""
-	}
-	return *c.FileName
-}
-
 // GetMessage returns the Message field if it's non-nil, zero value otherwise.
 func (c *CheckRunAnnotation) GetMessage() string {
 	if c == nil || c.Message == nil {
 		return ""
 	}
 	return *c.Message
+}
+
+// GetPath returns the Path field if it's non-nil, zero value otherwise.
+func (c *CheckRunAnnotation) GetPath() string {
+	if c == nil || c.Path == nil {
+		return ""
+	}
+	return *c.Path
 }
 
 // GetRawDetails returns the RawDetails field if it's non-nil, zero value otherwise.


### PR DESCRIPTION
This PR updates `CheckService` and `CheckSuiteAnnotation` to account for the [recent changes to the GitHub API](https://developer.github.com/changes/2018-08-16-changes-to-the-checks-rest-api/):

* `filename` is being renamed to `path`
* `blob_href` is no longer necessary (no changes required, as responses continue to provide this value)
* `warning_level` is being renamed to `annotation_level`
* `POST /repos/:owner/:repo/check-suite-requests` is being removed
* `POST /repos/:owner/:repo/check-suites/:check_suite_id/rerequest` is being added

Fixes https://github.com/google/go-github/issues/980