### PR TITLE
Add missing PullRequest.ReviewComments field

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -7324,6 +7324,14 @@ func (p *PullRequest) GetPatchURL() string {
 	return *p.PatchURL
 }
 
+// GetReviewComments returns the ReviewComments field if it's non-nil, zero value otherwise.
+func (p *PullRequest) GetReviewComments() int {
+	if p == nil || p.ReviewComments == nil {
+		return 0
+	}
+	return *p.ReviewComments
+}
+
 // GetReviewCommentsURL returns the ReviewCommentsURL field if it's non-nil, zero value otherwise.
 func (p *PullRequest) GetReviewCommentsURL() string {
 	if p == nil || p.ReviewCommentsURL == nil {

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -52,6 +52,7 @@ type PullRequest struct {
 	CommentsURL         *string    `json:"comments_url,omitempty"`
 	ReviewCommentsURL   *string    `json:"review_comments_url,omitempty"`
 	ReviewCommentURL    *string    `json:"review_comment_url,omitempty"`
+	ReviewComments      *int       `json:"review_comments,omitempty"`
 	Assignee            *User      `json:"assignee,omitempty"`
 	Assignees           []*User    `json:"assignees,omitempty"`
 	Milestone           *Milestone `json:"milestone,omitempty"`


### PR DESCRIPTION
According to the [GitHub docs](https://developer.github.com/v3/pulls/#get-a-single-pull-request), this field is only returned when
retrieving a single pull request by id, not when listing pull requests.

This commit does not include a test as it seems that most
fields and auto-generated accessors are not being tested.