### PR TITLE
Add DeleteWorkflowRunLogs function

### DIFF
--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -179,3 +179,17 @@ func (s *ActionsService) GetWorkflowRunLogs(ctx context.Context, owner, repo str
 	parsedURL, err := url.Parse(resp.Header.Get("Location"))
 	return parsedURL, newResponse(resp), err
 }
+
+// DeleteWorkflowRunLogs deletes all logs for a workflow run.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/workflow_runs/#delete-workflow-run-logs
+func (s *ActionsService) DeleteWorkflowRunLogs(ctx context.Context, owner, repo string, runID int64) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/logs", owner, repo, runID)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -182,7 +182,7 @@ func (s *ActionsService) GetWorkflowRunLogs(ctx context.Context, owner, repo str
 
 // DeleteWorkflowRunLogs deletes all logs for a workflow run.
 //
-// GitHub API docs: https://developer.github.com/v3/actions/workflow_runs/#delete-workflow-run-logs
+// GitHub API docs: https://developer.github.com/v3/actions/workflow-runs/#delete-workflow-run-logs
 func (s *ActionsService) DeleteWorkflowRunLogs(ctx context.Context, owner, repo string, runID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/logs", owner, repo, runID)
 

--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -235,3 +235,18 @@ func TestActionService_ListRepositoryWorkflowRuns(t *testing.T) {
 	}
 
 }
+
+func TestActionService_DeleteWorkflowRunLogs(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/runs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if _, err := client.Actions.DeleteWorkflowRunLogs(context.Background(), "o", "r", 399444496); err != nil {
+		t.Errorf("DeleteWorkflowRunLogs returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Adds support for the new endpoint added to delete logs.

Doc link: https://developer.github.com/v3/actions/workflow-runs/#delete-workflow-run-logs

Fixes #1500.
