### PR TITLE
Fix deprecated field

### DIFF
--- a/github/code-scanning.go
+++ b/github/code-scanning.go
@@ -72,7 +72,7 @@ type Alert struct {
 	Rule               *Rule               `json:"rule,omitempty"`
 	Tool               *Tool               `json:"tool,omitempty"`
 	CreatedAt          *Timestamp          `json:"created_at,omitempty"`
-	Open               *bool               `json:"open,omitempty"`
+	State              *string             `json:"state,omitempty"`
 	ClosedBy           *User               `json:"closed_by,omitempty"`
 	ClosedAt           *Timestamp          `json:"closed_at,omitempty"`
 	URL                *string             `json:"url,omitempty"`

--- a/github/code-scanning.go
+++ b/github/code-scanning.go
@@ -24,6 +24,7 @@ type Rule struct {
 	Severity        *string  `json:"severity,omitempty"`
 	Description     *string  `json:"description,omitempty"`
 	Name            *string  `json:"name,omitempty"`
+	SeverityLevel   *string  `json:"security_severity_level,omitempty"`
 	FullDescription *string  `json:"full_description,omitempty"`
 	Tags            []string `json:"tags,omitempty"`
 	Help            *string  `json:"help,omitempty"`

--- a/github/code-scanning.go
+++ b/github/code-scanning.go
@@ -20,14 +20,14 @@ type CodeScanningService service
 
 // Rule represents the complete details of GitHub Code Scanning alert type.
 type Rule struct {
-	ID              *string  `json:"id,omitempty"`
-	Severity        *string  `json:"severity,omitempty"`
-	Description     *string  `json:"description,omitempty"`
-	Name            *string  `json:"name,omitempty"`
-	SeverityLevel   *string  `json:"security_severity_level,omitempty"`
-	FullDescription *string  `json:"full_description,omitempty"`
-	Tags            []string `json:"tags,omitempty"`
-	Help            *string  `json:"help,omitempty"`
+	ID                    *string  `json:"id,omitempty"`
+	Severity              *string  `json:"severity,omitempty"`
+	Description           *string  `json:"description,omitempty"`
+	Name                  *string  `json:"name,omitempty"`
+	SecuritySeverityLevel *string  `json:"security_severity_level,omitempty"`
+	FullDescription       *string  `json:"full_description,omitempty"`
+	Tags                  []string `json:"tags,omitempty"`
+	Help                  *string  `json:"help,omitempty"`
 }
 
 // Location represents the exact location of the GitHub Code Scanning Alert in the scanned project.

--- a/github/code-scanning_test.go
+++ b/github/code-scanning_test.go
@@ -96,7 +96,7 @@ func TestActionsService_ListAlertsForRepo(t *testing.T) {
 					]
 				},
 				"created_at":"2020-05-06T12:00:00Z",
-				"open":true,
+				"state":"open",
 				"closed_by":null,
 				"closed_at":null,
 				"url":"https://api.github.com/repos/o/r/code-scanning/alerts/25",
@@ -138,7 +138,7 @@ func TestActionsService_ListAlertsForRepo(t *testing.T) {
 					]
 				},
 				"created_at":"2020-05-06T12:00:00Z",
-				"open":true,
+				"state":"open",
 				"closed_by":null,
 				"closed_at":null,
 				"url":"https://api.github.com/repos/o/r/code-scanning/alerts/88",
@@ -169,7 +169,7 @@ func TestActionsService_ListAlertsForRepo(t *testing.T) {
 				Help:            String("Expression has no effect"),
 			},
 			CreatedAt: &date,
-			Open:      Bool(true),
+			State:     String("open"),
 			ClosedBy:  nil,
 			ClosedAt:  nil,
 			URL:       String("https://api.github.com/repos/o/r/code-scanning/alerts/25"),
@@ -205,7 +205,7 @@ func TestActionsService_ListAlertsForRepo(t *testing.T) {
 				Help:            String("Expression has no effect"),
 			},
 			CreatedAt: &date,
-			Open:      Bool(true),
+			State:     String("open"),
 			ClosedBy:  nil,
 			ClosedAt:  nil,
 			URL:       String("https://api.github.com/repos/o/r/code-scanning/alerts/88"),
@@ -288,7 +288,7 @@ func TestActionsService_GetAlert(t *testing.T) {
 					]
 				},      
 				"created_at":"2019-01-02T15:04:05Z",
-				"open":true,
+				"state":"open",
 				"closed_by":null,
 				"closed_at":null,
 				"url":"https://api.github.com/repos/o/r/code-scanning/alerts/88",
@@ -316,7 +316,7 @@ func TestActionsService_GetAlert(t *testing.T) {
 			Help:            String("Expression has no effect"),
 		},
 		CreatedAt: &date,
-		Open:      Bool(true),
+		State:     String("open"),
 		ClosedBy:  nil,
 		ClosedAt:  nil,
 		URL:       String("https://api.github.com/repos/o/r/code-scanning/alerts/88"),
@@ -370,7 +370,7 @@ func TestAlert_Marshal(t *testing.T) {
 			Version: String("v"),
 		},
 		CreatedAt: &Timestamp{referenceTime},
