### PR TITLE
Remove obsolete apps manifest preview custom header

### DIFF
--- a/github/apps_manifest.go
+++ b/github/apps_manifest.go
@@ -10,10 +10,6 @@ import (
 	"fmt"
 )
 
-const (
-	mediaTypeAppManifestPreview = "application/vnd.github.fury-preview+json"
-)
-
 // AppConfig describes the configuration of a GitHub App.
 type AppConfig struct {
 	ID            *int64     `json:"id,omitempty"`
@@ -41,7 +37,6 @@ func (s *AppsService) CompleteAppManifest(ctx context.Context, code string) (*Ap
 	if err != nil {
 		return nil, nil, err
 	}
-	req.Header.Set("Accept", mediaTypeAppManifestPreview)
 
 	cfg := new(AppConfig)
 	resp, err := s.client.Do(ctx, req, cfg)

--- a/github/apps_manifest_test.go
+++ b/github/apps_manifest_test.go
@@ -30,7 +30,6 @@ func TestGetConfig(t *testing.T) {
 
 	mux.HandleFunc("/app-manifests/code/conversions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeAppManifestPreview)
 		fmt.Fprint(w, manifestJSON)
 	})
 


### PR DESCRIPTION
Apps manifest are now out of preview and uses mediaTypeV3:

https://docs.github.com/en/rest/reference/apps#create-a-github-app-from-a-manifest
