### PR TITLE
Update ListRepositoryWorkflowRuns to support all query parameters

### DIFF
--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -93,7 +93,7 @@ func (s *ActionsService) ListWorkflowRunsByFileName(ctx context.Context, owner, 
 // ListRepositoryWorkflowRuns lists all workflow runs for a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/workflow_runs/#list-repository-workflow-runs
-func (s *ActionsService) ListRepositoryWorkflowRuns(ctx context.Context, owner, repo string, opts *ListOptions) (*WorkflowRuns, *Response, error) {
+func (s *ActionsService) ListRepositoryWorkflowRuns(ctx context.Context, owner, repo string, opts *ListWorkflowRunsOptions) (*WorkflowRuns, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/actions/runs", owner, repo)
 	u, err := addOptions(u, opts)
 	if err != nil {

--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -215,7 +215,7 @@ func TestActionService_ListRepositoryWorkflowRuns(t *testing.T) {
 
 	})
 
-	opts := &ListOptions{Page: 2, PerPage: 2}
+	opts := &ListWorkflowRunsOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
 	runs, _, err := client.Actions.ListRepositoryWorkflowRuns(context.Background(), "o", "r", opts)
 
 	if err != nil {


### PR DESCRIPTION
closes #1497 
- update the method to use the more specific ListWorkflowRunsOptions struct

Let me know if I need to update any of the tests as well - I looked through the existing tests and didn't see any that were specifically testing the unique query params of workflow endpoints.