### PR TITLE
Repository.Hook: Add missing fields Type, Name, TestURL, PingURL and LastResponse

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -3956,6 +3956,38 @@ func (h *Hook) GetID() int64 {
 	return *h.ID
 }
 
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (h *Hook) GetName() string {
+	if h == nil || h.Name == nil {
+		return ""
+	}
+	return *h.Name
+}
+
+// GetPingURL returns the PingURL field if it's non-nil, zero value otherwise.
+func (h *Hook) GetPingURL() string {
+	if h == nil || h.PingURL == nil {
+		return ""
+	}
+	return *h.PingURL
+}
+
+// GetTestURL returns the TestURL field if it's non-nil, zero value otherwise.
+func (h *Hook) GetTestURL() string {
+	if h == nil || h.TestURL == nil {
+		return ""
+	}
+	return *h.TestURL
+}
+
+// GetType returns the Type field if it's non-nil, zero value otherwise.
+func (h *Hook) GetType() string {
+	if h == nil || h.Type == nil {
+		return ""
+	}
+	return *h.Type
+}
+
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (h *Hook) GetUpdatedAt() time.Time {
 	if h == nil || h.UpdatedAt == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -4616,6 +4616,46 @@ func TestHook_GetID(tt *testing.T) {
 	h.GetID()
 }
 
+func TestHook_GetName(tt *testing.T) {
+	var zeroValue string
+	h := &Hook{Name: &zeroValue}
+	h.GetName()
+	h = &Hook{}
+	h.GetName()
+	h = nil
+	h.GetName()
+}
+
+func TestHook_GetPingURL(tt *testing.T) {
+	var zeroValue string
+	h := &Hook{PingURL: &zeroValue}
+	h.GetPingURL()
+	h = &Hook{}
+	h.GetPingURL()
+	h = nil
+	h.GetPingURL()
+}
+
+func TestHook_GetTestURL(tt *testing.T) {
+	var zeroValue string
+	h := &Hook{TestURL: &zeroValue}
+	h.GetTestURL()
+	h = &Hook{}
+	h.GetTestURL()
+	h = nil
+	h.GetTestURL()
+}
+
+func TestHook_GetType(tt *testing.T) {
+	var zeroValue string
+	h := &Hook{Type: &zeroValue}
+	h.GetType()
+	h = &Hook{}
+	h.GetType()
+	h = nil
+	h.GetType()
+}
+
 func TestHook_GetUpdatedAt(tt *testing.T) {
 	var zeroValue time.Time
 	h := &Hook{UpdatedAt: &zeroValue}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -508,12 +508,17 @@ func TestHeadCommit_String(t *testing.T) {
 
 func TestHook_String(t *testing.T) {
 	v := Hook{
-		URL:    String(""),
-		ID:     Int64(0),
-		Config: nil,
-		Active: Bool(false),
+		URL:          String(""),
+		ID:           Int64(0),
+		Type:         String(""),
+		Name:         String(""),
+		TestURL:      String(""),
+		PingURL:      String(""),
+		LastResponse: nil,
+		Config:       nil,
+		Active:       Bool(false),
 	}
-	want := `github.Hook{URL:"", ID:0, Config:map[], Active:false}`
+	want := `github.Hook{URL:"", ID:0, Type:"", Name:"", TestURL:"", PingURL:"", LastResponse:map[], Config:map[], Active:false}`
 	if got := v.String(); got != want {
 		t.Errorf("Hook.String = %v, want %v", got, want)
 	}

--- a/github/repos_hooks.go
+++ b/github/repos_hooks.go
@@ -72,10 +72,15 @@ func (w WebHookAuthor) String() string {
 
 // Hook represents a GitHub (web and service) hook for a repository.
 type Hook struct {
-	CreatedAt *time.Time `json:"created_at,omitempty"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
-	URL       *string    `json:"url,omitempty"`
-	ID        *int64     `json:"id,omitempty"`
+	CreatedAt    *time.Time             `json:"created_at,omitempty"`
+	UpdatedAt    *time.Time             `json:"updated_at,omitempty"`
+	URL          *string                `json:"url,omitempty"`
+	ID           *int64                 `json:"id,omitempty"`
+	Type         *string                `json:"type,omitempty"`
+	Name         *string                `json:"name,omitempty"`
+	TestURL      *string                `json:"test_url,omitempty"`
+	PingURL      *string                `json:"ping_url,omitempty"`
+	LastResponse map[string]interface{} `json:"last_response,omitempty"`
 
 	// Only the following fields are used when creating a hook.
 	// Config is required.

--- a/github/strings_test.go
+++ b/github/strings_test.go
@@ -101,7 +101,7 @@ func TestString(t *testing.T) {
 		{Gist{ID: String("1")}, `github.Gist{ID:"1", Files:map[]}`},
 		{GitObject{SHA: String("s")}, `github.GitObject{SHA:"s"}`},
 		{Gitignore{Name: String("n")}, `github.Gitignore{Name:"n"}`},
-		{Hook{ID: Int64(1)}, `github.Hook{ID:1, Config:map[]}`},
+		{Hook{ID: Int64(1)}, `github.Hook{ID:1, LastResponse:map[], Config:map[]}`},
 		{IssueComment{ID: Int64(1)}, `github.IssueComment{ID:1}`},
 		{Issue{Number: Int(1)}, `github.Issue{Number:1}`},
 		{Key{ID: Int64(1)}, `github.Key{ID:1}`},


### PR DESCRIPTION
**What type of PR is this?**

feature

**What this PR does / why we need it**:

Adds support for missing fields in the Repository.Hook structure.

Here is an example of a full response of a public repo, where I am the owner + when I call ListHooks

```
{
    "type": "Repository",
    "id": <ID> (int),
    "name": "web",
    "active": true,
    "events": [
      "create",
      "delete",
      "issue_comment",
      "member",
      "public",
      "pull_request",
      "push",
      "repository"
    ],
    "config": {
      "url": "https://notify.travis-ci.org",
      "insecure_ssl": "0",
      "content_type": "form"
    },
    "updated_at": "2019-01-15T15:40:01Z",
    "created_at": "2019-01-15T15:40:01Z",
    "url": "https://api.github.com/repos/andygrunwald/go-jira/hooks/<ID>",
    "test_url": "https://api.github.com/repos/andygrunwald/go-jira/hooks/<ID>/test",
    "ping_url": "https://api.github.com/repos/andygrunwald/go-jira/hooks/<ID>/pings",
    "last_response": {
      "code": 204,
      "status": "active",
      "message": "OK"
    }
  }
```

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

None

**Additional documentation e.g., usage docs, etc.**:

- [List repository webhooks @ GitHub REST API docs](https://docs.github.com/en/rest/reference/repos#list-repository-webhooks)