### PR TITLE
Add ActionsAllowed and ActionsPermissions to Organization

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -28,14 +28,6 @@ func (a *ActionsAllowed) GetGithubOwnedAllowed() bool {
 	return *a.GithubOwnedAllowed
 }
 
-// GetPatternsAllowed returns the PatternsAllowed field if it's non-nil, zero value otherwise.
-func (a *ActionsAllowed) GetPatternsAllowed() []string {
-	if a == nil || a.PatternsAllowed == nil {
-		return nil
-	}
-	return *a.PatternsAllowed
-}
-
 // GetVerifiedAllowed returns the VerifiedAllowed field if it's non-nil, zero value otherwise.
 func (a *ActionsAllowed) GetVerifiedAllowed() bool {
 	if a == nil || a.VerifiedAllowed == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -20,6 +20,54 @@ func (a *AbuseRateLimitError) GetRetryAfter() time.Duration {
 	return *a.RetryAfter
 }
 
+// GetGithubOwnedAllowed returns the GithubOwnedAllowed field if it's non-nil, zero value otherwise.
+func (a *ActionsAllowed) GetGithubOwnedAllowed() bool {
+	if a == nil || a.GithubOwnedAllowed == nil {
+		return false
+	}
+	return *a.GithubOwnedAllowed
+}
+
+// GetPatternsAllowed returns the PatternsAllowed field if it's non-nil, zero value otherwise.
+func (a *ActionsAllowed) GetPatternsAllowed() []string {
+	if a == nil || a.PatternsAllowed == nil {
+		return nil
+	}
+	return *a.PatternsAllowed
+}
+
+// GetVerifiedAllowed returns the VerifiedAllowed field if it's non-nil, zero value otherwise.
+func (a *ActionsAllowed) GetVerifiedAllowed() bool {
+	if a == nil || a.VerifiedAllowed == nil {
+		return false
+	}
+	return *a.VerifiedAllowed
+}
+
+// GetAllowedActions returns the AllowedActions field if it's non-nil, zero value otherwise.
+func (a *ActionsPermissions) GetAllowedActions() string {
+	if a == nil || a.AllowedActions == nil {
+		return ""
+	}
+	return *a.AllowedActions
+}
+
+// GetEnabledRepositories returns the EnabledRepositories field if it's non-nil, zero value otherwise.
+func (a *ActionsPermissions) GetEnabledRepositories() string {
+	if a == nil || a.EnabledRepositories == nil {
+		return ""
+	}
+	return *a.EnabledRepositories
+}
+
+// GetSelectedActionsURL returns the SelectedActionsURL field if it's non-nil, zero value otherwise.
+func (a *ActionsPermissions) GetSelectedActionsURL() string {
+	if a == nil || a.SelectedActionsURL == nil {
+		return ""
+	}
+	return *a.SelectedActionsURL
+}
+
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
 func (a *AdminEnforcement) GetURL() string {
 	if a == nil || a.URL == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -23,6 +23,66 @@ func TestAbuseRateLimitError_GetRetryAfter(tt *testing.T) {
 	a.GetRetryAfter()
 }
 
+func TestActionsAllowed_GetGithubOwnedAllowed(tt *testing.T) {
+	var zeroValue bool
+	a := &ActionsAllowed{GithubOwnedAllowed: &zeroValue}
+	a.GetGithubOwnedAllowed()
+	a = &ActionsAllowed{}
+	a.GetGithubOwnedAllowed()
+	a = nil
+	a.GetGithubOwnedAllowed()
+}
+
+func TestActionsAllowed_GetPatternsAllowed(tt *testing.T) {
+	var zeroValue []string
+	a := &ActionsAllowed{PatternsAllowed: &zeroValue}
+	a.GetPatternsAllowed()
+	a = &ActionsAllowed{}
+	a.GetPatternsAllowed()
+	a = nil
+	a.GetPatternsAllowed()
+}
+
+func TestActionsAllowed_GetVerifiedAllowed(tt *testing.T) {
+	var zeroValue bool
+	a := &ActionsAllowed{VerifiedAllowed: &zeroValue}
+	a.GetVerifiedAllowed()
+	a = &ActionsAllowed{}
+	a.GetVerifiedAllowed()
+	a = nil
+	a.GetVerifiedAllowed()
+}
+
+func TestActionsPermissions_GetAllowedActions(tt *testing.T) {
+	var zeroValue string
+	a := &ActionsPermissions{AllowedActions: &zeroValue}
+	a.GetAllowedActions()
+	a = &ActionsPermissions{}
+	a.GetAllowedActions()
+	a = nil
+	a.GetAllowedActions()
+}
+
+func TestActionsPermissions_GetEnabledRepositories(tt *testing.T) {
+	var zeroValue string
+	a := &ActionsPermissions{EnabledRepositories: &zeroValue}
+	a.GetEnabledRepositories()
+	a = &ActionsPermissions{}
+	a.GetEnabledRepositories()
+	a = nil
+	a.GetEnabledRepositories()
+}
+
+func TestActionsPermissions_GetSelectedActionsURL(tt *testing.T) {
+	var zeroValue string
+	a := &ActionsPermissions{SelectedActionsURL: &zeroValue}
+	a.GetSelectedActionsURL()
+	a = &ActionsPermissions{}
+	a.GetSelectedActionsURL()
+	a = nil
+	a.GetSelectedActionsURL()
+}
+
 func TestAdminEnforcement_GetURL(tt *testing.T) {
 	var zeroValue string
 	a := &AdminEnforcement{URL: &zeroValue}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -33,16 +33,6 @@ func TestActionsAllowed_GetGithubOwnedAllowed(tt *testing.T) {
 	a.GetGithubOwnedAllowed()
 }
 
-func TestActionsAllowed_GetPatternsAllowed(tt *testing.T) {
-	var zeroValue []string
-	a := &ActionsAllowed{PatternsAllowed: &zeroValue}
-	a.GetPatternsAllowed()
-	a = &ActionsAllowed{}
-	a.GetPatternsAllowed()
-	a = nil
-	a.GetPatternsAllowed()
-}
-
 func TestActionsAllowed_GetVerifiedAllowed(tt *testing.T) {
 	var zeroValue bool
 	a := &ActionsAllowed{VerifiedAllowed: &zeroValue}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -13,6 +13,29 @@ import (
 
 func Float64(v float64) *float64 { return &v }
 
+func TestActionsAllowed_String(t *testing.T) {
+	v := ActionsAllowed{
+		GithubOwnedAllowed: Bool(false),
+		VerifiedAllowed:    Bool(false),
+	}
+	want := `github.ActionsAllowed{GithubOwnedAllowed:false, VerifiedAllowed:false}`
+	if got := v.String(); got != want {
+		t.Errorf("ActionsAllowed.String = %v, want %v", got, want)
+	}
+}
+
+func TestActionsPermissions_String(t *testing.T) {
+	v := ActionsPermissions{
+		EnabledRepositories: String(""),
+		AllowedActions:      String(""),
+		SelectedActionsURL:  String(""),
+	}
+	want := `github.ActionsPermissions{EnabledRepositories:"", AllowedActions:"", SelectedActionsURL:""}`
+	if got := v.String(); got != want {
+		t.Errorf("ActionsPermissions.String = %v, want %v", got, want)
+	}
+}
+
 func TestAdminStats_String(t *testing.T) {
 	v := AdminStats{
 		Issues:     &IssueStats{},

--- a/github/github.go
+++ b/github/github.go
@@ -1094,13 +1094,3 @@ func Int64(v int64) *int64 { return &v }
 // String is a helper routine that allocates a new string value
 // to store v and returns a pointer to it.
 func String(v string) *string { return &v }
-
-// StringSlice is a helper routine that allocates a new string slice value
-// to store v and returns a pointer to it.
-func StringSlice(v []string) *[]string {
-	var r []string
-	for _, s := range v {
-		r = append(r, s)
-	}
-	return &r
-}

--- a/github/github.go
+++ b/github/github.go
@@ -1094,3 +1094,13 @@ func Int64(v int64) *int64 { return &v }
 // String is a helper routine that allocates a new string value
 // to store v and returns a pointer to it.
 func String(v string) *string { return &v }
+
+// StringSlice is a helper routine that allocates a new string slice value
+// to store v and returns a pointer to it.
+func StringSlice(v []string) *[]string {
+	var r []string
+	for _, s := range v {
+		r = append(r, s)
+	}
+	return &r
+}

--- a/github/orgs_actions_allowed.go
+++ b/github/orgs_actions_allowed.go
@@ -46,7 +46,7 @@ func (s *OrganizationsService) GetActionsAllowed(ctx context.Context, org string
 // EditActionsAllowed sets the actions that are allowed in an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/actions#set-allowed-actions-for-an-organization
-func (s *OrganizationsService) EditActionsAllowed(ctx context.Context, org string, actionsAllowed *ActionsAllowed) (*ActionsAllowed, *Response, error) {
+func (s *OrganizationsService) EditActionsAllowed(ctx context.Context, org string, actionsAllowed ActionsAllowed) (*ActionsAllowed, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/selected-actions", org)
 	req, err := s.client.NewRequest("PUT", u, actionsAllowed)
 	if err != nil {

--- a/github/orgs_actions_allowed.go
+++ b/github/orgs_actions_allowed.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The go-github AUTHORS. All rights reserved.
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
@@ -10,19 +10,20 @@ import (
 	"fmt"
 )
 
-// ActionsAllowed represents selected actions that are allowed in an organization
+// ActionsAllowed represents selected actions that are allowed in an organization.
+//
 // GitHub API docs: https://docs.github.com/en/rest/reference/actions#get-allowed-actions-for-an-organization
 type ActionsAllowed struct {
-	GithubOwnedAllowed *bool     `json:"github_owned_allowed,omitempty"`
-	VerifiedAllowed    *bool     `json:"verified_allowed,omitempty"`
-	PatternsAllowed    *[]string `json:"patterns_allowed,omitempty"`
+	GithubOwnedAllowed *bool    `json:"github_owned_allowed,omitempty"`
+	VerifiedAllowed    *bool    `json:"verified_allowed,omitempty"`
+	PatternsAllowed    []string `json:"patterns_allowed,omitempty"`
 }
 
 func (a ActionsAllowed) String() string {
 	return Stringify(a)
 }
 
-// GetActionsAllowed gets a specific artifact for a workflow run.
+// GetActionsAllowed gets the actions that are allowed in an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/actions#get-allowed-actions-for-an-organization
 func (s *OrganizationsService) GetActionsAllowed(ctx context.Context, org string) (*ActionsAllowed, *Response, error) {
@@ -42,7 +43,7 @@ func (s *OrganizationsService) GetActionsAllowed(ctx context.Context, org string
 	return actionsAllowed, resp, nil
 }
 
-// EditActionsAllowed sets the actions that are allowed in an organization
+// EditActionsAllowed sets the actions that are allowed in an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/actions#set-allowed-actions-for-an-organization
 func (s *OrganizationsService) EditActionsAllowed(ctx context.Context, org string, actionsAllowed *ActionsAllowed) (*ActionsAllowed, *Response, error) {

--- a/github/orgs_actions_allowed.go
+++ b/github/orgs_actions_allowed.go
@@ -1,0 +1,57 @@
+// Copyright 2020 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// ActionsAllowed represents selected actions that are allowed in an organization
+// GitHub API docs: https://docs.github.com/en/rest/reference/actions#get-allowed-actions-for-an-organization
+type ActionsAllowed struct {
+	GithubOwnedAllowed *bool     `json:"github_owned_allowed,omitempty"`
+	VerifiedAllowed    *bool     `json:"verified_allowed,omitempty"`
+	PatternsAllowed    *[]string `json:"patterns_allowed,omitempty"`
+}
+
+func (a ActionsAllowed) String() string {
+	return Stringify(a)
+}
+
+// GetActionsAllowed gets a specific artifact for a workflow run.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/actions#get-allowed-actions-for-an-organization
+func (s *OrganizationsService) GetActionsAllowed(ctx context.Context, org string) (*ActionsAllowed, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/permissions/selected-actions", org)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	actionsAllowed := new(ActionsAllowed)
+	resp, err := s.client.Do(ctx, req, actionsAllowed)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return actionsAllowed, resp, nil
+}
+
+// EditActionsAllowed sets the actions that are allowed in an organization
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/actions#set-allowed-actions-for-an-organization
+func (s *OrganizationsService) EditActionsAllowed(ctx context.Context, org string, actionsAllowed *ActionsAllowed) (*ActionsAllowed, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/permissions/selected-actions", org)
+	req, err := s.client.NewRequest("PUT", u, actionsAllowed)
+	if err != nil {
+		return nil, nil, err
+	}
+	p := new(ActionsAllowed)
+	resp, err := s.client.Do(ctx, req, p)
+	return p, resp, err
+}

--- a/github/orgs_actions_allowed_test.go
+++ b/github/orgs_actions_allowed_test.go
@@ -28,7 +28,7 @@ func TestOrganizationsService_GetActionsAllowed(t *testing.T) {
 	if err != nil {
 		t.Errorf("Organizations.GetActionsAllowed returned error: %v", err)
 	}
-	want := &ActionsAllowed{GithubOwnedAllowed: Bool(true), VerifiedAllowed: Bool(false), PatternsAllowed: StringSlice([]string{"a/b"})}
+	want := &ActionsAllowed{GithubOwnedAllowed: Bool(true), VerifiedAllowed: Bool(false), PatternsAllowed: []string{"a/b"}}
 	if !reflect.DeepEqual(org, want) {
 		t.Errorf("Organizations.GetActionsAllowed returned %+v, want %+v", org, want)
 	}
@@ -51,7 +51,7 @@ func TestOrganizationsService_GetActionsAllowed(t *testing.T) {
 func TestOrganizationsService_EditActionsAllowed(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
-	input := &ActionsAllowed{GithubOwnedAllowed: Bool(true), VerifiedAllowed: Bool(false), PatternsAllowed: StringSlice([]string{"a/b"})}
+	input := &ActionsAllowed{GithubOwnedAllowed: Bool(true), VerifiedAllowed: Bool(false), PatternsAllowed: []string{"a/b"}}
 
 	mux.HandleFunc("/orgs/o/actions/permissions/selected-actions", func(w http.ResponseWriter, r *http.Request) {
 		v := new(ActionsAllowed)
@@ -71,7 +71,7 @@ func TestOrganizationsService_EditActionsAllowed(t *testing.T) {
 		t.Errorf("Organizations.EditActionsAllowed returned error: %v", err)
 	}
 
-	want := &ActionsAllowed{GithubOwnedAllowed: Bool(true), VerifiedAllowed: Bool(false), PatternsAllowed: StringSlice([]string{"a/b"})}
+	want := &ActionsAllowed{GithubOwnedAllowed: Bool(true), VerifiedAllowed: Bool(false), PatternsAllowed: []string{"a/b"}}
 	if !reflect.DeepEqual(org, want) {
 		t.Errorf("Organizations.EditActionsAllowed returned %+v, want %+v", org, want)
 	}

--- a/github/orgs_actions_allowed_test.go
+++ b/github/orgs_actions_allowed_test.go
@@ -66,7 +66,7 @@ func TestOrganizationsService_EditActionsAllowed(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	org, _, err := client.Organizations.EditActionsAllowed(ctx, "o", input)
+	org, _, err := client.Organizations.EditActionsAllowed(ctx, "o", *input)
 	if err != nil {
 		t.Errorf("Organizations.EditActionsAllowed returned error: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestOrganizationsService_EditActionsAllowed(t *testing.T) {
 
 	const methodName = "EditActionsAllowed"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Organizations.EditActionsAllowed(ctx, "\n", input)
+		_, _, err = client.Organizations.EditActionsAllowed(ctx, "\n", *input)
 		return err
 	})
 }

--- a/github/orgs_actions_allowed_test.go
+++ b/github/orgs_actions_allowed_test.go
@@ -1,0 +1,84 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestOrganizationsService_GetActionsAllowed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/permissions/selected-actions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"github_owned_allowed":true, "verified_allowed":false, "patterns_allowed":["a/b"]}`)
+	})
+
+	ctx := context.Background()
+	org, _, err := client.Organizations.GetActionsAllowed(ctx, "o")
+	if err != nil {
+		t.Errorf("Organizations.GetActionsAllowed returned error: %v", err)
+	}
+	want := &ActionsAllowed{GithubOwnedAllowed: Bool(true), VerifiedAllowed: Bool(false), PatternsAllowed: StringSlice([]string{"a/b"})}
+	if !reflect.DeepEqual(org, want) {
+		t.Errorf("Organizations.GetActionsAllowed returned %+v, want %+v", org, want)
+	}
+
+	const methodName = "GetActionsAllowed"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.GetActionsAllowed(ctx, "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Organizations.GetActionsAllowed(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestOrganizationsService_EditActionsAllowed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	input := &ActionsAllowed{GithubOwnedAllowed: Bool(true), VerifiedAllowed: Bool(false), PatternsAllowed: StringSlice([]string{"a/b"})}
+
+	mux.HandleFunc("/orgs/o/actions/permissions/selected-actions", func(w http.ResponseWriter, r *http.Request) {
+		v := new(ActionsAllowed)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "PUT")
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		fmt.Fprint(w, `{"github_owned_allowed":true, "verified_allowed":false, "patterns_allowed":["a/b"]}`)
+	})
+
+	ctx := context.Background()
+	org, _, err := client.Organizations.EditActionsAllowed(ctx, "o", input)
+	if err != nil {
+		t.Errorf("Organizations.EditActionsAllowed returned error: %v", err)
+	}
+
+	want := &ActionsAllowed{GithubOwnedAllowed: Bool(true), VerifiedAllowed: Bool(false), PatternsAllowed: StringSlice([]string{"a/b"})}
+	if !reflect.DeepEqual(org, want) {
+		t.Errorf("Organizations.EditActionsAllowed returned %+v, want %+v", org, want)
+	}
+
+	const methodName = "EditActionsAllowed"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.EditActionsAllowed(ctx, "\n", input)
+		return err
+	})
+}

--- a/github/orgs_actions_allowed_test.go
+++ b/github/orgs_actions_allowed_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013 The go-github AUTHORS. All rights reserved.
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/github/orgs_actions_permissions.go
+++ b/github/orgs_actions_permissions.go
@@ -1,0 +1,57 @@
+// Copyright 2020 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// ActionsPermissions represents a policy for repositories and allowed actions in an organization.
+// GitHub API docs: https://docs.github.com/en/rest/reference/actions#permissions
+type ActionsPermissions struct {
+	EnabledRepositories *string `json:"enabled_repositories,omitempty"`
+	AllowedActions      *string `json:"allowed_actions,omitempty"`
+	SelectedActionsURL  *string `json:"selected_actions_url,omitempty"`
+}
+
+func (a ActionsPermissions) String() string {
+	return Stringify(a)
+}
+
+// GetActionsPermissions gets a specific artifact for a workflow run.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/actions#get-github-actions-permissions-for-an-organization
+func (s *OrganizationsService) GetActionsPermissions(ctx context.Context, org string) (*ActionsPermissions, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/permissions", org)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	permissions := new(ActionsPermissions)
+	resp, err := s.client.Do(ctx, req, permissions)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return permissions, resp, nil
+}
+
+// EditActionsPermissions sets permissions policy for repositories and allowed actions in an organization.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/actions#set-github-actions-permissions-for-an-organization
+func (s *OrganizationsService) EditActionsPermissions(ctx context.Context, org string, actionsPermissions *ActionsPermissions) (*ActionsPermissions, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/permissions", org)
+	req, err := s.client.NewRequest("PUT", u, actionsPermissions)
+	if err != nil {
+		return nil, nil, err
+	}
+	p := new(ActionsPermissions)
+	resp, err := s.client.Do(ctx, req, p)
+	return p, resp, err
+}

--- a/github/orgs_actions_permissions.go
+++ b/github/orgs_actions_permissions.go
@@ -23,7 +23,7 @@ func (a ActionsPermissions) String() string {
 	return Stringify(a)
 }
 
-// GetActionsPermissions gets  the GitHub Actions permissions policy for repositories and allowed actions in an organization.
+// GetActionsPermissions gets the GitHub Actions permissions policy for repositories and allowed actions in an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/actions#get-github-actions-permissions-for-an-organization
 func (s *OrganizationsService) GetActionsPermissions(ctx context.Context, org string) (*ActionsPermissions, *Response, error) {
@@ -43,7 +43,7 @@ func (s *OrganizationsService) GetActionsPermissions(ctx context.Context, org st
 	return permissions, resp, nil
 }
 
-// EditActionsPermissions sets permissions policy for repositories and allowed actions in an organization.
+// EditActionsPermissions sets the permissions policy for repositories and allowed actions in an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/actions#set-github-actions-permissions-for-an-organization
 func (s *OrganizationsService) EditActionsPermissions(ctx context.Context, org string, actionsPermissions ActionsPermissions) (*ActionsPermissions, *Response, error) {

--- a/github/orgs_actions_permissions.go
+++ b/github/orgs_actions_permissions.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The go-github AUTHORS. All rights reserved.
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
@@ -11,6 +11,7 @@ import (
 )
 
 // ActionsPermissions represents a policy for repositories and allowed actions in an organization.
+//
 // GitHub API docs: https://docs.github.com/en/rest/reference/actions#permissions
 type ActionsPermissions struct {
 	EnabledRepositories *string `json:"enabled_repositories,omitempty"`
@@ -22,7 +23,7 @@ func (a ActionsPermissions) String() string {
 	return Stringify(a)
 }
 
-// GetActionsPermissions gets a specific artifact for a workflow run.
+// GetActionsPermissions gets  the GitHub Actions permissions policy for repositories and allowed actions in an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/actions#get-github-actions-permissions-for-an-organization
 func (s *OrganizationsService) GetActionsPermissions(ctx context.Context, org string) (*ActionsPermissions, *Response, error) {

--- a/github/orgs_actions_permissions.go
+++ b/github/orgs_actions_permissions.go
@@ -46,7 +46,7 @@ func (s *OrganizationsService) GetActionsPermissions(ctx context.Context, org st
 // EditActionsPermissions sets permissions policy for repositories and allowed actions in an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/actions#set-github-actions-permissions-for-an-organization
-func (s *OrganizationsService) EditActionsPermissions(ctx context.Context, org string, actionsPermissions *ActionsPermissions) (*ActionsPermissions, *Response, error) {
+func (s *OrganizationsService) EditActionsPermissions(ctx context.Context, org string, actionsPermissions ActionsPermissions) (*ActionsPermissions, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions", org)
 	req, err := s.client.NewRequest("PUT", u, actionsPermissions)
 	if err != nil {

--- a/github/orgs_actions_permissions_test.go
+++ b/github/orgs_actions_permissions_test.go
@@ -1,0 +1,85 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestOrganizationsService_GetActionsPermissions(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/permissions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"enabled_repositories": "all", "allowed_actions": "all"}`)
+	})
+
+	ctx := context.Background()
+	org, _, err := client.Organizations.GetActionsPermissions(ctx, "o")
+	if err != nil {
+		t.Errorf("Organizations.GetActionsPermissions returned error: %v", err)
+	}
+	want := &ActionsPermissions{EnabledRepositories: String("all"), AllowedActions: String("all")}
+	if !reflect.DeepEqual(org, want) {
+		t.Errorf("Organizations.GetActionsPermissions returned %+v, want %+v", org, want)
+	}
+
+	const methodName = "GetActionsPermissions"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.GetActionsPermissions(ctx, "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Organizations.GetActionsPermissions(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestOrganizationsService_EditActionsPermissions(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &ActionsPermissions{EnabledRepositories: String("all"), AllowedActions: String("selected")}
+
+	mux.HandleFunc("/orgs/o/actions/permissions", func(w http.ResponseWriter, r *http.Request) {
+		v := new(ActionsPermissions)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "PUT")
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		fmt.Fprint(w, `{"enabled_repositories": "all", "allowed_actions": "selected"}`)
+	})
+
+	ctx := context.Background()
+	org, _, err := client.Organizations.EditActionsPermissions(ctx, "o", input)
+	if err != nil {
+		t.Errorf("Organizations.EditActionsPermissions returned error: %v", err)
+	}
+
+	want := &ActionsPermissions{EnabledRepositories: String("all"), AllowedActions: String("selected")}
+	if !reflect.DeepEqual(org, want) {
+		t.Errorf("Organizations.EditActionsPermissions returned %+v, want %+v", org, want)
+	}
+
+	const methodName = "EditActionsPermissions"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.EditActionsPermissions(ctx, "\n", input)
+		return err
+	})
+}

--- a/github/orgs_actions_permissions_test.go
+++ b/github/orgs_actions_permissions_test.go
@@ -67,7 +67,7 @@ func TestOrganizationsService_EditActionsPermissions(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	org, _, err := client.Organizations.EditActionsPermissions(ctx, "o", input)
+	org, _, err := client.Organizations.EditActionsPermissions(ctx, "o", *input)
 	if err != nil {
 		t.Errorf("Organizations.EditActionsPermissions returned error: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestOrganizationsService_EditActionsPermissions(t *testing.T) {
 
 	const methodName = "EditActionsPermissions"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Organizations.EditActionsPermissions(ctx, "\n", input)
+		_, _, err = client.Organizations.EditActionsPermissions(ctx, "\n", *input)
 		return err
 	})
 }

--- a/github/orgs_actions_permissions_test.go
+++ b/github/orgs_actions_permissions_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013 The go-github AUTHORS. All rights reserved.
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
### What

Implements methods to interact with `/orgs/MY-ORG/actions` API:
- https://docs.github.com/en/rest/reference/actions

### Why

This is important to allow setting up github-actions policies at organization level using this library (e.g. enable/disable github-actions, set/edit filters for allowed actions).

### Additional notes 

I'm fairly new to using this library and I hope I covered all that's needed here, but please let me know if there is something missing or incomplete.