### PR TITLE
Add allows_public_repositories to actions_runner_group

### DIFF
--- a/github/actions_runner_groups.go
+++ b/github/actions_runner_groups.go
@@ -36,12 +36,15 @@ type CreateRunnerGroupRequest struct {
 	SelectedRepositoryIDs []int64 `json:"selected_repository_ids,omitempty"`
 	// Runners represent a list of runner IDs to add to the runner group.
 	Runners []int64 `json:"runners,omitempty"`
+	// If set to True, public repos can use this runner group
+	AllowsPublicRepositories *bool `json:"allows_public_repositories,omitempty"`
 }
 
 // UpdateRunnerGroupRequest represents a request to update a Runner group for an organization.
 type UpdateRunnerGroupRequest struct {
-	Name       *string `json:"name,omitempty"`
-	Visibility *string `json:"visibility,omitempty"`
+	Name                     *string `json:"name,omitempty"`
+	Visibility               *string `json:"visibility,omitempty"`
+	AllowsPublicRepositories *bool   `json:"allows_public_repositories,omitempty"`
 }
 
 // SetRepoAccessRunnerGroupRequest represents a request to replace the list of repositories

--- a/github/actions_runner_groups_test.go
+++ b/github/actions_runner_groups_test.go
@@ -139,8 +139,9 @@ func TestActionsService_CreateOrganizationRunnerGroup(t *testing.T) {
 
 	ctx := context.Background()
 	req := CreateRunnerGroupRequest{
-		Name:       String("octo-runner-group"),
-		Visibility: String("selected"),
+		Name:                     String("octo-runner-group"),
+		Visibility:               String("selected"),
+		AllowsPublicRepositories: Bool(true),
 	}
 	group, _, err := client.Actions.CreateOrganizationRunnerGroup(ctx, "o", req)
 	if err != nil {
@@ -188,8 +189,9 @@ func TestActionsService_UpdateOrganizationRunnerGroup(t *testing.T) {
 
 	ctx := context.Background()
 	req := UpdateRunnerGroupRequest{
-		Name:       String("octo-runner-group"),
-		Visibility: String("selected"),
+		Name:                     String("octo-runner-group"),
+		Visibility:               String("selected"),
+		AllowsPublicRepositories: Bool(true),
 	}
 	group, _, err := client.Actions.UpdateOrganizationRunnerGroup(ctx, "o", 2, req)
 	if err != nil {
@@ -541,17 +543,19 @@ func TestCreateRunnerGroupRequest_Marshal(t *testing.T) {
 	testJSONMarshal(t, &CreateRunnerGroupRequest{}, "{}")
 
 	u := &CreateRunnerGroupRequest{
-		Name:                  String("n"),
-		Visibility:            String("v"),
-		SelectedRepositoryIDs: []int64{1},
-		Runners:               []int64{1},
+		Name:                     String("n"),
+		Visibility:               String("v"),
+		SelectedRepositoryIDs:    []int64{1},
+		Runners:                  []int64{1},
+		AllowsPublicRepositories: Bool(true),
 	}
 
 	want := `{
 		"name": "n",
 		"visibility": "v",
 		"selected_repository_ids": [1],
-		"runners": [1]
+		"runners": [1],
+		"allows_public_repositories": true
 	}`
 
 	testJSONMarshal(t, u, want)
@@ -561,13 +565,15 @@ func TestUpdateRunnerGroupRequest_Marshal(t *testing.T) {
 	testJSONMarshal(t, &UpdateRunnerGroupRequest{}, "{}")
 
 	u := &UpdateRunnerGroupRequest{
-		Name:       String("n"),
-		Visibility: String("v"),
+		Name:                     String("n"),
+		Visibility:               String("v"),
+		AllowsPublicRepositories: Bool(true),
 	}
 
 	want := `{
 		"name": "n",
-		"visibility": "v"
+		"visibility": "v",
+		"allows_public_repositories": true
 	}`
 
 	testJSONMarshal(t, u, want)

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2916,6 +2916,14 @@ func (c *CreateOrgInvitationOptions) GetRole() string {
 	return *c.Role
 }
 
+// GetAllowsPublicRepositories returns the AllowsPublicRepositories field if it's non-nil, zero value otherwise.
+func (c *CreateRunnerGroupRequest) GetAllowsPublicRepositories() bool {
+	if c == nil || c.AllowsPublicRepositories == nil {
+		return false
+	}
+	return *c.AllowsPublicRepositories
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (c *CreateRunnerGroupRequest) GetName() string {
 	if c == nil || c.Name == nil {
@@ -15922,6 +15930,14 @@ func (u *UpdateCheckRunOptions) GetStatus() string {
 		return ""
 	}
 	return *u.Status
+}
+
+// GetAllowsPublicRepositories returns the AllowsPublicRepositories field if it's non-nil, zero value otherwise.
+func (u *UpdateRunnerGroupRequest) GetAllowsPublicRepositories() bool {
+	if u == nil || u.AllowsPublicRepositories == nil {
+		return false
+	}
+	return *u.AllowsPublicRepositories
 }
 
 // GetName returns the Name field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -3415,6 +3415,16 @@ func TestCreateOrgInvitationOptions_GetRole(tt *testing.T) {
 	c.GetRole()
 }
 
+func TestCreateRunnerGroupRequest_GetAllowsPublicRepositories(tt *testing.T) {
+	var zeroValue bool
+	c := &CreateRunnerGroupRequest{AllowsPublicRepositories: &zeroValue}
+	c.GetAllowsPublicRepositories()
+	c = &CreateRunnerGroupRequest{}
+	c.GetAllowsPublicRepositories()
+	c = nil
+	c.GetAllowsPublicRepositories()
+}
+
 func TestCreateRunnerGroupRequest_GetName(tt *testing.T) {
 	var zeroValue string
 	c := &CreateRunnerGroupRequest{Name: &zeroValue}
@@ -18617,6 +18627,16 @@ func TestUpdateCheckRunOptions_GetStatus(tt *testing.T) {
 	u.GetStatus()
 	u = nil
 	u.GetStatus()
+}
+
+func TestUpdateRunnerGroupRequest_GetAllowsPublicRepositories(tt *testing.T) {
+	var zeroValue bool
+	u := &UpdateRunnerGroupRequest{AllowsPublicRepositories: &zeroValue}
+	u.GetAllowsPublicRepositories()
+	u = &UpdateRunnerGroupRequest{}
+	u.GetAllowsPublicRepositories()
+	u = nil
+	u.GetAllowsPublicRepositories()
 }
 
 func TestUpdateRunnerGroupRequest_GetName(tt *testing.T) {


### PR DESCRIPTION
Adds allows_public_repositories to request bodies of the
CreateRunnerGroup as well as UpdateRunnerGroup methods for github
actions.

This allows us to set the allows_public_repositories flag even if it is
not yet properly documented see https://github.com/github/docs/issues/8209
That flag controls if public repos can use runners of this group.
If it is disabled(default) even public repos that are added to the
selected_repositories list cannot use runners of this group.

With this change we can now set this properly and thus use runner groups
created by go-github also for public repos.

Fixes #1996