### PR TITLE
github/repos: remove omitempty option in BranchRestrictionsRequest

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -864,9 +864,9 @@ type BranchRestrictions struct {
 // different from the response structure.
 type BranchRestrictionsRequest struct {
 	// The list of user logins with push access. (Required; use []string{} instead of nil for empty list.)
-	Users []string `json:"users,omitempty"`
+	Users []string `json:"users"`
 	// The list of team slugs with push access. (Required; use []string{} instead of nil for empty list.)
-	Teams []string `json:"teams,omitempty"`
+	Teams []string `json:"teams"`
 	// The list of app slugs with push access.
 	Apps []string `json:"apps,omitempty"`
 }


### PR DESCRIPTION
Closes #1546 

Notes:
* this reverts a previous change to the `BranchRestrictionsRequest` as it does not behave as expected such that restrictions configured for individual repositories still result in an error if users/teams fields are not set e.g.
```
No subschema in "anyOf" matched.
"teams", "users" weren't supplied.
Not all subschemas of "allOf" matched.
For 'anyOf/1', {"apps"=>["myApp"]} is not a null.
```
or if set to `nil` or `[]string{}` e.g.
```
422 Validation Failed [{Resource: Field: Code: Message:Only organization repositories can have users and team restrictions}]
```
* in addition, the change introduced a break in behavior for organization-level repositories as discussed in #1546
* a workaround didn't seem feasible as the validation issue seems to be upstream but any further suggestions are greatly appreciated 😃 