### PR TITLE
Handle github_app_authorization webhook

### DIFF
--- a/github/messages.go
+++ b/github/messages.go
@@ -50,6 +50,7 @@ var (
 		"deployment":                     "DeploymentEvent",
 		"deployment_status":              "DeploymentStatusEvent",
 		"fork":                           "ForkEvent",
+		"github_app_authorization":       "GitHubAppAuthorizationEvent",
 		"gollum":                         "GollumEvent",
 		"installation":                   "InstallationEvent",
 		"installation_repositories":      "InstallationRepositoriesEvent",

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -220,7 +220,7 @@ func TestParseWebHook(t *testing.T) {
 			messageType: "fork",
 		},
 		{
-			payload: &GitHubAppAuthorizationEvent{},
+			payload:     &GitHubAppAuthorizationEvent{},
 			messageType: "github_app_authorization",
 		},
 		{

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -220,6 +220,10 @@ func TestParseWebHook(t *testing.T) {
 			messageType: "fork",
 		},
 		{
+			payload: &GitHubAppAuthorizationEvent{},
+			messageType: "github_app_authorization",
+		},
+		{
 			payload:     &GollumEvent{},
 			messageType: "gollum",
 		},


### PR DESCRIPTION
Fixes #1543 by adding `github_app_authorization` to the event map used to parse webhooks.