### PR TITLE
Add support for multi-line comments.

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2972,6 +2972,14 @@ func (d *DraftReviewComment) GetBody() string {
 	return *d.Body
 }
 
+// GetLine returns the Line field if it's non-nil, zero value otherwise.
+func (d *DraftReviewComment) GetLine() int {
+	if d == nil || d.Line == nil {
+		return 0
+	}
+	return *d.Line
+}
+
 // GetPath returns the Path field if it's non-nil, zero value otherwise.
 func (d *DraftReviewComment) GetPath() string {
 	if d == nil || d.Path == nil {
@@ -2986,6 +2994,30 @@ func (d *DraftReviewComment) GetPosition() int {
 		return 0
 	}
 	return *d.Position
+}
+
+// GetSide returns the Side field if it's non-nil, zero value otherwise.
+func (d *DraftReviewComment) GetSide() string {
+	if d == nil || d.Side == nil {
+		return ""
+	}
+	return *d.Side
+}
+
+// GetStartLine returns the StartLine field if it's non-nil, zero value otherwise.
+func (d *DraftReviewComment) GetStartLine() int {
+	if d == nil || d.StartLine == nil {
+		return 0
+	}
+	return *d.StartLine
+}
+
+// GetStartSide returns the StartSide field if it's non-nil, zero value otherwise.
+func (d *DraftReviewComment) GetStartSide() string {
+	if d == nil || d.StartSide == nil {
+		return ""
+	}
+	return *d.StartSide
 }
 
 // GetAvatarURL returns the AvatarURL field if it's non-nil, zero value otherwise.

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -297,11 +297,15 @@ func TestDiscussionComment_String(t *testing.T) {
 
 func TestDraftReviewComment_String(t *testing.T) {
 	v := DraftReviewComment{
-		Path:     String(""),
-		Position: Int(0),
-		Body:     String(""),
+		Path:      String(""),
+		Position:  Int(0),
+		Body:      String(""),
+		StartSide: String(""),
+		Side:      String(""),
+		StartLine: Int(0),
+		Line:      Int(0),
 	}
-	want := `github.DraftReviewComment{Path:"", Position:0, Body:""}`
+	want := `github.DraftReviewComment{Path:"", Position:0, Body:"", StartSide:"", Side:"", StartLine:0, Line:0}`
 	if got := v.String(); got != want {
 		t.Errorf("DraftReviewComment.String = %v, want %v", got, want)
 	}

--- a/github/pulls_reviews.go
+++ b/github/pulls_reviews.go
@@ -210,6 +210,38 @@ func (s *PullRequestsService) ListReviewComments(ctx context.Context, owner, rep
 // Read more about it here - https://github.com/google/go-github/issues/540
 //
 // GitHub API docs: https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review
+//
+// In order to use multi-line comments, you must use the "comfort fade" preview.
+// This replaces the use of the "Position" field in comments with 4 new fields:
+//   [Start]Side, and [Start]Line.
+// These new fields must be used for ALL comments (including single-line),
+// with the following restrictions (empirically observed, so subject to change).
+//
+// For single-line "comfort fade" comments, you must use:
+//
+//    Path:  &path,  // as before
+//    Body:  &body,  // as before
+//    Side:  &"RIGHT" (or "LEFT")
+//    Line:  &123,  // NOT THE SAME AS POSITION, this is an actual line number.
+//
+// If StartSide or StartLine is used with single-line comments, a 422 is returned.
+//
+// For multi-line "comfort fade" comments, you must use:
+//
+//    Path:      &path,  // as before
+//    Body:      &body,  // as before
+//    StartSide: &"RIGHT" (or "LEFT")
+//    Side:      &"RIGHT" (or "LEFT")
+//    StartLine: &120,
+//    Line:      &125,
+//
+// Suggested edits are made by commenting on the lines to replace, and including the
+// suggested edit in a block like this (it may be surrounded in non-suggestion markdown):
+//
+//    ```suggestion
+//    Use this instead.
+//    It is waaaaaay better.
+//    ```
 func (s *PullRequestsService) CreateReview(ctx context.Context, owner, repo string, number int, review *PullRequestReviewRequest) (*PullRequestReview, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/reviews", owner, repo, number)
 
@@ -224,7 +256,7 @@ func (s *PullRequestsService) CreateReview(ctx context.Context, owner, repo stri
 	} else if isCF {
 		// If the review comments are using the comfort fade preview fields,
 		// then pass the comfort fade header.
-		req.Header.Set("Accept", "application/vnd.github.comfort-fade-preview+json")
+		req.Header.Set("Accept", mediaTypeMultiLineCommentsPreview)
 	}
 
 	r := new(PullRequestReview)


### PR DESCRIPTION
This adds support for the "comfort-fade" preview, which enables multi-line comments (incl. suggested edits).

I have been carrying a subset of this as a patch downstream for a while, which just hard wired things on, but I tried to make this "smart" for back-compat as part of upstreaming.