### PR TITLE
Add MembersCanCreate* to Organization

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -7228,6 +7228,30 @@ func (o *Organization) GetMembersCanCreatePrivateRepos() bool {
 	return *o.MembersCanCreatePrivateRepos
 }
 
+// GetMembersCanCreatePages returns the MembersCanCreatePages field if it's non-nil, zero value otherwise.
+func (o *Organization) GetMembersCanCreatePages() bool {
+	if o == nil || o.MembersCanCreatePages == nil {
+		return false
+	}
+	return *o.MembersCanCreatePages
+}
+
+// GetMembersCanCreatePrivatePages returns the MembersCanCreatePrivatePages field if it's non-nil, zero value otherwise.
+func (o *Organization) GetMembersCanCreatePrivatePages() bool {
+	if o == nil || o.MembersCanCreatePrivatePages == nil {
+		return false
+	}
+	return *o.MembersCanCreatePrivatePages
+}
+
+// GetMembersCanCreatePublicPages returns the MembersCanCreatePublicPages field if it's non-nil, zero value otherwise.
+func (o *Organization) GetMembersCanCreatePublicPages() bool {
+	if o == nil || o.MembersCanCreatePublicPages == nil {
+		return false
+	}
+	return *o.MembersCanCreatePublicPages
+}
+
 // GetMembersCanCreatePublicRepos returns the MembersCanCreatePublicRepos field if it's non-nil, zero value otherwise.
 func (o *Organization) GetMembersCanCreatePublicRepos() bool {
 	if o == nil || o.MembersCanCreatePublicRepos == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -7220,14 +7220,6 @@ func (o *Organization) GetMembersCanCreateInternalRepos() bool {
 	return *o.MembersCanCreateInternalRepos
 }
 
-// GetMembersCanCreatePrivateRepos returns the MembersCanCreatePrivateRepos field if it's non-nil, zero value otherwise.
-func (o *Organization) GetMembersCanCreatePrivateRepos() bool {
-	if o == nil || o.MembersCanCreatePrivateRepos == nil {
-		return false
-	}
-	return *o.MembersCanCreatePrivateRepos
-}
-
 // GetMembersCanCreatePages returns the MembersCanCreatePages field if it's non-nil, zero value otherwise.
 func (o *Organization) GetMembersCanCreatePages() bool {
 	if o == nil || o.MembersCanCreatePages == nil {
@@ -7242,6 +7234,14 @@ func (o *Organization) GetMembersCanCreatePrivatePages() bool {
 		return false
 	}
 	return *o.MembersCanCreatePrivatePages
+}
+
+// GetMembersCanCreatePrivateRepos returns the MembersCanCreatePrivateRepos field if it's non-nil, zero value otherwise.
+func (o *Organization) GetMembersCanCreatePrivateRepos() bool {
+	if o == nil || o.MembersCanCreatePrivateRepos == nil {
+		return false
+	}
+	return *o.MembersCanCreatePrivateRepos
 }
 
 // GetMembersCanCreatePublicPages returns the MembersCanCreatePublicPages field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -8472,6 +8472,36 @@ func TestOrganization_GetMembersCanCreatePrivateRepos(tt *testing.T) {
 	o.GetMembersCanCreatePrivateRepos()
 }
 
+func TestOrganization_GetMembersCanCreatePages(tt *testing.T) {
+	var zeroValue bool
+	o := &Organization{MembersCanCreatePages: &zeroValue}
+	o.GetMembersCanCreatePages()
+	o = &Organization{}
+	o.GetMembersCanCreatePages()
+	o = nil
+	o.GetMembersCanCreatePages()
+}
+
+func TestOrganization_GetMembersCanCreatePrivatePages(tt *testing.T) {
+	var zeroValue bool
+	o := &Organization{MembersCanCreatePrivatePages: &zeroValue}
+	o.GetMembersCanCreatePrivatePages()
+	o = &Organization{}
+	o.GetMembersCanCreatePrivatePages()
+	o = nil
+	o.GetMembersCanCreatePrivatePages()
+}
+
+func TestOrganization_GetMembersCanCreatePublicPages(tt *testing.T) {
+	var zeroValue bool
+	o := &Organization{MembersCanCreatePublicPages: &zeroValue}
+	o.GetMembersCanCreatePublicPages()
+	o = &Organization{}
+	o.GetMembersCanCreatePublicPages()
+	o = nil
+	o.GetMembersCanCreatePublicPages()
+}
+
 func TestOrganization_GetMembersCanCreatePublicRepos(tt *testing.T) {
 	var zeroValue bool
 	o := &Organization{MembersCanCreatePublicRepos: &zeroValue}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -8462,16 +8462,6 @@ func TestOrganization_GetMembersCanCreateInternalRepos(tt *testing.T) {
 	o.GetMembersCanCreateInternalRepos()
 }
 
-func TestOrganization_GetMembersCanCreatePrivateRepos(tt *testing.T) {
-	var zeroValue bool
-	o := &Organization{MembersCanCreatePrivateRepos: &zeroValue}
-	o.GetMembersCanCreatePrivateRepos()
-	o = &Organization{}
-	o.GetMembersCanCreatePrivateRepos()
-	o = nil
-	o.GetMembersCanCreatePrivateRepos()
-}
-
 func TestOrganization_GetMembersCanCreatePages(tt *testing.T) {
 	var zeroValue bool
 	o := &Organization{MembersCanCreatePages: &zeroValue}
@@ -8490,6 +8480,16 @@ func TestOrganization_GetMembersCanCreatePrivatePages(tt *testing.T) {
 	o.GetMembersCanCreatePrivatePages()
 	o = nil
 	o.GetMembersCanCreatePrivatePages()
+}
+
+func TestOrganization_GetMembersCanCreatePrivateRepos(tt *testing.T) {
+	var zeroValue bool
+	o := &Organization{MembersCanCreatePrivateRepos: &zeroValue}
+	o.GetMembersCanCreatePrivateRepos()
+	o = &Organization{}
+	o.GetMembersCanCreatePrivateRepos()
+	o = nil
+	o.GetMembersCanCreatePrivateRepos()
 }
 
 func TestOrganization_GetMembersCanCreatePublicPages(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -890,6 +890,9 @@ func TestOrganization_String(t *testing.T) {
 		MembersCanCreatePrivateRepos:         Bool(false),
 		MembersCanCreateInternalRepos:        Bool(false),
 		MembersAllowedRepositoryCreationType: String(""),
+		MembersCanCreatePages:                Bool(false),
+		MembersCanCreatePublicPages:          Bool(false),
+		MembersCanCreatePrivatePages:         Bool(false),
 		URL:                                  String(""),
 		EventsURL:                            String(""),
 		HooksURL:                             String(""),
@@ -898,7 +901,7 @@ func TestOrganization_String(t *testing.T) {
 		PublicMembersURL:                     String(""),
 		ReposURL:                             String(""),
 	}
-	want := `github.Organization{Login:"", ID:0, NodeID:"", AvatarURL:"", HTMLURL:"", Name:"", Company:"", Blog:"", Location:"", Email:"", TwitterUsername:"", Description:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, BillingEmail:"", Type:"", Plan:github.Plan{}, TwoFactorRequirementEnabled:false, IsVerified:false, HasOrganizationProjects:false, HasRepositoryProjects:false, DefaultRepoPermission:"", DefaultRepoSettings:"", MembersCanCreateRepos:false, MembersCanCreatePublicRepos:false, MembersCanCreatePrivateRepos:false, MembersCanCreateInternalRepos:false, MembersAllowedRepositoryCreationType:"", URL:"", EventsURL:"", HooksURL:"", IssuesURL:"", MembersURL:"", PublicMembersURL:"", ReposURL:""}`
+	want := `github.Organization{Login:"", ID:0, NodeID:"", AvatarURL:"", HTMLURL:"", Name:"", Company:"", Blog:"", Location:"", Email:"", TwitterUsername:"", Description:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, BillingEmail:"", Type:"", Plan:github.Plan{}, TwoFactorRequirementEnabled:false, IsVerified:false, HasOrganizationProjects:false, HasRepositoryProjects:false, DefaultRepoPermission:"", DefaultRepoSettings:"", MembersCanCreateRepos:false, MembersCanCreatePublicRepos:false, MembersCanCreatePrivateRepos:false, MembersCanCreateInternalRepos:false, MembersAllowedRepositoryCreationType:"", MembersCanCreatePages:false, MembersCanCreatePublicPages:false, MembersCanCreatePrivatePages:false, URL:"", EventsURL:"", HooksURL:"", IssuesURL:"", MembersURL:"", PublicMembersURL:"", ReposURL:""}`
 	if got := v.String(); got != want {
 		t.Errorf("Organization.String = %v, want %v", got, want)
 	}

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -73,7 +73,7 @@ type Organization struct {
 	// operation and does not consider 'internal' repositories during 'get' operation
 	MembersAllowedRepositoryCreationType *string `json:"members_allowed_repository_creation_type,omitempty"`
 
-	// MembersCanCreatePages toggles whether organization members can create GitHub Pages sites
+	// MembersCanCreatePages toggles whether organization members can create GitHub Pages sites.
 	MembersCanCreatePages *bool `json:"members_can_create_pages,omitempty"`
 	// MembersCanCreatePublicPages toggles whether organization members can create public GitHub Pages sites
 	MembersCanCreatePublicPages *bool `json:"members_can_create_public_pages,omitempty"`

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -75,7 +75,7 @@ type Organization struct {
 
 	// MembersCanCreatePages toggles whether organization members can create GitHub Pages sites.
 	MembersCanCreatePages *bool `json:"members_can_create_pages,omitempty"`
-	// MembersCanCreatePublicPages toggles whether organization members can create public GitHub Pages sites
+	// MembersCanCreatePublicPages toggles whether organization members can create public GitHub Pages sites.
 	MembersCanCreatePublicPages *bool `json:"members_can_create_public_pages,omitempty"`
 	// MembersCanCreatePrivatePages toggles whether organization members can create private GitHub Pages sites
 	MembersCanCreatePrivatePages *bool `json:"members_can_create_private_pages,omitempty"`

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -77,7 +77,7 @@ type Organization struct {
 	MembersCanCreatePages *bool `json:"members_can_create_pages,omitempty"`
 	// MembersCanCreatePublicPages toggles whether organization members can create public GitHub Pages sites.
 	MembersCanCreatePublicPages *bool `json:"members_can_create_public_pages,omitempty"`
-	// MembersCanCreatePrivatePages toggles whether organization members can create private GitHub Pages sites
+	// MembersCanCreatePrivatePages toggles whether organization members can create private GitHub Pages sites.
 	MembersCanCreatePrivatePages *bool `json:"members_can_create_private_pages,omitempty"`
 
 	// API URLs

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -73,6 +73,13 @@ type Organization struct {
 	// operation and does not consider 'internal' repositories during 'get' operation
 	MembersAllowedRepositoryCreationType *string `json:"members_allowed_repository_creation_type,omitempty"`
 
+	// MembersCanCreatePages toggles whether organization members can create GitHub Pages sites
+	MembersCanCreatePages *bool `json:"members_can_create_pages,omitempty"`
+	// MembersCanCreatePublicPages toggles whether organization members can create public GitHub Pages sites
+	MembersCanCreatePublicPages *bool `json:"members_can_create_public_pages,omitempty"`
+	// MembersCanCreatePrivatePages toggles whether organization members can create private GitHub Pages sites
+	MembersCanCreatePrivatePages *bool `json:"members_can_create_private_pages,omitempty"`
+
 	// API URLs
 	URL              *string `json:"url,omitempty"`
 	EventsURL        *string `json:"events_url,omitempty"`

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -35,6 +35,9 @@ func TestOrganization_marshal(t *testing.T) {
 		MembersCanCreatePrivateRepos:         Bool(true),
 		MembersCanCreatePublicRepos:          Bool(false),
 		MembersAllowedRepositoryCreationType: String("all"),
+		MembersCanCreatePages:                Bool(true),
+		MembersCanCreatePublicPages:          Bool(false),
+		MembersCanCreatePrivatePages:         Bool(true),
 	}
 	want := `
 		{
@@ -54,7 +57,10 @@ func TestOrganization_marshal(t *testing.T) {
 			"members_can_create_public_repositories": false,
 			"members_can_create_private_repositories": true,
 			"members_can_create_internal_repositories": true,
-			"members_allowed_repository_creation_type": "all"
+			"members_allowed_repository_creation_type": "all",
+			"members_can_create_pages": true,
+			"members_can_create_public_pages": false,
+			"members_can_create_private_pages": true
 		}
 	`
 	testJSONMarshal(t, o, want)


### PR DESCRIPTION
#### What type of PR is this?

Update Organization

#### What this PR does / why we need it

Bring Organization inline with the latest API changes  (see https://docs.github.com/en/rest/reference/orgs#get-an-organization)

