### PR TITLE
Add new branch protection values

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -7796,6 +7796,22 @@ func (p *ProjectPermissionLevel) GetUser() *User {
 	return p.User
 }
 
+// GetAllowDeletions returns the AllowDeletions field.
+func (p *Protection) GetAllowDeletions() *AllowDeletions {
+	if p == nil {
+		return nil
+	}
+	return p.AllowDeletions
+}
+
+// GetAllowForcePushes returns the AllowForcePushes field.
+func (p *Protection) GetAllowForcePushes() *AllowForcePushes {
+	if p == nil {
+		return nil
+	}
+	return p.AllowForcePushes
+}
+
 // GetEnforceAdmins returns the EnforceAdmins field.
 func (p *Protection) GetEnforceAdmins() *AdminEnforcement {
 	if p == nil {
@@ -7820,12 +7836,36 @@ func (p *Protection) GetRequiredStatusChecks() *RequiredStatusChecks {
 	return p.RequiredStatusChecks
 }
 
+// GetRequireLinearHistory returns the RequireLinearHistory field.
+func (p *Protection) GetRequireLinearHistory() *RequireLinearHistory {
+	if p == nil {
+		return nil
+	}
+	return p.RequireLinearHistory
+}
+
 // GetRestrictions returns the Restrictions field.
 func (p *Protection) GetRestrictions() *BranchRestrictions {
 	if p == nil {
 		return nil
 	}
 	return p.Restrictions
+}
+
+// GetAllowDeletions returns the AllowDeletions field if it's non-nil, zero value otherwise.
+func (p *ProtectionRequest) GetAllowDeletions() bool {
+	if p == nil || p.AllowDeletions == nil {
+		return false
+	}
+	return *p.AllowDeletions
+}
+
+// GetAllowForcePushes returns the AllowForcePushes field if it's non-nil, zero value otherwise.
+func (p *ProtectionRequest) GetAllowForcePushes() bool {
+	if p == nil || p.AllowForcePushes == nil {
+		return false
+	}
+	return *p.AllowForcePushes
 }
 
 // GetRequiredPullRequestReviews returns the RequiredPullRequestReviews field.
@@ -7842,6 +7882,14 @@ func (p *ProtectionRequest) GetRequiredStatusChecks() *RequiredStatusChecks {
 		return nil
 	}
 	return p.RequiredStatusChecks
+}
+
+// GetRequireLinearHistory returns the RequireLinearHistory field if it's non-nil, zero value otherwise.
+func (p *ProtectionRequest) GetRequireLinearHistory() bool {
+	if p == nil || p.RequireLinearHistory == nil {
+		return false
+	}
+	return *p.RequireLinearHistory
 }
 
 // GetRestrictions returns the Restrictions field.

--- a/github/repos.go
+++ b/github/repos.go
@@ -727,6 +727,9 @@ type Protection struct {
 	RequiredPullRequestReviews *PullRequestReviewsEnforcement `json:"required_pull_request_reviews"`
 	EnforceAdmins              *AdminEnforcement              `json:"enforce_admins"`
 	Restrictions               *BranchRestrictions            `json:"restrictions"`
+	RequireLinearHistory       *RequireLinearHistory          `json:"required_linear_history"`
+	AllowForcePushes           *AllowForcePushes              `json:"allow_force_pushes"`
+	AllowDeletions             *AllowDeletions                `json:"allow_deletions"`
 }
 
 // ProtectionRequest represents a request to create/edit a branch's protection.
@@ -735,6 +738,12 @@ type ProtectionRequest struct {
 	RequiredPullRequestReviews *PullRequestReviewsEnforcementRequest `json:"required_pull_request_reviews"`
 	EnforceAdmins              bool                                  `json:"enforce_admins"`
 	Restrictions               *BranchRestrictionsRequest            `json:"restrictions"`
+	// Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch.
+	RequireLinearHistory *bool `json:"required_linear_history,omitempty"`
+	// Permits force pushes to the protected branch by anyone with write access to the repository.
+	AllowForcePushes *bool `json:"allow_force_pushes,omitempty"`
+	// Allows deletion of the protected branch by anyone with write access to the repository.
+	AllowDeletions *bool `json:"allow_deletions,omitempty"`
 }
 
 // RequiredStatusChecks represents the protection status of a individual branch.
@@ -795,6 +804,21 @@ type PullRequestReviewsEnforcementUpdate struct {
 	// RequiredApprovingReviewCount specifies the number of approvals required before the pull request can be merged.
 	// Valid values are 1 - 6.
 	RequiredApprovingReviewCount int `json:"required_approving_review_count"`
+}
+
+// RequireLinearHistory represents the configuration to enfore branches with no merge commit.
+type RequireLinearHistory struct {
+	Enabled bool `json:"enabled"`
+}
+
+// AllowDeletions represents the configuration to accept deletion of protected branches.
+type AllowDeletions struct {
+	Enabled bool `json:"enabled"`
+}
+
+// AllowForcePushes represents the configuration to accept forced pushes on protected branches.
+type AllowForcePushes struct {
+	Enabled bool `json:"enabled"`
 }
 
 // AdminEnforcement represents the configuration to enforce required status checks for repository administrators.


### PR DESCRIPTION
GitHub has been adding some new fields in the branch protections
as documented:
https://developer.github.com/v3/repos/branches/#get-branch-protection

the documentation references the new fields in the branch protection as:

https://developer.github.com/v3/repos/branches/#get-branch-protection:
`GET /repos/:owner/:repo/branches/:branch/protection`

```
  "required_linear_history": {
    "enabled": true
  },
  "allow_force_pushes": {
    "enabled": true
  },
  "allow_deletions": {
    "enabled": true
  }
```

https://developer.github.com/v3/repos/branches/#update-branch-protection:
`PUT /repos/:owner/:repo/branches/:branch/protection`

|field|type|required?|
|-|-|-|
|`required_linear_history`|boolean|optional|
|`allow_force_pushes`|boolean|optional|
|`allow_deletions`|boolean|optional|

This PR achieves a similar goal as #1354, addressing comments.
Unlike suggestion in #1354 comment, the `EnabledType` is not defined as is, instead individual types are declared to prevent interface change if ever the field type changes.
 
Fixes #1345