### PR TITLE
Fix failure in closing PRs

### DIFF
--- a/github/pulls.go
+++ b/github/pulls.go
@@ -342,7 +342,10 @@ func (s *PullRequestsService) Edit(ctx context.Context, owner string, repo strin
 		State:               pull.State,
 		MaintainerCanModify: pull.MaintainerCanModify,
 	}
-	if pull.Base != nil {
+	// avoid updating the base branch when closing the Pull Request
+	// - otherwise the GitHub API server returns a "Validation Failed" error:
+	// "Cannot change base branch of closed pull request".
+	if pull.Base != nil && pull.GetState() != "closed" {
 		update.Base = pull.Base.Ref
 	}
 


### PR DESCRIPTION
Fix an error in PullRequestsService.Edit when closing PRs
due to 'base' field being present together with
State = 'closed'.  In this case the GitHub API v2.17.5
responds with an error:
'Cannot change base branch of closed pull request'.

Fixes #1250.