### PR TITLE
Organization Secrets

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6956,6 +6956,22 @@ func (o *OrganizationInstallations) GetTotalCount() int {
 	return *o.TotalCount
 }
 
+// GetKey returns the Key field if it's non-nil, zero value otherwise.
+func (o *OrganizationPublicKey) GetKey() string {
+	if o == nil || o.Key == nil {
+		return ""
+	}
+	return *o.Key
+}
+
+// GetKeyID returns the KeyID field if it's non-nil, zero value otherwise.
+func (o *OrganizationPublicKey) GetKeyID() string {
+	if o == nil || o.KeyID == nil {
+		return ""
+	}
+	return *o.KeyID
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (o *OrgBlockEvent) GetAction() string {
 	if o == nil || o.Action == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6972,6 +6972,14 @@ func (o *OrganizationPublicKey) GetKeyID() string {
 	return *o.KeyID
 }
 
+// GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
+func (o *OrganizationSecretSelectedRepositories) GetTotalCount() int64 {
+	if o == nil || o.TotalCount == nil {
+		return 0
+	}
+	return *o.TotalCount
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (o *OrgBlockEvent) GetAction() string {
 	if o == nil || o.Action == nil {

--- a/github/orgs_actions_secrets.go
+++ b/github/orgs_actions_secrets.go
@@ -166,3 +166,17 @@ func (s *OrganizationsService) SetSecretSelectedRepositories(ctx context.Context
 
 	return s.client.Do(ctx, req, nil)
 }
+
+// Adds a repository to an organization secret when the visibility for repository access is set to selected.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#add-selected-repository-to-an-organization-secret
+func (s *OrganizationsService) AddSelectedRepositoryToSecret(ctx context.Context, owner, name string, repositoryID int64) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories/%v", owner, name, repositoryID)
+
+	req, err := s.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/orgs_actions_secrets.go
+++ b/github/orgs_actions_secrets.go
@@ -87,6 +87,11 @@ func (s *OrganizationsService) GetSecret(ctx context.Context, owner, name string
 	return secret, resp, nil
 }
 
+// OrganizationEncryptedSecret represents an Organization secret that is encrypted using a public key.
+//
+// The value of EncryptedValue must be your secret, encrypted with
+// LibSodium (see documentation here: https://libsodium.gitbook.io/doc/bindings_for_other_languages)
+// using the public key retrieved using the GetPublicKey method.
 type OrganizationEncryptedSecret struct {
 	Name                  string   `json:"-"`
 	KeyID                 string   `json:"key_id"`
@@ -94,12 +99,6 @@ type OrganizationEncryptedSecret struct {
 	Visibility            string   `json:"visibility"`
 	SelectedRepositoryIDs []string `json:"selected_repository_ids,omitempty"`
 }
-
-// OrganizationEncryptedSecret represents an Organization secret that is encrypted using a public key.
-//
-// The value of EncryptedValue must be your secret, encrypted with
-// LibSodium (see documentation here: https://libsodium.gitbook.io/doc/bindings_for_other_languages)
-// using the public key retrieved using the GetPublicKey method.
 
 // CreateOrUpdateSecret creates or updates a secret with an encrypted value.
 //
@@ -127,4 +126,29 @@ func (s *OrganizationsService) DeleteSecret(ctx context.Context, owner, name str
 	}
 
 	return s.client.Do(ctx, req, nil)
+}
+
+// OrganizationSecretSelectedRepositories represents all repositories that have been selected to  have access to an OrganizationSecret
+type OrganizationSecretSelectedRepositories struct {
+	TotalCount   *int64        `json:"total_count,omitempty"`
+	Repositories []*Repository `json:"repositories,omitempty"`
+}
+
+// Lists all repositories that have been selected when the visibility for repository access to a secret is set to selected.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#list-selected-repositories-for-an-organization-secret
+func (s *OrganizationsService) ListSecretSelectedRepositories(ctx context.Context, owner, name string) (*OrganizationSecretSelectedRepositories, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories", owner, name)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	secretSelectedRepositories := new(OrganizationSecretSelectedRepositories)
+	resp, err := s.client.Do(ctx, req, secretSelectedRepositories)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return secretSelectedRepositories, resp, nil
 }

--- a/github/orgs_actions_secrets.go
+++ b/github/orgs_actions_secrets.go
@@ -86,3 +86,31 @@ func (s *OrganizationsService) GetSecret(ctx context.Context, owner, name string
 
 	return secret, resp, nil
 }
+
+type OrganizationEncryptedSecret struct {
+	Name                  string   `json:"-"`
+	KeyID                 string   `json:"key_id"`
+	EncryptedValue        string   `json:"encrypted_value"`
+	Visibility            string   `json:"visibility"`
+	SelectedRepositoryIDs []string `json:"selected_repository_ids,omitempty"`
+}
+
+// OrganizationEncryptedSecret represents an Organization secret that is encrypted using a public key.
+//
+// The value of EncryptedValue must be your secret, encrypted with
+// LibSodium (see documentation here: https://libsodium.gitbook.io/doc/bindings_for_other_languages)
+// using the public key retrieved using the GetPublicKey method.
+
+// CreateOrUpdateSecret creates or updates a secret with an encrypted value.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#create-or-update-an-organization-secret
+func (s *OrganizationsService) CreateOrUpdateSecret(ctx context.Context, owner string, eSecret *OrganizationEncryptedSecret) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/%v", owner, eSecret.Name)
+
+	req, err := s.client.NewRequest("PUT", u, eSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/orgs_actions_secrets.go
+++ b/github/orgs_actions_secrets.go
@@ -67,3 +67,22 @@ func (s *OrganizationsService) ListSecrets(ctx context.Context, owner string, op
 
 	return secrets, resp, nil
 }
+
+// GetSecret gets a single secret without revealing its encrypted value.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#get-an-organization-secret
+func (s *OrganizationsService) GetSecret(ctx context.Context, owner, name string) (*OrganizationSecret, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/%v", owner, name)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	secret := new(OrganizationSecret)
+	resp, err := s.client.Do(ctx, req, secret)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return secret, resp, nil
+}

--- a/github/orgs_actions_secrets.go
+++ b/github/orgs_actions_secrets.go
@@ -114,3 +114,17 @@ func (s *OrganizationsService) CreateOrUpdateSecret(ctx context.Context, owner s
 
 	return s.client.Do(ctx, req, nil)
 }
+
+// DeleteSecret deletes a secret in a repository using the secret name.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#delete-an-organization-secret
+func (s *OrganizationsService) DeleteSecret(ctx context.Context, owner, name string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/%v", owner, name)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/orgs_actions_secrets.go
+++ b/github/orgs_actions_secrets.go
@@ -180,3 +180,17 @@ func (s *OrganizationsService) AddSelectedRepositoryToSecret(ctx context.Context
 
 	return s.client.Do(ctx, req, nil)
 }
+
+// Removes a repository from an organization secret when the visibility for repository access is set to selected
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#remove-selected-repository-from-an-organization-secret
+func (s *OrganizationsService) RemoveSelectedRepositoryFromSecret(ctx context.Context, owner, name string, repositoryID int64) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories/%v", owner, name, repositoryID)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/orgs_actions_secrets.go
+++ b/github/orgs_actions_secrets.go
@@ -5,23 +5,65 @@ import (
 	"fmt"
 )
 
-type OrgsActionsPublicKey struct {
+// PublicKey represents the public key that should be used to encrypt secrets.
+type OrganizationPublicKey struct {
 	KeyID *string `json:"key_id"`
 	Key   *string `json:"key"`
 }
 
-func (s *OrganizationsService) GetPublicKey(ctx context.Context, owner string) (*OrgsActionsPublicKey, *Response, error) {
+// GetPublicKey gets a public key that should be used for secret encryption.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#get-an-organization-public-key
+func (s *OrganizationsService) GetPublicKey(ctx context.Context, owner string) (*OrganizationPublicKey, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/secrets/public-key", owner)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	pubKey := new(OrgsActionsPublicKey)
+	pubKey := new(OrganizationPublicKey)
 	resp, err := s.client.Do(ctx, req, pubKey)
 	if err != nil {
 		return nil, resp, err
 	}
 
 	return pubKey, resp, nil
+}
+
+type OrganizationSecret struct {
+	Name                    string    `json:"name"`
+	CreatedAt               Timestamp `json:"created_at"`
+	UpdatedAt               Timestamp `json:"updated_at"`
+	Visibility              string    `json:"visibility"`
+	SelectedRepositoriesUrl string    `json:"selected_repositories_url"`
+}
+
+type OrganizationSecrets struct {
+	TotalCount int                   `json:"total_count"`
+	Secrets    []*OrganizationSecret `json:"secrets"`
+}
+
+// ListSecrets lists all secrets available in an Organization
+// without revealing their encrypted values.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#list-organization-secrets
+func (s *OrganizationsService) ListSecrets(ctx context.Context, owner string, opts *ListOptions) (*OrganizationSecrets, *Response, error) {
+	u := fmt.Sprintf("orgs/%s/actions/secrets", owner)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	secrets := new(OrganizationSecrets)
+	resp, err := s.client.Do(ctx, req, &secrets)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return secrets, resp, nil
 }

--- a/github/orgs_actions_secrets.go
+++ b/github/orgs_actions_secrets.go
@@ -1,0 +1,27 @@
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+type OrgsActionsPublicKey struct {
+	KeyID *string `json:"key_id"`
+	Key   *string `json:"key"`
+}
+
+func (s *OrganizationsService) GetPublicKey(ctx context.Context, owner string) (*OrgsActionsPublicKey, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/public-key", owner)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pubKey := new(OrgsActionsPublicKey)
+	resp, err := s.client.Do(ctx, req, pubKey)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pubKey, resp, nil
+}

--- a/github/orgs_actions_secrets.go
+++ b/github/orgs_actions_secrets.go
@@ -152,3 +152,17 @@ func (s *OrganizationsService) ListSecretSelectedRepositories(ctx context.Contex
 
 	return secretSelectedRepositories, resp, nil
 }
+
+// Replaces all repositories for an organization secret when the visibility for repository access is set to selected.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#set-selected-repositories-for-an-organization-secret
+func (s *OrganizationsService) SetSecretSelectedRepositories(ctx context.Context, owner, name string, repositoryIDs []int64) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories", owner, name)
+
+	req, err := s.client.NewRequest("PUT", u, repositoryIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/orgs_actions_secrets_test.go
+++ b/github/orgs_actions_secrets_test.go
@@ -145,3 +145,17 @@ func TestOrganizationsService_ListSecretSelectedRepositories(t *testing.T) {
 		t.Errorf("Organizations.ListSecretSelectedRepositories returned %+v, want %+v", secretSelectedRepositories, want)
 	}
 }
+
+func TestOrganizationsService_SetSecretSelectedRepositories(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/SECRET_NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Content-Type", "application/json")
+	})
+	_, err := client.Organizations.SetSecretSelectedRepositories(context.Background(), "o", "SECRET_NAME", []int64{64780797})
+	if err != nil {
+		t.Errorf("Organizations.SetSecretSelectedRepositories returned error: %v", err)
+	}
+}

--- a/github/orgs_actions_secrets_test.go
+++ b/github/orgs_actions_secrets_test.go
@@ -159,3 +159,17 @@ func TestOrganizationsService_SetSecretSelectedRepositories(t *testing.T) {
 		t.Errorf("Organizations.SetSecretSelectedRepositories returned error: %v", err)
 	}
 }
+
+func TestOrganizationsService_AddSelectedRepositoryToSecret(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/SECRET_NAME/repositories/64780797", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+	})
+
+	_, err := client.Organizations.AddSelectedRepositoryToSecret(context.Background(), "o", "SECRET_NAME", int64(64780797))
+	if err != nil {
+		t.Errorf("Organizations.AddSelectedRepositoryToSecret returned error: %v", err)
+	}
+}

--- a/github/orgs_actions_secrets_test.go
+++ b/github/orgs_actions_secrets_test.go
@@ -121,3 +121,27 @@ func TestOrgnizationsService_DeleteSecret(t *testing.T) {
 		t.Errorf("Organizations.DeleteSecret returned error: %v", err)
 	}
 }
+
+func TestOrganizationsService_ListSecretSelectedRepositories(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/SECRET_NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"total_count":2,"repositories":[{"id":1},{"id":2}]}`)
+	})
+
+	secretSelectedRepositories, _, err := client.Organizations.ListSecretSelectedRepositories(context.Background(), "o", "SECRET_NAME")
+	if err != nil {
+		t.Errorf("Organizations.ListSecretSelectedRepositories returned error: %v", err)
+	}
+
+	want := &OrganizationSecretSelectedRepositories{
+		TotalCount:   Int64(2),
+		Repositories: []*Repository{{ID: Int64(1)}, {ID: Int64(2)}},
+	}
+
+	if !reflect.DeepEqual(secretSelectedRepositories, want) {
+		t.Errorf("Organizations.ListSecretSelectedRepositories returned %+v, want %+v", secretSelectedRepositories, want)
+	}
+}

--- a/github/orgs_actions_secrets_test.go
+++ b/github/orgs_actions_secrets_test.go
@@ -93,6 +93,7 @@ func TestOrgnizationsService_CreateOrUpdateSecret(t *testing.T) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
 		testBody(t, r, `{"key_id":"1234","encrypted_value":"QIv=","visibility":"selected","selected_repository_ids":["A","B","C"]}`+"\n")
+		w.WriteHeader(http.StatusCreated)
 	})
 
 	input := &OrganizationEncryptedSecret{
@@ -114,6 +115,7 @@ func TestOrgnizationsService_DeleteSecret(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	_, err := client.Organizations.DeleteSecret(context.Background(), "o", "NAME")
@@ -180,6 +182,7 @@ func TestOrganizationsService_RemoveSelectedRepositoryFromSecret(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/actions/secrets/SECRET_NAME/repositories/64780797", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	_, err := client.Organizations.RemoveSelectedRepositoryFromSecret(context.Background(), "o", "SECRET_NAME", int64(64780797))

--- a/github/orgs_actions_secrets_test.go
+++ b/github/orgs_actions_secrets_test.go
@@ -107,3 +107,17 @@ func TestOrgnizationsService_CreateOrUpdateSecret(t *testing.T) {
 		t.Errorf("Organizations.CreateOrUpdateSecret returned error: %v", err)
 	}
 }
+
+func TestOrgnizationsService_DeleteSecret(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	_, err := client.Organizations.DeleteSecret(context.Background(), "o", "NAME")
+	if err != nil {
+		t.Errorf("Organizations.DeleteSecret returned error: %v", err)
+	}
+}

--- a/github/orgs_actions_secrets_test.go
+++ b/github/orgs_actions_secrets_test.go
@@ -173,3 +173,17 @@ func TestOrganizationsService_AddSelectedRepositoryToSecret(t *testing.T) {
 		t.Errorf("Organizations.AddSelectedRepositoryToSecret returned error: %v", err)
 	}
 }
+
+func TestOrganizationsService_RemoveSelectedRepositoryFromSecret(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/SECRET_NAME/repositories/64780797", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	_, err := client.Organizations.RemoveSelectedRepositoryFromSecret(context.Background(), "o", "SECRET_NAME", int64(64780797))
+	if err != nil {
+		t.Errorf("Organizations.RemoveSelectedRepositoryFromSecret returned error: %v", err)
+	}
+}

--- a/github/orgs_actions_secrets_test.go
+++ b/github/orgs_actions_secrets_test.go
@@ -1,0 +1,29 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestOrganizationsService_GetPublicKey(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/public-key", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"key_id":"012345678912345678","key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
+	})
+
+	key, _, err := client.Organizations.GetPublicKey(context.Background(), "o")
+	if err != nil {
+		t.Errorf("OrgsActions.GetPublicKey returned error: %v", err)
+	}
+
+	want := &OrgsActionsPublicKey{KeyID: String("012345678912345678"), Key: String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234")}
+	if !reflect.DeepEqual(key, want) {
+		t.Errorf("OrgsActions.GetPublicKey returned %+v, want %+v", key, want)
+	}
+}

--- a/github/orgs_actions_secrets_test.go
+++ b/github/orgs_actions_secrets_test.go
@@ -84,3 +84,26 @@ func TestOrganizationsService_GetSecret(t *testing.T) {
 		t.Errorf("Organizations.GetSecret returned %+v, want %+v", secret, want)
 	}
 }
+
+func TestOrgnizationsService_CreateOrUpdateSecret(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Content-Type", "application/json")
+		testBody(t, r, `{"key_id":"1234","encrypted_value":"QIv=","visibility":"selected","selected_repository_ids":["A","B","C"]}`+"\n")
+	})
+
+	input := &OrganizationEncryptedSecret{
+		Name:                  "NAME",
+		EncryptedValue:        "QIv=",
+		KeyID:                 "1234",
+		Visibility:            "selected",
+		SelectedRepositoryIDs: []string{"A", "B", "C"},
+	}
+	_, err := client.Organizations.CreateOrUpdateSecret(context.Background(), "o", input)
+	if err != nil {
+		t.Errorf("Organizations.CreateOrUpdateSecret returned error: %v", err)
+	}
+}

--- a/github/orgs_actions_secrets_test.go
+++ b/github/orgs_actions_secrets_test.go
@@ -57,3 +57,30 @@ func TestOrganizationsService_ListSecrets(t *testing.T) {
 		t.Errorf("Organizations.ListSecrets returned %+v, want %+v", secrets, want)
 	}
 }
+
+func TestOrganizationsService_GetSecret(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/GH_TOKEN", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"name":"GH_TOKEN","created_at":"2019-08-10T14:59:22Z","updated_at":"2020-01-10T14:59:22Z","visibility":"selected","selected_repositories_url":"https://api.github.com/orgs/octo-org/actions/secrets/SUPER_SECRET/repositories"}`)
+	})
+
+	secret, _, err := client.Organizations.GetSecret(context.Background(), "o", "GH_TOKEN")
+	if err != nil {
+		t.Errorf("Organizations.GetSecret returned error: %v", err)
+	}
+
+	want := &OrganizationSecret{
+		Name:                    "GH_TOKEN",
+		CreatedAt:               Timestamp{time.Date(2019, time.August, 10, 14, 59, 22, 0, time.UTC)},
+		UpdatedAt:               Timestamp{time.Date(2020, time.January, 10, 14, 59, 22, 0, time.UTC)},
+		Visibility:              "selected",
+		SelectedRepositoriesUrl: "https://api.github.com/orgs/octo-org/actions/secrets/SUPER_SECRET/repositories",
+	}
+
+	if !reflect.DeepEqual(secret, want) {
+		t.Errorf("Organizations.GetSecret returned %+v, want %+v", secret, want)
+	}
+}


### PR DESCRIPTION
Closes #1525 and when available for use I intend to address after bumping to the new go-github version the usage for https://github.com/terraform-providers/terraform-provider-github/issues/468

- GitHub Blog: https://github.blog/changelog/2020-05-14-organization-secrets/
- GitHub API documentation: https://developer.github.com/v3/actions/secrets/#get-an-organization-public-key

Coverage: 
- [x] Get an organization public key
- [x] List organization secrets 
- [x] Get an organization secret 
- [x] Create or update an organization secret 
- [x] List selected repositories for an organization secret 
- [x] Set selected repositories for an organization secret 
- [x] Add selected repository to an organization secret 
- [x] Remove selected repository from an organization secret 
- [x] Delete an organization secret 