### PR TITLE
Extend IP ranges in meta API

### DIFF
--- a/github/misc.go
+++ b/github/misc.go
@@ -176,7 +176,7 @@ type APIMeta struct {
 // this endpoint on your organization’s GitHub Enterprise installation, this
 // endpoint provides information about that installation.
 //
-// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/meta/
+// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/meta#get-github-meta-information
 func (c *Client) APIMeta(ctx context.Context) (*APIMeta, *Response, error) {
 	req, err := c.NewRequest("GET", "meta", nil)
 	if err != nil {

--- a/github/misc.go
+++ b/github/misc.go
@@ -162,6 +162,14 @@ type APIMeta struct {
 	// An Array of IP addresses specifying the addresses that source imports
 	// will originate from on GitHub.com.
 	Importer []string `json:"importer,omitempty"`
+
+	// An array of IP addresses in CIDR format specifying the IP addresses
+	// GitHub Actions will originate from.
+	Actions []string `json:"actions,omitempty"`
+
+	// An array of IP addresses in CIDR format specifying the IP addresses
+	// Dependabot will originate from.
+	Dependabot []string `json:"dependabot,omitempty"`
 }
 
 // APIMeta returns information about GitHub.com, the service. Or, if you access

--- a/github/misc_test.go
+++ b/github/misc_test.go
@@ -185,12 +185,17 @@ func TestAPIMeta_marshal(t *testing.T) {
 		VerifiablePasswordAuthentication: Bool(true),
 		Pages:                            []string{"p"},
 		Importer:                         []string{"i"},
+		Actions:                          []string{"a"},
+		Dependabot:                       []string{"d"},
 	}
 	want := `{
 		"hooks":["h"],
 		"git":["g"],
 		"verifiable_password_authentication":true,
-		"pages":["p"],"importer":["i"]
+		"pages":["p"],
+		"importer":["i"],
+		"actions":["a"],
+		"dependabot":["d"]
 	}`
 
 	testJSONMarshal(t, a, want)
@@ -202,7 +207,7 @@ func TestAPIMeta(t *testing.T) {
 
 	mux.HandleFunc("/meta", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"hooks":["h"], "git":["g"], "pages":["p"], "importer":["i"], "verifiable_password_authentication": true}`)
+		fmt.Fprint(w, `{"hooks":["h"], "git":["g"], "pages":["p"], "importer":["i"], "actions":["a"], "dependabot":["d"], "verifiable_password_authentication": true}`)
 	})
 
 	ctx := context.Background()
@@ -212,10 +217,12 @@ func TestAPIMeta(t *testing.T) {
 	}
 
 	want := &APIMeta{
-		Hooks:    []string{"h"},
-		Git:      []string{"g"},
-		Pages:    []string{"p"},
-		Importer: []string{"i"},
+		Hooks:      []string{"h"},
+		Git:        []string{"g"},
+		Pages:      []string{"p"},
+		Importer:   []string{"i"},
+		Actions:    []string{"a"},
+		Dependabot: []string{"d"},
 
 		VerifiablePasswordAuthentication: Bool(true),
 	}


### PR DESCRIPTION
GitHub have added two extra IP address types in the `/meta` API. That is `actions` and `dependabot`.

I have extended the `APIMeta` method and struct with that new data, so we can consume it.

Closes https://github.com/google/go-github/issues/1777