### PR TITLE
Add Topics API preview to starred repos

### DIFF
--- a/github/activity_star.go
+++ b/github/activity_star.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 // StarredRepository is returned by ListStarred.
@@ -84,8 +85,9 @@ func (s *ActivityService) ListStarred(ctx context.Context, user string, opt *Act
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeStarringPreview)
+	// TODO: remove custom Accept header when APIs fully launch
+	acceptHeaders := []string{mediaTypeStarringPreview, mediaTypeTopicsPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var repos []*StarredRepository
 	resp, err := s.client.Do(ctx, req, &repos)

--- a/github/activity_star_test.go
+++ b/github/activity_star_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -45,7 +46,7 @@ func TestActivityService_ListStarred_authenticatedUser(t *testing.T) {
 
 	mux.HandleFunc("/user/starred", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeStarringPreview)
+		testHeader(t, r, "Accept", strings.Join([]string{mediaTypeStarringPreview, mediaTypeTopicsPreview}, ", "))
 		fmt.Fprint(w, `[{"starred_at":"2002-02-10T15:30:00Z","repo":{"id":1}}]`)
 	})
 
@@ -66,7 +67,7 @@ func TestActivityService_ListStarred_specifiedUser(t *testing.T) {
 
 	mux.HandleFunc("/users/u/starred", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeStarringPreview)
+		testHeader(t, r, "Accept", strings.Join([]string{mediaTypeStarringPreview, mediaTypeTopicsPreview}, ", "))
 		testFormValues(t, r, values{
 			"sort":      "created",
 			"direction": "asc",


### PR DESCRIPTION
Fixes https://github.com/google/go-github/issues/984

Changes:
- Add [`mediaTypeTopicsPreview` (`application/vnd.github.mercy-preview+json`)](https://github.com/google/go-github/blob/master/github/github.go#L94) HTTP header to [`ActivityService.ListStarred`](https://github.com/google/go-github/blob/master/github/activity_star.go#L70) to allow retrieving topics for starred repositories 