### PR TITLE
remove blob_href from check annotations

### DIFF
--- a/github/checks.go
+++ b/github/checks.go
@@ -51,7 +51,6 @@ type CheckRunOutput struct {
 // CheckRunAnnotation represents an annotation object for a CheckRun output.
 type CheckRunAnnotation struct {
 	Path            *string `json:"path,omitempty"`
-	BlobHRef        *string `json:"blob_href,omitempty"`
 	StartLine       *int    `json:"start_line,omitempty"`
 	EndLine         *int    `json:"end_line,omitempty"`
 	AnnotationLevel *string `json:"annotation_level,omitempty"`

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -591,7 +591,6 @@ func Test_CheckRunMarshal(t *testing.T) {
 			"annotations": [
 				{
 					"path": "p",
-					"blob_href": "b",
 					"start_line": 1,
 					"end_line": 1,
 					"annotation_level": "a",

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -148,7 +148,6 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 		})
 		fmt.Fprint(w, `[{
 		                           "path": "README.md",
-		                           "blob_href": "https://github.com/octocat/Hello-World/blob/837db83be4137ca555d9a5598d0a1ea2987ecfee/README.md",
 		                           "start_line": 2,
 		                           "end_line": 2,
 		                           "annotation_level": "warning",
@@ -165,7 +164,6 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 
 	want := []*CheckRunAnnotation{{
 		Path:            String("README.md"),
-		BlobHRef:        String("https://github.com/octocat/Hello-World/blob/837db83be4137ca555d9a5598d0a1ea2987ecfee/README.md"),
 		StartLine:       Int(2),
 		EndLine:         Int(2),
 		AnnotationLevel: String("warning"),
@@ -502,7 +500,6 @@ func Test_CheckRunMarshal(t *testing.T) {
 			Annotations: []*CheckRunAnnotation{
 				{
 					AnnotationLevel: String("a"),
-					BlobHRef:        String("b"),
 					EndLine:         Int(1),
 					Message:         String("m"),
 					Path:            String("p"),

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -636,14 +636,6 @@ func (c *CheckRunAnnotation) GetAnnotationLevel() string {
 	return *c.AnnotationLevel
 }
 
-// GetBlobHRef returns the BlobHRef field if it's non-nil, zero value otherwise.
-func (c *CheckRunAnnotation) GetBlobHRef() string {
-	if c == nil || c.BlobHRef == nil {
-		return ""
-	}
-	return *c.BlobHRef
-}
-
 // GetEndLine returns the EndLine field if it's non-nil, zero value otherwise.
 func (c *CheckRunAnnotation) GetEndLine() int {
 	if c == nil || c.EndLine == nil {


### PR DESCRIPTION
BREAKING

As defined on https://developer.github.com/v3/checks/runs/#annotations-object `blob_href` is no longer a parameter.


Opening this as discussed in https://github.com/google/go-github/pull/1241#pullrequestreview-266956347 