### PR TITLE
Add client.BareDo to allow user to handle the body

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -605,7 +605,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 	switch v := v.(type) {
 	case nil:
 	case io.Writer:
-		_, _ = io.Copy(v, resp.Body)
+		_, err = io.Copy(v, resp.Body)
 	default:
 		decErr := json.NewDecoder(resp.Body).Decode(v)
 		if decErr == io.EOF {

--- a/github/github.go
+++ b/github/github.go
@@ -512,12 +512,14 @@ func parseRate(r *http.Response) Rate {
 	return rate
 }
 
-// BareDo sends an API request and lets you handle the api response. If an
-// error or API Error occurs, the error will contain more information.
-// Otherwise you are supposed to read and close the response's Body.
+// BareDo sends an API request and lets you handle the api response. If an error
+// or API Error occurs, the error will contain more information. Otherwise you
+// are supposed to read and close the response's Body. If rate limit is exceeded
+// and reset time is in the future, BareDo returns *RateLimitError immediately
+// without making a network API call.
 //
-// The provided ctx must be non-nil, if it is nil an error is returned. If it
-// is canceled or times out, ctx.Err() will be returned.
+// The provided ctx must be non-nil, if it is nil an error is returned. If it is
+// canceled or times out, ctx.Err() will be returned.
 func (c *Client) BareDo(ctx context.Context, req *http.Request) (*Response, error) {
 	if ctx == nil {
 		return nil, errors.New("context must be non-nil")

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1586,7 +1586,7 @@ func TestBareDo_returnsOpenBody(t *testing.T) {
 
 	got, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		t.Fatalf("cioutil.ReadAll returned error: %v", err)
+		t.Fatalf("ioutil.ReadAll returned error: %v", err)
 	}
 	if string(got) != expectedBody {
 		t.Fatalf("Expected %q, got %q", expectedBody, string(got))

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1560,3 +1560,38 @@ func TestAddOptions_QueryValues(t *testing.T) {
 		t.Error("addOptions err = nil, want error")
 	}
 }
+
+func TestBareDo_returnsOpenBody(t *testing.T) {
+
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	expectedBody := "Hello from the other side !"
+
+	mux.HandleFunc("/test-url", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, expectedBody)
+	})
+
+	ctx := context.Background()
+	req, err := client.NewRequest("GET", "test-url", nil)
+	if err != nil {
+		t.Fatalf("client.NewRequest returned error: %v", err)
+	}
+
+	resp, err := client.BareDo(ctx, req)
+	if err != nil {
+		t.Fatalf("client.BareDo returned error: %v", err)
+	}
+
+	got, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("cioutil.ReadAll returned error: %v", err)
+	}
+	if string(got) != expectedBody {
+		t.Fatalf("Expected %q, got %q", expectedBody, string(got))
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("resp.Body.Close() returned error: %v", err)
+	}
+}


### PR DESCRIPTION
This allows the user to also treat bodies as plain go streams.
For more flexibility.

~Before this, passing a nil body would do the request but close the~
~body. Now it is up to the caller to close resp.Body.~

~I mainly wanted to be able to do this to stream bodies and to re-use the same HTTP client in order to download release files.~

Edit:
This PR enables using the client as an http client with Github Specific error handling and throttling management.