### PR TITLE
Coverage: activity.go

### DIFF
--- a/github/activity_test.go
+++ b/github/activity_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestActivityService_List(t *testing.T) {
@@ -23,12 +24,40 @@ func TestActivityService_List(t *testing.T) {
 		w.Write(feedsJSON)
 	})
 
-	got, _, err := client.Activity.ListFeeds(context.Background())
+	ctx := context.Background()
+	got, resp, err := client.Activity.ListFeeds(ctx)
 	if err != nil {
 		t.Errorf("Activity.ListFeeds returned error: %v", err)
 	}
 	if want := wantFeeds; !reflect.DeepEqual(got, want) {
 		t.Errorf("Activity.ListFeeds = %+v, want %+v", got, want)
+	}
+
+	// Test s.client.NewRequest failure
+	client.BaseURL.Path = ""
+	got, resp, err = client.Activity.ListFeeds(ctx)
+	if got != nil {
+		t.Errorf("client.BaseURL.Path='' ListFeeds = %#v, want nil", got)
+	}
+	if resp != nil {
+		t.Errorf("client.BaseURL.Path='' ListFeeds resp = %#v, want nil", resp)
+	}
+	if err == nil {
+		t.Error("client.BaseURL.Path='' ListFeeds err = nil, want error")
+	}
+
+	// Test s.client.Do failure
+	client.BaseURL.Path = "/api-v3/"
+	client.rateLimits[0].Reset.Time = time.Now().Add(10 * time.Minute)
+	got, resp, err = client.Activity.ListFeeds(ctx)
+	if got != nil {
+		t.Errorf("rate.Reset.Time > now ListFeeds = %#v, want nil", got)
+	}
+	if want := http.StatusForbidden; resp == nil || resp.Response.StatusCode != want {
+		t.Errorf("rate.Reset.Time > now ListFeeds resp = %#v, want StatusCode=%v", resp.Response, want)
+	}
+	if err == nil {
+		t.Error("rate.Reset.Time > now ListFeeds err = nil, want error")
 	}
 }
 


### PR DESCRIPTION
According to https://codecov.io/gh/google/go-github/tree/master/github
`activity.go` had the worst test coverage at 55%.
This PR increases the coverage to 100% for this file.

As maintainer of this repo, I'm going to go ahead and merge these coverage PRs to master without code review so as to not bother the other volunteer reviewers who we really want to keep happy. :smile:

Obviously, if you see any issues with these coverage PRs, you are totally welcome to comment, and I will work on addressing the issues in follow-on PRs.