### PR TITLE
Fix: Remove Sort & Direction Fields From IssueListCommentsOptions

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -5084,28 +5084,12 @@ func (i *IssueEvent) GetURL() string {
 	return *i.URL
 }
 
-// GetDirection returns the Direction field if it's non-nil, zero value otherwise.
-func (i *IssueListCommentsOptions) GetDirection() string {
-	if i == nil || i.Direction == nil {
-		return ""
-	}
-	return *i.Direction
-}
-
 // GetSince returns the Since field if it's non-nil, zero value otherwise.
 func (i *IssueListCommentsOptions) GetSince() time.Time {
 	if i == nil || i.Since == nil {
 		return time.Time{}
 	}
 	return *i.Since
-}
-
-// GetSort returns the Sort field if it's non-nil, zero value otherwise.
-func (i *IssueListCommentsOptions) GetSort() string {
-	if i == nil || i.Sort == nil {
-		return ""
-	}
-	return *i.Sort
 }
 
 // GetAssignee returns the Assignee field if it's non-nil, zero value otherwise.

--- a/github/issues_comments.go
+++ b/github/issues_comments.go
@@ -35,12 +35,6 @@ func (i IssueComment) String() string {
 // IssueListCommentsOptions specifies the optional parameters to the
 // IssuesService.ListComments method.
 type IssueListCommentsOptions struct {
-	// Sort specifies how to sort comments. Possible values are: created, updated.
-	Sort *string `url:"sort,omitempty"`
-
-	// Direction in which to sort comments. Possible values are: asc, desc.
-	Direction *string `url:"direction,omitempty"`
-
 	// Since filters comments by time.
 	Since *time.Time `url:"since,omitempty"`
 

--- a/github/issues_comments_test.go
+++ b/github/issues_comments_test.go
@@ -23,18 +23,14 @@ func TestIssuesService_ListComments_allIssues(t *testing.T) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		testFormValues(t, r, values{
-			"sort":      "updated",
-			"direction": "desc",
-			"since":     "2002-02-10T15:30:00Z",
-			"page":      "2",
+			"since": "2002-02-10T15:30:00Z",
+			"page":  "2",
 		})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
 	since := time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC)
 	opt := &IssueListCommentsOptions{
-		Sort:        String("updated"),
-		Direction:   String("desc"),
 		Since:       &since,
 		ListOptions: ListOptions{Page: 2},
 	}


### PR DESCRIPTION
For: #1583 

- The `Sort` & `Direction` fields in` IssueListCommentsOptions` were removed from the github api so they no longer work.
- Fields have been removed from the struct and any corresponding tests. 

- [x] tests pass
- [x] code fmt

> These are tagged as breaking changes so not sure if anything else needs to be updated to reflect that