### PR TITLE
Test for marshalling Organizations and make JSON comparison non sensitive to key order

### DIFF
--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -14,6 +14,38 @@ import (
 	"testing"
 )
 
+func TestOrganization_marshal(t *testing.T) {
+	testJSONMarshal(t, &Organization{}, "{}")
+
+	o := &Organization{
+		BillingEmail:                         String("support@github.com"),
+		Blog:                                 String("https://github.com/blog"),
+		Company:                              String("GitHub"),
+		Email:                                String("support@github.com"),
+		Location:                             String("San Francisco"),
+		Name:                                 String("github"),
+		Description:                          String("GitHub, the company."),
+		DefaultRepoPermission:                String("read"),
+		MembersCanCreateRepos:                Bool(true),
+		MembersAllowedRepositoryCreationType: String("all"),
+	}
+	want := `
+		{
+			"billing_email": "support@github.com",
+			"blog": "https://github.com/blog",
+			"company": "GitHub",
+			"email": "support@github.com",
+			"location": "San Francisco",
+			"name": "github",
+			"description": "GitHub, the company.",
+			"default_repository_permission": "read",
+			"members_can_create_repositories": true,
+			"members_allowed_repository_creation_type": "all"
+		}
+	`
+	testJSONMarshal(t, o, want)
+}
+
 func TestOrganizationsService_ListAll(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
This pull request contains two items:

1. Modifies the JSON comparison utility for checking marshalling, making it non sensible to key order.This makes it easier to write tests for marshalling, since there is no need to worry about keeping the right order of the JSON keys in the wanted string.  It also removes a non working part of the test. *I made sure old tests using this utility would still break if given the wrong input*.
2. Adds a new test for marshalling organizations (issue #55 )