### PR TITLE
Remove "everest" custom preview header on official GitHub release 

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -135,9 +135,6 @@ const (
 
 	// https://developer.github.com/changes/2019-10-03-multi-line-comments/
 	mediaTypeMultiLineCommentsPreview = "application/vnd.github.comfort-fade-preview+json"
-
-	// https://developer.github.com/v3/repos/#create-a-repository-dispatch-event
-	mediaTypeRepositoryDispatchPreview = "application/vnd.github.everest-preview+json"
 )
 
 // A Client manages communication with the GitHub API.

--- a/github/repos.go
+++ b/github/repos.go
@@ -1449,9 +1449,6 @@ func (s *RepositoriesService) Dispatch(ctx context.Context, owner, repo string, 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeRepositoryDispatchPreview)
-
 	r := new(Repository)
 	resp, err := s.client.Do(ctx, req, r)
 	if err != nil {

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -1808,7 +1808,6 @@ func TestRepositoriesService_Dispatch(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeRepositoryDispatchPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}


### PR DESCRIPTION
Fixes #1390.

Now GitHub officially supports **creating a repository dispatch event API**
https://developer.github.com/changes/2020-01-22-everest-preview-graduated/