### PR TITLE
Update IdP team-sync list and create/update endpoints with ByID and BySlug

### DIFF
--- a/github/teams.go
+++ b/github/teams.go
@@ -765,10 +765,31 @@ func (s *TeamsService) ListIDPGroupsInOrganization(ctx context.Context, org stri
 	return groups, resp, nil
 }
 
-// ListIDPGroupsForTeam lists IDP groups connected to a team on GitHub.
+// ListIDPGroupsForTeamByID lists IDP groups connected to a team on GitHub
+// given organization and team IDs.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/team_sync/#list-idp-groups-for-a-team
-func (s *TeamsService) ListIDPGroupsForTeam(ctx context.Context, org, slug string) (*IDPGroupList, *Response, error) {
+func (s *TeamsService) ListIDPGroupsForTeamByID(ctx context.Context, orgID, teamID int64) (*IDPGroupList, *Response, error) {
+	u := fmt.Sprintf("organizations/%v/team/%v/team-sync/group-mappings", orgID, teamID)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	groups := new(IDPGroupList)
+	resp, err := s.client.Do(ctx, req, groups)
+	if err != nil {
+		return nil, resp, err
+	}
+	return groups, resp, err
+}
+
+// ListIDPGroupsForTeamBySlug lists IDP groups connected to a team on GitHub
+// given organization name and team slug.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/team_sync/#list-idp-groups-for-a-team
+func (s *TeamsService) ListIDPGroupsForTeamBySlug(ctx context.Context, org, slug string) (*IDPGroupList, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/team-sync/group-mappings", org, slug)
 
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -784,11 +805,32 @@ func (s *TeamsService) ListIDPGroupsForTeam(ctx context.Context, org, slug strin
 	return groups, resp, err
 }
 
-// CreateOrUpdateIDPGroupConnections creates, updates, or removes a connection between a team
-// and an IDP group.
+// CreateOrUpdateIDPGroupConnectionsByID creates, updates, or removes a connection
+// between a team and an IDP group given organization and team IDs.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/team_sync/#create-or-update-idp-group-connections
-func (s *TeamsService) CreateOrUpdateIDPGroupConnections(ctx context.Context, org, slug string, opts IDPGroupList) (*IDPGroupList, *Response, error) {
+func (s *TeamsService) CreateOrUpdateIDPGroupConnectionsByID(ctx context.Context, orgID, teamID int64, opts IDPGroupList) (*IDPGroupList, *Response, error) {
+	u := fmt.Sprintf("organizations/%v/team/%v/team-sync/group-mappings", orgID, teamID)
+
+	req, err := s.client.NewRequest("PATCH", u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	groups := new(IDPGroupList)
+	resp, err := s.client.Do(ctx, req, groups)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return groups, resp, nil
+}
+
+// CreateOrUpdateIDPGroupConnectionsBySlug creates, updates, or removes a connection
+// between a team and an IDP group given organization name and team slug.
+//
+// GitHub API docs: https://developer.github.com/v3/teams/team_sync/#create-or-update-idp-group-connections
+func (s *TeamsService) CreateOrUpdateIDPGroupConnectionsBySlug(ctx context.Context, org, slug string, opts IDPGroupList) (*IDPGroupList, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/team-sync/group-mappings", org, slug)
 
 	req, err := s.client.NewRequest("PATCH", u, opts)

--- a/github/teams.go
+++ b/github/teams.go
@@ -768,8 +768,8 @@ func (s *TeamsService) ListIDPGroupsInOrganization(ctx context.Context, org stri
 // ListIDPGroupsForTeam lists IDP groups connected to a team on GitHub.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/team_sync/#list-idp-groups-for-a-team
-func (s *TeamsService) ListIDPGroupsForTeam(ctx context.Context, teamID string) (*IDPGroupList, *Response, error) {
-	u := fmt.Sprintf("teams/%v/team-sync/group-mappings", teamID)
+func (s *TeamsService) ListIDPGroupsForTeam(ctx context.Context, org, slug string) (*IDPGroupList, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/teams/%v/team-sync/group-mappings", org, slug)
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -788,8 +788,8 @@ func (s *TeamsService) ListIDPGroupsForTeam(ctx context.Context, teamID string) 
 // and an IDP group.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/team_sync/#create-or-update-idp-group-connections
-func (s *TeamsService) CreateOrUpdateIDPGroupConnections(ctx context.Context, teamID string, opts IDPGroupList) (*IDPGroupList, *Response, error) {
-	u := fmt.Sprintf("teams/%v/team-sync/group-mappings", teamID)
+func (s *TeamsService) CreateOrUpdateIDPGroupConnections(ctx context.Context, org, slug string, opts IDPGroupList) (*IDPGroupList, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/teams/%v/team-sync/group-mappings", org, slug)
 
 	req, err := s.client.NewRequest("PATCH", u, opts)
 	if err != nil {

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -946,18 +946,18 @@ func TestTeamsService_ListIDPGroupsInOrganization(t *testing.T) {
 	}
 }
 
-func TestTeamsService_ListIDPGroupsForTeam(t *testing.T) {
+func TestTeamsService_ListIDPGroupsForTeamByID(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/o/teams/slug/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/organizations/1/team/1/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"groups": [{"group_id": "1",  "group_name": "n", "group_description": "d"}]}`)
 	})
 
-	groups, _, err := client.Teams.ListIDPGroupsForTeam(context.Background(), "o", "slug")
+	groups, _, err := client.Teams.ListIDPGroupsForTeamByID(context.Background(), 1, 1)
 	if err != nil {
-		t.Errorf("Teams.ListIDPGroupsForTeam returned error: %v", err)
+		t.Errorf("Teams.ListIDPGroupsForTeamByID returned error: %v", err)
 	}
 
 	want := &IDPGroupList{
@@ -970,11 +970,77 @@ func TestTeamsService_ListIDPGroupsForTeam(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(groups, want) {
-		t.Errorf("Teams.ListIDPGroupsForTeam returned %+v. want %+v", groups, want)
+		t.Errorf("Teams.ListIDPGroupsForTeamByID returned %+v. want %+v", groups, want)
 	}
 }
 
-func TestTeamsService_CreateOrUpdateIDPGroupConnections(t *testing.T) {
+func TestTeamsService_ListIDPGroupsForTeamBySlug(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/teams/slug/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"groups": [{"group_id": "1",  "group_name": "n", "group_description": "d"}]}`)
+	})
+
+	groups, _, err := client.Teams.ListIDPGroupsForTeamBySlug(context.Background(), "o", "slug")
+	if err != nil {
+		t.Errorf("Teams.ListIDPGroupsForTeamBySlug returned error: %v", err)
+	}
+
+	want := &IDPGroupList{
+		Groups: []*IDPGroup{
+			{
+				GroupID:          String("1"),
+				GroupName:        String("n"),
+				GroupDescription: String("d"),
+			},
+		},
+	}
+	if !reflect.DeepEqual(groups, want) {
+		t.Errorf("Teams.ListIDPGroupsForTeamBySlug returned %+v. want %+v", groups, want)
+	}
+}
+
+func TestTeamsService_CreateOrUpdateIDPGroupConnectionsByID(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/organizations/1/team/1/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		fmt.Fprint(w, `{"groups": [{"group_id": "1",  "group_name": "n", "group_description": "d"}]}`)
+	})
+
+	input := IDPGroupList{
+		Groups: []*IDPGroup{
+			{
+				GroupID:          String("1"),
+				GroupName:        String("n"),
+				GroupDescription: String("d"),
+			},
+		},
+	}
+
+	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsByID(context.Background(), 1, 1, input)
+	if err != nil {
+		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsByID returned error: %v", err)
+	}
+
+	want := &IDPGroupList{
+		Groups: []*IDPGroup{
+			{
+				GroupID:          String("1"),
+				GroupName:        String("n"),
+				GroupDescription: String("d"),
+			},
+		},
+	}
+	if !reflect.DeepEqual(groups, want) {
+		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsByID returned %+v. want %+v", groups, want)
+	}
+}
+
+func TestTeamsService_CreateOrUpdateIDPGroupConnectionsBySlug(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -993,9 +1059,9 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnections(t *testing.T) {
 		},
 	}
 
-	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnections(context.Background(), "o", "slug", input)
+	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsBySlug(context.Background(), "o", "slug", input)
 	if err != nil {
-		t.Errorf("Teams.CreateOrUpdateIDPGroupConnections returned error: %v", err)
+		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsBySlug returned error: %v", err)
 	}
 
 	want := &IDPGroupList{
@@ -1008,11 +1074,36 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnections(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(groups, want) {
-		t.Errorf("Teams.CreateOrUpdateIDPGroupConnections returned %+v. want %+v", groups, want)
+		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsBySlug returned %+v. want %+v", groups, want)
+	}
+}
+func TestTeamsService_CreateOrUpdateIDPGroupConnectionsByID_empty(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/organizations/1/team/1/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		fmt.Fprint(w, `{"groups": []}`)
+	})
+
+	input := IDPGroupList{
+		Groups: []*IDPGroup{},
+	}
+
+	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsByID(context.Background(), 1, 1, input)
+	if err != nil {
+		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsByID returned error: %v", err)
+	}
+
+	want := &IDPGroupList{
+		Groups: []*IDPGroup{},
+	}
+	if !reflect.DeepEqual(groups, want) {
+		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsByID returned %+v. want %+v", groups, want)
 	}
 }
 
-func TestTeamsService_CreateOrUpdateIDPGroupConnections_empty(t *testing.T) {
+func TestTeamsService_CreateOrUpdateIDPGroupConnectionsBySlug_empty(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -1025,15 +1116,15 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnections_empty(t *testing.T) {
 		Groups: []*IDPGroup{},
 	}
 
-	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnections(context.Background(), "o", "slug", input)
+	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsBySlug(context.Background(), "o", "slug", input)
 	if err != nil {
-		t.Errorf("Teams.CreateOrUpdateIDPGroupConnections returned error: %v", err)
+		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsBySlug returned error: %v", err)
 	}
 
 	want := &IDPGroupList{
 		Groups: []*IDPGroup{},
 	}
 	if !reflect.DeepEqual(groups, want) {
-		t.Errorf("Teams.CreateOrUpdateIDPGroupConnections returned %+v. want %+v", groups, want)
+		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsBySlug returned %+v. want %+v", groups, want)
 	}
 }

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -950,12 +950,12 @@ func TestTeamsService_ListIDPGroupsForTeam(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/teams/1/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/teams/slug/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"groups": [{"group_id": "1",  "group_name": "n", "group_description": "d"}]}`)
 	})
 
-	groups, _, err := client.Teams.ListIDPGroupsForTeam(context.Background(), "1")
+	groups, _, err := client.Teams.ListIDPGroupsForTeam(context.Background(), "o", "slug")
 	if err != nil {
 		t.Errorf("Teams.ListIDPGroupsForTeam returned error: %v", err)
 	}
@@ -978,7 +978,7 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnections(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/teams/1/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/teams/slug/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
 		fmt.Fprint(w, `{"groups": [{"group_id": "1",  "group_name": "n", "group_description": "d"}]}`)
 	})
@@ -993,7 +993,7 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnections(t *testing.T) {
 		},
 	}
 
-	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnections(context.Background(), "1", input)
+	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnections(context.Background(), "o", "slug", input)
 	if err != nil {
 		t.Errorf("Teams.CreateOrUpdateIDPGroupConnections returned error: %v", err)
 	}
@@ -1016,7 +1016,7 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnections_empty(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/teams/1/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/teams/slug/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
 		fmt.Fprint(w, `{"groups": []}`)
 	})
@@ -1025,7 +1025,7 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnections_empty(t *testing.T) {
 		Groups: []*IDPGroup{},
 	}
 
-	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnections(context.Background(), "1", input)
+	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnections(context.Background(), "o", "slug", input)
 	if err != nil {
 		t.Errorf("Teams.CreateOrUpdateIDPGroupConnections returned error: %v", err)
 	}


### PR DESCRIPTION
Addresses Issue #1483 
Changes include:
* Update method signatures of `#ListIDPGroupsForTeam` and `#CreateOrUpdateIDPGroupConnections`  to include the organization name identified as `org` and rename the `teamID` attribute to `slug` as it can be misleading/the api requires the slug for these particular calls
* Update respective tests with corrected arguments