### PR TITLE
Add support for BranchListOptions

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -508,6 +508,14 @@ func (b *BranchCommit) GetProtected() string {
 	return *b.Protected
 }
 
+// GetProtected returns the Protected field if it's non-nil, zero value otherwise.
+func (b *BranchListOptions) GetProtected() bool {
+	if b == nil || b.Protected == nil {
+		return false
+	}
+	return *b.Protected
+}
+
 // GetApp returns the App field.
 func (c *CheckRun) GetApp() *App {
 	if c == nil {

--- a/github/repos.go
+++ b/github/repos.go
@@ -131,7 +131,7 @@ type BranchListOptions struct {
 	// Setting to true returns only protected branches.
 	// When set to false, only unprotected branches are returned.
 	// Omitting this parameter returns all branches.
-	// Default: null
+	// Default: nil
 	Protected *bool `url:"protected,omitempty"`
 
 	ListOptions

--- a/github/repos.go
+++ b/github/repos.go
@@ -125,6 +125,18 @@ func (r Repository) String() string {
 	return Stringify(r)
 }
 
+// BranchListOptions specifies the optional parameters to the
+// RepositoriesService.ListBranches method.
+type BranchListOptions struct {
+	// Setting to true returns only protected branches.
+	// When set to false, only unprotected branches are returned.
+	// Omitting this parameter returns all branches.
+	// Default: null
+	Protected *bool `url:"protected,omitempty"`
+
+	ListOptions
+}
+
 // RepositoryListOptions specifies the optional parameters to the
 // RepositoriesService.List method.
 type RepositoryListOptions struct {
@@ -814,7 +826,7 @@ type SignaturesProtectedBranch struct {
 // ListBranches lists branches for the specified repository.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/#list-branches
-func (s *RepositoriesService) ListBranches(ctx context.Context, owner string, repo string, opt *ListOptions) ([]*Branch, *Response, error) {
+func (s *RepositoriesService) ListBranches(ctx context.Context, owner string, repo string, opt *BranchListOptions) ([]*Branch, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -803,7 +803,10 @@ func TestRepositoriesService_ListBranches(t *testing.T) {
 		fmt.Fprint(w, `[{"name":"master", "commit" : {"sha" : "a57781", "url" : "https://api.github.com/repos/o/r/commits/a57781"}}]`)
 	})
 
-	opt := &ListOptions{Page: 2}
+	opt := &BranchListOptions{
+		Protected:   nil,
+		ListOptions: ListOptions{Page: 2},
+	}
 	branches, _, err := client.Repositories.ListBranches(context.Background(), "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListBranches returned error: %v", err)


### PR DESCRIPTION
Add support for BranchListOptions for `RepositoriesService.ListBranches`.

ref. https://developer.github.com/v3/repos/branches/#list-branches