### PR TITLE
Fix org webhook creation

### DIFF
--- a/github/orgs_hooks.go
+++ b/github/orgs_hooks.go
@@ -59,6 +59,7 @@ func (s *OrganizationsService) CreateHook(ctx context.Context, org string, hook 
 	u := fmt.Sprintf("orgs/%v/hooks", org)
 
 	hookReq := &createHookRequest{
+		Name:   "web",
 		Events: hook.Events,
 		Active: hook.Active,
 		Config: hook.Config,

--- a/github/orgs_hooks_test.go
+++ b/github/orgs_hooks_test.go
@@ -56,7 +56,7 @@ func TestOrganizationsService_CreateHook(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		want := &createHookRequest{}
+		want := &createHookRequest{Name: "web"}
 		if !reflect.DeepEqual(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}


### PR DESCRIPTION
Hello! This is fixing exactly what #1117 fixed but for org hooks too. The discussion on that PR implies that this only affects GitHub Enterprise but I've been experiencing issues with this in plain ol' GitHub. I suspect this has something to do with this deprecation timeline taking effect at the end of January: https://developer.github.com/v3/guides/replacing-github-services/#deprecation-timeline

