### PR TITLE
Update CreateInstallationToken url

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -164,7 +164,7 @@ func (s *AppsService) ListUserInstallations(ctx context.Context, opt *ListOption
 //
 // GitHub API docs: https://developer.github.com/v3/apps/#create-a-new-installation-token
 func (s *AppsService) CreateInstallationToken(ctx context.Context, id int64) (*InstallationToken, *Response, error) {
-	u := fmt.Sprintf("installations/%v/access_tokens", id)
+	u := fmt.Sprintf("app/installations/%v/access_tokens", id)
 
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -168,7 +168,7 @@ func TestAppsService_CreateInstallationToken(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/installations/1/access_tokens", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/app/installations/1/access_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", mediaTypeIntegrationPreview)
 		fmt.Fprint(w, `{"token":"t"}`)


### PR DESCRIPTION
This PR updates the URL used for CreateInstallationToken to the new one. Closes #981.