### PR TITLE
Add avatar_url field to RepoStatus

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -14212,6 +14212,14 @@ func (r *RepoStats) GetTotalWikis() int {
 	return *r.TotalWikis
 }
 
+// GetAvatarURL returns the AvatarURL field if it's non-nil, zero value otherwise.
+func (r *RepoStatus) GetAvatarURL() string {
+	if r == nil || r.AvatarURL == nil {
+		return ""
+	}
+	return *r.AvatarURL
+}
+
 // GetContext returns the Context field if it's non-nil, zero value otherwise.
 func (r *RepoStatus) GetContext() string {
 	if r == nil || r.Context == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -16599,6 +16599,16 @@ func TestRepoStats_GetTotalWikis(tt *testing.T) {
 	r.GetTotalWikis()
 }
 
+func TestRepoStatus_GetAvatarURL(tt *testing.T) {
+	var zeroValue string
+	r := &RepoStatus{AvatarURL: &zeroValue}
+	r.GetAvatarURL()
+	r = &RepoStatus{}
+	r.GetAvatarURL()
+	r = nil
+	r.GetAvatarURL()
+}
+
 func TestRepoStatus_GetContext(tt *testing.T) {
 	var zeroValue string
 	r := &RepoStatus{Context: &zeroValue}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1372,9 +1372,10 @@ func TestRepoStatus_String(t *testing.T) {
 		TargetURL:   String(""),
 		Description: String(""),
 		Context:     String(""),
+		AvatarURL:   String(""),
 		Creator:     &User{},
 	}
-	want := `github.RepoStatus{ID:0, NodeID:"", URL:"", State:"", TargetURL:"", Description:"", Context:"", Creator:github.User{}}`
+	want := `github.RepoStatus{ID:0, NodeID:"", URL:"", State:"", TargetURL:"", Description:"", Context:"", AvatarURL:"", Creator:github.User{}}`
 	if got := v.String(); got != want {
 		t.Errorf("RepoStatus.String = %v, want %v", got, want)
 	}

--- a/github/repos_statuses.go
+++ b/github/repos_statuses.go
@@ -31,6 +31,9 @@ type RepoStatus struct {
 	// A string label to differentiate this status from the statuses of other systems.
 	Context *string `json:"context,omitempty"`
 
+	// AvatarURL is the URL of the avatar of this status.
+	AvatarURL *string `json:"avatar_url,omitempty"`
+
 	Creator   *User      `json:"creator,omitempty"`
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`


### PR DESCRIPTION
I've added the `AvatarURL` field to `RepoStatus` to bind the `avatar_url` field from the response. Thanks.

[> Github document (combined status)](https://docs.github.com/en/rest/reference/repos#get-the-combined-status-for-a-specific-reference)