### PR TITLE
FIX: allow empty commitMessage for merging pulls

### DIFF
--- a/github/pulls.go
+++ b/github/pulls.go
@@ -449,7 +449,7 @@ type PullRequestOptions struct {
 }
 
 type pullRequestMergeRequest struct {
-	CommitMessage string `json:"commit_message"`
+	CommitMessage string `json:"commit_message,omitempty"`
 	CommitTitle   string `json:"commit_title,omitempty"`
 	MergeMethod   string `json:"merge_method,omitempty"`
 	SHA           string `json:"sha,omitempty"`


### PR DESCRIPTION
This change is specifically motivated by the desire to replicate
the same behavior as observed when merging PR's manually using
the "Squash and Merge" option. In that case, a commit message
including the title and commit message of all the commits in the
PR are included, and the squashed commit includes all of that
context.

I have tested that its possible to merge a Pull Request with
an empty commit message and verified that the api call replicates
the desired behavior:

```
curl -XPUT \
  -H "Accept: application/vnd.github.v3+json" \
  -H "Authorization: token $GITHUB_API_TOKEN" \
  -d '{"merge_method":"squash"}' \
  https://api.github.com/repos/pratikmallya/test/pulls/4/merge

{
  "sha": "08d173ee449e4ea505d8366b9fa416d6d3923f23",
  "merged": true,
  "message": "Pull Request successfully merged"
}
```

The merge commit: https://github.com/pratikmallya/test/commit/08d173ee449e4ea505d8366b9fa416d6d3923f23
is exactly the behavior that I am seeking.

Fixes: https://github.com/google/go-github/issues/1448