### PR TITLE
Fix JSON unmarshal error of App.app.events

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -30,7 +30,7 @@ type App struct {
 	CreatedAt   *Timestamp               `json:"created_at,omitempty"`
 	UpdatedAt   *Timestamp               `json:"updated_at,omitempty"`
 	Permissions *InstallationPermissions `json:"permissions,omitempty"`
-	Events      []*Event                 `json:"events,omitempty"`
+	Events      []string                 `json:"events,omitempty"`
 }
 
 // InstallationToken represents an installation token.


### PR DESCRIPTION
I got following error.
json: cannot unmarshal string into Go struct field App.app.events of
type github.Event

It's regression from #1283 and event type should be actually string.

https://developer.github.com/v3/apps/#get-a-single-github-app
https://developer.github.com/v3/repos/branches/#list-apps-with-access-to-protected-branch