### PR TITLE
Add support for listing and getting repository/organization webhook deliveries

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -4692,6 +4692,142 @@ func (h *HookConfig) GetURL() string {
 	return *h.URL
 }
 
+// GetAction returns the Action field if it's non-nil, zero value otherwise.
+func (h *HookDelivery) GetAction() string {
+	if h == nil || h.Action == nil {
+		return ""
+	}
+	return *h.Action
+}
+
+// GetDeliveredAt returns the DeliveredAt field if it's non-nil, zero value otherwise.
+func (h *HookDelivery) GetDeliveredAt() time.Time {
+	if h == nil || h.DeliveredAt == nil {
+		return time.Time{}
+	}
+	return *h.DeliveredAt
+}
+
+// GetDuration returns the Duration field.
+func (h *HookDelivery) GetDuration() *float64 {
+	if h == nil {
+		return nil
+	}
+	return h.Duration
+}
+
+// GetEvent returns the Event field if it's non-nil, zero value otherwise.
+func (h *HookDelivery) GetEvent() string {
+	if h == nil || h.Event == nil {
+		return ""
+	}
+	return *h.Event
+}
+
+// GetGUID returns the GUID field if it's non-nil, zero value otherwise.
+func (h *HookDelivery) GetGUID() string {
+	if h == nil || h.GUID == nil {
+		return ""
+	}
+	return *h.GUID
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (h *HookDelivery) GetID() int64 {
+	if h == nil || h.ID == nil {
+		return 0
+	}
+	return *h.ID
+}
+
+// GetInstallationID returns the InstallationID field if it's non-nil, zero value otherwise.
+func (h *HookDelivery) GetInstallationID() string {
+	if h == nil || h.InstallationID == nil {
+		return ""
+	}
+	return *h.InstallationID
+}
+
+// GetRedelivery returns the Redelivery field if it's non-nil, zero value otherwise.
+func (h *HookDelivery) GetRedelivery() bool {
+	if h == nil || h.Redelivery == nil {
+		return false
+	}
+	return *h.Redelivery
+}
+
+// GetRepositoryID returns the RepositoryID field if it's non-nil, zero value otherwise.
+func (h *HookDelivery) GetRepositoryID() int64 {
+	if h == nil || h.RepositoryID == nil {
+		return 0
+	}
+	return *h.RepositoryID
+}
+
+// GetRequest returns the Request field.
+func (h *HookDelivery) GetRequest() *HookRequest {
+	if h == nil {
+		return nil
+	}
+	return h.Request
+}
+
+// GetResponse returns the Response field.
+func (h *HookDelivery) GetResponse() *HookResponse {
+	if h == nil {
+		return nil
+	}
+	return h.Response
+}
+
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (h *HookDelivery) GetStatus() string {
+	if h == nil || h.Status == nil {
+		return ""
+	}
+	return *h.Status
+}
+
+// GetStatusCode returns the StatusCode field if it's non-nil, zero value otherwise.
+func (h *HookDelivery) GetStatusCode() int {
+	if h == nil || h.StatusCode == nil {
+		return 0
+	}
+	return *h.StatusCode
+}
+
+// GetHeader returns the Header map if it's non-nil, an empty map otherwise.
+func (h *HookRequest) GetHeader() map[string]string {
+	if h == nil || h.Header == nil {
+		return map[string]string{}
+	}
+	return h.Header
+}
+
+// GetRawPayload returns the RawPayload field if it's non-nil, zero value otherwise.
+func (h *HookRequest) GetRawPayload() json.RawMessage {
+	if h == nil || h.RawPayload == nil {
+		return json.RawMessage{}
+	}
+	return *h.RawPayload
+}
+
+// GetHeader returns the Header map if it's non-nil, an empty map otherwise.
+func (h *HookResponse) GetHeader() map[string]string {
+	if h == nil || h.Header == nil {
+		return map[string]string{}
+	}
+	return h.Header
+}
+
+// GetRawPayload returns the RawPayload field if it's non-nil, zero value otherwise.
+func (h *HookResponse) GetRawPayload() json.RawMessage {
+	if h == nil || h.RawPayload == nil {
+		return json.RawMessage{}
+	}
+	return *h.RawPayload
+}
+
 // GetActiveHooks returns the ActiveHooks field if it's non-nil, zero value otherwise.
 func (h *HookStats) GetActiveHooks() int {
 	if h == nil || h.ActiveHooks == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -4701,9 +4701,9 @@ func (h *HookDelivery) GetAction() string {
 }
 
 // GetDeliveredAt returns the DeliveredAt field if it's non-nil, zero value otherwise.
-func (h *HookDelivery) GetDeliveredAt() time.Time {
+func (h *HookDelivery) GetDeliveredAt() Timestamp {
 	if h == nil || h.DeliveredAt == nil {
-		return time.Time{}
+		return Timestamp{}
 	}
 	return *h.DeliveredAt
 }

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -4796,12 +4796,12 @@ func (h *HookDelivery) GetStatusCode() int {
 	return *h.StatusCode
 }
 
-// GetHeader returns the Header map if it's non-nil, an empty map otherwise.
-func (h *HookRequest) GetHeader() map[string]string {
-	if h == nil || h.Header == nil {
+// GetHeaders returns the Headers map if it's non-nil, an empty map otherwise.
+func (h *HookRequest) GetHeaders() map[string]string {
+	if h == nil || h.Headers == nil {
 		return map[string]string{}
 	}
-	return h.Header
+	return h.Headers
 }
 
 // GetRawPayload returns the RawPayload field if it's non-nil, zero value otherwise.
@@ -4812,12 +4812,12 @@ func (h *HookRequest) GetRawPayload() json.RawMessage {
 	return *h.RawPayload
 }
 
-// GetHeader returns the Header map if it's non-nil, an empty map otherwise.
-func (h *HookResponse) GetHeader() map[string]string {
-	if h == nil || h.Header == nil {
+// GetHeaders returns the Headers map if it's non-nil, an empty map otherwise.
+func (h *HookResponse) GetHeaders() map[string]string {
+	if h == nil || h.Headers == nil {
 		return map[string]string{}
 	}
-	return h.Header
+	return h.Headers
 }
 
 // GetRawPayload returns the RawPayload field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -5524,6 +5524,167 @@ func TestHookConfig_GetURL(tt *testing.T) {
 	h.GetURL()
 }
 
+func TestHookDelivery_GetAction(tt *testing.T) {
+	var zeroValue string
+	h := &HookDelivery{Action: &zeroValue}
+	h.GetAction()
+	h = &HookDelivery{}
+	h.GetAction()
+	h = nil
+	h.GetAction()
+}
+
+func TestHookDelivery_GetDeliveredAt(tt *testing.T) {
+	var zeroValue time.Time
+	h := &HookDelivery{DeliveredAt: &zeroValue}
+	h.GetDeliveredAt()
+	h = &HookDelivery{}
+	h.GetDeliveredAt()
+	h = nil
+	h.GetDeliveredAt()
+}
+
+func TestHookDelivery_GetDuration(tt *testing.T) {
+	h := &HookDelivery{}
+	h.GetDuration()
+	h = nil
+	h.GetDuration()
+}
+
+func TestHookDelivery_GetEvent(tt *testing.T) {
+	var zeroValue string
+	h := &HookDelivery{Event: &zeroValue}
+	h.GetEvent()
+	h = &HookDelivery{}
+	h.GetEvent()
+	h = nil
+	h.GetEvent()
+}
+
+func TestHookDelivery_GetGUID(tt *testing.T) {
+	var zeroValue string
+	h := &HookDelivery{GUID: &zeroValue}
+	h.GetGUID()
+	h = &HookDelivery{}
+	h.GetGUID()
+	h = nil
+	h.GetGUID()
+}
+
+func TestHookDelivery_GetID(tt *testing.T) {
+	var zeroValue int64
+	h := &HookDelivery{ID: &zeroValue}
+	h.GetID()
+	h = &HookDelivery{}
+	h.GetID()
+	h = nil
+	h.GetID()
+}
+
+func TestHookDelivery_GetInstallationID(tt *testing.T) {
+	var zeroValue string
+	h := &HookDelivery{InstallationID: &zeroValue}
+	h.GetInstallationID()
+	h = &HookDelivery{}
+	h.GetInstallationID()
+	h = nil
+	h.GetInstallationID()
+}
+
+func TestHookDelivery_GetRedelivery(tt *testing.T) {
+	var zeroValue bool
+	h := &HookDelivery{Redelivery: &zeroValue}
+	h.GetRedelivery()
+	h = &HookDelivery{}
+	h.GetRedelivery()
+	h = nil
+	h.GetRedelivery()
+}
+
+func TestHookDelivery_GetRepositoryID(tt *testing.T) {
+	var zeroValue int64
+	h := &HookDelivery{RepositoryID: &zeroValue}
+	h.GetRepositoryID()
+	h = &HookDelivery{}
+	h.GetRepositoryID()
+	h = nil
+	h.GetRepositoryID()
+}
+
+func TestHookDelivery_GetRequest(tt *testing.T) {
+	h := &HookDelivery{}
+	h.GetRequest()
+	h = nil
+	h.GetRequest()
+}
+
+func TestHookDelivery_GetResponse(tt *testing.T) {
+	h := &HookDelivery{}
+	h.GetResponse()
+	h = nil
+	h.GetResponse()
+}
+
+func TestHookDelivery_GetStatus(tt *testing.T) {
+	var zeroValue string
+	h := &HookDelivery{Status: &zeroValue}
+	h.GetStatus()
+	h = &HookDelivery{}
+	h.GetStatus()
+	h = nil
+	h.GetStatus()
+}
+
+func TestHookDelivery_GetStatusCode(tt *testing.T) {
+	var zeroValue int
+	h := &HookDelivery{StatusCode: &zeroValue}
+	h.GetStatusCode()
+	h = &HookDelivery{}
+	h.GetStatusCode()
+	h = nil
+	h.GetStatusCode()
+}
+
+func TestHookRequest_GetHeader(tt *testing.T) {
+	zeroValue := map[string]string{}
+	h := &HookRequest{Header: zeroValue}
+	h.GetHeader()
+	h = &HookRequest{}
+	h.GetHeader()
+	h = nil
+	h.GetHeader()
+}
+
+func TestHookRequest_GetRawPayload(tt *testing.T) {
+	var zeroValue json.RawMessage
+	h := &HookRequest{RawPayload: &zeroValue}
+	h.GetRawPayload()
+	h = &HookRequest{}
+	h.GetRawPayload()
+	h = nil
+	h.GetRawPayload()
+}
+
+func TestHookResponse_GetHeader(tt *testing.T) {
+	zeroValue := map[string]string{}
+	h := &HookResponse{Header: zeroValue}
+	h.GetHeader()
+	h = &HookResponse{}
+	h.GetHeader()
+	h = nil
+	h.GetHeader()
+}
+
+func TestHookResponse_GetRawPayload(tt *testing.T) {
+	var zeroValue json.RawMessage
+	h := &HookResponse{RawPayload: &zeroValue}
+	h.GetRawPayload()
+	h = &HookResponse{}
+	h.GetRawPayload()
+	h = nil
+	h.GetRawPayload()
+}
+
 func TestHookStats_GetActiveHooks(tt *testing.T) {
 	var zeroValue int
 	h := &HookStats{ActiveHooks: &zeroValue}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -5645,14 +5645,14 @@ func TestHookDelivery_GetStatusCode(tt *testing.T) {
 	h.GetStatusCode()
 }
 
-func TestHookRequest_GetHeader(tt *testing.T) {
+func TestHookRequest_GetHeaders(tt *testing.T) {
 	zeroValue := map[string]string{}
-	h := &HookRequest{Header: zeroValue}
-	h.GetHeader()
+	h := &HookRequest{Headers: zeroValue}
+	h.GetHeaders()
 	h = &HookRequest{}
-	h.GetHeader()
+	h.GetHeaders()
 	h = nil
-	h.GetHeader()
+	h.GetHeaders()
 }
 
 func TestHookRequest_GetRawPayload(tt *testing.T) {
@@ -5665,14 +5665,14 @@ func TestHookRequest_GetRawPayload(tt *testing.T) {
 	h.GetRawPayload()
 }
 
-func TestHookResponse_GetHeader(tt *testing.T) {
+func TestHookResponse_GetHeaders(tt *testing.T) {
 	zeroValue := map[string]string{}
-	h := &HookResponse{Header: zeroValue}
-	h.GetHeader()
+	h := &HookResponse{Headers: zeroValue}
+	h.GetHeaders()
 	h = &HookResponse{}
-	h.GetHeader()
+	h.GetHeaders()
 	h = nil
-	h.GetHeader()
+	h.GetHeaders()
 }
 
 func TestHookResponse_GetRawPayload(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -5535,7 +5535,7 @@ func TestHookDelivery_GetAction(tt *testing.T) {
 }
 
 func TestHookDelivery_GetDeliveredAt(tt *testing.T) {
-	var zeroValue time.Time
+	var zeroValue Timestamp
 	h := &HookDelivery{DeliveredAt: &zeroValue}
 	h.GetDeliveredAt()
 	h = &HookDelivery{}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -544,6 +544,27 @@ func TestHook_String(t *testing.T) {
 	}
 }
 
+func TestHookDelivery_String(t *testing.T) {
+	v := HookDelivery{
+		ID:             Int64(0),
+		GUID:           String(""),
+		Redelivery:     Bool(false),
+		Duration:       Float64(0.0),
+		Status:         String(""),
+		StatusCode:     Int(0),
+		Event:          String(""),
+		Action:         String(""),
+		InstallationID: String(""),
+		RepositoryID:   Int64(0),
+		Request:        &HookRequest{},
+		Response:       &HookResponse{},
+	}
+	want := `github.HookDelivery{ID:0, GUID:"", Redelivery:false, Duration:0, Status:"", StatusCode:0, Event:"", Action:"", InstallationID:"", RepositoryID:0, Request:github.HookRequest{}, Response:github.HookResponse{}}`
+	if got := v.String(); got != want {
+		t.Errorf("HookDelivery.String = %v, want %v", got, want)
+	}
+}
+
 func TestHookStats_String(t *testing.T) {
 	v := HookStats{
 		TotalHooks:    Int(0),

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -548,6 +548,7 @@ func TestHookDelivery_String(t *testing.T) {
 	v := HookDelivery{
 		ID:             Int64(0),
 		GUID:           String(""),
+		DeliveredAt:    &Timestamp{},
 		Redelivery:     Bool(false),
 		Duration:       Float64(0.0),
 		Status:         String(""),
@@ -559,7 +560,7 @@ func TestHookDelivery_String(t *testing.T) {
 		Request:        &HookRequest{},
 		Response:       &HookResponse{},
 	}
-	want := `github.HookDelivery{ID:0, GUID:"", Redelivery:false, Duration:0, Status:"", StatusCode:0, Event:"", Action:"", InstallationID:"", RepositoryID:0, Request:github.HookRequest{}, Response:github.HookResponse{}}`
+	want := `github.HookDelivery{ID:0, GUID:"", DeliveredAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Redelivery:false, Duration:0, Status:"", StatusCode:0, Event:"", Action:"", InstallationID:"", RepositoryID:0, Request:github.HookRequest{}, Response:github.HookResponse{}}`
 	if got := v.String(); got != want {
 		t.Errorf("HookDelivery.String = %v, want %v", got, want)
 	}

--- a/github/github.go
+++ b/github/github.go
@@ -490,31 +490,34 @@ func (r *Response) populatePageValues() {
 				continue
 			}
 
-			if page := url.Query().Get("page"); page != "" {
-				for _, segment := range segments[1:] {
-					switch strings.TrimSpace(segment) {
-					case `rel="next"`:
-						if r.NextPage, err = strconv.Atoi(page); err != nil {
-							r.NextPageToken = page
-						}
-					case `rel="prev"`:
-						r.PrevPage, _ = strconv.Atoi(page)
-					case `rel="first"`:
-						r.FirstPage, _ = strconv.Atoi(page)
-					case `rel="last"`:
-						r.LastPage, _ = strconv.Atoi(page)
-					}
-				}
+			q := url.Query()
 
-				continue
-			}
-
-			if cursor := url.Query().Get("cursor"); cursor != "" {
+			if cursor := q.Get("cursor"); cursor != "" {
 				for _, segment := range segments[1:] {
 					switch strings.TrimSpace(segment) {
 					case `rel="next"`:
 						r.Cursor = cursor
 					}
+				}
+			}
+
+			page := q.Get("page")
+			if page == "" {
+				continue
+			}
+
+			for _, segment := range segments[1:] {
+				switch strings.TrimSpace(segment) {
+				case `rel="next"`:
+					if r.NextPage, err = strconv.Atoi(page); err != nil {
+						r.NextPageToken = page
+					}
+				case `rel="prev"`:
+					r.PrevPage, _ = strconv.Atoi(page)
+				case `rel="first"`:
+					r.FirstPage, _ = strconv.Atoi(page)
+				case `rel="last"`:
+					r.LastPage, _ = strconv.Atoi(page)
 				}
 			}
 		}

--- a/github/github.go
+++ b/github/github.go
@@ -499,6 +499,8 @@ func (r *Response) populatePageValues() {
 						r.Cursor = cursor
 					}
 				}
+
+				continue
 			}
 
 			page := q.Get("page")

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -635,6 +635,20 @@ func TestResponse_cursorPagination(t *testing.T) {
 	if got, want := response.NextPageToken, "url-encoded-next-page-token"; want != got {
 		t.Errorf("response.NextPageToken: %v, want %v", got, want)
 	}
+
+	// cursor-based pagination with "cursor" param
+	r = http.Response{
+		Header: http.Header{
+			"Link": {
+				`<https://api.github.com/?cursor=v1_12345678>; rel="next"`,
+			},
+		},
+	}
+
+	response = newResponse(&r)
+	if got, want := response.Cursor, "v1_12345678"; got != want {
+		t.Errorf("response.Cursor: %v, want %v", got, want)
+	}
 }
 
 func TestResponse_populatePageValues_invalid(t *testing.T) {

--- a/github/orgs_hooks_deliveries.go
+++ b/github/orgs_hooks_deliveries.go
@@ -1,0 +1,48 @@
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// ListHookDeliveries lists webhook deliveries for a webhook configured in an organization.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/orgs#list-deliveries-for-an-organization-webhook
+func (s *OrganizationsService) ListHookDeliveries(ctx context.Context, org string, id int64, opts *ListCursorOptions) ([]*HookDelivery, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/hooks/%v/deliveries", org, id)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	deliveries := []*HookDelivery{}
+	resp, err := s.client.Do(ctx, req, &deliveries)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return deliveries, resp, nil
+}
+
+// GetHookDelivery returns a delivery for a webhook configured in an organization.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/orgs#get-a-webhook-delivery-for-an-organization-webhook
+func (s *OrganizationsService) GetHookDelivery(ctx context.Context, owner string, hookID, deliveryID int64) (*HookDelivery, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/hooks/%v/deliveries/%v", owner, hookID, deliveryID)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	h := new(HookDelivery)
+	resp, err := s.client.Do(ctx, req, h)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return h, resp, nil
+}

--- a/github/orgs_hooks_deliveries.go
+++ b/github/orgs_hooks_deliveries.go
@@ -43,6 +43,7 @@ func (s *OrganizationsService) GetHookDelivery(ctx context.Context, owner string
 	if err != nil {
 		return nil, nil, err
 	}
+
 	h := new(HookDelivery)
 	resp, err := s.client.Do(ctx, req, h)
 	if err != nil {

--- a/github/orgs_hooks_deliveries.go
+++ b/github/orgs_hooks_deliveries.go
@@ -1,3 +1,8 @@
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package github
 
 import (

--- a/github/orgs_hooks_deliveries_test.go
+++ b/github/orgs_hooks_deliveries_test.go
@@ -1,0 +1,106 @@
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestOrganizationsService_ListHookDeliveries(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/hooks/1/deliveries", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"cursor": "v1_12077215967"})
+		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
+	})
+
+	opt := &ListCursorOptions{Cursor: "v1_12077215967"}
+
+	ctx := context.Background()
+	hooks, _, err := client.Organizations.ListHookDeliveries(ctx, "o", 1, opt)
+	if err != nil {
+		t.Errorf("Organizations.ListHookDeliveries returned error: %v", err)
+	}
+
+	want := []*HookDelivery{{ID: Int64(1)}, {ID: Int64(2)}}
+	if d := cmp.Diff(hooks, want); d != "" {
+		t.Errorf("Organizations.ListHooks want (-), got (+):\n%s", d)
+	}
+
+	const methodName = "ListHookDeliveries"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.ListHookDeliveries(ctx, "\n", -1, opt)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Organizations.ListHookDeliveries(ctx, "o", 1, opt)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestOrganizationsService_ListHookDeliveries_invalidOwner(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	ctx := context.Background()
+	_, _, err := client.Organizations.ListHookDeliveries(ctx, "%", 1, nil)
+	testURLParseError(t, err)
+}
+
+func TestOrganizationsService_GetHookDelivery(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/hooks/1/deliveries/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":1}`)
+	})
+
+	ctx := context.Background()
+	hook, _, err := client.Organizations.GetHookDelivery(ctx, "o", 1, 1)
+	if err != nil {
+		t.Errorf("Organizations.GetHookDelivery returned error: %v", err)
+	}
+
+	want := &HookDelivery{ID: Int64(1)}
+	if !cmp.Equal(hook, want) {
+		t.Errorf("Organizations.GetHookDelivery returned %+v, want %+v", hook, want)
+	}
+
+	const methodName = "GetHookDelivery"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.GetHookDelivery(ctx, "\n", -1, -1)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Organizations.GetHookDelivery(ctx, "o", 1, 1)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestOrganizationsService_GetHookDelivery_invalidOwner(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	ctx := context.Background()
+	_, _, err := client.Organizations.GetHookDelivery(ctx, "%", 1, 1)
+	testURLParseError(t, err)
+}

--- a/github/repos_hooks_deliveries.go
+++ b/github/repos_hooks_deliveries.go
@@ -39,6 +39,8 @@ func (d HookDelivery) String() string {
 	return Stringify(d)
 }
 
+// HookRequest is a part of HookDelivery that contains
+// the HTTP headers and the JSON payload of the webhook request.
 type HookRequest struct {
 	Headers    map[string]string `json:"headers,omitempty"`
 	RawPayload *json.RawMessage  `json:"payload,omitempty"`
@@ -48,6 +50,8 @@ func (r HookRequest) String() string {
 	return Stringify(r)
 }
 
+// HookResponse is a part of HookDelivery that contains
+// the HTTP headers and the response body served by the webhook endpoint.
 type HookResponse struct {
 	Headers    map[string]string `json:"headers,omitempty"`
 	RawPayload *json.RawMessage  `json:"payload,omitempty"`

--- a/github/repos_hooks_deliveries.go
+++ b/github/repos_hooks_deliveries.go
@@ -29,9 +29,9 @@ type HookDelivery struct {
 	InstallationID *string    `json:"installation_id"`
 	RepositoryID   *int64     `json:"repository_id"`
 
-	// Request is populated by GetHookDelivery
+	// Request is populated by GetHookDelivery.
 	Request *HookRequest `json:"request,omitempty"`
-	// Response is populated by GetHookDelivery
+	// Response is populated by GetHookDelivery.
 	Response *HookResponse `json:"response,omitempty"`
 }
 

--- a/github/repos_hooks_deliveries.go
+++ b/github/repos_hooks_deliveries.go
@@ -61,7 +61,7 @@ func (r HookResponse) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/repos#list-deliveries-for-a-repository-webhook
 func (s *RepositoriesService) ListHookDeliveries(ctx context.Context, owner, repo string, id int64, opts *ListCursorOptions) ([]*HookDelivery, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%d/deliveries", owner, repo, id)
+	u := fmt.Sprintf("repos/%v/%v/hooks/%v/deliveries", owner, repo, id)
 	u, err := addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -85,7 +85,7 @@ func (s *RepositoriesService) ListHookDeliveries(ctx context.Context, owner, rep
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/repos#get-a-delivery-for-a-repository-webhook
 func (s *RepositoriesService) GetHookDelivery(ctx context.Context, owner, repo string, hookID, deliveryID int64) (*HookDelivery, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%d/deliveries/%d", owner, repo, hookID, deliveryID)
+	u := fmt.Sprintf("repos/%v/%v/hooks/%v/deliveries/%v", owner, repo, hookID, deliveryID)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/repos_hooks_deliveries.go
+++ b/github/repos_hooks_deliveries.go
@@ -40,7 +40,7 @@ func (d HookDelivery) String() string {
 }
 
 type HookRequest struct {
-	Header     map[string]string `json:"headers,omitempty"`
+	Headers    map[string]string `json:"headers,omitempty"`
 	RawPayload *json.RawMessage  `json:"payload,omitempty"`
 }
 
@@ -49,7 +49,7 @@ func (r HookRequest) String() string {
 }
 
 type HookResponse struct {
-	Header     map[string]string `json:"headers,omitempty"`
+	Headers    map[string]string `json:"headers,omitempty"`
 	RawPayload *json.RawMessage  `json:"payload,omitempty"`
 }
 

--- a/github/repos_hooks_deliveries.go
+++ b/github/repos_hooks_deliveries.go
@@ -94,6 +94,7 @@ func (s *RepositoriesService) GetHookDelivery(ctx context.Context, owner, repo s
 	if err != nil {
 		return nil, nil, err
 	}
+
 	h := new(HookDelivery)
 	resp, err := s.client.Do(ctx, req, h)
 	if err != nil {

--- a/github/repos_hooks_deliveries.go
+++ b/github/repos_hooks_deliveries.go
@@ -1,0 +1,205 @@
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// HookDelivery represents the data that is received from GitHub's Webhook Delivery API
+//
+// GitHub API docs:
+// - https://docs.github.com/en/rest/reference/repos#list-deliveries-for-a-repository-webhook
+// - https://docs.github.com/en/rest/reference/repos#get-a-delivery-for-a-repository-webhook
+type HookDelivery struct {
+	ID             *int64     `json:"id"`
+	GUID           *string    `json:"guid"`
+	DeliveredAt    *time.Time `json:"delivered_at"`
+	Redelivery     *bool      `json:"redelivery"`
+	Duration       *float64   `json:"duration"`
+	Status         *string    `json:"status"`
+	StatusCode     *int       `json:"status_code"`
+	Event          *string    `json:"event"`
+	Action         *string    `json:"action"`
+	InstallationID *string    `json:"installation_id"`
+	RepositoryID   *int64     `json:"repository_id"`
+
+	// Request is populated by GetHookDelivery
+	Request *HookRequest `json:"request,omitempty"`
+	// Response is populated by GetHookDelivery
+	Response *HookResponse `json:"response,omitempty"`
+}
+
+func (d HookDelivery) String() string {
+	return Stringify(d)
+}
+
+type HookRequest struct {
+	Header     map[string]string `json:"headers,omitempty"`
+	RawPayload *json.RawMessage  `json:"payload,omitempty"`
+}
+
+func (r HookRequest) String() string {
+	return Stringify(r)
+}
+
+type HookResponse struct {
+	Header     map[string]string `json:"headers,omitempty"`
+	RawPayload *json.RawMessage  `json:"payload,omitempty"`
+}
+
+func (r HookResponse) String() string {
+	return Stringify(r)
+}
+
+// ListHookDeliveries lists webhook deliveries for a webhook configured in a repository.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/repos#list-deliveries-for-a-repository-webhook
+func (s *RepositoriesService) ListHookDeliveries(ctx context.Context, owner, repo string, id int64, opts *ListCursorOptions) ([]*HookDelivery, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/hooks/%d/deliveries", owner, repo, id)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	deliveries := []*HookDelivery{}
+	resp, err := s.client.Do(ctx, req, &deliveries)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return deliveries, resp, nil
+}
+
+// GetHookDelivery returns a delivery for a webhook configured in a repository.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/repos#get-a-delivery-for-a-repository-webhook
+func (s *RepositoriesService) GetHookDelivery(ctx context.Context, owner, repo string, hookID, deliveryID int64) (*HookDelivery, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/hooks/%d/deliveries/%d", owner, repo, hookID, deliveryID)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	h := new(HookDelivery)
+	resp, err := s.client.Do(ctx, req, h)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return h, resp, nil
+}
+
+func (d *HookDelivery) ParseRequestPayload() (interface{}, error) {
+	var payload interface{}
+	switch *d.Event {
+	case "check_run":
+		payload = &CheckRunEvent{}
+	case "check_suite":
+		payload = &CheckSuiteEvent{}
+	case "commit_comment":
+		payload = &CommitCommentEvent{}
+	case "content_reference":
+		payload = &ContentReferenceEvent{}
+	case "create":
+		payload = &CreateEvent{}
+	case "delete":
+		payload = &DeleteEvent{}
+	case "deploy_ket":
+		payload = &DeployKeyEvent{}
+	case "deployment":
+		payload = &DeploymentEvent{}
+	case "deployment_status":
+		payload = &DeploymentStatusEvent{}
+	case "fork":
+		payload = &ForkEvent{}
+	case "github_app_authorization":
+		payload = &GitHubAppAuthorizationEvent{}
+	case "gollum":
+		payload = &GollumEvent{}
+	case "installation":
+		payload = &InstallationEvent{}
+	case "installation_repositories":
+		payload = &InstallationRepositoriesEvent{}
+	case "issue_comment":
+		payload = &IssueCommentEvent{}
+	case "issues":
+		payload = &IssuesEvent{}
+	case "label":
+		payload = &LabelEvent{}
+	case "marketplace_purchase":
+		payload = &MarketplacePurchaseEvent{}
+	case "member_event":
+		payload = &MemberEvent{}
+	case "membership_event":
+		payload = &MembershipEvent{}
+	case "meta":
+		payload = &MetaEvent{}
+	case "milestone":
+		payload = &MilestoneEvent{}
+	case "organization":
+		payload = &OrganizationEvent{}
+	case "org_block":
+		payload = &OrgBlockEvent{}
+	case "package":
+		payload = &PackageEvent{}
+	case "page_build":
+		payload = &PageBuildEvent{}
+	case "ping":
+		payload = &PingEvent{}
+	case "project":
+		payload = &ProjectEvent{}
+	case "project_card":
+		payload = &ProjectCardEvent{}
+	case "project_column":
+		payload = &ProjectColumnEvent{}
+	case "public":
+		payload = &PublicEvent{}
+	case "pull_request":
+		payload = &PullRequestEvent{}
+	case "pull_request_review":
+		payload = &PullRequestReviewEvent{}
+	case "pull_request_review_comment":
+		payload = &PullRequestReviewCommentEvent{}
+	case "pull_request_target":
+		payload = &PullRequestTargetEvent{}
+	case "push":
+		payload = &PushEvent{}
+	case "release":
+		payload = &ReleaseEvent{}
+	case "repository":
+		payload = &RepositoryEvent{}
+	case "repository_dispatch":
+		payload = &RepositoryDispatchEvent{}
+	case "repository_vulnerability_alert":
+		payload = &RepositoryVulnerabilityAlertEvent{}
+	case "star":
+		payload = &StarEvent{}
+	case "status":
+		payload = &StatusEvent{}
+	case "team":
+		payload = &TeamEvent{}
+	case "team_add":
+		payload = &TeamAddEvent{}
+	case "user":
+		payload = &UserEvent{}
+	case "watch":
+		payload = &WatchEvent{}
+	case "workflow_dispatch":
+		payload = &WorkflowDispatchEvent{}
+	case "workflow_run":
+		payload = &WorkflowRunEvent{}
+	}
+	err := json.Unmarshal(*d.Request.RawPayload, &payload)
+	return payload, err
+}

--- a/github/repos_hooks_deliveries.go
+++ b/github/repos_hooks_deliveries.go
@@ -103,106 +103,14 @@ func (s *RepositoriesService) GetHookDelivery(ctx context.Context, owner, repo s
 	return h, resp, nil
 }
 
+// ParseRequestPayload parses the request payload. For recognized event types,
+// a value of the corresponding struct type will be returned.
 func (d *HookDelivery) ParseRequestPayload() (interface{}, error) {
-	var payload interface{}
-	switch *d.Event {
-	case "check_run":
-		payload = &CheckRunEvent{}
-	case "check_suite":
-		payload = &CheckSuiteEvent{}
-	case "commit_comment":
-		payload = &CommitCommentEvent{}
-	case "content_reference":
-		payload = &ContentReferenceEvent{}
-	case "create":
-		payload = &CreateEvent{}
-	case "delete":
-		payload = &DeleteEvent{}
-	case "deploy_ket":
-		payload = &DeployKeyEvent{}
-	case "deployment":
-		payload = &DeploymentEvent{}
-	case "deployment_status":
-		payload = &DeploymentStatusEvent{}
-	case "fork":
-		payload = &ForkEvent{}
-	case "github_app_authorization":
-		payload = &GitHubAppAuthorizationEvent{}
-	case "gollum":
-		payload = &GollumEvent{}
-	case "installation":
-		payload = &InstallationEvent{}
-	case "installation_repositories":
-		payload = &InstallationRepositoriesEvent{}
-	case "issue_comment":
-		payload = &IssueCommentEvent{}
-	case "issues":
-		payload = &IssuesEvent{}
-	case "label":
-		payload = &LabelEvent{}
-	case "marketplace_purchase":
-		payload = &MarketplacePurchaseEvent{}
-	case "member_event":
-		payload = &MemberEvent{}
-	case "membership_event":
-		payload = &MembershipEvent{}
-	case "meta":
-		payload = &MetaEvent{}
-	case "milestone":
-		payload = &MilestoneEvent{}
-	case "organization":
-		payload = &OrganizationEvent{}
-	case "org_block":
-		payload = &OrgBlockEvent{}
-	case "package":
-		payload = &PackageEvent{}
-	case "page_build":
-		payload = &PageBuildEvent{}
-	case "ping":
-		payload = &PingEvent{}
-	case "project":
-		payload = &ProjectEvent{}
-	case "project_card":
-		payload = &ProjectCardEvent{}
-	case "project_column":
-		payload = &ProjectColumnEvent{}
-	case "public":
-		payload = &PublicEvent{}
-	case "pull_request":
-		payload = &PullRequestEvent{}
-	case "pull_request_review":
-		payload = &PullRequestReviewEvent{}
-	case "pull_request_review_comment":
-		payload = &PullRequestReviewCommentEvent{}
-	case "pull_request_target":
-		payload = &PullRequestTargetEvent{}
-	case "push":
-		payload = &PushEvent{}
-	case "release":
-		payload = &ReleaseEvent{}
-	case "repository":
-		payload = &RepositoryEvent{}
-	case "repository_dispatch":
-		payload = &RepositoryDispatchEvent{}
-	case "repository_vulnerability_alert":
-		payload = &RepositoryVulnerabilityAlertEvent{}
-	case "star":
-		payload = &StarEvent{}
-	case "status":
-		payload = &StatusEvent{}
-	case "team":
-		payload = &TeamEvent{}
-	case "team_add":
-		payload = &TeamAddEvent{}
-	case "user":
-		payload = &UserEvent{}
-	case "watch":
-		payload = &WatchEvent{}
-	case "workflow_dispatch":
-		payload = &WorkflowDispatchEvent{}
-	case "workflow_run":
-		payload = &WorkflowRunEvent{}
+	eType, ok := eventTypeMapping[*d.Event]
+	if !ok {
+		return nil, fmt.Errorf("unsupported event type %q", *d.Event)
 	}
-	err := json.Unmarshal(*d.Request.RawPayload, &payload)
-	return payload, err
+
+	e := &Event{Type: &eType, RawPayload: d.Request.RawPayload}
+	return e.ParsePayload()
 }

--- a/github/repos_hooks_deliveries.go
+++ b/github/repos_hooks_deliveries.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 )
 
 // HookDelivery represents the data that is received from GitHub's Webhook Delivery API
@@ -20,7 +19,7 @@ import (
 type HookDelivery struct {
 	ID             *int64     `json:"id"`
 	GUID           *string    `json:"guid"`
-	DeliveredAt    *time.Time `json:"delivered_at"`
+	DeliveredAt    *Timestamp `json:"delivered_at"`
 	Redelivery     *bool      `json:"redelivery"`
 	Duration       *float64   `json:"duration"`
 	Status         *string    `json:"status"`

--- a/github/repos_hooks_deliveries_test.go
+++ b/github/repos_hooks_deliveries_test.go
@@ -114,7 +114,7 @@ var hookDeliveryPayloadTypeToStruct = map[string]interface{}{
 	"content_reference":              &ContentReferenceEvent{},
 	"create":                         &CreateEvent{},
 	"delete":                         &DeleteEvent{},
-	"deploy_ket":                     &DeployKeyEvent{},
+	"deploy_key":                     &DeployKeyEvent{},
 	"deployment":                     &DeploymentEvent{},
 	"deployment_status":              &DeploymentStatusEvent{},
 	"fork":                           &ForkEvent{},
@@ -126,8 +126,8 @@ var hookDeliveryPayloadTypeToStruct = map[string]interface{}{
 	"issues":                         &IssuesEvent{},
 	"label":                          &LabelEvent{},
 	"marketplace_purchase":           &MarketplacePurchaseEvent{},
-	"member_event":                   &MemberEvent{},
-	"membership_event":               &MembershipEvent{},
+	"member":                         &MemberEvent{},
+	"membership":                     &MembershipEvent{},
 	"meta":                           &MetaEvent{},
 	"milestone":                      &MilestoneEvent{},
 	"organization":                   &OrganizationEvent{},
@@ -198,7 +198,7 @@ func TestHookDelivery_ParsePayload_invalidEvent(t *testing.T) {
 	}
 
 	_, err := d.ParseRequestPayload()
-	if err == nil || err.Error() != "unexpected end of JSON input" {
+	if err == nil || err.Error() != `unsupported event type "some_invalid_event"` {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/github/repos_hooks_deliveries_test.go
+++ b/github/repos_hooks_deliveries_test.go
@@ -1,0 +1,106 @@
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRepositoriesService_ListHookDeliveries(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/hooks/1/deliveries", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"cursor": "v1_12077215967"})
+		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
+	})
+
+	opt := &ListCursorOptions{Cursor: "v1_12077215967"}
+
+	ctx := context.Background()
+	hooks, _, err := client.Repositories.ListHookDeliveries(ctx, "o", "r", 1, opt)
+	if err != nil {
+		t.Errorf("Repositories.ListHookDeliveries returned error: %v", err)
+	}
+
+	want := []*HookDelivery{{ID: Int64(1)}, {ID: Int64(2)}}
+	if d := cmp.Diff(hooks, want); d != "" {
+		t.Errorf("Repositories.ListHooks want (-), got (+):\n%s", d)
+	}
+
+	const methodName = "ListHookDeliveries"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Repositories.ListHookDeliveries(ctx, "\n", "\n", -1, opt)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Repositories.ListHookDeliveries(ctx, "o", "r", 1, opt)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestRepositoriesService_ListHookDeliveries_invalidOwner(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	ctx := context.Background()
+	_, _, err := client.Repositories.ListHookDeliveries(ctx, "%", "%", 1, nil)
+	testURLParseError(t, err)
+}
+
+func TestRepositoriesService_GetHookDelivery(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/hooks/1/deliveries/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":1}`)
+	})
+
+	ctx := context.Background()
+	hook, _, err := client.Repositories.GetHookDelivery(ctx, "o", "r", 1, 1)
+	if err != nil {
+		t.Errorf("Repositories.GetHookDelivery returned error: %v", err)
+	}
+
+	want := &HookDelivery{ID: Int64(1)}
+	if !cmp.Equal(hook, want) {
+		t.Errorf("Repositories.GetHookDelivery returned %+v, want %+v", hook, want)
+	}
+
+	const methodName = "GetHookDelivery"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Repositories.GetHookDelivery(ctx, "\n", "\n", -1, -1)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Repositories.GetHookDelivery(ctx, "o", "r", 1, 1)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestRepositoriesService_GetHookDelivery_invalidOwner(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	ctx := context.Background()
+	_, _, err := client.Repositories.GetHookDelivery(ctx, "%", "%", 1, 1)
+	testURLParseError(t, err)
+}

--- a/github/repos_hooks_deliveries_test.go
+++ b/github/repos_hooks_deliveries_test.go
@@ -186,3 +186,35 @@ func TestHookDelivery_ParsePayload(t *testing.T) {
 		})
 	}
 }
+
+func TestHookDelivery_ParsePayload_invalidEvent(t *testing.T) {
+	p := json.RawMessage(nil)
+
+	d := &HookDelivery{
+		Event: String("some_invalid_event"),
+		Request: &HookRequest{
+			RawPayload: &p,
+		},
+	}
+
+	_, err := d.ParseRequestPayload()
+	if err == nil || err.Error() != "unexpected end of JSON input" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestHookDelivery_ParsePayload_invalidPayload(t *testing.T) {
+	p := json.RawMessage([]byte(`{"check_run":{"id":"invalid"}}`))
+
+	d := &HookDelivery{
+		Event: String("check_run"),
+		Request: &HookRequest{
+			RawPayload: &p,
+		},
+	}
+
+	_, err := d.ParseRequestPayload()
+	if err == nil || err.Error() != "json: cannot unmarshal string into Go struct field CheckRun.check_run.id of type int64" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Resolves #1933

To make this PR minimal as possible for ease of reviewing, I intentionally included only four APIs related to the webhook deliveries API:

- Listing repository hook deliveries
- Getting a specific repository hook delivery
- Listing organization hook deliveries
- GEtting a specific organization hook delivery

That being said, the following methods aren't covered in this PR. If you like, I'd gladly submit subsequent PRs to add all of them.

- Trigger redelivery of a hook delivery
- ~~List/get/redelivery for organizational webhooks~~

Note that changes on the following files are completely generated by running `go generate` as documented in your guide, so you won't need to read them that carefully.

- `github/github-accessors_test.go`
- `github/github-accessors.go`

FWIW, you can see how these additional methods can be used to retrieve historical webhook deliveries here:

https://github.com/actions-runner-controller/actions-runner-controller/blob/c3cfab81c85d33c65f7b6f6443da0d2f57fd72db/pkg/githubwebhookdeliveryforwarder/githubwebhookdelivery.go#L96-L139

The part that propagates `Cursor` from the response to the ListCursorOptions for the next paginated request is beneficial to understanding how the cursor can be used for pagination.