### PR TITLE
doc.go - include versioned import path

### DIFF
--- a/github/doc.go
+++ b/github/doc.go
@@ -8,7 +8,8 @@ Package github provides a client for using the GitHub API.
 
 Usage:
 
-	import "github.com/google/go-github/github"
+	import "github.com/google/go-github/v21/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
+	import "github.com/google/go-github/github"     // with go modules disabled
 
 Construct a new GitHub client, then use the various services on the client to
 access different parts of the GitHub API. For example:


### PR DESCRIPTION
copy import paths from top-level README.md - to have the versioned import path
to show on https://godoc.org/github.com/google/go-github/github