### PR TITLE
Add reactions preview to search service

### DIFF
--- a/github/search.go
+++ b/github/search.go
@@ -284,6 +284,10 @@ func (s *SearchService) search(ctx context.Context, searchType string, parameter
 		// Accept header for search repositories based on topics preview endpoint
 		// TODO: remove custom Accept header when this API fully launches.
 		req.Header.Set("Accept", mediaTypeTopicsPreview)
+	case searchType == "issues":
+		// Accept header for search issues based on reactions preview endpoint
+		// TODO: remove custom Accept header when this API fully launches.
+		req.Header.Set("Accept", mediaTypeReactionsPreview)
 	case opts != nil && opts.TextMatch:
 		// Accept header defaults to "application/vnd.github.v3+json"
 		// We change it here to fetch back text-match metadata


### PR DESCRIPTION
Currently the search service does not include the reactions preview media type header so issue searches do not include the reaction counts this preview provides. The issue struct already includes this [attribute](https://github.com/google/go-github/blob/b06cfbb1abc090e2ff47cac2f0d2d1750f847293/github/issues.go#L52) so adding this preview header is enough to populate it.

This PR adds that preview so this structure is populated.