### PR TITLE
Support specification of parameters for enable pages API

### DIFF
--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -46,7 +46,7 @@ type PagesBuild struct {
 // createPagesRequest is a subset of Pages and is used internally
 // by EnablePages to pass only the known fields for the endpoint.
 type createPagesRequest struct {
-	Source *PagesSource
+	Source *PagesSource `json:"source,omitempty"`
 }
 
 // EnablePages enables GitHub Pages for the named repo.

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -43,12 +43,23 @@ type PagesBuild struct {
 	UpdatedAt *Timestamp  `json:"updated_at,omitempty"`
 }
 
+// createPagesRequest is a subset of Pages and is used internally
+// by EnablePages to pass only the known fields for the endpoint.
+type createPagesRequest struct {
+	Source *PagesSource
+}
+
 // EnablePages enables GitHub Pages for the named repo.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/pages/#enable-a-pages-site
-func (s *RepositoriesService) EnablePages(ctx context.Context, owner, repo string) (*Pages, *Response, error) {
+func (s *RepositoriesService) EnablePages(ctx context.Context, owner, repo string, pages *Pages) (*Pages, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
-	req, err := s.client.NewRequest("POST", u, nil)
+
+	pagesReq := &createPagesRequest{
+		Source: pages.Source,
+	}
+
+	req, err := s.client.NewRequest("POST", u, pagesReq)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -23,7 +23,7 @@ func TestRepositoriesService_EnablePages(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u","status":"s","cname":"c","custom_404":false,"html_url":"h", "source": {"branch":"master", "path":"/"}}`)
 	})
 
-	page, _, err := client.Repositories.EnablePages(context.Background(), "o", "r")
+	page, _, err := client.Repositories.EnablePages(context.Background(), "o", "r", &Pages{Source: &PagesSource{Branch: String("master"), Path: String("/")}})
 	if err != nil {
 		t.Errorf("Repositories.EnablePages returned error: %v", err)
 	}

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -7,6 +7,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -17,13 +18,29 @@ func TestRepositoriesService_EnablePages(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	input := &Pages{
+		Source: &PagesSource{
+			Branch: String("master"),
+			Path:   String("/"),
+		},
+		CNAME: String("www.my-domain.com"), // not passed along.
+	}
+
 	mux.HandleFunc("/repos/o/r/pages", func(w http.ResponseWriter, r *http.Request) {
+		v := new(createPagesRequest)
+		json.NewDecoder(r.Body).Decode(v)
+
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", mediaTypeEnablePagesAPIPreview)
+		want := &createPagesRequest{Source: &PagesSource{Branch: String("master"), Path: String("/")}}
+		if !reflect.DeepEqual(v, want) {
+			t.Errorf("Request body = %+v, want %+v", v, want)
+		}
+
 		fmt.Fprint(w, `{"url":"u","status":"s","cname":"c","custom_404":false,"html_url":"h", "source": {"branch":"master", "path":"/"}}`)
 	})
 
-	page, _, err := client.Repositories.EnablePages(context.Background(), "o", "r", &Pages{Source: &PagesSource{Branch: String("master"), Path: String("/")}})
+	page, _, err := client.Repositories.EnablePages(context.Background(), "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.EnablePages returned error: %v", err)
 	}


### PR DESCRIPTION
Support specification of parameters for enable pages API as per: https://developer.github.com/v3/repos/pages/#parameters

Fixes #1408.