### PR TITLE
Add Target field to RepositoryContent

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9700,6 +9700,14 @@ func (r *RepositoryContent) GetSize() int {
 	return *r.Size
 }
 
+// GetTarget returns the Target field if it's non-nil, zero value otherwise.
+func (r *RepositoryContent) GetTarget() string {
+	if r == nil || r.Target == nil {
+		return ""
+	}
+	return *r.Target
+}
+
 // GetType returns the Type field if it's non-nil, zero value otherwise.
 func (r *RepositoryContent) GetType() string {
 	if r == nil || r.Type == nil {

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -21,7 +21,10 @@ import (
 
 // RepositoryContent represents a file or directory in a github repository.
 type RepositoryContent struct {
-	Type     *string `json:"type,omitempty"`
+	Type *string `json:"type,omitempty"`
+	// Target is only set if the type is "symlink" and the target is not a normal file.
+	// If Target is set, Path will be the symlink path.
+	Target   *string `json:"target,omitempty"`
 	Encoding *string `json:"encoding,omitempty"`
 	Size     *int    `json:"size,omitempty"`
 	Name     *string `json:"name,omitempty"`


### PR DESCRIPTION
When getting file contents and the file is a symlink that points to anything other than a normal file (for example, a directory), the target field is used to indicate this.

This PR adds the Target field and accessor.

Fixes #1106 