### PR TITLE
Implement support for action secrets

### DIFF
--- a/github/actions.go
+++ b/github/actions.go
@@ -1,0 +1,12 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+// ActionsService handles communication with the actions related
+// methods of the GitHub API.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/
+type ActionsService service

--- a/github/actions.go
+++ b/github/actions.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The go-github AUTHORS. All rights reserved.
+// Copyright 2020 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -94,7 +94,7 @@ func (s *ActionsService) GetSecret(ctx context.Context, owner, repo, name string
 
 // EncryptedSecret represents a secret that is encrypted using a public key.
 //
-// The value of EncryptedValue must value of your secret, encrypted with
+// The value of EncryptedValue must be your secret, encrypted with
 // LibSodium (see documentation here: https://libsodium.gitbook.io/doc/bindings_for_other_languages)
 // using the public key retrieved using the GetPublicKey method.
 type EncryptedSecret struct {

--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -1,4 +1,4 @@
-// Copyright 2013 The go-github AUTHORS. All rights reserved.
+// Copyright 2020 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -37,9 +37,9 @@ func (s *ActionsService) GetPublicKey(ctx context.Context, owner, repo string) (
 
 // Secret represents a repository action secret.
 type Secret struct {
-	Name      *string    `json:"name"`
-	CreatedAt *Timestamp `json:"created_at"`
-	UpdatedAt *Timestamp `json:"updated_at"`
+	Name      string    `json:"name"`
+	CreatedAt Timestamp `json:"created_at"`
+	UpdatedAt Timestamp `json:"updated_at"`
 }
 
 // Secrets represents one item from the ListSecrets response.
@@ -92,9 +92,9 @@ func (s *ActionsService) GetSecret(ctx context.Context, owner, repo, name string
 	return secret, resp, nil
 }
 
-// EncryptedSecret represents represents a secret that is encrypted using public key.
+// EncryptedSecret represents a secret that is encrypted using a public key.
 //
-// The value of EncryptedValue must value for your secret, encrypted with
+// The value of EncryptedValue must value of your secret, encrypted with
 // LibSodium (see documentation here: https://libsodium.gitbook.io/doc/bindings_for_other_languages)
 // using the public key retrieved using the GetPublicKey method.
 type EncryptedSecret struct {

--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -93,6 +93,10 @@ func (s *ActionsService) GetSecret(ctx context.Context, owner, repo, name string
 }
 
 // EncryptedSecret represents represents a secret that is encrypted using public key.
+//
+// The value of EncryptedValue must value for your secret, encrypted with
+// LibSodium (see documentation here: https://libsodium.gitbook.io/doc/bindings_for_other_languages)
+// using the public key retrieved using the GetPublicKey method.
 type EncryptedSecret struct {
 	Name           string `json:"-"`
 	KeyID          string `json:"key_id"`

--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -1,0 +1,130 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+type PublicKey struct {
+	ID  *string `json:"key_id,omitempty"`
+	Key *string `json:"key,omitempty"`
+}
+
+// GetPublicKey gets a public key that should be used for secret encryption.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#get-your-public-key
+func (s *ActionsService) GetPublicKey(ctx context.Context, owner string, repo string) (*PublicKey, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/secrets/public-key", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pubKey := new(PublicKey)
+	resp, err := s.client.Do(ctx, req, pubKey)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pubKey, resp, nil
+}
+
+// Secret represents a repository action secret.
+type Secret struct {
+	Name      *string    `json:"name,omitempty"`
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
+}
+
+type secrets struct {
+	Secrets []*Secret `json:"secrets,omitempty"`
+}
+
+// ListSecrets lists all secrets available in a repository
+// without revealing their encrypted values.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#list-secrets-for-a-repository
+func (s *ActionsService) ListSecrets(ctx context.Context, owner, repo string, opt *ListOptions) ([]*Secret, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/actions/secrets", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	secrets := new(secrets)
+	resp, err := s.client.Do(ctx, req, &secrets)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return secrets.Secrets, resp, nil
+}
+
+// GetSecret gets a single secret without revealing its encrypted value.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#get-a-secret
+func (s *ActionsService) GetSecret(ctx context.Context, owner, repo, name string) (*Secret, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/secrets/%v", owner, repo, name)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	secret := new(Secret)
+	resp, err := s.client.Do(ctx, req, secret)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return secret, resp, nil
+}
+
+type EncryptedSecret struct {
+	Name           *string `json:"-"`
+	KeyId          *string `json:"key_id,omitempty"`
+	EncryptedValue *string `json:"encrypted_value,omitempty"`
+}
+
+// CreateOrUpdateSecret creates or updates a secret with an encrypted value.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#create-or-update-a-secret-for-a-repository
+func (s *ActionsService) CreateOrUpdateSecret(ctx context.Context, owner, repo string, eSecret *EncryptedSecret) (*EncryptedSecret, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/secrets/%v", owner, repo, *eSecret.Name)
+
+	req, err := s.client.NewRequest("PUT", u, eSecret)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	es := new(EncryptedSecret)
+	resp, err := s.client.Do(ctx, req, es)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return es, resp, nil
+}
+
+// DeleteSecret deletes a secret in a repository using the secret name.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#delete-a-secret-from-a-repository
+func (s *ActionsService) DeleteSecret(ctx context.Context, owner, repo, name string) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/secrets/%v", owner, repo, name)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/actions_secrets_test.go
+++ b/github/actions_secrets_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013 The go-github AUTHORS. All rights reserved.
+// Copyright 2020 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/github/actions_secrets_test.go
+++ b/github/actions_secrets_test.go
@@ -1,0 +1,114 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestActionsService_GetPublicKey(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/secrets/public-key", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"key_id":"1234","key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
+	})
+
+	key, _, err := client.Actions.GetPublicKey(context.Background(), "o", "r")
+	if err != nil {
+		t.Errorf("Actions.GetPublicKey returned error: %v", err)
+	}
+
+	want := &PublicKey{ID: String("1234"), Key: String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234")}
+	if !reflect.DeepEqual(key, want) {
+		t.Errorf("Actions.GetPublicKey returned %+v, want %+v", key, want)
+	}
+}
+
+func TestActionsService_ListSecrets(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/secrets", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"page": "2"})
+		fmt.Fprint(w, `{"total_count":2,"secrets":[{"name":"A","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"},{"name":"B","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}]}`)
+	})
+
+	opt := &ListOptions{Page: 2}
+	secrets, _, err := client.Actions.ListSecrets(context.Background(), "o", "r", opt)
+	if err != nil {
+		t.Errorf("Actions.ListSecrets returned error: %v", err)
+	}
+
+	want := []*Secret{
+		{Name: String("A"), CreatedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
+		{Name: String("B"), CreatedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
+	}
+	if !reflect.DeepEqual(secrets, want) {
+		t.Errorf("Actions.ListSecrets returned %+v, want %+v", secrets, want)
+	}
+}
+
+func TestActionsService_GetSecret(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"name":"NAME","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
+	})
+
+	secret, _, err := client.Actions.GetSecret(context.Background(), "o", "r", "NAME")
+	if err != nil {
+		t.Errorf("Actions.GetSecret returned error: %v", err)
+	}
+
+	want := &Secret{
+		Name:      String("NAME"),
+		CreatedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
+		UpdatedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
+	}
+	if !reflect.DeepEqual(secret, want) {
+		t.Errorf("Actions.GetSecret returned %+v, want %+v", secret, want)
+	}
+}
+
+func TestActionsService_CreateOrUpdateSecret(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Content-Type", "application/json")
+		testBody(t, r, `{"key_id":"1234","encrypted_value":"QIv="}`+"\n")
+		fmt.Fprint(w, `{"key_id":"1234","encrypted_value":"QIv="}`)
+	})
+
+	input := &EncryptedSecret{
+		Name:           String("NAME"),
+		EncryptedValue: String("QIv="),
+		KeyId:          String("1234"),
+	}
+	secret, _, err := client.Actions.CreateOrUpdateSecret(context.Background(), "o", "r", input)
+	if err != nil {
+		t.Errorf("Actions.CreateOrUpdateSecret returned error: %v", err)
+	}
+
+	want := &EncryptedSecret{
+		EncryptedValue: String("QIv="),
+		KeyId:          String("1234"),
+	}
+	if !reflect.DeepEqual(secret, want) {
+		t.Errorf("Actions.CreateOrUpdateSecret returned %+v, want %+v", secret, want)
+	}
+}

