### PR TITLE
Add DeleteInstallation for GitHub Apps

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -211,6 +211,23 @@ func (s *AppsService) ListUserInstallations(ctx context.Context, opts *ListOptio
 	return i.Installations, resp, nil
 }
 
+// DeleteInstallation deletes the specified installation.
+//
+// GitHub API docs: https://developer.github.com/v3/apps/#delete-an-installation
+func (s *AppsService) DeleteInstallation(ctx context.Context, id int64) (*Response, error) {
+	u := fmt.Sprintf("app/installations/%v", id)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeIntegrationPreview)
+
+	return s.client.Do(ctx, req, nil)
+}
+
 // CreateInstallationToken creates a new installation token.
 //
 // GitHub API docs: https://developer.github.com/v3/apps/#create-a-new-installation-token

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -208,6 +208,22 @@ func TestAppsService_ListUserInstallations(t *testing.T) {
 	}
 }
 
+func TestAppsService_DeleteInstallation(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/app/installations/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+		testHeader(t, r, "Accept", mediaTypeIntegrationPreview)
+	})
+
+	_, err := client.Apps.DeleteInstallation(context.Background(), 1)
+	if err != nil {
+		t.Errorf("Apps.DeleteInstallation returned error: %v", err)
+	}
+}
+
 func TestAppsService_CreateInstallationToken(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
Adds support for deleting a GitHub app installation (https://developer.github.com/v3/apps/#delete-an-installation).

Closes #1436.