### PR TITLE
Remove graduated GitHub v3 API preview header

### DIFF
--- a/github/checks.go
+++ b/github/checks.go
@@ -104,7 +104,7 @@ func (s *ChecksService) GetCheckRun(ctx context.Context, owner, repo string, che
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+	req.Header.Set("Accept", mediaTypeV3)
 
 	checkRun := new(CheckRun)
 	resp, err := s.client.Do(ctx, req, checkRun)
@@ -125,7 +125,7 @@ func (s *ChecksService) GetCheckSuite(ctx context.Context, owner, repo string, c
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+	req.Header.Set("Accept", mediaTypeV3)
 
 	checkSuite := new(CheckSuite)
 	resp, err := s.client.Do(ctx, req, checkSuite)
@@ -167,7 +167,7 @@ func (s *ChecksService) CreateCheckRun(ctx context.Context, owner, repo string, 
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+	req.Header.Set("Accept", mediaTypeV3)
 
 	checkRun := new(CheckRun)
 	resp, err := s.client.Do(ctx, req, checkRun)
@@ -201,7 +201,7 @@ func (s *ChecksService) UpdateCheckRun(ctx context.Context, owner, repo string, 
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+	req.Header.Set("Accept", mediaTypeV3)
 
 	checkRun := new(CheckRun)
 	resp, err := s.client.Do(ctx, req, checkRun)
@@ -227,7 +227,7 @@ func (s *ChecksService) ListCheckRunAnnotations(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+	req.Header.Set("Accept", mediaTypeV3)
 
 	var checkRunAnnotations []*CheckRunAnnotation
 	resp, err := s.client.Do(ctx, req, &checkRunAnnotations)
@@ -268,7 +268,7 @@ func (s *ChecksService) ListCheckRunsForRef(ctx context.Context, owner, repo, re
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+	req.Header.Set("Accept", mediaTypeV3)
 
 	var checkRunResults *ListCheckRunsResults
 	resp, err := s.client.Do(ctx, req, &checkRunResults)
@@ -294,7 +294,7 @@ func (s *ChecksService) ListCheckRunsCheckSuite(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+	req.Header.Set("Accept", mediaTypeV3)
 
 	var checkRunResults *ListCheckRunsResults
 	resp, err := s.client.Do(ctx, req, &checkRunResults)
@@ -334,7 +334,7 @@ func (s *ChecksService) ListCheckSuitesForRef(ctx context.Context, owner, repo, 
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+	req.Header.Set("Accept", mediaTypeV3)
 
 	var checkSuiteResults *ListCheckSuiteResults
 	resp, err := s.client.Do(ctx, req, &checkSuiteResults)
@@ -377,7 +377,7 @@ func (s *ChecksService) SetCheckSuitePreferences(ctx context.Context, owner, rep
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+	req.Header.Set("Accept", mediaTypeV3)
 
 	var checkSuitePrefResults *CheckSuitePreferenceResults
 	resp, err := s.client.Do(ctx, req, &checkSuitePrefResults)
@@ -404,7 +404,7 @@ func (s *ChecksService) CreateCheckSuite(ctx context.Context, owner, repo string
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+	req.Header.Set("Accept", mediaTypeV3)
 
 	checkSuite := new(CheckSuite)
 	resp, err := s.client.Do(ctx, req, checkSuite)
@@ -426,7 +426,7 @@ func (s *ChecksService) ReRequestCheckSuite(ctx context.Context, owner, repo str
 		return nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+	req.Header.Set("Accept", mediaTypeV3)
 
 	resp, err := s.client.Do(ctx, req, nil)
 	return resp, err

--- a/github/checks.go
+++ b/github/checks.go
@@ -104,8 +104,6 @@ func (s *ChecksService) GetCheckRun(ctx context.Context, owner, repo string, che
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeV3)
-
 	checkRun := new(CheckRun)
 	resp, err := s.client.Do(ctx, req, checkRun)
 	if err != nil {
@@ -124,8 +122,6 @@ func (s *ChecksService) GetCheckSuite(ctx context.Context, owner, repo string, c
 	if err != nil {
 		return nil, nil, err
 	}
-
-	req.Header.Set("Accept", mediaTypeV3)
 
 	checkSuite := new(CheckSuite)
 	resp, err := s.client.Do(ctx, req, checkSuite)
@@ -167,8 +163,6 @@ func (s *ChecksService) CreateCheckRun(ctx context.Context, owner, repo string, 
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeV3)
-
 	checkRun := new(CheckRun)
 	resp, err := s.client.Do(ctx, req, checkRun)
 	if err != nil {
@@ -201,8 +195,6 @@ func (s *ChecksService) UpdateCheckRun(ctx context.Context, owner, repo string, 
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeV3)
-
 	checkRun := new(CheckRun)
 	resp, err := s.client.Do(ctx, req, checkRun)
 	if err != nil {
@@ -226,8 +218,6 @@ func (s *ChecksService) ListCheckRunAnnotations(ctx context.Context, owner, repo
 	if err != nil {
 		return nil, nil, err
 	}
-
-	req.Header.Set("Accept", mediaTypeV3)
 
 	var checkRunAnnotations []*CheckRunAnnotation
 	resp, err := s.client.Do(ctx, req, &checkRunAnnotations)
@@ -268,8 +258,6 @@ func (s *ChecksService) ListCheckRunsForRef(ctx context.Context, owner, repo, re
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeV3)
-
 	var checkRunResults *ListCheckRunsResults
 	resp, err := s.client.Do(ctx, req, &checkRunResults)
 	if err != nil {
@@ -293,8 +281,6 @@ func (s *ChecksService) ListCheckRunsCheckSuite(ctx context.Context, owner, repo
 	if err != nil {
 		return nil, nil, err
 	}
-
-	req.Header.Set("Accept", mediaTypeV3)
 
 	var checkRunResults *ListCheckRunsResults
 	resp, err := s.client.Do(ctx, req, &checkRunResults)
@@ -333,8 +319,6 @@ func (s *ChecksService) ListCheckSuitesForRef(ctx context.Context, owner, repo, 
 	if err != nil {
 		return nil, nil, err
 	}
-
-	req.Header.Set("Accept", mediaTypeV3)
 
 	var checkSuiteResults *ListCheckSuiteResults
 	resp, err := s.client.Do(ctx, req, &checkSuiteResults)
@@ -377,8 +361,6 @@ func (s *ChecksService) SetCheckSuitePreferences(ctx context.Context, owner, rep
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeV3)
-
 	var checkSuitePrefResults *CheckSuitePreferenceResults
 	resp, err := s.client.Do(ctx, req, &checkSuitePrefResults)
 	if err != nil {
@@ -404,8 +386,6 @@ func (s *ChecksService) CreateCheckSuite(ctx context.Context, owner, repo string
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeV3)
-
 	checkSuite := new(CheckSuite)
 	resp, err := s.client.Do(ctx, req, checkSuite)
 	if err != nil {
@@ -425,8 +405,6 @@ func (s *ChecksService) ReRequestCheckSuite(ctx context.Context, owner, repo str
 	if err != nil {
 		return nil, err
 	}
-
-	req.Header.Set("Accept", mediaTypeV3)
 
 	resp, err := s.client.Do(ctx, req, nil)
 	return resp, err

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -20,7 +20,7 @@ func TestChecksService_GetCheckRun(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-runs/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeV3)
+
 		fmt.Fprint(w, `{
 			"id": 1,
                         "name":"testCheckRun",
@@ -55,7 +55,7 @@ func TestChecksService_GetCheckSuite(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-suites/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeV3)
+
 		fmt.Fprint(w, `{
 			"id": 1,
                         "head_branch":"master",
@@ -89,7 +89,7 @@ func TestChecksService_CreateCheckRun(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeV3)
+
 		fmt.Fprint(w, `{
 			"id": 1,
                         "name":"testCreateCheckRun",
@@ -141,7 +141,7 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-runs/1/annotations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeV3)
+
 		testFormValues(t, r, values{
 			"page": "1",
 		})
@@ -186,7 +186,7 @@ func TestChecksService_UpdateCheckRun(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-runs/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", mediaTypeV3)
+
 		fmt.Fprint(w, `{
 			"id": 1,
                         "name":"testUpdateCheckRun",
@@ -240,7 +240,7 @@ func TestChecksService_ListCheckRunsForRef(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/commits/master/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeV3)
+
 		testFormValues(t, r, values{
 			"check_name": "testing",
 			"page":       "1",
@@ -292,7 +292,7 @@ func TestChecksService_ListCheckRunsCheckSuite(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-suites/1/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeV3)
+
 		testFormValues(t, r, values{
 			"check_name": "testing",
 			"page":       "1",
@@ -344,7 +344,7 @@ func TestChecksService_ListCheckSuiteForRef(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/commits/master/check-suites", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeV3)
+
 		testFormValues(t, r, values{
 			"check_name": "testing",
 			"page":       "1",
@@ -395,7 +395,7 @@ func TestChecksService_SetCheckSuitePreferences(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-suites/preferences", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", mediaTypeV3)
+
 		testBody(t, r, `{"auto_trigger_checks":[{"app_id":2,"setting":false}]}`+"\n")
 		fmt.Fprint(w, `{"preferences":{"auto_trigger_checks":[{"app_id": 2,"setting": false}]}}`)
 	})
@@ -427,7 +427,7 @@ func TestChecksService_CreateCheckSuite(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-suites", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeV3)
+
 		fmt.Fprint(w, `{
 			"id": 2,
                         "head_branch":"master",
@@ -468,7 +468,7 @@ func TestChecksService_ReRequestCheckSuite(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-suites/1/rerequest", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeV3)
+
 		w.WriteHeader(http.StatusCreated)
 	})
 	resp, err := client.Checks.ReRequestCheckSuite(context.Background(), "o", "r", 1)

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -20,7 +20,7 @@ func TestChecksService_GetCheckRun(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-runs/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
+		testHeader(t, r, "Accept", mediaTypeV3)
 		fmt.Fprint(w, `{
 			"id": 1,
                         "name":"testCheckRun",
@@ -55,7 +55,7 @@ func TestChecksService_GetCheckSuite(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-suites/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
+		testHeader(t, r, "Accept", mediaTypeV3)
 		fmt.Fprint(w, `{
 			"id": 1,
                         "head_branch":"master",
@@ -89,7 +89,7 @@ func TestChecksService_CreateCheckRun(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
+		testHeader(t, r, "Accept", mediaTypeV3)
 		fmt.Fprint(w, `{
 			"id": 1,
                         "name":"testCreateCheckRun",
@@ -141,7 +141,7 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-runs/1/annotations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
+		testHeader(t, r, "Accept", mediaTypeV3)
 		testFormValues(t, r, values{
 			"page": "1",
 		})
@@ -186,7 +186,7 @@ func TestChecksService_UpdateCheckRun(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-runs/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
+		testHeader(t, r, "Accept", mediaTypeV3)
 		fmt.Fprint(w, `{
 			"id": 1,
                         "name":"testUpdateCheckRun",
@@ -240,7 +240,7 @@ func TestChecksService_ListCheckRunsForRef(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/commits/master/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
+		testHeader(t, r, "Accept", mediaTypeV3)
 		testFormValues(t, r, values{
 			"check_name": "testing",
 			"page":       "1",
@@ -292,7 +292,7 @@ func TestChecksService_ListCheckRunsCheckSuite(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-suites/1/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
+		testHeader(t, r, "Accept", mediaTypeV3)
 		testFormValues(t, r, values{
 			"check_name": "testing",
 			"page":       "1",
@@ -344,7 +344,7 @@ func TestChecksService_ListCheckSuiteForRef(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/commits/master/check-suites", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
+		testHeader(t, r, "Accept", mediaTypeV3)
 		testFormValues(t, r, values{
 			"check_name": "testing",
 			"page":       "1",
@@ -395,7 +395,7 @@ func TestChecksService_SetCheckSuitePreferences(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-suites/preferences", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
+		testHeader(t, r, "Accept", mediaTypeV3)
 		testBody(t, r, `{"auto_trigger_checks":[{"app_id":2,"setting":false}]}`+"\n")
 		fmt.Fprint(w, `{"preferences":{"auto_trigger_checks":[{"app_id": 2,"setting": false}]}}`)
 	})
@@ -427,7 +427,7 @@ func TestChecksService_CreateCheckSuite(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-suites", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
+		testHeader(t, r, "Accept", mediaTypeV3)
 		fmt.Fprint(w, `{
 			"id": 2,
                         "head_branch":"master",
@@ -468,7 +468,7 @@ func TestChecksService_ReRequestCheckSuite(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-suites/1/rerequest", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
+		testHeader(t, r, "Accept", mediaTypeV3)
 		w.WriteHeader(http.StatusCreated)
 	})
 	resp, err := client.Checks.ReRequestCheckSuite(context.Background(), "o", "r", 1)

--- a/github/github.go
+++ b/github/github.go
@@ -86,9 +86,6 @@ const (
 	// https://developer.github.com/changes/2018-03-16-protected-branches-required-approving-reviews/
 	mediaTypeRequiredApprovingReviewsPreview = "application/vnd.github.luke-cage-preview+json"
 
-	// https://developer.github.com/changes/2018-05-07-new-checks-api-public-beta/
-	mediaTypeCheckRunsPreview = "application/vnd.github.antiope-preview+json"
-
 	// https://developer.github.com/enterprise/2.13/v3/repos/pre_receive_hooks/
 	mediaTypePreReceiveHooksPreview = "application/vnd.github.eye-scream-preview"
 


### PR DESCRIPTION
removed Accept header (with value mediaTypeCheckRunsPreview). Since checks run is out of preview, didn't see any value in keeping it.

Followed as per,

Graduation of preview: https://developer.github.com/changes/2020-10-01-graduate-antiope-preview/
Docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/checks