### PR TITLE
Support go1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: go
 
 go:
   - "1.x"
-  - "1.11.x"
+  - "1.12.x"
+  - "1.13.x"
   - master
 
 matrix:

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 // indirect
 	google.golang.org/appengine v1.1.0
 )
+
+go 1.13


### PR DESCRIPTION
Add support for go1.13 and bump Travis CI tests from 1.11 to 1.12 and 1.13.