### PR TITLE
Expose event message headers, introduce a new way to read the body from an `io.Reader`

### DIFF
--- a/github/messages.go
+++ b/github/messages.go
@@ -30,14 +30,14 @@ const (
 	// sha256Prefix and sha512Prefix are provided for future compatibility.
 	sha256Prefix = "sha256"
 	sha512Prefix = "sha512"
-	// sha1SignatureHeader is the GitHub header key used to pass the HMAC-SHA1 hexdigest.
-	sha1SignatureHeader = "X-Hub-Signature"
-	// sha256SignatureHeader is the GitHub header key used to pass the HMAC-SHA256 hexdigest.
-	sha256SignatureHeader = "X-Hub-Signature-256"
-	// eventTypeHeader is the GitHub header key used to pass the event type.
-	eventTypeHeader = "X-Github-Event"
-	// deliveryIDHeader is the GitHub header key used to pass the unique ID for the webhook event.
-	deliveryIDHeader = "X-Github-Delivery"
+	// SHA1SignatureHeader is the GitHub header key used to pass the HMAC-SHA1 hexdigest.
+	SHA1SignatureHeader = "X-Hub-Signature"
+	// SHA256SignatureHeader is the GitHub header key used to pass the HMAC-SHA256 hexdigest.
+	SHA256SignatureHeader = "X-Hub-Signature-256"
+	// EventTypeHeader is the GitHub header key used to pass the event type.
+	EventTypeHeader = "X-Github-Event"
+	// DeliveryIDHeader is the GitHub header key used to pass the unique ID for the webhook event.
+	DeliveryIDHeader = "X-Github-Delivery"
 )
 
 var (
@@ -193,9 +193,9 @@ func ValidatePayload(r *http.Request, secretToken []byte) (payload []byte, err e
 	// Only validate the signature if a secret token exists. This is intended for
 	// local development only and all webhooks should ideally set up a secret token.
 	if len(secretToken) > 0 {
-		sig := r.Header.Get(sha256SignatureHeader)
+		sig := r.Header.Get(SHA256SignatureHeader)
 		if sig == "" {
-			sig = r.Header.Get(sha1SignatureHeader)
+			sig = r.Header.Get(SHA1SignatureHeader)
 		}
 		if err := ValidateSignature(sig, body, secretToken); err != nil {
 			return nil, err
@@ -226,14 +226,14 @@ func ValidateSignature(signature string, payload, secretToken []byte) error {
 //
 // GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/repos/hooks/#webhook-headers
 func WebHookType(r *http.Request) string {
-	return r.Header.Get(eventTypeHeader)
+	return r.Header.Get(EventTypeHeader)
 }
 
 // DeliveryID returns the unique delivery ID of webhook request r.
 //
 // GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/repos/hooks/#webhook-headers
 func DeliveryID(r *http.Request) string {
-	return r.Header.Get(deliveryIDHeader)
+	return r.Header.Get(DeliveryIDHeader)
 }
 
 // ParseWebHook parses the event payload. For recognized event types, a

--- a/github/messages.go
+++ b/github/messages.go
@@ -225,10 +225,10 @@ func ValidatePayload(r *http.Request, secretToken []byte) (payload []byte, err e
 	if signature == "" {
 		signature = r.Header.Get(SHA1SignatureHeader)
 	}
-  
+
 	contentType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
 	if err != nil {
-    return nil, err
+		return nil, err
 	}
 
 	return ValidatePayloadFromBody(contentType, r.Body, signature, secretToken)

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -479,7 +479,7 @@ func TestParseWebHook_BadMessageType(t *testing.T) {
 
 func TestValidatePayloadFromBody_UnsupportedContentType(t *testing.T) {
 	if _, err := ValidatePayloadFromBody("invalid", bytes.NewReader([]byte(`{}`)), "sha1=", []byte{}); err == nil {
-		t.Errorf("ValidatePayloadFromBody returned nil;wanted error")
+		t.Errorf("ValidatePayloadFromBody returned nil; wanted error")
 	}
 }
 

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -66,7 +66,7 @@ func TestValidatePayload(t *testing.T) {
 		},
 		{
 			signature:       "sha256=b1f8020f5b4cd42042f807dd939015c4a418bc1ff7f604dd55b0a19b5d953d9b",
-			signatureHeader: sha256SignatureHeader,
+			signatureHeader: SHA256SignatureHeader,
 			event:           "ping",
 			wantEvent:       "ping",
 			wantPayload:     defaultBody,
@@ -89,7 +89,7 @@ func TestValidatePayload(t *testing.T) {
 			if test.signatureHeader != "" {
 				req.Header.Set(test.signatureHeader, test.signature)
 			} else {
-				req.Header.Set(sha1SignatureHeader, test.signature)
+				req.Header.Set(SHA1SignatureHeader, test.signature)
 			}
 		}
 		req.Header.Set("Content-Type", "application/json")
@@ -120,7 +120,7 @@ func TestValidatePayload_FormGet(t *testing.T) {
 	}
 	req.PostForm = form
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set(sha1SignatureHeader, signature)
+	req.Header.Set(SHA1SignatureHeader, signature)
 
 	got, err := ValidatePayload(req, secretKey)
 	if err != nil {
@@ -131,7 +131,7 @@ func TestValidatePayload_FormGet(t *testing.T) {
 	}
 
 	// check that if payload is invalid we get error
-	req.Header.Set(sha1SignatureHeader, "invalid signature")
+	req.Header.Set(SHA1SignatureHeader, "invalid signature")
 	if _, err = ValidatePayload(req, []byte{0}); err == nil {
 		t.Error("ValidatePayload = nil, want err")
 	}
@@ -150,7 +150,7 @@ func TestValidatePayload_FormPost(t *testing.T) {
 		t.Fatalf("NewRequest: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set(sha1SignatureHeader, signature)
+	req.Header.Set(SHA1SignatureHeader, signature)
 
 	got, err := ValidatePayload(req, secretKey)
 	if err != nil {
@@ -161,7 +161,7 @@ func TestValidatePayload_FormPost(t *testing.T) {
 	}
 
 	// check that if payload is invalid we get error
-	req.Header.Set(sha1SignatureHeader, "invalid signature")
+	req.Header.Set(SHA1SignatureHeader, "invalid signature")
 	if _, err = ValidatePayload(req, []byte{0}); err == nil {
 		t.Error("ValidatePayload = nil, want err")
 	}
@@ -467,7 +467,7 @@ func TestDeliveryID(t *testing.T) {
 func TestWebHookType(t *testing.T) {
 	want := "yo"
 	req := &http.Request{
-		Header: http.Header{eventTypeHeader: []string{want}},
+		Header: http.Header{EventTypeHeader: []string{want}},
 	}
 	if got := WebHookType(req); got != want {
 		t.Errorf("WebHookType = %q, want %q", got, want)

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -477,6 +477,12 @@ func TestParseWebHook_BadMessageType(t *testing.T) {
 	}
 }
 
+func TestValidatePayloadFromBody_UnableToParseBody(t *testing.T) {
+	if _, err := ValidatePayloadFromBody("application/x-www-form-urlencoded", bytes.NewReader([]byte(`%`)), "sha1=", []byte{}); err == nil {
+		t.Errorf("ValidatePayloadFromBody returned nil; wanted error")
+	}
+}
+
 func TestValidatePayloadFromBody_UnsupportedContentType(t *testing.T) {
 	if _, err := ValidatePayloadFromBody("invalid", bytes.NewReader([]byte(`{}`)), "sha1=", []byte{}); err == nil {
 		t.Errorf("ValidatePayloadFromBody returned nil; wanted error")

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -477,6 +477,12 @@ func TestParseWebHook_BadMessageType(t *testing.T) {
 	}
 }
 
+func TestValidatePayloadFromBody_UnsupportedContentType(t *testing.T) {
+	if _, err := ValidatePayloadFromBody("invalid", bytes.NewReader([]byte(`{}`)), "sha1=", []byte{}); err == nil {
+		t.Errorf("ValidatePayloadFromBody returned nil;wanted error")
+	}
+}
+
 func TestDeliveryID(t *testing.T) {
 	id := "8970a780-244e-11e7-91ca-da3aabcb9793"
 	req, err := http.NewRequest("POST", "http://localhost", nil)


### PR DESCRIPTION
This pull request introduces the changes described in #1944.

- Expose the constants `sha1SignatureHeader`, `sha256SignatureHeader`, `eventTypeHeader` and `deliveryIDHeader`
- Introduce a new public function called `ValidatePayloadFromBody` to read the body directly from an `io.Reader` rather than a `http.Request`.

The changes described enables the possibility to use `go-github` even with http libraries like `fiber` or `fasthttp`.

Example A:

```go
app.Get(func(ctx *fiber.Ctx) error {
	signature := ctx.Get(github.SHA256SignatureHeader)
	if signature == "" {
		signature = ctx.Get(github.SHA1SignatureHeader)
	}
	
	payload := ctx.Body()
	err := github.ValidateSignature(signature, payload, mySecretToken)
	// ...

	event, err := github.ParseWebHook(ctx.Get(github.EventTypeHeader), payload)
	// ...
})
```

Example B:

```go
app.Get(func(ctx *fiber.Ctx) error {
	signature := ctx.Get(github.SHA256SignatureHeader)
	if signature == "" {
		signature = ctx.Get(github.SHA1SignatureHeader)
	}
	
	payload, err := github.ValidatePayloadFromBody(ctx.Get("Content-Type"), ctx.Context().RequestBodyStream(), signature, mySecretToken)
	// ...

	event, err := github.ParseWebHook(ctx.Get(github.EventTypeHeader), payload)
	// ...
})
```

