### PR TITLE
Allow DownloadReleaseAsset to follow redirects

### DIFF
--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -288,9 +288,9 @@ func (s *RepositoriesService) downloadReleaseAssetFromURL(ctx context.Context, u
 		loc = req.URL.String()
 		return errors.New("disable redirect")
 	}
-	defer func() { s.client.client.CheckRedirect = saveRedirect }()
 	req = withContext(ctx, req)
 	resp, err := s.client.client.Do(req)
+	s.client.client.CheckRedirect = saveRedirect
 	s.client.clientMu.Unlock()
 	if err != nil {
 		if !strings.Contains(err.Error(), "disable redirect") {

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -268,7 +268,7 @@ func (s *RepositoriesService) GetReleaseAsset(ctx context.Context, owner, repo s
 //
 // followRedirectsClient can be passed to download the asset from a redirected
 // location. Passing http.DefaultClient is recommended unless special circumstances
-// exists, but it's possible to pass any http.Client. If nil is passed the
+// exist, but it's possible to pass any http.Client. If nil is passed the
 // redirectURL will be returned instead.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/releases/#get-a-single-release-asset

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -298,7 +298,7 @@ func TestRepositoriesService_DownloadReleaseAsset_FollowRedirect(t *testing.T) {
 	})
 	mux.HandleFunc("/yo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", defaultMediaType)
+		testHeader(t, r, "Accept", "*/*")
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.Header().Set("Content-Disposition", "attachment; filename=hello-world.txt")
 		fmt.Fprint(w, "Hello World")
@@ -309,6 +309,7 @@ func TestRepositoriesService_DownloadReleaseAsset_FollowRedirect(t *testing.T) {
 	if err != nil {
 		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
 	}
+	reader.Close()
 	want := []byte("Hello World")
 	if !bytes.Equal(want, content) {
 		t.Errorf("Repositories.DownloadReleaseAsset returned %+v, want %+v", content, want)

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -252,7 +252,7 @@ func TestRepositoriesService_DownloadReleaseAsset_Stream(t *testing.T) {
 		fmt.Fprint(w, "Hello World")
 	})
 
-	reader, _, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1)
+	reader, _, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, true)
 	if err != nil {
 		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
 	}
@@ -276,13 +276,42 @@ func TestRepositoriesService_DownloadReleaseAsset_Redirect(t *testing.T) {
 		http.Redirect(w, r, "/yo", http.StatusFound)
 	})
 
-	_, got, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1)
+	_, got, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, false)
 	if err != nil {
 		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
 	}
 	want := "/yo"
 	if !strings.HasSuffix(got, want) {
 		t.Errorf("Repositories.DownloadReleaseAsset returned %+v, want %+v", got, want)
+	}
+}
+
+func TestRepositoriesService_DownloadReleaseAsset_FollowRedirect(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", defaultMediaType)
+		// /yo, below will be served as baseURLPath/yo
+		http.Redirect(w, r, baseURLPath+"/yo", http.StatusFound)
+	})
+	mux.HandleFunc("/yo", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", defaultMediaType)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", "attachment; filename=hello-world.txt")
+		fmt.Fprint(w, "Hello World")
+	})
+
+	reader, _, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, true)
+	content, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
+	}
+	want := []byte("Hello World")
+	if !bytes.Equal(want, content) {
+		t.Errorf("Repositories.DownloadReleaseAsset returned %+v, want %+v", content, want)
 	}
 }
 
@@ -297,7 +326,7 @@ func TestRepositoriesService_DownloadReleaseAsset_APIError(t *testing.T) {
 		fmt.Fprint(w, `{"message":"Not Found","documentation_url":"https://developer.github.com/v3"}`)
 	})
 
-	resp, loc, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1)
+	resp, loc, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, false)
 	if err == nil {
 		t.Error("Repositories.DownloadReleaseAsset did not return an error")
 	}

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -252,7 +252,7 @@ func TestRepositoriesService_DownloadReleaseAsset_Stream(t *testing.T) {
 		fmt.Fprint(w, "Hello World")
 	})
 
-	reader, _, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, true)
+	reader, _, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestRepositoriesService_DownloadReleaseAsset_Redirect(t *testing.T) {
 		http.Redirect(w, r, "/yo", http.StatusFound)
 	})
 
-	_, got, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, false)
+	_, got, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestRepositoriesService_DownloadReleaseAsset_FollowRedirect(t *testing.T) {
 		fmt.Fprint(w, "Hello World")
 	})
 
-	reader, _, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, true)
+	reader, _, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, http.DefaultClient)
 	content, err := ioutil.ReadAll(reader)
 	if err != nil {
 		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
@@ -327,7 +327,7 @@ func TestRepositoriesService_DownloadReleaseAsset_APIError(t *testing.T) {
 		fmt.Fprint(w, `{"message":"Not Found","documentation_url":"https://developer.github.com/v3"}`)
 	})
 
-	resp, loc, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, false)
+	resp, loc, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, nil)
 	if err == nil {
 		t.Error("Repositories.DownloadReleaseAsset did not return an error")
 	}

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -9,6 +9,8 @@ package integration
 
 import (
 	"context"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
@@ -177,5 +179,21 @@ func TestRepositories_List(t *testing.T) {
 		if i > 0 && (*repos[i-1].CreatedAt).Time.Before((*repo.CreatedAt).Time) {
 			t.Fatalf("Repositories.List('google') with default descending Sort returned incorrect order")
 		}
+	}
+}
+
+func TestRepositories_DownloadReleaseAsset(t *testing.T) {
+	if !checkAuth("TestRepositories_DownloadReleaseAsset") {
+		return
+	}
+
+	rc, _, err := client.Repositories.DownloadReleaseAsset(context.Background(), "andersjanmyr", "goose", 484892, true)
+	if err != nil {
+		t.Fatalf("Repositories.DownloadReleaseAsset(andersjanmyr, goose, 484892, true) returned error: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+	_, err = io.Copy(ioutil.Discard, rc)
+	if err != nil {
+		t.Fatalf("Repositories.DownloadReleaseAsset(andersjanmyr, goose, 484892, true) returned error: %v", err)
 	}
 }

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -187,7 +187,7 @@ func TestRepositories_DownloadReleaseAsset(t *testing.T) {
 		return
 	}
 
-	rc, _, err := client.Repositories.DownloadReleaseAsset(context.Background(), "andersjanmyr", "goose", 484892, true)
+	rc, _, err := client.Repositories.DownloadReleaseAsset(context.Background(), "andersjanmyr", "goose", 484892, http.DefaultClient)
 	if err != nil {
 		t.Fatalf("Repositories.DownloadReleaseAsset(andersjanmyr, goose, 484892, true) returned error: %v", err)
 	}


### PR DESCRIPTION
Adds an extra parameter to DownloadReleaseAsset `followRedirects`. This will tell the client to follow one level of redirects when downloading the asset.

Solves #1378 