### PR TITLE
Apps-Service: Add baptiste-preview to ListRepos and ListUserRepos

### DIFF
--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -32,7 +32,11 @@ func (s *AppsService) ListRepos(ctx context.Context, opts *ListOptions) (*ListRe
 	}
 
 	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
+	acceptHeaders := []string{
+		mediaTypeTopicsPreview,
+		mediaTypeRepositoryVisibilityPreview,
+		mediaTypeRepositoryTemplatePreview,
+	}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var r *ListRepositories
@@ -62,7 +66,11 @@ func (s *AppsService) ListUserRepos(ctx context.Context, id int64, opts *ListOpt
 	}
 
 	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
+	acceptHeaders := []string{
+		mediaTypeTopicsPreview,
+		mediaTypeRepositoryVisibilityPreview,
+		mediaTypeRepositoryTemplatePreview,
+	}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var r *ListRepositories

--- a/github/apps_installation_test.go
+++ b/github/apps_installation_test.go
@@ -18,7 +18,11 @@ func TestAppsService_ListRepos(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
+	wantAcceptHeaders := []string{
+		mediaTypeTopicsPreview,
+		mediaTypeRepositoryVisibilityPreview,
+		mediaTypeRepositoryTemplatePreview,
+	}
 	mux.HandleFunc("/installation/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
@@ -55,7 +59,11 @@ func TestAppsService_ListUserRepos(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
+	wantAcceptHeaders := []string{
+		mediaTypeTopicsPreview,
+		mediaTypeRepositoryVisibilityPreview,
+		mediaTypeRepositoryTemplatePreview,
+	}
 	mux.HandleFunc("/user/installations/1/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))


### PR DESCRIPTION
The preview `application/vnd.github.baptiste-preview+json` ensures that the field `"is_template": false` is part of the repository response of the Apps Service.