### PR TITLE
define struct types instead of using anonymous structs

### DIFF
--- a/github/activity.go
+++ b/github/activity.go
@@ -21,22 +21,25 @@ type FeedLink struct {
 
 // Feeds represents timeline resources in Atom format.
 type Feeds struct {
-	TimelineURL                 *string  `json:"timeline_url,omitempty"`
-	UserURL                     *string  `json:"user_url,omitempty"`
-	CurrentUserPublicURL        *string  `json:"current_user_public_url,omitempty"`
-	CurrentUserURL              *string  `json:"current_user_url,omitempty"`
-	CurrentUserActorURL         *string  `json:"current_user_actor_url,omitempty"`
-	CurrentUserOrganizationURL  *string  `json:"current_user_organization_url,omitempty"`
-	CurrentUserOrganizationURLs []string `json:"current_user_organization_urls,omitempty"`
-	Links                       *struct {
-		Timeline                 *FeedLink   `json:"timeline,omitempty"`
-		User                     *FeedLink   `json:"user,omitempty"`
-		CurrentUserPublic        *FeedLink   `json:"current_user_public,omitempty"`
-		CurrentUser              *FeedLink   `json:"current_user,omitempty"`
-		CurrentUserActor         *FeedLink   `json:"current_user_actor,omitempty"`
-		CurrentUserOrganization  *FeedLink   `json:"current_user_organization,omitempty"`
-		CurrentUserOrganizations []*FeedLink `json:"current_user_organizations,omitempty"`
-	} `json:"_links,omitempty"`
+	TimelineURL                 *string    `json:"timeline_url,omitempty"`
+	UserURL                     *string    `json:"user_url,omitempty"`
+	CurrentUserPublicURL        *string    `json:"current_user_public_url,omitempty"`
+	CurrentUserURL              *string    `json:"current_user_url,omitempty"`
+	CurrentUserActorURL         *string    `json:"current_user_actor_url,omitempty"`
+	CurrentUserOrganizationURL  *string    `json:"current_user_organization_url,omitempty"`
+	CurrentUserOrganizationURLs []string   `json:"current_user_organization_urls,omitempty"`
+	Links                       *FeedLinks `json:"_links,omitempty"`
+}
+
+// FeedLinks represents the links in a Feed.
+type FeedLinks struct {
+	Timeline                 *FeedLink   `json:"timeline,omitempty"`
+	User                     *FeedLink   `json:"user,omitempty"`
+	CurrentUserPublic        *FeedLink   `json:"current_user_public,omitempty"`
+	CurrentUser              *FeedLink   `json:"current_user,omitempty"`
+	CurrentUserActor         *FeedLink   `json:"current_user_actor,omitempty"`
+	CurrentUserOrganization  *FeedLink   `json:"current_user_organization,omitempty"`
+	CurrentUserOrganizations []*FeedLink `json:"current_user_organizations,omitempty"`
 }
 
 // ListFeeds lists all the feeds available to the authenticated user.

--- a/github/activity_test.go
+++ b/github/activity_test.go
@@ -97,15 +97,7 @@ var wantFeeds = &Feeds{
 	CurrentUserOrganizationURLs: []string{
 		"https://github.com/organizations/github/defunkt.private.atom?token=abc123",
 	},
-	Links: &struct {
-		Timeline                 *FeedLink   `json:"timeline,omitempty"`
-		User                     *FeedLink   `json:"user,omitempty"`
-		CurrentUserPublic        *FeedLink   `json:"current_user_public,omitempty"`
-		CurrentUser              *FeedLink   `json:"current_user,omitempty"`
-		CurrentUserActor         *FeedLink   `json:"current_user_actor,omitempty"`
-		CurrentUserOrganization  *FeedLink   `json:"current_user_organization,omitempty"`
-		CurrentUserOrganizations []*FeedLink `json:"current_user_organizations,omitempty"`
-	}{
+	Links: &FeedLinks{
 		Timeline: &FeedLink{
 			HRef: String("https://github.com/timeline"),
 			Type: String("application/atom+xml"),

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -274,9 +274,12 @@ type ProjectCardNote struct {
 
 // ProjectColumnChange represents the changes when a project column has been edited.
 type ProjectColumnChange struct {
-	Name *struct {
-		From *string `json:"from,omitempty"`
-	} `json:"name,omitempty"`
+	Name *ProjectColumnName `json:"name,omitempty"`
+}
+
+// ProjectColumnName represents a project column name change.
+type ProjectColumnName struct {
+	From *string `json:"from,omitempty"`
 }
 
 // TeamChange represents the changes when a team has been edited.

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -215,20 +215,35 @@ type GollumEvent struct {
 // EditChange represents the changes when an issue, pull request, or comment has
 // been edited.
 type EditChange struct {
-	Title *struct {
-		From *string `json:"from,omitempty"`
-	} `json:"title,omitempty"`
-	Body *struct {
-		From *string `json:"from,omitempty"`
-	} `json:"body,omitempty"`
-	Base *struct {
-		Ref *struct {
-			From *string `json:"from,omitempty"`
-		} `json:"ref,omitempty"`
-		SHA *struct {
-			From *string `json:"from,omitempty"`
-		} `json:"sha,omitempty"`
-	} `json:"base,omitempty"`
+	Title *EditTitle `json:"title,omitempty"`
+	Body  *EditBody  `json:"body,omitempty"`
+	Base  *EditBase  `json:"base,omitempty"`
+}
+
+// EditTitle represents a pull-request title change.
+type EditTitle struct {
+	From *string `json:"from,omitempty"`
+}
+
+// EditBody represents a change of pull-request body.
+type EditBody struct {
+	From *string `json:"from,omitempty"`
+}
+
+// EditBase represents the change of a pull-request base branch.
+type EditBase struct {
+	Ref *EditRef `json:"ref,omitempty"`
+	SHA *EditSHA `json:"sha,omitempty"`
+}
+
+// EditBase represents a ref change of a pull-request.
+type EditRef struct {
+	From *string `json:"from,omitempty"`
+}
+
+// EditBase represents a sha change of a pull-request.
+type EditSHA struct {
+	From *string `json:"from,omitempty"`
 }
 
 // ProjectChange represents the changes when a project has been edited.

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -305,7 +305,7 @@ type TeamPrivacy struct {
 	From *string `json:"from,omitempty"`
 }
 
-// TeamPrivacy represents a team repository permission change.
+// TeamRepository represents a team repository permission change.
 type TeamRepository struct {
 	Permissions *TeamPermissions `json:"permissions,omitempty"`
 }

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -264,9 +264,12 @@ type ProjectBody struct {
 
 // ProjectCardChange represents the changes when a project card has been edited.
 type ProjectCardChange struct {
-	Note *struct {
-		From *string `json:"from,omitempty"`
-	} `json:"note,omitempty"`
+	Note *ProjectCardNote `json:"note,omitempty"`
+}
+
+// ProjectCardNote represents a change of a note of a project card.
+type ProjectCardNote struct {
+	From *string `json:"from,omitempty"`
 }
 
 // ProjectColumnChange represents the changes when a project column has been edited.

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -248,12 +248,18 @@ type EditSHA struct {
 
 // ProjectChange represents the changes when a project has been edited.
 type ProjectChange struct {
-	Name *struct {
-		From *string `json:"from,omitempty"`
-	} `json:"name,omitempty"`
-	Body *struct {
-		From *string `json:"from,omitempty"`
-	} `json:"body,omitempty"`
+	Name *ProjectName `json:"name,omitempty"`
+	Body *ProjectBody `json:"body,omitempty"`
+}
+
+// ProjectName represents a project name change.
+type ProjectName struct {
+	From *string `json:"from,omitempty"`
+}
+
+// ProjectBody represents a project body change.
+type ProjectBody struct {
+	From *string `json:"from,omitempty"`
 }
 
 // ProjectCardChange represents the changes when a project card has been edited.

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -935,20 +935,23 @@ type RepositoryVulnerabilityAlertEvent struct {
 	Action *string `json:"action,omitempty"`
 
 	//The security alert of the vulnerable dependency.
-	Alert *struct {
-		ID                  *int64     `json:"id,omitempty"`
-		AffectedRange       *string    `json:"affected_range,omitempty"`
-		AffectedPackageName *string    `json:"affected_package_name,omitempty"`
-		ExternalReference   *string    `json:"external_reference,omitempty"`
-		ExternalIdentifier  *string    `json:"external_identifier,omitempty"`
-		FixedIn             *string    `json:"fixed_in,omitempty"`
-		Dismisser           *User      `json:"dismisser,omitempty"`
-		DismissReason       *string    `json:"dismiss_reason,omitempty"`
-		DismissedAt         *Timestamp `json:"dismissed_at,omitempty"`
-	} `json:"alert,omitempty"`
+	Alert *RepositoryVulnerabilityAlert `json:"alert,omitempty"`
 
 	//The repository of the vulnerable dependency.
 	Repository *Repository `json:"repository,omitempty"`
+}
+
+// RepositoryVulnerabilityAlert represents a repository security alert.
+type RepositoryVulnerabilityAlert struct {
+	ID                  *int64     `json:"id,omitempty"`
+	AffectedRange       *string    `json:"affected_range,omitempty"`
+	AffectedPackageName *string    `json:"affected_package_name,omitempty"`
+	ExternalReference   *string    `json:"external_reference,omitempty"`
+	ExternalIdentifier  *string    `json:"external_identifier,omitempty"`
+	FixedIn             *string    `json:"fixed_in,omitempty"`
+	Dismisser           *User      `json:"dismisser,omitempty"`
+	DismissReason       *string    `json:"dismiss_reason,omitempty"`
+	DismissedAt         *Timestamp `json:"dismissed_at,omitempty"`
 }
 
 // StarEvent is triggered when a star is added or removed from a repository.

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -284,24 +284,42 @@ type ProjectColumnName struct {
 
 // TeamChange represents the changes when a team has been edited.
 type TeamChange struct {
-	Description *struct {
-		From *string `json:"from,omitempty"`
-	} `json:"description,omitempty"`
-	Name *struct {
-		From *string `json:"from,omitempty"`
-	} `json:"name,omitempty"`
-	Privacy *struct {
-		From *string `json:"from,omitempty"`
-	} `json:"privacy,omitempty"`
-	Repository *struct {
-		Permissions *struct {
-			From *struct {
-				Admin *bool `json:"admin,omitempty"`
-				Pull  *bool `json:"pull,omitempty"`
-				Push  *bool `json:"push,omitempty"`
-			} `json:"from,omitempty"`
-		} `json:"permissions,omitempty"`
-	} `json:"repository,omitempty"`
+	Description *TeamDescription `json:"description,omitempty"`
+	Name        *TeamName        `json:"name,omitempty"`
+	Privacy     *TeamPrivacy     `json:"privacy,omitempty"`
+	Repository  *TeamRepository  `json:"repository,omitempty"`
+}
+
+// TeamDescription represents a team description change.
+type TeamDescription struct {
+	From *string `json:"from,omitempty"`
+}
+
+// TeamName represents a team name change.
+type TeamName struct {
+	From *string `json:"from,omitempty"`
+}
+
+// TeamPrivacy represents a team privacy change.
+type TeamPrivacy struct {
+	From *string `json:"from,omitempty"`
+}
+
+// TeamPrivacy represents a team repository permission change.
+type TeamRepository struct {
+	Permissions *TeamPermissions `json:"permissions,omitempty"`
+}
+
+// TeamPermissions represents a team permission change.
+type TeamPermissions struct {
+	From *TeamPermissionsFrom `json:"from,omitempty"`
+}
+
+// TeamPermissionsFrom represents a team permission change.
+type TeamPermissionsFrom struct {
+	Admin *bool `json:"admin,omitempty"`
+	Pull  *bool `json:"pull,omitempty"`
+	Push  *bool `json:"push,omitempty"`
 }
 
 // InstallationEvent is triggered when a GitHub App has been installed, uninstalled, suspend, unsuspended

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -236,12 +236,12 @@ type EditBase struct {
 	SHA *EditSHA `json:"sha,omitempty"`
 }
 
-// EditBase represents a ref change of a pull-request.
+// EditRef represents a ref change of a pull-request.
 type EditRef struct {
 	From *string `json:"from,omitempty"`
 }
 
-// EditBase represents a sha change of a pull-request.
+// EditSHA represents a sha change of a pull-request.
 type EditSHA struct {
 	From *string `json:"from,omitempty"`
 }

--- a/github/event_types_test.go
+++ b/github/event_types_test.go
@@ -12,16 +12,12 @@ import (
 func TestEditChange_Marshal_TitleChange(t *testing.T) {
 	testJSONMarshal(t, &EditChange{}, "{}")
 
-	TitleFrom := struct {
-		From *string `json:"from,omitempty"`
-	}{
-		From: String("TitleFrom"),
-	}
-
 	u := &EditChange{
-		Title: &TitleFrom,
-		Body:  nil,
-		Base:  nil,
+		Title: &EditTitle{
+			From: String("TitleFrom"),
+		},
+		Body: nil,
+		Base: nil,
 	}
 
 	want := `{
@@ -36,16 +32,12 @@ func TestEditChange_Marshal_TitleChange(t *testing.T) {
 func TestEditChange_Marshal_BodyChange(t *testing.T) {
 	testJSONMarshal(t, &EditChange{}, "{}")
 
-	BodyFrom := struct {
-		From *string `json:"from,omitempty"`
-	}{
-		From: String("BodyFrom"),
-	}
-
 	u := &EditChange{
 		Title: nil,
-		Body:  &BodyFrom,
-		Base:  nil,
+		Body: &EditBody{
+			From: String("BodyFrom"),
+		},
+		Base: nil,
 	}
 
 	want := `{
@@ -60,28 +52,13 @@ func TestEditChange_Marshal_BodyChange(t *testing.T) {
 func TestEditChange_Marshal_BaseChange(t *testing.T) {
 	testJSONMarshal(t, &EditChange{}, "{}")
 
-	RefFrom := struct {
-		From *string `json:"from,omitempty"`
-	}{
-		From: String("BaseRefFrom"),
-	}
-
-	SHAFrom := struct {
-		From *string `json:"from,omitempty"`
-	}{
-		From: String("BaseSHAFrom"),
-	}
-
-	Base := struct {
-		Ref *struct {
-			From *string `json:"from,omitempty"`
-		} `json:"ref,omitempty"`
-		SHA *struct {
-			From *string `json:"from,omitempty"`
-		} `json:"sha,omitempty"`
-	}{
-		Ref: &RefFrom,
-		SHA: &SHAFrom,
+	Base := EditBase{
+		Ref: &EditRef{
+			From: String("BaseRefFrom"),
+		},
+		SHA: &EditSHA{
+			From: String("BaseSHAFrom"),
+		},
 	}
 
 	u := &EditChange{

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9388,6 +9388,14 @@ func (p *Project) GetURL() string {
 	return *p.URL
 }
 
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (p *ProjectBody) GetFrom() string {
+	if p == nil || p.From == nil {
+		return ""
+	}
+	return *p.From
+}
+
 // GetArchived returns the Archived field if it's non-nil, zero value otherwise.
 func (p *ProjectCard) GetArchived() bool {
 	if p == nil || p.Archived == nil {
@@ -9588,6 +9596,22 @@ func (p *ProjectCardOptions) GetArchived() bool {
 	return *p.Archived
 }
 
+// GetBody returns the Body field.
+func (p *ProjectChange) GetBody() *ProjectBody {
+	if p == nil {
+		return nil
+	}
+	return p.Body
+}
+
+// GetName returns the Name field.
+func (p *ProjectChange) GetName() *ProjectName {
+	if p == nil {
+		return nil
+	}
+	return p.Name
+}
+
 // GetPermission returns the Permission field if it's non-nil, zero value otherwise.
 func (p *ProjectCollaboratorOptions) GetPermission() string {
 	if p == nil || p.Permission == nil {
@@ -9778,6 +9802,14 @@ func (p *ProjectEvent) GetSender() *User {
 		return nil
 	}
 	return p.Sender
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (p *ProjectName) GetFrom() string {
+	if p == nil || p.From == nil {
+		return ""
+	}
+	return *p.From
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -13588,12 +13588,92 @@ func (r *RepositoryTag) GetZipballURL() string {
 	return *r.ZipballURL
 }
 
+// GetAffectedPackageName returns the AffectedPackageName field if it's non-nil, zero value otherwise.
+func (r *RepositoryVulnerabilityAlert) GetAffectedPackageName() string {
+	if r == nil || r.AffectedPackageName == nil {
+		return ""
+	}
+	return *r.AffectedPackageName
+}
+
+// GetAffectedRange returns the AffectedRange field if it's non-nil, zero value otherwise.
+func (r *RepositoryVulnerabilityAlert) GetAffectedRange() string {
+	if r == nil || r.AffectedRange == nil {
+		return ""
+	}
+	return *r.AffectedRange
+}
+
+// GetDismissedAt returns the DismissedAt field if it's non-nil, zero value otherwise.
+func (r *RepositoryVulnerabilityAlert) GetDismissedAt() Timestamp {
+	if r == nil || r.DismissedAt == nil {
+		return Timestamp{}
+	}
+	return *r.DismissedAt
+}
+
+// GetDismisser returns the Dismisser field.
+func (r *RepositoryVulnerabilityAlert) GetDismisser() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Dismisser
+}
+
+// GetDismissReason returns the DismissReason field if it's non-nil, zero value otherwise.
+func (r *RepositoryVulnerabilityAlert) GetDismissReason() string {
+	if r == nil || r.DismissReason == nil {
+		return ""
+	}
+	return *r.DismissReason
+}
+
+// GetExternalIdentifier returns the ExternalIdentifier field if it's non-nil, zero value otherwise.
+func (r *RepositoryVulnerabilityAlert) GetExternalIdentifier() string {
+	if r == nil || r.ExternalIdentifier == nil {
+		return ""
+	}
+	return *r.ExternalIdentifier
+}
+
+// GetExternalReference returns the ExternalReference field if it's non-nil, zero value otherwise.
+func (r *RepositoryVulnerabilityAlert) GetExternalReference() string {
+	if r == nil || r.ExternalReference == nil {
+		return ""
+	}
+	return *r.ExternalReference
+}
+
+// GetFixedIn returns the FixedIn field if it's non-nil, zero value otherwise.
+func (r *RepositoryVulnerabilityAlert) GetFixedIn() string {
+	if r == nil || r.FixedIn == nil {
+		return ""
+	}
+	return *r.FixedIn
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (r *RepositoryVulnerabilityAlert) GetID() int64 {
+	if r == nil || r.ID == nil {
+		return 0
+	}
+	return *r.ID
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (r *RepositoryVulnerabilityAlertEvent) GetAction() string {
 	if r == nil || r.Action == nil {
 		return ""
 	}
 	return *r.Action
+}
+
+// GetAlert returns the Alert field.
+func (r *RepositoryVulnerabilityAlertEvent) GetAlert() *RepositoryVulnerabilityAlert {
+	if r == nil {
+		return nil
+	}
+	return r.Alert
 }
 
 // GetRepository returns the Repository field.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -3620,6 +3620,78 @@ func (d *DraftReviewComment) GetStartSide() string {
 	return *d.StartSide
 }
 
+// GetRef returns the Ref field.
+func (e *EditBase) GetRef() *EditRef {
+	if e == nil {
+		return nil
+	}
+	return e.Ref
+}
+
+// GetSHA returns the SHA field.
+func (e *EditBase) GetSHA() *EditSHA {
+	if e == nil {
+		return nil
+	}
+	return e.SHA
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (e *EditBody) GetFrom() string {
+	if e == nil || e.From == nil {
+		return ""
+	}
+	return *e.From
+}
+
+// GetBase returns the Base field.
+func (e *EditChange) GetBase() *EditBase {
+	if e == nil {
+		return nil
+	}
+	return e.Base
+}
+
+// GetBody returns the Body field.
+func (e *EditChange) GetBody() *EditBody {
+	if e == nil {
+		return nil
+	}
+	return e.Body
+}
+
+// GetTitle returns the Title field.
+func (e *EditChange) GetTitle() *EditTitle {
+	if e == nil {
+		return nil
+	}
+	return e.Title
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (e *EditRef) GetFrom() string {
+	if e == nil || e.From == nil {
+		return ""
+	}
+	return *e.From
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (e *EditSHA) GetFrom() string {
+	if e == nil || e.From == nil {
+		return ""
+	}
+	return *e.From
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (e *EditTitle) GetFrom() string {
+	if e == nil || e.From == nil {
+		return ""
+	}
+	return *e.From
+}
+
 // GetAvatarURL returns the AvatarURL field if it's non-nil, zero value otherwise.
 func (e *Enterprise) GetAvatarURL() string {
 	if e == nil || e.AvatarURL == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9700,6 +9700,14 @@ func (p *ProjectColumn) GetURL() string {
 	return *p.URL
 }
 
+// GetName returns the Name field.
+func (p *ProjectColumnChange) GetName() *ProjectColumnName {
+	if p == nil {
+		return nil
+	}
+	return p.Name
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (p *ProjectColumnEvent) GetAction() string {
 	if p == nil || p.Action == nil {
@@ -9762,6 +9770,14 @@ func (p *ProjectColumnEvent) GetSender() *User {
 		return nil
 	}
 	return p.Sender
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (p *ProjectColumnName) GetFrom() string {
+	if p == nil || p.From == nil {
+		return ""
+	}
+	return *p.From
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -3892,6 +3892,22 @@ func (e *EnvReviewers) GetType() string {
 	return *e.Type
 }
 
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (e *ErrorBlock) GetCreatedAt() Timestamp {
+	if e == nil || e.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *e.CreatedAt
+}
+
+// GetBlock returns the Block field.
+func (e *ErrorResponse) GetBlock() *ErrorBlock {
+	if e == nil {
+		return nil
+	}
+	return e.Block
+}
+
 // GetActor returns the Actor field.
 func (e *Event) GetActor() *User {
 	if e == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -14604,6 +14604,46 @@ func (t *TeamAddEvent) GetTeam() *Team {
 	return t.Team
 }
 
+// GetDescription returns the Description field.
+func (t *TeamChange) GetDescription() *TeamDescription {
+	if t == nil {
+		return nil
+	}
+	return t.Description
+}
+
+// GetName returns the Name field.
+func (t *TeamChange) GetName() *TeamName {
+	if t == nil {
+		return nil
+	}
+	return t.Name
+}
+
+// GetPrivacy returns the Privacy field.
+func (t *TeamChange) GetPrivacy() *TeamPrivacy {
+	if t == nil {
+		return nil
+	}
+	return t.Privacy
+}
+
+// GetRepository returns the Repository field.
+func (t *TeamChange) GetRepository() *TeamRepository {
+	if t == nil {
+		return nil
+	}
+	return t.Repository
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (t *TeamDescription) GetFrom() string {
+	if t == nil || t.From == nil {
+		return ""
+	}
+	return *t.From
+}
+
 // GetAuthor returns the Author field.
 func (t *TeamDiscussion) GetAuthor() *User {
 	if t == nil {
@@ -14884,12 +14924,68 @@ func (t *TeamLDAPMapping) GetURL() string {
 	return *t.URL
 }
 
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (t *TeamName) GetFrom() string {
+	if t == nil || t.From == nil {
+		return ""
+	}
+	return *t.From
+}
+
+// GetFrom returns the From field.
+func (t *TeamPermissions) GetFrom() *TeamPermissionsFrom {
+	if t == nil {
+		return nil
+	}
+	return t.From
+}
+
+// GetAdmin returns the Admin field if it's non-nil, zero value otherwise.
+func (t *TeamPermissionsFrom) GetAdmin() bool {
+	if t == nil || t.Admin == nil {
+		return false
+	}
+	return *t.Admin
+}
+
+// GetPull returns the Pull field if it's non-nil, zero value otherwise.
+func (t *TeamPermissionsFrom) GetPull() bool {
+	if t == nil || t.Pull == nil {
+		return false
+	}
+	return *t.Pull
+}
+
+// GetPush returns the Push field if it's non-nil, zero value otherwise.
+func (t *TeamPermissionsFrom) GetPush() bool {
+	if t == nil || t.Push == nil {
+		return false
+	}
+	return *t.Push
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (t *TeamPrivacy) GetFrom() string {
+	if t == nil || t.From == nil {
+		return ""
+	}
+	return *t.From
+}
+
 // GetPermission returns the Permission field if it's non-nil, zero value otherwise.
 func (t *TeamProjectOptions) GetPermission() string {
 	if t == nil || t.Permission == nil {
 		return ""
 	}
 	return *t.Permission
+}
+
+// GetPermissions returns the Permissions field.
+func (t *TeamRepository) GetPermissions() *TeamPermissions {
+	if t == nil {
+		return nil
+	}
+	return t.Permissions
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -3972,6 +3972,54 @@ func (f *FeedLink) GetType() string {
 	return *f.Type
 }
 
+// GetCurrentUser returns the CurrentUser field.
+func (f *FeedLinks) GetCurrentUser() *FeedLink {
+	if f == nil {
+		return nil
+	}
+	return f.CurrentUser
+}
+
+// GetCurrentUserActor returns the CurrentUserActor field.
+func (f *FeedLinks) GetCurrentUserActor() *FeedLink {
+	if f == nil {
+		return nil
+	}
+	return f.CurrentUserActor
+}
+
+// GetCurrentUserOrganization returns the CurrentUserOrganization field.
+func (f *FeedLinks) GetCurrentUserOrganization() *FeedLink {
+	if f == nil {
+		return nil
+	}
+	return f.CurrentUserOrganization
+}
+
+// GetCurrentUserPublic returns the CurrentUserPublic field.
+func (f *FeedLinks) GetCurrentUserPublic() *FeedLink {
+	if f == nil {
+		return nil
+	}
+	return f.CurrentUserPublic
+}
+
+// GetTimeline returns the Timeline field.
+func (f *FeedLinks) GetTimeline() *FeedLink {
+	if f == nil {
+		return nil
+	}
+	return f.Timeline
+}
+
+// GetUser returns the User field.
+func (f *FeedLinks) GetUser() *FeedLink {
+	if f == nil {
+		return nil
+	}
+	return f.User
+}
+
 // GetCurrentUserActorURL returns the CurrentUserActorURL field if it's non-nil, zero value otherwise.
 func (f *Feeds) GetCurrentUserActorURL() string {
 	if f == nil || f.CurrentUserActorURL == nil {
@@ -4002,6 +4050,14 @@ func (f *Feeds) GetCurrentUserURL() string {
 		return ""
 	}
 	return *f.CurrentUserURL
+}
+
+// GetLinks returns the Links field.
+func (f *Feeds) GetLinks() *FeedLinks {
+	if f == nil {
+		return nil
+	}
+	return f.Links
 }
 
 // GetTimelineURL returns the TimelineURL field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9516,6 +9516,14 @@ func (p *ProjectCard) GetURL() string {
 	return *p.URL
 }
 
+// GetNote returns the Note field.
+func (p *ProjectCardChange) GetNote() *ProjectCardNote {
+	if p == nil {
+		return nil
+	}
+	return p.Note
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (p *ProjectCardEvent) GetAction() string {
 	if p == nil || p.Action == nil {
@@ -9586,6 +9594,14 @@ func (p *ProjectCardListOptions) GetArchivedState() string {
 		return ""
 	}
 	return *p.ArchivedState
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (p *ProjectCardNote) GetFrom() string {
+	if p == nil || p.From == nil {
+		return ""
+	}
+	return *p.From
 }
 
 // GetArchived returns the Archived field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -17089,6 +17089,44 @@ func TestTeamAddEvent_GetTeam(tt *testing.T) {
 	t.GetTeam()
 }
 
+func TestTeamChange_GetDescription(tt *testing.T) {
+	t := &TeamChange{}
+	t.GetDescription()
+	t = nil
+	t.GetDescription()
+}
+
+func TestTeamChange_GetName(tt *testing.T) {
+	t := &TeamChange{}
+	t.GetName()
+	t = nil
+	t.GetName()
+}
+
+func TestTeamChange_GetPrivacy(tt *testing.T) {
+	t := &TeamChange{}
+	t.GetPrivacy()
+	t = nil
+	t.GetPrivacy()
+}
+
+func TestTeamChange_GetRepository(tt *testing.T) {
+	t := &TeamChange{}
+	t.GetRepository()
+	t = nil
+	t.GetRepository()
+}
+
+func TestTeamDescription_GetFrom(tt *testing.T) {
+	var zeroValue string
+	t := &TeamDescription{From: &zeroValue}
+	t.GetFrom()
+	t = &TeamDescription{}
+	t.GetFrom()
+	t = nil
+	t.GetFrom()
+}
+
 func TestTeamDiscussion_GetAuthor(tt *testing.T) {
 	t := &TeamDiscussion{}
 	t.GetAuthor()
@@ -17415,6 +17453,63 @@ func TestTeamLDAPMapping_GetURL(tt *testing.T) {
 	t.GetURL()
 }
 
+func TestTeamName_GetFrom(tt *testing.T) {
+	var zeroValue string
+	t := &TeamName{From: &zeroValue}
+	t.GetFrom()
+	t = &TeamName{}
+	t.GetFrom()
+	t = nil
+	t.GetFrom()
+}
+
+func TestTeamPermissions_GetFrom(tt *testing.T) {
+	t := &TeamPermissions{}
+	t.GetFrom()
+	t = nil
+	t.GetFrom()
+}
+
+func TestTeamPermissionsFrom_GetAdmin(tt *testing.T) {
+	var zeroValue bool
+	t := &TeamPermissionsFrom{Admin: &zeroValue}
+	t.GetAdmin()
+	t = &TeamPermissionsFrom{}
+	t.GetAdmin()
+	t = nil
+	t.GetAdmin()
+}
+
+func TestTeamPermissionsFrom_GetPull(tt *testing.T) {
+	var zeroValue bool
+	t := &TeamPermissionsFrom{Pull: &zeroValue}
+	t.GetPull()
+	t = &TeamPermissionsFrom{}
+	t.GetPull()
+	t = nil
+	t.GetPull()
+}
+
+func TestTeamPermissionsFrom_GetPush(tt *testing.T) {
+	var zeroValue bool
+	t := &TeamPermissionsFrom{Push: &zeroValue}
+	t.GetPush()
+	t = &TeamPermissionsFrom{}
+	t.GetPush()
+	t = nil
+	t.GetPush()
+}
+
+func TestTeamPrivacy_GetFrom(tt *testing.T) {
+	var zeroValue string
+	t := &TeamPrivacy{From: &zeroValue}
+	t.GetFrom()
+	t = &TeamPrivacy{}
+	t.GetFrom()
+	t = nil
+	t.GetFrom()
+}
+
 func TestTeamProjectOptions_GetPermission(tt *testing.T) {
 	var zeroValue string
 	t := &TeamProjectOptions{Permission: &zeroValue}
@@ -17423,6 +17518,13 @@ func TestTeamProjectOptions_GetPermission(tt *testing.T) {
 	t.GetPermission()
 	t = nil
 	t.GetPermission()
+}
+
+func TestTeamRepository_GetPermissions(tt *testing.T) {
+	t := &TeamRepository{}
+	t.GetPermissions()
+	t = nil
+	t.GetPermissions()
 }
 
 func TestTemplateRepoRequest_GetDescription(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11185,6 +11185,13 @@ func TestProjectCard_GetURL(tt *testing.T) {
 	p.GetURL()
 }
 
+func TestProjectCardChange_GetNote(tt *testing.T) {
+	p := &ProjectCardChange{}
+	p.GetNote()
+	p = nil
+	p.GetNote()
+}
+
 func TestProjectCardEvent_GetAction(tt *testing.T) {
 	var zeroValue string
 	p := &ProjectCardEvent{Action: &zeroValue}
@@ -11255,6 +11262,16 @@ func TestProjectCardListOptions_GetArchivedState(tt *testing.T) {
 	p.GetArchivedState()
 	p = nil
 	p.GetArchivedState()
+}
+
+func TestProjectCardNote_GetFrom(tt *testing.T) {
+	var zeroValue string
+	p := &ProjectCardNote{From: &zeroValue}
+	p.GetFrom()
+	p = &ProjectCardNote{}
+	p.GetFrom()
+	p = nil
+	p.GetFrom()
 }
 
 func TestProjectCardOptions_GetArchived(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11028,6 +11028,16 @@ func TestProject_GetURL(tt *testing.T) {
 	p.GetURL()
 }
 
+func TestProjectBody_GetFrom(tt *testing.T) {
+	var zeroValue string
+	p := &ProjectBody{From: &zeroValue}
+	p.GetFrom()
+	p = &ProjectBody{}
+	p.GetFrom()
+	p = nil
+	p.GetFrom()
+}
+
 func TestProjectCard_GetArchived(tt *testing.T) {
 	var zeroValue bool
 	p := &ProjectCard{Archived: &zeroValue}
@@ -11257,6 +11267,20 @@ func TestProjectCardOptions_GetArchived(tt *testing.T) {
 	p.GetArchived()
 }
 
+func TestProjectChange_GetBody(tt *testing.T) {
+	p := &ProjectChange{}
+	p.GetBody()
+	p = nil
+	p.GetBody()
+}
+
+func TestProjectChange_GetName(tt *testing.T) {
+	p := &ProjectChange{}
+	p.GetName()
+	p = nil
+	p.GetName()
+}
+
 func TestProjectCollaboratorOptions_GetPermission(tt *testing.T) {
 	var zeroValue string
 	p := &ProjectCollaboratorOptions{Permission: &zeroValue}
@@ -11459,6 +11483,16 @@ func TestProjectEvent_GetSender(tt *testing.T) {
 	p.GetSender()
 	p = nil
 	p.GetSender()
+}
+
+func TestProjectName_GetFrom(tt *testing.T) {
+	var zeroValue string
+	p := &ProjectName{From: &zeroValue}
+	p.GetFrom()
+	p = &ProjectName{}
+	p.GetFrom()
+	p = nil
+	p.GetFrom()
 }
 
 func TestProjectOptions_GetBody(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -4566,6 +4566,23 @@ func TestEnvReviewers_GetType(tt *testing.T) {
 	e.GetType()
 }
 
+func TestErrorBlock_GetCreatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	e := &ErrorBlock{CreatedAt: &zeroValue}
+	e.GetCreatedAt()
+	e = &ErrorBlock{}
+	e.GetCreatedAt()
+	e = nil
+	e.GetCreatedAt()
+}
+
+func TestErrorResponse_GetBlock(tt *testing.T) {
+	e := &ErrorResponse{}
+	e.GetBlock()
+	e = nil
+	e.GetBlock()
+}
+
 func TestEvent_GetActor(tt *testing.T) {
 	e := &Event{}
 	e.GetActor()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -4657,6 +4657,48 @@ func TestFeedLink_GetType(tt *testing.T) {
 	f.GetType()
 }
 
+func TestFeedLinks_GetCurrentUser(tt *testing.T) {
+	f := &FeedLinks{}
+	f.GetCurrentUser()
+	f = nil
+	f.GetCurrentUser()
+}
+
+func TestFeedLinks_GetCurrentUserActor(tt *testing.T) {
+	f := &FeedLinks{}
+	f.GetCurrentUserActor()
+	f = nil
+	f.GetCurrentUserActor()
+}
+
+func TestFeedLinks_GetCurrentUserOrganization(tt *testing.T) {
+	f := &FeedLinks{}
+	f.GetCurrentUserOrganization()
+	f = nil
+	f.GetCurrentUserOrganization()
+}
+
+func TestFeedLinks_GetCurrentUserPublic(tt *testing.T) {
+	f := &FeedLinks{}
+	f.GetCurrentUserPublic()
+	f = nil
+	f.GetCurrentUserPublic()
+}
+
+func TestFeedLinks_GetTimeline(tt *testing.T) {
+	f := &FeedLinks{}
+	f.GetTimeline()
+	f = nil
+	f.GetTimeline()
+}
+
+func TestFeedLinks_GetUser(tt *testing.T) {
+	f := &FeedLinks{}
+	f.GetUser()
+	f = nil
+	f.GetUser()
+}
+
 func TestFeeds_GetCurrentUserActorURL(tt *testing.T) {
 	var zeroValue string
 	f := &Feeds{CurrentUserActorURL: &zeroValue}
@@ -4695,6 +4737,13 @@ func TestFeeds_GetCurrentUserURL(tt *testing.T) {
 	f.GetCurrentUserURL()
 	f = nil
 	f.GetCurrentUserURL()
+}
+
+func TestFeeds_GetLinks(tt *testing.T) {
+	f := &Feeds{}
+	f.GetLinks()
+	f = nil
+	f.GetLinks()
 }
 
 func TestFeeds_GetTimelineURL(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -15888,6 +15888,93 @@ func TestRepositoryTag_GetZipballURL(tt *testing.T) {
 	r.GetZipballURL()
 }
 
+func TestRepositoryVulnerabilityAlert_GetAffectedPackageName(tt *testing.T) {
+	var zeroValue string
+	r := &RepositoryVulnerabilityAlert{AffectedPackageName: &zeroValue}
+	r.GetAffectedPackageName()
+	r = &RepositoryVulnerabilityAlert{}
+	r.GetAffectedPackageName()
+	r = nil
+	r.GetAffectedPackageName()
+}
+
+func TestRepositoryVulnerabilityAlert_GetAffectedRange(tt *testing.T) {
+	var zeroValue string
+	r := &RepositoryVulnerabilityAlert{AffectedRange: &zeroValue}
+	r.GetAffectedRange()
+	r = &RepositoryVulnerabilityAlert{}
+	r.GetAffectedRange()
+	r = nil
+	r.GetAffectedRange()
+}
+
+func TestRepositoryVulnerabilityAlert_GetDismissedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	r := &RepositoryVulnerabilityAlert{DismissedAt: &zeroValue}
+	r.GetDismissedAt()
+	r = &RepositoryVulnerabilityAlert{}
+	r.GetDismissedAt()
+	r = nil
+	r.GetDismissedAt()
+}
+
+func TestRepositoryVulnerabilityAlert_GetDismisser(tt *testing.T) {
+	r := &RepositoryVulnerabilityAlert{}
+	r.GetDismisser()
+	r = nil
+	r.GetDismisser()
+}
+
+func TestRepositoryVulnerabilityAlert_GetDismissReason(tt *testing.T) {
+	var zeroValue string
+	r := &RepositoryVulnerabilityAlert{DismissReason: &zeroValue}
+	r.GetDismissReason()
+	r = &RepositoryVulnerabilityAlert{}
+	r.GetDismissReason()
+	r = nil
+	r.GetDismissReason()
+}
+
+func TestRepositoryVulnerabilityAlert_GetExternalIdentifier(tt *testing.T) {
+	var zeroValue string
+	r := &RepositoryVulnerabilityAlert{ExternalIdentifier: &zeroValue}
+	r.GetExternalIdentifier()
+	r = &RepositoryVulnerabilityAlert{}
+	r.GetExternalIdentifier()
+	r = nil
+	r.GetExternalIdentifier()
+}
+
+func TestRepositoryVulnerabilityAlert_GetExternalReference(tt *testing.T) {
+	var zeroValue string
+	r := &RepositoryVulnerabilityAlert{ExternalReference: &zeroValue}
+	r.GetExternalReference()
+	r = &RepositoryVulnerabilityAlert{}
+	r.GetExternalReference()
+	r = nil
+	r.GetExternalReference()
+}
+
+func TestRepositoryVulnerabilityAlert_GetFixedIn(tt *testing.T) {
+	var zeroValue string
+	r := &RepositoryVulnerabilityAlert{FixedIn: &zeroValue}
+	r.GetFixedIn()
+	r = &RepositoryVulnerabilityAlert{}
+	r.GetFixedIn()
+	r = nil
+	r.GetFixedIn()
+}
+
+func TestRepositoryVulnerabilityAlert_GetID(tt *testing.T) {
+	var zeroValue int64
+	r := &RepositoryVulnerabilityAlert{ID: &zeroValue}
+	r.GetID()
+	r = &RepositoryVulnerabilityAlert{}
+	r.GetID()
+	r = nil
+	r.GetID()
+}
+
 func TestRepositoryVulnerabilityAlertEvent_GetAction(tt *testing.T) {
 	var zeroValue string
 	r := &RepositoryVulnerabilityAlertEvent{Action: &zeroValue}
@@ -15896,6 +15983,13 @@ func TestRepositoryVulnerabilityAlertEvent_GetAction(tt *testing.T) {
 	r.GetAction()
 	r = nil
 	r.GetAction()
+}
+
+func TestRepositoryVulnerabilityAlertEvent_GetAlert(tt *testing.T) {
+	r := &RepositoryVulnerabilityAlertEvent{}
+	r.GetAlert()
+	r = nil
+	r.GetAlert()
 }
 
 func TestRepositoryVulnerabilityAlertEvent_GetRepository(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11388,6 +11388,13 @@ func TestProjectColumn_GetURL(tt *testing.T) {
 	p.GetURL()
 }
 
+func TestProjectColumnChange_GetName(tt *testing.T) {
+	p := &ProjectColumnChange{}
+	p.GetName()
+	p = nil
+	p.GetName()
+}
+
 func TestProjectColumnEvent_GetAction(tt *testing.T) {
 	var zeroValue string
 	p := &ProjectColumnEvent{Action: &zeroValue}
@@ -11448,6 +11455,16 @@ func TestProjectColumnEvent_GetSender(tt *testing.T) {
 	p.GetSender()
 	p = nil
 	p.GetSender()
+}
+
+func TestProjectColumnName_GetFrom(tt *testing.T) {
+	var zeroValue string
+	p := &ProjectColumnName{From: &zeroValue}
+	p.GetFrom()
+	p = &ProjectColumnName{}
+	p.GetFrom()
+	p = nil
+	p.GetFrom()
 }
 
 func TestProjectEvent_GetAction(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -4244,6 +4244,81 @@ func TestDraftReviewComment_GetStartSide(tt *testing.T) {
 	d.GetStartSide()
 }
 
+func TestEditBase_GetRef(tt *testing.T) {
+	e := &EditBase{}
+	e.GetRef()
+	e = nil
+	e.GetRef()
+}
+
+func TestEditBase_GetSHA(tt *testing.T) {
+	e := &EditBase{}
+	e.GetSHA()
+	e = nil
+	e.GetSHA()
+}
+
+func TestEditBody_GetFrom(tt *testing.T) {
+	var zeroValue string
+	e := &EditBody{From: &zeroValue}
+	e.GetFrom()
+	e = &EditBody{}
+	e.GetFrom()
+	e = nil
+	e.GetFrom()
+}
+
+func TestEditChange_GetBase(tt *testing.T) {
+	e := &EditChange{}
+	e.GetBase()
+	e = nil
+	e.GetBase()
+}
+
+func TestEditChange_GetBody(tt *testing.T) {
+	e := &EditChange{}
+	e.GetBody()
+	e = nil
+	e.GetBody()
+}
+
+func TestEditChange_GetTitle(tt *testing.T) {
+	e := &EditChange{}
+	e.GetTitle()
+	e = nil
+	e.GetTitle()
+}
+
+func TestEditRef_GetFrom(tt *testing.T) {
+	var zeroValue string
+	e := &EditRef{From: &zeroValue}
+	e.GetFrom()
+	e = &EditRef{}
+	e.GetFrom()
+	e = nil
+	e.GetFrom()
+}
+
+func TestEditSHA_GetFrom(tt *testing.T) {
+	var zeroValue string
+	e := &EditSHA{From: &zeroValue}
+	e.GetFrom()
+	e = &EditSHA{}
+	e.GetFrom()
+	e = nil
+	e.GetFrom()
+}
+
+func TestEditTitle_GetFrom(tt *testing.T) {
+	var zeroValue string
+	e := &EditTitle{From: &zeroValue}
+	e.GetFrom()
+	e = &EditTitle{}
+	e.GetFrom()
+	e = nil
+	e.GetFrom()
+}
+
 func TestEnterprise_GetAvatarURL(tt *testing.T) {
 	var zeroValue string
 	e := &Enterprise{AvatarURL: &zeroValue}

--- a/github/github.go
+++ b/github/github.go
@@ -679,16 +679,19 @@ type ErrorResponse struct {
 	Message  string         `json:"message"` // error message
 	Errors   []Error        `json:"errors"`  // more detail on individual errors
 	// Block is only populated on certain types of errors such as code 451.
-	// See https://developer.github.com/changes/2016-03-17-the-451-status-code-is-now-supported/
-	// for more information.
-	Block *struct {
-		Reason    string     `json:"reason,omitempty"`
-		CreatedAt *Timestamp `json:"created_at,omitempty"`
-	} `json:"block,omitempty"`
+	Block *ErrorBlock `json:"block,omitempty"`
 	// Most errors will also include a documentation_url field pointing
 	// to some content that might help you resolve the error, see
 	// https://docs.github.com/en/free-pro-team@latest/rest/reference/#client-errors
 	DocumentationURL string `json:"documentation_url,omitempty"`
+}
+
+// ErrorBlock contains a further explanation for the reason of an error.
+// See https://developer.github.com/changes/2016-03-17-the-451-status-code-is-now-supported/
+// for more information.
+type ErrorBlock struct {
+	Reason    string     `json:"reason,omitempty"`
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
 }
 
 func (r *ErrorResponse) Error() string {

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1091,10 +1091,7 @@ func TestCheckResponse(t *testing.T) {
 		Response: res,
 		Message:  "m",
 		Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
-		Block: &struct {
-			Reason    string     `json:"reason,omitempty"`
-			CreatedAt *Timestamp `json:"created_at,omitempty"`
-		}{
+		Block: &ErrorBlock{
 			Reason:    "dmca",
 			CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
 		},
@@ -1194,10 +1191,7 @@ func TestErrorResponse_Is(t *testing.T) {
 		Response: &http.Response{},
 		Message:  "m",
 		Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
-		Block: &struct {
-			Reason    string     `json:"reason,omitempty"`
-			CreatedAt *Timestamp `json:"created_at,omitempty"`
-		}{
+		Block: &ErrorBlock{
 			Reason:    "r",
 			CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
 		},
@@ -1213,10 +1207,7 @@ func TestErrorResponse_Is(t *testing.T) {
 				Response: &http.Response{},
 				Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
 				Message:  "m",
-				Block: &struct {
-					Reason    string     `json:"reason,omitempty"`
-					CreatedAt *Timestamp `json:"created_at,omitempty"`
-				}{
+				Block: &ErrorBlock{
 					Reason:    "r",
 					CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
 				},
@@ -1229,10 +1220,7 @@ func TestErrorResponse_Is(t *testing.T) {
 				Response: &http.Response{},
 				Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
 				Message:  "m1",
-				Block: &struct {
-					Reason    string     `json:"reason,omitempty"`
-					CreatedAt *Timestamp `json:"created_at,omitempty"`
-				}{
+				Block: &ErrorBlock{
 					Reason:    "r",
 					CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
 				},
@@ -1245,10 +1233,7 @@ func TestErrorResponse_Is(t *testing.T) {
 				Response: &http.Response{},
 				Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
 				Message:  "m",
-				Block: &struct {
-					Reason    string     `json:"reason,omitempty"`
-					CreatedAt *Timestamp `json:"created_at,omitempty"`
-				}{
+				Block: &ErrorBlock{
 					Reason:    "r",
 					CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
 				},
@@ -1260,10 +1245,7 @@ func TestErrorResponse_Is(t *testing.T) {
 			otherError: &ErrorResponse{
 				Errors:  []Error{{Resource: "r", Field: "f", Code: "c"}},
 				Message: "m",
-				Block: &struct {
-					Reason    string     `json:"reason,omitempty"`
-					CreatedAt *Timestamp `json:"created_at,omitempty"`
-				}{
+				Block: &ErrorBlock{
 					Reason:    "r",
 					CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
 				},
@@ -1276,10 +1258,7 @@ func TestErrorResponse_Is(t *testing.T) {
 				Response: &http.Response{},
 				Errors:   []Error{{Resource: "r1", Field: "f1", Code: "c1"}},
 				Message:  "m",
-				Block: &struct {
-					Reason    string     `json:"reason,omitempty"`
-					CreatedAt *Timestamp `json:"created_at,omitempty"`
-				}{
+				Block: &ErrorBlock{
 					Reason:    "r",
 					CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
 				},
@@ -1292,10 +1271,7 @@ func TestErrorResponse_Is(t *testing.T) {
 				Response: &http.Response{},
 				Errors:   []Error{},
 				Message:  "m",
-				Block: &struct {
-					Reason    string     `json:"reason,omitempty"`
-					CreatedAt *Timestamp `json:"created_at,omitempty"`
-				}{
+				Block: &ErrorBlock{
 					Reason:    "r",
 					CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
 				},
@@ -1317,10 +1293,7 @@ func TestErrorResponse_Is(t *testing.T) {
 				Response: &http.Response{},
 				Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
 				Message:  "m",
-				Block: &struct {
-					Reason    string     `json:"reason,omitempty"`
-					CreatedAt *Timestamp `json:"created_at,omitempty"`
-				}{
+				Block: &ErrorBlock{
 					Reason:    "r1",
 					CreatedAt: &Timestamp{time.Date(2016, time.March, 17, 15, 39, 46, 0, time.UTC)},
 				},
@@ -1333,10 +1306,7 @@ func TestErrorResponse_Is(t *testing.T) {
 				Response: &http.Response{},
 				Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
 				Message:  "m",
-				Block: &struct {
-					Reason    string     `json:"reason,omitempty"`
-					CreatedAt *Timestamp `json:"created_at,omitempty"`
-				}{
+				Block: &ErrorBlock{
 					Reason:    "r",
 					CreatedAt: nil,
 				},
@@ -1349,10 +1319,7 @@ func TestErrorResponse_Is(t *testing.T) {
 				Response: &http.Response{},
 				Errors:   []Error{{Resource: "r", Field: "f", Code: "c"}},
 				Message:  "m",
-				Block: &struct {
-					Reason    string     `json:"reason,omitempty"`
-					CreatedAt *Timestamp `json:"created_at,omitempty"`
-				}{
+				Block: &ErrorBlock{
 					Reason:    "r",
 					CreatedAt: &Timestamp{time.Date(2017, time.March, 17, 15, 39, 46, 0, time.UTC)},
 				},

--- a/update-urls/main.go
+++ b/update-urls/main.go
@@ -655,12 +655,12 @@ func (e *Endpoint) String() string {
 	return b.String()
 }
 
-func (ep *Endpoint) checkHttpMethodOverride(path string) {
-	lookupOverride := fmt.Sprintf("%v.%v: %v %v", ep.serviceName, ep.endpointName, ep.httpMethod, path)
+func (e *Endpoint) checkHttpMethodOverride(path string) {
+	lookupOverride := fmt.Sprintf("%v.%v: %v %v", e.serviceName, e.endpointName, e.httpMethod, path)
 	logf("Looking up override for %q", lookupOverride)
 	if v, ok := methodOverrides[lookupOverride]; ok {
 		logf("overriding method for %v to %q", lookupOverride, v)
-		ep.httpMethod = v
+		e.httpMethod = v
 		return
 	}
 }


### PR DESCRIPTION
Some fields were defined inline as anonymous structs.
This made it tedious to use these structs in testcases, because
the anonymous type needed to be redefined (incl the exact same JSON
tags) whenever it was assigned. 

Using anonymous struct also does not scale well when the struct changes.
For example when a field is added to an anonymous struct, every place
where the anonymous struct is assigned must also be changed.

Another advantage of using regular types is that accessors  will be
generated automatically and can be used instead of having to manually
check for nil values when accessing the struct fields.

Define the types as regular structs instead.

-----------

**PR Status:** PR is finished but I noticed that my company hasn't signed the CA yet. As soon as it is done, I'll transition the PR to "ready for review".