### PR TITLE
Add methods to add and remove repos for actions on org level

### DIFF
--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -264,6 +264,46 @@ func (s *ActionsService) ListEnabledReposInOrg(ctx context.Context, owner string
 	return repos, resp, nil
 }
 
+// AddEnabledReposInOrg adds a list of repositories to the list of enabled repos for GitHub Actions in an organization.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/actions#enable-a-selected-repository-for-github-actions-in-an-organization
+func (s *ActionsService) AddEnabledReposInOrg(ctx context.Context, owner string, repositoryIDs []int64) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/permissions/repositories", owner)
+
+	req, err := s.client.NewRequest("PUT", u, struct {
+		Repository_id []int64 `json:"repository_id"`
+	}{Repository_id: repositoryIDs})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// RemoveEnabledReposInOrg removes a single repositorie from the list of enabled repos for GitHub Actions in an organization.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/actions#disable-a-selected-repository-for-github-actions-in-an-organization
+func (s *ActionsService) RemoveEnabledRepoInOrg(ctx context.Context, owner string, repositoryID int64) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/permissions/repositories/%v", owner, repositoryID)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
 // GetOrganizationRunner gets a specific self-hosted runner for an organization using its runner ID.
 //
 // GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/actions/#get-a-self-hosted-runner-for-an-organization

--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -264,15 +264,34 @@ func (s *ActionsService) ListEnabledReposInOrg(ctx context.Context, owner string
 	return repos, resp, nil
 }
 
-// AddEnabledReposInOrg adds a list of repositories to the list of enabled repos for GitHub Actions in an organization.
+// SetEnabledReposInOrg replaces the list of selected repositories that are enabled for GitHub Actions in an organization..
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/actions#set-selected-repositories-enabled-for-github-actions-in-an-organization
-func (s *ActionsService) AddEnabledReposInOrg(ctx context.Context, owner string, repositoryIDs []int64) (*Response, error) {
+func (s *ActionsService) SetEnabledReposInOrg(ctx context.Context, owner string, repositoryIDs []int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/repositories", owner)
 
 	req, err := s.client.NewRequest("PUT", u, struct {
 		IDs []int64 `json:"selected_repository_ids"`
 	}{IDs: repositoryIDs})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// AddEnabledReposInOrg adds a repository to the list of selected repositories that are enabled for GitHub Actions in an organization.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/actions#enable-a-selected-repository-for-github-actions-in-an-organization
+func (s *ActionsService) AddEnabledReposInOrg(ctx context.Context, owner string, repositoryID int64) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/permissions/repositories/%v", owner, repositoryID)
+
+	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -266,13 +266,13 @@ func (s *ActionsService) ListEnabledReposInOrg(ctx context.Context, owner string
 
 // AddEnabledReposInOrg adds a list of repositories to the list of enabled repos for GitHub Actions in an organization.
 //
-// GitHub API docs: https://docs.github.com/en/rest/reference/actions#enable-a-selected-repository-for-github-actions-in-an-organization
+// GitHub API docs: https://docs.github.com/en/rest/reference/actions#set-selected-repositories-enabled-for-github-actions-in-an-organization
 func (s *ActionsService) AddEnabledReposInOrg(ctx context.Context, owner string, repositoryIDs []int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/repositories", owner)
 
 	req, err := s.client.NewRequest("PUT", u, struct {
-		Repository_id []int64 `json:"repository_id"`
-	}{Repository_id: repositoryIDs})
+		IDs []int64 `json:"selected_repository_ids"`
+	}{IDs: repositoryIDs})
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func (s *ActionsService) AddEnabledReposInOrg(ctx context.Context, owner string,
 	return resp, nil
 }
 
-// RemoveEnabledReposInOrg removes a single repositorie from the list of enabled repos for GitHub Actions in an organization.
+// RemoveEnabledRepoInOrg removes a single repository from the list of enabled repos for GitHub Actions in an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/actions#disable-a-selected-repository-for-github-actions-in-an-organization
 func (s *ActionsService) RemoveEnabledRepoInOrg(ctx context.Context, owner string, repositoryID int64) (*Response, error) {

--- a/github/actions_runners_test.go
+++ b/github/actions_runners_test.go
@@ -428,7 +428,6 @@ func TestActionsService_AddEnabledReposInOrg(t *testing.T) {
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Actions.AddEnabledReposInOrg(ctx, "o", []int64{123, 1234})
 	})
-
 }
 
 func TestActionsService_RemoveEnabledRepoInOrg(t *testing.T) {
@@ -456,7 +455,6 @@ func TestActionsService_RemoveEnabledRepoInOrg(t *testing.T) {
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Actions.RemoveEnabledRepoInOrg(ctx, "o", 123)
 	})
-
 }
 
 func TestActionsService_GetOrganizationRunner(t *testing.T) {

--- a/github/actions_runners_test.go
+++ b/github/actions_runners_test.go
@@ -401,6 +401,64 @@ func TestActionsService_ListEnabledReposInOrg(t *testing.T) {
 	})
 }
 
