### PR TITLE
Support GitHub app authorization

### DIFF
--- a/github/event.go
+++ b/github/event.go
@@ -46,6 +46,8 @@ func (e *Event) ParsePayload() (payload interface{}, err error) {
 		payload = &DeploymentStatusEvent{}
 	case "ForkEvent":
 		payload = &ForkEvent{}
+	case "GitHubAppAuthorizationEvent":
+		payload = &GitHubAppAuthorizationEvent{}
 	case "GollumEvent":
 		payload = &GollumEvent{}
 	case "InstallationEvent":

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -139,6 +139,18 @@ type ForkEvent struct {
 	Installation *Installation `json:"installation,omitempty"`
 }
 
+// GitHubAppAuthorizationEvent is triggered when a user's authorization for a
+// GitHub Application is revoked.
+//
+// GitHub API docs: https://developer.github.com/v3/activity/events/types/#githubappauthorizationevent
+type GitHubAppAuthorizationEvent struct {
+	// The action performed. Can be "revoked".
+	Action *string `json:"action,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Sender *User `json:"sender,omitempty"`
+}
+
 // Page represents a single Wiki page.
 type Page struct {
 	PageName *string `json:"page_name,omitempty"`

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2932,6 +2932,22 @@ func (g *GistStats) GetTotalGists() int {
 	return *g.TotalGists
 }
 
+// GetAction returns the Action field if it's non-nil, zero value otherwise.
+func (g *GitHubAppAuthorizationEvent) GetAction() string {
+	if g == nil || g.Action == nil {
+		return ""
+	}
+	return *g.Action
+}
+
+// GetSender returns the Sender field.
+func (g *GitHubAppAuthorizationEvent) GetSender() *User {
+	if g == nil {
+		return nil
+	}
+	return g.Sender
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (g *Gitignore) GetName() string {
 	if g == nil || g.Name == nil {


### PR DESCRIPTION
Fixes #959 by adding support new webhook event, `github_app_authorization`.