### PR TITLE
Update teams_discussion_comments with ByID and BySlug endpoints

### DIFF
--- a/github/teams_discussion_comments.go
+++ b/github/teams_discussion_comments.go
@@ -37,9 +37,10 @@ type DiscussionCommentListOptions struct {
 	// Sorts the discussion comments by the date they were created.
 	// Accepted values are asc and desc. Default is desc.
 	Direction string `url:"direction,omitempty"`
+	ListOptions
 }
 
-// ListCommentsByID lists all comments on a team discussion.
+// ListCommentsByID lists all comments on a team discussion by team ID.
 // Authenticated user must grant read:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#list-comments
@@ -64,7 +65,7 @@ func (s *TeamsService) ListCommentsByID(ctx context.Context, orgID, teamID int64
 	return comments, resp, nil
 }
 
-// ListCommentsBySlug lists all comments on a team discussion.
+// ListCommentsBySlug lists all comments on a team discussion by team slug.
 // Authenticated user must grant read:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#list-comments
@@ -89,7 +90,7 @@ func (s *TeamsService) ListCommentsBySlug(ctx context.Context, org, slug string,
 	return comments, resp, nil
 }
 
-// GetCommentByID gets a specific comment on a team discussion.
+// GetCommentByID gets a specific comment on a team discussion by team ID.
 // Authenticated user must grant read:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#get-a-single-comment
@@ -109,7 +110,7 @@ func (s *TeamsService) GetCommentByID(ctx context.Context, orgID, teamID int64, 
 	return discussionComment, resp, nil
 }
 
-// GetCommentBySlug gets a specific comment on a team discussion.
+// GetCommentBySlug gets a specific comment on a team discussion by team slug.
 // Authenticated user must grant read:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#get-a-single-comment
@@ -130,7 +131,7 @@ func (s *TeamsService) GetCommentBySlug(ctx context.Context, org, slug string, d
 	return discussionComment, resp, nil
 }
 
-// CreateCommentByID creates a new comment on a team discussion.
+// CreateCommentByID creates a new comment on a team discussion by team ID.
 // Authenticated user must grant write:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#create-a-comment
@@ -150,7 +151,7 @@ func (s *TeamsService) CreateCommentByID(ctx context.Context, orgID, teamID int6
 	return discussionComment, resp, nil
 }
 
-// CreateCommentBySlug creates a new comment on a team discussion.
+// CreateCommentBySlug creates a new comment on a team discussion by team slug.
 // Authenticated user must grant write:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#create-a-comment
@@ -170,7 +171,7 @@ func (s *TeamsService) CreateCommentBySlug(ctx context.Context, org, slug string
 	return discussionComment, resp, nil
 }
 
-// EditCommentByID edits the body text of a discussion comment.
+// EditCommentByID edits the body text of a discussion comment by team ID.
 // Authenticated user must grant write:discussion scope.
 // User is allowed to edit body of a comment only.
 //
@@ -191,7 +192,7 @@ func (s *TeamsService) EditCommentByID(ctx context.Context, orgID, teamID int64,
 	return discussionComment, resp, nil
 }
 
-// EditCommentBySlug edits the body text of a discussion comment.
+// EditCommentBySlug edits the body text of a discussion comment by team slug.
 // Authenticated user must grant write:discussion scope.
 // User is allowed to edit body of a comment only.
 //
@@ -212,7 +213,7 @@ func (s *TeamsService) EditCommentBySlug(ctx context.Context, org, slug string, 
 	return discussionComment, resp, nil
 }
 
-// DeleteCommentByID deletes a comment on a team discussion.
+// DeleteCommentByID deletes a comment on a team discussion by team ID.
 // Authenticated user must grant write:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#delete-a-comment
@@ -226,7 +227,7 @@ func (s *TeamsService) DeleteCommentByID(ctx context.Context, orgID, teamID int6
 	return s.client.Do(ctx, req, nil)
 }
 
-// DeleteCommentBySlug deletes a comment on a team discussion.
+// DeleteCommentBySlug deletes a comment on a team discussion by team slug.
 // Authenticated user must grant write:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#delete-a-comment

--- a/github/teams_discussion_comments.go
+++ b/github/teams_discussion_comments.go
@@ -39,12 +39,12 @@ type DiscussionCommentListOptions struct {
 	Direction string `url:"direction,omitempty"`
 }
 
-// ListComments lists all comments on a team discussion.
+// ListCommentsByID lists all comments on a team discussion.
 // Authenticated user must grant read:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#list-comments
