### PR TITLE
API subdomain fix for Github Enterprise and a few golint fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.sh
 *.test
 coverage.out
+
+# intellij files
+.idea/

--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -154,7 +154,7 @@ func (s *ActionsService) GetWorkflowRunByID(ctx context.Context, owner, repo str
 	return run, resp, nil
 }
 
-// RerunWorkflow re-runs a workflow by ID.
+// RerunWorkflowByID re-runs a workflow by ID.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/workflow-runs/#re-run-a-workflow
 func (s *ActionsService) RerunWorkflowByID(ctx context.Context, owner, repo string, runID int64) (*Response, error) {

--- a/github/github.go
+++ b/github/github.go
@@ -313,7 +313,9 @@ func NewEnterpriseClient(baseURL, uploadURL string, httpClient *http.Client) (*C
 	if !strings.HasSuffix(baseEndpoint.Path, "/") {
 		baseEndpoint.Path += "/"
 	}
-	if !strings.HasSuffix(baseEndpoint.Path, "/api/v3/") {
+	if !strings.HasSuffix(baseEndpoint.Path, "/api/v3/") &&
+		!strings.HasPrefix(baseEndpoint.Host, "api.") &&
+		!strings.Contains(baseEndpoint.Host, ".api.") {
 		baseEndpoint.Path += "api/v3/"
 	}
 
@@ -324,7 +326,9 @@ func NewEnterpriseClient(baseURL, uploadURL string, httpClient *http.Client) (*C
 	if !strings.HasSuffix(uploadEndpoint.Path, "/") {
 		uploadEndpoint.Path += "/"
 	}
-	if !strings.HasSuffix(uploadEndpoint.Path, "/api/uploads/") {
+	if !strings.HasSuffix(uploadEndpoint.Path, "/api/uploads/") &&
+		!strings.HasPrefix(uploadEndpoint.Host, "api.") &&
+		!strings.Contains(uploadEndpoint.Host, ".api.") {
 		uploadEndpoint.Path += "api/uploads/"
 	}
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -255,6 +255,116 @@ func TestNewEnterpriseClient_addsEnterpriseSuffixAndTrailingSlashToURLs(t *testi
 	}
 }
 
+func TestNewEnterpriseClient_URLHasExistingAPIPrefix_AddTrailingSlash(t *testing.T) {
+	baseURL := "https://api.custom-url"
+	uploadURL := "https://api.custom-upload-url"
+	formattedBaseURL := baseURL + "/"
+	formattedUploadURL := uploadURL + "/"
+
+	c, err := NewEnterpriseClient(baseURL, uploadURL, nil)
+	if err != nil {
+		t.Fatalf("NewEnterpriseClient returned unexpected error: %v", err)
+	}
+
+	if got, want := c.BaseURL.String(), formattedBaseURL; got != want {
+		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
+	}
+	if got, want := c.UploadURL.String(), formattedUploadURL; got != want {
+		t.Errorf("NewClient UploadURL is %v, want %v", got, want)
+	}
+}
+
+func TestNewEnterpriseClient_URLHasExistingAPIPrefixAndTrailingSlash(t *testing.T) {
+	baseURL := "https://api.custom-url/"
+	uploadURL := "https://api.custom-upload-url/"
+
+	c, err := NewEnterpriseClient(baseURL, uploadURL, nil)
+	if err != nil {
+		t.Fatalf("NewEnterpriseClient returned unexpected error: %v", err)
+	}
+
+	if got, want := c.BaseURL.String(), baseURL; got != want {
+		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
+	}
+	if got, want := c.UploadURL.String(), uploadURL; got != want {
+		t.Errorf("NewClient UploadURL is %v, want %v", got, want)
+	}
+}
+
+func TestNewEnterpriseClient_URLHasAPISubdomain_AddTrailingSlash(t *testing.T) {
+	baseURL := "https://catalog.api.custom-url"
+	uploadURL := "https://catalog.api.custom-upload-url"
+	formattedBaseURL := baseURL + "/"
+	formattedUploadURL := uploadURL + "/"
+
+	c, err := NewEnterpriseClient(baseURL, uploadURL, nil)
+	if err != nil {
+		t.Fatalf("NewEnterpriseClient returned unexpected error: %v", err)
+	}
+
+	if got, want := c.BaseURL.String(), formattedBaseURL; got != want {
+		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
+	}
+	if got, want := c.UploadURL.String(), formattedUploadURL; got != want {
+		t.Errorf("NewClient UploadURL is %v, want %v", got, want)
+	}
+}
+
+func TestNewEnterpriseClient_URLHasAPISubdomainAndTrailingSlash(t *testing.T) {
+	baseURL := "https://catalog.api.custom-url/"
+	uploadURL := "https://catalog.api.custom-upload-url/"
+
+	c, err := NewEnterpriseClient(baseURL, uploadURL, nil)
+	if err != nil {
+		t.Fatalf("NewEnterpriseClient returned unexpected error: %v", err)
+	}
+
+	if got, want := c.BaseURL.String(), baseURL; got != want {
+		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
+	}
+	if got, want := c.UploadURL.String(), uploadURL; got != want {
+		t.Errorf("NewClient UploadURL is %v, want %v", got, want)
+	}
+}
+
+func TestNewEnterpriseClient_URLIsNotAProperAPISubdomain_addsEnterpriseSuffixAndSlash(t *testing.T) {
+	baseURL := "https://cloud-api.custom-url"
+	uploadURL := "https://cloud-api.custom-upload-url"
+	formattedBaseURL := baseURL + "/api/v3/"
+	formattedUploadURL := uploadURL + "/api/uploads/"
+
+	c, err := NewEnterpriseClient(baseURL, uploadURL, nil)
+	if err != nil {
+		t.Fatalf("NewEnterpriseClient returned unexpected error: %v", err)
+	}
+
+	if got, want := c.BaseURL.String(), formattedBaseURL; got != want {
+		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
+	}
+	if got, want := c.UploadURL.String(), formattedUploadURL; got != want {
+		t.Errorf("NewClient UploadURL is %v, want %v", got, want)
+	}
+}
+
+func TestNewEnterpriseClient_URLIsNotAProperAPISubdomain_addsEnterpriseSuffix(t *testing.T) {
+	baseURL := "https://cloud-api.custom-url/"
+	uploadURL := "https://cloud-api.custom-upload-url/"
+	formattedBaseURL := baseURL + "api/v3/"
+	formattedUploadURL := uploadURL + "api/uploads/"
+
+	c, err := NewEnterpriseClient(baseURL, uploadURL, nil)
+	if err != nil {
+		t.Fatalf("NewEnterpriseClient returned unexpected error: %v", err)
+	}
+
+	if got, want := c.BaseURL.String(), formattedBaseURL; got != want {
+		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
+	}
+	if got, want := c.UploadURL.String(), formattedUploadURL; got != want {
+		t.Errorf("NewClient UploadURL is %v, want %v", got, want)
+	}
+}
+
 // Ensure that length of Client.rateLimits is the same as number of fields in RateLimits struct.
 func TestClient_rateLimits(t *testing.T) {
 	if got, want := len(Client{}.rateLimits), reflect.TypeOf(RateLimits{}).NumField(); got != want {

--- a/github/teams_members.go
+++ b/github/teams_members.go
@@ -124,7 +124,7 @@ type TeamAddTeamMembershipOptions struct {
 	Role string `json:"role,omitempty"`
 }
 
-// AddTeamMembership adds or invites a user to a team, given a specified
+// AddTeamMembershipByID adds or invites a user to a team, given a specified
 // organization ID, by team ID.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/members/#add-or-update-team-membership-for-a-user
@@ -164,7 +164,7 @@ func (s *TeamsService) AddTeamMembershipBySlug(ctx context.Context, org, slug, u
 	return t, resp, nil
 }
 
-// RemoveTeamMembership removes a user from a team, given a specified
+// RemoveTeamMembershipByID removes a user from a team, given a specified
 // organization ID, by team ID.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/members/#remove-team-membership-for-a-user
@@ -178,7 +178,7 @@ func (s *TeamsService) RemoveTeamMembershipByID(ctx context.Context, orgID, team
 	return s.client.Do(ctx, req, nil)
 }
 
-// RemoveTeamMembership removes a user from a team, given a specified
+// RemoveTeamMembershipBySlug removes a user from a team, given a specified
 // organization name, by team slug.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/members/#remove-team-membership-for-a-user
@@ -217,7 +217,7 @@ func (s *TeamsService) ListPendingTeamInvitationsByID(ctx context.Context, orgID
 	return pendingInvitations, resp, nil
 }
 
-// ListPendingTeamInvitationsByID get pending invitation list of a team, given a specified
+// ListPendingTeamInvitationsBySlug get pending invitation list of a team, given a specified
 // organization name, by team slug.
 //
 // GitHub API docs: https://developer.github.com/v3/teams/members/#list-pending-team-invitations


### PR DESCRIPTION
Hi,

This is a fix for issue #1552 

I added a condition that if the enterprise URL is something like `api.enterprise-url` or has an api-subdomain such as `something.api.enterprise-url` then there's no need to append `api/v3/` to the base endpoint URL. 

A few comment changes have also been done that were highlighted by the `golint` tool. 