### PR TITLE
Remove unnecessary variable declaration.

### DIFF
--- a/github/event.go
+++ b/github/event.go
@@ -129,8 +129,7 @@ func (e *Event) ParsePayload() (payload interface{}, err error) {
 // Deprecated: Use ParsePayload instead, which returns an error
 // rather than panics if JSON unmarshaling raw payload fails.
 func (e *Event) Payload() (payload interface{}) {
-	var err error
-	payload, err = e.ParsePayload()
+	payload, err := e.ParsePayload()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
We don't need the `err` variable declaration prior to initialization. Since `err` is not needed as a return value at the end of the function, I think that relying on Go's built-in type inference makes sense here.