### PR TITLE
Add comment explaining use of examples_test.go

### DIFF
--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -3,6 +3,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// These examples are inlined in godoc.
+
 package github_test
 
 import (


### PR DESCRIPTION
Adds a comment explaining what these examples are used for. This is to clarify how they differ from example/ and test/