### PR TITLE
Fix Webhook creation.

### DIFF
--- a/github/repos_hooks.go
+++ b/github/repos_hooks.go
@@ -92,7 +92,7 @@ func (h Hook) String() string {
 // information.
 type createHookRequest struct {
 	// Config is required.
-	Name   string                 `json:"name,omitempty"`
+	Name   string                 `json:"name"`
 	Config map[string]interface{} `json:"config,omitempty"`
 	Events []string               `json:"events,omitempty"`
 	Active *bool                  `json:"active,omitempty"`

--- a/github/repos_hooks.go
+++ b/github/repos_hooks.go
@@ -92,6 +92,7 @@ func (h Hook) String() string {
 // information.
 type createHookRequest struct {
 	// Config is required.
+	Name   string                 `json:"name,omitempty"`
 	Config map[string]interface{} `json:"config,omitempty"`
 	Events []string               `json:"events,omitempty"`
 	Active *bool                  `json:"active,omitempty"`
@@ -108,6 +109,7 @@ func (s *RepositoriesService) CreateHook(ctx context.Context, owner, repo string
 	u := fmt.Sprintf("repos/%v/%v/hooks", owner, repo)
 
 	hookReq := &createHookRequest{
+		Name: 	"web",
 		Events: hook.Events,
 		Active: hook.Active,
 		Config: hook.Config,

--- a/github/repos_hooks.go
+++ b/github/repos_hooks.go
@@ -109,7 +109,7 @@ func (s *RepositoriesService) CreateHook(ctx context.Context, owner, repo string
 	u := fmt.Sprintf("repos/%v/%v/hooks", owner, repo)
 
 	hookReq := &createHookRequest{
-		Name: 	"web",
+		Name:   "web",
 		Events: hook.Events,
 		Active: hook.Active,
 		Config: hook.Config,

--- a/github/repos_hooks_test.go
+++ b/github/repos_hooks_test.go
@@ -25,7 +25,7 @@ func TestRepositoriesService_CreateHook(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		want := &createHookRequest{}
+		want := &createHookRequest{Name: "web"}
 		if !reflect.DeepEqual(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}


### PR DESCRIPTION
## Changes

Attempting to create webhooks fail unless a name is specified. As per the documentation the only name that is valid is "web", so I haven't opted to allow modification of this but creation seems to fail without it.