### PR TITLE
Update error handling as per Go 1.13 guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 go-github is a Go client library for accessing the [GitHub API v3][].
 
-Currently, **go-github requires Go version 1.9 or greater**.  go-github tracks
+Currently, **go-github requires Go version 1.13 or greater**.  go-github tracks
 [Go's version support policy][support-policy].  We do our best not to break
 older versions of Go if we don't have to, but due to tooling constraints, we
 don't always test older versions.

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1188,7 +1188,7 @@ func TestCompareHttpResponse(t *testing.T) {
 }
 
 func TestErrorResponse_Is(t *testing.T) {
-	err := ErrorResponse{
+	err := &ErrorResponse{
 		Response: &http.Response{},
 		Message:  "m",
 		Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
@@ -1271,8 +1271,9 @@ func TestErrorResponse_Is(t *testing.T) {
 		"errors have different values - Errors": {
 			wantSame: false,
 			otherError: &ErrorResponse{
-				Errors:  []Error{{Resource: "r1", Field: "f1", Code: "c1"}},
-				Message: "m",
+				Response: &http.Response{},
+				Errors:   []Error{{Resource: "r1", Field: "f1", Code: "c1"}},
+				Message:  "m",
 				Block: &struct {
 					Reason    string     `json:"reason,omitempty"`
 					CreatedAt *Timestamp `json:"created_at,omitempty"`
@@ -1283,11 +1284,76 @@ func TestErrorResponse_Is(t *testing.T) {
 				DocumentationURL: "https://github.com",
 			},
 		},
-		"errors have different values - Block": {
+		"errors have different values - Errors have different length": {
 			wantSame: false,
 			otherError: &ErrorResponse{
+				Response: &http.Response{},
+				Errors:   []Error{},
+				Message:  "m",
+				Block: &struct {
+					Reason    string     `json:"reason,omitempty"`
+					CreatedAt *Timestamp `json:"created_at,omitempty"`
+				}{
+					Reason:    "r",
+					CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
+				},
+				DocumentationURL: "https://github.com",
+			},
+		},
+		"errors have different values - Block - one is nil, other is not": {
+			wantSame: false,
+			otherError: &ErrorResponse{
+				Response:         &http.Response{},
 				Errors:           []Error{{Resource: "r", Field: "f", Code: "c"}},
 				Message:          "m",
+				DocumentationURL: "https://github.com",
+			},
+		},
+		"errors have different values - Block - different Reason": {
+			wantSame: false,
+			otherError: &ErrorResponse{
+				Response: &http.Response{},
+				Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
+				Message:  "m",
+				Block: &struct {
+					Reason    string     `json:"reason,omitempty"`
+					CreatedAt *Timestamp `json:"created_at,omitempty"`
+				}{
+					Reason:    "r1",
+					CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
+				},
+				DocumentationURL: "https://github.com",
+			},
+		},
+		"errors have different values - Block - different CreatedAt #1": {
+			wantSame: false,
+			otherError: &ErrorResponse{
+				Response: &http.Response{},
+				Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
+				Message:  "m",
+				Block: &struct {
+					Reason    string     `json:"reason,omitempty"`
+					CreatedAt *Timestamp `json:"created_at,omitempty"`
+				}{
+					Reason:    "r",
+					CreatedAt: nil,
+				},
+				DocumentationURL: "https://github.com",
+			},
+		},
+		"errors have different values - Block - different CreatedAt #2": {
+			wantSame: false,
+			otherError: &ErrorResponse{
+				Response: &http.Response{},
+				Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
+				Message:  "m",
+				Block: &struct {
+					Reason    string     `json:"reason,omitempty"`
+					CreatedAt *Timestamp `json:"created_at,omitempty"`
+				}{
+					Reason:    "r",
+					CreatedAt: &Timestamp{time.Date(2017, time.March, 17, 15, 39, 46, 0, time.UTC)},
+				},
 				DocumentationURL: "https://github.com",
 			},
 		},

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1152,6 +1152,340 @@ func TestCheckResponse_AbuseRateLimit(t *testing.T) {
 	}
 }
 
+func TestCompareHttpResponse(t *testing.T) {
+	testcases := map[string]struct {
+		h1       *http.Response
+		h2       *http.Response
+		expected bool
+	}{
+		"both are nil": {
+			expected: true,
+		},
+		"both are non nil - same StatusCode": {
+			expected: true,
+			h1:       &http.Response{StatusCode: 200},
+			h2:       &http.Response{StatusCode: 200},
+		},
+		"both are non nil - different StatusCode": {
+			expected: false,
+			h1:       &http.Response{StatusCode: 200},
+			h2:       &http.Response{StatusCode: 404},
+		},
+		"one is nil, other is not": {
+			expected: false,
+			h2:       &http.Response{},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			v := compareHttpResponse(tc.h1, tc.h2)
+			if tc.expected != v {
+				t.Errorf("Expected %t, got %t for (%#v, %#v)", tc.expected, v, tc.h1, tc.h2)
+			}
+		})
+	}
+}
+
+func TestErrorResponse_Is(t *testing.T) {
+	err := ErrorResponse{
+		Response: &http.Response{},
+		Message:  "m",
+		Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
+		Block: &struct {
+			Reason    string     `json:"reason,omitempty"`
+			CreatedAt *Timestamp `json:"created_at,omitempty"`
+		}{
+			Reason:    "r",
+			CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
+		},
+		DocumentationURL: "https://github.com",
+	}
+	testcases := map[string]struct {
+		wantSame   bool
+		otherError error
+	}{
+		"errors are same": {
+			wantSame: true,
+			otherError: &ErrorResponse{
+				Response: &http.Response{},
+				Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
+				Message:  "m",
+				Block: &struct {
+					Reason    string     `json:"reason,omitempty"`
+					CreatedAt *Timestamp `json:"created_at,omitempty"`
+				}{
+					Reason:    "r",
+					CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
+				},
+				DocumentationURL: "https://github.com",
+			},
+		},
+		"errors have different values - Message": {
+			wantSame: false,
+			otherError: &ErrorResponse{
+				Response: &http.Response{},
+				Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
+				Message:  "m1",
+				Block: &struct {
+					Reason    string     `json:"reason,omitempty"`
+					CreatedAt *Timestamp `json:"created_at,omitempty"`
+				}{
+					Reason:    "r",
+					CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
+				},
+				DocumentationURL: "https://github.com",
+			},
+		},
+		"errors have different values - DocumentationURL": {
+			wantSame: false,
+			otherError: &ErrorResponse{
+				Response: &http.Response{},
+				Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
+				Message:  "m",
+				Block: &struct {
+					Reason    string     `json:"reason,omitempty"`
+					CreatedAt *Timestamp `json:"created_at,omitempty"`
+				}{
+					Reason:    "r",
+					CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
+				},
+				DocumentationURL: "https://google.com",
+			},
+		},
+		"errors have different values - Response is nil": {
+			wantSame: false,
+			otherError: &ErrorResponse{
+				Errors:  []Error{{Resource: "r", Field: "f", Code: "c"}},
+				Message: "m",
+				Block: &struct {
+					Reason    string     `json:"reason,omitempty"`
+					CreatedAt *Timestamp `json:"created_at,omitempty"`
+				}{
+					Reason:    "r",
+					CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
+				},
+				DocumentationURL: "https://github.com",
+			},
+		},
+		"errors have different values - Errors": {
+			wantSame: false,
+			otherError: &ErrorResponse{
+				Errors:  []Error{{Resource: "r1", Field: "f1", Code: "c1"}},
+				Message: "m",
+				Block: &struct {
+					Reason    string     `json:"reason,omitempty"`
+					CreatedAt *Timestamp `json:"created_at,omitempty"`
+				}{
+					Reason:    "r",
+					CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
+				},
+				DocumentationURL: "https://github.com",
+			},
+		},
+		"errors have different values - Block": {
+			wantSame: false,
+			otherError: &ErrorResponse{
+				Errors:           []Error{{Resource: "r", Field: "f", Code: "c"}},
+				Message:          "m",
+				DocumentationURL: "https://github.com",
+			},
+		},
+		"errors have different types": {
+			wantSame:   false,
+			otherError: errors.New("Github"),
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			if tc.wantSame != err.Is(tc.otherError) {
+				t.Errorf("Error = %#v, want %#v", err, tc.otherError)
+			}
+		})
+	}
+}
+
+func TestRateLimitError_Is(t *testing.T) {
+	err := &RateLimitError{
+		Response: &http.Response{},
+		Message:  "Github",
+	}
+	testcases := map[string]struct {
+		wantSame   bool
+		err        *RateLimitError
+		otherError error
+	}{
+		"errors are same": {
+			wantSame: true,
+			err:      err,
+			otherError: &RateLimitError{
+				Response: &http.Response{},
+				Message:  "Github",
+			},
+		},
+		"errors are same - Response is nil": {
+			wantSame: true,
+			err: &RateLimitError{
+				Message: "Github",
+			},
+			otherError: &RateLimitError{
+				Message: "Github",
+			},
+		},
+		"errors have different values - Rate": {
+			wantSame: false,
+			err:      err,
+			otherError: &RateLimitError{
+				Rate:     Rate{Limit: 10},
+				Response: &http.Response{},
+				Message:  "Gitlab",
+			},
+		},
+		"errors have different values - Response is nil": {
+			wantSame: false,
+			err:      err,
+			otherError: &RateLimitError{
+				Message: "Github",
+			},
+		},
+		"errors have different values - StatusCode": {
+			wantSame: false,
+			err:      err,
+			otherError: &RateLimitError{
+				Response: &http.Response{StatusCode: 200},
+				Message:  "Github",
+			},
+		},
+		"errors have different types": {
+			wantSame:   false,
+			err:        err,
+			otherError: errors.New("Github"),
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			if tc.wantSame != tc.err.Is(tc.otherError) {
+				t.Errorf("Error = %#v, want %#v", tc.err, tc.otherError)
+			}
+		})
+	}
+}
+
+func TestAbuseRateLimitError_Is(t *testing.T) {
+	t1 := 1 * time.Second
+	t2 := 2 * time.Second
+	err := &AbuseRateLimitError{
+		Response:   &http.Response{},
+		Message:    "Github",
+		RetryAfter: &t1,
+	}
+	testcases := map[string]struct {
+		wantSame   bool
+		err        *AbuseRateLimitError
+		otherError error
+	}{
+		"errors are same": {
+			wantSame: true,
+			err:      err,
+			otherError: &AbuseRateLimitError{
+				Response:   &http.Response{},
+				Message:    "Github",
+				RetryAfter: &t1,
+			},
+		},
+		"errors are same - Response is nil": {
+			wantSame: true,
+			err: &AbuseRateLimitError{
+				Message:    "Github",
+				RetryAfter: &t1,
+			},
+			otherError: &AbuseRateLimitError{
+				Message:    "Github",
+				RetryAfter: &t1,
+			},
+		},
+		"errors have different values - Message": {
+			wantSame: false,
+			err:      err,
+			otherError: &AbuseRateLimitError{
+				Response:   &http.Response{},
+				Message:    "Gitlab",
+				RetryAfter: nil,
+			},
+		},
+		"errors have different values - RetryAfter": {
+			wantSame: false,
+			err:      err,
+			otherError: &AbuseRateLimitError{
+				Response:   &http.Response{},
+				Message:    "Github",
+				RetryAfter: &t2,
+			},
+		},
+		"errors have different values - Response is nil": {
+			wantSame: false,
+			err:      err,
+			otherError: &AbuseRateLimitError{
+				Message:    "Github",
+				RetryAfter: &t1,
+			},
+		},
+		"errors have different values - StatusCode": {
+			wantSame: false,
+			err:      err,
+			otherError: &AbuseRateLimitError{
+				Response:   &http.Response{StatusCode: 200},
+				Message:    "Github",
+				RetryAfter: &t1,
+			},
+		},
+		"errors have different types": {
+			wantSame:   false,
+			err:        err,
+			otherError: errors.New("Github"),
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			if tc.wantSame != tc.err.Is(tc.otherError) {
+				t.Errorf("Error = %#v, want %#v", tc.err, tc.otherError)
+			}
+		})
+	}
+}
+
+func TestAcceptedError_Is(t *testing.T) {
+	err := &AcceptedError{Raw: []byte("Github")}
+	testcases := map[string]struct {
+		wantSame   bool
+		otherError error
+	}{
+		"errors are same": {
+			wantSame:   true,
+			otherError: &AcceptedError{Raw: []byte("Github")},
+		},
+		"errors have different values": {
+			wantSame:   false,
+			otherError: &AcceptedError{Raw: []byte("Gitlab")},
+		},
+		"errors have different types": {
+			wantSame:   false,
+			otherError: errors.New("Github"),
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			if tc.wantSame != err.Is(tc.otherError) {
+				t.Errorf("Error = %#v, want %#v", err, tc.otherError)
+			}
+		})
+	}
+}
+
 // ensure that we properly handle API errors that do not contain a response body
 func TestCheckResponse_noBody(t *testing.T) {
 	res := &http.Response{

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -705,7 +705,7 @@ func TestDo_nilContext(t *testing.T) {
 	req, _ := client.NewRequest("GET", ".", nil)
 	_, err := client.Do(nil, req, nil)
 
-	if !reflect.DeepEqual(err, errors.New("context must be non-nil")) {
+	if !errors.Is(err, errNonNilContext) {
 		t.Errorf("Expected context must be non-nil error")
 	}
 }
@@ -1097,7 +1097,7 @@ func TestCheckResponse(t *testing.T) {
 			CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
 		},
 	}
-	if !reflect.DeepEqual(err, want) {
+	if !errors.Is(err, want) {
 		t.Errorf("Error = %#v, want %#v", err, want)
 	}
 }
@@ -1125,7 +1125,7 @@ func TestCheckResponse_RateLimit(t *testing.T) {
 		Response: res,
 		Message:  "m",
 	}
-	if !reflect.DeepEqual(err, want) {
+	if !errors.Is(err, want) {
 		t.Errorf("Error = %#v, want %#v", err, want)
 	}
 }
@@ -1147,7 +1147,7 @@ func TestCheckResponse_AbuseRateLimit(t *testing.T) {
 		Response: res,
 		Message:  "m",
 	}
-	if !reflect.DeepEqual(err, want) {
+	if !errors.Is(err, want) {
 		t.Errorf("Error = %#v, want %#v", err, want)
 	}
 }
@@ -1168,7 +1168,7 @@ func TestCheckResponse_noBody(t *testing.T) {
 	want := &ErrorResponse{
 		Response: res,
 	}
-	if !reflect.DeepEqual(err, want) {
+	if !errors.Is(err, want) {
 		t.Errorf("Error = %#v, want %#v", err, want)
 	}
 }
@@ -1191,7 +1191,7 @@ func TestCheckResponse_unexpectedErrorStructure(t *testing.T) {
 		Message:  "m",
 		Errors:   []Error{{Message: "error 1"}},
 	}
-	if !reflect.DeepEqual(err, want) {
+	if !errors.Is(err, want) {
 		t.Errorf("Error = %#v, want %#v", err, want)
 	}
 	data, err2 := ioutil.ReadAll(err.Response.Body)


### PR DESCRIPTION
Fixes [1846](https://github.com/google/go-github/issues/1846)

1. Updated `README.md` to reflect that it is no longer Go 1.9 that we require, but instead we need a minimum of Go 1.13.
2. Replaced `reflect.DeepEqual` with `errors.Is` in all the affected tests.
3. Implemented `Is(error) bool` interface for all the required errors (`ErrorResponse`, `RateLimitError`, `AcceptedError` and `AbuseRateLimitError`). All the individual fields are directly compared. However, for the `*http Response` field, only `StatusCode` is being compared. If the other fields of the `http.Response` struct need to be compared, please let me know.