### PR TITLE
Fix printing for Response instances.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -375,7 +375,9 @@ type Response struct {
 	FirstPage int
 	LastPage  int
 
-	Rate
+	// Explicitly specify the Rate type so Rate's String() receiver doesn't
+	// propagate to Response.
+	Rate Rate
 }
 
 // newResponse creates a new Response for the provided http.Response.


### PR DESCRIPTION
Explicitly specify the Rate type so Rate's String() receiver doesn't propagate to Response.

(Otherwise, `fmt.Printf("%+v", resp)` will just output the embedded Rate instead of the whole Response.)