### PR TITLE
Add content_reference event

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -112,6 +112,13 @@ type Attachment struct {
 	Body  *string `json:"body,omitempty"`
 }
 
+// ContentReference represents a reference to a URL in an issue or pull request
+type ContentReference struct {
+	ID        *int64  `json:"id,omitempty"`
+	NodeID    *string `json:"node_id,omitempty"`
+	Reference *string `json:"reference,omitempty"`
+}
+
 func (i Installation) String() string {
 	return Stringify(i)
 }

--- a/github/event.go
+++ b/github/event.go
@@ -36,6 +36,8 @@ func (e *Event) ParsePayload() (payload interface{}, err error) {
 		payload = &CheckSuiteEvent{}
 	case "CommitCommentEvent":
 		payload = &CommitCommentEvent{}
+	case "ContentReferenceEvent":
+		payload = &ContentReferenceEvent{}
 	case "CreateEvent":
 		payload = &CreateEvent{}
 	case "DeleteEvent":

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -64,6 +64,19 @@ type CommitCommentEvent struct {
 	Installation *Installation `json:"installation,omitempty"`
 }
 
+// ContentReferenceEvent is triggered when the body or comment of an issue or
+// pull request includes a URL that matches a configured content reference
+// domain.
+// The Webhook event name is "content_reference".
+//
+// GitHub API docs: https://developer.github.com/webhooks/event-payloads/#content_reference
+type ContentReferenceEvent struct {
+	Action       *string       `json:"action,omitempty"`
+	Repo         *Repository   `json:"repository,omitempty"`
+	Sender       *User         `json:"sender,omitempty"`
+	Installation *Installation `json:"installation,omitempty"`
+}
+
 // CreateEvent represents a created repository, branch, or tag.
 // The Webhook event name is "create".
 //

--- a/github/messages.go
+++ b/github/messages.go
@@ -44,6 +44,7 @@ var (
 		"check_run":                      "CheckRunEvent",
 		"check_suite":                    "CheckSuiteEvent",
 		"commit_comment":                 "CommitCommentEvent",
+		"content_reference":              "ContentReferenceEvent",
 		"create":                         "CreateEvent",
 		"delete":                         "DeleteEvent",
 		"deploy_key":                     "DeployKeyEvent",


### PR DESCRIPTION
Adds the content_reference web hook event along with the content reference type. 

`github/apps.go` seemed the best place for `ContentReference` to live but if there is a better place let me know.

GitHub API docs: https://developer.github.com/webhooks/event-payloads/#content_reference