### PR TITLE
Required signatures on protected branches

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -10100,6 +10100,14 @@ func (s *ServiceHook) GetName() string {
 	return *s.Name
 }
 
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (s *SignaturesProtectedBranch) GetURL() string {
+	if s == nil || s.URL == nil {
+		return ""
+	}
+	return *s.URL
+}
+
 // GetPayload returns the Payload field if it's non-nil, zero value otherwise.
 func (s *SignatureVerification) GetPayload() string {
 	if s == nil || s.Payload == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -10100,6 +10100,14 @@ func (s *ServiceHook) GetName() string {
 	return *s.Name
 }
 
+// GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
+func (s *SignaturesProtectedBranch) GetEnabled() bool {
+	if s == nil || s.Enabled == nil {
+		return false
+	}
+	return *s.Enabled
+}
+
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
 func (s *SignaturesProtectedBranch) GetURL() string {
 	if s == nil || s.URL == nil {

--- a/github/github.go
+++ b/github/github.go
@@ -122,6 +122,9 @@ const (
 
 	// https://developer.github.com/enterprise/2.13/v3/repos/pre_receive_hooks/
 	mediaTypePreReceiveHooksPreview = "application/vnd.github.eye-scream-preview"
+
+	// https://developer.github.com/changes/2018-02-22-protected-branches-required-signatures/
+	mediaTypeSignaturePreview = "application/vnd.github.zzzax-preview+json"
 )
 
 // A Client manages communication with the GitHub API.

--- a/github/repos.go
+++ b/github/repos.go
@@ -698,6 +698,13 @@ type DismissalRestrictionsRequest struct {
 	Teams *[]string `json:"teams,omitempty"`
 }
 
+// SignaturesProtectedBranch represents the protection status of a individual branch.
+type SignaturesProtectedBranch struct {
+	URL *string `json:"url,omitempty"`
+	// Commits pushed to matching branches must have verified signatures.
+	Enabled bool `json:"strict"`
+}
+
 // ListBranches lists branches for the specified repository.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/#list-branches
@@ -846,6 +853,67 @@ func (s *RepositoriesService) RemoveBranchProtection(ctx context.Context, owner,
 
 	// TODO: remove custom Accept header when this API fully launches
 	req.Header.Set("Accept", mediaTypeRequiredApprovingReviewsPreview)
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// GetSignaturesProtectedBranch get required signatures of protected branch
+//
+// GitHub API docs: https://developer.github.com/v3/repos/branches/#get-required-signatures-of-protected-branch
+func (s *RepositoriesService) GetSignaturesProtectedBranch(ctx context.Context, owner, repo, branch string) (*SignaturesProtectedBranch, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_signatures", owner, repo, branch)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeSignaturePreview)
+
+	p := new(SignaturesProtectedBranch)
+	resp, err := s.client.Do(ctx, req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, nil
+}
+
+// AddSignatureProtectedBranch Require signed commits to a protected branch.
+// It requires admin access and branch protection to be enabled.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/branches/#add-required-signatures-of-protected-branch
+func (s *RepositoriesService) AddSignatureProtectedBranch(ctx context.Context, owner, repo, branch string) (*SignaturesProtectedBranch, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_signatures", owner, repo, branch)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeSignaturePreview)
+
+	r := new(SignaturesProtectedBranch)
+	resp, err := s.client.Do(ctx, req, r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r, resp, err
+}
+
+// RemoveSignatureProtectedBranch removes required signed commits on a given branch.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/branches/#remove-required-signatures-of-protected-branch
+func (s *RepositoriesService) RemoveSignatureProtectedBranch(ctx context.Context, owner, repo, branch string) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_signatures", owner, repo, branch)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeSignaturePreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/repos.go
+++ b/github/repos.go
@@ -702,7 +702,7 @@ type DismissalRestrictionsRequest struct {
 type SignaturesProtectedBranch struct {
 	URL *string `json:"url,omitempty"`
 	// Commits pushed to matching branches must have verified signatures.
-	Enabled *bool `json:"strict,omitempty"`
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 // ListBranches lists branches for the specified repository.

--- a/github/repos.go
+++ b/github/repos.go
@@ -698,11 +698,11 @@ type DismissalRestrictionsRequest struct {
 	Teams *[]string `json:"teams,omitempty"`
 }
 
-// SignaturesProtectedBranch represents the protection status of a individual branch.
+// SignaturesProtectedBranch represents the protection status of an individual branch.
 type SignaturesProtectedBranch struct {
 	URL *string `json:"url,omitempty"`
 	// Commits pushed to matching branches must have verified signatures.
-	Enabled bool `json:"strict"`
+	Enabled bool `json:"strict,omitempty"`
 }
 
 // ListBranches lists branches for the specified repository.
@@ -857,7 +857,7 @@ func (s *RepositoriesService) RemoveBranchProtection(ctx context.Context, owner,
 	return s.client.Do(ctx, req, nil)
 }
 
-// GetSignaturesProtectedBranch get required signatures of protected branch
+// GetSignaturesProtectedBranch gets required signatures of protected branch.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/branches/#get-required-signatures-of-protected-branch
 func (s *RepositoriesService) GetSignaturesProtectedBranch(ctx context.Context, owner, repo, branch string) (*SignaturesProtectedBranch, *Response, error) {
@@ -879,11 +879,11 @@ func (s *RepositoriesService) GetSignaturesProtectedBranch(ctx context.Context, 
 	return p, resp, nil
 }
 
-// AddSignatureProtectedBranch Require signed commits to a protected branch.
+// RequireSignaturesOnProtectedBranch makes signed commits required on a protected branch.
 // It requires admin access and branch protection to be enabled.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/branches/#add-required-signatures-of-protected-branch
-func (s *RepositoriesService) AddSignatureProtectedBranch(ctx context.Context, owner, repo, branch string) (*SignaturesProtectedBranch, *Response, error) {
+func (s *RepositoriesService) RequireSignaturesOnProtectedBranch(ctx context.Context, owner, repo, branch string) (*SignaturesProtectedBranch, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_signatures", owner, repo, branch)
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -902,10 +902,10 @@ func (s *RepositoriesService) AddSignatureProtectedBranch(ctx context.Context, o
 	return r, resp, err
 }
 
-// RemoveSignatureProtectedBranch removes required signed commits on a given branch.
+// OptionalSignaturesOnProtectedBranch removes required signed commits on a given branch.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/branches/#remove-required-signatures-of-protected-branch
-func (s *RepositoriesService) RemoveSignatureProtectedBranch(ctx context.Context, owner, repo, branch string) (*Response, error) {
+func (s *RepositoriesService) OptionalSignaturesOnProtectedBranch(ctx context.Context, owner, repo, branch string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_signatures", owner, repo, branch)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/repos.go
+++ b/github/repos.go
@@ -702,7 +702,7 @@ type DismissalRestrictionsRequest struct {
 type SignaturesProtectedBranch struct {
 	URL *string `json:"url,omitempty"`
 	// Commits pushed to matching branches must have verified signatures.
-	Enabled bool `json:"strict,omitempty"`
+	Enabled *bool `json:"strict,omitempty"`
 }
 
 // ListBranches lists branches for the specified repository.

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -1066,13 +1066,13 @@ func TestRepositoriesService_GetSignaturesProtectedBranch(t *testing.T) {
 	})
 
 	signature, _, err := client.Repositories.GetSignaturesProtectedBranch(context.Background(), "o", "r", "b")
-
 	if err != nil {
 		t.Errorf("Repositories.GetSignaturesProtectedBranch returned error: %v", err)
 	}
 
 	want := &SignaturesProtectedBranch{
-		URL: String("/repos/o/r/branches/b/protection/required_signatures"),
+		URL:     String("/repos/o/r/branches/b/protection/required_signatures"),
+		Enabled: Bool(false),
 	}
 
 	if !reflect.DeepEqual(signature, want) {
@@ -1080,7 +1080,7 @@ func TestRepositoriesService_GetSignaturesProtectedBranch(t *testing.T) {
 	}
 }
 
-func TestRepositoriesService_AddSignatureProtectedBranch(t *testing.T) {
+func TestRepositoriesService_RequireSignaturesOnProtectedBranch(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -1095,8 +1095,9 @@ func TestRepositoriesService_AddSignatureProtectedBranch(t *testing.T) {
 		t.Errorf("Repositories.RequireSignaturesOnProtectedBranch returned error: %v", err)
 	}
 
-	want := &SignaturesProtectedBranch{
-		URL: String("/repos/o/r/branches/b/protection/required_signatures"),
+	want := SignaturesProtectedBranch{
+		URL:     String("/repos/o/r/branches/b/protection/required_signatures"),
+		Enabled: Bool(false),
 	}
 
 	if !reflect.DeepEqual(signature, want) {

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -1055,6 +1055,71 @@ func TestRepositoriesService_RemoveAdminEnforcement(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_GetSignaturesProtectedBranch(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/branches/b/protection/required_signatures", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeSignaturePreview)
+		fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/required_signatures","enabled":false}`)
+	})
+
+	signature, _, err := client.Repositories.GetSignaturesProtectedBranch(context.Background(), "o", "r", "b")
+	if err != nil {
+		t.Errorf("Repositories.GetSignaturesProtectedBranch returned error: %v", err)
+	}
+
+	want := &SignaturesProtectedBranch{
+		URL:     String("/repos/o/r/branches/b/protection/required_signatures"),
+		Enabled: false,
+	}
+
+	if !reflect.DeepEqual(signature, want) {
+		t.Errorf("Repositories.GetSignaturesProtectedBranch returned %+v, want %+v", signature, want)
+	}
+}
+
+func TestRepositoriesService_AddSignatureProtectedBranch(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/branches/b/protection/required_signatures", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeSignaturePreview)
+		fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/required_signatures","enabled":false}`)
+	})
+
+	signature, _, err := client.Repositories.AddSignatureProtectedBranch(context.Background(), "o", "r", "b")
+	if err != nil {
+		t.Errorf("Repositories.AddSignatureProtectedBranch returned error: %v", err)
+	}
+
+	want := &SignaturesProtectedBranch{
+		URL:     String("/repos/o/r/branches/b/protection/required_signatures"),
+		Enabled: false,
+	}
+	if !reflect.DeepEqual(signature, want) {
+		t.Errorf("Repositories.AddSignatureProtectedBranch returned %+v, want %+v", signature, want)
+	}
+}
+
+func TestRepositoriesService_RemoveSignatureProtectedBranch(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/branches/b/protection/required_signatures", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testHeader(t, r, "Accept", mediaTypeSignaturePreview)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	_, err := client.Repositories.RemoveSignatureProtectedBranch(context.Background(), "o", "r", "b")
+	if err != nil {
+		t.Errorf("Repositories.RemoveSignatureProtectedBranch returned error: %v", err)
+	}
+}
+
 func TestPullRequestReviewsEnforcementRequest_MarshalJSON_nilDismissalRestirctions(t *testing.T) {
 	req := PullRequestReviewsEnforcementRequest{}
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -1090,9 +1090,9 @@ func TestRepositoriesService_AddSignatureProtectedBranch(t *testing.T) {
 		fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/required_signatures","enabled":false}`)
 	})
 
-	signature, _, err := client.Repositories.AddSignatureProtectedBranch(context.Background(), "o", "r", "b")
+	signature, _, err := client.Repositories.RequireSignaturesOnProtectedBranch(context.Background(), "o", "r", "b")
 	if err != nil {
-		t.Errorf("Repositories.AddSignatureProtectedBranch returned error: %v", err)
+		t.Errorf("Repositories.RequireSignaturesOnProtectedBranch returned error: %v", err)
 	}
 
 	want := &SignaturesProtectedBranch{
@@ -1100,7 +1100,7 @@ func TestRepositoriesService_AddSignatureProtectedBranch(t *testing.T) {
 		Enabled: false,
 	}
 	if !reflect.DeepEqual(signature, want) {
-		t.Errorf("Repositories.AddSignatureProtectedBranch returned %+v, want %+v", signature, want)
+		t.Errorf("Repositories.RequireSignaturesOnProtectedBranch returned %+v, want %+v", signature, want)
 	}
 }
 
@@ -1114,9 +1114,9 @@ func TestRepositoriesService_RemoveSignatureProtectedBranch(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Repositories.RemoveSignatureProtectedBranch(context.Background(), "o", "r", "b")
+	_, err := client.Repositories.OptionalSignaturesOnProtectedBranch(context.Background(), "o", "r", "b")
 	if err != nil {
-		t.Errorf("Repositories.RemoveSignatureProtectedBranch returned error: %v", err)
+		t.Errorf("Repositories.OptionalSignaturesOnProtectedBranch returned error: %v", err)
 	}
 }
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -1105,7 +1105,7 @@ func TestRepositoriesService_RequireSignaturesOnProtectedBranch(t *testing.T) {
 	}
 }
 
-func TestRepositoriesService_RemoveSignatureProtectedBranch(t *testing.T) {
+func TestRepositoriesService_OptionalSignaturesOnProtectedBranch(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -1066,13 +1066,13 @@ func TestRepositoriesService_GetSignaturesProtectedBranch(t *testing.T) {
 	})
 
 	signature, _, err := client.Repositories.GetSignaturesProtectedBranch(context.Background(), "o", "r", "b")
+
 	if err != nil {
 		t.Errorf("Repositories.GetSignaturesProtectedBranch returned error: %v", err)
 	}
 
 	want := &SignaturesProtectedBranch{
 		URL:     String("/repos/o/r/branches/b/protection/required_signatures"),
-		Enabled: false,
 	}
 
 	if !reflect.DeepEqual(signature, want) {
@@ -1097,8 +1097,8 @@ func TestRepositoriesService_AddSignatureProtectedBranch(t *testing.T) {
 
 	want := &SignaturesProtectedBranch{
 		URL:     String("/repos/o/r/branches/b/protection/required_signatures"),
-		Enabled: false,
 	}
+
 	if !reflect.DeepEqual(signature, want) {
 		t.Errorf("Repositories.RequireSignaturesOnProtectedBranch returned %+v, want %+v", signature, want)
 	}

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -1072,7 +1072,7 @@ func TestRepositoriesService_GetSignaturesProtectedBranch(t *testing.T) {
 	}
 
 	want := &SignaturesProtectedBranch{
-		URL:     String("/repos/o/r/branches/b/protection/required_signatures"),
+		URL: String("/repos/o/r/branches/b/protection/required_signatures"),
 	}
 
 	if !reflect.DeepEqual(signature, want) {
@@ -1096,7 +1096,7 @@ func TestRepositoriesService_AddSignatureProtectedBranch(t *testing.T) {
 	}
 
 	want := &SignaturesProtectedBranch{
-		URL:     String("/repos/o/r/branches/b/protection/required_signatures"),
+		URL: String("/repos/o/r/branches/b/protection/required_signatures"),
 	}
 
 	if !reflect.DeepEqual(signature, want) {

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -1087,7 +1087,7 @@ func TestRepositoriesService_RequireSignaturesOnProtectedBranch(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/branches/b/protection/required_signatures", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", mediaTypeSignaturePreview)
-		fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/required_signatures","enabled":false}`)
+		fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/required_signatures","enabled":true}`)
 	})
 
 	signature, _, err := client.Repositories.RequireSignaturesOnProtectedBranch(context.Background(), "o", "r", "b")
@@ -1095,9 +1095,9 @@ func TestRepositoriesService_RequireSignaturesOnProtectedBranch(t *testing.T) {
 		t.Errorf("Repositories.RequireSignaturesOnProtectedBranch returned error: %v", err)
 	}
 
-	want := SignaturesProtectedBranch{
+	want := &SignaturesProtectedBranch{
 		URL:     String("/repos/o/r/branches/b/protection/required_signatures"),
-		Enabled: Bool(false),
+		Enabled: Bool(true),
 	}
 
 	if !reflect.DeepEqual(signature, want) {


### PR DESCRIPTION
Added support for the preview required commit signatures for Protected Branches API.

https://developer.github.com/changes/2018-02-22-protected-branches-required-signatures/

This solves: https://github.com/google/go-github/issues/902