### PR TITLE
Add option to follow 301 redirects for GetArchiveLink

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -246,6 +246,9 @@ func (s *RepositoriesService) GetArchiveLink(ctx context.Context, owner, repo st
 		u += fmt.Sprintf("/%s", opt.Ref)
 	}
 	resp, err := s.getArchiveLinkFromURL(ctx, u, followRedirects)
+	if err != nil {
+		return nil, nil, err
+	}
 	if resp.StatusCode != http.StatusFound {
 		return nil, newResponse(resp), fmt.Errorf("unexpected status code: %s", resp.Status)
 	}

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -246,7 +246,6 @@ func (s *RepositoriesService) GetArchiveLink(ctx context.Context, owner, repo st
 		u += fmt.Sprintf("/%s", opt.Ref)
 	}
 	resp, err := s.getArchiveLinkFromURL(ctx, u, followRedirects)
-	resp.Body.Close()
 	if resp.StatusCode != http.StatusFound {
 		return nil, newResponse(resp), fmt.Errorf("unexpected status code: %s", resp.Status)
 	}
@@ -255,12 +254,12 @@ func (s *RepositoriesService) GetArchiveLink(ctx context.Context, owner, repo st
 }
 
 func (s *RepositoriesService) getArchiveLinkFromURL(ctx context.Context, u string, followRedirects bool) (*http.Response, error) {
-	var resp *http.Response
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
+	var resp *http.Response
 	// Use http.DefaultTransport if no custom Transport is configured
 	req = withContext(ctx, req)
 	if s.client.client.Transport == nil {
@@ -271,12 +270,12 @@ func (s *RepositoriesService) getArchiveLinkFromURL(ctx context.Context, u strin
 	if err != nil {
 		return nil, err
 	}
+	resp.Body.Close()
 
 	// If redirect response is returned, follow it
 	if followRedirects && resp.StatusCode == http.StatusMovedPermanently {
 		u = resp.Header.Get("Location")
 		resp, err = s.getArchiveLinkFromURL(ctx, u, false)
 	}
-	resp.Body.Close()
-	return resp, nil
+	return resp, err
 }

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -240,12 +240,12 @@ const (
 // or github.Zipball constant.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/contents/#get-archive-link
-func (s *RepositoriesService) GetArchiveLink(ctx context.Context, owner, repo string, archiveformat archiveFormat, opt *RepositoryContentGetOptions, dontFollowRedirects bool) (*url.URL, *Response, error) {
+func (s *RepositoriesService) GetArchiveLink(ctx context.Context, owner, repo string, archiveformat archiveFormat, opt *RepositoryContentGetOptions, followRedirects bool) (*url.URL, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/%s", owner, repo, archiveformat)
 	if opt != nil && opt.Ref != "" {
 		u += fmt.Sprintf("/%s", opt.Ref)
 	}
-	resp, err := s.getArchiveLinkFromURL(ctx, u, dontFollowRedirects)
+	resp, err := s.getArchiveLinkFromURL(ctx, u, followRedirects)
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusFound {
 		return nil, newResponse(resp), fmt.Errorf("unexpected status code: %s", resp.Status)
@@ -254,7 +254,7 @@ func (s *RepositoriesService) GetArchiveLink(ctx context.Context, owner, repo st
 	return parsedURL, newResponse(resp), err
 }
 
-func (s *RepositoriesService) getArchiveLinkFromURL(ctx context.Context, u string, dontFollowRedirects bool) (*http.Response, error) {
+func (s *RepositoriesService) getArchiveLinkFromURL(ctx context.Context, u string, followRedirects bool) (*http.Response, error) {
 	var resp *http.Response
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -273,7 +273,7 @@ func (s *RepositoriesService) getArchiveLinkFromURL(ctx context.Context, u strin
 	}
 
 	// If redirect response is returned, follow it
-	if !dontFollowRedirects && resp.StatusCode == http.StatusMovedPermanently {
+	if followRedirects && resp.StatusCode == http.StatusMovedPermanently {
 		u = resp.Header.Get("Location")
 		resp, err = s.getArchiveLinkFromURL(ctx, u, false)
 	}

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -240,12 +240,12 @@ const (
 // or github.Zipball constant.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/contents/#get-archive-link
-func (s *RepositoriesService) GetArchiveLink(ctx context.Context, owner, repo string, archiveformat archiveFormat, dontFollowRedirects bool, opt *RepositoryContentGetOptions) (*url.URL, *Response, error) {
+func (s *RepositoriesService) GetArchiveLink(ctx context.Context, owner, repo string, archiveformat archiveFormat, opt *RepositoryContentGetOptions, dontFollowRedirects bool) (*url.URL, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/%s", owner, repo, archiveformat)
 	if opt != nil && opt.Ref != "" {
 		u += fmt.Sprintf("/%s", opt.Ref)
 	}
-	resp, err := s.getArchiveLinkFromURL(ctx, dontFollowRedirects, u)
+	resp, err := s.getArchiveLinkFromURL(ctx, u, dontFollowRedirects)
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusFound {
 		return nil, newResponse(resp), fmt.Errorf("unexpected status code: %s", resp.Status)
@@ -254,7 +254,7 @@ func (s *RepositoriesService) GetArchiveLink(ctx context.Context, owner, repo st
 	return parsedURL, newResponse(resp), err
 }
 
-func (s *RepositoriesService) getArchiveLinkFromURL(ctx context.Context, dontFollowRedirects bool, u string) (*http.Response, error) {
+func (s *RepositoriesService) getArchiveLinkFromURL(ctx context.Context, u string, dontFollowRedirects bool) (*http.Response, error) {
 	var resp *http.Response
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -275,7 +275,7 @@ func (s *RepositoriesService) getArchiveLinkFromURL(ctx context.Context, dontFol
 	// If redirect response is returned, follow it
 	if !dontFollowRedirects && resp.StatusCode == http.StatusMovedPermanently {
 		u = resp.Header.Get("Location")
-		resp, err = s.getArchiveLinkFromURL(ctx, false, u)
+		resp, err = s.getArchiveLinkFromURL(ctx, u, false)
 	}
 	resp.Body.Close()
 	return resp, nil

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"reflect"
 	"testing"

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -375,7 +375,7 @@ func TestRepositoriesService_GetArchiveLink(t *testing.T) {
 		testMethod(t, r, "GET")
 		http.Redirect(w, r, "http://github.com/a", http.StatusFound)
 	})
-	url, resp, err := client.Repositories.GetArchiveLink(context.Background(), "o", "r", Tarball, &RepositoryContentGetOptions{})
+	url, resp, err := client.Repositories.GetArchiveLink(context.Background(), "o", "r", Tarball, false, &RepositoryContentGetOptions{})
 	if err != nil {
 		t.Errorf("Repositories.GetArchiveLink returned error: %v", err)
 	}

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -387,3 +387,16 @@ func TestRepositoriesService_GetArchiveLink(t *testing.T) {
 		t.Errorf("Repositories.GetArchiveLink returned %+v, want %+v", url.String(), want)
 	}
 }
+
+func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_dontFollowRedirects(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/repos/o/r/tarball", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		http.Redirect(w, r, "http://github.com/a", http.StatusMovedPermanently)
+	})
+	_, resp, _ := client.Repositories.GetArchiveLink(context.Background(), "o", "r", Tarball, true, &RepositoryContentGetOptions{})
+	if resp.StatusCode != http.StatusMovedPermanently {
+		t.Errorf("Repositories.GetArchiveLink returned status: %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `followRedirects` parameter, which when `true` will follow the URLs returned with `301 Moved Permanently` statuses (i.e if a repo has been renamed). Once a 302 status is found, that `Location` will be returned to the user.

## Testing 

Adds 2 unit tests for 301 status code return, for when `followRedirects` is `true` and `false`. 

Manually tested, invoking the function against repos both renamed and not renamed.

Fixes https://github.com/google/go-github/issues/1248