### PR TITLE
Remove trailing slash when passing directory path to GetContent

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 )
 
 // RepositoryContent represents a file or directory in a github repository.
@@ -152,7 +153,7 @@ func (s *RepositoriesService) DownloadContents(ctx context.Context, owner, repo,
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/repos/#get-repository-content
 func (s *RepositoriesService) GetContents(ctx context.Context, owner, repo, path string, opts *RepositoryContentGetOptions) (fileContent *RepositoryContent, directoryContent []*RepositoryContent, resp *Response, err error) {
-	escapedPath := (&url.URL{Path: path}).String()
+	escapedPath := (&url.URL{Path: strings.TrimSuffix(path, "/")}).String()
 	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, escapedPath)
 	u, err = addOptions(u, opts)
 	if err != nil {

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -482,9 +482,15 @@ func TestRepositoriesService_GetContents_NoTrailingSlashInDirectoryApiPath(t *te
 	defer teardown()
 	mux.HandleFunc("/repos/o/r/contents/.github", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		query := r.URL.Query()
+		if query.Get("ref") != "mybranch" {
+			t.Errorf("Repositories.GetContents returned %+v, want %+v", query.Get("ref"), "mybranch")
+		}
 		fmt.Fprint(w, `{}`)
 	})
-	_, _, _, err := client.Repositories.GetContents(context.Background(), "o", "r", ".github/", &RepositoryContentGetOptions{})
+	_, _, _, err := client.Repositories.GetContents(context.Background(), "o", "r", ".github/", &RepositoryContentGetOptions{
+		Ref: "mybranch",
+	})
 	if err != nil {
 		t.Fatalf("Repositories.GetContents returned error: %v", err)
 	}

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -476,3 +476,16 @@ func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_followRedirec
 		t.Errorf("Repositories.GetArchiveLink returned %+v, want %+v", url.String(), want)
 	}
 }
+
+func TestRepositoriesService_GetContents_NoTrailingSlashInDirectoryApiPath(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/repos/o/r/contents/.github", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{}`)
+	})
+	_, _, _, err := client.Repositories.GetContents(context.Background(), "o", "r", ".github/", &RepositoryContentGetOptions{})
+	if err != nil {
+		t.Fatalf("Repositories.GetContents returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Fix #1629 

To avoid producing an invalid request URL like `.github/?ref`.