### PR TITLE
Add RequestedTeam to PullRequestEvent

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -585,11 +585,14 @@ type PullRequestEvent struct {
 	// RequestedReviewer is populated in "review_requested", "review_request_removed" event deliveries.
 	// A request affecting multiple reviewers at once is split into multiple
 	// such event deliveries, each with a single, different RequestedReviewer.
-	RequestedReviewer *User         `json:"requested_reviewer,omitempty"`
-	Repo              *Repository   `json:"repository,omitempty"`
-	Sender            *User         `json:"sender,omitempty"`
-	Installation      *Installation `json:"installation,omitempty"`
-	Label             *Label        `json:"label,omitempty"` // Populated in "labeled" event deliveries.
+	RequestedReviewer *User `json:"requested_reviewer,omitempty"`
+	// In the event that a team is requested instead of a user, "requested_team" gets sent in place of
+	// "requested_user" with the same delivery behavior.
+	RequestedTeam *Team         `json:"requested_team,omitempty"`
+	Repo          *Repository   `json:"repository,omitempty"`
+	Sender        *User         `json:"sender,omitempty"`
+	Installation  *Installation `json:"installation,omitempty"`
+	Label         *Label        `json:"label,omitempty"` // Populated in "labeled" event deliveries.
 
 	// The following field is only present when the webhook is triggered on
 	// a repository belonging to an organization.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -7828,6 +7828,14 @@ func (p *PullRequestEvent) GetRequestedReviewer() *User {
 	return p.RequestedReviewer
 }
 
+// GetRequestedTeam returns the RequestedTeam field.
+func (p *PullRequestEvent) GetRequestedTeam() *Team {
+	if p == nil {
+		return nil
+	}
+	return p.RequestedTeam
+}
+
 // GetSender returns the Sender field.
 func (p *PullRequestEvent) GetSender() *User {
 	if p == nil {


### PR DESCRIPTION
Adds `RequestedTeam` to the `PullRequestEvent` event type.

In the event that a Team is requested for a review instead of a User, it will replace the `requested_reviewer` in the JSON payload with `requested_team`.

This allows for reusing similar logic employed when consuming `RequestedReviewer` without having to iterate through `PullRequest.RequestedTeams` which could potentially cause duplication events without additional logic.

Tested with Github Enterprise 2.15.9.