### PR TITLE
Add support for filter parameter to the list workflow jobs endpoint

### DIFF
--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -46,10 +46,16 @@ type Jobs struct {
 	Jobs       []*WorkflowJob `json:"jobs,omitempty"`
 }
 
+// ListWorkflowJobsOptions specifies optional parameters to ListWorkflowJobs
+type ListWorkflowJobsOptions struct {
+	Filter string `url:"filter,omitempty"`
+	ListOptions
+}
+
 // ListWorkflowJobs lists all jobs for a workflow run.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/workflow_jobs/#list-jobs-for-a-workflow-run
-func (s *ActionsService) ListWorkflowJobs(ctx context.Context, owner, repo string, runID int64, opts *ListOptions) (*Jobs, *Response, error) {
+func (s *ActionsService) ListWorkflowJobs(ctx context.Context, owner, repo string, runID int64, opts *ListWorkflowJobsOptions) (*Jobs, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/actions/runs/%v/jobs", owner, repo, runID)
 	u, err := addOptions(u, opts)
 	if err != nil {

--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -46,7 +46,7 @@ type Jobs struct {
 	Jobs       []*WorkflowJob `json:"jobs,omitempty"`
 }
 
-// ListWorkflowJobsOptions specifies optional parameters to ListWorkflowJobs
+// ListWorkflowJobsOptions specifies optional parameters to ListWorkflowJobs.
 type ListWorkflowJobsOptions struct {
 	// Filter specifies how jobs should be filtered by their completed_at timestamp.
 	// Possible values are:

--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -48,6 +48,12 @@ type Jobs struct {
 
 // ListWorkflowJobsOptions specifies optional parameters to ListWorkflowJobs
 type ListWorkflowJobsOptions struct {
+	// Filter specifies how jobs should be filtered by their completed_at timestamp.
+	// Possible values are:
+	//     latest - Returns jobs from the most recent execution of the workflow run
+	//     all - Returns all jobs for a workflow run, including from old executions of the workflow run
+	//
+	// Default value is "latest".
 	Filter string `url:"filter,omitempty"`
 	ListOptions
 }

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -25,7 +25,7 @@ func TestActionsService_ListWorkflowJobs(t *testing.T) {
 		fmt.Fprint(w, `{"total_count":4,"jobs":[{"id":399444496,"run_id":29679449,"started_at":"2019-01-02T15:04:05Z","completed_at":"2020-01-02T15:04:05Z"},{"id":399444497,"run_id":29679449,"started_at":"2019-01-02T15:04:05Z","completed_at":"2020-01-02T15:04:05Z"}]}`)
 	})
 
-	opts := &ListOptions{Page: 2, PerPage: 2}
+	opts := &ListWorkflowJobsOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
 	jobs, _, err := client.Actions.ListWorkflowJobs(context.Background(), "o", "r", 29679449, opts)
 	if err != nil {
 		t.Errorf("Actions.ListWorkflowJobs returned error: %v", err)

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -43,6 +43,34 @@ func TestActionsService_ListWorkflowJobs(t *testing.T) {
 	}
 }
 
+func TestActionsService_ListWorkflowJobs_Filter(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/runs/29679449/jobs", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"filter": "all", "per_page": "2", "page": "2"})
+		fmt.Fprint(w, `{"total_count":4,"jobs":[{"id":399444496,"run_id":29679449,"started_at":"2019-01-02T15:04:05Z","completed_at":"2020-01-02T15:04:05Z"},{"id":399444497,"run_id":29679449,"started_at":"2019-01-02T15:04:05Z","completed_at":"2020-01-02T15:04:05Z"}]}`)
+	})
+
+	opts := &ListWorkflowJobsOptions{Filter: "all", ListOptions: ListOptions{Page: 2, PerPage: 2}}
+	jobs, _, err := client.Actions.ListWorkflowJobs(context.Background(), "o", "r", 29679449, opts)
+	if err != nil {
+		t.Errorf("Actions.ListWorkflowJobs returned error: %v", err)
+	}
+
+	want := &Jobs{
+		TotalCount: Int(4),
+		Jobs: []*WorkflowJob{
+			{ID: Int64(399444496), RunID: Int64(29679449), StartedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, CompletedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
+			{ID: Int64(399444497), RunID: Int64(29679449), StartedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, CompletedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
+		},
+	}
+	if !reflect.DeepEqual(jobs, want) {
+		t.Errorf("Actions.ListWorkflowJobs returned %+v, want %+v", jobs, want)
+	}
+}
+
 func TestActionsService_GetWorkflowJobByID(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
This adds support for an optional `filter` parameter to the list workflow jobs endpoint that was recently announced. See #1454.