### PR TITLE
Add "all" as possible value for PullRequestListOptions.State

### DIFF
--- a/github/pulls.go
+++ b/github/pulls.go
@@ -107,7 +107,7 @@ type PullRequestBranch struct {
 // PullRequestsService.List method.
 type PullRequestListOptions struct {
 	// State filters pull requests based on their state. Possible values are:
-	// open, closed. Default is "open".
+	// open, closed, all. Default is "open".
 	State string `url:"state,omitempty"`
 
 	// Head filters pull requests by head user and branch name in the format of:


### PR DESCRIPTION
According to [docs](https://developer.github.com/v3/pulls/#parameters):

> Either open, closed, or all to filter by state. Default: open