-func (s *TeamsService) ListComments(ctx context.Context, teamID int64, discussionNumber int, options *DiscussionCommentListOptions) ([]*DiscussionComment, *Response, error) {
-	u := fmt.Sprintf("teams/%v/discussions/%v/comments", teamID, discussionNumber)
+func (s *TeamsService) ListCommentsByID(ctx context.Context, orgID, teamID int64, discussionNumber int, options *DiscussionCommentListOptions) ([]*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/comments", orgID, teamID, discussionNumber)
 	u, err := addOptions(u, options)
 	if err != nil {
 		return nil, nil, err
@@ -64,12 +64,37 @@ func (s *TeamsService) ListComments(ctx context.Context, teamID int64, discussio
 	return comments, resp, nil
 }
 
-// GetComment gets a specific comment on a team discussion.
+// ListCommentsBySlug lists all comments on a team discussion.
+// Authenticated user must grant read:discussion scope.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#list-comments
+func (s *TeamsService) ListCommentsBySlug(ctx context.Context, org, slug string, discussionNumber int, options *DiscussionCommentListOptions) ([]*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments", org, slug, discussionNumber)
+	u, err := addOptions(u, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var comments []*DiscussionComment
+	resp, err := s.client.Do(ctx, req, &comments)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return comments, resp, nil
+}
+
+// GetCommentByID gets a specific comment on a team discussion.
 // Authenticated user must grant read:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#get-a-single-comment
-func (s *TeamsService) GetComment(ctx context.Context, teamID int64, discussionNumber, commentNumber int) (*DiscussionComment, *Response, error) {
-	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v", teamID, discussionNumber, commentNumber)
+func (s *TeamsService) GetCommentByID(ctx context.Context, orgID, teamID int64, discussionNumber, commentNumber int) (*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/comments/%v", orgID, teamID, discussionNumber, commentNumber)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -84,12 +109,33 @@ func (s *TeamsService) GetComment(ctx context.Context, teamID int64, discussionN
 	return discussionComment, resp, nil
 }
 
-// CreateComment creates a new discussion post on a team discussion.
+// GetCommentBySlug gets a specific comment on a team discussion.
+// Authenticated user must grant read:discussion scope.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#get-a-single-comment
+func (s *TeamsService) GetCommentBySlug(ctx context.Context, org, slug string, discussionNumber, commentNumber int) (*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments/%v", org, slug, discussionNumber, commentNumber)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	discussionComment := &DiscussionComment{}
+	resp, err := s.client.Do(ctx, req, discussionComment)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return discussionComment, resp, nil
+}
+
+// CreateCommentByID creates a new discussion post on a team discussion.
 // Authenticated user must grant write:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#create-a-comment
-func (s *TeamsService) CreateComment(ctx context.Context, teamID int64, discsusionNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
-	u := fmt.Sprintf("teams/%v/discussions/%v/comments", teamID, discsusionNumber)
+func (s *TeamsService) CreateCommentByID(ctx context.Context, orgID, teamID int64, discsusionNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/comments", orgID, teamID, discsusionNumber)
 	req, err := s.client.NewRequest("POST", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -104,13 +150,33 @@ func (s *TeamsService) CreateComment(ctx context.Context, teamID int64, discsusi
 	return discussionComment, resp, nil
 }
 
-// EditComment edits the body text of a discussion comment.
+// CreateCommentBySlug creates a new discussion post on a team discussion.
+// Authenticated user must grant write:discussion scope.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#create-a-comment
+func (s *TeamsService) CreateCommentBySlug(ctx context.Context, org, slug string, discsusionNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments", org, slug, discsusionNumber)
+	req, err := s.client.NewRequest("POST", u, comment)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	discussionComment := &DiscussionComment{}
+	resp, err := s.client.Do(ctx, req, discussionComment)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return discussionComment, resp, nil
+}
+
+// EditCommentByID edits the body text of a discussion comment.
 // Authenticated user must grant write:discussion scope.
 // User is allowed to edit body of a comment only.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#edit-a-comment
-func (s *TeamsService) EditComment(ctx context.Context, teamID int64, discussionNumber, commentNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
-	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v", teamID, discussionNumber, commentNumber)
+func (s *TeamsService) EditCommentByID(ctx context.Context, orgID, teamID int64, discussionNumber, commentNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/comments/%v", orgID, teamID, discussionNumber, commentNumber)
 	req, err := s.client.NewRequest("PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -125,12 +191,47 @@ func (s *TeamsService) EditComment(ctx context.Context, teamID int64, discussion
 	return discussionComment, resp, nil
 }
 
-// DeleteComment deletes a comment on a team discussion.
+// EditCommentBySlug edits the body text of a discussion comment.
+// Authenticated user must grant write:discussion scope.
+// User is allowed to edit body of a comment only.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#edit-a-comment
+func (s *TeamsService) EditCommentBySlug(ctx context.Context, org, slug string, discussionNumber, commentNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments/%v", org, slug, discussionNumber, commentNumber)
+	req, err := s.client.NewRequest("PATCH", u, comment)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	discussionComment := &DiscussionComment{}
+	resp, err := s.client.Do(ctx, req, discussionComment)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return discussionComment, resp, nil
+}
+
+// DeleteCommentByID deletes a comment on a team discussion.
 // Authenticated user must grant write:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#delete-a-comment
-func (s *TeamsService) DeleteComment(ctx context.Context, teamID int64, discussionNumber, commentNumber int) (*Response, error) {
-	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v", teamID, discussionNumber, commentNumber)
+func (s *TeamsService) DeleteCommentByID(ctx context.Context, orgID, teamID int64, discussionNumber, commentNumber int) (*Response, error) {
+	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/comments/%v", orgID, teamID, discussionNumber, commentNumber)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// DeleteCommentBySlug deletes a comment on a team discussion.
+// Authenticated user must grant write:discussion scope.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#delete-a-comment
+func (s *TeamsService) DeleteCommentBySlug(ctx context.Context, org, slug string, discussionNumber, commentNumber int) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments/%v", org, slug, discussionNumber, commentNumber)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/teams_discussion_comments.go
+++ b/github/teams_discussion_comments.go
@@ -130,7 +130,7 @@ func (s *TeamsService) GetCommentBySlug(ctx context.Context, org, slug string, d
 	return discussionComment, resp, nil
 }
 
-// CreateCommentByID creates a new discussion post on a team discussion.
+// CreateCommentByID creates a new comment on a team discussion.
 // Authenticated user must grant write:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#create-a-comment
@@ -150,7 +150,7 @@ func (s *TeamsService) CreateCommentByID(ctx context.Context, orgID, teamID int6
 	return discussionComment, resp, nil
 }
 
-// CreateCommentBySlug creates a new discussion post on a team discussion.
+// CreateCommentBySlug creates a new comment on a team discussion.
 // Authenticated user must grant write:discussion scope.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/discussion_comments/#create-a-comment

--- a/github/teams_discussion_comments_test.go
+++ b/github/teams_discussion_comments_test.go
@@ -15,7 +15,7 @@ import (
 	"time"
 )
 
-// "teams discussion comments" endpoint, when using a teamID.
+// "Team Discussion Comments" endpoint, when using a teamID.
 func tdcEndpointByID(orgID, teamID, discussionNumber, commentNumber string) string {
 	out := fmt.Sprintf("/organizations/%v/team/%v/discussions/%v/comments", orgID, teamID, discussionNumber)
 	if commentNumber != "" {
@@ -24,7 +24,7 @@ func tdcEndpointByID(orgID, teamID, discussionNumber, commentNumber string) stri
 	return out
 }
 
-// "teams discussion comments" endpoint, when using a team slug.
+// "Team Discussion Comments" endpoint, when using a team slug.
 func tdcEndpointBySlug(org, slug, dicsuccionsNumber, commentNumber string) string {
 	out := fmt.Sprintf("/orgs/%v/teams/%v/discussions/%v/comments", org, slug, dicsuccionsNumber)
 	if commentNumber != "" {

--- a/github/teams_discussion_comments_test.go
+++ b/github/teams_discussion_comments_test.go
@@ -117,7 +117,8 @@ func TestTeamsService_ListComments(t *testing.T) {
 	e := tdcEndpointByID("1", "2", "3", "")
 	mux.HandleFunc(e, handleFunc)
 
-	commentsByID, _, err := client.Teams.ListCommentsByID(context.Background(), 1, 2, 3, &DiscussionCommentListOptions{"desc"})
+	commentsByID, _, err := client.Teams.ListCommentsByID(context.Background(), 1, 2, 3,
+		&DiscussionCommentListOptions{Direction: "desc"})
 	if err != nil {
 		t.Errorf("Teams.ListCommentsByID returned error: %v", err)
 	}
@@ -129,7 +130,8 @@ func TestTeamsService_ListComments(t *testing.T) {
 	e = tdcEndpointBySlug("a", "b", "3", "")
 	mux.HandleFunc(e, handleFunc)
 
-	commentsBySlug, _, err := client.Teams.ListCommentsBySlug(context.Background(), "a", "b", 3, &DiscussionCommentListOptions{"desc"})
+	commentsBySlug, _, err := client.Teams.ListCommentsBySlug(context.Background(), "a", "b", 3,
+		&DiscussionCommentListOptions{Direction: "desc"})
 	if err != nil {
 		t.Errorf("Teams.ListCommentsBySlug returned error: %v", err)
 	}


### PR DESCRIPTION
Update endpoints for:
https://developer.github.com/v3/teams/discussion_comments/

All endpoints in "Team Discussion Endpoints" now have two ways to call
them: ByID and BySlug.

Fixes #1423.