### PR TITLE
Apps.ListRepos/Apps.ListUserRepos: Add mercy-preview + nebula-preview headers

### DIFF
--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 // ListRepositories represents the response from the list repos endpoints.
@@ -29,6 +30,10 @@ func (s *AppsService) ListRepos(ctx context.Context, opts *ListOptions) (*ListRe
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var r *ListRepositories
 
@@ -55,6 +60,10 @@ func (s *AppsService) ListUserRepos(ctx context.Context, id int64, opts *ListOpt
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept headers when APIs fully launch.
+	acceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
+	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var r *ListRepositories
 	resp, err := s.client.Do(ctx, req, &r)

--- a/github/apps_installation_test.go
+++ b/github/apps_installation_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -17,8 +18,10 @@ func TestAppsService_ListRepos(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/installation/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"page":     "1",
 			"per_page": "2",
@@ -52,8 +55,10 @@ func TestAppsService_ListUserRepos(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/user/installations/1/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"page":     "1",
 			"per_page": "2",


### PR DESCRIPTION
**What type of PR is this?**

feature

**What this PR does / why we need it**:

* mercy-preview: For receiving repository topics
* nebula-preview: For visibility information

When calling `Apps.ListRepos` or `Apps.ListUserRepos`, the field `visibility` and `topic` are always `nil`.

The reason: Missing headers for developers preview API.

**Special notes for your reviewer**:

This applies the same fix as in https://github.com/google/go-github/pull/1780

**Does this PR introduce a user-facing change?**:

None

**Additional documentation e.g., usage docs, etc.**:

- [API changes to support internal repository visibility (2019-12-03)](https://developer.github.com/changes/2019-12-03-internal-visibility-changes/#repository-visibility-fields)
