### PR TITLE
Support List GitHub App installations for organization

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6380,6 +6380,14 @@ func (o *OrganizationEvent) GetSender() *User {
 	return o.Sender
 }
 
+// GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
+func (o *OrganizationInstallations) GetTotalCount() int {
+	if o == nil || o.TotalCount == nil {
+		return 0
+	}
+	return *o.TotalCount
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (o *OrgBlockEvent) GetAction() string {
 	if o == nil || o.Action == nil {

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -70,9 +70,10 @@ type Organization struct {
 	ReposURL         *string `json:"repos_url,omitempty"`
 }
 
+// OrganizationInstallations represents Github app installations of an organization
 type OrganizationInstallations struct {
-	TotalCount    *int           `json:"total_count,omitempty"`
-	Installations []Installation `json:"installations,omitempty"`
+	TotalCount    *int            `json:"total_count,omitempty"`
+	Installations []*Installation `json:"installations,omitempty"`
 }
 
 func (o Organization) String() string {
@@ -232,11 +233,11 @@ func (s *OrganizationsService) ListInstallations(ctx context.Context, org string
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeIntegrationPreview)
 
-	org_installations := new(OrganizationInstallations)
-	resp, err := s.client.Do(ctx, req, org_installations)
+	result := new(OrganizationInstallations)
+	resp, err := s.client.Do(ctx, req, result)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return org_installations, resp, nil
+	return result, resp, nil
 }

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -223,8 +223,14 @@ func (s *OrganizationsService) Edit(ctx context.Context, name string, org *Organ
 // List installations for an organization.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/#list-installations-for-an-organization
-func (s *OrganizationsService) ListInstallations(ctx context.Context, org string) (*OrganizationInstallations, *Response, error) {
+func (s *OrganizationsService) ListInstallations(ctx context.Context, org string, opt *ListOptions) (*OrganizationInstallations, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/installations", org)
+
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -70,7 +70,7 @@ type Organization struct {
 	ReposURL         *string `json:"repos_url,omitempty"`
 }
 
-// OrganizationInstallations represents Github app installations of an organization
+// OrganizationInstallations represents GitHub app installations for an organization.
 type OrganizationInstallations struct {
 	TotalCount    *int            `json:"total_count,omitempty"`
 	Installations []*Installation `json:"installations,omitempty"`

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -70,6 +70,11 @@ type Organization struct {
 	ReposURL         *string `json:"repos_url,omitempty"`
 }
 
+type OrganizationInstallations struct {
+	TotalCount    *int           `json:"total_count,omitempty"`
+	Installations []Installation `json:"installations,omitempty"`
+}
+
 func (o Organization) String() string {
 	return Stringify(o)
 }
@@ -212,4 +217,26 @@ func (s *OrganizationsService) Edit(ctx context.Context, name string, org *Organ
 	}
 
 	return o, resp, nil
+}
+
+// List installations for an organization.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/#list-installations-for-an-organization
+func (s *OrganizationsService) ListInstallations(ctx context.Context, org string) (*OrganizationInstallations, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/installations", org)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeIntegrationPreview)
+
+	org_installations := new(OrganizationInstallations)
+	resp, err := s.client.Do(ctx, req, org_installations)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return org_installations, resp, nil
 }

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -200,9 +200,10 @@ func TestOrganizationsService_ListInstallations_invalidOrg(t *testing.T) {
 
 	_, _, err := client.Organizations.ListInstallations(context.Background(), "%", nil)
 	testURLParseError(t, err)
+
 }
 
-func TestOrganizationsService_ListInstallations_withOptions(t *testing.T) {
+func TestOrganizationsService_ListInstallations_withListOptions(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -213,8 +214,7 @@ func TestOrganizationsService_ListInstallations_withOptions(t *testing.T) {
 		fmt.Fprint(w, `{"total_count": 2, "installations": [{ "id": 2, "app_id": 10}]}`)
 	})
 
-	opt := &ListOptions{Page: 2}
-	apps, _, err := client.Organizations.ListInstallations(context.Background(), "o", opt)
+	apps, _, err := client.Organizations.ListInstallations(context.Background(), "o", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Organizations.ListInstallations returned error: %v", err)
 	}
@@ -222,5 +222,11 @@ func TestOrganizationsService_ListInstallations_withOptions(t *testing.T) {
 	want := &OrganizationInstallations{TotalCount: Int(2), Installations: []*Installation{{ID: Int64(2), AppID: Int64(10)}}}
 	if !reflect.DeepEqual(apps, want) {
 		t.Errorf("Organizations.ListInstallations returned %+v, want %+v", apps, want)
+	}
+
+	// Test ListOptions failure
+	_, _, err = client.Organizations.ListInstallations(context.Background(), "%", &ListOptions{})
+	if err == nil {
+		t.Error("Organizations.ListInstallations returned error: nil")
 	}
 }

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -172,3 +172,32 @@ func TestOrganizationsService_Edit_invalidOrg(t *testing.T) {
 	_, _, err := client.Organizations.Edit(context.Background(), "%", nil)
 	testURLParseError(t, err)
 }
+
+func TestOrganizationsService_ListInstallations(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/installations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeIntegrationPreview)
+		fmt.Fprint(w, `{"total_count": 1, "installations": [{ "id": 1, "app_id": 5}]}`)
+	})
+
+	apps, _, err := client.Organizations.ListInstallations(context.Background(), "o")
+	if err != nil {
+		t.Errorf("Organizations.ListInstallations returned error: %v", err)
+	}
+
+	want := &OrganizationInstallations{TotalCount: Int(1), Installations: []Installation{{ID: Int64(1), AppID: Int64(5)}}}
+	if !reflect.DeepEqual(apps, want) {
+		t.Errorf("Organizations.ListInstallations returned %+v, want %+v", apps, want)
+	}
+}
+
+func TestOrganizationsService_ListInstallations_invalidOrg(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, _, err := client.Organizations.ListInstallations(context.Background(), "%")
+	testURLParseError(t, err)
+}

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -188,7 +188,7 @@ func TestOrganizationsService_ListInstallations(t *testing.T) {
 		t.Errorf("Organizations.ListInstallations returned error: %v", err)
 	}
 
-	want := &OrganizationInstallations{TotalCount: Int(1), Installations: []Installation{{ID: Int64(1), AppID: Int64(5)}}}
+	want := &OrganizationInstallations{TotalCount: Int(1), Installations: []*Installation{{ID: Int64(1), AppID: Int64(5)}}}
 	if !reflect.DeepEqual(apps, want) {
 		t.Errorf("Organizations.ListInstallations returned %+v, want %+v", apps, want)
 	}


### PR DESCRIPTION
Support the new preview API endpoint to list GitHub
App installations for an organization

This commit fixes #1319 