-		Open:      Bool(false),
+		State:     String("fixed"),
 		ClosedBy: &User{
 			Login:     String("l"),
 			ID:        Int64(1),
@@ -395,7 +395,7 @@ func TestAlert_Marshal(t *testing.T) {
 			"version": "v"
 		},
 		"created_at": ` + referenceTimeStr + `,
-		"open": false,
+		"state": "fixed",
 		"closed_by": {
 			"login": "l",
 			"id": 1,

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -14356,20 +14356,20 @@ func (r *Rule) GetName() string {
 	return *r.Name
 }
 
+// GetSecuritySeverityLevel returns the SecuritySeverityLevel field if it's non-nil, zero value otherwise.
+func (r *Rule) GetSecuritySeverityLevel() string {
+	if r == nil || r.SecuritySeverityLevel == nil {
+		return ""
+	}
+	return *r.SecuritySeverityLevel
+}
+
 // GetSeverity returns the Severity field if it's non-nil, zero value otherwise.
 func (r *Rule) GetSeverity() string {
 	if r == nil || r.Severity == nil {
 		return ""
 	}
 	return *r.Severity
-}
-
-// GetSeverityLevel returns the SeverityLevel field if it's non-nil, zero value otherwise.
-func (r *Rule) GetSeverityLevel() string {
-	if r == nil || r.SeverityLevel == nil {
-		return ""
-	}
-	return *r.SeverityLevel
 }
 
 // GetBusy returns the Busy field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -14364,6 +14364,14 @@ func (r *Rule) GetSeverity() string {
 	return *r.Severity
 }
 
+// GetSeverityLevel returns the SeverityLevel field if it's non-nil, zero value otherwise.
+func (r *Rule) GetSeverityLevel() string {
+	if r == nil || r.SeverityLevel == nil {
+		return ""
+	}
+	return *r.SeverityLevel
+}
+
 // GetBusy returns the Busy field if it's non-nil, zero value otherwise.
 func (r *Runner) GetBusy() bool {
 	if r == nil || r.Busy == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -220,14 +220,6 @@ func (a *Alert) GetMostRecentInstance() *MostRecentInstance {
 	return a.MostRecentInstance
 }
 
-// GetOpen returns the Open field if it's non-nil, zero value otherwise.
-func (a *Alert) GetOpen() bool {
-	if a == nil || a.Open == nil {
-		return false
-	}
-	return *a.Open
-}
-
 // GetRule returns the Rule field.
 func (a *Alert) GetRule() *Rule {
 	if a == nil {
@@ -258,6 +250,14 @@ func (a *Alert) GetRuleSeverity() string {
 		return ""
 	}
 	return *a.RuleSeverity
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (a *Alert) GetState() string {
+	if a == nil || a.State == nil {
+		return ""
+	}
+	return *a.State
 }
 
 // GetTool returns the Tool field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -16776,6 +16776,16 @@ func TestRule_GetName(tt *testing.T) {
 	r.GetName()
 }
 
+func TestRule_GetSecuritySeverityLevel(tt *testing.T) {
+	var zeroValue string
+	r := &Rule{SecuritySeverityLevel: &zeroValue}
+	r.GetSecuritySeverityLevel()
+	r = &Rule{}
+	r.GetSecuritySeverityLevel()
+	r = nil
+	r.GetSecuritySeverityLevel()
+}
+
 func TestRule_GetSeverity(tt *testing.T) {
 	var zeroValue string
 	r := &Rule{Severity: &zeroValue}
@@ -16784,16 +16794,6 @@ func TestRule_GetSeverity(tt *testing.T) {
 	r.GetSeverity()
 	r = nil
 	r.GetSeverity()
-}
-
-func TestRule_GetSeverityLevel(tt *testing.T) {
-	var zeroValue string
-	r := &Rule{SeverityLevel: &zeroValue}
-	r.GetSeverityLevel()
-	r = &Rule{}
-	r.GetSeverityLevel()
-	r = nil
-	r.GetSeverityLevel()
 }
 
 func TestRunner_GetBusy(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -234,16 +234,6 @@ func TestAlert_GetMostRecentInstance(tt *testing.T) {
 	a.GetMostRecentInstance()
 }
 
-func TestAlert_GetOpen(tt *testing.T) {
-	var zeroValue bool
-	a := &Alert{Open: &zeroValue}
-	a.GetOpen()
-	a = &Alert{}
-	a.GetOpen()
-	a = nil
-	a.GetOpen()
-}
-
 func TestAlert_GetRule(tt *testing.T) {
 	a := &Alert{}
 	a.GetRule()
@@ -279,6 +269,16 @@ func TestAlert_GetRuleSeverity(tt *testing.T) {
 	a.GetRuleSeverity()
 	a = nil
 	a.GetRuleSeverity()
+}
+
+func TestAlert_GetState(tt *testing.T) {
+	var zeroValue string
+	a := &Alert{State: &zeroValue}
+	a.GetState()
+	a = &Alert{}
+	a.GetState()
+	a = nil
+	a.GetState()
 }
 
 func TestAlert_GetTool(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -16786,6 +16786,16 @@ func TestRule_GetSeverity(tt *testing.T) {
 	r.GetSeverity()
 }
 
+func TestRule_GetSeverityLevel(tt *testing.T) {
+	var zeroValue string
+	r := &Rule{SeverityLevel: &zeroValue}
+	r.GetSeverityLevel()
+	r = &Rule{}
+	r.GetSeverityLevel()
+	r = nil
+	r.GetSeverityLevel()
+}
+
 func TestRunner_GetBusy(tt *testing.T) {
 	var zeroValue bool
 	r := &Runner{Busy: &zeroValue}


### PR DESCRIPTION
The deprecated field `open` got changed to `state` to hold 3 different values (`open, dismissed, and fixed`)