### PR TITLE
Make ValidateSignature public when the original request is unavailable

### DIFF
--- a/github/messages.go
+++ b/github/messages.go
@@ -175,19 +175,19 @@ func ValidatePayload(r *http.Request, secretKey []byte) (payload []byte, err err
 	}
 
 	sig := r.Header.Get(signatureHeader)
-	if err := validateSignature(sig, body, secretKey); err != nil {
+	if err := ValidateSignature(sig, body, secretKey); err != nil {
 		return nil, err
 	}
 	return payload, nil
 }
 
-// validateSignature validates the signature for the given payload.
+// ValidateSignature validates the signature for the given payload.
 // signature is the GitHub hash signature delivered in the X-Hub-Signature header.
 // payload is the JSON payload sent by GitHub Webhooks.
 // secretKey is the GitHub Webhook secret message.
 //
 // GitHub API docs: https://developer.github.com/webhooks/securing/#validating-payloads-from-github
-func validateSignature(signature string, payload, secretKey []byte) error {
+func ValidateSignature(signature string, payload, secretKey []byte) error {
 	messageMAC, hashFunc, err := messageMAC(signature)
 	if err != nil {
 		return err


### PR DESCRIPTION
In an AWS Lambda invoked via API Gateway, I do not have direct access to the original `*http.Request`, but instead will typically have a signature of:

`func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (Response, error) {`

The `events.APIGatewayProxyRequest` contains the original body as well as headers, and I would like to be able to invoke `ValidateSignature` directly.