### PR TITLE
Read response body for TCP connection reuse

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -554,7 +554,23 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 
 		return nil, err
 	}
-	defer resp.Body.Close()
+
+	defer func() {
+		// Ensure the response body is fully read and closed
+		// before we reconnect, so that we reuse the same TCP connection.
+		// Close the previous response's body. But read at least some of
+		// the body so if it's small the underlying TCP connection will be
+		// re-used. No need to check for errors: if it fails, the Transport
+		// won't reuse it anyway.
+		const maxBodySlurpSize = 2 << 10
+		if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
+			io.CopyN(ioutil.Discard, resp.Body, maxBodySlurpSize)
+		}
+
+		if rerr := resp.Body.Close(); err == nil {
+			err = rerr
+		}
+	}()
 
 	response := newResponse(resp)
 

--- a/github/github.go
+++ b/github/github.go
@@ -567,9 +567,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 			io.CopyN(ioutil.Discard, resp.Body, maxBodySlurpSize)
 		}
 
-		if rerr := resp.Body.Close(); err == nil {
-			err = rerr
-		}
+		resp.Body.Close()
 	}()
 
 	response := newResponse(resp)


### PR DESCRIPTION
According to the official Go docs:
https://golang.org/pkg/net/http/#Body

```
// The http Client and Transport guarantee that Body is always
// non-nil, even on responses without a body or responses with
// a zero-length body. It is the caller's responsibility to
// close Body. The default HTTP client's Transport may not
// reuse HTTP/1.x "keep-alive" TCP connections if the Body is
// not read to completion and closed.
```
To ensure http.Client connection reuse, I did the following things:

- Read until Response is complete (i.e. ioutil.ReadAll(resp.Body) or similar)
- Call Body.Close()

Closes #1575 