### PR TITLE
Repository.ListByOrg: Add nebula-preview to receive visibility field

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -248,7 +248,7 @@ func (s *RepositoriesService) ListByOrg(ctx context.Context, org string, opts *R
 	}
 
 	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeTopicsPreview}
+	acceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var repos []*Repository

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -131,7 +131,7 @@ func TestRepositoriesService_ListByOrg(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeTopicsPreview}
+	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/orgs/o/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))


### PR DESCRIPTION
**What type of PR is this?**

feature

**What this PR does / why we need it:**

In addition to the changes added in https://github.com/google/go-github/pull/1780, this change also ensures the `Visibility` field is included when calling `Repositories.ListByOrg`.

**Special notes for your reviewer:**

None