### PR TITLE
Add support within Actions for creating a workflow dispatch event

### DIFF
--- a/github/actions_workflows.go
+++ b/github/actions_workflows.go
@@ -47,10 +47,12 @@ type WorkflowBill struct {
 	TotalMS *int64 `json:"total_ms,omitempty"`
 }
 
-// CreateWorkflowDispatchEventRequest represents a request to create a workflow dispatch event
+// CreateWorkflowDispatchEventRequest represents a request to create a workflow dispatch event.
 type CreateWorkflowDispatchEventRequest struct {
-	// Ref is required when creating a workflow dispatch event
-	Ref string `json:"ref,omitempty"`
+	// Ref represents the reference of the workflow run.
+	// The reference can be a branch, tag, or a commit SHA.
+	// Ref is required when creating a workflow dispatch event.
+	Ref string `json:"ref"`
 }
 
 // ListWorkflows lists all workflows in a repository.
@@ -143,13 +145,13 @@ func (s *ActionsService) getWorkflowUsage(ctx context.Context, url string) (*Wor
 	return workflowUsage, resp, nil
 }
 
-// CreateWorkflowDispatchEvent manually triggers a Github Actions workflow run
+// CreateWorkflowDispatchEvent manually triggers a GitHub Actions workflow run.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event
-func (s *ActionsService) CreateWorkflowDispatchEvent(ctx context.Context, owner, repo string, workflowID int64, createWorkflowDispatchEvent CreateWorkflowDispatchEventRequest) (*Response, error) {
+func (s *ActionsService) CreateWorkflowDispatchEvent(ctx context.Context, owner, repo string, workflowID int64, event CreateWorkflowDispatchEventRequest) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/workflows/%v/dispatches", owner, repo, workflowID)
 
-	req, err := s.client.NewRequest("POST", u, &createWorkflowDispatchEvent)
+	req, err := s.client.NewRequest("POST", u, &event)
 	if err != nil {
 		return nil, err
 	}

--- a/github/actions_workflows.go
+++ b/github/actions_workflows.go
@@ -53,6 +53,10 @@ type CreateWorkflowDispatchEventRequest struct {
 	// The reference can be a branch, tag, or a commit SHA.
 	// Ref is required when creating a workflow dispatch event.
 	Ref string `json:"ref"`
+	// Inputs represents input keys and values configured in the workflow file.
+	// The maximum number of properties is 10.
+	// Default: Any default properties configured in the workflow file will be used when `inputs` are omitted.
+	Inputs map[string]interface{} `json:"inputs,omitempty"`
 }
 
 // ListWorkflows lists all workflows in a repository.

--- a/github/actions_workflows.go
+++ b/github/actions_workflows.go
@@ -47,6 +47,12 @@ type WorkflowBill struct {
 	TotalMS *int64 `json:"total_ms,omitempty"`
 }
 
+// CreateWorkflowDispatchEventRequest represents a request to create a workflow dispatch event
+type CreateWorkflowDispatchEventRequest struct {
+	// Ref is required when creating a workflow dispatch event
+	Ref string `json:"ref,omitempty"`
+}
+
 // ListWorkflows lists all workflows in a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/actions/workflows/#list-repository-workflows
@@ -135,4 +141,18 @@ func (s *ActionsService) getWorkflowUsage(ctx context.Context, url string) (*Wor
 	}
 
 	return workflowUsage, resp, nil
+}
+
+// CreateWorkflowDispatchEvent manually triggers a Github Actions workflow run
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event
+func (s *ActionsService) CreateWorkflowDispatchEvent(ctx context.Context, owner, repo string, workflowID int64, createWorkflowDispatchEvent CreateWorkflowDispatchEventRequest) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/workflows/%v/dispatches", owner, repo, workflowID)
+
+	req, err := s.client.NewRequest("POST", u, &createWorkflowDispatchEvent)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
 }

--- a/github/actions_workflows_test.go
+++ b/github/actions_workflows_test.go
@@ -159,25 +159,30 @@ func TestActionsService_CreateWorkflowDispatchEvent(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	input := CreateWorkflowDispatchEventRequest{Ref: "d4cfb6e7"}
+	event := CreateWorkflowDispatchEventRequest{
+		Ref: "d4cfb6e7",
+		Inputs: map[string]interface{}{
+			"key": "value",
+		},
+	}
 	mux.HandleFunc("/repos/o/r/actions/workflows/72844/dispatches", func(w http.ResponseWriter, r *http.Request) {
 		var v CreateWorkflowDispatchEventRequest
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
+		if !reflect.DeepEqual(v, event) {
+			t.Errorf("Request body = %+v, want %+v", v, event)
 		}
 	})
 
-	_, err := client.Actions.CreateWorkflowDispatchEvent(context.Background(), "o", "r", 72844, input)
+	_, err := client.Actions.CreateWorkflowDispatchEvent(context.Background(), "o", "r", 72844, event)
 	if err != nil {
 		t.Errorf("Actions.CreateWorkflowDispatchEvent returned error: %v", err)
 	}
 
 	// Test s.client.NewRequest failure
 	client.BaseURL.Path = ""
-	_, err = client.Actions.CreateWorkflowDispatchEvent(context.Background(), "o", "r", 72844, input)
+	_, err = client.Actions.CreateWorkflowDispatchEvent(context.Background(), "o", "r", 72844, event)
 	if err == nil {
 		t.Error("client.BaseURL.Path='' CreateWorkflowDispatchEvent err = nil, want error")
 	}

--- a/github/actions_workflows_test.go
+++ b/github/actions_workflows_test.go
@@ -7,6 +7,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -151,5 +152,33 @@ func TestActionsService_GetWorkflowUsageByFileName(t *testing.T) {
 	}
 	if !reflect.DeepEqual(workflowUsage, want) {
 		t.Errorf("Actions.GetWorkflowUsageByFileName returned %+v, want %+v", workflowUsage, want)
+	}
+}
+
+func TestActionsService_CreateWorkflowDispatchEvent(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := CreateWorkflowDispatchEventRequest{Ref: "d4cfb6e7"}
+	mux.HandleFunc("/repos/o/r/actions/workflows/72844/dispatches", func(w http.ResponseWriter, r *http.Request) {
+		var v CreateWorkflowDispatchEventRequest
+		json.NewDecoder(r.Body).Decode(&v)
+
+		testMethod(t, r, "POST")
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+	})
+
+	_, err := client.Actions.CreateWorkflowDispatchEvent(context.Background(), "o", "r", 72844, input)
+	if err != nil {
+		t.Errorf("Actions.CreateWorkflowDispatchEvent returned error: %v", err)
+	}
+
+	// Test s.client.NewRequest failure
+	client.BaseURL.Path = ""
+	_, err = client.Actions.CreateWorkflowDispatchEvent(context.Background(), "o", "r", 72844, input)
+	if err == nil {
+		t.Error("client.BaseURL.Path='' CreateWorkflowDispatchEvent err = nil, want error")
 	}
 }


### PR DESCRIPTION
I noticed that the github client hadn't added support for this functionality yet.

According to https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event, this endpoint is utilized for manually triggering a Github Actions workflow run.

I purposely left out support for the `inputs` key, since due to its dynamic nature, might be a larger  and more complicated change than we want. 