### PR TITLE
Checking for nil response before closing it.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -555,7 +555,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 		return nil, err
 	}
 
-	//Closing nil response will throw a panic. 
+	// Closing nil response will throw a panic.
 	if resp != nil {
 		defer func() {
 			// Ensure the response body is fully read and closed

--- a/github/github.go
+++ b/github/github.go
@@ -556,7 +556,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 	}
 
 	//Closing nil response will throw a panic. 
-	if resp != nil{
+	if resp != nil {
 		defer func() {
 			// Ensure the response body is fully read and closed
 			// before we reconnect, so that we reuse the same TCP connection.


### PR DESCRIPTION
Closing nil response will throw a panic so added a nil check before calling accessing resp object, defer function will be called even if there will be an error in response. 