### PR TITLE
Support self-hosted organization runners

### DIFF
--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -20,7 +20,7 @@ type RunnerApplicationDownload struct {
 
 // ListRunnerApplicationDownloads lists self-hosted runner application binaries that can be downloaded and run.
 //
-// GitHub API docs: https://developer.github.com/v3/actions/self_hosted_runners/#list-downloads-for-the-self-hosted-runner-application
+// GitHub API docs: https://developer.github.com/v3/actions/self-hosted-runners/#list-runner-applications-for-a-repository
 func (s *ActionsService) ListRunnerApplicationDownloads(ctx context.Context, owner, repo string) ([]*RunnerApplicationDownload, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners/downloads", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -45,7 +45,7 @@ type RegistrationToken struct {
 
 // CreateRegistrationToken creates a token that can be used to add a self-hosted runner.
 //
-// GitHub API docs: https://developer.github.com/v3/actions/self_hosted_runners/#create-a-registration-token
+// GitHub API docs: https://developer.github.com/v3/actions/self-hosted-runners/#create-a-registration-token-for-a-repository
 func (s *ActionsService) CreateRegistrationToken(ctx context.Context, owner, repo string) (*RegistrationToken, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners/registration-token", owner, repo)
 
@@ -79,7 +79,7 @@ type Runners struct {
 
 // ListRunners lists all the self-hosted runners for a repository.
 //
-// GitHub API docs: https://developer.github.com/v3/actions/self_hosted_runners/#list-self-hosted-runners-for-a-repository
+// GitHub API docs: https://developer.github.com/v3/actions/self-hosted-runners/#list-self-hosted-runners-for-a-repository
 func (s *ActionsService) ListRunners(ctx context.Context, owner, repo string, opts *ListOptions) (*Runners, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners", owner, repo)
 	u, err := addOptions(u, opts)
@@ -103,7 +103,7 @@ func (s *ActionsService) ListRunners(ctx context.Context, owner, repo string, op
 
 // GetRunner gets a specific self-hosted runner for a repository using its runner ID.
 //
-// GitHub API docs: https://developer.github.com/v3/actions/self_hosted_runners/#get-a-self-hosted-runner
+// GitHub API docs: https://developer.github.com/v3/actions/self-hosted-runners/#get-a-self-hosted-runner-for-a-repository
 func (s *ActionsService) GetRunner(ctx context.Context, owner, repo string, runnerID int64) (*Runner, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners/%v", owner, repo, runnerID)
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -128,7 +128,7 @@ type RemoveToken struct {
 
 // CreateRemoveToken creates a token that can be used to remove a self-hosted runner from a repository.
 //
-// GitHub API docs: https://developer.github.com/v3/actions/self_hosted_runners/#create-a-remove-token
+// GitHub API docs: https://developer.github.com/v3/actions/self-hosted-runners/#create-a-remove-token-for-a-repository
 func (s *ActionsService) CreateRemoveToken(ctx context.Context, owner, repo string) (*RemoveToken, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners/remove-token", owner, repo)
 
@@ -148,9 +148,125 @@ func (s *ActionsService) CreateRemoveToken(ctx context.Context, owner, repo stri
 
 // RemoveRunner forces the removal of a self-hosted runner in a repository using the runner id.
 //
-// GitHub API docs: https://developer.github.com/v3/actions/self_hosted_runners/#remove-a-self-hosted-runner
+// GitHub API docs: https://developer.github.com/v3/actions/self-hosted-runners/#delete-a-self-hosted-runner-from-a-repository
 func (s *ActionsService) RemoveRunner(ctx context.Context, owner, repo string, runnerID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners/%v", owner, repo, runnerID)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// ListOrganizationRunnerApplicationDownloads lists self-hosted runner application binaries that can be downloaded and run.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/self-hosted-runners/#list-runner-applications-for-an-organization
+func (s *ActionsService) ListOrganizationRunnerApplicationDownloads(ctx context.Context, owner string) ([]*RunnerApplicationDownload, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/runners/downloads", owner)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rads []*RunnerApplicationDownload
+	resp, err := s.client.Do(ctx, req, &rads)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return rads, resp, nil
+}
+
+// CreateOrganizationRegistrationToken creates a token that can be used to add a self-hosted runner to an organization.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/self-hosted-runners/#create-a-registration-token-for-an-organization
+func (s *ActionsService) CreateOrganizationRegistrationToken(ctx context.Context, owner string) (*RegistrationToken, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/runners/registration-token", owner)
+
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	registrationToken := new(RegistrationToken)
+	resp, err := s.client.Do(ctx, req, registrationToken)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return registrationToken, resp, nil
+}
+
+// ListOrganizationRunners lists all the self-hosted runners for an organization.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/self-hosted-runners/#list-self-hosted-runners-for-an-organization
+func (s *ActionsService) ListOrganizationRunners(ctx context.Context, owner string, opts *ListOptions) (*Runners, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/runners", owner)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	runners := &Runners{}
+	resp, err := s.client.Do(ctx, req, &runners)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return runners, resp, nil
+}
+
+// GetOrganizationRunner gets a specific self-hosted runner for an organization using its runner ID.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/self-hosted-runners/#list-self-hosted-runners-for-an-organization
+func (s *ActionsService) GetOrganizationRunner(ctx context.Context, owner string, runnerID int64) (*Runner, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/runners/%v", owner, runnerID)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	runner := new(Runner)
+	resp, err := s.client.Do(ctx, req, runner)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return runner, resp, nil
+}
+
+// CreateOrganizationRemoveToken creates a token that can be used to remove a self-hosted runner from an organization.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/self-hosted-runners/#create-a-remove-token-for-an-organization
+func (s *ActionsService) CreateOrganizationRemoveToken(ctx context.Context, owner string) (*RemoveToken, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/runners/remove-token", owner)
+
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	removeToken := new(RemoveToken)
+	resp, err := s.client.Do(ctx, req, removeToken)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return removeToken, resp, nil
+}
+
+// RemoveOrganizationRunner forces the removal of a self-hosted runner from an organization using the runner id.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/self-hosted-runners/#delete-a-self-hosted-runner-from-an-organization
+func (s *ActionsService) RemoveOrganizationRunner(ctx context.Context, owner string, runnerID int64) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/runners/%v", owner, runnerID)
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/actions_runners_test.go
+++ b/github/actions_runners_test.go
@@ -148,3 +148,138 @@ func TestActionsService_RemoveRunner(t *testing.T) {
 		t.Errorf("Actions.RemoveRunner returned error: %v", err)
 	}
 }
+
+func TestActionsService_ListOrganizationRunnerApplicationDownloads(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/runners/downloads", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{"os":"osx","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-osx-x64-2.164.0.tar.gz","filename":"actions-runner-osx-x64-2.164.0.tar.gz"},{"os":"linux","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-x64-2.164.0.tar.gz","filename":"actions-runner-linux-x64-2.164.0.tar.gz"},{"os": "linux","architecture":"arm","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm-2.164.0.tar.gz","filename":"actions-runner-linux-arm-2.164.0.tar.gz"},{"os":"win","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-win-x64-2.164.0.zip","filename":"actions-runner-win-x64-2.164.0.zip"},{"os":"linux","architecture":"arm64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm64-2.164.0.tar.gz","filename":"actions-runner-linux-arm64-2.164.0.tar.gz"}]`)
+	})
+
+	downloads, _, err := client.Actions.ListOrganizationRunnerApplicationDownloads(context.Background(), "o")
+	if err != nil {
+		t.Errorf("Actions.ListRunnerApplicationDownloads returned error: %v", err)
+	}
+
+	want := []*RunnerApplicationDownload{
+		{OS: String("osx"), Architecture: String("x64"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-osx-x64-2.164.0.tar.gz"), Filename: String("actions-runner-osx-x64-2.164.0.tar.gz")},
+		{OS: String("linux"), Architecture: String("x64"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-x64-2.164.0.tar.gz"), Filename: String("actions-runner-linux-x64-2.164.0.tar.gz")},
+		{OS: String("linux"), Architecture: String("arm"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm-2.164.0.tar.gz"), Filename: String("actions-runner-linux-arm-2.164.0.tar.gz")},
+		{OS: String("win"), Architecture: String("x64"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-win-x64-2.164.0.zip"), Filename: String("actions-runner-win-x64-2.164.0.zip")},
+		{OS: String("linux"), Architecture: String("arm64"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm64-2.164.0.tar.gz"), Filename: String("actions-runner-linux-arm64-2.164.0.tar.gz")},
+	}
+	if !reflect.DeepEqual(downloads, want) {
+		t.Errorf("Actions.ListOrganizationRunnerApplicationDownloads returned %+v, want %+v", downloads, want)
+	}
+}
+
+func TestActionsService_CreateOrganizationRegistrationToken(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/runners/registration-token", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"token":"LLBF3JGZDX3P5PMEXLND6TS6FCWO6","expires_at":"2020-01-22T12:13:35.123Z"}`)
+	})
+
+	token, _, err := client.Actions.CreateOrganizationRegistrationToken(context.Background(), "o")
+	if err != nil {
+		t.Errorf("Actions.CreateRegistrationToken returned error: %v", err)
+	}
+
+	want := &RegistrationToken{Token: String("LLBF3JGZDX3P5PMEXLND6TS6FCWO6"),
+		ExpiresAt: &Timestamp{time.Date(2020, time.January, 22, 12, 13, 35,
+			123000000, time.UTC)}}
+	if !reflect.DeepEqual(token, want) {
+		t.Errorf("Actions.CreateRegistrationToken returned %+v, want %+v", token, want)
+	}
+}
+
+func TestActionsService_ListOrganizationRunners(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/runners", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"per_page": "2", "page": "2"})
+		fmt.Fprint(w, `{"total_count":2,"runners":[{"id":23,"name":"MBP","os":"macos","status":"online"},{"id":24,"name":"iMac","os":"macos","status":"offline"}]}`)
+	})
+
+	opts := &ListOptions{Page: 2, PerPage: 2}
+	runners, _, err := client.Actions.ListOrganizationRunners(context.Background(), "o", opts)
+	if err != nil {
+		t.Errorf("Actions.ListRunners returned error: %v", err)
+	}
+
+	want := &Runners{
+		TotalCount: 2,
+		Runners: []*Runner{
+			{ID: Int64(23), Name: String("MBP"), OS: String("macos"), Status: String("online")},
+			{ID: Int64(24), Name: String("iMac"), OS: String("macos"), Status: String("offline")},
+		},
+	}
+	if !reflect.DeepEqual(runners, want) {
+		t.Errorf("Actions.ListRunners returned %+v, want %+v", runners, want)
+	}
+}
+
+func TestActionsService_GetOrganizationRunner(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/runners/23", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":23,"name":"MBP","os":"macos","status":"online"}`)
+	})
+
+	runner, _, err := client.Actions.GetOrganizationRunner(context.Background(), "o", 23)
+	if err != nil {
+		t.Errorf("Actions.GetRunner returned error: %v", err)
+	}
+
+	want := &Runner{
+		ID:     Int64(23),
+		Name:   String("MBP"),
+		OS:     String("macos"),
+		Status: String("online"),
+	}
+	if !reflect.DeepEqual(runner, want) {
+		t.Errorf("Actions.GetRunner returned %+v, want %+v", runner, want)
+	}
+}
+
+func TestActionsService_CreateOrganizationRemoveToken(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/runners/remove-token", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"token":"AABF3JGZDX3P5PMEXLND6TS6FCWO6","expires_at":"2020-01-29T12:13:35.123Z"}`)
+	})
+
+	token, _, err := client.Actions.CreateOrganizationRemoveToken(context.Background(), "o")
+	if err != nil {
+		t.Errorf("Actions.CreateRemoveToken returned error: %v", err)
+	}
+
+	want := &RemoveToken{Token: String("AABF3JGZDX3P5PMEXLND6TS6FCWO6"), ExpiresAt: &Timestamp{time.Date(2020, time.January, 29, 12, 13, 35, 123000000, time.UTC)}}
+	if !reflect.DeepEqual(token, want) {
+		t.Errorf("Actions.CreateRemoveToken returned %+v, want %+v", token, want)
+	}
+}
+
+func TestActionsService_RemoveOrganizationRunner(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/runners/21", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	_, err := client.Actions.RemoveOrganizationRunner(context.Background(), "o", 21)
+	if err != nil {
+		t.Errorf("Actions.RemoveOganizationRunner returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #1505 

This adds support for the organization-wide self-hosted runners API

The API for self-hosted runners on organization level is almost similar to the ones for repositories, only the the URL path is slightly different, and you need an organization owner token for the new functions to work.

Because of the similarities, this was basically a large copy & paste operation, so for each function there is now an `Organization` counterpart. This is not really DRY, but it makes it more explicit what API is being used.

(An alternative solution would be to have a switch inside each function to decide to use the organization or repository API based on the presence of the repo parameter. I have made that as well on a separate branch. The implementation is much smaller, but the organization functionality is a little more hidden there. If there's any votes for that, I could offer that implementation instead)