### PR TITLE
CheckSuiteEvent and CheckRunEvent: fix doc typos

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -13,7 +13,7 @@ type RequestedAction struct {
 	Identifier string `json:"identifier"` // The integrator reference of the action requested by the user.
 }
 
-// CheckRunEvent is triggered when a check run is "created", "updated", or "re-requested".
+// CheckRunEvent is triggered when a check run is "created", "updated", or "rerequested".
 // The Webhook event name is "check_run".
 //
 // GitHub API docs: https://developer.github.com/v3/activity/events/types/#checkrunevent
@@ -32,13 +32,13 @@ type CheckRunEvent struct {
 	RequestedAction *RequestedAction `json:"requested_action,omitempty"` //
 }
 
-// CheckSuiteEvent is triggered when a check suite is "completed", "requested", or "re-requested".
+// CheckSuiteEvent is triggered when a check suite is "completed", "requested", or "rerequested".
 // The Webhook event name is "check_suite".
 //
 // GitHub API docs: https://developer.github.com/v3/activity/events/types/#checksuiteevent
 type CheckSuiteEvent struct {
 	CheckSuite *CheckSuite `json:"check_suite,omitempty"`
-	// The action performed. Possible values are: "completed", "requested" or "re-requested".
+	// The action performed. Possible values are: "completed", "requested" or "rerequested".
 	Action *string `json:"action,omitempty"`
 
 	// The following fields are only populated by Webhook events.


### PR DESCRIPTION
Just fixing minor godoc typos -- the checks API uses "rerequested" (no dash) rather than "re-requested", per GitHub API docs:

* https://developer.github.com/v3/activity/events/types/#checksuiteevent
* https://developer.github.com/v3/activity/events/types/#checkrunevent

Also confirmed via actual interactions with the GitHub API; when a check suite or check run is rerequested, no dash was present in the action string of the events received.

Thanks!