### PR TITLE
Enable BranchRestriction fields to be empty

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -864,9 +864,9 @@ type BranchRestrictions struct {
 // different from the response structure.
 type BranchRestrictionsRequest struct {
 	// The list of user logins with push access. (Required; use []string{} instead of nil for empty list.)
-	Users []string `json:"users"`
+	Users []string `json:"users,omitempty"`
 	// The list of team slugs with push access. (Required; use []string{} instead of nil for empty list.)
-	Teams []string `json:"teams"`
+	Teams []string `json:"teams,omitempty"`
 	// The list of app slugs with push access.
 	Apps []string `json:"apps,omitempty"`
 }


### PR DESCRIPTION
## Description
I've encountered an issue trying to update BranchRestriction on a personal repository. Github doesn't allow `teams` and `users` fields in the request payload.

## How to reproduce
```go
p := github.ProtectionRequest{
	Restrictions: &github.BranchRestrictionsRequest{
		Apps: []string{"myapp"},
	},
}
client.Repositories.UpdateBranchProtection(ctx, org, repo, branch, p)
```
will return
```
No subschema in "anyOf" matched.
For 'properties/users', nil is not an array.
For 'properties/teams', nil is not an array.
Not all subschemas of "allOf" matched.
For 'anyOf/1', {"users"=>nil, "teams"=>nil, "apps"=>["myapp"]} is not a null.
```
but if I set `Teams` and `Users` fields as `[]string{}` Github returns `422 Validation Failed [{Resource: Field: Code: Message:Only organization repositories can have users and team restrictions}]` as described above.

## Fix
Allow `Teams` and `Users` fields to be empty by using `omitempty`.