### PR TITLE
Fix receivers and other breaking changes

### DIFF
--- a/github/gitignore.go
+++ b/github/gitignore.go
@@ -29,7 +29,7 @@ func (g Gitignore) String() string {
 // List all available Gitignore templates.
 //
 // GitHub API docs: https://developer.github.com/v3/gitignore/#listing-available-templates
-func (s GitignoresService) List(ctx context.Context) ([]string, *Response, error) {
+func (s *GitignoresService) List(ctx context.Context) ([]string, *Response, error) {
 	req, err := s.client.NewRequest("GET", "gitignore/templates", nil)
 	if err != nil {
 		return nil, nil, err
@@ -47,7 +47,7 @@ func (s GitignoresService) List(ctx context.Context) ([]string, *Response, error
 // Get a Gitignore by name.
 //
 // GitHub API docs: https://developer.github.com/v3/gitignore/#get-a-single-template
-func (s GitignoresService) Get(ctx context.Context, name string) (*Gitignore, *Response, error) {
+func (s *GitignoresService) Get(ctx context.Context, name string) (*Gitignore, *Response, error) {
 	u := fmt.Sprintf("gitignore/templates/%v", name)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/reactions.go
+++ b/github/reactions.go
@@ -89,7 +89,7 @@ func (s *ReactionsService) ListCommentReactions(ctx context.Context, owner, repo
 // The content should have one of the following values: "+1", "-1", "laugh", "confused", "heart", "hooray".
 //
 // GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment
-func (s ReactionsService) CreateCommentReaction(ctx context.Context, owner, repo string, id int64, content string) (*Reaction, *Response, error) {
+func (s *ReactionsService) CreateCommentReaction(ctx context.Context, owner, repo string, id int64, content string) (*Reaction, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions", owner, repo, id)
 
 	body := &Reaction{Content: String(content)}
@@ -161,7 +161,7 @@ func (s *ReactionsService) ListIssueReactions(ctx context.Context, owner, repo s
 // The content should have one of the following values: "+1", "-1", "laugh", "confused", "heart", "hooray".
 //
 // GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue
-func (s ReactionsService) CreateIssueReaction(ctx context.Context, owner, repo string, number int, content string) (*Reaction, *Response, error) {
+func (s *ReactionsService) CreateIssueReaction(ctx context.Context, owner, repo string, number int, content string) (*Reaction, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v/reactions", owner, repo, number)
 
 	body := &Reaction{Content: String(content)}
@@ -233,7 +233,7 @@ func (s *ReactionsService) ListIssueCommentReactions(ctx context.Context, owner,
 // The content should have one of the following values: "+1", "-1", "laugh", "confused", "heart", "hooray".
 //
 // GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment
-func (s ReactionsService) CreateIssueCommentReaction(ctx context.Context, owner, repo string, id int64, content string) (*Reaction, *Response, error) {
+func (s *ReactionsService) CreateIssueCommentReaction(ctx context.Context, owner, repo string, id int64, content string) (*Reaction, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/comments/%v/reactions", owner, repo, id)
 
 	body := &Reaction{Content: String(content)}
@@ -305,7 +305,7 @@ func (s *ReactionsService) ListPullRequestCommentReactions(ctx context.Context, 
 // The content should have one of the following values: "+1", "-1", "laugh", "confused", "heart", "hooray".
 //
 // GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment
-func (s ReactionsService) CreatePullRequestCommentReaction(ctx context.Context, owner, repo string, id int64, content string) (*Reaction, *Response, error) {
+func (s *ReactionsService) CreatePullRequestCommentReaction(ctx context.Context, owner, repo string, id int64, content string) (*Reaction, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%v/reactions", owner, repo, id)
 
 	body := &Reaction{Content: String(content)}
@@ -479,7 +479,7 @@ func (s *ReactionsService) DeleteTeamDiscussionCommentReactionByOrgIDAndTeamID(c
 	return s.deleteReaction(ctx, url)
 }
 
-func (s ReactionsService) deleteReaction(ctx context.Context, url string) (*Response, error) {
+func (s *ReactionsService) deleteReaction(ctx context.Context, url string) (*Response, error) {
 	req, err := s.client.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
 		return nil, err

--- a/github/repos_keys.go
+++ b/github/repos_keys.go
@@ -76,26 +76,6 @@ func (s *RepositoriesService) CreateKey(ctx context.Context, owner string, repo 
 	return k, resp, nil
 }
 
-// EditKey edits a deploy key.
-//
-// GitHub API docs: https://developer.github.com/v3/repos/keys/#edit
-func (s *RepositoriesService) EditKey(ctx context.Context, owner string, repo string, id int64, key *Key) (*Key, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/keys/%v", owner, repo, id)
-
-	req, err := s.client.NewRequest("PATCH", u, key)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	k := new(Key)
-	resp, err := s.client.Do(ctx, req, k)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return k, resp, nil
-}
-
 // DeleteKey deletes a deploy key.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/keys/#delete

--- a/github/repos_keys_test.go
+++ b/github/repos_keys_test.go
@@ -109,43 +109,6 @@ func TestRepositoriesService_CreateKey_invalidOwner(t *testing.T) {
 	testURLParseError(t, err)
 }
 
-func TestRepositoriesService_EditKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	input := &Key{Key: String("k"), Title: String("t")}
-
-	mux.HandleFunc("/repos/o/r/keys/1", func(w http.ResponseWriter, r *http.Request) {
-		v := new(Key)
-		json.NewDecoder(r.Body).Decode(v)
-
-		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
-		}
-
-		fmt.Fprint(w, `{"id":1}`)
-	})
-
-	key, _, err := client.Repositories.EditKey(context.Background(), "o", "r", 1, input)
-	if err != nil {
-		t.Errorf("Repositories.EditKey returned error: %v", err)
-	}
-
-	want := &Key{ID: Int64(1)}
-	if !reflect.DeepEqual(key, want) {
-		t.Errorf("Repositories.EditKey returned %+v, want %+v", key, want)
-	}
-}
-
-func TestRepositoriesService_EditKey_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	_, _, err := client.Repositories.EditKey(context.Background(), "%", "%", 1, nil)
-	testURLParseError(t, err)
-}
-
 func TestRepositoriesService_DeleteKey(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()

--- a/github/users_projects.go
+++ b/github/users_projects.go
@@ -49,7 +49,7 @@ type CreateUserProjectOptions struct {
 //
 // GitHub API docs: https://developer.github.com/v3/projects/#create-a-user-project
 func (s *UsersService) CreateProject(ctx context.Context, opts *CreateUserProjectOptions) (*Project, *Response, error) {
-	u := "users/projects"
+	u := "user/projects"
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
 		return nil, nil, err

--- a/github/users_projects_test.go
+++ b/github/users_projects_test.go
@@ -43,7 +43,7 @@ func TestUsersService_CreateProject(t *testing.T) {
 
 	input := &CreateUserProjectOptions{Name: "Project Name", Body: String("Project body.")}
 
-	mux.HandleFunc("/users/projects", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 


### PR DESCRIPTION
#1477 found a number of problems in the repo that would cause breaking API changes to fix them.

Instead of including them there, it [was decided](https://github.com/google/go-github/pull/1477#pullrequestreview-391172913) to pull the breaking API changes into a separate PR, which is this one.
