### PR TITLE
SuspendInstallation and UnsuspendInstallation for GitHub Apps

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -211,6 +211,20 @@ func (s *AppsService) ListUserInstallations(ctx context.Context, opts *ListOptio
 	return i.Installations, resp, nil
 }
 
+// SuspendInstallation suspends the specified installation.
+//
+// GitHub API docs: https://developer.github.com/v3/apps/#suspend-an-installation
+func (s *AppsService) SuspendInstallation(ctx context.Context, id int64) (*Response, error) {
+	u := fmt.Sprintf("app/installations/%v/suspended", id)
+
+	req, err := s.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
 // CreateInstallationToken creates a new installation token.
 //
 // GitHub API docs: https://developer.github.com/v3/apps/#create-a-new-installation-token

--- a/github/apps.go
+++ b/github/apps.go
@@ -225,6 +225,20 @@ func (s *AppsService) SuspendInstallation(ctx context.Context, id int64) (*Respo
 	return s.client.Do(ctx, req, nil)
 }
 
+// UnsuspendInstallation unsuspends the specified installation.
+//
+// GitHub API docs: https://developer.github.com/v3/apps/#unsuspend-an-installation
+func (s *AppsService) UnsuspendInstallation(ctx context.Context, id int64) (*Response, error) {
+	u := fmt.Sprintf("app/installations/%v/suspended", id)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
 // CreateInstallationToken creates a new installation token.
 //
 // GitHub API docs: https://developer.github.com/v3/apps/#create-a-new-installation-token

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -223,6 +223,21 @@ func TestAppsService_SuspendInstallation(t *testing.T) {
 	}
 }
 
+func TestAppsService_UnsuspendInstallation(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/app/installations/1/suspended", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if _, err := client.Apps.UnsuspendInstallation(context.Background(), 1); err != nil {
+		t.Errorf("Apps.UnsuspendInstallation returned error: %v", err)
+	}
+}
+
 func TestAppsService_CreateInstallationToken(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -208,6 +208,21 @@ func TestAppsService_ListUserInstallations(t *testing.T) {
 	}
 }
 
+func TestAppsService_SuspendInstallation(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/app/installations/1/suspended", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if _, err := client.Apps.SuspendInstallation(context.Background(), 1); err != nil {
+		t.Errorf("Apps.SuspendInstallation returned error: %v", err)
+	}
+}
+
 func TestAppsService_CreateInstallationToken(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
Add support for [Suspend](https://developer.github.com/v3/apps/#suspend-an-installation) and [Unsuspend](https://developer.github.com/v3/apps/#unsuspend-an-installation) GitHub App installation.

Fixes #1517 