### PR TITLE
Ability to get repo labels with repo service

### DIFF
--- a/github/repos_labels.go
+++ b/github/repos_labels.go
@@ -1,0 +1,112 @@
+// Copyright 2014 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+func stringpointertostring(s *string) string {
+	if s != nil {
+		strPointerValue := *s
+		return strPointerValue
+	}
+	return ""
+}
+
+// ListLabels lists all labels for a repository.
+//
+// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/issues/#list-labels-for-a-repository
+func (s *RepositoriesService) ListLabels(ctx context.Context, repo *Repository, opts *ListOptions) ([]*Label, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/labels", stringpointertostring(repo.Owner.Login), stringpointertostring(repo.Name))
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var labels []*Label
+	resp, err := s.client.Do(ctx, req, &labels)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return labels, resp, nil
+}
+
+// GetLabel gets a single label.
+//
+// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/issues/#get-a-label
+func (s *RepositoriesService) GetLabel(ctx context.Context, repo *Repository, name string) (*Label, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/labels/%v", stringpointertostring(repo.Owner.Login), stringpointertostring(repo.Name), name)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	label := new(Label)
+	resp, err := s.client.Do(ctx, req, label)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return label, resp, nil
+}
+
+// CreateLabel creates a new label on the specified repository.
+//
+// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/issues/#create-a-label
+func (s *RepositoriesService) CreateLabel(ctx context.Context, repo *Repository, label *Label) (*Label, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/labels", stringpointertostring(repo.Owner.Login), stringpointertostring(repo.Name))
+	req, err := s.client.NewRequest("POST", u, label)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	l := new(Label)
+	resp, err := s.client.Do(ctx, req, l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return l, resp, nil
+}
+
+// EditLabel edits a label.
+//
+// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/issues/#update-a-label
+func (s *RepositoriesService) EditLabel(ctx context.Context, repo *Repository, name string, label *Label) (*Label, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/labels/%v", stringpointertostring(repo.Owner.Login), stringpointertostring(repo.Name), name)
+	req, err := s.client.NewRequest("PATCH", u, label)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	l := new(Label)
+	resp, err := s.client.Do(ctx, req, l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return l, resp, nil
+}
+
+// DeleteLabel deletes a label.
+//
+// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/issues/#delete-a-label
+func (s *RepositoriesService) DeleteLabel(ctx context.Context, repo *Repository, name string) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/labels/%v", stringpointertostring(repo.Owner.Login), stringpointertostring(repo.Name), name)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/repos_labels.go
+++ b/github/repos_labels.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 func stringpointertostring(s *string) string {
@@ -22,91 +21,59 @@ func stringpointertostring(s *string) string {
 //
 // GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/issues/#list-labels-for-a-repository
 func (s *RepositoriesService) ListLabels(ctx context.Context, repo *Repository, opts *ListOptions) ([]*Label, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/labels", stringpointertostring(repo.Owner.Login), stringpointertostring(repo.Name))
-	u, err := addOptions(u, opts)
-	if err != nil {
-		return nil, nil, err
+	convertedService := &IssuesService{
+		client: s.client,
 	}
-
-	req, err := s.client.NewRequest("GET", u, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var labels []*Label
-	resp, err := s.client.Do(ctx, req, &labels)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return labels, resp, nil
+	return convertedService.ListLabels(
+		ctx, stringpointertostring(repo.Owner.Login), stringpointertostring(repo.Name), opts,
+	)
 }
 
 // GetLabel gets a single label.
 //
 // GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/issues/#get-a-label
 func (s *RepositoriesService) GetLabel(ctx context.Context, repo *Repository, name string) (*Label, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/labels/%v", stringpointertostring(repo.Owner.Login), stringpointertostring(repo.Name), name)
-	req, err := s.client.NewRequest("GET", u, nil)
-	if err != nil {
-		return nil, nil, err
+	convertedService := &IssuesService{
+		client: s.client,
 	}
-
-	label := new(Label)
-	resp, err := s.client.Do(ctx, req, label)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return label, resp, nil
+	return convertedService.GetLabel(
+		ctx, stringpointertostring(repo.Owner.Login), stringpointertostring(repo.Name), name,
+	)
 }
 
 // CreateLabel creates a new label on the specified repository.
 //
 // GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/issues/#create-a-label
 func (s *RepositoriesService) CreateLabel(ctx context.Context, repo *Repository, label *Label) (*Label, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/labels", stringpointertostring(repo.Owner.Login), stringpointertostring(repo.Name))
-	req, err := s.client.NewRequest("POST", u, label)
-	if err != nil {
-		return nil, nil, err
+	convertedService := &IssuesService{
+		client: s.client,
 	}
+	return convertedService.CreateLabel(
+		ctx, stringpointertostring(repo.Owner.Login), stringpointertostring(repo.Name), label,
+	)
 
-	l := new(Label)
-	resp, err := s.client.Do(ctx, req, l)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return l, resp, nil
 }
 
 // EditLabel edits a label.
 //
 // GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/issues/#update-a-label
 func (s *RepositoriesService) EditLabel(ctx context.Context, repo *Repository, name string, label *Label) (*Label, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/labels/%v", stringpointertostring(repo.Owner.Login), stringpointertostring(repo.Name), name)
-	req, err := s.client.NewRequest("PATCH", u, label)
-	if err != nil {
-		return nil, nil, err
+	convertedService := &IssuesService{
+		client: s.client,
 	}
-
-	l := new(Label)
-	resp, err := s.client.Do(ctx, req, l)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return l, resp, nil
+	return convertedService.EditLabel(
+		ctx, stringpointertostring(repo.Owner.Login), stringpointertostring(repo.Name), name, label,
+	)
 }
 
 // DeleteLabel deletes a label.
 //
 // GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/issues/#delete-a-label
 func (s *RepositoriesService) DeleteLabel(ctx context.Context, repo *Repository, name string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/labels/%v", stringpointertostring(repo.Owner.Login), stringpointertostring(repo.Name), name)
-	req, err := s.client.NewRequest("DELETE", u, nil)
-	if err != nil {
-		return nil, err
+	convertedService := &IssuesService{
+		client: s.client,
 	}
-	return s.client.Do(ctx, req, nil)
+	return convertedService.DeleteLabel(
+		ctx, stringpointertostring(repo.Owner.Login), stringpointertostring(repo.Name), name,
+	)
 }

--- a/github/repos_labels_test.go
+++ b/github/repos_labels_test.go
@@ -1,0 +1,273 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func CreateTestRepos() (goodRepo *Repository, badRepo *Repository) {
+	user := "o"
+	invalidUser := "\n"
+	repoName := "r"
+	invalidName := "%"
+	return &Repository{
+			Owner: &User{
+				Login: &user,
+			},
+			Name: &repoName,
+		}, &Repository{
+			Owner: &User{
+				Login: &invalidUser,
+			},
+			Name: &invalidName,
+		}
+}
+
+func TestRepoService_ListLabels(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/labels", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"page": "2"})
+		fmt.Fprint(w, `[{"name": "a"},{"name": "b"}]`)
+	})
+	goodRepo, badRepo := CreateTestRepos()
+	opt := &ListOptions{Page: 2}
+	ctx := context.Background()
+	labels, _, err := client.Repositories.ListLabels(ctx, goodRepo, opt)
+	if err != nil {
+		t.Errorf("Repo.ListLabels returned error: %v", err)
+	}
+
+	want := []*Label{{Name: String("a")}, {Name: String("b")}}
+	if !cmp.Equal(labels, want) {
+		t.Errorf("Repo.ListLabels returned %+v, want %+v", labels, want)
+	}
+
+	const methodName = "ListLabels"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Repositories.ListLabels(ctx, badRepo, opt)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Repositories.ListLabels(ctx, goodRepo, opt)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestRepoService_ListLabels_invalidOwner(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	ctx := context.Background()
+	_, badRepo := CreateTestRepos()
+	_, _, err := client.Repositories.ListLabels(ctx, badRepo, nil)
+	testURLParseError(t, err)
+}
+
+func TestRepoService_GetLabel(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/labels/n", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"url":"u", "name": "n", "color": "c", "description": "d"}`)
+	})
+	goodRepo, badRepo := CreateTestRepos()
+
+	ctx := context.Background()
+	label, _, err := client.Repositories.GetLabel(ctx, goodRepo, "n")
+	if err != nil {
+		t.Errorf("Repo.GetLabel returned error: %v", err)
+	}
+
+	want := &Label{URL: String("u"), Name: String("n"), Color: String("c"), Description: String("d")}
+	if !cmp.Equal(label, want) {
+		t.Errorf("Repo.GetLabel returned %+v, want %+v", label, want)
+	}
+
+	const methodName = "GetLabel"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Repositories.GetLabel(ctx, badRepo, "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Repositories.GetLabel(ctx, goodRepo, "n")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestRepoService_GetLabel_invalidOwner(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	ctx := context.Background()
+	_, badRepo := CreateTestRepos()
+	_, _, err := client.Repositories.GetLabel(ctx, badRepo, "%")
+	testURLParseError(t, err)
+}
+
+func TestRepoService_CreateLabel(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &Label{Name: String("n")}
+
+	mux.HandleFunc("/repos/o/r/labels", func(w http.ResponseWriter, r *http.Request) {
+		v := new(Label)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "POST")
+		if !cmp.Equal(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		fmt.Fprint(w, `{"url":"u"}`)
+	})
+
+	ctx := context.Background()
+	goodRepo, badRepo := CreateTestRepos()
+	label, _, err := client.Repositories.CreateLabel(ctx, goodRepo, input)
+	if err != nil {
+		t.Errorf("Repo.CreateLabel returned error: %v", err)
+	}
+
+	want := &Label{URL: String("u")}
+	if !cmp.Equal(label, want) {
+		t.Errorf("Repo.CreateLabel returned %+v, want %+v", label, want)
+	}
+
+	const methodName = "CreateLabel"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Repositories.CreateLabel(ctx, badRepo, input)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Repositories.CreateLabel(ctx, goodRepo, input)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestRepoService_CreateLabel_invalidOwner(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	ctx := context.Background()
+	_, badRepo := CreateTestRepos()
+	_, _, err := client.Repositories.CreateLabel(ctx, badRepo, nil)
+	testURLParseError(t, err)
+}
+
+func TestRepoService_EditLabel(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &Label{Name: String("z")}
+
+	mux.HandleFunc("/repos/o/r/labels/n", func(w http.ResponseWriter, r *http.Request) {
+		v := new(Label)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "PATCH")
+		if !cmp.Equal(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		fmt.Fprint(w, `{"url":"u"}`)
+	})
+
+	ctx := context.Background()
+	goodRepo, badRepo := CreateTestRepos()
+	label, _, err := client.Repositories.EditLabel(ctx, goodRepo, "n", input)
+	if err != nil {
+		t.Errorf("Repo.EditLabel returned error: %v", err)
+	}
+
+	want := &Label{URL: String("u")}
+	if !cmp.Equal(label, want) {
+		t.Errorf("Repo.EditLabel returned %+v, want %+v", label, want)
+	}
+
+	const methodName = "EditLabel"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Repositories.EditLabel(ctx, badRepo, "\n", input)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Repositories.EditLabel(ctx, goodRepo, "n", input)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestRepoService_EditLabel_invalidOwner(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	ctx := context.Background()
+	_, badRepo := CreateTestRepos()
+	_, _, err := client.Repositories.EditLabel(ctx, badRepo, "%", nil)
+	testURLParseError(t, err)
+}
+
+func TestRepoService_DeleteLabel(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/labels/n", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	ctx := context.Background()
+	goodRepo, badRepo := CreateTestRepos()
+	_, err := client.Repositories.DeleteLabel(ctx, goodRepo, "n")
+	if err != nil {
+		t.Errorf("Repo.DeleteLabel returned error: %v", err)
+	}
+
+	const methodName = "DeleteLabel"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Repositories.DeleteLabel(ctx, badRepo, "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Repositories.DeleteLabel(ctx, goodRepo, "n")
+	})
+}
+
+func TestRepoService_DeleteLabel_invalidOwner(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	ctx := context.Background()
+	_, badRepo := CreateTestRepos()
+	_, err := client.Repositories.DeleteLabel(ctx, badRepo, "%")
+	testURLParseError(t, err)
+}


### PR DESCRIPTION
Adds functions that enable users to get the labels of a repo with the `RepositoriesService`. It translates the given repo to the `IssuesService` functions to avoid the need to update it in two places.


Would close #1877 