### PR TITLE
Add tokenauth example

### DIFF
--- a/example/basicauth/main.go
+++ b/example/basicauth/main.go
@@ -6,6 +6,12 @@
 // The basicauth command demonstrates using the github.BasicAuthTransport,
 // including handling two-factor authentication. This won't currently work for
 // accounts that use SMS to receive one-time passwords.
+
+// Deprecation Notice: GitHub will discontinue password authentication to the API.
+// You must now authenticate to the GitHub API with an API token, such as an OAuth access token,
+// GitHub App installation access token, or personal access token, depending on what you need to do with the token.
+// Password authentication to the API will be removed on November 13, 2020.
+
 package main
 
 import (

--- a/example/tokenauth/main.go
+++ b/example/tokenauth/main.go
@@ -1,0 +1,40 @@
+// Copyright 2015 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// The tokenauth command demonstrates using the oauth2.StaticTokenSource
+package main
+
+import (
+	"context"
+	"fmt"
+	"syscall"
+
+	"github.com/google/go-github/v32/github"
+	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/oauth2"
+)
+
+func main() {
+	fmt.Print("GitHub Token: ")
+	byteToken, _ := terminal.ReadPassword(int(syscall.Stdin))
+	token := string(byteToken)
+
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+
+	client := github.NewClient(tc)
+
+	user, _, err := client.Users.Get(ctx, "")
+
+	if err != nil {
+		fmt.Printf("\nerror: %v\n", err)
+		return
+	}
+
+	fmt.Printf("\n%v\n", github.Stringify(user))
+}

--- a/example/tokenauth/main.go
+++ b/example/tokenauth/main.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The go-github AUTHORS. All rights reserved.
+// Copyright 2020 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
Basic authentication via username and password for the GitHub API is deprecated and will be discontinued November 13, 2020.
As such, I think It's important to have an example for how to use a personal access token to authenticate. 
This new `tokenauth` example is completely identical to `basicauth` except it creates a `*github.Client` using `oauth2.StaticTokenSource`. 