### PR TITLE
Add Visibility to UserEmail

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -12388,6 +12388,14 @@ func (u *UserEmail) GetVerified() bool {
 	return *u.Verified
 }
 
+// GetVisibility returns the Visibility field if it's non-nil, zero value otherwise.
+func (u *UserEmail) GetVisibility() string {
+	if u == nil || u.Visibility == nil {
+		return ""
+	}
+	return *u.Visibility
+}
+
 // GetAvatarURL returns the AvatarURL field if it's non-nil, zero value otherwise.
 func (u *UserLDAPMapping) GetAvatarURL() string {
 	if u == nil || u.AvatarURL == nil {

--- a/github/users_emails.go
+++ b/github/users_emails.go
@@ -9,9 +9,10 @@ import "context"
 
 // UserEmail represents user's email address
 type UserEmail struct {
-	Email    *string `json:"email,omitempty"`
-	Primary  *bool   `json:"primary,omitempty"`
-	Verified *bool   `json:"verified,omitempty"`
+	Email      *string `json:"email,omitempty"`
+	Primary    *bool   `json:"primary,omitempty"`
+	Verified   *bool   `json:"verified,omitempty"`
+	Visibility *string `json:"visibility,omitempty"`
 }
 
 // ListEmails lists all email addresses for the authenticated user.


### PR DESCRIPTION
Because `UserEmail.Visibility` field is missed.
https://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user