### PR TITLE
Add list and create projects for users

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1996,14 +1996,6 @@ func (c *CreateUserProjectOptions) GetBody() string {
 	return *c.Body
 }
 
-// GetName returns the Name field if it's non-nil, zero value otherwise.
-func (c *CreateUserProjectOptions) GetName() string {
-	if c == nil || c.Name == nil {
-		return ""
-	}
-	return *c.Name
-}
-
 // GetInstallation returns the Installation field.
 func (d *DeleteEvent) GetInstallation() *Installation {
 	if d == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1988,6 +1988,22 @@ func (c *CreateOrgInvitationOptions) GetRole() string {
 	return *c.Role
 }
 
+// GetBody returns the Body field if it's non-nil, zero value otherwise.
+func (c *CreateUserProjectOptions) GetBody() string {
+	if c == nil || c.Body == nil {
+		return ""
+	}
+	return *c.Body
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (c *CreateUserProjectOptions) GetName() string {
+	if c == nil || c.Name == nil {
+		return ""
+	}
+	return *c.Name
+}
+
 // GetInstallation returns the Installation field.
 func (d *DeleteEvent) GetInstallation() *Installation {
 	if d == nil {

--- a/github/users_projects.go
+++ b/github/users_projects.go
@@ -1,0 +1,60 @@
+// Copyright 2019 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// ListProjects lists the projects for an user.
+//
+// GitHub API docs: https://developer.github.com/v3/projects/#list-user-projects
+func (s *UsersService) ListProjects(ctx context.Context, user string, opt *ProjectListOptions) ([]*Project, *Response, error) {
+	u := fmt.Sprintf("users/%v/projects", user)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	var projects []*Project
+	resp, err := s.client.Do(ctx, req, &projects)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return projects, resp, nil
+}
+
+// CreateProject creates a GitHub Project for the specified user.
+//
+// GitHub API docs: https://developer.github.com/v3/projects/#create-a-user-project
+func (s *UsersService) CreateProject(ctx context.Context, user string, opt *ProjectOptions) (*Project, *Response, error) {
+	u := fmt.Sprintf("users/%v/projects", user)
+	req, err := s.client.NewRequest("POST", u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	project := &Project{}
+	resp, err := s.client.Do(ctx, req, project)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return project, resp, nil
+}

--- a/github/users_projects.go
+++ b/github/users_projects.go
@@ -10,14 +10,6 @@ import (
 	"fmt"
 )
 
-// CreateUserProjectOptions specifies the parameters to the UsersService.CreateProject method.
-type CreateUserProjectOptions struct {
-	// The name of the project. (Required.)
-	Name *string `json:"name"`
-	// The description of the project. (Optional.)
-	Body *string `json:"body,omitempty"`
-}
-
 // ListProjects lists the projects for the specified user.
 //
 // GitHub API docs: https://developer.github.com/v3/projects/#list-user-projects
@@ -43,6 +35,14 @@ func (s *UsersService) ListProjects(ctx context.Context, user string, opt *Proje
 	}
 
 	return projects, resp, nil
+}
+
+// CreateUserProjectOptions specifies the parameters to the UsersService.CreateProject method.
+type CreateUserProjectOptions struct {
+	// The name of the project. (Required.)
+	Name *string `json:"name"`
+	// The description of the project. (Optional.)
+	Body *string `json:"body,omitempty"`
 }
 
 // CreateProject creates a GitHub Project for the current user.

--- a/github/users_projects.go
+++ b/github/users_projects.go
@@ -40,8 +40,8 @@ func (s *UsersService) ListProjects(ctx context.Context, user string, opt *Proje
 // CreateProject creates a GitHub Project for the current user.
 //
 // GitHub API docs: https://developer.github.com/v3/projects/#create-a-user-project
-func (s *UsersService) CreateProject(ctx context.Context, user string, opt *ProjectOptions) (*Project, *Response, error) {
-	u := fmt.Sprintf("users/%v/projects", user)
+func (s *UsersService) CreateProject(ctx context.Context, opt *ProjectOptions) (*Project, *Response, error) {
+	u := "users/projects"
 	req, err := s.client.NewRequest("POST", u, opt)
 	if err != nil {
 		return nil, nil, err

--- a/github/users_projects.go
+++ b/github/users_projects.go
@@ -10,6 +10,14 @@ import (
 	"fmt"
 )
 
+// CreateUserProjectOptions specifies the parameters to the UsersService.CreateProject method.
+type CreateUserProjectOptions struct {
+	// The name of the project. (Required.)
+	Name *string `json:"name"`
+	// The description of the project. (Optional.)
+	Body *string `json:"body,omitempty"`
+}
+
 // ListProjects lists the projects for the specified user.
 //
 // GitHub API docs: https://developer.github.com/v3/projects/#list-user-projects
@@ -40,7 +48,7 @@ func (s *UsersService) ListProjects(ctx context.Context, user string, opt *Proje
 // CreateProject creates a GitHub Project for the current user.
 //
 // GitHub API docs: https://developer.github.com/v3/projects/#create-a-user-project
-func (s *UsersService) CreateProject(ctx context.Context, opt *ProjectOptions) (*Project, *Response, error) {
+func (s *UsersService) CreateProject(ctx context.Context, opt *CreateUserProjectOptions) (*Project, *Response, error) {
 	u := "users/projects"
 	req, err := s.client.NewRequest("POST", u, opt)
 	if err != nil {

--- a/github/users_projects.go
+++ b/github/users_projects.go
@@ -40,7 +40,7 @@ func (s *UsersService) ListProjects(ctx context.Context, user string, opt *Proje
 // CreateUserProjectOptions specifies the parameters to the UsersService.CreateProject method.
 type CreateUserProjectOptions struct {
 	// The name of the project. (Required.)
-	Name *string `json:"name"`
+	Name string `json:"name"`
 	// The description of the project. (Optional.)
 	Body *string `json:"body,omitempty"`
 }

--- a/github/users_projects.go
+++ b/github/users_projects.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 )
 
-// ListProjects lists the projects for an user.
+// ListProjects lists the projects for the specified user.
 //
 // GitHub API docs: https://developer.github.com/v3/projects/#list-user-projects
 func (s *UsersService) ListProjects(ctx context.Context, user string, opt *ProjectListOptions) ([]*Project, *Response, error) {
@@ -37,7 +37,7 @@ func (s *UsersService) ListProjects(ctx context.Context, user string, opt *Proje
 	return projects, resp, nil
 }
 
-// CreateProject creates a GitHub Project for the specified user.
+// CreateProject creates a GitHub Project for the current user.
 //
 // GitHub API docs: https://developer.github.com/v3/projects/#create-a-user-project
 func (s *UsersService) CreateProject(ctx context.Context, user string, opt *ProjectOptions) (*Project, *Response, error) {

--- a/github/users_projects_test.go
+++ b/github/users_projects_test.go
@@ -1,0 +1,68 @@
+// Copyright 2019 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestUsersService_ListProjects(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/u/projects", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
+		testFormValues(t, r, values{"state": "open", "page": "2"})
+		fmt.Fprint(w, `[{"id":1}]`)
+	})
+
+	opt := &ProjectListOptions{State: "open", ListOptions: ListOptions{Page: 2}}
+	projects, _, err := client.Users.ListProjects(context.Background(), "u", opt)
+	if err != nil {
+		t.Errorf("Users.ListProjects returned error: %v", err)
+	}
+
+	want := []*Project{{ID: Int64(1)}}
+	if !reflect.DeepEqual(projects, want) {
+		t.Errorf("Users.ListProjects returned %+v, want %+v", projects, want)
+	}
+}
+
+func TestUsersService_CreateProject(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &ProjectOptions{Name: String("Project Name"), Body: String("Project body.")}
+
+	mux.HandleFunc("/users/u/projects", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
+
+		v := &ProjectOptions{}
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		fmt.Fprint(w, `{"id":1}`)
+	})
+
+	project, _, err := client.Users.CreateProject(context.Background(), "u", input)
+	if err != nil {
+		t.Errorf("Users.CreateProject returned error: %v", err)
+	}
+
+	want := &Project{ID: Int64(1)}
+	if !reflect.DeepEqual(project, want) {
+		t.Errorf("Users.CreateProject returned %+v, want %+v", project, want)
+	}
+}

--- a/github/users_projects_test.go
+++ b/github/users_projects_test.go
@@ -43,7 +43,7 @@ func TestUsersService_CreateProject(t *testing.T) {
 
 	input := &ProjectOptions{Name: String("Project Name"), Body: String("Project body.")}
 
-	mux.HandleFunc("/users/u/projects", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/users/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 
@@ -56,7 +56,7 @@ func TestUsersService_CreateProject(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	project, _, err := client.Users.CreateProject(context.Background(), "u", input)
+	project, _, err := client.Users.CreateProject(context.Background(), input)
 	if err != nil {
 		t.Errorf("Users.CreateProject returned error: %v", err)
 	}

--- a/github/users_projects_test.go
+++ b/github/users_projects_test.go
@@ -41,7 +41,7 @@ func TestUsersService_CreateProject(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	input := &CreateUserProjectOptions{Name: String("Project Name"), Body: String("Project body.")}
+	input := &CreateUserProjectOptions{Name: "Project Name", Body: String("Project body.")}
 
 	mux.HandleFunc("/users/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/github/users_projects_test.go
+++ b/github/users_projects_test.go
@@ -41,13 +41,13 @@ func TestUsersService_CreateProject(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	input := &ProjectOptions{Name: String("Project Name"), Body: String("Project body.")}
+	input := &CreateUserProjectOptions{Name: String("Project Name"), Body: String("Project body.")}
 
 	mux.HandleFunc("/users/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 
-		v := &ProjectOptions{}
+		v := &CreateUserProjectOptions{}
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)


### PR DESCRIPTION
## Background

GitHub Projects support user-based projects and there are APIs about `List user projects` and `Create a user project`.

Seems go-github does not support them and I want to implement the feature.

## Goal

* Add `List user projects` and `Create a user project`

Fixes #1294.