### PR TITLE
Update the comment for NewEnterpriseClient

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -296,7 +296,7 @@ func NewClient(httpClient *http.Client) *Client {
 // NewEnterpriseClient returns a new GitHub API client with provided
 // base URL and upload URL (often the same URL and is your GitHub Enterprise hostname).
 // If either URL does not have the suffix "/api/v3/", it will be added automatically.
-// If a nil httpClient is provided, http.DefaultClient will be used.
+// If a nil httpClient is provided, a new http.Client will be used.
 //
 // Note that NewEnterpriseClient is a convenience helper only;
 // its behavior is equivalent to using NewClient, followed by setting


### PR DESCRIPTION
In the pull request #1178, the behavior on the client instantiation change to use a new `http.Client` instead of using the `http.DefaultClient`. This change is reflected in the comment block for `NewClient` but not for `NewEnterpriseClient` .