### PR TITLE
Clean up connection reuse code inside Do func as now Go HTTP packge does it internally

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -556,20 +556,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 		return nil, err
 	}
 
-	defer func() {
-		// Ensure the response body is fully read and closed
-		// before we reconnect, so that we reuse the same TCP connection.
-		// Close the previous response's body. But read at least some of
-		// the body so if it's small the underlying TCP connection will be
-		// re-used. No need to check for errors: if it fails, the Transport
-		// won't reuse it anyway.
-		const maxBodySlurpSize = 2 << 10
-		if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
-			io.CopyN(ioutil.Discard, resp.Body, maxBodySlurpSize)
-		}
-
-		resp.Body.Close()
-	}()
+	defer resp.Body.Close()
 
 	response := newResponse(resp)
 


### PR DESCRIPTION
The changes in the PR #1576 are not needed now as the latest official Go Http package does it internally. So Now, it is possible to remove the code from the PR.

https://github.com/golang/go/blob/master/src/net/http/client.go#L698

closes #1646 