### PR TITLE
Add links to pull struct

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6180,6 +6180,78 @@ func (p *PreReceiveHook) GetName() string {
 	return *p.Name
 }
 
+// GetHref returns the Href field if it's non-nil, zero value otherwise.
+func (p *PRLink) GetHref() string {
+	if p == nil || p.Href == nil {
+		return ""
+	}
+	return *p.Href
+}
+
+// GetComments returns the Comments field.
+func (p *PRLinks) GetComments() *PRLink {
+	if p == nil {
+		return nil
+	}
+	return p.Comments
+}
+
+// GetCommits returns the Commits field.
+func (p *PRLinks) GetCommits() *PRLink {
+	if p == nil {
+		return nil
+	}
+	return p.Commits
+}
+
+// GetHTML returns the HTML field.
+func (p *PRLinks) GetHTML() *PRLink {
+	if p == nil {
+		return nil
+	}
+	return p.HTML
+}
+
+// GetIssue returns the Issue field.
+func (p *PRLinks) GetIssue() *PRLink {
+	if p == nil {
+		return nil
+	}
+	return p.Issue
+}
+
+// GetReviewComment returns the ReviewComment field.
+func (p *PRLinks) GetReviewComment() *PRLink {
+	if p == nil {
+		return nil
+	}
+	return p.ReviewComment
+}
+
+// GetReviewComments returns the ReviewComments field.
+func (p *PRLinks) GetReviewComments() *PRLink {
+	if p == nil {
+		return nil
+	}
+	return p.ReviewComments
+}
+
+// GetSelf returns the Self field.
+func (p *PRLinks) GetSelf() *PRLink {
+	if p == nil {
+		return nil
+	}
+	return p.Self
+}
+
+// GetStatuses returns the Statuses field.
+func (p *PRLinks) GetStatuses() *PRLink {
+	if p == nil {
+		return nil
+	}
+	return p.Statuses
+}
+
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
 func (p *Project) GetBody() string {
 	if p == nil || p.Body == nil {
@@ -6906,6 +6978,14 @@ func (p *PullRequest) GetIssueURL() string {
 		return ""
 	}
 	return *p.IssueURL
+}
+
+// GetLinks returns the Links field.
+func (p *PullRequest) GetLinks() *PRLinks {
+	if p == nil {
+		return nil
+	}
+	return p.Links
 }
 
 // GetMaintainerCanModify returns the MaintainerCanModify field if it's non-nil, zero value otherwise.

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -82,16 +82,21 @@ type PullRequestBranch struct {
 	User  *User       `json:"user,omitempty"`
 }
 
-// PRLinks represents the "_links" object from the pull request payload.
+// PRLink represents a single link object from Github pull request _links
+type PRLink struct {
+	Href *string `json:"href,omitempty"`
+}
+
+// PRLinks represents the "_links" object in a Github pull request.
 type PRLinks struct {
-	URL               *string `json:"url,omitempty"`
-	HTMLURL           *string `json:"html_url,omitempty"`
-	IssueURL          *string `json:"issue_url,omitempty"`
-	CommentsURL       *string `json:"comments_url,omitempty"`
-	ReviewCommentsURL *string `json:"review_comments_url,omitempty"`
-	ReviewCommentURL  *string `json:"review_comment_url,omitempty"`
-	CommitsURL        *string `json:"commits_url,omitempty"`
-	StatusesURL       *string `json:"statuses_url,omitempty"`
+	Self           *PRLink `json:"self,omitempty"`
+	HTML           *PRLink `json:"html,omitempty"`
+	Issue          *PRLink `json:"issue,omitempty"`
+	Comments       *PRLink `json:"comments,omitempty"`
+	ReviewComments *PRLink `json:"review_comments,omitempty"`
+	ReviewComment  *PRLink `json:"review_comment,omitempty"`
+	Commits        *PRLink `json:"commits,omitempty"`
+	Statuses       *PRLink `json:"statuses,omitempty"`
 }
 
 // PullRequestListOptions specifies the optional parameters to the

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -60,8 +60,9 @@ type PullRequest struct {
 	NodeID              *string    `json:"node_id,omitempty"`
 	RequestedReviewers  []*User    `json:"requested_reviewers,omitempty"`
 
-	Head *PullRequestBranch `json:"head,omitempty"`
-	Base *PullRequestBranch `json:"base,omitempty"`
+	Links *PRLinks           `json:"_links,omitempty"`
+	Head  *PullRequestBranch `json:"head,omitempty"`
+	Base  *PullRequestBranch `json:"base,omitempty"`
 
 	// ActiveLockReason is populated only when LockReason is provided while locking the pull request.
 	// Possible values are: "off-topic", "too heated", "resolved", and "spam".
@@ -79,6 +80,18 @@ type PullRequestBranch struct {
 	SHA   *string     `json:"sha,omitempty"`
 	Repo  *Repository `json:"repo,omitempty"`
 	User  *User       `json:"user,omitempty"`
+}
+
+// PRLinks represents the "_links" object from the pull request payload.
+type PRLinks struct {
+	URL               *string `json:"url,omitempty"`
+	HTMLURL           *string `json:"html_url,omitempty"`
+	IssueURL          *string `json:"issue_url,omitempty"`
+	CommentsURL       *string `json:"comments_url,omitempty"`
+	ReviewCommentsURL *string `json:"review_comments_url,omitempty"`
+	ReviewCommentURL  *string `json:"review_comment_url,omitempty"`
+	CommitsURL        *string `json:"commits_url,omitempty"`
+	StatusesURL       *string `json:"statuses_url,omitempty"`
 }
 
 // PullRequestListOptions specifies the optional parameters to the

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -82,7 +82,7 @@ type PullRequestBranch struct {
 	User  *User       `json:"user,omitempty"`
 }
 
-// PRLink represents a single link object from Github pull request _links
+// PRLink represents a single link object from Github pull request _links.
 type PRLink struct {
 	Href *string `json:"href,omitempty"`
 }

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -164,6 +164,59 @@ func TestPullRequestsService_Get_headAndBase(t *testing.T) {
 	}
 }
 
+func TestPullRequestsService_Get_links(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/pulls/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"number":1,
+			"_links":{
+				"self":{"href":"https://api.github.com/repos/octocat/Hello-World/pulls/1347"},
+				"html":{"href":"https://github.com/octocat/Hello-World/pull/1347"},
+				"issue":{"href":"https://api.github.com/repos/octocat/Hello-World/issues/1347"},
+				"comments":{"href":"https://api.github.com/repos/octocat/Hello-World/issues/1347/comments"},
+				"review_comments":{"href":"https://api.github.com/repos/octocat/Hello-World/pulls/1347/comments"},
+				"review_comment":{"href":"https://api.github.com/repos/octocat/Hello-World/pulls/comments{/number}"},
+				"commits":{"href":"https://api.github.com/repos/octocat/Hello-World/pulls/1347/commits"},
+				"statuses":{"href":"https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e"}
+				}
+			}`)
+	})
+
+	pull, _, err := client.PullRequests.Get(context.Background(), "o", "r", 1)
+	if err != nil {
+		t.Errorf("PullRequests.Get returned error: %v", err)
+	}
+
+	want := &PullRequest{
+		Number: Int(1),
+		Links: &PRLinks{
+			Self: &PRLink{
+				Href: String("https://api.github.com/repos/octocat/Hello-World/pulls/1347"),
+			}, HTML: &PRLink{
+				Href: String("https://github.com/octocat/Hello-World/pull/1347"),
+			}, Issue: &PRLink{
+				Href: String("https://api.github.com/repos/octocat/Hello-World/issues/1347"),
+			}, Comments: &PRLink{
+				Href: String("https://api.github.com/repos/octocat/Hello-World/issues/1347/comments"),
+			}, ReviewComments: &PRLink{
+				String("https://api.github.com/repos/octocat/Hello-World/pulls/1347/comments"),
+			}, ReviewComment: &PRLink{
+				Href: String("https://api.github.com/repos/octocat/Hello-World/pulls/comments{/number}"),
+			}, Commits: &PRLink{
+				Href: String("https://api.github.com/repos/octocat/Hello-World/pulls/1347/commits"),
+			}, Statuses: &PRLink{
+				Href: String("https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e"),
+			},
+		},
+	}
+	if !reflect.DeepEqual(pull, want) {
+		t.Errorf("PullRequests.Get returned %+v, want %+v", pull, want)
+	}
+}
+
 func TestPullRequestsService_Get_urlFields(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
closes #1001 

Hello and Welcome to my **first** pull request to a big open-source project.

In reference to #1001, I needed to add `"_links"` *object* to [`PullRequest` *structure*](https://godoc.org/github.com/google/go-github/github#PullRequest).

`_links` object preview from [Github API documentation](https://developer.github.com/v3/pulls/#response-1):
```json
 "_links": {
      "self": {
        "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1347"
      },
      "html": {
        "href": "https://github.com/octocat/Hello-World/pull/1347"
      },
      "issue": {
        "href": "https://api.github.com/repos/octocat/Hello-World/issues/1347"
      },
      "comments": {
        "href": "https://api.github.com/repos/octocat/Hello-World/issues/1347/comments"
      },
      "review_comments": {
        "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1347/comments"
      },
      "review_comment": {
        "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments{/number}"
      },
      "commits": {
        "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1347/commits"
      },
      "statuses": {
        "href": "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e"
      }
    },
```

To achieve this, I've implemented `PRLinks` *structure* and inside it created properties of type `PRLink` for each link inside `"_links"` *object* from API payload.

I've generated accessors using `go generate ./...` from inside the repository directory.

I've wrote test similar to those present in [pulls_test.go](https://github.com/google/go-github/blob/master/github/pulls_test.go).

My main concern are names of both `PRLinks` and `PRLink` types. I wanted to name it `PullRequestLinks` and `PullRequestLink` accordingly, unfortunately such type [already exists](https://github.com/google/go-github/blob/c3e9de61cf0678e682ea2b98cf1301ae3a814bc8/github/issues.go#L119)

