### PR TITLE
github.App: Use *Timestamp instead of *time.Time

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -26,8 +26,8 @@ type App struct {
 	Description *string    `json:"description,omitempty"`
 	ExternalURL *string    `json:"external_url,omitempty"`
 	HTMLURL     *string    `json:"html_url,omitempty"`
-	CreatedAt   *time.Time `json:"created_at,omitempty"`
-	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
+	CreatedAt   *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt   *Timestamp `json:"updated_at,omitempty"`
 }
 
 // InstallationToken represents an installation token.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -117,9 +117,9 @@ func (a *APIMeta) GetVerifiablePasswordAuthentication() bool {
 }
 
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
-func (a *App) GetCreatedAt() time.Time {
+func (a *App) GetCreatedAt() Timestamp {
 	if a == nil || a.CreatedAt == nil {
-		return time.Time{}
+		return Timestamp{}
 	}
 	return *a.CreatedAt
 }
@@ -181,9 +181,9 @@ func (a *App) GetOwner() *User {
 }
 
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
-func (a *App) GetUpdatedAt() time.Time {
+func (a *App) GetUpdatedAt() Timestamp {
 	if a == nil || a.UpdatedAt == nil {
-		return time.Time{}
+		return Timestamp{}
 	}
 	return *a.UpdatedAt
 }


### PR DESCRIPTION
This is a similar issue to #965 - the `created_at` and `updated_at` fields in the `app` field of webhooks are formatted as Unix epoch integers, rather than RFC3339 for the CRUD APIs.