### PR TITLE
Add support for the X-Hub-Signature-256 header

### DIFF
--- a/github/messages.go
+++ b/github/messages.go
@@ -30,8 +30,8 @@ const (
 	// sha256Prefix and sha512Prefix are provided for future compatibility.
 	sha256Prefix = "sha256"
 	sha512Prefix = "sha512"
-	// signatureHeader is the GitHub header key used to pass the HMAC hexdigest.
-	signatureHeader = "X-Hub-Signature"
+	// sha1SignatureHeader is the GitHub header key used to pass the HMAC-SHA1 hexdigest.
+	sha1SignatureHeader = "X-Hub-Signature"
 	// eventTypeHeader is the GitHub header key used to pass the event type.
 	eventTypeHeader = "X-Github-Event"
 	// deliveryIDHeader is the GitHub header key used to pass the unique ID for the webhook event.
@@ -190,7 +190,7 @@ func ValidatePayload(r *http.Request, secretToken []byte) (payload []byte, err e
 	// Only validate the signature if a secret token exists. This is intended for
 	// local development only and all webhooks should ideally set up a secret token.
 	if len(secretToken) > 0 {
-		sig := r.Header.Get(signatureHeader)
+		sig := r.Header.Get(sha1SignatureHeader)
 		if err := ValidateSignature(sig, body, secretToken); err != nil {
 			return nil, err
 		}

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -29,12 +29,13 @@ func TestValidatePayload(t *testing.T) {
 	const defaultSignature = "sha1=126f2c800419c60137ce748d7672e77b65cf16d6"
 	secretKey := []byte("0123456789abcdef")
 	tests := []struct {
-		signature   string
-		eventID     string
-		event       string
-		wantEventID string
-		wantEvent   string
-		wantPayload string
+		signature       string
+		signatureHeader string
+		eventID         string
+		event           string
+		wantEventID     string
+		wantEvent       string
+		wantPayload     string
 	}{
 		// The following tests generate expected errors:
 		{},                         // Missing signature
@@ -77,7 +78,11 @@ func TestValidatePayload(t *testing.T) {
 			t.Fatalf("NewRequest: %v", err)
 		}
 		if test.signature != "" {
-			req.Header.Set(sha1SignatureHeader, test.signature)
+			if test.signatureHeader != "" {
+				req.Header.Set(test.signatureHeader, test.signature)
+			} else {
+				req.Header.Set(sha1SignatureHeader, test.signature)
+			}
 		}
 		req.Header.Set("Content-Type", "application/json")
 

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -64,6 +64,13 @@ func TestValidatePayload(t *testing.T) {
 			wantPayload: defaultBody,
 		},
 		{
+			signature:       "sha256=b1f8020f5b4cd42042f807dd939015c4a418bc1ff7f604dd55b0a19b5d953d9b",
+			signatureHeader: sha256SignatureHeader,
+			event:           "ping",
+			wantEvent:       "ping",
+			wantPayload:     defaultBody,
+		},
+		{
 			signature:   "sha512=8456767023c1195682e182a23b3f5d19150ecea598fde8cb85918f7281b16079471b1329f92b912c4d8bd7455cb159777db8f29608b20c7c87323ba65ae62e1f",
 			event:       "ping",
 			wantEvent:   "ping",

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -77,7 +77,7 @@ func TestValidatePayload(t *testing.T) {
 			t.Fatalf("NewRequest: %v", err)
 		}
 		if test.signature != "" {
-			req.Header.Set(signatureHeader, test.signature)
+			req.Header.Set(sha1SignatureHeader, test.signature)
 		}
 		req.Header.Set("Content-Type", "application/json")
 
@@ -107,7 +107,7 @@ func TestValidatePayload_FormGet(t *testing.T) {
 	}
 	req.PostForm = form
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set(signatureHeader, signature)
+	req.Header.Set(sha1SignatureHeader, signature)
 
 	got, err := ValidatePayload(req, secretKey)
 	if err != nil {
@@ -118,7 +118,7 @@ func TestValidatePayload_FormGet(t *testing.T) {
 	}
 
 	// check that if payload is invalid we get error
-	req.Header.Set(signatureHeader, "invalid signature")
+	req.Header.Set(sha1SignatureHeader, "invalid signature")
 	if _, err = ValidatePayload(req, []byte{0}); err == nil {
 		t.Error("ValidatePayload = nil, want err")
 	}
@@ -137,7 +137,7 @@ func TestValidatePayload_FormPost(t *testing.T) {
 		t.Fatalf("NewRequest: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set(signatureHeader, signature)
+	req.Header.Set(sha1SignatureHeader, signature)
 
 	got, err := ValidatePayload(req, secretKey)
 	if err != nil {
@@ -148,7 +148,7 @@ func TestValidatePayload_FormPost(t *testing.T) {
 	}
 
 	// check that if payload is invalid we get error
-	req.Header.Set(signatureHeader, "invalid signature")
+	req.Header.Set(sha1SignatureHeader, "invalid signature")
 	if _, err = ValidatePayload(req, []byte{0}); err == nil {
 		t.Error("ValidatePayload = nil, want err")
 	}


### PR DESCRIPTION
This relates to #592 and adds support for the `X-Hub-Signature-256` header. I've chosen to set the SHA256 header as the default and falling back to the SHA1 header when the SHA256 header is empty. The GitHub documentation [recommends](https://docs.github.com/en/developers/webhooks-and-events/securing-your-webhooks#validating-payloads-from-github) using the SHA256 header so I don't expect the fallback to be needed in a live environment. Still, this fallback prevents introducing breaking changes when used in tests.