### PR TITLE
Add Support For Millisecond Timestamps

### DIFF
--- a/github/enterprise_audit_log_test.go
+++ b/github/enterprise_audit_log_test.go
@@ -55,7 +55,7 @@ func TestEnterpriseService_GetAuditLog(t *testing.T) {
 	}
 	startedAt, _ := time.Parse(time.RFC3339, "2021-03-07T00:33:04.000Z")
 	completedAt, _ := time.Parse(time.RFC3339, "2021-03-07T00:35:08.000Z")
-	timestamp := time.Unix(0, 0).Add(time.Duration(1615077308538) * time.Millisecond)
+	timestamp := time.Unix(0, 1615077308538*1e6)
 
 	want := []*AuditEntry{
 		{

--- a/github/enterprise_audit_log_test.go
+++ b/github/enterprise_audit_log_test.go
@@ -55,7 +55,7 @@ func TestEnterpriseService_GetAuditLog(t *testing.T) {
 	}
 	startedAt, _ := time.Parse(time.RFC3339, "2021-03-07T00:33:04.000Z")
 	completedAt, _ := time.Parse(time.RFC3339, "2021-03-07T00:35:08.000Z")
-	timestamp := time.Unix(1615077308538, 0)
+	timestamp := time.Unix(0, 0).Add(time.Duration(1615077308538) * time.Millisecond)
 
 	want := []*AuditEntry{
 		{

--- a/github/orgs_audit_log_test.go
+++ b/github/orgs_audit_log_test.go
@@ -62,7 +62,8 @@ func TestOrganizationService_GetAuditLog(t *testing.T) {
 	}
 	startedAt, _ := time.Parse(time.RFC3339, "2021-03-07T00:33:04.000Z")
 	completedAt, _ := time.Parse(time.RFC3339, "2021-03-07T00:35:08.000Z")
-	timestamp := time.Unix(1615077308538, 0)
+	timestamp := time.Unix(0, 0).Add(time.Duration(1615077308538) * time.Millisecond)
+
 	want := []*AuditEntry{
 		{
 			Timestamp:     &Timestamp{timestamp},

--- a/github/orgs_audit_log_test.go
+++ b/github/orgs_audit_log_test.go
@@ -62,7 +62,7 @@ func TestOrganizationService_GetAuditLog(t *testing.T) {
 	}
 	startedAt, _ := time.Parse(time.RFC3339, "2021-03-07T00:33:04.000Z")
 	completedAt, _ := time.Parse(time.RFC3339, "2021-03-07T00:35:08.000Z")
-	timestamp := time.Unix(0, 0).Add(time.Duration(1615077308538) * time.Millisecond)
+	timestamp := time.Unix(0, 1615077308538*1e6)
 
 	want := []*AuditEntry{
 		{

--- a/github/timestamp.go
+++ b/github/timestamp.go
@@ -29,6 +29,9 @@ func (t *Timestamp) UnmarshalJSON(data []byte) (err error) {
 	i, err := strconv.ParseInt(str, 10, 64)
 	if err == nil {
 		t.Time = time.Unix(i, 0)
+		if t.Time.Year() > 3000 {
+			t.Time = time.Unix(0, 0).Add(time.Duration(i) * time.Millisecond)
+		}
 	} else {
 		t.Time, err = time.Parse(`"`+time.RFC3339+`"`, str)
 	}

--- a/github/timestamp.go
+++ b/github/timestamp.go
@@ -30,7 +30,7 @@ func (t *Timestamp) UnmarshalJSON(data []byte) (err error) {
 	if err == nil {
 		t.Time = time.Unix(i, 0)
 		if t.Time.Year() > 3000 {
-			t.Time = time.Unix(0, 0).Add(time.Duration(i) * time.Millisecond)
+			t.Time = time.Unix(0, i*1e6)
 		}
 	} else {
 		t.Time, err = time.Parse(`"`+time.RFC3339+`"`, str)

--- a/github/timestamp_test.go
+++ b/github/timestamp_test.go
@@ -13,10 +13,11 @@ import (
 )
 
 const (
-	emptyTimeStr               = `"0001-01-01T00:00:00Z"`
-	referenceTimeStr           = `"2006-01-02T15:04:05Z"`
-	referenceTimeStrFractional = `"2006-01-02T15:04:05.000Z"` // This format was returned by the Projects API before October 1, 2017.
-	referenceUnixTimeStr       = `1136214245`
+	emptyTimeStr                     = `"0001-01-01T00:00:00Z"`
+	referenceTimeStr                 = `"2006-01-02T15:04:05Z"`
+	referenceTimeStrFractional       = `"2006-01-02T15:04:05.000Z"` // This format was returned by the Projects API before October 1, 2017.
+	referenceUnixTimeStr             = `1136214245`
+	referenceUnixTimeStrMilliSeconds = `1136214245000` // Millisecond-granular timestamps were introduced in the Audit log API.
 )
 
 var (
@@ -59,12 +60,14 @@ func TestTimestamp_Unmarshal(t *testing.T) {
 	}{
 		{"Reference", referenceTimeStr, Timestamp{referenceTime}, false, true},
 		{"ReferenceUnix", referenceUnixTimeStr, Timestamp{referenceTime}, false, true},
+		{"ReferenceUnixMillisecond", referenceUnixTimeStrMilliSeconds, Timestamp{referenceTime}, false, true},
 		{"ReferenceFractional", referenceTimeStrFractional, Timestamp{referenceTime}, false, true},
 		{"Empty", emptyTimeStr, Timestamp{}, false, true},
 		{"UnixStart", `0`, Timestamp{unixOrigin}, false, true},
 		{"Mismatch", referenceTimeStr, Timestamp{}, false, false},
 		{"MismatchUnix", `0`, Timestamp{}, false, false},
 		{"Invalid", `"asdf"`, Timestamp{referenceTime}, true, false},
+		{"OffByMillisecond", `1136214245001`, Timestamp{referenceTime}, false, false},
 	}
 	for _, tc := range testCases {
 		var got Timestamp
@@ -144,11 +147,13 @@ func TestWrappedTimestamp_Unmarshal(t *testing.T) {
 	}{
 		{"Reference", referenceTimeStr, WrappedTimestamp{0, Timestamp{referenceTime}}, false, true},
 		{"ReferenceUnix", referenceUnixTimeStr, WrappedTimestamp{0, Timestamp{referenceTime}}, false, true},
+		{"ReferenceUnixMillisecond", referenceUnixTimeStrMilliSeconds, WrappedTimestamp{0, Timestamp{referenceTime}}, false, true},
 		{"Empty", emptyTimeStr, WrappedTimestamp{0, Timestamp{}}, false, true},
 		{"UnixStart", `0`, WrappedTimestamp{0, Timestamp{unixOrigin}}, false, true},
 		{"Mismatch", referenceTimeStr, WrappedTimestamp{0, Timestamp{}}, false, false},
 		{"MismatchUnix", `0`, WrappedTimestamp{0, Timestamp{}}, false, false},
 		{"Invalid", `"asdf"`, WrappedTimestamp{0, Timestamp{referenceTime}}, true, false},
+		{"OffByMillisecond", `1136214245001`, WrappedTimestamp{0, Timestamp{referenceTime}}, false, false},
 	}
 	for _, tc := range testCases {
 		var got Timestamp


### PR DESCRIPTION
The GitHub Audit Log API introduced timestamps with millisecond granularity. We add support for these timestamps by first parsing the timestamp into a Unix timestamp and then checking to see if the generated timestamp is in the future. If the timestamp is in the future we re-parse it as a Unix timestamp in Milliseconds.

Tests were added to ensure that when the timestamp is 1 millisecond off that the granularity of the timestamp is preserved by milliseconds correctly being parsed.

Closes #1849

Signed-off-by: Brett Logan <lindluni@github.com>