### PR TITLE
Add draft field to NewPullRequest

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -5500,6 +5500,14 @@ func (n *NewPullRequest) GetBody() string {
 	return *n.Body
 }
 
+// GetDraft returns the Draft field if it's non-nil, zero value otherwise.
+func (n *NewPullRequest) GetDraft() bool {
+	if n == nil || n.Draft == nil {
+		return false
+	}
+	return *n.Draft
+}
+
 // GetHead returns the Head field if it's non-nil, zero value otherwise.
 func (n *NewPullRequest) GetHead() string {
 	if n == nil || n.Head == nil {

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -216,6 +216,7 @@ type NewPullRequest struct {
 	Body                *string `json:"body,omitempty"`
 	Issue               *int    `json:"issue,omitempty"`
 	MaintainerCanModify *bool   `json:"maintainer_can_modify,omitempty"`
+	Draft               *bool   `json:"draft,omitempty"`
 }
 
 // Create a new pull request on the specified repository.
@@ -229,7 +230,8 @@ func (s *PullRequestsService) Create(ctx context.Context, owner string, repo str
 	}
 
 	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeLabelDescriptionSearchPreview)
+	acceptHeaders := []string{mediaTypeLabelDescriptionSearchPreview, mediaTypeDraftPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	p := new(PullRequest)
 	resp, err := s.client.Do(ctx, req, p)

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -275,7 +275,8 @@ func TestPullRequestsService_Create(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeLabelDescriptionSearchPreview)
+		wantAcceptHeaders := []string{mediaTypeLabelDescriptionSearchPreview, mediaTypeDraftPreview}
+		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}


### PR DESCRIPTION
Resolves https://github.com/davidji99/go-github/issues/1

Per https://developer.github.com/changes/2019-02-14-draft-pull-requests/, the `draft` parameter is now available for Github APIv3:
> [Updated 03-22-19] You can also create draft pull requests using a new draft field in the Create a pull request endpoint.

