### PR TITLE
Update and remove OAuth endpoints

### DIFF
--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -43,6 +43,10 @@ const (
 	ScopeAdminGPGKey    Scope = "admin:gpg_key"
 )
 
+const (
+	mediaTypeOAuthAppPreview = "application/vnd.github.doctor-strange-preview+json"
+)
+
 // AuthorizationsService handles communication with the authorization related
 // methods of the GitHub API.
 //
@@ -154,6 +158,7 @@ func (s *AuthorizationsService) Check(ctx context.Context, clientID, accessToken
 	if err != nil {
 		return nil, nil, err
 	}
+	req.Header.Set("Accept", mediaTypeOAuthAppPreview)
 
 	a := new(Authorization)
 	resp, err := s.client.Do(ctx, req, a)
@@ -186,6 +191,7 @@ func (s *AuthorizationsService) Reset(ctx context.Context, clientID, accessToken
 	if err != nil {
 		return nil, nil, err
 	}
+	req.Header.Set("Accept", mediaTypeOAuthAppPreview)
 
 	a := new(Authorization)
 	resp, err := s.client.Do(ctx, req, a)
@@ -214,6 +220,7 @@ func (s *AuthorizationsService) Revoke(ctx context.Context, clientID, accessToke
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", mediaTypeOAuthAppPreview)
 
 	return s.client.Do(ctx, req, nil)
 }
@@ -234,6 +241,7 @@ func (s *AuthorizationsService) DeleteGrant(ctx context.Context, clientID, acces
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", mediaTypeOAuthAppPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -134,137 +134,6 @@ func (a AuthorizationUpdateRequest) String() string {
 	return Stringify(a)
 }
 
-// List the authorizations for the authenticated user.
-//
-// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations
-func (s *AuthorizationsService) List(ctx context.Context, opts *ListOptions) ([]*Authorization, *Response, error) {
-	u := "authorizations"
-	u, err := addOptions(u, opts)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	req, err := s.client.NewRequest("GET", u, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var auths []*Authorization
-	resp, err := s.client.Do(ctx, req, &auths)
-	if err != nil {
-		return nil, resp, err
-	}
-	return auths, resp, nil
-}
-
-// Get a single authorization.
-//
-// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#get-a-single-authorization
-func (s *AuthorizationsService) Get(ctx context.Context, id int64) (*Authorization, *Response, error) {
-	u := fmt.Sprintf("authorizations/%d", id)
-
-	req, err := s.client.NewRequest("GET", u, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	a := new(Authorization)
-	resp, err := s.client.Do(ctx, req, a)
-	if err != nil {
-		return nil, resp, err
-	}
-	return a, resp, nil
-}
-
-// Create a new authorization for the specified OAuth application.
-//
-// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
-func (s *AuthorizationsService) Create(ctx context.Context, auth *AuthorizationRequest) (*Authorization, *Response, error) {
-	u := "authorizations"
-
-	req, err := s.client.NewRequest("POST", u, auth)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	a := new(Authorization)
-	resp, err := s.client.Do(ctx, req, a)
-	if err != nil {
-		return nil, resp, err
-	}
-	return a, resp, nil
-}
-
-// GetOrCreateForApp creates a new authorization for the specified OAuth
-// application, only if an authorization for that application doesn’t already
-// exist for the user.
-//
-// If a new token is created, the HTTP status code will be "201 Created", and
-// the returned Authorization.Token field will be populated. If an existing
-// token is returned, the status code will be "200 OK" and the
-// Authorization.Token field will be empty.
-//
-// clientID is the OAuth Client ID with which to create the token.
-//
-// GitHub API docs:
-// https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app
-// https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint
-func (s *AuthorizationsService) GetOrCreateForApp(ctx context.Context, clientID string, auth *AuthorizationRequest) (*Authorization, *Response, error) {
-	var u string
-	if auth.Fingerprint == nil || *auth.Fingerprint == "" {
-		u = fmt.Sprintf("authorizations/clients/%v", clientID)
-	} else {
-		u = fmt.Sprintf("authorizations/clients/%v/%v", clientID, *auth.Fingerprint)
-	}
-
-	req, err := s.client.NewRequest("PUT", u, auth)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	a := new(Authorization)
-	resp, err := s.client.Do(ctx, req, a)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return a, resp, nil
-}
-
-// Edit a single authorization.
-//
-// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#update-an-existing-authorization
-func (s *AuthorizationsService) Edit(ctx context.Context, id int64, auth *AuthorizationUpdateRequest) (*Authorization, *Response, error) {
-	u := fmt.Sprintf("authorizations/%d", id)
-
-	req, err := s.client.NewRequest("PATCH", u, auth)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	a := new(Authorization)
-	resp, err := s.client.Do(ctx, req, a)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return a, resp, nil
-}
-
-// Delete a single authorization.
-//
-// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#delete-an-authorization
-func (s *AuthorizationsService) Delete(ctx context.Context, id int64) (*Response, error) {
-	u := fmt.Sprintf("authorizations/%d", id)
-
-	req, err := s.client.NewRequest("DELETE", u, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.client.Do(ctx, req, nil)
-}
-
 // Check if an OAuth token is valid for a specific app.
 //
 // Note that this operation requires the use of BasicAuth, but where the
@@ -273,11 +142,15 @@ func (s *AuthorizationsService) Delete(ctx context.Context, id int64) (*Response
 //
 // The returned Authorization.User field will be populated.
 //
-// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#check-an-authorization
-func (s *AuthorizationsService) Check(ctx context.Context, clientID string, token string) (*Authorization, *Response, error) {
-	u := fmt.Sprintf("applications/%v/tokens/%v", clientID, token)
+// GitHub API docs: https://developer.github.com/v3/apps/oauth_applications/#check-a-token
+func (s *AuthorizationsService) Check(ctx context.Context, clientID, accessToken string) (*Authorization, *Response, error) {
+	u := fmt.Sprintf("applications/%v/token", clientID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	reqBody := &struct {
+		AccessToken string `json:"access_token"`
+	}{AccessToken: accessToken}
+
+	req, err := s.client.NewRequest("POST", u, reqBody)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -301,11 +174,15 @@ func (s *AuthorizationsService) Check(ctx context.Context, clientID string, toke
 //
 // The returned Authorization.User field will be populated.
 //
-// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#reset-an-authorization
-func (s *AuthorizationsService) Reset(ctx context.Context, clientID string, token string) (*Authorization, *Response, error) {
-	u := fmt.Sprintf("applications/%v/tokens/%v", clientID, token)
+// GitHub API docs: https://developer.github.com/v3/apps/oauth_applications/#reset-a-token
+func (s *AuthorizationsService) Reset(ctx context.Context, clientID, accessToken string) (*Authorization, *Response, error) {
+	u := fmt.Sprintf("applications/%v/token", clientID)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	reqBody := &struct {
+		AccessToken string `json:"access_token"`
+	}{AccessToken: accessToken}
+
+	req, err := s.client.NewRequest("PATCH", u, reqBody)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -325,11 +202,15 @@ func (s *AuthorizationsService) Reset(ctx context.Context, clientID string, toke
 // username is the OAuth application clientID, and the password is its
 // clientSecret. Invalid tokens will return a 404 Not Found.
 //
-// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#revoke-an-authorization-for-an-application
-func (s *AuthorizationsService) Revoke(ctx context.Context, clientID string, token string) (*Response, error) {
-	u := fmt.Sprintf("applications/%v/tokens/%v", clientID, token)
+// GitHub API docs: https://developer.github.com/v3/apps/oauth_applications/#delete-an-app-token
+func (s *AuthorizationsService) Revoke(ctx context.Context, clientID, accessToken string) (*Response, error) {
+	u := fmt.Sprintf("applications/%v/token", clientID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	reqBody := &struct {
+		AccessToken string `json:"access_token"`
+	}{AccessToken: accessToken}
+
+	req, err := s.client.NewRequest("DELETE", u, reqBody)
 	if err != nil {
 		return nil, err
 	}
@@ -337,59 +218,19 @@ func (s *AuthorizationsService) Revoke(ctx context.Context, clientID string, tok
 	return s.client.Do(ctx, req, nil)
 }
 
-// ListGrants lists the set of OAuth applications that have been granted
-// access to a user's account. This will return one entry for each application
-// that has been granted access to the account, regardless of the number of
-// tokens an application has generated for the user.
-//
-// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#list-your-grants
-func (s *AuthorizationsService) ListGrants(ctx context.Context, opts *ListOptions) ([]*Grant, *Response, error) {
-	u, err := addOptions("applications/grants", opts)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	req, err := s.client.NewRequest("GET", u, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	grants := []*Grant{}
-	resp, err := s.client.Do(ctx, req, &grants)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return grants, resp, nil
-}
-
-// GetGrant gets a single OAuth application grant.
-//
-// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#get-a-single-grant
-func (s *AuthorizationsService) GetGrant(ctx context.Context, id int64) (*Grant, *Response, error) {
-	u := fmt.Sprintf("applications/grants/%d", id)
-	req, err := s.client.NewRequest("GET", u, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	grant := new(Grant)
-	resp, err := s.client.Do(ctx, req, grant)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return grant, resp, nil
-}
-
 // DeleteGrant deletes an OAuth application grant. Deleting an application's
 // grant will also delete all OAuth tokens associated with the application for
 // the user.
 //
-// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#delete-a-grant
-func (s *AuthorizationsService) DeleteGrant(ctx context.Context, id int64) (*Response, error) {
-	u := fmt.Sprintf("applications/grants/%d", id)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+// GitHub API docs: https://developer.github.com/v3/apps/oauth_applications/#delete-an-app-authorization
+func (s *AuthorizationsService) DeleteGrant(ctx context.Context, clientID, accessToken string) (*Response, error) {
+	u := fmt.Sprintf("applications/%v/grant", clientID)
+
+	reqBody := &struct {
+		AccessToken string `json:"access_token"`
+	}{AccessToken: accessToken}
+
+	req, err := s.client.NewRequest("DELETE", u, reqBody)
 	if err != nil {
 		return nil, err
 	}

--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -43,10 +43,6 @@ const (
 	ScopeAdminGPGKey    Scope = "admin:gpg_key"
 )
 
-const (
-	mediaTypeOAuthAppPreview = "application/vnd.github.doctor-strange-preview+json"
-)
-
 // AuthorizationsService handles communication with the authorization related
 // methods of the GitHub API.
 //

--- a/github/authorizations_test.go
+++ b/github/authorizations_test.go
@@ -20,6 +20,7 @@ func TestAuthorizationsService_Check(t *testing.T) {
 	mux.HandleFunc("/applications/id/token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testBody(t, r, `{"access_token":"a"}`+"\n")
+		testHeader(t, r, "Accept", mediaTypeOAuthAppPreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -41,6 +42,7 @@ func TestAuthorizationsService_Reset(t *testing.T) {
 	mux.HandleFunc("/applications/id/token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
 		testBody(t, r, `{"access_token":"a"}`+"\n")
+		testHeader(t, r, "Accept", mediaTypeOAuthAppPreview)
 		fmt.Fprint(w, `{"ID":1}`)
 	})
 
@@ -62,6 +64,7 @@ func TestAuthorizationsService_Revoke(t *testing.T) {
 	mux.HandleFunc("/applications/id/token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		testBody(t, r, `{"access_token":"a"}`+"\n")
+		testHeader(t, r, "Accept", mediaTypeOAuthAppPreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -78,6 +81,7 @@ func TestDeleteGrant(t *testing.T) {
 	mux.HandleFunc("/applications/id/grant", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		testBody(t, r, `{"access_token":"a"}`+"\n")
+		testHeader(t, r, "Accept", mediaTypeOAuthAppPreview)
 	})
 
 	_, err := client.Authorizations.DeleteGrant(context.Background(), "id", "a")

--- a/github/authorizations_test.go
+++ b/github/authorizations_test.go
@@ -7,205 +7,23 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
 )
 
-func TestAuthorizationsService_List(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/authorizations", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		testFormValues(t, r, values{"page": "1", "per_page": "2"})
-		fmt.Fprint(w, `[{"id":1}]`)
-	})
-
-	opt := &ListOptions{Page: 1, PerPage: 2}
-	got, _, err := client.Authorizations.List(context.Background(), opt)
-	if err != nil {
-		t.Errorf("Authorizations.List returned error: %v", err)
-	}
-
-	want := []*Authorization{{ID: Int64(1)}}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Authorizations.List returned %+v, want %+v", *got[0].ID, *want[0].ID)
-	}
-}
-
-func TestAuthorizationsService_Get(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/authorizations/1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"id":1}`)
-	})
-
-	got, _, err := client.Authorizations.Get(context.Background(), 1)
-	if err != nil {
-		t.Errorf("Authorizations.Get returned error: %v", err)
-	}
-
-	want := &Authorization{ID: Int64(1)}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Authorizations.Get returned auth %+v, want %+v", got, want)
-	}
-}
-
-func TestAuthorizationsService_Create(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	input := &AuthorizationRequest{
-		Note: String("test"),
-	}
-
-	mux.HandleFunc("/authorizations", func(w http.ResponseWriter, r *http.Request) {
-		v := new(AuthorizationRequest)
-		json.NewDecoder(r.Body).Decode(v)
-
-		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
-		}
-
-		fmt.Fprint(w, `{"ID":1}`)
-	})
-
-	got, _, err := client.Authorizations.Create(context.Background(), input)
-	if err != nil {
-		t.Errorf("Authorizations.Create returned error: %v", err)
-	}
-
-	want := &Authorization{ID: Int64(1)}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Authorization.Create returned %+v, want %+v", got, want)
-	}
-}
-
-func TestAuthorizationsService_GetOrCreateForApp(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	input := &AuthorizationRequest{
-		Note: String("test"),
-	}
-
-	mux.HandleFunc("/authorizations/clients/id", func(w http.ResponseWriter, r *http.Request) {
-		v := new(AuthorizationRequest)
-		json.NewDecoder(r.Body).Decode(v)
-
-		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
-		}
-
-		fmt.Fprint(w, `{"ID":1}`)
-	})
-
-	got, _, err := client.Authorizations.GetOrCreateForApp(context.Background(), "id", input)
-	if err != nil {
-		t.Errorf("Authorizations.GetOrCreateForApp returned error: %v", err)
-	}
-
-	want := &Authorization{ID: Int64(1)}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Authorization.GetOrCreateForApp returned %+v, want %+v", got, want)
-	}
-}
-
-func TestAuthorizationsService_GetOrCreateForApp_Fingerprint(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	input := &AuthorizationRequest{
-		Note:        String("test"),
-		Fingerprint: String("fp"),
-	}
-
-	mux.HandleFunc("/authorizations/clients/id/fp", func(w http.ResponseWriter, r *http.Request) {
-		v := new(AuthorizationRequest)
-		json.NewDecoder(r.Body).Decode(v)
-
-		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
-		}
-
-		fmt.Fprint(w, `{"ID":1}`)
-	})
-
-	got, _, err := client.Authorizations.GetOrCreateForApp(context.Background(), "id", input)
-	if err != nil {
-		t.Errorf("Authorizations.GetOrCreateForApp returned error: %v", err)
-	}
-
-	want := &Authorization{ID: Int64(1)}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Authorization.GetOrCreateForApp returned %+v, want %+v", got, want)
-	}
-}
-
-func TestAuthorizationsService_Edit(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	input := &AuthorizationUpdateRequest{
-		Note: String("test"),
-	}
-
-	mux.HandleFunc("/authorizations/1", func(w http.ResponseWriter, r *http.Request) {
-		v := new(AuthorizationUpdateRequest)
-		json.NewDecoder(r.Body).Decode(v)
-
-		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
-		}
-
-		fmt.Fprint(w, `{"ID":1}`)
-	})
-
-	got, _, err := client.Authorizations.Edit(context.Background(), 1, input)
-	if err != nil {
-		t.Errorf("Authorizations.Edit returned error: %v", err)
-	}
-
-	want := &Authorization{ID: Int64(1)}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Authorization.Update returned %+v, want %+v", got, want)
-	}
-}
-
-func TestAuthorizationsService_Delete(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/authorizations/1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	_, err := client.Authorizations.Delete(context.Background(), 1)
-	if err != nil {
-		t.Errorf("Authorizations.Delete returned error: %v", err)
-	}
-}
-
 func TestAuthorizationsService_Check(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/applications/id/tokens/t", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+	mux.HandleFunc("/applications/id/token", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testBody(t, r, `{"access_token":"a"}`+"\n")
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	got, _, err := client.Authorizations.Check(context.Background(), "id", "t")
+	got, _, err := client.Authorizations.Check(context.Background(), "id", "a")
 	if err != nil {
 		t.Errorf("Authorizations.Check returned error: %v", err)
 	}
@@ -220,12 +38,13 @@ func TestAuthorizationsService_Reset(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/applications/id/tokens/t", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
+	mux.HandleFunc("/applications/id/token", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		testBody(t, r, `{"access_token":"a"}`+"\n")
 		fmt.Fprint(w, `{"ID":1}`)
 	})
 
-	got, _, err := client.Authorizations.Reset(context.Background(), "id", "t")
+	got, _, err := client.Authorizations.Reset(context.Background(), "id", "a")
 	if err != nil {
 		t.Errorf("Authorizations.Reset returned error: %v", err)
 	}
@@ -240,72 +59,15 @@ func TestAuthorizationsService_Revoke(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/applications/id/tokens/t", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/applications/id/token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
+		testBody(t, r, `{"access_token":"a"}`+"\n")
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Authorizations.Revoke(context.Background(), "id", "t")
+	_, err := client.Authorizations.Revoke(context.Background(), "id", "a")
 	if err != nil {
 		t.Errorf("Authorizations.Revoke returned error: %v", err)
-	}
-}
-
-func TestListGrants(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/applications/grants", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{"id": 1}]`)
-	})
-
-	got, _, err := client.Authorizations.ListGrants(context.Background(), nil)
-	if err != nil {
-		t.Errorf("OAuthAuthorizations.ListGrants returned error: %v", err)
-	}
-
-	want := []*Grant{{ID: Int64(1)}}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("OAuthAuthorizations.ListGrants = %+v, want %+v", got, want)
-	}
-}
-
-func TestListGrants_withOptions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/applications/grants", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		testFormValues(t, r, values{
-			"page": "2",
-		})
-		fmt.Fprint(w, `[{"id": 1}]`)
-	})
-
-	_, _, err := client.Authorizations.ListGrants(context.Background(), &ListOptions{Page: 2})
-	if err != nil {
-		t.Errorf("OAuthAuthorizations.ListGrants returned error: %v", err)
-	}
-}
-
-func TestGetGrant(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/applications/grants/1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"id": 1}`)
-	})
-
-	got, _, err := client.Authorizations.GetGrant(context.Background(), 1)
-	if err != nil {
-		t.Errorf("OAuthAuthorizations.GetGrant returned error: %v", err)
-	}
-
-	want := &Grant{ID: Int64(1)}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("OAuthAuthorizations.GetGrant = %+v, want %+v", got, want)
 	}
 }
 
@@ -313,11 +75,12 @@ func TestDeleteGrant(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/applications/grants/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/applications/id/grant", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
+		testBody(t, r, `{"access_token":"a"}`+"\n")
 	})
 
-	_, err := client.Authorizations.DeleteGrant(context.Background(), 1)
+	_, err := client.Authorizations.DeleteGrant(context.Background(), "id", "a")
 	if err != nil {
 		t.Errorf("OAuthAuthorizations.DeleteGrant returned error: %v", err)
 	}

--- a/github/github.go
+++ b/github/github.go
@@ -136,7 +136,7 @@ const (
 	// https://developer.github.com/changes/2019-10-03-multi-line-comments/
 	mediaTypeMultiLineCommentsPreview = "application/vnd.github.comfort-fade-preview+json"
 
-	// https://developer.github.com/v3/previews/#new-oauth-applications-api-endpoints
+	// https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/
 	mediaTypeOAuthAppPreview = "application/vnd.github.doctor-strange-preview+json"
 )
 

--- a/github/github.go
+++ b/github/github.go
@@ -135,6 +135,9 @@ const (
 
 	// https://developer.github.com/changes/2019-10-03-multi-line-comments/
 	mediaTypeMultiLineCommentsPreview = "application/vnd.github.comfort-fade-preview+json"
+
+	// https://developer.github.com/v3/previews/#new-oauth-applications-api-endpoints
+	mediaTypeOAuthAppPreview = "application/vnd.github.doctor-strange-preview+json"
 )
 
 // A Client manages communication with the GitHub API.

--- a/test/integration/authorizations_test.go
+++ b/test/integration/authorizations_test.go
@@ -24,124 +24,27 @@ const envKeyGitHubUsername = "GITHUB_USERNAME"
 const envKeyGitHubPassword = "GITHUB_PASSWORD"
 const envKeyClientID = "GITHUB_CLIENT_ID"
 const envKeyClientSecret = "GITHUB_CLIENT_SECRET"
+const envKeyAccessToken = "GITHUB_ACCESS_TOKEN"
 const InvalidTokenValue = "iamnotacroken"
-
-// TestAuthorizationsBasicOperations tests the basic CRUD operations of the API (mostly for
-// the Personal Access Token scenario).
-func TestAuthorizationsBasicOperations(t *testing.T) {
-
-	client := getUserPassClient(t)
-
-	auths, resp, err := client.Authorizations.List(context.Background(), nil)
-	failOnError(t, err)
-	failIfNotStatusCode(t, resp, 200)
-
-	initialAuthCount := len(auths)
-
-	authReq := generatePersonalAuthTokenRequest()
-
-	createdAuth, resp, err := client.Authorizations.Create(context.Background(), authReq)
-	failOnError(t, err)
-	failIfNotStatusCode(t, resp, 201)
-
-	if *authReq.Note != *createdAuth.Note {
-		t.Fatal("Returned Authorization does not match the requested Authorization.")
-	}
-
-	auths, resp, err = client.Authorizations.List(context.Background(), nil)
-	failOnError(t, err)
-	failIfNotStatusCode(t, resp, 200)
-
-	if len(auths) != initialAuthCount+1 {
-		t.Fatalf("The number of Authorizations should have increased. Expected [%v], was [%v]", initialAuthCount+1, len(auths))
-	}
-
-	// Test updating the authorization
-	authUpdate := new(github.AuthorizationUpdateRequest)
-	authUpdate.Note = github.String("Updated note: " + randString())
-
-	updatedAuth, resp, err := client.Authorizations.Edit(context.Background(), *createdAuth.ID, authUpdate)
-	failOnError(t, err)
-	failIfNotStatusCode(t, resp, 200)
-
-	if *updatedAuth.Note != *authUpdate.Note {
-		t.Fatal("The returned Authorization does not match the requested updated value.")
-	}
-
-	// Verify that the Get operation also reflects the update
-	retrievedAuth, resp, err := client.Authorizations.Get(context.Background(), *createdAuth.ID)
-	failOnError(t, err)
-	failIfNotStatusCode(t, resp, 200)
-
-	if *retrievedAuth.Note != *updatedAuth.Note {
-		t.Fatal("The retrieved Authorization does not match the expected (updated) value.")
-	}
-
-	// Now, let's delete...
-	resp, err = client.Authorizations.Delete(context.Background(), *createdAuth.ID)
-	failOnError(t, err)
-	failIfNotStatusCode(t, resp, 204)
-
-	// Verify that we can no longer retrieve the auth
-	retrievedAuth, resp, err = client.Authorizations.Get(context.Background(), *createdAuth.ID)
-	if err == nil {
-		t.Fatal("Should have failed due to 404")
-	}
-	failIfNotStatusCode(t, resp, 404)
-
-	// Verify that our count reset back to the initial value
-	auths, resp, err = client.Authorizations.List(context.Background(), nil)
-	failOnError(t, err)
-	failIfNotStatusCode(t, resp, 200)
-
-	if len(auths) != initialAuthCount {
-		t.Fatalf("The number of Authorizations should match the initial count Expected [%v], got [%v]", initialAuthCount, len(auths))
-	}
-
-}
 
 // TestAuthorizationsAppOperations tests the application/token related operations, such
 // as creating, testing, resetting and revoking application OAuth tokens.
 func TestAuthorizationsAppOperations(t *testing.T) {
-
-	userAuthenticatedClient := getUserPassClient(t)
 
 	appAuthenticatedClient := getOAuthAppClient(t)
 
 	// We know these vars are set because getOAuthAppClient would have
 	// skipped the test by now
 	clientID := os.Getenv(envKeyClientID)
-	clientSecret := os.Getenv(envKeyClientSecret)
-
-	authRequest := generateAppAuthTokenRequest(clientID, clientSecret)
-
-	createdAuth, resp, err := userAuthenticatedClient.Authorizations.GetOrCreateForApp(context.Background(), clientID, authRequest)
-	failOnError(t, err)
-	failIfNotStatusCode(t, resp, 201)
-
-	// Quick sanity check:
-	if *createdAuth.Note != *authRequest.Note {
-		t.Fatal("The returned auth does not match expected value.")
-	}
-
-	// Let's try the same request again, this time it should return the same
-	// auth instead of creating a new one
-	secondAuth, resp, err := userAuthenticatedClient.Authorizations.GetOrCreateForApp(context.Background(), clientID, authRequest)
-	failOnError(t, err)
-	failIfNotStatusCode(t, resp, 200)
-
-	// Verify that the IDs are the same
-	if *createdAuth.ID != *secondAuth.ID {
-		t.Fatalf("The ID of the second returned auth should be the same as the first. Expected [%v], got [%v]", createdAuth.ID, secondAuth.ID)
-	}
+	accessToken := os.Getenv(envKeyAccessToken)
 
 	// Verify the token
-	appAuth, resp, err := appAuthenticatedClient.Authorizations.Check(context.Background(), clientID, *createdAuth.Token)
+	appAuth, resp, err := appAuthenticatedClient.Authorizations.Check(context.Background(), clientID, accessToken)
 	failOnError(t, err)
 	failIfNotStatusCode(t, resp, 200)
 
 	// Quick sanity check
-	if *appAuth.ID != *createdAuth.ID || *appAuth.Token != *createdAuth.Token {
+	if *appAuth.Token != accessToken {
 		t.Fatal("The returned auth/token does not match.")
 	}
 
@@ -153,7 +56,7 @@ func TestAuthorizationsAppOperations(t *testing.T) {
 	failIfNotStatusCode(t, resp, 404)
 
 	// Let's reset the token
-	resetAuth, resp, err := appAuthenticatedClient.Authorizations.Reset(context.Background(), clientID, *createdAuth.Token)
+	resetAuth, resp, err := appAuthenticatedClient.Authorizations.Reset(context.Background(), clientID, accessToken)
 	failOnError(t, err)
 	failIfNotStatusCode(t, resp, 200)
 
@@ -165,7 +68,7 @@ func TestAuthorizationsAppOperations(t *testing.T) {
 	failIfNotStatusCode(t, resp, 404)
 
 	// Verify that the token has changed
-	if resetAuth.Token == createdAuth.Token {
+	if *resetAuth.Token == accessToken {
 		t.Fatal("The reset token should be different from the original.")
 	}
 
@@ -175,7 +78,7 @@ func TestAuthorizationsAppOperations(t *testing.T) {
 	}
 
 	// Verify that the original token is now invalid
-	_, resp, err = appAuthenticatedClient.Authorizations.Check(context.Background(), clientID, *createdAuth.Token)
+	_, resp, err = appAuthenticatedClient.Authorizations.Check(context.Background(), clientID, accessToken)
 	if err == nil {
 		t.Fatal("The original token should be invalid.")
 	}


### PR DESCRIPTION
Updates based on https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters

Fixes #1331.