### PR TITLE
add requested_teams to PullRequest

### DIFF
--- a/github/pulls.go
+++ b/github/pulls.go
@@ -60,6 +60,10 @@ type PullRequest struct {
 	NodeID              *string    `json:"node_id,omitempty"`
 	RequestedReviewers  []*User    `json:"requested_reviewers,omitempty"`
 
+	// RequestedTeams is populated as part of the PullRequestEvent.
+	// See, https://developer.github.com/v3/activity/events/types/#pullrequestevent for an example.
+	RequestedTeams []*Team `json:"requested_teams,omitempty"`
+
 	Head *PullRequestBranch `json:"head,omitempty"`
 	Base *PullRequestBranch `json:"base,omitempty"`
 


### PR DESCRIPTION
`requested_teams` was added to the `pull_request` object in the `review_requested` event, see [payload example](https://developer.github.com/v3/activity/events/types/#webhook-payload-example-25) for definition.