### PR TITLE
Remove HeadSHA parameter from UpdateCheckRunOptions

### DIFF
--- a/github/checks.go
+++ b/github/checks.go
@@ -175,7 +175,6 @@ func (s *ChecksService) CreateCheckRun(ctx context.Context, owner, repo string, 
 // UpdateCheckRunOptions sets up parameters needed to update a CheckRun.
 type UpdateCheckRunOptions struct {
 	Name        string            `json:"name"`                   // The name of the check (e.g., "code-coverage"). (Required.)
-	HeadSHA     *string           `json:"head_sha,omitempty"`     // The SHA of the commit. (Optional.)
 	DetailsURL  *string           `json:"details_url,omitempty"`  // The URL of the integrator's site that has the full details of the check. (Optional.)
 	ExternalID  *string           `json:"external_id,omitempty"`  // A reference for the run on the integrator's system. (Optional.)
 	Status      *string           `json:"status,omitempty"`       // The current status. Can be one of "queued", "in_progress", or "completed". Default: "queued". (Optional.)

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -191,7 +191,6 @@ func TestChecksService_UpdateCheckRun(t *testing.T) {
 			"id": 1,
                         "name":"testUpdateCheckRun",
 			"status": "completed",            
-			"status": "completed",
 			"conclusion": "neutral",
 			"started_at": "2018-05-04T01:14:52Z",
 			"completed_at": "2018-05-04T01:14:52Z",

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -190,7 +190,7 @@ func TestChecksService_UpdateCheckRun(t *testing.T) {
 		fmt.Fprint(w, `{
 			"id": 1,
                         "name":"testUpdateCheckRun",
-                        "head_sha":"deadbeef",
+			"status": "completed",            
 			"status": "completed",
 			"conclusion": "neutral",
 			"started_at": "2018-05-04T01:14:52Z",
@@ -200,7 +200,6 @@ func TestChecksService_UpdateCheckRun(t *testing.T) {
 	startedAt, _ := time.Parse(time.RFC3339, "2018-05-04T01:14:52Z")
 	updateCheckRunOpt := UpdateCheckRunOptions{
 		Name:        "testUpdateCheckRun",
-		HeadSHA:     String("deadbeef"),
 		Status:      String("completed"),
 		CompletedAt: &Timestamp{startedAt},
 		Output: &CheckRunOutput{
@@ -221,7 +220,6 @@ func TestChecksService_UpdateCheckRun(t *testing.T) {
 		StartedAt:   &Timestamp{startedAt},
 		CompletedAt: &Timestamp{startedAt},
 		Conclusion:  String("neutral"),
-		HeadSHA:     String("deadbeef"),
 		Name:        String("testUpdateCheckRun"),
 		Output: &CheckRunOutput{
 			Title:   String("Mighty test report"),

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -14068,14 +14068,6 @@ func (u *UpdateCheckRunOptions) GetExternalID() string {
 	return *u.ExternalID
 }
 
-// GetHeadSHA returns the HeadSHA field if it's non-nil, zero value otherwise.
-func (u *UpdateCheckRunOptions) GetHeadSHA() string {
-	if u == nil || u.HeadSHA == nil {
-		return ""
-	}
-	return *u.HeadSHA
-}
-
 // GetOutput returns the Output field.
 func (u *UpdateCheckRunOptions) GetOutput() *CheckRunOutput {
 	if u == nil {


### PR DESCRIPTION
This PR is regarding [issue 1652.](https://github.com/google/go-github/issues/1652) head_sha is no longer supported as a parameter in case of [updating a check run](https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#update-a-check-run). Therefore it is being removed from **type UpdateCheckRunOptions** in this PR. 

Fixes #1652.