### PR TITLE
Allow any Payload during deployment creation

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2132,14 +2132,6 @@ func (d *DeploymentRequest) GetEnvironment() string {
 	return *d.Environment
 }
 
-// GetPayload returns the Payload field if it's non-nil, zero value otherwise.
-func (d *DeploymentRequest) GetPayload() string {
-	if d == nil || d.Payload == nil {
-		return ""
-	}
-	return *d.Payload
-}
-
 // GetProductionEnvironment returns the ProductionEnvironment field if it's non-nil, zero value otherwise.
 func (d *DeploymentRequest) GetProductionEnvironment() bool {
 	if d == nil || d.ProductionEnvironment == nil {

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -32,15 +32,15 @@ type Deployment struct {
 
 // DeploymentRequest represents a deployment request
 type DeploymentRequest struct {
-	Ref                   *string   `json:"ref,omitempty"`
-	Task                  *string   `json:"task,omitempty"`
-	AutoMerge             *bool     `json:"auto_merge,omitempty"`
-	RequiredContexts      *[]string `json:"required_contexts,omitempty"`
-	Payload               *string   `json:"payload,omitempty"`
-	Environment           *string   `json:"environment,omitempty"`
-	Description           *string   `json:"description,omitempty"`
-	TransientEnvironment  *bool     `json:"transient_environment,omitempty"`
-	ProductionEnvironment *bool     `json:"production_environment,omitempty"`
+	Ref                   *string     `json:"ref,omitempty"`
+	Task                  *string     `json:"task,omitempty"`
+	AutoMerge             *bool       `json:"auto_merge,omitempty"`
+	RequiredContexts      *[]string   `json:"required_contexts,omitempty"`
+	Payload               interface{} `json:"payload,omitempty"`
+	Environment           *string     `json:"environment,omitempty"`
+	Description           *string     `json:"description,omitempty"`
+	TransientEnvironment  *bool       `json:"transient_environment,omitempty"`
+	ProductionEnvironment *bool       `json:"production_environment,omitempty"`
 }
 
 // DeploymentsListOptions specifies the optional parameters to the


### PR DESCRIPTION
Fixes #1116.

I tested this change with the following code:

```go
func createDeployment() {
	owner := "gmlewis"
	repo := "my-test-repo"
	foo := struct {
		Foo int    `json:"foo,omitempty"`
		Bar string `json:"bar,omitempty"`
	}{Foo: 1, Bar: "test create deployment with interface{}"}
	req := &github.DeploymentRequest{
		Ref:                  github.String("master"),
		TransientEnvironment: github.Bool(true),
		// Payload:              github.String(`{"foo":1}`),
		Payload: &foo,
	}
	ctx := context.Background()
	deployment, _, err := client.Repositories.CreateDeployment(ctx, owner, repo, req)
	if err != nil {
		log.Fatalf("Repositories.CreateDeployment returned error: %v", err)
	}
	goon.Dump(deployment)
}
```

and when listing the deployments created on multiple runs, I see:

```
2019/02/12 09:55:03 #0: payload={"foo":1,"bar":"test create deployment with interface{}"}
2019/02/12 09:55:03 #1: payload={"Foo":1}
2019/02/12 09:55:03 #2: payload="{\"foo\":1}"
```