### PR TITLE
add other missing org field

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -5556,20 +5556,20 @@ func (o *Organization) GetCreatedAt() time.Time {
 	return *o.CreatedAt
 }
 
-// GetDefaultRepoPermissionEdit returns the DefaultRepoPermissionEdit field if it's non-nil, zero value otherwise.
-func (o *Organization) GetDefaultRepoPermissionEdit() string {
-	if o == nil || o.DefaultRepoPermissionEdit == nil {
+// GetDefaultRepoPermission returns the DefaultRepoPermission field if it's non-nil, zero value otherwise.
+func (o *Organization) GetDefaultRepoPermission() string {
+	if o == nil || o.DefaultRepoPermission == nil {
 		return ""
 	}
-	return *o.DefaultRepoPermissionEdit
+	return *o.DefaultRepoPermission
 }
 
-// GetDefaultRepoPermissionGet returns the DefaultRepoPermissionGet field if it's non-nil, zero value otherwise.
-func (o *Organization) GetDefaultRepoPermissionGet() string {
-	if o == nil || o.DefaultRepoPermissionGet == nil {
+// GetDefaultRepoSettings returns the DefaultRepoSettings field if it's non-nil, zero value otherwise.
+func (o *Organization) GetDefaultRepoSettings() string {
+	if o == nil || o.DefaultRepoSettings == nil {
 		return ""
 	}
-	return *o.DefaultRepoPermissionGet
+	return *o.DefaultRepoSettings
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -5556,12 +5556,20 @@ func (o *Organization) GetCreatedAt() time.Time {
 	return *o.CreatedAt
 }
 
-// GetDefaultRepoPermission returns the DefaultRepoPermission field if it's non-nil, zero value otherwise.
-func (o *Organization) GetDefaultRepoPermission() string {
-	if o == nil || o.DefaultRepoPermission == nil {
+// GetDefaultRepoPermissionEdit returns the DefaultRepoPermissionEdit field if it's non-nil, zero value otherwise.
+func (o *Organization) GetDefaultRepoPermissionEdit() string {
+	if o == nil || o.DefaultRepoPermissionEdit == nil {
 		return ""
 	}
-	return *o.DefaultRepoPermission
+	return *o.DefaultRepoPermissionEdit
+}
+
+// GetDefaultRepoPermissionGet returns the DefaultRepoPermissionGet field if it's non-nil, zero value otherwise.
+func (o *Organization) GetDefaultRepoPermissionGet() string {
+	if o == nil || o.DefaultRepoPermissionGet == nil {
+		return ""
+	}
+	return *o.DefaultRepoPermissionGet
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -46,12 +46,12 @@ type Organization struct {
 	Plan                        *Plan      `json:"plan,omitempty"`
 	TwoFactorRequirementEnabled *bool      `json:"two_factor_requirement_enabled,omitempty"`
 
-	// DefaultRepoPermissionEdit can be one of: "read", "write", "admin", or "none". (Default: "read").
+	// DefaultRepoPermission can be one of: "read", "write", "admin", or "none". (Default: "read").
 	// It is only used in OrganizationsService.Edit.
-	DefaultRepoPermissionEdit *string `json:"default_repository_permission,omitempty"`
-	// DefaultRepoPermissionGet can be one of: "read", "write", "admin", or "none". (Default: "read").
+	DefaultRepoPermission *string `json:"default_repository_permission,omitempty"`
+	// DefaultRepoSettings can be one of: "read", "write", "admin", or "none". (Default: "read").
 	// It is only used in OrganizationsService.Get.
-	DefaultRepoPermissionGet *string `json:"default_repository_settings,omitempty"`
+	DefaultRepoSettings *string `json:"default_repository_settings,omitempty"`
 
 	// MembersCanCreateRepos default value is true and is only used in Organizations.Edit.
 	MembersCanCreateRepos *bool `json:"members_can_create_repositories,omitempty"`

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -46,9 +46,13 @@ type Organization struct {
 	Plan                        *Plan      `json:"plan,omitempty"`
 	TwoFactorRequirementEnabled *bool      `json:"two_factor_requirement_enabled,omitempty"`
 
-	// DefaultRepoPermission can be one of: "read", "write", "admin", or "none". (Default: "read").
+	// DefaultRepoPermissionEdit can be one of: "read", "write", "admin", or "none". (Default: "read").
 	// It is only used in OrganizationsService.Edit.
-	DefaultRepoPermission *string `json:"default_repository_settings,omitempty"`
+	DefaultRepoPermissionEdit *string `json:"default_repository_permission,omitempty"`
+	// DefaultRepoPermissionGet can be one of: "read", "write", "admin", or "none". (Default: "read").
+	// It is only used in OrganizationsService.Get.
+	DefaultRepoPermissionGet *string `json:"default_repository_settings,omitempty"`
+
 	// MembersCanCreateRepos default value is true and is only used in Organizations.Edit.
 	MembersCanCreateRepos *bool `json:"members_can_create_repositories,omitempty"`
 


### PR DESCRIPTION
related: https://github.com/google/go-github/pull/996

unfortunately i only added the field that matches `default_repository_settings` which is used to GET the org info. according to the docs (https://developer.github.com/v3/orgs/#get-an-organization):

* `default_repository_settings` is used for getting info about the org, using `Get`
* `default_repository_permission` is used to set the value on the org, using `Edit`

ive named the field `GetDefaultRepoPermissionXyz`, using the `Get` and `Edit` suffix to define the field, and using the correct json deserialization in each instance.