### PR TITLE
Parse 'reviewed' event object 'state' property

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -14924,6 +14924,14 @@ func (t *Timeline) GetSource() *Source {
 	return t.Source
 }
 
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (t *Timeline) GetState() string {
+	if t == nil || t.State == nil {
+		return ""
+	}
+	return *t.State
+}
+
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
 func (t *Timeline) GetURL() string {
 	if t == nil || t.URL == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -17471,6 +17471,16 @@ func TestTimeline_GetSource(tt *testing.T) {
 	t.GetSource()
 }
 
+func TestTimeline_GetState(tt *testing.T) {
+	var zeroValue string
+	t := &Timeline{State: &zeroValue}
+	t.GetState()
+	t = &Timeline{}
+	t.GetState()
+	t = nil
+	t.GetState()
+}
+
 func TestTimeline_GetURL(tt *testing.T) {
 	var zeroValue string
 	t := &Timeline{URL: &zeroValue}

--- a/github/issues_timeline.go
+++ b/github/issues_timeline.go
@@ -81,6 +81,9 @@ type Timeline struct {
 	//     reopened
 	//       The issue was reopened by the actor.
 	//
+	//     reviewed
+	//       The pull request was reviewed.
+	//
 	//     subscribed
 	//       The actor subscribed to receive notifications for an issue.
 	//
@@ -118,6 +121,10 @@ type Timeline struct {
 	// Only provided for 'renamed' events.
 	Rename      *Rename      `json:"rename,omitempty"`
 	ProjectCard *ProjectCard `json:"project_card,omitempty"`
+	// The state of a submitted review. Can be one of: 'commented',
+	// 'changes_requested' or 'approved'.
+	// Only provided for 'reviewed' events.
+	State *string `json:"state,omitempty"`
 }
 
 // Source represents a reference's source.


### PR DESCRIPTION
The Timeline Events API can return a `reviewed` event object when listing events for a pull request. One of the properties of [this object](https://docs.github.com/en/developers/webhooks-and-events/events/issue-event-types#reviewed) is `state`, which tells you the state of a submitted review.

The values `state` can have are:

- `commented`
- `changes_requested`
- `approved`

This PR adds this field to the `Timeline` struct defined in `issues_timeline.go` to make it possible to tell the state of a review when listing pull request events.