### PR TITLE
Adding name and email fields to Repository.Contributor

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2100,6 +2100,14 @@ func (c *Contributor) GetContributions() int {
 	return *c.Contributions
 }
 
+// GetEmail returns the Email field if it's non-nil, zero value otherwise.
+func (c *Contributor) GetEmail() string {
+	if c == nil || c.Email == nil {
+		return ""
+	}
+	return *c.Email
+}
+
 // GetEventsURL returns the EventsURL field if it's non-nil, zero value otherwise.
 func (c *Contributor) GetEventsURL() string {
 	if c == nil || c.EventsURL == nil {
@@ -2162,6 +2170,14 @@ func (c *Contributor) GetLogin() string {
 		return ""
 	}
 	return *c.Login
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (c *Contributor) GetName() string {
+	if c == nil || c.Name == nil {
+		return ""
+	}
+	return *c.Name
 }
 
 // GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -2421,7 +2421,7 @@ func TestContributor_GetContributions(tt *testing.T) {
 
 func TestContributor_GetEmail(tt *testing.T) {
 	var zeroValue string
-	c := &Contributor{NodeID: &zeroValue}
+	c := &Contributor{Email: &zeroValue}
 	c.GetEmail()
 	c = &Contributor{}
 	c.GetEmail()
@@ -2511,7 +2511,7 @@ func TestContributor_GetLogin(tt *testing.T) {
 
 func TestContributor_GetName(tt *testing.T) {
 	var zeroValue string
-	c := &Contributor{NodeID: &zeroValue}
+	c := &Contributor{Name: &zeroValue}
 	c.GetName()
 	c = &Contributor{}
 	c.GetName()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -2419,6 +2419,16 @@ func TestContributor_GetContributions(tt *testing.T) {
 	c.GetContributions()
 }
 
+func TestContributor_GetEmail(tt *testing.T) {
+	var zeroValue string
+	c := &Contributor{NodeID: &zeroValue}
+	c.GetEmail()
+	c = &Contributor{}
+	c.GetEmail()
+	c = nil
+	c.GetEmail()
+}
+
 func TestContributor_GetEventsURL(tt *testing.T) {
 	var zeroValue string
 	c := &Contributor{EventsURL: &zeroValue}
@@ -2497,6 +2507,16 @@ func TestContributor_GetLogin(tt *testing.T) {
 	c.GetLogin()
 	c = nil
 	c.GetLogin()
+}
+
+func TestContributor_GetName(tt *testing.T) {
+	var zeroValue string
+	c := &Contributor{NodeID: &zeroValue}
+	c.GetName()
+	c = &Contributor{}
+	c.GetName()
+	c = nil
+	c.GetName()
 }
 
 func TestContributor_GetNodeID(tt *testing.T) {

--- a/github/repos.go
+++ b/github/repos.go
@@ -534,6 +534,8 @@ type Contributor struct {
 	Type              *string `json:"type,omitempty"`
 	SiteAdmin         *bool   `json:"site_admin,omitempty"`
 	Contributions     *int    `json:"contributions,omitempty"`
+	Name              *string `json:"name,omitempty"`
+	Email             *string `json:"email,omitempty"`
 }
 
 // ListContributorsOptions specifies the optional parameters to the


### PR DESCRIPTION
According to the [documentation](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#list-repository-contributors) for ListContributors:

> To improve performance, only the first 500 author email addresses in the repository link to GitHub users. The rest will appear as anonymous contributors without associated GitHub user information.

Anonymous user results are returned from the API like this:

```
{
    "email": "email@email.com",
    "name": "First Last",
    "type": "Anonymous",
    "contributions": 109
}
```

Both name and email are only returned for anonymous users and are not currently mapped in the [contributor](https://github.com/google/go-github/blob/master/github/repos.go#L517) struct. This PR adds those two fields to the struct and accessors.