### PR TITLE
Add comment to describe possible status values for CommitFile

### DIFF
--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -54,6 +54,8 @@ type CommitFile struct {
 	Additions        *int    `json:"additions,omitempty"`
 	Deletions        *int    `json:"deletions,omitempty"`
 	Changes          *int    `json:"changes,omitempty"`
+
+	// Status returns status of the changed file. Possible values include: "added", "modified", and "removed".
 	Status           *string `json:"status,omitempty"`
 	Patch            *string `json:"patch,omitempty"`
 	BlobURL          *string `json:"blob_url,omitempty"`


### PR DESCRIPTION
It'd be great if we have this comment to describe the type of values CommitFile status might return. https://developer.github.com/v3/pulls/#list-pull-requests-files doesn't expand on CommitFile status much. Had to make a separate GET request to understand what values are supported. For example one might choose to compare commitFile.GetStatus() to "deleted" instead of "removed" as it appears much more natural.

EDIT: I can't sign the CLA, would have to go through a long process, can someone add this in a different PR? 