### PR TITLE
Clean URLs before fetching directory contents

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"reflect"
 	"strconv"
 	"strings"
@@ -343,6 +344,15 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 	if !strings.HasSuffix(c.BaseURL.Path, "/") {
 		return nil, fmt.Errorf("BaseURL must have a trailing slash, but %q does not", c.BaseURL)
 	}
+
+	// clean up the URL path
+	origURLStr := urlStr
+	urlStr = path.Clean(origURLStr)
+	// put the trailing slash back if necessary
+	if origURLStr[len(origURLStr)-1] == '/' && origURLStr != "/" {
+		urlStr += "/"
+	}
+
 	u, err := c.BaseURL.Parse(urlStr)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #217 
Clean URLs before fetching directory contents, but attempt to make this more generic to the entire repository by cleaning the string in `NewRequest` itself, based on the discussion in #217 

Not sure of any potential downstream impacts this may have, or if a new test has to be introduced (I only see a test for [`testURLParseError`](https://github.com/google/go-github/blob/master/github/github_test.go#L122) )