### PR TITLE
Use url.QueryEscape instead of url.PathEscape to escape query string

### DIFF
--- a/github/search.go
+++ b/github/search.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
-	"strings"
 
 	qs "github.com/google/go-querystring/query"
 )
@@ -223,11 +222,10 @@ func (s *SearchService) search(ctx context.Context, searchType string, parameter
 	if err != nil {
 		return nil, err
 	}
-	q := strings.Replace(parameters.Query, " ", "+", -1)
 	if parameters.RepositoryID != nil {
 		params.Set("repository_id", strconv.FormatInt(*parameters.RepositoryID, 10))
 	}
-	query := "q=" + url.PathEscape(q)
+	query := "q=" + url.QueryEscape(parameters.Query)
 	if v := params.Encode(); v != "" {
 		query = query + "&" + v
 	}

--- a/github/search.go
+++ b/github/search.go
@@ -216,6 +216,9 @@ func (s *SearchService) Labels(ctx context.Context, repoID int64, query string, 
 
 // Helper function that executes search queries against different
 // GitHub search types (repositories, commits, code, issues, users, labels)
+//
+// If *searchParameters.Query includes multiple condition, it MUST NOT include "+" as condition separator.
+// For example, querying with "language:c++" and "leveldb", then *searchParameters.Query should be "language:c++ leveldb" but not "language:c+++leveldb".
 func (s *SearchService) search(ctx context.Context, searchType string, parameters *searchParameters, opt *SearchOptions, result interface{}) (*Response, error) {
 	params, err := qs.Values(opt)
 	if err != nil {

--- a/github/search.go
+++ b/github/search.go
@@ -217,8 +217,8 @@ func (s *SearchService) Labels(ctx context.Context, repoID int64, query string, 
 // Helper function that executes search queries against different
 // GitHub search types (repositories, commits, code, issues, users, labels)
 //
-// If *searchParameters.Query includes multiple condition, it MUST NOT include "+" as condition separator.
-// For example, querying with "language:c++" and "leveldb", then *searchParameters.Query should be "language:c++ leveldb" but not "language:c+++leveldb".
+// If searchParameters.Query includes multiple condition, it MUST NOT include "+" as condition separator.
+// For example, querying with "language:c++" and "leveldb", then searchParameters.Query should be "language:c++ leveldb" but not "language:c+++leveldb".
 func (s *SearchService) search(ctx context.Context, searchType string, parameters *searchParameters, opt *SearchOptions, result interface{}) (*Response, error) {
 	params, err := qs.Values(opt)
 	if err != nil {

--- a/github/search.go
+++ b/github/search.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"strconv"
 
 	qs "github.com/google/go-querystring/query"
@@ -225,11 +224,8 @@ func (s *SearchService) search(ctx context.Context, searchType string, parameter
 	if parameters.RepositoryID != nil {
 		params.Set("repository_id", strconv.FormatInt(*parameters.RepositoryID, 10))
 	}
-	query := "q=" + url.QueryEscape(parameters.Query)
-	if v := params.Encode(); v != "" {
-		query = query + "&" + v
-	}
-	u := fmt.Sprintf("search/%s?%s", searchType, query)
+	params.Set("q", parameters.Query)
+	u := fmt.Sprintf("search/%s?%s", searchType, params.Encode())
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/search_test.go
+++ b/github/search_test.go
@@ -115,7 +115,7 @@ func TestSearchService_Issues_withQualifiersNoOpts(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	const q = "gopher is:issue label:bug language:go pushed:>=2018-01-01 stars:>=200"
+	const q = "gopher is:issue label:bug language:c++ pushed:>=2018-01-01 stars:>=200"
 
 	var requestURI string
 	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
@@ -134,7 +134,7 @@ func TestSearchService_Issues_withQualifiersNoOpts(t *testing.T) {
 		t.Errorf("Search.Issues returned error: %v", err)
 	}
 
-	if want := "/api-v3/search/issues?q=gopher+is%3Aissue+label%3Abug+language%3Ago+pushed%3A%3E%3D2018-01-01+stars%3A%3E%3D200"; requestURI != want {
+	if want := "/api-v3/search/issues?q=gopher+is%3Aissue+label%3Abug+language%3Ac%2B%2B+pushed%3A%3E%3D2018-01-01+stars%3A%3E%3D200"; requestURI != want {
 		t.Fatalf("URI encoding failed: got %v, want %v", requestURI, want)
 	}
 
@@ -152,7 +152,7 @@ func TestSearchService_Issues_withQualifiersAndOpts(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	const q = "gopher is:issue label:bug language:go pushed:>=2018-01-01 stars:>=200"
+	const q = "gopher is:issue label:bug language:c++ pushed:>=2018-01-01 stars:>=200"
 
 	var requestURI string
 	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
@@ -172,7 +172,7 @@ func TestSearchService_Issues_withQualifiersAndOpts(t *testing.T) {
 		t.Errorf("Search.Issues returned error: %v", err)
 	}
 
-	if want := "/api-v3/search/issues?q=gopher+is%3Aissue+label%3Abug+language%3Ago+pushed%3A%3E%3D2018-01-01+stars%3A%3E%3D200&sort=forks"; requestURI != want {
+	if want := "/api-v3/search/issues?q=gopher+is%3Aissue+label%3Abug+language%3Ac%2B%2B+pushed%3A%3E%3D2018-01-01+stars%3A%3E%3D200&sort=forks"; requestURI != want {
 		t.Fatalf("URI encoding failed: got %v, want %v", requestURI, want)
 	}
 

--- a/github/search_test.go
+++ b/github/search_test.go
@@ -134,7 +134,7 @@ func TestSearchService_Issues_withQualifiersNoOpts(t *testing.T) {
 		t.Errorf("Search.Issues returned error: %v", err)
 	}
 
-	if want := "/api-v3/search/issues?q=gopher+is:issue+label:bug+language:go+pushed:%3E=2018-01-01+stars:%3E=200"; requestURI != want {
+	if want := "/api-v3/search/issues?q=gopher+is%3Aissue+label%3Abug+language%3Ago+pushed%3A%3E%3D2018-01-01+stars%3A%3E%3D200"; requestURI != want {
 		t.Fatalf("URI encoding failed: got %v, want %v", requestURI, want)
 	}
 
@@ -172,7 +172,7 @@ func TestSearchService_Issues_withQualifiersAndOpts(t *testing.T) {
 		t.Errorf("Search.Issues returned error: %v", err)
 	}
 
-	if want := "/api-v3/search/issues?q=gopher+is:issue+label:bug+language:go+pushed:%3E=2018-01-01+stars:%3E=200&sort=forks"; requestURI != want {
+	if want := "/api-v3/search/issues?q=gopher+is%3Aissue+label%3Abug+language%3Ago+pushed%3A%3E%3D2018-01-01+stars%3A%3E%3D200&sort=forks"; requestURI != want {
 		t.Fatalf("URI encoding failed: got %v, want %v", requestURI, want)
 	}
 


### PR DESCRIPTION
Fixes #1122.

- Quit replacing white space with "+"
- Use url.QueryEscape instead of url.PathEscape to escape query string
