### PR TITLE
Fix invalid response and rename ListPlanAccountsForAccount (fixes #1270)

### DIFF
--- a/github/apps_marketplace.go
+++ b/github/apps_marketplace.go
@@ -129,14 +129,10 @@ func (s *MarketplaceService) ListPlanAccountsForPlan(ctx context.Context, planID
 // ListPlanAccountsForAccount lists all GitHub accounts (user or organization) associated with an account.
 //
 // GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/apps/#check-if-a-github-account-is-associated-with-any-marketplace-listing
-func (s *MarketplaceService) ListPlanAccountsForAccount(ctx context.Context, accountID int64, opts *ListOptions) ([]*MarketplacePlanAccount, *Response, error) {
+func (s *MarketplaceService) ListPlanAccountsForAccount(ctx context.Context, accountID int64) ([]*MarketplacePlanAccount, *Response, error) {
 	uri := s.marketplaceURI(fmt.Sprintf("accounts/%v", accountID))
-	u, err := addOptions(uri, opts)
-	if err != nil {
-		return nil, nil, err
-	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", uri, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/apps_marketplace.go
+++ b/github/apps_marketplace.go
@@ -51,7 +51,6 @@ type MarketplacePurchase struct {
 	NextBillingDate *Timestamp              `json:"next_billing_date,omitempty"`
 	UnitCount       *int                    `json:"unit_count,omitempty"`
 	Plan            *MarketplacePlan        `json:"plan,omitempty"`
-	Account         *MarketplacePlanAccount `json:"account,omitempty"`
 	OnFreeTrial     *bool                   `json:"on_free_trial,omitempty"`
 	FreeTrialEndsOn *Timestamp              `json:"free_trial_ends_on,omitempty"`
 	UpdatedAt       *Timestamp              `json:"updated_at,omitempty"`
@@ -70,9 +69,7 @@ type MarketplacePlanAccount struct {
 	URL                      *string                   `json:"url,omitempty"`
 	Type                     *string                   `json:"type,omitempty"`
 	ID                       *int64                    `json:"id,omitempty"`
-	NodeID                   *string                   `json:"node_id,omitempty"`
 	Login                    *string                   `json:"login,omitempty"`
-	Email                    *string                   `json:"email,omitempty"`
 	OrganizationBillingEmail *string                   `json:"organization_billing_email,omitempty"`
 	MarketplacePurchase      *MarketplacePurchase      `json:"marketplace_purchase,omitempty"`
 	MarketplacePendingChange *MarketplacePendingChange `json:"marketplace_pending_change,omitempty"`

--- a/github/apps_marketplace.go
+++ b/github/apps_marketplace.go
@@ -104,7 +104,7 @@ func (s *MarketplaceService) ListPlans(ctx context.Context, opts *ListOptions) (
 
 // ListPlanAccountsForPlan lists all GitHub accounts (user or organization) on a specific plan.
 //
-// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/apps/#list-all-github-accounts-user-or-organization-on-a-specific-plan
+// GitHub API docs: https://docs.github.com/en/rest/reference/apps#list-accounts-for-a-plan
 func (s *MarketplaceService) ListPlanAccountsForPlan(ctx context.Context, planID int64, opts *ListOptions) ([]*MarketplacePlanAccount, *Response, error) {
 	uri := s.marketplaceURI(fmt.Sprintf("plans/%v/accounts", planID))
 	u, err := addOptions(uri, opts)
@@ -128,7 +128,7 @@ func (s *MarketplaceService) ListPlanAccountsForPlan(ctx context.Context, planID
 
 // ListPlanAccountsForAccount lists all GitHub accounts (user or organization) associated with an account.
 //
-// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/apps/#check-if-a-github-account-is-associated-with-any-marketplace-listing
+// GitHub API docs: https://docs.github.com/en/rest/reference/apps#get-a-subscription-plan-for-an-account
 func (s *MarketplaceService) ListPlanAccountsForAccount(ctx context.Context, accountID int64) ([]*MarketplacePlanAccount, *Response, error) {
 	uri := s.marketplaceURI(fmt.Sprintf("accounts/%v", accountID))
 

--- a/github/apps_marketplace.go
+++ b/github/apps_marketplace.go
@@ -47,13 +47,13 @@ type MarketplacePlan struct {
 // MarketplacePurchase represents a GitHub Apps Marketplace Purchase.
 type MarketplacePurchase struct {
 	// BillingCycle can be one of the values "yearly", "monthly" or nil.
-	BillingCycle    *string                 `json:"billing_cycle,omitempty"`
-	NextBillingDate *Timestamp              `json:"next_billing_date,omitempty"`
-	UnitCount       *int                    `json:"unit_count,omitempty"`
-	Plan            *MarketplacePlan        `json:"plan,omitempty"`
-	OnFreeTrial     *bool                   `json:"on_free_trial,omitempty"`
-	FreeTrialEndsOn *Timestamp              `json:"free_trial_ends_on,omitempty"`
-	UpdatedAt       *Timestamp              `json:"updated_at,omitempty"`
+	BillingCycle    *string          `json:"billing_cycle,omitempty"`
+	NextBillingDate *Timestamp       `json:"next_billing_date,omitempty"`
+	UnitCount       *int             `json:"unit_count,omitempty"`
+	Plan            *MarketplacePlan `json:"plan,omitempty"`
+	OnFreeTrial     *bool            `json:"on_free_trial,omitempty"`
+	FreeTrialEndsOn *Timestamp       `json:"free_trial_ends_on,omitempty"`
+	UpdatedAt       *Timestamp       `json:"updated_at,omitempty"`
 }
 
 // MarketplacePendingChange represents a pending change to a GitHub Apps Marketplace Plan.

--- a/github/apps_marketplace.go
+++ b/github/apps_marketplace.go
@@ -123,10 +123,10 @@ func (s *MarketplaceService) ListPlanAccountsForPlan(ctx context.Context, planID
 	return accounts, resp, nil
 }
 
-// ListPlanAccountsForAccount lists all GitHub accounts (user or organization) associated with an account.
+// GetPlanAccountForAccount get GitHub account (user or organization) associated with an account.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/apps#get-a-subscription-plan-for-an-account
-func (s *MarketplaceService) ListPlanAccountsForAccount(ctx context.Context, accountID int64) (*MarketplacePlanAccount, *Response, error) {
+func (s *MarketplaceService) GetPlanAccountForAccount(ctx context.Context, accountID int64) (*MarketplacePlanAccount, *Response, error) {
 	uri := s.marketplaceURI(fmt.Sprintf("accounts/%v", accountID))
 
 	req, err := s.client.NewRequest("GET", uri, nil)
@@ -134,13 +134,13 @@ func (s *MarketplaceService) ListPlanAccountsForAccount(ctx context.Context, acc
 		return nil, nil, err
 	}
 
-	var accounts *MarketplacePlanAccount
-	resp, err := s.client.Do(ctx, req, &accounts)
+	var account *MarketplacePlanAccount
+	resp, err := s.client.Do(ctx, req, &account)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return accounts, resp, nil
+	return account, resp, nil
 }
 
 // ListMarketplacePurchasesForUser lists all GitHub marketplace purchases made by a user.

--- a/github/apps_marketplace.go
+++ b/github/apps_marketplace.go
@@ -126,7 +126,7 @@ func (s *MarketplaceService) ListPlanAccountsForPlan(ctx context.Context, planID
 // ListPlanAccountsForAccount lists all GitHub accounts (user or organization) associated with an account.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/apps#get-a-subscription-plan-for-an-account
-func (s *MarketplaceService) ListPlanAccountsForAccount(ctx context.Context, accountID int64) ([]*MarketplacePlanAccount, *Response, error) {
+func (s *MarketplaceService) ListPlanAccountsForAccount(ctx context.Context, accountID int64) (*MarketplacePlanAccount, *Response, error) {
 	uri := s.marketplaceURI(fmt.Sprintf("accounts/%v", accountID))
 
 	req, err := s.client.NewRequest("GET", uri, nil)
@@ -134,7 +134,7 @@ func (s *MarketplaceService) ListPlanAccountsForAccount(ctx context.Context, acc
 		return nil, nil, err
 	}
 
-	var accounts []*MarketplacePlanAccount
+	var accounts *MarketplacePlanAccount
 	resp, err := s.client.Do(ctx, req, &accounts)
 	if err != nil {
 		return nil, resp, err

--- a/github/apps_marketplace_test.go
+++ b/github/apps_marketplace_test.go
@@ -136,10 +136,9 @@ func TestMarketplaceService_ListPlanAccountsForAccount(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1, "marketplace_pending_change": {"id": 77}}]`)
 	})
 
-	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = false
 	ctx := context.Background()
-	accounts, _, err := client.Marketplace.ListPlanAccountsForAccount(ctx, 1, opt)
+	accounts, _, err := client.Marketplace.ListPlanAccountsForAccount(ctx, 1)
 	if err != nil {
 		t.Errorf("Marketplace.ListPlanAccountsForAccount returned error: %v", err)
 	}
@@ -151,7 +150,7 @@ func TestMarketplaceService_ListPlanAccountsForAccount(t *testing.T) {
 
 	const methodName = "ListPlanAccountsForAccount"
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Marketplace.ListPlanAccountsForAccount(ctx, 1, opt)
+		got, resp, err := client.Marketplace.ListPlanAccountsForAccount(ctx, 1)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -168,10 +167,9 @@ func TestMarketplaceService_Stubbed_ListPlanAccountsForAccount(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = true
 	ctx := context.Background()
-	accounts, _, err := client.Marketplace.ListPlanAccountsForAccount(ctx, 1, opt)
+	accounts, _, err := client.Marketplace.ListPlanAccountsForAccount(ctx, 1)
 	if err != nil {
 		t.Errorf("Marketplace.ListPlanAccountsForAccount (Stubbed) returned error: %v", err)
 	}

--- a/github/apps_marketplace_test.go
+++ b/github/apps_marketplace_test.go
@@ -133,7 +133,7 @@ func TestMarketplaceService_ListPlanAccountsForAccount(t *testing.T) {
 
 	mux.HandleFunc("/marketplace_listing/accounts/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{"id":1, "marketplace_pending_change": {"id": 77}}]`)
+		fmt.Fprint(w, `{"id":1, "marketplace_pending_change": {"id": 77}}`)
 	})
 
 	client.Marketplace.Stubbed = false
@@ -143,7 +143,7 @@ func TestMarketplaceService_ListPlanAccountsForAccount(t *testing.T) {
 		t.Errorf("Marketplace.ListPlanAccountsForAccount returned error: %v", err)
 	}
 
-	want := []*MarketplacePlanAccount{{ID: Int64(1), MarketplacePendingChange: &MarketplacePendingChange{ID: Int64(77)}}}
+	want := &MarketplacePlanAccount{ID: Int64(1), MarketplacePendingChange: &MarketplacePendingChange{ID: Int64(77)}}
 	if !reflect.DeepEqual(accounts, want) {
 		t.Errorf("Marketplace.ListPlanAccountsForAccount returned %+v, want %+v", accounts, want)
 	}
@@ -164,7 +164,7 @@ func TestMarketplaceService_Stubbed_ListPlanAccountsForAccount(t *testing.T) {
 
 	mux.HandleFunc("/marketplace_listing/stubbed/accounts/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{"id":1}]`)
+		fmt.Fprint(w, `{"id":1}`)
 	})
 
 	client.Marketplace.Stubbed = true
@@ -174,7 +174,7 @@ func TestMarketplaceService_Stubbed_ListPlanAccountsForAccount(t *testing.T) {
 		t.Errorf("Marketplace.ListPlanAccountsForAccount (Stubbed) returned error: %v", err)
 	}
 
-	want := []*MarketplacePlanAccount{{ID: Int64(1)}}
+	want := &MarketplacePlanAccount{ID: Int64(1)}
 	if !reflect.DeepEqual(accounts, want) {
 		t.Errorf("Marketplace.ListPlanAccountsForAccount (Stubbed) returned %+v, want %+v", accounts, want)
 	}

--- a/github/apps_marketplace_test.go
+++ b/github/apps_marketplace_test.go
@@ -127,7 +127,7 @@ func TestMarketplaceService_Stubbed_ListPlanAccountsForPlan(t *testing.T) {
 	}
 }
 
-func TestMarketplaceService_ListPlanAccountsForAccount(t *testing.T) {
+func TestMarketplaceService_GetPlanAccountForAccount(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -138,19 +138,19 @@ func TestMarketplaceService_ListPlanAccountsForAccount(t *testing.T) {
 
 	client.Marketplace.Stubbed = false
 	ctx := context.Background()
-	accounts, _, err := client.Marketplace.ListPlanAccountsForAccount(ctx, 1)
+	account, _, err := client.Marketplace.GetPlanAccountForAccount(ctx, 1)
 	if err != nil {
-		t.Errorf("Marketplace.ListPlanAccountsForAccount returned error: %v", err)
+		t.Errorf("Marketplace.GetPlanAccountForAccount returned error: %v", err)
 	}
 
 	want := &MarketplacePlanAccount{ID: Int64(1), MarketplacePendingChange: &MarketplacePendingChange{ID: Int64(77)}}
-	if !reflect.DeepEqual(accounts, want) {
-		t.Errorf("Marketplace.ListPlanAccountsForAccount returned %+v, want %+v", accounts, want)
+	if !reflect.DeepEqual(account, want) {
+		t.Errorf("Marketplace.GetPlanAccountForAccount returned %+v, want %+v", account, want)
 	}
 
-	const methodName = "ListPlanAccountsForAccount"
+	const methodName = "GetPlanAccountForAccount"
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Marketplace.ListPlanAccountsForAccount(ctx, 1)
+		got, resp, err := client.Marketplace.GetPlanAccountForAccount(ctx, 1)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -158,7 +158,7 @@ func TestMarketplaceService_ListPlanAccountsForAccount(t *testing.T) {
 	})
 }
 
-func TestMarketplaceService_Stubbed_ListPlanAccountsForAccount(t *testing.T) {
+func TestMarketplaceService_Stubbed_GetPlanAccountForAccount(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -169,14 +169,14 @@ func TestMarketplaceService_Stubbed_ListPlanAccountsForAccount(t *testing.T) {
 
 	client.Marketplace.Stubbed = true
 	ctx := context.Background()
-	accounts, _, err := client.Marketplace.ListPlanAccountsForAccount(ctx, 1)
+	account, _, err := client.Marketplace.GetPlanAccountForAccount(ctx, 1)
 	if err != nil {
-		t.Errorf("Marketplace.ListPlanAccountsForAccount (Stubbed) returned error: %v", err)
+		t.Errorf("Marketplace.GetPlanAccountForAccount (Stubbed) returned error: %v", err)
 	}
 
 	want := &MarketplacePlanAccount{ID: Int64(1)}
-	if !reflect.DeepEqual(accounts, want) {
-		t.Errorf("Marketplace.ListPlanAccountsForAccount (Stubbed) returned %+v, want %+v", accounts, want)
+	if !reflect.DeepEqual(account, want) {
+		t.Errorf("Marketplace.GetPlanAccountForAccount (Stubbed) returned %+v, want %+v", account, want)
 	}
 }
 

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6700,14 +6700,6 @@ func (m *MarketplacePlan) GetYearlyPriceInCents() int {
 	return *m.YearlyPriceInCents
 }
 
-// GetEmail returns the Email field if it's non-nil, zero value otherwise.
-func (m *MarketplacePlanAccount) GetEmail() string {
-	if m == nil || m.Email == nil {
-		return ""
-	}
-	return *m.Email
-}
-
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (m *MarketplacePlanAccount) GetID() int64 {
 	if m == nil || m.ID == nil {
@@ -6740,14 +6732,6 @@ func (m *MarketplacePlanAccount) GetMarketplacePurchase() *MarketplacePurchase {
 	return m.MarketplacePurchase
 }
 
-// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
-func (m *MarketplacePlanAccount) GetNodeID() string {
-	if m == nil || m.NodeID == nil {
-		return ""
-	}
-	return *m.NodeID
-}
-
 // GetOrganizationBillingEmail returns the OrganizationBillingEmail field if it's non-nil, zero value otherwise.
 func (m *MarketplacePlanAccount) GetOrganizationBillingEmail() string {
 	if m == nil || m.OrganizationBillingEmail == nil {
@@ -6770,14 +6754,6 @@ func (m *MarketplacePlanAccount) GetURL() string {
 		return ""
 	}
 	return *m.URL
-}
-
-// GetAccount returns the Account field.
-func (m *MarketplacePurchase) GetAccount() *MarketplacePlanAccount {
-	if m == nil {
-		return nil
-	}
-	return m.Account
 }
 
 // GetBillingCycle returns the BillingCycle field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -7890,16 +7890,6 @@ func TestMarketplacePlan_GetYearlyPriceInCents(tt *testing.T) {
 	m.GetYearlyPriceInCents()
 }
 
-func TestMarketplacePlanAccount_GetEmail(tt *testing.T) {
-	var zeroValue string
-	m := &MarketplacePlanAccount{Email: &zeroValue}
-	m.GetEmail()
-	m = &MarketplacePlanAccount{}
-	m.GetEmail()
-	m = nil
-	m.GetEmail()
-}
-
 func TestMarketplacePlanAccount_GetID(tt *testing.T) {
 	var zeroValue int64
 	m := &MarketplacePlanAccount{ID: &zeroValue}
@@ -7934,16 +7924,6 @@ func TestMarketplacePlanAccount_GetMarketplacePurchase(tt *testing.T) {
 	m.GetMarketplacePurchase()
 }
 
-func TestMarketplacePlanAccount_GetNodeID(tt *testing.T) {
-	var zeroValue string
-	m := &MarketplacePlanAccount{NodeID: &zeroValue}
-	m.GetNodeID()
-	m = &MarketplacePlanAccount{}
-	m.GetNodeID()
-	m = nil
-	m.GetNodeID()
-}
-
 func TestMarketplacePlanAccount_GetOrganizationBillingEmail(tt *testing.T) {
 	var zeroValue string
 	m := &MarketplacePlanAccount{OrganizationBillingEmail: &zeroValue}
@@ -7972,13 +7952,6 @@ func TestMarketplacePlanAccount_GetURL(tt *testing.T) {
 	m.GetURL()
 	m = nil
 	m.GetURL()
-}
-
-func TestMarketplacePurchase_GetAccount(tt *testing.T) {
-	m := &MarketplacePurchase{}
-	m.GetAccount()
-	m = nil
-	m.GetAccount()
 }
 
 func TestMarketplacePurchase_GetBillingCycle(tt *testing.T) {


### PR DESCRIPTION
To simplify review and address specific requests from https://github.com/google/go-github/issues/1270#issuecomment-791389308 I've made separate commits.

Also wording doesn't seem to match GitHub docs anymore.

If that's ok @gmlewis, I'd like to rename:
- GetPlanAccountForAccount to GetSubscriptionPlanForAccount https://octokit.github.io/rest.js/v18#apps-get-subscription-plan-for-account
- MarketplacePlanAccount to MarketplaceSubscriptionPlan

What do you think?