### PR TITLE
Add missing name field from workflow run

### DIFF
--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -15,6 +15,7 @@ import (
 // WorkflowRun represents a repository action workflow run.
 type WorkflowRun struct {
 	ID             *int64         `json:"id,omitempty"`
+	Name           *string        `json:"name,omitempty"`
 	NodeID         *string        `json:"node_id,omitempty"`
 	HeadBranch     *string        `json:"head_branch,omitempty"`
 	HeadSHA        *string        `json:"head_sha,omitempty"`

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -15676,6 +15676,14 @@ func (w *WorkflowRun) GetLogsURL() string {
 	return *w.LogsURL
 }
 
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (w *WorkflowRun) GetName() string {
+	if w == nil || w.Name == nil {
+		return ""
+	}
+	return *w.Name
+}
+
 // GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
 func (w *WorkflowRun) GetNodeID() string {
 	if w == nil || w.NodeID == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -18384,6 +18384,16 @@ func TestWorkflowRun_GetLogsURL(tt *testing.T) {
 	w.GetLogsURL()
 }
 
+func TestWorkflowRun_GetName(tt *testing.T) {
+	var zeroValue string
+	w := &WorkflowRun{Name: &zeroValue}
+	w.GetName()
+	w = &WorkflowRun{}
+	w.GetName()
+	w = nil
+	w.GetName()
+}
+
 func TestWorkflowRun_GetNodeID(tt *testing.T) {
 	var zeroValue string
 	w := &WorkflowRun{NodeID: &zeroValue}


### PR DESCRIPTION
Adds the missing name field from workflow runs endpoint.

See docs: https://docs.github.com/en/rest/reference/actions#get-a-workflow-run