### PR TITLE
correct the api endpoint for issue comment reactions

### DIFF
--- a/github/reactions.go
+++ b/github/reactions.go
@@ -48,7 +48,7 @@ func (r Reaction) String() string {
 //
 // GitHub API docs: https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment
 func (s *ReactionsService) ListCommentReactions(ctx context.Context, owner, repo string, id int64, opt *ListOptions) ([]*Reaction, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions", owner, repo, id)
+	u := fmt.Sprintf("repos/%v/%v/issues/comments/%v/reactions", owner, repo, id)
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err

--- a/github/reactions_test.go
+++ b/github/reactions_test.go
@@ -16,7 +16,7 @@ func TestReactionsService_ListCommentReactions(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/repos/o/r/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/issues/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 // indirect
 	google.golang.org/appengine v1.1.0
 )
+
+go 1.13


### PR DESCRIPTION
documentation at https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment
gives this pattern: "GET /repos/:owner/:repo/issues/comments/:comment_id/reactions"
which i have merely translated into this one-liner fix. now works for me in my app.