### PR TITLE
Use embeded CheckSuite and HeadCommit field for CheckSuiteEvent

### DIFF
--- a/github/checks.go
+++ b/github/checks.go
@@ -81,6 +81,9 @@ type CheckSuite struct {
 	App          *App           `json:"app,omitempty"`
 	Repository   *Repository    `json:"repository,omitempty"`
 	PullRequests []*PullRequest `json:"pull_requests,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	HeadCommit *Commit `json:"head_commit,omitempty"`
 }
 
 func (c CheckRun) String() string {

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -37,7 +37,10 @@ type CheckRunEvent struct {
 //
 // GitHub API docs: https://developer.github.com/v3/activity/events/types/#checksuiteevent
 type CheckSuiteEvent struct {
-	CheckSuite *CheckSuite `json:"check_suite,omitempty"`
+	CheckSuite struct {
+		*CheckSuite
+		HeadCommit *Commit `json:"head_commit,omitempty"`
+	} `json:"check_suite,omitempty"`
 	// The action performed. Can be "completed", "requested" or "re-requested".
 	Action *string `json:"action,omitempty"`
 

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -37,10 +37,7 @@ type CheckRunEvent struct {
 //
 // GitHub API docs: https://developer.github.com/v3/activity/events/types/#checksuiteevent
 type CheckSuiteEvent struct {
-	CheckSuite struct {
-		*CheckSuite
-		HeadCommit *Commit `json:"head_commit,omitempty"`
-	} `json:"check_suite,omitempty"`
+	CheckSuite *CheckSuite `json:"check_suite,omitempty"`
 	// The action performed. Can be "completed", "requested" or "re-requested".
 	Action *string `json:"action,omitempty"`
 

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -804,6 +804,14 @@ func (c *CheckSuite) GetHeadBranch() string {
 	return *c.HeadBranch
 }
 
+// GetHeadCommit returns the HeadCommit field.
+func (c *CheckSuite) GetHeadCommit() *Commit {
+	if c == nil {
+		return nil
+	}
+	return c.HeadCommit
+}
+
 // GetHeadSHA returns the HeadSHA field if it's non-nil, zero value otherwise.
 func (c *CheckSuite) GetHeadSHA() string {
 	if c == nil || c.HeadSHA == nil {
@@ -858,6 +866,14 @@ func (c *CheckSuiteEvent) GetAction() string {
 		return ""
 	}
 	return *c.Action
+}
+
+// GetCheckSuite returns the CheckSuite field.
+func (c *CheckSuiteEvent) GetCheckSuite() *CheckSuite {
+	if c == nil {
+		return nil
+	}
+	return c.CheckSuite
 }
 
 // GetInstallation returns the Installation field.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -860,14 +860,6 @@ func (c *CheckSuiteEvent) GetAction() string {
 	return *c.Action
 }
 
-// GetCheckSuite returns the CheckSuite field.
-func (c *CheckSuiteEvent) GetCheckSuite() *CheckSuite {
-	if c == nil {
-		return nil
-	}
-	return c.CheckSuite
-}
-
 // GetInstallation returns the Installation field.
 func (c *CheckSuiteEvent) GetInstallation() *Installation {
 	if c == nil {


### PR DESCRIPTION
Connects https://github.com/google/go-github/issues/1131

The `check_suite` object from github's check_suite event also includes `head_commit`, which is not present in the `check_suite` object.

The `CheckSuiteEvent` also uses `CheckSuite` as one of its fields in the struct which does not has the head_commit, and therefore is not parsed during json parsing in the current `CheckSuiteEvent`, hence `head_commit` data is unavailable from the `CheckSuiteEvent` struct.

~To also parse the `head_commit`, `CheckSuiteEvent` should use an embeded field for `CheckSuite` with `HeadCommit`, so that all the details are received from the github api.~

To also parse the `head_commit`, 
add the missing field `HeadCommit` in the `CheckSuite` struct with a comment stating that the field is only populated by a webhook event.

```go
type CheckSuite struct {
	ID           *int64         `json:"id,omitempty"`
	NodeID       *string        `json:"node_id,omitempty"`
	HeadBranch   *string        `json:"head_branch,omitempty"`
	HeadSHA      *string        `json:"head_sha,omitempty"`
	URL          *string        `json:"url,omitempty"`
	BeforeSHA    *string        `json:"before,omitempty"`
	AfterSHA     *string        `json:"after,omitempty"`
	Status       *string        `json:"status,omitempty"`
	Conclusion   *string        `json:"conclusion,omitempty"`
	App          *App           `json:"app,omitempty"`
	Repository   *Repository    `json:"repository,omitempty"`
	PullRequests []*PullRequest `json:"pull_requests,omitempty"`

	// The following fields are only populated by Webhook events.
	HeadCommit *Commit `json:"head_commit,omitempty"`
}
```

~This would remove a function from `github-accessors.go`~

This would add a new accessor function for `head_commit` .
```go
// GetHeadCommit returns the HeadCommit field.
func (c *CheckSuite) GetHeadCommit() *Commit {
	if c == nil {
		return nil
	}
	return c.HeadCommit
}
```