### PR TITLE
Repository.List: Add nebula-preview to receive visibility field

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -202,7 +202,7 @@ func (s *RepositoriesService) List(ctx context.Context, user string, opts *Repos
 	}
 
 	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeTopicsPreview}
+	acceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var repos []*Repository

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -19,7 +19,7 @@ func TestRepositoriesService_List_authenticatedUser(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeTopicsPreview}
+	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
@@ -56,7 +56,7 @@ func TestRepositoriesService_List_specifiedUser(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeTopicsPreview}
+	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/users/u/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
@@ -93,7 +93,7 @@ func TestRepositoriesService_List_specifiedUser_type(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeTopicsPreview}
+	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/users/u/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))


### PR DESCRIPTION
**What type of PR is this?**

feature

**What this PR does / why we need it**:

When calling `Repositories.List` (API Method: [List repositories for the authenticated user](https://docs.github.com/en/rest/reference/repos#list-repositories-for-the-authenticated-user)), the field `visibility` is always `nil`.

The `visibility` was introduced in a developer / API preview controlled by the media accept header. 
This PR enabled the API preview `nebula-preview` for `Repositories.List`, to retrieve the `visibility` of a repository.

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

None

**Additional documentation e.g., usage docs, etc.**:

- [List repositories for the authenticated user @ GitHub REST API docs](https://docs.github.com/en/rest/reference/repos#list-repositories-for-the-authenticated-user): In the response, the `visibility` field is available.
- [API changes to support internal repository visibility (2019-12-03)](https://developer.github.com/changes/2019-12-03-internal-visibility-changes/#repository-visibility-fields)
