### PR TITLE
feat: support new release discussions feature

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -13212,6 +13212,14 @@ func (r *RepositoryRelease) GetCreatedAt() Timestamp {
 	return *r.CreatedAt
 }
 
+// GetDiscussionCategoryName returns the DiscussionCategoryName field if it's non-nil, zero value otherwise.
+func (r *RepositoryRelease) GetDiscussionCategoryName() string {
+	if r == nil || r.DiscussionCategoryName == nil {
+		return ""
+	}
+	return *r.DiscussionCategoryName
+}
+
 // GetDraft returns the Draft field if it's non-nil, zero value otherwise.
 func (r *RepositoryRelease) GetDraft() bool {
 	if r == nil || r.Draft == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -15448,6 +15448,16 @@ func TestRepositoryRelease_GetCreatedAt(tt *testing.T) {
 	r.GetCreatedAt()
 }
 
+func TestRepositoryRelease_GetDiscussionCategoryName(tt *testing.T) {
+	var zeroValue string
+	r := &RepositoryRelease{DiscussionCategoryName: &zeroValue}
+	r.GetDiscussionCategoryName()
+	r = &RepositoryRelease{}
+	r.GetDiscussionCategoryName()
+	r = nil
+	r.GetDiscussionCategoryName()
+}
+
 func TestRepositoryRelease_GetDraft(tt *testing.T) {
 	var zeroValue bool
 	r := &RepositoryRelease{Draft: &zeroValue}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1534,25 +1534,26 @@ func TestRepositoryLicense_String(t *testing.T) {
 
 func TestRepositoryRelease_String(t *testing.T) {
 	v := RepositoryRelease{
-		TagName:         String(""),
-		TargetCommitish: String(""),
-		Name:            String(""),
-		Body:            String(""),
-		Draft:           Bool(false),
-		Prerelease:      Bool(false),
-		ID:              Int64(0),
-		CreatedAt:       &Timestamp{},
-		PublishedAt:     &Timestamp{},
-		URL:             String(""),
-		HTMLURL:         String(""),
-		AssetsURL:       String(""),
-		UploadURL:       String(""),
-		ZipballURL:      String(""),
-		TarballURL:      String(""),
-		Author:          &User{},
-		NodeID:          String(""),
+		TagName:                String(""),
+		TargetCommitish:        String(""),
+		Name:                   String(""),
+		Body:                   String(""),
+		Draft:                  Bool(false),
+		Prerelease:             Bool(false),
+		DiscussionCategoryName: String(""),
+		ID:                     Int64(0),
+		CreatedAt:              &Timestamp{},
+		PublishedAt:            &Timestamp{},
+		URL:                    String(""),
+		HTMLURL:                String(""),
+		AssetsURL:              String(""),
+		UploadURL:              String(""),
+		ZipballURL:             String(""),
+		TarballURL:             String(""),
+		Author:                 &User{},
+		NodeID:                 String(""),
 	}
-	want := `github.RepositoryRelease{TagName:"", TargetCommitish:"", Name:"", Body:"", Draft:false, Prerelease:false, ID:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, PublishedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, URL:"", HTMLURL:"", AssetsURL:"", UploadURL:"", ZipballURL:"", TarballURL:"", Author:github.User{}, NodeID:""}`
+	want := `github.RepositoryRelease{TagName:"", TargetCommitish:"", Name:"", Body:"", Draft:false, Prerelease:false, DiscussionCategoryName:"", ID:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, PublishedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, URL:"", HTMLURL:"", AssetsURL:"", UploadURL:"", ZipballURL:"", TarballURL:"", Author:github.User{}, NodeID:""}`
 	if got := v.String(); got != want {
 		t.Errorf("RepositoryRelease.String = %v, want %v", got, want)
 	}

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -19,12 +19,13 @@ import (
 
 // RepositoryRelease represents a GitHub release in a repository.
 type RepositoryRelease struct {
-	TagName         *string `json:"tag_name,omitempty"`
-	TargetCommitish *string `json:"target_commitish,omitempty"`
-	Name            *string `json:"name,omitempty"`
-	Body            *string `json:"body,omitempty"`
-	Draft           *bool   `json:"draft,omitempty"`
-	Prerelease      *bool   `json:"prerelease,omitempty"`
+	TagName                *string `json:"tag_name,omitempty"`
+	TargetCommitish        *string `json:"target_commitish,omitempty"`
+	Name                   *string `json:"name,omitempty"`
+	Body                   *string `json:"body,omitempty"`
+	Draft                  *bool   `json:"draft,omitempty"`
+	Prerelease             *bool   `json:"prerelease,omitempty"`
+	DiscussionCategoryName *string `json:"discussion_category_name,omitempty"`
 
 	// The following fields are not used in CreateRelease or EditRelease:
 	ID          *int64          `json:"id,omitempty"`
@@ -134,12 +135,13 @@ func (s *RepositoriesService) getSingleRelease(ctx context.Context, url string) 
 // See https://github.com/google/go-github/issues/992 for more
 // information.
 type repositoryReleaseRequest struct {
-	TagName         *string `json:"tag_name,omitempty"`
-	TargetCommitish *string `json:"target_commitish,omitempty"`
-	Name            *string `json:"name,omitempty"`
-	Body            *string `json:"body,omitempty"`
-	Draft           *bool   `json:"draft,omitempty"`
-	Prerelease      *bool   `json:"prerelease,omitempty"`
+	TagName                *string `json:"tag_name,omitempty"`
+	TargetCommitish        *string `json:"target_commitish,omitempty"`
+	Name                   *string `json:"name,omitempty"`
+	Body                   *string `json:"body,omitempty"`
+	Draft                  *bool   `json:"draft,omitempty"`
+	Prerelease             *bool   `json:"prerelease,omitempty"`
+	DiscussionCategoryName *string `json:"discussion_category_name,omitempty"`
 }
 
 // CreateRelease adds a new release for a repository.
@@ -152,12 +154,13 @@ func (s *RepositoriesService) CreateRelease(ctx context.Context, owner, repo str
 	u := fmt.Sprintf("repos/%s/%s/releases", owner, repo)
 
 	releaseReq := &repositoryReleaseRequest{
-		TagName:         release.TagName,
-		TargetCommitish: release.TargetCommitish,
-		Name:            release.Name,
-		Body:            release.Body,
-		Draft:           release.Draft,
-		Prerelease:      release.Prerelease,
+		TagName:                release.TagName,
+		TargetCommitish:        release.TargetCommitish,
+		Name:                   release.Name,
+		Body:                   release.Body,
+		Draft:                  release.Draft,
+		Prerelease:             release.Prerelease,
+		DiscussionCategoryName: release.DiscussionCategoryName,
 	}
 
 	req, err := s.client.NewRequest("POST", u, releaseReq)
@@ -183,12 +186,13 @@ func (s *RepositoriesService) EditRelease(ctx context.Context, owner, repo strin
 	u := fmt.Sprintf("repos/%s/%s/releases/%d", owner, repo, id)
 
 	releaseReq := &repositoryReleaseRequest{
-		TagName:         release.TagName,
-		TargetCommitish: release.TargetCommitish,
-		Name:            release.Name,
-		Body:            release.Body,
-		Draft:           release.Draft,
-		Prerelease:      release.Prerelease,
+		TagName:                release.TagName,
+		TargetCommitish:        release.TargetCommitish,
+		Name:                   release.Name,
+		Body:                   release.Body,
+		Draft:                  release.Draft,
+		Prerelease:             release.Prerelease,
+		DiscussionCategoryName: release.DiscussionCategoryName,
 	}
 
 	req, err := s.client.NewRequest("PATCH", u, releaseReq)

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -164,7 +164,8 @@ func TestRepositoriesService_CreateRelease(t *testing.T) {
 	defer teardown()
 
 	input := &RepositoryRelease{
-		Name: String("v1.0"),
+		Name:                   String("v1.0"),
+		DiscussionCategoryName: String("General"),
 		// Fields to be removed:
 		ID:          Int64(2),
 		CreatedAt:   &Timestamp{referenceTime},
@@ -185,7 +186,10 @@ func TestRepositoriesService_CreateRelease(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		want := &repositoryReleaseRequest{Name: String("v1.0")}
+		want := &repositoryReleaseRequest{
+			Name:                   String("v1.0"),
+			DiscussionCategoryName: String("General"),
+		}
 		if !reflect.DeepEqual(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
@@ -223,7 +227,8 @@ func TestRepositoriesService_EditRelease(t *testing.T) {
 	defer teardown()
 
 	input := &RepositoryRelease{
-		Name: String("n"),
+		Name:                   String("n"),
+		DiscussionCategoryName: String("General"),
 		// Fields to be removed:
 		ID:          Int64(2),
 		CreatedAt:   &Timestamp{referenceTime},
@@ -244,7 +249,10 @@ func TestRepositoriesService_EditRelease(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		want := &repositoryReleaseRequest{Name: String("n")}
+		want := &repositoryReleaseRequest{
+			Name:                   String("n"),
+			DiscussionCategoryName: String("General"),
+		}
 		if !reflect.DeepEqual(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}


### PR DESCRIPTION
support the new `discussion_category_name` field when creating/updating a release.

refs https://github.blog/changelog/2021-04-06-releases-support-comments-and-reactions-with-discussion-linking/
refs https://docs.github.com/en/rest/reference/repos#create-a-release
refs https://github.com/goreleaser/goreleaser/issues/2161
