### PR TITLE
Update hook_id to int64

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -701,9 +701,9 @@ func (a *AuditEntry) GetHeadSHA() string {
 }
 
 // GetHookID returns the HookID field if it's non-nil, zero value otherwise.
-func (a *AuditEntry) GetHookID() string {
+func (a *AuditEntry) GetHookID() int64 {
 	if a == nil || a.HookID == nil {
-		return ""
+		return 0
 	}
 	return *a.HookID
 }

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -826,7 +826,7 @@ func TestAuditEntry_GetHeadSHA(tt *testing.T) {
 }
 
 func TestAuditEntry_GetHookID(tt *testing.T) {
-	var zeroValue string
+	var zeroValue int64
 	a := &AuditEntry{HookID: &zeroValue}
 	a.GetHookID()
 	a = &AuditEntry{}

--- a/github/orgs_audit_log.go
+++ b/github/orgs_audit_log.go
@@ -53,7 +53,7 @@ type AuditEntry struct {
 	Fingerprint           *string     `json:"fingerprint,omitempty"`
 	HeadBranch            *string     `json:"head_branch,omitempty"`
 	HeadSHA               *string     `json:"head_sha,omitempty"`
-	HookID                *string     `json:"hook_id,omitempty"`
+	HookID                *int64      `json:"hook_id,omitempty"`
 	IsHostedRunner        *bool       `json:"is_hosted_runner,omitempty"`
 	JobName               *string     `json:"job_name,omitempty"`
 	LimitedAvailability   *bool       `json:"limited_availability,omitempty"`


### PR DESCRIPTION
The hook_id field  of the Audit Log API is not a string. It is represented as a number, updated the HookID to int64 to match other fields of type number.

Signed-off-by: Brett Logan <lindluni@github.com>