### PR TITLE
Removing 3 service hooks endpoints from the code and the test

### DIFF
--- a/github/repos_hooks.go
+++ b/github/repos_hooks.go
@@ -169,54 +169,12 @@ func (s *RepositoriesService) GetHook(ctx context.Context, owner, repo string, i
 	return h, resp, nil
 }
 
-// EditHook updates a specified Hook.
-//
-// GitHub API docs: https://developer.github.com/v3/repos/hooks/#edit-a-hook
-func (s *RepositoriesService) EditHook(ctx context.Context, owner, repo string, id int64, hook *Hook) (*Hook, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%d", owner, repo, id)
-	req, err := s.client.NewRequest("PATCH", u, hook)
-	if err != nil {
-		return nil, nil, err
-	}
-	h := new(Hook)
-	resp, err := s.client.Do(ctx, req, h)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return h, resp, nil
-}
-
 // DeleteHook deletes a specified Hook.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/hooks/#delete-a-hook
 func (s *RepositoriesService) DeleteHook(ctx context.Context, owner, repo string, id int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/hooks/%d", owner, repo, id)
 	req, err := s.client.NewRequest("DELETE", u, nil)
-	if err != nil {
-		return nil, err
-	}
-	return s.client.Do(ctx, req, nil)
-}
-
-// PingHook triggers a 'ping' event to be sent to the Hook.
-//
-// GitHub API docs: https://developer.github.com/v3/repos/hooks/#ping-a-hook
-func (s *RepositoriesService) PingHook(ctx context.Context, owner, repo string, id int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%d/pings", owner, repo, id)
-	req, err := s.client.NewRequest("POST", u, nil)
-	if err != nil {
-		return nil, err
-	}
-	return s.client.Do(ctx, req, nil)
-}
-
-// TestHook triggers a test Hook by github.
-//
-// GitHub API docs: https://developer.github.com/v3/repos/hooks/#test-a-push-hook
-func (s *RepositoriesService) TestHook(ctx context.Context, owner, repo string, id int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%d/tests", owner, repo, id)
-	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/github/repos_hooks_test.go
+++ b/github/repos_hooks_test.go
@@ -103,43 +103,6 @@ func TestRepositoriesService_GetHook_invalidOwner(t *testing.T) {
 	testURLParseError(t, err)
 }
 
-func TestRepositoriesService_EditHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	input := &Hook{}
-
-	mux.HandleFunc("/repos/o/r/hooks/1", func(w http.ResponseWriter, r *http.Request) {
-		v := new(Hook)
-		json.NewDecoder(r.Body).Decode(v)
-
-		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
-		}
-
-		fmt.Fprint(w, `{"id":1}`)
-	})
-
-	hook, _, err := client.Repositories.EditHook(context.Background(), "o", "r", 1, input)
-	if err != nil {
-		t.Errorf("Repositories.EditHook returned error: %v", err)
-	}
-
-	want := &Hook{ID: Int64(1)}
-	if !reflect.DeepEqual(hook, want) {
-		t.Errorf("Repositories.EditHook returned %+v, want %+v", hook, want)
-	}
-}
-
-func TestRepositoriesService_EditHook_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	_, _, err := client.Repositories.EditHook(context.Background(), "%", "%", 1, nil)
-	testURLParseError(t, err)
-}
-
 func TestRepositoriesService_DeleteHook(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
@@ -159,41 +122,5 @@ func TestRepositoriesService_DeleteHook_invalidOwner(t *testing.T) {
 	defer teardown()
 
 	_, err := client.Repositories.DeleteHook(context.Background(), "%", "%", 1)
-	testURLParseError(t, err)
-}
-
-func TestRepositoriesService_PingHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/repos/o/r/hooks/1/pings", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-	})
-
-	_, err := client.Repositories.PingHook(context.Background(), "o", "r", 1)
-	if err != nil {
-		t.Errorf("Repositories.PingHook returned error: %v", err)
-	}
-}
-
-func TestRepositoriesService_TestHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/repos/o/r/hooks/1/tests", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-	})
-
-	_, err := client.Repositories.TestHook(context.Background(), "o", "r", 1)
-	if err != nil {
-		t.Errorf("Repositories.TestHook returned error: %v", err)
-	}
-}
-
-func TestRepositoriesService_TestHook_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	_, err := client.Repositories.TestHook(context.Background(), "%", "%", 1)
 	testURLParseError(t, err)
 }


### PR DESCRIPTION
Issue: https://github.com/google/go-github/issues/1109

According to this [post](https://developer.github.com/changes/2019-01-29-life-after-github-services/), there will be 3 endpoints affected which will be deprecated: Edit a Hook, Test a Hook, and Ping a Hook. This PR removes the code regarding those 3 endpoints and also from the test file.

cc: @gmlewis 