### PR TITLE
Add signature field to commit creation

### DIFF
--- a/github/git_commits.go
+++ b/github/git_commits.go
@@ -84,6 +84,7 @@ type createCommit struct {
 	Message   *string       `json:"message,omitempty"`
 	Tree      *string       `json:"tree,omitempty"`
 	Parents   []string      `json:"parents,omitempty"`
+	Signature *string       `json:"signature,omitempty"`
 }
 
 // CreateCommit creates a new commit in a repository.
@@ -114,6 +115,9 @@ func (s *GitService) CreateCommit(ctx context.Context, owner string, repo string
 	}
 	if commit.Tree != nil {
 		body.Tree = commit.Tree.SHA
+	}
+	if commit.Verification != nil {
+		body.Signature = commit.Verification.Signature
 	}
 
 	req, err := s.client.NewRequest("POST", u, body)

--- a/github/git_commits_test.go
+++ b/github/git_commits_test.go
@@ -80,6 +80,50 @@ func TestGitService_CreateCommit(t *testing.T) {
 	}
 }
 
+func TestGitService_CreateSignedCommit(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	signature := "----- BEGIN PGP SIGNATURE -----\n\naaaa\naaaa\n----- END PGP SIGNATURE -----"
+
+	input := &Commit{
+		Message: String("m"),
+		Tree:    &Tree{SHA: String("t")},
+		Parents: []Commit{{SHA: String("p")}},
+		Verification: &SignatureVerification{
+			Signature: String(signature),
+		}
+	}
+
+	mux.HandleFunc("/repos/o/r/git/commits", func(w http.ResponseWriter, r *http.Request) {
+		v := new(createCommit)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "POST")
+
+		want := &createCommit{
+			Message: input.Message,
+			Tree:    String("t"),
+			Parents: []string{"p"},
+			Signature: String(signature),
+		}
+		if !reflect.DeepEqual(v, want) {
+			t.Errorf("Request body = %+v, want %+v", v, want)
+		}
+		fmt.Fprint(w, `{"sha":"s"}`)
+	})
+
+	commit, _, err := client.Git.CreateCommit(context.Background(), "o", "r", input)
+	if err != nil {
+		t.Errorf("Git.CreateCommit returned error: %v", err)
+	}
+
+	want := &Commit{SHA: String("s")}
+	if !reflect.DeepEqual(commit, want) {
+		t.Errorf("Git.CreateCommit returned %+v, want %+v", commit, want)
+	}
+}
+
 func TestGitService_CreateCommit_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()

--- a/github/git_commits_test.go
+++ b/github/git_commits_test.go
@@ -92,7 +92,7 @@ func TestGitService_CreateSignedCommit(t *testing.T) {
 		Parents: []Commit{{SHA: String("p")}},
 		Verification: &SignatureVerification{
 			Signature: String(signature),
-		}
+		},
 	}
 
 	mux.HandleFunc("/repos/o/r/git/commits", func(w http.ResponseWriter, r *http.Request) {
@@ -102,9 +102,9 @@ func TestGitService_CreateSignedCommit(t *testing.T) {
 		testMethod(t, r, "POST")
 
 		want := &createCommit{
-			Message: input.Message,
-			Tree:    String("t"),
-			Parents: []string{"p"},
+			Message:   input.Message,
+			Tree:      String("t"),
+			Parents:   []string{"p"},
 			Signature: String(signature),
 		}
 		if !reflect.DeepEqual(v, want) {


### PR DESCRIPTION
Closes #1123 

This adds the `signature` field for GPG signing of commits.