### PR TITLE
Implement support for actions workflow jobs

### DIFF
--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -14,35 +14,35 @@ import (
 
 // Step represents a single task from a sequence of tasks of a job.
 type Step struct {
-	Name        string    `json:"name"`
-	Status      string    `json:"status"`
-	Conclusion  string    `json:"conclusion"`
-	Number      int64     `json:"number"`
-	StartedAt   Timestamp `json:"started_at"`
-	CompletedAt Timestamp `json:"completed_at"`
+	Name        *string    `json:"name"`
+	Status      *string    `json:"status"`
+	Conclusion  *string    `json:"conclusion"`
+	Number      *int64     `json:"number"`
+	StartedAt   *Timestamp `json:"started_at"`
+	CompletedAt *Timestamp `json:"completed_at"`
 }
 
 // Job represents a repository action workflow job.
 type Job struct {
-	ID          int64     `json:"id"`
-	RunID       int64     `json:"run_id"`
-	RunURL      string    `json:"run_url"`
-	NodeID      string    `json:"node_id"`
-	HeadSHA     string    `json:"head_sha"`
-	URL         string    `json:"url"`
-	HTMLURL     string    `json:"html_url"`
-	Status      string    `json:"status"`
-	Conclusion  string    `json:"conclusion"`
-	StartedAt   Timestamp `json:"started_at"`
-	CompletedAt Timestamp `json:"completed_at"`
-	Name        string    `json:"name"`
-	Steps       []*Step   `json:"steps"`
-	CheckRunURL string    `json:"check_run_url"`
+	ID          *int64     `json:"id"`
+	RunID       *int64     `json:"run_id"`
+	RunURL      *string    `json:"run_url"`
+	NodeID      *string    `json:"node_id"`
+	HeadSHA     *string    `json:"head_sha"`
+	URL         *string    `json:"url"`
+	HTMLURL     *string    `json:"html_url"`
+	Status      *string    `json:"status"`
+	Conclusion  *string    `json:"conclusion"`
+	StartedAt   *Timestamp `json:"started_at"`
+	CompletedAt *Timestamp `json:"completed_at"`
+	Name        *string    `json:"name"`
+	Steps       []*Step    `json:"steps"`
+	CheckRunURL *string    `json:"check_run_url"`
 }
 
 // Jobs represents a slice of repository action workflow job.
 type Jobs struct {
-	TotalCount int    `json:"total_count"`
+	TotalCount *int   `json:"total_count"`
 	Jobs       []*Job `json:"jobs"`
 }
 

--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -12,8 +12,8 @@ import (
 	"net/url"
 )
 
-// Step represents a single task from a sequence of tasks of a job.
-type Step struct {
+// TaskStep represents a single task step from a sequence of tasks of a job.
+type TaskStep struct {
 	Name        *string    `json:"name,omitempty"`
 	Status      *string    `json:"status,omitempty"`
 	Conclusion  *string    `json:"conclusion,omitempty"`
@@ -22,28 +22,28 @@ type Step struct {
 	CompletedAt *Timestamp `json:"completed_at,omitempty"`
 }
 
-// Job represents a repository action workflow job.
-type Job struct {
-	ID          *int64     `json:"id,omitempty"`
-	RunID       *int64     `json:"run_id,omitempty"`
-	RunURL      *string    `json:"run_url,omitempty"`
-	NodeID      *string    `json:"node_id,omitempty"`
-	HeadSHA     *string    `json:"head_sha,omitempty"`
-	URL         *string    `json:"url,omitempty"`
-	HTMLURL     *string    `json:"html_url,omitempty"`
-	Status      *string    `json:"status,omitempty"`
-	Conclusion  *string    `json:"conclusion,omitempty"`
-	StartedAt   *Timestamp `json:"started_at,omitempty"`
-	CompletedAt *Timestamp `json:"completed_at,omitempty"`
-	Name        *string    `json:"name,omitempty"`
-	Steps       []*Step    `json:"steps,omitempty"`
-	CheckRunURL *string    `json:"check_run_url,omitempty"`
+// WorkflowJob represents a repository action workflow job.
+type WorkflowJob struct {
+	ID          *int64      `json:"id,omitempty"`
+	RunID       *int64      `json:"run_id,omitempty"`
+	RunURL      *string     `json:"run_url,omitempty"`
+	NodeID      *string     `json:"node_id,omitempty"`
+	HeadSHA     *string     `json:"head_sha,omitempty"`
+	URL         *string     `json:"url,omitempty"`
+	HTMLURL     *string     `json:"html_url,omitempty"`
+	Status      *string     `json:"status,omitempty"`
+	Conclusion  *string     `json:"conclusion,omitempty"`
+	StartedAt   *Timestamp  `json:"started_at,omitempty"`
+	CompletedAt *Timestamp  `json:"completed_at,omitempty"`
+	Name        *string     `json:"name,omitempty"`
+	Steps       []*TaskStep `json:"steps,omitempty"`
+	CheckRunURL *string     `json:"check_run_url,omitempty"`
 }
 
 // Jobs represents a slice of repository action workflow job.
 type Jobs struct {
-	TotalCount *int   `json:"total_count,omitempty"`
-	Jobs       []*Job `json:"jobs,omitempty"`
+	TotalCount *int           `json:"total_count,omitempty"`
+	Jobs       []*WorkflowJob `json:"jobs,omitempty"`
 }
 
 // ListWorkflowJobs lists all jobs for a workflow run.
@@ -73,7 +73,7 @@ func (s *ActionsService) ListWorkflowJobs(ctx context.Context, owner, repo strin
 // GetWorkflowJobByID gets a specific job in a workflow run by ID.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/workflow_jobs/#list-jobs-for-a-workflow-run
-func (s *ActionsService) GetWorkflowJobByID(ctx context.Context, owner, repo string, jobID int64) (*Job, *Response, error) {
+func (s *ActionsService) GetWorkflowJobByID(ctx context.Context, owner, repo string, jobID int64) (*WorkflowJob, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/jobs/%v", owner, repo, jobID)
 
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -81,7 +81,7 @@ func (s *ActionsService) GetWorkflowJobByID(ctx context.Context, owner, repo str
 		return nil, nil, err
 	}
 
-	job := new(Job)
+	job := new(WorkflowJob)
 	resp, err := s.client.Do(ctx, req, job)
 	if err != nil {
 		return nil, resp, err

--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -90,7 +90,7 @@ func (s *ActionsService) GetWorkflowJobByID(ctx context.Context, owner, repo str
 	return job, resp, nil
 }
 
-// GetWorkflowJobLogs gets a redirect URL to a download a plain text file of logs for a workflow job.
+// GetWorkflowJobLogs gets a redirect URL to download a plain text file of logs for a workflow job.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/workflow_jobs/#list-workflow-job-logs
 func (s *ActionsService) GetWorkflowJobLogs(ctx context.Context, owner, repo string, jobID int64, followRedirects bool) (*url.URL, *Response, error) {

--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -1,0 +1,110 @@
+// Copyright 2020 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// Step represents a single task from a sequence of tasks of a job.
+type Step struct {
+	Name        string    `json:"name"`
+	Status      string    `json:"status"`
+	Conclusion  string    `json:"conclusion"`
+	Number      int64     `json:"number"`
+	StartedAt   Timestamp `json:"started_at"`
+	CompletedAt Timestamp `json:"completed_at"`
+}
+
+// Job represents a repository action workflow job.
+type Job struct {
+	ID          int64     `json:"id"`
+	RunID       int64     `json:"run_id"`
+	RunURL      string    `json:"run_url"`
+	NodeID      string    `json:"node_id"`
+	HeadSHA     string    `json:"head_sha"`
+	URL         string    `json:"url"`
+	HTMLURL     string    `json:"html_url"`
+	Status      string    `json:"status"`
+	Conclusion  string    `json:"conclusion"`
+	StartedAt   Timestamp `json:"started_at"`
+	CompletedAt Timestamp `json:"completed_at"`
+	Name        string    `json:"name"`
+	Steps       []*Step   `json:"steps"`
+	CheckRunURL string    `json:"check_run_url"`
+}
+
+// Jobs represents a slice of repository action workflow job.
+type Jobs struct {
+	TotalCount int    `json:"total_count"`
+	Jobs       []*Job `json:"jobs"`
+}
+
+// ListWorkflowJobs lists all jobs for a workflow run.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/workflow_jobs/#list-jobs-for-a-workflow-run
+func (s *ActionsService) ListWorkflowJobs(ctx context.Context, owner, repo string, runID int64, opts *ListOptions) (*Jobs, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/actions/runs/%v/jobs", owner, repo, runID)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	jobs := new(Jobs)
+	resp, err := s.client.Do(ctx, req, &jobs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return jobs, resp, nil
+}
+
+// GetWorkflowJobByID gets a specific job in a workflow run by ID.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/workflow_jobs/#list-jobs-for-a-workflow-run
+func (s *ActionsService) GetWorkflowJobByID(ctx context.Context, owner, repo string, jobID int64) (*Job, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/jobs/%v", owner, repo, jobID)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	job := new(Job)
+	resp, err := s.client.Do(ctx, req, job)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return job, resp, nil
+}
+
+// ListWorkflowJobLogs gets a redirect URL to a download a plain text file of logs for a workflow job.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/workflow_jobs/#list-workflow-job-logs
+func (s *ActionsService) ListWorkflowJobLogs(ctx context.Context, owner, repo string, jobID int64) (string, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/jobs/%v/logs", owner, repo, jobID)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return "", nil, err
+	}
+
+	var logFileURL string
+	resp, err := s.client.Do(ctx, req, &logFileURL)
+
+	if err != nil {
+		return "", resp, err
+	}
+
+	return logFileURL, resp, nil
+}

--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -14,35 +14,35 @@ import (
 
 // Step represents a single task from a sequence of tasks of a job.
 type Step struct {
-	Name        *string    `json:"name"`
-	Status      *string    `json:"status"`
-	Conclusion  *string    `json:"conclusion"`
-	Number      *int64     `json:"number"`
-	StartedAt   *Timestamp `json:"started_at"`
-	CompletedAt *Timestamp `json:"completed_at"`
+	Name        *string    `json:"name,omitempty"`
+	Status      *string    `json:"status,omitempty"`
+	Conclusion  *string    `json:"conclusion,omitempty"`
+	Number      *int64     `json:"number,omitempty"`
+	StartedAt   *Timestamp `json:"started_at,omitempty"`
+	CompletedAt *Timestamp `json:"completed_at,omitempty"`
 }
 
 // Job represents a repository action workflow job.
 type Job struct {
-	ID          *int64     `json:"id"`
-	RunID       *int64     `json:"run_id"`
-	RunURL      *string    `json:"run_url"`
-	NodeID      *string    `json:"node_id"`
-	HeadSHA     *string    `json:"head_sha"`
-	URL         *string    `json:"url"`
-	HTMLURL     *string    `json:"html_url"`
-	Status      *string    `json:"status"`
-	Conclusion  *string    `json:"conclusion"`
-	StartedAt   *Timestamp `json:"started_at"`
-	CompletedAt *Timestamp `json:"completed_at"`
-	Name        *string    `json:"name"`
-	Steps       []*Step    `json:"steps"`
-	CheckRunURL *string    `json:"check_run_url"`
+	ID          *int64     `json:"id,omitempty"`
+	RunID       *int64     `json:"run_id,omitempty"`
+	RunURL      *string    `json:"run_url,omitempty"`
+	NodeID      *string    `json:"node_id,omitempty"`
+	HeadSHA     *string    `json:"head_sha,omitempty"`
+	URL         *string    `json:"url,omitempty"`
+	HTMLURL     *string    `json:"html_url,omitempty"`
+	Status      *string    `json:"status,omitempty"`
+	Conclusion  *string    `json:"conclusion,omitempty"`
+	StartedAt   *Timestamp `json:"started_at,omitempty"`
+	CompletedAt *Timestamp `json:"completed_at,omitempty"`
+	Name        *string    `json:"name,omitempty"`
+	Steps       []*Step    `json:"steps,omitempty"`
+	CheckRunURL *string    `json:"check_run_url,omitempty"`
 }
 
 // Jobs represents a slice of repository action workflow job.
 type Jobs struct {
-	TotalCount *int   `json:"total_count"`
+	TotalCount *int   `json:"total_count,omitempty"`
 	Jobs       []*Job `json:"jobs"`
 }
 

--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -43,7 +43,7 @@ type Job struct {
 // Jobs represents a slice of repository action workflow job.
 type Jobs struct {
 	TotalCount *int   `json:"total_count,omitempty"`
-	Jobs       []*Job `json:"jobs"`
+	Jobs       []*Job `json:"jobs,omitempty"`
 }
 
 // ListWorkflowJobs lists all jobs for a workflow run.

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -1,0 +1,91 @@
+// Copyright 2020 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestActionsService_ListWorkflows(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/workflows", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"per_page": "2", "page": "2"})
+		fmt.Fprint(w, `{"total_count":4,"workflows":[{"id":72844,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"},{"id":72845,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}]}`)
+	})
+
+	opts := &ListOptions{Page: 2, PerPage: 2}
+	workflows, _, err := client.Actions.ListWorkflows(context.Background(), "o", "r", opts)
+	if err != nil {
+		t.Errorf("Actions.ListWorkflows returned error: %v", err)
+	}
+
+	want := &Workflows{
+		TotalCount: 4,
+		Workflows: []*Workflow{
+			{ID: 72844, CreatedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
+			{ID: 72845, CreatedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
+		},
+	}
+	if !reflect.DeepEqual(workflows, want) {
+		t.Errorf("Actions.ListWorkflows returned %+v, want %+v", workflows, want)
+	}
+}
+
+func TestActionsService_GetWorkflowByID(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/workflows/72844", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":72844,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
+	})
+
+	workflow, _, err := client.Actions.GetWorkflowByID(context.Background(), "o", "r", 72844)
+	if err != nil {
+		t.Errorf("Actions.GetWorkflowByID returned error: %v", err)
+	}
+
+	want := &Workflow{
+		ID:        72844,
+		CreatedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
+		UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
+	}
+	if !reflect.DeepEqual(workflow, want) {
+		t.Errorf("Actions.GetWorkflowByID returned %+v, want %+v", workflow, want)
+	}
+}
+
+func TestActionsService_GetWorkflowByFileName(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/workflows/main.yml", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":72844,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
+	})
+
+	workflow, _, err := client.Actions.GetWorkflowByFileName(context.Background(), "o", "r", "main.yml")
+	if err != nil {
+		t.Errorf("Actions.GetWorkflowByFileName returned error: %v", err)
+	}
+
+	want := &Workflow{
+		ID:        72844,
+		CreatedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
+		UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
+	}
+	if !reflect.DeepEqual(workflow, want) {
+		t.Errorf("Actions.GetWorkflowByFileName returned %+v, want %+v", workflow, want)
+	}
+}

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -14,78 +14,74 @@ import (
 	"time"
 )
 
-func TestActionsService_ListWorkflows(t *testing.T) {
+func TestActionsService_ListWorkflowJobs(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/repos/o/r/actions/workflows", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/runs/29679449/jobs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"per_page": "2", "page": "2"})
-		fmt.Fprint(w, `{"total_count":4,"workflows":[{"id":72844,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"},{"id":72845,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}]}`)
+		fmt.Fprint(w, `{"total_count":4,"jobs":[{"id":399444496,"run_id":29679449,"started_at":"2019-01-02T15:04:05Z","completed_at":"2020-01-02T15:04:05Z"},{"id":399444497,"run_id":29679449,"started_at":"2019-01-02T15:04:05Z","completed_at":"2020-01-02T15:04:05Z"}]}`)
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	workflows, _, err := client.Actions.ListWorkflows(context.Background(), "o", "r", opts)
+	jobs, _, err := client.Actions.ListWorkflowJobs(context.Background(), "o", "r", 29679449, opts)
 	if err != nil {
-		t.Errorf("Actions.ListWorkflows returned error: %v", err)
+		t.Errorf("Actions.ListWorkflowJobs returned error: %v", err)
 	}
 
-	want := &Workflows{
+	want := &Jobs{
 		TotalCount: 4,
-		Workflows: []*Workflow{
-			{ID: 72844, CreatedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
-			{ID: 72845, CreatedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
+		Jobs: []*Job{
+			{ID: 399444496, RunID: 29679449, StartedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, CompletedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
+			{ID: 399444497, RunID: 29679449, StartedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, CompletedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
 		},
 	}
-	if !reflect.DeepEqual(workflows, want) {
-		t.Errorf("Actions.ListWorkflows returned %+v, want %+v", workflows, want)
+	if !reflect.DeepEqual(jobs, want) {
+		t.Errorf("Actions.ListWorkflowJobs returned %+v, want %+v", jobs, want)
 	}
 }
 
-func TestActionsService_GetWorkflowByID(t *testing.T) {
+func TestActionsService_GetWorkflowJobByID(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/repos/o/r/actions/workflows/72844", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/jobs/399444496", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"id":72844,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
+		fmt.Fprint(w, `{"id":399444496,"started_at":"2019-01-02T15:04:05Z","completed_at":"2020-01-02T15:04:05Z"}`)
 	})
 
-	workflow, _, err := client.Actions.GetWorkflowByID(context.Background(), "o", "r", 72844)
+	job, _, err := client.Actions.GetWorkflowJobByID(context.Background(), "o", "r", 399444496)
 	if err != nil {
-		t.Errorf("Actions.GetWorkflowByID returned error: %v", err)
+		t.Errorf("Actions.GetWorkflowJobByID returned error: %v", err)
 	}
 
-	want := &Workflow{
-		ID:        72844,
-		CreatedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
-		UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
+	want := &Job{
+		ID:          399444496,
+		StartedAt:   Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
+		CompletedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
 	}
-	if !reflect.DeepEqual(workflow, want) {
-		t.Errorf("Actions.GetWorkflowByID returned %+v, want %+v", workflow, want)
+	if !reflect.DeepEqual(job, want) {
+		t.Errorf("Actions.GetWorkflowJobByID returned %+v, want %+v", job, want)
 	}
 }
 
-func TestActionsService_GetWorkflowByFileName(t *testing.T) {
+func TestActionsService_ListWorkflowJobLogs(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/repos/o/r/actions/workflows/main.yml", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/jobs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"id":72844,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
+		fmt.Fprint(w, `https://pipelines.actions.githubusercontent.com/ab1f3cCFPB34Nd6imvFxpGZH5hNlDp2wijMwl2gDoO0bcrrlJj/_apis/pipelines/1/jobs/19/signedlogcontent?urlExpires=2020-01-22T22%3A44%3A54.1389777Z&urlSigningMethod=HMACV1&urlSignature=2TUDfIg4fm36OJmfPy6km5QD5DLCOkBVzvhWZM8B%2BUY%3D`)
 	})
 
-	workflow, _, err := client.Actions.GetWorkflowByFileName(context.Background(), "o", "r", "main.yml")
+	logFileURL, _, err := client.Actions.ListWorkflowJobLogs(context.Background(), "o", "r", 399444496)
 	if err != nil {
-		t.Errorf("Actions.GetWorkflowByFileName returned error: %v", err)
+		t.Errorf("Actions.ListWorkflowJobLogs returned error: %v", err)
 	}
 
-	want := &Workflow{
-		ID:        72844,
-		CreatedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
-		UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
-	}
-	if !reflect.DeepEqual(workflow, want) {
-		t.Errorf("Actions.GetWorkflowByFileName returned %+v, want %+v", workflow, want)
+	want := "https://pipelines.actions.githubusercontent.com/ab1f3cCFPB34Nd6imvFxpGZH5hNlDp2wijMwl2gDoO0bcrrlJj/_apis/pipelines/1/jobs/19/signedlogcontent?urlExpires=2020-01-22T22%3A44%3A54.1389777Z&urlSigningMethod=HMACV1&urlSignature=2TUDfIg4fm36OJmfPy6km5QD5DLCOkBVzvhWZM8B%2BUY%3D"
+	if !reflect.DeepEqual(logFileURL, want) {
+		t.Errorf("Actions.GetWorkflowByFileName returned %+v, want %+v", logFileURL, want)
 	}
 }

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -58,9 +58,9 @@ func TestActionsService_GetWorkflowJobByID(t *testing.T) {
 	}
 
 	want := &WorkflowJob{
-		ID:          399444496,
-		StartedAt:   Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
-		CompletedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
+		ID:          Int64(399444496),
+		StartedAt:   &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
+		CompletedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
 	}
 	if !reflect.DeepEqual(job, want) {
 		t.Errorf("Actions.GetWorkflowJobByID returned %+v, want %+v", job, want)

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -32,10 +32,10 @@ func TestActionsService_ListWorkflowJobs(t *testing.T) {
 	}
 
 	want := &Jobs{
-		TotalCount: 4,
+		TotalCount: Int(4),
 		Jobs: []*WorkflowJob{
-			{ID: 399444496, RunID: 29679449, StartedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, CompletedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
-			{ID: 399444497, RunID: 29679449, StartedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, CompletedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
+			{ID: Int64(399444496), RunID: Int64(29679449), StartedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, CompletedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
+			{ID: Int64(399444497), RunID: Int64(29679449), StartedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, CompletedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
 		},
 	}
 	if !reflect.DeepEqual(jobs, want) {

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -33,7 +33,7 @@ func TestActionsService_ListWorkflowJobs(t *testing.T) {
 
 	want := &Jobs{
 		TotalCount: 4,
-		Jobs: []*Job{
+		Jobs: []*WorkflowJob{
 			{ID: 399444496, RunID: 29679449, StartedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, CompletedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
 			{ID: 399444497, RunID: 29679449, StartedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, CompletedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
 		},
@@ -57,7 +57,7 @@ func TestActionsService_GetWorkflowJobByID(t *testing.T) {
 		t.Errorf("Actions.GetWorkflowJobByID returned error: %v", err)
 	}
 
-	want := &Job{
+	want := &WorkflowJob{
 		ID:          399444496,
 		StartedAt:   Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
 		CompletedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -67,7 +67,7 @@ func TestActionsService_GetWorkflowJobByID(t *testing.T) {
 	}
 }
 
-func TestActionsService_GetWorkflowJobLogsFile(t *testing.T) {
+func TestActionsService_GetWorkflowJobLogs(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -76,16 +76,16 @@ func TestActionsService_GetWorkflowJobLogsFile(t *testing.T) {
 		http.Redirect(w, r, "http://github.com/a", http.StatusFound)
 	})
 
-	url, resp, err := client.Actions.GetWorkflowJobLogsFile(context.Background(), "o", "r", 399444496, true)
+	url, resp, err := client.Actions.GetWorkflowJobLogs(context.Background(), "o", "r", 399444496, true)
 	if err != nil {
-		t.Errorf("Actions.GetWorkflowJobLogsFile returned error: %v", err)
+		t.Errorf("Actions.GetWorkflowJobLogs returned error: %v", err)
 	}
 	if resp.StatusCode != http.StatusFound {
-		t.Errorf("Actions.GetWorkflowJobLogsFile returned status: %d, want %d", resp.StatusCode, http.StatusFound)
+		t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusFound)
 	}
 	want := "http://github.com/a"
 	if url.String() != want {
-		t.Errorf("Actions.GetWorkflowJobLogsFile returned %+v, want %+v", url.String(), want)
+		t.Errorf("Actions.GetWorkflowJobLogs returned %+v, want %+v", url.String(), want)
 	}
 }
 
@@ -98,7 +98,7 @@ func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_dontFollowRedi
 		http.Redirect(w, r, "http://github.com/a", http.StatusMovedPermanently)
 	})
 
-	_, resp, _ := client.Actions.GetWorkflowJobLogsFile(context.Background(), "o", "r", 399444496, false)
+	_, resp, _ := client.Actions.GetWorkflowJobLogs(context.Background(), "o", "r", 399444496, false)
 	if resp.StatusCode != http.StatusMovedPermanently {
 		t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
 	}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -4972,6 +4972,14 @@ func (i *IssueStats) GetTotalIssues() int {
 	return *i.TotalIssues
 }
 
+// GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
+func (j *Jobs) GetTotalCount() int {
+	if j == nil || j.TotalCount == nil {
+		return 0
+	}
+	return *j.TotalCount
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (k *Key) GetCreatedAt() Timestamp {
 	if k == nil || k.CreatedAt == nil {
@@ -11916,6 +11924,54 @@ func (t *Tag) GetVerification() *SignatureVerification {
 	return t.Verification
 }
 
+// GetCompletedAt returns the CompletedAt field if it's non-nil, zero value otherwise.
+func (t *TaskStep) GetCompletedAt() Timestamp {
+	if t == nil || t.CompletedAt == nil {
+		return Timestamp{}
+	}
+	return *t.CompletedAt
+}
+
+// GetConclusion returns the Conclusion field if it's non-nil, zero value otherwise.
+func (t *TaskStep) GetConclusion() string {
+	if t == nil || t.Conclusion == nil {
+		return ""
+	}
+	return *t.Conclusion
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (t *TaskStep) GetName() string {
+	if t == nil || t.Name == nil {
+		return ""
+	}
+	return *t.Name
+}
+
+// GetNumber returns the Number field if it's non-nil, zero value otherwise.
+func (t *TaskStep) GetNumber() int64 {
+	if t == nil || t.Number == nil {
+		return 0
+	}
+	return *t.Number
+}
+
+// GetStartedAt returns the StartedAt field if it's non-nil, zero value otherwise.
+func (t *TaskStep) GetStartedAt() Timestamp {
+	if t == nil || t.StartedAt == nil {
+		return Timestamp{}
+	}
+	return *t.StartedAt
+}
+
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (t *TaskStep) GetStatus() string {
+	if t == nil || t.Status == nil {
+		return ""
+	}
+	return *t.Status
+}
+
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
 func (t *Team) GetDescription() string {
 	if t == nil || t.Description == nil {
@@ -13850,4 +13906,108 @@ func (w *WeeklyStats) GetWeek() Timestamp {
 		return Timestamp{}
 	}
 	return *w.Week
+}
+
+// GetCheckRunURL returns the CheckRunURL field if it's non-nil, zero value otherwise.
+func (w *WorkflowJob) GetCheckRunURL() string {
+	if w == nil || w.CheckRunURL == nil {
+		return ""
+	}
+	return *w.CheckRunURL
+}
+
+// GetCompletedAt returns the CompletedAt field if it's non-nil, zero value otherwise.
+func (w *WorkflowJob) GetCompletedAt() Timestamp {
+	if w == nil || w.CompletedAt == nil {
+		return Timestamp{}
+	}
+	return *w.CompletedAt
+}
+
+// GetConclusion returns the Conclusion field if it's non-nil, zero value otherwise.
+func (w *WorkflowJob) GetConclusion() string {
+	if w == nil || w.Conclusion == nil {
+		return ""
+	}
+	return *w.Conclusion
+}
+
+// GetHeadSHA returns the HeadSHA field if it's non-nil, zero value otherwise.
+func (w *WorkflowJob) GetHeadSHA() string {
+	if w == nil || w.HeadSHA == nil {
+		return ""
+	}
+	return *w.HeadSHA
+}
+
+// GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
+func (w *WorkflowJob) GetHTMLURL() string {
+	if w == nil || w.HTMLURL == nil {
+		return ""
+	}
+	return *w.HTMLURL
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (w *WorkflowJob) GetID() int64 {
+	if w == nil || w.ID == nil {
+		return 0
+	}
+	return *w.ID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (w *WorkflowJob) GetName() string {
+	if w == nil || w.Name == nil {
+		return ""
+	}
+	return *w.Name
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (w *WorkflowJob) GetNodeID() string {
+	if w == nil || w.NodeID == nil {
+		return ""
+	}
+	return *w.NodeID
+}
+
+// GetRunID returns the RunID field if it's non-nil, zero value otherwise.
+func (w *WorkflowJob) GetRunID() int64 {
+	if w == nil || w.RunID == nil {
+		return 0
+	}
+	return *w.RunID
+}
+
+// GetRunURL returns the RunURL field if it's non-nil, zero value otherwise.
+func (w *WorkflowJob) GetRunURL() string {
+	if w == nil || w.RunURL == nil {
+		return ""
+	}
+	return *w.RunURL
+}
+
+// GetStartedAt returns the StartedAt field if it's non-nil, zero value otherwise.
+func (w *WorkflowJob) GetStartedAt() Timestamp {
+	if w == nil || w.StartedAt == nil {
+		return Timestamp{}
+	}
+	return *w.StartedAt
+}
+
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (w *WorkflowJob) GetStatus() string {
+	if w == nil || w.Status == nil {
+		return ""
+	}
+	return *w.Status
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (w *WorkflowJob) GetURL() string {
+	if w == nil || w.URL == nil {
+		return ""
+	}
+	return *w.URL
 }


### PR DESCRIPTION
This PR adds support for managing the most recent update of Action Workflow Jobs.

Relates to: #1399

By the way, there are several things that I am still not sure of:
- The action in the original GitHub documentation is "List workflow job logs" thus I name the function `ListWorkflowJobLogs` but since it basically retrieve a URL to download a text file that contain the logs I think it would be better to name it `GetLogsFileURL`.
- I am still not sure of perhaps how `go-github` would implement this particular function since the URL of the file is in the header of the response. Do you have any example of other functions that implement this kind of response? 

Thank you very much beforehand :slightly_smiling_face: 