### PR TITLE
Add Repository to the RepositoryVulnerabilityAlertEvent struct

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -819,6 +819,9 @@ type RepositoryVulnerabilityAlertEvent struct {
 		DismissReason       *string    `json:"dismiss_reason,omitempty"`
 		DismissedAt         *Timestamp `json:"dismissed_at,omitempty"`
 	} `json:"alert,omitempty"`
+
+	//The repository of the vulnerable dependency.
+	Repository *Repository `json:"repository,omitempty"`
 }
 
 // StarEvent is triggered when a star is added or removed from a repository.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11540,6 +11540,14 @@ func (r *RepositoryVulnerabilityAlertEvent) GetAction() string {
 	return *r.Action
 }
 
+// GetRepository returns the Repository field.
+func (r *RepositoryVulnerabilityAlertEvent) GetRepository() *Repository {
+	if r == nil {
+		return nil
+	}
+	return r.Repository
+}
+
 // GetForkRepos returns the ForkRepos field if it's non-nil, zero value otherwise.
 func (r *RepoStats) GetForkRepos() int {
 	if r == nil || r.ForkRepos == nil {


### PR DESCRIPTION
The RepositoryVulnerabilityAlertEvent payload includes the Repository key which is important to add context to the Alert. The alert by itself does not capture what repo the alert is on.

https://developer.github.com/v3/activity/events/types/#repositoryvulnerabilityalertevent

```
{
    "action": "create",
    "alert": {
      "id": 271940701,
      "affected_range": "< 2.2.3",
      "affected_package_name": "https-proxy-agent",
      "external_reference": "https://github.com/TooTallNate/node-https-proxy-agent/commit/36d8cf509f877fa44f4404fce57ebaf9410fe51b",
      "external_identifier": "WS-2019-0310",
      "ghsa_id": "GHSA-pc5p-h8pf-mvwp",
      "created_at": "2020-04-16T22:28:10Z",
      "fixed_in": "2.2.3"
    },
    "repository": {
// repo details here
    }
```
