### PR TITLE
Added test case for commit ref with percent encoding

### DIFF
--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -257,7 +257,7 @@ func TestRepositoriesService_NonAlphabetCharacter_GetCommitSHA1(t *testing.T) {
 		t.Errorf("Expected HTTP 304 response")
 	}
 
-	if want = ""; got != want {
+	if want := ""; got != want {
 		t.Errorf("Repositories.GetCommitSHA1 = %v, want %v", got, want)
 	}
 }

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -223,6 +223,47 @@ func TestRepositoriesService_GetCommitSHA1(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_NonAlphabetCharacter_GetCommitSHA1(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	const sha1 = "01234abcde"
+
+	mux.HandleFunc("/repos/o/r/commits/master%20hash", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeV3SHA)
+
+		fmt.Fprintf(w, sha1)
+	})
+
+	got, _, err := client.Repositories.GetCommitSHA1(context.Background(), "o", "r", "master%20hash", "")
+	if err != nil {
+		t.Errorf("Repositories.GetCommitSHA1 returned error: %v", err)
+	}
+
+	want := sha1
+	if got != want {
+		t.Errorf("Repositories.GetCommitSHA1 = %v, want %v", got, want)
+	}
+
+	mux.HandleFunc("/repos/o/r/commits/tag", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeV3SHA)
+		testHeader(t, r, "If-None-Match", `"`+sha1+`"`)
+
+		w.WriteHeader(http.StatusNotModified)
+	})
+
+	got, _, err = client.Repositories.GetCommitSHA1(context.Background(), "o", "r", "tag", sha1)
+	if err == nil {
+		t.Errorf("Expected HTTP 304 response")
+	}
+
+	want = ""
+	if got != want {
+		t.Errorf("Repositories.GetCommitSHA1 = %v, want %v", got, want)
+	}
+}
+
 func TestRepositoriesService_CompareCommits(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -240,8 +240,7 @@ func TestRepositoriesService_NonAlphabetCharacter_GetCommitSHA1(t *testing.T) {
 		t.Errorf("Repositories.GetCommitSHA1 returned error: %v", err)
 	}
 
-	want := sha1
-	if got != want {
+	if want := sha1; got != want {
 		t.Errorf("Repositories.GetCommitSHA1 = %v, want %v", got, want)
 	}
 
@@ -258,8 +257,7 @@ func TestRepositoriesService_NonAlphabetCharacter_GetCommitSHA1(t *testing.T) {
 		t.Errorf("Expected HTTP 304 response")
 	}
 
-	want = ""
-	if got != want {
+	if want = ""; got != want {
 		t.Errorf("Repositories.GetCommitSHA1 = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/google/go-github/issues/1101

Added test case for `Repositories.GetCommitSHA1`, when it was called with the branch name which includes the non-alphabet character.