+func TestActionsService_AddEnabledReposInOrg(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/permissions/repositories", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Content-Type", "application/json")
+		testBody(t, r, `{"repository_id":[123,1234]}`+"\n")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := context.Background()
+	_, err := client.Actions.AddEnabledReposInOrg(ctx, "o", []int64{123, 1234})
+	if err != nil {
+		t.Errorf("Actions.AddEnabledReposInOrg returned error: %v", err)
+	}
+
+	const methodName = "AddEnabledReposInOrg"
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.AddEnabledReposInOrg(ctx, "\n", []int64{123, 1234})
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.AddEnabledReposInOrg(ctx, "o", []int64{123, 1234})
+	})
+
+}
+
+func TestActionsService_RemoveEnabledRepoInOrg(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/permissions/repositories/123", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := context.Background()
+	_, err := client.Actions.RemoveEnabledRepoInOrg(ctx, "o", 123)
+	if err != nil {
+		t.Errorf("Actions.RemoveEnabledRepoInOrg returned error: %v", err)
+	}
+
+	const methodName = "RemoveEnabledRepoInOrg"
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.RemoveEnabledRepoInOrg(ctx, "\n", 123)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.RemoveEnabledRepoInOrg(ctx, "o", 123)
+	})
+
+}
+
 func TestActionsService_GetOrganizationRunner(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()

--- a/github/actions_runners_test.go
+++ b/github/actions_runners_test.go
@@ -401,19 +401,46 @@ func TestActionsService_ListEnabledReposInOrg(t *testing.T) {
 	})
 }
 
-func TestActionsService_AddEnabledReposInOrg(t *testing.T) {
+func TestActionsService_SetEnabledReposInOrg(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/orgs/o/actions/permissions/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
-		testBody(t, r, `{"repository_id":[123,1234]}`+"\n")
+		testBody(t, r, `{"selected_repository_ids":[123,1234]}`+"\n")
 		w.WriteHeader(http.StatusNoContent)
 	})
 
 	ctx := context.Background()
-	_, err := client.Actions.AddEnabledReposInOrg(ctx, "o", []int64{123, 1234})
+	_, err := client.Actions.SetEnabledReposInOrg(ctx, "o", []int64{123, 1234})
+	if err != nil {
+		t.Errorf("Actions.SetEnabledReposInOrg returned error: %v", err)
+	}
+
+	const methodName = "SetEnabledReposInOrg"
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.SetEnabledReposInOrg(ctx, "\n", []int64{123, 1234})
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.SetEnabledReposInOrg(ctx, "o", []int64{123, 1234})
+	})
+}
+
+func TestActionsService_AddEnabledReposInOrg(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/permissions/repositories/123", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := context.Background()
+	_, err := client.Actions.AddEnabledReposInOrg(ctx, "o", 123)
 	if err != nil {
 		t.Errorf("Actions.AddEnabledReposInOrg returned error: %v", err)
 	}
@@ -421,12 +448,12 @@ func TestActionsService_AddEnabledReposInOrg(t *testing.T) {
 	const methodName = "AddEnabledReposInOrg"
 
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.AddEnabledReposInOrg(ctx, "\n", []int64{123, 1234})
+		_, err = client.Actions.AddEnabledReposInOrg(ctx, "\n", 123)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.AddEnabledReposInOrg(ctx, "o", []int64{123, 1234})
+		return client.Actions.AddEnabledReposInOrg(ctx, "o", 123)
 	})
 }
 


### PR DESCRIPTION
This commit adds the abillity to add one or more repositories to the
list of enabled repositories for github actions on org level.
It also adds the abillity to remove them from this list.
With this change we can now enable and disable repos to use github actions on org level.

The used endpoints for this are:
https://docs.github.com/en/rest/reference/actions#set-selected-repositories-enabled-for-github-actions-in-an-organization
https://docs.github.com/en/rest/reference/actions#disable-a-selected-repository-for-github-actions-in-an-organization

fixes #1995 