### PR TITLE
[New Method] Actions/Runner: List enabled repos in organization for Actions

### DIFF
--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"strings"
 )
 
 // RunnerApplicationDownload represents a binary for the self-hosted runner application that can be downloaded.
@@ -242,20 +241,20 @@ func (s *ActionsService) ListOrganizationRunners(ctx context.Context, owner stri
 // ListEnabledReposInOrg lists the selected repositories that are enabled for GitHub Actions in an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/actions#list-selected-repositories-enabled-for-github-actions-in-an-organization
-func (s *ActionsService) ListEnabledReposInOrg(ctx context.Context, owner string) (*ActionsEnabledOnOrgRepos, *Response, error) {
+func (s *ActionsService) ListEnabledReposInOrg(ctx context.Context, owner string, opts *ListOptions) (*ActionsEnabledOnOrgRepos, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/repositories", owner)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeTopicsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
-
 	repos := &ActionsEnabledOnOrgRepos{}
-	resp, err := s.client.Do(ctx, req, &repos)
+	resp, err := s.client.Do(ctx, req, repos)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -18,7 +18,7 @@ type RunnerApplicationDownload struct {
 	Filename     *string `json:"filename,omitempty"`
 }
 
-// ActionsEnabledOnOrgRepos represents all the repsositories in an organization for which Actions is enabled.
+// ActionsEnabledOnOrgRepos represents all the repositories in an organization for which Actions is enabled.
 type ActionsEnabledOnOrgRepos struct {
 	TotalCount   int           `json:"total_count"`
 	Repositories []*Repository `json:"repositories"`


### PR DESCRIPTION
This PR implements the `List selected repositories enabled for GitHub Actions in an organization` method. The endpoint for this feature is `/orgs/{org}/actions/permissions/repositories`. More details around this can be found here: https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-selected-repositories-enabled-for-github-actions-in-an-organization