### PR TITLE
update broken and old enterprise doc links

### DIFF
--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -403,7 +403,7 @@ func (s *AuthorizationsService) DeleteGrant(ctx context.Context, id int64) (*Res
 // you can e.g. create or delete a user's public SSH key. NOTE: creating a
 // new token automatically revokes an existing one.
 //
-// GitHub API docs: https://developer.github.com/enterprise/2.5/v3/users/administration/#create-an-impersonation-oauth-token
+// GitHub API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#create-an-impersonation-oauth-token
 func (s *AuthorizationsService) CreateImpersonation(ctx context.Context, username string, authReq *AuthorizationRequest) (*Authorization, *Response, error) {
 	u := fmt.Sprintf("admin/users/%v/authorizations", username)
 	req, err := s.client.NewRequest("POST", u, authReq)
@@ -423,7 +423,7 @@ func (s *AuthorizationsService) CreateImpersonation(ctx context.Context, usernam
 //
 // NOTE: there can be only one at a time.
 //
-// GitHub API docs: https://developer.github.com/enterprise/2.5/v3/users/administration/#delete-an-impersonation-oauth-token
+// GitHub API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#delete-an-impersonation-oauth-token
 func (s *AuthorizationsService) DeleteImpersonation(ctx context.Context, username string) (*Response, error) {
 	u := fmt.Sprintf("admin/users/%v/authorizations", username)
 	req, err := s.client.NewRequest("DELETE", u, nil)

--- a/github/users_administration.go
+++ b/github/users_administration.go
@@ -12,7 +12,7 @@ import (
 
 // PromoteSiteAdmin promotes a user to a site administrator of a GitHub Enterprise instance.
 //
-// GitHub API docs: https://developer.github.com/v3/users/administration/#promote-an-ordinary-user-to-a-site-administrator
+// GitHub API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#promote-an-ordinary-user-to-a-site-administrator
 func (s *UsersService) PromoteSiteAdmin(ctx context.Context, user string) (*Response, error) {
 	u := fmt.Sprintf("users/%v/site_admin", user)
 
@@ -26,7 +26,7 @@ func (s *UsersService) PromoteSiteAdmin(ctx context.Context, user string) (*Resp
 
 // DemoteSiteAdmin demotes a user from site administrator of a GitHub Enterprise instance.
 //
-// GitHub API docs: https://developer.github.com/v3/users/administration/#demote-a-site-administrator-to-an-ordinary-user
+// GitHub API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#demote-a-site-administrator-to-an-ordinary-user
 func (s *UsersService) DemoteSiteAdmin(ctx context.Context, user string) (*Response, error) {
 	u := fmt.Sprintf("users/%v/site_admin", user)
 
@@ -40,7 +40,7 @@ func (s *UsersService) DemoteSiteAdmin(ctx context.Context, user string) (*Respo
 
 // Suspend a user on a GitHub Enterprise instance.
 //
-// GitHub API docs: https://developer.github.com/v3/users/administration/#suspend-a-user
+// GitHub API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#suspend-a-user
 func (s *UsersService) Suspend(ctx context.Context, user string) (*Response, error) {
 	u := fmt.Sprintf("users/%v/suspended", user)
 
@@ -54,7 +54,7 @@ func (s *UsersService) Suspend(ctx context.Context, user string) (*Response, err
 
 // Unsuspend a user on a GitHub Enterprise instance.
 //
-// GitHub API docs: https://developer.github.com/v3/users/administration/#unsuspend-a-user
+// GitHub API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#unsuspend-a-user
 func (s *UsersService) Unsuspend(ctx context.Context, user string) (*Response, error) {
 	u := fmt.Sprintf("users/%v/suspended", user)
 


### PR DESCRIPTION
This PR updates the existing documentation links that are either broken or outdated. You will note that `https://developer.github.com/enterprise/v3/` redirects to `https://developer.github.com/enterprise/<lastest enterprise version>/v3/`, so this will hopefully help from having the links become outdated in the future.

