### PR TITLE
head_sha remove from update check run

### DIFF
--- a/github/checks.go
+++ b/github/checks.go
@@ -175,7 +175,6 @@ func (s *ChecksService) CreateCheckRun(ctx context.Context, owner, repo string, 
 // UpdateCheckRunOptions sets up parameters needed to update a CheckRun.
 type UpdateCheckRunOptions struct {
 	Name        string            `json:"name"`                   // The name of the check (e.g., "code-coverage"). (Required.)
-	HeadSHA     *string           `json:"head_sha,omitempty"`     // The SHA of the commit. (Optional.)
 	DetailsURL  *string           `json:"details_url,omitempty"`  // The URL of the integrator's site that has the full details of the check. (Optional.)
 	ExternalID  *string           `json:"external_id,omitempty"`  // A reference for the run on the integrator's system. (Optional.)
 	Status      *string           `json:"status,omitempty"`       // The current status. Can be one of "queued", "in_progress", or "completed". Default: "queued". (Optional.)

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -189,8 +189,7 @@ func TestChecksService_UpdateCheckRun(t *testing.T) {
 
 		fmt.Fprint(w, `{
 			"id": 1,
-                        "name":"testUpdateCheckRun",
-                        "head_sha":"deadbeef",
+            "name":"testUpdateCheckRun",
 			"status": "completed",
 			"conclusion": "neutral",
 			"started_at": "2018-05-04T01:14:52Z",
@@ -200,7 +199,6 @@ func TestChecksService_UpdateCheckRun(t *testing.T) {
 	startedAt, _ := time.Parse(time.RFC3339, "2018-05-04T01:14:52Z")
 	updateCheckRunOpt := UpdateCheckRunOptions{
 		Name:        "testUpdateCheckRun",
-		HeadSHA:     String("deadbeef"),
 		Status:      String("completed"),
 		CompletedAt: &Timestamp{startedAt},
 		Output: &CheckRunOutput{
@@ -221,7 +219,6 @@ func TestChecksService_UpdateCheckRun(t *testing.T) {
 		StartedAt:   &Timestamp{startedAt},
 		CompletedAt: &Timestamp{startedAt},
 		Conclusion:  String("neutral"),
-		HeadSHA:     String("deadbeef"),
 		Name:        String("testUpdateCheckRun"),
 		Output: &CheckRunOutput{
 			Title:   String("Mighty test report"),


### PR DESCRIPTION
This PR is regarding [issue 1652](https://github.com/google/go-github/issues/1652). head_sha is no longer supported as a parameter in case of [update a check run](https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#update-a-check-run). Therefore it is being removed from **type UpdateCheckRunOptions**