### PR TITLE
Add support for creating scoped installation tokens

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -3676,6 +3676,14 @@ func (i *InstallationToken) GetExpiresAt() time.Time {
 	return *i.ExpiresAt
 }
 
+// GetPermissions returns the Permissions field.
+func (i *InstallationToken) GetPermissions() *InstallationPermissions {
+	if i == nil {
+		return nil
+	}
+	return i.Permissions
+}
+
 // GetToken returns the Token field if it's non-nil, zero value otherwise.
 func (i *InstallationToken) GetToken() string {
 	if i == nil || i.Token == nil {
@@ -10546,6 +10554,22 @@ func (r *ReviewersRequest) GetNodeID() string {
 		return ""
 	}
 	return *r.NodeID
+}
+
+// GetPermissions returns the Permissions field.
+func (s *ScopedInstallationTokenRequest) GetPermissions() *InstallationPermissions {
+	if s == nil {
+		return nil
+	}
+	return s.Permissions
+}
+
+// GetRepositoryIds returns the RepositoryIds field if it's non-nil, zero value otherwise.
+func (s *ScopedInstallationTokenRequest) GetRepositoryIds() []int64 {
+	if s == nil || s.RepositoryIds == nil {
+		return nil
+	}
+	return *s.RepositoryIds
 }
 
 // GetName returns the Name field if it's non-nil, zero value otherwise.


### PR DESCRIPTION
See https://developer.github.com/v3/apps/#create-a-new-installation-token

This creates a new function `CreateScopedInstallationToken`, which allows the caller to limit an installation's access to a subset of repositories and permissions.

These parameters are optional which is why I opted to created a new function for this.

✨  Feedback appreciated ✨ 