### PR TITLE
Add download token and sha to ListRunnerApplicationDownloads

### DIFF
--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -12,10 +12,12 @@ import (
 
 // RunnerApplicationDownload represents a binary for the self-hosted runner application that can be downloaded.
 type RunnerApplicationDownload struct {
-	OS           *string `json:"os,omitempty"`
-	Architecture *string `json:"architecture,omitempty"`
-	DownloadURL  *string `json:"download_url,omitempty"`
-	Filename     *string `json:"filename,omitempty"`
+	OS                *string `json:"os,omitempty"`
+	Architecture      *string `json:"architecture,omitempty"`
+	DownloadURL       *string `json:"download_url,omitempty"`
+	Filename          *string `json:"filename,omitempty"`
+	TempDownloadToken *string `json:"temp_download_token,omitempty"`
+	Sha256Checksum    *string `json:"sha256_checksum,omitempty"`
 }
 
 // ActionsEnabledOnOrgRepos represents all the repositories in an organization for which Actions is enabled.

--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -17,7 +17,7 @@ type RunnerApplicationDownload struct {
 	DownloadURL       *string `json:"download_url,omitempty"`
 	Filename          *string `json:"filename,omitempty"`
 	TempDownloadToken *string `json:"temp_download_token,omitempty"`
-	Sha256Checksum    *string `json:"sha256_checksum,omitempty"`
+	SHA256Checksum    *string `json:"sha256_checksum,omitempty"`
 }
 
 // ActionsEnabledOnOrgRepos represents all the repositories in an organization for which Actions is enabled.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -13612,6 +13612,22 @@ func (r *RunnerApplicationDownload) GetOS() string {
 	return *r.OS
 }
 
+// GetSHA256Checksum returns the SHA256Checksum field if it's non-nil, zero value otherwise.
+func (r *RunnerApplicationDownload) GetSHA256Checksum() string {
+	if r == nil || r.SHA256Checksum == nil {
+		return ""
+	}
+	return *r.SHA256Checksum
+}
+
+// GetTempDownloadToken returns the TempDownloadToken field if it's non-nil, zero value otherwise.
+func (r *RunnerApplicationDownload) GetTempDownloadToken() string {
+	if r == nil || r.TempDownloadToken == nil {
+		return ""
+	}
+	return *r.TempDownloadToken
+}
+
 // GetAllowsPublicRepositories returns the AllowsPublicRepositories field if it's non-nil, zero value otherwise.
 func (r *RunnerGroup) GetAllowsPublicRepositories() bool {
 	if r == nil || r.AllowsPublicRepositories == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -15939,6 +15939,26 @@ func TestRunnerApplicationDownload_GetOS(tt *testing.T) {
 	r.GetOS()
 }
 
+func TestRunnerApplicationDownload_GetSHA256Checksum(tt *testing.T) {
+	var zeroValue string
+	r := &RunnerApplicationDownload{SHA256Checksum: &zeroValue}
+	r.GetSHA256Checksum()
+	r = &RunnerApplicationDownload{}
+	r.GetSHA256Checksum()
+	r = nil
+	r.GetSHA256Checksum()
+}
+
+func TestRunnerApplicationDownload_GetTempDownloadToken(tt *testing.T) {
+	var zeroValue string
+	r := &RunnerApplicationDownload{TempDownloadToken: &zeroValue}
+	r.GetTempDownloadToken()
+	r = &RunnerApplicationDownload{}
+	r.GetTempDownloadToken()
+	r = nil
+	r.GetTempDownloadToken()
+}
+
 func TestRunnerGroup_GetAllowsPublicRepositories(tt *testing.T) {
 	var zeroValue bool
 	r := &RunnerGroup{AllowsPublicRepositories: &zeroValue}


### PR DESCRIPTION
See https://github.com/google/go-github/issues/1861

When using Git Hub Enterprise APIs a temp_download_token is included when querying runner downloads via the API.

This PR updates the response structure to include the necessary token and SHA checksum.

```
>:~$ curl -k -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github.v3+json" https://HOST/api/v3/orgs/actions-sauron/actions/runners/downloads
[
  {
    "os": "osx",
    "architecture": "x64",
    "download_url": "https://HOST/_services/pipelines/_apis/distributedtask/packagedownload/agent/osx-x64/2.277.1",
    "filename": "actions-runner-osx-x64-2.277.1.tar.gz",
    "temp_download_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJ...",
    "sha256_checksum": "f1fa173889dc9036cd5294..."
  },
  {
    "os": "linux",
    "architecture": "x64",
    "download_url": "https://HOST/_services/pipelines/_apis/distributedtask/packagedownload/agent/linux-x64/2.277.1",
    "filename": "actions-runner-linux-x64-2.277.1.tar.gz",
    "temp_download_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1...",
    "sha256_checksum": "02d710fc9e0008e641274bb7da7fde61f7c9a..."
  },
  ...
]
```