### PR TITLE
fix: Remove parent for a child team

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9724,6 +9724,46 @@ func (r *ReleaseEvent) GetSender() *User {
 	return r.Sender
 }
 
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (r *RemoveParentTeam) GetDescription() string {
+	if r == nil || r.Description == nil {
+		return ""
+	}
+	return *r.Description
+}
+
+// GetLDAPDN returns the LDAPDN field if it's non-nil, zero value otherwise.
+func (r *RemoveParentTeam) GetLDAPDN() string {
+	if r == nil || r.LDAPDN == nil {
+		return ""
+	}
+	return *r.LDAPDN
+}
+
+// GetParentTeamID returns the ParentTeamID field if it's non-nil, zero value otherwise.
+func (r *RemoveParentTeam) GetParentTeamID() int64 {
+	if r == nil || r.ParentTeamID == nil {
+		return 0
+	}
+	return *r.ParentTeamID
+}
+
+// GetPermission returns the Permission field if it's non-nil, zero value otherwise.
+func (r *RemoveParentTeam) GetPermission() string {
+	if r == nil || r.Permission == nil {
+		return ""
+	}
+	return *r.Permission
+}
+
+// GetPrivacy returns the Privacy field if it's non-nil, zero value otherwise.
+func (r *RemoveParentTeam) GetPrivacy() string {
+	if r == nil || r.Privacy == nil {
+		return ""
+	}
+	return *r.Privacy
+}
+
 // GetFrom returns the From field if it's non-nil, zero value otherwise.
 func (r *Rename) GetFrom() string {
 	if r == nil || r.From == nil {

--- a/github/github.go
+++ b/github/github.go
@@ -318,6 +318,21 @@ func NewEnterpriseClient(baseURL, uploadURL string, httpClient *http.Client) (*C
 	return c, nil
 }
 
+func (c *Client) GetJSONEncodedData(body interface{}) (io.ReadWriter, error) {
+	var buf io.ReadWriter
+	if body != nil {
+		buf = new(bytes.Buffer)
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		err := enc.Encode(body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	fmt.Println(buf)
+	return buf, nil
+}
+
 // NewRequest creates an API request. A relative URL can be provided in urlStr,
 // in which case it is resolved relative to the BaseURL of the Client.
 // Relative URLs should always be specified without a preceding slash. If
@@ -332,17 +347,10 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 		return nil, err
 	}
 
-	var buf io.ReadWriter
-	if body != nil {
-		buf = new(bytes.Buffer)
-		enc := json.NewEncoder(buf)
-		enc.SetEscapeHTML(false)
-		err := enc.Encode(body)
-		if err != nil {
-			return nil, err
-		}
+	buf, err := c.GetJSONEncodedData(body)
+	if err != nil {
+		return nil, err
 	}
-
 	req, err := http.NewRequest(method, u.String(), buf)
 	if err != nil {
 		return nil, err

--- a/github/github.go
+++ b/github/github.go
@@ -318,6 +318,9 @@ func NewEnterpriseClient(baseURL, uploadURL string, httpClient *http.Client) (*C
 	return c, nil
 }
 
+// GetJSONEncodedData creates io writer object for sending API call. The usage
+// can also be extended to use for parsing the bytes array data for some edge
+// case validations while parsing the struct.
 func (c *Client) GetJSONEncodedData(body interface{}) (io.ReadWriter, error) {
 	var buf io.ReadWriter
 	if body != nil {

--- a/github/github.go
+++ b/github/github.go
@@ -329,7 +329,6 @@ func (c *Client) GetJSONEncodedData(body interface{}) (io.ReadWriter, error) {
 			return nil, err
 		}
 	}
-	fmt.Println(buf)
 	return buf, nil
 }
 

--- a/github/teams.go
+++ b/github/teams.go
@@ -203,6 +203,52 @@ func (s *TeamsService) EditTeam(ctx context.Context, id int64, team NewTeam) (*T
 	return t, resp, nil
 }
 
+// RemoveParentTeam represents a new team with no parent
+type RemoveParentTeam struct {
+		Name         string   `json:"name"` // Name of the team. (Required.)
+	Description  *string  `json:"description,omitempty"`
+	Maintainers  []string `json:"maintainers,omitempty"`
+	RepoNames    []string `json:"repo_names,omitempty"`
+	ParentTeamID *int64   `json:"parent_team_id,omitempty"`
+
+	// Deprecated: Permission is deprecated when creating or editing a team in an org
+	// using the new GitHub permission model. It no longer identifies the
+	// permission a team has on its repos, but only specifies the default
+	// permission a repo is initially added with. Avoid confusion by
+	// specifying a permission value when calling AddTeamRepo.
+	Permission *string `json:"permission,omitempty"`
+
+	// Privacy identifies the level of privacy this team should have.
+	// Possible values are:
+	//     secret - only visible to organization owners and members of this team
+	//     closed - visible to all members of this organization
+	// Default is "secret".
+	Privacy *string `json:"privacy,omitempty"`
+
+	// LDAPDN may be used in GitHub Enterprise when the team membership
+	// is synchronized with LDAP.
+	LDAPDN *string `json:"ldap_dn,omitempty"`
+}
+
+// EditTeamRemoveParent sets the parent for the team to be nil.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/#edit-team
+func (s *TeamsService) EditTeamRemoveParent(ctx context.Context, id int64, team RemoveParentTeam) (*Team, *Response, error) {
+	u := fmt.Sprintf("teams/%v", id)
+	req, err := s.client.NewRequest("PATCH", u, team)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t := new(Team)
+	resp, err := s.client.Do(ctx, req, t)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return t, resp, nil
+}
+
 // DeleteTeam deletes a team.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/#delete-team

--- a/github/teams.go
+++ b/github/teams.go
@@ -205,7 +205,7 @@ func (s *TeamsService) EditTeam(ctx context.Context, id int64, team NewTeam) (*T
 
 // RemoveParentTeam represents a new team with no parent
 type RemoveParentTeam struct {
-		Name         string   `json:"name"` // Name of the team. (Required.)
+	Name         string   `json:"name"` // Name of the team. (Required.)
 	Description  *string  `json:"description,omitempty"`
 	Maintainers  []string `json:"maintainers,omitempty"`
 	RepoNames    []string `json:"repo_names,omitempty"`

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -204,6 +204,35 @@ func TestTeamsService_EditTeam(t *testing.T) {
 	}
 }
 
+func TestTeamsRemoveParentsService_EditTeam(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := RemoveParentTeam{Name: "n", Privacy: String("closed"), ParentTeamID: nil}
+
+	mux.HandleFunc("/teams/1", func(w http.ResponseWriter, r *http.Request) {
+		v := new(RemoveParentTeam)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "PATCH")
+		if !reflect.DeepEqual(v, &input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		fmt.Fprint(w, `{"id":1}`)
+	})
+
+	team, _, err := client.Teams.EditTeamRemoveParent(context.Background(), 1, input)
+	if err != nil {
+		t.Errorf("Teams.EditTeamRemoveParent returned error: %v", err)
+	}
+
+	want := &Team{ID: Int64(1)}
+	if !reflect.DeepEqual(team, want) {
+		t.Errorf("Teams.EditTeamRemoveParent returned %+v, want %+v", team, want)
+	}
+}
+
 func TestTeamsService_DeleteTeam(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -179,7 +179,7 @@ func TestTeamsService_EditTeam(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	input := NewTeam{Name: "n", Privacy: String("closed")}
+	input := NewTeam{Name: "n", Privacy: String("closed"), ParentTeamID: nil}
 
 	mux.HandleFunc("/teams/1", func(w http.ResponseWriter, r *http.Request) {
 		v := new(NewTeam)
@@ -193,7 +193,7 @@ func TestTeamsService_EditTeam(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	team, _, err := client.Teams.EditTeam(context.Background(), 1, input)
+	team, _, err := client.Teams.EditTeam(context.Background(), 1, input, true)
 	if err != nil {
 		t.Errorf("Teams.EditTeam returned error: %v", err)
 	}


### PR DESCRIPTION
This PR conatins following changes:

* new method `EditTeamRemoveParent`

Fixes: #1267