### PR TITLE
fix: add start and end column to Annotation

### DIFF
--- a/github/checks.go
+++ b/github/checks.go
@@ -54,6 +54,8 @@ type CheckRunAnnotation struct {
 	BlobHRef        *string `json:"blob_href,omitempty"`
 	StartLine       *int    `json:"start_line,omitempty"`
 	EndLine         *int    `json:"end_line,omitempty"`
+	StartColumn     *int    `json:"start_column,omitempty"`
+	EndColumn       *int    `json:"end_column,omitempty"`
 	AnnotationLevel *string `json:"annotation_level,omitempty"`
 	Message         *string `json:"message,omitempty"`
 	Title           *string `json:"title,omitempty"`

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -151,6 +151,8 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 		                           "blob_href": "https://github.com/octocat/Hello-World/blob/837db83be4137ca555d9a5598d0a1ea2987ecfee/README.md",
 		                           "start_line": 2,
 		                           "end_line": 2,
+		                           "start_column": 1,
+		                           "end_column": 5,									
 		                           "annotation_level": "warning",
 		                           "message": "Check your spelling for 'banaas'.",
                                            "title": "Spell check",
@@ -168,10 +170,12 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 		BlobHRef:        String("https://github.com/octocat/Hello-World/blob/837db83be4137ca555d9a5598d0a1ea2987ecfee/README.md"),
 		StartLine:       Int(2),
 		EndLine:         Int(2),
+		StartColumn:     Int(1),
+		EndColumn:       Int(5),
 		AnnotationLevel: String("warning"),
 		Message:         String("Check your spelling for 'banaas'."),
-		RawDetails:      String("Do you mean 'bananas' or 'banana'?"),
 		Title:           String("Spell check"),
+		RawDetails:      String("Do you mean 'bananas' or 'banana'?"),
 	}}
 
 	if !reflect.DeepEqual(checkRunAnnotations, want) {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -644,6 +644,14 @@ func (c *CheckRunAnnotation) GetBlobHRef() string {
 	return *c.BlobHRef
 }
 
+// GetEndColumn returns the EndColumn field if it's non-nil, zero value otherwise.
+func (c *CheckRunAnnotation) GetEndColumn() int {
+	if c == nil || c.EndColumn == nil {
+		return 0
+	}
+	return *c.EndColumn
+}
+
 // GetEndLine returns the EndLine field if it's non-nil, zero value otherwise.
 func (c *CheckRunAnnotation) GetEndLine() int {
 	if c == nil || c.EndLine == nil {
@@ -674,6 +682,14 @@ func (c *CheckRunAnnotation) GetRawDetails() string {
 		return ""
 	}
 	return *c.RawDetails
+}
+
+// GetStartColumn returns the StartColumn field if it's non-nil, zero value otherwise.
+func (c *CheckRunAnnotation) GetStartColumn() int {
+	if c == nil || c.StartColumn == nil {
+		return 0
+	}
+	return *c.StartColumn
 }
 
 // GetStartLine returns the StartLine field if it's non-nil, zero value otherwise.


### PR DESCRIPTION
According to https://developer.github.com/v3/checks/runs/#annotations-object `start_column` and `end_column` are part of the Annotation



Additionally I noticed `blob_href` is no longer listed on the docs. Should I remove it in this PR or raise another?  
https://github.com/google/go-github/pull/1241/files#diff-065d35fd95f6db43a7395a47966b9505R54