### PR TITLE
Implement support for actions runners

### DIFF
--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -1,0 +1,155 @@
+// Copyright 2020 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// RunnerApplicationDownload represents a binary for the self-hosted runner application that can be downloaded.
+type RunnerApplicationDownload struct {
+	OS           *string `json:"os,omitempty"`
+	Architecture *string `json:"architecture,omitempty"`
+	DownloadURL  *string `json:"download_url,omitempty"`
+	Filename     *string `json:"filename,omitempty"`
+}
+
+// ListRunnerApplicationDownloads lists self-hosted runner applicatio binaries that can be downloaded and run.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/self_hosted_runners/#list-downloads-for-the-self-hosted-runner-application
+func (s *ActionsService) ListRunnerApplicationDownloads(ctx context.Context, owner, repo string) (*[]RunnerApplicationDownload, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/runners/downloads", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	runnerApplicationDownloads := new([]RunnerApplicationDownload)
+	resp, err := s.client.Do(ctx, req, runnerApplicationDownloads)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return runnerApplicationDownloads, resp, nil
+}
+
+// RegistrationToken represents a token that can be used to add a self-hosted runner to a repository.
+type RegistrationToken struct {
+	Token     *string    `json:"token,omitempty"`
+	ExpiresAt *Timestamp `json:"expires_at,omitempty"`
+}
+
+// CreateRegistrationToken creates a token that can be used to add a self-hosted runner.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/self_hosted_runners/#create-a-registration-token
+func (s *ActionsService) CreateRegistrationToken(ctx context.Context, owner, repo string) (*RegistrationToken, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/runners/registration-token", owner, repo)
+
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	registrationToken := new(RegistrationToken)
+	resp, err := s.client.Do(ctx, req, registrationToken)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return registrationToken, resp, nil
+}
+
+// Runner represents a self-hosted runner registered with a repository.
+type Runner struct {
+	ID     *int64  `json:"id,omitempty"`
+	Name   *string `json:"name,omitempty"`
+	OS     *string `json:"os,omitempty"`
+	Status *string `json:"status,omitempty"`
+}
+
+// ListRunners lists all the self-hosted runners for a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/self_hosted_runners/#list-self-hosted-runners-for-a-repository
+func (s *ActionsService) ListRunners(ctx context.Context, owner, repo string, opts *ListOptions) (*[]Runner, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/runners", owner, repo)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	runners := new([]Runner)
+	resp, err := s.client.Do(ctx, req, runners)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return runners, resp, nil
+}
+
+// GetRunner gets a specific self-hosted runner for a repository using its runner ID.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/self_hosted_runners/#get-a-self-hosted-runner
+func (s *ActionsService) GetRunner(ctx context.Context, owner, repo string, runnerID int64) (*Runner, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/runners/%v", owner, repo, runnerID)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	runner := new(Runner)
+	resp, err := s.client.Do(ctx, req, runner)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return runner, resp, nil
+}
+
+// RemoveToken represents a token that can be used to remove a self-hosted runner from a repository.
+type RemoveToken struct {
+	Token     *string    `json:"token,omitempty"`
+	ExpiresAt *Timestamp `json:"expires_at,omitempty"`
+}
+
+// CreateRemoveToken creates a token that can be used to remove a self-hosted runner from a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/self_hosted_runners/#create-a-remove-token
+func (s *ActionsService) CreateRemoveToken(ctx context.Context, owner, repo string) (*RemoveToken, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/runners/remove-token", owner, repo)
+
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	removeToken := new(RemoveToken)
+	resp, err := s.client.Do(ctx, req, removeToken)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return removeToken, resp, nil
+}
+
+// RemoveRunner forces the removal of a self-hosted runner in a repository using the runner id.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/self_hosted_runners/#remove-a-self-hosted-runner
+func (s *ActionsService) RemoveRunner(ctx context.Context, owner, repo string, runnerID int64) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/runners/%v", owner, repo, runnerID)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -18,23 +18,23 @@ type RunnerApplicationDownload struct {
 	Filename     *string `json:"filename,omitempty"`
 }
 
