### PR TITLE
Implement support for update pages API

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -7220,6 +7220,22 @@ func (p *PageStats) GetTotalPages() int {
 	return *p.TotalPages
 }
 
+// GetCNAME returns the CNAME field if it's non-nil, zero value otherwise.
+func (p *PagesUpdate) GetCNAME() string {
+	if p == nil || p.CNAME == nil {
+		return ""
+	}
+	return *p.CNAME
+}
+
+// GetSource returns the Source field if it's non-nil, zero value otherwise.
+func (p *PagesUpdate) GetSource() string {
+	if p == nil || p.Source == nil {
+		return ""
+	}
+	return *p.Source
+}
+
 // GetHook returns the Hook field.
 func (p *PingEvent) GetHook() *Hook {
 	if p == nil {

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -100,8 +100,6 @@ func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo strin
 		return nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeEnablePagesAPIPreview)
-
 	if *opts.CNAME == "" {
 		update := new(pagesUpdateNullCNAME)
 		resp, err := s.client.Do(ctx, req, update)
@@ -112,8 +110,7 @@ func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo strin
 		return resp, nil
 	}
 
-	update := new(PagesUpdate)
-	resp, err := s.client.Do(ctx, req, update)
+	resp, err := s.client.Do(ctx, req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -78,18 +78,10 @@ func (s *RepositoriesService) EnablePages(ctx context.Context, owner, repo strin
 // PagesUpdate sets up parameters needed to update a GitHub Pages site.
 type PagesUpdate struct {
 	// CNAME represents a custom domain for the repository.
-	// Setting CNAME as an empty string will remove the custom domain.
-	CNAME *string `json:"cname,omitempty"`
+	// Leaving CNAME empty will remove the custom domain.
+	CNAME *string `json:"cname"`
 	// Source must include the branch name, and may optionally specify the subdirectory "/docs".
 	// Possible values are: "gh-pages", "master", and "master /docs".
-	Source *string `json:"source,omitempty"`
-}
-
-// pagesUpdateNullCNAME is used internally by UpdatePages to pass a null
-// value for the CNAME field when an empty string has been provided in
-// order to remove the custom domain.
-type pagesUpdateNullCNAME struct {
-	CNAME  *string `json:"cname"`
 	Source *string `json:"source,omitempty"`
 }
 
@@ -102,16 +94,6 @@ func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo strin
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, err
-	}
-
-	if *opts.CNAME == "" {
-		update := new(pagesUpdateNullCNAME)
-		resp, err := s.client.Do(ctx, req, update)
-		if err != nil {
-			return resp, err
-		}
-
-		return resp, nil
 	}
 
 	resp, err := s.client.Do(ctx, req, nil)

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -75,6 +75,39 @@ func (s *RepositoriesService) EnablePages(ctx context.Context, owner, repo strin
 	return enable, resp, nil
 }
 
+// UpdatePagesRequest sets up parameters needed to update a GitHub Pages site.
+type UpdatePagesRequest struct {
+	CNAME  *string `json:"cname,omitempty"`
+	Source *string `json:"source,omitempty"`
+}
+
+// UpdatePages updates GitHub Pages for the named repo.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/pages/#update-information-about-a-pages-site
+func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo string, opts *UpdatePagesRequest) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
+
+	pagesReq := &UpdatePagesRequest{
+		Source: opts.Source,
+		CNAME:  opts.CNAME,
+	}
+
+	req, err := s.client.NewRequest("PUT", u, pagesReq)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", mediaTypeEnablePagesAPIPreview)
+
+	update := new(Pages)
+	resp, err := s.client.Do(ctx, req, update)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
 // DisablePages disables GitHub Pages for the named repo.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/pages/#disable-a-pages-site

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -75,8 +75,8 @@ func (s *RepositoriesService) EnablePages(ctx context.Context, owner, repo strin
 	return enable, resp, nil
 }
 
-// UpdatePagesRequest sets up parameters needed to update a GitHub Pages site.
-type UpdatePagesRequest struct {
+// PagesUpdate sets up parameters needed to update a GitHub Pages site.
+type PagesUpdate struct {
 	CNAME  *string `json:"cname,omitempty"`
 	Source *string `json:"source,omitempty"`
 }
@@ -84,22 +84,17 @@ type UpdatePagesRequest struct {
 // UpdatePages updates GitHub Pages for the named repo.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/pages/#update-information-about-a-pages-site
-func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo string, opts *UpdatePagesRequest) (*Response, error) {
+func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo string, opts *PagesUpdate) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
 
-	pagesReq := &UpdatePagesRequest{
-		Source: opts.Source,
-		CNAME:  opts.CNAME,
-	}
-
-	req, err := s.client.NewRequest("PUT", u, pagesReq)
+	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeEnablePagesAPIPreview)
 
-	update := new(Pages)
+	update := new(PagesUpdate)
 	resp, err := s.client.Do(ctx, req, update)
 	if err != nil {
 		return resp, err

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -77,7 +77,11 @@ func (s *RepositoriesService) EnablePages(ctx context.Context, owner, repo strin
 
 // PagesUpdate sets up parameters needed to update a GitHub Pages site.
 type PagesUpdate struct {
+	// CNAME represents a custom domain for the repository.
+	// Setting CNAME as an empty string will remove the custom domain.
 	CNAME  *string `json:"cname,omitempty"`
+	// Source must include the branch name, and may optionally specify the subdirectory "/docs".
+	// Possible values are: "gh-pages", "master", and "master /docs".
 	Source *string `json:"source,omitempty"`
 }
 

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -79,7 +79,7 @@ func (s *RepositoriesService) EnablePages(ctx context.Context, owner, repo strin
 type PagesUpdate struct {
 	// CNAME represents a custom domain for the repository.
 	// Setting CNAME as an empty string will remove the custom domain.
-	CNAME  *string `json:"cname,omitempty"`
+	CNAME *string `json:"cname,omitempty"`
 	// Source must include the branch name, and may optionally specify the subdirectory "/docs".
 	// Possible values are: "gh-pages", "master", and "master /docs".
 	Source *string `json:"source,omitempty"`

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -81,6 +81,14 @@ type PagesUpdate struct {
 	Source *string `json:"source,omitempty"`
 }
 
+// pagesUpdateNullCNAME is used internally by UpdatePages to pass a null
+// value for the CNAME field when an empty string has been provided in
+// order to remove the custom domain.
+type pagesUpdateNullCNAME struct {
+	CNAME  *string `json:"cname"`
+	Source *string `json:"source,omitempty"`
+}
+
 // UpdatePages updates GitHub Pages for the named repo.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/pages/#update-information-about-a-pages-site
@@ -93,6 +101,16 @@ func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo strin
 	}
 
 	req.Header.Set("Accept", mediaTypeEnablePagesAPIPreview)
+
+	if *opts.CNAME == "" {
+		update := new(pagesUpdateNullCNAME)
+		resp, err := s.client.Do(ctx, req, update)
+		if err != nil {
+			return resp, err
+		}
+
+		return resp, nil
+	}
 
 	update := new(PagesUpdate)
 	resp, err := s.client.Do(ctx, req, update)

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -52,6 +52,35 @@ func TestRepositoriesService_EnablePages(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_UpdatePages(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &UpdatePagesRequest{
+		CNAME:  String("www.my-domain.com"),
+		Source: String("gh-pages"),
+	}
+
+	mux.HandleFunc("/repos/o/r/pages", func(w http.ResponseWriter, r *http.Request) {
+		v := new(UpdatePagesRequest)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Accept", mediaTypeEnablePagesAPIPreview)
+		want := &UpdatePagesRequest{CNAME: String("www.my-domain.com"), Source: String("gh-pages")}
+		if !reflect.DeepEqual(v, want) {
+			t.Errorf("Request body = %+v, want %+v", v, want)
+		}
+
+		fmt.Fprint(w, `{"cname":"www.my-domain.com","source":"gh-pages"}`)
+	})
+
+	_, err := client.Repositories.UpdatePages(context.Background(), "o", "r", input)
+	if err != nil {
+		t.Errorf("Repositories.UpdatePages returned error: %v", err)
+	}
+}
+
 func TestRepositoriesService_DisablePages(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -6,9 +6,11 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
@@ -89,13 +91,14 @@ func TestRepositoriesService_UpdatePages_NullCNAME(t *testing.T) {
 	}
 
 	mux.HandleFunc("/repos/o/r/pages", func(w http.ResponseWriter, r *http.Request) {
-		v := new(PagesUpdate)
-		json.NewDecoder(r.Body).Decode(v)
+		got, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("unable to read body: %v", err)
+		}
 
-		testMethod(t, r, "PUT")
-		want := &PagesUpdate{CNAME: nil, Source: String("gh-pages")}
-		if !reflect.DeepEqual(v, want) {
-			t.Errorf("Request body = %+v, want %+v", v, want)
+		want := []byte(`{"cname":null,"source":"gh-pages"}` + "\n")
+		if !bytes.Equal(got, want) {
+			t.Errorf("Request body = %+v, want %+v", got, want)
 		}
 
 		fmt.Fprint(w, `{"cname":null,"source":"gh-pages"}`)

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -66,7 +66,6 @@ func TestRepositoriesService_UpdatePages(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeEnablePagesAPIPreview)
 		want := &PagesUpdate{CNAME: String("www.my-domain.com"), Source: String("gh-pages")}
 		if !reflect.DeepEqual(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -80,6 +80,33 @@ func TestRepositoriesService_UpdatePages(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_UpdatePages_NullCNAME(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &PagesUpdate{
+		Source: String("gh-pages"),
+	}
+
+	mux.HandleFunc("/repos/o/r/pages", func(w http.ResponseWriter, r *http.Request) {
+		v := new(PagesUpdate)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "PUT")
+		want := &PagesUpdate{CNAME: nil, Source: String("gh-pages")}
+		if !reflect.DeepEqual(v, want) {
+			t.Errorf("Request body = %+v, want %+v", v, want)
+		}
+
+		fmt.Fprint(w, `{"cname":null,"source":"gh-pages"}`)
+	})
+
+	_, err := client.Repositories.UpdatePages(context.Background(), "o", "r", input)
+	if err != nil {
+		t.Errorf("Repositories.UpdatePages returned error: %v", err)
+	}
+}
+
 func TestRepositoriesService_DisablePages(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -56,18 +56,18 @@ func TestRepositoriesService_UpdatePages(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	input := &UpdatePagesRequest{
+	input := &PagesUpdate{
 		CNAME:  String("www.my-domain.com"),
 		Source: String("gh-pages"),
 	}
 
 	mux.HandleFunc("/repos/o/r/pages", func(w http.ResponseWriter, r *http.Request) {
-		v := new(UpdatePagesRequest)
+		v := new(PagesUpdate)
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Accept", mediaTypeEnablePagesAPIPreview)
-		want := &UpdatePagesRequest{CNAME: String("www.my-domain.com"), Source: String("gh-pages")}
+		want := &PagesUpdate{CNAME: String("www.my-domain.com"), Source: String("gh-pages")}
 		if !reflect.DeepEqual(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}


### PR DESCRIPTION
Implements support for updating Github Pages sites - allowing CName and
Source to be customized.

Fixes: #1361 