### PR TITLE
WIP : Adding the new Interactions API support

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -125,6 +125,9 @@ const (
 
 	// https://developer.github.com/changes/2018-09-05-project-card-events/
 	mediaTypeProjectCardDetailsPreview = "application/vnd.github.starfox-preview+json"
+
+	// https://developer.github.com/changes/2018-12-18-interactions-preview/
+	mediaTypeRepositoryInteractionsPreview = "application/vnd.github.sombra-preview+json"
 )
 
 // A Client manages communication with the GitHub API.

--- a/github/repos_interactions.go
+++ b/github/repos_interactions.go
@@ -1,0 +1,42 @@
+// Copyright 2018 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// RepositoryInteraction represents the interaction
+// restrictions for a repository
+type RepositoryInteraction struct {
+	Limit     *string    `json:"limit,omitempty"`
+	Origin    *string    `json:"origin,omitempty"`
+	ExpiresAt *Timestamp `json:"expires_at,omitempty"`
+}
+
+// GetInteractions fetches the interaction restrictions for a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/interactions/repos/#get-interaction-restrictions-for-a-repository
+func (s *RepositoriesService) GetInteractions(ctx context.Context, owner string, repo string) (*RepositoryInteraction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/interaction-limits", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeRepositoryInteractionsPreview)
+
+	repositoryInteractions := new(RepositoryInteraction)
+
+	resp, err := s.client.Do(ctx, req, repositoryInteractions)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return repositoryInteractions, resp, nil
+}

--- a/github/repos_interactions_test.go
+++ b/github/repos_interactions_test.go
@@ -1,0 +1,35 @@
+// Copyright 2018 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestReactionService_GetInteractions(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/interaction-limits", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeRepositoryInteractionsPreview)
+		fmt.Fprint(w, `{"origin":"repository"}`)
+	})
+
+	repoInteractions, _, err := client.Repositories.GetInteractions(context.Background(), "o", "r")
+	if err != nil {
+		t.Errorf("Repositories.GetInteractions returned error: %v", err)
+	}
+
+	want := &RepositoryInteraction{Origin: String("repository")}
+	if !reflect.DeepEqual(repoInteractions, want) {
+		t.Errorf("Repositories.GetInteractions returned %+v, want %+v", repoInteractions, want)
+	}
+}


### PR DESCRIPTION
GitHub release Interactions API for both repositories and organisations.

This PR adds `GetInteractions` method for `RepositoriesService` and the respective test case.
In the next commit will add support for `UpdateInteractions` and `DeleteInteractions` for repositories.

