### PR TITLE
Add support to delete commit comment reaction

### DIFF
--- a/github/reactions.go
+++ b/github/reactions.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"net/http"
 )
 
 // ReactionsService provides access to the reactions-related functions in the
@@ -107,6 +108,23 @@ func (s ReactionsService) CreateCommentReaction(ctx context.Context, owner, repo
 	}
 
 	return m, resp, nil
+}
+
+// DeleteCommentReaction delete the reaction for a commit comment.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#delete-a-commit-comment-reaction
+func (s *ReactionsService) DeleteCommentReaction(ctx context.Context, owner, repo string, id, reactionID int64) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions/%v", owner, repo, id, reactionID)
+
+	req, err := s.client.NewRequest(http.MethodDelete, u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept headers when APIs fully launch.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	return s.client.Do(ctx, req, nil)
 }
 
 // ListIssueReactions lists the reactions for an issue.

--- a/github/reactions.go
+++ b/github/reactions.go
@@ -110,11 +110,11 @@ func (s ReactionsService) CreateCommentReaction(ctx context.Context, owner, repo
 	return m, resp, nil
 }
 
-// DeleteCommentReaction delete the reaction for a commit comment.
+// DeleteCommentReaction deletes the reaction for a commit comment.
 //
 // GitHub API docs: https://developer.github.com/v3/reactions/#delete-a-commit-comment-reaction
-func (s *ReactionsService) DeleteCommentReaction(ctx context.Context, owner, repo string, id, reactionID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions/%v", owner, repo, id, reactionID)
+func (s *ReactionsService) DeleteCommentReaction(ctx context.Context, owner, repo string, commentID, reactionID int64) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions/%v", owner, repo, commentID, reactionID)
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil)
 	if err != nil {

--- a/github/reactions.go
+++ b/github/reactions.go
@@ -116,7 +116,20 @@ func (s ReactionsService) CreateCommentReaction(ctx context.Context, owner, repo
 func (s *ReactionsService) DeleteCommentReaction(ctx context.Context, owner, repo string, commentID, reactionID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions/%v", owner, repo, commentID, reactionID)
 
-	req, err := s.client.NewRequest(http.MethodDelete, u, nil)
+	return s.deleteCommentReaction(ctx, u)
+}
+
+// DeleteCommentReactionByRepoID deletes the reaction for a commit comment by repository ID.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#delete-a-commit-comment-reaction
+func (s *ReactionsService) DeleteCommentReactionByRepoID(ctx context.Context, repoID, commentID, reactionID int64) (*Response, error) {
+	u := fmt.Sprintf("repositories/%v/comments/%v/reactions/%v", repoID, commentID, reactionID)
+
+	return s.deleteCommentReaction(ctx, u)
+}
+
+func (s ReactionsService) deleteCommentReaction(ctx context.Context, url string) (*Response, error) {
+	req, err := s.client.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/github/reactions_test.go
+++ b/github/reactions_test.go
@@ -356,3 +356,19 @@ func TestReactionsService_DeleteCommitCommentReaction(t *testing.T) {
 		t.Errorf("DeleteCommentReaction returned error: %v", err)
 	}
 }
+
+func TestReactionsService_DeleteCommitCommentReactionByRepoID(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repositories/1/comments/2/reactions/3", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if _, err := client.Reactions.DeleteCommentReactionByRepoID(context.Background(), 1, 2, 3); err != nil {
+		t.Errorf("DeleteCommentReactionByRepoID returned error: %v", err)
+	}
+}

--- a/github/reactions_test.go
+++ b/github/reactions_test.go
@@ -340,3 +340,19 @@ func TestReactionsService_DeleteReaction(t *testing.T) {
 		t.Errorf("DeleteReaction returned error: %v", err)
 	}
 }
+
+func TestReactionsService_DeleteCommitCommentReaction(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/comments/1/reactions/2", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if _, err := client.Reactions.DeleteCommentReaction(context.Background(), "o", "r", 1, 2); err != nil {
+		t.Errorf("DeleteReaction returned error: %v", err)
+	}
+}

--- a/github/reactions_test.go
+++ b/github/reactions_test.go
@@ -353,6 +353,6 @@ func TestReactionsService_DeleteCommitCommentReaction(t *testing.T) {
 	})
 
 	if _, err := client.Reactions.DeleteCommentReaction(context.Background(), "o", "r", 1, 2); err != nil {
-		t.Errorf("DeleteReaction returned error: %v", err)
+		t.Errorf("DeleteCommentReaction returned error: %v", err)
 	}
 }


### PR DESCRIPTION
Delete a commit comment reaction
- `DELETE /repos/:owner/:repo/comments/:comment_id/reactions/:reaction_id`
- Docs: https://developer.github.com/v3/reactions/#delete-a-commit-comment-reaction