### PR TITLE
Fix pull request comments endpoint (#1650)

### DIFF
--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -71,9 +71,9 @@ type PullRequestListCommentsOptions struct {
 func (s *PullRequestsService) ListComments(ctx context.Context, owner string, repo string, number int, opts *PullRequestListCommentsOptions) ([]*PullRequestComment, *Response, error) {
 	var u string
 	if number == 0 {
-		u = fmt.Sprintf("repos/%v/%v/pulls/comments", owner, repo)
+		u = fmt.Sprintf("repos/%v/%v/issues/comments", owner, repo)
 	} else {
-		u = fmt.Sprintf("repos/%v/%v/pulls/%d/comments", owner, repo, number)
+		u = fmt.Sprintf("repos/%v/%v/issues/%d/comments", owner, repo, number)
 	}
 	u, err := addOptions(u, opts)
 	if err != nil {

--- a/github/pulls_comments_test.go
+++ b/github/pulls_comments_test.go
@@ -137,7 +137,7 @@ func TestPullRequestsService_ListComments_allPulls(t *testing.T) {
 	defer teardown()
 
 	wantAcceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeMultiLineCommentsPreview}
-	mux.HandleFunc("/repos/o/r/pulls/comments", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/issues/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{
@@ -171,7 +171,7 @@ func TestPullRequestsService_ListComments_specificPull(t *testing.T) {
 	defer teardown()
 
 	wantAcceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeMultiLineCommentsPreview}
-	mux.HandleFunc("/repos/o/r/pulls/1/comments", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		fmt.Fprint(w, `[{"id":1, "pull_request_review_id":42}]`)
@@ -201,7 +201,7 @@ func TestPullRequestsService_GetComment(t *testing.T) {
 	defer teardown()
 
 	wantAcceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeMultiLineCommentsPreview}
-	mux.HandleFunc("/repos/o/r/pulls/comments/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/issues/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		fmt.Fprint(w, `{"id":1}`)
@@ -233,7 +233,7 @@ func TestPullRequestsService_CreateComment(t *testing.T) {
 	input := &PullRequestComment{Body: String("b")}
 
 	wantAcceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeMultiLineCommentsPreview}
-	mux.HandleFunc("/repos/o/r/pulls/1/comments", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		v := new(PullRequestComment)
 		json.NewDecoder(r.Body).Decode(v)
 
@@ -272,7 +272,7 @@ func TestPullRequestsService_EditComment(t *testing.T) {
 
 	input := &PullRequestComment{Body: String("b")}
 
-	mux.HandleFunc("/repos/o/r/pulls/comments/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/issues/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		v := new(PullRequestComment)
 		json.NewDecoder(r.Body).Decode(v)
 
@@ -307,7 +307,7 @@ func TestPullRequestsService_DeleteComment(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/repos/o/r/pulls/comments/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/issues/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 


### PR DESCRIPTION
This PR fixes the endpoint in the Golang Github API library so that PR comments can be successfully listed.

Fixes: #1650