### PR TITLE
Support Go 1.16 and 1.15 in workflows/tests.yml 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.x, 1.14.x]
+        go-version: [1.x, 1.16.x]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.x, 1.16.x]
+        go-version: [1.x, 1.15.x]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
**What type of PR is this?**

improvement

**What this PR does / why we need it**:

go v1.16 is released.
go-github still tests against v1.14.

This PR raises the go version to v1.16 to test against.

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

None

**Additional documentation e.g., usage docs, etc.**:

- [Go 1.16 is released)](https://blog.golang.org/go1.16)
