### PR TITLE
Update anchor with GitHub API docs in annotation

### DIFF
--- a/github/issues.go
+++ b/github/issues.go
@@ -215,7 +215,7 @@ type IssueListByRepoOptions struct {
 
 // ListByRepo lists the issues for the specified repository.
 //
-// GitHub API docs: https://developer.github.com/v3/issues/#list-issues-for-a-repository
+// GitHub API docs: https://developer.github.com/v3/issues/#list-repository-issues
 func (s *IssuesService) ListByRepo(ctx context.Context, owner string, repo string, opts *IssueListByRepoOptions) ([]*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues", owner, repo)
 	u, err := addOptions(u, opts)


### PR DESCRIPTION
Hi,

I found a very small problem when using [go-github](https://github.com/google/go-github). 

`https://developer.github.com/v3/issues/#list-issues-for-a-repository` is exists, but the anchor point (`#list-issues-for-a-repository`) is invalid.

I try to find the correct anchor point (`#list-repository-issues`) and update the corresponding content of the annotation.

This is a sacred moment for me! Please check it.
