### PR TITLE
fixes AcceptedError unmarshaling

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -502,13 +502,23 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 
 	err = CheckResponse(resp)
 	if err != nil {
-		// Even though there was an error, we still return the response
-		// in case the caller wants to inspect it further.
-		// However, if the error is AcceptedError, decode it below before
-		// returning from this function and closing the response body.
-		if _, ok := err.(*AcceptedError); !ok {
-			return response, err
+		// Special case for AcceptedErrors. If an AcceptedError
+		// has been encountered, the response's payload will be
+		// added to the AcceptedError and returned.
+		//
+		// Issue #1022
+		aerr, ok := err.(*AcceptedError)
+		if ok {
+			b, readErr := ioutil.ReadAll(resp.Body)
+			if readErr != nil {
+				return response, readErr
+			}
+
+			aerr.Raw = b
+			return response, aerr
 		}
+
+		return response, err
 	}
 
 	if v != nil {
@@ -610,7 +620,10 @@ func (r *RateLimitError) Error() string {
 // Technically, 202 Accepted is not a real error, it's just used to
 // indicate that results are not ready yet, but should be available soon.
 // The request can be repeated after some time.
-type AcceptedError struct{}
+type AcceptedError struct {
+	// Raw contains the response body.
+	Raw []byte
+}
 
 func (*AcceptedError) Error() string {
 	return "job scheduled on GitHub side; try again later"

--- a/github/repos_forks.go
+++ b/github/repos_forks.go
@@ -8,6 +8,8 @@ package github
 import (
 	"context"
 	"fmt"
+
+	"encoding/json"
 )
 
 // RepositoryListForksOptions specifies the optional parameters to the
@@ -78,10 +80,15 @@ func (s *RepositoriesService) CreateFork(ctx context.Context, owner, repo string
 
 	fork := new(Repository)
 	resp, err := s.client.Do(ctx, req, fork)
-	if _, ok := err.(*AcceptedError); ok {
-		return fork, resp, err
-	}
 	if err != nil {
+		// Persist AcceptedError's metadata to the Repository object.
+		if aerr, ok := err.(*AcceptedError); ok {
+			if err := json.Unmarshal(aerr.Raw, fork); err != nil {
+				return fork, resp, err
+			}
+
+			return fork, resp, err
+		}
 		return nil, resp, err
 	}
 


### PR DESCRIPTION
Fixes #1022 

`AcceptedError` had a change in behavior in https://github.com/google/go-github/commit/88eb4e9dc91cb2db1bbc56c936f1ee39bbe72ba5

This change adds a `Raw` field to `AcceptedError`s. This allows for per API handling of the accepted error.