### PR TITLE
Add permissions to teams

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -14276,14 +14276,6 @@ func (t *Team) GetPermission() string {
 	return *t.Permission
 }
 
-// GetPermissions returns the Permissions field if it's non-nil, zero value otherwise.
-func (t *Team) GetPermissions() map[string]bool {
-	if t == nil || t.Permissions == nil {
-		return map[string]bool{}
-	}
-	return *t.Permissions
-}
-
 // GetPrivacy returns the Privacy field if it's non-nil, zero value otherwise.
 func (t *Team) GetPrivacy() string {
 	if t == nil || t.Privacy == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -14276,6 +14276,14 @@ func (t *Team) GetPermission() string {
 	return *t.Permission
 }
 
+// GetPermissions returns the Permissions field if it's non-nil, zero value otherwise.
+func (t *Team) GetPermissions() map[string]bool {
+	if t == nil || t.Permissions == nil {
+		return map[string]bool{}
+	}
+	return *t.Permissions
+}
+
 // GetPrivacy returns the Privacy field if it's non-nil, zero value otherwise.
 func (t *Team) GetPrivacy() string {
 	if t == nil || t.Privacy == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -16730,6 +16730,16 @@ func TestTeam_GetPermission(tt *testing.T) {
 	t.GetPermission()
 }
 
+func TestTeam_GetPermissions(tt *testing.T) {
+	var zeroValue map[string]bool
+	t := &Team{Permissions: &zeroValue}
+	t.GetPermissions()
+	t = &Team{}
+	t.GetPermissions()
+	t = nil
+	t.GetPermissions()
+}
+
 func TestTeam_GetPrivacy(tt *testing.T) {
 	var zeroValue string
 	t := &Team{Privacy: &zeroValue}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1584,6 +1584,7 @@ func TestTeam_String(t *testing.T) {
 		URL:             String(""),
 		Slug:            String(""),
 		Permission:      String(""),
+		Permissions:     nil,
 		Privacy:         String(""),
 		MembersCount:    Int(0),
 		ReposCount:      Int(0),
@@ -1593,7 +1594,7 @@ func TestTeam_String(t *testing.T) {
 		Parent:          &Team{},
 		LDAPDN:          String(""),
 	}
-	want := `github.Team{ID:0, NodeID:"", Name:"", Description:"", URL:"", Slug:"", Permission:"", Privacy:"", MembersCount:0, ReposCount:0, Organization:github.Organization{}, MembersURL:"", RepositoriesURL:"", Parent:github.Team{}, LDAPDN:""}`
+	want := `github.Team{ID:0, NodeID:"", Name:"", Description:"", URL:"", Slug:"", Permission:"", Permissions:map[], Privacy:"", MembersCount:0, ReposCount:0, Organization:github.Organization{}, MembersURL:"", RepositoriesURL:"", Parent:github.Team{}, LDAPDN:""}`
 	if got := v.String(); got != want {
 		t.Errorf("Team.String = %v, want %v", got, want)
 	}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1584,7 +1584,6 @@ func TestTeam_String(t *testing.T) {
 		URL:             String(""),
 		Slug:            String(""),
 		Permission:      String(""),
-		Permissions:     nil,
 		Privacy:         String(""),
 		MembersCount:    Int(0),
 		ReposCount:      Int(0),
@@ -1594,7 +1593,7 @@ func TestTeam_String(t *testing.T) {
 		Parent:          &Team{},
 		LDAPDN:          String(""),
 	}
-	want := `github.Team{ID:0, NodeID:"", Name:"", Description:"", URL:"", Slug:"", Permission:"", Permissions:map[], Privacy:"", MembersCount:0, ReposCount:0, Organization:github.Organization{}, MembersURL:"", RepositoriesURL:"", Parent:github.Team{}, LDAPDN:""}`
+	want := `github.Team{ID:0, NodeID:"", Name:"", Description:"", URL:"", Slug:"", Permission:"", Privacy:"", MembersCount:0, ReposCount:0, Organization:github.Organization{}, MembersURL:"", RepositoriesURL:"", Parent:github.Team{}, LDAPDN:""}`
 	if got := v.String(); got != want {
 		t.Errorf("Team.String = %v, want %v", got, want)
 	}

--- a/github/teams.go
+++ b/github/teams.go
@@ -32,6 +32,10 @@ type Team struct {
 	// Permission specifies the default permission for repositories owned by the team.
 	Permission *string `json:"permission,omitempty"`
 
+	// Permissions identifies the permissions that a team has on a given
+	// repository. This is only populated when calling Repositories.ListTeams.
+	Permissions *map[string]bool `json:"permissions,omitempty"`
+
 	// Privacy identifies the level of privacy this team should have.
 	// Possible values are:
 	//     secret - only visible to organization owners and members of this team

--- a/github/teams.go
+++ b/github/teams.go
@@ -34,7 +34,7 @@ type Team struct {
 
 	// Permissions identifies the permissions that a team has on a given
 	// repository. This is only populated when calling Repositories.ListTeams.
-	Permissions map[string]bool `json:"permissions,omitempty"`
+	Permissions *map[string]bool `json:"permissions,omitempty"`
 
 	// Privacy identifies the level of privacy this team should have.
 	// Possible values are:

--- a/github/teams.go
+++ b/github/teams.go
@@ -34,7 +34,7 @@ type Team struct {
 
 	// Permissions identifies the permissions that a team has on a given
 	// repository. This is only populated when calling Repositories.ListTeams.
-	Permissions *map[string]bool `json:"permissions,omitempty"`
+	Permissions map[string]bool `json:"permissions,omitempty"`
 
 	// Privacy identifies the level of privacy this team should have.
 	// Possible values are:


### PR DESCRIPTION
This PR addresses https://github.com/google/go-github/issues/1863 by adding a Permissions field to the Team type.