### PR TITLE
add UserSuspendOptions for user.Suspend

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -12148,6 +12148,14 @@ func (u *UserStats) GetTotalUsers() int {
 	return *u.TotalUsers
 }
 
+// GetReason returns the Reason field if it's non-nil, zero value otherwise.
+func (u *UserSuspendOptions) GetReason() string {
+	if u == nil || u.Reason == nil {
+		return ""
+	}
+	return *u.Reason
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (w *WatchEvent) GetAction() string {
 	if w == nil || w.Action == nil {

--- a/github/users_administration.go
+++ b/github/users_administration.go
@@ -40,17 +40,16 @@ func (s *UsersService) DemoteSiteAdmin(ctx context.Context, user string) (*Respo
 
 // userSuspendOptions represents the reason a user is being suspended.
 type userSuspendOptions struct {
-	Reason string `json:"reason,omitempty"`
+	Reason *string `json:"reason,omitempty"`
 }
 
 // Suspend a user on a GitHub Enterprise instance.
 //
 // GitHub API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#suspend-a-user
-func (s *UsersService) Suspend(ctx context.Context, user string, reason string) (*Response, error) {
+func (s *UsersService) Suspend(ctx context.Context, user string, opt *userSuspendOptions) (*Response, error) {
 	u := fmt.Sprintf("users/%v/suspended", user)
-	opts := &userSuspendOptions{Reason: reason}
 
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest("PUT", u, opt)
 	if err != nil {
 		return nil, err
 	}

--- a/github/users_administration.go
+++ b/github/users_administration.go
@@ -38,15 +38,15 @@ func (s *UsersService) DemoteSiteAdmin(ctx context.Context, user string) (*Respo
 	return s.client.Do(ctx, req, nil)
 }
 
-// userSuspendOptions represents the reason a user is being suspended.
-type userSuspendOptions struct {
+// UserSuspendOptions represents the reason a user is being suspended.
+type UserSuspendOptions struct {
 	Reason *string `json:"reason,omitempty"`
 }
 
 // Suspend a user on a GitHub Enterprise instance.
 //
 // GitHub API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#suspend-a-user
-func (s *UsersService) Suspend(ctx context.Context, user string, opt *userSuspendOptions) (*Response, error) {
+func (s *UsersService) Suspend(ctx context.Context, user string, opt *UserSuspendOptions) (*Response, error) {
 	u := fmt.Sprintf("users/%v/suspended", user)
 
 	req, err := s.client.NewRequest("PUT", u, opt)

--- a/github/users_administration.go
+++ b/github/users_administration.go
@@ -38,13 +38,19 @@ func (s *UsersService) DemoteSiteAdmin(ctx context.Context, user string) (*Respo
 	return s.client.Do(ctx, req, nil)
 }
 
+// userSuspendOptions represents the reason a user is being suspended.
+type userSuspendOptions struct {
+	Reason string `json:"reason,omitempty"`
+}
+
 // Suspend a user on a GitHub Enterprise instance.
 //
 // GitHub API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#suspend-a-user
-func (s *UsersService) Suspend(ctx context.Context, user string) (*Response, error) {
+func (s *UsersService) Suspend(ctx context.Context, user string, reason string) (*Response, error) {
 	u := fmt.Sprintf("users/%v/suspended", user)
+	opts := &userSuspendOptions{Reason: reason}
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/github/users_administration_test.go
+++ b/github/users_administration_test.go
@@ -52,8 +52,7 @@ func TestUsersService_Suspend(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	opt := &userSuspendOptions{}
-	_, err := client.Users.Suspend(context.Background(), "u", opt)
+	_, err := client.Users.Suspend(context.Background(), "u", nil)
 	if err != nil {
 		t.Errorf("Users.Suspend returned error: %v", err)
 	}
@@ -63,10 +62,10 @@ func TestUsersServiceReason_Suspend(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	input := &userSuspendOptions{Reason: String("test")}
+	input := &UserSuspendOptions{Reason: String("test")}
 
 	mux.HandleFunc("/users/u/suspended", func(w http.ResponseWriter, r *http.Request) {
-		v := new(userSuspendOptions)
+		v := new(UserSuspendOptions)
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")

--- a/github/users_administration_test.go
+++ b/github/users_administration_test.go
@@ -50,7 +50,7 @@ func TestUsersService_Suspend(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Users.Suspend(context.Background(), "u")
+	_, err := client.Users.Suspend(context.Background(), "u", "test")
 	if err != nil {
 		t.Errorf("Users.Suspend returned error: %v", err)
 	}


### PR DESCRIPTION
GitHub updated the [suspend a user endpoint](https://developer.github.com/enterprise/v3/enterprise-admin/users/#suspend-a-user) to allow you to send a JSON payload containing the reason that the specified user is being suspended. If you input `""` for the reason, GitHub will default the reason to `Suspended via API by SITE_ADMINISTRATOR` in the audit log.