--- a/github/actions_secrets_test.go
+++ b/github/actions_secrets_test.go
@@ -112,3 +112,17 @@ func TestActionsService_CreateOrUpdateSecret(t *testing.T) {
 		t.Errorf("Actions.CreateOrUpdateSecret returned %+v, want %+v", secret, want)
 	}
 }
+
+func TestActionsService_DeleteSecret(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	_, err := client.Actions.DeleteSecret(context.Background(), "o", "r", "NAME")
+	if err != nil {
+		t.Errorf("Actions.DeleteSecret returned error: %v", err)
+	}
+}

--- a/github/actions_secrets_test.go
+++ b/github/actions_secrets_test.go
@@ -53,8 +53,8 @@ func TestActionsService_ListSecrets(t *testing.T) {
 	want := &Secrets{
 		TotalCount: 4,
 		Secrets: []*Secret{
-			{Name: String("A"), CreatedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
-			{Name: String("B"), CreatedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
+			{Name: "A", CreatedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
+			{Name: "B", CreatedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
 		},
 	}
 	if !reflect.DeepEqual(secrets, want) {
@@ -77,9 +77,9 @@ func TestActionsService_GetSecret(t *testing.T) {
 	}
 
 	want := &Secret{
-		Name:      String("NAME"),
-		CreatedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
-		UpdatedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
+		Name:      "NAME",
+		CreatedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
+		UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
 	}
 	if !reflect.DeepEqual(secret, want) {
 		t.Errorf("Actions.GetSecret returned %+v, want %+v", secret, want)

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2796,30 +2796,6 @@ func (d *DraftReviewComment) GetPosition() int {
 	return *d.Position
 }
 
-// GetEncryptedValue returns the EncryptedValue field if it's non-nil, zero value otherwise.
-func (e *EncryptedSecret) GetEncryptedValue() string {
-	if e == nil || e.EncryptedValue == nil {
-		return ""
-	}
-	return *e.EncryptedValue
-}
-
-// GetKeyId returns the KeyId field if it's non-nil, zero value otherwise.
-func (e *EncryptedSecret) GetKeyId() string {
-	if e == nil || e.KeyId == nil {
-		return ""
-	}
-	return *e.KeyId
-}
-
-// GetName returns the Name field if it's non-nil, zero value otherwise.
-func (e *EncryptedSecret) GetName() string {
-	if e == nil || e.Name == nil {
-		return ""
-	}
-	return *e.Name
-}
-
 // GetAvatarURL returns the AvatarURL field if it's non-nil, zero value otherwise.
 func (e *Enterprise) GetAvatarURL() string {
 	if e == nil || e.AvatarURL == nil {
@@ -7948,20 +7924,20 @@ func (p *PublicEvent) GetSender() *User {
 	return p.Sender
 }
 
-// GetID returns the ID field if it's non-nil, zero value otherwise.
-func (p *PublicKey) GetID() string {
-	if p == nil || p.ID == nil {
-		return ""
-	}
-	return *p.ID
-}
-
 // GetKey returns the Key field if it's non-nil, zero value otherwise.
 func (p *PublicKey) GetKey() string {
 	if p == nil || p.Key == nil {
 		return ""
 	}
 	return *p.Key
+}
+
+// GetKeyID returns the KeyID field if it's non-nil, zero value otherwise.
+func (p *PublicKey) GetKeyID() string {
+	if p == nil || p.KeyID == nil {
+		return ""
+	}
+	return *p.KeyID
 }
 
 // GetActiveLockReason returns the ActiveLockReason field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2796,6 +2796,30 @@ func (d *DraftReviewComment) GetPosition() int {
 	return *d.Position
 }
 
+// GetEncryptedValue returns the EncryptedValue field if it's non-nil, zero value otherwise.
+func (e *EncryptedSecret) GetEncryptedValue() string {
+	if e == nil || e.EncryptedValue == nil {
+		return ""
+	}
+	return *e.EncryptedValue
+}
+
+// GetKeyId returns the KeyId field if it's non-nil, zero value otherwise.
+func (e *EncryptedSecret) GetKeyId() string {
+	if e == nil || e.KeyId == nil {
+		return ""
+	}
+	return *e.KeyId
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (e *EncryptedSecret) GetName() string {
+	if e == nil || e.Name == nil {
+		return ""
+	}
+	return *e.Name
+}
+
 // GetAvatarURL returns the AvatarURL field if it's non-nil, zero value otherwise.
 func (e *Enterprise) GetAvatarURL() string {
 	if e == nil || e.AvatarURL == nil {
@@ -7924,6 +7948,22 @@ func (p *PublicEvent) GetSender() *User {
 	return p.Sender
 }
 
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (p *PublicKey) GetID() string {
+	if p == nil || p.ID == nil {
+		return ""
+	}
+	return *p.ID
+}
+
+// GetKey returns the Key field if it's non-nil, zero value otherwise.
+func (p *PublicKey) GetKey() string {
+	if p == nil || p.Key == nil {
+		return ""
+	}
+	return *p.Key
+}
+
 // GetActiveLockReason returns the ActiveLockReason field if it's non-nil, zero value otherwise.
 func (p *PullRequest) GetActiveLockReason() string {
 	if p == nil || p.ActiveLockReason == nil {
@@ -11442,6 +11482,30 @@ func (r *ReviewersRequest) GetNodeID() string {
 		return ""
 	}
 	return *r.NodeID
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (s *Secret) GetCreatedAt() Timestamp {
+	if s == nil || s.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *s.CreatedAt
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (s *Secret) GetName() string {
+	if s == nil || s.Name == nil {
+		return ""
+	}
+	return *s.Name
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (s *Secret) GetUpdatedAt() Timestamp {
+	if s == nil || s.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *s.UpdatedAt
 }
 
 // GetName returns the Name field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11460,30 +11460,6 @@ func (r *ReviewersRequest) GetNodeID() string {
 	return *r.NodeID
 }
 
-// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
-func (s *Secret) GetCreatedAt() Timestamp {
-	if s == nil || s.CreatedAt == nil {
-		return Timestamp{}
-	}
-	return *s.CreatedAt
-}
-
-// GetName returns the Name field if it's non-nil, zero value otherwise.
-func (s *Secret) GetName() string {
-	if s == nil || s.Name == nil {
-		return ""
-	}
-	return *s.Name
-}
-
-// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
-func (s *Secret) GetUpdatedAt() Timestamp {
-	if s == nil || s.UpdatedAt == nil {
-		return Timestamp{}
-	}
-	return *s.UpdatedAt
-}
-
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (s *ServiceHook) GetName() string {
 	if s == nil || s.Name == nil {

--- a/github/github.go
+++ b/github/github.go
@@ -159,6 +159,7 @@ type Client struct {
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
 
 	// Services used for talking to different parts of the GitHub API.
+	Actions        *ActionsService
 	Activity       *ActivityService
 	Admin          *AdminService
 	Apps           *AppsService
@@ -264,6 +265,7 @@ func NewClient(httpClient *http.Client) *Client {
 
 	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent, UploadURL: uploadURL}
 	c.common.client = c
+	c.Actions = (*ActionsService)(&c.common)
 	c.Activity = (*ActivityService)(&c.common)
 	c.Admin = (*AdminService)(&c.common)
 	c.Apps = (*AppsService)(&c.common)


### PR DESCRIPTION
This adds support for managing [github action secrets](https://developer.github.com/v3/actions/), an API feature that was recently announced.

Relates to: #1399 