### PR TITLE
Refactor context.Background in tests

### DIFF
--- a/github/actions_artifacts_test.go
+++ b/github/actions_artifacts_test.go
@@ -30,7 +30,8 @@ func TestActionsService_ListArtifacts(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2}
-	artifacts, _, err := client.Actions.ListArtifacts(context.Background(), "o", "r", opts)
+	ctx := context.Background()
+	artifacts, _, err := client.Actions.ListArtifacts(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Actions.ListArtifacts returned error: %v", err)
 	}
@@ -45,7 +46,8 @@ func TestActionsService_ListArtifacts_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Actions.ListArtifacts(context.Background(), "%", "r", nil)
+	ctx := context.Background()
+	_, _, err := client.Actions.ListArtifacts(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
 
@@ -53,7 +55,8 @@ func TestActionsService_ListArtifacts_invalidRepo(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Actions.ListArtifacts(context.Background(), "o", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Actions.ListArtifacts(ctx, "o", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -66,7 +69,8 @@ func TestActionsService_ListArtifacts_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	artifacts, resp, err := client.Actions.ListArtifacts(context.Background(), "o", "r", nil)
+	ctx := context.Background()
+	artifacts, resp, err := client.Actions.ListArtifacts(ctx, "o", "r", nil)
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -94,7 +98,8 @@ func TestActionsService_ListWorkflowRunArtifacts(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2}
-	artifacts, _, err := client.Actions.ListWorkflowRunArtifacts(context.Background(), "o", "r", 1, opts)
+	ctx := context.Background()
+	artifacts, _, err := client.Actions.ListWorkflowRunArtifacts(ctx, "o", "r", 1, opts)
 	if err != nil {
 		t.Errorf("Actions.ListWorkflowRunArtifacts returned error: %v", err)
 	}
@@ -109,7 +114,8 @@ func TestActionsService_ListWorkflowRunArtifacts_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Actions.ListWorkflowRunArtifacts(context.Background(), "%", "r", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Actions.ListWorkflowRunArtifacts(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -117,7 +123,8 @@ func TestActionsService_ListWorkflowRunArtifacts_invalidRepo(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Actions.ListWorkflowRunArtifacts(context.Background(), "o", "%", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Actions.ListWorkflowRunArtifacts(ctx, "o", "%", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -130,7 +137,8 @@ func TestActionsService_ListWorkflowRunArtifacts_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	artifacts, resp, err := client.Actions.ListWorkflowRunArtifacts(context.Background(), "o", "r", 1, nil)
+	ctx := context.Background()
+	artifacts, resp, err := client.Actions.ListWorkflowRunArtifacts(ctx, "o", "r", 1, nil)
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -157,7 +165,8 @@ func TestActionsService_GetArtifact(t *testing.T) {
 		}`)
 	})
 
-	artifact, _, err := client.Actions.GetArtifact(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	artifact, _, err := client.Actions.GetArtifact(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Actions.GetArtifact returned error: %v", err)
 	}
@@ -178,7 +187,8 @@ func TestActionsService_GetArtifact_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Actions.GetArtifact(context.Background(), "%", "r", 1)
+	ctx := context.Background()
+	_, _, err := client.Actions.GetArtifact(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
 
@@ -186,7 +196,8 @@ func TestActionsService_GetArtifact_invalidRepo(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Actions.GetArtifact(context.Background(), "o", "%", 1)
+	ctx := context.Background()
+	_, _, err := client.Actions.GetArtifact(ctx, "o", "%", 1)
 	testURLParseError(t, err)
 }
 
@@ -199,7 +210,8 @@ func TestActionsService_GetArtifact_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	artifact, resp, err := client.Actions.GetArtifact(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	artifact, resp, err := client.Actions.GetArtifact(ctx, "o", "r", 1)
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -220,7 +232,8 @@ func TestActionsSerivice_DownloadArtifact(t *testing.T) {
 		http.Redirect(w, r, "https://github.com/artifact", http.StatusFound)
 	})
 
-	url, resp, err := client.Actions.DownloadArtifact(context.Background(), "o", "r", 1, true)
+	ctx := context.Background()
+	url, resp, err := client.Actions.DownloadArtifact(ctx, "o", "r", 1, true)
 	if err != nil {
 		t.Errorf("Actions.DownloadArtifact returned error: %v", err)
 	}
@@ -238,7 +251,8 @@ func TestActionsService_DownloadArtifact_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Actions.DownloadArtifact(context.Background(), "%", "r", 1, true)
+	ctx := context.Background()
+	_, _, err := client.Actions.DownloadArtifact(ctx, "%", "r", 1, true)
 	testURLParseError(t, err)
 }
 
@@ -246,7 +260,8 @@ func TestActionsService_DownloadArtifact_invalidRepo(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Actions.DownloadArtifact(context.Background(), "o", "%", 1, true)
+	ctx := context.Background()
+	_, _, err := client.Actions.DownloadArtifact(ctx, "o", "%", 1, true)
 	testURLParseError(t, err)
 }
 
@@ -259,7 +274,8 @@ func TestActionsService_DownloadArtifact_StatusMovedPermanently_dontFollowRedire
 		http.Redirect(w, r, "https://github.com/artifact", http.StatusMovedPermanently)
 	})
 
-	_, resp, _ := client.Actions.DownloadArtifact(context.Background(), "o", "r", 1, false)
+	ctx := context.Background()
+	_, resp, _ := client.Actions.DownloadArtifact(ctx, "o", "r", 1, false)
 	if resp.StatusCode != http.StatusMovedPermanently {
 		t.Errorf("Actions.DownloadArtifact return status %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
 	}
@@ -279,7 +295,8 @@ func TestActionsService_DownloadArtifact_StatusMovedPermanently_followRedirects(
 		http.Redirect(w, r, "http://github.com/artifact", http.StatusFound)
 	})
 
-	url, resp, err := client.Actions.DownloadArtifact(context.Background(), "o", "r", 1, true)
+	ctx := context.Background()
+	url, resp, err := client.Actions.DownloadArtifact(ctx, "o", "r", 1, true)
 	if err != nil {
 		t.Errorf("Actions.DownloadArtifact return error: %v", err)
 	}
@@ -300,7 +317,8 @@ func TestActionsService_DeleteArtifact(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Actions.DeleteArtifact(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	_, err := client.Actions.DeleteArtifact(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Actions.DeleteArtifact return error: %v", err)
 	}
@@ -310,7 +328,8 @@ func TestActionsService_DeleteArtifact_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Actions.DeleteArtifact(context.Background(), "%", "r", 1)
+	ctx := context.Background()
+	_, err := client.Actions.DeleteArtifact(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
 
@@ -318,7 +337,8 @@ func TestActionsService_DeleteArtifact_invalidRepo(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Actions.DeleteArtifact(context.Background(), "o", "%", 1)
+	ctx := context.Background()
+	_, err := client.Actions.DeleteArtifact(ctx, "o", "%", 1)
 	testURLParseError(t, err)
 }
 
@@ -331,7 +351,8 @@ func TestActionsService_DeleteArtifact_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	resp, err := client.Actions.DeleteArtifact(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	resp, err := client.Actions.DeleteArtifact(ctx, "o", "r", 1)
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}

--- a/github/actions_runners_test.go
+++ b/github/actions_runners_test.go
@@ -23,7 +23,8 @@ func TestActionsService_ListRunnerApplicationDownloads(t *testing.T) {
 		fmt.Fprint(w, `[{"os":"osx","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-osx-x64-2.164.0.tar.gz","filename":"actions-runner-osx-x64-2.164.0.tar.gz"},{"os":"linux","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-x64-2.164.0.tar.gz","filename":"actions-runner-linux-x64-2.164.0.tar.gz"},{"os": "linux","architecture":"arm","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm-2.164.0.tar.gz","filename":"actions-runner-linux-arm-2.164.0.tar.gz"},{"os":"win","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-win-x64-2.164.0.zip","filename":"actions-runner-win-x64-2.164.0.zip"},{"os":"linux","architecture":"arm64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm64-2.164.0.tar.gz","filename":"actions-runner-linux-arm64-2.164.0.tar.gz"}]`)
 	})
 
-	downloads, _, err := client.Actions.ListRunnerApplicationDownloads(context.Background(), "o", "r")
+	ctx := context.Background()
+	downloads, _, err := client.Actions.ListRunnerApplicationDownloads(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Actions.ListRunnerApplicationDownloads returned error: %v", err)
 	}
@@ -49,7 +50,8 @@ func TestActionsService_CreateRegistrationToken(t *testing.T) {
 		fmt.Fprint(w, `{"token":"LLBF3JGZDX3P5PMEXLND6TS6FCWO6","expires_at":"2020-01-22T12:13:35.123Z"}`)
 	})
 
-	token, _, err := client.Actions.CreateRegistrationToken(context.Background(), "o", "r")
+	ctx := context.Background()
+	token, _, err := client.Actions.CreateRegistrationToken(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Actions.CreateRegistrationToken returned error: %v", err)
 	}
@@ -73,7 +75,8 @@ func TestActionsService_ListRunners(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	runners, _, err := client.Actions.ListRunners(context.Background(), "o", "r", opts)
+	ctx := context.Background()
+	runners, _, err := client.Actions.ListRunners(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Actions.ListRunners returned error: %v", err)
 	}
@@ -99,7 +102,8 @@ func TestActionsService_GetRunner(t *testing.T) {
 		fmt.Fprint(w, `{"id":23,"name":"MBP","os":"macos","status":"online"}`)
 	})
 
-	runner, _, err := client.Actions.GetRunner(context.Background(), "o", "r", 23)
+	ctx := context.Background()
+	runner, _, err := client.Actions.GetRunner(ctx, "o", "r", 23)
 	if err != nil {
 		t.Errorf("Actions.GetRunner returned error: %v", err)
 	}
@@ -124,7 +128,8 @@ func TestActionsService_CreateRemoveToken(t *testing.T) {
 		fmt.Fprint(w, `{"token":"AABF3JGZDX3P5PMEXLND6TS6FCWO6","expires_at":"2020-01-29T12:13:35.123Z"}`)
 	})
 
-	token, _, err := client.Actions.CreateRemoveToken(context.Background(), "o", "r")
+	ctx := context.Background()
+	token, _, err := client.Actions.CreateRemoveToken(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Actions.CreateRemoveToken returned error: %v", err)
 	}
@@ -143,7 +148,8 @@ func TestActionsService_RemoveRunner(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Actions.RemoveRunner(context.Background(), "o", "r", 21)
+	ctx := context.Background()
+	_, err := client.Actions.RemoveRunner(ctx, "o", "r", 21)
 	if err != nil {
 		t.Errorf("Actions.RemoveRunner returned error: %v", err)
 	}
@@ -158,7 +164,8 @@ func TestActionsService_ListOrganizationRunnerApplicationDownloads(t *testing.T)
 		fmt.Fprint(w, `[{"os":"osx","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-osx-x64-2.164.0.tar.gz","filename":"actions-runner-osx-x64-2.164.0.tar.gz"},{"os":"linux","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-x64-2.164.0.tar.gz","filename":"actions-runner-linux-x64-2.164.0.tar.gz"},{"os": "linux","architecture":"arm","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm-2.164.0.tar.gz","filename":"actions-runner-linux-arm-2.164.0.tar.gz"},{"os":"win","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-win-x64-2.164.0.zip","filename":"actions-runner-win-x64-2.164.0.zip"},{"os":"linux","architecture":"arm64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm64-2.164.0.tar.gz","filename":"actions-runner-linux-arm64-2.164.0.tar.gz"}]`)
 	})
 
-	downloads, _, err := client.Actions.ListOrganizationRunnerApplicationDownloads(context.Background(), "o")
+	ctx := context.Background()
+	downloads, _, err := client.Actions.ListOrganizationRunnerApplicationDownloads(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.ListRunnerApplicationDownloads returned error: %v", err)
 	}
@@ -184,7 +191,8 @@ func TestActionsService_CreateOrganizationRegistrationToken(t *testing.T) {
 		fmt.Fprint(w, `{"token":"LLBF3JGZDX3P5PMEXLND6TS6FCWO6","expires_at":"2020-01-22T12:13:35.123Z"}`)
 	})
 
-	token, _, err := client.Actions.CreateOrganizationRegistrationToken(context.Background(), "o")
+	ctx := context.Background()
+	token, _, err := client.Actions.CreateOrganizationRegistrationToken(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.CreateRegistrationToken returned error: %v", err)
 	}
@@ -208,7 +216,8 @@ func TestActionsService_ListOrganizationRunners(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	runners, _, err := client.Actions.ListOrganizationRunners(context.Background(), "o", opts)
+	ctx := context.Background()
+	runners, _, err := client.Actions.ListOrganizationRunners(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Actions.ListRunners returned error: %v", err)
 	}
@@ -284,7 +293,8 @@ func TestActionsService_GetOrganizationRunner(t *testing.T) {
 		fmt.Fprint(w, `{"id":23,"name":"MBP","os":"macos","status":"online"}`)
 	})
 
-	runner, _, err := client.Actions.GetOrganizationRunner(context.Background(), "o", 23)
+	ctx := context.Background()
+	runner, _, err := client.Actions.GetOrganizationRunner(ctx, "o", 23)
 	if err != nil {
 		t.Errorf("Actions.GetRunner returned error: %v", err)
 	}
@@ -309,7 +319,8 @@ func TestActionsService_CreateOrganizationRemoveToken(t *testing.T) {
 		fmt.Fprint(w, `{"token":"AABF3JGZDX3P5PMEXLND6TS6FCWO6","expires_at":"2020-01-29T12:13:35.123Z"}`)
 	})
 
-	token, _, err := client.Actions.CreateOrganizationRemoveToken(context.Background(), "o")
+	ctx := context.Background()
+	token, _, err := client.Actions.CreateOrganizationRemoveToken(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.CreateRemoveToken returned error: %v", err)
 	}
@@ -328,7 +339,8 @@ func TestActionsService_RemoveOrganizationRunner(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Actions.RemoveOrganizationRunner(context.Background(), "o", 21)
+	ctx := context.Background()
+	_, err := client.Actions.RemoveOrganizationRunner(ctx, "o", 21)
 	if err != nil {
 		t.Errorf("Actions.RemoveOganizationRunner returned error: %v", err)
 	}

--- a/github/actions_secrets_test.go
+++ b/github/actions_secrets_test.go
@@ -23,7 +23,8 @@ func TestActionsService_GetRepoPublicKey(t *testing.T) {
 		fmt.Fprint(w, `{"key_id":"1234","key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
 	})
 
-	key, _, err := client.Actions.GetRepoPublicKey(context.Background(), "o", "r")
+	ctx := context.Background()
+	key, _, err := client.Actions.GetRepoPublicKey(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Actions.GetRepoPublicKey returned error: %v", err)
 	}
@@ -45,7 +46,8 @@ func TestActionsService_ListRepoSecrets(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	secrets, _, err := client.Actions.ListRepoSecrets(context.Background(), "o", "r", opts)
+	ctx := context.Background()
+	secrets, _, err := client.Actions.ListRepoSecrets(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Actions.ListRepoSecrets returned error: %v", err)
 	}
@@ -71,7 +73,8 @@ func TestActionsService_GetRepoSecret(t *testing.T) {
 		fmt.Fprint(w, `{"name":"NAME","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
 	})
 
-	secret, _, err := client.Actions.GetRepoSecret(context.Background(), "o", "r", "NAME")
+	ctx := context.Background()
+	secret, _, err := client.Actions.GetRepoSecret(ctx, "o", "r", "NAME")
 	if err != nil {
 		t.Errorf("Actions.GetRepoSecret returned error: %v", err)
 	}
@@ -102,7 +105,8 @@ func TestActionsService_CreateOrUpdateRepoSecret(t *testing.T) {
 		EncryptedValue: "QIv=",
 		KeyID:          "1234",
 	}
-	_, err := client.Actions.CreateOrUpdateRepoSecret(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	_, err := client.Actions.CreateOrUpdateRepoSecret(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Actions.CreateOrUpdateRepoSecret returned error: %v", err)
 	}
@@ -116,7 +120,8 @@ func TestActionsService_DeleteRepoSecret(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Actions.DeleteRepoSecret(context.Background(), "o", "r", "NAME")
+	ctx := context.Background()
+	_, err := client.Actions.DeleteRepoSecret(ctx, "o", "r", "NAME")
 	if err != nil {
 		t.Errorf("Actions.DeleteRepoSecret returned error: %v", err)
 	}
@@ -131,7 +136,8 @@ func TestActionsService_GetOrgPublicKey(t *testing.T) {
 		fmt.Fprint(w, `{"key_id":"012345678","key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
 	})
 
-	key, _, err := client.Actions.GetOrgPublicKey(context.Background(), "o")
+	ctx := context.Background()
+	key, _, err := client.Actions.GetOrgPublicKey(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.GetOrgPublicKey returned error: %v", err)
 	}
@@ -153,7 +159,8 @@ func TestActionsService_ListOrgSecrets(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	secrets, _, err := client.Actions.ListOrgSecrets(context.Background(), "o", opts)
+	ctx := context.Background()
+	secrets, _, err := client.Actions.ListOrgSecrets(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Actions.ListOrgSecrets returned error: %v", err)
 	}
@@ -180,7 +187,8 @@ func TestActionsService_GetOrgSecret(t *testing.T) {
 		fmt.Fprint(w, `{"name":"NAME","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z","visibility":"selected","selected_repositories_url":"https://api.github.com/orgs/octo-org/actions/secrets/SUPER_SECRET/repositories"}`)
 	})
 
-	secret, _, err := client.Actions.GetOrgSecret(context.Background(), "o", "NAME")
+	ctx := context.Background()
+	secret, _, err := client.Actions.GetOrgSecret(ctx, "o", "NAME")
 	if err != nil {
 		t.Errorf("Actions.GetOrgSecret returned error: %v", err)
 	}
@@ -215,7 +223,8 @@ func TestActionsService_CreateOrUpdateOrgSecret(t *testing.T) {
 		Visibility:            "selected",
 		SelectedRepositoryIDs: SelectedRepoIDs{1296269, 1269280},
 	}
-	_, err := client.Actions.CreateOrUpdateOrgSecret(context.Background(), "o", input)
+	ctx := context.Background()
+	_, err := client.Actions.CreateOrUpdateOrgSecret(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Actions.CreateOrUpdateOrgSecret returned error: %v", err)
 	}
@@ -230,7 +239,8 @@ func TestActionsService_ListSelectedReposForOrgSecret(t *testing.T) {
 		fmt.Fprintf(w, `{"total_count":1,"repositories":[{"id":1}]}`)
 	})
 
-	repos, _, err := client.Actions.ListSelectedReposForOrgSecret(context.Background(), "o", "NAME")
+	ctx := context.Background()
+	repos, _, err := client.Actions.ListSelectedReposForOrgSecret(ctx, "o", "NAME")
 	if err != nil {
 		t.Errorf("Actions.ListSelectedReposForOrgSecret returned error: %v", err)
 	}
@@ -256,7 +266,8 @@ func TestActionsService_SetSelectedReposForOrgSecret(t *testing.T) {
 		testBody(t, r, `{"selected_repository_ids":[64780797]}`+"\n")
 	})
 
-	_, err := client.Actions.SetSelectedReposForOrgSecret(context.Background(), "o", "NAME", SelectedRepoIDs{64780797})
+	ctx := context.Background()
+	_, err := client.Actions.SetSelectedReposForOrgSecret(ctx, "o", "NAME", SelectedRepoIDs{64780797})
 	if err != nil {
 		t.Errorf("Actions.SetSelectedReposForOrgSecret returned error: %v", err)
 	}
@@ -271,7 +282,8 @@ func TestActionsService_AddSelectedRepoToOrgSecret(t *testing.T) {
 	})
 
 	repo := &Repository{ID: Int64(1234)}
-	_, err := client.Actions.AddSelectedRepoToOrgSecret(context.Background(), "o", "NAME", repo)
+	ctx := context.Background()
+	_, err := client.Actions.AddSelectedRepoToOrgSecret(ctx, "o", "NAME", repo)
 	if err != nil {
 		t.Errorf("Actions.AddSelectedRepoToOrgSecret returned error: %v", err)
 	}
@@ -286,7 +298,8 @@ func TestActionsService_RemoveSelectedRepoFromOrgSecret(t *testing.T) {
 	})
 
 	repo := &Repository{ID: Int64(1234)}
-	_, err := client.Actions.RemoveSelectedRepoFromOrgSecret(context.Background(), "o", "NAME", repo)
+	ctx := context.Background()
+	_, err := client.Actions.RemoveSelectedRepoFromOrgSecret(ctx, "o", "NAME", repo)
 	if err != nil {
 		t.Errorf("Actions.RemoveSelectedRepoFromOrgSecret returned error: %v", err)
 	}
@@ -300,7 +313,8 @@ func TestActionsService_DeleteOrgSecret(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Actions.DeleteOrgSecret(context.Background(), "o", "NAME")
+	ctx := context.Background()
+	_, err := client.Actions.DeleteOrgSecret(ctx, "o", "NAME")
 	if err != nil {
 		t.Errorf("Actions.DeleteOrgSecret returned error: %v", err)
 	}

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -26,7 +26,8 @@ func TestActionsService_ListWorkflowJobs(t *testing.T) {
 	})
 
 	opts := &ListWorkflowJobsOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	jobs, _, err := client.Actions.ListWorkflowJobs(context.Background(), "o", "r", 29679449, opts)
+	ctx := context.Background()
+	jobs, _, err := client.Actions.ListWorkflowJobs(ctx, "o", "r", 29679449, opts)
 	if err != nil {
 		t.Errorf("Actions.ListWorkflowJobs returned error: %v", err)
 	}
@@ -54,7 +55,8 @@ func TestActionsService_ListWorkflowJobs_Filter(t *testing.T) {
 	})
 
 	opts := &ListWorkflowJobsOptions{Filter: "all", ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	jobs, _, err := client.Actions.ListWorkflowJobs(context.Background(), "o", "r", 29679449, opts)
+	ctx := context.Background()
+	jobs, _, err := client.Actions.ListWorkflowJobs(ctx, "o", "r", 29679449, opts)
 	if err != nil {
 		t.Errorf("Actions.ListWorkflowJobs returned error: %v", err)
 	}
@@ -80,7 +82,8 @@ func TestActionsService_GetWorkflowJobByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":399444496,"started_at":"2019-01-02T15:04:05Z","completed_at":"2020-01-02T15:04:05Z"}`)
 	})
 
-	job, _, err := client.Actions.GetWorkflowJobByID(context.Background(), "o", "r", 399444496)
+	ctx := context.Background()
+	job, _, err := client.Actions.GetWorkflowJobByID(ctx, "o", "r", 399444496)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowJobByID returned error: %v", err)
 	}
@@ -104,7 +107,8 @@ func TestActionsService_GetWorkflowJobLogs(t *testing.T) {
 		http.Redirect(w, r, "http://github.com/a", http.StatusFound)
 	})
 
-	url, resp, err := client.Actions.GetWorkflowJobLogs(context.Background(), "o", "r", 399444496, true)
+	ctx := context.Background()
+	url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, true)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowJobLogs returned error: %v", err)
 	}
@@ -126,7 +130,8 @@ func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_dontFollowRedi
 		http.Redirect(w, r, "http://github.com/a", http.StatusMovedPermanently)
 	})
 
-	_, resp, _ := client.Actions.GetWorkflowJobLogs(context.Background(), "o", "r", 399444496, false)
+	ctx := context.Background()
+	_, resp, _ := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, false)
 	if resp.StatusCode != http.StatusMovedPermanently {
 		t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
 	}
@@ -148,7 +153,8 @@ func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_followRedirect
 		http.Redirect(w, r, "http://github.com/a", http.StatusFound)
 	})
 
-	url, resp, err := client.Actions.GetWorkflowJobLogs(context.Background(), "o", "r", 399444496, true)
+	ctx := context.Background()
+	url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, true)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowJobLogs returned error: %v", err)
 	}

--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -26,7 +26,8 @@ func TestActionsService_ListWorkflowRunsByID(t *testing.T) {
 	})
 
 	opts := &ListWorkflowRunsOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	runs, _, err := client.Actions.ListWorkflowRunsByID(context.Background(), "o", "r", 29679449, opts)
+	ctx := context.Background()
+	runs, _, err := client.Actions.ListWorkflowRunsByID(ctx, "o", "r", 29679449, opts)
 	if err != nil {
 		t.Errorf("Actions.ListWorkFlowRunsByID returned error: %v", err)
 	}
@@ -54,7 +55,8 @@ func TestActionsService_ListWorkflowRunsFileName(t *testing.T) {
 	})
 
 	opts := &ListWorkflowRunsOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	runs, _, err := client.Actions.ListWorkflowRunsByFileName(context.Background(), "o", "r", "29679449", opts)
+	ctx := context.Background()
+	runs, _, err := client.Actions.ListWorkflowRunsByFileName(ctx, "o", "r", "29679449", opts)
 	if err != nil {
 		t.Errorf("Actions.ListWorkFlowRunsByFileName returned error: %v", err)
 	}
@@ -80,7 +82,8 @@ func TestActionsService_GetWorkflowRunByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":399444496,"run_number":296,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}}`)
 	})
 
-	runs, _, err := client.Actions.GetWorkflowRunByID(context.Background(), "o", "r", 29679449)
+	ctx := context.Background()
+	runs, _, err := client.Actions.GetWorkflowRunByID(ctx, "o", "r", 29679449)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowRunByID returned error: %v", err)
 	}
@@ -106,7 +109,8 @@ func TestActionsService_RerunWorkflowRunByID(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 	})
 
-	resp, err := client.Actions.RerunWorkflowByID(context.Background(), "o", "r", 3434)
+	ctx := context.Background()
+	resp, err := client.Actions.RerunWorkflowByID(ctx, "o", "r", 3434)
 	if err != nil {
 		t.Errorf("Actions.RerunWorkflowByID returned error: %v", err)
 	}
@@ -124,7 +128,8 @@ func TestActionsService_CancelWorkflowRunByID(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 
-	resp, err := client.Actions.CancelWorkflowRunByID(context.Background(), "o", "r", 3434)
+	ctx := context.Background()
+	resp, err := client.Actions.CancelWorkflowRunByID(ctx, "o", "r", 3434)
 	if _, ok := err.(*AcceptedError); !ok {
 		t.Errorf("Actions.CancelWorkflowRunByID returned error: %v (want AcceptedError)", err)
 	}
@@ -142,7 +147,8 @@ func TestActionsService_GetWorkflowRunLogs(t *testing.T) {
 		http.Redirect(w, r, "http://github.com/a", http.StatusFound)
 	})
 
-	url, resp, err := client.Actions.GetWorkflowRunLogs(context.Background(), "o", "r", 399444496, true)
+	ctx := context.Background()
+	url, resp, err := client.Actions.GetWorkflowRunLogs(ctx, "o", "r", 399444496, true)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowRunLogs returned error: %v", err)
 	}
@@ -164,7 +170,8 @@ func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_dontFollowRedi
 		http.Redirect(w, r, "http://github.com/a", http.StatusMovedPermanently)
 	})
 
-	_, resp, _ := client.Actions.GetWorkflowRunLogs(context.Background(), "o", "r", 399444496, false)
+	ctx := context.Background()
+	_, resp, _ := client.Actions.GetWorkflowRunLogs(ctx, "o", "r", 399444496, false)
 	if resp.StatusCode != http.StatusMovedPermanently {
 		t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
 	}
@@ -186,7 +193,8 @@ func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_followRedirect
 		http.Redirect(w, r, "http://github.com/a", http.StatusFound)
 	})
 
-	url, resp, err := client.Actions.GetWorkflowRunLogs(context.Background(), "o", "r", 399444496, true)
+	ctx := context.Background()
+	url, resp, err := client.Actions.GetWorkflowRunLogs(ctx, "o", "r", 399444496, true)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowJobLogs returned error: %v", err)
 	}
@@ -216,7 +224,8 @@ func TestActionService_ListRepositoryWorkflowRuns(t *testing.T) {
 	})
 
 	opts := &ListWorkflowRunsOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	runs, _, err := client.Actions.ListRepositoryWorkflowRuns(context.Background(), "o", "r", opts)
+	ctx := context.Background()
+	runs, _, err := client.Actions.ListRepositoryWorkflowRuns(ctx, "o", "r", opts)
 
 	if err != nil {
 		t.Errorf("Actions.ListRepositoryWorkflowRuns returned error: %v", err)
@@ -246,7 +255,8 @@ func TestActionService_DeleteWorkflowRunLogs(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Actions.DeleteWorkflowRunLogs(context.Background(), "o", "r", 399444496); err != nil {
+	ctx := context.Background()
+	if _, err := client.Actions.DeleteWorkflowRunLogs(ctx, "o", "r", 399444496); err != nil {
 		t.Errorf("DeleteWorkflowRunLogs returned error: %v", err)
 	}
 }
@@ -260,7 +270,8 @@ func TestActionsService_GetWorkflowRunUsageByID(t *testing.T) {
 		fmt.Fprint(w, `{"billable":{"UBUNTU":{"total_ms":180000,"jobs":1},"MACOS":{"total_ms":240000,"jobs":4},"WINDOWS":{"total_ms":300000,"jobs":2}},"run_duration_ms":500000}`)
 	})
 
-	workflowRunUsage, _, err := client.Actions.GetWorkflowRunUsageByID(context.Background(), "o", "r", 29679449)
+	ctx := context.Background()
+	workflowRunUsage, _, err := client.Actions.GetWorkflowRunUsageByID(ctx, "o", "r", 29679449)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowRunUsageByID returned error: %v", err)
 	}

--- a/github/actions_workflows_test.go
+++ b/github/actions_workflows_test.go
@@ -26,7 +26,8 @@ func TestActionsService_ListWorkflows(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	workflows, _, err := client.Actions.ListWorkflows(context.Background(), "o", "r", opts)
+	ctx := context.Background()
+	workflows, _, err := client.Actions.ListWorkflows(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Actions.ListWorkflows returned error: %v", err)
 	}
@@ -52,7 +53,8 @@ func TestActionsService_GetWorkflowByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":72844,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
 	})
 
-	workflow, _, err := client.Actions.GetWorkflowByID(context.Background(), "o", "r", 72844)
+	ctx := context.Background()
+	workflow, _, err := client.Actions.GetWorkflowByID(ctx, "o", "r", 72844)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowByID returned error: %v", err)
 	}
@@ -76,7 +78,8 @@ func TestActionsService_GetWorkflowByFileName(t *testing.T) {
 		fmt.Fprint(w, `{"id":72844,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
 	})
 
-	workflow, _, err := client.Actions.GetWorkflowByFileName(context.Background(), "o", "r", "main.yml")
+	ctx := context.Background()
+	workflow, _, err := client.Actions.GetWorkflowByFileName(ctx, "o", "r", "main.yml")
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowByFileName returned error: %v", err)
 	}
@@ -100,7 +103,8 @@ func TestActionsService_GetWorkflowUsageByID(t *testing.T) {
 		fmt.Fprint(w, `{"billable":{"UBUNTU":{"total_ms":180000},"MACOS":{"total_ms":240000},"WINDOWS":{"total_ms":300000}}}`)
 	})
 
-	workflowUsage, _, err := client.Actions.GetWorkflowUsageByID(context.Background(), "o", "r", 72844)
+	ctx := context.Background()
+	workflowUsage, _, err := client.Actions.GetWorkflowUsageByID(ctx, "o", "r", 72844)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowUsageByID returned error: %v", err)
 	}
@@ -132,7 +136,8 @@ func TestActionsService_GetWorkflowUsageByFileName(t *testing.T) {
 		fmt.Fprint(w, `{"billable":{"UBUNTU":{"total_ms":180000},"MACOS":{"total_ms":240000},"WINDOWS":{"total_ms":300000}}}`)
 	})
 
-	workflowUsage, _, err := client.Actions.GetWorkflowUsageByFileName(context.Background(), "o", "r", "main.yml")
+	ctx := context.Background()
+	workflowUsage, _, err := client.Actions.GetWorkflowUsageByFileName(ctx, "o", "r", "main.yml")
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowUsageByFileName returned error: %v", err)
 	}
@@ -175,14 +180,15 @@ func TestActionsService_CreateWorkflowDispatchEventByID(t *testing.T) {
 		}
 	})
 
-	_, err := client.Actions.CreateWorkflowDispatchEventByID(context.Background(), "o", "r", 72844, event)
+	ctx := context.Background()
+	_, err := client.Actions.CreateWorkflowDispatchEventByID(ctx, "o", "r", 72844, event)
 	if err != nil {
 		t.Errorf("Actions.CreateWorkflowDispatchEventByID returned error: %v", err)
 	}
 
 	// Test s.client.NewRequest failure
 	client.BaseURL.Path = ""
-	_, err = client.Actions.CreateWorkflowDispatchEventByID(context.Background(), "o", "r", 72844, event)
+	_, err = client.Actions.CreateWorkflowDispatchEventByID(ctx, "o", "r", 72844, event)
 	if err == nil {
 		t.Error("client.BaseURL.Path='' CreateWorkflowDispatchEventByID err = nil, want error")
 	}
@@ -208,14 +214,15 @@ func TestActionsService_CreateWorkflowDispatchEventByFileName(t *testing.T) {
 		}
 	})
 
-	_, err := client.Actions.CreateWorkflowDispatchEventByFileName(context.Background(), "o", "r", "main.yml", event)
+	ctx := context.Background()
+	_, err := client.Actions.CreateWorkflowDispatchEventByFileName(ctx, "o", "r", "main.yml", event)
 	if err != nil {
 		t.Errorf("Actions.CreateWorkflowDispatchEventByFileName returned error: %v", err)
 	}
 
 	// Test s.client.NewRequest failure
 	client.BaseURL.Path = ""
-	_, err = client.Actions.CreateWorkflowDispatchEventByFileName(context.Background(), "o", "r", "main.yml", event)
+	_, err = client.Actions.CreateWorkflowDispatchEventByFileName(ctx, "o", "r", "main.yml", event)
 	if err == nil {
 		t.Error("client.BaseURL.Path='' CreateWorkflowDispatchEventByFileName err = nil, want error")
 	}
@@ -232,14 +239,15 @@ func TestActionsService_EnableWorkflowByID(t *testing.T) {
 		}
 	})
 
-	_, err := client.Actions.EnableWorkflowByID(context.Background(), "o", "r", 72844)
+	ctx := context.Background()
+	_, err := client.Actions.EnableWorkflowByID(ctx, "o", "r", 72844)
 	if err != nil {
 		t.Errorf("Actions.EnableWorkflowByID returned error: %v", err)
 	}
 
 	// Test s.client.NewRequest failure
 	client.BaseURL.Path = ""
-	_, err = client.Actions.EnableWorkflowByID(context.Background(), "o", "r", 72844)
+	_, err = client.Actions.EnableWorkflowByID(ctx, "o", "r", 72844)
 	if err == nil {
 		t.Error("client.BaseURL.Path='' EnableWorkflowByID err = nil, want error")
 	}
@@ -256,14 +264,15 @@ func TestActionsService_EnableWorkflowByFilename(t *testing.T) {
 		}
 	})
 
-	_, err := client.Actions.EnableWorkflowByFileName(context.Background(), "o", "r", "main.yml")
+	ctx := context.Background()
+	_, err := client.Actions.EnableWorkflowByFileName(ctx, "o", "r", "main.yml")
 	if err != nil {
 		t.Errorf("Actions.EnableWorkflowByFilename returned error: %v", err)
 	}
 
 	// Test s.client.NewRequest failure
 	client.BaseURL.Path = ""
-	_, err = client.Actions.EnableWorkflowByFileName(context.Background(), "o", "r", "main.yml")
+	_, err = client.Actions.EnableWorkflowByFileName(ctx, "o", "r", "main.yml")
 	if err == nil {
 		t.Error("client.BaseURL.Path='' EnableWorkflowByFilename err = nil, want error")
 	}
@@ -280,14 +289,15 @@ func TestActionsService_DisableWorkflowByID(t *testing.T) {
 		}
 	})
 
-	_, err := client.Actions.DisableWorkflowByID(context.Background(), "o", "r", 72844)
+	ctx := context.Background()
+	_, err := client.Actions.DisableWorkflowByID(ctx, "o", "r", 72844)
 	if err != nil {
 		t.Errorf("Actions.DisableWorkflowByID returned error: %v", err)
 	}
 
 	// Test s.client.NewRequest failure
 	client.BaseURL.Path = ""
-	_, err = client.Actions.DisableWorkflowByID(context.Background(), "o", "r", 72844)
+	_, err = client.Actions.DisableWorkflowByID(ctx, "o", "r", 72844)
 	if err == nil {
 		t.Error("client.BaseURL.Path='' DisableWorkflowByID err = nil, want error")
 	}
@@ -304,14 +314,15 @@ func TestActionsService_DisableWorkflowByFileName(t *testing.T) {
 		}
 	})
 
-	_, err := client.Actions.DisableWorkflowByFileName(context.Background(), "o", "r", "main.yml")
+	ctx := context.Background()
+	_, err := client.Actions.DisableWorkflowByFileName(ctx, "o", "r", "main.yml")
 	if err != nil {
 		t.Errorf("Actions.DisableWorkflowByFileName returned error: %v", err)
 	}
 
 	// Test s.client.NewRequest failure
 	client.BaseURL.Path = ""
-	_, err = client.Actions.DisableWorkflowByFileName(context.Background(), "o", "r", "main.yml")
+	_, err = client.Actions.DisableWorkflowByFileName(ctx, "o", "r", "main.yml")
 	if err == nil {
 		t.Error("client.BaseURL.Path='' DisableWorkflowByFileName err = nil, want error")
 	}

--- a/github/activity_events_test.go
+++ b/github/activity_events_test.go
@@ -27,7 +27,8 @@ func TestActivityService_ListEvents(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	events, _, err := client.Activity.ListEvents(context.Background(), opt)
+	ctx := context.Background()
+	events, _, err := client.Activity.ListEvents(ctx, opt)
 	if err != nil {
 		t.Errorf("Activities.ListEvents returned error: %v", err)
 	}
@@ -51,7 +52,8 @@ func TestActivityService_ListRepositoryEvents(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	events, _, err := client.Activity.ListRepositoryEvents(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	events, _, err := client.Activity.ListRepositoryEvents(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Activities.ListRepositoryEvents returned error: %v", err)
 	}
@@ -66,7 +68,8 @@ func TestActivityService_ListRepositoryEvents_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Activity.ListRepositoryEvents(context.Background(), "%", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Activity.ListRepositoryEvents(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -83,7 +86,8 @@ func TestActivityService_ListIssueEventsForRepository(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	events, _, err := client.Activity.ListIssueEventsForRepository(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	events, _, err := client.Activity.ListIssueEventsForRepository(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Activities.ListIssueEventsForRepository returned error: %v", err)
 	}
@@ -98,7 +102,8 @@ func TestActivityService_ListIssueEventsForRepository_invalidOwner(t *testing.T)
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Activity.ListIssueEventsForRepository(context.Background(), "%", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Activity.ListIssueEventsForRepository(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -115,7 +120,8 @@ func TestActivityService_ListEventsForRepoNetwork(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	events, _, err := client.Activity.ListEventsForRepoNetwork(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	events, _, err := client.Activity.ListEventsForRepoNetwork(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Activities.ListEventsForRepoNetwork returned error: %v", err)
 	}
@@ -130,7 +136,8 @@ func TestActivityService_ListEventsForRepoNetwork_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Activity.ListEventsForRepoNetwork(context.Background(), "%", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Activity.ListEventsForRepoNetwork(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -147,7 +154,8 @@ func TestActivityService_ListEventsForOrganization(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	events, _, err := client.Activity.ListEventsForOrganization(context.Background(), "o", opt)
+	ctx := context.Background()
+	events, _, err := client.Activity.ListEventsForOrganization(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Activities.ListEventsForOrganization returned error: %v", err)
 	}
@@ -162,7 +170,8 @@ func TestActivityService_ListEventsForOrganization_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Activity.ListEventsForOrganization(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Activity.ListEventsForOrganization(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -179,7 +188,8 @@ func TestActivityService_ListEventsPerformedByUser_all(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	events, _, err := client.Activity.ListEventsPerformedByUser(context.Background(), "u", false, opt)
+	ctx := context.Background()
+	events, _, err := client.Activity.ListEventsPerformedByUser(ctx, "u", false, opt)
 	if err != nil {
 		t.Errorf("Events.ListPerformedByUser returned error: %v", err)
 	}
@@ -199,7 +209,8 @@ func TestActivityService_ListEventsPerformedByUser_publicOnly(t *testing.T) {
 		fmt.Fprint(w, `[{"id":"1"},{"id":"2"}]`)
 	})
 
-	events, _, err := client.Activity.ListEventsPerformedByUser(context.Background(), "u", true, nil)
+	ctx := context.Background()
+	events, _, err := client.Activity.ListEventsPerformedByUser(ctx, "u", true, nil)
 	if err != nil {
 		t.Errorf("Events.ListPerformedByUser returned error: %v", err)
 	}
@@ -214,7 +225,8 @@ func TestActivityService_ListEventsPerformedByUser_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Activity.ListEventsPerformedByUser(context.Background(), "%", false, nil)
+	ctx := context.Background()
+	_, _, err := client.Activity.ListEventsPerformedByUser(ctx, "%", false, nil)
 	testURLParseError(t, err)
 }
 
@@ -231,7 +243,8 @@ func TestActivityService_ListEventsReceivedByUser_all(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	events, _, err := client.Activity.ListEventsReceivedByUser(context.Background(), "u", false, opt)
+	ctx := context.Background()
+	events, _, err := client.Activity.ListEventsReceivedByUser(ctx, "u", false, opt)
 	if err != nil {
 		t.Errorf("Events.ListReceivedByUser returned error: %v", err)
 	}
@@ -251,7 +264,8 @@ func TestActivityService_ListEventsReceivedByUser_publicOnly(t *testing.T) {
 		fmt.Fprint(w, `[{"id":"1"},{"id":"2"}]`)
 	})
 
-	events, _, err := client.Activity.ListEventsReceivedByUser(context.Background(), "u", true, nil)
+	ctx := context.Background()
+	events, _, err := client.Activity.ListEventsReceivedByUser(ctx, "u", true, nil)
 	if err != nil {
 		t.Errorf("Events.ListReceivedByUser returned error: %v", err)
 	}
@@ -266,7 +280,8 @@ func TestActivityService_ListEventsReceivedByUser_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Activity.ListEventsReceivedByUser(context.Background(), "%", false, nil)
+	ctx := context.Background()
+	_, _, err := client.Activity.ListEventsReceivedByUser(ctx, "%", false, nil)
 	testURLParseError(t, err)
 }
 
@@ -283,7 +298,8 @@ func TestActivityService_ListUserEventsForOrganization(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	events, _, err := client.Activity.ListUserEventsForOrganization(context.Background(), "o", "u", opt)
+	ctx := context.Background()
+	events, _, err := client.Activity.ListUserEventsForOrganization(ctx, "o", "u", opt)
 	if err != nil {
 		t.Errorf("Activities.ListUserEventsForOrganization returned error: %v", err)
 	}

--- a/github/activity_notifications_test.go
+++ b/github/activity_notifications_test.go
@@ -37,7 +37,8 @@ func TestActivityService_ListNotification(t *testing.T) {
 		Since:         time.Date(2006, time.January, 02, 15, 04, 05, 0, time.UTC),
 		Before:        time.Date(2007, time.March, 04, 15, 04, 05, 0, time.UTC),
 	}
-	notifications, _, err := client.Activity.ListNotifications(context.Background(), opt)
+	ctx := context.Background()
+	notifications, _, err := client.Activity.ListNotifications(ctx, opt)
 	if err != nil {
 		t.Errorf("Activity.ListNotifications returned error: %v", err)
 	}
@@ -57,7 +58,8 @@ func TestActivityService_ListRepositoryNotification(t *testing.T) {
 		fmt.Fprint(w, `[{"id":"1"}]`)
 	})
 
-	notifications, _, err := client.Activity.ListRepositoryNotifications(context.Background(), "o", "r", nil)
+	ctx := context.Background()
+	notifications, _, err := client.Activity.ListRepositoryNotifications(ctx, "o", "r", nil)
 	if err != nil {
 		t.Errorf("Activity.ListRepositoryNotifications returned error: %v", err)
 	}
@@ -80,7 +82,8 @@ func TestActivityService_MarkNotificationsRead(t *testing.T) {
 		w.WriteHeader(http.StatusResetContent)
 	})
 
-	_, err := client.Activity.MarkNotificationsRead(context.Background(), time.Date(2006, time.January, 02, 15, 04, 05, 0, time.UTC))
+	ctx := context.Background()
+	_, err := client.Activity.MarkNotificationsRead(ctx, time.Date(2006, time.January, 02, 15, 04, 05, 0, time.UTC))
 	if err != nil {
 		t.Errorf("Activity.MarkNotificationsRead returned error: %v", err)
 	}
@@ -98,7 +101,8 @@ func TestActivityService_MarkRepositoryNotificationsRead(t *testing.T) {
 		w.WriteHeader(http.StatusResetContent)
 	})
 
-	_, err := client.Activity.MarkRepositoryNotificationsRead(context.Background(), "o", "r", time.Date(2006, time.January, 02, 15, 04, 05, 0, time.UTC))
+	ctx := context.Background()
+	_, err := client.Activity.MarkRepositoryNotificationsRead(ctx, "o", "r", time.Date(2006, time.January, 02, 15, 04, 05, 0, time.UTC))
 	if err != nil {
 		t.Errorf("Activity.MarkRepositoryNotificationsRead returned error: %v", err)
 	}
@@ -113,7 +117,8 @@ func TestActivityService_GetThread(t *testing.T) {
 		fmt.Fprint(w, `{"id":"1"}`)
 	})
 
-	notification, _, err := client.Activity.GetThread(context.Background(), "1")
+	ctx := context.Background()
+	notification, _, err := client.Activity.GetThread(ctx, "1")
 	if err != nil {
 		t.Errorf("Activity.GetThread returned error: %v", err)
 	}
@@ -133,7 +138,8 @@ func TestActivityService_MarkThreadRead(t *testing.T) {
 		w.WriteHeader(http.StatusResetContent)
 	})
 
-	_, err := client.Activity.MarkThreadRead(context.Background(), "1")
+	ctx := context.Background()
+	_, err := client.Activity.MarkThreadRead(ctx, "1")
 	if err != nil {
 		t.Errorf("Activity.MarkThreadRead returned error: %v", err)
 	}
@@ -148,7 +154,8 @@ func TestActivityService_GetThreadSubscription(t *testing.T) {
 		fmt.Fprint(w, `{"subscribed":true}`)
 	})
 
-	sub, _, err := client.Activity.GetThreadSubscription(context.Background(), "1")
+	ctx := context.Background()
+	sub, _, err := client.Activity.GetThreadSubscription(ctx, "1")
 	if err != nil {
 		t.Errorf("Activity.GetThreadSubscription returned error: %v", err)
 	}
@@ -177,7 +184,8 @@ func TestActivityService_SetThreadSubscription(t *testing.T) {
 		fmt.Fprint(w, `{"ignored":true}`)
 	})
 
-	sub, _, err := client.Activity.SetThreadSubscription(context.Background(), "1", input)
+	ctx := context.Background()
+	sub, _, err := client.Activity.SetThreadSubscription(ctx, "1", input)
 	if err != nil {
 		t.Errorf("Activity.SetThreadSubscription returned error: %v", err)
 	}
@@ -197,7 +205,8 @@ func TestActivityService_DeleteThreadSubscription(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Activity.DeleteThreadSubscription(context.Background(), "1")
+	ctx := context.Background()
+	_, err := client.Activity.DeleteThreadSubscription(ctx, "1")
 	if err != nil {
 		t.Errorf("Activity.DeleteThreadSubscription returned error: %v", err)
 	}

--- a/github/activity_star_test.go
+++ b/github/activity_star_test.go
@@ -29,7 +29,8 @@ func TestActivityService_ListStargazers(t *testing.T) {
 		fmt.Fprint(w, `[{"starred_at":"2002-02-10T15:30:00Z","user":{"id":1}}]`)
 	})
 
-	stargazers, _, err := client.Activity.ListStargazers(context.Background(), "o", "r", &ListOptions{Page: 2})
+	ctx := context.Background()
+	stargazers, _, err := client.Activity.ListStargazers(ctx, "o", "r", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Activity.ListStargazers returned error: %v", err)
 	}
@@ -50,7 +51,8 @@ func TestActivityService_ListStarred_authenticatedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"starred_at":"2002-02-10T15:30:00Z","repo":{"id":1}}]`)
 	})
 
-	repos, _, err := client.Activity.ListStarred(context.Background(), "", nil)
+	ctx := context.Background()
+	repos, _, err := client.Activity.ListStarred(ctx, "", nil)
 	if err != nil {
 		t.Errorf("Activity.ListStarred returned error: %v", err)
 	}
@@ -77,7 +79,8 @@ func TestActivityService_ListStarred_specifiedUser(t *testing.T) {
 	})
 
 	opt := &ActivityListStarredOptions{"created", "asc", ListOptions{Page: 2}}
-	repos, _, err := client.Activity.ListStarred(context.Background(), "u", opt)
+	ctx := context.Background()
+	repos, _, err := client.Activity.ListStarred(ctx, "u", opt)
 	if err != nil {
 		t.Errorf("Activity.ListStarred returned error: %v", err)
 	}
@@ -92,7 +95,8 @@ func TestActivityService_ListStarred_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Activity.ListStarred(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Activity.ListStarred(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -105,7 +109,8 @@ func TestActivityService_IsStarred_hasStar(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	star, _, err := client.Activity.IsStarred(context.Background(), "o", "r")
+	ctx := context.Background()
+	star, _, err := client.Activity.IsStarred(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Activity.IsStarred returned error: %v", err)
 	}
@@ -123,7 +128,8 @@ func TestActivityService_IsStarred_noStar(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	star, _, err := client.Activity.IsStarred(context.Background(), "o", "r")
+	ctx := context.Background()
+	star, _, err := client.Activity.IsStarred(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Activity.IsStarred returned error: %v", err)
 	}
@@ -136,7 +142,8 @@ func TestActivityService_IsStarred_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Activity.IsStarred(context.Background(), "%", "%")
+	ctx := context.Background()
+	_, _, err := client.Activity.IsStarred(ctx, "%", "%")
 	testURLParseError(t, err)
 }
 
@@ -148,7 +155,8 @@ func TestActivityService_Star(t *testing.T) {
 		testMethod(t, r, "PUT")
 	})
 
-	_, err := client.Activity.Star(context.Background(), "o", "r")
+	ctx := context.Background()
+	_, err := client.Activity.Star(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Activity.Star returned error: %v", err)
 	}
@@ -158,7 +166,8 @@ func TestActivityService_Star_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Activity.Star(context.Background(), "%", "%")
+	ctx := context.Background()
+	_, err := client.Activity.Star(ctx, "%", "%")
 	testURLParseError(t, err)
 }
 
@@ -170,7 +179,8 @@ func TestActivityService_Unstar(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Activity.Unstar(context.Background(), "o", "r")
+	ctx := context.Background()
+	_, err := client.Activity.Unstar(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Activity.Unstar returned error: %v", err)
 	}
@@ -180,6 +190,7 @@ func TestActivityService_Unstar_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Activity.Unstar(context.Background(), "%", "%")
+	ctx := context.Background()
+	_, err := client.Activity.Unstar(ctx, "%", "%")
 	testURLParseError(t, err)
 }

--- a/github/activity_watching_test.go
+++ b/github/activity_watching_test.go
@@ -27,7 +27,8 @@ func TestActivityService_ListWatchers(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	watchers, _, err := client.Activity.ListWatchers(context.Background(), "o", "r", &ListOptions{Page: 2})
+	ctx := context.Background()
+	watchers, _, err := client.Activity.ListWatchers(ctx, "o", "r", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Activity.ListWatchers returned error: %v", err)
 	}
@@ -50,7 +51,8 @@ func TestActivityService_ListWatched_authenticatedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	watched, _, err := client.Activity.ListWatched(context.Background(), "", &ListOptions{Page: 2})
+	ctx := context.Background()
+	watched, _, err := client.Activity.ListWatched(ctx, "", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Activity.ListWatched returned error: %v", err)
 	}
@@ -73,7 +75,8 @@ func TestActivityService_ListWatched_specifiedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	watched, _, err := client.Activity.ListWatched(context.Background(), "u", &ListOptions{Page: 2})
+	ctx := context.Background()
+	watched, _, err := client.Activity.ListWatched(ctx, "u", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Activity.ListWatched returned error: %v", err)
 	}
@@ -93,7 +96,8 @@ func TestActivityService_GetRepositorySubscription_true(t *testing.T) {
 		fmt.Fprint(w, `{"subscribed":true}`)
 	})
 
-	sub, _, err := client.Activity.GetRepositorySubscription(context.Background(), "o", "r")
+	ctx := context.Background()
+	sub, _, err := client.Activity.GetRepositorySubscription(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Activity.GetRepositorySubscription returned error: %v", err)
 	}
@@ -113,7 +117,8 @@ func TestActivityService_GetRepositorySubscription_false(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	sub, _, err := client.Activity.GetRepositorySubscription(context.Background(), "o", "r")
+	ctx := context.Background()
+	sub, _, err := client.Activity.GetRepositorySubscription(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Activity.GetRepositorySubscription returned error: %v", err)
 	}
@@ -133,7 +138,8 @@ func TestActivityService_GetRepositorySubscription_error(t *testing.T) {
 		w.WriteHeader(http.StatusBadRequest)
 	})
 
-	_, _, err := client.Activity.GetRepositorySubscription(context.Background(), "o", "r")
+	ctx := context.Background()
+	_, _, err := client.Activity.GetRepositorySubscription(ctx, "o", "r")
 	if err == nil {
 		t.Errorf("Expected HTTP 400 response")
 	}
@@ -157,7 +163,8 @@ func TestActivityService_SetRepositorySubscription(t *testing.T) {
 		fmt.Fprint(w, `{"ignored":true}`)
 	})
 
-	sub, _, err := client.Activity.SetRepositorySubscription(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	sub, _, err := client.Activity.SetRepositorySubscription(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Activity.SetRepositorySubscription returned error: %v", err)
 	}
@@ -177,7 +184,8 @@ func TestActivityService_DeleteRepositorySubscription(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Activity.DeleteRepositorySubscription(context.Background(), "o", "r")
+	ctx := context.Background()
+	_, err := client.Activity.DeleteRepositorySubscription(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Activity.DeleteRepositorySubscription returned error: %v", err)
 	}

--- a/github/admin_orgs_test.go
+++ b/github/admin_orgs_test.go
@@ -35,7 +35,8 @@ func TestAdminOrgs_Create(t *testing.T) {
 		fmt.Fprint(w, `{"login":"github","id":1}`)
 	})
 
-	org, _, err := client.Admin.CreateOrg(context.Background(), input, "ghAdmin")
+	ctx := context.Background()
+	org, _, err := client.Admin.CreateOrg(ctx, input, "ghAdmin")
 	if err != nil {
 		t.Errorf("Admin.CreateOrg returned error: %v", err)
 	}
@@ -67,7 +68,8 @@ func TestAdminOrgs_Rename(t *testing.T) {
 		fmt.Fprint(w, `{"message":"Job queued to rename organization. It may take a few minutes to complete.","url":"https://<hostname>/api/v3/organizations/1"}`)
 	})
 
-	resp, _, err := client.Admin.RenameOrg(context.Background(), input, "the-new-octocats")
+	ctx := context.Background()
+	resp, _, err := client.Admin.RenameOrg(ctx, input, "the-new-octocats")
 	if err != nil {
 		t.Errorf("Admin.RenameOrg returned error: %v", err)
 	}
@@ -95,7 +97,8 @@ func TestAdminOrgs_RenameByName(t *testing.T) {
 		fmt.Fprint(w, `{"message":"Job queued to rename organization. It may take a few minutes to complete.","url":"https://<hostname>/api/v3/organizations/1"}`)
 	})
 
-	resp, _, err := client.Admin.RenameOrgByName(context.Background(), "o", "the-new-octocats")
+	ctx := context.Background()
+	resp, _, err := client.Admin.RenameOrgByName(ctx, "o", "the-new-octocats")
 	if err != nil {
 		t.Errorf("Admin.RenameOrg returned error: %v", err)
 	}

--- a/github/admin_users_test.go
+++ b/github/admin_users_test.go
@@ -32,7 +32,8 @@ func TestAdminUsers_Create(t *testing.T) {
 		fmt.Fprint(w, `{"login":"github","id":1}`)
 	})
 
-	org, _, err := client.Admin.CreateUser(context.Background(), "github", "email@domain.com")
+	ctx := context.Background()
+	org, _, err := client.Admin.CreateUser(ctx, "github", "email@domain.com")
 	if err != nil {
 		t.Errorf("Admin.CreateUser returned error: %v", err)
 	}
@@ -51,7 +52,8 @@ func TestAdminUsers_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Admin.DeleteUser(context.Background(), "github")
+	ctx := context.Background()
+	_, err := client.Admin.DeleteUser(ctx, "github")
 	if err != nil {
 		t.Errorf("Admin.DeleteUser returned error: %v", err)
 	}
@@ -85,7 +87,8 @@ func TestUserImpersonation_Create(t *testing.T) {
 	})
 
 	opt := &ImpersonateUserOptions{Scopes: []string{"repo"}}
-	auth, _, err := client.Admin.CreateUserImpersonation(context.Background(), "github", opt)
+	ctx := context.Background()
+	auth, _, err := client.Admin.CreateUserImpersonation(ctx, "github", opt)
 	if err != nil {
 		t.Errorf("Admin.CreateUserImpersonation returned error: %v", err)
 	}
@@ -122,7 +125,8 @@ func TestUserImpersonation_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Admin.DeleteUserImpersonation(context.Background(), "github")
+	ctx := context.Background()
+	_, err := client.Admin.DeleteUserImpersonation(ctx, "github")
 	if err != nil {
 		t.Errorf("Admin.DeleteUserImpersonation returned error: %v", err)
 	}

--- a/github/apps_installation_test.go
+++ b/github/apps_installation_test.go
@@ -27,7 +27,8 @@ func TestAppsService_ListRepos(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	repositories, _, err := client.Apps.ListRepos(context.Background(), opt)
+	ctx := context.Background()
+	repositories, _, err := client.Apps.ListRepos(ctx, opt)
 	if err != nil {
 		t.Errorf("Apps.ListRepos returned error: %v", err)
 	}
@@ -52,7 +53,8 @@ func TestAppsService_ListUserRepos(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	repositories, _, err := client.Apps.ListUserRepos(context.Background(), 1, opt)
+	ctx := context.Background()
+	repositories, _, err := client.Apps.ListUserRepos(ctx, 1, opt)
 	if err != nil {
 		t.Errorf("Apps.ListUserRepos returned error: %v", err)
 	}
@@ -72,7 +74,8 @@ func TestAppsService_AddRepository(t *testing.T) {
 		fmt.Fprint(w, `{"id":1,"name":"n","description":"d","owner":{"login":"l"},"license":{"key":"mit"}}`)
 	})
 
-	repo, _, err := client.Apps.AddRepository(context.Background(), 1, 1)
+	ctx := context.Background()
+	repo, _, err := client.Apps.AddRepository(ctx, 1, 1)
 	if err != nil {
 		t.Errorf("Apps.AddRepository returned error: %v", err)
 	}
@@ -92,7 +95,8 @@ func TestAppsService_RemoveRepository(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Apps.RemoveRepository(context.Background(), 1, 1)
+	ctx := context.Background()
+	_, err := client.Apps.RemoveRepository(ctx, 1, 1)
 	if err != nil {
 		t.Errorf("Apps.RemoveRepository returned error: %v", err)
 	}
@@ -107,7 +111,8 @@ func TestAppsService_RevokeInstallationToken(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Apps.RevokeInstallationToken(context.Background())
+	ctx := context.Background()
+	_, err := client.Apps.RevokeInstallationToken(ctx)
 	if err != nil {
 		t.Errorf("Apps.RevokeInstallationToken returned error: %v", err)
 	}

--- a/github/apps_manifest_test.go
+++ b/github/apps_manifest_test.go
@@ -34,7 +34,8 @@ func TestGetConfig(t *testing.T) {
 		fmt.Fprint(w, manifestJSON)
 	})
 
-	cfg, _, err := client.Apps.CompleteAppManifest(context.Background(), "code")
+	ctx := context.Background()
+	cfg, _, err := client.Apps.CompleteAppManifest(ctx, "code")
 	if err != nil {
 		t.Errorf("AppManifest.GetConfig returned error: %v", err)
 	}

--- a/github/apps_marketplace_test.go
+++ b/github/apps_marketplace_test.go
@@ -28,7 +28,8 @@ func TestMarketplaceService_ListPlans(t *testing.T) {
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = false
-	plans, _, err := client.Marketplace.ListPlans(context.Background(), opt)
+	ctx := context.Background()
+	plans, _, err := client.Marketplace.ListPlans(ctx, opt)
 	if err != nil {
 		t.Errorf("Marketplace.ListPlans returned error: %v", err)
 	}
@@ -50,7 +51,8 @@ func TestMarketplaceService_Stubbed_ListPlans(t *testing.T) {
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = true
-	plans, _, err := client.Marketplace.ListPlans(context.Background(), opt)
+	ctx := context.Background()
+	plans, _, err := client.Marketplace.ListPlans(ctx, opt)
 	if err != nil {
 		t.Errorf("Marketplace.ListPlans (Stubbed) returned error: %v", err)
 	}
@@ -72,7 +74,8 @@ func TestMarketplaceService_ListPlanAccountsForPlan(t *testing.T) {
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = false
-	accounts, _, err := client.Marketplace.ListPlanAccountsForPlan(context.Background(), 1, opt)
+	ctx := context.Background()
+	accounts, _, err := client.Marketplace.ListPlanAccountsForPlan(ctx, 1, opt)
 	if err != nil {
 		t.Errorf("Marketplace.ListPlanAccountsForPlan returned error: %v", err)
 	}
@@ -94,7 +97,8 @@ func TestMarketplaceService_Stubbed_ListPlanAccountsForPlan(t *testing.T) {
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = true
-	accounts, _, err := client.Marketplace.ListPlanAccountsForPlan(context.Background(), 1, opt)
+	ctx := context.Background()
+	accounts, _, err := client.Marketplace.ListPlanAccountsForPlan(ctx, 1, opt)
 	if err != nil {
 		t.Errorf("Marketplace.ListPlanAccountsForPlan (Stubbed) returned error: %v", err)
 	}
@@ -116,7 +120,8 @@ func TestMarketplaceService_ListPlanAccountsForAccount(t *testing.T) {
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = false
-	accounts, _, err := client.Marketplace.ListPlanAccountsForAccount(context.Background(), 1, opt)
+	ctx := context.Background()
+	accounts, _, err := client.Marketplace.ListPlanAccountsForAccount(ctx, 1, opt)
 	if err != nil {
 		t.Errorf("Marketplace.ListPlanAccountsForAccount returned error: %v", err)
 	}
@@ -138,7 +143,8 @@ func TestMarketplaceService_Stubbed_ListPlanAccountsForAccount(t *testing.T) {
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = true
-	accounts, _, err := client.Marketplace.ListPlanAccountsForAccount(context.Background(), 1, opt)
+	ctx := context.Background()
+	accounts, _, err := client.Marketplace.ListPlanAccountsForAccount(ctx, 1, opt)
 	if err != nil {
 		t.Errorf("Marketplace.ListPlanAccountsForAccount (Stubbed) returned error: %v", err)
 	}
@@ -160,7 +166,8 @@ func TestMarketplaceService_ListMarketplacePurchasesForUser(t *testing.T) {
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = false
-	purchases, _, err := client.Marketplace.ListMarketplacePurchasesForUser(context.Background(), opt)
+	ctx := context.Background()
+	purchases, _, err := client.Marketplace.ListMarketplacePurchasesForUser(ctx, opt)
 	if err != nil {
 		t.Errorf("Marketplace.ListMarketplacePurchasesForUser returned error: %v", err)
 	}
@@ -182,7 +189,8 @@ func TestMarketplaceService_Stubbed_ListMarketplacePurchasesForUser(t *testing.T
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = true
-	purchases, _, err := client.Marketplace.ListMarketplacePurchasesForUser(context.Background(), opt)
+	ctx := context.Background()
+	purchases, _, err := client.Marketplace.ListMarketplacePurchasesForUser(ctx, opt)
 	if err != nil {
 		t.Errorf("Marketplace.ListMarketplacePurchasesForUser returned error: %v", err)
 	}

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -27,7 +27,8 @@ func TestAppsService_Get_authenticatedApp(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	app, _, err := client.Apps.Get(context.Background(), "")
+	ctx := context.Background()
+	app, _, err := client.Apps.Get(ctx, "")
 	if err != nil {
 		t.Errorf("Apps.Get returned error: %v", err)
 	}
@@ -47,7 +48,8 @@ func TestAppsService_Get_specifiedApp(t *testing.T) {
 		fmt.Fprint(w, `{"html_url":"https://github.com/apps/a"}`)
 	})
 
-	app, _, err := client.Apps.Get(context.Background(), "a")
+	ctx := context.Background()
+	app, _, err := client.Apps.Get(ctx, "a")
 	if err != nil {
 		t.Errorf("Apps.Get returned error: %v", err)
 	}
@@ -111,7 +113,8 @@ func TestAppsService_ListInstallations(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	installations, _, err := client.Apps.ListInstallations(context.Background(), opt)
+	ctx := context.Background()
+	installations, _, err := client.Apps.ListInstallations(ctx, opt)
 	if err != nil {
 		t.Errorf("Apps.ListInstallations returned error: %v", err)
 	}
@@ -167,7 +170,8 @@ func TestAppsService_GetInstallation(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "app_id":1, "target_id":1, "target_type": "Organization"}`)
 	})
 
-	installation, _, err := client.Apps.GetInstallation(context.Background(), 1)
+	ctx := context.Background()
+	installation, _, err := client.Apps.GetInstallation(ctx, 1)
 	if err != nil {
 		t.Errorf("Apps.GetInstallation returned error: %v", err)
 	}
@@ -192,7 +196,8 @@ func TestAppsService_ListUserInstallations(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	installations, _, err := client.Apps.ListUserInstallations(context.Background(), opt)
+	ctx := context.Background()
+	installations, _, err := client.Apps.ListUserInstallations(ctx, opt)
 	if err != nil {
 		t.Errorf("Apps.ListUserInstallations returned error: %v", err)
 	}
@@ -213,7 +218,8 @@ func TestAppsService_SuspendInstallation(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Apps.SuspendInstallation(context.Background(), 1); err != nil {
+	ctx := context.Background()
+	if _, err := client.Apps.SuspendInstallation(ctx, 1); err != nil {
 		t.Errorf("Apps.SuspendInstallation returned error: %v", err)
 	}
 }
@@ -228,7 +234,8 @@ func TestAppsService_UnsuspendInstallation(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Apps.UnsuspendInstallation(context.Background(), 1); err != nil {
+	ctx := context.Background()
+	if _, err := client.Apps.UnsuspendInstallation(ctx, 1); err != nil {
 		t.Errorf("Apps.UnsuspendInstallation returned error: %v", err)
 	}
 }
@@ -242,7 +249,8 @@ func TestAppsService_DeleteInstallation(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Apps.DeleteInstallation(context.Background(), 1)
+	ctx := context.Background()
+	_, err := client.Apps.DeleteInstallation(ctx, 1)
 	if err != nil {
 		t.Errorf("Apps.DeleteInstallation returned error: %v", err)
 	}
@@ -257,7 +265,8 @@ func TestAppsService_CreateInstallationToken(t *testing.T) {
 		fmt.Fprint(w, `{"token":"t"}`)
 	})
 
-	token, _, err := client.Apps.CreateInstallationToken(context.Background(), 1, nil)
+	ctx := context.Background()
+	token, _, err := client.Apps.CreateInstallationToken(ctx, 1, nil)
 	if err != nil {
 		t.Errorf("Apps.CreateInstallationToken returned error: %v", err)
 	}
@@ -303,7 +312,8 @@ func TestAppsService_CreateInstallationTokenWithOptions(t *testing.T) {
 		fmt.Fprint(w, `{"token":"t"}`)
 	})
 
-	token, _, err := client.Apps.CreateInstallationToken(context.Background(), 1, installationTokenOptions)
+	ctx := context.Background()
+	token, _, err := client.Apps.CreateInstallationToken(ctx, 1, installationTokenOptions)
 	if err != nil {
 		t.Errorf("Apps.CreateInstallationToken returned error: %v", err)
 	}
@@ -326,7 +336,8 @@ func TestAppsService_CreateAttachement(t *testing.T) {
 		w.Write([]byte(`{"id":1,"title":"title1","body":"body1"}`))
 	})
 
-	got, _, err := client.Apps.CreateAttachment(context.Background(), 11, "title1", "body1")
+	ctx := context.Background()
+	got, _, err := client.Apps.CreateAttachment(ctx, 11, "title1", "body1")
 	if err != nil {
 		t.Errorf("CreateAttachment returned error: %v", err)
 	}
@@ -346,7 +357,8 @@ func TestAppsService_FindOrganizationInstallation(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "app_id":1, "target_id":1, "target_type": "Organization"}`)
 	})
 
-	installation, _, err := client.Apps.FindOrganizationInstallation(context.Background(), "o")
+	ctx := context.Background()
+	installation, _, err := client.Apps.FindOrganizationInstallation(ctx, "o")
 	if err != nil {
 		t.Errorf("Apps.FindOrganizationInstallation returned error: %v", err)
 	}
@@ -366,7 +378,8 @@ func TestAppsService_FindRepositoryInstallation(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "app_id":1, "target_id":1, "target_type": "Organization"}`)
 	})
 
-	installation, _, err := client.Apps.FindRepositoryInstallation(context.Background(), "o", "r")
+	ctx := context.Background()
+	installation, _, err := client.Apps.FindRepositoryInstallation(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Apps.FindRepositoryInstallation returned error: %v", err)
 	}
@@ -386,7 +399,8 @@ func TestAppsService_FindRepositoryInstallationByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "app_id":1, "target_id":1, "target_type": "Organization"}`)
 	})
 
-	installation, _, err := client.Apps.FindRepositoryInstallationByID(context.Background(), 1)
+	ctx := context.Background()
+	installation, _, err := client.Apps.FindRepositoryInstallationByID(ctx, 1)
 	if err != nil {
 		t.Errorf("Apps.FindRepositoryInstallationByID returned error: %v", err)
 	}
@@ -406,7 +420,8 @@ func TestAppsService_FindUserInstallation(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "app_id":1, "target_id":1, "target_type": "User"}`)
 	})
 
-	installation, _, err := client.Apps.FindUserInstallation(context.Background(), "u")
+	ctx := context.Background()
+	installation, _, err := client.Apps.FindUserInstallation(ctx, "u")
 	if err != nil {
 		t.Errorf("Apps.FindUserInstallation returned error: %v", err)
 	}

--- a/github/authorizations_test.go
+++ b/github/authorizations_test.go
@@ -24,7 +24,8 @@ func TestAuthorizationsService_Check(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	got, _, err := client.Authorizations.Check(context.Background(), "id", "a")
+	ctx := context.Background()
+	got, _, err := client.Authorizations.Check(ctx, "id", "a")
 	if err != nil {
 		t.Errorf("Authorizations.Check returned error: %v", err)
 	}
@@ -46,7 +47,8 @@ func TestAuthorizationsService_Reset(t *testing.T) {
 		fmt.Fprint(w, `{"ID":1}`)
 	})
 
-	got, _, err := client.Authorizations.Reset(context.Background(), "id", "a")
+	ctx := context.Background()
+	got, _, err := client.Authorizations.Reset(ctx, "id", "a")
 	if err != nil {
 		t.Errorf("Authorizations.Reset returned error: %v", err)
 	}
@@ -68,7 +70,8 @@ func TestAuthorizationsService_Revoke(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Authorizations.Revoke(context.Background(), "id", "a")
+	ctx := context.Background()
+	_, err := client.Authorizations.Revoke(ctx, "id", "a")
 	if err != nil {
 		t.Errorf("Authorizations.Revoke returned error: %v", err)
 	}
@@ -84,7 +87,8 @@ func TestDeleteGrant(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeOAuthAppPreview)
 	})
 
-	_, err := client.Authorizations.DeleteGrant(context.Background(), "id", "a")
+	ctx := context.Background()
+	_, err := client.Authorizations.DeleteGrant(ctx, "id", "a")
 	if err != nil {
 		t.Errorf("OAuthAuthorizations.DeleteGrant returned error: %v", err)
 	}
@@ -100,7 +104,8 @@ func TestAuthorizationsService_CreateImpersonation(t *testing.T) {
 	})
 
 	req := &AuthorizationRequest{Scopes: []Scope{ScopePublicRepo}}
-	got, _, err := client.Authorizations.CreateImpersonation(context.Background(), "u", req)
+	ctx := context.Background()
+	got, _, err := client.Authorizations.CreateImpersonation(ctx, "u", req)
 	if err != nil {
 		t.Errorf("Authorizations.CreateImpersonation returned error: %+v", err)
 	}
@@ -119,7 +124,8 @@ func TestAuthorizationsService_DeleteImpersonation(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Authorizations.DeleteImpersonation(context.Background(), "u")
+	ctx := context.Background()
+	_, err := client.Authorizations.DeleteImpersonation(ctx, "u")
 	if err != nil {
 		t.Errorf("Authorizations.DeleteImpersonation returned error: %+v", err)
 	}

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -29,7 +29,8 @@ func TestChecksService_GetCheckRun(t *testing.T) {
 			"started_at": "2018-05-04T01:14:52Z",
 			"completed_at": "2018-05-04T01:14:52Z"}`)
 	})
-	checkRun, _, err := client.Checks.GetCheckRun(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	checkRun, _, err := client.Checks.GetCheckRun(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Checks.GetCheckRun return error: %v", err)
 	}
@@ -65,7 +66,8 @@ func TestChecksService_GetCheckSuite(t *testing.T) {
                         "after": "deadbeefa",
 			"status": "completed"}`)
 	})
-	checkSuite, _, err := client.Checks.GetCheckSuite(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	checkSuite, _, err := client.Checks.GetCheckSuite(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Checks.GetCheckSuite return error: %v", err)
 	}
@@ -113,7 +115,8 @@ func TestChecksService_CreateCheckRun(t *testing.T) {
 		},
 	}
 
-	checkRun, _, err := client.Checks.CreateCheckRun(context.Background(), "o", "r", checkRunOpt)
+	ctx := context.Background()
+	checkRun, _, err := client.Checks.CreateCheckRun(ctx, "o", "r", checkRunOpt)
 	if err != nil {
 		t.Errorf("Checks.CreateCheckRun return error: %v", err)
 	}
@@ -158,7 +161,8 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 		)
 	})
 
-	checkRunAnnotations, _, err := client.Checks.ListCheckRunAnnotations(context.Background(), "o", "r", 1, &ListOptions{Page: 1})
+	ctx := context.Background()
+	checkRunAnnotations, _, err := client.Checks.ListCheckRunAnnotations(ctx, "o", "r", 1, &ListOptions{Page: 1})
 	if err != nil {
 		t.Errorf("Checks.ListCheckRunAnnotations return error: %v", err)
 	}
@@ -208,7 +212,8 @@ func TestChecksService_UpdateCheckRun(t *testing.T) {
 		},
 	}
 
-	checkRun, _, err := client.Checks.UpdateCheckRun(context.Background(), "o", "r", 1, updateCheckRunOpt)
+	ctx := context.Background()
+	checkRun, _, err := client.Checks.UpdateCheckRun(ctx, "o", "r", 1, updateCheckRunOpt)
 	if err != nil {
 		t.Errorf("Checks.UpdateCheckRun return error: %v", err)
 	}
@@ -261,7 +266,8 @@ func TestChecksService_ListCheckRunsForRef(t *testing.T) {
 		Filter:      String("all"),
 		ListOptions: ListOptions{Page: 1},
 	}
-	checkRuns, _, err := client.Checks.ListCheckRunsForRef(context.Background(), "o", "r", "master", opt)
+	ctx := context.Background()
+	checkRuns, _, err := client.Checks.ListCheckRunsForRef(ctx, "o", "r", "master", opt)
 	if err != nil {
 		t.Errorf("Checks.ListCheckRunsForRef return error: %v", err)
 	}
@@ -313,7 +319,8 @@ func TestChecksService_ListCheckRunsCheckSuite(t *testing.T) {
 		Filter:      String("all"),
 		ListOptions: ListOptions{Page: 1},
 	}
-	checkRuns, _, err := client.Checks.ListCheckRunsCheckSuite(context.Background(), "o", "r", 1, opt)
+	ctx := context.Background()
+	checkRuns, _, err := client.Checks.ListCheckRunsCheckSuite(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Checks.ListCheckRunsCheckSuite return error: %v", err)
 	}
@@ -364,7 +371,8 @@ func TestChecksService_ListCheckSuiteForRef(t *testing.T) {
 		AppID:       Int(2),
 		ListOptions: ListOptions{Page: 1},
 	}
-	checkSuites, _, err := client.Checks.ListCheckSuitesForRef(context.Background(), "o", "r", "master", opt)
+	ctx := context.Background()
+	checkSuites, _, err := client.Checks.ListCheckSuitesForRef(ctx, "o", "r", "master", opt)
 	if err != nil {
 		t.Errorf("Checks.ListCheckSuitesForRef return error: %v", err)
 	}
@@ -401,7 +409,8 @@ func TestChecksService_SetCheckSuitePreferences(t *testing.T) {
 		Setting: Bool(false),
 	}}
 	opt := CheckSuitePreferenceOptions{AutoTriggerChecks: a}
-	prefResults, _, err := client.Checks.SetCheckSuitePreferences(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	prefResults, _, err := client.Checks.SetCheckSuitePreferences(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Checks.SetCheckSuitePreferences return error: %v", err)
 	}
@@ -440,7 +449,8 @@ func TestChecksService_CreateCheckSuite(t *testing.T) {
 		HeadBranch: String("master"),
 	}
 
-	checkSuite, _, err := client.Checks.CreateCheckSuite(context.Background(), "o", "r", checkSuiteOpt)
+	ctx := context.Background()
+	checkSuite, _, err := client.Checks.CreateCheckSuite(ctx, "o", "r", checkSuiteOpt)
 	if err != nil {
 		t.Errorf("Checks.CreateCheckSuite return error: %v", err)
 	}
@@ -468,7 +478,8 @@ func TestChecksService_ReRequestCheckSuite(t *testing.T) {
 
 		w.WriteHeader(http.StatusCreated)
 	})
-	resp, err := client.Checks.ReRequestCheckSuite(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	resp, err := client.Checks.ReRequestCheckSuite(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Checks.ReRequestCheckSuite return error: %v", err)
 	}

--- a/github/code-scanning_test.go
+++ b/github/code-scanning_test.go
@@ -86,7 +86,8 @@ func TestActionsService_ListAlertsForRepo(t *testing.T) {
 	})
 
 	opts := &AlertListOptions{State: "open", Ref: "heads/master"}
-	alerts, _, err := client.CodeScanning.ListAlertsForRepo(context.Background(), "o", "r", opts)
+	ctx := context.Background()
+	alerts, _, err := client.CodeScanning.ListAlertsForRepo(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("CodeScanning.ListAlertsForRepo returned error: %v", err)
 	}
@@ -141,7 +142,8 @@ func TestActionsService_GetAlert(t *testing.T) {
 				"html_url":"https://github.com/o/r/security/code-scanning/88"}`)
 	})
 
-	alert, _, err := client.CodeScanning.GetAlert(context.Background(), "o", "r", 88)
+	ctx := context.Background()
+	alert, _, err := client.CodeScanning.GetAlert(ctx, "o", "r", 88)
 	if err != nil {
 		t.Errorf("CodeScanning.GetAlert returned error: %v", err)
 	}

--- a/github/enterprise_actions_runners_test.go
+++ b/github/enterprise_actions_runners_test.go
@@ -23,7 +23,8 @@ func TestEnterpriseService_CreateRegistrationToken(t *testing.T) {
 		fmt.Fprint(w, `{"token":"LLBF3JGZDX3P5PMEXLND6TS6FCWO6","expires_at":"2020-01-22T12:13:35.123Z"}`)
 	})
 
-	token, _, err := client.Enterprise.CreateRegistrationToken(context.Background(), "e")
+	ctx := context.Background()
+	token, _, err := client.Enterprise.CreateRegistrationToken(ctx, "e")
 	if err != nil {
 		t.Errorf("Enterprise.CreateRegistrationToken returned error: %v", err)
 	}
@@ -47,7 +48,8 @@ func TestEnterpriseService_ListRunners(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	runners, _, err := client.Enterprise.ListRunners(context.Background(), "e", opts)
+	ctx := context.Background()
+	runners, _, err := client.Enterprise.ListRunners(ctx, "e", opts)
 	if err != nil {
 		t.Errorf("Enterprise.ListRunners returned error: %v", err)
 	}

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -21,7 +21,8 @@ func ExampleClient_Markdown() {
 	input := "# heading #\n\nLink to issue #1"
 	opt := &github.MarkdownOptions{Mode: "gfm", Context: "google/go-github"}
 
-	output, _, err := client.Markdown(context.Background(), input, opt)
+	ctx := context.Background()
+	output, _, err := client.Markdown(ctx, input, opt)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -32,7 +33,8 @@ func ExampleClient_Markdown() {
 func ExampleRepositoriesService_GetReadme() {
 	client := github.NewClient(nil)
 
-	readme, _, err := client.Repositories.GetReadme(context.Background(), "google", "go-github", nil)
+	ctx := context.Background()
+	readme, _, err := client.Repositories.GetReadme(ctx, "google", "go-github", nil)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -53,7 +55,8 @@ func ExampleRepositoriesService_List() {
 	user := "willnorris"
 	opt := &github.RepositoryListOptions{Type: "owner", Sort: "updated", Direction: "desc"}
 
-	repos, _, err := client.Repositories.List(context.Background(), user, opt)
+	ctx := context.Background()
+	repos, _, err := client.Repositories.List(ctx, user, opt)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -94,7 +97,8 @@ func ExampleUsersService_ListAll() {
 	client := github.NewClient(nil)
 	opts := &github.UserListOptions{}
 	for {
-		users, _, err := client.Users.ListAll(context.Background(), opts)
+		ctx := context.Background()
+		users, _, err := client.Users.ListAll(ctx, opts)
 		if err != nil {
 			log.Fatalf("error listing users: %v", err)
 		}
@@ -124,7 +128,8 @@ func ExamplePullRequestsService_Create() {
 		MaintainerCanModify: github.Bool(true),
 	}
 
-	pr, _, err := client.PullRequests.Create(context.Background(), "myOrganization", "myRepository", newPR)
+	ctx := context.Background()
+	pr, _, err := client.PullRequests.Create(ctx, "myOrganization", "myRepository", newPR)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/github/gists_comments_test.go
+++ b/github/gists_comments_test.go
@@ -81,7 +81,8 @@ func TestGistsService_ListComments(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	comments, _, err := client.Gists.ListComments(context.Background(), "1", opt)
+	ctx := context.Background()
+	comments, _, err := client.Gists.ListComments(ctx, "1", opt)
 	if err != nil {
 		t.Errorf("Gists.Comments returned error: %v", err)
 	}
@@ -96,7 +97,8 @@ func TestGistsService_ListComments_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Gists.ListComments(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Gists.ListComments(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -109,7 +111,8 @@ func TestGistsService_GetComment(t *testing.T) {
 		fmt.Fprint(w, `{"id": 1}`)
 	})
 
-	comment, _, err := client.Gists.GetComment(context.Background(), "1", 2)
+	ctx := context.Background()
+	comment, _, err := client.Gists.GetComment(ctx, "1", 2)
 	if err != nil {
 		t.Errorf("Gists.GetComment returned error: %v", err)
 	}
@@ -124,7 +127,8 @@ func TestGistsService_GetComment_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Gists.GetComment(context.Background(), "%", 1)
+	ctx := context.Background()
+	_, _, err := client.Gists.GetComment(ctx, "%", 1)
 	testURLParseError(t, err)
 }
 
@@ -146,7 +150,8 @@ func TestGistsService_CreateComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	comment, _, err := client.Gists.CreateComment(context.Background(), "1", input)
+	ctx := context.Background()
+	comment, _, err := client.Gists.CreateComment(ctx, "1", input)
 	if err != nil {
 		t.Errorf("Gists.CreateComment returned error: %v", err)
 	}
@@ -161,7 +166,8 @@ func TestGistsService_CreateComment_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Gists.CreateComment(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Gists.CreateComment(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -183,7 +189,8 @@ func TestGistsService_EditComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	comment, _, err := client.Gists.EditComment(context.Background(), "1", 2, input)
+	ctx := context.Background()
+	comment, _, err := client.Gists.EditComment(ctx, "1", 2, input)
 	if err != nil {
 		t.Errorf("Gists.EditComment returned error: %v", err)
 	}
@@ -198,7 +205,8 @@ func TestGistsService_EditComment_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Gists.EditComment(context.Background(), "%", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Gists.EditComment(ctx, "%", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -210,7 +218,8 @@ func TestGistsService_DeleteComment(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Gists.DeleteComment(context.Background(), "1", 2)
+	ctx := context.Background()
+	_, err := client.Gists.DeleteComment(ctx, "1", 2)
 	if err != nil {
 		t.Errorf("Gists.Delete returned error: %v", err)
 	}
@@ -220,6 +229,7 @@ func TestGistsService_DeleteComment_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Gists.DeleteComment(context.Background(), "%", 1)
+	ctx := context.Background()
+	_, err := client.Gists.DeleteComment(ctx, "%", 1)
 	testURLParseError(t, err)
 }

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -239,7 +239,8 @@ func TestGistsService_List_specifiedUser(t *testing.T) {
 	})
 
 	opt := &GistListOptions{Since: time.Date(2013, time.January, 1, 0, 0, 0, 0, time.UTC)}
-	gists, _, err := client.Gists.List(context.Background(), "u", opt)
+	ctx := context.Background()
+	gists, _, err := client.Gists.List(ctx, "u", opt)
 	if err != nil {
 		t.Errorf("Gists.List returned error: %v", err)
 	}
@@ -259,7 +260,8 @@ func TestGistsService_List_authenticatedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id": "1"}]`)
 	})
 
-	gists, _, err := client.Gists.List(context.Background(), "", nil)
+	ctx := context.Background()
+	gists, _, err := client.Gists.List(ctx, "", nil)
 	if err != nil {
 		t.Errorf("Gists.List returned error: %v", err)
 	}
@@ -274,7 +276,8 @@ func TestGistsService_List_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Gists.List(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Gists.List(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -293,7 +296,8 @@ func TestGistsService_ListAll(t *testing.T) {
 	})
 
 	opt := &GistListOptions{Since: time.Date(2013, time.January, 1, 0, 0, 0, 0, time.UTC)}
-	gists, _, err := client.Gists.ListAll(context.Background(), opt)
+	ctx := context.Background()
+	gists, _, err := client.Gists.ListAll(ctx, opt)
 	if err != nil {
 		t.Errorf("Gists.ListAll returned error: %v", err)
 	}
@@ -319,7 +323,8 @@ func TestGistsService_ListStarred(t *testing.T) {
 	})
 
 	opt := &GistListOptions{Since: time.Date(2013, time.January, 1, 0, 0, 0, 0, time.UTC)}
-	gists, _, err := client.Gists.ListStarred(context.Background(), opt)
+	ctx := context.Background()
+	gists, _, err := client.Gists.ListStarred(ctx, opt)
 	if err != nil {
 		t.Errorf("Gists.ListStarred returned error: %v", err)
 	}
@@ -339,7 +344,8 @@ func TestGistsService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"id": "1"}`)
 	})
 
-	gist, _, err := client.Gists.Get(context.Background(), "1")
+	ctx := context.Background()
+	gist, _, err := client.Gists.Get(ctx, "1")
 	if err != nil {
 		t.Errorf("Gists.Get returned error: %v", err)
 	}
@@ -354,7 +360,8 @@ func TestGistsService_Get_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Gists.Get(context.Background(), "%")
+	ctx := context.Background()
+	_, _, err := client.Gists.Get(ctx, "%")
 	testURLParseError(t, err)
 }
 
@@ -367,7 +374,8 @@ func TestGistsService_GetRevision(t *testing.T) {
 		fmt.Fprint(w, `{"id": "1"}`)
 	})
 
-	gist, _, err := client.Gists.GetRevision(context.Background(), "1", "s")
+	ctx := context.Background()
+	gist, _, err := client.Gists.GetRevision(ctx, "1", "s")
 	if err != nil {
 		t.Errorf("Gists.Get returned error: %v", err)
 	}
@@ -382,7 +390,8 @@ func TestGistsService_GetRevision_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Gists.GetRevision(context.Background(), "%", "%")
+	ctx := context.Background()
+	_, _, err := client.Gists.GetRevision(ctx, "%", "%")
 	testURLParseError(t, err)
 }
 
@@ -421,7 +430,8 @@ func TestGistsService_Create(t *testing.T) {
 			}`)
 	})
 
-	gist, _, err := client.Gists.Create(context.Background(), input)
+	ctx := context.Background()
+	gist, _, err := client.Gists.Create(ctx, input)
 	if err != nil {
 		t.Errorf("Gists.Create returned error: %v", err)
 	}
@@ -476,7 +486,8 @@ func TestGistsService_Edit(t *testing.T) {
 			}`)
 	})
 
-	gist, _, err := client.Gists.Edit(context.Background(), "1", input)
+	ctx := context.Background()
+	gist, _, err := client.Gists.Edit(ctx, "1", input)
 	if err != nil {
 		t.Errorf("Gists.Edit returned error: %v", err)
 	}
@@ -499,7 +510,8 @@ func TestGistsService_Edit_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Gists.Edit(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Gists.Edit(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -529,7 +541,8 @@ func TestGistsService_ListCommits(t *testing.T) {
 		`)
 	})
 
-	gistCommits, _, err := client.Gists.ListCommits(context.Background(), "1", nil)
+	ctx := context.Background()
+	gistCommits, _, err := client.Gists.ListCommits(ctx, "1", nil)
 	if err != nil {
 		t.Errorf("Gists.ListCommits returned error: %v", err)
 	}
@@ -562,7 +575,8 @@ func TestGistsService_ListCommits_withOptions(t *testing.T) {
 		fmt.Fprint(w, `[]`)
 	})
 
-	_, _, err := client.Gists.ListCommits(context.Background(), "1", &ListOptions{Page: 2})
+	ctx := context.Background()
+	_, _, err := client.Gists.ListCommits(ctx, "1", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Gists.ListCommits returned error: %v", err)
 	}
@@ -572,7 +586,8 @@ func TestGistsService_ListCommits_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Gists.ListCommits(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Gists.ListCommits(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -584,7 +599,8 @@ func TestGistsService_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Gists.Delete(context.Background(), "1")
+	ctx := context.Background()
+	_, err := client.Gists.Delete(ctx, "1")
 	if err != nil {
 		t.Errorf("Gists.Delete returned error: %v", err)
 	}
@@ -594,7 +610,8 @@ func TestGistsService_Delete_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Gists.Delete(context.Background(), "%")
+	ctx := context.Background()
+	_, err := client.Gists.Delete(ctx, "%")
 	testURLParseError(t, err)
 }
 
@@ -606,7 +623,8 @@ func TestGistsService_Star(t *testing.T) {
 		testMethod(t, r, "PUT")
 	})
 
-	_, err := client.Gists.Star(context.Background(), "1")
+	ctx := context.Background()
+	_, err := client.Gists.Star(ctx, "1")
 	if err != nil {
 		t.Errorf("Gists.Star returned error: %v", err)
 	}
@@ -616,7 +634,8 @@ func TestGistsService_Star_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Gists.Star(context.Background(), "%")
+	ctx := context.Background()
+	_, err := client.Gists.Star(ctx, "%")
 	testURLParseError(t, err)
 }
 
@@ -628,7 +647,8 @@ func TestGistsService_Unstar(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Gists.Unstar(context.Background(), "1")
+	ctx := context.Background()
+	_, err := client.Gists.Unstar(ctx, "1")
 	if err != nil {
 		t.Errorf("Gists.Unstar returned error: %v", err)
 	}
@@ -638,7 +658,8 @@ func TestGistsService_Unstar_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Gists.Unstar(context.Background(), "%")
+	ctx := context.Background()
+	_, err := client.Gists.Unstar(ctx, "%")
 	testURLParseError(t, err)
 }
 
@@ -651,7 +672,8 @@ func TestGistsService_IsStarred_hasStar(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	star, _, err := client.Gists.IsStarred(context.Background(), "1")
+	ctx := context.Background()
+	star, _, err := client.Gists.IsStarred(ctx, "1")
 	if err != nil {
 		t.Errorf("Gists.Starred returned error: %v", err)
 	}
@@ -669,7 +691,8 @@ func TestGistsService_IsStarred_noStar(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	star, _, err := client.Gists.IsStarred(context.Background(), "1")
+	ctx := context.Background()
+	star, _, err := client.Gists.IsStarred(ctx, "1")
 	if err != nil {
 		t.Errorf("Gists.Starred returned error: %v", err)
 	}
@@ -682,7 +705,8 @@ func TestGistsService_IsStarred_invalidID(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Gists.IsStarred(context.Background(), "%")
+	ctx := context.Background()
+	_, _, err := client.Gists.IsStarred(ctx, "%")
 	testURLParseError(t, err)
 }
 
@@ -695,7 +719,8 @@ func TestGistsService_Fork(t *testing.T) {
 		fmt.Fprint(w, `{"id": "2"}`)
 	})
 
-	gist, _, err := client.Gists.Fork(context.Background(), "1")
+	ctx := context.Background()
+	gist, _, err := client.Gists.Fork(ctx, "1")
 	if err != nil {
 		t.Errorf("Gists.Fork returned error: %v", err)
 	}
@@ -725,7 +750,8 @@ func TestGistsService_ListForks(t *testing.T) {
 		`)
 	})
 
-	gistForks, _, err := client.Gists.ListForks(context.Background(), "1", nil)
+	ctx := context.Background()
+	gistForks, _, err := client.Gists.ListForks(ctx, "1", nil)
 	if err != nil {
 		t.Errorf("Gists.ListForks returned error: %v", err)
 	}
@@ -755,7 +781,8 @@ func TestGistsService_ListForks_withOptions(t *testing.T) {
 		fmt.Fprint(w, `[]`)
 	})
 
-	gistForks, _, err := client.Gists.ListForks(context.Background(), "1", &ListOptions{Page: 2})
+	ctx := context.Background()
+	gistForks, _, err := client.Gists.ListForks(ctx, "1", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Gists.ListForks returned error: %v", err)
 	}
@@ -766,13 +793,13 @@ func TestGistsService_ListForks_withOptions(t *testing.T) {
 	}
 
 	// Test addOptions failure
-	_, _, err = client.Gists.ListForks(context.Background(), "%", &ListOptions{})
+	_, _, err = client.Gists.ListForks(ctx, "%", &ListOptions{})
 	if err == nil {
 		t.Error("Gists.ListForks returned err = nil")
 	}
 
 	// Test client.NewRequest failure
-	got, resp, err := client.Gists.ListForks(context.Background(), "%", nil)
+	got, resp, err := client.Gists.ListForks(ctx, "%", nil)
 	if got != nil {
 		t.Errorf("Gists.ListForks = %#v, want nil", got)
 	}
@@ -785,7 +812,7 @@ func TestGistsService_ListForks_withOptions(t *testing.T) {
 
 	// Test client.Do failure
 	client.rateLimits[0].Reset.Time = time.Now().Add(10 * time.Minute)
-	got, resp, err = client.Gists.ListForks(context.Background(), "1", &ListOptions{Page: 2})
+	got, resp, err = client.Gists.ListForks(ctx, "1", &ListOptions{Page: 2})
 	if got != nil {
 		t.Errorf("Gists.ListForks returned = %#v, want nil", got)
 	}

--- a/github/git_blobs_test.go
+++ b/github/git_blobs_test.go
@@ -28,7 +28,8 @@ func TestGitService_GetBlob(t *testing.T) {
 			}`)
 	})
 
-	blob, _, err := client.Git.GetBlob(context.Background(), "o", "r", "s")
+	ctx := context.Background()
+	blob, _, err := client.Git.GetBlob(ctx, "o", "r", "s")
 	if err != nil {
 		t.Errorf("Git.GetBlob returned error: %v", err)
 	}
@@ -47,7 +48,8 @@ func TestGitService_GetBlob_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Git.GetBlob(context.Background(), "%", "%", "%")
+	ctx := context.Background()
+	_, _, err := client.Git.GetBlob(ctx, "%", "%", "%")
 	testURLParseError(t, err)
 }
 
@@ -62,7 +64,8 @@ func TestGitService_GetBlobRaw(t *testing.T) {
 		fmt.Fprint(w, `raw contents here`)
 	})
 
-	blob, _, err := client.Git.GetBlobRaw(context.Background(), "o", "r", "s")
+	ctx := context.Background()
+	blob, _, err := client.Git.GetBlobRaw(ctx, "o", "r", "s")
 	if err != nil {
 		t.Errorf("Git.GetBlobRaw returned error: %v", err)
 	}
@@ -103,7 +106,8 @@ func TestGitService_CreateBlob(t *testing.T) {
 		}`)
 	})
 
-	blob, _, err := client.Git.CreateBlob(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	blob, _, err := client.Git.CreateBlob(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Git.CreateBlob returned error: %v", err)
 	}
@@ -119,6 +123,7 @@ func TestGitService_CreateBlob_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Git.CreateBlob(context.Background(), "%", "%", &Blob{})
+	ctx := context.Background()
+	_, _, err := client.Git.CreateBlob(ctx, "%", "%", &Blob{})
 	testURLParseError(t, err)
 }

--- a/github/git_commits_test.go
+++ b/github/git_commits_test.go
@@ -127,7 +127,8 @@ func TestGitService_GetCommit(t *testing.T) {
 		fmt.Fprint(w, `{"sha":"s","message":"Commit Message.","author":{"name":"n"}}`)
 	})
 
-	commit, _, err := client.Git.GetCommit(context.Background(), "o", "r", "s")
+	ctx := context.Background()
+	commit, _, err := client.Git.GetCommit(ctx, "o", "r", "s")
 	if err != nil {
 		t.Errorf("Git.GetCommit returned error: %v", err)
 	}
@@ -142,7 +143,8 @@ func TestGitService_GetCommit_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Git.GetCommit(context.Background(), "%", "%", "%")
+	ctx := context.Background()
+	_, _, err := client.Git.GetCommit(ctx, "%", "%", "%")
 	testURLParseError(t, err)
 }
 
@@ -173,7 +175,8 @@ func TestGitService_CreateCommit(t *testing.T) {
 		fmt.Fprint(w, `{"sha":"s"}`)
 	})
 
-	commit, _, err := client.Git.CreateCommit(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	commit, _, err := client.Git.CreateCommit(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Git.CreateCommit returned error: %v", err)
 	}
@@ -217,7 +220,8 @@ func TestGitService_CreateSignedCommit(t *testing.T) {
 		fmt.Fprint(w, `{"sha":"commitSha"}`)
 	})
 
-	commit, _, err := client.Git.CreateCommit(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	commit, _, err := client.Git.CreateCommit(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Git.CreateCommit returned error: %v", err)
 	}
@@ -235,7 +239,8 @@ func TestGitService_CreateSignedCommitWithInvalidParams(t *testing.T) {
 		SigningKey: &openpgp.Entity{},
 	}
 
-	_, _, err := client.Git.CreateCommit(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	_, _, err := client.Git.CreateCommit(ctx, "o", "r", input)
 	if err == nil {
 		t.Errorf("Expected error to be returned because invalid params was passed")
 	}
@@ -300,7 +305,8 @@ Commit Message.`)
 		fmt.Fprint(w, `{"sha":"commitSha"}`)
 	})
 
-	commit, _, err := client.Git.CreateCommit(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	commit, _, err := client.Git.CreateCommit(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Git.CreateCommit returned error: %v", err)
 	}
@@ -471,7 +477,8 @@ func TestGitService_CreateCommit_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Git.CreateCommit(context.Background(), "%", "%", &Commit{})
+	ctx := context.Background()
+	_, _, err := client.Git.CreateCommit(ctx, "%", "%", &Commit{})
 	testURLParseError(t, err)
 }
 

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -33,7 +33,8 @@ func TestGitService_GetRef_singleRef(t *testing.T) {
 		  }`)
 	})
 
-	ref, _, err := client.Git.GetRef(context.Background(), "o", "r", "refs/heads/b")
+	ctx := context.Background()
+	ref, _, err := client.Git.GetRef(ctx, "o", "r", "refs/heads/b")
 	if err != nil {
 		t.Fatalf("Git.GetRef returned error: %v", err)
 	}
@@ -52,7 +53,7 @@ func TestGitService_GetRef_singleRef(t *testing.T) {
 	}
 
 	// without 'refs/' prefix
-	if _, _, err := client.Git.GetRef(context.Background(), "o", "r", "heads/b"); err != nil {
+	if _, _, err := client.Git.GetRef(ctx, "o", "r", "heads/b"); err != nil {
 		t.Errorf("Git.GetRef returned error: %v", err)
 	}
 }
@@ -66,7 +67,8 @@ func TestGitService_GetRef_noRefs(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ref, resp, err := client.Git.GetRef(context.Background(), "o", "r", "refs/heads/b")
+	ctx := context.Background()
+	ref, resp, err := client.Git.GetRef(ctx, "o", "r", "refs/heads/b")
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -99,7 +101,8 @@ func TestGitService_ListMatchingRefs_singleRef(t *testing.T) {
 	})
 
 	opts := &ReferenceListOptions{Ref: "refs/heads/b"}
-	refs, _, err := client.Git.ListMatchingRefs(context.Background(), "o", "r", opts)
+	ctx := context.Background()
+	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
 	if err != nil {
 		t.Fatalf("Git.ListMatchingRefs returned error: %v", err)
 	}
@@ -120,7 +123,7 @@ func TestGitService_ListMatchingRefs_singleRef(t *testing.T) {
 
 	// without 'refs/' prefix
 	opts = &ReferenceListOptions{Ref: "heads/b"}
-	if _, _, err := client.Git.ListMatchingRefs(context.Background(), "o", "r", opts); err != nil {
+	if _, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts); err != nil {
 		t.Errorf("Git.ListMatchingRefs returned error: %v", err)
 	}
 }
@@ -156,7 +159,8 @@ func TestGitService_ListMatchingRefs_multipleRefs(t *testing.T) {
 	})
 
 	opts := &ReferenceListOptions{Ref: "refs/heads/b"}
-	refs, _, err := client.Git.ListMatchingRefs(context.Background(), "o", "r", opts)
+	ctx := context.Background()
+	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Git.ListMatchingRefs returned error: %v", err)
 	}
@@ -185,7 +189,8 @@ func TestGitService_ListMatchingRefs_noRefs(t *testing.T) {
 	})
 
 	opts := &ReferenceListOptions{Ref: "refs/heads/b"}
-	refs, _, err := client.Git.ListMatchingRefs(context.Background(), "o", "r", opts)
+	ctx := context.Background()
+	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Git.ListMatchingRefs returned error: %v", err)
 	}
@@ -224,7 +229,8 @@ func TestGitService_ListMatchingRefs_allRefs(t *testing.T) {
 		  ]`)
 	})
 
-	refs, _, err := client.Git.ListMatchingRefs(context.Background(), "o", "r", nil)
+	ctx := context.Background()
+	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", nil)
 	if err != nil {
 		t.Errorf("Git.ListMatchingRefs returned error: %v", err)
 	}
@@ -265,7 +271,8 @@ func TestGitService_ListMatchingRefs_options(t *testing.T) {
 	})
 
 	opts := &ReferenceListOptions{Ref: "t", ListOptions: ListOptions{Page: 2}}
-	refs, _, err := client.Git.ListMatchingRefs(context.Background(), "o", "r", opts)
+	ctx := context.Background()
+	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Git.ListMatchingRefs returned error: %v", err)
 	}
@@ -305,7 +312,8 @@ func TestGitService_CreateRef(t *testing.T) {
 		  }`)
 	})
 
-	ref, _, err := client.Git.CreateRef(context.Background(), "o", "r", &Reference{
+	ctx := context.Background()
+	ref, _, err := client.Git.CreateRef(ctx, "o", "r", &Reference{
 		Ref: String("refs/heads/b"),
 		Object: &GitObject{
 			SHA: String("aa218f56b14c9653891f9e74264a383fa43fefbd"),
@@ -329,7 +337,7 @@ func TestGitService_CreateRef(t *testing.T) {
 	}
 
 	// without 'refs/' prefix
-	_, _, err = client.Git.CreateRef(context.Background(), "o", "r", &Reference{
+	_, _, err = client.Git.CreateRef(ctx, "o", "r", &Reference{
 		Ref: String("heads/b"),
 		Object: &GitObject{
 			SHA: String("aa218f56b14c9653891f9e74264a383fa43fefbd"),
@@ -369,7 +377,8 @@ func TestGitService_UpdateRef(t *testing.T) {
 		  }`)
 	})
 
-	ref, _, err := client.Git.UpdateRef(context.Background(), "o", "r", &Reference{
+	ctx := context.Background()
+	ref, _, err := client.Git.UpdateRef(ctx, "o", "r", &Reference{
 		Ref:    String("refs/heads/b"),
 		Object: &GitObject{SHA: String("aa218f56b14c9653891f9e74264a383fa43fefbd")},
 	}, true)
@@ -391,7 +400,7 @@ func TestGitService_UpdateRef(t *testing.T) {
 	}
 
 	// without 'refs/' prefix
-	_, _, err = client.Git.UpdateRef(context.Background(), "o", "r", &Reference{
+	_, _, err = client.Git.UpdateRef(ctx, "o", "r", &Reference{
 		Ref:    String("heads/b"),
 		Object: &GitObject{SHA: String("aa218f56b14c9653891f9e74264a383fa43fefbd")},
 	}, true)
@@ -408,13 +417,14 @@ func TestGitService_DeleteRef(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Git.DeleteRef(context.Background(), "o", "r", "refs/heads/b")
+	ctx := context.Background()
+	_, err := client.Git.DeleteRef(ctx, "o", "r", "refs/heads/b")
 	if err != nil {
 		t.Errorf("Git.DeleteRef returned error: %v", err)
 	}
 
 	// without 'refs/' prefix
-	if _, err := client.Git.DeleteRef(context.Background(), "o", "r", "heads/b"); err != nil {
+	if _, err := client.Git.DeleteRef(ctx, "o", "r", "heads/b"); err != nil {
 		t.Errorf("Git.DeleteRef returned error: %v", err)
 	}
 }
@@ -440,7 +450,8 @@ func TestGitService_GetRef_pathEscape(t *testing.T) {
 		  }`)
 	})
 
-	_, _, err := client.Git.GetRef(context.Background(), "o", "r", "refs/heads/b")
+	ctx := context.Background()
+	_, _, err := client.Git.GetRef(ctx, "o", "r", "refs/heads/b")
 	if err != nil {
 		t.Fatalf("Git.GetRef returned error: %v", err)
 	}

--- a/github/git_tags_test.go
+++ b/github/git_tags_test.go
@@ -23,7 +23,8 @@ func TestGitService_GetTag(t *testing.T) {
 		fmt.Fprint(w, `{"tag": "t"}`)
 	})
 
-	tag, _, err := client.Git.GetTag(context.Background(), "o", "r", "s")
+	ctx := context.Background()
+	tag, _, err := client.Git.GetTag(ctx, "o", "r", "s")
 	if err != nil {
 		t.Errorf("Git.GetTag returned error: %v", err)
 	}
@@ -52,7 +53,8 @@ func TestGitService_CreateTag(t *testing.T) {
 		fmt.Fprint(w, `{"tag": "t"}`)
 	})
 
-	tag, _, err := client.Git.CreateTag(context.Background(), "o", "r", &Tag{
+	ctx := context.Background()
+	tag, _, err := client.Git.CreateTag(ctx, "o", "r", &Tag{
 		Tag:    input.Tag,
 		Object: &GitObject{SHA: input.Object},
 	})

--- a/github/git_trees_test.go
+++ b/github/git_trees_test.go
@@ -28,7 +28,8 @@ func TestGitService_GetTree(t *testing.T) {
 			}`)
 	})
 
-	tree, _, err := client.Git.GetTree(context.Background(), "o", "r", "s", true)
+	ctx := context.Background()
+	tree, _, err := client.Git.GetTree(ctx, "o", "r", "s", true)
 	if err != nil {
 		t.Errorf("Git.GetTree returned error: %v", err)
 	}
@@ -51,7 +52,8 @@ func TestGitService_GetTree_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Git.GetTree(context.Background(), "%", "%", "%", false)
+	ctx := context.Background()
+	_, _, err := client.Git.GetTree(ctx, "%", "%", "%", false)
 	testURLParseError(t, err)
 }
 
@@ -95,7 +97,8 @@ func TestGitService_CreateTree(t *testing.T) {
 		}`)
 	})
 
-	tree, _, err := client.Git.CreateTree(context.Background(), "o", "r", "b", input)
+	ctx := context.Background()
+	tree, _, err := client.Git.CreateTree(ctx, "o", "r", "b", input)
 	if err != nil {
 		t.Errorf("Git.CreateTree returned error: %v", err)
 	}
@@ -160,7 +163,8 @@ func TestGitService_CreateTree_Content(t *testing.T) {
 		}`)
 	})
 
-	tree, _, err := client.Git.CreateTree(context.Background(), "o", "r", "b", input)
+	ctx := context.Background()
+	tree, _, err := client.Git.CreateTree(ctx, "o", "r", "b", input)
 	if err != nil {
 		t.Errorf("Git.CreateTree returned error: %v", err)
 	}
@@ -225,7 +229,8 @@ func TestGitService_CreateTree_Delete(t *testing.T) {
 		}`)
 	})
 
-	tree, _, err := client.Git.CreateTree(context.Background(), "o", "r", "b", input)
+	ctx := context.Background()
+	tree, _, err := client.Git.CreateTree(ctx, "o", "r", "b", input)
 	if err != nil {
 		t.Errorf("Git.CreateTree returned error: %v", err)
 	}
@@ -254,6 +259,7 @@ func TestGitService_CreateTree_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Git.CreateTree(context.Background(), "%", "%", "", nil)
+	ctx := context.Background()
+	_, _, err := client.Git.CreateTree(ctx, "%", "%", "", nil)
 	testURLParseError(t, err)
 }

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -615,7 +615,8 @@ func TestDo(t *testing.T) {
 
 	req, _ := client.NewRequest("GET", ".", nil)
 	body := new(foo)
-	client.Do(context.Background(), req, body)
+	ctx := context.Background()
+	client.Do(ctx, req, body)
 
 	want := &foo{"a"}
 	if !reflect.DeepEqual(body, want) {
@@ -644,7 +645,8 @@ func TestDo_httpError(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	resp, err := client.Do(context.Background(), req, nil)
+	ctx := context.Background()
+	resp, err := client.Do(ctx, req, nil)
 
 	if err == nil {
 		t.Fatal("Expected HTTP 400 error, got no error.")
@@ -666,7 +668,8 @@ func TestDo_redirectLoop(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	_, err := client.Do(context.Background(), req, nil)
+	ctx := context.Background()
+	_, err := client.Do(ctx, req, nil)
 
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -689,7 +692,8 @@ func TestDo_sanitizeURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRequest returned unexpected error: %v", err)
 	}
-	_, err = unauthedClient.Do(context.Background(), req, nil)
+	ctx := context.Background()
+	_, err = unauthedClient.Do(ctx, req, nil)
 	if err == nil {
 		t.Fatal("Expected error to be returned.")
 	}
@@ -709,7 +713,8 @@ func TestDo_rateLimit(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	resp, err := client.Do(context.Background(), req, nil)
+	ctx := context.Background()
+	resp, err := client.Do(ctx, req, nil)
 	if err != nil {
 		t.Errorf("Do returned unexpected error: %v", err)
 	}
@@ -738,7 +743,8 @@ func TestDo_rateLimit_errorResponse(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	resp, err := client.Do(context.Background(), req, nil)
+	ctx := context.Background()
+	resp, err := client.Do(ctx, req, nil)
 	if err == nil {
 		t.Error("Expected error to be returned.")
 	}
@@ -775,7 +781,8 @@ func TestDo_rateLimit_rateLimitError(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	_, err := client.Do(context.Background(), req, nil)
+	ctx := context.Background()
+	_, err := client.Do(ctx, req, nil)
 
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -822,11 +829,12 @@ func TestDo_rateLimit_noNetworkCall(t *testing.T) {
 
 	// First request is made, and it makes the client aware of rate reset time being in the future.
 	req, _ := client.NewRequest("GET", "first", nil)
-	client.Do(context.Background(), req, nil)
+	ctx := context.Background()
+	client.Do(ctx, req, nil)
 
 	// Second request should not cause a network call to be made, since client can predict a rate limit error.
 	req, _ = client.NewRequest("GET", "second", nil)
-	_, err := client.Do(context.Background(), req, nil)
+	_, err := client.Do(ctx, req, nil)
 
 	if madeNetworkCall {
 		t.Fatal("Network call was made, even though rate limit is known to still be exceeded.")
@@ -868,7 +876,8 @@ func TestDo_rateLimit_abuseRateLimitError(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	_, err := client.Do(context.Background(), req, nil)
+	ctx := context.Background()
+	_, err := client.Do(ctx, req, nil)
 
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -902,7 +911,8 @@ func TestDo_rateLimit_abuseRateLimitErrorEnterprise(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	_, err := client.Do(context.Background(), req, nil)
+	ctx := context.Background()
+	_, err := client.Do(ctx, req, nil)
 
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -932,7 +942,8 @@ func TestDo_rateLimit_abuseRateLimitError_retryAfter(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	_, err := client.Do(context.Background(), req, nil)
+	ctx := context.Background()
+	_, err := client.Do(ctx, req, nil)
 
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -960,7 +971,8 @@ func TestDo_noContent(t *testing.T) {
 	var body json.RawMessage
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	_, err := client.Do(context.Background(), req, &body)
+	ctx := context.Background()
+	_, err := client.Do(ctx, req, &body)
 	if err != nil {
 		t.Fatalf("Do returned unexpected error: %v", err)
 	}
@@ -1180,7 +1192,8 @@ func TestRateLimits(t *testing.T) {
 		}}`)
 	})
 
-	rate, _, err := client.RateLimits(context.Background())
+	ctx := context.Background()
+	rate, _, err := client.RateLimits(ctx)
 	if err != nil {
 		t.Errorf("RateLimits returned error: %v", err)
 	}
@@ -1253,7 +1266,8 @@ func TestUnauthenticatedRateLimitedTransport(t *testing.T) {
 	unauthedClient := NewClient(tp.Client())
 	unauthedClient.BaseURL = client.BaseURL
 	req, _ := unauthedClient.NewRequest("GET", ".", nil)
-	unauthedClient.Do(context.Background(), req, nil)
+	ctx := context.Background()
+	unauthedClient.Do(ctx, req, nil)
 }
 
 func TestUnauthenticatedRateLimitedTransport_missingFields(t *testing.T) {
@@ -1327,7 +1341,8 @@ func TestBasicAuthTransport(t *testing.T) {
 	basicAuthClient := NewClient(tp.Client())
 	basicAuthClient.BaseURL = client.BaseURL
 	req, _ := basicAuthClient.NewRequest("GET", ".", nil)
-	basicAuthClient.Do(context.Background(), req, nil)
+	ctx := context.Background()
+	basicAuthClient.Do(ctx, req, nil)
 }
 
 func TestBasicAuthTransport_transport(t *testing.T) {

--- a/github/gitignore_test.go
+++ b/github/gitignore_test.go
@@ -22,7 +22,8 @@ func TestGitignoresService_List(t *testing.T) {
 		fmt.Fprint(w, `["C", "Go"]`)
 	})
 
-	available, _, err := client.Gitignores.List(context.Background())
+	ctx := context.Background()
+	available, _, err := client.Gitignores.List(ctx)
 	if err != nil {
 		t.Errorf("Gitignores.List returned error: %v", err)
 	}
@@ -42,7 +43,8 @@ func TestGitignoresService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"name":"Name","source":"template source"}`)
 	})
 
-	gitignore, _, err := client.Gitignores.Get(context.Background(), "name")
+	ctx := context.Background()
+	gitignore, _, err := client.Gitignores.Get(ctx, "name")
 	if err != nil {
 		t.Errorf("Gitignores.List returned error: %v", err)
 	}
@@ -57,6 +59,7 @@ func TestGitignoresService_Get_invalidTemplate(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Gitignores.Get(context.Background(), "%")
+	ctx := context.Background()
+	_, _, err := client.Gitignores.Get(ctx, "%")
 	testURLParseError(t, err)
 }

--- a/github/interactions_orgs_test.go
+++ b/github/interactions_orgs_test.go
@@ -24,7 +24,8 @@ func TestInteractionsService_GetRestrictionsForOrgs(t *testing.T) {
 		fmt.Fprint(w, `{"origin":"organization"}`)
 	})
 
-	organizationInteractions, _, err := client.Interactions.GetRestrictionsForOrg(context.Background(), "o")
+	ctx := context.Background()
+	organizationInteractions, _, err := client.Interactions.GetRestrictionsForOrg(ctx, "o")
 	if err != nil {
 		t.Errorf("Interactions.GetRestrictionsForOrg returned error: %v", err)
 	}
@@ -53,7 +54,8 @@ func TestInteractionsService_UpdateRestrictionsForOrg(t *testing.T) {
 		fmt.Fprint(w, `{"origin":"organization"}`)
 	})
 
-	organizationInteractions, _, err := client.Interactions.UpdateRestrictionsForOrg(context.Background(), "o", input.GetLimit())
+	ctx := context.Background()
+	organizationInteractions, _, err := client.Interactions.UpdateRestrictionsForOrg(ctx, "o", input.GetLimit())
 	if err != nil {
 		t.Errorf("Interactions.UpdateRestrictionsForOrg returned error: %v", err)
 	}
@@ -73,7 +75,8 @@ func TestInteractionsService_RemoveRestrictionsFromOrg(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeInteractionRestrictionsPreview)
 	})
 
-	_, err := client.Interactions.RemoveRestrictionsFromOrg(context.Background(), "o")
+	ctx := context.Background()
+	_, err := client.Interactions.RemoveRestrictionsFromOrg(ctx, "o")
 	if err != nil {
 		t.Errorf("Interactions.RemoveRestrictionsFromOrg returned error: %v", err)
 	}

--- a/github/interactions_repos_test.go
+++ b/github/interactions_repos_test.go
@@ -24,7 +24,8 @@ func TestInteractionsService_GetRestrictionsForRepo(t *testing.T) {
 		fmt.Fprint(w, `{"origin":"repository"}`)
 	})
 
-	repoInteractions, _, err := client.Interactions.GetRestrictionsForRepo(context.Background(), "o", "r")
+	ctx := context.Background()
+	repoInteractions, _, err := client.Interactions.GetRestrictionsForRepo(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Interactions.GetRestrictionsForRepo returned error: %v", err)
 	}
@@ -53,7 +54,8 @@ func TestInteractionsService_UpdateRestrictionsForRepo(t *testing.T) {
 		fmt.Fprint(w, `{"origin":"repository"}`)
 	})
 
-	repoInteractions, _, err := client.Interactions.UpdateRestrictionsForRepo(context.Background(), "o", "r", input.GetLimit())
+	ctx := context.Background()
+	repoInteractions, _, err := client.Interactions.UpdateRestrictionsForRepo(ctx, "o", "r", input.GetLimit())
 	if err != nil {
 		t.Errorf("Interactions.UpdateRestrictionsForRepo returned error: %v", err)
 	}
@@ -73,7 +75,8 @@ func TestInteractionsService_RemoveRestrictionsFromRepo(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeInteractionRestrictionsPreview)
 	})
 
-	_, err := client.Interactions.RemoveRestrictionsFromRepo(context.Background(), "o", "r")
+	ctx := context.Background()
+	_, err := client.Interactions.RemoveRestrictionsFromRepo(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Interactions.RemoveRestrictionsFromRepo returned error: %v", err)
 	}

--- a/github/issue_import_test.go
+++ b/github/issue_import_test.go
@@ -48,7 +48,8 @@ func TestIssueImportService_Create(t *testing.T) {
 		w.Write(issueImportResponseJSON)
 	})
 
-	got, _, err := client.IssueImport.Create(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	got, _, err := client.IssueImport.Create(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Create returned error: %v", err)
 	}
@@ -63,7 +64,8 @@ func TestIssueImportService_Create_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.IssueImport.Create(context.Background(), "%", "r", nil)
+	ctx := context.Background()
+	_, _, err := client.IssueImport.Create(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
 
@@ -78,7 +80,8 @@ func TestIssueImportService_CheckStatus(t *testing.T) {
 		w.Write(issueImportResponseJSON)
 	})
 
-	got, _, err := client.IssueImport.CheckStatus(context.Background(), "o", "r", 3)
+	ctx := context.Background()
+	got, _, err := client.IssueImport.CheckStatus(ctx, "o", "r", 3)
 	if err != nil {
 		t.Errorf("CheckStatus returned error: %v", err)
 	}
@@ -93,7 +96,8 @@ func TestIssueImportService_CheckStatus_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.IssueImport.CheckStatus(context.Background(), "%", "r", 1)
+	ctx := context.Background()
+	_, _, err := client.IssueImport.CheckStatus(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
 
@@ -108,7 +112,8 @@ func TestIssueImportService_CheckStatusSince(t *testing.T) {
 		w.Write([]byte(fmt.Sprintf("[%s]", issueImportResponseJSON)))
 	})
 
-	got, _, err := client.IssueImport.CheckStatusSince(context.Background(), "o", "r", time.Now())
+	ctx := context.Background()
+	got, _, err := client.IssueImport.CheckStatusSince(ctx, "o", "r", time.Now())
 	if err != nil {
 		t.Errorf("CheckStatusSince returned error: %v", err)
 	}
@@ -123,7 +128,8 @@ func TestIssueImportService_CheckStatusSince_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.IssueImport.CheckStatusSince(context.Background(), "%", "r", time.Now())
+	ctx := context.Background()
+	_, _, err := client.IssueImport.CheckStatusSince(ctx, "%", "r", time.Now())
 	testURLParseError(t, err)
 }
 

--- a/github/issues_assignees_test.go
+++ b/github/issues_assignees_test.go
@@ -25,7 +25,8 @@ func TestIssuesService_ListAssignees(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	assignees, _, err := client.Issues.ListAssignees(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	assignees, _, err := client.Issues.ListAssignees(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Issues.ListAssignees returned error: %v", err)
 	}
@@ -40,7 +41,8 @@ func TestIssuesService_ListAssignees_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.ListAssignees(context.Background(), "%", "r", nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.ListAssignees(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
 
@@ -52,7 +54,8 @@ func TestIssuesService_IsAssignee_true(t *testing.T) {
 		testMethod(t, r, "GET")
 	})
 
-	assignee, _, err := client.Issues.IsAssignee(context.Background(), "o", "r", "u")
+	ctx := context.Background()
+	assignee, _, err := client.Issues.IsAssignee(ctx, "o", "r", "u")
 	if err != nil {
 		t.Errorf("Issues.IsAssignee returned error: %v", err)
 	}
@@ -70,7 +73,8 @@ func TestIssuesService_IsAssignee_false(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	assignee, _, err := client.Issues.IsAssignee(context.Background(), "o", "r", "u")
+	ctx := context.Background()
+	assignee, _, err := client.Issues.IsAssignee(ctx, "o", "r", "u")
 	if err != nil {
 		t.Errorf("Issues.IsAssignee returned error: %v", err)
 	}
@@ -88,7 +92,8 @@ func TestIssuesService_IsAssignee_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	assignee, _, err := client.Issues.IsAssignee(context.Background(), "o", "r", "u")
+	ctx := context.Background()
+	assignee, _, err := client.Issues.IsAssignee(ctx, "o", "r", "u")
 	if err == nil {
 		t.Errorf("Expected HTTP 400 response")
 	}
@@ -101,7 +106,8 @@ func TestIssuesService_IsAssignee_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.IsAssignee(context.Background(), "%", "r", "u")
+	ctx := context.Background()
+	_, _, err := client.Issues.IsAssignee(ctx, "%", "r", "u")
 	testURLParseError(t, err)
 }
 
@@ -123,7 +129,8 @@ func TestIssuesService_AddAssignees(t *testing.T) {
 		fmt.Fprint(w, `{"number":1,"assignees":[{"login":"user1"},{"login":"user2"}]}`)
 	})
 
-	got, _, err := client.Issues.AddAssignees(context.Background(), "o", "r", 1, []string{"user1", "user2"})
+	ctx := context.Background()
+	got, _, err := client.Issues.AddAssignees(ctx, "o", "r", 1, []string{"user1", "user2"})
 	if err != nil {
 		t.Errorf("Issues.AddAssignees returned error: %v", err)
 	}
@@ -152,7 +159,8 @@ func TestIssuesService_RemoveAssignees(t *testing.T) {
 		fmt.Fprint(w, `{"number":1,"assignees":[]}`)
 	})
 
-	got, _, err := client.Issues.RemoveAssignees(context.Background(), "o", "r", 1, []string{"user1", "user2"})
+	ctx := context.Background()
+	got, _, err := client.Issues.RemoveAssignees(ctx, "o", "r", 1, []string{"user1", "user2"})
 	if err != nil {
 		t.Errorf("Issues.RemoveAssignees returned error: %v", err)
 	}

--- a/github/issues_comments_test.go
+++ b/github/issues_comments_test.go
@@ -34,7 +34,8 @@ func TestIssuesService_ListComments_allIssues(t *testing.T) {
 		Since:       &since,
 		ListOptions: ListOptions{Page: 2},
 	}
-	comments, _, err := client.Issues.ListComments(context.Background(), "o", "r", 0, opt)
+	ctx := context.Background()
+	comments, _, err := client.Issues.ListComments(ctx, "o", "r", 0, opt)
 	if err != nil {
 		t.Errorf("Issues.ListComments returned error: %v", err)
 	}
@@ -55,7 +56,8 @@ func TestIssuesService_ListComments_specificIssue(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	comments, _, err := client.Issues.ListComments(context.Background(), "o", "r", 1, nil)
+	ctx := context.Background()
+	comments, _, err := client.Issues.ListComments(ctx, "o", "r", 1, nil)
 	if err != nil {
 		t.Errorf("Issues.ListComments returned error: %v", err)
 	}
@@ -70,7 +72,8 @@ func TestIssuesService_ListComments_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.ListComments(context.Background(), "%", "r", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.ListComments(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -84,7 +87,8 @@ func TestIssuesService_GetComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	comment, _, err := client.Issues.GetComment(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	comment, _, err := client.Issues.GetComment(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Issues.GetComment returned error: %v", err)
 	}
@@ -99,7 +103,8 @@ func TestIssuesService_GetComment_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.GetComment(context.Background(), "%", "r", 1)
+	ctx := context.Background()
+	_, _, err := client.Issues.GetComment(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
 
@@ -121,7 +126,8 @@ func TestIssuesService_CreateComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	comment, _, err := client.Issues.CreateComment(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	comment, _, err := client.Issues.CreateComment(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Issues.CreateComment returned error: %v", err)
 	}
@@ -136,7 +142,8 @@ func TestIssuesService_CreateComment_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.CreateComment(context.Background(), "%", "r", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.CreateComment(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -158,7 +165,8 @@ func TestIssuesService_EditComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	comment, _, err := client.Issues.EditComment(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	comment, _, err := client.Issues.EditComment(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Issues.EditComment returned error: %v", err)
 	}
@@ -173,7 +181,8 @@ func TestIssuesService_EditComment_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.EditComment(context.Background(), "%", "r", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.EditComment(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -185,7 +194,8 @@ func TestIssuesService_DeleteComment(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Issues.DeleteComment(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	_, err := client.Issues.DeleteComment(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Issues.DeleteComments returned error: %v", err)
 	}
@@ -195,6 +205,7 @@ func TestIssuesService_DeleteComment_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Issues.DeleteComment(context.Background(), "%", "r", 1)
+	ctx := context.Background()
+	_, err := client.Issues.DeleteComment(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }

--- a/github/issues_events_test.go
+++ b/github/issues_events_test.go
@@ -28,7 +28,8 @@ func TestIssuesService_ListIssueEvents(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	events, _, err := client.Issues.ListIssueEvents(context.Background(), "o", "r", 1, opt)
+	ctx := context.Background()
+	events, _, err := client.Issues.ListIssueEvents(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Issues.ListIssueEvents returned error: %v", err)
 	}
@@ -53,7 +54,8 @@ func TestIssuesService_ListRepositoryEvents(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	events, _, err := client.Issues.ListRepositoryEvents(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	events, _, err := client.Issues.ListRepositoryEvents(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Issues.ListRepositoryEvents returned error: %v", err)
 	}
@@ -73,7 +75,8 @@ func TestIssuesService_GetEvent(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	event, _, err := client.Issues.GetEvent(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	event, _, err := client.Issues.GetEvent(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Issues.GetEvent returned error: %v", err)
 	}

--- a/github/issues_labels_test.go
+++ b/github/issues_labels_test.go
@@ -25,7 +25,8 @@ func TestIssuesService_ListLabels(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	labels, _, err := client.Issues.ListLabels(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	labels, _, err := client.Issues.ListLabels(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Issues.ListLabels returned error: %v", err)
 	}
@@ -40,7 +41,8 @@ func TestIssuesService_ListLabels_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.ListLabels(context.Background(), "%", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.ListLabels(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -53,7 +55,8 @@ func TestIssuesService_GetLabel(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u", "name": "n", "color": "c", "description": "d"}`)
 	})
 
-	label, _, err := client.Issues.GetLabel(context.Background(), "o", "r", "n")
+	ctx := context.Background()
+	label, _, err := client.Issues.GetLabel(ctx, "o", "r", "n")
 	if err != nil {
 		t.Errorf("Issues.GetLabel returned error: %v", err)
 	}
@@ -68,7 +71,8 @@ func TestIssuesService_GetLabel_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.GetLabel(context.Background(), "%", "%", "%")
+	ctx := context.Background()
+	_, _, err := client.Issues.GetLabel(ctx, "%", "%", "%")
 	testURLParseError(t, err)
 }
 
@@ -90,7 +94,8 @@ func TestIssuesService_CreateLabel(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u"}`)
 	})
 
-	label, _, err := client.Issues.CreateLabel(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	label, _, err := client.Issues.CreateLabel(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Issues.CreateLabel returned error: %v", err)
 	}
@@ -105,7 +110,8 @@ func TestIssuesService_CreateLabel_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.CreateLabel(context.Background(), "%", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.CreateLabel(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -127,7 +133,8 @@ func TestIssuesService_EditLabel(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u"}`)
 	})
 
-	label, _, err := client.Issues.EditLabel(context.Background(), "o", "r", "n", input)
+	ctx := context.Background()
+	label, _, err := client.Issues.EditLabel(ctx, "o", "r", "n", input)
 	if err != nil {
 		t.Errorf("Issues.EditLabel returned error: %v", err)
 	}
@@ -142,7 +149,8 @@ func TestIssuesService_EditLabel_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.EditLabel(context.Background(), "%", "%", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.EditLabel(ctx, "%", "%", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -154,7 +162,8 @@ func TestIssuesService_DeleteLabel(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Issues.DeleteLabel(context.Background(), "o", "r", "n")
+	ctx := context.Background()
+	_, err := client.Issues.DeleteLabel(ctx, "o", "r", "n")
 	if err != nil {
 		t.Errorf("Issues.DeleteLabel returned error: %v", err)
 	}
@@ -164,7 +173,8 @@ func TestIssuesService_DeleteLabel_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Issues.DeleteLabel(context.Background(), "%", "%", "%")
+	ctx := context.Background()
+	_, err := client.Issues.DeleteLabel(ctx, "%", "%", "%")
 	testURLParseError(t, err)
 }
 
@@ -179,7 +189,8 @@ func TestIssuesService_ListLabelsByIssue(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	labels, _, err := client.Issues.ListLabelsByIssue(context.Background(), "o", "r", 1, opt)
+	ctx := context.Background()
+	labels, _, err := client.Issues.ListLabelsByIssue(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Issues.ListLabelsByIssue returned error: %v", err)
 	}
@@ -197,7 +208,8 @@ func TestIssuesService_ListLabelsByIssue_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.ListLabelsByIssue(context.Background(), "%", "%", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.ListLabelsByIssue(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -219,7 +231,8 @@ func TestIssuesService_AddLabelsToIssue(t *testing.T) {
 		fmt.Fprint(w, `[{"url":"u"}]`)
 	})
 
-	labels, _, err := client.Issues.AddLabelsToIssue(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	labels, _, err := client.Issues.AddLabelsToIssue(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Issues.AddLabelsToIssue returned error: %v", err)
 	}
@@ -234,7 +247,8 @@ func TestIssuesService_AddLabelsToIssue_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.AddLabelsToIssue(context.Background(), "%", "%", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.AddLabelsToIssue(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -246,7 +260,8 @@ func TestIssuesService_RemoveLabelForIssue(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Issues.RemoveLabelForIssue(context.Background(), "o", "r", 1, "l")
+	ctx := context.Background()
+	_, err := client.Issues.RemoveLabelForIssue(ctx, "o", "r", 1, "l")
 	if err != nil {
 		t.Errorf("Issues.RemoveLabelForIssue returned error: %v", err)
 	}
@@ -256,7 +271,8 @@ func TestIssuesService_RemoveLabelForIssue_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Issues.RemoveLabelForIssue(context.Background(), "%", "%", 1, "%")
+	ctx := context.Background()
+	_, err := client.Issues.RemoveLabelForIssue(ctx, "%", "%", 1, "%")
 	testURLParseError(t, err)
 }
 
@@ -278,7 +294,8 @@ func TestIssuesService_ReplaceLabelsForIssue(t *testing.T) {
 		fmt.Fprint(w, `[{"url":"u"}]`)
 	})
 
-	labels, _, err := client.Issues.ReplaceLabelsForIssue(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	labels, _, err := client.Issues.ReplaceLabelsForIssue(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Issues.ReplaceLabelsForIssue returned error: %v", err)
 	}
@@ -293,7 +310,8 @@ func TestIssuesService_ReplaceLabelsForIssue_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.ReplaceLabelsForIssue(context.Background(), "%", "%", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.ReplaceLabelsForIssue(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -305,7 +323,8 @@ func TestIssuesService_RemoveLabelsForIssue(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Issues.RemoveLabelsForIssue(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	_, err := client.Issues.RemoveLabelsForIssue(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Issues.RemoveLabelsForIssue returned error: %v", err)
 	}
@@ -315,7 +334,8 @@ func TestIssuesService_RemoveLabelsForIssue_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Issues.RemoveLabelsForIssue(context.Background(), "%", "%", 1)
+	ctx := context.Background()
+	_, err := client.Issues.RemoveLabelsForIssue(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }
 
@@ -330,7 +350,8 @@ func TestIssuesService_ListLabelsForMilestone(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	labels, _, err := client.Issues.ListLabelsForMilestone(context.Background(), "o", "r", 1, opt)
+	ctx := context.Background()
+	labels, _, err := client.Issues.ListLabelsForMilestone(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Issues.ListLabelsForMilestone returned error: %v", err)
 	}
@@ -345,6 +366,7 @@ func TestIssuesService_ListLabelsForMilestone_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.ListLabelsForMilestone(context.Background(), "%", "%", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.ListLabelsForMilestone(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }

--- a/github/issues_milestones_test.go
+++ b/github/issues_milestones_test.go
@@ -30,7 +30,8 @@ func TestIssuesService_ListMilestones(t *testing.T) {
 	})
 
 	opt := &MilestoneListOptions{"closed", "due_date", "asc", ListOptions{Page: 2}}
-	milestones, _, err := client.Issues.ListMilestones(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	milestones, _, err := client.Issues.ListMilestones(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("IssuesService.ListMilestones returned error: %v", err)
 	}
@@ -45,7 +46,8 @@ func TestIssuesService_ListMilestones_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.ListMilestones(context.Background(), "%", "r", nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.ListMilestones(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
 
@@ -58,7 +60,8 @@ func TestIssuesService_GetMilestone(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	milestone, _, err := client.Issues.GetMilestone(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	milestone, _, err := client.Issues.GetMilestone(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("IssuesService.GetMilestone returned error: %v", err)
 	}
@@ -73,7 +76,8 @@ func TestIssuesService_GetMilestone_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.GetMilestone(context.Background(), "%", "r", 1)
+	ctx := context.Background()
+	_, _, err := client.Issues.GetMilestone(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
 
@@ -95,7 +99,8 @@ func TestIssuesService_CreateMilestone(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	milestone, _, err := client.Issues.CreateMilestone(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	milestone, _, err := client.Issues.CreateMilestone(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("IssuesService.CreateMilestone returned error: %v", err)
 	}
@@ -110,7 +115,8 @@ func TestIssuesService_CreateMilestone_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.CreateMilestone(context.Background(), "%", "r", nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.CreateMilestone(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
 
@@ -132,7 +138,8 @@ func TestIssuesService_EditMilestone(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	milestone, _, err := client.Issues.EditMilestone(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	milestone, _, err := client.Issues.EditMilestone(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("IssuesService.EditMilestone returned error: %v", err)
 	}
@@ -147,7 +154,8 @@ func TestIssuesService_EditMilestone_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.EditMilestone(context.Background(), "%", "r", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.EditMilestone(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -159,7 +167,8 @@ func TestIssuesService_DeleteMilestone(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Issues.DeleteMilestone(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	_, err := client.Issues.DeleteMilestone(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("IssuesService.DeleteMilestone returned error: %v", err)
 	}
@@ -169,6 +178,7 @@ func TestIssuesService_DeleteMilestone_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Issues.DeleteMilestone(context.Background(), "%", "r", 1)
+	ctx := context.Background()
+	_, err := client.Issues.DeleteMilestone(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -40,7 +40,8 @@ func TestIssuesService_List_all(t *testing.T) {
 		time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC),
 		ListOptions{Page: 1, PerPage: 2},
 	}
-	issues, _, err := client.Issues.List(context.Background(), true, opt)
+	ctx := context.Background()
+	issues, _, err := client.Issues.List(ctx, true, opt)
 	if err != nil {
 		t.Errorf("Issues.List returned error: %v", err)
 	}
@@ -61,7 +62,8 @@ func TestIssuesService_List_owned(t *testing.T) {
 		fmt.Fprint(w, `[{"number":1}]`)
 	})
 
-	issues, _, err := client.Issues.List(context.Background(), false, nil)
+	ctx := context.Background()
+	issues, _, err := client.Issues.List(ctx, false, nil)
 	if err != nil {
 		t.Errorf("Issues.List returned error: %v", err)
 	}
@@ -82,7 +84,8 @@ func TestIssuesService_ListByOrg(t *testing.T) {
 		fmt.Fprint(w, `[{"number":1}]`)
 	})
 
-	issues, _, err := client.Issues.ListByOrg(context.Background(), "o", nil)
+	ctx := context.Background()
+	issues, _, err := client.Issues.ListByOrg(ctx, "o", nil)
 	if err != nil {
 		t.Errorf("Issues.ListByOrg returned error: %v", err)
 	}
@@ -97,7 +100,8 @@ func TestIssuesService_ListByOrg_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.ListByOrg(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.ListByOrg(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -127,7 +131,8 @@ func TestIssuesService_ListByRepo(t *testing.T) {
 		time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC),
 		ListOptions{0, 0},
 	}
-	issues, _, err := client.Issues.ListByRepo(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	issues, _, err := client.Issues.ListByRepo(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Issues.ListByOrg returned error: %v", err)
 	}
@@ -142,7 +147,8 @@ func TestIssuesService_ListByRepo_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.ListByRepo(context.Background(), "%", "r", nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.ListByRepo(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
 
@@ -156,7 +162,8 @@ func TestIssuesService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"number":1, "author_association": "MEMBER","labels": [{"url": "u", "name": "n", "color": "c"}]}`)
 	})
 
-	issue, _, err := client.Issues.Get(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	issue, _, err := client.Issues.Get(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Issues.Get returned error: %v", err)
 	}
@@ -179,7 +186,8 @@ func TestIssuesService_Get_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.Get(context.Background(), "%", "r", 1)
+	ctx := context.Background()
+	_, _, err := client.Issues.Get(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
 
@@ -206,7 +214,8 @@ func TestIssuesService_Create(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	issue, _, err := client.Issues.Create(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	issue, _, err := client.Issues.Create(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Issues.Create returned error: %v", err)
 	}
@@ -221,7 +230,8 @@ func TestIssuesService_Create_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.Create(context.Background(), "%", "r", nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.Create(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
 
@@ -243,7 +253,8 @@ func TestIssuesService_Edit(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	issue, _, err := client.Issues.Edit(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	issue, _, err := client.Issues.Edit(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Issues.Edit returned error: %v", err)
 	}
@@ -258,7 +269,8 @@ func TestIssuesService_Edit_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Issues.Edit(context.Background(), "%", "r", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Issues.Edit(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -272,7 +284,8 @@ func TestIssuesService_Lock(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Issues.Lock(context.Background(), "o", "r", 1, nil); err != nil {
+	ctx := context.Background()
+	if _, err := client.Issues.Lock(ctx, "o", "r", 1, nil); err != nil {
 		t.Errorf("Issues.Lock returned error: %v", err)
 	}
 }
@@ -288,7 +301,8 @@ func TestIssuesService_LockWithReason(t *testing.T) {
 
 	opt := &LockIssueOptions{LockReason: "off-topic"}
 
-	if _, err := client.Issues.Lock(context.Background(), "o", "r", 1, opt); err != nil {
+	ctx := context.Background()
+	if _, err := client.Issues.Lock(ctx, "o", "r", 1, opt); err != nil {
 		t.Errorf("Issues.Lock returned error: %v", err)
 	}
 }
@@ -303,7 +317,8 @@ func TestIssuesService_Unlock(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Issues.Unlock(context.Background(), "o", "r", 1); err != nil {
+	ctx := context.Background()
+	if _, err := client.Issues.Unlock(ctx, "o", "r", 1); err != nil {
 		t.Errorf("Issues.Unlock returned error: %v", err)
 	}
 }

--- a/github/issues_timeline_test.go
+++ b/github/issues_timeline_test.go
@@ -30,7 +30,8 @@ func TestIssuesService_ListIssueTimeline(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	events, _, err := client.Issues.ListIssueTimeline(context.Background(), "o", "r", 1, opt)
+	ctx := context.Background()
+	events, _, err := client.Issues.ListIssueTimeline(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Issues.ListIssueTimeline returned error: %v", err)
 	}

--- a/github/licenses_test.go
+++ b/github/licenses_test.go
@@ -116,7 +116,8 @@ func TestLicensesService_List(t *testing.T) {
 		fmt.Fprint(w, `[{"key":"mit","name":"MIT","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","featured":true}]`)
 	})
 
-	licenses, _, err := client.Licenses.List(context.Background())
+	ctx := context.Background()
+	licenses, _, err := client.Licenses.List(ctx)
 	if err != nil {
 		t.Errorf("Licenses.List returned error: %v", err)
 	}
@@ -142,7 +143,8 @@ func TestLicensesService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"key":"mit","name":"MIT"}`)
 	})
 
-	license, _, err := client.Licenses.Get(context.Background(), "mit")
+	ctx := context.Background()
+	license, _, err := client.Licenses.Get(ctx, "mit")
 	if err != nil {
 		t.Errorf("Licenses.Get returned error: %v", err)
 	}
@@ -157,6 +159,7 @@ func TestLicensesService_Get_invalidTemplate(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Licenses.Get(context.Background(), "%")
+	ctx := context.Background()
+	_, _, err := client.Licenses.Get(ctx, "%")
 	testURLParseError(t, err)
 }

--- a/github/migrations_source_import_test.go
+++ b/github/migrations_source_import_test.go
@@ -38,7 +38,8 @@ func TestMigrationService_StartImport(t *testing.T) {
 		fmt.Fprint(w, `{"status":"importing"}`)
 	})
 
-	got, _, err := client.Migrations.StartImport(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	got, _, err := client.Migrations.StartImport(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("StartImport returned error: %v", err)
 	}
@@ -57,7 +58,8 @@ func TestMigrationService_ImportProgress(t *testing.T) {
 		fmt.Fprint(w, `{"status":"complete"}`)
 	})
 
-	got, _, err := client.Migrations.ImportProgress(context.Background(), "o", "r")
+	ctx := context.Background()
+	got, _, err := client.Migrations.ImportProgress(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("ImportProgress returned error: %v", err)
 	}
@@ -91,7 +93,8 @@ func TestMigrationService_UpdateImport(t *testing.T) {
 		fmt.Fprint(w, `{"status":"importing"}`)
 	})
 
-	got, _, err := client.Migrations.UpdateImport(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	got, _, err := client.Migrations.UpdateImport(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("UpdateImport returned error: %v", err)
 	}
@@ -110,7 +113,8 @@ func TestMigrationService_CommitAuthors(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1,"name":"a"},{"id":2,"name":"b"}]`)
 	})
 
-	got, _, err := client.Migrations.CommitAuthors(context.Background(), "o", "r")
+	ctx := context.Background()
+	got, _, err := client.Migrations.CommitAuthors(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("CommitAuthors returned error: %v", err)
 	}
@@ -141,7 +145,8 @@ func TestMigrationService_MapCommitAuthor(t *testing.T) {
 		fmt.Fprint(w, `{"id": 1}`)
 	})
 
-	got, _, err := client.Migrations.MapCommitAuthor(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	got, _, err := client.Migrations.MapCommitAuthor(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("MapCommitAuthor returned error: %v", err)
 	}
@@ -170,7 +175,8 @@ func TestMigrationService_SetLFSPreference(t *testing.T) {
 		fmt.Fprint(w, `{"status":"importing"}`)
 	})
 
-	got, _, err := client.Migrations.SetLFSPreference(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	got, _, err := client.Migrations.SetLFSPreference(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("SetLFSPreference returned error: %v", err)
 	}
@@ -189,7 +195,8 @@ func TestMigrationService_LargeFiles(t *testing.T) {
 		fmt.Fprint(w, `[{"oid":"a"},{"oid":"b"}]`)
 	})
 
-	got, _, err := client.Migrations.LargeFiles(context.Background(), "o", "r")
+	ctx := context.Background()
+	got, _, err := client.Migrations.LargeFiles(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("LargeFiles returned error: %v", err)
 	}
@@ -211,7 +218,8 @@ func TestMigrationService_CancelImport(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Migrations.CancelImport(context.Background(), "o", "r")
+	ctx := context.Background()
+	_, err := client.Migrations.CancelImport(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("CancelImport returned error: %v", err)
 	}

--- a/github/migrations_test.go
+++ b/github/migrations_test.go
@@ -30,7 +30,8 @@ func TestMigrationService_StartMigration(t *testing.T) {
 		LockRepositories:   true,
 		ExcludeAttachments: false,
 	}
-	got, _, err := client.Migrations.StartMigration(context.Background(), "o", []string{"r"}, opt)
+	ctx := context.Background()
+	got, _, err := client.Migrations.StartMigration(ctx, "o", []string{"r"}, opt)
 	if err != nil {
 		t.Errorf("StartMigration returned error: %v", err)
 	}
@@ -51,7 +52,8 @@ func TestMigrationService_ListMigrations(t *testing.T) {
 		w.Write([]byte(fmt.Sprintf("[%s]", migrationJSON)))
 	})
 
-	got, _, err := client.Migrations.ListMigrations(context.Background(), "o", &ListOptions{Page: 1, PerPage: 2})
+	ctx := context.Background()
+	got, _, err := client.Migrations.ListMigrations(ctx, "o", &ListOptions{Page: 1, PerPage: 2})
 	if err != nil {
 		t.Errorf("ListMigrations returned error: %v", err)
 	}
@@ -72,7 +74,8 @@ func TestMigrationService_MigrationStatus(t *testing.T) {
 		w.Write(migrationJSON)
 	})
 
-	got, _, err := client.Migrations.MigrationStatus(context.Background(), "o", 1)
+	ctx := context.Background()
+	got, _, err := client.Migrations.MigrationStatus(ctx, "o", 1)
 	if err != nil {
 		t.Errorf("MigrationStatus returned error: %v", err)
 	}
@@ -98,7 +101,8 @@ func TestMigrationService_MigrationArchiveURL(t *testing.T) {
 		w.Write([]byte("0123456789abcdef"))
 	})
 
-	got, err := client.Migrations.MigrationArchiveURL(context.Background(), "o", 1)
+	ctx := context.Background()
+	got, err := client.Migrations.MigrationArchiveURL(ctx, "o", 1)
 	if err != nil {
 		t.Errorf("MigrationStatus returned error: %v", err)
 	}
@@ -118,7 +122,8 @@ func TestMigrationService_DeleteMigration(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Migrations.DeleteMigration(context.Background(), "o", 1); err != nil {
+	ctx := context.Background()
+	if _, err := client.Migrations.DeleteMigration(ctx, "o", 1); err != nil {
 		t.Errorf("DeleteMigration returned error: %v", err)
 	}
 }
@@ -134,7 +139,8 @@ func TestMigrationService_UnlockRepo(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Migrations.UnlockRepo(context.Background(), "o", 1, "r"); err != nil {
+	ctx := context.Background()
+	if _, err := client.Migrations.UnlockRepo(ctx, "o", 1, "r"); err != nil {
 		t.Errorf("UnlockRepo returned error: %v", err)
 	}
 }

--- a/github/migrations_user_test.go
+++ b/github/migrations_user_test.go
@@ -31,7 +31,8 @@ func TestMigrationService_StartUserMigration(t *testing.T) {
 		ExcludeAttachments: false,
 	}
 
-	got, _, err := client.Migrations.StartUserMigration(context.Background(), []string{"r"}, opt)
+	ctx := context.Background()
+	got, _, err := client.Migrations.StartUserMigration(ctx, []string{"r"}, opt)
 	if err != nil {
 		t.Errorf("StartUserMigration returned error: %v", err)
 	}
@@ -54,7 +55,8 @@ func TestMigrationService_ListUserMigrations(t *testing.T) {
 		w.Write([]byte(fmt.Sprintf("[%s]", userMigrationJSON)))
 	})
 
-	got, _, err := client.Migrations.ListUserMigrations(context.Background())
+	ctx := context.Background()
+	got, _, err := client.Migrations.ListUserMigrations(ctx)
 	if err != nil {
 		t.Errorf("ListUserMigrations returned error %v", err)
 	}
@@ -77,7 +79,8 @@ func TestMigrationService_UserMigrationStatus(t *testing.T) {
 		w.Write(userMigrationJSON)
 	})
 
-	got, _, err := client.Migrations.UserMigrationStatus(context.Background(), 1)
+	ctx := context.Background()
+	got, _, err := client.Migrations.UserMigrationStatus(ctx, 1)
 	if err != nil {
 		t.Errorf("UserMigrationStatus returned error %v", err)
 	}
@@ -105,7 +108,8 @@ func TestMigrationService_UserMigrationArchiveURL(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	got, err := client.Migrations.UserMigrationArchiveURL(context.Background(), 1)
+	ctx := context.Background()
+	got, err := client.Migrations.UserMigrationArchiveURL(ctx, 1)
 	if err != nil {
 		t.Errorf("UserMigrationArchiveURL returned error %v", err)
 	}
@@ -127,7 +131,8 @@ func TestMigrationService_DeleteUserMigration(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	got, err := client.Migrations.DeleteUserMigration(context.Background(), 1)
+	ctx := context.Background()
+	got, err := client.Migrations.DeleteUserMigration(ctx, 1)
 	if err != nil {
 		t.Errorf("DeleteUserMigration returned error %v", err)
 	}
@@ -148,7 +153,8 @@ func TestMigrationService_UnlockUserRepo(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	got, err := client.Migrations.UnlockUserRepo(context.Background(), 1, "r")
+	ctx := context.Background()
+	got, err := client.Migrations.UnlockUserRepo(ctx, 1, "r")
 	if err != nil {
 		t.Errorf("UnlockUserRepo returned error %v", err)
 	}

--- a/github/misc_test.go
+++ b/github/misc_test.go
@@ -34,7 +34,8 @@ func TestMarkdown(t *testing.T) {
 		fmt.Fprint(w, `<h1>text</h1>`)
 	})
 
-	md, _, err := client.Markdown(context.Background(), "# text #", &MarkdownOptions{
+	ctx := context.Background()
+	md, _, err := client.Markdown(ctx, "# text #", &MarkdownOptions{
 		Mode:    "gfm",
 		Context: "google/go-github",
 	})
@@ -56,7 +57,8 @@ func TestListEmojis(t *testing.T) {
 		fmt.Fprint(w, `{"+1": "+1.png"}`)
 	})
 
-	emoji, _, err := client.ListEmojis(context.Background())
+	ctx := context.Background()
+	emoji, _, err := client.ListEmojis(ctx)
 	if err != nil {
 		t.Errorf("ListEmojis returned error: %v", err)
 	}
@@ -81,7 +83,8 @@ func TestListCodesOfConduct(t *testing.T) {
 						]`)
 	})
 
-	cs, _, err := client.ListCodesOfConduct(context.Background())
+	ctx := context.Background()
+	cs, _, err := client.ListCodesOfConduct(ctx)
 	if err != nil {
 		t.Errorf("ListCodesOfConduct returned error: %v", err)
 	}
@@ -112,7 +115,8 @@ func TestGetCodeOfConduct(t *testing.T) {
 		)
 	})
 
-	coc, _, err := client.GetCodeOfConduct(context.Background(), "k")
+	ctx := context.Background()
+	coc, _, err := client.GetCodeOfConduct(ctx, "k")
 	if err != nil {
 		t.Errorf("ListCodesOfConduct returned error: %v", err)
 	}
@@ -157,7 +161,8 @@ func TestAPIMeta(t *testing.T) {
 		fmt.Fprint(w, `{"hooks":["h"], "git":["g"], "pages":["p"], "importer":["i"], "verifiable_password_authentication": true}`)
 	})
 
-	meta, _, err := client.APIMeta(context.Background())
+	ctx := context.Background()
+	meta, _, err := client.APIMeta(ctx)
 	if err != nil {
 		t.Errorf("APIMeta returned error: %v", err)
 	}
@@ -189,7 +194,8 @@ func TestOctocat(t *testing.T) {
 		fmt.Fprint(w, output)
 	})
 
-	got, _, err := client.Octocat(context.Background(), input)
+	ctx := context.Background()
+	got, _, err := client.Octocat(ctx, input)
 	if err != nil {
 		t.Errorf("Octocat returned error: %v", err)
 	}
@@ -211,7 +217,8 @@ func TestZen(t *testing.T) {
 		fmt.Fprint(w, output)
 	})
 
-	got, _, err := client.Zen(context.Background())
+	ctx := context.Background()
+	got, _, err := client.Zen(ctx)
 	if err != nil {
 		t.Errorf("Zen returned error: %v", err)
 	}
@@ -237,7 +244,8 @@ func TestListServiceHooks(t *testing.T) {
 		}]`)
 	})
 
-	hooks, _, err := client.ListServiceHooks(context.Background())
+	ctx := context.Background()
+	hooks, _, err := client.ListServiceHooks(ctx)
 	if err != nil {
 		t.Errorf("ListServiceHooks returned error: %v", err)
 	}

--- a/github/orgs_hooks_test.go
+++ b/github/orgs_hooks_test.go
@@ -26,7 +26,8 @@ func TestOrganizationsService_ListHooks(t *testing.T) {
 
 	opt := &ListOptions{Page: 2}
 
-	hooks, _, err := client.Organizations.ListHooks(context.Background(), "o", opt)
+	ctx := context.Background()
+	hooks, _, err := client.Organizations.ListHooks(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListHooks returned error: %v", err)
 	}
@@ -41,7 +42,8 @@ func TestOrganizationsService_ListHooks_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Organizations.ListHooks(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Organizations.ListHooks(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -64,7 +66,8 @@ func TestOrganizationsService_CreateHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	hook, _, err := client.Organizations.CreateHook(context.Background(), "o", input)
+	ctx := context.Background()
+	hook, _, err := client.Organizations.CreateHook(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Organizations.CreateHook returned error: %v", err)
 	}
@@ -84,7 +87,8 @@ func TestOrganizationsService_GetHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	hook, _, err := client.Organizations.GetHook(context.Background(), "o", 1)
+	ctx := context.Background()
+	hook, _, err := client.Organizations.GetHook(ctx, "o", 1)
 	if err != nil {
 		t.Errorf("Organizations.GetHook returned error: %v", err)
 	}
@@ -99,7 +103,8 @@ func TestOrganizationsService_GetHook_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Organizations.GetHook(context.Background(), "%", 1)
+	ctx := context.Background()
+	_, _, err := client.Organizations.GetHook(ctx, "%", 1)
 	testURLParseError(t, err)
 }
 
@@ -121,7 +126,8 @@ func TestOrganizationsService_EditHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	hook, _, err := client.Organizations.EditHook(context.Background(), "o", 1, input)
+	ctx := context.Background()
+	hook, _, err := client.Organizations.EditHook(ctx, "o", 1, input)
 	if err != nil {
 		t.Errorf("Organizations.EditHook returned error: %v", err)
 	}
@@ -136,7 +142,8 @@ func TestOrganizationsService_EditHook_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Organizations.EditHook(context.Background(), "%", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Organizations.EditHook(ctx, "%", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -148,7 +155,8 @@ func TestOrganizationsService_PingHook(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	_, err := client.Organizations.PingHook(context.Background(), "o", 1)
+	ctx := context.Background()
+	_, err := client.Organizations.PingHook(ctx, "o", 1)
 	if err != nil {
 		t.Errorf("Organizations.PingHook returned error: %v", err)
 	}
@@ -162,7 +170,8 @@ func TestOrganizationsService_DeleteHook(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Organizations.DeleteHook(context.Background(), "o", 1)
+	ctx := context.Background()
+	_, err := client.Organizations.DeleteHook(ctx, "o", 1)
 	if err != nil {
 		t.Errorf("Organizations.DeleteHook returned error: %v", err)
 	}
@@ -172,6 +181,7 @@ func TestOrganizationsService_DeleteHook_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Organizations.DeleteHook(context.Background(), "%", 1)
+	ctx := context.Background()
+	_, err := client.Organizations.DeleteHook(ctx, "%", 1)
 	testURLParseError(t, err)
 }

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -35,7 +35,8 @@ func TestOrganizationsService_ListMembers(t *testing.T) {
 		Role:        "admin",
 		ListOptions: ListOptions{Page: 2},
 	}
-	members, _, err := client.Organizations.ListMembers(context.Background(), "o", opt)
+	ctx := context.Background()
+	members, _, err := client.Organizations.ListMembers(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListMembers returned error: %v", err)
 	}
@@ -50,7 +51,8 @@ func TestOrganizationsService_ListMembers_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Organizations.ListMembers(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Organizations.ListMembers(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -64,7 +66,8 @@ func TestOrganizationsService_ListMembers_public(t *testing.T) {
 	})
 
 	opt := &ListMembersOptions{PublicOnly: true}
-	members, _, err := client.Organizations.ListMembers(context.Background(), "o", opt)
+	ctx := context.Background()
+	members, _, err := client.Organizations.ListMembers(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListMembers returned error: %v", err)
 	}
@@ -84,7 +87,8 @@ func TestOrganizationsService_IsMember(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	member, _, err := client.Organizations.IsMember(context.Background(), "o", "u")
+	ctx := context.Background()
+	member, _, err := client.Organizations.IsMember(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.IsMember returned error: %v", err)
 	}
@@ -103,7 +107,8 @@ func TestOrganizationsService_IsMember_notMember(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	member, _, err := client.Organizations.IsMember(context.Background(), "o", "u")
+	ctx := context.Background()
+	member, _, err := client.Organizations.IsMember(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.IsMember returned error: %+v", err)
 	}
@@ -123,7 +128,8 @@ func TestOrganizationsService_IsMember_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	member, _, err := client.Organizations.IsMember(context.Background(), "o", "u")
+	ctx := context.Background()
+	member, _, err := client.Organizations.IsMember(ctx, "o", "u")
 	if err == nil {
 		t.Errorf("Expected HTTP 400 response")
 	}
@@ -136,7 +142,8 @@ func TestOrganizationsService_IsMember_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Organizations.IsMember(context.Background(), "%", "u")
+	ctx := context.Background()
+	_, _, err := client.Organizations.IsMember(ctx, "%", "u")
 	testURLParseError(t, err)
 }
 
@@ -149,7 +156,8 @@ func TestOrganizationsService_IsPublicMember(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	member, _, err := client.Organizations.IsPublicMember(context.Background(), "o", "u")
+	ctx := context.Background()
+	member, _, err := client.Organizations.IsPublicMember(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.IsPublicMember returned error: %v", err)
 	}
@@ -168,7 +176,8 @@ func TestOrganizationsService_IsPublicMember_notMember(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	member, _, err := client.Organizations.IsPublicMember(context.Background(), "o", "u")
+	ctx := context.Background()
+	member, _, err := client.Organizations.IsPublicMember(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.IsPublicMember returned error: %v", err)
 	}
@@ -188,7 +197,8 @@ func TestOrganizationsService_IsPublicMember_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	member, _, err := client.Organizations.IsPublicMember(context.Background(), "o", "u")
+	ctx := context.Background()
+	member, _, err := client.Organizations.IsPublicMember(ctx, "o", "u")
 	if err == nil {
 		t.Errorf("Expected HTTP 400 response")
 	}
@@ -201,7 +211,8 @@ func TestOrganizationsService_IsPublicMember_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Organizations.IsPublicMember(context.Background(), "%", "u")
+	ctx := context.Background()
+	_, _, err := client.Organizations.IsPublicMember(ctx, "%", "u")
 	testURLParseError(t, err)
 }
 
@@ -213,7 +224,8 @@ func TestOrganizationsService_RemoveMember(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Organizations.RemoveMember(context.Background(), "o", "u")
+	ctx := context.Background()
+	_, err := client.Organizations.RemoveMember(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.RemoveMember returned error: %v", err)
 	}
@@ -223,7 +235,8 @@ func TestOrganizationsService_RemoveMember_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Organizations.RemoveMember(context.Background(), "%", "u")
+	ctx := context.Background()
+	_, err := client.Organizations.RemoveMember(ctx, "%", "u")
 	testURLParseError(t, err)
 }
 
@@ -244,7 +257,8 @@ func TestOrganizationsService_ListOrgMemberships(t *testing.T) {
 		State:       "active",
 		ListOptions: ListOptions{Page: 2},
 	}
-	memberships, _, err := client.Organizations.ListOrgMemberships(context.Background(), opt)
+	ctx := context.Background()
+	memberships, _, err := client.Organizations.ListOrgMemberships(ctx, opt)
 	if err != nil {
 		t.Errorf("Organizations.ListOrgMemberships returned error: %v", err)
 	}
@@ -264,7 +278,8 @@ func TestOrganizationsService_GetOrgMembership_AuthenticatedUser(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u"}`)
 	})
 
-	membership, _, err := client.Organizations.GetOrgMembership(context.Background(), "", "o")
+	ctx := context.Background()
+	membership, _, err := client.Organizations.GetOrgMembership(ctx, "", "o")
 	if err != nil {
 		t.Errorf("Organizations.GetOrgMembership returned error: %v", err)
 	}
@@ -284,7 +299,8 @@ func TestOrganizationsService_GetOrgMembership_SpecifiedUser(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u"}`)
 	})
 
-	membership, _, err := client.Organizations.GetOrgMembership(context.Background(), "u", "o")
+	ctx := context.Background()
+	membership, _, err := client.Organizations.GetOrgMembership(ctx, "u", "o")
 	if err != nil {
 		t.Errorf("Organizations.GetOrgMembership returned error: %v", err)
 	}
@@ -313,7 +329,8 @@ func TestOrganizationsService_EditOrgMembership_AuthenticatedUser(t *testing.T) 
 		fmt.Fprint(w, `{"url":"u"}`)
 	})
 
-	membership, _, err := client.Organizations.EditOrgMembership(context.Background(), "", "o", input)
+	ctx := context.Background()
+	membership, _, err := client.Organizations.EditOrgMembership(ctx, "", "o", input)
 	if err != nil {
 		t.Errorf("Organizations.EditOrgMembership returned error: %v", err)
 	}
@@ -342,7 +359,8 @@ func TestOrganizationsService_EditOrgMembership_SpecifiedUser(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u"}`)
 	})
 
-	membership, _, err := client.Organizations.EditOrgMembership(context.Background(), "u", "o", input)
+	ctx := context.Background()
+	membership, _, err := client.Organizations.EditOrgMembership(ctx, "u", "o", input)
 	if err != nil {
 		t.Errorf("Organizations.EditOrgMembership returned error: %v", err)
 	}
@@ -362,7 +380,8 @@ func TestOrganizationsService_RemoveOrgMembership(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Organizations.RemoveOrgMembership(context.Background(), "u", "o")
+	ctx := context.Background()
+	_, err := client.Organizations.RemoveOrgMembership(ctx, "u", "o")
 	if err != nil {
 		t.Errorf("Organizations.RemoveOrgMembership returned error: %v", err)
 	}
@@ -408,7 +427,8 @@ func TestOrganizationsService_ListPendingOrgInvitations(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1}
-	invitations, _, err := client.Organizations.ListPendingOrgInvitations(context.Background(), "o", opt)
+	ctx := context.Background()
+	invitations, _, err := client.Organizations.ListPendingOrgInvitations(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListPendingOrgInvitations returned error: %v", err)
 	}
@@ -474,7 +494,8 @@ func TestOrganizationsService_CreateOrgInvitation(t *testing.T) {
 
 	})
 
-	invitations, _, err := client.Organizations.CreateOrgInvitation(context.Background(), "o", input)
+	ctx := context.Background()
+	invitations, _, err := client.Organizations.CreateOrgInvitation(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Organizations.CreateOrgInvitation returned error: %v", err)
 	}
@@ -508,7 +529,8 @@ func TestOrganizationsService_ListOrgInvitationTeams(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1}
-	invitations, _, err := client.Organizations.ListOrgInvitationTeams(context.Background(), "o", "22", opt)
+	ctx := context.Background()
+	invitations, _, err := client.Organizations.ListOrgInvitationTeams(ctx, "o", "22", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListOrgInvitationTeams returned error: %v", err)
 	}

--- a/github/orgs_outside_collaborators_test.go
+++ b/github/orgs_outside_collaborators_test.go
@@ -30,7 +30,8 @@ func TestOrganizationsService_ListOutsideCollaborators(t *testing.T) {
 		Filter:      "2fa_disabled",
 		ListOptions: ListOptions{Page: 2},
 	}
-	members, _, err := client.Organizations.ListOutsideCollaborators(context.Background(), "o", opt)
+	ctx := context.Background()
+	members, _, err := client.Organizations.ListOutsideCollaborators(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListOutsideCollaborators returned error: %v", err)
 	}
@@ -45,7 +46,8 @@ func TestOrganizationsService_ListOutsideCollaborators_invalidOrg(t *testing.T) 
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Organizations.ListOutsideCollaborators(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Organizations.ListOutsideCollaborators(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -58,7 +60,8 @@ func TestOrganizationsService_RemoveOutsideCollaborator(t *testing.T) {
 	}
 	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
 
-	_, err := client.Organizations.RemoveOutsideCollaborator(context.Background(), "o", "u")
+	ctx := context.Background()
+	_, err := client.Organizations.RemoveOutsideCollaborator(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.RemoveOutsideCollaborator returned error: %v", err)
 	}
@@ -74,7 +77,8 @@ func TestOrganizationsService_RemoveOutsideCollaborator_NonMember(t *testing.T) 
 	}
 	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
 
-	_, err := client.Organizations.RemoveOutsideCollaborator(context.Background(), "o", "u")
+	ctx := context.Background()
+	_, err := client.Organizations.RemoveOutsideCollaborator(ctx, "o", "u")
 	if err, ok := err.(*ErrorResponse); !ok {
 		t.Errorf("Organizations.RemoveOutsideCollaborator did not return an error")
 	} else if err.Response.StatusCode != http.StatusNotFound {
@@ -92,7 +96,8 @@ func TestOrganizationsService_RemoveOutsideCollaborator_Member(t *testing.T) {
 	}
 	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
 
-	_, err := client.Organizations.RemoveOutsideCollaborator(context.Background(), "o", "u")
+	ctx := context.Background()
+	_, err := client.Organizations.RemoveOutsideCollaborator(ctx, "o", "u")
 	if err, ok := err.(*ErrorResponse); !ok {
 		t.Errorf("Organizations.RemoveOutsideCollaborator did not return an error")
 	} else if err.Response.StatusCode != http.StatusUnprocessableEntity {
@@ -109,7 +114,8 @@ func TestOrganizationsService_ConvertMemberToOutsideCollaborator(t *testing.T) {
 	}
 	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
 
-	_, err := client.Organizations.ConvertMemberToOutsideCollaborator(context.Background(), "o", "u")
+	ctx := context.Background()
+	_, err := client.Organizations.ConvertMemberToOutsideCollaborator(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator returned error: %v", err)
 	}
@@ -125,7 +131,8 @@ func TestOrganizationsService_ConvertMemberToOutsideCollaborator_NonMemberOrLast
 	}
 	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
 
-	_, err := client.Organizations.ConvertMemberToOutsideCollaborator(context.Background(), "o", "u")
+	ctx := context.Background()
+	_, err := client.Organizations.ConvertMemberToOutsideCollaborator(ctx, "o", "u")
 	if err, ok := err.(*ErrorResponse); !ok {
 		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator did not return an error")
 	} else if err.Response.StatusCode != http.StatusForbidden {

--- a/github/orgs_projects_test.go
+++ b/github/orgs_projects_test.go
@@ -26,7 +26,8 @@ func TestOrganizationsService_ListProjects(t *testing.T) {
 	})
 
 	opt := &ProjectListOptions{State: "open", ListOptions: ListOptions{Page: 2}}
-	projects, _, err := client.Organizations.ListProjects(context.Background(), "o", opt)
+	ctx := context.Background()
+	projects, _, err := client.Organizations.ListProjects(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListProjects returned error: %v", err)
 	}
@@ -56,7 +57,8 @@ func TestOrganizationsService_CreateProject(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	project, _, err := client.Organizations.CreateProject(context.Background(), "o", input)
+	ctx := context.Background()
+	project, _, err := client.Organizations.CreateProject(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Organizations.CreateProject returned error: %v", err)
 	}

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -72,7 +72,8 @@ func TestOrganizationsService_ListAll(t *testing.T) {
 	})
 
 	opt := &OrganizationsListOptions{Since: since}
-	orgs, _, err := client.Organizations.ListAll(context.Background(), opt)
+	ctx := context.Background()
+	orgs, _, err := client.Organizations.ListAll(ctx, opt)
 	if err != nil {
 		t.Errorf("Organizations.ListAll returned error: %v", err)
 	}
@@ -92,7 +93,8 @@ func TestOrganizationsService_List_authenticatedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	orgs, _, err := client.Organizations.List(context.Background(), "", nil)
+	ctx := context.Background()
+	orgs, _, err := client.Organizations.List(ctx, "", nil)
 	if err != nil {
 		t.Errorf("Organizations.List returned error: %v", err)
 	}
@@ -114,7 +116,8 @@ func TestOrganizationsService_List_specifiedUser(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	orgs, _, err := client.Organizations.List(context.Background(), "u", opt)
+	ctx := context.Background()
+	orgs, _, err := client.Organizations.List(ctx, "u", opt)
 	if err != nil {
 		t.Errorf("Organizations.List returned error: %v", err)
 	}
@@ -129,7 +132,8 @@ func TestOrganizationsService_List_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Organizations.List(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Organizations.List(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -143,7 +147,8 @@ func TestOrganizationsService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "login":"l", "url":"u", "avatar_url": "a", "location":"l"}`)
 	})
 
-	org, _, err := client.Organizations.Get(context.Background(), "o")
+	ctx := context.Background()
+	org, _, err := client.Organizations.Get(ctx, "o")
 	if err != nil {
 		t.Errorf("Organizations.Get returned error: %v", err)
 	}
@@ -158,7 +163,8 @@ func TestOrganizationsService_Get_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Organizations.Get(context.Background(), "%")
+	ctx := context.Background()
+	_, _, err := client.Organizations.Get(ctx, "%")
 	testURLParseError(t, err)
 }
 
@@ -171,7 +177,8 @@ func TestOrganizationsService_GetByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "login":"l", "url":"u", "avatar_url": "a", "location":"l"}`)
 	})
 
-	org, _, err := client.Organizations.GetByID(context.Background(), 1)
+	ctx := context.Background()
+	org, _, err := client.Organizations.GetByID(ctx, 1)
 	if err != nil {
 		t.Fatalf("Organizations.GetByID returned error: %v", err)
 	}
@@ -201,7 +208,8 @@ func TestOrganizationsService_Edit(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	org, _, err := client.Organizations.Edit(context.Background(), "o", input)
+	ctx := context.Background()
+	org, _, err := client.Organizations.Edit(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Organizations.Edit returned error: %v", err)
 	}
@@ -216,7 +224,8 @@ func TestOrganizationsService_Edit_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Organizations.Edit(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Organizations.Edit(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -229,7 +238,8 @@ func TestOrganizationsService_ListInstallations(t *testing.T) {
 		fmt.Fprint(w, `{"total_count": 1, "installations": [{ "id": 1, "app_id": 5}]}`)
 	})
 
-	apps, _, err := client.Organizations.ListInstallations(context.Background(), "o", nil)
+	ctx := context.Background()
+	apps, _, err := client.Organizations.ListInstallations(ctx, "o", nil)
 	if err != nil {
 		t.Errorf("Organizations.ListInstallations returned error: %v", err)
 	}
@@ -244,7 +254,8 @@ func TestOrganizationsService_ListInstallations_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Organizations.ListInstallations(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Organizations.ListInstallations(ctx, "%", nil)
 	testURLParseError(t, err)
 
 }
@@ -259,7 +270,8 @@ func TestOrganizationsService_ListInstallations_withListOptions(t *testing.T) {
 		fmt.Fprint(w, `{"total_count": 2, "installations": [{ "id": 2, "app_id": 10}]}`)
 	})
 
-	apps, _, err := client.Organizations.ListInstallations(context.Background(), "o", &ListOptions{Page: 2})
+	ctx := context.Background()
+	apps, _, err := client.Organizations.ListInstallations(ctx, "o", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Organizations.ListInstallations returned error: %v", err)
 	}
@@ -270,7 +282,7 @@ func TestOrganizationsService_ListInstallations_withListOptions(t *testing.T) {
 	}
 
 	// Test ListOptions failure
-	_, _, err = client.Organizations.ListInstallations(context.Background(), "%", &ListOptions{})
+	_, _, err = client.Organizations.ListInstallations(ctx, "%", &ListOptions{})
 	if err == nil {
 		t.Error("Organizations.ListInstallations returned error: nil")
 	}

--- a/github/orgs_users_blocking_test.go
+++ b/github/orgs_users_blocking_test.go
@@ -27,7 +27,8 @@ func TestOrganizationsService_ListBlockedUsers(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	blockedUsers, _, err := client.Organizations.ListBlockedUsers(context.Background(), "o", opt)
+	ctx := context.Background()
+	blockedUsers, _, err := client.Organizations.ListBlockedUsers(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListBlockedUsers returned error: %v", err)
 	}
@@ -48,7 +49,8 @@ func TestOrganizationsService_IsBlocked(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	isBlocked, _, err := client.Organizations.IsBlocked(context.Background(), "o", "u")
+	ctx := context.Background()
+	isBlocked, _, err := client.Organizations.IsBlocked(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.IsBlocked returned error: %v", err)
 	}
@@ -67,7 +69,8 @@ func TestOrganizationsService_BlockUser(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Organizations.BlockUser(context.Background(), "o", "u")
+	ctx := context.Background()
+	_, err := client.Organizations.BlockUser(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.BlockUser returned error: %v", err)
 	}
@@ -83,7 +86,8 @@ func TestOrganizationsService_UnblockUser(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Organizations.UnblockUser(context.Background(), "o", "u")
+	ctx := context.Background()
+	_, err := client.Organizations.UnblockUser(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.UnblockUser returned error: %v", err)
 	}

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -108,7 +108,8 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	project, _, err := client.Projects.UpdateProject(context.Background(), 1, input)
+	ctx := context.Background()
+	project, _, err := client.Projects.UpdateProject(ctx, 1, input)
 	if err != nil {
 		t.Errorf("Projects.UpdateProject returned error: %v", err)
 	}
@@ -129,7 +130,8 @@ func TestProjectsService_GetProject(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	project, _, err := client.Projects.GetProject(context.Background(), 1)
+	ctx := context.Background()
+	project, _, err := client.Projects.GetProject(ctx, 1)
 	if err != nil {
 		t.Errorf("Projects.GetProject returned error: %v", err)
 	}
@@ -149,7 +151,8 @@ func TestProjectsService_DeleteProject(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 	})
 
-	_, err := client.Projects.DeleteProject(context.Background(), 1)
+	ctx := context.Background()
+	_, err := client.Projects.DeleteProject(ctx, 1)
 	if err != nil {
 		t.Errorf("Projects.DeleteProject returned error: %v", err)
 	}
@@ -168,7 +171,8 @@ func TestProjectsService_ListProjectColumns(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	columns, _, err := client.Projects.ListProjectColumns(context.Background(), 1, opt)
+	ctx := context.Background()
+	columns, _, err := client.Projects.ListProjectColumns(ctx, 1, opt)
 	if err != nil {
 		t.Errorf("Projects.ListProjectColumns returned error: %v", err)
 	}
@@ -189,7 +193,8 @@ func TestProjectsService_GetProjectColumn(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	column, _, err := client.Projects.GetProjectColumn(context.Background(), 1)
+	ctx := context.Background()
+	column, _, err := client.Projects.GetProjectColumn(ctx, 1)
 	if err != nil {
 		t.Errorf("Projects.GetProjectColumn returned error: %v", err)
 	}
@@ -219,7 +224,8 @@ func TestProjectsService_CreateProjectColumn(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	column, _, err := client.Projects.CreateProjectColumn(context.Background(), 1, input)
+	ctx := context.Background()
+	column, _, err := client.Projects.CreateProjectColumn(ctx, 1, input)
 	if err != nil {
 		t.Errorf("Projects.CreateProjectColumn returned error: %v", err)
 	}
@@ -249,7 +255,8 @@ func TestProjectsService_UpdateProjectColumn(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	column, _, err := client.Projects.UpdateProjectColumn(context.Background(), 1, input)
+	ctx := context.Background()
+	column, _, err := client.Projects.UpdateProjectColumn(ctx, 1, input)
 	if err != nil {
 		t.Errorf("Projects.UpdateProjectColumn returned error: %v", err)
 	}
@@ -269,7 +276,8 @@ func TestProjectsService_DeleteProjectColumn(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 	})
 
-	_, err := client.Projects.DeleteProjectColumn(context.Background(), 1)
+	ctx := context.Background()
+	_, err := client.Projects.DeleteProjectColumn(ctx, 1)
 	if err != nil {
 		t.Errorf("Projects.DeleteProjectColumn returned error: %v", err)
 	}
@@ -292,7 +300,8 @@ func TestProjectsService_MoveProjectColumn(t *testing.T) {
 		}
 	})
 
-	_, err := client.Projects.MoveProjectColumn(context.Background(), 1, input)
+	ctx := context.Background()
+	_, err := client.Projects.MoveProjectColumn(ctx, 1, input)
 	if err != nil {
 		t.Errorf("Projects.MoveProjectColumn returned error: %v", err)
 	}
@@ -314,7 +323,8 @@ func TestProjectsService_ListProjectCards(t *testing.T) {
 	opt := &ProjectCardListOptions{
 		ArchivedState: String("all"),
 		ListOptions:   ListOptions{Page: 2}}
-	cards, _, err := client.Projects.ListProjectCards(context.Background(), 1, opt)
+	ctx := context.Background()
+	cards, _, err := client.Projects.ListProjectCards(ctx, 1, opt)
 	if err != nil {
 		t.Errorf("Projects.ListProjectCards returned error: %v", err)
 	}
@@ -335,7 +345,8 @@ func TestProjectsService_GetProjectCard(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	card, _, err := client.Projects.GetProjectCard(context.Background(), 1)
+	ctx := context.Background()
+	card, _, err := client.Projects.GetProjectCard(ctx, 1)
 	if err != nil {
 		t.Errorf("Projects.GetProjectCard returned error: %v", err)
 	}
@@ -368,7 +379,8 @@ func TestProjectsService_CreateProjectCard(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	card, _, err := client.Projects.CreateProjectCard(context.Background(), 1, input)
+	ctx := context.Background()
+	card, _, err := client.Projects.CreateProjectCard(ctx, 1, input)
 	if err != nil {
 		t.Errorf("Projects.CreateProjectCard returned error: %v", err)
 	}
@@ -401,7 +413,8 @@ func TestProjectsService_UpdateProjectCard(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "archived":false}`)
 	})
 
-	card, _, err := client.Projects.UpdateProjectCard(context.Background(), 1, input)
+	ctx := context.Background()
+	card, _, err := client.Projects.UpdateProjectCard(ctx, 1, input)
 	if err != nil {
 		t.Errorf("Projects.UpdateProjectCard returned error: %v", err)
 	}
@@ -421,7 +434,8 @@ func TestProjectsService_DeleteProjectCard(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 	})
 
-	_, err := client.Projects.DeleteProjectCard(context.Background(), 1)
+	ctx := context.Background()
+	_, err := client.Projects.DeleteProjectCard(ctx, 1)
 	if err != nil {
 		t.Errorf("Projects.DeleteProjectCard returned error: %v", err)
 	}
@@ -444,7 +458,8 @@ func TestProjectsService_MoveProjectCard(t *testing.T) {
 		}
 	})
 
-	_, err := client.Projects.MoveProjectCard(context.Background(), 1, input)
+	ctx := context.Background()
+	_, err := client.Projects.MoveProjectCard(ctx, 1, input)
 	if err != nil {
 		t.Errorf("Projects.MoveProjectCard returned error: %v", err)
 	}
@@ -471,7 +486,8 @@ func TestProjectsService_AddProjectCollaborator(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Projects.AddProjectCollaborator(context.Background(), 1, "u", opt)
+	ctx := context.Background()
+	_, err := client.Projects.AddProjectCollaborator(ctx, 1, "u", opt)
 	if err != nil {
 		t.Errorf("Projects.AddProjectCollaborator returned error: %v", err)
 	}
@@ -481,7 +497,8 @@ func TestProjectsService_AddCollaborator_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Projects.AddProjectCollaborator(context.Background(), 1, "%", nil)
+	ctx := context.Background()
+	_, err := client.Projects.AddProjectCollaborator(ctx, 1, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -495,7 +512,8 @@ func TestProjectsService_RemoveCollaborator(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Projects.RemoveProjectCollaborator(context.Background(), 1, "u")
+	ctx := context.Background()
+	_, err := client.Projects.RemoveProjectCollaborator(ctx, 1, "u")
 	if err != nil {
 		t.Errorf("Projects.RemoveProjectCollaborator returned error: %v", err)
 	}
@@ -505,7 +523,8 @@ func TestProjectsService_RemoveCollaborator_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Projects.RemoveProjectCollaborator(context.Background(), 1, "%")
+	ctx := context.Background()
+	_, err := client.Projects.RemoveProjectCollaborator(ctx, 1, "%")
 	testURLParseError(t, err)
 }
 
@@ -523,7 +542,8 @@ func TestProjectsService_ListCollaborators(t *testing.T) {
 	opt := &ListCollaboratorOptions{
 		ListOptions: ListOptions{Page: 2},
 	}
-	users, _, err := client.Projects.ListProjectCollaborators(context.Background(), 1, opt)
+	ctx := context.Background()
+	users, _, err := client.Projects.ListProjectCollaborators(ctx, 1, opt)
 	if err != nil {
 		t.Errorf("Projects.ListProjectCollaborators returned error: %v", err)
 	}
@@ -549,7 +569,8 @@ func TestProjectsService_ListCollaborators_withAffiliation(t *testing.T) {
 		ListOptions: ListOptions{Page: 2},
 		Affiliation: String("all"),
 	}
-	users, _, err := client.Projects.ListProjectCollaborators(context.Background(), 1, opt)
+	ctx := context.Background()
+	users, _, err := client.Projects.ListProjectCollaborators(ctx, 1, opt)
 	if err != nil {
 		t.Errorf("Projects.ListProjectCollaborators returned error: %v", err)
 	}
@@ -570,7 +591,8 @@ func TestProjectsService_GetPermissionLevel(t *testing.T) {
 		fmt.Fprintf(w, `{"permission":"admin","user":{"login":"u"}}`)
 	})
 
-	ppl, _, err := client.Projects.ReviewProjectCollaboratorPermission(context.Background(), 1, "u")
+	ctx := context.Background()
+	ppl, _, err := client.Projects.ReviewProjectCollaboratorPermission(ctx, 1, "u")
 	if err != nil {
 		t.Errorf("Projects.ReviewProjectCollaboratorPermission returned error: %v", err)
 	}

--- a/github/pulls_comments_test.go
+++ b/github/pulls_comments_test.go
@@ -155,7 +155,8 @@ func TestPullRequestsService_ListComments_allPulls(t *testing.T) {
 		Since:       time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC),
 		ListOptions: ListOptions{Page: 2},
 	}
-	pulls, _, err := client.PullRequests.ListComments(context.Background(), "o", "r", 0, opt)
+	ctx := context.Background()
+	pulls, _, err := client.PullRequests.ListComments(ctx, "o", "r", 0, opt)
 	if err != nil {
 		t.Errorf("PullRequests.ListComments returned error: %v", err)
 	}
@@ -177,7 +178,8 @@ func TestPullRequestsService_ListComments_specificPull(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1, "pull_request_review_id":42}]`)
 	})
 
-	pulls, _, err := client.PullRequests.ListComments(context.Background(), "o", "r", 1, nil)
+	ctx := context.Background()
+	pulls, _, err := client.PullRequests.ListComments(ctx, "o", "r", 1, nil)
 	if err != nil {
 		t.Errorf("PullRequests.ListComments returned error: %v", err)
 	}
@@ -192,7 +194,8 @@ func TestPullRequestsService_ListComments_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.ListComments(context.Background(), "%", "r", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.PullRequests.ListComments(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -207,7 +210,8 @@ func TestPullRequestsService_GetComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	comment, _, err := client.PullRequests.GetComment(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	comment, _, err := client.PullRequests.GetComment(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("PullRequests.GetComment returned error: %v", err)
 	}
@@ -222,7 +226,8 @@ func TestPullRequestsService_GetComment_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.GetComment(context.Background(), "%", "r", 1)
+	ctx := context.Background()
+	_, _, err := client.PullRequests.GetComment(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
 
@@ -247,7 +252,8 @@ func TestPullRequestsService_CreateComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	comment, _, err := client.PullRequests.CreateComment(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	comment, _, err := client.PullRequests.CreateComment(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("PullRequests.CreateComment returned error: %v", err)
 	}
@@ -262,7 +268,8 @@ func TestPullRequestsService_CreateComment_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.CreateComment(context.Background(), "%", "r", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.PullRequests.CreateComment(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -284,7 +291,8 @@ func TestPullRequestsService_EditComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	comment, _, err := client.PullRequests.EditComment(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	comment, _, err := client.PullRequests.EditComment(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("PullRequests.EditComment returned error: %v", err)
 	}
@@ -299,7 +307,8 @@ func TestPullRequestsService_EditComment_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.EditComment(context.Background(), "%", "r", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.PullRequests.EditComment(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -311,7 +320,8 @@ func TestPullRequestsService_DeleteComment(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.PullRequests.DeleteComment(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	_, err := client.PullRequests.DeleteComment(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("PullRequests.DeleteComment returned error: %v", err)
 	}
@@ -321,6 +331,7 @@ func TestPullRequestsService_DeleteComment_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.PullRequests.DeleteComment(context.Background(), "%", "r", 1)
+	ctx := context.Background()
+	_, err := client.PullRequests.DeleteComment(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }

--- a/github/pulls_reviewers_test.go
+++ b/github/pulls_reviewers_test.go
@@ -162,13 +162,14 @@ func TestListReviewers_withOptions(t *testing.T) {
 		fmt.Fprint(w, `{}`)
 	})
 
-	_, _, err := client.PullRequests.ListReviewers(context.Background(), "o", "r", 1, &ListOptions{Page: 2})
+	ctx := context.Background()
+	_, _, err := client.PullRequests.ListReviewers(ctx, "o", "r", 1, &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("PullRequests.ListReviewers returned error: %v", err)
 	}
 
 	// Test addOptions failure
-	_, _, err = client.PullRequests.ListReviewers(context.Background(), "\n", "\n", 1, &ListOptions{Page: 2})
+	_, _, err = client.PullRequests.ListReviewers(ctx, "\n", "\n", 1, &ListOptions{Page: 2})
 	if err == nil {
 		t.Error("bad options ListReviewers err = nil, want error")
 	}

--- a/github/pulls_reviews_test.go
+++ b/github/pulls_reviews_test.go
@@ -109,7 +109,8 @@ func TestPullRequestsService_ListReviews(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	reviews, _, err := client.PullRequests.ListReviews(context.Background(), "o", "r", 1, opt)
+	ctx := context.Background()
+	reviews, _, err := client.PullRequests.ListReviews(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("PullRequests.ListReviews returned error: %v", err)
 	}
@@ -127,7 +128,8 @@ func TestPullRequestsService_ListReviews_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.ListReviews(context.Background(), "%", "r", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.PullRequests.ListReviews(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -140,7 +142,8 @@ func TestPullRequestsService_GetReview(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	review, _, err := client.PullRequests.GetReview(context.Background(), "o", "r", 1, 1)
+	ctx := context.Background()
+	review, _, err := client.PullRequests.GetReview(ctx, "o", "r", 1, 1)
 	if err != nil {
 		t.Errorf("PullRequests.GetReview returned error: %v", err)
 	}
@@ -155,7 +158,8 @@ func TestPullRequestsService_GetReview_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.GetReview(context.Background(), "%", "r", 1, 1)
+	ctx := context.Background()
+	_, _, err := client.PullRequests.GetReview(ctx, "%", "r", 1, 1)
 	testURLParseError(t, err)
 }
 
@@ -168,7 +172,8 @@ func TestPullRequestsService_DeletePendingReview(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	review, _, err := client.PullRequests.DeletePendingReview(context.Background(), "o", "r", 1, 1)
+	ctx := context.Background()
+	review, _, err := client.PullRequests.DeletePendingReview(ctx, "o", "r", 1, 1)
 	if err != nil {
 		t.Errorf("PullRequests.DeletePendingReview returned error: %v", err)
 	}
@@ -183,7 +188,8 @@ func TestPullRequestsService_DeletePendingReview_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.DeletePendingReview(context.Background(), "%", "r", 1, 1)
+	ctx := context.Background()
+	_, _, err := client.PullRequests.DeletePendingReview(ctx, "%", "r", 1, 1)
 	testURLParseError(t, err)
 }
 
@@ -196,7 +202,8 @@ func TestPullRequestsService_ListReviewComments(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	comments, _, err := client.PullRequests.ListReviewComments(context.Background(), "o", "r", 1, 1, nil)
+	ctx := context.Background()
+	comments, _, err := client.PullRequests.ListReviewComments(ctx, "o", "r", 1, 1, nil)
 	if err != nil {
 		t.Errorf("PullRequests.ListReviewComments returned error: %v", err)
 	}
@@ -222,7 +229,8 @@ func TestPullRequestsService_ListReviewComments_withOptions(t *testing.T) {
 		fmt.Fprint(w, `[]`)
 	})
 
-	_, _, err := client.PullRequests.ListReviewComments(context.Background(), "o", "r", 1, 1, &ListOptions{Page: 2})
+	ctx := context.Background()
+	_, _, err := client.PullRequests.ListReviewComments(ctx, "o", "r", 1, 1, &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("PullRequests.ListReviewComments returned error: %v", err)
 	}
@@ -347,7 +355,8 @@ func TestPullRequestsService_ListReviewComments_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.ListReviewComments(context.Background(), "%", "r", 1, 1, nil)
+	ctx := context.Background()
+	_, _, err := client.PullRequests.ListReviewComments(ctx, "%", "r", 1, 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -373,7 +382,8 @@ func TestPullRequestsService_CreateReview(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	review, _, err := client.PullRequests.CreateReview(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	review, _, err := client.PullRequests.CreateReview(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("PullRequests.CreateReview returned error: %v", err)
 	}
@@ -388,7 +398,8 @@ func TestPullRequestsService_CreateReview_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.CreateReview(context.Background(), "%", "r", 1, &PullRequestReviewRequest{})
+	ctx := context.Background()
+	_, _, err := client.PullRequests.CreateReview(ctx, "%", "r", 1, &PullRequestReviewRequest{})
 	testURLParseError(t, err)
 }
 
@@ -401,7 +412,8 @@ func TestPullRequestsService_UpdateReview(t *testing.T) {
 		fmt.Fprintf(w, `{"id":1}`)
 	})
 
-	got, _, err := client.PullRequests.UpdateReview(context.Background(), "o", "r", 1, 1, "updated_body")
+	ctx := context.Background()
+	got, _, err := client.PullRequests.UpdateReview(ctx, "o", "r", 1, 1, "updated_body")
 	if err != nil {
 		t.Errorf("PullRequests.UpdateReview returned error: %v", err)
 	}
@@ -433,7 +445,8 @@ func TestPullRequestsService_SubmitReview(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	review, _, err := client.PullRequests.SubmitReview(context.Background(), "o", "r", 1, 1, input)
+	ctx := context.Background()
+	review, _, err := client.PullRequests.SubmitReview(ctx, "o", "r", 1, 1, input)
 	if err != nil {
 		t.Errorf("PullRequests.SubmitReview returned error: %v", err)
 	}
@@ -448,7 +461,8 @@ func TestPullRequestsService_SubmitReview_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.SubmitReview(context.Background(), "%", "r", 1, 1, &PullRequestReviewRequest{})
+	ctx := context.Background()
+	_, _, err := client.PullRequests.SubmitReview(ctx, "%", "r", 1, 1, &PullRequestReviewRequest{})
 	testURLParseError(t, err)
 }
 
@@ -470,7 +484,8 @@ func TestPullRequestsService_DismissReview(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	review, _, err := client.PullRequests.DismissReview(context.Background(), "o", "r", 1, 1, input)
+	ctx := context.Background()
+	review, _, err := client.PullRequests.DismissReview(ctx, "o", "r", 1, 1, input)
 	if err != nil {
 		t.Errorf("PullRequests.DismissReview returned error: %v", err)
 	}
@@ -485,6 +500,7 @@ func TestPullRequestsService_DismissReview_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.DismissReview(context.Background(), "%", "r", 1, 1, &PullRequestReviewDismissalRequest{})
+	ctx := context.Background()
+	_, _, err := client.PullRequests.DismissReview(ctx, "%", "r", 1, 1, &PullRequestReviewDismissalRequest{})
 	testURLParseError(t, err)
 }

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -34,7 +34,8 @@ func TestPullRequestsService_List(t *testing.T) {
 	})
 
 	opts := &PullRequestListOptions{"closed", "h", "b", "created", "desc", ListOptions{Page: 2}}
-	pulls, _, err := client.PullRequests.List(context.Background(), "o", "r", opts)
+	ctx := context.Background()
+	pulls, _, err := client.PullRequests.List(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("PullRequests.List returned error: %v", err)
 	}
@@ -64,7 +65,8 @@ func TestPullRequestsService_ListPullRequestsWithCommit(t *testing.T) {
 	})
 
 	opts := &PullRequestListOptions{"closed", "h", "b", "created", "desc", ListOptions{Page: 2}}
-	pulls, _, err := client.PullRequests.ListPullRequestsWithCommit(context.Background(), "o", "r", "sha", opts)
+	ctx := context.Background()
+	pulls, _, err := client.PullRequests.ListPullRequestsWithCommit(ctx, "o", "r", "sha", opts)
 	if err != nil {
 		t.Errorf("PullRequests.ListPullRequestsWithCommit returned error: %v", err)
 	}
@@ -79,7 +81,8 @@ func TestPullRequestsService_List_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.List(context.Background(), "%", "r", nil)
+	ctx := context.Background()
+	_, _, err := client.PullRequests.List(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
 
@@ -92,7 +95,8 @@ func TestPullRequestsService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	pull, _, err := client.PullRequests.Get(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	pull, _, err := client.PullRequests.Get(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("PullRequests.Get returned error: %v", err)
 	}
@@ -115,7 +119,8 @@ func TestPullRequestsService_GetRaw_diff(t *testing.T) {
 		fmt.Fprint(w, rawStr)
 	})
 
-	got, _, err := client.PullRequests.GetRaw(context.Background(), "o", "r", 1, RawOptions{Diff})
+	ctx := context.Background()
+	got, _, err := client.PullRequests.GetRaw(ctx, "o", "r", 1, RawOptions{Diff})
 	if err != nil {
 		t.Fatalf("PullRequests.GetRaw returned error: %v", err)
 	}
@@ -137,7 +142,8 @@ func TestPullRequestsService_GetRaw_patch(t *testing.T) {
 		fmt.Fprint(w, rawStr)
 	})
 
-	got, _, err := client.PullRequests.GetRaw(context.Background(), "o", "r", 1, RawOptions{Patch})
+	ctx := context.Background()
+	got, _, err := client.PullRequests.GetRaw(ctx, "o", "r", 1, RawOptions{Patch})
 	if err != nil {
 		t.Fatalf("PullRequests.GetRaw returned error: %v", err)
 	}
@@ -151,7 +157,8 @@ func TestPullRequestsService_GetRaw_invalid(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.GetRaw(context.Background(), "o", "r", 1, RawOptions{100})
+	ctx := context.Background()
+	_, _, err := client.PullRequests.GetRaw(ctx, "o", "r", 1, RawOptions{100})
 	if err == nil {
 		t.Fatal("PullRequests.GetRaw should return error")
 	}
@@ -181,7 +188,8 @@ func TestPullRequestsService_Get_links(t *testing.T) {
 			}`)
 	})
 
-	pull, _, err := client.PullRequests.Get(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	pull, _, err := client.PullRequests.Get(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("PullRequests.Get returned error: %v", err)
 	}
@@ -222,7 +230,8 @@ func TestPullRequestsService_Get_headAndBase(t *testing.T) {
 		fmt.Fprint(w, `{"number":1,"head":{"ref":"r2","repo":{"id":2}},"base":{"ref":"r1","repo":{"id":1}}}`)
 	})
 
-	pull, _, err := client.PullRequests.Get(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	pull, _, err := client.PullRequests.Get(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("PullRequests.Get returned error: %v", err)
 	}
@@ -260,7 +269,8 @@ func TestPullRequestsService_Get_urlFields(t *testing.T) {
 			"review_comment_url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments{/number}"}`)
 	})
 
-	pull, _, err := client.PullRequests.Get(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	pull, _, err := client.PullRequests.Get(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("PullRequests.Get returned error: %v", err)
 	}
@@ -286,7 +296,8 @@ func TestPullRequestsService_Get_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.Get(context.Background(), "%", "r", 1)
+	ctx := context.Background()
+	_, _, err := client.PullRequests.Get(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
 
@@ -308,7 +319,8 @@ func TestPullRequestsService_Create(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	pull, _, err := client.PullRequests.Create(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	pull, _, err := client.PullRequests.Create(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("PullRequests.Create returned error: %v", err)
 	}
@@ -323,7 +335,8 @@ func TestPullRequestsService_Create_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.Create(context.Background(), "%", "r", nil)
+	ctx := context.Background()
+	_, _, err := client.PullRequests.Create(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
 
@@ -345,7 +358,8 @@ func TestPullRequestsService_UpdateBranch(t *testing.T) {
 		ExpectedHeadSHA: String("s"),
 	}
 
-	pull, _, err := client.PullRequests.UpdateBranch(context.Background(), "o", "r", 1, opts)
+	ctx := context.Background()
+	pull, _, err := client.PullRequests.UpdateBranch(ctx, "o", "r", 1, opts)
 	if err != nil {
 		t.Errorf("PullRequests.UpdateBranch returned error: %v", err)
 	}
@@ -398,7 +412,8 @@ func TestPullRequestsService_Edit(t *testing.T) {
 			madeRequest = true
 		})
 
-		pull, _, err := client.PullRequests.Edit(context.Background(), "o", "r", i, tt.input)
+		ctx := context.Background()
+		pull, _, err := client.PullRequests.Edit(ctx, "o", "r", i, tt.input)
 		if err != nil {
 			t.Errorf("%d: PullRequests.Edit returned error: %v", i, err)
 		}
@@ -417,7 +432,8 @@ func TestPullRequestsService_Edit_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.PullRequests.Edit(context.Background(), "%", "r", 1, &PullRequest{})
+	ctx := context.Background()
+	_, _, err := client.PullRequests.Edit(ctx, "%", "r", 1, &PullRequest{})
 	testURLParseError(t, err)
 }
 
@@ -450,7 +466,8 @@ func TestPullRequestsService_ListCommits(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2}
-	commits, _, err := client.PullRequests.ListCommits(context.Background(), "o", "r", 1, opts)
+	ctx := context.Background()
+	commits, _, err := client.PullRequests.ListCommits(ctx, "o", "r", 1, opts)
 	if err != nil {
 		t.Errorf("PullRequests.ListCommits returned error: %v", err)
 	}
@@ -509,7 +526,8 @@ func TestPullRequestsService_ListFiles(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2}
-	commitFiles, _, err := client.PullRequests.ListFiles(context.Background(), "o", "r", 1, opts)
+	ctx := context.Background()
+	commitFiles, _, err := client.PullRequests.ListFiles(ctx, "o", "r", 1, opts)
 	if err != nil {
 		t.Errorf("PullRequests.ListFiles returned error: %v", err)
 	}
@@ -549,7 +567,8 @@ func TestPullRequestsService_IsMerged(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	isMerged, _, err := client.PullRequests.IsMerged(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	isMerged, _, err := client.PullRequests.IsMerged(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("PullRequests.IsMerged returned error: %v", err)
 	}
@@ -575,7 +594,8 @@ func TestPullRequestsService_Merge(t *testing.T) {
 	})
 
 	options := &PullRequestOptions{MergeMethod: "rebase"}
-	merge, _, err := client.PullRequests.Merge(context.Background(), "o", "r", 1, "merging pull request", options)
+	ctx := context.Background()
+	merge, _, err := client.PullRequests.Merge(ctx, "o", "r", 1, "merging pull request", options)
 	if err != nil {
 		t.Errorf("PullRequests.Merge returned error: %v", err)
 	}
@@ -632,7 +652,8 @@ func TestPullRequestsService_Merge_options(t *testing.T) {
 			testBody(t, r, test.wantBody+"\n")
 			madeRequest = true
 		})
-		_, _, _ = client.PullRequests.Merge(context.Background(), "o", "r", i, "merging pull request", test.options)
+		ctx := context.Background()
+		_, _, _ = client.PullRequests.Merge(ctx, "o", "r", i, "merging pull request", test.options)
 		if !madeRequest {
 			t.Errorf("%d: PullRequests.Merge(%#v): expected request was not made", i, test.options)
 		}

--- a/github/reactions_test.go
+++ b/github/reactions_test.go
@@ -77,7 +77,8 @@ func TestReactionsService_ListCommentReactions(t *testing.T) {
 	})
 
 	opt := &ListCommentReactionOptions{Content: "+1"}
-	reactions, _, err := client.Reactions.ListCommentReactions(context.Background(), "o", "r", 1, opt)
+	ctx := context.Background()
+	reactions, _, err := client.Reactions.ListCommentReactions(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("ListCommentReactions returned error: %v", err)
 	}
@@ -99,7 +100,8 @@ func TestReactionsService_CreateCommentReaction(t *testing.T) {
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
 	})
 
-	got, _, err := client.Reactions.CreateCommentReaction(context.Background(), "o", "r", 1, "+1")
+	ctx := context.Background()
+	got, _, err := client.Reactions.CreateCommentReaction(ctx, "o", "r", 1, "+1")
 	if err != nil {
 		t.Errorf("CreateCommentReaction returned error: %v", err)
 	}
@@ -121,7 +123,8 @@ func TestReactionsService_ListIssueReactions(t *testing.T) {
 		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
 	})
 
-	got, _, err := client.Reactions.ListIssueReactions(context.Background(), "o", "r", 1, nil)
+	ctx := context.Background()
+	got, _, err := client.Reactions.ListIssueReactions(ctx, "o", "r", 1, nil)
 	if err != nil {
 		t.Errorf("ListIssueReactions returned error: %v", err)
 	}
@@ -143,7 +146,8 @@ func TestReactionsService_CreateIssueReaction(t *testing.T) {
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
 	})
 
-	got, _, err := client.Reactions.CreateIssueReaction(context.Background(), "o", "r", 1, "+1")
+	ctx := context.Background()
+	got, _, err := client.Reactions.CreateIssueReaction(ctx, "o", "r", 1, "+1")
 	if err != nil {
 		t.Errorf("CreateIssueReaction returned error: %v", err)
 	}
@@ -165,7 +169,8 @@ func TestReactionsService_ListIssueCommentReactions(t *testing.T) {
 		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
 	})
 
-	got, _, err := client.Reactions.ListIssueCommentReactions(context.Background(), "o", "r", 1, nil)
+	ctx := context.Background()
+	got, _, err := client.Reactions.ListIssueCommentReactions(ctx, "o", "r", 1, nil)
 	if err != nil {
 		t.Errorf("ListIssueCommentReactions returned error: %v", err)
 	}
@@ -187,7 +192,8 @@ func TestReactionsService_CreateIssueCommentReaction(t *testing.T) {
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
 	})
 
-	got, _, err := client.Reactions.CreateIssueCommentReaction(context.Background(), "o", "r", 1, "+1")
+	ctx := context.Background()
+	got, _, err := client.Reactions.CreateIssueCommentReaction(ctx, "o", "r", 1, "+1")
 	if err != nil {
 		t.Errorf("CreateIssueCommentReaction returned error: %v", err)
 	}
@@ -209,7 +215,8 @@ func TestReactionsService_ListPullRequestCommentReactions(t *testing.T) {
 		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
 	})
 
-	got, _, err := client.Reactions.ListPullRequestCommentReactions(context.Background(), "o", "r", 1, nil)
+	ctx := context.Background()
+	got, _, err := client.Reactions.ListPullRequestCommentReactions(ctx, "o", "r", 1, nil)
 	if err != nil {
 		t.Errorf("ListPullRequestCommentReactions returned error: %v", err)
 	}
@@ -231,7 +238,8 @@ func TestReactionsService_CreatePullRequestCommentReaction(t *testing.T) {
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
 	})
 
-	got, _, err := client.Reactions.CreatePullRequestCommentReaction(context.Background(), "o", "r", 1, "+1")
+	ctx := context.Background()
+	got, _, err := client.Reactions.CreatePullRequestCommentReaction(ctx, "o", "r", 1, "+1")
 	if err != nil {
 		t.Errorf("CreatePullRequestCommentReaction returned error: %v", err)
 	}
@@ -253,7 +261,8 @@ func TestReactionsService_ListTeamDiscussionReactions(t *testing.T) {
 		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
 	})
 
-	got, _, err := client.Reactions.ListTeamDiscussionReactions(context.Background(), 1, 2, nil)
+	ctx := context.Background()
+	got, _, err := client.Reactions.ListTeamDiscussionReactions(ctx, 1, 2, nil)
 	if err != nil {
 		t.Errorf("ListTeamDiscussionReactions returned error: %v", err)
 	}
@@ -275,7 +284,8 @@ func TestReactionsService_CreateTeamDiscussionReaction(t *testing.T) {
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
 	})
 
-	got, _, err := client.Reactions.CreateTeamDiscussionReaction(context.Background(), 1, 2, "+1")
+	ctx := context.Background()
+	got, _, err := client.Reactions.CreateTeamDiscussionReaction(ctx, 1, 2, "+1")
 	if err != nil {
 		t.Errorf("CreateTeamDiscussionReaction returned error: %v", err)
 	}
@@ -297,7 +307,8 @@ func TestReactionService_ListTeamDiscussionCommentReactions(t *testing.T) {
 		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
 	})
 
-	got, _, err := client.Reactions.ListTeamDiscussionCommentReactions(context.Background(), 1, 2, 3, nil)
+	ctx := context.Background()
+	got, _, err := client.Reactions.ListTeamDiscussionCommentReactions(ctx, 1, 2, 3, nil)
 	if err != nil {
 		t.Errorf("ListTeamDiscussionCommentReactions returned error: %v", err)
 	}
@@ -319,7 +330,8 @@ func TestReactionService_CreateTeamDiscussionCommentReaction(t *testing.T) {
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
 	})
 
-	got, _, err := client.Reactions.CreateTeamDiscussionCommentReaction(context.Background(), 1, 2, 3, "+1")
+	ctx := context.Background()
+	got, _, err := client.Reactions.CreateTeamDiscussionCommentReaction(ctx, 1, 2, 3, "+1")
 	if err != nil {
 		t.Errorf("CreateTeamDiscussionCommentReaction returned error: %v", err)
 	}
@@ -340,7 +352,8 @@ func TestReactionsService_DeleteCommitCommentReaction(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Reactions.DeleteCommentReaction(context.Background(), "o", "r", 1, 2); err != nil {
+	ctx := context.Background()
+	if _, err := client.Reactions.DeleteCommentReaction(ctx, "o", "r", 1, 2); err != nil {
 		t.Errorf("DeleteCommentReaction returned error: %v", err)
 	}
 }
@@ -356,7 +369,8 @@ func TestReactionsService_DeleteCommitCommentReactionByRepoID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Reactions.DeleteCommentReactionByID(context.Background(), 1, 2, 3); err != nil {
+	ctx := context.Background()
+	if _, err := client.Reactions.DeleteCommentReactionByID(ctx, 1, 2, 3); err != nil {
 		t.Errorf("DeleteCommentReactionByRepoID returned error: %v", err)
 	}
 }
@@ -372,7 +386,8 @@ func TestReactionsService_DeleteIssueReaction(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Reactions.DeleteIssueReaction(context.Background(), "o", "r", 1, 2); err != nil {
+	ctx := context.Background()
+	if _, err := client.Reactions.DeleteIssueReaction(ctx, "o", "r", 1, 2); err != nil {
 		t.Errorf("DeleteIssueReaction returned error: %v", err)
 	}
 }
@@ -388,7 +403,8 @@ func TestReactionsService_DeleteIssueReactionByRepoID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Reactions.DeleteIssueReactionByID(context.Background(), 1, 2, 3); err != nil {
+	ctx := context.Background()
+	if _, err := client.Reactions.DeleteIssueReactionByID(ctx, 1, 2, 3); err != nil {
 		t.Errorf("DeleteIssueReactionByRepoID returned error: %v", err)
 	}
 }
@@ -404,7 +420,8 @@ func TestReactionsService_DeleteIssueCommentReaction(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Reactions.DeleteIssueCommentReaction(context.Background(), "o", "r", 1, 2); err != nil {
+	ctx := context.Background()
+	if _, err := client.Reactions.DeleteIssueCommentReaction(ctx, "o", "r", 1, 2); err != nil {
 		t.Errorf("DeleteIssueCommentReaction returned error: %v", err)
 	}
 }
@@ -420,7 +437,8 @@ func TestReactionsService_DeleteIssueCommentReactionByRepoID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Reactions.DeleteIssueCommentReactionByID(context.Background(), 1, 2, 3); err != nil {
+	ctx := context.Background()
+	if _, err := client.Reactions.DeleteIssueCommentReactionByID(ctx, 1, 2, 3); err != nil {
 		t.Errorf("DeleteIssueCommentReactionByRepoID returned error: %v", err)
 	}
 }
@@ -436,7 +454,8 @@ func TestReactionsService_DeletePullRequestCommentReaction(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Reactions.DeletePullRequestCommentReaction(context.Background(), "o", "r", 1, 2); err != nil {
+	ctx := context.Background()
+	if _, err := client.Reactions.DeletePullRequestCommentReaction(ctx, "o", "r", 1, 2); err != nil {
 		t.Errorf("DeletePullRequestCommentReaction returned error: %v", err)
 	}
 }
@@ -452,7 +471,8 @@ func TestReactionsService_DeletePullRequestCommentReactionByRepoID(t *testing.T)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Reactions.DeletePullRequestCommentReactionByID(context.Background(), 1, 2, 3); err != nil {
+	ctx := context.Background()
+	if _, err := client.Reactions.DeletePullRequestCommentReactionByID(ctx, 1, 2, 3); err != nil {
 		t.Errorf("DeletePullRequestCommentReactionByRepoID returned error: %v", err)
 	}
 }
@@ -468,7 +488,8 @@ func TestReactionsService_DeleteTeamDiscussionReaction(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Reactions.DeleteTeamDiscussionReaction(context.Background(), "o", "s", 1, 2); err != nil {
+	ctx := context.Background()
+	if _, err := client.Reactions.DeleteTeamDiscussionReaction(ctx, "o", "s", 1, 2); err != nil {
 		t.Errorf("DeleteTeamDiscussionReaction returned error: %v", err)
 	}
 }
@@ -484,7 +505,8 @@ func TestReactionsService_DeleteTeamDiscussionReactionByTeamIDAndOrgID(t *testin
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Reactions.DeleteTeamDiscussionReactionByOrgIDAndTeamID(context.Background(), 1, 2, 3, 4); err != nil {
+	ctx := context.Background()
+	if _, err := client.Reactions.DeleteTeamDiscussionReactionByOrgIDAndTeamID(ctx, 1, 2, 3, 4); err != nil {
 		t.Errorf("DeleteTeamDiscussionReactionByTeamIDAndOrgID returned error: %v", err)
 	}
 }
@@ -500,7 +522,8 @@ func TestReactionsService_DeleteTeamDiscussionCommentReaction(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Reactions.DeleteTeamDiscussionCommentReaction(context.Background(), "o", "s", 1, 2, 3); err != nil {
+	ctx := context.Background()
+	if _, err := client.Reactions.DeleteTeamDiscussionCommentReaction(ctx, "o", "s", 1, 2, 3); err != nil {
 		t.Errorf("DeleteTeamDiscussionCommentReaction returned error: %v", err)
 	}
 }
@@ -516,7 +539,8 @@ func TestReactionsService_DeleteTeamDiscussionCommentReactionByTeamIDAndOrgID(t 
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Reactions.DeleteTeamDiscussionCommentReactionByOrgIDAndTeamID(context.Background(), 1, 2, 3, 4, 5); err != nil {
+	ctx := context.Background()
+	if _, err := client.Reactions.DeleteTeamDiscussionCommentReactionByOrgIDAndTeamID(ctx, 1, 2, 3, 4, 5); err != nil {
 		t.Errorf("DeleteTeamDiscussionCommentReactionByTeamIDAndOrgID returned error: %v", err)
 	}
 }

--- a/github/repos_collaborators_test.go
+++ b/github/repos_collaborators_test.go
@@ -27,7 +27,8 @@ func TestRepositoriesService_ListCollaborators(t *testing.T) {
 	opt := &ListCollaboratorsOptions{
 		ListOptions: ListOptions{Page: 2},
 	}
-	users, _, err := client.Repositories.ListCollaborators(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	users, _, err := client.Repositories.ListCollaborators(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListCollaborators returned error: %v", err)
 	}
@@ -52,7 +53,8 @@ func TestRepositoriesService_ListCollaborators_withAffiliation(t *testing.T) {
 		ListOptions: ListOptions{Page: 2},
 		Affiliation: "all",
 	}
-	users, _, err := client.Repositories.ListCollaborators(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	users, _, err := client.Repositories.ListCollaborators(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListCollaborators returned error: %v", err)
 	}
@@ -67,7 +69,8 @@ func TestRepositoriesService_ListCollaborators_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.ListCollaborators(context.Background(), "%", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.ListCollaborators(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -80,7 +83,8 @@ func TestRepositoriesService_IsCollaborator_True(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	isCollab, _, err := client.Repositories.IsCollaborator(context.Background(), "o", "r", "u")
+	ctx := context.Background()
+	isCollab, _, err := client.Repositories.IsCollaborator(ctx, "o", "r", "u")
 	if err != nil {
 		t.Errorf("Repositories.IsCollaborator returned error: %v", err)
 	}
@@ -99,7 +103,8 @@ func TestRepositoriesService_IsCollaborator_False(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	isCollab, _, err := client.Repositories.IsCollaborator(context.Background(), "o", "r", "u")
+	ctx := context.Background()
+	isCollab, _, err := client.Repositories.IsCollaborator(ctx, "o", "r", "u")
 	if err != nil {
 		t.Errorf("Repositories.IsCollaborator returned error: %v", err)
 	}
@@ -113,7 +118,8 @@ func TestRepositoriesService_IsCollaborator_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.IsCollaborator(context.Background(), "%", "%", "%")
+	ctx := context.Background()
+	_, _, err := client.Repositories.IsCollaborator(ctx, "%", "%", "%")
 	testURLParseError(t, err)
 }
 
@@ -126,7 +132,8 @@ func TestRepositoryService_GetPermissionLevel(t *testing.T) {
 		fmt.Fprintf(w, `{"permission":"admin","user":{"login":"u"}}`)
 	})
 
-	rpl, _, err := client.Repositories.GetPermissionLevel(context.Background(), "o", "r", "u")
+	ctx := context.Background()
+	rpl, _, err := client.Repositories.GetPermissionLevel(ctx, "o", "r", "u")
 	if err != nil {
 		t.Errorf("Repositories.GetPermissionLevel returned error: %v", err)
 	}
@@ -158,7 +165,8 @@ func TestRepositoriesService_AddCollaborator(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"permissions": "write","url": "https://api.github.com/user/repository_invitations/1296269","html_url": "https://github.com/octocat/Hello-World/invitations","id":1,"permissions":"write","repository":{"url":"s","name":"r","id":1},"invitee":{"login":"u"},"inviter":{"login":"o"}}`))
 	})
-	collaboratorInvitation, _, err := client.Repositories.AddCollaborator(context.Background(), "o", "r", "u", opt)
+	ctx := context.Background()
+	collaboratorInvitation, _, err := client.Repositories.AddCollaborator(ctx, "o", "r", "u", opt)
 	if err != nil {
 		t.Errorf("Repositories.AddCollaborator returned error: %v", err)
 	}
@@ -189,7 +197,8 @@ func TestRepositoriesService_AddCollaborator_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.AddCollaborator(context.Background(), "%", "%", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.AddCollaborator(ctx, "%", "%", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -202,7 +211,8 @@ func TestRepositoriesService_RemoveCollaborator(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Repositories.RemoveCollaborator(context.Background(), "o", "r", "u")
+	ctx := context.Background()
+	_, err := client.Repositories.RemoveCollaborator(ctx, "o", "r", "u")
 	if err != nil {
 		t.Errorf("Repositories.RemoveCollaborator returned error: %v", err)
 	}
@@ -212,6 +222,7 @@ func TestRepositoriesService_RemoveCollaborator_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Repositories.RemoveCollaborator(context.Background(), "%", "%", "%")
+	ctx := context.Background()
+	_, err := client.Repositories.RemoveCollaborator(ctx, "%", "%", "%")
 	testURLParseError(t, err)
 }

--- a/github/repos_comments_test.go
+++ b/github/repos_comments_test.go
@@ -26,7 +26,8 @@ func TestRepositoriesService_ListComments(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	comments, _, err := client.Repositories.ListComments(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	comments, _, err := client.Repositories.ListComments(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListComments returned error: %v", err)
 	}
@@ -41,7 +42,8 @@ func TestRepositoriesService_ListComments_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.ListComments(context.Background(), "%", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.ListComments(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -57,7 +59,8 @@ func TestRepositoriesService_ListCommitComments(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	comments, _, err := client.Repositories.ListCommitComments(context.Background(), "o", "r", "s", opt)
+	ctx := context.Background()
+	comments, _, err := client.Repositories.ListCommitComments(ctx, "o", "r", "s", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListCommitComments returned error: %v", err)
 	}
@@ -72,7 +75,8 @@ func TestRepositoriesService_ListCommitComments_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.ListCommitComments(context.Background(), "%", "%", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.ListCommitComments(ctx, "%", "%", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -94,7 +98,8 @@ func TestRepositoriesService_CreateComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	comment, _, err := client.Repositories.CreateComment(context.Background(), "o", "r", "s", input)
+	ctx := context.Background()
+	comment, _, err := client.Repositories.CreateComment(ctx, "o", "r", "s", input)
 	if err != nil {
 		t.Errorf("Repositories.CreateComment returned error: %v", err)
 	}
@@ -109,7 +114,8 @@ func TestRepositoriesService_CreateComment_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.CreateComment(context.Background(), "%", "%", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.CreateComment(ctx, "%", "%", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -123,7 +129,8 @@ func TestRepositoriesService_GetComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	comment, _, err := client.Repositories.GetComment(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	comment, _, err := client.Repositories.GetComment(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetComment returned error: %v", err)
 	}
@@ -138,7 +145,8 @@ func TestRepositoriesService_GetComment_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.GetComment(context.Background(), "%", "%", 1)
+	ctx := context.Background()
+	_, _, err := client.Repositories.GetComment(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }
 
@@ -160,7 +168,8 @@ func TestRepositoriesService_UpdateComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	comment, _, err := client.Repositories.UpdateComment(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	comment, _, err := client.Repositories.UpdateComment(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Repositories.UpdateComment returned error: %v", err)
 	}
@@ -175,7 +184,8 @@ func TestRepositoriesService_UpdateComment_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.UpdateComment(context.Background(), "%", "%", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.UpdateComment(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -187,7 +197,8 @@ func TestRepositoriesService_DeleteComment(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Repositories.DeleteComment(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	_, err := client.Repositories.DeleteComment(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeleteComment returned error: %v", err)
 	}
@@ -197,6 +208,7 @@ func TestRepositoriesService_DeleteComment_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Repositories.DeleteComment(context.Background(), "%", "%", 1)
+	ctx := context.Background()
+	_, err := client.Repositories.DeleteComment(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -40,7 +40,8 @@ func TestRepositoriesService_ListCommits(t *testing.T) {
 		Since:  time.Date(2013, time.August, 1, 0, 0, 0, 0, time.UTC),
 		Until:  time.Date(2013, time.September, 3, 0, 0, 0, 0, time.UTC),
 	}
-	commits, _, err := client.Repositories.ListCommits(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	commits, _, err := client.Repositories.ListCommits(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListCommits returned error: %v", err)
 	}
@@ -80,7 +81,8 @@ func TestRepositoriesService_GetCommit(t *testing.T) {
 		}`)
 	})
 
-	commit, _, err := client.Repositories.GetCommit(context.Background(), "o", "r", "s")
+	ctx := context.Background()
+	commit, _, err := client.Repositories.GetCommit(ctx, "o", "r", "s")
 	if err != nil {
 		t.Errorf("Repositories.GetCommit returned error: %v", err)
 	}
@@ -137,7 +139,8 @@ func TestRepositoriesService_GetCommitRaw_diff(t *testing.T) {
 		fmt.Fprint(w, rawStr)
 	})
 
-	got, _, err := client.Repositories.GetCommitRaw(context.Background(), "o", "r", "s", RawOptions{Type: Diff})
+	ctx := context.Background()
+	got, _, err := client.Repositories.GetCommitRaw(ctx, "o", "r", "s", RawOptions{Type: Diff})
 	if err != nil {
 		t.Fatalf("Repositories.GetCommitRaw returned error: %v", err)
 	}
@@ -159,7 +162,8 @@ func TestRepositoriesService_GetCommitRaw_patch(t *testing.T) {
 		fmt.Fprint(w, rawStr)
 	})
 
-	got, _, err := client.Repositories.GetCommitRaw(context.Background(), "o", "r", "s", RawOptions{Type: Patch})
+	ctx := context.Background()
+	got, _, err := client.Repositories.GetCommitRaw(ctx, "o", "r", "s", RawOptions{Type: Patch})
 	if err != nil {
 		t.Fatalf("Repositories.GetCommitRaw returned error: %v", err)
 	}
@@ -173,7 +177,8 @@ func TestRepositoriesService_GetCommitRaw_invalid(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.GetCommitRaw(context.Background(), "o", "r", "s", RawOptions{100})
+	ctx := context.Background()
+	_, _, err := client.Repositories.GetCommitRaw(ctx, "o", "r", "s", RawOptions{100})
 	if err == nil {
 		t.Fatal("Repositories.GetCommitRaw should return error")
 	}
@@ -194,7 +199,8 @@ func TestRepositoriesService_GetCommitSHA1(t *testing.T) {
 		fmt.Fprintf(w, sha1)
 	})
 
-	got, _, err := client.Repositories.GetCommitSHA1(context.Background(), "o", "r", "master", "")
+	ctx := context.Background()
+	got, _, err := client.Repositories.GetCommitSHA1(ctx, "o", "r", "master", "")
 	if err != nil {
 		t.Errorf("Repositories.GetCommitSHA1 returned error: %v", err)
 	}
@@ -212,7 +218,7 @@ func TestRepositoriesService_GetCommitSHA1(t *testing.T) {
 		w.WriteHeader(http.StatusNotModified)
 	})
 
-	got, _, err = client.Repositories.GetCommitSHA1(context.Background(), "o", "r", "tag", sha1)
+	got, _, err = client.Repositories.GetCommitSHA1(ctx, "o", "r", "tag", sha1)
 	if err == nil {
 		t.Errorf("Expected HTTP 304 response")
 	}
@@ -235,7 +241,8 @@ func TestRepositoriesService_NonAlphabetCharacter_GetCommitSHA1(t *testing.T) {
 		fmt.Fprintf(w, sha1)
 	})
 
-	got, _, err := client.Repositories.GetCommitSHA1(context.Background(), "o", "r", "master%20hash", "")
+	ctx := context.Background()
+	got, _, err := client.Repositories.GetCommitSHA1(ctx, "o", "r", "master%20hash", "")
 	if err != nil {
 		t.Errorf("Repositories.GetCommitSHA1 returned error: %v", err)
 	}
@@ -252,7 +259,7 @@ func TestRepositoriesService_NonAlphabetCharacter_GetCommitSHA1(t *testing.T) {
 		w.WriteHeader(http.StatusNotModified)
 	})
 
-	got, _, err = client.Repositories.GetCommitSHA1(context.Background(), "o", "r", "tag", sha1)
+	got, _, err = client.Repositories.GetCommitSHA1(ctx, "o", "r", "tag", sha1)
 	if err == nil {
 		t.Errorf("Expected HTTP 304 response")
 	}
@@ -274,7 +281,8 @@ func TestRepositoriesService_TrailingPercent_GetCommitSHA1(t *testing.T) {
 		fmt.Fprintf(w, sha1)
 	})
 
-	got, _, err := client.Repositories.GetCommitSHA1(context.Background(), "o", "r", "comm%", "")
+	ctx := context.Background()
+	got, _, err := client.Repositories.GetCommitSHA1(ctx, "o", "r", "comm%", "")
 	if err != nil {
 		t.Errorf("Repositories.GetCommitSHA1 returned error: %v", err)
 	}
@@ -291,7 +299,7 @@ func TestRepositoriesService_TrailingPercent_GetCommitSHA1(t *testing.T) {
 		w.WriteHeader(http.StatusNotModified)
 	})
 
-	got, _, err = client.Repositories.GetCommitSHA1(context.Background(), "o", "r", "tag", sha1)
+	got, _, err = client.Repositories.GetCommitSHA1(ctx, "o", "r", "tag", sha1)
 	if err == nil {
 		t.Errorf("Expected HTTP 304 response")
 	}
@@ -342,7 +350,8 @@ func TestRepositoriesService_CompareCommits(t *testing.T) {
 		}`)
 	})
 
-	got, _, err := client.Repositories.CompareCommits(context.Background(), "o", "r", "b", "h")
+	ctx := context.Background()
+	got, _, err := client.Repositories.CompareCommits(ctx, "o", "r", "b", "h")
 	if err != nil {
 		t.Errorf("Repositories.CompareCommits returned error: %v", err)
 	}
@@ -412,7 +421,8 @@ func TestRepositoriesService_CompareCommitsRaw_diff(t *testing.T) {
 		fmt.Fprint(w, rawStr)
 	})
 
-	got, _, err := client.Repositories.CompareCommitsRaw(context.Background(), "o", "r", "b", "h", RawOptions{Type: Diff})
+	ctx := context.Background()
+	got, _, err := client.Repositories.CompareCommitsRaw(ctx, "o", "r", "b", "h", RawOptions{Type: Diff})
 	if err != nil {
 		t.Fatalf("Repositories.GetCommitRaw returned error: %v", err)
 	}
@@ -434,7 +444,8 @@ func TestRepositoriesService_CompareCommitsRaw_patch(t *testing.T) {
 		fmt.Fprint(w, rawStr)
 	})
 
-	got, _, err := client.Repositories.CompareCommitsRaw(context.Background(), "o", "r", "b", "h", RawOptions{Type: Patch})
+	ctx := context.Background()
+	got, _, err := client.Repositories.CompareCommitsRaw(ctx, "o", "r", "b", "h", RawOptions{Type: Patch})
 	if err != nil {
 		t.Fatalf("Repositories.GetCommitRaw returned error: %v", err)
 	}
@@ -448,7 +459,8 @@ func TestRepositoriesService_CompareCommitsRaw_invalid(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.CompareCommitsRaw(context.Background(), "o", "r", "s", "h", RawOptions{100})
+	ctx := context.Background()
+	_, _, err := client.Repositories.CompareCommitsRaw(ctx, "o", "r", "s", "h", RawOptions{100})
 	if err == nil {
 		t.Fatal("Repositories.GetCommitRaw should return error")
 	}
@@ -466,7 +478,8 @@ func TestRepositoriesService_ListBranchesHeadCommit(t *testing.T) {
 		fmt.Fprintf(w, `[{"name": "b","commit":{"sha":"2e90302801c870f17b6152327d9b9a03c8eca0e2","url":"https://api.github.com/repos/google/go-github/commits/2e90302801c870f17b6152327d9b9a03c8eca0e2"},"protected":true}]`)
 	})
 
-	branches, _, err := client.Repositories.ListBranchesHeadCommit(context.Background(), "o", "r", "s")
+	ctx := context.Background()
+	branches, _, err := client.Repositories.ListBranchesHeadCommit(ctx, "o", "r", "s")
 	if err != nil {
 		t.Errorf("Repositories.ListBranchesHeadCommit returned error: %v", err)
 	}

--- a/github/repos_community_health_test.go
+++ b/github/repos_community_health_test.go
@@ -49,7 +49,8 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 			}`)
 	})
 
-	got, _, err := client.Repositories.GetCommunityHealthMetrics(context.Background(), "o", "r")
+	ctx := context.Background()
+	got, _, err := client.Repositories.GetCommunityHealthMetrics(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetCommunityHealthMetrics returned error: %v", err)
 	}

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -92,7 +92,8 @@ func TestRepositoriesService_GetReadme(t *testing.T) {
 		  "path": "README.md"
 		}`)
 	})
-	readme, _, err := client.Repositories.GetReadme(context.Background(), "o", "r", &RepositoryContentGetOptions{})
+	ctx := context.Background()
+	readme, _, err := client.Repositories.GetReadme(ctx, "o", "r", &RepositoryContentGetOptions{})
 	if err != nil {
 		t.Errorf("Repositories.GetReadme returned error: %v", err)
 	}
@@ -118,7 +119,8 @@ func TestRepositoriesService_DownloadContents_Success(t *testing.T) {
 		fmt.Fprint(w, "foo")
 	})
 
-	r, resp, err := client.Repositories.DownloadContents(context.Background(), "o", "r", "d/f", nil)
+	ctx := context.Background()
+	r, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadContents returned error: %v", err)
 	}
@@ -155,7 +157,8 @@ func TestRepositoriesService_DownloadContents_FailedResponse(t *testing.T) {
 		fmt.Fprint(w, "foo error")
 	})
 
-	r, resp, err := client.Repositories.DownloadContents(context.Background(), "o", "r", "d/f", nil)
+	ctx := context.Background()
+	r, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadContents returned error: %v", err)
 	}
@@ -186,7 +189,8 @@ func TestRepositoriesService_DownloadContents_NoDownloadURL(t *testing.T) {
 		}]`)
 	})
 
-	_, resp, err := client.Repositories.DownloadContents(context.Background(), "o", "r", "d/f", nil)
+	ctx := context.Background()
+	_, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err == nil {
 		t.Errorf("Repositories.DownloadContents did not return expected error")
 	}
@@ -204,7 +208,8 @@ func TestRepositoriesService_DownloadContents_NoFile(t *testing.T) {
 		fmt.Fprint(w, `[]`)
 	})
 
-	_, resp, err := client.Repositories.DownloadContents(context.Background(), "o", "r", "d/f", nil)
+	ctx := context.Background()
+	_, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err == nil {
 		t.Errorf("Repositories.DownloadContents did not return expected error")
 	}
@@ -227,7 +232,8 @@ func TestRepositoriesService_GetContents_File(t *testing.T) {
 		  "path": "LICENSE"
 		}`)
 	})
-	fileContents, _, _, err := client.Repositories.GetContents(context.Background(), "o", "r", "p", &RepositoryContentGetOptions{})
+	ctx := context.Background()
+	fileContents, _, _, err := client.Repositories.GetContents(ctx, "o", "r", "p", &RepositoryContentGetOptions{})
 	if err != nil {
 		t.Errorf("Repositories.GetContents returned error: %v", err)
 	}
@@ -244,7 +250,8 @@ func TestRepositoriesService_GetContents_FilenameNeedsEscape(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{}`)
 	})
-	_, _, _, err := client.Repositories.GetContents(context.Background(), "o", "r", "p#?%/中.go", &RepositoryContentGetOptions{})
+	ctx := context.Background()
+	_, _, _, err := client.Repositories.GetContents(ctx, "o", "r", "p#?%/中.go", &RepositoryContentGetOptions{})
 	if err != nil {
 		t.Fatalf("Repositories.GetContents returned error: %v", err)
 	}
@@ -257,7 +264,8 @@ func TestRepositoriesService_GetContents_DirectoryWithSpaces(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{}`)
 	})
-	_, _, _, err := client.Repositories.GetContents(context.Background(), "o", "r", "some directory/file.go", &RepositoryContentGetOptions{})
+	ctx := context.Background()
+	_, _, _, err := client.Repositories.GetContents(ctx, "o", "r", "some directory/file.go", &RepositoryContentGetOptions{})
 	if err != nil {
 		t.Fatalf("Repositories.GetContents returned error: %v", err)
 	}
@@ -270,7 +278,8 @@ func TestRepositoriesService_GetContents_DirectoryWithPlusChars(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{}`)
 	})
-	_, _, _, err := client.Repositories.GetContents(context.Background(), "o", "r", "some directory+name/file.go", &RepositoryContentGetOptions{})
+	ctx := context.Background()
+	_, _, _, err := client.Repositories.GetContents(ctx, "o", "r", "some directory+name/file.go", &RepositoryContentGetOptions{})
 	if err != nil {
 		t.Fatalf("Repositories.GetContents returned error: %v", err)
 	}
@@ -293,7 +302,8 @@ func TestRepositoriesService_GetContents_Directory(t *testing.T) {
 		  "path": "LICENSE"
 		}]`)
 	})
-	_, directoryContents, _, err := client.Repositories.GetContents(context.Background(), "o", "r", "p", &RepositoryContentGetOptions{})
+	ctx := context.Background()
+	_, directoryContents, _, err := client.Repositories.GetContents(ctx, "o", "r", "p", &RepositoryContentGetOptions{})
 	if err != nil {
 		t.Errorf("Repositories.GetContents returned error: %v", err)
 	}
@@ -326,7 +336,8 @@ func TestRepositoriesService_CreateFile(t *testing.T) {
 		Content:   content,
 		Committer: &CommitAuthor{Name: String("n"), Email: String("e")},
 	}
-	createResponse, _, err := client.Repositories.CreateFile(context.Background(), "o", "r", "p", repositoryContentsOptions)
+	ctx := context.Background()
+	createResponse, _, err := client.Repositories.CreateFile(ctx, "o", "r", "p", repositoryContentsOptions)
 	if err != nil {
 		t.Errorf("Repositories.CreateFile returned error: %v", err)
 	}
@@ -366,7 +377,8 @@ func TestRepositoriesService_UpdateFile(t *testing.T) {
 		SHA:       &sha,
 		Committer: &CommitAuthor{Name: String("n"), Email: String("e")},
 	}
-	updateResponse, _, err := client.Repositories.UpdateFile(context.Background(), "o", "r", "p", repositoryContentsOptions)
+	ctx := context.Background()
+	updateResponse, _, err := client.Repositories.UpdateFile(ctx, "o", "r", "p", repositoryContentsOptions)
 	if err != nil {
 		t.Errorf("Repositories.UpdateFile returned error: %v", err)
 	}
@@ -402,7 +414,8 @@ func TestRepositoriesService_DeleteFile(t *testing.T) {
 		SHA:       &sha,
 		Committer: &CommitAuthor{Name: String("n"), Email: String("e")},
 	}
-	deleteResponse, _, err := client.Repositories.DeleteFile(context.Background(), "o", "r", "p", repositoryContentsOptions)
+	ctx := context.Background()
+	deleteResponse, _, err := client.Repositories.DeleteFile(ctx, "o", "r", "p", repositoryContentsOptions)
 	if err != nil {
 		t.Errorf("Repositories.DeleteFile returned error: %v", err)
 	}
@@ -425,7 +438,8 @@ func TestRepositoriesService_GetArchiveLink(t *testing.T) {
 		testMethod(t, r, "GET")
 		http.Redirect(w, r, "http://github.com/a", http.StatusFound)
 	})
-	url, resp, err := client.Repositories.GetArchiveLink(context.Background(), "o", "r", Tarball, &RepositoryContentGetOptions{}, true)
+	ctx := context.Background()
+	url, resp, err := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{}, true)
 	if err != nil {
 		t.Errorf("Repositories.GetArchiveLink returned error: %v", err)
 	}
@@ -445,7 +459,8 @@ func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_dontFollowRed
 		testMethod(t, r, "GET")
 		http.Redirect(w, r, "http://github.com/a", http.StatusMovedPermanently)
 	})
-	_, resp, _ := client.Repositories.GetArchiveLink(context.Background(), "o", "r", Tarball, &RepositoryContentGetOptions{}, false)
+	ctx := context.Background()
+	_, resp, _ := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{}, false)
 	if resp.StatusCode != http.StatusMovedPermanently {
 		t.Errorf("Repositories.GetArchiveLink returned status: %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
 	}
@@ -464,7 +479,8 @@ func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_followRedirec
 		testMethod(t, r, "GET")
 		http.Redirect(w, r, "http://github.com/a", http.StatusFound)
 	})
-	url, resp, err := client.Repositories.GetArchiveLink(context.Background(), "o", "r", Tarball, &RepositoryContentGetOptions{}, true)
+	ctx := context.Background()
+	url, resp, err := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{}, true)
 	if err != nil {
 		t.Errorf("Repositories.GetArchiveLink returned error: %v", err)
 	}
@@ -488,7 +504,8 @@ func TestRepositoriesService_GetContents_NoTrailingSlashInDirectoryApiPath(t *te
 		}
 		fmt.Fprint(w, `{}`)
 	})
-	_, _, _, err := client.Repositories.GetContents(context.Background(), "o", "r", ".github/", &RepositoryContentGetOptions{
+	ctx := context.Background()
+	_, _, _, err := client.Repositories.GetContents(ctx, "o", "r", ".github/", &RepositoryContentGetOptions{
 		Ref: "mybranch",
 	})
 	if err != nil {

--- a/github/repos_deployments_test.go
+++ b/github/repos_deployments_test.go
@@ -26,7 +26,8 @@ func TestRepositoriesService_ListDeployments(t *testing.T) {
 	})
 
 	opt := &DeploymentsListOptions{Environment: "test"}
-	deployments, _, err := client.Repositories.ListDeployments(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	deployments, _, err := client.Repositories.ListDeployments(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListDeployments returned error: %v", err)
 	}
@@ -46,7 +47,8 @@ func TestRepositoriesService_GetDeployment(t *testing.T) {
 		fmt.Fprint(w, `{"id":3}`)
 	})
 
-	deployment, _, err := client.Repositories.GetDeployment(context.Background(), "o", "r", 3)
+	ctx := context.Background()
+	deployment, _, err := client.Repositories.GetDeployment(ctx, "o", "r", 3)
 	if err != nil {
 		t.Errorf("Repositories.GetDeployment returned error: %v", err)
 	}
@@ -78,7 +80,8 @@ func TestRepositoriesService_CreateDeployment(t *testing.T) {
 		fmt.Fprint(w, `{"ref": "1111", "task": "deploy"}`)
 	})
 
-	deployment, _, err := client.Repositories.CreateDeployment(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	deployment, _, err := client.Repositories.CreateDeployment(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.CreateDeployment returned error: %v", err)
 	}
@@ -98,7 +101,8 @@ func TestRepositoriesService_DeleteDeployment(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	resp, err := client.Repositories.DeleteDeployment(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	resp, err := client.Repositories.DeleteDeployment(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeleteDeployment returned error: %v", err)
 	}
@@ -106,7 +110,7 @@ func TestRepositoriesService_DeleteDeployment(t *testing.T) {
 		t.Error("Repositories.DeleteDeployment should return a 204 status")
 	}
 
-	resp, err = client.Repositories.DeleteDeployment(context.Background(), "o", "r", 2)
+	resp, err = client.Repositories.DeleteDeployment(ctx, "o", "r", 2)
 	if err == nil {
 		t.Error("Repositories.DeleteDeployment should return an error")
 	}
@@ -128,7 +132,8 @@ func TestRepositoriesService_ListDeploymentStatuses(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	statutses, _, err := client.Repositories.ListDeploymentStatuses(context.Background(), "o", "r", 1, opt)
+	ctx := context.Background()
+	statutses, _, err := client.Repositories.ListDeploymentStatuses(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Repositories.ListDeploymentStatuses returned error: %v", err)
 	}
@@ -150,7 +155,8 @@ func TestRepositoriesService_GetDeploymentStatus(t *testing.T) {
 		fmt.Fprint(w, `{"id":4}`)
 	})
 
-	deploymentStatus, _, err := client.Repositories.GetDeploymentStatus(context.Background(), "o", "r", 3, 4)
+	ctx := context.Background()
+	deploymentStatus, _, err := client.Repositories.GetDeploymentStatus(ctx, "o", "r", 3, 4)
 	if err != nil {
 		t.Errorf("Repositories.GetDeploymentStatus returned error: %v", err)
 	}
@@ -181,7 +187,8 @@ func TestRepositoriesService_CreateDeploymentStatus(t *testing.T) {
 		fmt.Fprint(w, `{"state": "inactive", "description": "deploy"}`)
 	})
 
-	deploymentStatus, _, err := client.Repositories.CreateDeploymentStatus(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	deploymentStatus, _, err := client.Repositories.CreateDeploymentStatus(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Repositories.CreateDeploymentStatus returned error: %v", err)
 	}

--- a/github/repos_forks_test.go
+++ b/github/repos_forks_test.go
@@ -31,7 +31,8 @@ func TestRepositoriesService_ListForks(t *testing.T) {
 		Sort:        "newest",
 		ListOptions: ListOptions{Page: 3},
 	}
-	repos, _, err := client.Repositories.ListForks(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	repos, _, err := client.Repositories.ListForks(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListForks returned error: %v", err)
 	}
@@ -46,7 +47,8 @@ func TestRepositoriesService_ListForks_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.ListForks(context.Background(), "%", "r", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.ListForks(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
 
@@ -61,7 +63,8 @@ func TestRepositoriesService_CreateFork(t *testing.T) {
 	})
 
 	opt := &RepositoryCreateForkOptions{Organization: "o"}
-	repo, _, err := client.Repositories.CreateFork(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	repo, _, err := client.Repositories.CreateFork(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.CreateFork returned error: %v", err)
 	}
@@ -85,7 +88,8 @@ func TestRepositoriesService_CreateFork_deferred(t *testing.T) {
 	})
 
 	opt := &RepositoryCreateForkOptions{Organization: "o"}
-	repo, _, err := client.Repositories.CreateFork(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	repo, _, err := client.Repositories.CreateFork(ctx, "o", "r", opt)
 	if _, ok := err.(*AcceptedError); !ok {
 		t.Errorf("Repositories.CreateFork returned error: %v (want AcceptedError)", err)
 	}
@@ -100,6 +104,7 @@ func TestRepositoriesService_CreateFork_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.CreateFork(context.Background(), "%", "r", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.CreateFork(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }

--- a/github/repos_hooks_test.go
+++ b/github/repos_hooks_test.go
@@ -33,7 +33,8 @@ func TestRepositoriesService_CreateHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	hook, _, err := client.Repositories.CreateHook(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	hook, _, err := client.Repositories.CreateHook(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.CreateHook returned error: %v", err)
 	}
@@ -56,7 +57,8 @@ func TestRepositoriesService_ListHooks(t *testing.T) {
 
 	opt := &ListOptions{Page: 2}
 
-	hooks, _, err := client.Repositories.ListHooks(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	hooks, _, err := client.Repositories.ListHooks(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListHooks returned error: %v", err)
 	}
@@ -71,7 +73,8 @@ func TestRepositoriesService_ListHooks_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.ListHooks(context.Background(), "%", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.ListHooks(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -84,7 +87,8 @@ func TestRepositoriesService_GetHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	hook, _, err := client.Repositories.GetHook(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	hook, _, err := client.Repositories.GetHook(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetHook returned error: %v", err)
 	}
@@ -99,7 +103,8 @@ func TestRepositoriesService_GetHook_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.GetHook(context.Background(), "%", "%", 1)
+	ctx := context.Background()
+	_, _, err := client.Repositories.GetHook(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }
 
@@ -121,7 +126,8 @@ func TestRepositoriesService_EditHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	hook, _, err := client.Repositories.EditHook(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	hook, _, err := client.Repositories.EditHook(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Repositories.EditHook returned error: %v", err)
 	}
@@ -136,7 +142,8 @@ func TestRepositoriesService_EditHook_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.EditHook(context.Background(), "%", "%", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.EditHook(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -148,7 +155,8 @@ func TestRepositoriesService_DeleteHook(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Repositories.DeleteHook(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	_, err := client.Repositories.DeleteHook(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeleteHook returned error: %v", err)
 	}
@@ -158,7 +166,8 @@ func TestRepositoriesService_DeleteHook_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Repositories.DeleteHook(context.Background(), "%", "%", 1)
+	ctx := context.Background()
+	_, err := client.Repositories.DeleteHook(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }
 
@@ -170,7 +179,8 @@ func TestRepositoriesService_PingHook(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	_, err := client.Repositories.PingHook(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	_, err := client.Repositories.PingHook(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.PingHook returned error: %v", err)
 	}
@@ -184,7 +194,8 @@ func TestRepositoriesService_TestHook(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	_, err := client.Repositories.TestHook(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	_, err := client.Repositories.TestHook(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.TestHook returned error: %v", err)
 	}
@@ -194,6 +205,7 @@ func TestRepositoriesService_TestHook_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Repositories.TestHook(context.Background(), "%", "%", 1)
+	ctx := context.Background()
+	_, err := client.Repositories.TestHook(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }

--- a/github/repos_invitations_test.go
+++ b/github/repos_invitations_test.go
@@ -24,7 +24,8 @@ func TestRepositoriesService_ListInvitations(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	got, _, err := client.Repositories.ListInvitations(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	got, _, err := client.Repositories.ListInvitations(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListInvitations returned error: %v", err)
 	}
@@ -44,7 +45,8 @@ func TestRepositoriesService_DeleteInvitation(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Repositories.DeleteInvitation(context.Background(), "o", "r", 2)
+	ctx := context.Background()
+	_, err := client.Repositories.DeleteInvitation(ctx, "o", "r", 2)
 	if err != nil {
 		t.Errorf("Repositories.DeleteInvitation returned error: %v", err)
 	}
@@ -59,7 +61,8 @@ func TestRepositoriesService_UpdateInvitation(t *testing.T) {
 		fmt.Fprintf(w, `{"id":1}`)
 	})
 
-	got, _, err := client.Repositories.UpdateInvitation(context.Background(), "o", "r", 2, "write")
+	ctx := context.Background()
+	got, _, err := client.Repositories.UpdateInvitation(ctx, "o", "r", 2, "write")
 	if err != nil {
 		t.Errorf("Repositories.UpdateInvitation returned error: %v", err)
 	}

--- a/github/repos_keys_test.go
+++ b/github/repos_keys_test.go
@@ -25,7 +25,8 @@ func TestRepositoriesService_ListKeys(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	keys, _, err := client.Repositories.ListKeys(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	keys, _, err := client.Repositories.ListKeys(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListKeys returned error: %v", err)
 	}
@@ -40,7 +41,8 @@ func TestRepositoriesService_ListKeys_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.ListKeys(context.Background(), "%", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.ListKeys(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -53,7 +55,8 @@ func TestRepositoriesService_GetKey(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	key, _, err := client.Repositories.GetKey(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	key, _, err := client.Repositories.GetKey(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetKey returned error: %v", err)
 	}
@@ -68,7 +71,8 @@ func TestRepositoriesService_GetKey_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.GetKey(context.Background(), "%", "%", 1)
+	ctx := context.Background()
+	_, _, err := client.Repositories.GetKey(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }
 
@@ -90,7 +94,8 @@ func TestRepositoriesService_CreateKey(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	key, _, err := client.Repositories.CreateKey(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	key, _, err := client.Repositories.CreateKey(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.GetKey returned error: %v", err)
 	}
@@ -105,7 +110,8 @@ func TestRepositoriesService_CreateKey_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.CreateKey(context.Background(), "%", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.CreateKey(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -117,7 +123,8 @@ func TestRepositoriesService_DeleteKey(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Repositories.DeleteKey(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	_, err := client.Repositories.DeleteKey(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeleteKey returned error: %v", err)
 	}
@@ -127,6 +134,7 @@ func TestRepositoriesService_DeleteKey_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Repositories.DeleteKey(context.Background(), "%", "%", 1)
+	ctx := context.Background()
+	_, err := client.Repositories.DeleteKey(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }

--- a/github/repos_merging_test.go
+++ b/github/repos_merging_test.go
@@ -36,7 +36,8 @@ func TestRepositoriesService_Merge(t *testing.T) {
 		fmt.Fprint(w, `{"sha":"s"}`)
 	})
 
-	commit, _, err := client.Repositories.Merge(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	commit, _, err := client.Repositories.Merge(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.Merge returned error: %v", err)
 	}

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -42,7 +42,8 @@ func TestRepositoriesService_EnablePages(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u","status":"s","cname":"c","custom_404":false,"html_url":"h", "source": {"branch":"master", "path":"/"}}`)
 	})
 
-	page, _, err := client.Repositories.EnablePages(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	page, _, err := client.Repositories.EnablePages(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.EnablePages returned error: %v", err)
 	}
@@ -76,7 +77,8 @@ func TestRepositoriesService_UpdatePages(t *testing.T) {
 		fmt.Fprint(w, `{"cname":"www.my-domain.com","source":"gh-pages"}`)
 	})
 
-	_, err := client.Repositories.UpdatePages(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	_, err := client.Repositories.UpdatePages(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.UpdatePages returned error: %v", err)
 	}
@@ -104,7 +106,8 @@ func TestRepositoriesService_UpdatePages_NullCNAME(t *testing.T) {
 		fmt.Fprint(w, `{"cname":null,"source":"gh-pages"}`)
 	})
 
-	_, err := client.Repositories.UpdatePages(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	_, err := client.Repositories.UpdatePages(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.UpdatePages returned error: %v", err)
 	}
@@ -119,7 +122,8 @@ func TestRepositoriesService_DisablePages(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeEnablePagesAPIPreview)
 	})
 
-	_, err := client.Repositories.DisablePages(context.Background(), "o", "r")
+	ctx := context.Background()
+	_, err := client.Repositories.DisablePages(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.DisablePages returned error: %v", err)
 	}
@@ -134,7 +138,8 @@ func TestRepositoriesService_GetPagesInfo(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u","status":"s","cname":"c","custom_404":false,"html_url":"h"}`)
 	})
 
-	page, _, err := client.Repositories.GetPagesInfo(context.Background(), "o", "r")
+	ctx := context.Background()
+	page, _, err := client.Repositories.GetPagesInfo(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetPagesInfo returned error: %v", err)
 	}
@@ -154,7 +159,8 @@ func TestRepositoriesService_ListPagesBuilds(t *testing.T) {
 		fmt.Fprint(w, `[{"url":"u","status":"s","commit":"c"}]`)
 	})
 
-	pages, _, err := client.Repositories.ListPagesBuilds(context.Background(), "o", "r", nil)
+	ctx := context.Background()
+	pages, _, err := client.Repositories.ListPagesBuilds(ctx, "o", "r", nil)
 	if err != nil {
 		t.Errorf("Repositories.ListPagesBuilds returned error: %v", err)
 	}
@@ -177,7 +183,8 @@ func TestRepositoriesService_ListPagesBuilds_withOptions(t *testing.T) {
 		fmt.Fprint(w, `[]`)
 	})
 
-	_, _, err := client.Repositories.ListPagesBuilds(context.Background(), "o", "r", &ListOptions{Page: 2})
+	ctx := context.Background()
+	_, _, err := client.Repositories.ListPagesBuilds(ctx, "o", "r", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Repositories.ListPagesBuilds returned error: %v", err)
 	}
@@ -192,7 +199,8 @@ func TestRepositoriesService_GetLatestPagesBuild(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u","status":"s","commit":"c"}`)
 	})
 
-	build, _, err := client.Repositories.GetLatestPagesBuild(context.Background(), "o", "r")
+	ctx := context.Background()
+	build, _, err := client.Repositories.GetLatestPagesBuild(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetLatestPagesBuild returned error: %v", err)
 	}
@@ -212,7 +220,8 @@ func TestRepositoriesService_GetPageBuild(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u","status":"s","commit":"c"}`)
 	})
 
-	build, _, err := client.Repositories.GetPageBuild(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	build, _, err := client.Repositories.GetPageBuild(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetPageBuild returned error: %v", err)
 	}
@@ -232,7 +241,8 @@ func TestRepositoriesService_RequestPageBuild(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u","status":"s"}`)
 	})
 
-	build, _, err := client.Repositories.RequestPageBuild(context.Background(), "o", "r")
+	ctx := context.Background()
+	build, _, err := client.Repositories.RequestPageBuild(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.RequestPageBuild returned error: %v", err)
 	}

--- a/github/repos_prereceive_hooks_test.go
+++ b/github/repos_prereceive_hooks_test.go
@@ -27,7 +27,8 @@ func TestRepositoriesService_ListPreReceiveHooks(t *testing.T) {
 
 	opt := &ListOptions{Page: 2}
 
-	hooks, _, err := client.Repositories.ListPreReceiveHooks(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	hooks, _, err := client.Repositories.ListPreReceiveHooks(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListHooks returned error: %v", err)
 	}
@@ -42,7 +43,8 @@ func TestRepositoriesService_ListPreReceiveHooks_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.ListPreReceiveHooks(context.Background(), "%", "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.ListPreReceiveHooks(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -56,7 +58,8 @@ func TestRepositoriesService_GetPreReceiveHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	hook, _, err := client.Repositories.GetPreReceiveHook(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	hook, _, err := client.Repositories.GetPreReceiveHook(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetPreReceiveHook returned error: %v", err)
 	}
@@ -71,7 +74,8 @@ func TestRepositoriesService_GetPreReceiveHook_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.GetPreReceiveHook(context.Background(), "%", "%", 1)
+	ctx := context.Background()
+	_, _, err := client.Repositories.GetPreReceiveHook(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }
 
@@ -93,7 +97,8 @@ func TestRepositoriesService_UpdatePreReceiveHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	hook, _, err := client.Repositories.UpdatePreReceiveHook(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	hook, _, err := client.Repositories.UpdatePreReceiveHook(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Repositories.UpdatePreReceiveHook returned error: %v", err)
 	}
@@ -108,7 +113,8 @@ func TestRepositoriesService_PreReceiveHook_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.UpdatePreReceiveHook(context.Background(), "%", "%", 1, nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.UpdatePreReceiveHook(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }
 
@@ -120,7 +126,8 @@ func TestRepositoriesService_DeletePreReceiveHook(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Repositories.DeletePreReceiveHook(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	_, err := client.Repositories.DeletePreReceiveHook(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeletePreReceiveHook returned error: %v", err)
 	}
@@ -130,6 +137,7 @@ func TestRepositoriesService_DeletePreReceiveHook_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Repositories.DeletePreReceiveHook(context.Background(), "%", "%", 1)
+	ctx := context.Background()
+	_, err := client.Repositories.DeletePreReceiveHook(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }

--- a/github/repos_projects_test.go
+++ b/github/repos_projects_test.go
@@ -26,7 +26,8 @@ func TestRepositoriesService_ListProjects(t *testing.T) {
 	})
 
 	opt := &ProjectListOptions{ListOptions: ListOptions{Page: 2}}
-	projects, _, err := client.Repositories.ListProjects(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	projects, _, err := client.Repositories.ListProjects(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListProjects returned error: %v", err)
 	}
@@ -56,7 +57,8 @@ func TestRepositoriesService_CreateProject(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	project, _, err := client.Repositories.CreateProject(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	project, _, err := client.Repositories.CreateProject(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.CreateProject returned error: %v", err)
 	}

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -29,7 +29,8 @@ func TestRepositoriesService_ListReleases(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	releases, _, err := client.Repositories.ListReleases(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	releases, _, err := client.Repositories.ListReleases(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListReleases returned error: %v", err)
 	}
@@ -48,7 +49,8 @@ func TestRepositoriesService_GetRelease(t *testing.T) {
 		fmt.Fprint(w, `{"id":1,"author":{"login":"l"}}`)
 	})
 
-	release, resp, err := client.Repositories.GetRelease(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	release, resp, err := client.Repositories.GetRelease(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetRelease returned error: %v\n%v", err, resp.Body)
 	}
@@ -68,7 +70,8 @@ func TestRepositoriesService_GetLatestRelease(t *testing.T) {
 		fmt.Fprint(w, `{"id":3}`)
 	})
 
-	release, resp, err := client.Repositories.GetLatestRelease(context.Background(), "o", "r")
+	ctx := context.Background()
+	release, resp, err := client.Repositories.GetLatestRelease(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetLatestRelease returned error: %v\n%v", err, resp.Body)
 	}
@@ -88,7 +91,8 @@ func TestRepositoriesService_GetReleaseByTag(t *testing.T) {
 		fmt.Fprint(w, `{"id":13}`)
 	})
 
-	release, resp, err := client.Repositories.GetReleaseByTag(context.Background(), "o", "r", "foo")
+	ctx := context.Background()
+	release, resp, err := client.Repositories.GetReleaseByTag(ctx, "o", "r", "foo")
 	if err != nil {
 		t.Errorf("Repositories.GetReleaseByTag returned error: %v\n%v", err, resp.Body)
 	}
@@ -132,7 +136,8 @@ func TestRepositoriesService_CreateRelease(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	release, _, err := client.Repositories.CreateRelease(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	release, _, err := client.Repositories.CreateRelease(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.CreateRelease returned error: %v", err)
 	}
@@ -176,7 +181,8 @@ func TestRepositoriesService_EditRelease(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	release, _, err := client.Repositories.EditRelease(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	release, _, err := client.Repositories.EditRelease(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Repositories.EditRelease returned error: %v", err)
 	}
@@ -194,7 +200,8 @@ func TestRepositoriesService_DeleteRelease(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Repositories.DeleteRelease(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	_, err := client.Repositories.DeleteRelease(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeleteRelease returned error: %v", err)
 	}
@@ -211,7 +218,8 @@ func TestRepositoriesService_ListReleaseAssets(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	assets, _, err := client.Repositories.ListReleaseAssets(context.Background(), "o", "r", 1, opt)
+	ctx := context.Background()
+	assets, _, err := client.Repositories.ListReleaseAssets(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Repositories.ListReleaseAssets returned error: %v", err)
 	}
@@ -230,7 +238,8 @@ func TestRepositoriesService_GetReleaseAsset(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	asset, _, err := client.Repositories.GetReleaseAsset(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	asset, _, err := client.Repositories.GetReleaseAsset(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetReleaseAsset returned error: %v", err)
 	}
@@ -252,7 +261,8 @@ func TestRepositoriesService_DownloadReleaseAsset_Stream(t *testing.T) {
 		fmt.Fprint(w, "Hello World")
 	})
 
-	reader, _, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, nil)
+	ctx := context.Background()
+	reader, _, err := client.Repositories.DownloadReleaseAsset(ctx, "o", "r", 1, nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
 	}
@@ -276,7 +286,8 @@ func TestRepositoriesService_DownloadReleaseAsset_Redirect(t *testing.T) {
 		http.Redirect(w, r, "/yo", http.StatusFound)
 	})
 
-	_, got, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, nil)
+	ctx := context.Background()
+	_, got, err := client.Repositories.DownloadReleaseAsset(ctx, "o", "r", 1, nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
 	}
@@ -304,7 +315,8 @@ func TestRepositoriesService_DownloadReleaseAsset_FollowRedirect(t *testing.T) {
 		fmt.Fprint(w, "Hello World")
 	})
 
-	reader, _, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, http.DefaultClient)
+	ctx := context.Background()
+	reader, _, err := client.Repositories.DownloadReleaseAsset(ctx, "o", "r", 1, http.DefaultClient)
 	content, err := ioutil.ReadAll(reader)
 	if err != nil {
 		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
@@ -327,7 +339,8 @@ func TestRepositoriesService_DownloadReleaseAsset_APIError(t *testing.T) {
 		fmt.Fprint(w, `{"message":"Not Found","documentation_url":"https://developer.github.com/v3"}`)
 	})
 
-	resp, loc, err := client.Repositories.DownloadReleaseAsset(context.Background(), "o", "r", 1, nil)
+	ctx := context.Background()
+	resp, loc, err := client.Repositories.DownloadReleaseAsset(ctx, "o", "r", 1, nil)
 	if err == nil {
 		t.Error("Repositories.DownloadReleaseAsset did not return an error")
 	}
@@ -359,7 +372,8 @@ func TestRepositoriesService_EditReleaseAsset(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	asset, _, err := client.Repositories.EditReleaseAsset(context.Background(), "o", "r", 1, input)
+	ctx := context.Background()
+	asset, _, err := client.Repositories.EditReleaseAsset(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Repositories.EditReleaseAsset returned error: %v", err)
 	}
@@ -377,7 +391,8 @@ func TestRepositoriesService_DeleteReleaseAsset(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Repositories.DeleteReleaseAsset(context.Background(), "o", "r", 1)
+	ctx := context.Background()
+	_, err := client.Repositories.DeleteReleaseAsset(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeleteReleaseAsset returned error: %v", err)
 	}
@@ -460,7 +475,8 @@ func TestRepositoriesService_UploadReleaseAsset(t *testing.T) {
 		}
 		defer os.RemoveAll(dir)
 
-		asset, _, err := client.Repositories.UploadReleaseAsset(context.Background(), "o", "r", int64(key), test.uploadOpts, file)
+		ctx := context.Background()
+		asset, _, err := client.Repositories.UploadReleaseAsset(ctx, "o", "r", int64(key), test.uploadOpts, file)
 		if err != nil {
 			t.Errorf("Repositories.UploadReleaseAssert returned error: %v", err)
 		}

--- a/github/repos_stats_test.go
+++ b/github/repos_stats_test.go
@@ -42,7 +42,8 @@ func TestRepositoriesService_ListContributorsStats(t *testing.T) {
 `)
 	})
 
-	stats, _, err := client.Repositories.ListContributorsStats(context.Background(), "o", "r")
+	ctx := context.Background()
+	stats, _, err := client.Repositories.ListContributorsStats(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("RepositoriesService.ListContributorsStats returned error: %v", err)
 	}
@@ -88,7 +89,8 @@ func TestRepositoriesService_ListCommitActivity(t *testing.T) {
 `)
 	})
 
-	activity, _, err := client.Repositories.ListCommitActivity(context.Background(), "o", "r")
+	ctx := context.Background()
+	activity, _, err := client.Repositories.ListCommitActivity(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("RepositoriesService.ListCommitActivity returned error: %v", err)
 	}
@@ -116,7 +118,8 @@ func TestRepositoriesService_ListCodeFrequency(t *testing.T) {
 		fmt.Fprint(w, `[[1302998400, 1124, -435]]`)
 	})
 
-	code, _, err := client.Repositories.ListCodeFrequency(context.Background(), "o", "r")
+	ctx := context.Background()
+	code, _, err := client.Repositories.ListCodeFrequency(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("RepositoriesService.ListCodeFrequency returned error: %v", err)
 	}
@@ -157,7 +160,8 @@ func TestRepositoriesService_Participation(t *testing.T) {
 `)
 	})
 
-	participation, _, err := client.Repositories.ListParticipation(context.Background(), "o", "r")
+	ctx := context.Background()
+	participation, _, err := client.Repositories.ListParticipation(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("RepositoriesService.ListParticipation returned error: %v", err)
 	}
@@ -196,7 +200,8 @@ func TestRepositoriesService_ListPunchCard(t *testing.T) {
 		]`)
 	})
 
-	card, _, err := client.Repositories.ListPunchCard(context.Background(), "o", "r")
+	ctx := context.Background()
+	card, _, err := client.Repositories.ListPunchCard(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("RepositoriesService.ListPunchCard returned error: %v", err)
 	}
@@ -223,7 +228,8 @@ func TestRepositoriesService_AcceptedError(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	stats, _, err := client.Repositories.ListContributorsStats(context.Background(), "o", "r")
+	ctx := context.Background()
+	stats, _, err := client.Repositories.ListContributorsStats(ctx, "o", "r")
 	if err == nil {
 		t.Errorf("RepositoriesService.AcceptedError should have returned an error")
 	}

--- a/github/repos_statuses_test.go
+++ b/github/repos_statuses_test.go
@@ -25,7 +25,8 @@ func TestRepositoriesService_ListStatuses(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	statuses, _, err := client.Repositories.ListStatuses(context.Background(), "o", "r", "r", opt)
+	ctx := context.Background()
+	statuses, _, err := client.Repositories.ListStatuses(ctx, "o", "r", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListStatuses returned error: %v", err)
 	}
@@ -40,7 +41,8 @@ func TestRepositoriesService_ListStatuses_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.ListStatuses(context.Background(), "%", "r", "r", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.ListStatuses(ctx, "%", "r", "r", nil)
 	testURLParseError(t, err)
 }
 
@@ -61,7 +63,8 @@ func TestRepositoriesService_CreateStatus(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	status, _, err := client.Repositories.CreateStatus(context.Background(), "o", "r", "r", input)
+	ctx := context.Background()
+	status, _, err := client.Repositories.CreateStatus(ctx, "o", "r", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.CreateStatus returned error: %v", err)
 	}
@@ -76,7 +79,8 @@ func TestRepositoriesService_CreateStatus_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.CreateStatus(context.Background(), "%", "r", "r", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.CreateStatus(ctx, "%", "r", "r", nil)
 	testURLParseError(t, err)
 }
 
@@ -91,7 +95,8 @@ func TestRepositoriesService_GetCombinedStatus(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	status, _, err := client.Repositories.GetCombinedStatus(context.Background(), "o", "r", "r", opt)
+	ctx := context.Background()
+	status, _, err := client.Repositories.GetCombinedStatus(ctx, "o", "r", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.GetCombinedStatus returned error: %v", err)
 	}

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -84,7 +84,8 @@ func TestRepositoriesService_List_specifiedUser(t *testing.T) {
 		Direction:   "asc",
 		ListOptions: ListOptions{Page: 2},
 	}
-	repos, _, err := client.Repositories.List(context.Background(), "u", opt)
+	ctx := context.Background()
+	repos, _, err := client.Repositories.List(ctx, "u", opt)
 	if err != nil {
 		t.Errorf("Repositories.List returned error: %v", err)
 	}
@@ -112,7 +113,8 @@ func TestRepositoriesService_List_specifiedUser_type(t *testing.T) {
 	opt := &RepositoryListOptions{
 		Type: "owner",
 	}
-	repos, _, err := client.Repositories.List(context.Background(), "u", opt)
+	ctx := context.Background()
+	repos, _, err := client.Repositories.List(ctx, "u", opt)
 	if err != nil {
 		t.Errorf("Repositories.List returned error: %v", err)
 	}
@@ -127,7 +129,8 @@ func TestRepositoriesService_List_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.List(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.List(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -186,7 +189,8 @@ func TestRepositoriesService_ListByOrg_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.ListByOrg(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.ListByOrg(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -329,7 +333,8 @@ func TestRepositoriesService_Create_org(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	repo, _, err := client.Repositories.Create(context.Background(), "o", input)
+	ctx := context.Background()
+	repo, _, err := client.Repositories.Create(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Repositories.Create returned error: %v", err)
 	}
@@ -621,7 +626,8 @@ func TestRepositoriesService_Get_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.Get(context.Background(), "%", "r")
+	ctx := context.Background()
+	_, _, err := client.Repositories.Get(ctx, "%", "r")
 	testURLParseError(t, err)
 }
 
@@ -629,7 +635,8 @@ func TestRepositoriesService_Edit_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.Edit(context.Background(), "%", "r", nil)
+	ctx := context.Background()
+	_, _, err := client.Repositories.Edit(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
 
@@ -644,7 +651,8 @@ func TestRepositoriesService_GetVulnerabilityAlerts(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	vulnerabilityAlertsEnabled, _, err := client.Repositories.GetVulnerabilityAlerts(context.Background(), "o", "r")
+	ctx := context.Background()
+	vulnerabilityAlertsEnabled, _, err := client.Repositories.GetVulnerabilityAlerts(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetVulnerabilityAlerts returned error: %v", err)
 	}
@@ -665,7 +673,8 @@ func TestRepositoriesService_EnableVulnerabilityAlerts(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Repositories.EnableVulnerabilityAlerts(context.Background(), "o", "r"); err != nil {
+	ctx := context.Background()
+	if _, err := client.Repositories.EnableVulnerabilityAlerts(ctx, "o", "r"); err != nil {
 		t.Errorf("Repositories.EnableVulnerabilityAlerts returned error: %v", err)
 	}
 }
@@ -681,7 +690,8 @@ func TestRepositoriesService_DisableVulnerabilityAlerts(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Repositories.DisableVulnerabilityAlerts(context.Background(), "o", "r"); err != nil {
+	ctx := context.Background()
+	if _, err := client.Repositories.DisableVulnerabilityAlerts(ctx, "o", "r"); err != nil {
 		t.Errorf("Repositories.DisableVulnerabilityAlerts returned error: %v", err)
 	}
 }
@@ -697,7 +707,8 @@ func TestRepositoriesService_EnableAutomatedSecurityFixes(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Repositories.EnableAutomatedSecurityFixes(context.Background(), "o", "r"); err != nil {
+	ctx := context.Background()
+	if _, err := client.Repositories.EnableAutomatedSecurityFixes(ctx, "o", "r"); err != nil {
 		t.Errorf("Repositories.EnableAutomatedSecurityFixes returned error: %v", err)
 	}
 }
@@ -713,7 +724,8 @@ func TestRepositoriesService_DisableAutomatedSecurityFixes(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Repositories.DisableAutomatedSecurityFixes(context.Background(), "o", "r"); err != nil {
+	ctx := context.Background()
+	if _, err := client.Repositories.DisableAutomatedSecurityFixes(ctx, "o", "r"); err != nil {
 		t.Errorf("Repositories.DisableAutomatedSecurityFixes returned error: %v", err)
 	}
 }
@@ -732,7 +744,8 @@ func TestRepositoriesService_ListContributors(t *testing.T) {
 	})
 
 	opts := &ListContributorsOptions{Anon: "true", ListOptions: ListOptions{Page: 2}}
-	contributors, _, err := client.Repositories.ListContributors(context.Background(), "o", "r", opts)
+	ctx := context.Background()
+	contributors, _, err := client.Repositories.ListContributors(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Repositories.ListContributors returned error: %v", err)
 	}
@@ -752,7 +765,8 @@ func TestRepositoriesService_ListLanguages(t *testing.T) {
 		fmt.Fprint(w, `{"go":1}`)
 	})
 
-	languages, _, err := client.Repositories.ListLanguages(context.Background(), "o", "r")
+	ctx := context.Background()
+	languages, _, err := client.Repositories.ListLanguages(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.ListLanguages returned error: %v", err)
 	}
@@ -774,7 +788,8 @@ func TestRepositoriesService_ListTeams(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	teams, _, err := client.Repositories.ListTeams(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	teams, _, err := client.Repositories.ListTeams(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListTeams returned error: %v", err)
 	}
@@ -796,7 +811,8 @@ func TestRepositoriesService_ListTags(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	tags, _, err := client.Repositories.ListTags(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	tags, _, err := client.Repositories.ListTags(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListTags returned error: %v", err)
 	}
@@ -833,7 +849,8 @@ func TestRepositoriesService_ListBranches(t *testing.T) {
 		Protected:   nil,
 		ListOptions: ListOptions{Page: 2},
 	}
-	branches, _, err := client.Repositories.ListBranches(context.Background(), "o", "r", opt)
+	ctx := context.Background()
+	branches, _, err := client.Repositories.ListBranches(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListBranches returned error: %v", err)
 	}
@@ -855,7 +872,8 @@ func TestRepositoriesService_GetBranch(t *testing.T) {
 		fmt.Fprint(w, `{"name":"n", "commit":{"sha":"s","commit":{"message":"m"}}, "protected":true}`)
 	})
 
-	branch, _, err := client.Repositories.GetBranch(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	branch, _, err := client.Repositories.GetBranch(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.GetBranch returned error: %v", err)
 	}
@@ -918,7 +936,8 @@ func TestRepositoriesService_GetBranchProtection(t *testing.T) {
 				}`)
 	})
 
-	protection, _, err := client.Repositories.GetBranchProtection(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	protection, _, err := client.Repositories.GetBranchProtection(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.GetBranchProtection returned error: %v", err)
 	}
@@ -989,7 +1008,8 @@ func TestRepositoriesService_GetBranchProtection_noDismissalRestrictions(t *test
 				}`)
 	})
 
-	protection, _, err := client.Repositories.GetBranchProtection(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	protection, _, err := client.Repositories.GetBranchProtection(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.GetBranchProtection returned error: %v", err)
 	}
@@ -1084,7 +1104,8 @@ func TestRepositoriesService_UpdateBranchProtection(t *testing.T) {
 		}`)
 	})
 
-	protection, _, err := client.Repositories.UpdateBranchProtection(context.Background(), "o", "r", "b", input)
+	ctx := context.Background()
+	protection, _, err := client.Repositories.UpdateBranchProtection(ctx, "o", "r", "b", input)
 	if err != nil {
 		t.Errorf("Repositories.UpdateBranchProtection returned error: %v", err)
 	}
@@ -1134,7 +1155,8 @@ func TestRepositoriesService_RemoveBranchProtection(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Repositories.RemoveBranchProtection(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	_, err := client.Repositories.RemoveBranchProtection(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.RemoveBranchProtection returned error: %v", err)
 	}
@@ -1144,7 +1166,8 @@ func TestRepositoriesService_ListLanguages_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Repositories.ListLanguages(context.Background(), "%", "%")
+	ctx := context.Background()
+	_, _, err := client.Repositories.ListLanguages(ctx, "%", "%")
 	testURLParseError(t, err)
 }
 
@@ -1157,7 +1180,8 @@ func TestRepositoriesService_License(t *testing.T) {
 		fmt.Fprint(w, `{"name": "LICENSE", "path": "LICENSE", "license":{"key":"mit","name":"MIT License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","featured":true}}`)
 	})
 
-	got, _, err := client.Repositories.License(context.Background(), "o", "r")
+	ctx := context.Background()
+	got, _, err := client.Repositories.License(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.License returned error: %v", err)
 	}
@@ -1193,7 +1217,8 @@ func TestRepositoriesService_GetRequiredStatusChecks(t *testing.T) {
 		fmt.Fprint(w, `{"strict": true,"contexts": ["x","y","z"]}`)
 	})
 
-	checks, _, err := client.Repositories.GetRequiredStatusChecks(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	checks, _, err := client.Repositories.GetRequiredStatusChecks(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.GetRequiredStatusChecks returned error: %v", err)
 	}
@@ -1228,7 +1253,8 @@ func TestRepositoriesService_UpdateRequiredStatusChecks(t *testing.T) {
 		fmt.Fprintf(w, `{"strict":true,"contexts":["continuous-integration"]}`)
 	})
 
-	statusChecks, _, err := client.Repositories.UpdateRequiredStatusChecks(context.Background(), "o", "r", "b", input)
+	ctx := context.Background()
+	statusChecks, _, err := client.Repositories.UpdateRequiredStatusChecks(ctx, "o", "r", "b", input)
 	if err != nil {
 		t.Errorf("Repositories.UpdateRequiredStatusChecks returned error: %v", err)
 	}
@@ -1256,7 +1282,8 @@ func TestRepositoriesService_ListRequiredStatusChecksContexts(t *testing.T) {
 		fmt.Fprint(w, `["x", "y", "z"]`)
 	})
 
-	contexts, _, err := client.Repositories.ListRequiredStatusChecksContexts(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	contexts, _, err := client.Repositories.ListRequiredStatusChecksContexts(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.ListRequiredStatusChecksContexts returned error: %v", err)
 	}
@@ -1286,7 +1313,8 @@ func TestRepositoriesService_GetPullRequestReviewEnforcement(t *testing.T) {
 		}`)
 	})
 
-	enforcement, _, err := client.Repositories.GetPullRequestReviewEnforcement(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	enforcement, _, err := client.Repositories.GetPullRequestReviewEnforcement(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.GetPullRequestReviewEnforcement returned error: %v", err)
 	}
@@ -1342,7 +1370,8 @@ func TestRepositoriesService_UpdatePullRequestReviewEnforcement(t *testing.T) {
 		}`)
 	})
 
-	enforcement, _, err := client.Repositories.UpdatePullRequestReviewEnforcement(context.Background(), "o", "r", "b", input)
+	ctx := context.Background()
+	enforcement, _, err := client.Repositories.UpdatePullRequestReviewEnforcement(ctx, "o", "r", "b", input)
 	if err != nil {
 		t.Errorf("Repositories.UpdatePullRequestReviewEnforcement returned error: %v", err)
 	}
@@ -1377,7 +1406,8 @@ func TestRepositoriesService_DisableDismissalRestrictions(t *testing.T) {
 		fmt.Fprintf(w, `{"dismiss_stale_reviews":true,"require_code_owner_reviews":true,"required_approving_review_count":1}`)
 	})
 
-	enforcement, _, err := client.Repositories.DisableDismissalRestrictions(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	enforcement, _, err := client.Repositories.DisableDismissalRestrictions(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.DisableDismissalRestrictions returned error: %v", err)
 	}
@@ -1403,7 +1433,8 @@ func TestRepositoriesService_RemovePullRequestReviewEnforcement(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Repositories.RemovePullRequestReviewEnforcement(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	_, err := client.Repositories.RemovePullRequestReviewEnforcement(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.RemovePullRequestReviewEnforcement returned error: %v", err)
 	}
@@ -1419,7 +1450,8 @@ func TestRepositoriesService_GetAdminEnforcement(t *testing.T) {
 		fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/enforce_admins","enabled":true}`)
 	})
 
-	enforcement, _, err := client.Repositories.GetAdminEnforcement(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	enforcement, _, err := client.Repositories.GetAdminEnforcement(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.GetAdminEnforcement returned error: %v", err)
 	}
@@ -1444,7 +1476,8 @@ func TestRepositoriesService_AddAdminEnforcement(t *testing.T) {
 		fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/enforce_admins","enabled":true}`)
 	})
 
-	enforcement, _, err := client.Repositories.AddAdminEnforcement(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	enforcement, _, err := client.Repositories.AddAdminEnforcement(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.AddAdminEnforcement returned error: %v", err)
 	}
@@ -1468,7 +1501,8 @@ func TestRepositoriesService_RemoveAdminEnforcement(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Repositories.RemoveAdminEnforcement(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	_, err := client.Repositories.RemoveAdminEnforcement(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.RemoveAdminEnforcement returned error: %v", err)
 	}
@@ -1484,7 +1518,8 @@ func TestRepositoriesService_GetSignaturesProtectedBranch(t *testing.T) {
 		fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/required_signatures","enabled":false}`)
 	})
 
-	signature, _, err := client.Repositories.GetSignaturesProtectedBranch(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	signature, _, err := client.Repositories.GetSignaturesProtectedBranch(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.GetSignaturesProtectedBranch returned error: %v", err)
 	}
@@ -1509,7 +1544,8 @@ func TestRepositoriesService_RequireSignaturesOnProtectedBranch(t *testing.T) {
 		fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/required_signatures","enabled":true}`)
 	})
 
-	signature, _, err := client.Repositories.RequireSignaturesOnProtectedBranch(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	signature, _, err := client.Repositories.RequireSignaturesOnProtectedBranch(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.RequireSignaturesOnProtectedBranch returned error: %v", err)
 	}
@@ -1534,7 +1570,8 @@ func TestRepositoriesService_OptionalSignaturesOnProtectedBranch(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Repositories.OptionalSignaturesOnProtectedBranch(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	_, err := client.Repositories.OptionalSignaturesOnProtectedBranch(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.OptionalSignaturesOnProtectedBranch returned error: %v", err)
 	}
@@ -1595,7 +1632,8 @@ func TestRepositoriesService_ListAllTopics(t *testing.T) {
 		fmt.Fprint(w, `{"names":["go", "go-github", "github"]}`)
 	})
 
-	got, _, err := client.Repositories.ListAllTopics(context.Background(), "o", "r")
+	ctx := context.Background()
+	got, _, err := client.Repositories.ListAllTopics(ctx, "o", "r")
 	if err != nil {
 		t.Fatalf("Repositories.ListAllTopics returned error: %v", err)
 	}
@@ -1616,7 +1654,8 @@ func TestRepositoriesService_ListAllTopics_emptyTopics(t *testing.T) {
 		fmt.Fprint(w, `{"names":[]}`)
 	})
 
-	got, _, err := client.Repositories.ListAllTopics(context.Background(), "o", "r")
+	ctx := context.Background()
+	got, _, err := client.Repositories.ListAllTopics(ctx, "o", "r")
 	if err != nil {
 		t.Fatalf("Repositories.ListAllTopics returned error: %v", err)
 	}
@@ -1637,7 +1676,8 @@ func TestRepositoriesService_ReplaceAllTopics(t *testing.T) {
 		fmt.Fprint(w, `{"names":["go", "go-github", "github"]}`)
 	})
 
-	got, _, err := client.Repositories.ReplaceAllTopics(context.Background(), "o", "r", []string{"go", "go-github", "github"})
+	ctx := context.Background()
+	got, _, err := client.Repositories.ReplaceAllTopics(ctx, "o", "r", []string{"go", "go-github", "github"})
 	if err != nil {
 		t.Fatalf("Repositories.ReplaceAllTopics returned error: %v", err)
 	}
@@ -1659,7 +1699,8 @@ func TestRepositoriesService_ReplaceAllTopics_nilSlice(t *testing.T) {
 		fmt.Fprint(w, `{"names":[]}`)
 	})
 
-	got, _, err := client.Repositories.ReplaceAllTopics(context.Background(), "o", "r", nil)
+	ctx := context.Background()
+	got, _, err := client.Repositories.ReplaceAllTopics(ctx, "o", "r", nil)
 	if err != nil {
 		t.Fatalf("Repositories.ReplaceAllTopics returned error: %v", err)
 	}
@@ -1681,7 +1722,8 @@ func TestRepositoriesService_ReplaceAllTopics_emptySlice(t *testing.T) {
 		fmt.Fprint(w, `{"names":[]}`)
 	})
 
-	got, _, err := client.Repositories.ReplaceAllTopics(context.Background(), "o", "r", []string{})
+	ctx := context.Background()
+	got, _, err := client.Repositories.ReplaceAllTopics(ctx, "o", "r", []string{})
 	if err != nil {
 		t.Fatalf("Repositories.ReplaceAllTopics returned error: %v", err)
 	}
@@ -1700,7 +1742,8 @@ func TestRepositoriesService_ListApps(t *testing.T) {
 		testMethod(t, r, "GET")
 	})
 
-	_, _, err := client.Repositories.ListApps(context.Background(), "o", "r", "b")
+	ctx := context.Background()
+	_, _, err := client.Repositories.ListApps(ctx, "o", "r", "b")
 	if err != nil {
 		t.Errorf("Repositories.ListApps returned error: %v", err)
 	}
@@ -1717,7 +1760,8 @@ func TestRepositoriesService_ReplaceAppRestrictions(t *testing.T) {
 			}]`)
 	})
 	input := []string{"octocat"}
-	got, _, err := client.Repositories.ReplaceAppRestrictions(context.Background(), "o", "r", "b", input)
+	ctx := context.Background()
+	got, _, err := client.Repositories.ReplaceAppRestrictions(ctx, "o", "r", "b", input)
 	if err != nil {
 		t.Errorf("Repositories.ReplaceAppRestrictions returned error: %v", err)
 	}
@@ -1740,7 +1784,8 @@ func TestRepositoriesService_AddAppRestrictions(t *testing.T) {
 			}]`)
 	})
 	input := []string{"octocat"}
-	got, _, err := client.Repositories.AddAppRestrictions(context.Background(), "o", "r", "b", input)
+	ctx := context.Background()
+	got, _, err := client.Repositories.AddAppRestrictions(ctx, "o", "r", "b", input)
 	if err != nil {
 		t.Errorf("Repositories.AddAppRestrictions returned error: %v", err)
 	}
@@ -1761,7 +1806,8 @@ func TestRepositoriesService_RemoveAppRestrictions(t *testing.T) {
 		fmt.Fprint(w, `[]`)
 	})
 	input := []string{"octocat"}
-	got, _, err := client.Repositories.RemoveAppRestrictions(context.Background(), "o", "r", "b", input)
+	ctx := context.Background()
+	got, _, err := client.Repositories.RemoveAppRestrictions(ctx, "o", "r", "b", input)
 	if err != nil {
 		t.Errorf("Repositories.RemoveAppRestrictions returned error: %v", err)
 	}
@@ -1789,7 +1835,8 @@ func TestRepositoriesService_Transfer(t *testing.T) {
 		fmt.Fprint(w, `{"owner":{"login":"a"}}`)
 	})
 
-	got, _, err := client.Repositories.Transfer(context.Background(), "o", "r", input)
+	ctx := context.Background()
+	got, _, err := client.Repositories.Transfer(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.Transfer returned error: %v", err)
 	}

--- a/github/search_test.go
+++ b/github/search_test.go
@@ -31,7 +31,8 @@ func TestSearchService_Repositories(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "forks", Order: "desc", ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	result, _, err := client.Search.Repositories(context.Background(), "blah", opts)
+	ctx := context.Background()
+	result, _, err := client.Search.Repositories(ctx, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Repositories returned error: %v", err)
 	}
@@ -62,7 +63,8 @@ func TestSearchService_Topics(t *testing.T) {
 	})
 
 	opts := &SearchOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	result, _, err := client.Search.Topics(context.Background(), "blah", opts)
+	ctx := context.Background()
+	result, _, err := client.Search.Topics(ctx, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Topics returned error: %v", err)
 	}
@@ -93,7 +95,8 @@ func TestSearchService_Commits(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "author-date", Order: "desc"}
-	result, _, err := client.Search.Commits(context.Background(), "blah", opts)
+	ctx := context.Background()
+	result, _, err := client.Search.Commits(ctx, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Commits returned error: %v", err)
 	}
@@ -126,7 +129,8 @@ func TestSearchService_Issues(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "forks", Order: "desc", ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	result, _, err := client.Search.Issues(context.Background(), "blah", opts)
+	ctx := context.Background()
+	result, _, err := client.Search.Issues(ctx, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Issues returned error: %v", err)
 	}
@@ -159,7 +163,8 @@ func TestSearchService_Issues_withQualifiersNoOpts(t *testing.T) {
 	})
 
 	opts := &SearchOptions{}
-	result, _, err := client.Search.Issues(context.Background(), q, opts)
+	ctx := context.Background()
+	result, _, err := client.Search.Issues(ctx, q, opts)
 	if err != nil {
 		t.Errorf("Search.Issues returned error: %v", err)
 	}
@@ -197,7 +202,8 @@ func TestSearchService_Issues_withQualifiersAndOpts(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "forks"}
-	result, _, err := client.Search.Issues(context.Background(), q, opts)
+	ctx := context.Background()
+	result, _, err := client.Search.Issues(ctx, q, opts)
 	if err != nil {
 		t.Errorf("Search.Issues returned error: %v", err)
 	}
@@ -234,7 +240,8 @@ func TestSearchService_Users(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "forks", Order: "desc", ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	result, _, err := client.Search.Users(context.Background(), "blah", opts)
+	ctx := context.Background()
+	result, _, err := client.Search.Users(ctx, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Issues returned error: %v", err)
 	}
@@ -267,7 +274,8 @@ func TestSearchService_Code(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "forks", Order: "desc", ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	result, _, err := client.Search.Code(context.Background(), "blah", opts)
+	ctx := context.Background()
+	result, _, err := client.Search.Code(ctx, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Code returned error: %v", err)
 	}
@@ -319,7 +327,8 @@ func TestSearchService_CodeTextMatch(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "forks", Order: "desc", ListOptions: ListOptions{Page: 2, PerPage: 2}, TextMatch: true}
-	result, _, err := client.Search.Code(context.Background(), "blah", opts)
+	ctx := context.Background()
+	result, _, err := client.Search.Code(ctx, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Code returned error: %v", err)
 	}
@@ -362,7 +371,8 @@ func TestSearchService_Labels(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "updated", Order: "desc", ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	result, _, err := client.Search.Labels(context.Background(), 1234, "blah", opts)
+	ctx := context.Background()
+	result, _, err := client.Search.Labels(ctx, 1234, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Code returned error: %v", err)
 	}

--- a/github/teams_discussion_comments_test.go
+++ b/github/teams_discussion_comments_test.go
@@ -117,7 +117,8 @@ func TestTeamsService_ListComments(t *testing.T) {
 	e := tdcEndpointByID("1", "2", "3", "")
 	mux.HandleFunc(e, handleFunc)
 
-	commentsByID, _, err := client.Teams.ListCommentsByID(context.Background(), 1, 2, 3,
+	ctx := context.Background()
+	commentsByID, _, err := client.Teams.ListCommentsByID(ctx, 1, 2, 3,
 		&DiscussionCommentListOptions{Direction: "desc"})
 	if err != nil {
 		t.Errorf("Teams.ListCommentsByID returned error: %v", err)
@@ -130,7 +131,7 @@ func TestTeamsService_ListComments(t *testing.T) {
 	e = tdcEndpointBySlug("a", "b", "3", "")
 	mux.HandleFunc(e, handleFunc)
 
-	commentsBySlug, _, err := client.Teams.ListCommentsBySlug(context.Background(), "a", "b", 3,
+	commentsBySlug, _, err := client.Teams.ListCommentsBySlug(ctx, "a", "b", 3,
 		&DiscussionCommentListOptions{Direction: "desc"})
 	if err != nil {
 		t.Errorf("Teams.ListCommentsBySlug returned error: %v", err)
@@ -154,7 +155,8 @@ func TestTeamsService_GetComment(t *testing.T) {
 	e := tdcEndpointByID("1", "2", "3", "4")
 	mux.HandleFunc(e, handlerFunc)
 
-	commentByID, _, err := client.Teams.GetCommentByID(context.Background(), 1, 2, 3, 4)
+	ctx := context.Background()
+	commentByID, _, err := client.Teams.GetCommentByID(ctx, 1, 2, 3, 4)
 	if err != nil {
 		t.Errorf("Teams.GetCommentByID returned error: %v", err)
 	}
@@ -166,7 +168,7 @@ func TestTeamsService_GetComment(t *testing.T) {
 	e = tdcEndpointBySlug("a", "b", "3", "4")
 	mux.HandleFunc(e, handlerFunc)
 
-	commentBySlug, _, err := client.Teams.GetCommentBySlug(context.Background(), "a", "b", 3, 4)
+	commentBySlug, _, err := client.Teams.GetCommentBySlug(ctx, "a", "b", 3, 4)
 	if err != nil {
 		t.Errorf("Teams.GetCommentBySlug returned error: %v", err)
 	}
@@ -199,7 +201,8 @@ func TestTeamsService_CreateComment(t *testing.T) {
 	e := tdcEndpointByID("1", "2", "3", "")
 	mux.HandleFunc(e, handlerFunc)
 
-	commentByID, _, err := client.Teams.CreateCommentByID(context.Background(), 1, 2, 3, input)
+	ctx := context.Background()
+	commentByID, _, err := client.Teams.CreateCommentByID(ctx, 1, 2, 3, input)
 	if err != nil {
 		t.Errorf("Teams.CreateCommentByID returned error: %v", err)
 	}
@@ -211,7 +214,7 @@ func TestTeamsService_CreateComment(t *testing.T) {
 	e = tdcEndpointBySlug("a", "b", "3", "")
 	mux.HandleFunc(e, handlerFunc)
 
-	commentBySlug, _, err := client.Teams.CreateCommentBySlug(context.Background(), "a", "b", 3, input)
+	commentBySlug, _, err := client.Teams.CreateCommentBySlug(ctx, "a", "b", 3, input)
 	if err != nil {
 		t.Errorf("Teams.CreateCommentBySlug returned error: %v", err)
 	}
@@ -242,7 +245,8 @@ func TestTeamsService_EditComment(t *testing.T) {
 	e := tdcEndpointByID("1", "2", "3", "4")
 	mux.HandleFunc(e, handlerFunc)
 
-	commentByID, _, err := client.Teams.EditCommentByID(context.Background(), 1, 2, 3, 4, input)
+	ctx := context.Background()
+	commentByID, _, err := client.Teams.EditCommentByID(ctx, 1, 2, 3, 4, input)
 	if err != nil {
 		t.Errorf("Teams.EditCommentByID returned error: %v", err)
 	}
@@ -254,7 +258,7 @@ func TestTeamsService_EditComment(t *testing.T) {
 	e = tdcEndpointBySlug("a", "b", "3", "4")
 	mux.HandleFunc(e, handlerFunc)
 
-	commentBySlug, _, err := client.Teams.EditCommentBySlug(context.Background(), "a", "b", 3, 4, input)
+	commentBySlug, _, err := client.Teams.EditCommentBySlug(ctx, "a", "b", 3, 4, input)
 	if err != nil {
 		t.Errorf("Teams.EditCommentBySlug returned error: %v", err)
 	}
@@ -275,7 +279,8 @@ func TestTeamsService_DeleteComment(t *testing.T) {
 	e := tdcEndpointByID("1", "2", "3", "4")
 	mux.HandleFunc(e, handlerFunc)
 
-	_, err := client.Teams.DeleteCommentByID(context.Background(), 1, 2, 3, 4)
+	ctx := context.Background()
+	_, err := client.Teams.DeleteCommentByID(ctx, 1, 2, 3, 4)
 	if err != nil {
 		t.Errorf("Teams.DeleteCommentByID returned error: %v", err)
 	}
@@ -283,7 +288,7 @@ func TestTeamsService_DeleteComment(t *testing.T) {
 	e = tdcEndpointBySlug("a", "b", "3", "4")
 	mux.HandleFunc(e, handlerFunc)
 
-	_, err = client.Teams.DeleteCommentBySlug(context.Background(), "a", "b", 3, 4)
+	_, err = client.Teams.DeleteCommentBySlug(ctx, "a", "b", 3, 4)
 	if err != nil {
 		t.Errorf("Teams.DeleteCommentBySlug returned error: %v", err)
 	}

--- a/github/teams_discussions_test.go
+++ b/github/teams_discussions_test.go
@@ -66,7 +66,8 @@ func TestTeamsService_ListDiscussionsByID(t *testing.T) {
 				}
 			]`)
 	})
-	discussions, _, err := client.Teams.ListDiscussionsByID(context.Background(), 1, 2, &DiscussionListOptions{"desc", ListOptions{Page: 2}})
+	ctx := context.Background()
+	discussions, _, err := client.Teams.ListDiscussionsByID(ctx, 1, 2, &DiscussionListOptions{"desc", ListOptions{Page: 2}})
 	if err != nil {
 		t.Errorf("Teams.ListDiscussionsByID returned error: %v", err)
 	}
@@ -166,7 +167,8 @@ func TestTeamsService_ListDiscussionsBySlug(t *testing.T) {
 				}
 			]`)
 	})
-	discussions, _, err := client.Teams.ListDiscussionsBySlug(context.Background(), "o", "s", &DiscussionListOptions{"desc", ListOptions{Page: 2}})
+	ctx := context.Background()
+	discussions, _, err := client.Teams.ListDiscussionsBySlug(ctx, "o", "s", &DiscussionListOptions{"desc", ListOptions{Page: 2}})
 	if err != nil {
 		t.Errorf("Teams.ListDiscussionsBySlug returned error: %v", err)
 	}
@@ -224,7 +226,8 @@ func TestTeamsService_GetDiscussionByID(t *testing.T) {
 		fmt.Fprint(w, `{"number":3}`)
 	})
 
-	discussion, _, err := client.Teams.GetDiscussionByID(context.Background(), 1, 2, 3)
+	ctx := context.Background()
+	discussion, _, err := client.Teams.GetDiscussionByID(ctx, 1, 2, 3)
 	if err != nil {
 		t.Errorf("Teams.GetDiscussionByID returned error: %v", err)
 	}
@@ -244,7 +247,8 @@ func TestTeamsService_GetDiscussionBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"number":3}`)
 	})
 
-	discussion, _, err := client.Teams.GetDiscussionBySlug(context.Background(), "o", "s", 3)
+	ctx := context.Background()
+	discussion, _, err := client.Teams.GetDiscussionBySlug(ctx, "o", "s", 3)
 	if err != nil {
 		t.Errorf("Teams.GetDiscussionBySlug returned error: %v", err)
 	}
@@ -273,7 +277,8 @@ func TestTeamsService_CreateDiscussionByID(t *testing.T) {
 		fmt.Fprint(w, `{"number":3}`)
 	})
 
-	comment, _, err := client.Teams.CreateDiscussionByID(context.Background(), 1, 2, input)
+	ctx := context.Background()
+	comment, _, err := client.Teams.CreateDiscussionByID(ctx, 1, 2, input)
 	if err != nil {
 		t.Errorf("Teams.CreateDiscussionByID returned error: %v", err)
 	}
@@ -302,7 +307,8 @@ func TestTeamsService_CreateDiscussionBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"number":3}`)
 	})
 
-	comment, _, err := client.Teams.CreateDiscussionBySlug(context.Background(), "o", "s", input)
+	ctx := context.Background()
+	comment, _, err := client.Teams.CreateDiscussionBySlug(ctx, "o", "s", input)
 	if err != nil {
 		t.Errorf("Teams.CreateDiscussionBySlug returned error: %v", err)
 	}
@@ -331,7 +337,8 @@ func TestTeamsService_EditDiscussionByID(t *testing.T) {
 		fmt.Fprint(w, `{"number":3}`)
 	})
 
-	comment, _, err := client.Teams.EditDiscussionByID(context.Background(), 1, 2, 3, input)
+	ctx := context.Background()
+	comment, _, err := client.Teams.EditDiscussionByID(ctx, 1, 2, 3, input)
 	if err != nil {
 		t.Errorf("Teams.EditDiscussionByID returned error: %v", err)
 	}
@@ -360,7 +367,8 @@ func TestTeamsService_EditDiscussionBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"number":3}`)
 	})
 
-	comment, _, err := client.Teams.EditDiscussionBySlug(context.Background(), "o", "s", 3, input)
+	ctx := context.Background()
+	comment, _, err := client.Teams.EditDiscussionBySlug(ctx, "o", "s", 3, input)
 	if err != nil {
 		t.Errorf("Teams.EditDiscussionBySlug returned error: %v", err)
 	}
@@ -379,7 +387,8 @@ func TestTeamsService_DeleteDiscussionByID(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Teams.DeleteDiscussionByID(context.Background(), 1, 2, 3)
+	ctx := context.Background()
+	_, err := client.Teams.DeleteDiscussionByID(ctx, 1, 2, 3)
 	if err != nil {
 		t.Errorf("Teams.DeleteDiscussionByID returned error: %v", err)
 	}
@@ -393,7 +402,8 @@ func TestTeamsService_DeleteDiscussionBySlug(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Teams.DeleteDiscussionBySlug(context.Background(), "o", "s", 3)
+	ctx := context.Background()
+	_, err := client.Teams.DeleteDiscussionBySlug(ctx, "o", "s", 3)
 	if err != nil {
 		t.Errorf("Teams.DeleteDiscussionBySlug returned error: %v", err)
 	}

--- a/github/teams_members_test.go
+++ b/github/teams_members_test.go
@@ -25,7 +25,8 @@ func TestTeamsService__ListTeamMembersByID(t *testing.T) {
 	})
 
 	opt := &TeamListTeamMembersOptions{Role: "member", ListOptions: ListOptions{Page: 2}}
-	members, _, err := client.Teams.ListTeamMembersByID(context.Background(), 1, 2, opt)
+	ctx := context.Background()
+	members, _, err := client.Teams.ListTeamMembersByID(ctx, 1, 2, opt)
 	if err != nil {
 		t.Errorf("Teams.ListTeamMembersByID returned error: %v", err)
 	}
@@ -47,7 +48,8 @@ func TestTeamsService__ListTeamMembersByID_notFound(t *testing.T) {
 	})
 
 	opt := &TeamListTeamMembersOptions{Role: "member", ListOptions: ListOptions{Page: 2}}
-	members, resp, err := client.Teams.ListTeamMembersByID(context.Background(), 1, 2, opt)
+	ctx := context.Background()
+	members, resp, err := client.Teams.ListTeamMembersByID(ctx, 1, 2, opt)
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -70,7 +72,8 @@ func TestTeamsService__ListTeamMembersBySlug(t *testing.T) {
 	})
 
 	opt := &TeamListTeamMembersOptions{Role: "member", ListOptions: ListOptions{Page: 2}}
-	members, _, err := client.Teams.ListTeamMembersBySlug(context.Background(), "o", "s", opt)
+	ctx := context.Background()
+	members, _, err := client.Teams.ListTeamMembersBySlug(ctx, "o", "s", opt)
 	if err != nil {
 		t.Errorf("Teams.ListTeamMembersBySlug returned error: %v", err)
 	}
@@ -92,7 +95,8 @@ func TestTeamsService__ListTeamMembersBySlug_notFound(t *testing.T) {
 	})
 
 	opt := &TeamListTeamMembersOptions{Role: "member", ListOptions: ListOptions{Page: 2}}
-	members, resp, err := client.Teams.ListTeamMembersBySlug(context.Background(), "o", "s", opt)
+	ctx := context.Background()
+	members, resp, err := client.Teams.ListTeamMembersBySlug(ctx, "o", "s", opt)
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -108,7 +112,8 @@ func TestTeamsService__ListTeamMembersBySlug_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Teams.ListTeamMembersBySlug(context.Background(), "%", "s", nil)
+	ctx := context.Background()
+	_, _, err := client.Teams.ListTeamMembersBySlug(ctx, "%", "s", nil)
 	testURLParseError(t, err)
 }
 
@@ -121,7 +126,8 @@ func TestTeamsService__GetTeamMembershipByID(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u", "state":"active"}`)
 	})
 
-	membership, _, err := client.Teams.GetTeamMembershipByID(context.Background(), 1, 2, "u")
+	ctx := context.Background()
+	membership, _, err := client.Teams.GetTeamMembershipByID(ctx, 1, 2, "u")
 	if err != nil {
 		t.Errorf("Teams.GetTeamMembershipByID returned error: %v", err)
 	}
@@ -141,7 +147,8 @@ func TestTeamsService__GetTeamMembershipByID_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	membership, resp, err := client.Teams.GetTeamMembershipByID(context.Background(), 1, 2, "u")
+	ctx := context.Background()
+	membership, resp, err := client.Teams.GetTeamMembershipByID(ctx, 1, 2, "u")
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -162,7 +169,8 @@ func TestTeamsService__GetTeamMembershipBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u", "state":"active"}`)
 	})
 
-	membership, _, err := client.Teams.GetTeamMembershipBySlug(context.Background(), "o", "s", "u")
+	ctx := context.Background()
+	membership, _, err := client.Teams.GetTeamMembershipBySlug(ctx, "o", "s", "u")
 	if err != nil {
 		t.Errorf("Teams.GetTeamMembershipBySlug returned error: %v", err)
 	}
@@ -182,7 +190,8 @@ func TestTeamsService__GetTeamMembershipBySlug_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	membership, resp, err := client.Teams.GetTeamMembershipBySlug(context.Background(), "o", "s", "u")
+	ctx := context.Background()
+	membership, resp, err := client.Teams.GetTeamMembershipBySlug(ctx, "o", "s", "u")
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -198,7 +207,8 @@ func TestTeamsService__GetTeamMembershipBySlug_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Teams.GetTeamMembershipBySlug(context.Background(), "%s", "s", "u")
+	ctx := context.Background()
+	_, _, err := client.Teams.GetTeamMembershipBySlug(ctx, "%s", "s", "u")
 	testURLParseError(t, err)
 }
 
@@ -220,7 +230,8 @@ func TestTeamsService__AddTeamMembershipByID(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u", "state":"pending"}`)
 	})
 
-	membership, _, err := client.Teams.AddTeamMembershipByID(context.Background(), 1, 2, "u", opt)
+	ctx := context.Background()
+	membership, _, err := client.Teams.AddTeamMembershipByID(ctx, 1, 2, "u", opt)
 	if err != nil {
 		t.Errorf("Teams.AddTeamMembershipByID returned error: %v", err)
 	}
@@ -249,7 +260,8 @@ func TestTeamsService__AddTeamMembershipByID_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	membership, resp, err := client.Teams.AddTeamMembershipByID(context.Background(), 1, 2, "u", opt)
+	ctx := context.Background()
+	membership, resp, err := client.Teams.AddTeamMembershipByID(ctx, 1, 2, "u", opt)
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -279,7 +291,8 @@ func TestTeamsService__AddTeamMembershipBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u", "state":"pending"}`)
 	})
 
-	membership, _, err := client.Teams.AddTeamMembershipBySlug(context.Background(), "o", "s", "u", opt)
+	ctx := context.Background()
+	membership, _, err := client.Teams.AddTeamMembershipBySlug(ctx, "o", "s", "u", opt)
 	if err != nil {
 		t.Errorf("Teams.AddTeamMembershipBySlug returned error: %v", err)
 	}
@@ -308,7 +321,8 @@ func TestTeamsService__AddTeamMembershipBySlug_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	membership, resp, err := client.Teams.AddTeamMembershipBySlug(context.Background(), "o", "s", "u", opt)
+	ctx := context.Background()
+	membership, resp, err := client.Teams.AddTeamMembershipBySlug(ctx, "o", "s", "u", opt)
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -324,7 +338,8 @@ func TestTeamsService__AddTeamMembershipBySlug_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Teams.AddTeamMembershipBySlug(context.Background(), "%", "s", "u", nil)
+	ctx := context.Background()
+	_, _, err := client.Teams.AddTeamMembershipBySlug(ctx, "%", "s", "u", nil)
 	testURLParseError(t, err)
 }
 
@@ -337,7 +352,8 @@ func TestTeamsService__RemoveTeamMembershipByID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Teams.RemoveTeamMembershipByID(context.Background(), 1, 2, "u")
+	ctx := context.Background()
+	_, err := client.Teams.RemoveTeamMembershipByID(ctx, 1, 2, "u")
 	if err != nil {
 		t.Errorf("Teams.RemoveTeamMembershipByID returned error: %v", err)
 	}
@@ -352,7 +368,8 @@ func TestTeamsService__RemoveTeamMembershipByID_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	resp, err := client.Teams.RemoveTeamMembershipByID(context.Background(), 1, 2, "u")
+	ctx := context.Background()
+	resp, err := client.Teams.RemoveTeamMembershipByID(ctx, 1, 2, "u")
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -370,7 +387,8 @@ func TestTeamsService__RemoveTeamMembershipBySlug(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Teams.RemoveTeamMembershipBySlug(context.Background(), "o", "s", "u")
+	ctx := context.Background()
+	_, err := client.Teams.RemoveTeamMembershipBySlug(ctx, "o", "s", "u")
 	if err != nil {
 		t.Errorf("Teams.RemoveTeamMembershipBySlug returned error: %v", err)
 	}
@@ -385,7 +403,8 @@ func TestTeamsService__RemoveTeamMembershipBySlug_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	resp, err := client.Teams.RemoveTeamMembershipBySlug(context.Background(), "o", "s", "u")
+	ctx := context.Background()
+	resp, err := client.Teams.RemoveTeamMembershipBySlug(ctx, "o", "s", "u")
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -398,7 +417,8 @@ func TestTeamsService__RemoveTeamMembershipBySlug_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Teams.RemoveTeamMembershipBySlug(context.Background(), "%", "s", "u")
+	ctx := context.Background()
+	_, err := client.Teams.RemoveTeamMembershipBySlug(ctx, "%", "s", "u")
 	testURLParseError(t, err)
 }
 
@@ -413,7 +433,8 @@ func TestTeamsService__ListPendingTeamInvitationsByID(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	invitations, _, err := client.Teams.ListPendingTeamInvitationsByID(context.Background(), 1, 2, opt)
+	ctx := context.Background()
+	invitations, _, err := client.Teams.ListPendingTeamInvitationsByID(ctx, 1, 2, opt)
 	if err != nil {
 		t.Errorf("Teams.ListPendingTeamInvitationsByID returned error: %v", err)
 	}
@@ -435,7 +456,8 @@ func TestTeamsService__ListPendingTeamInvitationsByID_notFound(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	invitations, resp, err := client.Teams.ListPendingTeamInvitationsByID(context.Background(), 1, 2, opt)
+	ctx := context.Background()
+	invitations, resp, err := client.Teams.ListPendingTeamInvitationsByID(ctx, 1, 2, opt)
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -458,7 +480,8 @@ func TestTeamsService__ListPendingTeamInvitationsBySlug(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	invitations, _, err := client.Teams.ListPendingTeamInvitationsBySlug(context.Background(), "o", "s", opt)
+	ctx := context.Background()
+	invitations, _, err := client.Teams.ListPendingTeamInvitationsBySlug(ctx, "o", "s", opt)
 	if err != nil {
 		t.Errorf("Teams.ListPendingTeamInvitationsByID returned error: %v", err)
 	}
@@ -480,7 +503,8 @@ func TestTeamsService__ListPendingTeamInvitationsBySlug_notFound(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	invitations, resp, err := client.Teams.ListPendingTeamInvitationsBySlug(context.Background(), "o", "s", opt)
+	ctx := context.Background()
+	invitations, resp, err := client.Teams.ListPendingTeamInvitationsBySlug(ctx, "o", "s", opt)
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -496,6 +520,7 @@ func TestTeamsService__ListPendingTeamInvitationsBySlug_invalidOrg(t *testing.T)
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Teams.ListPendingTeamInvitationsBySlug(context.Background(), "%", "s", nil)
+	ctx := context.Background()
+	_, _, err := client.Teams.ListPendingTeamInvitationsBySlug(ctx, "%", "s", nil)
 	testURLParseError(t, err)
 }

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -28,7 +28,8 @@ func TestTeamsService_ListTeams(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	teams, _, err := client.Teams.ListTeams(context.Background(), "o", opt)
+	ctx := context.Background()
+	teams, _, err := client.Teams.ListTeams(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Teams.ListTeams returned error: %v", err)
 	}
@@ -43,7 +44,8 @@ func TestTeamsService_ListTeams_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Teams.ListTeams(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Teams.ListTeams(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -56,7 +58,8 @@ func TestTeamsService_GetTeamByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "name":"n", "description": "d", "url":"u", "slug": "s", "permission":"p", "ldap_dn":"cn=n,ou=groups,dc=example,dc=com", "parent":null}`)
 	})
 
-	team, _, err := client.Teams.GetTeamByID(context.Background(), 1, 1)
+	ctx := context.Background()
+	team, _, err := client.Teams.GetTeamByID(ctx, 1, 1)
 	if err != nil {
 		t.Errorf("Teams.GetTeamByID returned error: %v", err)
 	}
@@ -76,7 +79,8 @@ func TestTeamsService_GetTeamByID_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	team, resp, err := client.Teams.GetTeamByID(context.Background(), 1, 2)
+	ctx := context.Background()
+	team, resp, err := client.Teams.GetTeamByID(ctx, 1, 2)
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -97,7 +101,8 @@ func TestTeamsService_GetTeamBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "name":"n", "description": "d", "url":"u", "slug": "s", "permission":"p", "ldap_dn":"cn=n,ou=groups,dc=example,dc=com", "parent":null}`)
 	})
 
-	team, _, err := client.Teams.GetTeamBySlug(context.Background(), "o", "s")
+	ctx := context.Background()
+	team, _, err := client.Teams.GetTeamBySlug(ctx, "o", "s")
 	if err != nil {
 		t.Errorf("Teams.GetTeamBySlug returned error: %v", err)
 	}
@@ -112,7 +117,8 @@ func TestTeamsService_GetTeamBySlug_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Teams.GetTeamBySlug(context.Background(), "%", "s")
+	ctx := context.Background()
+	_, _, err := client.Teams.GetTeamBySlug(ctx, "%", "s")
 	testURLParseError(t, err)
 }
 
@@ -125,7 +131,8 @@ func TestTeamsService_GetTeamBySlug_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	team, resp, err := client.Teams.GetTeamBySlug(context.Background(), "o", "s")
+	ctx := context.Background()
+	team, resp, err := client.Teams.GetTeamBySlug(ctx, "o", "s")
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -155,7 +162,8 @@ func TestTeamsService_CreateTeam(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	team, _, err := client.Teams.CreateTeam(context.Background(), "o", input)
+	ctx := context.Background()
+	team, _, err := client.Teams.CreateTeam(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Teams.CreateTeam returned error: %v", err)
 	}
@@ -170,7 +178,8 @@ func TestTeamsService_CreateTeam_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Teams.CreateTeam(context.Background(), "%", NewTeam{})
+	ctx := context.Background()
+	_, _, err := client.Teams.CreateTeam(ctx, "%", NewTeam{})
 	testURLParseError(t, err)
 }
 
@@ -192,7 +201,8 @@ func TestTeamsService_EditTeamByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	team, _, err := client.Teams.EditTeamByID(context.Background(), 1, 1, input, false)
+	ctx := context.Background()
+	team, _, err := client.Teams.EditTeamByID(ctx, 1, 1, input, false)
 	if err != nil {
 		t.Errorf("Teams.EditTeamByID returned error: %v", err)
 	}
@@ -227,7 +237,8 @@ func TestTeamsService_EditTeamByID_RemoveParent(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	team, _, err := client.Teams.EditTeamByID(context.Background(), 1, 1, input, true)
+	ctx := context.Background()
+	team, _, err := client.Teams.EditTeamByID(ctx, 1, 1, input, true)
 	if err != nil {
 		t.Errorf("Teams.EditTeamByID returned error: %v", err)
 	}
@@ -260,7 +271,8 @@ func TestTeamsService_EditTeamBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	team, _, err := client.Teams.EditTeamBySlug(context.Background(), "o", "s", input, false)
+	ctx := context.Background()
+	team, _, err := client.Teams.EditTeamBySlug(ctx, "o", "s", input, false)
 	if err != nil {
 		t.Errorf("Teams.EditTeamBySlug returned error: %v", err)
 	}
@@ -295,7 +307,8 @@ func TestTeamsService_EditTeamBySlug_RemoveParent(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	team, _, err := client.Teams.EditTeamBySlug(context.Background(), "o", "s", input, true)
+	ctx := context.Background()
+	team, _, err := client.Teams.EditTeamBySlug(ctx, "o", "s", input, true)
 	if err != nil {
 		t.Errorf("Teams.EditTeam returned error: %v", err)
 	}
@@ -318,7 +331,8 @@ func TestTeamsService_DeleteTeamByID(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Teams.DeleteTeamByID(context.Background(), 1, 1)
+	ctx := context.Background()
+	_, err := client.Teams.DeleteTeamByID(ctx, 1, 1)
 	if err != nil {
 		t.Errorf("Teams.DeleteTeamByID returned error: %v", err)
 	}
@@ -332,7 +346,8 @@ func TestTeamsService_DeleteTeamBySlug(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Teams.DeleteTeamBySlug(context.Background(), "o", "s")
+	ctx := context.Background()
+	_, err := client.Teams.DeleteTeamBySlug(ctx, "o", "s")
 	if err != nil {
 		t.Errorf("Teams.DeleteTeamBySlug returned error: %v", err)
 	}
@@ -349,7 +364,8 @@ func TestTeamsService_ListChildTeamsByParentID(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	teams, _, err := client.Teams.ListChildTeamsByParentID(context.Background(), 1, 2, opt)
+	ctx := context.Background()
+	teams, _, err := client.Teams.ListChildTeamsByParentID(ctx, 1, 2, opt)
 	if err != nil {
 		t.Errorf("Teams.ListChildTeamsByParentID returned error: %v", err)
 	}
@@ -371,7 +387,8 @@ func TestTeamsService_ListChildTeamsByParentSlug(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	teams, _, err := client.Teams.ListChildTeamsByParentSlug(context.Background(), "o", "s", opt)
+	ctx := context.Background()
+	teams, _, err := client.Teams.ListChildTeamsByParentSlug(ctx, "o", "s", opt)
 	if err != nil {
 		t.Errorf("Teams.ListChildTeamsByParentSlug returned error: %v", err)
 	}
@@ -395,7 +412,8 @@ func TestTeamsService_ListTeamReposByID(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	members, _, err := client.Teams.ListTeamReposByID(context.Background(), 1, 1, opt)
+	ctx := context.Background()
+	members, _, err := client.Teams.ListTeamReposByID(ctx, 1, 1, opt)
 	if err != nil {
 		t.Errorf("Teams.ListTeamReposByID returned error: %v", err)
 	}
@@ -419,7 +437,8 @@ func TestTeamsService_ListTeamReposBySlug(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	members, _, err := client.Teams.ListTeamReposBySlug(context.Background(), "o", "s", opt)
+	ctx := context.Background()
+	members, _, err := client.Teams.ListTeamReposBySlug(ctx, "o", "s", opt)
 	if err != nil {
 		t.Errorf("Teams.ListTeamReposBySlug returned error: %v", err)
 	}
@@ -441,7 +460,8 @@ func TestTeamsService_IsTeamRepoByID_true(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	repo, _, err := client.Teams.IsTeamRepoByID(context.Background(), 1, 1, "owner", "repo")
+	ctx := context.Background()
+	repo, _, err := client.Teams.IsTeamRepoByID(ctx, 1, 1, "owner", "repo")
 	if err != nil {
 		t.Errorf("Teams.IsTeamRepoByID returned error: %v", err)
 	}
@@ -463,7 +483,8 @@ func TestTeamsService_IsTeamRepoBySlug_true(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	repo, _, err := client.Teams.IsTeamRepoBySlug(context.Background(), "org", "slug", "owner", "repo")
+	ctx := context.Background()
+	repo, _, err := client.Teams.IsTeamRepoBySlug(ctx, "org", "slug", "owner", "repo")
 	if err != nil {
 		t.Errorf("Teams.IsTeamRepoBySlug returned error: %v", err)
 	}
@@ -483,7 +504,8 @@ func TestTeamsService_IsTeamRepoByID_false(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	repo, resp, err := client.Teams.IsTeamRepoByID(context.Background(), 1, 1, "owner", "repo")
+	ctx := context.Background()
+	repo, resp, err := client.Teams.IsTeamRepoByID(ctx, 1, 1, "owner", "repo")
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -504,7 +526,8 @@ func TestTeamsService_IsTeamRepoBySlug_false(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	repo, resp, err := client.Teams.IsTeamRepoBySlug(context.Background(), "org", "slug", "owner", "repo")
+	ctx := context.Background()
+	repo, resp, err := client.Teams.IsTeamRepoBySlug(ctx, "org", "slug", "owner", "repo")
 	if err == nil {
 		t.Errorf("Expected HTTP 404 response")
 	}
@@ -525,7 +548,8 @@ func TestTeamsService_IsTeamRepoByID_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	repo, resp, err := client.Teams.IsTeamRepoByID(context.Background(), 1, 1, "owner", "repo")
+	ctx := context.Background()
+	repo, resp, err := client.Teams.IsTeamRepoByID(ctx, 1, 1, "owner", "repo")
 	if err == nil {
 		t.Errorf("Expected HTTP 400 response")
 	}
@@ -546,7 +570,8 @@ func TestTeamsService_IsTeamRepoBySlug_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	repo, resp, err := client.Teams.IsTeamRepoBySlug(context.Background(), "org", "slug", "owner", "repo")
+	ctx := context.Background()
+	repo, resp, err := client.Teams.IsTeamRepoBySlug(ctx, "org", "slug", "owner", "repo")
 	if err == nil {
 		t.Errorf("Expected HTTP 400 response")
 	}
@@ -562,7 +587,8 @@ func TestTeamsService_IsTeamRepoByID_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Teams.IsTeamRepoByID(context.Background(), 1, 1, "%", "r")
+	ctx := context.Background()
+	_, _, err := client.Teams.IsTeamRepoByID(ctx, 1, 1, "%", "r")
 	testURLParseError(t, err)
 }
 
@@ -570,7 +596,8 @@ func TestTeamsService_IsTeamRepoBySlug_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Teams.IsTeamRepoBySlug(context.Background(), "o", "s", "%", "r")
+	ctx := context.Background()
+	_, _, err := client.Teams.IsTeamRepoBySlug(ctx, "o", "s", "%", "r")
 	testURLParseError(t, err)
 }
 
@@ -592,7 +619,8 @@ func TestTeamsService_AddTeamRepoByID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Teams.AddTeamRepoByID(context.Background(), 1, 1, "owner", "repo", opt)
+	ctx := context.Background()
+	_, err := client.Teams.AddTeamRepoByID(ctx, 1, 1, "owner", "repo", opt)
 	if err != nil {
 		t.Errorf("Teams.AddTeamRepoByID returned error: %v", err)
 	}
@@ -616,7 +644,8 @@ func TestTeamsService_AddTeamRepoBySlug(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Teams.AddTeamRepoBySlug(context.Background(), "org", "slug", "owner", "repo", opt)
+	ctx := context.Background()
+	_, err := client.Teams.AddTeamRepoBySlug(ctx, "org", "slug", "owner", "repo", opt)
 	if err != nil {
 		t.Errorf("Teams.AddTeamRepoBySlug returned error: %v", err)
 	}
@@ -631,7 +660,8 @@ func TestTeamsService_AddTeamRepoByID_noAccess(t *testing.T) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 	})
 
-	_, err := client.Teams.AddTeamRepoByID(context.Background(), 1, 1, "owner", "repo", nil)
+	ctx := context.Background()
+	_, err := client.Teams.AddTeamRepoByID(ctx, 1, 1, "owner", "repo", nil)
 	if err == nil {
 		t.Errorf("Expcted error to be returned")
 	}
@@ -646,7 +676,8 @@ func TestTeamsService_AddTeamRepoBySlug_noAccess(t *testing.T) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 	})
 
-	_, err := client.Teams.AddTeamRepoBySlug(context.Background(), "org", "slug", "owner", "repo", nil)
+	ctx := context.Background()
+	_, err := client.Teams.AddTeamRepoBySlug(ctx, "org", "slug", "owner", "repo", nil)
 	if err == nil {
 		t.Errorf("Expcted error to be returned")
 	}
@@ -656,7 +687,8 @@ func TestTeamsService_AddTeamRepoByID_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Teams.AddTeamRepoByID(context.Background(), 1, 1, "%", "r", nil)
+	ctx := context.Background()
+	_, err := client.Teams.AddTeamRepoByID(ctx, 1, 1, "%", "r", nil)
 	testURLParseError(t, err)
 }
 
@@ -664,7 +696,8 @@ func TestTeamsService_AddTeamRepoBySlug_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Teams.AddTeamRepoBySlug(context.Background(), "o", "s", "%", "r", nil)
+	ctx := context.Background()
+	_, err := client.Teams.AddTeamRepoBySlug(ctx, "o", "s", "%", "r", nil)
 	testURLParseError(t, err)
 }
 
@@ -677,7 +710,8 @@ func TestTeamsService_RemoveTeamRepoByID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Teams.RemoveTeamRepoByID(context.Background(), 1, 1, "owner", "repo")
+	ctx := context.Background()
+	_, err := client.Teams.RemoveTeamRepoByID(ctx, 1, 1, "owner", "repo")
 	if err != nil {
 		t.Errorf("Teams.RemoveTeamRepoByID returned error: %v", err)
 	}
@@ -692,7 +726,8 @@ func TestTeamsService_RemoveTeamRepoBySlug(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Teams.RemoveTeamRepoBySlug(context.Background(), "org", "slug", "owner", "repo")
+	ctx := context.Background()
+	_, err := client.Teams.RemoveTeamRepoBySlug(ctx, "org", "slug", "owner", "repo")
 	if err != nil {
 		t.Errorf("Teams.RemoveTeamRepoBySlug returned error: %v", err)
 	}
@@ -702,7 +737,8 @@ func TestTeamsService_RemoveTeamRepoByID_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Teams.RemoveTeamRepoByID(context.Background(), 1, 1, "%", "r")
+	ctx := context.Background()
+	_, err := client.Teams.RemoveTeamRepoByID(ctx, 1, 1, "%", "r")
 	testURLParseError(t, err)
 }
 
@@ -710,7 +746,8 @@ func TestTeamsService_RemoveTeamRepoBySlug_invalidOwner(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Teams.RemoveTeamRepoBySlug(context.Background(), "o", "s", "%", "r")
+	ctx := context.Background()
+	_, err := client.Teams.RemoveTeamRepoBySlug(ctx, "o", "s", "%", "r")
 	testURLParseError(t, err)
 }
 
@@ -725,7 +762,8 @@ func TestTeamsService_ListUserTeams(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1}
-	teams, _, err := client.Teams.ListUserTeams(context.Background(), opt)
+	ctx := context.Background()
+	teams, _, err := client.Teams.ListUserTeams(ctx, opt)
 	if err != nil {
 		t.Errorf("Teams.ListUserTeams returned error: %v", err)
 	}
@@ -747,7 +785,8 @@ func TestTeamsService_ListProjectsByID(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	projects, _, err := client.Teams.ListTeamProjectsByID(context.Background(), 1, 1)
+	ctx := context.Background()
+	projects, _, err := client.Teams.ListTeamProjectsByID(ctx, 1, 1)
 	if err != nil {
 		t.Errorf("Teams.ListTeamProjectsByID returned error: %v", err)
 	}
@@ -769,7 +808,8 @@ func TestTeamsService_ListProjectsBySlug(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	projects, _, err := client.Teams.ListTeamProjectsBySlug(context.Background(), "o", "s")
+	ctx := context.Background()
+	projects, _, err := client.Teams.ListTeamProjectsBySlug(ctx, "o", "s")
 	if err != nil {
 		t.Errorf("Teams.ListTeamProjectsBySlug returned error: %v", err)
 	}
@@ -791,7 +831,8 @@ func TestTeamsService_ReviewProjectsByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	project, _, err := client.Teams.ReviewTeamProjectsByID(context.Background(), 1, 1, 1)
+	ctx := context.Background()
+	project, _, err := client.Teams.ReviewTeamProjectsByID(ctx, 1, 1, 1)
 	if err != nil {
 		t.Errorf("Teams.ReviewTeamProjectsByID returned error: %v", err)
 	}
@@ -813,7 +854,8 @@ func TestTeamsService_ReviewProjectsBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	project, _, err := client.Teams.ReviewTeamProjectsBySlug(context.Background(), "o", "s", 1)
+	ctx := context.Background()
+	project, _, err := client.Teams.ReviewTeamProjectsBySlug(ctx, "o", "s", 1)
 	if err != nil {
 		t.Errorf("Teams.ReviewTeamProjectsBySlug returned error: %v", err)
 	}
@@ -846,7 +888,8 @@ func TestTeamsService_AddTeamProjectByID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Teams.AddTeamProjectByID(context.Background(), 1, 1, 1, opt)
+	ctx := context.Background()
+	_, err := client.Teams.AddTeamProjectByID(ctx, 1, 1, 1, opt)
 	if err != nil {
 		t.Errorf("Teams.AddTeamProjectByID returned error: %v", err)
 	}
@@ -874,7 +917,8 @@ func TestTeamsService_AddTeamProjectBySlug(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Teams.AddTeamProjectBySlug(context.Background(), "o", "s", 1, opt)
+	ctx := context.Background()
+	_, err := client.Teams.AddTeamProjectBySlug(ctx, "o", "s", 1, opt)
 	if err != nil {
 		t.Errorf("Teams.AddTeamProjectBySlug returned error: %v", err)
 	}
@@ -891,7 +935,8 @@ func TestTeamsService_RemoveTeamProjectByID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Teams.RemoveTeamProjectByID(context.Background(), 1, 1, 1)
+	ctx := context.Background()
+	_, err := client.Teams.RemoveTeamProjectByID(ctx, 1, 1, 1)
 	if err != nil {
 		t.Errorf("Teams.RemoveTeamProjectByID returned error: %v", err)
 	}
@@ -908,7 +953,8 @@ func TestTeamsService_RemoveTeamProjectBySlug(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Teams.RemoveTeamProjectBySlug(context.Background(), "o", "s", 1)
+	ctx := context.Background()
+	_, err := client.Teams.RemoveTeamProjectBySlug(ctx, "o", "s", 1)
 	if err != nil {
 		t.Errorf("Teams.RemoveTeamProjectBySlug returned error: %v", err)
 	}
@@ -927,7 +973,8 @@ func TestTeamsService_ListIDPGroupsInOrganization(t *testing.T) {
 	})
 
 	opt := &ListCursorOptions{Page: "url-encoded-next-page-token"}
-	groups, _, err := client.Teams.ListIDPGroupsInOrganization(context.Background(), "o", opt)
+	ctx := context.Background()
+	groups, _, err := client.Teams.ListIDPGroupsInOrganization(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Teams.ListIDPGroupsInOrganization returned error: %v", err)
 	}
@@ -955,7 +1002,8 @@ func TestTeamsService_ListIDPGroupsForTeamByID(t *testing.T) {
 		fmt.Fprint(w, `{"groups": [{"group_id": "1",  "group_name": "n", "group_description": "d"}]}`)
 	})
 
-	groups, _, err := client.Teams.ListIDPGroupsForTeamByID(context.Background(), 1, 1)
+	ctx := context.Background()
+	groups, _, err := client.Teams.ListIDPGroupsForTeamByID(ctx, 1, 1)
 	if err != nil {
 		t.Errorf("Teams.ListIDPGroupsForTeamByID returned error: %v", err)
 	}
@@ -983,7 +1031,8 @@ func TestTeamsService_ListIDPGroupsForTeamBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"groups": [{"group_id": "1",  "group_name": "n", "group_description": "d"}]}`)
 	})
 
-	groups, _, err := client.Teams.ListIDPGroupsForTeamBySlug(context.Background(), "o", "slug")
+	ctx := context.Background()
+	groups, _, err := client.Teams.ListIDPGroupsForTeamBySlug(ctx, "o", "slug")
 	if err != nil {
 		t.Errorf("Teams.ListIDPGroupsForTeamBySlug returned error: %v", err)
 	}
@@ -1021,7 +1070,8 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnectionsByID(t *testing.T) {
 		},
 	}
 
-	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsByID(context.Background(), 1, 1, input)
+	ctx := context.Background()
+	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsByID(ctx, 1, 1, input)
 	if err != nil {
 		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsByID returned error: %v", err)
 	}
@@ -1059,7 +1109,8 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnectionsBySlug(t *testing.T) {
 		},
 	}
 
-	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsBySlug(context.Background(), "o", "slug", input)
+	ctx := context.Background()
+	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsBySlug(ctx, "o", "slug", input)
 	if err != nil {
 		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsBySlug returned error: %v", err)
 	}
@@ -1090,7 +1141,8 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnectionsByID_empty(t *testing.T) 
 		Groups: []*IDPGroup{},
 	}
 
-	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsByID(context.Background(), 1, 1, input)
+	ctx := context.Background()
+	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsByID(ctx, 1, 1, input)
 	if err != nil {
 		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsByID returned error: %v", err)
 	}
@@ -1116,7 +1168,8 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnectionsBySlug_empty(t *testing.T
 		Groups: []*IDPGroup{},
 	}
 
-	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsBySlug(context.Background(), "o", "slug", input)
+	ctx := context.Background()
+	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsBySlug(ctx, "o", "slug", input)
 	if err != nil {
 		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsBySlug returned error: %v", err)
 	}

--- a/github/users_administration_test.go
+++ b/github/users_administration_test.go
@@ -22,7 +22,8 @@ func TestUsersService_PromoteSiteAdmin(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Users.PromoteSiteAdmin(context.Background(), "u")
+	ctx := context.Background()
+	_, err := client.Users.PromoteSiteAdmin(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.PromoteSiteAdmin returned error: %v", err)
 	}
@@ -37,7 +38,8 @@ func TestUsersService_DemoteSiteAdmin(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Users.DemoteSiteAdmin(context.Background(), "u")
+	ctx := context.Background()
+	_, err := client.Users.DemoteSiteAdmin(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.DemoteSiteAdmin returned error: %v", err)
 	}
@@ -52,7 +54,8 @@ func TestUsersService_Suspend(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Users.Suspend(context.Background(), "u", nil)
+	ctx := context.Background()
+	_, err := client.Users.Suspend(ctx, "u", nil)
 	if err != nil {
 		t.Errorf("Users.Suspend returned error: %v", err)
 	}
@@ -76,7 +79,8 @@ func TestUsersServiceReason_Suspend(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Users.Suspend(context.Background(), "u", input)
+	ctx := context.Background()
+	_, err := client.Users.Suspend(ctx, "u", input)
 	if err != nil {
 		t.Errorf("Users.Suspend returned error: %v", err)
 	}
@@ -91,7 +95,8 @@ func TestUsersService_Unsuspend(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Users.Unsuspend(context.Background(), "u")
+	ctx := context.Background()
+	_, err := client.Users.Unsuspend(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.Unsuspend returned error: %v", err)
 	}

--- a/github/users_blocking_test.go
+++ b/github/users_blocking_test.go
@@ -27,7 +27,8 @@ func TestUsersService_ListBlockedUsers(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	blockedUsers, _, err := client.Users.ListBlockedUsers(context.Background(), opt)
+	ctx := context.Background()
+	blockedUsers, _, err := client.Users.ListBlockedUsers(ctx, opt)
 	if err != nil {
 		t.Errorf("Users.ListBlockedUsers returned error: %v", err)
 	}
@@ -48,7 +49,8 @@ func TestUsersService_IsBlocked(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	isBlocked, _, err := client.Users.IsBlocked(context.Background(), "u")
+	ctx := context.Background()
+	isBlocked, _, err := client.Users.IsBlocked(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.IsBlocked returned error: %v", err)
 	}
@@ -67,7 +69,8 @@ func TestUsersService_BlockUser(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Users.BlockUser(context.Background(), "u")
+	ctx := context.Background()
+	_, err := client.Users.BlockUser(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.BlockUser returned error: %v", err)
 	}
@@ -83,7 +86,8 @@ func TestUsersService_UnblockUser(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Users.UnblockUser(context.Background(), "u")
+	ctx := context.Background()
+	_, err := client.Users.UnblockUser(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.UnblockUser returned error: %v", err)
 	}

--- a/github/users_emails_test.go
+++ b/github/users_emails_test.go
@@ -29,7 +29,8 @@ func TestUsersService_ListEmails(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	emails, _, err := client.Users.ListEmails(context.Background(), opt)
+	ctx := context.Background()
+	emails, _, err := client.Users.ListEmails(ctx, opt)
 	if err != nil {
 		t.Errorf("Users.ListEmails returned error: %v", err)
 	}
@@ -58,7 +59,8 @@ func TestUsersService_AddEmails(t *testing.T) {
 		fmt.Fprint(w, `[{"email":"old@example.com"}, {"email":"new@example.com"}]`)
 	})
 
-	emails, _, err := client.Users.AddEmails(context.Background(), input)
+	ctx := context.Background()
+	emails, _, err := client.Users.AddEmails(ctx, input)
 	if err != nil {
 		t.Errorf("Users.AddEmails returned error: %v", err)
 	}
@@ -88,7 +90,8 @@ func TestUsersService_DeleteEmails(t *testing.T) {
 		}
 	})
 
-	_, err := client.Users.DeleteEmails(context.Background(), input)
+	ctx := context.Background()
+	_, err := client.Users.DeleteEmails(ctx, input)
 	if err != nil {
 		t.Errorf("Users.DeleteEmails returned error: %v", err)
 	}

--- a/github/users_followers_test.go
+++ b/github/users_followers_test.go
@@ -24,7 +24,8 @@ func TestUsersService_ListFollowers_authenticatedUser(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	users, _, err := client.Users.ListFollowers(context.Background(), "", opt)
+	ctx := context.Background()
+	users, _, err := client.Users.ListFollowers(ctx, "", opt)
 	if err != nil {
 		t.Errorf("Users.ListFollowers returned error: %v", err)
 	}
@@ -44,7 +45,8 @@ func TestUsersService_ListFollowers_specifiedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	users, _, err := client.Users.ListFollowers(context.Background(), "u", nil)
+	ctx := context.Background()
+	users, _, err := client.Users.ListFollowers(ctx, "u", nil)
 	if err != nil {
 		t.Errorf("Users.ListFollowers returned error: %v", err)
 	}
@@ -59,7 +61,8 @@ func TestUsersService_ListFollowers_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Users.ListFollowers(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Users.ListFollowers(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -74,7 +77,8 @@ func TestUsersService_ListFollowing_authenticatedUser(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2}
-	users, _, err := client.Users.ListFollowing(context.Background(), "", opts)
+	ctx := context.Background()
+	users, _, err := client.Users.ListFollowing(ctx, "", opts)
 	if err != nil {
 		t.Errorf("Users.ListFollowing returned error: %v", err)
 	}
@@ -94,7 +98,8 @@ func TestUsersService_ListFollowing_specifiedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	users, _, err := client.Users.ListFollowing(context.Background(), "u", nil)
+	ctx := context.Background()
+	users, _, err := client.Users.ListFollowing(ctx, "u", nil)
 	if err != nil {
 		t.Errorf("Users.ListFollowing returned error: %v", err)
 	}
@@ -109,7 +114,8 @@ func TestUsersService_ListFollowing_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Users.ListFollowing(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Users.ListFollowing(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -122,7 +128,8 @@ func TestUsersService_IsFollowing_authenticatedUser(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	following, _, err := client.Users.IsFollowing(context.Background(), "", "t")
+	ctx := context.Background()
+	following, _, err := client.Users.IsFollowing(ctx, "", "t")
 	if err != nil {
 		t.Errorf("Users.IsFollowing returned error: %v", err)
 	}
@@ -140,7 +147,8 @@ func TestUsersService_IsFollowing_specifiedUser(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	following, _, err := client.Users.IsFollowing(context.Background(), "u", "t")
+	ctx := context.Background()
+	following, _, err := client.Users.IsFollowing(ctx, "u", "t")
 	if err != nil {
 		t.Errorf("Users.IsFollowing returned error: %v", err)
 	}
@@ -158,7 +166,8 @@ func TestUsersService_IsFollowing_false(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	following, _, err := client.Users.IsFollowing(context.Background(), "u", "t")
+	ctx := context.Background()
+	following, _, err := client.Users.IsFollowing(ctx, "u", "t")
 	if err != nil {
 		t.Errorf("Users.IsFollowing returned error: %v", err)
 	}
@@ -176,7 +185,8 @@ func TestUsersService_IsFollowing_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	following, _, err := client.Users.IsFollowing(context.Background(), "u", "t")
+	ctx := context.Background()
+	following, _, err := client.Users.IsFollowing(ctx, "u", "t")
 	if err == nil {
 		t.Errorf("Expected HTTP 400 response")
 	}
@@ -189,7 +199,8 @@ func TestUsersService_IsFollowing_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Users.IsFollowing(context.Background(), "%", "%")
+	ctx := context.Background()
+	_, _, err := client.Users.IsFollowing(ctx, "%", "%")
 	testURLParseError(t, err)
 }
 
@@ -201,7 +212,8 @@ func TestUsersService_Follow(t *testing.T) {
 		testMethod(t, r, "PUT")
 	})
 
-	_, err := client.Users.Follow(context.Background(), "u")
+	ctx := context.Background()
+	_, err := client.Users.Follow(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.Follow returned error: %v", err)
 	}
@@ -211,7 +223,8 @@ func TestUsersService_Follow_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Users.Follow(context.Background(), "%")
+	ctx := context.Background()
+	_, err := client.Users.Follow(ctx, "%")
 	testURLParseError(t, err)
 }
 
@@ -223,7 +236,8 @@ func TestUsersService_Unfollow(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Users.Unfollow(context.Background(), "u")
+	ctx := context.Background()
+	_, err := client.Users.Unfollow(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.Follow returned error: %v", err)
 	}
@@ -233,6 +247,7 @@ func TestUsersService_Unfollow_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, err := client.Users.Unfollow(context.Background(), "%")
+	ctx := context.Background()
+	_, err := client.Users.Unfollow(ctx, "%")
 	testURLParseError(t, err)
 }

--- a/github/users_gpg_keys_test.go
+++ b/github/users_gpg_keys_test.go
@@ -25,7 +25,8 @@ func TestUsersService_ListGPGKeys_authenticatedUser(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	keys, _, err := client.Users.ListGPGKeys(context.Background(), "", opt)
+	ctx := context.Background()
+	keys, _, err := client.Users.ListGPGKeys(ctx, "", opt)
 	if err != nil {
 		t.Errorf("Users.ListGPGKeys returned error: %v", err)
 	}
@@ -45,7 +46,8 @@ func TestUsersService_ListGPGKeys_specifiedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1,"primary_key_id":2}]`)
 	})
 
-	keys, _, err := client.Users.ListGPGKeys(context.Background(), "u", nil)
+	ctx := context.Background()
+	keys, _, err := client.Users.ListGPGKeys(ctx, "u", nil)
 	if err != nil {
 		t.Errorf("Users.ListGPGKeys returned error: %v", err)
 	}
@@ -60,7 +62,8 @@ func TestUsersService_ListGPGKeys_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Users.ListGPGKeys(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Users.ListGPGKeys(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -73,7 +76,8 @@ func TestUsersService_GetGPGKey(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	key, _, err := client.Users.GetGPGKey(context.Background(), 1)
+	ctx := context.Background()
+	key, _, err := client.Users.GetGPGKey(ctx, 1)
 	if err != nil {
 		t.Errorf("Users.GetGPGKey returned error: %v", err)
 	}
@@ -111,7 +115,8 @@ mQINBFcEd9kBEACo54TDbGhKlXKWMvJgecEUKPPcv7XdnpKdGb3LRw5MvFwT0V0f
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	gpgKey, _, err := client.Users.CreateGPGKey(context.Background(), input)
+	ctx := context.Background()
+	gpgKey, _, err := client.Users.CreateGPGKey(ctx, input)
 	if err != nil {
 		t.Errorf("Users.GetGPGKey returned error: %v", err)
 	}
@@ -130,7 +135,8 @@ func TestUsersService_DeleteGPGKey(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Users.DeleteGPGKey(context.Background(), 1)
+	ctx := context.Background()
+	_, err := client.Users.DeleteGPGKey(ctx, 1)
 	if err != nil {
 		t.Errorf("Users.DeleteGPGKey returned error: %v", err)
 	}

--- a/github/users_keys_test.go
+++ b/github/users_keys_test.go
@@ -25,7 +25,8 @@ func TestUsersService_ListKeys_authenticatedUser(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	keys, _, err := client.Users.ListKeys(context.Background(), "", opt)
+	ctx := context.Background()
+	keys, _, err := client.Users.ListKeys(ctx, "", opt)
 	if err != nil {
 		t.Errorf("Users.ListKeys returned error: %v", err)
 	}
@@ -45,7 +46,8 @@ func TestUsersService_ListKeys_specifiedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	keys, _, err := client.Users.ListKeys(context.Background(), "u", nil)
+	ctx := context.Background()
+	keys, _, err := client.Users.ListKeys(ctx, "u", nil)
 	if err != nil {
 		t.Errorf("Users.ListKeys returned error: %v", err)
 	}
@@ -60,7 +62,8 @@ func TestUsersService_ListKeys_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Users.ListKeys(context.Background(), "%", nil)
+	ctx := context.Background()
+	_, _, err := client.Users.ListKeys(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
@@ -73,7 +76,8 @@ func TestUsersService_GetKey(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	key, _, err := client.Users.GetKey(context.Background(), 1)
+	ctx := context.Background()
+	key, _, err := client.Users.GetKey(ctx, 1)
 	if err != nil {
 		t.Errorf("Users.GetKey returned error: %v", err)
 	}
@@ -102,7 +106,8 @@ func TestUsersService_CreateKey(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	key, _, err := client.Users.CreateKey(context.Background(), input)
+	ctx := context.Background()
+	key, _, err := client.Users.CreateKey(ctx, input)
 	if err != nil {
 		t.Errorf("Users.GetKey returned error: %v", err)
 	}
@@ -121,7 +126,8 @@ func TestUsersService_DeleteKey(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Users.DeleteKey(context.Background(), 1)
+	ctx := context.Background()
+	_, err := client.Users.DeleteKey(ctx, 1)
 	if err != nil {
 		t.Errorf("Users.DeleteKey returned error: %v", err)
 	}

--- a/github/users_projects_test.go
+++ b/github/users_projects_test.go
@@ -26,7 +26,8 @@ func TestUsersService_ListProjects(t *testing.T) {
 	})
 
 	opt := &ProjectListOptions{State: "open", ListOptions: ListOptions{Page: 2}}
-	projects, _, err := client.Users.ListProjects(context.Background(), "u", opt)
+	ctx := context.Background()
+	projects, _, err := client.Users.ListProjects(ctx, "u", opt)
 	if err != nil {
 		t.Errorf("Users.ListProjects returned error: %v", err)
 	}
@@ -56,7 +57,8 @@ func TestUsersService_CreateProject(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	project, _, err := client.Users.CreateProject(context.Background(), input)
+	ctx := context.Background()
+	project, _, err := client.Users.CreateProject(ctx, input)
 	if err != nil {
 		t.Errorf("Users.CreateProject returned error: %v", err)
 	}

--- a/github/users_test.go
+++ b/github/users_test.go
@@ -69,7 +69,8 @@ func TestUsersService_Get_authenticatedUser(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	user, _, err := client.Users.Get(context.Background(), "")
+	ctx := context.Background()
+	user, _, err := client.Users.Get(ctx, "")
 	if err != nil {
 		t.Errorf("Users.Get returned error: %v", err)
 	}
@@ -89,7 +90,8 @@ func TestUsersService_Get_specifiedUser(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	user, _, err := client.Users.Get(context.Background(), "u")
+	ctx := context.Background()
+	user, _, err := client.Users.Get(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.Get returned error: %v", err)
 	}
@@ -104,7 +106,8 @@ func TestUsersService_Get_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	_, _, err := client.Users.Get(context.Background(), "%")
+	ctx := context.Background()
+	_, _, err := client.Users.Get(ctx, "%")
 	testURLParseError(t, err)
 }
 
@@ -117,7 +120,8 @@ func TestUsersService_GetByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	user, _, err := client.Users.GetByID(context.Background(), 1)
+	ctx := context.Background()
+	user, _, err := client.Users.GetByID(ctx, 1)
 	if err != nil {
 		t.Fatalf("Users.GetByID returned error: %v", err)
 	}
@@ -146,7 +150,8 @@ func TestUsersService_Edit(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	user, _, err := client.Users.Edit(context.Background(), input)
+	ctx := context.Background()
+	user, _, err := client.Users.Edit(ctx, input)
 	if err != nil {
 		t.Errorf("Users.Edit returned error: %v", err)
 	}
@@ -168,7 +173,8 @@ func TestUsersService_GetHovercard(t *testing.T) {
 	})
 
 	opt := &HovercardOptions{SubjectType: "repository", SubjectID: "20180408"}
-	hovercard, _, err := client.Users.GetHovercard(context.Background(), "u", opt)
+	ctx := context.Background()
+	hovercard, _, err := client.Users.GetHovercard(ctx, "u", opt)
 	if err != nil {
 		t.Errorf("Users.GetHovercard returned error: %v", err)
 	}
@@ -190,7 +196,8 @@ func TestUsersService_ListAll(t *testing.T) {
 	})
 
 	opt := &UserListOptions{1, ListOptions{Page: 2}}
-	users, _, err := client.Users.ListAll(context.Background(), opt)
+	ctx := context.Background()
+	users, _, err := client.Users.ListAll(ctx, opt)
 	if err != nil {
 		t.Errorf("Users.Get returned error: %v", err)
 	}
@@ -210,7 +217,8 @@ func TestUsersService_ListInvitations(t *testing.T) {
 		fmt.Fprintf(w, `[{"id":1}, {"id":2}]`)
 	})
 
-	got, _, err := client.Users.ListInvitations(context.Background(), nil)
+	ctx := context.Background()
+	got, _, err := client.Users.ListInvitations(ctx, nil)
 	if err != nil {
 		t.Errorf("Users.ListInvitations returned error: %v", err)
 	}
@@ -233,7 +241,8 @@ func TestUsersService_ListInvitations_withOptions(t *testing.T) {
 		fmt.Fprintf(w, `[{"id":1}, {"id":2}]`)
 	})
 
-	_, _, err := client.Users.ListInvitations(context.Background(), &ListOptions{Page: 2})
+	ctx := context.Background()
+	_, _, err := client.Users.ListInvitations(ctx, &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Users.ListInvitations returned error: %v", err)
 	}
@@ -247,7 +256,8 @@ func TestUsersService_AcceptInvitation(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Users.AcceptInvitation(context.Background(), 1); err != nil {
+	ctx := context.Background()
+	if _, err := client.Users.AcceptInvitation(ctx, 1); err != nil {
 		t.Errorf("Users.AcceptInvitation returned error: %v", err)
 	}
 }
@@ -261,7 +271,8 @@ func TestUsersService_DeclineInvitation(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.Users.DeclineInvitation(context.Background(), 1); err != nil {
+	ctx := context.Background()
+	if _, err := client.Users.DeclineInvitation(ctx, 1); err != nil {
 		t.Errorf("Users.DeclineInvitation returned error: %v", err)
 	}
 }


### PR DESCRIPTION
This PR is in preparation of adding code coverage improvement PRs which will be much easier to write when the tests consistently create a single background context.

The only changes made in this PR are to pull out `context.Background()` into a separate assignment in the test files.