### PR TITLE
Adding the new Interactions API support for repositories

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -3612,6 +3612,30 @@ func (i *InstallationToken) GetToken() string {
 	return *i.Token
 }
 
+// GetExpiresAt returns the ExpiresAt field if it's non-nil, zero value otherwise.
+func (i *Interaction) GetExpiresAt() Timestamp {
+	if i == nil || i.ExpiresAt == nil {
+		return Timestamp{}
+	}
+	return *i.ExpiresAt
+}
+
+// GetLimit returns the Limit field if it's non-nil, zero value otherwise.
+func (i *Interaction) GetLimit() string {
+	if i == nil || i.Limit == nil {
+		return ""
+	}
+	return *i.Limit
+}
+
+// GetOrigin returns the Origin field if it's non-nil, zero value otherwise.
+func (i *Interaction) GetOrigin() string {
+	if i == nil || i.Origin == nil {
+		return ""
+	}
+	return *i.Origin
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (i *Invitation) GetCreatedAt() time.Time {
 	if i == nil || i.CreatedAt == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -3613,7 +3613,7 @@ func (i *InstallationToken) GetToken() string {
 }
 
 // GetExpiresAt returns the ExpiresAt field if it's non-nil, zero value otherwise.
-func (i *Interaction) GetExpiresAt() Timestamp {
+func (i *InteractionRestriction) GetExpiresAt() Timestamp {
 	if i == nil || i.ExpiresAt == nil {
 		return Timestamp{}
 	}
@@ -3621,7 +3621,7 @@ func (i *Interaction) GetExpiresAt() Timestamp {
 }
 
 // GetLimit returns the Limit field if it's non-nil, zero value otherwise.
-func (i *Interaction) GetLimit() string {
+func (i *InteractionRestriction) GetLimit() string {
 	if i == nil || i.Limit == nil {
 		return ""
 	}
@@ -3629,7 +3629,7 @@ func (i *Interaction) GetLimit() string {
 }
 
 // GetOrigin returns the Origin field if it's non-nil, zero value otherwise.
-func (i *Interaction) GetOrigin() string {
+func (i *InteractionRestriction) GetOrigin() string {
 	if i == nil || i.Origin == nil {
 		return ""
 	}

--- a/github/github.go
+++ b/github/github.go
@@ -125,6 +125,9 @@ const (
 
 	// https://developer.github.com/changes/2018-09-05-project-card-events/
 	mediaTypeProjectCardDetailsPreview = "application/vnd.github.starfox-preview+json"
+
+	// https://developer.github.com/changes/2018-12-18-interactions-preview/
+	mediaTypeRepositoryInteractionsPreview = "application/vnd.github.sombra-preview+json"
 )
 
 // A Client manages communication with the GitHub API.
@@ -157,6 +160,7 @@ type Client struct {
 	Gists          *GistsService
 	Git            *GitService
 	Gitignores     *GitignoresService
+	Interactions   *InteractionsService
 	Issues         *IssuesService
 	Licenses       *LicensesService
 	Marketplace    *MarketplaceService
@@ -249,6 +253,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Gists = (*GistsService)(&c.common)
 	c.Git = (*GitService)(&c.common)
 	c.Gitignores = (*GitignoresService)(&c.common)
+	c.Interactions = (*InteractionsService)(&c.common)
 	c.Issues = (*IssuesService)(&c.common)
 	c.Licenses = (*LicensesService)(&c.common)
 	c.Marketplace = &MarketplaceService{client: c}

--- a/github/interactions.go
+++ b/github/interactions.go
@@ -1,0 +1,20 @@
+// Copyright 2018 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+// InteractionsService handles communication with the repo and org related
+// methods of the GitHub API.
+//
+// GitHub API docs: https://developer.github.com/v3/interactions/
+type InteractionsService service
+
+// Interaction represents the interaction restrictions
+// for repository and organisation
+type Interaction struct {
+	Limit     *string    `json:"limit,omitempty"`
+	Origin    *string    `json:"origin,omitempty"`
+	ExpiresAt *Timestamp `json:"expires_at,omitempty"`
+}

--- a/github/interactions.go
+++ b/github/interactions.go
@@ -11,8 +11,8 @@ package github
 // GitHub API docs: https://developer.github.com/v3/interactions/
 type InteractionsService service
 
-// Interaction represents the interaction restrictions for repository and organization.
-type Interaction struct {
+// InteractionRestriction represents the interaction restrictions for repository and organization.
+type InteractionRestriction struct {
 	// Specifies the group of GitHub users who can
 	// comment, open issues, or create pull requests for the given repository.
 	// Possible values are: "existing_users", "contributors_only" and "collaborators_only".

--- a/github/interactions.go
+++ b/github/interactions.go
@@ -5,16 +5,24 @@
 
 package github
 
-// InteractionsService handles communication with the repo and org related
+// InteractionsService handles communication with the repository and organization related
 // methods of the GitHub API.
 //
 // GitHub API docs: https://developer.github.com/v3/interactions/
 type InteractionsService service
 
-// Interaction represents the interaction restrictions
-// for repository and organisation
+// Interaction represents the interaction restrictions for repository and organization.
 type Interaction struct {
-	Limit     *string    `json:"limit,omitempty"`
-	Origin    *string    `json:"origin,omitempty"`
+	// Specifies the group of GitHub users who can
+	// comment, open issues, or create pull requests for the given repository.
+	// Possible values are: "existing_users", "contributors_only" and "collaborators_only".
+	Limit *string `json:"limit,omitempty"`
+
+	// Origin specifies the type of the resource to interact with.
+	// Possible values are: "repository" and "organization".
+	Origin *string `json:"origin,omitempty"`
+
+	// ExpiresAt specifies the time after which the interaction restrictions expire.
+	// The default expiry time is 24 hours from the time restriction is created.
 	ExpiresAt *Timestamp `json:"expires_at,omitempty"`
 }

--- a/github/interactions_repos.go
+++ b/github/interactions_repos.go
@@ -1,0 +1,34 @@
+// Copyright 2018 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// GetInteractions fetches the interaction restrictions for a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/interactions/repos/#get-interaction-restrictions-for-a-repository
+func (s *InteractionsService) GetInteractions(ctx context.Context, owner string, repo string) (*Interaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/interaction-limits", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeRepositoryInteractionsPreview)
+
+	repositoryInteractions := new(Interaction)
+
+	resp, err := s.client.Do(ctx, req, repositoryInteractions)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return repositoryInteractions, resp, nil
+}

--- a/github/interactions_repos.go
+++ b/github/interactions_repos.go
@@ -10,10 +10,10 @@ import (
 	"fmt"
 )
 
-// GetInteractions fetches the interaction restrictions for a repository.
+// GetRestrictions fetches the interaction restrictions for a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/interactions/repos/#get-interaction-restrictions-for-a-repository
-func (s *InteractionsService) GetInteractions(ctx context.Context, owner string, repo string) (*Interaction, *Response, error) {
+func (s *InteractionsService) GetRestrictions(ctx context.Context, owner, repo string) (*Interaction, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/interaction-limits", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -33,10 +33,10 @@ func (s *InteractionsService) GetInteractions(ctx context.Context, owner string,
 	return repositoryInteractions, resp, nil
 }
 
-// UpdateInteractions adds or updates the interaction restrictions for a repository.
+// UpdateRestrictions adds or updates the interaction restrictions for a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/interactions/repos/#add-or-update-interaction-restrictions-for-a-repository
-func (s *InteractionsService) UpdateInteractions(ctx context.Context, owner string, repo string, interaction *Interaction) (*Interaction, *Response, error) {
+func (s *InteractionsService) UpdateRestrictions(ctx context.Context, owner, repo string, interaction *Interaction) (*Interaction, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/interaction-limits", owner, repo)
 	req, err := s.client.NewRequest("PUT", u, interaction)
 	if err != nil {
@@ -56,10 +56,10 @@ func (s *InteractionsService) UpdateInteractions(ctx context.Context, owner stri
 	return repositoryInteractions, resp, nil
 }
 
-// RemoveInteractions removes the interaction restrictions for a repository.
+// RemoveRestrictions removes the interaction restrictions for a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/interactions/repos/#remove-interaction-restrictions-for-a-repository
-func (s *InteractionsService) RemoveInteractions(ctx context.Context, owner string, repo string) (*Response, error) {
+func (s *InteractionsService) RemoveRestrictions(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/interaction-limits", owner, repo)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/interactions_repos.go
+++ b/github/interactions_repos.go
@@ -32,3 +32,26 @@ func (s *InteractionsService) GetInteractions(ctx context.Context, owner string,
 
 	return repositoryInteractions, resp, nil
 }
+
+// UpdateInteractions adds or updates the interaction restrictions for a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/interactions/repos/#add-or-update-interaction-restrictions-for-a-repository
+func (s *InteractionsService) UpdateInteractions(ctx context.Context, owner string, repo string, interaction *Interaction) (*Interaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/interaction-limits", owner, repo)
+	req, err := s.client.NewRequest("PUT", u, interaction)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeRepositoryInteractionsPreview)
+
+	repositoryInteractions := new(Interaction)
+
+	resp, err := s.client.Do(ctx, req, repositoryInteractions)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return repositoryInteractions, resp, nil
+}

--- a/github/interactions_repos.go
+++ b/github/interactions_repos.go
@@ -55,3 +55,19 @@ func (s *InteractionsService) UpdateInteractions(ctx context.Context, owner stri
 
 	return repositoryInteractions, resp, nil
 }
+
+// RemoveInteractions removes the interaction restrictions for a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/interactions/repos/#remove-interaction-restrictions-for-a-repository
+func (s *InteractionsService) RemoveInteractions(ctx context.Context, owner string, repo string) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/interaction-limits", owner, repo)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeRepositoryInteractionsPreview)
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/interactions_repos.go
+++ b/github/interactions_repos.go
@@ -13,7 +13,7 @@ import (
 // GetRestrictions fetches the interaction restrictions for a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/interactions/repos/#get-interaction-restrictions-for-a-repository
-func (s *InteractionsService) GetRestrictions(ctx context.Context, owner, repo string) (*Interaction, *Response, error) {
+func (s *InteractionsService) GetRestrictions(ctx context.Context, owner, repo string) (*InteractionRestriction, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/interaction-limits", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -23,7 +23,7 @@ func (s *InteractionsService) GetRestrictions(ctx context.Context, owner, repo s
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeRepositoryInteractionsPreview)
 
-	repositoryInteractions := new(Interaction)
+	repositoryInteractions := new(InteractionRestriction)
 
 	resp, err := s.client.Do(ctx, req, repositoryInteractions)
 	if err != nil {
@@ -36,7 +36,7 @@ func (s *InteractionsService) GetRestrictions(ctx context.Context, owner, repo s
 // UpdateRestrictions adds or updates the interaction restrictions for a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/interactions/repos/#add-or-update-interaction-restrictions-for-a-repository
-func (s *InteractionsService) UpdateRestrictions(ctx context.Context, owner, repo string, interaction *Interaction) (*Interaction, *Response, error) {
+func (s *InteractionsService) UpdateRestrictions(ctx context.Context, owner, repo string, interaction *InteractionRestriction) (*InteractionRestriction, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/interaction-limits", owner, repo)
 	req, err := s.client.NewRequest("PUT", u, interaction)
 	if err != nil {
@@ -46,7 +46,7 @@ func (s *InteractionsService) UpdateRestrictions(ctx context.Context, owner, rep
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeRepositoryInteractionsPreview)
 
-	repositoryInteractions := new(Interaction)
+	repositoryInteractions := new(InteractionRestriction)
 
 	resp, err := s.client.Do(ctx, req, repositoryInteractions)
 	if err != nil {

--- a/github/interactions_repos_test.go
+++ b/github/interactions_repos_test.go
@@ -1,0 +1,35 @@
+// Copyright 2018 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestInteractionsService_GetInteractions(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/interaction-limits", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeRepositoryInteractionsPreview)
+		fmt.Fprint(w, `{"origin":"repository"}`)
+	})
+
+	repoInteractions, _, err := client.Interactions.GetInteractions(context.Background(), "o", "r")
+	if err != nil {
+		t.Errorf("Interactions.GetInteractions returned error: %v", err)
+	}
+
+	want := &Interaction{Origin: String("repository")}
+	if !reflect.DeepEqual(repoInteractions, want) {
+		t.Errorf("Interactions.GetInteractions returned %+v, want %+v", repoInteractions, want)
+	}
+}

--- a/github/interactions_repos_test.go
+++ b/github/interactions_repos_test.go
@@ -63,3 +63,18 @@ func TestInteractionsService_UpdateInteractions(t *testing.T) {
 		t.Errorf("Interactions.UpdateInteractions returned %+v, want %+v", repoInteractions, want)
 	}
 }
+
+func TestInteractionsService_RemoveInteractions(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/interaction-limits", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testHeader(t, r, "Accept", mediaTypeRepositoryInteractionsPreview)
+	})
+
+	_, err := client.Interactions.RemoveInteractions(context.Background(), "o", "r")
+	if err != nil {
+		t.Errorf("Interactions.RemoveInteractions returned error: %v", err)
+	}
+}

--- a/github/interactions_repos_test.go
+++ b/github/interactions_repos_test.go
@@ -29,7 +29,7 @@ func TestInteractionsService_GetRestrictions(t *testing.T) {
 		t.Errorf("Interactions.GetRestrictions returned error: %v", err)
 	}
 
-	want := &Interaction{Origin: String("repository")}
+	want := &InteractionRestriction{Origin: String("repository")}
 	if !reflect.DeepEqual(repoInteractions, want) {
 		t.Errorf("Interactions.GetRestrictions returned %+v, want %+v", repoInteractions, want)
 	}
@@ -39,10 +39,10 @@ func TestInteractionsService_UpdateRestrictions(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	input := &Interaction{Limit: String("existing_users")}
+	input := &InteractionRestriction{Limit: String("existing_users")}
 
 	mux.HandleFunc("/repos/o/r/interaction-limits", func(w http.ResponseWriter, r *http.Request) {
-		v := new(Interaction)
+		v := new(InteractionRestriction)
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
@@ -58,7 +58,7 @@ func TestInteractionsService_UpdateRestrictions(t *testing.T) {
 		t.Errorf("Interactions.UpdateRestrictions returned error: %v", err)
 	}
 
-	want := &Interaction{Origin: String("repository")}
+	want := &InteractionRestriction{Origin: String("repository")}
 	if !reflect.DeepEqual(repoInteractions, want) {
 		t.Errorf("Interactions.UpdateRestrictions returned %+v, want %+v", repoInteractions, want)
 	}

--- a/github/interactions_repos_test.go
+++ b/github/interactions_repos_test.go
@@ -55,11 +55,11 @@ func TestInteractionsService_UpdateInteractions(t *testing.T) {
 
 	repoInteractions, _, err := client.Interactions.UpdateInteractions(context.Background(), "o", "r", input)
 	if err != nil {
-		t.Errorf("Interactions.GetInteractions returned error: %v", err)
+		t.Errorf("Interactions.UpdateInteractions returned error: %v", err)
 	}
 
 	want := &Interaction{Origin: String("repository")}
 	if !reflect.DeepEqual(repoInteractions, want) {
-		t.Errorf("Interactions.GetInteractions returned %+v, want %+v", repoInteractions, want)
+		t.Errorf("Interactions.UpdateInteractions returned %+v, want %+v", repoInteractions, want)
 	}
 }

--- a/github/interactions_repos_test.go
+++ b/github/interactions_repos_test.go
@@ -7,6 +7,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -24,6 +25,35 @@ func TestInteractionsService_GetInteractions(t *testing.T) {
 	})
 
 	repoInteractions, _, err := client.Interactions.GetInteractions(context.Background(), "o", "r")
+	if err != nil {
+		t.Errorf("Interactions.GetInteractions returned error: %v", err)
+	}
+
+	want := &Interaction{Origin: String("repository")}
+	if !reflect.DeepEqual(repoInteractions, want) {
+		t.Errorf("Interactions.GetInteractions returned %+v, want %+v", repoInteractions, want)
+	}
+}
+
+func TestInteractionsService_UpdateInteractions(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &Interaction{Limit: String("existing_users")}
+
+	mux.HandleFunc("/repos/o/r/interaction-limits", func(w http.ResponseWriter, r *http.Request) {
+		v := new(Interaction)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Accept", mediaTypeRepositoryInteractionsPreview)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		fmt.Fprint(w, `{"origin":"repository"}`)
+	})
+
+	repoInteractions, _, err := client.Interactions.UpdateInteractions(context.Background(), "o", "r", input)
 	if err != nil {
 		t.Errorf("Interactions.GetInteractions returned error: %v", err)
 	}

--- a/github/interactions_repos_test.go
+++ b/github/interactions_repos_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 )
 
-func TestInteractionsService_GetInteractions(t *testing.T) {
+func TestInteractionsService_GetRestrictions(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -24,18 +24,18 @@ func TestInteractionsService_GetInteractions(t *testing.T) {
 		fmt.Fprint(w, `{"origin":"repository"}`)
 	})
 
-	repoInteractions, _, err := client.Interactions.GetInteractions(context.Background(), "o", "r")
+	repoInteractions, _, err := client.Interactions.GetRestrictions(context.Background(), "o", "r")
 	if err != nil {
-		t.Errorf("Interactions.GetInteractions returned error: %v", err)
+		t.Errorf("Interactions.GetRestrictions returned error: %v", err)
 	}
 
 	want := &Interaction{Origin: String("repository")}
 	if !reflect.DeepEqual(repoInteractions, want) {
-		t.Errorf("Interactions.GetInteractions returned %+v, want %+v", repoInteractions, want)
+		t.Errorf("Interactions.GetRestrictions returned %+v, want %+v", repoInteractions, want)
 	}
 }
 
-func TestInteractionsService_UpdateInteractions(t *testing.T) {
+func TestInteractionsService_UpdateRestrictions(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -53,18 +53,18 @@ func TestInteractionsService_UpdateInteractions(t *testing.T) {
 		fmt.Fprint(w, `{"origin":"repository"}`)
 	})
 
-	repoInteractions, _, err := client.Interactions.UpdateInteractions(context.Background(), "o", "r", input)
+	repoInteractions, _, err := client.Interactions.UpdateRestrictions(context.Background(), "o", "r", input)
 	if err != nil {
-		t.Errorf("Interactions.UpdateInteractions returned error: %v", err)
+		t.Errorf("Interactions.UpdateRestrictions returned error: %v", err)
 	}
 
 	want := &Interaction{Origin: String("repository")}
 	if !reflect.DeepEqual(repoInteractions, want) {
-		t.Errorf("Interactions.UpdateInteractions returned %+v, want %+v", repoInteractions, want)
+		t.Errorf("Interactions.UpdateRestrictions returned %+v, want %+v", repoInteractions, want)
 	}
 }
 
-func TestInteractionsService_RemoveInteractions(t *testing.T) {
+func TestInteractionsService_RemoveRestrictions(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -73,8 +73,8 @@ func TestInteractionsService_RemoveInteractions(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeRepositoryInteractionsPreview)
 	})
 
-	_, err := client.Interactions.RemoveInteractions(context.Background(), "o", "r")
+	_, err := client.Interactions.RemoveRestrictions(context.Background(), "o", "r")
 	if err != nil {
-		t.Errorf("Interactions.RemoveInteractions returned error: %v", err)
+		t.Errorf("Interactions.RemoveRestrictions returned error: %v", err)
 	}
 }


### PR DESCRIPTION
Created files based on the `{service}_{api}.go` format i.e `interactions_repos.go`.

API response for repository interactions and organisation interactions is same so I've abstracted the `Interaction` struct in `interactions.go`.

This PR adds the API's to `GetRestrictions`, `UpdateRestrictions` and `RemoveRestrictions` for a given repository.