### PR TITLE
Add RequiredConversationResolution protection field

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9788,6 +9788,14 @@ func (p *Protection) GetEnforceAdmins() *AdminEnforcement {
 	return p.EnforceAdmins
 }
 
+// GetRequiredConversationResolution returns the RequiredConversationResolution field.
+func (p *Protection) GetRequiredConversationResolution() *RequiredConversationResolution {
+	if p == nil {
+		return nil
+	}
+	return p.RequiredConversationResolution
+}
+
 // GetRequiredPullRequestReviews returns the RequiredPullRequestReviews field.
 func (p *Protection) GetRequiredPullRequestReviews() *PullRequestReviewsEnforcement {
 	if p == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11474,6 +11474,13 @@ func TestProtection_GetEnforceAdmins(tt *testing.T) {
 	p.GetEnforceAdmins()
 }
 
+func TestProtection_GetRequiredConversationResolution(tt *testing.T) {
+	p := &Protection{}
+	p.GetRequiredConversationResolution()
+	p = nil
+	p.GetRequiredConversationResolution()
+}
+
 func TestProtection_GetRequiredPullRequestReviews(tt *testing.T) {
 	p := &Protection{}
 	p.GetRequiredPullRequestReviews()

--- a/github/repos.go
+++ b/github/repos.go
@@ -751,13 +751,14 @@ type Branch struct {
 
 // Protection represents a repository branch's protection.
 type Protection struct {
-	RequiredStatusChecks       *RequiredStatusChecks          `json:"required_status_checks"`
-	RequiredPullRequestReviews *PullRequestReviewsEnforcement `json:"required_pull_request_reviews"`
-	EnforceAdmins              *AdminEnforcement              `json:"enforce_admins"`
-	Restrictions               *BranchRestrictions            `json:"restrictions"`
-	RequireLinearHistory       *RequireLinearHistory          `json:"required_linear_history"`
-	AllowForcePushes           *AllowForcePushes              `json:"allow_force_pushes"`
-	AllowDeletions             *AllowDeletions                `json:"allow_deletions"`
+	RequiredStatusChecks           *RequiredStatusChecks           `json:"required_status_checks"`
+	RequiredPullRequestReviews     *PullRequestReviewsEnforcement  `json:"required_pull_request_reviews"`
+	EnforceAdmins                  *AdminEnforcement               `json:"enforce_admins"`
+	Restrictions                   *BranchRestrictions             `json:"restrictions"`
+	RequireLinearHistory           *RequireLinearHistory           `json:"required_linear_history"`
+	AllowForcePushes               *AllowForcePushes               `json:"allow_force_pushes"`
+	AllowDeletions                 *AllowDeletions                 `json:"allow_deletions"`
+	RequiredConversationResolution *RequiredConversationResolution `json:"required_conversation_resolution"`
 }
 
 // ProtectionRequest represents a request to create/edit a branch's protection.
@@ -846,6 +847,11 @@ type AllowDeletions struct {
 
 // AllowForcePushes represents the configuration to accept forced pushes on protected branches.
 type AllowForcePushes struct {
+	Enabled bool `json:"enabled"`
+}
+
+// RequiredConversationResolution, if enabled, requires all comments on the pull request to be resolved before it can be merged to a protected branch.
+type RequiredConversationResolution struct {
 	Enabled bool `json:"enabled"`
 }
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -959,6 +959,9 @@ func TestRepositoriesService_GetBranchProtection(t *testing.T) {
 					"restrictions":{
 						"users":[{"id":1,"login":"u"}],
 						"teams":[{"id":2,"slug":"t"}]
+					},
+					"required_conversation_resolution": {
+						"enabled": true
 					}
 				}`)
 	})
@@ -998,6 +1001,9 @@ func TestRepositoriesService_GetBranchProtection(t *testing.T) {
 			Teams: []*Team{
 				{Slug: String("t"), ID: Int64(2)},
 			},
+		},
+		RequiredConversationResolution: &RequiredConversationResolution{
+			Enabled: true,
 		},
 	}
 	if !cmp.Equal(protection, want) {


### PR DESCRIPTION
Fixes #1945 - added a new field for `Protection` struct
to parse `required_conversation_resolution` JSON field
from API response for branch protection rules.
Updated test.