### PR TITLE
Add support for review events

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -5156,6 +5156,22 @@ func (i *IssueEvent) GetRename() *Rename {
 	return i.Rename
 }
 
+// GetRequestedReviewer returns the RequestedReviewer field.
+func (i *IssueEvent) GetRequestedReviewer() *User {
+	if i == nil {
+		return nil
+	}
+	return i.RequestedReviewer
+}
+
+// GetReviewRequester returns the ReviewRequester field.
+func (i *IssueEvent) GetReviewRequester() *User {
+	if i == nil {
+		return nil
+	}
+	return i.ReviewRequester
+}
+
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
 func (i *IssueEvent) GetURL() string {
 	if i == nil || i.URL == nil {

--- a/github/issues_events.go
+++ b/github/issues_events.go
@@ -65,21 +65,27 @@ type IssueEvent struct {
 	//    review_dismissed
 	//       The review was dismissed and `DismissedReview` will be populated below.
 	//
+	//    review_requested, review_request_removed
+	//       The Actor requested or removed the request for a review.
+	//       RequestedReviewer and ReviewRequester will be populated below.
+	//
 	Event *string `json:"event,omitempty"`
 
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	Issue     *Issue     `json:"issue,omitempty"`
 
 	// Only present on certain events; see above.
-	Assignee        *User            `json:"assignee,omitempty"`
-	Assigner        *User            `json:"assigner,omitempty"`
-	CommitID        *string          `json:"commit_id,omitempty"`
-	Milestone       *Milestone       `json:"milestone,omitempty"`
-	Label           *Label           `json:"label,omitempty"`
-	Rename          *Rename          `json:"rename,omitempty"`
-	LockReason      *string          `json:"lock_reason,omitempty"`
-	ProjectCard     *ProjectCard     `json:"project_card,omitempty"`
-	DismissedReview *DismissedReview `json:"dismissed_review,omitempty"`
+	Assignee          *User            `json:"assignee,omitempty"`
+	Assigner          *User            `json:"assigner,omitempty"`
+	CommitID          *string          `json:"commit_id,omitempty"`
+	Milestone         *Milestone       `json:"milestone,omitempty"`
+	Label             *Label           `json:"label,omitempty"`
+	Rename            *Rename          `json:"rename,omitempty"`
+	LockReason        *string          `json:"lock_reason,omitempty"`
+	ProjectCard       *ProjectCard     `json:"project_card,omitempty"`
+	DismissedReview   *DismissedReview `json:"dismissed_review,omitempty"`
+	RequestedReviewer *User            `json:"requested_reviewer,omitempty"`
+	ReviewRequester   *User            `json:"review_requester,omitempty"`
 }
 
 // DismissedReview represents details for 'dismissed_review' events.


### PR DESCRIPTION
Hey, this PR adds support for the [review_requested](https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/issue-event-types#review_requested) and [review_request_removed](https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/issue-event-types#review_request_removed) issue events.