### PR TITLE
Add Label data to Runner calls

### DIFF
--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -65,11 +65,19 @@ func (s *ActionsService) CreateRegistrationToken(ctx context.Context, owner, rep
 
 // Runner represents a self-hosted runner registered with a repository.
 type Runner struct {
-	ID     *int64  `json:"id,omitempty"`
-	Name   *string `json:"name,omitempty"`
-	OS     *string `json:"os,omitempty"`
-	Status *string `json:"status,omitempty"`
-	Busy   *bool   `json:"busy,omitempty"`
+	ID     *int64          `json:"id,omitempty"`
+	Name   *string         `json:"name,omitempty"`
+	OS     *string         `json:"os,omitempty"`
+	Status *string         `json:"status,omitempty"`
+	Busy   *bool           `json:"busy,omitempty"`
+	Labels []*RunnerLabels `json:"labels,omitempty"`
+}
+
+// RunnerLabels represents a collection of labels attached to each runner.
+type RunnerLabels struct {
+	ID   *int64  `json:"id,omitempty"`
+	Name *string `json:"name,omitempty"`
+	Type *string `json:"type,omitempty"`
 }
 
 // Runners represents a collection of self-hosted runners for a repository.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -12636,6 +12636,30 @@ func (r *RunnerApplicationDownload) GetOS() string {
 	return *r.OS
 }
 
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (r *RunnerLabels) GetID() int64 {
+	if r == nil || r.ID == nil {
+		return 0
+	}
+	return *r.ID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (r *RunnerLabels) GetName() string {
+	if r == nil || r.Name == nil {
+		return ""
+	}
+	return *r.Name
+}
+
+// GetType returns the Type field if it's non-nil, zero value otherwise.
+func (r *RunnerLabels) GetType() string {
+	if r == nil || r.Type == nil {
+		return ""
+	}
+	return *r.Type
+}
+
 // GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
 func (s *SelectedReposList) GetTotalCount() int {
 	if s == nil || s.TotalCount == nil {


### PR DESCRIPTION
Related to [this](https://github.com/google/go-github/issues/1647) issue.

When calling ListOrganizationRunners there is additional information in a label array (see [here](https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-self-hosted-runners-for-an-organization) ) 