### PR TITLE
add options to list gist forks endpoint

### DIFF
--- a/github/gists.go
+++ b/github/gists.go
@@ -341,8 +341,13 @@ func (s *GistsService) Fork(ctx context.Context, id string) (*Gist, *Response, e
 // ListForks lists forks of a gist.
 //
 // GitHub API docs: https://developer.github.com/v3/gists/#list-gist-forks
-func (s *GistsService) ListForks(ctx context.Context, id string) ([]*GistFork, *Response, error) {
+func (s *GistsService) ListForks(ctx context.Context, id string, opt *ListOptions) ([]*GistFork, *Response, error) {
 	u := fmt.Sprintf("gists/%v/forks", id)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -704,7 +704,7 @@ func TestGistsService_ListForks(t *testing.T) {
 
 	mux.HandleFunc("/gists/1/forks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testFormValues(t, r, nil)
+		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `
 		  [
 		    {"url": "https://api.github.com/gists/1",
@@ -717,7 +717,8 @@ func TestGistsService_ListForks(t *testing.T) {
 		`)
 	})
 
-	gistForks, _, err := client.Gists.ListForks(context.Background(), "1")
+	opt := &ListOptions{Page: 2}
+	gistForks, _, err := client.Gists.ListForks(context.Background(), "1", opt)
 	if err != nil {
 		t.Errorf("Gists.ListForks returned error: %v", err)
 	}


### PR DESCRIPTION
Hi,
I am pretty new to Go. 
I found that GET /gists/{id}/forks{?page} endpoint had add options (field missed) from the google docs on Github API definition.
I have signed the CLA. 
I welcome comments from reviewers and would be interested to correct them. 

Thanks,
Srivignessh