### PR TITLE
Fix inline docs for InstallationEvent type

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -277,16 +277,18 @@ type TeamChange struct {
 	} `json:"repository,omitempty"`
 }
 
-// InstallationEvent is triggered when a GitHub App has been installed or uninstalled.
+// InstallationEvent is triggered when a GitHub App has been installed, uninstalled, suspend, unsuspended
+// or new permissions have been accepted.
 // The Webhook event name is "installation".
 //
-// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/activity/events/types/#installationevent
+// GitHub API docs: https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#installation
 type InstallationEvent struct {
-	// The action that was performed. Can be either "created" or "deleted".
+	// The action that was performed. Can be either "created", "deleted", "suspend", "unsuspend" or "new_permissions_accepted".
 	Action       *string       `json:"action,omitempty"`
 	Repositories []*Repository `json:"repositories,omitempty"`
 	Sender       *User         `json:"sender,omitempty"`
 	Installation *Installation `json:"installation,omitempty"`
+	// TODO key "requester" is not covered
 }
 
 // InstallationRepositoriesEvent is triggered when a repository is added or


### PR DESCRIPTION
**What type of PR is this?**

documentation

**What this PR does / why we need it**:

The inline documentation for the `InstallationEvent` went out of date.
This PR fixes the link + possible values.

Furthermore, does the REST API send a `requester` key as well.
In my current use-case, this was `null`, hence I am not aware of the type (is not documented).
As a trade-off for now, I added a TODO. Once the type is known, this can be extended

**Special notes for your reviewer**:

This applies the same fix as in https://github.com/google/go-github/pull/1780

**Does this PR introduce a user-facing change?**:

None

**Additional documentation e.g., usage docs, etc.**:

- [Webhook events and payloads: installation](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#installation)
