### PR TITLE
Fix BranchCommit.Protected

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -501,9 +501,9 @@ func (b *BranchCommit) GetName() string {
 }
 
 // GetProtected returns the Protected field if it's non-nil, zero value otherwise.
-func (b *BranchCommit) GetProtected() string {
+func (b *BranchCommit) GetProtected() bool {
 	if b == nil || b.Protected == nil {
-		return ""
+		return false
 	}
 	return *b.Protected
 }

--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -119,7 +119,7 @@ type CommitsListOptions struct {
 type BranchCommit struct {
 	Name      *string `json:"name,omitempty"`
 	Commit    *Commit `json:"commit,omitempty"`
-	Protected *string `json:"protected,omitempty"`
+	Protected *bool   `json:"protected,omitempty"`
 }
 
 // ListCommits lists the commits of a repository.

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -367,7 +367,7 @@ func TestRepositoriesService_ListBranchesHeadCommit(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/commits/s/branches-where-head", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `[{"name": "b"}]`)
+		fmt.Fprintf(w, `[{"name": "b","commit":{"sha":"2e90302801c870f17b6152327d9b9a03c8eca0e2","url":"https://api.github.com/repos/google/go-github/commits/2e90302801c870f17b6152327d9b9a03c8eca0e2"},"protected":true}]`)
 	})
 
 	branches, _, err := client.Repositories.ListBranchesHeadCommit(context.Background(), "o", "r", "s")
@@ -375,7 +375,16 @@ func TestRepositoriesService_ListBranchesHeadCommit(t *testing.T) {
 		t.Errorf("Repositories.ListBranchesHeadCommit returned error: %v", err)
 	}
 
-	want := []*BranchCommit{{Name: String("b")}}
+	want := []*BranchCommit{
+		{
+			Name: String("b"),
+			Commit: &Commit{
+				SHA: String("2e90302801c870f17b6152327d9b9a03c8eca0e2"),
+				URL: String("https://api.github.com/repos/google/go-github/commits/2e90302801c870f17b6152327d9b9a03c8eca0e2"),
+			},
+			Protected: Bool(true),
+		},
+	}1
 	if !reflect.DeepEqual(branches, want) {
 		t.Errorf("Repositories.ListBranchesHeadCommit returned %+v, want %+v", branches, want)
 	}

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -384,7 +384,7 @@ func TestRepositoriesService_ListBranchesHeadCommit(t *testing.T) {
 			},
 			Protected: Bool(true),
 		},
-	}1
+	}
 	if !reflect.DeepEqual(branches, want) {
 		t.Errorf("Repositories.ListBranchesHeadCommit returned %+v, want %+v", branches, want)
 	}


### PR DESCRIPTION
When using [ListBranchesHeadCommit](https://godoc.org/github.com/google/go-github/github#RepositoriesService.ListBranchesHeadCommit) I'm seeing the error:
```
json: cannot unmarshal bool into Go struct field BranchCommit.protected of type string
```

That's because although the [documentation](https://developer.github.com/v3/repos/commits/#response-3) statements that `protected` field is a string but the response is boolean in fact:
**Request**
```
curl -H "Accept: application/vnd.github.groot-preview+json" \
'https://api.github.com/repos/google/go-github/commits/master/branches-where-head'
```
**Response**
```json
[
  {
    "name": "master",
    "commit": {
      "sha": "2e90302801c870f17b6152327d9b9a03c8eca0e2",
      "url": "https://api.github.com/repos/google/go-github/commits/2e90302801c870f17b6152327d9b9a03c8eca0e2"
    },
    "protected": true
  }
]
```