### PR TITLE
Bump Go version to 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 // indirect
 	google.golang.org/appengine v1.1.0
 )
+
+go 1.13


### PR DESCRIPTION
Updated `go.mod` to use Go 1.13.

SEE: https://github.com/google/go-github/pull/1272