### PR TITLE
Fix error message for the test of GetWorkflowRunByID

### DIFF
--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -82,7 +82,7 @@ func TestActionsService_GetWorkflowRunByID(t *testing.T) {
 
 	runs, _, err := client.Actions.GetWorkflowRunByID(context.Background(), "o", "r", 29679449)
 	if err != nil {
-		t.Errorf("Actions.ListWorkFlowRunsByFileName returned error: %v", err)
+		t.Errorf("Actions.GetWorkflowRunByID returned error: %v", err)
 	}
 
 	want := &WorkflowRun{


### PR DESCRIPTION
Fixes #1528 

Small PR to change the error message of the test of `GetWorfklowRunByID` that uses `ListWorkFlowRunsByFileName` instead.