### PR TITLE
Add missing workflow_id field from workflow run

### DIFF
--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -22,6 +22,7 @@ type WorkflowRun struct {
 	Event          *string        `json:"event,omitempty"`
 	Status         *string        `json:"status,omitempty"`
 	Conclusion     *string        `json:"conclusion,omitempty"`
+	WorkflowID     *int           `json:"workflow_id,omitempty"`
 	URL            *string        `json:"url,omitempty"`
 	HTMLURL        *string        `json:"html_url,omitempty"`
 	PullRequests   []*PullRequest `json:"pull_requests,omitempty"`

--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -22,7 +22,7 @@ type WorkflowRun struct {
 	Event          *string        `json:"event,omitempty"`
 	Status         *string        `json:"status,omitempty"`
 	Conclusion     *string        `json:"conclusion,omitempty"`
-	WorkflowID     *int           `json:"workflow_id,omitempty"`
+	WorkflowID     *int64         `json:"workflow_id,omitempty"`
 	URL            *string        `json:"url,omitempty"`
 	HTMLURL        *string        `json:"html_url,omitempty"`
 	PullRequests   []*PullRequest `json:"pull_requests,omitempty"`

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -14597,7 +14597,7 @@ func (w *WorkflowRun) GetURL() string {
 }
 
 // GetWorkflowID returns the WorkflowID field if it's non-nil, zero value otherwise.
-func (w *WorkflowRun) GetWorkflowID() int {
+func (w *WorkflowRun) GetWorkflowID() int64 {
 	if w == nil || w.WorkflowID == nil {
 		return 0
 	}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -14596,6 +14596,14 @@ func (w *WorkflowRun) GetURL() string {
 	return *w.URL
 }
 
+// GetWorkflowID returns the WorkflowID field if it's non-nil, zero value otherwise.
+func (w *WorkflowRun) GetWorkflowID() int {
+	if w == nil || w.WorkflowID == nil {
+		return 0
+	}
+	return *w.WorkflowID
+}
+
 // GetWorkflowURL returns the WorkflowURL field if it's non-nil, zero value otherwise.
 func (w *WorkflowRun) GetWorkflowURL() string {
 	if w == nil || w.WorkflowURL == nil {


### PR DESCRIPTION
Adds the missing `workflow_id` field from workflow runs endpoint.

See docs: https://developer.github.com/v3/actions/workflow-runs