### PR TITLE
Update comparisons in test files from reflect to cmp

### DIFF
--- a/github/actions_artifacts_test.go
+++ b/github/actions_artifacts_test.go
@@ -10,8 +10,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestActionsService_ListArtifacts(t *testing.T) {
@@ -37,7 +38,7 @@ func TestActionsService_ListArtifacts(t *testing.T) {
 	}
 
 	want := &ArtifactList{TotalCount: Int64(1), Artifacts: []*Artifact{{ID: Int64(1)}}}
-	if !reflect.DeepEqual(artifacts, want) {
+	if !cmp.Equal(artifacts, want) {
 		t.Errorf("Actions.ListArtifacts returned %+v, want %+v", artifacts, want)
 	}
 
@@ -119,7 +120,7 @@ func TestActionsService_ListWorkflowRunArtifacts(t *testing.T) {
 	}
 
 	want := &ArtifactList{TotalCount: Int64(1), Artifacts: []*Artifact{{ID: Int64(1)}}}
-	if !reflect.DeepEqual(artifacts, want) {
+	if !cmp.Equal(artifacts, want) {
 		t.Errorf("Actions.ListWorkflowRunArtifacts returned %+v, want %+v", artifacts, want)
 	}
 
@@ -206,7 +207,7 @@ func TestActionsService_GetArtifact(t *testing.T) {
 		SizeInBytes:        Int64(5),
 		ArchiveDownloadURL: String("u"),
 	}
-	if !reflect.DeepEqual(artifact, want) {
+	if !cmp.Equal(artifact, want) {
 		t.Errorf("Actions.GetArtifact returned %+v, want %+v", artifact, want)
 	}
 

--- a/github/actions_runner_groups_test.go
+++ b/github/actions_runner_groups_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestActionsService_ListOrganizationRunnerGroups(t *testing.T) {
@@ -38,7 +39,7 @@ func TestActionsService_ListOrganizationRunnerGroups(t *testing.T) {
 			{ID: Int64(3), Name: String("expensive-hardware"), Visibility: String("private"), Default: Bool(false), RunnersURL: String("https://api.github.com/orgs/octo-org/actions/runner_groups/3/runners"), Inherited: Bool(false), AllowsPublicRepositories: Bool(true)},
 		},
 	}
-	if !reflect.DeepEqual(groups, want) {
+	if !cmp.Equal(groups, want) {
 		t.Errorf("Actions.ListOrganizationRunnerGroups returned %+v, want %+v", groups, want)
 	}
 
@@ -83,7 +84,7 @@ func TestActionsService_GetOrganizationRunnerGroup(t *testing.T) {
 		AllowsPublicRepositories: Bool(true),
 	}
 
-	if !reflect.DeepEqual(group, want) {
+	if !cmp.Equal(group, want) {
 		t.Errorf("Actions.GetOrganizationRunnerGroup returned %+v, want %+v", group, want)
 	}
 
@@ -157,7 +158,7 @@ func TestActionsService_CreateOrganizationRunnerGroup(t *testing.T) {
 		AllowsPublicRepositories: Bool(true),
 	}
 
-	if !reflect.DeepEqual(group, want) {
+	if !cmp.Equal(group, want) {
 		t.Errorf("Actions.CreateOrganizationRunnerGroup returned %+v, want %+v", group, want)
 	}
 
@@ -206,7 +207,7 @@ func TestActionsService_UpdateOrganizationRunnerGroup(t *testing.T) {
 		AllowsPublicRepositories: Bool(true),
 	}
 
-	if !reflect.DeepEqual(group, want) {
+	if !cmp.Equal(group, want) {
 		t.Errorf("Actions.UpdateOrganizationRunnerGroup returned %+v, want %+v", group, want)
 	}
 
@@ -246,7 +247,7 @@ func TestActionsService_ListRepositoryAccessRunnerGroup(t *testing.T) {
 			{ID: Int64(43), NodeID: String("MDEwOlJlcG9zaXRvcnkxMjk2MjY5"), Name: String("Hello-World"), FullName: String("octocat/Hello-World")},
 		},
 	}
-	if !reflect.DeepEqual(groups, want) {
+	if !cmp.Equal(groups, want) {
 		t.Errorf("Actions.ListRepositoryAccessRunnerGroup returned %+v, want %+v", groups, want)
 	}
 
@@ -371,7 +372,7 @@ func TestActionsService_ListRunerGroupRunners(t *testing.T) {
 			{ID: Int64(24), Name: String("iMac"), OS: String("macos"), Status: String("offline")},
 		},
 	}
-	if !reflect.DeepEqual(runners, want) {
+	if !cmp.Equal(runners, want) {
 		t.Errorf("Actions.ListRunerGroupRunners returned %+v, want %+v", runners, want)
 	}
 

--- a/github/actions_runners_test.go
+++ b/github/actions_runners_test.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestActionsService_ListRunnerApplicationDownloads(t *testing.T) {
@@ -36,7 +37,7 @@ func TestActionsService_ListRunnerApplicationDownloads(t *testing.T) {
 		{OS: String("win"), Architecture: String("x64"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-win-x64-2.164.0.zip"), Filename: String("actions-runner-win-x64-2.164.0.zip")},
 		{OS: String("linux"), Architecture: String("arm64"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm64-2.164.0.tar.gz"), Filename: String("actions-runner-linux-arm64-2.164.0.tar.gz")},
 	}
-	if !reflect.DeepEqual(downloads, want) {
+	if !cmp.Equal(downloads, want) {
 		t.Errorf("Actions.ListRunnerApplicationDownloads returned %+v, want %+v", downloads, want)
 	}
 
@@ -73,7 +74,7 @@ func TestActionsService_CreateRegistrationToken(t *testing.T) {
 	want := &RegistrationToken{Token: String("LLBF3JGZDX3P5PMEXLND6TS6FCWO6"),
 		ExpiresAt: &Timestamp{time.Date(2020, time.January, 22, 12, 13, 35,
 			123000000, time.UTC)}}
-	if !reflect.DeepEqual(token, want) {
+	if !cmp.Equal(token, want) {
 		t.Errorf("Actions.CreateRegistrationToken returned %+v, want %+v", token, want)
 	}
 
@@ -116,7 +117,7 @@ func TestActionsService_ListRunners(t *testing.T) {
 			{ID: Int64(24), Name: String("iMac"), OS: String("macos"), Status: String("offline")},
 		},
 	}
-	if !reflect.DeepEqual(runners, want) {
+	if !cmp.Equal(runners, want) {
 		t.Errorf("Actions.ListRunners returned %+v, want %+v", runners, want)
 	}
 
@@ -156,7 +157,7 @@ func TestActionsService_GetRunner(t *testing.T) {
 		OS:     String("macos"),
 		Status: String("online"),
 	}
-	if !reflect.DeepEqual(runner, want) {
+	if !cmp.Equal(runner, want) {
 		t.Errorf("Actions.GetRunner returned %+v, want %+v", runner, want)
 	}
 
@@ -191,7 +192,7 @@ func TestActionsService_CreateRemoveToken(t *testing.T) {
 	}
 
 	want := &RemoveToken{Token: String("AABF3JGZDX3P5PMEXLND6TS6FCWO6"), ExpiresAt: &Timestamp{time.Date(2020, time.January, 29, 12, 13, 35, 123000000, time.UTC)}}
-	if !reflect.DeepEqual(token, want) {
+	if !cmp.Equal(token, want) {
 		t.Errorf("Actions.CreateRemoveToken returned %+v, want %+v", token, want)
 	}
 
@@ -257,7 +258,7 @@ func TestActionsService_ListOrganizationRunnerApplicationDownloads(t *testing.T)
 		{OS: String("win"), Architecture: String("x64"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-win-x64-2.164.0.zip"), Filename: String("actions-runner-win-x64-2.164.0.zip")},
 		{OS: String("linux"), Architecture: String("arm64"), DownloadURL: String("https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm64-2.164.0.tar.gz"), Filename: String("actions-runner-linux-arm64-2.164.0.tar.gz")},
 	}
-	if !reflect.DeepEqual(downloads, want) {
+	if !cmp.Equal(downloads, want) {
 		t.Errorf("Actions.ListOrganizationRunnerApplicationDownloads returned %+v, want %+v", downloads, want)
 	}
 
@@ -294,7 +295,7 @@ func TestActionsService_CreateOrganizationRegistrationToken(t *testing.T) {
 	want := &RegistrationToken{Token: String("LLBF3JGZDX3P5PMEXLND6TS6FCWO6"),
 		ExpiresAt: &Timestamp{time.Date(2020, time.January, 22, 12, 13, 35,
 			123000000, time.UTC)}}
-	if !reflect.DeepEqual(token, want) {
+	if !cmp.Equal(token, want) {
 		t.Errorf("Actions.CreateRegistrationToken returned %+v, want %+v", token, want)
 	}
 
@@ -337,7 +338,7 @@ func TestActionsService_ListOrganizationRunners(t *testing.T) {
 			{ID: Int64(24), Name: String("iMac"), OS: String("macos"), Status: String("offline")},
 		},
 	}
-	if !reflect.DeepEqual(runners, want) {
+	if !cmp.Equal(runners, want) {
 		t.Errorf("Actions.ListRunners returned %+v, want %+v", runners, want)
 	}
 
@@ -381,7 +382,7 @@ func TestActionsService_ListEnabledReposInOrg(t *testing.T) {
 		{ID: Int64(2)},
 		{ID: Int64(3)},
 	}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Actions.ListEnabledReposInOrg returned %+v, want %+v", got, want)
 	}
 
@@ -421,7 +422,7 @@ func TestActionsService_GetOrganizationRunner(t *testing.T) {
 		OS:     String("macos"),
 		Status: String("online"),
 	}
-	if !reflect.DeepEqual(runner, want) {
+	if !cmp.Equal(runner, want) {
 		t.Errorf("Actions.GetRunner returned %+v, want %+v", runner, want)
 	}
 
@@ -456,7 +457,7 @@ func TestActionsService_CreateOrganizationRemoveToken(t *testing.T) {
 	}
 
 	want := &RemoveToken{Token: String("AABF3JGZDX3P5PMEXLND6TS6FCWO6"), ExpiresAt: &Timestamp{time.Date(2020, time.January, 29, 12, 13, 35, 123000000, time.UTC)}}
-	if !reflect.DeepEqual(token, want) {
+	if !cmp.Equal(token, want) {
 		t.Errorf("Actions.CreateRemoveToken returned %+v, want %+v", token, want)
 	}
 

--- a/github/actions_secrets_test.go
+++ b/github/actions_secrets_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestPublicKey_UnmarshalJSON(t *testing.T) {
@@ -84,7 +85,7 @@ func TestPublicKey_UnmarshalJSON(t *testing.T) {
 			if err != nil && !tt.wantErr {
 				t.Errorf("PublicKey.UnmarshalJSON returned an unexpected error: %+v", err)
 			}
-			if !reflect.DeepEqual(tt.wantPublicKey, pk) {
+			if !cmp.Equal(tt.wantPublicKey, pk) {
 				t.Errorf("PublicKey.UnmarshalJSON expected public key %+v, got %+v", tt.wantPublicKey, pk)
 			}
 		})
@@ -107,7 +108,7 @@ func TestActionsService_GetRepoPublicKey(t *testing.T) {
 	}
 
 	want := &PublicKey{KeyID: String("1234"), Key: String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234")}
-	if !reflect.DeepEqual(key, want) {
+	if !cmp.Equal(key, want) {
 		t.Errorf("Actions.GetRepoPublicKey returned %+v, want %+v", key, want)
 	}
 
@@ -142,7 +143,7 @@ func TestActionsService_GetRepoPublicKeyNumeric(t *testing.T) {
 	}
 
 	want := &PublicKey{KeyID: String("1234"), Key: String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234")}
-	if !reflect.DeepEqual(key, want) {
+	if !cmp.Equal(key, want) {
 		t.Errorf("Actions.GetRepoPublicKey returned %+v, want %+v", key, want)
 	}
 
@@ -185,7 +186,7 @@ func TestActionsService_ListRepoSecrets(t *testing.T) {
 			{Name: "B", CreatedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
 		},
 	}
-	if !reflect.DeepEqual(secrets, want) {
+	if !cmp.Equal(secrets, want) {
 		t.Errorf("Actions.ListRepoSecrets returned %+v, want %+v", secrets, want)
 	}
 
@@ -224,7 +225,7 @@ func TestActionsService_GetRepoSecret(t *testing.T) {
 		CreatedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
 		UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
 	}
-	if !reflect.DeepEqual(secret, want) {
+	if !cmp.Equal(secret, want) {
 		t.Errorf("Actions.GetRepoSecret returned %+v, want %+v", secret, want)
 	}
 
@@ -317,7 +318,7 @@ func TestActionsService_GetOrgPublicKey(t *testing.T) {
 	}
 
 	want := &PublicKey{KeyID: String("012345678"), Key: String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234")}
-	if !reflect.DeepEqual(key, want) {
+	if !cmp.Equal(key, want) {
 		t.Errorf("Actions.GetOrgPublicKey returned %+v, want %+v", key, want)
 	}
 
@@ -361,7 +362,7 @@ func TestActionsService_ListOrgSecrets(t *testing.T) {
 			{Name: "GH_TOKEN", CreatedAt: Timestamp{time.Date(2019, time.August, 10, 14, 59, 22, 0, time.UTC)}, UpdatedAt: Timestamp{time.Date(2020, time.January, 10, 14, 59, 22, 0, time.UTC)}, Visibility: "selected", SelectedRepositoriesURL: "https://api.github.com/orgs/octo-org/actions/secrets/SUPER_SECRET/repositories"},
 		},
 	}
-	if !reflect.DeepEqual(secrets, want) {
+	if !cmp.Equal(secrets, want) {
 		t.Errorf("Actions.ListOrgSecrets returned %+v, want %+v", secrets, want)
 	}
 
@@ -402,7 +403,7 @@ func TestActionsService_GetOrgSecret(t *testing.T) {
 		Visibility:              "selected",
 		SelectedRepositoriesURL: "https://api.github.com/orgs/octo-org/actions/secrets/SUPER_SECRET/repositories",
 	}
-	if !reflect.DeepEqual(secret, want) {
+	if !cmp.Equal(secret, want) {
 		t.Errorf("Actions.GetOrgSecret returned %+v, want %+v", secret, want)
 	}
 
@@ -477,7 +478,7 @@ func TestActionsService_ListSelectedReposForOrgSecret(t *testing.T) {
 			{ID: Int64(1)},
 		},
 	}
-	if !reflect.DeepEqual(repos, want) {
+	if !cmp.Equal(repos, want) {
 		t.Errorf("Actions.ListSelectedReposForOrgSecret returned %+v, want %+v", repos, want)
 	}
 
@@ -615,7 +616,7 @@ func TestActionsService_GetEnvPublicKey(t *testing.T) {
 	}
 
 	want := &PublicKey{KeyID: String("1234"), Key: String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234")}
-	if !reflect.DeepEqual(key, want) {
+	if !cmp.Equal(key, want) {
 		t.Errorf("Actions.GetEnvPublicKey returned %+v, want %+v", key, want)
 	}
 
@@ -650,7 +651,7 @@ func TestActionsService_GetEnvPublicKeyNumeric(t *testing.T) {
 	}
 
 	want := &PublicKey{KeyID: String("1234"), Key: String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234")}
-	if !reflect.DeepEqual(key, want) {
+	if !cmp.Equal(key, want) {
 		t.Errorf("Actions.GetEnvPublicKey returned %+v, want %+v", key, want)
 	}
 
@@ -693,7 +694,7 @@ func TestActionsService_ListEnvSecrets(t *testing.T) {
 			{Name: "B", CreatedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
 		},
 	}
-	if !reflect.DeepEqual(secrets, want) {
+	if !cmp.Equal(secrets, want) {
 		t.Errorf("Actions.ListEnvSecrets returned %+v, want %+v", secrets, want)
 	}
 
@@ -732,7 +733,7 @@ func TestActionsService_GetEnvSecret(t *testing.T) {
 		CreatedAt: Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
 		UpdatedAt: Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
 	}
-	if !reflect.DeepEqual(secret, want) {
+	if !cmp.Equal(secret, want) {
 		t.Errorf("Actions.GetEnvSecret returned %+v, want %+v", secret, want)
 	}
 

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -10,9 +10,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestActionsService_ListWorkflowJobs(t *testing.T) {
@@ -39,7 +40,7 @@ func TestActionsService_ListWorkflowJobs(t *testing.T) {
 			{ID: Int64(399444497), RunID: Int64(29679449), StartedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, CompletedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
 		},
 	}
-	if !reflect.DeepEqual(jobs, want) {
+	if !cmp.Equal(jobs, want) {
 		t.Errorf("Actions.ListWorkflowJobs returned %+v, want %+v", jobs, want)
 	}
 
@@ -82,7 +83,7 @@ func TestActionsService_ListWorkflowJobs_Filter(t *testing.T) {
 			{ID: Int64(399444497), RunID: Int64(29679449), StartedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, CompletedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
 		},
 	}
-	if !reflect.DeepEqual(jobs, want) {
+	if !cmp.Equal(jobs, want) {
 		t.Errorf("Actions.ListWorkflowJobs returned %+v, want %+v", jobs, want)
 	}
 }
@@ -107,7 +108,7 @@ func TestActionsService_GetWorkflowJobByID(t *testing.T) {
 		StartedAt:   &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
 		CompletedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
 	}
-	if !reflect.DeepEqual(job, want) {
+	if !cmp.Equal(job, want) {
 		t.Errorf("Actions.GetWorkflowJobByID returned %+v, want %+v", job, want)
 	}
 

--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -10,9 +10,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestActionsService_ListWorkflowRunsByID(t *testing.T) {
@@ -39,7 +40,7 @@ func TestActionsService_ListWorkflowRunsByID(t *testing.T) {
 			{ID: Int64(399444497), RunNumber: Int(296), CreatedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
 		},
 	}
-	if !reflect.DeepEqual(runs, want) {
+	if !cmp.Equal(runs, want) {
 		t.Errorf("Actions.ListWorkflowRunsByID returned %+v, want %+v", runs, want)
 	}
 
@@ -82,7 +83,7 @@ func TestActionsService_ListWorkflowRunsFileName(t *testing.T) {
 			{ID: Int64(399444497), RunNumber: Int(296), CreatedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
 		},
 	}
-	if !reflect.DeepEqual(runs, want) {
+	if !cmp.Equal(runs, want) {
 		t.Errorf("Actions.ListWorkflowRunsByFileName returned %+v, want %+v", runs, want)
 	}
 
@@ -123,7 +124,7 @@ func TestActionsService_GetWorkflowRunByID(t *testing.T) {
 		UpdatedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
 	}
 
-	if !reflect.DeepEqual(runs, want) {
+	if !cmp.Equal(runs, want) {
 		t.Errorf("Actions.GetWorkflowRunByID returned %+v, want %+v", runs, want)
 	}
 
@@ -313,7 +314,7 @@ func TestActionService_ListRepositoryWorkflowRuns(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(runs, expected) {
+	if !cmp.Equal(runs, expected) {
 		t.Errorf("Actions.ListRepositoryWorkflowRuns returned %+v, want %+v", runs, expected)
 	}
 
@@ -393,7 +394,7 @@ func TestActionsService_GetWorkflowRunUsageByID(t *testing.T) {
 		RunDurationMS: Int64(500000),
 	}
 
-	if !reflect.DeepEqual(workflowRunUsage, want) {
+	if !cmp.Equal(workflowRunUsage, want) {
 		t.Errorf("Actions.GetWorkflowRunUsageByID returned %+v, want %+v", workflowRunUsage, want)
 	}
 

--- a/github/actions_workflows_test.go
+++ b/github/actions_workflows_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestActionsService_ListWorkflows(t *testing.T) {
@@ -39,7 +40,7 @@ func TestActionsService_ListWorkflows(t *testing.T) {
 			{ID: Int64(72845), CreatedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)}},
 		},
 	}
-	if !reflect.DeepEqual(workflows, want) {
+	if !cmp.Equal(workflows, want) {
 		t.Errorf("Actions.ListWorkflows returned %+v, want %+v", workflows, want)
 	}
 
@@ -78,7 +79,7 @@ func TestActionsService_GetWorkflowByID(t *testing.T) {
 		CreatedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
 		UpdatedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
 	}
-	if !reflect.DeepEqual(workflow, want) {
+	if !cmp.Equal(workflow, want) {
 		t.Errorf("Actions.GetWorkflowByID returned %+v, want %+v", workflow, want)
 	}
 
@@ -117,7 +118,7 @@ func TestActionsService_GetWorkflowByFileName(t *testing.T) {
 		CreatedAt: &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
 		UpdatedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
 	}
-	if !reflect.DeepEqual(workflow, want) {
+	if !cmp.Equal(workflow, want) {
 		t.Errorf("Actions.GetWorkflowByFileName returned %+v, want %+v", workflow, want)
 	}
 
@@ -164,7 +165,7 @@ func TestActionsService_GetWorkflowUsageByID(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(workflowUsage, want) {
+	if !cmp.Equal(workflowUsage, want) {
 		t.Errorf("Actions.GetWorkflowUsageByID returned %+v, want %+v", workflowUsage, want)
 	}
 
@@ -211,7 +212,7 @@ func TestActionsService_GetWorkflowUsageByFileName(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(workflowUsage, want) {
+	if !cmp.Equal(workflowUsage, want) {
 		t.Errorf("Actions.GetWorkflowUsageByFileName returned %+v, want %+v", workflowUsage, want)
 	}
 
@@ -245,7 +246,7 @@ func TestActionsService_CreateWorkflowDispatchEventByID(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, event) {
+		if !cmp.Equal(v, event) {
 			t.Errorf("Request body = %+v, want %+v", v, event)
 		}
 	})
@@ -289,7 +290,7 @@ func TestActionsService_CreateWorkflowDispatchEventByFileName(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, event) {
+		if !cmp.Equal(v, event) {
 			t.Errorf("Request body = %+v, want %+v", v, event)
 		}
 	})

--- a/github/activity_events_test.go
+++ b/github/activity_events_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestActivityService_ListEvents(t *testing.T) {
@@ -34,7 +35,7 @@ func TestActivityService_ListEvents(t *testing.T) {
 	}
 
 	want := []*Event{{ID: String("1")}, {ID: String("2")}}
-	if !reflect.DeepEqual(events, want) {
+	if !cmp.Equal(events, want) {
 		t.Errorf("Activities.ListEvents returned %+v, want %+v", events, want)
 	}
 
@@ -68,7 +69,7 @@ func TestActivityService_ListRepositoryEvents(t *testing.T) {
 	}
 
 	want := []*Event{{ID: String("1")}, {ID: String("2")}}
-	if !reflect.DeepEqual(events, want) {
+	if !cmp.Equal(events, want) {
 		t.Errorf("Activities.ListRepositoryEvents returned %+v, want %+v", events, want)
 	}
 
@@ -116,7 +117,7 @@ func TestActivityService_ListIssueEventsForRepository(t *testing.T) {
 	}
 
 	want := []*IssueEvent{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(events, want) {
+	if !cmp.Equal(events, want) {
 		t.Errorf("Activities.ListIssueEventsForRepository returned %+v, want %+v", events, want)
 	}
 
@@ -164,7 +165,7 @@ func TestActivityService_ListEventsForRepoNetwork(t *testing.T) {
 	}
 
 	want := []*Event{{ID: String("1")}, {ID: String("2")}}
-	if !reflect.DeepEqual(events, want) {
+	if !cmp.Equal(events, want) {
 		t.Errorf("Activities.ListEventsForRepoNetwork returned %+v, want %+v", events, want)
 	}
 
@@ -212,7 +213,7 @@ func TestActivityService_ListEventsForOrganization(t *testing.T) {
 	}
 
 	want := []*Event{{ID: String("1")}, {ID: String("2")}}
-	if !reflect.DeepEqual(events, want) {
+	if !cmp.Equal(events, want) {
 		t.Errorf("Activities.ListEventsForOrganization returned %+v, want %+v", events, want)
 	}
 
@@ -260,7 +261,7 @@ func TestActivityService_ListEventsPerformedByUser_all(t *testing.T) {
 	}
 
 	want := []*Event{{ID: String("1")}, {ID: String("2")}}
-	if !reflect.DeepEqual(events, want) {
+	if !cmp.Equal(events, want) {
 		t.Errorf("Events.ListPerformedByUser returned %+v, want %+v", events, want)
 	}
 
@@ -295,7 +296,7 @@ func TestActivityService_ListEventsPerformedByUser_publicOnly(t *testing.T) {
 	}
 
 	want := []*Event{{ID: String("1")}, {ID: String("2")}}
-	if !reflect.DeepEqual(events, want) {
+	if !cmp.Equal(events, want) {
 		t.Errorf("Events.ListPerformedByUser returned %+v, want %+v", events, want)
 	}
 }
@@ -329,7 +330,7 @@ func TestActivityService_ListEventsReceivedByUser_all(t *testing.T) {
 	}
 
 	want := []*Event{{ID: String("1")}, {ID: String("2")}}
-	if !reflect.DeepEqual(events, want) {
+	if !cmp.Equal(events, want) {
 		t.Errorf("Events.ListReceivedUser returned %+v, want %+v", events, want)
 	}
 
@@ -364,7 +365,7 @@ func TestActivityService_ListEventsReceivedByUser_publicOnly(t *testing.T) {
 	}
 
 	want := []*Event{{ID: String("1")}, {ID: String("2")}}
-	if !reflect.DeepEqual(events, want) {
+	if !cmp.Equal(events, want) {
 		t.Errorf("Events.ListReceivedByUser returned %+v, want %+v", events, want)
 	}
 }
@@ -398,7 +399,7 @@ func TestActivityService_ListUserEventsForOrganization(t *testing.T) {
 	}
 
 	want := []*Event{{ID: String("1")}, {ID: String("2")}}
-	if !reflect.DeepEqual(events, want) {
+	if !cmp.Equal(events, want) {
 		t.Errorf("Activities.ListUserEventsForOrganization returned %+v, want %+v", events, want)
 	}
 
@@ -429,7 +430,7 @@ func TestActivityService_EventParsePayload_typed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParsePayload returned unexpected error: %v", err)
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Event.ParsePayload returned %+v, want %+v", got, want)
 	}
 }
@@ -449,7 +450,7 @@ func TestActivityService_EventParsePayload_untyped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParsePayload returned unexpected error: %v", err)
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Event.ParsePayload returned %+v, want %+v", got, want)
 	}
 }
@@ -466,7 +467,7 @@ func TestActivityService_EventParsePayload_installation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParsePayload returned unexpected error: %v", err)
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Event.ParsePayload returned %+v, want %+v", got, want)
 	}
 }

--- a/github/activity_notifications_test.go
+++ b/github/activity_notifications_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestActivityService_ListNotification(t *testing.T) {
@@ -44,7 +45,7 @@ func TestActivityService_ListNotification(t *testing.T) {
 	}
 
 	want := []*Notification{{ID: String("1"), Subject: &NotificationSubject{Title: String("t")}}}
-	if !reflect.DeepEqual(notifications, want) {
+	if !cmp.Equal(notifications, want) {
 		t.Errorf("Activity.ListNotifications returned %+v, want %+v", notifications, want)
 	}
 
@@ -74,7 +75,7 @@ func TestActivityService_ListRepositoryNotification(t *testing.T) {
 	}
 
 	want := []*Notification{{ID: String("1")}}
-	if !reflect.DeepEqual(notifications, want) {
+	if !cmp.Equal(notifications, want) {
 		t.Errorf("Activity.ListRepositoryNotifications returned %+v, want %+v", notifications, want)
 	}
 
@@ -162,7 +163,7 @@ func TestActivityService_GetThread(t *testing.T) {
 	}
 
 	want := &Notification{ID: String("1")}
-	if !reflect.DeepEqual(notification, want) {
+	if !cmp.Equal(notification, want) {
 		t.Errorf("Activity.GetThread returned %+v, want %+v", notification, want)
 	}
 
@@ -223,7 +224,7 @@ func TestActivityService_GetThreadSubscription(t *testing.T) {
 	}
 
 	want := &Subscription{Subscribed: Bool(true)}
-	if !reflect.DeepEqual(sub, want) {
+	if !cmp.Equal(sub, want) {
 		t.Errorf("Activity.GetThreadSubscription returned %+v, want %+v", sub, want)
 	}
 
@@ -253,7 +254,7 @@ func TestActivityService_SetThreadSubscription(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -267,7 +268,7 @@ func TestActivityService_SetThreadSubscription(t *testing.T) {
 	}
 
 	want := &Subscription{Ignored: Bool(true)}
-	if !reflect.DeepEqual(sub, want) {
+	if !cmp.Equal(sub, want) {
 		t.Errorf("Activity.SetThreadSubscription returned %+v, want %+v", sub, want)
 	}
 

--- a/github/activity_star_test.go
+++ b/github/activity_star_test.go
@@ -9,10 +9,11 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestActivityService_ListStargazers(t *testing.T) {
@@ -36,7 +37,7 @@ func TestActivityService_ListStargazers(t *testing.T) {
 	}
 
 	want := []*Stargazer{{StarredAt: &Timestamp{time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC)}, User: &User{ID: Int64(1)}}}
-	if !reflect.DeepEqual(stargazers, want) {
+	if !cmp.Equal(stargazers, want) {
 		t.Errorf("Activity.ListStargazers returned %+v, want %+v", stargazers, want)
 	}
 
@@ -72,7 +73,7 @@ func TestActivityService_ListStarred_authenticatedUser(t *testing.T) {
 	}
 
 	want := []*StarredRepository{{StarredAt: &Timestamp{time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC)}, Repository: &Repository{ID: Int64(1)}}}
-	if !reflect.DeepEqual(repos, want) {
+	if !cmp.Equal(repos, want) {
 		t.Errorf("Activity.ListStarred returned %+v, want %+v", repos, want)
 	}
 
@@ -114,7 +115,7 @@ func TestActivityService_ListStarred_specifiedUser(t *testing.T) {
 	}
 
 	want := []*StarredRepository{{StarredAt: &Timestamp{time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC)}, Repository: &Repository{ID: Int64(2)}}}
-	if !reflect.DeepEqual(repos, want) {
+	if !cmp.Equal(repos, want) {
 		t.Errorf("Activity.ListStarred returned %+v, want %+v", repos, want)
 	}
 

--- a/github/activity_test.go
+++ b/github/activity_test.go
@@ -8,8 +8,9 @@ package github
 import (
 	"context"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestActivityService_List(t *testing.T) {
@@ -28,7 +29,7 @@ func TestActivityService_List(t *testing.T) {
 	if err != nil {
 		t.Errorf("Activity.ListFeeds returned error: %v", err)
 	}
-	if want := wantFeeds; !reflect.DeepEqual(got, want) {
+	if want := wantFeeds; !cmp.Equal(got, want) {
 		t.Errorf("Activity.ListFeeds = %+v, want %+v", got, want)
 	}
 

--- a/github/activity_watching_test.go
+++ b/github/activity_watching_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestActivityService_ListWatchers(t *testing.T) {
@@ -34,7 +35,7 @@ func TestActivityService_ListWatchers(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(1)}}
-	if !reflect.DeepEqual(watchers, want) {
+	if !cmp.Equal(watchers, want) {
 		t.Errorf("Activity.ListWatchers returned %+v, want %+v", watchers, want)
 	}
 
@@ -72,7 +73,7 @@ func TestActivityService_ListWatched_authenticatedUser(t *testing.T) {
 	}
 
 	want := []*Repository{{ID: Int64(1)}}
-	if !reflect.DeepEqual(watched, want) {
+	if !cmp.Equal(watched, want) {
 		t.Errorf("Activity.ListWatched returned %+v, want %+v", watched, want)
 	}
 
@@ -110,7 +111,7 @@ func TestActivityService_ListWatched_specifiedUser(t *testing.T) {
 	}
 
 	want := []*Repository{{ID: Int64(1)}}
-	if !reflect.DeepEqual(watched, want) {
+	if !cmp.Equal(watched, want) {
 		t.Errorf("Activity.ListWatched returned %+v, want %+v", watched, want)
 	}
 }
@@ -131,7 +132,7 @@ func TestActivityService_GetRepositorySubscription_true(t *testing.T) {
 	}
 
 	want := &Subscription{Subscribed: Bool(true)}
-	if !reflect.DeepEqual(sub, want) {
+	if !cmp.Equal(sub, want) {
 		t.Errorf("Activity.GetRepositorySubscription returned %+v, want %+v", sub, want)
 	}
 
@@ -166,7 +167,7 @@ func TestActivityService_GetRepositorySubscription_false(t *testing.T) {
 	}
 
 	var want *Subscription
-	if !reflect.DeepEqual(sub, want) {
+	if !cmp.Equal(sub, want) {
 		t.Errorf("Activity.GetRepositorySubscription returned %+v, want %+v", sub, want)
 	}
 }
@@ -198,7 +199,7 @@ func TestActivityService_SetRepositorySubscription(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -212,7 +213,7 @@ func TestActivityService_SetRepositorySubscription(t *testing.T) {
 	}
 
 	want := &Subscription{Ignored: Bool(true)}
-	if !reflect.DeepEqual(sub, want) {
+	if !cmp.Equal(sub, want) {
 		t.Errorf("Activity.SetRepositorySubscription returned %+v, want %+v", sub, want)
 	}
 

--- a/github/admin_orgs_test.go
+++ b/github/admin_orgs_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestAdminOrgs_Create(t *testing.T) {
@@ -28,7 +29,7 @@ func TestAdminOrgs_Create(t *testing.T) {
 
 		testMethod(t, r, "POST")
 		want := &createOrgRequest{Login: String("github"), Admin: String("ghAdmin")}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 
@@ -42,7 +43,7 @@ func TestAdminOrgs_Create(t *testing.T) {
 	}
 
 	want := &Organization{ID: Int64(1), Login: String("github")}
-	if !reflect.DeepEqual(org, want) {
+	if !cmp.Equal(org, want) {
 		t.Errorf("Admin.CreateOrg returned %+v, want %+v", org, want)
 	}
 
@@ -70,7 +71,7 @@ func TestAdminOrgs_Rename(t *testing.T) {
 
 		testMethod(t, r, "PATCH")
 		want := &renameOrgRequest{Login: String("the-new-octocats")}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 
@@ -84,7 +85,7 @@ func TestAdminOrgs_Rename(t *testing.T) {
 	}
 
 	want := &RenameOrgResponse{Message: String("Job queued to rename organization. It may take a few minutes to complete."), URL: String("https://<hostname>/api/v3/organizations/1")}
-	if !reflect.DeepEqual(resp, want) {
+	if !cmp.Equal(resp, want) {
 		t.Errorf("Admin.RenameOrg returned %+v, want %+v", resp, want)
 	}
 
@@ -108,7 +109,7 @@ func TestAdminOrgs_RenameByName(t *testing.T) {
 
 		testMethod(t, r, "PATCH")
 		want := &renameOrgRequest{Login: String("the-new-octocats")}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 
@@ -122,7 +123,7 @@ func TestAdminOrgs_RenameByName(t *testing.T) {
 	}
 
 	want := &RenameOrgResponse{Message: String("Job queued to rename organization. It may take a few minutes to complete."), URL: String("https://<hostname>/api/v3/organizations/1")}
-	if !reflect.DeepEqual(resp, want) {
+	if !cmp.Equal(resp, want) {
 		t.Errorf("Admin.RenameOrg returned %+v, want %+v", resp, want)
 	}
 

--- a/github/admin_stats_test.go
+++ b/github/admin_stats_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestAdminService_GetAdminStats(t *testing.T) {
@@ -81,7 +82,7 @@ func TestAdminService_GetAdminStats(t *testing.T) {
 		t.Errorf("AdminService.GetAdminStats returned error: %v", err)
 	}
 
-	if want := testAdminStats; !reflect.DeepEqual(stats, want) {
+	if want := testAdminStats; !cmp.Equal(stats, want) {
 		t.Errorf("AdminService.GetAdminStats returned %+v, want %+v", stats, want)
 	}
 

--- a/github/admin_test.go
+++ b/github/admin_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestAdminService_UpdateUserLDAPMapping(t *testing.T) {
@@ -27,7 +28,7 @@ func TestAdminService_UpdateUserLDAPMapping(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 		fmt.Fprint(w, `{"id":1,"ldap_dn":"uid=asdf,ou=users,dc=github,dc=com"}`)
@@ -43,7 +44,7 @@ func TestAdminService_UpdateUserLDAPMapping(t *testing.T) {
 		ID:     Int64(1),
 		LDAPDN: String("uid=asdf,ou=users,dc=github,dc=com"),
 	}
-	if !reflect.DeepEqual(mapping, want) {
+	if !cmp.Equal(mapping, want) {
 		t.Errorf("Admin.UpdateUserLDAPMapping returned %+v, want %+v", mapping, want)
 	}
 
@@ -75,7 +76,7 @@ func TestAdminService_UpdateTeamLDAPMapping(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 		fmt.Fprint(w, `{"id":1,"ldap_dn":"cn=Enterprise Ops,ou=teams,dc=github,dc=com"}`)
@@ -91,7 +92,7 @@ func TestAdminService_UpdateTeamLDAPMapping(t *testing.T) {
 		ID:     Int64(1),
 		LDAPDN: String("cn=Enterprise Ops,ou=teams,dc=github,dc=com"),
 	}
-	if !reflect.DeepEqual(mapping, want) {
+	if !cmp.Equal(mapping, want) {
 		t.Errorf("Admin.UpdateTeamLDAPMapping returned %+v, want %+v", mapping, want)
 	}
 

--- a/github/admin_users_test.go
+++ b/github/admin_users_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestAdminUsers_Create(t *testing.T) {
@@ -25,7 +26,7 @@ func TestAdminUsers_Create(t *testing.T) {
 
 		testMethod(t, r, "POST")
 		want := &createUserRequest{Login: String("github"), Email: String("email@domain.com")}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 
@@ -39,7 +40,7 @@ func TestAdminUsers_Create(t *testing.T) {
 	}
 
 	want := &User{ID: Int64(1), Login: String("github")}
-	if !reflect.DeepEqual(org, want) {
+	if !cmp.Equal(org, want) {
 		t.Errorf("Admin.CreateUser returned %+v, want %+v", org, want)
 	}
 
@@ -131,7 +132,7 @@ func TestUserImpersonation_Create(t *testing.T) {
 		Scopes:         []string{"repo"},
 		Fingerprint:    nil,
 	}
-	if !reflect.DeepEqual(auth, want) {
+	if !cmp.Equal(auth, want) {
 		t.Errorf("Admin.CreateUserImpersonation returned %+v, want %+v", auth, want)
 	}
 

--- a/github/apps_installation_test.go
+++ b/github/apps_installation_test.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestAppsService_ListRepos(t *testing.T) {
@@ -41,7 +42,7 @@ func TestAppsService_ListRepos(t *testing.T) {
 	}
 
 	want := &ListRepositories{TotalCount: Int(1), Repositories: []*Repository{{ID: Int64(1)}}}
-	if !reflect.DeepEqual(repositories, want) {
+	if !cmp.Equal(repositories, want) {
 		t.Errorf("Apps.ListRepos returned %+v, want %+v", repositories, want)
 	}
 
@@ -82,7 +83,7 @@ func TestAppsService_ListUserRepos(t *testing.T) {
 	}
 
 	want := &ListRepositories{TotalCount: Int(1), Repositories: []*Repository{{ID: Int64(1)}}}
-	if !reflect.DeepEqual(repositories, want) {
+	if !cmp.Equal(repositories, want) {
 		t.Errorf("Apps.ListUserRepos returned %+v, want %+v", repositories, want)
 	}
 
@@ -117,7 +118,7 @@ func TestAppsService_AddRepository(t *testing.T) {
 	}
 
 	want := &Repository{ID: Int64(1), Name: String("n"), Description: String("d"), Owner: &User{Login: String("l")}, License: &License{Key: String("mit")}}
-	if !reflect.DeepEqual(repo, want) {
+	if !cmp.Equal(repo, want) {
 		t.Errorf("AddRepository returned %+v, want %+v", repo, want)
 	}
 

--- a/github/apps_manifest_test.go
+++ b/github/apps_manifest_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 const (
@@ -47,7 +48,7 @@ func TestGetConfig(t *testing.T) {
 		PEM:           String("key"),
 	}
 
-	if !reflect.DeepEqual(cfg, want) {
+	if !cmp.Equal(cfg, want) {
 		t.Errorf("GetConfig returned %+v, want %+v", cfg, want)
 	}
 

--- a/github/apps_marketplace_test.go
+++ b/github/apps_marketplace_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestMarketplaceService_ListPlans(t *testing.T) {
@@ -35,7 +36,7 @@ func TestMarketplaceService_ListPlans(t *testing.T) {
 	}
 
 	want := []*MarketplacePlan{{ID: Int64(1)}}
-	if !reflect.DeepEqual(plans, want) {
+	if !cmp.Equal(plans, want) {
 		t.Errorf("Marketplace.ListPlans returned %+v, want %+v", plans, want)
 	}
 
@@ -67,7 +68,7 @@ func TestMarketplaceService_Stubbed_ListPlans(t *testing.T) {
 	}
 
 	want := []*MarketplacePlan{{ID: Int64(1)}}
-	if !reflect.DeepEqual(plans, want) {
+	if !cmp.Equal(plans, want) {
 		t.Errorf("Marketplace.ListPlans (Stubbed) returned %+v, want %+v", plans, want)
 	}
 }
@@ -90,7 +91,7 @@ func TestMarketplaceService_ListPlanAccountsForPlan(t *testing.T) {
 	}
 
 	want := []*MarketplacePlanAccount{{ID: Int64(1)}}
-	if !reflect.DeepEqual(accounts, want) {
+	if !cmp.Equal(accounts, want) {
 		t.Errorf("Marketplace.ListPlanAccountsForPlan returned %+v, want %+v", accounts, want)
 	}
 
@@ -122,7 +123,7 @@ func TestMarketplaceService_Stubbed_ListPlanAccountsForPlan(t *testing.T) {
 	}
 
 	want := []*MarketplacePlanAccount{{ID: Int64(1)}}
-	if !reflect.DeepEqual(accounts, want) {
+	if !cmp.Equal(accounts, want) {
 		t.Errorf("Marketplace.ListPlanAccountsForPlan (Stubbed) returned %+v, want %+v", accounts, want)
 	}
 }
@@ -144,7 +145,7 @@ func TestMarketplaceService_GetPlanAccountForAccount(t *testing.T) {
 	}
 
 	want := &MarketplacePlanAccount{ID: Int64(1), MarketplacePendingChange: &MarketplacePendingChange{ID: Int64(77)}}
-	if !reflect.DeepEqual(account, want) {
+	if !cmp.Equal(account, want) {
 		t.Errorf("Marketplace.GetPlanAccountForAccount returned %+v, want %+v", account, want)
 	}
 
@@ -175,7 +176,7 @@ func TestMarketplaceService_Stubbed_GetPlanAccountForAccount(t *testing.T) {
 	}
 
 	want := &MarketplacePlanAccount{ID: Int64(1)}
-	if !reflect.DeepEqual(account, want) {
+	if !cmp.Equal(account, want) {
 		t.Errorf("Marketplace.GetPlanAccountForAccount (Stubbed) returned %+v, want %+v", account, want)
 	}
 }
@@ -198,7 +199,7 @@ func TestMarketplaceService_ListMarketplacePurchasesForUser(t *testing.T) {
 	}
 
 	want := []*MarketplacePurchase{{BillingCycle: String("monthly")}}
-	if !reflect.DeepEqual(purchases, want) {
+	if !cmp.Equal(purchases, want) {
 		t.Errorf("Marketplace.ListMarketplacePurchasesForUser returned %+v, want %+v", purchases, want)
 	}
 
@@ -230,7 +231,7 @@ func TestMarketplaceService_Stubbed_ListMarketplacePurchasesForUser(t *testing.T
 	}
 
 	want := []*MarketplacePurchase{{BillingCycle: String("monthly")}}
-	if !reflect.DeepEqual(purchases, want) {
+	if !cmp.Equal(purchases, want) {
 		t.Errorf("Marketplace.ListMarketplacePurchasesForUser returned %+v, want %+v", purchases, want)
 	}
 }

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -13,9 +13,10 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestAppsService_Get_authenticatedApp(t *testing.T) {
@@ -34,7 +35,7 @@ func TestAppsService_Get_authenticatedApp(t *testing.T) {
 	}
 
 	want := &App{ID: Int64(1)}
-	if !reflect.DeepEqual(app, want) {
+	if !cmp.Equal(app, want) {
 		t.Errorf("Apps.Get returned %+v, want %+v", app, want)
 	}
 
@@ -69,7 +70,7 @@ func TestAppsService_Get_specifiedApp(t *testing.T) {
 	}
 
 	want := &App{HTMLURL: String("https://github.com/apps/a")}
-	if !reflect.DeepEqual(app, want) {
+	if !cmp.Equal(app, want) {
 		t.Errorf("Apps.Get returned %+v, want %+v", *app.HTMLURL, *want.HTMLURL)
 	}
 }
@@ -172,7 +173,7 @@ func TestAppsService_ListInstallations(t *testing.T) {
 		CreatedAt: &date,
 		UpdatedAt: &date,
 	}}
-	if !reflect.DeepEqual(installations, want) {
+	if !cmp.Equal(installations, want) {
 		t.Errorf("Apps.ListInstallations returned %+v, want %+v", installations, want)
 	}
 
@@ -202,7 +203,7 @@ func TestAppsService_GetInstallation(t *testing.T) {
 	}
 
 	want := &Installation{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1), TargetType: String("Organization")}
-	if !reflect.DeepEqual(installation, want) {
+	if !cmp.Equal(installation, want) {
 		t.Errorf("Apps.GetInstallation returned %+v, want %+v", installation, want)
 	}
 
@@ -242,7 +243,7 @@ func TestAppsService_ListUserInstallations(t *testing.T) {
 	}
 
 	want := []*Installation{{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1), TargetType: String("Organization")}}
-	if !reflect.DeepEqual(installations, want) {
+	if !cmp.Equal(installations, want) {
 		t.Errorf("Apps.ListUserInstallations returned %+v, want %+v", installations, want)
 	}
 
@@ -350,7 +351,7 @@ func TestAppsService_CreateInstallationToken(t *testing.T) {
 	}
 
 	want := &InstallationToken{Token: String("t")}
-	if !reflect.DeepEqual(token, want) {
+	if !cmp.Equal(token, want) {
 		t.Errorf("Apps.CreateInstallationToken returned %+v, want %+v", token, want)
 	}
 
@@ -396,7 +397,7 @@ func TestAppsService_CreateInstallationTokenWithOptions(t *testing.T) {
 		}
 		r.Body = ioutil.NopCloser(bytes.NewBuffer(gotBodyBytes))
 
-		if !reflect.DeepEqual(r.Body, wantBody) {
+		if !cmp.Equal(r.Body, wantBody, cmp.AllowUnexported(bytes.Buffer{})) {
 			t.Errorf("request sent %+v, want %+v", r.Body, wantBody)
 		}
 
@@ -411,7 +412,7 @@ func TestAppsService_CreateInstallationTokenWithOptions(t *testing.T) {
 	}
 
 	want := &InstallationToken{Token: String("t")}
-	if !reflect.DeepEqual(token, want) {
+	if !cmp.Equal(token, want) {
 		t.Errorf("Apps.CreateInstallationToken returned %+v, want %+v", token, want)
 	}
 }
@@ -435,7 +436,7 @@ func TestAppsService_CreateAttachement(t *testing.T) {
 	}
 
 	want := &Attachment{ID: Int64(1), Title: String("title1"), Body: String("body1")}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("CreateAttachment = %+v, want %+v", got, want)
 	}
 
@@ -470,7 +471,7 @@ func TestAppsService_FindOrganizationInstallation(t *testing.T) {
 	}
 
 	want := &Installation{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1), TargetType: String("Organization")}
-	if !reflect.DeepEqual(installation, want) {
+	if !cmp.Equal(installation, want) {
 		t.Errorf("Apps.FindOrganizationInstallation returned %+v, want %+v", installation, want)
 	}
 
@@ -505,7 +506,7 @@ func TestAppsService_FindRepositoryInstallation(t *testing.T) {
 	}
 
 	want := &Installation{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1), TargetType: String("Organization")}
-	if !reflect.DeepEqual(installation, want) {
+	if !cmp.Equal(installation, want) {
 		t.Errorf("Apps.FindRepositoryInstallation returned %+v, want %+v", installation, want)
 	}
 
@@ -540,7 +541,7 @@ func TestAppsService_FindRepositoryInstallationByID(t *testing.T) {
 	}
 
 	want := &Installation{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1), TargetType: String("Organization")}
-	if !reflect.DeepEqual(installation, want) {
+	if !cmp.Equal(installation, want) {
 		t.Errorf("Apps.FindRepositoryInstallationByID returned %+v, want %+v", installation, want)
 	}
 
@@ -575,7 +576,7 @@ func TestAppsService_FindUserInstallation(t *testing.T) {
 	}
 
 	want := &Installation{ID: Int64(1), AppID: Int64(1), TargetID: Int64(1), TargetType: String("User")}
-	if !reflect.DeepEqual(installation, want) {
+	if !cmp.Equal(installation, want) {
 		t.Errorf("Apps.FindUserInstallation returned %+v, want %+v", installation, want)
 	}
 

--- a/github/authorizations_test.go
+++ b/github/authorizations_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestAuthorizationsService_Check(t *testing.T) {
@@ -31,7 +32,7 @@ func TestAuthorizationsService_Check(t *testing.T) {
 	}
 
 	want := &Authorization{ID: Int64(1)}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Authorizations.Check returned auth %+v, want %+v", got, want)
 	}
 
@@ -68,7 +69,7 @@ func TestAuthorizationsService_Reset(t *testing.T) {
 	}
 
 	want := &Authorization{ID: Int64(1)}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Authorizations.Reset returned auth %+v, want %+v", got, want)
 	}
 
@@ -159,7 +160,7 @@ func TestAuthorizationsService_CreateImpersonation(t *testing.T) {
 	}
 
 	want := &Authorization{ID: Int64(1)}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Authorizations.CreateImpersonation returned %+v, want %+v", *got.ID, *want.ID)
 	}
 

--- a/github/billing_test.go
+++ b/github/billing_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestBillingService_GetActionsBillingOrg(t *testing.T) {
@@ -47,7 +48,7 @@ func TestBillingService_GetActionsBillingOrg(t *testing.T) {
 			Windows: 90,
 		},
 	}
-	if !reflect.DeepEqual(hook, want) {
+	if !cmp.Equal(hook, want) {
 		t.Errorf("Billing.GetActionsBillingOrg returned %+v, want %+v", hook, want)
 	}
 
@@ -91,7 +92,7 @@ func TestBillingService_GetPackagesBillingOrg(t *testing.T) {
 		TotalPaidGigabytesBandwidthUsed: 40,
 		IncludedGigabytesBandwidth:      10,
 	}
-	if !reflect.DeepEqual(hook, want) {
+	if !cmp.Equal(hook, want) {
 		t.Errorf("Billing.GetPackagesBillingOrg returned %+v, want %+v", hook, want)
 	}
 
@@ -135,7 +136,7 @@ func TestBillingService_GetStorageBillingOrg(t *testing.T) {
 		EstimatedPaidStorageForMonth: 15,
 		EstimatedStorageForMonth:     40,
 	}
-	if !reflect.DeepEqual(hook, want) {
+	if !cmp.Equal(hook, want) {
 		t.Errorf("Billing.GetStorageBillingOrg returned %+v, want %+v", hook, want)
 	}
 
@@ -189,7 +190,7 @@ func TestBillingService_GetActionsBillingUser(t *testing.T) {
 			Windows: 90,
 		},
 	}
-	if !reflect.DeepEqual(hook, want) {
+	if !cmp.Equal(hook, want) {
 		t.Errorf("Billing.GetActionsBillingUser returned %+v, want %+v", hook, want)
 	}
 
@@ -233,7 +234,7 @@ func TestBillingService_GetPackagesBillingUser(t *testing.T) {
 		TotalPaidGigabytesBandwidthUsed: 40,
 		IncludedGigabytesBandwidth:      10,
 	}
-	if !reflect.DeepEqual(hook, want) {
+	if !cmp.Equal(hook, want) {
 		t.Errorf("Billing.GetPackagesBillingUser returned %+v, want %+v", hook, want)
 	}
 
@@ -277,7 +278,7 @@ func TestBillingService_GetStorageBillingUser(t *testing.T) {
 		EstimatedPaidStorageForMonth: 15,
 		EstimatedStorageForMonth:     40,
 	}
-	if !reflect.DeepEqual(hook, want) {
+	if !cmp.Equal(hook, want) {
 		t.Errorf("Billing.GetStorageBillingUser returned %+v, want %+v", hook, want)
 	}
 

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestChecksService_GetCheckRun(t *testing.T) {
@@ -45,7 +46,7 @@ func TestChecksService_GetCheckRun(t *testing.T) {
 		CompletedAt: &Timestamp{completeAt},
 		Name:        String("testCheckRun"),
 	}
-	if !reflect.DeepEqual(checkRun, want) {
+	if !cmp.Equal(checkRun, want) {
 		t.Errorf("Checks.GetCheckRun return %+v, want %+v", checkRun, want)
 	}
 
@@ -94,7 +95,7 @@ func TestChecksService_GetCheckSuite(t *testing.T) {
 		Status:     String("completed"),
 		Conclusion: String("neutral"),
 	}
-	if !reflect.DeepEqual(checkSuite, want) {
+	if !cmp.Equal(checkSuite, want) {
 		t.Errorf("Checks.GetCheckSuite return %+v, want %+v", checkSuite, want)
 	}
 
@@ -161,7 +162,7 @@ func TestChecksService_CreateCheckRun(t *testing.T) {
 			Text:    String(""),
 		},
 	}
-	if !reflect.DeepEqual(checkRun, want) {
+	if !cmp.Equal(checkRun, want) {
 		t.Errorf("Checks.CreateCheckRun return %+v, want %+v", checkRun, want)
 	}
 
@@ -221,7 +222,7 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 		RawDetails:      String("Do you mean 'bananas' or 'banana'?"),
 	}}
 
-	if !reflect.DeepEqual(checkRunAnnotations, want) {
+	if !cmp.Equal(checkRunAnnotations, want) {
 		t.Errorf("Checks.ListCheckRunAnnotations returned %+v, want %+v", checkRunAnnotations, want)
 	}
 
@@ -287,7 +288,7 @@ func TestChecksService_UpdateCheckRun(t *testing.T) {
 			Text:    String("You may have misspelled some words."),
 		},
 	}
-	if !reflect.DeepEqual(checkRun, want) {
+	if !cmp.Equal(checkRun, want) {
 		t.Errorf("Checks.UpdateCheckRun return %+v, want %+v", checkRun, want)
 	}
 
@@ -354,7 +355,7 @@ func TestChecksService_ListCheckRunsForRef(t *testing.T) {
 		}},
 	}
 
-	if !reflect.DeepEqual(checkRuns, want) {
+	if !cmp.Equal(checkRuns, want) {
 		t.Errorf("Checks.ListCheckRunsForRef returned %+v, want %+v", checkRuns, want)
 	}
 
@@ -421,7 +422,7 @@ func TestChecksService_ListCheckRunsCheckSuite(t *testing.T) {
 		}},
 	}
 
-	if !reflect.DeepEqual(checkRuns, want) {
+	if !cmp.Equal(checkRuns, want) {
 		t.Errorf("Checks.ListCheckRunsCheckSuite returned %+v, want %+v", checkRuns, want)
 	}
 
@@ -487,7 +488,7 @@ func TestChecksService_ListCheckSuiteForRef(t *testing.T) {
 		}},
 	}
 
-	if !reflect.DeepEqual(checkSuites, want) {
+	if !cmp.Equal(checkSuites, want) {
 		t.Errorf("Checks.ListCheckSuitesForRef returned %+v, want %+v", checkSuites, want)
 	}
 
@@ -534,7 +535,7 @@ func TestChecksService_SetCheckSuitePreferences(t *testing.T) {
 		Preferences: p,
 	}
 
-	if !reflect.DeepEqual(prefResults, want) {
+	if !cmp.Equal(prefResults, want) {
 		t.Errorf("Checks.SetCheckSuitePreferences return %+v, want %+v", prefResults, want)
 	}
 
@@ -590,7 +591,7 @@ func TestChecksService_CreateCheckSuite(t *testing.T) {
 		BeforeSHA:  String("deadbeefb"),
 		AfterSHA:   String("deadbeefa"),
 	}
-	if !reflect.DeepEqual(checkSuite, want) {
+	if !cmp.Equal(checkSuite, want) {
 		t.Errorf("Checks.CreateCheckSuite return %+v, want %+v", checkSuite, want)
 	}
 

--- a/github/code-scanning_test.go
+++ b/github/code-scanning_test.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestActionsService_Alert_ID(t *testing.T) {
@@ -29,7 +30,7 @@ func TestActionsService_Alert_ID(t *testing.T) {
 	}
 	id = a.ID()
 	want = 88
-	if !reflect.DeepEqual(id, want) {
+	if !cmp.Equal(id, want) {
 		t.Errorf("Alert.ID error returned %+v, want %+v", id, want)
 	}
 
@@ -37,7 +38,7 @@ func TestActionsService_Alert_ID(t *testing.T) {
 	a = &Alert{}
 	id = a.ID()
 	want = 0
-	if !reflect.DeepEqual(id, want) {
+	if !cmp.Equal(id, want) {
 		t.Errorf("Alert.ID error returned %+v, want %+v", id, want)
 	}
 
@@ -47,7 +48,7 @@ func TestActionsService_Alert_ID(t *testing.T) {
 	}
 	id = a.ID()
 	want = 0
-	if !reflect.DeepEqual(id, want) {
+	if !cmp.Equal(id, want) {
 		t.Errorf("Alert.ID error returned %+v, want %+v", id, want)
 	}
 }
@@ -119,7 +120,7 @@ func TestActionsService_ListAlertsForRepo(t *testing.T) {
 			HTMLURL:         String("https://github.com/o/r/security/code-scanning/88"),
 		},
 	}
-	if !reflect.DeepEqual(alerts, want) {
+	if !cmp.Equal(alerts, want) {
 		t.Errorf("CodeScanning.ListAlertsForRepo returned %+v, want %+v", alerts, want)
 	}
 
@@ -175,7 +176,7 @@ func TestActionsService_GetAlert(t *testing.T) {
 		URL:             String("https://api.github.com/repos/o/r/code-scanning/alerts/88"),
 		HTMLURL:         String("https://github.com/o/r/security/code-scanning/88"),
 	}
-	if !reflect.DeepEqual(alert, want) {
+	if !cmp.Equal(alert, want) {
 		t.Errorf("CodeScanning.GetAlert returned %+v, want %+v", alert, want)
 	}
 

--- a/github/enterprise_actions_runners_test.go
+++ b/github/enterprise_actions_runners_test.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestEnterpriseService_CreateRegistrationToken(t *testing.T) {
@@ -32,7 +33,7 @@ func TestEnterpriseService_CreateRegistrationToken(t *testing.T) {
 	want := &RegistrationToken{Token: String("LLBF3JGZDX3P5PMEXLND6TS6FCWO6"),
 		ExpiresAt: &Timestamp{time.Date(2020, time.January, 22, 12, 13, 35,
 			123000000, time.UTC)}}
-	if !reflect.DeepEqual(token, want) {
+	if !cmp.Equal(token, want) {
 		t.Errorf("Enterprise.CreateRegistrationToken returned %+v, want %+v", token, want)
 	}
 
@@ -75,7 +76,7 @@ func TestEnterpriseService_ListRunners(t *testing.T) {
 			{ID: Int64(24), Name: String("iMac"), OS: String("macos"), Status: String("offline")},
 		},
 	}
-	if !reflect.DeepEqual(runners, want) {
+	if !cmp.Equal(runners, want) {
 		t.Errorf("Actions.ListRunners returned %+v, want %+v", runners, want)
 	}
 

--- a/github/enterprise_audit_log_test.go
+++ b/github/enterprise_audit_log_test.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestEnterpriseService_GetAuditLog(t *testing.T) {
@@ -78,7 +79,7 @@ func TestEnterpriseService_GetAuditLog(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(auditEntries, want) {
+	if !cmp.Equal(auditEntries, want) {
 		t.Errorf("Enterprise.GetAuditLog return \ngot: %+v,\nwant:%+v", auditEntries, want)
 	}
 

--- a/github/gists_comments_test.go
+++ b/github/gists_comments_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestGistComments_marshall(t *testing.T) {
@@ -88,7 +89,7 @@ func TestGistsService_ListComments(t *testing.T) {
 	}
 
 	want := []*GistComment{{ID: Int64(1)}}
-	if !reflect.DeepEqual(comments, want) {
+	if !cmp.Equal(comments, want) {
 		t.Errorf("Gists.ListComments returned %+v, want %+v", comments, want)
 	}
 
@@ -132,7 +133,7 @@ func TestGistsService_GetComment(t *testing.T) {
 	}
 
 	want := &GistComment{ID: Int64(1)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("Gists.GetComment returned %+v, want %+v", comment, want)
 	}
 
@@ -171,7 +172,7 @@ func TestGistsService_CreateComment(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -185,7 +186,7 @@ func TestGistsService_CreateComment(t *testing.T) {
 	}
 
 	want := &GistComment{ID: Int64(1)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("Gists.CreateComment returned %+v, want %+v", comment, want)
 	}
 
@@ -224,7 +225,7 @@ func TestGistsService_EditComment(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -238,7 +239,7 @@ func TestGistsService_EditComment(t *testing.T) {
 	}
 
 	want := &GistComment{ID: Int64(1)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("Gists.EditComment returned %+v, want %+v", comment, want)
 	}
 

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestGist_marshall(t *testing.T) {
@@ -246,7 +247,7 @@ func TestGistsService_List_specifiedUser(t *testing.T) {
 	}
 
 	want := []*Gist{{ID: String("1")}}
-	if !reflect.DeepEqual(gists, want) {
+	if !cmp.Equal(gists, want) {
 		t.Errorf("Gists.List returned %+v, want %+v", gists, want)
 	}
 
@@ -281,7 +282,7 @@ func TestGistsService_List_authenticatedUser(t *testing.T) {
 	}
 
 	want := []*Gist{{ID: String("1")}}
-	if !reflect.DeepEqual(gists, want) {
+	if !cmp.Equal(gists, want) {
 		t.Errorf("Gists.List returned %+v, want %+v", gists, want)
 	}
 
@@ -331,7 +332,7 @@ func TestGistsService_ListAll(t *testing.T) {
 	}
 
 	want := []*Gist{{ID: String("1")}}
-	if !reflect.DeepEqual(gists, want) {
+	if !cmp.Equal(gists, want) {
 		t.Errorf("Gists.ListAll returned %+v, want %+v", gists, want)
 	}
 
@@ -367,7 +368,7 @@ func TestGistsService_ListStarred(t *testing.T) {
 	}
 
 	want := []*Gist{{ID: String("1")}}
-	if !reflect.DeepEqual(gists, want) {
+	if !cmp.Equal(gists, want) {
 		t.Errorf("Gists.ListStarred returned %+v, want %+v", gists, want)
 	}
 
@@ -397,7 +398,7 @@ func TestGistsService_Get(t *testing.T) {
 	}
 
 	want := &Gist{ID: String("1")}
-	if !reflect.DeepEqual(gist, want) {
+	if !cmp.Equal(gist, want) {
 		t.Errorf("Gists.Get returned %+v, want %+v", gist, want)
 	}
 
@@ -441,7 +442,7 @@ func TestGistsService_GetRevision(t *testing.T) {
 	}
 
 	want := &Gist{ID: String("1")}
-	if !reflect.DeepEqual(gist, want) {
+	if !cmp.Equal(gist, want) {
 		t.Errorf("Gists.Get returned %+v, want %+v", gist, want)
 	}
 
@@ -486,7 +487,7 @@ func TestGistsService_Create(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -518,7 +519,7 @@ func TestGistsService_Create(t *testing.T) {
 			"test.txt": {Filename: String("test.txt")},
 		},
 	}
-	if !reflect.DeepEqual(gist, want) {
+	if !cmp.Equal(gist, want) {
 		t.Errorf("Gists.Create returned %+v, want %+v", gist, want)
 	}
 
@@ -548,7 +549,7 @@ func TestGistsService_Edit(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -584,7 +585,7 @@ func TestGistsService_Edit(t *testing.T) {
 			"new.txt":  {Filename: String("new.txt")},
 		},
 	}
-	if !reflect.DeepEqual(gist, want) {
+	if !cmp.Equal(gist, want) {
 		t.Errorf("Gists.Edit returned %+v, want %+v", gist, want)
 	}
 
@@ -655,7 +656,7 @@ func TestGistsService_ListCommits(t *testing.T) {
 			Total:     Int(180),
 		}}}
 
-	if !reflect.DeepEqual(gistCommits, want) {
+	if !cmp.Equal(gistCommits, want) {
 		t.Errorf("Gists.ListCommits returned %+v, want %+v", gistCommits, want)
 	}
 
@@ -909,7 +910,7 @@ func TestGistsService_Fork(t *testing.T) {
 	}
 
 	want := &Gist{ID: String("2")}
-	if !reflect.DeepEqual(gist, want) {
+	if !cmp.Equal(gist, want) {
 		t.Errorf("Gists.Fork returned %+v, want %+v", gist, want)
 	}
 
@@ -960,7 +961,7 @@ func TestGistsService_ListForks(t *testing.T) {
 		CreatedAt: &Timestamp{time.Date(2010, time.January, 1, 00, 00, 00, 0, time.UTC)},
 		UpdatedAt: &Timestamp{time.Date(2013, time.January, 1, 00, 00, 00, 0, time.UTC)}}}
 
-	if !reflect.DeepEqual(gistForks, want) {
+	if !cmp.Equal(gistForks, want) {
 		t.Errorf("Gists.ListForks returned %+v, want %+v", gistForks, want)
 	}
 
@@ -998,7 +999,7 @@ func TestGistsService_ListForks_withOptions(t *testing.T) {
 	}
 
 	want := []*GistFork{}
-	if !reflect.DeepEqual(gistForks, want) {
+	if !cmp.Equal(gistForks, want) {
 		t.Errorf("Gists.ListForks returned %+v, want %+v", gistForks, want)
 	}
 

--- a/github/git_blobs_test.go
+++ b/github/git_blobs_test.go
@@ -11,8 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestGitService_GetBlob(t *testing.T) {
@@ -39,7 +40,7 @@ func TestGitService_GetBlob(t *testing.T) {
 		Content: String("blob content"),
 	}
 
-	if !reflect.DeepEqual(*blob, want) {
+	if !cmp.Equal(*blob, want) {
 		t.Errorf("Blob.Get returned %+v, want %+v", *blob, want)
 	}
 
@@ -114,7 +115,7 @@ func TestGitService_CreateBlob(t *testing.T) {
 		testMethod(t, r, "POST")
 
 		want := input
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Git.CreateBlob request body: %+v, want %+v", v, want)
 		}
 
@@ -134,7 +135,7 @@ func TestGitService_CreateBlob(t *testing.T) {
 
 	want := input
 
-	if !reflect.DeepEqual(*blob, *want) {
+	if !cmp.Equal(*blob, *want) {
 		t.Errorf("Git.CreateBlob returned %+v, want %+v", *blob, *want)
 	}
 

--- a/github/git_commits_test.go
+++ b/github/git_commits_test.go
@@ -10,11 +10,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/crypto/openpgp"
 )
 
@@ -134,7 +134,7 @@ func TestGitService_GetCommit(t *testing.T) {
 	}
 
 	want := &Commit{SHA: String("s"), Message: String("Commit Message."), Author: &CommitAuthor{Name: String("n")}}
-	if !reflect.DeepEqual(commit, want) {
+	if !cmp.Equal(commit, want) {
 		t.Errorf("Git.GetCommit returned %+v, want %+v", commit, want)
 	}
 
@@ -183,7 +183,7 @@ func TestGitService_CreateCommit(t *testing.T) {
 			Tree:    String("t"),
 			Parents: []string{"p"},
 		}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 		fmt.Fprint(w, `{"sha":"s"}`)
@@ -196,7 +196,7 @@ func TestGitService_CreateCommit(t *testing.T) {
 	}
 
 	want := &Commit{SHA: String("s")}
-	if !reflect.DeepEqual(commit, want) {
+	if !cmp.Equal(commit, want) {
 		t.Errorf("Git.CreateCommit returned %+v, want %+v", commit, want)
 	}
 
@@ -242,7 +242,7 @@ func TestGitService_CreateSignedCommit(t *testing.T) {
 			Parents:   []string{"p"},
 			Signature: String(signature),
 		}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 		fmt.Fprint(w, `{"sha":"commitSha"}`)
@@ -255,7 +255,7 @@ func TestGitService_CreateSignedCommit(t *testing.T) {
 	}
 
 	want := &Commit{SHA: String("commitSha")}
-	if !reflect.DeepEqual(commit, want) {
+	if !cmp.Equal(commit, want) {
 		t.Errorf("Git.CreateCommit returned %+v, want %+v", commit, want)
 	}
 
@@ -342,7 +342,7 @@ Commit Message.`)
 		}
 		// Nullify Signature since we checked it above
 		v.Signature = nil
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 		fmt.Fprint(w, `{"sha":"commitSha"}`)
@@ -355,7 +355,7 @@ Commit Message.`)
 	}
 
 	want := &Commit{SHA: String("commitSha")}
-	if !reflect.DeepEqual(commit, want) {
+	if !cmp.Equal(commit, want) {
 		t.Errorf("Git.CreateCommit returned %+v, want %+v", commit, want)
 	}
 }

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestGitService_GetRef_singleRef(t *testing.T) {
@@ -48,7 +49,7 @@ func TestGitService_GetRef_singleRef(t *testing.T) {
 			URL:  String("https://api.github.com/repos/o/r/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"),
 		},
 	}
-	if !reflect.DeepEqual(ref, want) {
+	if !cmp.Equal(ref, want) {
 		t.Errorf("Git.GetRef returned %+v, want %+v", ref, want)
 	}
 
@@ -145,7 +146,7 @@ func TestGitService_ListMatchingRefs_singleRef(t *testing.T) {
 			URL:  String("https://api.github.com/repos/o/r/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"),
 		},
 	}
-	if !reflect.DeepEqual(ref, want) {
+	if !cmp.Equal(ref, want) {
 		t.Errorf("Git.ListMatchingRefs returned %+v, want %+v", ref, want)
 	}
 
@@ -216,7 +217,7 @@ func TestGitService_ListMatchingRefs_multipleRefs(t *testing.T) {
 			URL:  String("https://api.github.com/repos/o/r/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"),
 		},
 	}
-	if !reflect.DeepEqual(refs[0], want) {
+	if !cmp.Equal(refs[0], want) {
 		t.Errorf("Git.ListMatchingRefs returned %+v, want %+v", refs[0], want)
 	}
 
@@ -325,7 +326,7 @@ func TestGitService_ListMatchingRefs_allRefs(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(refs, want) {
+	if !cmp.Equal(refs, want) {
 		t.Errorf("Git.ListMatchingRefs returned %+v, want %+v", refs, want)
 	}
 
@@ -362,7 +363,7 @@ func TestGitService_ListMatchingRefs_options(t *testing.T) {
 	}
 
 	want := []*Reference{{Ref: String("r")}}
-	if !reflect.DeepEqual(refs, want) {
+	if !cmp.Equal(refs, want) {
 		t.Errorf("Git.ListMatchingRefs returned %+v, want %+v", refs, want)
 	}
 
@@ -395,7 +396,7 @@ func TestGitService_CreateRef(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, args) {
+		if !cmp.Equal(v, args) {
 			t.Errorf("Request body = %+v, want %+v", v, args)
 		}
 		fmt.Fprint(w, `
@@ -430,7 +431,7 @@ func TestGitService_CreateRef(t *testing.T) {
 			URL:  String("https://api.github.com/repos/o/r/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"),
 		},
 	}
-	if !reflect.DeepEqual(ref, want) {
+	if !cmp.Equal(ref, want) {
 		t.Errorf("Git.CreateRef returned %+v, want %+v", ref, want)
 	}
 
@@ -484,7 +485,7 @@ func TestGitService_UpdateRef(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, args) {
+		if !cmp.Equal(v, args) {
 			t.Errorf("Request body = %+v, want %+v", v, args)
 		}
 		fmt.Fprint(w, `
@@ -517,7 +518,7 @@ func TestGitService_UpdateRef(t *testing.T) {
 			URL:  String("https://api.github.com/repos/o/r/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"),
 		},
 	}
-	if !reflect.DeepEqual(ref, want) {
+	if !cmp.Equal(ref, want) {
 		t.Errorf("Git.UpdateRef returned %+v, want %+v", ref, want)
 	}
 

--- a/github/git_tags_test.go
+++ b/github/git_tags_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestGitService_GetTag(t *testing.T) {
@@ -30,7 +31,7 @@ func TestGitService_GetTag(t *testing.T) {
 	}
 
 	want := &Tag{Tag: String("t")}
-	if !reflect.DeepEqual(tag, want) {
+	if !cmp.Equal(tag, want) {
 		t.Errorf("Git.GetTag returned %+v, want %+v", tag, want)
 	}
 
@@ -52,7 +53,7 @@ func TestGitService_CreateTag(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -69,7 +70,7 @@ func TestGitService_CreateTag(t *testing.T) {
 	}
 
 	want := &Tag{Tag: String("t")}
-	if !reflect.DeepEqual(tag, want) {
+	if !cmp.Equal(tag, want) {
 		t.Errorf("Git.GetTag returned %+v, want %+v", tag, want)
 	}
 

--- a/github/git_trees_test.go
+++ b/github/git_trees_test.go
@@ -11,8 +11,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestMarshalJSON_withNilContentAndSHA(t *testing.T) {
@@ -63,7 +64,7 @@ func TestGitService_GetTree(t *testing.T) {
 		},
 		Truncated: Bool(true),
 	}
-	if !reflect.DeepEqual(*tree, want) {
+	if !cmp.Equal(*tree, want) {
 		t.Errorf("Tree.Get returned %+v, want %+v", *tree, want)
 	}
 
@@ -151,7 +152,7 @@ func TestGitService_CreateTree(t *testing.T) {
 		nil,
 	}
 
-	if !reflect.DeepEqual(*tree, want) {
+	if !cmp.Equal(*tree, want) {
 		t.Errorf("Git.CreateTree returned %+v, want %+v", *tree, want)
 	}
 
@@ -232,7 +233,7 @@ func TestGitService_CreateTree_Content(t *testing.T) {
 		nil,
 	}
 
-	if !reflect.DeepEqual(*tree, want) {
+	if !cmp.Equal(*tree, want) {
 		t.Errorf("Git.CreateTree returned %+v, want %+v", *tree, want)
 	}
 
@@ -312,7 +313,7 @@ func TestGitService_CreateTree_Delete(t *testing.T) {
 		nil,
 	}
 
-	if !reflect.DeepEqual(*tree, want) {
+	if !cmp.Equal(*tree, want) {
 		t.Errorf("Git.CreateTree returned %+v, want %+v", *tree, want)
 	}
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 const (
@@ -107,7 +109,7 @@ func testFormValues(t *testing.T, r *http.Request, values values) {
 	}
 
 	r.ParseForm()
-	if got := r.Form; !reflect.DeepEqual(got, want) {
+	if got := r.Form; !cmp.Equal(got, want) {
 		t.Errorf("Request parameters: %v, want %v", got, want)
 	}
 }
@@ -693,7 +695,7 @@ func TestDo(t *testing.T) {
 	client.Do(ctx, req, body)
 
 	want := &foo{"a"}
-	if !reflect.DeepEqual(body, want) {
+	if !cmp.Equal(body, want) {
 		t.Errorf("Response body = %v, want %v", body, want)
 	}
 }
@@ -1065,7 +1067,7 @@ func TestSanitizeURL(t *testing.T) {
 		inURL, _ := url.Parse(tt.in)
 		want, _ := url.Parse(tt.want)
 
-		if got := sanitizeURL(inURL); !reflect.DeepEqual(got, want) {
+		if got := sanitizeURL(inURL); !cmp.Equal(got, want) {
 			t.Errorf("sanitizeURL(%v) returned %v, want %v", tt.in, got, want)
 		}
 	}
@@ -1684,7 +1686,7 @@ func TestRateLimits(t *testing.T) {
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 54, 0, time.UTC).Local()},
 		},
 	}
-	if !reflect.DeepEqual(rate, want) {
+	if !cmp.Equal(rate, want) {
 		t.Errorf("RateLimits returned %+v, want %+v", rate, want)
 	}
 

--- a/github/gitignore_test.go
+++ b/github/gitignore_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestGitignoresService_List(t *testing.T) {
@@ -29,7 +30,7 @@ func TestGitignoresService_List(t *testing.T) {
 	}
 
 	want := []string{"C", "Go"}
-	if !reflect.DeepEqual(available, want) {
+	if !cmp.Equal(available, want) {
 		t.Errorf("Gitignores.List returned %+v, want %+v", available, want)
 	}
 
@@ -59,7 +60,7 @@ func TestGitignoresService_Get(t *testing.T) {
 	}
 
 	want := &Gitignore{Name: String("Name"), Source: String("template source")}
-	if !reflect.DeepEqual(gitignore, want) {
+	if !cmp.Equal(gitignore, want) {
 		t.Errorf("Gitignores.Get returned %+v, want %+v", gitignore, want)
 	}
 

--- a/github/interactions_orgs_test.go
+++ b/github/interactions_orgs_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestInteractionsService_GetRestrictionsForOrgs(t *testing.T) {
@@ -31,7 +32,7 @@ func TestInteractionsService_GetRestrictionsForOrgs(t *testing.T) {
 	}
 
 	want := &InteractionRestriction{Origin: String("organization")}
-	if !reflect.DeepEqual(organizationInteractions, want) {
+	if !cmp.Equal(organizationInteractions, want) {
 		t.Errorf("Interactions.GetRestrictionsForOrg returned %+v, want %+v", organizationInteractions, want)
 	}
 
@@ -62,7 +63,7 @@ func TestInteractionsService_UpdateRestrictionsForOrg(t *testing.T) {
 
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Accept", mediaTypeInteractionRestrictionsPreview)
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 		fmt.Fprint(w, `{"origin":"organization"}`)
@@ -75,7 +76,7 @@ func TestInteractionsService_UpdateRestrictionsForOrg(t *testing.T) {
 	}
 
 	want := &InteractionRestriction{Origin: String("organization")}
-	if !reflect.DeepEqual(organizationInteractions, want) {
+	if !cmp.Equal(organizationInteractions, want) {
 		t.Errorf("Interactions.UpdateRestrictionsForOrg returned %+v, want %+v", organizationInteractions, want)
 	}
 

--- a/github/interactions_repos_test.go
+++ b/github/interactions_repos_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestInteractionsService_GetRestrictionsForRepo(t *testing.T) {
@@ -31,7 +32,7 @@ func TestInteractionsService_GetRestrictionsForRepo(t *testing.T) {
 	}
 
 	want := &InteractionRestriction{Origin: String("repository")}
-	if !reflect.DeepEqual(repoInteractions, want) {
+	if !cmp.Equal(repoInteractions, want) {
 		t.Errorf("Interactions.GetRestrictionsForRepo returned %+v, want %+v", repoInteractions, want)
 	}
 
@@ -62,7 +63,7 @@ func TestInteractionsService_UpdateRestrictionsForRepo(t *testing.T) {
 
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Accept", mediaTypeInteractionRestrictionsPreview)
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 		fmt.Fprint(w, `{"origin":"repository"}`)
@@ -75,7 +76,7 @@ func TestInteractionsService_UpdateRestrictionsForRepo(t *testing.T) {
 	}
 
 	want := &InteractionRestriction{Origin: String("repository")}
-	if !reflect.DeepEqual(repoInteractions, want) {
+	if !cmp.Equal(repoInteractions, want) {
 		t.Errorf("Interactions.UpdateRestrictionsForRepo returned %+v, want %+v", repoInteractions, want)
 	}
 

--- a/github/issue_import_test.go
+++ b/github/issue_import_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestIssueImportService_Create(t *testing.T) {
@@ -40,7 +41,7 @@ func TestIssueImportService_Create(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", mediaTypeIssueImportAPI)
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -55,7 +56,7 @@ func TestIssueImportService_Create(t *testing.T) {
 	}
 
 	want := wantIssueImportResponse
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Create = %+v, want %+v", got, want)
 	}
 
@@ -101,7 +102,7 @@ func TestIssueImportService_CheckStatus(t *testing.T) {
 	}
 
 	want := wantIssueImportResponse
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("CheckStatus = %+v, want %+v", got, want)
 	}
 
@@ -147,7 +148,7 @@ func TestIssueImportService_CheckStatusSince(t *testing.T) {
 	}
 
 	want := []*IssueImportResponse{wantIssueImportResponse}
-	if !reflect.DeepEqual(want, got) {
+	if !cmp.Equal(want, got) {
 		t.Errorf("CheckStatusSince = %v, want = %v", got, want)
 	}
 

--- a/github/issues_assignees_test.go
+++ b/github/issues_assignees_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestIssuesService_ListAssignees(t *testing.T) {
@@ -32,7 +33,7 @@ func TestIssuesService_ListAssignees(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(1)}}
-	if !reflect.DeepEqual(assignees, want) {
+	if !cmp.Equal(assignees, want) {
 		t.Errorf("Issues.ListAssignees returned %+v, want %+v", assignees, want)
 	}
 
@@ -179,7 +180,7 @@ func TestIssuesService_AddAssignees(t *testing.T) {
 
 		testMethod(t, r, "POST")
 		want := []string{"user1", "user2"}
-		if !reflect.DeepEqual(assignees.Assignees, want) {
+		if !cmp.Equal(assignees.Assignees, want) {
 			t.Errorf("assignees = %+v, want %+v", assignees, want)
 		}
 		fmt.Fprint(w, `{"number":1,"assignees":[{"login":"user1"},{"login":"user2"}]}`)
@@ -192,7 +193,7 @@ func TestIssuesService_AddAssignees(t *testing.T) {
 	}
 
 	want := &Issue{Number: Int(1), Assignees: []*User{{Login: String("user1")}, {Login: String("user2")}}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Issues.AddAssignees = %+v, want %+v", got, want)
 	}
 
@@ -215,7 +216,7 @@ func TestIssuesService_RemoveAssignees(t *testing.T) {
 
 		testMethod(t, r, "DELETE")
 		want := []string{"user1", "user2"}
-		if !reflect.DeepEqual(assignees.Assignees, want) {
+		if !cmp.Equal(assignees.Assignees, want) {
 			t.Errorf("assignees = %+v, want %+v", assignees, want)
 		}
 		fmt.Fprint(w, `{"number":1,"assignees":[]}`)
@@ -228,7 +229,7 @@ func TestIssuesService_RemoveAssignees(t *testing.T) {
 	}
 
 	want := &Issue{Number: Int(1), Assignees: []*User{}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Issues.RemoveAssignees = %+v, want %+v", got, want)
 	}
 

--- a/github/issues_comments_test.go
+++ b/github/issues_comments_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestIssuesService_ListComments_allIssues(t *testing.T) {
@@ -45,7 +46,7 @@ func TestIssuesService_ListComments_allIssues(t *testing.T) {
 	}
 
 	want := []*IssueComment{{ID: Int64(1)}}
-	if !reflect.DeepEqual(comments, want) {
+	if !cmp.Equal(comments, want) {
 		t.Errorf("Issues.ListComments returned %+v, want %+v", comments, want)
 	}
 
@@ -81,7 +82,7 @@ func TestIssuesService_ListComments_specificIssue(t *testing.T) {
 	}
 
 	want := []*IssueComment{{ID: Int64(1)}}
-	if !reflect.DeepEqual(comments, want) {
+	if !cmp.Equal(comments, want) {
 		t.Errorf("Issues.ListComments returned %+v, want %+v", comments, want)
 	}
 
@@ -126,7 +127,7 @@ func TestIssuesService_GetComment(t *testing.T) {
 	}
 
 	want := &IssueComment{ID: Int64(1)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("Issues.GetComment returned %+v, want %+v", comment, want)
 	}
 
@@ -165,7 +166,7 @@ func TestIssuesService_CreateComment(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -179,7 +180,7 @@ func TestIssuesService_CreateComment(t *testing.T) {
 	}
 
 	want := &IssueComment{ID: Int64(1)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("Issues.CreateComment returned %+v, want %+v", comment, want)
 	}
 
@@ -218,7 +219,7 @@ func TestIssuesService_EditComment(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -232,7 +233,7 @@ func TestIssuesService_EditComment(t *testing.T) {
 	}
 
 	want := &IssueComment{ID: Int64(1)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("Issues.EditComment returned %+v, want %+v", comment, want)
 	}
 

--- a/github/issues_events_test.go
+++ b/github/issues_events_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestIssuesService_ListIssueEvents(t *testing.T) {
@@ -35,7 +36,7 @@ func TestIssuesService_ListIssueEvents(t *testing.T) {
 	}
 
 	want := []*IssueEvent{{ID: Int64(1)}}
-	if !reflect.DeepEqual(events, want) {
+	if !cmp.Equal(events, want) {
 		t.Errorf("Issues.ListIssueEvents returned %+v, want %+v", events, want)
 	}
 
@@ -75,7 +76,7 @@ func TestIssuesService_ListRepositoryEvents(t *testing.T) {
 	}
 
 	want := []*IssueEvent{{ID: Int64(1)}}
-	if !reflect.DeepEqual(events, want) {
+	if !cmp.Equal(events, want) {
 		t.Errorf("Issues.ListRepositoryEvents returned %+v, want %+v", events, want)
 	}
 
@@ -110,7 +111,7 @@ func TestIssuesService_GetEvent(t *testing.T) {
 	}
 
 	want := &IssueEvent{ID: Int64(1)}
-	if !reflect.DeepEqual(event, want) {
+	if !cmp.Equal(event, want) {
 		t.Errorf("Issues.GetEvent returned %+v, want %+v", event, want)
 	}
 

--- a/github/issues_labels_test.go
+++ b/github/issues_labels_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestIssuesService_ListLabels(t *testing.T) {
@@ -32,7 +33,7 @@ func TestIssuesService_ListLabels(t *testing.T) {
 	}
 
 	want := []*Label{{Name: String("a")}, {Name: String("b")}}
-	if !reflect.DeepEqual(labels, want) {
+	if !cmp.Equal(labels, want) {
 		t.Errorf("Issues.ListLabels returned %+v, want %+v", labels, want)
 	}
 
@@ -76,7 +77,7 @@ func TestIssuesService_GetLabel(t *testing.T) {
 	}
 
 	want := &Label{URL: String("u"), Name: String("n"), Color: String("c"), Description: String("d")}
-	if !reflect.DeepEqual(label, want) {
+	if !cmp.Equal(label, want) {
 		t.Errorf("Issues.GetLabel returned %+v, want %+v", label, want)
 	}
 
@@ -115,7 +116,7 @@ func TestIssuesService_CreateLabel(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -129,7 +130,7 @@ func TestIssuesService_CreateLabel(t *testing.T) {
 	}
 
 	want := &Label{URL: String("u")}
-	if !reflect.DeepEqual(label, want) {
+	if !cmp.Equal(label, want) {
 		t.Errorf("Issues.CreateLabel returned %+v, want %+v", label, want)
 	}
 
@@ -168,7 +169,7 @@ func TestIssuesService_EditLabel(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -182,7 +183,7 @@ func TestIssuesService_EditLabel(t *testing.T) {
 	}
 
 	want := &Label{URL: String("u")}
-	if !reflect.DeepEqual(label, want) {
+	if !cmp.Equal(label, want) {
 		t.Errorf("Issues.EditLabel returned %+v, want %+v", label, want)
 	}
 
@@ -265,7 +266,7 @@ func TestIssuesService_ListLabelsByIssue(t *testing.T) {
 		{Name: String("a"), ID: Int64(1)},
 		{Name: String("b"), ID: Int64(2)},
 	}
-	if !reflect.DeepEqual(labels, want) {
+	if !cmp.Equal(labels, want) {
 		t.Errorf("Issues.ListLabelsByIssue returned %+v, want %+v", labels, want)
 	}
 
@@ -304,7 +305,7 @@ func TestIssuesService_AddLabelsToIssue(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -318,7 +319,7 @@ func TestIssuesService_AddLabelsToIssue(t *testing.T) {
 	}
 
 	want := []*Label{{URL: String("u")}}
-	if !reflect.DeepEqual(labels, want) {
+	if !cmp.Equal(labels, want) {
 		t.Errorf("Issues.AddLabelsToIssue returned %+v, want %+v", labels, want)
 	}
 
@@ -391,7 +392,7 @@ func TestIssuesService_ReplaceLabelsForIssue(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -405,7 +406,7 @@ func TestIssuesService_ReplaceLabelsForIssue(t *testing.T) {
 	}
 
 	want := []*Label{{URL: String("u")}}
-	if !reflect.DeepEqual(labels, want) {
+	if !cmp.Equal(labels, want) {
 		t.Errorf("Issues.ReplaceLabelsForIssue returned %+v, want %+v", labels, want)
 	}
 
@@ -485,7 +486,7 @@ func TestIssuesService_ListLabelsForMilestone(t *testing.T) {
 	}
 
 	want := []*Label{{Name: String("a")}, {Name: String("b")}}
-	if !reflect.DeepEqual(labels, want) {
+	if !cmp.Equal(labels, want) {
 		t.Errorf("Issues.ListLabelsForMilestone returned %+v, want %+v", labels, want)
 	}
 

--- a/github/issues_milestones_test.go
+++ b/github/issues_milestones_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestIssuesService_ListMilestones(t *testing.T) {
@@ -37,7 +38,7 @@ func TestIssuesService_ListMilestones(t *testing.T) {
 	}
 
 	want := []*Milestone{{Number: Int(1)}}
-	if !reflect.DeepEqual(milestones, want) {
+	if !cmp.Equal(milestones, want) {
 		t.Errorf("IssuesService.ListMilestones returned %+v, want %+v", milestones, want)
 	}
 
@@ -81,7 +82,7 @@ func TestIssuesService_GetMilestone(t *testing.T) {
 	}
 
 	want := &Milestone{Number: Int(1)}
-	if !reflect.DeepEqual(milestone, want) {
+	if !cmp.Equal(milestone, want) {
 		t.Errorf("IssuesService.GetMilestone returned %+v, want %+v", milestone, want)
 	}
 
@@ -120,7 +121,7 @@ func TestIssuesService_CreateMilestone(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -134,7 +135,7 @@ func TestIssuesService_CreateMilestone(t *testing.T) {
 	}
 
 	want := &Milestone{Number: Int(1)}
-	if !reflect.DeepEqual(milestone, want) {
+	if !cmp.Equal(milestone, want) {
 		t.Errorf("IssuesService.CreateMilestone returned %+v, want %+v", milestone, want)
 	}
 
@@ -173,7 +174,7 @@ func TestIssuesService_EditMilestone(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -187,7 +188,7 @@ func TestIssuesService_EditMilestone(t *testing.T) {
 	}
 
 	want := &Milestone{Number: Int(1)}
-	if !reflect.DeepEqual(milestone, want) {
+	if !cmp.Equal(milestone, want) {
 		t.Errorf("IssuesService.EditMilestone returned %+v, want %+v", milestone, want)
 	}
 

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestIssuesService_List_all(t *testing.T) {
@@ -47,7 +48,7 @@ func TestIssuesService_List_all(t *testing.T) {
 	}
 
 	want := []*Issue{{Number: Int(1)}}
-	if !reflect.DeepEqual(issues, want) {
+	if !cmp.Equal(issues, want) {
 		t.Errorf("Issues.List returned %+v, want %+v", issues, want)
 	}
 
@@ -78,7 +79,7 @@ func TestIssuesService_List_owned(t *testing.T) {
 	}
 
 	want := []*Issue{{Number: Int(1)}}
-	if !reflect.DeepEqual(issues, want) {
+	if !cmp.Equal(issues, want) {
 		t.Errorf("Issues.List returned %+v, want %+v", issues, want)
 	}
 }
@@ -100,7 +101,7 @@ func TestIssuesService_ListByOrg(t *testing.T) {
 	}
 
 	want := []*Issue{{Number: Int(1)}}
-	if !reflect.DeepEqual(issues, want) {
+	if !cmp.Equal(issues, want) {
 		t.Errorf("Issues.List returned %+v, want %+v", issues, want)
 	}
 
@@ -161,7 +162,7 @@ func TestIssuesService_ListByRepo(t *testing.T) {
 	}
 
 	want := []*Issue{{Number: Int(1)}}
-	if !reflect.DeepEqual(issues, want) {
+	if !cmp.Equal(issues, want) {
 		t.Errorf("Issues.List returned %+v, want %+v", issues, want)
 	}
 
@@ -214,7 +215,7 @@ func TestIssuesService_Get(t *testing.T) {
 			Color: String("c"),
 		}},
 	}
-	if !reflect.DeepEqual(issue, want) {
+	if !cmp.Equal(issue, want) {
 		t.Errorf("Issues.Get returned %+v, want %+v", issue, want)
 	}
 
@@ -258,7 +259,7 @@ func TestIssuesService_Create(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -272,7 +273,7 @@ func TestIssuesService_Create(t *testing.T) {
 	}
 
 	want := &Issue{Number: Int(1)}
-	if !reflect.DeepEqual(issue, want) {
+	if !cmp.Equal(issue, want) {
 		t.Errorf("Issues.Create returned %+v, want %+v", issue, want)
 	}
 
@@ -311,7 +312,7 @@ func TestIssuesService_Edit(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -325,7 +326,7 @@ func TestIssuesService_Edit(t *testing.T) {
 	}
 
 	want := &Issue{Number: Int(1)}
-	if !reflect.DeepEqual(issue, want) {
+	if !cmp.Equal(issue, want) {
 		t.Errorf("Issues.Edit returned %+v, want %+v", issue, want)
 	}
 

--- a/github/issues_timeline_test.go
+++ b/github/issues_timeline_test.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestIssuesService_ListIssueTimeline(t *testing.T) {
@@ -37,7 +38,7 @@ func TestIssuesService_ListIssueTimeline(t *testing.T) {
 	}
 
 	want := []*Timeline{{ID: Int64(1)}}
-	if !reflect.DeepEqual(events, want) {
+	if !cmp.Equal(events, want) {
 		t.Errorf("Issues.ListIssueTimeline = %+v, want %+v", events, want)
 	}
 

--- a/github/licenses_test.go
+++ b/github/licenses_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoryLicense_marshal(t *testing.T) {
@@ -129,7 +130,7 @@ func TestLicensesService_List(t *testing.T) {
 		URL:      String("https://api.github.com/licenses/mit"),
 		Featured: Bool(true),
 	}}
-	if !reflect.DeepEqual(licenses, want) {
+	if !cmp.Equal(licenses, want) {
 		t.Errorf("Licenses.List returned %+v, want %+v", licenses, want)
 	}
 
@@ -159,7 +160,7 @@ func TestLicensesService_Get(t *testing.T) {
 	}
 
 	want := &License{Key: String("mit"), Name: String("MIT")}
-	if !reflect.DeepEqual(license, want) {
+	if !cmp.Equal(license, want) {
 		t.Errorf("Licenses.Get returned %+v, want %+v", license, want)
 	}
 

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -12,9 +12,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestMessageMAC_BadHashTypePrefix(t *testing.T) {
@@ -437,7 +438,7 @@ func TestParseWebHook(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ParseWebHook: %v", err)
 		}
-		if want := test.payload; !reflect.DeepEqual(got, want) {
+		if want := test.payload; !cmp.Equal(got, want) {
 			t.Errorf("ParseWebHook(%#v, %#v) = %#v, want %#v", test.messageType, p, got, want)
 		}
 	}

--- a/github/migrations_source_import_test.go
+++ b/github/migrations_source_import_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestMigrationService_StartImport(t *testing.T) {
@@ -30,7 +31,7 @@ func TestMigrationService_StartImport(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -44,7 +45,7 @@ func TestMigrationService_StartImport(t *testing.T) {
 		t.Errorf("StartImport returned error: %v", err)
 	}
 	want := &Import{Status: String("importing")}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("StartImport = %+v, want %+v", got, want)
 	}
 
@@ -78,7 +79,7 @@ func TestMigrationService_ImportProgress(t *testing.T) {
 		t.Errorf("ImportProgress returned error: %v", err)
 	}
 	want := &Import{Status: String("complete")}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("ImportProgress = %+v, want %+v", got, want)
 	}
 
@@ -113,7 +114,7 @@ func TestMigrationService_UpdateImport(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -127,7 +128,7 @@ func TestMigrationService_UpdateImport(t *testing.T) {
 		t.Errorf("UpdateImport returned error: %v", err)
 	}
 	want := &Import{Status: String("importing")}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("UpdateImport = %+v, want %+v", got, want)
 	}
 
@@ -164,7 +165,7 @@ func TestMigrationService_CommitAuthors(t *testing.T) {
 		{ID: Int64(1), Name: String("a")},
 		{ID: Int64(2), Name: String("b")},
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("CommitAuthors = %+v, want %+v", got, want)
 	}
 
@@ -194,7 +195,7 @@ func TestMigrationService_MapCommitAuthor(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -207,7 +208,7 @@ func TestMigrationService_MapCommitAuthor(t *testing.T) {
 		t.Errorf("MapCommitAuthor returned error: %v", err)
 	}
 	want := &SourceImportAuthor{ID: Int64(1)}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("MapCommitAuthor = %+v, want %+v", got, want)
 	}
 
@@ -237,7 +238,7 @@ func TestMigrationService_SetLFSPreference(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -251,7 +252,7 @@ func TestMigrationService_SetLFSPreference(t *testing.T) {
 		t.Errorf("SetLFSPreference returned error: %v", err)
 	}
 	want := &Import{Status: String("importing")}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("SetLFSPreference = %+v, want %+v", got, want)
 	}
 
@@ -288,7 +289,7 @@ func TestMigrationService_LargeFiles(t *testing.T) {
 		{OID: String("a")},
 		{OID: String("b")},
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("LargeFiles = %+v, want %+v", got, want)
 	}
 

--- a/github/migrations_test.go
+++ b/github/migrations_test.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestMigrationService_StartMigration(t *testing.T) {
@@ -35,7 +36,7 @@ func TestMigrationService_StartMigration(t *testing.T) {
 	if err != nil {
 		t.Errorf("StartMigration returned error: %v", err)
 	}
-	if want := wantMigration; !reflect.DeepEqual(got, want) {
+	if want := wantMigration; !cmp.Equal(got, want) {
 		t.Errorf("StartMigration = %+v, want %+v", got, want)
 	}
 
@@ -71,7 +72,7 @@ func TestMigrationService_ListMigrations(t *testing.T) {
 	if err != nil {
 		t.Errorf("ListMigrations returned error: %v", err)
 	}
-	if want := []*Migration{wantMigration}; !reflect.DeepEqual(got, want) {
+	if want := []*Migration{wantMigration}; !cmp.Equal(got, want) {
 		t.Errorf("ListMigrations = %+v, want %+v", got, want)
 	}
 
@@ -107,7 +108,7 @@ func TestMigrationService_MigrationStatus(t *testing.T) {
 	if err != nil {
 		t.Errorf("MigrationStatus returned error: %v", err)
 	}
-	if want := wantMigration; !reflect.DeepEqual(got, want) {
+	if want := wantMigration; !cmp.Equal(got, want) {
 		t.Errorf("MigrationStatus = %+v, want %+v", got, want)
 	}
 

--- a/github/migrations_user_test.go
+++ b/github/migrations_user_test.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestMigrationService_StartUserMigration(t *testing.T) {
@@ -38,7 +39,7 @@ func TestMigrationService_StartUserMigration(t *testing.T) {
 	}
 
 	want := wantUserMigration
-	if !reflect.DeepEqual(want, got) {
+	if !cmp.Equal(want, got) {
 		t.Errorf("StartUserMigration = %v, want = %v", got, want)
 	}
 
@@ -71,7 +72,7 @@ func TestMigrationService_ListUserMigrations(t *testing.T) {
 	}
 
 	want := []*UserMigration{wantUserMigration}
-	if !reflect.DeepEqual(want, got) {
+	if !cmp.Equal(want, got) {
 		t.Errorf("ListUserMigrations = %v, want = %v", got, want)
 	}
 
@@ -104,7 +105,7 @@ func TestMigrationService_UserMigrationStatus(t *testing.T) {
 	}
 
 	want := wantUserMigration
-	if !reflect.DeepEqual(want, got) {
+	if !cmp.Equal(want, got) {
 		t.Errorf("UserMigrationStatus = %v, want = %v", got, want)
 	}
 

--- a/github/misc_test.go
+++ b/github/misc_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestMarkdown(t *testing.T) {
@@ -28,7 +29,7 @@ func TestMarkdown(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 		fmt.Fprint(w, `<h1>text</h1>`)
@@ -76,7 +77,7 @@ func TestListEmojis(t *testing.T) {
 	}
 
 	want := map[string]string{"+1": "+1.png"}
-	if !reflect.DeepEqual(want, emoji) {
+	if !cmp.Equal(want, emoji) {
 		t.Errorf("ListEmojis returned %+v, want %+v", emoji, want)
 	}
 
@@ -116,7 +117,7 @@ func TestListCodesOfConduct(t *testing.T) {
 			Name: String("name"),
 			URL:  String("url"),
 		}}
-	if !reflect.DeepEqual(want, cs) {
+	if !cmp.Equal(want, cs) {
 		t.Errorf("ListCodesOfConduct returned %+v, want %+v", cs, want)
 	}
 
@@ -157,7 +158,7 @@ func TestGetCodeOfConduct(t *testing.T) {
 		URL:  String("url"),
 		Body: String("body"),
 	}
-	if !reflect.DeepEqual(want, coc) {
+	if !cmp.Equal(want, coc) {
 		t.Errorf("GetCodeOfConductByKey returned %+v, want %+v", coc, want)
 	}
 
@@ -226,7 +227,7 @@ func TestAPIMeta(t *testing.T) {
 
 		VerifiablePasswordAuthentication: Bool(true),
 	}
-	if !reflect.DeepEqual(want, meta) {
+	if !cmp.Equal(want, meta) {
 		t.Errorf("APIMeta returned %+v, want %+v", meta, want)
 	}
 
@@ -334,7 +335,7 @@ func TestListServiceHooks(t *testing.T) {
 		SupportedEvents: []string{"s"},
 		Schema:          [][]string{{"a", "b"}},
 	}}
-	if !reflect.DeepEqual(hooks, want) {
+	if !cmp.Equal(hooks, want) {
 		t.Errorf("ListServiceHooks returned %+v, want %+v", hooks, want)
 	}
 

--- a/github/orgs_actions_allowed_test.go
+++ b/github/orgs_actions_allowed_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestOrganizationsService_GetActionsAllowed(t *testing.T) {
@@ -29,7 +30,7 @@ func TestOrganizationsService_GetActionsAllowed(t *testing.T) {
 		t.Errorf("Organizations.GetActionsAllowed returned error: %v", err)
 	}
 	want := &ActionsAllowed{GithubOwnedAllowed: Bool(true), VerifiedAllowed: Bool(false), PatternsAllowed: []string{"a/b"}}
-	if !reflect.DeepEqual(org, want) {
+	if !cmp.Equal(org, want) {
 		t.Errorf("Organizations.GetActionsAllowed returned %+v, want %+v", org, want)
 	}
 
@@ -58,7 +59,7 @@ func TestOrganizationsService_EditActionsAllowed(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -72,7 +73,7 @@ func TestOrganizationsService_EditActionsAllowed(t *testing.T) {
 	}
 
 	want := &ActionsAllowed{GithubOwnedAllowed: Bool(true), VerifiedAllowed: Bool(false), PatternsAllowed: []string{"a/b"}}
-	if !reflect.DeepEqual(org, want) {
+	if !cmp.Equal(org, want) {
 		t.Errorf("Organizations.EditActionsAllowed returned %+v, want %+v", org, want)
 	}
 

--- a/github/orgs_actions_permissions_test.go
+++ b/github/orgs_actions_permissions_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestOrganizationsService_GetActionsPermissions(t *testing.T) {
@@ -29,7 +30,7 @@ func TestOrganizationsService_GetActionsPermissions(t *testing.T) {
 		t.Errorf("Organizations.GetActionsPermissions returned error: %v", err)
 	}
 	want := &ActionsPermissions{EnabledRepositories: String("all"), AllowedActions: String("all")}
-	if !reflect.DeepEqual(org, want) {
+	if !cmp.Equal(org, want) {
 		t.Errorf("Organizations.GetActionsPermissions returned %+v, want %+v", org, want)
 	}
 
@@ -59,7 +60,7 @@ func TestOrganizationsService_EditActionsPermissions(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -73,7 +74,7 @@ func TestOrganizationsService_EditActionsPermissions(t *testing.T) {
 	}
 
 	want := &ActionsPermissions{EnabledRepositories: String("all"), AllowedActions: String("selected")}
-	if !reflect.DeepEqual(org, want) {
+	if !cmp.Equal(org, want) {
 		t.Errorf("Organizations.EditActionsPermissions returned %+v, want %+v", org, want)
 	}
 

--- a/github/orgs_audit_log_test.go
+++ b/github/orgs_audit_log_test.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestOrganizationService_GetAuditLog(t *testing.T) {
@@ -92,7 +93,7 @@ func TestOrganizationService_GetAuditLog(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(auditEntries, want) {
+	if !cmp.Equal(auditEntries, want) {
 		t.Errorf("Organizations.GetAuditLog return \ngot: %+v,\nwant:%+v", auditEntries, want)
 	}
 

--- a/github/orgs_hooks_test.go
+++ b/github/orgs_hooks_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestOrganizationsService_ListHooks(t *testing.T) {
@@ -33,7 +34,7 @@ func TestOrganizationsService_ListHooks(t *testing.T) {
 	}
 
 	want := []*Hook{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(hooks, want) {
+	if !cmp.Equal(hooks, want) {
 		t.Errorf("Organizations.ListHooks returned %+v, want %+v", hooks, want)
 	}
 
@@ -73,7 +74,7 @@ func TestOrganizationsService_CreateHook(t *testing.T) {
 
 		testMethod(t, r, "POST")
 		want := &createHookRequest{Name: "web"}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 
@@ -87,7 +88,7 @@ func TestOrganizationsService_CreateHook(t *testing.T) {
 	}
 
 	want := &Hook{ID: Int64(1)}
-	if !reflect.DeepEqual(hook, want) {
+	if !cmp.Equal(hook, want) {
 		t.Errorf("Organizations.CreateHook returned %+v, want %+v", hook, want)
 	}
 
@@ -122,7 +123,7 @@ func TestOrganizationsService_GetHook(t *testing.T) {
 	}
 
 	want := &Hook{ID: Int64(1)}
-	if !reflect.DeepEqual(hook, want) {
+	if !cmp.Equal(hook, want) {
 		t.Errorf("Organizations.GetHook returned %+v, want %+v", hook, want)
 	}
 
@@ -153,7 +154,7 @@ func TestOrganizationsService_EditHook(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -167,7 +168,7 @@ func TestOrganizationsService_EditHook(t *testing.T) {
 	}
 
 	want := &Hook{ID: Int64(1)}
-	if !reflect.DeepEqual(hook, want) {
+	if !cmp.Equal(hook, want) {
 		t.Errorf("Organizations.EditHook returned %+v, want %+v", hook, want)
 	}
 

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestOrganizationsService_ListMembers(t *testing.T) {
@@ -42,7 +43,7 @@ func TestOrganizationsService_ListMembers(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(1)}}
-	if !reflect.DeepEqual(members, want) {
+	if !cmp.Equal(members, want) {
 		t.Errorf("Organizations.ListMembers returned %+v, want %+v", members, want)
 	}
 
@@ -87,7 +88,7 @@ func TestOrganizationsService_ListMembers_public(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(1)}}
-	if !reflect.DeepEqual(members, want) {
+	if !cmp.Equal(members, want) {
 		t.Errorf("Organizations.ListMembers returned %+v, want %+v", members, want)
 	}
 }
@@ -366,7 +367,7 @@ func TestOrganizationsService_ListOrgMemberships(t *testing.T) {
 	}
 
 	want := []*Membership{{URL: String("u")}}
-	if !reflect.DeepEqual(memberships, want) {
+	if !cmp.Equal(memberships, want) {
 		t.Errorf("Organizations.ListOrgMemberships returned %+v, want %+v", memberships, want)
 	}
 
@@ -396,7 +397,7 @@ func TestOrganizationsService_GetOrgMembership_AuthenticatedUser(t *testing.T) {
 	}
 
 	want := &Membership{URL: String("u")}
-	if !reflect.DeepEqual(membership, want) {
+	if !cmp.Equal(membership, want) {
 		t.Errorf("Organizations.GetOrgMembership returned %+v, want %+v", membership, want)
 	}
 
@@ -431,7 +432,7 @@ func TestOrganizationsService_GetOrgMembership_SpecifiedUser(t *testing.T) {
 	}
 
 	want := &Membership{URL: String("u")}
-	if !reflect.DeepEqual(membership, want) {
+	if !cmp.Equal(membership, want) {
 		t.Errorf("Organizations.GetOrgMembership returned %+v, want %+v", membership, want)
 	}
 }
@@ -447,7 +448,7 @@ func TestOrganizationsService_EditOrgMembership_AuthenticatedUser(t *testing.T) 
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -461,7 +462,7 @@ func TestOrganizationsService_EditOrgMembership_AuthenticatedUser(t *testing.T) 
 	}
 
 	want := &Membership{URL: String("u")}
-	if !reflect.DeepEqual(membership, want) {
+	if !cmp.Equal(membership, want) {
 		t.Errorf("Organizations.EditOrgMembership returned %+v, want %+v", membership, want)
 	}
 
@@ -491,7 +492,7 @@ func TestOrganizationsService_EditOrgMembership_SpecifiedUser(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -505,7 +506,7 @@ func TestOrganizationsService_EditOrgMembership_SpecifiedUser(t *testing.T) {
 	}
 
 	want := &Membership{URL: String("u")}
-	if !reflect.DeepEqual(membership, want) {
+	if !cmp.Equal(membership, want) {
 		t.Errorf("Organizations.EditOrgMembership returned %+v, want %+v", membership, want)
 	}
 }
@@ -613,7 +614,7 @@ func TestOrganizationsService_ListPendingOrgInvitations(t *testing.T) {
 			InvitationTeamURL: String("https://api.github.com/organizations/2/invitations/1/teams"),
 		}}
 
-	if !reflect.DeepEqual(invitations, want) {
+	if !cmp.Equal(invitations, want) {
 		t.Errorf("Organizations.ListPendingOrgInvitations returned %+v, want %+v", invitations, want)
 	}
 
@@ -649,7 +650,7 @@ func TestOrganizationsService_CreateOrgInvitation(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -664,7 +665,7 @@ func TestOrganizationsService_CreateOrgInvitation(t *testing.T) {
 	}
 
 	want := &Invitation{Email: String("octocat@github.com")}
-	if !reflect.DeepEqual(invitations, want) {
+	if !cmp.Equal(invitations, want) {
 		t.Errorf("Organizations.ListPendingOrgInvitations returned %+v, want %+v", invitations, want)
 	}
 
@@ -726,7 +727,7 @@ func TestOrganizationsService_ListOrgInvitationTeams(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(invitations, want) {
+	if !cmp.Equal(invitations, want) {
 		t.Errorf("Organizations.ListOrgInvitationTeams returned %+v, want %+v", invitations, want)
 	}
 
@@ -831,7 +832,7 @@ func TestOrganizationsService_ListFailedOrgInvitations(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(failedInvitations, want) {
+	if !cmp.Equal(failedInvitations, want) {
 		t.Errorf("Organizations.ListFailedOrgInvitations returned %+v, want %+v", failedInvitations, want)
 	}
 

--- a/github/orgs_outside_collaborators_test.go
+++ b/github/orgs_outside_collaborators_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestOrganizationsService_ListOutsideCollaborators(t *testing.T) {
@@ -37,7 +38,7 @@ func TestOrganizationsService_ListOutsideCollaborators(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(1)}}
-	if !reflect.DeepEqual(members, want) {
+	if !cmp.Equal(members, want) {
 		t.Errorf("Organizations.ListOutsideCollaborators returned %+v, want %+v", members, want)
 	}
 

--- a/github/orgs_projects_test.go
+++ b/github/orgs_projects_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestOrganizationsService_ListProjects(t *testing.T) {
@@ -33,7 +34,7 @@ func TestOrganizationsService_ListProjects(t *testing.T) {
 	}
 
 	want := []*Project{{ID: Int64(1)}}
-	if !reflect.DeepEqual(projects, want) {
+	if !cmp.Equal(projects, want) {
 		t.Errorf("Organizations.ListProjects returned %+v, want %+v", projects, want)
 	}
 
@@ -64,7 +65,7 @@ func TestOrganizationsService_CreateProject(t *testing.T) {
 
 		v := &ProjectOptions{}
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -78,7 +79,7 @@ func TestOrganizationsService_CreateProject(t *testing.T) {
 	}
 
 	want := &Project{ID: Int64(1)}
-	if !reflect.DeepEqual(project, want) {
+	if !cmp.Equal(project, want) {
 		t.Errorf("Organizations.CreateProject returned %+v, want %+v", project, want)
 	}
 

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestOrganization_marshal(t *testing.T) {
@@ -85,7 +86,7 @@ func TestOrganizationsService_ListAll(t *testing.T) {
 	}
 
 	want := []*Organization{{ID: Int64(4314092)}}
-	if !reflect.DeepEqual(orgs, want) {
+	if !cmp.Equal(orgs, want) {
 		t.Errorf("Organizations.ListAll returned %+v, want %+v", orgs, want)
 	}
 
@@ -115,7 +116,7 @@ func TestOrganizationsService_List_authenticatedUser(t *testing.T) {
 	}
 
 	want := []*Organization{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(orgs, want) {
+	if !cmp.Equal(orgs, want) {
 		t.Errorf("Organizations.List returned %+v, want %+v", orgs, want)
 	}
 
@@ -152,7 +153,7 @@ func TestOrganizationsService_List_specifiedUser(t *testing.T) {
 	}
 
 	want := []*Organization{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(orgs, want) {
+	if !cmp.Equal(orgs, want) {
 		t.Errorf("Organizations.List returned %+v, want %+v", orgs, want)
 	}
 
@@ -197,7 +198,7 @@ func TestOrganizationsService_Get(t *testing.T) {
 	}
 
 	want := &Organization{ID: Int64(1), Login: String("l"), URL: String("u"), AvatarURL: String("a"), Location: String("l")}
-	if !reflect.DeepEqual(org, want) {
+	if !cmp.Equal(org, want) {
 		t.Errorf("Organizations.Get returned %+v, want %+v", org, want)
 	}
 
@@ -241,7 +242,7 @@ func TestOrganizationsService_GetByID(t *testing.T) {
 	}
 
 	want := &Organization{ID: Int64(1), Login: String("l"), URL: String("u"), AvatarURL: String("a"), Location: String("l")}
-	if !reflect.DeepEqual(org, want) {
+	if !cmp.Equal(org, want) {
 		t.Errorf("Organizations.GetByID returned %+v, want %+v", org, want)
 	}
 
@@ -272,7 +273,7 @@ func TestOrganizationsService_Edit(t *testing.T) {
 
 		testHeader(t, r, "Accept", mediaTypeMemberAllowedRepoCreationTypePreview)
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -286,7 +287,7 @@ func TestOrganizationsService_Edit(t *testing.T) {
 	}
 
 	want := &Organization{ID: Int64(1)}
-	if !reflect.DeepEqual(org, want) {
+	if !cmp.Equal(org, want) {
 		t.Errorf("Organizations.Edit returned %+v, want %+v", org, want)
 	}
 
@@ -330,7 +331,7 @@ func TestOrganizationsService_ListInstallations(t *testing.T) {
 	}
 
 	want := &OrganizationInstallations{TotalCount: Int(1), Installations: []*Installation{{ID: Int64(1), AppID: Int64(5)}}}
-	if !reflect.DeepEqual(apps, want) {
+	if !cmp.Equal(apps, want) {
 		t.Errorf("Organizations.ListInstallations returned %+v, want %+v", apps, want)
 	}
 
@@ -376,7 +377,7 @@ func TestOrganizationsService_ListInstallations_withListOptions(t *testing.T) {
 	}
 
 	want := &OrganizationInstallations{TotalCount: Int(2), Installations: []*Installation{{ID: Int64(2), AppID: Int64(10)}}}
-	if !reflect.DeepEqual(apps, want) {
+	if !cmp.Equal(apps, want) {
 		t.Errorf("Organizations.ListInstallations returned %+v, want %+v", apps, want)
 	}
 

--- a/github/orgs_users_blocking_test.go
+++ b/github/orgs_users_blocking_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestOrganizationsService_ListBlockedUsers(t *testing.T) {
@@ -34,7 +35,7 @@ func TestOrganizationsService_ListBlockedUsers(t *testing.T) {
 	}
 
 	want := []*User{{Login: String("octocat")}}
-	if !reflect.DeepEqual(blockedUsers, want) {
+	if !cmp.Equal(blockedUsers, want) {
 		t.Errorf("Organizations.ListBlockedUsers returned %+v, want %+v", blockedUsers, want)
 	}
 

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestProject_marshall(t *testing.T) {
@@ -102,7 +103,7 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 
 		v := &ProjectOptions{}
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -116,7 +117,7 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 	}
 
 	want := &Project{ID: Int64(1)}
-	if !reflect.DeepEqual(project, want) {
+	if !cmp.Equal(project, want) {
 		t.Errorf("Projects.UpdateProject returned %+v, want %+v", project, want)
 	}
 
@@ -152,7 +153,7 @@ func TestProjectsService_GetProject(t *testing.T) {
 	}
 
 	want := &Project{ID: Int64(1)}
-	if !reflect.DeepEqual(project, want) {
+	if !cmp.Equal(project, want) {
 		t.Errorf("Projects.GetProject returned %+v, want %+v", project, want)
 	}
 
@@ -217,7 +218,7 @@ func TestProjectsService_ListProjectColumns(t *testing.T) {
 	}
 
 	want := []*ProjectColumn{{ID: Int64(1)}}
-	if !reflect.DeepEqual(columns, want) {
+	if !cmp.Equal(columns, want) {
 		t.Errorf("Projects.ListProjectColumns returned %+v, want %+v", columns, want)
 	}
 
@@ -253,7 +254,7 @@ func TestProjectsService_GetProjectColumn(t *testing.T) {
 	}
 
 	want := &ProjectColumn{ID: Int64(1)}
-	if !reflect.DeepEqual(column, want) {
+	if !cmp.Equal(column, want) {
 		t.Errorf("Projects.GetProjectColumn returned %+v, want %+v", column, want)
 	}
 
@@ -284,7 +285,7 @@ func TestProjectsService_CreateProjectColumn(t *testing.T) {
 
 		v := &ProjectColumnOptions{}
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -298,7 +299,7 @@ func TestProjectsService_CreateProjectColumn(t *testing.T) {
 	}
 
 	want := &ProjectColumn{ID: Int64(1)}
-	if !reflect.DeepEqual(column, want) {
+	if !cmp.Equal(column, want) {
 		t.Errorf("Projects.CreateProjectColumn returned %+v, want %+v", column, want)
 	}
 
@@ -329,7 +330,7 @@ func TestProjectsService_UpdateProjectColumn(t *testing.T) {
 
 		v := &ProjectColumnOptions{}
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -343,7 +344,7 @@ func TestProjectsService_UpdateProjectColumn(t *testing.T) {
 	}
 
 	want := &ProjectColumn{ID: Int64(1)}
-	if !reflect.DeepEqual(column, want) {
+	if !cmp.Equal(column, want) {
 		t.Errorf("Projects.UpdateProjectColumn returned %+v, want %+v", column, want)
 	}
 
@@ -400,7 +401,7 @@ func TestProjectsService_MoveProjectColumn(t *testing.T) {
 
 		v := &ProjectColumnMoveOptions{}
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 	})
@@ -445,7 +446,7 @@ func TestProjectsService_ListProjectCards(t *testing.T) {
 	}
 
 	want := []*ProjectCard{{ID: Int64(1)}}
-	if !reflect.DeepEqual(cards, want) {
+	if !cmp.Equal(cards, want) {
 		t.Errorf("Projects.ListProjectCards returned %+v, want %+v", cards, want)
 	}
 
@@ -481,7 +482,7 @@ func TestProjectsService_GetProjectCard(t *testing.T) {
 	}
 
 	want := &ProjectCard{ID: Int64(1)}
-	if !reflect.DeepEqual(card, want) {
+	if !cmp.Equal(card, want) {
 		t.Errorf("Projects.GetProjectCard returned %+v, want %+v", card, want)
 	}
 
@@ -515,7 +516,7 @@ func TestProjectsService_CreateProjectCard(t *testing.T) {
 
 		v := &ProjectCardOptions{}
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -529,7 +530,7 @@ func TestProjectsService_CreateProjectCard(t *testing.T) {
 	}
 
 	want := &ProjectCard{ID: Int64(1)}
-	if !reflect.DeepEqual(card, want) {
+	if !cmp.Equal(card, want) {
 		t.Errorf("Projects.CreateProjectCard returned %+v, want %+v", card, want)
 	}
 
@@ -563,7 +564,7 @@ func TestProjectsService_UpdateProjectCard(t *testing.T) {
 
 		v := &ProjectCardOptions{}
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -577,7 +578,7 @@ func TestProjectsService_UpdateProjectCard(t *testing.T) {
 	}
 
 	want := &ProjectCard{ID: Int64(1), Archived: Bool(false)}
-	if !reflect.DeepEqual(card, want) {
+	if !cmp.Equal(card, want) {
 		t.Errorf("Projects.UpdateProjectCard returned %+v, want %+v", card, want)
 	}
 
@@ -634,7 +635,7 @@ func TestProjectsService_MoveProjectCard(t *testing.T) {
 
 		v := &ProjectCardMoveOptions{}
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 	})
@@ -670,7 +671,7 @@ func TestProjectsService_AddProjectCollaborator(t *testing.T) {
 
 		v := &ProjectCollaboratorOptions{}
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, opt) {
+		if !cmp.Equal(v, opt) {
 			t.Errorf("Request body = %+v, want %+v", v, opt)
 		}
 
@@ -760,7 +761,7 @@ func TestProjectsService_ListCollaborators(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(users, want) {
+	if !cmp.Equal(users, want) {
 		t.Errorf("Projects.ListProjectCollaborators returned %+v, want %+v", users, want)
 	}
 
@@ -801,7 +802,7 @@ func TestProjectsService_ListCollaborators_withAffiliation(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(users, want) {
+	if !cmp.Equal(users, want) {
 		t.Errorf("Projects.ListProjectCollaborators returned %+v, want %+v", users, want)
 	}
 }
@@ -829,7 +830,7 @@ func TestProjectsService_ReviewProjectCollaboratorPermission(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(ppl, want) {
+	if !cmp.Equal(ppl, want) {
 		t.Errorf("Projects.ReviewProjectCollaboratorPermission returned %+v, want %+v", ppl, want)
 	}
 

--- a/github/pulls_comments_test.go
+++ b/github/pulls_comments_test.go
@@ -10,10 +10,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestPullComments_marshall(t *testing.T) {
@@ -162,7 +163,7 @@ func TestPullRequestsService_ListComments_allPulls(t *testing.T) {
 	}
 
 	want := []*PullRequestComment{{ID: Int64(1)}}
-	if !reflect.DeepEqual(pulls, want) {
+	if !cmp.Equal(pulls, want) {
 		t.Errorf("PullRequests.ListComments returned %+v, want %+v", pulls, want)
 	}
 
@@ -199,7 +200,7 @@ func TestPullRequestsService_ListComments_specificPull(t *testing.T) {
 	}
 
 	want := []*PullRequestComment{{ID: Int64(1), PullRequestReviewID: Int64(42)}}
-	if !reflect.DeepEqual(pulls, want) {
+	if !cmp.Equal(pulls, want) {
 		t.Errorf("PullRequests.ListComments returned %+v, want %+v", pulls, want)
 	}
 }
@@ -231,7 +232,7 @@ func TestPullRequestsService_GetComment(t *testing.T) {
 	}
 
 	want := &PullRequestComment{ID: Int64(1)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("PullRequests.GetComment returned %+v, want %+v", comment, want)
 	}
 
@@ -273,7 +274,7 @@ func TestPullRequestsService_CreateComment(t *testing.T) {
 		// TODO: remove custom Accept header assertion when the API fully launches.
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -287,7 +288,7 @@ func TestPullRequestsService_CreateComment(t *testing.T) {
 	}
 
 	want := &PullRequestComment{ID: Int64(1)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("PullRequests.CreateComment returned %+v, want %+v", comment, want)
 	}
 
@@ -326,7 +327,7 @@ func TestPullRequestsService_CreateCommentInReplyTo(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -340,7 +341,7 @@ func TestPullRequestsService_CreateCommentInReplyTo(t *testing.T) {
 	}
 
 	want := &PullRequestComment{ID: Int64(1)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("PullRequests.CreateCommentInReplyTo returned %+v, want %+v", comment, want)
 	}
 
@@ -370,7 +371,7 @@ func TestPullRequestsService_EditComment(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -384,7 +385,7 @@ func TestPullRequestsService_EditComment(t *testing.T) {
 	}
 
 	want := &PullRequestComment{ID: Int64(1)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("PullRequests.EditComment returned %+v, want %+v", comment, want)
 	}
 

--- a/github/pulls_reviewers_test.go
+++ b/github/pulls_reviewers_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestReviewersRequest_marshal(t *testing.T) {
@@ -134,7 +135,7 @@ func TestRequestReviewers(t *testing.T) {
 		t.Errorf("PullRequests.RequestReviewers returned error: %v", err)
 	}
 	want := &PullRequest{Number: Int(1)}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("PullRequests.RequestReviewers returned %+v, want %+v", got, want)
 	}
 
@@ -198,7 +199,7 @@ func TestListReviewers(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("PullRequests.ListReviewers returned %+v, want %+v", got, want)
 	}
 

--- a/github/pulls_reviews_test.go
+++ b/github/pulls_reviews_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestPullRequestsService_ListReviews(t *testing.T) {
@@ -37,7 +38,7 @@ func TestPullRequestsService_ListReviews(t *testing.T) {
 		{ID: Int64(1)},
 		{ID: Int64(2)},
 	}
-	if !reflect.DeepEqual(reviews, want) {
+	if !cmp.Equal(reviews, want) {
 		t.Errorf("PullRequests.ListReviews returned %+v, want %+v", reviews, want)
 	}
 
@@ -81,7 +82,7 @@ func TestPullRequestsService_GetReview(t *testing.T) {
 	}
 
 	want := &PullRequestReview{ID: Int64(1)}
-	if !reflect.DeepEqual(review, want) {
+	if !cmp.Equal(review, want) {
 		t.Errorf("PullRequests.GetReview returned %+v, want %+v", review, want)
 	}
 
@@ -125,7 +126,7 @@ func TestPullRequestsService_DeletePendingReview(t *testing.T) {
 	}
 
 	want := &PullRequestReview{ID: Int64(1)}
-	if !reflect.DeepEqual(review, want) {
+	if !cmp.Equal(review, want) {
 		t.Errorf("PullRequests.DeletePendingReview returned %+v, want %+v", review, want)
 	}
 
@@ -172,7 +173,7 @@ func TestPullRequestsService_ListReviewComments(t *testing.T) {
 		{ID: Int64(1)},
 		{ID: Int64(2)},
 	}
-	if !reflect.DeepEqual(comments, want) {
+	if !cmp.Equal(comments, want) {
 		t.Errorf("PullRequests.ListReviewComments returned %+v, want %+v", comments, want)
 	}
 
@@ -367,7 +368,7 @@ func TestPullRequestsService_CreateReview(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -381,7 +382,7 @@ func TestPullRequestsService_CreateReview(t *testing.T) {
 	}
 
 	want := &PullRequestReview{ID: Int64(1)}
-	if !reflect.DeepEqual(review, want) {
+	if !cmp.Equal(review, want) {
 		t.Errorf("PullRequests.CreateReview returned %+v, want %+v", review, want)
 	}
 
@@ -470,7 +471,7 @@ func TestPullRequestsService_CreateReview_addHeader(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -501,7 +502,7 @@ func TestPullRequestsService_UpdateReview(t *testing.T) {
 	}
 
 	want := &PullRequestReview{ID: Int64(1)}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("PullRequests.UpdateReview = %+v, want %+v", got, want)
 	}
 
@@ -534,7 +535,7 @@ func TestPullRequestsService_SubmitReview(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -548,7 +549,7 @@ func TestPullRequestsService_SubmitReview(t *testing.T) {
 	}
 
 	want := &PullRequestReview{ID: Int64(1)}
-	if !reflect.DeepEqual(review, want) {
+	if !cmp.Equal(review, want) {
 		t.Errorf("PullRequests.SubmitReview returned %+v, want %+v", review, want)
 	}
 
@@ -587,7 +588,7 @@ func TestPullRequestsService_DismissReview(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -601,7 +602,7 @@ func TestPullRequestsService_DismissReview(t *testing.T) {
 	}
 
 	want := &PullRequestReview{ID: Int64(1)}
-	if !reflect.DeepEqual(review, want) {
+	if !cmp.Equal(review, want) {
 		t.Errorf("PullRequests.DismissReview returned %+v, want %+v", review, want)
 	}
 

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -11,9 +11,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestPullRequestsService_List(t *testing.T) {
@@ -41,7 +42,7 @@ func TestPullRequestsService_List(t *testing.T) {
 	}
 
 	want := []*PullRequest{{Number: Int(1)}}
-	if !reflect.DeepEqual(pulls, want) {
+	if !cmp.Equal(pulls, want) {
 		t.Errorf("PullRequests.List returned %+v, want %+v", pulls, want)
 	}
 
@@ -86,7 +87,7 @@ func TestPullRequestsService_ListPullRequestsWithCommit(t *testing.T) {
 	}
 
 	want := []*PullRequest{{Number: Int(1)}}
-	if !reflect.DeepEqual(pulls, want) {
+	if !cmp.Equal(pulls, want) {
 		t.Errorf("PullRequests.ListPullRequestsWithCommit returned %+v, want %+v", pulls, want)
 	}
 
@@ -130,7 +131,7 @@ func TestPullRequestsService_Get(t *testing.T) {
 	}
 
 	want := &PullRequest{Number: Int(1)}
-	if !reflect.DeepEqual(pull, want) {
+	if !cmp.Equal(pull, want) {
 		t.Errorf("PullRequests.Get returned %+v, want %+v", pull, want)
 	}
 
@@ -272,7 +273,7 @@ func TestPullRequestsService_Get_links(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(pull, want) {
+	if !cmp.Equal(pull, want) {
 		t.Errorf("PullRequests.Get returned %+v, want %+v", pull, want)
 	}
 }
@@ -303,7 +304,7 @@ func TestPullRequestsService_Get_headAndBase(t *testing.T) {
 			Repo: &Repository{ID: Int64(1)},
 		},
 	}
-	if !reflect.DeepEqual(pull, want) {
+	if !cmp.Equal(pull, want) {
 		t.Errorf("PullRequests.Get returned %+v, want %+v", pull, want)
 	}
 }
@@ -343,7 +344,7 @@ func TestPullRequestsService_Get_urlFields(t *testing.T) {
 		ReviewCommentURL:  String("https://api.github.com/repos/octocat/Hello-World/pulls/comments{/number}"),
 	}
 
-	if !reflect.DeepEqual(pull, want) {
+	if !cmp.Equal(pull, want) {
 		t.Errorf("PullRequests.Get returned %+v, want %+v", pull, want)
 	}
 }
@@ -368,7 +369,7 @@ func TestPullRequestsService_Create(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -382,7 +383,7 @@ func TestPullRequestsService_Create(t *testing.T) {
 	}
 
 	want := &PullRequest{Number: Int(1)}
-	if !reflect.DeepEqual(pull, want) {
+	if !cmp.Equal(pull, want) {
 		t.Errorf("PullRequests.Create returned %+v, want %+v", pull, want)
 	}
 
@@ -439,7 +440,7 @@ func TestPullRequestsService_UpdateBranch(t *testing.T) {
 		URL:     String("https://github.com/repos/o/r/pulls/1"),
 	}
 
-	if !reflect.DeepEqual(pull, want) {
+	if !cmp.Equal(pull, want) {
 		t.Errorf("PullRequests.UpdateBranch returned %+v, want %+v", pull, want)
 	}
 
@@ -502,7 +503,7 @@ func TestPullRequestsService_Edit(t *testing.T) {
 			t.Errorf("%d: PullRequests.Edit returned error: %v", i, err)
 		}
 
-		if !reflect.DeepEqual(pull, tt.want) {
+		if !cmp.Equal(pull, tt.want) {
 			t.Errorf("%d: PullRequests.Edit returned %+v, want %+v", i, pull, tt.want)
 		}
 
@@ -580,7 +581,7 @@ func TestPullRequestsService_ListCommits(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(commits, want) {
+	if !cmp.Equal(commits, want) {
 		t.Errorf("PullRequests.ListCommits returned %+v, want %+v", commits, want)
 	}
 
@@ -657,7 +658,7 @@ func TestPullRequestsService_ListFiles(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(commitFiles, want) {
+	if !cmp.Equal(commitFiles, want) {
 		t.Errorf("PullRequests.ListFiles returned %+v, want %+v", commitFiles, want)
 	}
 
@@ -692,7 +693,7 @@ func TestPullRequestsService_IsMerged(t *testing.T) {
 	}
 
 	want := true
-	if !reflect.DeepEqual(isMerged, want) {
+	if !cmp.Equal(isMerged, want) {
 		t.Errorf("PullRequests.IsMerged returned %+v, want %+v", isMerged, want)
 	}
 
@@ -737,7 +738,7 @@ func TestPullRequestsService_Merge(t *testing.T) {
 		Merged:  Bool(true),
 		Message: String("Pull Request successfully merged"),
 	}
-	if !reflect.DeepEqual(merge, want) {
+	if !cmp.Equal(merge, want) {
 		t.Errorf("PullRequests.Merge returned %+v, want %+v", merge, want)
 	}
 

--- a/github/reactions_test.go
+++ b/github/reactions_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestReaction_Marshal(t *testing.T) {
@@ -83,7 +84,7 @@ func TestReactionsService_ListCommentReactions(t *testing.T) {
 		t.Errorf("ListCommentReactions returned error: %v", err)
 	}
 	want := []*Reaction{{ID: Int64(1), User: &User{Login: String("l"), ID: Int64(2)}, Content: String("+1")}}
-	if !reflect.DeepEqual(reactions, want) {
+	if !cmp.Equal(reactions, want) {
 		t.Errorf("ListCommentReactions = %+v, want %+v", reactions, want)
 	}
 
@@ -120,7 +121,7 @@ func TestReactionsService_CreateCommentReaction(t *testing.T) {
 		t.Errorf("CreateCommentReaction returned error: %v", err)
 	}
 	want := &Reaction{ID: Int64(1), User: &User{Login: String("l"), ID: Int64(2)}, Content: String("+1")}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("CreateCommentReaction = %+v, want %+v", got, want)
 	}
 
@@ -157,7 +158,7 @@ func TestReactionsService_ListIssueReactions(t *testing.T) {
 		t.Errorf("ListIssueReactions returned error: %v", err)
 	}
 	want := []*Reaction{{ID: Int64(1), User: &User{Login: String("l"), ID: Int64(2)}, Content: String("+1")}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("ListIssueReactions = %+v, want %+v", got, want)
 	}
 }
@@ -201,7 +202,7 @@ func TestReactionsService_CreateIssueReaction(t *testing.T) {
 		t.Errorf("CreateIssueReaction returned error: %v", err)
 	}
 	want := &Reaction{ID: Int64(1), User: &User{Login: String("l"), ID: Int64(2)}, Content: String("+1")}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("CreateIssueReaction = %+v, want %+v", got, want)
 	}
 
@@ -238,7 +239,7 @@ func TestReactionsService_ListIssueCommentReactions(t *testing.T) {
 		t.Errorf("ListIssueCommentReactions returned error: %v", err)
 	}
 	want := []*Reaction{{ID: Int64(1), User: &User{Login: String("l"), ID: Int64(2)}, Content: String("+1")}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("ListIssueCommentReactions = %+v, want %+v", got, want)
 	}
 }
@@ -282,7 +283,7 @@ func TestReactionsService_CreateIssueCommentReaction(t *testing.T) {
 		t.Errorf("CreateIssueCommentReaction returned error: %v", err)
 	}
 	want := &Reaction{ID: Int64(1), User: &User{Login: String("l"), ID: Int64(2)}, Content: String("+1")}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("CreateIssueCommentReaction = %+v, want %+v", got, want)
 	}
 
@@ -319,7 +320,7 @@ func TestReactionsService_ListPullRequestCommentReactions(t *testing.T) {
 		t.Errorf("ListPullRequestCommentReactions returned error: %v", err)
 	}
 	want := []*Reaction{{ID: Int64(1), User: &User{Login: String("l"), ID: Int64(2)}, Content: String("+1")}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("ListPullRequestCommentReactions = %+v, want %+v", got, want)
 	}
 }
@@ -363,7 +364,7 @@ func TestReactionsService_CreatePullRequestCommentReaction(t *testing.T) {
 		t.Errorf("CreatePullRequestCommentReaction returned error: %v", err)
 	}
 	want := &Reaction{ID: Int64(1), User: &User{Login: String("l"), ID: Int64(2)}, Content: String("+1")}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("CreatePullRequestCommentReaction = %+v, want %+v", got, want)
 	}
 
@@ -400,7 +401,7 @@ func TestReactionsService_ListTeamDiscussionReactions(t *testing.T) {
 		t.Errorf("ListTeamDiscussionReactions returned error: %v", err)
 	}
 	want := []*Reaction{{ID: Int64(1), User: &User{Login: String("l"), ID: Int64(2)}, Content: String("+1")}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("ListTeamDiscussionReactions = %+v, want %+v", got, want)
 	}
 }
@@ -444,7 +445,7 @@ func TestReactionsService_CreateTeamDiscussionReaction(t *testing.T) {
 		t.Errorf("CreateTeamDiscussionReaction returned error: %v", err)
 	}
 	want := &Reaction{ID: Int64(1), User: &User{Login: String("l"), ID: Int64(2)}, Content: String("+1")}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("CreateTeamDiscussionReaction = %+v, want %+v", got, want)
 	}
 
@@ -481,7 +482,7 @@ func TestReactionService_ListTeamDiscussionCommentReactions(t *testing.T) {
 		t.Errorf("ListTeamDiscussionCommentReactions returned error: %v", err)
 	}
 	want := []*Reaction{{ID: Int64(1), User: &User{Login: String("l"), ID: Int64(2)}, Content: String("+1")}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("ListTeamDiscussionCommentReactions = %+v, want %+v", got, want)
 	}
 }
@@ -525,7 +526,7 @@ func TestReactionService_CreateTeamDiscussionCommentReaction(t *testing.T) {
 		t.Errorf("CreateTeamDiscussionCommentReaction returned error: %v", err)
 	}
 	want := &Reaction{ID: Int64(1), User: &User{Login: String("l"), ID: Int64(2)}, Content: String("+1")}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("CreateTeamDiscussionCommentReaction = %+v, want %+v", got, want)
 	}
 

--- a/github/repos_collaborators_test.go
+++ b/github/repos_collaborators_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_ListCollaborators(t *testing.T) {
@@ -34,7 +35,7 @@ func TestRepositoriesService_ListCollaborators(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(users, want) {
+	if !cmp.Equal(users, want) {
 		t.Errorf("Repositories.ListCollaborators returned %+v, want %+v", users, want)
 	}
 
@@ -74,7 +75,7 @@ func TestRepositoriesService_ListCollaborators_withAffiliation(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(users, want) {
+	if !cmp.Equal(users, want) {
 		t.Errorf("Repositories.ListCollaborators returned %+v, want %+v", users, want)
 	}
 
@@ -201,7 +202,7 @@ func TestRepositoryService_GetPermissionLevel(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(rpl, want) {
+	if !cmp.Equal(rpl, want) {
 		t.Errorf("Repositories.GetPermissionLevel returned %+v, want %+v", rpl, want)
 	}
 
@@ -229,7 +230,7 @@ func TestRepositoriesService_AddCollaborator(t *testing.T) {
 		v := new(RepositoryAddCollaboratorOptions)
 		json.NewDecoder(r.Body).Decode(v)
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, opt) {
+		if !cmp.Equal(v, opt) {
 			t.Errorf("Request body = %+v, want %+v", v, opt)
 		}
 		w.WriteHeader(http.StatusOK)
@@ -258,7 +259,7 @@ func TestRepositoriesService_AddCollaborator(t *testing.T) {
 		HTMLURL:     String("https://github.com/octocat/Hello-World/invitations"),
 	}
 
-	if !reflect.DeepEqual(collaboratorInvitation, want) {
+	if !cmp.Equal(collaboratorInvitation, want) {
 		t.Errorf("AddCollaborator returned %+v, want %+v", collaboratorInvitation, want)
 	}
 

--- a/github/repos_comments_test.go
+++ b/github/repos_comments_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_ListComments(t *testing.T) {
@@ -33,7 +34,7 @@ func TestRepositoriesService_ListComments(t *testing.T) {
 	}
 
 	want := []*RepositoryComment{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(comments, want) {
+	if !cmp.Equal(comments, want) {
 		t.Errorf("Repositories.ListComments returned %+v, want %+v", comments, want)
 	}
 
@@ -80,7 +81,7 @@ func TestRepositoriesService_ListCommitComments(t *testing.T) {
 	}
 
 	want := []*RepositoryComment{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(comments, want) {
+	if !cmp.Equal(comments, want) {
 		t.Errorf("Repositories.ListCommitComments returned %+v, want %+v", comments, want)
 	}
 
@@ -119,7 +120,7 @@ func TestRepositoriesService_CreateComment(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -133,7 +134,7 @@ func TestRepositoriesService_CreateComment(t *testing.T) {
 	}
 
 	want := &RepositoryComment{ID: Int64(1)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("Repositories.CreateComment returned %+v, want %+v", comment, want)
 	}
 
@@ -178,7 +179,7 @@ func TestRepositoriesService_GetComment(t *testing.T) {
 	}
 
 	want := &RepositoryComment{ID: Int64(1)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("Repositories.GetComment returned %+v, want %+v", comment, want)
 	}
 
@@ -217,7 +218,7 @@ func TestRepositoriesService_UpdateComment(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -231,7 +232,7 @@ func TestRepositoriesService_UpdateComment(t *testing.T) {
 	}
 
 	want := &RepositoryComment{ID: Int64(1)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("Repositories.UpdateComment returned %+v, want %+v", comment, want)
 	}
 

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -10,10 +10,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_ListCommits(t *testing.T) {
@@ -48,7 +49,7 @@ func TestRepositoriesService_ListCommits(t *testing.T) {
 	}
 
 	want := []*RepositoryCommit{{SHA: String("s")}}
-	if !reflect.DeepEqual(commits, want) {
+	if !cmp.Equal(commits, want) {
 		t.Errorf("Repositories.ListCommits returned %+v, want %+v", commits, want)
 	}
 
@@ -137,7 +138,7 @@ func TestRepositoriesService_GetCommit(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(commit, want) {
+	if !cmp.Equal(commit, want) {
 		t.Errorf("Repositories.GetCommit returned \n%+v, want \n%+v", commit, want)
 	}
 
@@ -477,7 +478,7 @@ func TestRepositoriesService_CompareCommits(t *testing.T) {
 			URL:          String(fmt.Sprintf("https://api.github.com/repos/o/r/compare/%v...%v", escapedBase, escapedHead)),
 		}
 
-		if !reflect.DeepEqual(got, want) {
+		if !cmp.Equal(got, want) {
 			t.Errorf("Repositories.CompareCommits returned \n%+v, want \n%+v", got, want)
 		}
 
@@ -639,7 +640,7 @@ func TestRepositoriesService_ListBranchesHeadCommit(t *testing.T) {
 			Protected: Bool(true),
 		},
 	}
-	if !reflect.DeepEqual(branches, want) {
+	if !cmp.Equal(branches, want) {
 		t.Errorf("Repositories.ListBranchesHeadCommit returned %+v, want %+v", branches, want)
 	}
 

--- a/github/repos_community_health_test.go
+++ b/github/repos_community_health_test.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
@@ -81,7 +82,7 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.GetCommunityHealthMetrics:\ngot:\n%v\nwant:\n%v", Stringify(got), Stringify(want))
 	}
 

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -11,8 +11,9 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoryContent_GetContent(t *testing.T) {
@@ -98,7 +99,7 @@ func TestRepositoriesService_GetReadme(t *testing.T) {
 		t.Errorf("Repositories.GetReadme returned error: %v", err)
 	}
 	want := &RepositoryContent{Type: String("file"), Name: String("README.md"), Size: Int(5362), Encoding: String("base64"), Path: String("README.md")}
-	if !reflect.DeepEqual(readme, want) {
+	if !cmp.Equal(readme, want) {
 		t.Errorf("Repositories.GetReadme returned %+v, want %+v", readme, want)
 	}
 
@@ -415,7 +416,7 @@ func TestRepositoriesService_GetContents_File(t *testing.T) {
 		t.Errorf("Repositories.GetContents returned error: %v", err)
 	}
 	want := &RepositoryContent{Type: String("file"), Name: String("LICENSE"), Size: Int(20678), Encoding: String("base64"), Path: String("LICENSE")}
-	if !reflect.DeepEqual(fileContents, want) {
+	if !cmp.Equal(fileContents, want) {
 		t.Errorf("Repositories.GetContents returned %+v, want %+v", fileContents, want)
 	}
 
@@ -500,7 +501,7 @@ func TestRepositoriesService_GetContents_Directory(t *testing.T) {
 	}
 	want := []*RepositoryContent{{Type: String("dir"), Name: String("lib"), Path: String("lib")},
 		{Type: String("file"), Name: String("LICENSE"), Size: Int(20678), Path: String("LICENSE")}}
-	if !reflect.DeepEqual(directoryContents, want) {
+	if !cmp.Equal(directoryContents, want) {
 		t.Errorf("Repositories.GetContents_Directory returned %+v, want %+v", directoryContents, want)
 	}
 }
@@ -539,7 +540,7 @@ func TestRepositoriesService_CreateFile(t *testing.T) {
 			SHA:     String("f5f369044773ff9c6383c087466d12adb6fa0828"),
 		},
 	}
-	if !reflect.DeepEqual(createResponse, want) {
+	if !cmp.Equal(createResponse, want) {
 		t.Errorf("Repositories.CreateFile returned %+v, want %+v", createResponse, want)
 	}
 
@@ -594,7 +595,7 @@ func TestRepositoriesService_UpdateFile(t *testing.T) {
 			SHA:     String("f5f369044773ff9c6383c087466d12adb6fa0828"),
 		},
 	}
-	if !reflect.DeepEqual(updateResponse, want) {
+	if !cmp.Equal(updateResponse, want) {
 		t.Errorf("Repositories.UpdateFile returned %+v, want %+v", updateResponse, want)
 	}
 
@@ -645,7 +646,7 @@ func TestRepositoriesService_DeleteFile(t *testing.T) {
 			SHA:     String("f5f369044773ff9c6383c087466d12adb6fa0828"),
 		},
 	}
-	if !reflect.DeepEqual(deleteResponse, want) {
+	if !cmp.Equal(deleteResponse, want) {
 		t.Errorf("Repositories.DeleteFile returned %+v, want %+v", deleteResponse, want)
 	}
 

--- a/github/repos_deployments_test.go
+++ b/github/repos_deployments_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_ListDeployments(t *testing.T) {
@@ -33,7 +34,7 @@ func TestRepositoriesService_ListDeployments(t *testing.T) {
 	}
 
 	want := []*Deployment{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(deployments, want) {
+	if !cmp.Equal(deployments, want) {
 		t.Errorf("Repositories.ListDeployments returned %+v, want %+v", deployments, want)
 	}
 
@@ -69,7 +70,7 @@ func TestRepositoriesService_GetDeployment(t *testing.T) {
 
 	want := &Deployment{ID: Int64(3)}
 
-	if !reflect.DeepEqual(deployment, want) {
+	if !cmp.Equal(deployment, want) {
 		t.Errorf("Repositories.GetDeployment returned %+v, want %+v", deployment, want)
 	}
 
@@ -101,7 +102,7 @@ func TestRepositoriesService_CreateDeployment(t *testing.T) {
 		testMethod(t, r, "POST")
 		wantAcceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeExpandDeploymentStatusPreview}
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -115,7 +116,7 @@ func TestRepositoriesService_CreateDeployment(t *testing.T) {
 	}
 
 	want := &Deployment{Ref: String("1111"), Task: String("deploy")}
-	if !reflect.DeepEqual(deployment, want) {
+	if !cmp.Equal(deployment, want) {
 		t.Errorf("Repositories.CreateDeployment returned %+v, want %+v", deployment, want)
 	}
 
@@ -191,7 +192,7 @@ func TestRepositoriesService_ListDeploymentStatuses(t *testing.T) {
 	}
 
 	want := []*DeploymentStatus{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(statutses, want) {
+	if !cmp.Equal(statutses, want) {
 		t.Errorf("Repositories.ListDeploymentStatuses returned %+v, want %+v", statutses, want)
 	}
 
@@ -228,7 +229,7 @@ func TestRepositoriesService_GetDeploymentStatus(t *testing.T) {
 	}
 
 	want := &DeploymentStatus{ID: Int64(4)}
-	if !reflect.DeepEqual(deploymentStatus, want) {
+	if !cmp.Equal(deploymentStatus, want) {
 		t.Errorf("Repositories.GetDeploymentStatus returned %+v, want %+v", deploymentStatus, want)
 	}
 
@@ -260,7 +261,7 @@ func TestRepositoriesService_CreateDeploymentStatus(t *testing.T) {
 		testMethod(t, r, "POST")
 		wantAcceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeExpandDeploymentStatusPreview}
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -274,7 +275,7 @@ func TestRepositoriesService_CreateDeploymentStatus(t *testing.T) {
 	}
 
 	want := &DeploymentStatus{State: String("inactive"), Description: String("deploy")}
-	if !reflect.DeepEqual(deploymentStatus, want) {
+	if !cmp.Equal(deploymentStatus, want) {
 		t.Errorf("Repositories.CreateDeploymentStatus returned %+v, want %+v", deploymentStatus, want)
 	}
 

--- a/github/repos_environments_test.go
+++ b/github/repos_environments_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRequiredReviewer_UnmarshalJSON(t *testing.T) {
@@ -77,7 +78,7 @@ func TestRequiredReviewer_UnmarshalJSON(t *testing.T) {
 			if err == nil && test.wantError {
 				t.Errorf("RequiredReviewer.UnmarshalJSON returned no error when we expected one")
 			}
-			if !reflect.DeepEqual(test.wantRule, rule) {
+			if !cmp.Equal(test.wantRule, rule) {
 				t.Errorf("RequiredReviewer.UnmarshalJSON expected rule %+v, got %+v", test.wantRule, rule)
 			}
 		})
@@ -113,7 +114,7 @@ func TestRepositoriesService_ListEnvironments(t *testing.T) {
 		t.Errorf("Repositories.ListEnvironments returned error: %v", err)
 	}
 	want := &EnvResponse{TotalCount: Int(1), Environments: []*Environment{{ID: Int64(1)}, {ID: Int64(2)}}}
-	if !reflect.DeepEqual(environments, want) {
+	if !cmp.Equal(environments, want) {
 		t.Errorf("Repositories.ListEnvironments returned %+v, want %+v", environments, want)
 	}
 
@@ -148,7 +149,7 @@ func TestRepositoriesService_GetEnvironment(t *testing.T) {
 	}
 
 	want := &Environment{ID: Int64(1), Name: String("staging"), DeploymentBranchPolicy: &BranchPolicy{ProtectedBranches: Bool(true), CustomBranchPolicies: Bool(false)}}
-	if !reflect.DeepEqual(release, want) {
+	if !cmp.Equal(release, want) {
 		t.Errorf("Repositories.GetEnvironment returned %+v, want %+v", release, want)
 	}
 
@@ -181,7 +182,7 @@ func TestRepositoriesService_CreateEnvironment(t *testing.T) {
 
 		testMethod(t, r, "PUT")
 		want := &CreateUpdateEnvironment{WaitTimer: Int(30)}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 		fmt.Fprint(w, `{"id": 1, "name": "staging",	"protection_rules": [{"id": 1, "type": "wait_timer", "wait_timer": 30}]}`)
@@ -194,7 +195,7 @@ func TestRepositoriesService_CreateEnvironment(t *testing.T) {
 	}
 
 	want := &Environment{ID: Int64(1), Name: String("staging"), ProtectionRules: []*ProtectionRule{{ID: Int64(1), Type: String("wait_timer"), WaitTimer: Int(30)}}}
-	if !reflect.DeepEqual(release, want) {
+	if !cmp.Equal(release, want) {
 		t.Errorf("Repositories.CreateUpdateEnvironment returned %+v, want %+v", release, want)
 	}
 

--- a/github/repos_forks_test.go
+++ b/github/repos_forks_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_ListForks(t *testing.T) {
@@ -38,7 +39,7 @@ func TestRepositoriesService_ListForks(t *testing.T) {
 	}
 
 	want := []*Repository{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(repos, want) {
+	if !cmp.Equal(repos, want) {
 		t.Errorf("Repositories.ListForks returned %+v, want %+v", repos, want)
 	}
 
@@ -84,7 +85,7 @@ func TestRepositoriesService_CreateFork(t *testing.T) {
 	}
 
 	want := &Repository{ID: Int64(1)}
-	if !reflect.DeepEqual(repo, want) {
+	if !cmp.Equal(repo, want) {
 		t.Errorf("Repositories.CreateFork returned %+v, want %+v", repo, want)
 	}
 
@@ -123,7 +124,7 @@ func TestRepositoriesService_CreateFork_deferred(t *testing.T) {
 	}
 
 	want := &Repository{ID: Int64(1)}
-	if !reflect.DeepEqual(repo, want) {
+	if !cmp.Equal(repo, want) {
 		t.Errorf("Repositories.CreateFork returned %+v, want %+v", repo, want)
 	}
 }

--- a/github/repos_hooks_test.go
+++ b/github/repos_hooks_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_CreateHook(t *testing.T) {
@@ -26,7 +27,7 @@ func TestRepositoriesService_CreateHook(t *testing.T) {
 
 		testMethod(t, r, "POST")
 		want := &createHookRequest{Name: "web"}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 
@@ -40,7 +41,7 @@ func TestRepositoriesService_CreateHook(t *testing.T) {
 	}
 
 	want := &Hook{ID: Int64(1)}
-	if !reflect.DeepEqual(hook, want) {
+	if !cmp.Equal(hook, want) {
 		t.Errorf("Repositories.CreateHook returned %+v, want %+v", hook, want)
 	}
 
@@ -78,7 +79,7 @@ func TestRepositoriesService_ListHooks(t *testing.T) {
 	}
 
 	want := []*Hook{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(hooks, want) {
+	if !cmp.Equal(hooks, want) {
 		t.Errorf("Repositories.ListHooks returned %+v, want %+v", hooks, want)
 	}
 
@@ -122,7 +123,7 @@ func TestRepositoriesService_GetHook(t *testing.T) {
 	}
 
 	want := &Hook{ID: Int64(1)}
-	if !reflect.DeepEqual(hook, want) {
+	if !cmp.Equal(hook, want) {
 		t.Errorf("Repositories.GetHook returned %+v, want %+v", hook, want)
 	}
 
@@ -161,7 +162,7 @@ func TestRepositoriesService_EditHook(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -175,7 +176,7 @@ func TestRepositoriesService_EditHook(t *testing.T) {
 	}
 
 	want := &Hook{ID: Int64(1)}
-	if !reflect.DeepEqual(hook, want) {
+	if !cmp.Equal(hook, want) {
 		t.Errorf("Repositories.EditHook returned %+v, want %+v", hook, want)
 	}
 

--- a/github/repos_invitations_test.go
+++ b/github/repos_invitations_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_ListInvitations(t *testing.T) {
@@ -31,7 +32,7 @@ func TestRepositoriesService_ListInvitations(t *testing.T) {
 	}
 
 	want := []*RepositoryInvitation{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.ListInvitations = %+v, want %+v", got, want)
 	}
 
@@ -92,7 +93,7 @@ func TestRepositoriesService_UpdateInvitation(t *testing.T) {
 	}
 
 	want := &RepositoryInvitation{ID: Int64(1)}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.UpdateInvitation = %+v, want %+v", got, want)
 	}
 

--- a/github/repos_keys_test.go
+++ b/github/repos_keys_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_ListKeys(t *testing.T) {
@@ -32,7 +33,7 @@ func TestRepositoriesService_ListKeys(t *testing.T) {
 	}
 
 	want := []*Key{{ID: Int64(1)}}
-	if !reflect.DeepEqual(keys, want) {
+	if !cmp.Equal(keys, want) {
 		t.Errorf("Repositories.ListKeys returned %+v, want %+v", keys, want)
 	}
 
@@ -76,7 +77,7 @@ func TestRepositoriesService_GetKey(t *testing.T) {
 	}
 
 	want := &Key{ID: Int64(1)}
-	if !reflect.DeepEqual(key, want) {
+	if !cmp.Equal(key, want) {
 		t.Errorf("Repositories.GetKey returned %+v, want %+v", key, want)
 	}
 
@@ -115,7 +116,7 @@ func TestRepositoriesService_CreateKey(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -129,7 +130,7 @@ func TestRepositoriesService_CreateKey(t *testing.T) {
 	}
 
 	want := &Key{ID: Int64(1)}
-	if !reflect.DeepEqual(key, want) {
+	if !cmp.Equal(key, want) {
 		t.Errorf("Repositories.GetKey returned %+v, want %+v", key, want)
 	}
 

--- a/github/repos_merging_test.go
+++ b/github/repos_merging_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_Merge(t *testing.T) {
@@ -29,7 +30,7 @@ func TestRepositoriesService_Merge(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -43,7 +44,7 @@ func TestRepositoriesService_Merge(t *testing.T) {
 	}
 
 	want := &RepositoryCommit{SHA: String("s")}
-	if !reflect.DeepEqual(commit, want) {
+	if !cmp.Equal(commit, want) {
 		t.Errorf("Repositories.Merge returned %+v, want %+v", commit, want)
 	}
 

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -12,8 +12,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_EnablePages(t *testing.T) {
@@ -35,7 +36,7 @@ func TestRepositoriesService_EnablePages(t *testing.T) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", mediaTypeEnablePagesAPIPreview)
 		want := &createPagesRequest{Source: &PagesSource{Branch: String("master"), Path: String("/")}}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 
@@ -50,7 +51,7 @@ func TestRepositoriesService_EnablePages(t *testing.T) {
 
 	want := &Pages{URL: String("u"), Status: String("s"), CNAME: String("c"), Custom404: Bool(false), HTMLURL: String("h"), Source: &PagesSource{Branch: String("master"), Path: String("/")}}
 
-	if !reflect.DeepEqual(page, want) {
+	if !cmp.Equal(page, want) {
 		t.Errorf("Repositories.EnablePages returned %v, want %v", page, want)
 	}
 
@@ -84,7 +85,7 @@ func TestRepositoriesService_UpdatePages(t *testing.T) {
 
 		testMethod(t, r, "PUT")
 		want := &PagesUpdate{CNAME: String("www.my-domain.com"), Source: String("gh-pages")}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 
@@ -179,7 +180,7 @@ func TestRepositoriesService_GetPagesInfo(t *testing.T) {
 	}
 
 	want := &Pages{URL: String("u"), Status: String("s"), CNAME: String("c"), Custom404: Bool(false), HTMLURL: String("h")}
-	if !reflect.DeepEqual(page, want) {
+	if !cmp.Equal(page, want) {
 		t.Errorf("Repositories.GetPagesInfo returned %+v, want %+v", page, want)
 	}
 
@@ -214,7 +215,7 @@ func TestRepositoriesService_ListPagesBuilds(t *testing.T) {
 	}
 
 	want := []*PagesBuild{{URL: String("u"), Status: String("s"), Commit: String("c")}}
-	if !reflect.DeepEqual(pages, want) {
+	if !cmp.Equal(pages, want) {
 		t.Errorf("Repositories.ListPagesBuilds returned %+v, want %+v", pages, want)
 	}
 
@@ -268,7 +269,7 @@ func TestRepositoriesService_GetLatestPagesBuild(t *testing.T) {
 	}
 
 	want := &PagesBuild{URL: String("u"), Status: String("s"), Commit: String("c")}
-	if !reflect.DeepEqual(build, want) {
+	if !cmp.Equal(build, want) {
 		t.Errorf("Repositories.GetLatestPagesBuild returned %+v, want %+v", build, want)
 	}
 
@@ -303,7 +304,7 @@ func TestRepositoriesService_GetPageBuild(t *testing.T) {
 	}
 
 	want := &PagesBuild{URL: String("u"), Status: String("s"), Commit: String("c")}
-	if !reflect.DeepEqual(build, want) {
+	if !cmp.Equal(build, want) {
 		t.Errorf("Repositories.GetPageBuild returned %+v, want %+v", build, want)
 	}
 
@@ -338,7 +339,7 @@ func TestRepositoriesService_RequestPageBuild(t *testing.T) {
 	}
 
 	want := &PagesBuild{URL: String("u"), Status: String("s")}
-	if !reflect.DeepEqual(build, want) {
+	if !cmp.Equal(build, want) {
 		t.Errorf("Repositories.RequestPageBuild returned %+v, want %+v", build, want)
 	}
 

--- a/github/repos_prereceive_hooks_test.go
+++ b/github/repos_prereceive_hooks_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_ListPreReceiveHooks(t *testing.T) {
@@ -34,7 +35,7 @@ func TestRepositoriesService_ListPreReceiveHooks(t *testing.T) {
 	}
 
 	want := []*PreReceiveHook{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(hooks, want) {
+	if !cmp.Equal(hooks, want) {
 		t.Errorf("Repositories.ListPreReceiveHooks returned %+v, want %+v", hooks, want)
 	}
 
@@ -79,7 +80,7 @@ func TestRepositoriesService_GetPreReceiveHook(t *testing.T) {
 	}
 
 	want := &PreReceiveHook{ID: Int64(1)}
-	if !reflect.DeepEqual(hook, want) {
+	if !cmp.Equal(hook, want) {
 		t.Errorf("Repositories.GetPreReceiveHook returned %+v, want %+v", hook, want)
 	}
 
@@ -118,7 +119,7 @@ func TestRepositoriesService_UpdatePreReceiveHook(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -132,7 +133,7 @@ func TestRepositoriesService_UpdatePreReceiveHook(t *testing.T) {
 	}
 
 	want := &PreReceiveHook{ID: Int64(1)}
-	if !reflect.DeepEqual(hook, want) {
+	if !cmp.Equal(hook, want) {
 		t.Errorf("Repositories.UpdatePreReceiveHook returned %+v, want %+v", hook, want)
 	}
 

--- a/github/repos_projects_test.go
+++ b/github/repos_projects_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_ListProjects(t *testing.T) {
@@ -33,7 +34,7 @@ func TestRepositoriesService_ListProjects(t *testing.T) {
 	}
 
 	want := []*Project{{ID: Int64(1)}}
-	if !reflect.DeepEqual(projects, want) {
+	if !cmp.Equal(projects, want) {
 		t.Errorf("Repositories.ListProjects returned %+v, want %+v", projects, want)
 	}
 
@@ -64,7 +65,7 @@ func TestRepositoriesService_CreateProject(t *testing.T) {
 
 		v := &ProjectOptions{}
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -78,7 +79,7 @@ func TestRepositoriesService_CreateProject(t *testing.T) {
 	}
 
 	want := &Project{ID: Int64(1)}
-	if !reflect.DeepEqual(project, want) {
+	if !cmp.Equal(project, want) {
 		t.Errorf("Repositories.CreateProject returned %+v, want %+v", project, want)
 	}
 

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -13,9 +13,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_ListReleases(t *testing.T) {
@@ -35,7 +36,7 @@ func TestRepositoriesService_ListReleases(t *testing.T) {
 		t.Errorf("Repositories.ListReleases returned error: %v", err)
 	}
 	want := []*RepositoryRelease{{ID: Int64(1)}}
-	if !reflect.DeepEqual(releases, want) {
+	if !cmp.Equal(releases, want) {
 		t.Errorf("Repositories.ListReleases returned %+v, want %+v", releases, want)
 	}
 
@@ -70,7 +71,7 @@ func TestRepositoriesService_GetRelease(t *testing.T) {
 	}
 
 	want := &RepositoryRelease{ID: Int64(1), Author: &User{Login: String("l")}}
-	if !reflect.DeepEqual(release, want) {
+	if !cmp.Equal(release, want) {
 		t.Errorf("Repositories.GetRelease returned %+v, want %+v", release, want)
 	}
 
@@ -105,7 +106,7 @@ func TestRepositoriesService_GetLatestRelease(t *testing.T) {
 	}
 
 	want := &RepositoryRelease{ID: Int64(3)}
-	if !reflect.DeepEqual(release, want) {
+	if !cmp.Equal(release, want) {
 		t.Errorf("Repositories.GetLatestRelease returned %+v, want %+v", release, want)
 	}
 
@@ -140,7 +141,7 @@ func TestRepositoriesService_GetReleaseByTag(t *testing.T) {
 	}
 
 	want := &RepositoryRelease{ID: Int64(13)}
-	if !reflect.DeepEqual(release, want) {
+	if !cmp.Equal(release, want) {
 		t.Errorf("Repositories.GetReleaseByTag returned %+v, want %+v", release, want)
 	}
 
@@ -190,7 +191,7 @@ func TestRepositoriesService_CreateRelease(t *testing.T) {
 			Name:                   String("v1.0"),
 			DiscussionCategoryName: String("General"),
 		}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 		fmt.Fprint(w, `{"id":1}`)
@@ -203,7 +204,7 @@ func TestRepositoriesService_CreateRelease(t *testing.T) {
 	}
 
 	want := &RepositoryRelease{ID: Int64(1)}
-	if !reflect.DeepEqual(release, want) {
+	if !cmp.Equal(release, want) {
 		t.Errorf("Repositories.CreateRelease returned %+v, want %+v", release, want)
 	}
 
@@ -253,7 +254,7 @@ func TestRepositoriesService_EditRelease(t *testing.T) {
 			Name:                   String("n"),
 			DiscussionCategoryName: String("General"),
 		}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 		fmt.Fprint(w, `{"id":1}`)
@@ -265,7 +266,7 @@ func TestRepositoriesService_EditRelease(t *testing.T) {
 		t.Errorf("Repositories.EditRelease returned error: %v", err)
 	}
 	want := &RepositoryRelease{ID: Int64(1)}
-	if !reflect.DeepEqual(release, want) {
+	if !cmp.Equal(release, want) {
 		t.Errorf("Repositories.EditRelease returned = %+v, want %+v", release, want)
 	}
 
@@ -326,7 +327,7 @@ func TestRepositoriesService_ListReleaseAssets(t *testing.T) {
 		t.Errorf("Repositories.ListReleaseAssets returned error: %v", err)
 	}
 	want := []*ReleaseAsset{{ID: Int64(1)}}
-	if !reflect.DeepEqual(assets, want) {
+	if !cmp.Equal(assets, want) {
 		t.Errorf("Repositories.ListReleaseAssets returned %+v, want %+v", assets, want)
 	}
 
@@ -360,7 +361,7 @@ func TestRepositoriesService_GetReleaseAsset(t *testing.T) {
 		t.Errorf("Repositories.GetReleaseAsset returned error: %v", err)
 	}
 	want := &ReleaseAsset{ID: Int64(1)}
-	if !reflect.DeepEqual(asset, want) {
+	if !cmp.Equal(asset, want) {
 		t.Errorf("Repositories.GetReleaseAsset returned %+v, want %+v", asset, want)
 	}
 
@@ -502,7 +503,7 @@ func TestRepositoriesService_EditReleaseAsset(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 		fmt.Fprint(w, `{"id":1}`)
@@ -514,7 +515,7 @@ func TestRepositoriesService_EditReleaseAsset(t *testing.T) {
 		t.Errorf("Repositories.EditReleaseAsset returned error: %v", err)
 	}
 	want := &ReleaseAsset{ID: Int64(1)}
-	if !reflect.DeepEqual(asset, want) {
+	if !cmp.Equal(asset, want) {
 		t.Errorf("Repositories.EditReleaseAsset returned = %+v, want %+v", asset, want)
 	}
 
@@ -641,7 +642,7 @@ func TestRepositoriesService_UploadReleaseAsset(t *testing.T) {
 			t.Errorf("Repositories.UploadReleaseAssert returned error: %v", err)
 		}
 		want := &ReleaseAsset{ID: Int64(1)}
-		if !reflect.DeepEqual(asset, want) {
+		if !cmp.Equal(asset, want) {
 			t.Errorf("Repositories.UploadReleaseAssert returned %+v, want %+v", asset, want)
 		}
 

--- a/github/repos_stats_test.go
+++ b/github/repos_stats_test.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_ListContributorsStats(t *testing.T) {
@@ -66,7 +67,7 @@ func TestRepositoriesService_ListContributorsStats(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(stats, want) {
+	if !cmp.Equal(stats, want) {
 		t.Errorf("RepositoriesService.ListContributorsStats returned %+v, want %+v", stats, want)
 	}
 
@@ -117,7 +118,7 @@ func TestRepositoriesService_ListCommitActivity(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(activity, want) {
+	if !cmp.Equal(activity, want) {
 		t.Errorf("RepositoriesService.ListCommitActivity returned %+v, want %+v", activity, want)
 	}
 
@@ -158,7 +159,7 @@ func TestRepositoriesService_ListCodeFrequency(t *testing.T) {
 		Deletions: Int(-435),
 	}}
 
-	if !reflect.DeepEqual(code, want) {
+	if !cmp.Equal(code, want) {
 		t.Errorf("RepositoriesService.ListCodeFrequency returned %+v, want %+v", code, want)
 	}
 
@@ -223,7 +224,7 @@ func TestRepositoriesService_Participation(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(participation, want) {
+	if !cmp.Equal(participation, want) {
 		t.Errorf("RepositoriesService.ListParticipation returned %+v, want %+v", participation, want)
 	}
 
@@ -268,7 +269,7 @@ func TestRepositoriesService_ListPunchCard(t *testing.T) {
 		{Day: Int(0), Hour: Int(2), Commits: Int(21)},
 	}
 
-	if !reflect.DeepEqual(card, want) {
+	if !cmp.Equal(card, want) {
 		t.Errorf("RepositoriesService.ListPunchCard returned %+v, want %+v", card, want)
 	}
 

--- a/github/repos_statuses_test.go
+++ b/github/repos_statuses_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_ListStatuses(t *testing.T) {
@@ -32,7 +33,7 @@ func TestRepositoriesService_ListStatuses(t *testing.T) {
 	}
 
 	want := []*RepoStatus{{ID: Int64(1)}}
-	if !reflect.DeepEqual(statuses, want) {
+	if !cmp.Equal(statuses, want) {
 		t.Errorf("Repositories.ListStatuses returned %+v, want %+v", statuses, want)
 	}
 
@@ -71,7 +72,7 @@ func TestRepositoriesService_CreateStatus(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 		fmt.Fprint(w, `{"id":1}`)
@@ -84,7 +85,7 @@ func TestRepositoriesService_CreateStatus(t *testing.T) {
 	}
 
 	want := &RepoStatus{ID: Int64(1)}
-	if !reflect.DeepEqual(status, want) {
+	if !cmp.Equal(status, want) {
 		t.Errorf("Repositories.CreateStatus returned %+v, want %+v", status, want)
 	}
 
@@ -130,7 +131,7 @@ func TestRepositoriesService_GetCombinedStatus(t *testing.T) {
 	}
 
 	want := &CombinedStatus{State: String("success"), Statuses: []*RepoStatus{{ID: Int64(1)}}}
-	if !reflect.DeepEqual(status, want) {
+	if !cmp.Equal(status, want) {
 		t.Errorf("Repositories.GetCombinedStatus returned %+v, want %+v", status, want)
 	}
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_List_authenticatedUser(t *testing.T) {
@@ -33,7 +34,7 @@ func TestRepositoriesService_List_authenticatedUser(t *testing.T) {
 	}
 
 	want := []*Repository{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.List returned %+v, want %+v", got, want)
 	}
 
@@ -84,7 +85,7 @@ func TestRepositoriesService_List_specifiedUser(t *testing.T) {
 	}
 
 	want := []*Repository{{ID: Int64(1)}}
-	if !reflect.DeepEqual(repos, want) {
+	if !cmp.Equal(repos, want) {
 		t.Errorf("Repositories.List returned %+v, want %+v", repos, want)
 	}
 }
@@ -113,7 +114,7 @@ func TestRepositoriesService_List_specifiedUser_type(t *testing.T) {
 	}
 
 	want := []*Repository{{ID: Int64(1)}}
-	if !reflect.DeepEqual(repos, want) {
+	if !cmp.Equal(repos, want) {
 		t.Errorf("Repositories.List returned %+v, want %+v", repos, want)
 	}
 }
@@ -153,7 +154,7 @@ func TestRepositoriesService_ListByOrg(t *testing.T) {
 	}
 
 	want := []*Repository{{ID: Int64(1)}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.ListByOrg returned %+v, want %+v", got, want)
 	}
 
@@ -201,7 +202,7 @@ func TestRepositoriesService_ListAll(t *testing.T) {
 	}
 
 	want := []*Repository{{ID: Int64(1)}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.ListAll returned %+v, want %+v", got, want)
 	}
 
@@ -232,7 +233,7 @@ func TestRepositoriesService_Create_user(t *testing.T) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		want := &createRepoRequest{Name: String("n")}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 
@@ -246,7 +247,7 @@ func TestRepositoriesService_Create_user(t *testing.T) {
 	}
 
 	want := &Repository{ID: Int64(1)}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.Create returned %+v, want %+v", got, want)
 	}
 
@@ -282,7 +283,7 @@ func TestRepositoriesService_Create_org(t *testing.T) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		want := &createRepoRequest{Name: String("n")}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 
@@ -296,7 +297,7 @@ func TestRepositoriesService_Create_org(t *testing.T) {
 	}
 
 	want := &Repository{ID: Int64(1)}
-	if !reflect.DeepEqual(repo, want) {
+	if !cmp.Equal(repo, want) {
 		t.Errorf("Repositories.Create returned %+v, want %+v", repo, want)
 	}
 }
@@ -316,7 +317,7 @@ func TestRepositoriesService_CreateFromTemplate(t *testing.T) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Accept", mediaTypeRepositoryTemplatePreview)
 		want := &TemplateRepoRequest{Name: String("n")}
-		if !reflect.DeepEqual(v, want) {
+		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
 		}
 
@@ -330,7 +331,7 @@ func TestRepositoriesService_CreateFromTemplate(t *testing.T) {
 	}
 
 	want := &Repository{ID: Int64(1), Name: String("n")}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.CreateFromTemplate returned %+v, want %+v", got, want)
 	}
 
@@ -367,7 +368,7 @@ func TestRepositoriesService_Get(t *testing.T) {
 	}
 
 	want := &Repository{ID: Int64(1), Name: String("n"), Description: String("d"), Owner: &User{Login: String("l")}, License: &License{Key: String("mit")}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.Get returned %+v, want %+v", got, want)
 	}
 
@@ -414,7 +415,7 @@ func TestRepositoriesService_GetCodeOfConduct(t *testing.T) {
 		Body: String("body"),
 	}
 
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.GetCodeOfConduct returned %+v, want %+v", got, want)
 	}
 
@@ -449,7 +450,7 @@ func TestRepositoriesService_GetByID(t *testing.T) {
 	}
 
 	want := &Repository{ID: Int64(1), Name: String("n"), Description: String("d"), Owner: &User{Login: String("l")}, License: &License{Key: String("mit")}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.GetByID returned %+v, want %+v", got, want)
 	}
 
@@ -477,7 +478,7 @@ func TestRepositoriesService_Edit(t *testing.T) {
 
 		testMethod(t, r, "PATCH")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 		fmt.Fprint(w, `{"id":1}`)
@@ -490,7 +491,7 @@ func TestRepositoriesService_Edit(t *testing.T) {
 	}
 
 	want := &Repository{ID: Int64(1)}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.Edit returned %+v, want %+v", got, want)
 	}
 
@@ -697,7 +698,7 @@ func TestRepositoriesService_ListContributors(t *testing.T) {
 	}
 
 	want := []*Contributor{{Contributions: Int(42)}}
-	if !reflect.DeepEqual(contributors, want) {
+	if !cmp.Equal(contributors, want) {
 		t.Errorf("Repositories.ListContributors returned %+v, want %+v", contributors, want)
 	}
 
@@ -732,7 +733,7 @@ func TestRepositoriesService_ListLanguages(t *testing.T) {
 	}
 
 	want := map[string]int{"go": 1}
-	if !reflect.DeepEqual(languages, want) {
+	if !cmp.Equal(languages, want) {
 		t.Errorf("Repositories.ListLanguages returned %+v, want %+v", languages, want)
 	}
 
@@ -769,7 +770,7 @@ func TestRepositoriesService_ListTeams(t *testing.T) {
 	}
 
 	want := []*Team{{ID: Int64(1)}}
-	if !reflect.DeepEqual(teams, want) {
+	if !cmp.Equal(teams, want) {
 		t.Errorf("Repositories.ListTeams returned %+v, want %+v", teams, want)
 	}
 
@@ -816,7 +817,7 @@ func TestRepositoriesService_ListTags(t *testing.T) {
 			TarballURL: String("t"),
 		},
 	}
-	if !reflect.DeepEqual(tags, want) {
+	if !cmp.Equal(tags, want) {
 		t.Errorf("Repositories.ListTags returned %+v, want %+v", tags, want)
 	}
 
@@ -856,7 +857,7 @@ func TestRepositoriesService_ListBranches(t *testing.T) {
 	}
 
 	want := []*Branch{{Name: String("master"), Commit: &RepositoryCommit{SHA: String("a57781"), URL: String("https://api.github.com/repos/o/r/commits/a57781")}}}
-	if !reflect.DeepEqual(branches, want) {
+	if !cmp.Equal(branches, want) {
 		t.Errorf("Repositories.ListBranches returned %+v, want %+v", branches, want)
 	}
 
@@ -901,7 +902,7 @@ func TestRepositoriesService_GetBranch(t *testing.T) {
 		Protected: Bool(true),
 	}
 
-	if !reflect.DeepEqual(branch, want) {
+	if !cmp.Equal(branch, want) {
 		t.Errorf("Repositories.GetBranch returned %+v, want %+v", branch, want)
 	}
 
@@ -999,7 +1000,7 @@ func TestRepositoriesService_GetBranchProtection(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(protection, want) {
+	if !cmp.Equal(protection, want) {
 		t.Errorf("Repositories.GetBranchProtection returned %+v, want %+v", protection, want)
 	}
 
@@ -1078,7 +1079,7 @@ func TestRepositoriesService_GetBranchProtection_noDismissalRestrictions(t *test
 			},
 		},
 	}
-	if !reflect.DeepEqual(protection, want) {
+	if !cmp.Equal(protection, want) {
 		t.Errorf("Repositories.GetBranchProtection returned %+v, want %+v", protection, want)
 	}
 }
@@ -1111,7 +1112,7 @@ func TestRepositoriesService_UpdateBranchProtection(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -1179,7 +1180,7 @@ func TestRepositoriesService_UpdateBranchProtection(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(protection, want) {
+	if !cmp.Equal(protection, want) {
 		t.Errorf("Repositories.UpdateBranchProtection returned %+v, want %+v", protection, want)
 	}
 
@@ -1260,7 +1261,7 @@ func TestRepositoriesService_License(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.License returned %+v, want %+v", got, want)
 	}
 
@@ -1301,7 +1302,7 @@ func TestRepositoriesService_GetRequiredStatusChecks(t *testing.T) {
 		Strict:   true,
 		Contexts: []string{"x", "y", "z"},
 	}
-	if !reflect.DeepEqual(checks, want) {
+	if !cmp.Equal(checks, want) {
 		t.Errorf("Repositories.GetRequiredStatusChecks returned %+v, want %+v", checks, want)
 	}
 
@@ -1334,7 +1335,7 @@ func TestRepositoriesService_UpdateRequiredStatusChecks(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 		testHeader(t, r, "Accept", mediaTypeV3)
@@ -1351,7 +1352,7 @@ func TestRepositoriesService_UpdateRequiredStatusChecks(t *testing.T) {
 		Strict:   true,
 		Contexts: []string{"continuous-integration"},
 	}
-	if !reflect.DeepEqual(statusChecks, want) {
+	if !cmp.Equal(statusChecks, want) {
 		t.Errorf("Repositories.UpdateRequiredStatusChecks returned %+v, want %+v", statusChecks, want)
 	}
 
@@ -1416,7 +1417,7 @@ func TestRepositoriesService_ListRequiredStatusChecksContexts(t *testing.T) {
 	}
 
 	want := []string{"x", "y", "z"}
-	if !reflect.DeepEqual(contexts, want) {
+	if !cmp.Equal(contexts, want) {
 		t.Errorf("Repositories.ListRequiredStatusChecksContexts returned %+v, want %+v", contexts, want)
 	}
 
@@ -1474,7 +1475,7 @@ func TestRepositoriesService_GetPullRequestReviewEnforcement(t *testing.T) {
 		RequiredApprovingReviewCount: 1,
 	}
 
-	if !reflect.DeepEqual(enforcement, want) {
+	if !cmp.Equal(enforcement, want) {
 		t.Errorf("Repositories.GetPullRequestReviewEnforcement returned %+v, want %+v", enforcement, want)
 	}
 
@@ -1509,7 +1510,7 @@ func TestRepositoriesService_UpdatePullRequestReviewEnforcement(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 		// TODO: remove custom Accept header when this API fully launches
@@ -1544,7 +1545,7 @@ func TestRepositoriesService_UpdatePullRequestReviewEnforcement(t *testing.T) {
 		RequireCodeOwnerReviews:      true,
 		RequiredApprovingReviewCount: 3,
 	}
-	if !reflect.DeepEqual(enforcement, want) {
+	if !cmp.Equal(enforcement, want) {
 		t.Errorf("Repositories.UpdatePullRequestReviewEnforcement returned %+v, want %+v", enforcement, want)
 	}
 
@@ -1587,7 +1588,7 @@ func TestRepositoriesService_DisableDismissalRestrictions(t *testing.T) {
 		RequireCodeOwnerReviews:      true,
 		RequiredApprovingReviewCount: 1,
 	}
-	if !reflect.DeepEqual(enforcement, want) {
+	if !cmp.Equal(enforcement, want) {
 		t.Errorf("Repositories.DisableDismissalRestrictions returned %+v, want %+v", enforcement, want)
 	}
 
@@ -1652,7 +1653,7 @@ func TestRepositoriesService_GetAdminEnforcement(t *testing.T) {
 		Enabled: true,
 	}
 
-	if !reflect.DeepEqual(enforcement, want) {
+	if !cmp.Equal(enforcement, want) {
 		t.Errorf("Repositories.GetAdminEnforcement returned %+v, want %+v", enforcement, want)
 	}
 
@@ -1690,7 +1691,7 @@ func TestRepositoriesService_AddAdminEnforcement(t *testing.T) {
 		URL:     String("/repos/o/r/branches/b/protection/enforce_admins"),
 		Enabled: true,
 	}
-	if !reflect.DeepEqual(enforcement, want) {
+	if !cmp.Equal(enforcement, want) {
 		t.Errorf("Repositories.AddAdminEnforcement returned %+v, want %+v", enforcement, want)
 	}
 
@@ -1756,7 +1757,7 @@ func TestRepositoriesService_GetSignaturesProtectedBranch(t *testing.T) {
 		Enabled: Bool(false),
 	}
 
-	if !reflect.DeepEqual(signature, want) {
+	if !cmp.Equal(signature, want) {
 		t.Errorf("Repositories.GetSignaturesProtectedBranch returned %+v, want %+v", signature, want)
 	}
 
@@ -1796,7 +1797,7 @@ func TestRepositoriesService_RequireSignaturesOnProtectedBranch(t *testing.T) {
 		Enabled: Bool(true),
 	}
 
-	if !reflect.DeepEqual(signature, want) {
+	if !cmp.Equal(signature, want) {
 		t.Errorf("Repositories.RequireSignaturesOnProtectedBranch returned %+v, want %+v", signature, want)
 	}
 
@@ -1904,7 +1905,7 @@ func TestRepositoriesService_ListAllTopics(t *testing.T) {
 	}
 
 	want := []string{"go", "go-github", "github"}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.ListAllTopics returned %+v, want %+v", got, want)
 	}
 
@@ -1940,7 +1941,7 @@ func TestRepositoriesService_ListAllTopics_emptyTopics(t *testing.T) {
 	}
 
 	want := []string{}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.ListAllTopics returned %+v, want %+v", got, want)
 	}
 }
@@ -1962,7 +1963,7 @@ func TestRepositoriesService_ReplaceAllTopics(t *testing.T) {
 	}
 
 	want := []string{"go", "go-github", "github"}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.ReplaceAllTopics returned %+v, want %+v", got, want)
 	}
 
@@ -1999,7 +2000,7 @@ func TestRepositoriesService_ReplaceAllTopics_nilSlice(t *testing.T) {
 	}
 
 	want := []string{}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.ReplaceAllTopics returned %+v, want %+v", got, want)
 	}
 }
@@ -2022,7 +2023,7 @@ func TestRepositoriesService_ReplaceAllTopics_emptySlice(t *testing.T) {
 	}
 
 	want := []string{}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.ReplaceAllTopics returned %+v, want %+v", got, want)
 	}
 }
@@ -2075,7 +2076,7 @@ func TestRepositoriesService_ReplaceAppRestrictions(t *testing.T) {
 	want := []*App{
 		{Name: String("octocat")},
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.ReplaceAppRestrictions returned %+v, want %+v", got, want)
 	}
 
@@ -2113,7 +2114,7 @@ func TestRepositoriesService_AddAppRestrictions(t *testing.T) {
 	want := []*App{
 		{Name: String("octocat")},
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.AddAppRestrictions returned %+v, want %+v", got, want)
 	}
 
@@ -2147,7 +2148,7 @@ func TestRepositoriesService_RemoveAppRestrictions(t *testing.T) {
 		t.Errorf("Repositories.RemoveAppRestrictions returned error: %v", err)
 	}
 	want := []*App{}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.RemoveAppRestrictions returned %+v, want %+v", got, want)
 	}
 
@@ -2177,7 +2178,7 @@ func TestRepositoriesService_Transfer(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -2191,7 +2192,7 @@ func TestRepositoriesService_Transfer(t *testing.T) {
 	}
 
 	want := &Repository{Owner: &User{Login: String("a")}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.Transfer returned %+v, want %+v", got, want)
 	}
 
@@ -2221,7 +2222,7 @@ func TestRepositoriesService_Dispatch(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -2268,7 +2269,7 @@ func TestRepositoriesService_Dispatch(t *testing.T) {
 		}
 
 		want := &Repository{Owner: &User{Login: String("a")}}
-		if !reflect.DeepEqual(got, want) {
+		if !cmp.Equal(got, want) {
 			t.Errorf("Repositories.Dispatch returned %+v, want %+v", got, want)
 		}
 	}

--- a/github/repos_traffic_test.go
+++ b/github/repos_traffic_test.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_ListTrafficReferrers(t *testing.T) {
@@ -37,7 +38,7 @@ func TestRepositoriesService_ListTrafficReferrers(t *testing.T) {
 		Count:    Int(4),
 		Uniques:  Int(3),
 	}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.ListTrafficReferrers returned %+v, want %+v", got, want)
 	}
 
@@ -81,7 +82,7 @@ func TestRepositoriesService_ListTrafficPaths(t *testing.T) {
 		Count:   Int(3542),
 		Uniques: Int(2225),
 	}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.ListTrafficPaths returned %+v, want %+v", got, want)
 	}
 
@@ -131,7 +132,7 @@ func TestRepositoriesService_ListTrafficViews(t *testing.T) {
 		Uniques: Int(6),
 	}
 
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.ListTrafficViews returned %+v, want %+v", got, want)
 	}
 
@@ -181,7 +182,7 @@ func TestRepositoriesService_ListTrafficClones(t *testing.T) {
 		Uniques: Int(6),
 	}
 
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.ListTrafficClones returned %+v, want %+v", got, want)
 	}
 

--- a/github/search_test.go
+++ b/github/search_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSearchService_Repositories(t *testing.T) {
@@ -42,7 +43,7 @@ func TestSearchService_Repositories(t *testing.T) {
 		IncompleteResults: Bool(false),
 		Repositories:      []*Repository{{ID: Int64(1)}, {ID: Int64(2)}},
 	}
-	if !reflect.DeepEqual(result, want) {
+	if !cmp.Equal(result, want) {
 		t.Errorf("Search.Repositories returned %+v, want %+v", result, want)
 	}
 }
@@ -87,7 +88,7 @@ func TestSearchService_Topics(t *testing.T) {
 		IncompleteResults: Bool(false),
 		Topics:            []*TopicResult{{Name: String("blah")}, {Name: String("blahblah")}},
 	}
-	if !reflect.DeepEqual(result, want) {
+	if !cmp.Equal(result, want) {
 		t.Errorf("Search.Topics returned %+v, want %+v", result, want)
 	}
 }
@@ -132,7 +133,7 @@ func TestSearchService_Commits(t *testing.T) {
 		IncompleteResults: Bool(false),
 		Commits:           []*CommitResult{{SHA: String("random_hash1")}, {SHA: String("random_hash2")}},
 	}
-	if !reflect.DeepEqual(result, want) {
+	if !cmp.Equal(result, want) {
 		t.Errorf("Search.Commits returned %+v, want %+v", result, want)
 	}
 }
@@ -179,7 +180,7 @@ func TestSearchService_Issues(t *testing.T) {
 		IncompleteResults: Bool(true),
 		Issues:            []*Issue{{Number: Int(1)}, {Number: Int(2)}},
 	}
-	if !reflect.DeepEqual(result, want) {
+	if !cmp.Equal(result, want) {
 		t.Errorf("Search.Issues returned %+v, want %+v", result, want)
 	}
 }
@@ -230,7 +231,7 @@ func TestSearchService_Issues_withQualifiersNoOpts(t *testing.T) {
 		IncompleteResults: Bool(true),
 		Issues:            []*Issue{{Number: Int(1)}, {Number: Int(2)}},
 	}
-	if !reflect.DeepEqual(result, want) {
+	if !cmp.Equal(result, want) {
 		t.Errorf("Search.Issues returned %+v, want %+v", result, want)
 	}
 }
@@ -269,7 +270,7 @@ func TestSearchService_Issues_withQualifiersAndOpts(t *testing.T) {
 		IncompleteResults: Bool(true),
 		Issues:            []*Issue{{Number: Int(1)}, {Number: Int(2)}},
 	}
-	if !reflect.DeepEqual(result, want) {
+	if !cmp.Equal(result, want) {
 		t.Errorf("Search.Issues returned %+v, want %+v", result, want)
 	}
 }
@@ -303,7 +304,7 @@ func TestSearchService_Users(t *testing.T) {
 		IncompleteResults: Bool(false),
 		Users:             []*User{{ID: Int64(1)}, {ID: Int64(2)}},
 	}
-	if !reflect.DeepEqual(result, want) {
+	if !cmp.Equal(result, want) {
 		t.Errorf("Search.Users returned %+v, want %+v", result, want)
 	}
 }
@@ -350,7 +351,7 @@ func TestSearchService_Code(t *testing.T) {
 		IncompleteResults: Bool(false),
 		CodeResults:       []*CodeResult{{Name: String("1")}, {Name: String("2")}},
 	}
-	if !reflect.DeepEqual(result, want) {
+	if !cmp.Equal(result, want) {
 		t.Errorf("Search.Code returned %+v, want %+v", result, want)
 	}
 }
@@ -425,7 +426,7 @@ func TestSearchService_CodeTextMatch(t *testing.T) {
 		IncompleteResults: Bool(false),
 		CodeResults:       []*CodeResult{wantedCodeResult},
 	}
-	if !reflect.DeepEqual(result, want) {
+	if !cmp.Equal(result, want) {
 		t.Errorf("Search.Code returned %+v, want %+v", result, want)
 	}
 }
@@ -463,7 +464,7 @@ func TestSearchService_Labels(t *testing.T) {
 			{ID: Int64(4567), Name: String("feature")},
 		},
 	}
-	if !reflect.DeepEqual(result, want) {
+	if !cmp.Equal(result, want) {
 		t.Errorf("Search.Labels returned %+v, want %+v", result, want)
 	}
 }

--- a/github/teams_discussion_comments_test.go
+++ b/github/teams_discussion_comments_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // "Team Discussion Comments" endpoint, when using a teamID.
@@ -124,7 +125,7 @@ func TestTeamsService_ListComments(t *testing.T) {
 		t.Errorf("Teams.ListCommentsByID returned error: %v", err)
 	}
 
-	if !reflect.DeepEqual(commentsByID, want) {
+	if !cmp.Equal(commentsByID, want) {
 		t.Errorf("Teams.ListCommentsByID returned %+v, want %+v", commentsByID, want)
 	}
 
@@ -137,7 +138,7 @@ func TestTeamsService_ListComments(t *testing.T) {
 		t.Errorf("Teams.ListCommentsBySlug returned error: %v", err)
 	}
 
-	if !reflect.DeepEqual(commentsBySlug, want) {
+	if !cmp.Equal(commentsBySlug, want) {
 		t.Errorf("Teams.ListCommentsBySlug returned %+v, want %+v", commentsBySlug, want)
 	}
 
@@ -193,7 +194,7 @@ func TestTeamsService_GetComment(t *testing.T) {
 		t.Errorf("Teams.GetCommentByID returned error: %v", err)
 	}
 
-	if !reflect.DeepEqual(commentByID, want) {
+	if !cmp.Equal(commentByID, want) {
 		t.Errorf("Teams.GetCommentByID returned %+v, want %+v", commentByID, want)
 	}
 
@@ -205,7 +206,7 @@ func TestTeamsService_GetComment(t *testing.T) {
 		t.Errorf("Teams.GetCommentBySlug returned error: %v", err)
 	}
 
-	if !reflect.DeepEqual(commentBySlug, want) {
+	if !cmp.Equal(commentBySlug, want) {
 		t.Errorf("Teams.GetCommentBySlug returned %+v, want %+v", commentBySlug, want)
 	}
 
@@ -249,7 +250,7 @@ func TestTeamsService_CreateComment(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, &input) {
+		if !cmp.Equal(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -266,7 +267,7 @@ func TestTeamsService_CreateComment(t *testing.T) {
 		t.Errorf("Teams.CreateCommentByID returned error: %v", err)
 	}
 
-	if !reflect.DeepEqual(commentByID, want) {
+	if !cmp.Equal(commentByID, want) {
 		t.Errorf("Teams.CreateCommentByID returned %+v, want %+v", commentByID, want)
 	}
 
@@ -278,7 +279,7 @@ func TestTeamsService_CreateComment(t *testing.T) {
 		t.Errorf("Teams.CreateCommentBySlug returned error: %v", err)
 	}
 
-	if !reflect.DeepEqual(commentBySlug, want) {
+	if !cmp.Equal(commentBySlug, want) {
 		t.Errorf("Teams.CreateCommentBySlug returned %+v, want %+v", commentBySlug, want)
 	}
 
@@ -321,7 +322,7 @@ func TestTeamsService_EditComment(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, &input) {
+		if !cmp.Equal(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -338,7 +339,7 @@ func TestTeamsService_EditComment(t *testing.T) {
 		t.Errorf("Teams.EditCommentByID returned error: %v", err)
 	}
 
-	if !reflect.DeepEqual(commentByID, want) {
+	if !cmp.Equal(commentByID, want) {
 		t.Errorf("Teams.EditCommentByID returned %+v, want %+v", commentByID, want)
 	}
 
@@ -350,7 +351,7 @@ func TestTeamsService_EditComment(t *testing.T) {
 		t.Errorf("Teams.EditCommentBySlug returned error: %v", err)
 	}
 
-	if !reflect.DeepEqual(commentBySlug, want) {
+	if !cmp.Equal(commentBySlug, want) {
 		t.Errorf("Teams.EditCommentBySlug returned %+v, want %+v", commentBySlug, want)
 	}
 

--- a/github/teams_discussions_test.go
+++ b/github/teams_discussions_test.go
@@ -10,9 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestTeamsService_ListDiscussionsByID(t *testing.T) {
@@ -111,7 +112,7 @@ func TestTeamsService_ListDiscussionsByID(t *testing.T) {
 			URL:           String("https://api.github.com/teams/2/discussions/3"),
 		},
 	}
-	if !reflect.DeepEqual(discussions, want) {
+	if !cmp.Equal(discussions, want) {
 		t.Errorf("Teams.ListDiscussionsByID returned %+v, want %+v", discussions, want)
 	}
 
@@ -226,7 +227,7 @@ func TestTeamsService_ListDiscussionsBySlug(t *testing.T) {
 			URL:           String("https://api.github.com/teams/2/discussions/3"),
 		},
 	}
-	if !reflect.DeepEqual(discussions, want) {
+	if !cmp.Equal(discussions, want) {
 		t.Errorf("Teams.ListDiscussionsBySlug returned %+v, want %+v", discussions, want)
 	}
 
@@ -261,7 +262,7 @@ func TestTeamsService_GetDiscussionByID(t *testing.T) {
 	}
 
 	want := &TeamDiscussion{Number: Int(3)}
-	if !reflect.DeepEqual(discussion, want) {
+	if !cmp.Equal(discussion, want) {
 		t.Errorf("Teams.GetDiscussionByID returned %+v, want %+v", discussion, want)
 	}
 
@@ -296,7 +297,7 @@ func TestTeamsService_GetDiscussionBySlug(t *testing.T) {
 	}
 
 	want := &TeamDiscussion{Number: Int(3)}
-	if !reflect.DeepEqual(discussion, want) {
+	if !cmp.Equal(discussion, want) {
 		t.Errorf("Teams.GetDiscussionBySlug returned %+v, want %+v", discussion, want)
 	}
 
@@ -326,7 +327,7 @@ func TestTeamsService_CreateDiscussionByID(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, &input) {
+		if !cmp.Equal(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -340,7 +341,7 @@ func TestTeamsService_CreateDiscussionByID(t *testing.T) {
 	}
 
 	want := &TeamDiscussion{Number: Int(3)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("Teams.CreateDiscussionByID returned %+v, want %+v", comment, want)
 	}
 
@@ -370,7 +371,7 @@ func TestTeamsService_CreateDiscussionBySlug(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, &input) {
+		if !cmp.Equal(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -384,7 +385,7 @@ func TestTeamsService_CreateDiscussionBySlug(t *testing.T) {
 	}
 
 	want := &TeamDiscussion{Number: Int(3)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("Teams.CreateDiscussionBySlug returned %+v, want %+v", comment, want)
 	}
 
@@ -414,7 +415,7 @@ func TestTeamsService_EditDiscussionByID(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, &input) {
+		if !cmp.Equal(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -428,7 +429,7 @@ func TestTeamsService_EditDiscussionByID(t *testing.T) {
 	}
 
 	want := &TeamDiscussion{Number: Int(3)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("Teams.EditDiscussionByID returned %+v, want %+v", comment, want)
 	}
 
@@ -458,7 +459,7 @@ func TestTeamsService_EditDiscussionBySlug(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, &input) {
+		if !cmp.Equal(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -472,7 +473,7 @@ func TestTeamsService_EditDiscussionBySlug(t *testing.T) {
 	}
 
 	want := &TeamDiscussion{Number: Int(3)}
-	if !reflect.DeepEqual(comment, want) {
+	if !cmp.Equal(comment, want) {
 		t.Errorf("Teams.EditDiscussionBySlug returned %+v, want %+v", comment, want)
 	}
 

--- a/github/teams_members_test.go
+++ b/github/teams_members_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestTeamsService__ListTeamMembersByID(t *testing.T) {
@@ -32,7 +33,7 @@ func TestTeamsService__ListTeamMembersByID(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(1)}}
-	if !reflect.DeepEqual(members, want) {
+	if !cmp.Equal(members, want) {
 		t.Errorf("Teams.ListTeamMembersByID returned %+v, want %+v", members, want)
 	}
 
@@ -107,7 +108,7 @@ func TestTeamsService__ListTeamMembersBySlug(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(1)}}
-	if !reflect.DeepEqual(members, want) {
+	if !cmp.Equal(members, want) {
 		t.Errorf("Teams.ListTeamMembersBySlug returned %+v, want %+v", members, want)
 	}
 
@@ -189,7 +190,7 @@ func TestTeamsService__GetTeamMembershipByID(t *testing.T) {
 	}
 
 	want := &Membership{URL: String("u"), State: String("active")}
-	if !reflect.DeepEqual(membership, want) {
+	if !cmp.Equal(membership, want) {
 		t.Errorf("Teams.GetTeamMembershipByID returned %+v, want %+v", membership, want)
 	}
 
@@ -260,7 +261,7 @@ func TestTeamsService__GetTeamMembershipBySlug(t *testing.T) {
 	}
 
 	want := &Membership{URL: String("u"), State: String("active")}
-	if !reflect.DeepEqual(membership, want) {
+	if !cmp.Equal(membership, want) {
 		t.Errorf("Teams.GetTeamMembershipBySlug returned %+v, want %+v", membership, want)
 	}
 
@@ -335,7 +336,7 @@ func TestTeamsService__AddTeamMembershipByID(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, opt) {
+		if !cmp.Equal(v, opt) {
 			t.Errorf("Request body = %+v, want %+v", v, opt)
 		}
 
@@ -349,7 +350,7 @@ func TestTeamsService__AddTeamMembershipByID(t *testing.T) {
 	}
 
 	want := &Membership{URL: String("u"), State: String("pending")}
-	if !reflect.DeepEqual(membership, want) {
+	if !cmp.Equal(membership, want) {
 		t.Errorf("Teams.AddTeamMembershipByID returned %+v, want %+v", membership, want)
 	}
 
@@ -379,7 +380,7 @@ func TestTeamsService__AddTeamMembershipByID_notFound(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, opt) {
+		if !cmp.Equal(v, opt) {
 			t.Errorf("Request body = %+v, want %+v", v, opt)
 		}
 
@@ -424,7 +425,7 @@ func TestTeamsService__AddTeamMembershipBySlug(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, opt) {
+		if !cmp.Equal(v, opt) {
 			t.Errorf("Request body = %+v, want %+v", v, opt)
 		}
 
@@ -438,7 +439,7 @@ func TestTeamsService__AddTeamMembershipBySlug(t *testing.T) {
 	}
 
 	want := &Membership{URL: String("u"), State: String("pending")}
-	if !reflect.DeepEqual(membership, want) {
+	if !cmp.Equal(membership, want) {
 		t.Errorf("Teams.AddTeamMembershipBySlug returned %+v, want %+v", membership, want)
 	}
 
@@ -468,7 +469,7 @@ func TestTeamsService__AddTeamMembershipBySlug_notFound(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, opt) {
+		if !cmp.Equal(v, opt) {
 			t.Errorf("Request body = %+v, want %+v", v, opt)
 		}
 
@@ -648,7 +649,7 @@ func TestTeamsService__ListPendingTeamInvitationsByID(t *testing.T) {
 	}
 
 	want := []*Invitation{{ID: Int64(1)}}
-	if !reflect.DeepEqual(invitations, want) {
+	if !cmp.Equal(invitations, want) {
 		t.Errorf("Teams.ListPendingTeamInvitationsByID returned %+v, want %+v", invitations, want)
 	}
 
@@ -723,7 +724,7 @@ func TestTeamsService__ListPendingTeamInvitationsBySlug(t *testing.T) {
 	}
 
 	want := []*Invitation{{ID: Int64(1)}}
-	if !reflect.DeepEqual(invitations, want) {
+	if !cmp.Equal(invitations, want) {
 		t.Errorf("Teams.ListPendingTeamInvitationsByID returned %+v, want %+v", invitations, want)
 	}
 

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -12,9 +12,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestTeamsService_ListTeams(t *testing.T) {
@@ -35,7 +36,7 @@ func TestTeamsService_ListTeams(t *testing.T) {
 	}
 
 	want := []*Team{{ID: Int64(1)}}
-	if !reflect.DeepEqual(teams, want) {
+	if !cmp.Equal(teams, want) {
 		t.Errorf("Teams.ListTeams returned %+v, want %+v", teams, want)
 	}
 
@@ -79,7 +80,7 @@ func TestTeamsService_GetTeamByID(t *testing.T) {
 	}
 
 	want := &Team{ID: Int64(1), Name: String("n"), Description: String("d"), URL: String("u"), Slug: String("s"), Permission: String("p"), LDAPDN: String("cn=n,ou=groups,dc=example,dc=com")}
-	if !reflect.DeepEqual(team, want) {
+	if !cmp.Equal(team, want) {
 		t.Errorf("Teams.GetTeamByID returned %+v, want %+v", team, want)
 	}
 
@@ -136,7 +137,7 @@ func TestTeamsService_GetTeamBySlug(t *testing.T) {
 	}
 
 	want := &Team{ID: Int64(1), Name: String("n"), Description: String("d"), URL: String("u"), Slug: String("s"), Permission: String("p"), LDAPDN: String("cn=n,ou=groups,dc=example,dc=com")}
-	if !reflect.DeepEqual(team, want) {
+	if !cmp.Equal(team, want) {
 		t.Errorf("Teams.GetTeamBySlug returned %+v, want %+v", team, want)
 	}
 
@@ -197,7 +198,7 @@ func TestTeamsService_CreateTeam(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, &input) {
+		if !cmp.Equal(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -211,7 +212,7 @@ func TestTeamsService_CreateTeam(t *testing.T) {
 	}
 
 	want := &Team{ID: Int64(1)}
-	if !reflect.DeepEqual(team, want) {
+	if !cmp.Equal(team, want) {
 		t.Errorf("Teams.CreateTeam returned %+v, want %+v", team, want)
 	}
 
@@ -250,7 +251,7 @@ func TestTeamsService_EditTeamByID(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, &input) {
+		if !cmp.Equal(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -264,7 +265,7 @@ func TestTeamsService_EditTeamByID(t *testing.T) {
 	}
 
 	want := &Team{ID: Int64(1)}
-	if !reflect.DeepEqual(team, want) {
+	if !cmp.Equal(team, want) {
 		t.Errorf("Teams.EditTeamByID returned %+v, want %+v", team, want)
 	}
 
@@ -300,7 +301,7 @@ func TestTeamsService_EditTeamByID_RemoveParent(t *testing.T) {
 		json.NewDecoder(bytes.NewBuffer(buf)).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, &input) {
+		if !cmp.Equal(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -314,7 +315,7 @@ func TestTeamsService_EditTeamByID_RemoveParent(t *testing.T) {
 	}
 
 	want := &Team{ID: Int64(1)}
-	if !reflect.DeepEqual(team, want) {
+	if !cmp.Equal(team, want) {
 		t.Errorf("Teams.EditTeamByID returned %+v, want %+v", team, want)
 	}
 
@@ -334,7 +335,7 @@ func TestTeamsService_EditTeamBySlug(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, &input) {
+		if !cmp.Equal(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -348,7 +349,7 @@ func TestTeamsService_EditTeamBySlug(t *testing.T) {
 	}
 
 	want := &Team{ID: Int64(1)}
-	if !reflect.DeepEqual(team, want) {
+	if !cmp.Equal(team, want) {
 		t.Errorf("Teams.EditTeamBySlug returned %+v, want %+v", team, want)
 	}
 
@@ -384,7 +385,7 @@ func TestTeamsService_EditTeamBySlug_RemoveParent(t *testing.T) {
 		json.NewDecoder(bytes.NewBuffer(buf)).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, &input) {
+		if !cmp.Equal(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -398,7 +399,7 @@ func TestTeamsService_EditTeamBySlug_RemoveParent(t *testing.T) {
 	}
 
 	want := &Team{ID: Int64(1)}
-	if !reflect.DeepEqual(team, want) {
+	if !cmp.Equal(team, want) {
 		t.Errorf("Teams.EditTeam returned %+v, want %+v", team, want)
 	}
 
@@ -475,7 +476,7 @@ func TestTeamsService_ListChildTeamsByParentID(t *testing.T) {
 	}
 
 	want := []*Team{{ID: Int64(2)}}
-	if !reflect.DeepEqual(teams, want) {
+	if !cmp.Equal(teams, want) {
 		t.Errorf("Teams.ListChildTeamsByParentID returned %+v, want %+v", teams, want)
 	}
 
@@ -512,7 +513,7 @@ func TestTeamsService_ListChildTeamsByParentSlug(t *testing.T) {
 	}
 
 	want := []*Team{{ID: Int64(2)}}
-	if !reflect.DeepEqual(teams, want) {
+	if !cmp.Equal(teams, want) {
 		t.Errorf("Teams.ListChildTeamsByParentSlug returned %+v, want %+v", teams, want)
 	}
 
@@ -551,7 +552,7 @@ func TestTeamsService_ListTeamReposByID(t *testing.T) {
 	}
 
 	want := []*Repository{{ID: Int64(1)}}
-	if !reflect.DeepEqual(members, want) {
+	if !cmp.Equal(members, want) {
 		t.Errorf("Teams.ListTeamReposByID returned %+v, want %+v", members, want)
 	}
 
@@ -590,7 +591,7 @@ func TestTeamsService_ListTeamReposBySlug(t *testing.T) {
 	}
 
 	want := []*Repository{{ID: Int64(1)}}
-	if !reflect.DeepEqual(members, want) {
+	if !cmp.Equal(members, want) {
 		t.Errorf("Teams.ListTeamReposBySlug returned %+v, want %+v", members, want)
 	}
 
@@ -627,7 +628,7 @@ func TestTeamsService_IsTeamRepoByID_true(t *testing.T) {
 	}
 
 	want := &Repository{ID: Int64(1)}
-	if !reflect.DeepEqual(repo, want) {
+	if !cmp.Equal(repo, want) {
 		t.Errorf("Teams.IsTeamRepoByID returned %+v, want %+v", repo, want)
 	}
 
@@ -664,7 +665,7 @@ func TestTeamsService_IsTeamRepoBySlug_true(t *testing.T) {
 	}
 
 	want := &Repository{ID: Int64(1)}
-	if !reflect.DeepEqual(repo, want) {
+	if !cmp.Equal(repo, want) {
 		t.Errorf("Teams.IsTeamRepoBySlug returned %+v, want %+v", repo, want)
 	}
 
@@ -800,7 +801,7 @@ func TestTeamsService_AddTeamRepoByID(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, opt) {
+		if !cmp.Equal(v, opt) {
 			t.Errorf("Request body = %+v, want %+v", v, opt)
 		}
 
@@ -835,7 +836,7 @@ func TestTeamsService_AddTeamRepoBySlug(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, opt) {
+		if !cmp.Equal(v, opt) {
 			t.Errorf("Request body = %+v, want %+v", v, opt)
 		}
 
@@ -997,7 +998,7 @@ func TestTeamsService_ListUserTeams(t *testing.T) {
 	}
 
 	want := []*Team{{ID: Int64(1)}}
-	if !reflect.DeepEqual(teams, want) {
+	if !cmp.Equal(teams, want) {
 		t.Errorf("Teams.ListUserTeams returned %+v, want %+v", teams, want)
 	}
 
@@ -1029,7 +1030,7 @@ func TestTeamsService_ListProjectsByID(t *testing.T) {
 	}
 
 	want := []*Project{{ID: Int64(1)}}
-	if !reflect.DeepEqual(projects, want) {
+	if !cmp.Equal(projects, want) {
 		t.Errorf("Teams.ListTeamProjectsByID returned %+v, want %+v", projects, want)
 	}
 
@@ -1066,7 +1067,7 @@ func TestTeamsService_ListProjectsBySlug(t *testing.T) {
 	}
 
 	want := []*Project{{ID: Int64(1)}}
-	if !reflect.DeepEqual(projects, want) {
+	if !cmp.Equal(projects, want) {
 		t.Errorf("Teams.ListTeamProjectsBySlug returned %+v, want %+v", projects, want)
 	}
 
@@ -1103,7 +1104,7 @@ func TestTeamsService_ReviewProjectsByID(t *testing.T) {
 	}
 
 	want := &Project{ID: Int64(1)}
-	if !reflect.DeepEqual(project, want) {
+	if !cmp.Equal(project, want) {
 		t.Errorf("Teams.ReviewTeamProjectsByID returned %+v, want %+v", project, want)
 	}
 
@@ -1140,7 +1141,7 @@ func TestTeamsService_ReviewProjectsBySlug(t *testing.T) {
 	}
 
 	want := &Project{ID: Int64(1)}
-	if !reflect.DeepEqual(project, want) {
+	if !cmp.Equal(project, want) {
 		t.Errorf("Teams.ReviewTeamProjectsBySlug returned %+v, want %+v", project, want)
 	}
 
@@ -1174,7 +1175,7 @@ func TestTeamsService_AddTeamProjectByID(t *testing.T) {
 
 		v := &TeamProjectOptions{}
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, opt) {
+		if !cmp.Equal(v, opt) {
 			t.Errorf("Request body = %+v, want %+v", v, opt)
 		}
 
@@ -1213,7 +1214,7 @@ func TestTeamsService_AddTeamProjectBySlug(t *testing.T) {
 
 		v := &TeamProjectOptions{}
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, opt) {
+		if !cmp.Equal(v, opt) {
 			t.Errorf("Request body = %+v, want %+v", v, opt)
 		}
 
@@ -1321,7 +1322,7 @@ func TestTeamsService_ListIDPGroupsInOrganization(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(groups, want) {
+	if !cmp.Equal(groups, want) {
 		t.Errorf("Teams.ListIDPGroupsInOrganization returned %+v. want %+v", groups, want)
 	}
 
@@ -1364,7 +1365,7 @@ func TestTeamsService_ListIDPGroupsForTeamByID(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(groups, want) {
+	if !cmp.Equal(groups, want) {
 		t.Errorf("Teams.ListIDPGroupsForTeamByID returned %+v. want %+v", groups, want)
 	}
 
@@ -1407,7 +1408,7 @@ func TestTeamsService_ListIDPGroupsForTeamBySlug(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(groups, want) {
+	if !cmp.Equal(groups, want) {
 		t.Errorf("Teams.ListIDPGroupsForTeamBySlug returned %+v. want %+v", groups, want)
 	}
 
@@ -1460,7 +1461,7 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnectionsByID(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(groups, want) {
+	if !cmp.Equal(groups, want) {
 		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsByID returned %+v. want %+v", groups, want)
 	}
 
@@ -1513,7 +1514,7 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnectionsBySlug(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(groups, want) {
+	if !cmp.Equal(groups, want) {
 		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsBySlug returned %+v. want %+v", groups, want)
 	}
 
@@ -1553,7 +1554,7 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnectionsByID_empty(t *testing.T) 
 	want := &IDPGroupList{
 		Groups: []*IDPGroup{},
 	}
-	if !reflect.DeepEqual(groups, want) {
+	if !cmp.Equal(groups, want) {
 		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsByID returned %+v. want %+v", groups, want)
 	}
 }
@@ -1580,7 +1581,7 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnectionsBySlug_empty(t *testing.T
 	want := &IDPGroupList{
 		Groups: []*IDPGroup{},
 	}
-	if !reflect.DeepEqual(groups, want) {
+	if !cmp.Equal(groups, want) {
 		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsBySlug returned %+v. want %+v", groups, want)
 	}
 }

--- a/github/users_administration_test.go
+++ b/github/users_administration_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestUsersService_PromoteSiteAdmin(t *testing.T) {
@@ -102,7 +103,7 @@ func TestUsersServiceReason_Suspend(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 

--- a/github/users_blocking_test.go
+++ b/github/users_blocking_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestUsersService_ListBlockedUsers(t *testing.T) {
@@ -34,7 +35,7 @@ func TestUsersService_ListBlockedUsers(t *testing.T) {
 	}
 
 	want := []*User{{Login: String("octocat")}}
-	if !reflect.DeepEqual(blockedUsers, want) {
+	if !cmp.Equal(blockedUsers, want) {
 		t.Errorf("Users.ListBlockedUsers returned %+v, want %+v", blockedUsers, want)
 	}
 

--- a/github/users_emails_test.go
+++ b/github/users_emails_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestUsersService_ListEmails(t *testing.T) {
@@ -36,7 +37,7 @@ func TestUsersService_ListEmails(t *testing.T) {
 	}
 
 	want := []*UserEmail{{Email: String("user@example.com"), Verified: Bool(false), Primary: Bool(true)}}
-	if !reflect.DeepEqual(emails, want) {
+	if !cmp.Equal(emails, want) {
 		t.Errorf("Users.ListEmails returned %+v, want %+v", emails, want)
 	}
 
@@ -61,7 +62,7 @@ func TestUsersService_AddEmails(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -78,7 +79,7 @@ func TestUsersService_AddEmails(t *testing.T) {
 		{Email: String("old@example.com")},
 		{Email: String("new@example.com")},
 	}
-	if !reflect.DeepEqual(emails, want) {
+	if !cmp.Equal(emails, want) {
 		t.Errorf("Users.AddEmails returned %+v, want %+v", emails, want)
 	}
 
@@ -103,7 +104,7 @@ func TestUsersService_DeleteEmails(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "DELETE")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 	})

--- a/github/users_followers_test.go
+++ b/github/users_followers_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestUsersService_ListFollowers_authenticatedUser(t *testing.T) {
@@ -31,7 +32,7 @@ func TestUsersService_ListFollowers_authenticatedUser(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(1)}}
-	if !reflect.DeepEqual(users, want) {
+	if !cmp.Equal(users, want) {
 		t.Errorf("Users.ListFollowers returned %+v, want %+v", users, want)
 	}
 
@@ -66,7 +67,7 @@ func TestUsersService_ListFollowers_specifiedUser(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(1)}}
-	if !reflect.DeepEqual(users, want) {
+	if !cmp.Equal(users, want) {
 		t.Errorf("Users.ListFollowers returned %+v, want %+v", users, want)
 	}
 
@@ -112,7 +113,7 @@ func TestUsersService_ListFollowing_authenticatedUser(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(1)}}
-	if !reflect.DeepEqual(users, want) {
+	if !cmp.Equal(users, want) {
 		t.Errorf("Users.ListFollowing returned %+v, want %+v", users, want)
 	}
 
@@ -147,7 +148,7 @@ func TestUsersService_ListFollowing_specifiedUser(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(1)}}
-	if !reflect.DeepEqual(users, want) {
+	if !cmp.Equal(users, want) {
 		t.Errorf("Users.ListFollowing returned %+v, want %+v", users, want)
 	}
 

--- a/github/users_gpg_keys_test.go
+++ b/github/users_gpg_keys_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestUsersService_ListGPGKeys_authenticatedUser(t *testing.T) {
@@ -32,7 +33,7 @@ func TestUsersService_ListGPGKeys_authenticatedUser(t *testing.T) {
 	}
 
 	want := []*GPGKey{{ID: Int64(1), PrimaryKeyID: Int64(2)}}
-	if !reflect.DeepEqual(keys, want) {
+	if !cmp.Equal(keys, want) {
 		t.Errorf("Users.ListGPGKeys = %+v, want %+v", keys, want)
 	}
 
@@ -67,7 +68,7 @@ func TestUsersService_ListGPGKeys_specifiedUser(t *testing.T) {
 	}
 
 	want := []*GPGKey{{ID: Int64(1), PrimaryKeyID: Int64(2)}}
-	if !reflect.DeepEqual(keys, want) {
+	if !cmp.Equal(keys, want) {
 		t.Errorf("Users.ListGPGKeys = %+v, want %+v", keys, want)
 	}
 }
@@ -97,7 +98,7 @@ func TestUsersService_GetGPGKey(t *testing.T) {
 	}
 
 	want := &GPGKey{ID: Int64(1)}
-	if !reflect.DeepEqual(key, want) {
+	if !cmp.Equal(key, want) {
 		t.Errorf("Users.GetGPGKey = %+v, want %+v", key, want)
 	}
 
@@ -150,7 +151,7 @@ mQINBFcEd9kBEACo54TDbGhKlXKWMvJgecEUKPPcv7XdnpKdGb3LRw5MvFwT0V0f
 	}
 
 	want := &GPGKey{ID: Int64(1)}
-	if !reflect.DeepEqual(gpgKey, want) {
+	if !cmp.Equal(gpgKey, want) {
 		t.Errorf("Users.GetGPGKey = %+v, want %+v", gpgKey, want)
 	}
 

--- a/github/users_keys_test.go
+++ b/github/users_keys_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestUsersService_ListKeys_authenticatedUser(t *testing.T) {
@@ -32,7 +33,7 @@ func TestUsersService_ListKeys_authenticatedUser(t *testing.T) {
 	}
 
 	want := []*Key{{ID: Int64(1)}}
-	if !reflect.DeepEqual(keys, want) {
+	if !cmp.Equal(keys, want) {
 		t.Errorf("Users.ListKeys returned %+v, want %+v", keys, want)
 	}
 
@@ -67,7 +68,7 @@ func TestUsersService_ListKeys_specifiedUser(t *testing.T) {
 	}
 
 	want := []*Key{{ID: Int64(1)}}
-	if !reflect.DeepEqual(keys, want) {
+	if !cmp.Equal(keys, want) {
 		t.Errorf("Users.ListKeys returned %+v, want %+v", keys, want)
 	}
 }
@@ -97,7 +98,7 @@ func TestUsersService_GetKey(t *testing.T) {
 	}
 
 	want := &Key{ID: Int64(1)}
-	if !reflect.DeepEqual(key, want) {
+	if !cmp.Equal(key, want) {
 		t.Errorf("Users.GetKey returned %+v, want %+v", key, want)
 	}
 
@@ -127,7 +128,7 @@ func TestUsersService_CreateKey(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -141,7 +142,7 @@ func TestUsersService_CreateKey(t *testing.T) {
 	}
 
 	want := &Key{ID: Int64(1)}
-	if !reflect.DeepEqual(key, want) {
+	if !cmp.Equal(key, want) {
 		t.Errorf("Users.GetKey returned %+v, want %+v", key, want)
 	}
 

--- a/github/users_projects_test.go
+++ b/github/users_projects_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestUsersService_ListProjects(t *testing.T) {
@@ -33,7 +34,7 @@ func TestUsersService_ListProjects(t *testing.T) {
 	}
 
 	want := []*Project{{ID: Int64(1)}}
-	if !reflect.DeepEqual(projects, want) {
+	if !cmp.Equal(projects, want) {
 		t.Errorf("Users.ListProjects returned %+v, want %+v", projects, want)
 	}
 
@@ -64,7 +65,7 @@ func TestUsersService_CreateProject(t *testing.T) {
 
 		v := &CreateUserProjectOptions{}
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -78,7 +79,7 @@ func TestUsersService_CreateProject(t *testing.T) {
 	}
 
 	want := &Project{ID: Int64(1)}
-	if !reflect.DeepEqual(project, want) {
+	if !cmp.Equal(project, want) {
 		t.Errorf("Users.CreateProject returned %+v, want %+v", project, want)
 	}
 

--- a/github/users_test.go
+++ b/github/users_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestUser_marshall(t *testing.T) {
@@ -76,7 +77,7 @@ func TestUsersService_Get_authenticatedUser(t *testing.T) {
 	}
 
 	want := &User{ID: Int64(1)}
-	if !reflect.DeepEqual(user, want) {
+	if !cmp.Equal(user, want) {
 		t.Errorf("Users.Get returned %+v, want %+v", user, want)
 	}
 
@@ -111,7 +112,7 @@ func TestUsersService_Get_specifiedUser(t *testing.T) {
 	}
 
 	want := &User{ID: Int64(1)}
-	if !reflect.DeepEqual(user, want) {
+	if !cmp.Equal(user, want) {
 		t.Errorf("Users.Get returned %+v, want %+v", user, want)
 	}
 }
@@ -141,7 +142,7 @@ func TestUsersService_GetByID(t *testing.T) {
 	}
 
 	want := &User{ID: Int64(1)}
-	if !reflect.DeepEqual(user, want) {
+	if !cmp.Equal(user, want) {
 		t.Errorf("Users.GetByID returned %+v, want %+v", user, want)
 	}
 
@@ -171,7 +172,7 @@ func TestUsersService_Edit(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		if !reflect.DeepEqual(v, input) {
+		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
@@ -185,7 +186,7 @@ func TestUsersService_Edit(t *testing.T) {
 	}
 
 	want := &User{ID: Int64(1)}
-	if !reflect.DeepEqual(user, want) {
+	if !cmp.Equal(user, want) {
 		t.Errorf("Users.Edit returned %+v, want %+v", user, want)
 	}
 
@@ -217,7 +218,7 @@ func TestUsersService_GetHovercard(t *testing.T) {
 	}
 
 	want := &Hovercard{Contexts: []*UserContext{{Message: String("Owns this repository"), Octicon: String("repo")}}}
-	if !reflect.DeepEqual(hovercard, want) {
+	if !cmp.Equal(hovercard, want) {
 		t.Errorf("Users.GetHovercard returned %+v, want %+v", hovercard, want)
 	}
 
@@ -254,7 +255,7 @@ func TestUsersService_ListAll(t *testing.T) {
 	}
 
 	want := []*User{{ID: Int64(2)}}
-	if !reflect.DeepEqual(users, want) {
+	if !cmp.Equal(users, want) {
 		t.Errorf("Users.ListAll returned %+v, want %+v", users, want)
 	}
 
@@ -284,7 +285,7 @@ func TestUsersService_ListInvitations(t *testing.T) {
 	}
 
 	want := []*RepositoryInvitation{{ID: Int64(1)}, {ID: Int64(2)}}
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("Users.ListInvitations = %+v, want %+v", got, want)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/google/go-github/v35
 
 require (
 	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/google/go-cmp v0.5.6
 	github.com/google/go-querystring v1.0.0
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
@@ -11,5 +13,7 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -12,9 +12,9 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/v35/github"
 )
 
@@ -145,7 +145,7 @@ func TestRepositories_EditBranches(t *testing.T) {
 		},
 		Restrictions: nil,
 	}
-	if !reflect.DeepEqual(protection, want) {
+	if !cmp.Equal(protection, want) {
 		t.Errorf("Repositories.UpdateBranchProtection() returned %+v, want %+v", protection, want)
 	}
 

--- a/update-urls/main_test.go
+++ b/update-urls/main_test.go
@@ -10,11 +10,11 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
-	"reflect"
 	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/pmezard/go-difflib/difflib"
 )
 
@@ -445,7 +445,7 @@ func TestSortAndMergeFileEdits(t *testing.T) {
 				if i < len(tt.want) {
 					wantFileEdit = tt.want[i]
 				}
-				if !reflect.DeepEqual(got[i], wantFileEdit) {
+				if !cmp.Equal(got[i], wantFileEdit) {
 					t.Errorf("got[%v] =\n%#v\nwant[%v]:\n%#v", i, got[i], i, wantFileEdit)
 				}
 			}
@@ -551,7 +551,7 @@ func testWebPageHelper(t *testing.T, got, want map[string][]*Endpoint) {
 			if ok && i < len(w) {
 				wantEndpoint = w[i]
 			}
-			if !reflect.DeepEqual(got[k][i], wantEndpoint) {
+			if !cmp.Equal(got[k][i], wantEndpoint) {
 				t.Errorf("got[%q][%v] =\n%#v\nwant[%q][%v]:\n%#v", k, i, got[k][i], k, i, wantEndpoint)
 			}
 		}
@@ -590,7 +590,7 @@ func TestParseEndpoint(t *testing.T) {
 		t.Run(fmt.Sprintf("test #%v: %v", i, tt.name), func(t *testing.T) {
 			got := parseEndpoint(tt.s, tt.method)
 
-			if !reflect.DeepEqual(got, tt.want) {
+			if !cmp.Equal(got, tt.want) {
 				t.Errorf("parseEndpoint = %#v, want %#v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Replaced all reflect.DeepEqual comparisons in test files with cmp.Equal.

Fixes: #1851