### PR TITLE
Add NodeID field to Installation

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -90,6 +90,7 @@ type InstallationPermissions struct {
 // Installation represents a GitHub Apps installation.
 type Installation struct {
 	ID                  *int64                   `json:"id,omitempty"`
+	NodeID              *string                  `json:"node_id,omitempty"`
 	AppID               *int64                   `json:"app_id,omitempty"`
 	TargetID            *int64                   `json:"target_id,omitempty"`
 	Account             *User                    `json:"account,omitempty"`

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -4228,6 +4228,14 @@ func (i *Installation) GetID() int64 {
 	return *i.ID
 }
 
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (i *Installation) GetNodeID() string {
+	if i == nil || i.NodeID == nil {
+		return ""
+	}
+	return *i.NodeID
+}
+
 // GetPermissions returns the Permissions field.
 func (i *Installation) GetPermissions() *InstallationPermissions {
 	if i == nil {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -565,6 +565,7 @@ func TestImport_String(t *testing.T) {
 func TestInstallation_String(t *testing.T) {
 	v := Installation{
 		ID:                  Int64(0),
+		NodeID:              String(""),
 		AppID:               Int64(0),
 		TargetID:            Int64(0),
 		Account:             &User{},
@@ -578,7 +579,7 @@ func TestInstallation_String(t *testing.T) {
 		CreatedAt:           &Timestamp{},
 		UpdatedAt:           &Timestamp{},
 	}
-	want := `github.Installation{ID:0, AppID:0, TargetID:0, Account:github.User{}, AccessTokensURL:"", RepositoriesURL:"", HTMLURL:"", TargetType:"", SingleFileName:"", RepositorySelection:"", Permissions:github.InstallationPermissions{}, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}`
+	want := `github.Installation{ID:0, NodeID:"", AppID:0, TargetID:0, Account:github.User{}, AccessTokensURL:"", RepositoriesURL:"", HTMLURL:"", TargetType:"", SingleFileName:"", RepositorySelection:"", Permissions:github.InstallationPermissions{}, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}`
 	if got := v.String(); got != want {
 		t.Errorf("Installation.String = %v, want %v", got, want)
 	}


### PR DESCRIPTION
Since Github exposes the node_id fields on the installation object, this PR enables reading the field.


