### PR TITLE
Support empty string as a commit message when merging a pull request

### DIFF
--- a/github/pulls.go
+++ b/github/pulls.go
@@ -458,8 +458,7 @@ func (s *PullRequestsService) Merge(ctx context.Context, owner string, repo stri
 		pullRequestBody.MergeMethod = options.MergeMethod
 		pullRequestBody.SHA = options.SHA
 		if options.DontDefaultIfBlank && commitMessage == "" {
-			emptyMessage := ""
-			pullRequestBody.CommitMessage = &emptyMessage
+			pullRequestBody.CommitMessage = &commitMessage
 		}
 	}
 	req, err := s.client.NewRequest("PUT", u, pullRequestBody)

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -430,13 +430,16 @@ type PullRequestOptions struct {
 
 	// The merge method to use. Possible values include: "merge", "squash", and "rebase" with the default being merge. (Optional.)
 	MergeMethod string
+
+	// If false, an empty string commit message will use the default commit message. If true, an empty string commit message will be used
+	DontDefaultIfBlank bool
 }
 
 type pullRequestMergeRequest struct {
-	CommitMessage string `json:"commit_message,omitempty"`
-	CommitTitle   string `json:"commit_title,omitempty"`
-	MergeMethod   string `json:"merge_method,omitempty"`
-	SHA           string `json:"sha,omitempty"`
+	CommitMessage *string `json:"commit_message,omitempty"`
+	CommitTitle   string  `json:"commit_title,omitempty"`
+	MergeMethod   string  `json:"merge_method,omitempty"`
+	SHA           string  `json:"sha,omitempty"`
 }
 
 // Merge a pull request.
@@ -446,11 +449,14 @@ type pullRequestMergeRequest struct {
 func (s *PullRequestsService) Merge(ctx context.Context, owner string, repo string, number int, commitMessage string, options *PullRequestOptions) (*PullRequestMergeResult, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/merge", owner, repo, number)
 
-	pullRequestBody := &pullRequestMergeRequest{CommitMessage: commitMessage}
+	pullRequestBody := &pullRequestMergeRequest{CommitMessage: &commitMessage}
 	if options != nil {
 		pullRequestBody.CommitTitle = options.CommitTitle
 		pullRequestBody.MergeMethod = options.MergeMethod
 		pullRequestBody.SHA = options.SHA
+		if options.DontDefaultIfBlank && commitMessage == "" {
+			pullRequestBody.CommitMessage = nil
+		}
 	}
 	req, err := s.client.NewRequest("PUT", u, pullRequestBody)
 	if err != nil {

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -431,7 +431,7 @@ type PullRequestOptions struct {
 	// The merge method to use. Possible values include: "merge", "squash", and "rebase" with the default being merge. (Optional.)
 	MergeMethod string
 
-	// If false, an empty string commit message will use the default commit message. If true, an empty string commit message will be used
+	// If false, an empty string commit message will use the default commit message. If true, an empty string commit message will be used.
 	DontDefaultIfBlank bool
 }
 
@@ -449,13 +449,17 @@ type pullRequestMergeRequest struct {
 func (s *PullRequestsService) Merge(ctx context.Context, owner string, repo string, number int, commitMessage string, options *PullRequestOptions) (*PullRequestMergeResult, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/merge", owner, repo, number)
 
-	pullRequestBody := &pullRequestMergeRequest{CommitMessage: &commitMessage}
+	pullRequestBody := &pullRequestMergeRequest{}
+	if commitMessage != "" {
+		pullRequestBody.CommitMessage = &commitMessage
+	}
 	if options != nil {
 		pullRequestBody.CommitTitle = options.CommitTitle
 		pullRequestBody.MergeMethod = options.MergeMethod
 		pullRequestBody.SHA = options.SHA
 		if options.DontDefaultIfBlank && commitMessage == "" {
-			pullRequestBody.CommitMessage = nil
+			emptyMessage := ""
+			pullRequestBody.CommitMessage = &emptyMessage
 		}
 	}
 	req, err := s.client.NewRequest("PUT", u, pullRequestBody)

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -805,3 +805,32 @@ func TestPullRequestsService_Merge_options(t *testing.T) {
 		}
 	}
 }
+
+func TestPullRequestsService_Merge_Blank_Message(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	madeRequest := false
+	expectedBody := ""
+	mux.HandleFunc("/repos/o/r/pulls/1/merge", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testBody(t, r, expectedBody+"\n")
+		madeRequest = true
+	})
+
+	ctx := context.Background()
+	expectedBody = `{"commit_message":""}`
+	_, _, _ = client.PullRequests.Merge(ctx, "o", "r", 1, "", nil)
+	if !madeRequest {
+		t.Error("TestPullRequestsService_Merge_Blank_Message #1 did not make request")
+	}
+
+	madeRequest = false
+	opts := PullRequestOptions{
+		DontDefaultIfBlank: true,
+	}
+	expectedBody = `{}`
+	_, _, _ = client.PullRequests.Merge(ctx, "o", "r", 1, "", &opts)
+	if !madeRequest {
+		t.Error("TestPullRequestsService_Merge_Blank_Message #2 did not make request")
+	}
+}

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -789,6 +789,12 @@ func TestPullRequestsService_Merge_options(t *testing.T) {
 			},
 			wantBody: `{"commit_message":"merging pull request","commit_title":"Extra detail","merge_method":"squash","sha":"6dcb09b5b57875f334f61aebed695e2e4193db5e"}`,
 		},
+		{
+			options: &PullRequestOptions{
+				DontDefaultIfBlank: true,
+			},
+			wantBody: `{"commit_message":"merging pull request"}`,
+		},
 	}
 
 	for i, test := range tests {
@@ -818,7 +824,7 @@ func TestPullRequestsService_Merge_Blank_Message(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	expectedBody = `{"commit_message":""}`
+	expectedBody = `{}`
 	_, _, _ = client.PullRequests.Merge(ctx, "o", "r", 1, "", nil)
 	if !madeRequest {
 		t.Error("TestPullRequestsService_Merge_Blank_Message #1 did not make request")
@@ -828,7 +834,7 @@ func TestPullRequestsService_Merge_Blank_Message(t *testing.T) {
 	opts := PullRequestOptions{
 		DontDefaultIfBlank: true,
 	}
-	expectedBody = `{}`
+	expectedBody = `{"commit_message":""}`
 	_, _, _ = client.PullRequests.Merge(ctx, "o", "r", 1, "", &opts)
 	if !madeRequest {
 		t.Error("TestPullRequestsService_Merge_Blank_Message #2 did not make request")


### PR DESCRIPTION
Fixes https://github.com/google/go-github/issues/1815

- changes the CommitMessage field in the request to merge a PR to a pointer
- adds a new boolean flag to the PullRequestOptions struct, which will make the commit message null if set and the given message is ""