### PR TITLE
Godoc: Add GitHub API doc link for "Get the authenticated user"

### DIFF
--- a/github/users.go
+++ b/github/users.go
@@ -76,7 +76,7 @@ func (u User) String() string {
 // user.
 //
 // GitHub API docs: https://developer.github.com/v3/users/#get-a-single-user
-// GitHub API docs: https://developer.github.com/v3/users/#get-the-authenticated-user
+// and: https://developer.github.com/v3/users/#get-the-authenticated-user
 func (s *UsersService) Get(ctx context.Context, user string) (*User, *Response, error) {
 	var u string
 	if user != "" {

--- a/github/users.go
+++ b/github/users.go
@@ -76,6 +76,7 @@ func (u User) String() string {
 // user.
 //
 // GitHub API docs: https://developer.github.com/v3/users/#get-a-single-user
+// GitHub API docs: https://developer.github.com/v3/users/#get-the-authenticated-user
 func (s *UsersService) Get(ctx context.Context, user string) (*User, *Response, error) {
 	var u string
 	if user != "" {


### PR DESCRIPTION
The `func (s *UsersService) Get` methods supports both calls: Getting a single user with name or getting the authenticated when you pass an empty string. The GitHub API docs for https://developer.github.com/v3/users/#get-the-authenticated-user were missing here.

During developing a tool with this client lib, i often go to the GitHub-API to check the correct API method. After this i get the URL and search in the godoc after the part of the `#`. In this case `get-the-authenticated-user`. With this workflow i reach quite fast the related go client lib method.
I was not able to find the `get-the-authenticated-user` method. Here we go.