### PR TITLE
User.Keys: Add verified field

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -5580,6 +5580,14 @@ func (k *Key) GetURL() string {
 	return *k.URL
 }
 
+// GetVerified returns the Verified field if it's non-nil, zero value otherwise.
+func (k *Key) GetVerified() bool {
+	if k == nil || k.Verified == nil {
+		return false
+	}
+	return *k.Verified
+}
+
 // GetColor returns the Color field if it's non-nil, zero value otherwise.
 func (l *Label) GetColor() string {
 	if l == nil || l.Color == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -6520,6 +6520,16 @@ func TestKey_GetURL(tt *testing.T) {
 	k.GetURL()
 }
 
+func TestKey_GetVerified(tt *testing.T) {
+	var zeroValue bool
+	k := &Key{Verified: &zeroValue}
+	k.GetVerified()
+	k = &Key{}
+	k.GetVerified()
+	k = nil
+	k.GetVerified()
+}
+
 func TestLabel_GetColor(tt *testing.T) {
 	var zeroValue string
 	l := &Label{Color: &zeroValue}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -671,9 +671,10 @@ func TestKey_String(t *testing.T) {
 		URL:       String(""),
 		Title:     String(""),
 		ReadOnly:  Bool(false),
+		Verified:  Bool(false),
 		CreatedAt: &Timestamp{},
 	}
-	want := `github.Key{ID:0, Key:"", URL:"", Title:"", ReadOnly:false, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}`
+	want := `github.Key{ID:0, Key:"", URL:"", Title:"", ReadOnly:false, Verified:false, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}`
 	if got := v.String(); got != want {
 		t.Errorf("Key.String = %v, want %v", got, want)
 	}

--- a/github/users_keys.go
+++ b/github/users_keys.go
@@ -17,6 +17,7 @@ type Key struct {
 	URL       *string    `json:"url,omitempty"`
 	Title     *string    `json:"title,omitempty"`
 	ReadOnly  *bool      `json:"read_only,omitempty"`
+	Verified  *bool      `json:"verified,omitempty"`
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 }
 


### PR DESCRIPTION
**What type of PR is this?**

feature

**What this PR does / why we need it**:

When calling `Users.ListKeys` (API Method: [List public SSH keys for the authenticated user](https://docs.github.com/en/rest/reference/users#list-public-ssh-keys-for-the-authenticated-user)), the field `verified` is not populated.

This PR enabled adds `visibility` files to the USers.Key structure.

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

None

**Additional documentation e.g., usage docs, etc.**:

- [List public SSH keys for the authenticated user @ GitHub REST API docs](https://docs.github.com/en/rest/reference/users#list-public-ssh-keys-for-the-authenticated-user)