### PR TITLE
[Proposal] pull_request: add GetLabels function to get the labels from a PR

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -8284,6 +8284,14 @@ func (p *PullRequest) GetIssueURL() string {
 	return *p.IssueURL
 }
 
+// GetLabels returns the Labels field if it's non-nil, zero value otherwise.
+func (p *PullRequest) GetLabels() []*Label {
+	if p == nil || p.Labels == nil {
+		return nil
+	}
+	return p.Labels
+}
+
 // GetLinks returns the Links field.
 func (p *PullRequest) GetLinks() *PRLinks {
 	if p == nil {


### PR DESCRIPTION
Add GetLabels for a PR

When I receive the webhook event for a PR it comes with the PR struct as well and in my use case, I need also to get in a nice way the existing labels for that PR.