### PR TITLE
Added feature to Update information about a Pages site

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -7052,6 +7052,22 @@ func (p *PageStats) GetTotalPages() int {
 	return *p.TotalPages
 }
 
+// GetCName returns the CName field if it's non-nil, zero value otherwise.
+func (p *PageUpdate) GetCName() string {
+	if p == nil || p.CName == nil {
+		return ""
+	}
+	return *p.CName
+}
+
+// GetSource returns the Source field if it's non-nil, zero value otherwise.
+func (p *PageUpdate) GetSource() string {
+	if p == nil || p.Source == nil {
+		return ""
+	}
+	return *p.Source
+}
+
 // GetHook returns the Hook field.
 func (p *PingEvent) GetHook() *Hook {
 	if p == nil {
@@ -9722,6 +9738,22 @@ func (r *ReleaseEvent) GetSender() *User {
 		return nil
 	}
 	return r.Sender
+}
+
+// GetCName returns the CName field if it's non-nil, zero value otherwise.
+func (r *RemoveCName) GetCName() string {
+	if r == nil || r.CName == nil {
+		return ""
+	}
+	return *r.CName
+}
+
+// GetSource returns the Source field if it's non-nil, zero value otherwise.
+func (r *RemoveCName) GetSource() string {
+	if r == nil || r.Source == nil {
+		return ""
+	}
+	return *r.Source
 }
 
 // GetFrom returns the From field if it's non-nil, zero value otherwise.

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -43,6 +43,12 @@ type PagesBuild struct {
 	UpdatedAt *Timestamp  `json:"updated_at,omitempty"`
 }
 
+//PageUpdate represents options for updating page
+type PageUpdate struct {
+	Cname  *string `json:"cname,omitempty"`
+	Source *string `json:"source,omitempty"`
+}
+
 // EnablePages enables GitHub Pages for the named repo.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/pages/#enable-a-pages-site
@@ -62,6 +68,24 @@ func (s *RepositoriesService) EnablePages(ctx context.Context, owner, repo strin
 	}
 
 	return enable, resp, nil
+}
+
+// UpdatePages https://developer.github.com/v3/repos/pages/#update-information-about-a-pages-site
+func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo string, body *PageUpdate) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
+
+	req, err := s.client.NewRequest("PUT", u, body)
+	if err != nil {
+		return nil, err
+	}
+
+	enable := new(Pages)
+	resp, err := s.client.Do(ctx, req, enable)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
 }
 
 // DisablePages disables GitHub Pages for the named repo.

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -45,7 +45,6 @@ type PagesBuild struct {
 }
 
 // PageUpdateOptions represents options for updating a GitHub Page.
-
 type PageUpdate struct {
 	CName  *string `json:"cname,omitempty"`
 	Source *string `json:"source,omitempty"`
@@ -72,17 +71,16 @@ func (s *RepositoriesService) EnablePages(ctx context.Context, owner, repo strin
 
 	return enable, resp, nil
 
-
 }
 
 type RemoveCName struct {
-	CName *string `json:"cname"`
+	CName  *string `json:"cname"`
 	Source *string `json:"source,omitempty"`
 }
 
 func copyRemoveCName(opts *PageUpdate) *RemoveCName {
 	return &RemoveCName{
-		CName: opts.CName,
+		CName:  opts.CName,
 		Source: opts.Source,
 	}
 }
@@ -105,20 +103,19 @@ func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo strin
 		req, err = s.client.NewRequest("PUT", u, opts)
 	}
 
-		if err != nil {
-			return nil, err
-		}
-
-		enable := new(Pages)
-		resp, err := s.client.Do(ctx, req, enable)
-		if err != nil {
-			return resp, err
-		}
-
-		return resp, nil
-
+	if err != nil {
+		return nil, err
 	}
 
+	enable := new(Pages)
+	resp, err := s.client.Do(ctx, req, enable)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+
+}
 
 // DisablePages disables GitHub Pages for the named repo.
 //


### PR DESCRIPTION
Added [this](https://developer.github.com/v3/repos/pages/#update-information-about-a-pages-site) API functionality.

For reference : [Issue](https://github.com/google/go-github/issues/1361)