-// ListRunnerApplicationDownloads lists self-hosted runner applicatio binaries that can be downloaded and run.
+// ListRunnerApplicationDownloads lists self-hosted runner application binaries that can be downloaded and run.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/self_hosted_runners/#list-downloads-for-the-self-hosted-runner-application
-func (s *ActionsService) ListRunnerApplicationDownloads(ctx context.Context, owner, repo string) (*[]RunnerApplicationDownload, *Response, error) {
+func (s *ActionsService) ListRunnerApplicationDownloads(ctx context.Context, owner, repo string) ([]*RunnerApplicationDownload, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners/downloads", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	runnerApplicationDownloads := new([]RunnerApplicationDownload)
-	resp, err := s.client.Do(ctx, req, runnerApplicationDownloads)
+	var rads []*RunnerApplicationDownload
+	resp, err := s.client.Do(ctx, req, &rads)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return runnerApplicationDownloads, resp, nil
+	return rads, resp, nil
 }
 
 // RegistrationToken represents a token that can be used to add a self-hosted runner to a repository.
@@ -74,7 +74,7 @@ type Runner struct {
 // ListRunners lists all the self-hosted runners for a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/self_hosted_runners/#list-self-hosted-runners-for-a-repository
-func (s *ActionsService) ListRunners(ctx context.Context, owner, repo string, opts *ListOptions) (*[]Runner, *Response, error) {
+func (s *ActionsService) ListRunners(ctx context.Context, owner, repo string, opts *ListOptions) ([]*Runner, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners", owner, repo)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -86,8 +86,8 @@ func (s *ActionsService) ListRunners(ctx context.Context, owner, repo string, op
 		return nil, nil, err
 	}
 
-	runners := new([]Runner)
-	resp, err := s.client.Do(ctx, req, runners)
+	var runners []*Runner
+	resp, err := s.client.Do(ctx, req, &runners)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/actions_runners_test.go
+++ b/github/actions_runners_test.go
@@ -28,7 +28,7 @@ func TestActionsService_ListRunnerApplicationDownloads(t *testing.T) {
 		t.Errorf("Actions.ListRunnerApplicationDownloads returned error: %v", err)
 	}
 
-	want := &[]RunnerApplicationDownload{
+	want := []*RunnerApplicationDownload{
 		{OS: String("osx"), Architecture: String("x64"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-osx-x64-2.164.0.tar.gz"), Filename: String("actions-runner-osx-x64-2.164.0.tar.gz")},
 		{OS: String("linux"), Architecture: String("x64"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-x64-2.164.0.tar.gz"), Filename: String("actions-runner-linux-x64-2.164.0.tar.gz")},
 		{OS: String("linux"), Architecture: String("arm"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm-2.164.0.tar.gz"), Filename: String("actions-runner-linux-arm-2.164.0.tar.gz")},
@@ -78,7 +78,7 @@ func TestActionsService_ListRunners(t *testing.T) {
 		t.Errorf("Actions.ListRunners returned error: %v", err)
 	}
 
-	want := &[]Runner{
+	want := []*Runner{
 		{ID: Int64(23), Name: String("MBP"), OS: String("macos"), Status: String("online")},
 		{ID: Int64(24), Name: String("iMac"), OS: String("macos"), Status: String("offline")},
 	}

--- a/github/actions_runners_test.go
+++ b/github/actions_runners_test.go
@@ -1,0 +1,147 @@
+// Copyright 2020 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestActionsService_ListRunnerApplicationDownloads(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/runners/downloads", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{"os":"osx","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-osx-x64-2.164.0.tar.gz","filename":"actions-runner-osx-x64-2.164.0.tar.gz"},{"os":"linux","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-x64-2.164.0.tar.gz","filename":"actions-runner-linux-x64-2.164.0.tar.gz"},{"os": "linux","architecture":"arm","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm-2.164.0.tar.gz","filename":"actions-runner-linux-arm-2.164.0.tar.gz"},{"os":"win","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-win-x64-2.164.0.zip","filename":"actions-runner-win-x64-2.164.0.zip"},{"os":"linux","architecture":"arm64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm64-2.164.0.tar.gz","filename":"actions-runner-linux-arm64-2.164.0.tar.gz"}]`)
+	})
+
+	downloads, _, err := client.Actions.ListRunnerApplicationDownloads(context.Background(), "o", "r")
+	if err != nil {
+		t.Errorf("Actions.ListRunnerApplicationDownloads returned error: %v", err)
+	}
+
+	want := &[]RunnerApplicationDownload{
+		{OS: String("osx"), Architecture: String("x64"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-osx-x64-2.164.0.tar.gz"), Filename: String("actions-runner-osx-x64-2.164.0.tar.gz")},
+		{OS: String("linux"), Architecture: String("x64"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-x64-2.164.0.tar.gz"), Filename: String("actions-runner-linux-x64-2.164.0.tar.gz")},
+		{OS: String("linux"), Architecture: String("arm"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm-2.164.0.tar.gz"), Filename: String("actions-runner-linux-arm-2.164.0.tar.gz")},
+		{OS: String("win"), Architecture: String("x64"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-win-x64-2.164.0.zip"), Filename: String("actions-runner-win-x64-2.164.0.zip")},
+		{OS: String("linux"), Architecture: String("arm64"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm64-2.164.0.tar.gz"), Filename: String("actions-runner-linux-arm64-2.164.0.tar.gz")},
+	}
+	if !reflect.DeepEqual(downloads, want) {
+		t.Errorf("Actions.ListRunnerApplicationDownloads returned %+v, want %+v", downloads, want)
+	}
+}
+
+func TestActionsService_CreateRegistrationToken(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/runners/registration-token", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"token":"LLBF3JGZDX3P5PMEXLND6TS6FCWO6","expires_at":"2020-01-22T12:13:35.123Z"}`)
+	})
+
+	token, _, err := client.Actions.CreateRegistrationToken(context.Background(), "o", "r")
+	if err != nil {
+		t.Errorf("Actions.CreateRegistrationToken returned error: %v", err)
+	}
+
+	want := &RegistrationToken{Token: String("LLBF3JGZDX3P5PMEXLND6TS6FCWO6"),
+		ExpiresAt: &Timestamp{time.Date(2020, time.January, 22, 12, 13, 35,
+			123000000, time.UTC)}}
+	if !reflect.DeepEqual(token, want) {
+		t.Errorf("Actions.CreateRegistrationToken returned %+v, want %+v", token, want)
+	}
+}
+
+func TestActionsService_ListRunners(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/runners", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"per_page": "2", "page": "2"})
+		fmt.Fprint(w, `[{"id":23,"name":"MBP","os":"macos","status":"online"},{"id":24,"name":"iMac","os":"macos","status":"offline"}]`)
+	})
+
+	opts := &ListOptions{Page: 2, PerPage: 2}
+	runners, _, err := client.Actions.ListRunners(context.Background(), "o", "r", opts)
+	if err != nil {
+		t.Errorf("Actions.ListRunners returned error: %v", err)
+	}
+
+	want := &[]Runner{
+		{ID: Int64(23), Name: String("MBP"), OS: String("macos"), Status: String("online")},
+		{ID: Int64(24), Name: String("iMac"), OS: String("macos"), Status: String("offline")},
+	}
+	if !reflect.DeepEqual(runners, want) {
+		t.Errorf("Actions.ListRunners returned %+v, want %+v", runners, want)
+	}
+}
+
+func TestActionsService_GetRunner(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/runners/23", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":23,"name":"MBP","os":"macos","status":"online"}`)
+	})
+
+	runner, _, err := client.Actions.GetRunner(context.Background(), "o", "r", 23)
+	if err != nil {
+		t.Errorf("Actions.GetRunner returned error: %v", err)
+	}
+
+	want := &Runner{
+		ID:     Int64(23),
+		Name:   String("MBP"),
+		OS:     String("macos"),
+		Status: String("online"),
+	}
+	if !reflect.DeepEqual(runner, want) {
+		t.Errorf("Actions.GetRunner returned %+v, want %+v", runner, want)
+	}
+}
+
+func TestActionsService_CreateRemoveToken(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/runners/remove-token", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"token":"AABF3JGZDX3P5PMEXLND6TS6FCWO6","expires_at":"2020-01-29T12:13:35.123Z"}`)
+	})
+
+	token, _, err := client.Actions.CreateRemoveToken(context.Background(), "o", "r")
+	if err != nil {
+		t.Errorf("Actions.CreateRemoveToken returned error: %v", err)
+	}
+
+	want := &RemoveToken{Token: String("AABF3JGZDX3P5PMEXLND6TS6FCWO6"), ExpiresAt: &Timestamp{time.Date(2020, time.January, 29, 12, 13, 35, 123000000, time.UTC)}}
+	if !reflect.DeepEqual(token, want) {
+		t.Errorf("Actions.CreateRemoveToken returned %+v, want %+v", token, want)
+	}
+}
+
+func TestActionsService_RemoveRunner(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/runners/21", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	_, err := client.Actions.RemoveRunner(context.Background(), "o", "r", 21)
+	if err != nil {
+		t.Errorf("Actions.RemoveRunner returned error: %v", err)
+	}
+}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9780,6 +9780,22 @@ func (r *Reference) GetURL() string {
 	return *r.URL
 }
 
+// GetExpiresAt returns the ExpiresAt field if it's non-nil, zero value otherwise.
+func (r *RegistrationToken) GetExpiresAt() Timestamp {
+	if r == nil || r.ExpiresAt == nil {
+		return Timestamp{}
+	}
+	return *r.ExpiresAt
+}
+
+// GetToken returns the Token field if it's non-nil, zero value otherwise.
+func (r *RegistrationToken) GetToken() string {
+	if r == nil || r.Token == nil {
+		return ""
+	}
+	return *r.Token
+}
+
 // GetBrowserDownloadURL returns the BrowserDownloadURL field if it's non-nil, zero value otherwise.
 func (r *ReleaseAsset) GetBrowserDownloadURL() string {
 	if r == nil || r.BrowserDownloadURL == nil {
@@ -9922,6 +9938,22 @@ func (r *ReleaseEvent) GetSender() *User {
 		return nil
 	}
 	return r.Sender
+}
+
+// GetExpiresAt returns the ExpiresAt field if it's non-nil, zero value otherwise.
+func (r *RemoveToken) GetExpiresAt() Timestamp {
+	if r == nil || r.ExpiresAt == nil {
+		return Timestamp{}
+	}
+	return *r.ExpiresAt
+}
+
+// GetToken returns the Token field if it's non-nil, zero value otherwise.
+func (r *RemoveToken) GetToken() string {
+	if r == nil || r.Token == nil {
+		return ""
+	}
+	return *r.Token
 }
 
 // GetFrom returns the From field if it's non-nil, zero value otherwise.
@@ -11570,6 +11602,70 @@ func (r *ReviewersRequest) GetNodeID() string {
 		return ""
 	}
 	return *r.NodeID
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (r *Runner) GetID() int64 {
+	if r == nil || r.ID == nil {
+		return 0
+	}
+	return *r.ID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (r *Runner) GetName() string {
+	if r == nil || r.Name == nil {
+		return ""
+	}
+	return *r.Name
+}
+
+// GetOS returns the OS field if it's non-nil, zero value otherwise.
+func (r *Runner) GetOS() string {
+	if r == nil || r.OS == nil {
+		return ""
+	}
+	return *r.OS
+}
+
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (r *Runner) GetStatus() string {
+	if r == nil || r.Status == nil {
+		return ""
+	}
+	return *r.Status
+}
+
+// GetArchitecture returns the Architecture field if it's non-nil, zero value otherwise.
+func (r *RunnerApplicationDownload) GetArchitecture() string {
+	if r == nil || r.Architecture == nil {
+		return ""
+	}
+	return *r.Architecture
+}
+
+// GetDownloadURL returns the DownloadURL field if it's non-nil, zero value otherwise.
+func (r *RunnerApplicationDownload) GetDownloadURL() string {
+	if r == nil || r.DownloadURL == nil {
+		return ""
+	}
+	return *r.DownloadURL
+}
+
+// GetFilename returns the Filename field if it's non-nil, zero value otherwise.
+func (r *RunnerApplicationDownload) GetFilename() string {
+	if r == nil || r.Filename == nil {
+		return ""
+	}
+	return *r.Filename
+}
+
+// GetOS returns the OS field if it's non-nil, zero value otherwise.
+func (r *RunnerApplicationDownload) GetOS() string {
+	if r == nil || r.OS == nil {
+		return ""
+	}
+	return *r.OS
 }
 
 // GetName returns the Name field if it's non-nil, zero value otherwise.


### PR DESCRIPTION
This PR adds support for the GitHub Actions [Runners API](https://developer.github.com/v3/actions/self_hosted_runners/).

Relates to: #1399

For the [list self hosted runners](https://developer.github.com/v3/actions/self_hosted_runners/#list-self-hosted-runners-for-a-repository) endpoint I sent an email to support regarding the example showing the array nested two levels deep which doesn't match the actual responses I was getting, and inquiring about if they intended to include a `total_count` field like most other endpoints that support pagination.

One of the things I'm not sure about is the return and struct field types, specifically which ones should be references (e.g. `*[]Type` or `*[]*Type` for a list return type, or something else?)