### PR TITLE
Simplify rate limit error check

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -648,7 +648,7 @@ type TwoFactorAuthError ErrorResponse
 func (r *TwoFactorAuthError) Error() string { return (*ErrorResponse)(r).Error() }
 
 // RateLimitError occurs when GitHub returns 403 Forbidden response with a rate limit
-// remaining value of 0
+// remaining value of 0.
 type RateLimitError struct {
 	Rate     Rate           // Rate specifies last known rate limit for the client
 	Response *http.Response // HTTP response that caused this error

--- a/github/github.go
+++ b/github/github.go
@@ -648,7 +648,7 @@ type TwoFactorAuthError ErrorResponse
 func (r *TwoFactorAuthError) Error() string { return (*ErrorResponse)(r).Error() }
 
 // RateLimitError occurs when GitHub returns 403 Forbidden response with a rate limit
-// remaining value of 0, and error message starts with "API rate limit exceeded for ".
+// remaining value of 0
 type RateLimitError struct {
 	Rate     Rate           // Rate specifies last known rate limit for the client
 	Response *http.Response // HTTP response that caused this error
@@ -763,7 +763,7 @@ func CheckResponse(r *http.Response) error {
 	switch {
 	case r.StatusCode == http.StatusUnauthorized && strings.HasPrefix(r.Header.Get(headerOTP), "required"):
 		return (*TwoFactorAuthError)(errorResponse)
-	case r.StatusCode == http.StatusForbidden && r.Header.Get(headerRateRemaining) == "0" && strings.HasPrefix(errorResponse.Message, "API rate limit exceeded for "):
+	case r.StatusCode == http.StatusForbidden && r.Header.Get(headerRateRemaining) == "0":
 		return &RateLimitError{
 			Rate:     parseRate(r),
 			Response: errorResponse.Response,


### PR DESCRIPTION
PR for the enhancement mentioned in Issue #1318. Also added unit tests for both RateLimitError and AbuseRateLimitError.

Why remove the message check for RateLimitError?
The message can be different for enterprise versions of GitHub. Besides, the rate limit header and HTTP status codes are sufficient to identify a rate limit error.

Why not remove the URL check for AbuseRateLimitError?
HTTP response in this situation does not contain any unique header values that would be sufficient to confirm an abuse. Although it is not ideal to do a suffix match on documentation_url, there seems to be no better way.

Reference to GitHub API rate limiting: https://developer.github.com/v3/#rate-limiting