### PR TITLE
Update workflows/tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.x, 1.12.x]
+        go-version: [1.x, 1.13.x]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
Since Go 1.14 has been released, and we want to test the two most recent major releases of Go on this repo, this PR bumps `workflows/tests.yml` to test the most recent (`1.x`) version of Go, and the next-most-recent (`1.13.x`) version.