### PR TITLE
Update content type header for AppsService.CreateAttachment

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -291,7 +291,7 @@ func (s *AppsService) CreateAttachment(ctx context.Context, contentReferenceID i
 	}
 
 	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
+	req.Header.Set("Accept", mediaTypeContentAttachmentsPreview)
 
 	m := &Attachment{}
 	resp, err := s.client.Do(ctx, req, m)

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -328,7 +328,7 @@ func TestAppsService_CreateAttachement(t *testing.T) {
 
 	mux.HandleFunc("/content_references/11/attachments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+		testHeader(t, r, "Accept", mediaTypeContentAttachmentsPreview)
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"id":1,"title":"title1","body":"body1"}`))

--- a/github/github.go
+++ b/github/github.go
@@ -135,6 +135,9 @@ const (
 
 	// https://developer.github.com/changes/2019-12-03-internal-visibility-changes/
 	mediaTypeRepositoryVisibilityPreview = "application/vnd.github.nebula-preview+json"
+
+	// https://developer.github.com/changes/2018-12-10-content-attachments-api/
+	mediaTypeContentAttachmentsPreview = "application/vnd.github.corsair-preview+json"
 )
 
 // A Client manages communication with the GitHub API.


### PR DESCRIPTION
While implementing the content attachment flow I found that the header needed to use this API has been changed. Included the link to the changes blog post referencing this.