### PR TITLE
repos: add option include_all_branches to template repo request

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -14764,6 +14764,14 @@ func (t *TemplateRepoRequest) GetDescription() string {
 	return *t.Description
 }
 
+// GetIncludeAllBranches returns the IncludeAllBranches field if it's non-nil, zero value otherwise.
+func (t *TemplateRepoRequest) GetIncludeAllBranches() bool {
+	if t == nil || t.IncludeAllBranches == nil {
+		return false
+	}
+	return *t.IncludeAllBranches
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (t *TemplateRepoRequest) GetName() string {
 	if t == nil || t.Name == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -17292,6 +17292,16 @@ func TestTemplateRepoRequest_GetDescription(tt *testing.T) {
 	t.GetDescription()
 }
 
+func TestTemplateRepoRequest_GetIncludeAllBranches(tt *testing.T) {
+	var zeroValue bool
+	t := &TemplateRepoRequest{IncludeAllBranches: &zeroValue}
+	t.GetIncludeAllBranches()
+	t = &TemplateRepoRequest{}
+	t.GetIncludeAllBranches()
+	t = nil
+	t.GetIncludeAllBranches()
+}
+
 func TestTemplateRepoRequest_GetName(tt *testing.T) {
 	var zeroValue string
 	t := &TemplateRepoRequest{Name: &zeroValue}

--- a/github/repos.go
+++ b/github/repos.go
@@ -385,7 +385,8 @@ type TemplateRepoRequest struct {
 	Owner       *string `json:"owner,omitempty"`
 	Description *string `json:"description,omitempty"`
 
-	Private *bool `json:"private,omitempty"`
+	IncludeAllBranches *bool `json:"include_all_branches,omitempty"`
+	Private            *bool `json:"private,omitempty"`
 }
 
 // CreateFromTemplate generates a repository from a template.


### PR DESCRIPTION
This option, when set to true, the created repository will get files
from all the branches, not just the default branch.

See [create-a-repository-using-a-template][1] for more information.

[1]: https://docs.github.com/en/rest/reference/repos#create-a-repository-using-a-template