### PR TITLE
Add organization secret API support

### DIFF
--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -16,10 +16,10 @@ type PublicKey struct {
 	Key   *string `json:"key"`
 }
 
-// GetRepositoryPublicKey gets a public key that should be used for secret encryption.
+// GetRepoPublicKey gets a public key that should be used for secret encryption.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#get-a-repository-public-key
-func (s *ActionsService) GetRepositoryPublicKey(ctx context.Context, owner, repo string) (*PublicKey, *Response, error) {
+func (s *ActionsService) GetRepoPublicKey(ctx context.Context, owner, repo string) (*PublicKey, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/secrets/public-key", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -35,10 +35,10 @@ func (s *ActionsService) GetRepositoryPublicKey(ctx context.Context, owner, repo
 	return pubKey, resp, nil
 }
 
-// GetOrganizationPublicKey gets a public key that should be used for secret encryption.
+// GetOrgPublicKey gets a public key that should be used for secret encryption.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#get-an-organization-public-key
-func (s *ActionsService) GetOrganizationPublicKey(ctx context.Context, org string) (*PublicKey, *Response, error) {
+func (s *ActionsService) GetOrgPublicKey(ctx context.Context, org string) (*PublicKey, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/secrets/public-key", org)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -69,11 +69,11 @@ type Secrets struct {
 	Secrets    []*Secret `json:"secrets"`
 }
 
-// ListRepositorySecrets lists all secrets available in a repository
+// ListRepoSecrets lists all secrets available in a repository
 // without revealing their encrypted values.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#list-repository-secrets
-func (s *ActionsService) ListRepositorySecrets(ctx context.Context, owner, repo string, opts *ListOptions) (*Secrets, *Response, error) {
+func (s *ActionsService) ListRepoSecrets(ctx context.Context, owner, repo string, opts *ListOptions) (*Secrets, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/secrets", owner, repo)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -94,10 +94,10 @@ func (s *ActionsService) ListRepositorySecrets(ctx context.Context, owner, repo 
 	return secrets, resp, nil
 }
 
-// GetRepositorySecret gets a single repository secret without revealing its encrypted value.
+// GetRepoSecret gets a single repository secret without revealing its encrypted value.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#get-a-repository-secret
-func (s *ActionsService) GetRepositorySecret(ctx context.Context, owner, repo, name string) (*Secret, *Response, error) {
+func (s *ActionsService) GetRepoSecret(ctx context.Context, owner, repo, name string) (*Secret, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/secrets/%v", owner, repo, name)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -113,10 +113,8 @@ func (s *ActionsService) GetRepositorySecret(ctx context.Context, owner, repo, n
 	return secret, resp, nil
 }
 
-// SelectedRepositoryIDs are the repository IDs that have access to the secret.
-type SelectedRepositoryIDs struct {
-	SelectedRepositoryIDs []int64 `json:"selected_repository_ids,omitempty"`
-}
+// SelectedRepoIDs are the repository IDs that have access to the secret.
+type SelectedRepoIDs []int64
 
 // EncryptedSecret represents a secret that is encrypted using a public key.
 //
@@ -124,17 +122,17 @@ type SelectedRepositoryIDs struct {
 // LibSodium (see documentation here: https://libsodium.gitbook.io/doc/bindings_for_other_languages)
 // using the public key retrieved using the GetPublicKey method.
 type EncryptedSecret struct {
-	Name           string `json:"-"`
-	KeyID          string `json:"key_id"`
-	EncryptedValue string `json:"encrypted_value"`
-	Visibility     string `json:"visibility,omitempty"`
-	SelectedRepositoryIDs
+	Name                  string          `json:"-"`
+	KeyID                 string          `json:"key_id"`
+	EncryptedValue        string          `json:"encrypted_value"`
+	Visibility            string          `json:"visibility,omitempty"`
+	SelectedRepositoryIDs SelectedRepoIDs `json:"selected_repository_ids,omitempty"`
 }
 
-// CreateOrUpdateRepositorySecret creates or updates a repository secret with an encrypted value.
+// CreateOrUpdateRepoSecret creates or updates a repository secret with an encrypted value.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#create-or-update-a-repository-secret
-func (s *ActionsService) CreateOrUpdateRepositorySecret(ctx context.Context, owner, repo string, eSecret *EncryptedSecret) (*Response, error) {
+func (s *ActionsService) CreateOrUpdateRepoSecret(ctx context.Context, owner, repo string, eSecret *EncryptedSecret) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/secrets/%v", owner, repo, eSecret.Name)
 
 	req, err := s.client.NewRequest("PUT", u, eSecret)
@@ -145,10 +143,10 @@ func (s *ActionsService) CreateOrUpdateRepositorySecret(ctx context.Context, own
 	return s.client.Do(ctx, req, nil)
 }
 
-// DeleteRepositorySecret deletes a secret in a repository using the secret name.
+// DeleteRepoSecret deletes a secret in a repository using the secret name.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#delete-a-repository-secret
-func (s *ActionsService) DeleteRepositorySecret(ctx context.Context, owner, repo, name string) (*Response, error) {
+func (s *ActionsService) DeleteRepoSecret(ctx context.Context, owner, repo, name string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/secrets/%v", owner, repo, name)
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
@@ -159,11 +157,11 @@ func (s *ActionsService) DeleteRepositorySecret(ctx context.Context, owner, repo
 	return s.client.Do(ctx, req, nil)
 }
 
-// ListOrganizationSecrets lists all secrets available in an organization
+// ListOrgSecrets lists all secrets available in an organization
 // without revealing their encrypted values.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#list-organization-secrets
-func (s *ActionsService) ListOrganizationSecrets(ctx context.Context, org string, opts *ListOptions) (*Secrets, *Response, error) {
+func (s *ActionsService) ListOrgSecrets(ctx context.Context, org string, opts *ListOptions) (*Secrets, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/secrets", org)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -184,10 +182,10 @@ func (s *ActionsService) ListOrganizationSecrets(ctx context.Context, org string
 	return secrets, resp, nil
 }
 
-// GetOrganizationSecret gets a single organization secret without revealing its encrypted value.
+// GetOrgSecret gets a single organization secret without revealing its encrypted value.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#get-an-organization-secret
-func (s *ActionsService) GetOrganizationSecret(ctx context.Context, org, name string) (*Secret, *Response, error) {
+func (s *ActionsService) GetOrgSecret(ctx context.Context, org, name string) (*Secret, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/secrets/%v", org, name)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -203,10 +201,10 @@ func (s *ActionsService) GetOrganizationSecret(ctx context.Context, org, name st
 	return secret, resp, nil
 }
 
-// CreateOrUpdateOrganizationSecret creates or updates an organization secret with an encrypted value.
+// CreateOrUpdateOrgSecret creates or updates an organization secret with an encrypted value.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#create-or-update-an-organization-secret
-func (s *ActionsService) CreateOrUpdateOrganizationSecret(ctx context.Context, org string, eSecret *EncryptedSecret) (*Response, error) {
+func (s *ActionsService) CreateOrUpdateOrgSecret(ctx context.Context, org string, eSecret *EncryptedSecret) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/secrets/%v", org, eSecret.Name)
 
 	req, err := s.client.NewRequest("PUT", u, eSecret)
@@ -217,23 +215,23 @@ func (s *ActionsService) CreateOrUpdateOrganizationSecret(ctx context.Context, o
 	return s.client.Do(ctx, req, nil)
 }
 
-// SelectedRepositoriesList represents the list of repositories selected for an organization secret.
-type SelectedRepositoriesList struct {
+// SelectedReposList represents the list of repositories selected for an organization secret.
+type SelectedReposList struct {
 	TotalCount   *int          `json:"total_count,omitempty"`
 	Repositories []*Repository `json:"repositories,omitempty"`
 }
 
-// ListSelectedRepositoriesForOrganizationSecret lists all repositories that have access to a secret.
+// ListSelectedReposForOrgSecret lists all repositories that have access to a secret.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#list-selected-repositories-for-an-organization-secret
-func (s *ActionsService) ListSelectedRepositoriesForOrganizationSecret(ctx context.Context, org, name string) (*SelectedRepositoriesList, *Response, error) {
+func (s *ActionsService) ListSelectedReposForOrgSecret(ctx context.Context, org, name string) (*SelectedReposList, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories", org, name)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	result := new(SelectedRepositoriesList)
+	result := new(SelectedReposList)
 	resp, err := s.client.Do(ctx, req, result)
 	if err != nil {
 		return nil, resp, err
@@ -242,12 +240,17 @@ func (s *ActionsService) ListSelectedRepositoriesForOrganizationSecret(ctx conte
 	return result, resp, nil
 }
 
-// SetSelectedRepositoriesForOrganizationSecret sets the repositories that have access to a secret.
+// SetSelectedReposForOrgSecret sets the repositories that have access to a secret.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#set-selected-repositories-for-an-organization-secret
-func (s *ActionsService) SetSelectedRepositoriesForOrganizationSecret(ctx context.Context, org, name string, ids SelectedRepositoryIDs) (*Response, error) {
+func (s *ActionsService) SetSelectedReposForOrgSecret(ctx context.Context, org, name string, ids SelectedRepoIDs) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories", org, name)
-	req, err := s.client.NewRequest("PUT", u, ids)
+
+	type repoIDs struct {
+		SelectedIDs SelectedRepoIDs `json:"selected_repository_ids,omitempty"`
+	}
+
+	req, err := s.client.NewRequest("PUT", u, repoIDs{SelectedIDs: ids})
 	if err != nil {
 		return nil, err
 	}
@@ -255,10 +258,10 @@ func (s *ActionsService) SetSelectedRepositoriesForOrganizationSecret(ctx contex
 	return s.client.Do(ctx, req, nil)
 }
 
-// AddSelectedRepositoryToOrganizationSecret adds a repository to an organization secret.
+// AddSelectedRepoToOrgSecret adds a repository to an organization secret.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#add-selected-repository-to-an-organization-secret
-func (s *ActionsService) AddSelectedRepositoryToOrganizationSecret(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
+func (s *ActionsService) AddSelectedRepoToOrgSecret(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories/%v", org, name, *repo.ID)
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
@@ -268,10 +271,10 @@ func (s *ActionsService) AddSelectedRepositoryToOrganizationSecret(ctx context.C
 	return s.client.Do(ctx, req, nil)
 }
 
-// RemoveSelectedRepositoryFromOrganizationSecret removes a repository from an organization secret.
+// RemoveSelectedRepoFromOrgSecret removes a repository from an organization secret.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#remove-selected-repository-from-an-organization-secret
-func (s *ActionsService) RemoveSelectedRepositoryFromOrganizationSecret(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
+func (s *ActionsService) RemoveSelectedRepoFromOrgSecret(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories/%v", org, name, *repo.ID)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -281,10 +284,10 @@ func (s *ActionsService) RemoveSelectedRepositoryFromOrganizationSecret(ctx cont
 	return s.client.Do(ctx, req, nil)
 }
 
-// DeleteOrganizationSecret deletes a secret in an organization using the secret name.
+// DeleteOrgSecret deletes a secret in an organization using the secret name.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#delete-an-organization-secret
-func (s *ActionsService) DeleteOrganizationSecret(ctx context.Context, org, name string) (*Response, error) {
+func (s *ActionsService) DeleteOrgSecret(ctx context.Context, org, name string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/secrets/%v", org, name)
 
 	req, err := s.client.NewRequest("DELETE", u, nil)

--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -35,11 +35,32 @@ func (s *ActionsService) GetRepositoryPublicKey(ctx context.Context, owner, repo
 	return pubKey, resp, nil
 }
 
+// GetOrganizationPublicKey gets a public key that should be used for secret encryption.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#get-an-organization-public-key
+func (s *ActionsService) GetOrganizationPublicKey(ctx context.Context, org string) (*PublicKey, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/public-key", org)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pubKey := new(PublicKey)
+	resp, err := s.client.Do(ctx, req, pubKey)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pubKey, resp, nil
+}
+
 // Secret represents a repository action secret.
 type Secret struct {
-	Name      string    `json:"name"`
-	CreatedAt Timestamp `json:"created_at"`
-	UpdatedAt Timestamp `json:"updated_at"`
+	Name                    string    `json:"name"`
+	CreatedAt               Timestamp `json:"created_at"`
+	UpdatedAt               Timestamp `json:"updated_at"`
+	Visibility              string    `json:"visibility,omitempty"`
+	SelectedRepositoriesURL string    `json:"selected_repositories_url,omitempty"`
 }
 
 // Secrets represents one item from the ListSecrets response.
@@ -53,7 +74,7 @@ type Secrets struct {
 //
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#list-repository-secrets
 func (s *ActionsService) ListRepositorySecrets(ctx context.Context, owner, repo string, opts *ListOptions) (*Secrets, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/actions/secrets", owner, repo)
+	u := fmt.Sprintf("repos/%v/%v/actions/secrets", owner, repo)
 	u, err := addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -92,6 +113,11 @@ func (s *ActionsService) GetRepositorySecret(ctx context.Context, owner, repo, n
 	return secret, resp, nil
 }
 
+// SelectedRepositoryIDs are the repository IDs that have access to the secret.
+type SelectedRepositoryIDs struct {
+	SelectedRepositoryIDs []int64 `json:"selected_repository_ids,omitempty"`
+}
+
 // EncryptedSecret represents a secret that is encrypted using a public key.
 //
 // The value of EncryptedValue must be your secret, encrypted with
@@ -101,6 +127,8 @@ type EncryptedSecret struct {
 	Name           string `json:"-"`
 	KeyID          string `json:"key_id"`
 	EncryptedValue string `json:"encrypted_value"`
+	Visibility     string `json:"visibility,omitempty"`
+	SelectedRepositoryIDs
 }
 
 // CreateOrUpdateRepositorySecret creates or updates a repository secret with an encrypted value.
@@ -122,6 +150,142 @@ func (s *ActionsService) CreateOrUpdateRepositorySecret(ctx context.Context, own
 // GitHub API docs: https://developer.github.com/v3/actions/secrets/#delete-a-repository-secret
 func (s *ActionsService) DeleteRepositorySecret(ctx context.Context, owner, repo, name string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/secrets/%v", owner, repo, name)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// ListOrganizationSecrets lists all secrets available in an organization
+// without revealing their encrypted values.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#list-organization-secrets
+func (s *ActionsService) ListOrganizationSecrets(ctx context.Context, org string, opts *ListOptions) (*Secrets, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets", org)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	secrets := new(Secrets)
+	resp, err := s.client.Do(ctx, req, &secrets)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return secrets, resp, nil
+}
+
+// GetOrganizationSecret gets a single organization secret without revealing its encrypted value.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#get-an-organization-secret
+func (s *ActionsService) GetOrganizationSecret(ctx context.Context, org, name string) (*Secret, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/%v", org, name)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	secret := new(Secret)
+	resp, err := s.client.Do(ctx, req, secret)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return secret, resp, nil
+}
+
+// CreateOrUpdateOrganizationSecret creates or updates an organization secret with an encrypted value.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#create-or-update-an-organization-secret
+func (s *ActionsService) CreateOrUpdateOrganizationSecret(ctx context.Context, org string, eSecret *EncryptedSecret) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/%v", org, eSecret.Name)
+
+	req, err := s.client.NewRequest("PUT", u, eSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// SelectedRepositoriesList represents the list of repositories selected for an organization secret.
+type SelectedRepositoriesList struct {
+	TotalCount   *int          `json:"total_count,omitempty"`
+	Repositories []*Repository `json:"repositories,omitempty"`
+}
+
+// ListSelectedRepositoriesForOrganizationSecret lists all repositories that have access to a secret.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#list-selected-repositories-for-an-organization-secret
+func (s *ActionsService) ListSelectedRepositoriesForOrganizationSecret(ctx context.Context, org, name string) (*SelectedRepositoriesList, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories", org, name)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(SelectedRepositoriesList)
+	resp, err := s.client.Do(ctx, req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// SetSelectedRepositoriesForOrganizationSecret sets the repositories that have access to a secret.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#set-selected-repositories-for-an-organization-secret
+func (s *ActionsService) SetSelectedRepositoriesForOrganizationSecret(ctx context.Context, org, name string, ids SelectedRepositoryIDs) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories", org, name)
+	req, err := s.client.NewRequest("PUT", u, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// AddSelectedRepositoryToOrganizationSecret adds a repository to an organization secret.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#add-selected-repository-to-an-organization-secret
+func (s *ActionsService) AddSelectedRepositoryToOrganizationSecret(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories/%v", org, name, *repo.ID)
+	req, err := s.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// RemoveSelectedRepositoryFromOrganizationSecret removes a repository from an organization secret.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#remove-selected-repository-from-an-organization-secret
+func (s *ActionsService) RemoveSelectedRepositoryFromOrganizationSecret(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories/%v", org, name, *repo.ID)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// DeleteOrganizationSecret deletes a secret in an organization using the secret name.
+//
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#delete-an-organization-secret
+func (s *ActionsService) DeleteOrganizationSecret(ctx context.Context, org, name string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/secrets/%v", org, name)
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -16,10 +16,10 @@ type PublicKey struct {
 	Key   *string `json:"key"`
 }
 
-// GetPublicKey gets a public key that should be used for secret encryption.
+// GetRepositoryPublicKey gets a public key that should be used for secret encryption.
 //
-// GitHub API docs: https://developer.github.com/v3/actions/secrets/#get-your-public-key
-func (s *ActionsService) GetPublicKey(ctx context.Context, owner, repo string) (*PublicKey, *Response, error) {
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#get-a-repository-public-key
+func (s *ActionsService) GetRepositoryPublicKey(ctx context.Context, owner, repo string) (*PublicKey, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/secrets/public-key", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -48,11 +48,11 @@ type Secrets struct {
 	Secrets    []*Secret `json:"secrets"`
 }
 
-// ListSecrets lists all secrets available in a repository
+// ListRepositorySecrets lists all secrets available in a repository
 // without revealing their encrypted values.
 //
-// GitHub API docs: https://developer.github.com/v3/actions/secrets/#list-secrets-for-a-repository
-func (s *ActionsService) ListSecrets(ctx context.Context, owner, repo string, opts *ListOptions) (*Secrets, *Response, error) {
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#list-repository-secrets
+func (s *ActionsService) ListRepositorySecrets(ctx context.Context, owner, repo string, opts *ListOptions) (*Secrets, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/actions/secrets", owner, repo)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -73,10 +73,10 @@ func (s *ActionsService) ListSecrets(ctx context.Context, owner, repo string, op
 	return secrets, resp, nil
 }
 
-// GetSecret gets a single secret without revealing its encrypted value.
+// GetRepositorySecret gets a single repository secret without revealing its encrypted value.
 //
-// GitHub API docs: https://developer.github.com/v3/actions/secrets/#get-a-secret
-func (s *ActionsService) GetSecret(ctx context.Context, owner, repo, name string) (*Secret, *Response, error) {
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#get-a-repository-secret
+func (s *ActionsService) GetRepositorySecret(ctx context.Context, owner, repo, name string) (*Secret, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/secrets/%v", owner, repo, name)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -103,10 +103,10 @@ type EncryptedSecret struct {
 	EncryptedValue string `json:"encrypted_value"`
 }
 
-// CreateOrUpdateSecret creates or updates a secret with an encrypted value.
+// CreateOrUpdateRepositorySecret creates or updates a repository secret with an encrypted value.
 //
-// GitHub API docs: https://developer.github.com/v3/actions/secrets/#create-or-update-a-secret-for-a-repository
-func (s *ActionsService) CreateOrUpdateSecret(ctx context.Context, owner, repo string, eSecret *EncryptedSecret) (*Response, error) {
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#create-or-update-a-repository-secret
+func (s *ActionsService) CreateOrUpdateRepositorySecret(ctx context.Context, owner, repo string, eSecret *EncryptedSecret) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/secrets/%v", owner, repo, eSecret.Name)
 
 	req, err := s.client.NewRequest("PUT", u, eSecret)
@@ -117,10 +117,10 @@ func (s *ActionsService) CreateOrUpdateSecret(ctx context.Context, owner, repo s
 	return s.client.Do(ctx, req, nil)
 }
 
-// DeleteSecret deletes a secret in a repository using the secret name.
+// DeleteRepositorySecret deletes a secret in a repository using the secret name.
 //
-// GitHub API docs: https://developer.github.com/v3/actions/secrets/#delete-a-secret-from-a-repository
-func (s *ActionsService) DeleteSecret(ctx context.Context, owner, repo, name string) (*Response, error) {
+// GitHub API docs: https://developer.github.com/v3/actions/secrets/#delete-a-repository-secret
+func (s *ActionsService) DeleteRepositorySecret(ctx context.Context, owner, repo, name string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/secrets/%v", owner, repo, name)
 
 	req, err := s.client.NewRequest("DELETE", u, nil)

--- a/github/actions_secrets_test.go
+++ b/github/actions_secrets_test.go
@@ -121,3 +121,187 @@ func TestActionsService_DeleteRepositorySecret(t *testing.T) {
 		t.Errorf("Actions.DeleteRepositorySecret returned error: %v", err)
 	}
 }
+
+func TestActionsService_GetOrganizationPublicKey(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/public-key", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"key_id":"012345678","key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
+	})
+
+	key, _, err := client.Actions.GetOrganizationPublicKey(context.Background(), "o")
+	if err != nil {
+		t.Errorf("Actions.GetOrganizationPublicKey returned error: %v", err)
+	}
+
+	want := &PublicKey{KeyID: String("012345678"), Key: String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234")}
+	if !reflect.DeepEqual(key, want) {
+		t.Errorf("Actions.GetOrganizationPublicKey returned %+v, want %+v", key, want)
+	}
+}
+
+func TestActionsService_ListOrganizationSecrets(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"per_page": "2", "page": "2"})
+		fmt.Fprint(w, `{"total_count":3,"secrets":[{"name":"GIST_ID","created_at":"2019-08-10T14:59:22Z","updated_at":"2020-01-10T14:59:22Z","visibility":"private"},{"name":"DEPLOY_TOKEN","created_at":"2019-08-10T14:59:22Z","updated_at":"2020-01-10T14:59:22Z","visibility":"all"},{"name":"GH_TOKEN","created_at":"2019-08-10T14:59:22Z","updated_at":"2020-01-10T14:59:22Z","visibility":"selected","selected_repositories_url":"https://api.github.com/orgs/octo-org/actions/secrets/SUPER_SECRET/repositories"}]}`)
+	})
+
+	opts := &ListOptions{Page: 2, PerPage: 2}
+	secrets, _, err := client.Actions.ListOrganizationSecrets(context.Background(), "o", opts)
+	if err != nil {
+		t.Errorf("Actions.ListOrganizationSecrets returned error: %v", err)
+	}
+
+	want := &Secrets{
+		TotalCount: 3,
+		Secrets: []*Secret{
+			{Name: "GIST_ID", CreatedAt: Timestamp{time.Date(2019, time.August, 10, 14, 59, 22, 0, time.UTC)}, UpdatedAt: Timestamp{time.Date(2020, time.January, 10, 14, 59, 22, 0, time.UTC)}, Visibility: "private"},
+			{Name: "DEPLOY_TOKEN", CreatedAt: Timestamp{time.Date(2019, time.August, 10, 14, 59, 22, 0, time.UTC)}, UpdatedAt: Timestamp{time.Date(2020, time.January, 10, 14, 59, 22, 0, time.UTC)}, Visibility: "all"},
+			{Name: "GH_TOKEN", CreatedAt: Timestamp{time.Date(2019, time.August, 10, 14, 59, 22, 0, time.UTC)}, UpdatedAt: Timestamp{time.Date(2020, time.January, 10, 14, 59, 22, 0, time.UTC)}, Visibility: "selected", SelectedRepositoriesURL: "https://api.github.com/orgs/octo-org/actions/secrets/SUPER_SECRET/repositories"},
+		},
+	}
+	if !reflect.DeepEqual(secrets, want) {
+		t.Errorf("Actions.ListOrganizationSecrets returned %+v, want %+v", secrets, want)
+	}
+}
+
+func TestActionsService_GetOrganizationSecret(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"name":"NAME","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z","visibility":"selected","selected_repositories_url":"https://api.github.com/orgs/octo-org/actions/secrets/SUPER_SECRET/repositories"}`)
+	})
+
+	secret, _, err := client.Actions.GetOrganizationSecret(context.Background(), "o", "NAME")
+	if err != nil {
+		t.Errorf("Actions.GetRepositorySecret returned error: %v", err)
+	}
+
+	want := &Secret{
+		Name:                    "NAME",
+		CreatedAt:               Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
+		UpdatedAt:               Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
+		Visibility:              "selected",
+		SelectedRepositoriesURL: "https://api.github.com/orgs/octo-org/actions/secrets/SUPER_SECRET/repositories",
+	}
+	if !reflect.DeepEqual(secret, want) {
+		t.Errorf("Actions.GetOrganizationSecret returned %+v, want %+v", secret, want)
+	}
+}
+
+func TestActionsService_CreateOrUpdateOrganizationSecret(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Content-Type", "application/json")
+		testBody(t, r, `{"key_id":"1234","encrypted_value":"QIv=","visibility":"selected","selected_repository_ids":[1296269,1269280]}`+"\n")
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	input := &EncryptedSecret{
+		Name:                  "NAME",
+		EncryptedValue:        "QIv=",
+		KeyID:                 "1234",
+		Visibility:            "selected",
+		SelectedRepositoryIDs: SelectedRepositoryIDs{[]int64{1296269, 1269280}},
+	}
+	_, err := client.Actions.CreateOrUpdateOrganizationSecret(context.Background(), "o", input)
+	if err != nil {
+		t.Errorf("Actions.CreateOrUpdateOrganizationSecret returned error: %v", err)
+	}
+}
+
+func TestActionsService_ListSelectedRepositoriesForOrganizationSecret(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprintf(w, `{"total_count":1,"repositories":[{"id":1}]}`)
+	})
+
+	repos, _, err := client.Actions.ListSelectedRepositoriesForOrganizationSecret(context.Background(), "o", "NAME")
+	if err != nil {
+		t.Errorf("Actions.ListSelectedRepositoriesForOrganizationSecret returned error: %v", err)
+	}
+
+	want := &SelectedRepositoriesList{
+		TotalCount: Int(1),
+		Repositories: []*Repository{
+			{ID: Int64(1)},
+		},
+	}
+	if !reflect.DeepEqual(repos, want) {
+		t.Errorf("Actions.ListSelectedRepositoriesForOrganizationSecret returned %+v, want %+v", repos, want)
+	}
+}
+
+func TestActionsService_SetSelectedRepositoriesForOrganizationSecret(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Content-Type", "application/json")
+		testBody(t, r, `{"selected_repository_ids":[64780797]}`+"\n")
+	})
+
+	_, err := client.Actions.SetSelectedRepositoriesForOrganizationSecret(context.Background(), "o", "NAME", SelectedRepositoryIDs{[]int64{64780797}})
+	if err != nil {
+		t.Errorf("Actions.SetSelectedRepositoriesForOrganizationSecret returned error: %v", err)
+	}
+}
+
+func TestActionsService_AddSelectedRepositoryToOrganizationSecret(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+	})
+
+	repo := &Repository{ID: Int64(1234)}
+	_, err := client.Actions.AddSelectedRepositoryToOrganizationSecret(context.Background(), "o", "NAME", repo)
+	if err != nil {
+		t.Errorf("Actions.AddSelectedRepositoryToOrganizationSecret returned error: %v", err)
+	}
+}
+
+func TestActionsService_RemoveSelectedRepositoryFromOrganizationSecret(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	repo := &Repository{ID: Int64(1234)}
+	_, err := client.Actions.RemoveSelectedRepositoryFromOrganizationSecret(context.Background(), "o", "NAME", repo)
+	if err != nil {
+		t.Errorf("Actions.RemoveSelectedRepositoryFromOrganizationSecret returned error: %v", err)
+	}
+}
+
+func TestActionsService_DeleteOrganizationSecret(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	_, err := client.Actions.DeleteOrganizationSecret(context.Background(), "o", "NAME")
+	if err != nil {
+		t.Errorf("Actions.DeleteOrganizationSecret returned error: %v", err)
+	}
+}

--- a/github/actions_secrets_test.go
+++ b/github/actions_secrets_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-func TestActionsService_GetPublicKey(t *testing.T) {
+func TestActionsService_GetRepositoryPublicKey(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -23,18 +23,18 @@ func TestActionsService_GetPublicKey(t *testing.T) {
 		fmt.Fprint(w, `{"key_id":"1234","key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
 	})
 
-	key, _, err := client.Actions.GetPublicKey(context.Background(), "o", "r")
+	key, _, err := client.Actions.GetRepositoryPublicKey(context.Background(), "o", "r")
 	if err != nil {
-		t.Errorf("Actions.GetPublicKey returned error: %v", err)
+		t.Errorf("Actions.GetRepositoryPublicKey returned error: %v", err)
 	}
 
 	want := &PublicKey{KeyID: String("1234"), Key: String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234")}
 	if !reflect.DeepEqual(key, want) {
-		t.Errorf("Actions.GetPublicKey returned %+v, want %+v", key, want)
+		t.Errorf("Actions.GetRepositoryPublicKey returned %+v, want %+v", key, want)
 	}
 }
 
-func TestActionsService_ListSecrets(t *testing.T) {
+func TestActionsService_ListRepositorySecrets(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -45,9 +45,9 @@ func TestActionsService_ListSecrets(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	secrets, _, err := client.Actions.ListSecrets(context.Background(), "o", "r", opts)
+	secrets, _, err := client.Actions.ListRepositorySecrets(context.Background(), "o", "r", opts)
 	if err != nil {
-		t.Errorf("Actions.ListSecrets returned error: %v", err)
+		t.Errorf("Actions.ListRepositorySecrets returned error: %v", err)
 	}
 
 	want := &Secrets{
@@ -58,11 +58,11 @@ func TestActionsService_ListSecrets(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(secrets, want) {
-		t.Errorf("Actions.ListSecrets returned %+v, want %+v", secrets, want)
+		t.Errorf("Actions.ListRepositorySecrets returned %+v, want %+v", secrets, want)
 	}
 }
 
-func TestActionsService_GetSecret(t *testing.T) {
+func TestActionsService_GetRepositorySecret(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -71,9 +71,9 @@ func TestActionsService_GetSecret(t *testing.T) {
 		fmt.Fprint(w, `{"name":"NAME","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
 	})
 
-	secret, _, err := client.Actions.GetSecret(context.Background(), "o", "r", "NAME")
+	secret, _, err := client.Actions.GetRepositorySecret(context.Background(), "o", "r", "NAME")
 	if err != nil {
-		t.Errorf("Actions.GetSecret returned error: %v", err)
+		t.Errorf("Actions.GetRepositorySecret returned error: %v", err)
 	}
 
 	want := &Secret{
@@ -82,11 +82,11 @@ func TestActionsService_GetSecret(t *testing.T) {
 		UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
 	}
 	if !reflect.DeepEqual(secret, want) {
-		t.Errorf("Actions.GetSecret returned %+v, want %+v", secret, want)
+		t.Errorf("Actions.GetRepositorySecret returned %+v, want %+v", secret, want)
 	}
 }
 
-func TestActionsService_CreateOrUpdateSecret(t *testing.T) {
+func TestActionsService_CreateOrUpdateRepositorySecret(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -102,13 +102,13 @@ func TestActionsService_CreateOrUpdateSecret(t *testing.T) {
 		EncryptedValue: "QIv=",
 		KeyID:          "1234",
 	}
-	_, err := client.Actions.CreateOrUpdateSecret(context.Background(), "o", "r", input)
+	_, err := client.Actions.CreateOrUpdateRepositorySecret(context.Background(), "o", "r", input)
 	if err != nil {
-		t.Errorf("Actions.CreateOrUpdateSecret returned error: %v", err)
+		t.Errorf("Actions.CreateOrUpdateRepositorySecret returned error: %v", err)
 	}
 }
 
-func TestActionsService_DeleteSecret(t *testing.T) {
+func TestActionsService_DeleteRepositorySecret(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -116,8 +116,8 @@ func TestActionsService_DeleteSecret(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Actions.DeleteSecret(context.Background(), "o", "r", "NAME")
+	_, err := client.Actions.DeleteRepositorySecret(context.Background(), "o", "r", "NAME")
 	if err != nil {
-		t.Errorf("Actions.DeleteSecret returned error: %v", err)
+		t.Errorf("Actions.DeleteRepositorySecret returned error: %v", err)
 	}
 }

--- a/github/actions_secrets_test.go
+++ b/github/actions_secrets_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-func TestActionsService_GetRepositoryPublicKey(t *testing.T) {
+func TestActionsService_GetRepoPublicKey(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -23,18 +23,18 @@ func TestActionsService_GetRepositoryPublicKey(t *testing.T) {
 		fmt.Fprint(w, `{"key_id":"1234","key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
 	})
 
-	key, _, err := client.Actions.GetRepositoryPublicKey(context.Background(), "o", "r")
+	key, _, err := client.Actions.GetRepoPublicKey(context.Background(), "o", "r")
 	if err != nil {
-		t.Errorf("Actions.GetRepositoryPublicKey returned error: %v", err)
+		t.Errorf("Actions.GetRepoPublicKey returned error: %v", err)
 	}
 
 	want := &PublicKey{KeyID: String("1234"), Key: String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234")}
 	if !reflect.DeepEqual(key, want) {
-		t.Errorf("Actions.GetRepositoryPublicKey returned %+v, want %+v", key, want)
+		t.Errorf("Actions.GetRepoPublicKey returned %+v, want %+v", key, want)
 	}
 }
 
-func TestActionsService_ListRepositorySecrets(t *testing.T) {
+func TestActionsService_ListRepoSecrets(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -45,9 +45,9 @@ func TestActionsService_ListRepositorySecrets(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	secrets, _, err := client.Actions.ListRepositorySecrets(context.Background(), "o", "r", opts)
+	secrets, _, err := client.Actions.ListRepoSecrets(context.Background(), "o", "r", opts)
 	if err != nil {
-		t.Errorf("Actions.ListRepositorySecrets returned error: %v", err)
+		t.Errorf("Actions.ListRepoSecrets returned error: %v", err)
 	}
 
 	want := &Secrets{
@@ -58,11 +58,11 @@ func TestActionsService_ListRepositorySecrets(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(secrets, want) {
-		t.Errorf("Actions.ListRepositorySecrets returned %+v, want %+v", secrets, want)
+		t.Errorf("Actions.ListRepoSecrets returned %+v, want %+v", secrets, want)
 	}
 }
 
-func TestActionsService_GetRepositorySecret(t *testing.T) {
+func TestActionsService_GetRepoSecret(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -71,9 +71,9 @@ func TestActionsService_GetRepositorySecret(t *testing.T) {
 		fmt.Fprint(w, `{"name":"NAME","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
 	})
 
-	secret, _, err := client.Actions.GetRepositorySecret(context.Background(), "o", "r", "NAME")
+	secret, _, err := client.Actions.GetRepoSecret(context.Background(), "o", "r", "NAME")
 	if err != nil {
-		t.Errorf("Actions.GetRepositorySecret returned error: %v", err)
+		t.Errorf("Actions.GetRepoSecret returned error: %v", err)
 	}
 
 	want := &Secret{
@@ -82,11 +82,11 @@ func TestActionsService_GetRepositorySecret(t *testing.T) {
 		UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
 	}
 	if !reflect.DeepEqual(secret, want) {
-		t.Errorf("Actions.GetRepositorySecret returned %+v, want %+v", secret, want)
+		t.Errorf("Actions.GetRepoSecret returned %+v, want %+v", secret, want)
 	}
 }
 
-func TestActionsService_CreateOrUpdateRepositorySecret(t *testing.T) {
+func TestActionsService_CreateOrUpdateRepoSecret(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -102,13 +102,13 @@ func TestActionsService_CreateOrUpdateRepositorySecret(t *testing.T) {
 		EncryptedValue: "QIv=",
 		KeyID:          "1234",
 	}
-	_, err := client.Actions.CreateOrUpdateRepositorySecret(context.Background(), "o", "r", input)
+	_, err := client.Actions.CreateOrUpdateRepoSecret(context.Background(), "o", "r", input)
 	if err != nil {
-		t.Errorf("Actions.CreateOrUpdateRepositorySecret returned error: %v", err)
+		t.Errorf("Actions.CreateOrUpdateRepoSecret returned error: %v", err)
 	}
 }
 
-func TestActionsService_DeleteRepositorySecret(t *testing.T) {
+func TestActionsService_DeleteRepoSecret(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -116,13 +116,13 @@ func TestActionsService_DeleteRepositorySecret(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Actions.DeleteRepositorySecret(context.Background(), "o", "r", "NAME")
+	_, err := client.Actions.DeleteRepoSecret(context.Background(), "o", "r", "NAME")
 	if err != nil {
-		t.Errorf("Actions.DeleteRepositorySecret returned error: %v", err)
+		t.Errorf("Actions.DeleteRepoSecret returned error: %v", err)
 	}
 }
 
-func TestActionsService_GetOrganizationPublicKey(t *testing.T) {
+func TestActionsService_GetOrgPublicKey(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -131,18 +131,18 @@ func TestActionsService_GetOrganizationPublicKey(t *testing.T) {
 		fmt.Fprint(w, `{"key_id":"012345678","key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
 	})
 
-	key, _, err := client.Actions.GetOrganizationPublicKey(context.Background(), "o")
+	key, _, err := client.Actions.GetOrgPublicKey(context.Background(), "o")
 	if err != nil {
-		t.Errorf("Actions.GetOrganizationPublicKey returned error: %v", err)
+		t.Errorf("Actions.GetOrgPublicKey returned error: %v", err)
 	}
 
 	want := &PublicKey{KeyID: String("012345678"), Key: String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234")}
 	if !reflect.DeepEqual(key, want) {
-		t.Errorf("Actions.GetOrganizationPublicKey returned %+v, want %+v", key, want)
+		t.Errorf("Actions.GetOrgPublicKey returned %+v, want %+v", key, want)
 	}
 }
 
-func TestActionsService_ListOrganizationSecrets(t *testing.T) {
+func TestActionsService_ListOrgSecrets(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -153,9 +153,9 @@ func TestActionsService_ListOrganizationSecrets(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	secrets, _, err := client.Actions.ListOrganizationSecrets(context.Background(), "o", opts)
+	secrets, _, err := client.Actions.ListOrgSecrets(context.Background(), "o", opts)
 	if err != nil {
-		t.Errorf("Actions.ListOrganizationSecrets returned error: %v", err)
+		t.Errorf("Actions.ListOrgSecrets returned error: %v", err)
 	}
 
 	want := &Secrets{
@@ -167,11 +167,11 @@ func TestActionsService_ListOrganizationSecrets(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(secrets, want) {
-		t.Errorf("Actions.ListOrganizationSecrets returned %+v, want %+v", secrets, want)
+		t.Errorf("Actions.ListOrgSecrets returned %+v, want %+v", secrets, want)
 	}
 }
 
-func TestActionsService_GetOrganizationSecret(t *testing.T) {
+func TestActionsService_GetOrgSecret(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -180,9 +180,9 @@ func TestActionsService_GetOrganizationSecret(t *testing.T) {
 		fmt.Fprint(w, `{"name":"NAME","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z","visibility":"selected","selected_repositories_url":"https://api.github.com/orgs/octo-org/actions/secrets/SUPER_SECRET/repositories"}`)
 	})
 
-	secret, _, err := client.Actions.GetOrganizationSecret(context.Background(), "o", "NAME")
+	secret, _, err := client.Actions.GetOrgSecret(context.Background(), "o", "NAME")
 	if err != nil {
-		t.Errorf("Actions.GetRepositorySecret returned error: %v", err)
+		t.Errorf("Actions.GetOrgSecret returned error: %v", err)
 	}
 
 	want := &Secret{
@@ -193,11 +193,11 @@ func TestActionsService_GetOrganizationSecret(t *testing.T) {
 		SelectedRepositoriesURL: "https://api.github.com/orgs/octo-org/actions/secrets/SUPER_SECRET/repositories",
 	}
 	if !reflect.DeepEqual(secret, want) {
-		t.Errorf("Actions.GetOrganizationSecret returned %+v, want %+v", secret, want)
+		t.Errorf("Actions.GetOrgSecret returned %+v, want %+v", secret, want)
 	}
 }
 
-func TestActionsService_CreateOrUpdateOrganizationSecret(t *testing.T) {
+func TestActionsService_CreateOrUpdateOrgSecret(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -213,15 +213,15 @@ func TestActionsService_CreateOrUpdateOrganizationSecret(t *testing.T) {
 		EncryptedValue:        "QIv=",
 		KeyID:                 "1234",
 		Visibility:            "selected",
-		SelectedRepositoryIDs: SelectedRepositoryIDs{[]int64{1296269, 1269280}},
+		SelectedRepositoryIDs: SelectedRepoIDs{1296269, 1269280},
 	}
-	_, err := client.Actions.CreateOrUpdateOrganizationSecret(context.Background(), "o", input)
+	_, err := client.Actions.CreateOrUpdateOrgSecret(context.Background(), "o", input)
 	if err != nil {
-		t.Errorf("Actions.CreateOrUpdateOrganizationSecret returned error: %v", err)
+		t.Errorf("Actions.CreateOrUpdateOrgSecret returned error: %v", err)
 	}
 }
 
-func TestActionsService_ListSelectedRepositoriesForOrganizationSecret(t *testing.T) {
+func TestActionsService_ListSelectedReposForOrgSecret(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -230,23 +230,23 @@ func TestActionsService_ListSelectedRepositoriesForOrganizationSecret(t *testing
 		fmt.Fprintf(w, `{"total_count":1,"repositories":[{"id":1}]}`)
 	})
 
-	repos, _, err := client.Actions.ListSelectedRepositoriesForOrganizationSecret(context.Background(), "o", "NAME")
+	repos, _, err := client.Actions.ListSelectedReposForOrgSecret(context.Background(), "o", "NAME")
 	if err != nil {
-		t.Errorf("Actions.ListSelectedRepositoriesForOrganizationSecret returned error: %v", err)
+		t.Errorf("Actions.ListSelectedReposForOrgSecret returned error: %v", err)
 	}
 
-	want := &SelectedRepositoriesList{
+	want := &SelectedReposList{
 		TotalCount: Int(1),
 		Repositories: []*Repository{
 			{ID: Int64(1)},
 		},
 	}
 	if !reflect.DeepEqual(repos, want) {
-		t.Errorf("Actions.ListSelectedRepositoriesForOrganizationSecret returned %+v, want %+v", repos, want)
+		t.Errorf("Actions.ListSelectedReposForOrgSecret returned %+v, want %+v", repos, want)
 	}
 }
 
-func TestActionsService_SetSelectedRepositoriesForOrganizationSecret(t *testing.T) {
+func TestActionsService_SetSelectedReposForOrgSecret(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -256,13 +256,13 @@ func TestActionsService_SetSelectedRepositoriesForOrganizationSecret(t *testing.
 		testBody(t, r, `{"selected_repository_ids":[64780797]}`+"\n")
 	})
 
-	_, err := client.Actions.SetSelectedRepositoriesForOrganizationSecret(context.Background(), "o", "NAME", SelectedRepositoryIDs{[]int64{64780797}})
+	_, err := client.Actions.SetSelectedReposForOrgSecret(context.Background(), "o", "NAME", SelectedRepoIDs{64780797})
 	if err != nil {
-		t.Errorf("Actions.SetSelectedRepositoriesForOrganizationSecret returned error: %v", err)
+		t.Errorf("Actions.SetSelectedReposForOrgSecret returned error: %v", err)
 	}
 }
 
-func TestActionsService_AddSelectedRepositoryToOrganizationSecret(t *testing.T) {
+func TestActionsService_AddSelectedRepoToOrgSecret(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -271,13 +271,13 @@ func TestActionsService_AddSelectedRepositoryToOrganizationSecret(t *testing.T) 
 	})
 
 	repo := &Repository{ID: Int64(1234)}
-	_, err := client.Actions.AddSelectedRepositoryToOrganizationSecret(context.Background(), "o", "NAME", repo)
+	_, err := client.Actions.AddSelectedRepoToOrgSecret(context.Background(), "o", "NAME", repo)
 	if err != nil {
-		t.Errorf("Actions.AddSelectedRepositoryToOrganizationSecret returned error: %v", err)
+		t.Errorf("Actions.AddSelectedRepoToOrgSecret returned error: %v", err)
 	}
 }
 
-func TestActionsService_RemoveSelectedRepositoryFromOrganizationSecret(t *testing.T) {
+func TestActionsService_RemoveSelectedRepoFromOrgSecret(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -286,13 +286,13 @@ func TestActionsService_RemoveSelectedRepositoryFromOrganizationSecret(t *testin
 	})
 
 	repo := &Repository{ID: Int64(1234)}
-	_, err := client.Actions.RemoveSelectedRepositoryFromOrganizationSecret(context.Background(), "o", "NAME", repo)
+	_, err := client.Actions.RemoveSelectedRepoFromOrgSecret(context.Background(), "o", "NAME", repo)
 	if err != nil {
-		t.Errorf("Actions.RemoveSelectedRepositoryFromOrganizationSecret returned error: %v", err)
+		t.Errorf("Actions.RemoveSelectedRepoFromOrgSecret returned error: %v", err)
 	}
 }
 
-func TestActionsService_DeleteOrganizationSecret(t *testing.T) {
+func TestActionsService_DeleteOrgSecret(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -300,8 +300,8 @@ func TestActionsService_DeleteOrganizationSecret(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Actions.DeleteOrganizationSecret(context.Background(), "o", "NAME")
+	_, err := client.Actions.DeleteOrgSecret(context.Background(), "o", "NAME")
 	if err != nil {
-		t.Errorf("Actions.DeleteOrganizationSecret returned error: %v", err)
+		t.Errorf("Actions.DeleteOrgSecret returned error: %v", err)
 	}
 }

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11757,7 +11757,7 @@ func (r *RunnerApplicationDownload) GetOS() string {
 }
 
 // GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
-func (s *SelectedRepositoriesList) GetTotalCount() int {
+func (s *SelectedReposList) GetTotalCount() int {
 	if s == nil || s.TotalCount == nil {
 		return 0
 	}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11756,6 +11756,14 @@ func (r *RunnerApplicationDownload) GetOS() string {
 	return *r.OS
 }
 
+// GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
+func (s *SelectedRepositoriesList) GetTotalCount() int {
+	if s == nil || s.TotalCount == nil {
+		return 0
+	}
+	return *s.TotalCount
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (s *ServiceHook) GetName() string {
 	if s == nil || s.Name == nil {


### PR DESCRIPTION
Related to #1525 and #1532.

Adds organization secrets https://developer.github.com/v3/actions/secrets/#get-an-organization-public-key and updates the repository secret actions API (probably would match how they would be named if org support had been in from the beginning, though it would be considered a breaking change).

Some possible issues:
- Checking with GitHub support if parameter selected repository ids should be an array of integers instead of array of strings. I think its been ~1 week?
-  Naming of the functions using the API endpoint header results in very long names.
- Handling of extra values in `Secret` and `EncryptedSecret` for organization secrets that repository secrets don't have: does omitempty make sense or should they be separate structs?
- Should there be an underlying function used for both organization and repository secrets that takes the base url as an argument? Quite a bit of duplication.
- Repository id (and id array) argument using int64 (or int64[]), or use the Repository type for the argument?
- Handling of selected repository IDs parameter as a type that wraps int64[], so that it gets marshaled to json correctly for `SetSelectedRepositoriesForOrganizationSecret` or is there a cleaner way to do this and use int64[] directly?