### PR TITLE
Add support for removing enterprise Actions runners

### DIFF
--- a/github/enterprise_actions_runners.go
+++ b/github/enterprise_actions_runners.go
@@ -54,10 +54,10 @@ func (s *EnterpriseService) ListRunners(ctx context.Context, enterprise string, 
 	return runners, resp, nil
 }
 
-// RemoveEnterpriseRunner forces the removal of a self-hosted runner from an enterprise using the runner id.
+// RemoveRunner forces the removal of a self-hosted runner from an enterprise using the runner id.
 //
 // GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/enterprise-admin/#delete-a-self-hosted-runner-from-an-enterprise
-func (s *ActionsService) RemoveEnterpriseRunner(ctx context.Context, enterprise string, runnerID int64) (*Response, error) {
+func (s *EnterpriseService) RemoveRunner(ctx context.Context, enterprise string, runnerID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runners/%v", enterprise, runnerID)
 
 	req, err := s.client.NewRequest("DELETE", u, nil)

--- a/github/enterprise_actions_runners.go
+++ b/github/enterprise_actions_runners.go
@@ -56,7 +56,7 @@ func (s *EnterpriseService) ListRunners(ctx context.Context, enterprise string, 
 
 // RemoveEnterpriseRunner forces the removal of a self-hosted runner from an enterprise using the runner id.
 //
-// GitHub API docs: https://docs.github.com/en/rest/reference/enterprise-admin#delete-a-self-hosted-runner-from-an-enterprise
+// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/enterprise-admin/#delete-a-self-hosted-runner-from-an-enterprise
 func (s *ActionsService) RemoveEnterpriseRunner(ctx context.Context, enterprise string, runnerID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runners/%v", enterprise, runnerID)
 

--- a/github/enterprise_actions_runners.go
+++ b/github/enterprise_actions_runners.go
@@ -53,3 +53,17 @@ func (s *EnterpriseService) ListRunners(ctx context.Context, enterprise string, 
 
 	return runners, resp, nil
 }
+
+// RemoveEnterpriseRunner forces the removal of a self-hosted runner from an enterprise using the runner id.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/enterprise-admin#delete-a-self-hosted-runner-from-an-enterprise
+func (s *ActionsService) RemoveEnterpriseRunner(ctx context.Context, enterprise string, runnerID int64) (*Response, error) {
+	u := fmt.Sprintf("enterprises/%v/actions/runners/%v", enterprise, runnerID)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/enterprise_actions_runners_test.go
+++ b/github/enterprise_actions_runners_test.go
@@ -94,7 +94,7 @@ func TestEnterpriseService_ListRunners(t *testing.T) {
 	})
 }
 
-func TestActionsService_RemoveEnterpriseRunner(t *testing.T) {
+func TestEnterpriseService_RemoveRunner(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -103,18 +103,18 @@ func TestActionsService_RemoveEnterpriseRunner(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	_, err := client.Actions.RemoveEnterpriseRunner(ctx, "o", 21)
+	_, err := client.Enterprise.RemoveRunner(ctx, "o", 21)
 	if err != nil {
-		t.Errorf("Actions.RemoveEnterpriseRunner returned error: %v", err)
+		t.Errorf("Actions.RemoveRunner returned error: %v", err)
 	}
 
-	const methodName = "RemoveEnterpriseRunner"
+	const methodName = "RemoveRunner"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.RemoveEnterpriseRunner(ctx, "\n", 21)
+		_, err = client.Enterprise.RemoveRunner(ctx, "\n", 21)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.RemoveEnterpriseRunner(ctx, "o", 21)
+		return client.Enterprise.RemoveRunner(ctx, "o", 21)
 	})
 }

--- a/github/enterprise_actions_runners_test.go
+++ b/github/enterprise_actions_runners_test.go
@@ -93,3 +93,28 @@ func TestEnterpriseService_ListRunners(t *testing.T) {
 		return resp, err
 	})
 }
+
+func TestActionsService_RemoveEnterpriseRunner(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/enterprises/o/actions/runners/21", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	ctx := context.Background()
+	_, err := client.Actions.RemoveEnterpriseRunner(ctx, "o", 21)
+	if err != nil {
+		t.Errorf("Actions.RemoveEnterpriseRunner returned error: %v", err)
+	}
+
+	const methodName = "RemoveEnterpriseRunner"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.RemoveEnterpriseRunner(ctx, "\n", 21)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.RemoveEnterpriseRunner(ctx, "o", 21)
+	})
+}


### PR DESCRIPTION
adds support for

https://docs.github.com/en/rest/reference/enterprise-admin#delete-a-self-hosted-runner-from-an-enterprise
