### PR TITLE
Support unexpected error response format

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -706,6 +706,10 @@ These are the possible validation error codes:
         some resources return this (e.g. github.User.CreateKey()), additional
         information is set in the Message field of the Error
 
+GitHub error responses structure are often undocumented and inconsistent.
+Sometimes error is just a simple string (Issue #540).
+In such cases, Message represents an error message as a workaround.
+
 GitHub API docs: https://developer.github.com/v3/#client-errors
 */
 type Error struct {
@@ -718,6 +722,14 @@ type Error struct {
 func (e *Error) Error() string {
 	return fmt.Sprintf("%v error caused by %v field on %v resource",
 		e.Code, e.Field, e.Resource)
+}
+
+func (e *Error) UnmarshalJSON(data []byte) error {
+	type aliasError Error // avoid infinite recursion by using type alias.
+	if err := json.Unmarshal(data, (*aliasError)(e)); err != nil {
+		return json.Unmarshal(data, &e.Message) // data can be json string.
+	}
+	return nil
 }
 
 // CheckResponse checks the API response for errors, and returns them if

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -942,6 +942,29 @@ func TestCheckResponse_noBody(t *testing.T) {
 	}
 }
 
+func TestCheckResponse_unexpectedErrorStructure(t *testing.T) {
+	httpBody := `{"message":"m", "errors": ["error 1"]}`
+	res := &http.Response{
+		Request:    &http.Request{},
+		StatusCode: http.StatusBadRequest,
+		Body:       ioutil.NopCloser(strings.NewReader(httpBody)),
+	}
+	err := CheckResponse(res).(*ErrorResponse)
+
+	if err == nil {
+		t.Errorf("Expected error response.")
+	}
+
+	want := &ErrorResponse{
+		Response: res,
+		Message:  "m",
+		Errors:   []Error{{Message: "error 1"}},
+	}
+	if !reflect.DeepEqual(err, want) {
+		t.Errorf("Error = %#v, want %#v", err, want)
+	}
+}
+
 func TestParseBooleanResponse_true(t *testing.T) {
 	result, err := parseBoolResponse(nil)
 	if err != nil {


### PR DESCRIPTION

> "errors" is list of string for review API.
```
{
  "message": "Validation Failed",
  "errors": [
    "Cannot return null for non-nullable field PullRequestReviewComment.position"
  ],
  "documentation_url": "https://developer.github.com/v3/pulls/reviews/#get-a-single-reviews-comments"
}
```

See #540 for the detail of the problem.
Related: #1136

I assume GitHub won't change the error structure as it's already in production.
I hope they will document the error format, but anyway go-github needs to support it for the sane error handling,
Even if #1136 is implemented, it should be better to represent error as ErrorResponse struct, IMO.
so I implement it by re-using `message` field as a workaround.