### PR TITLE
Add Slug field to AppConfig in manifest workflow

### DIFF
--- a/github/apps_manifest.go
+++ b/github/apps_manifest.go
@@ -13,6 +13,7 @@ import (
 // AppConfig describes the configuration of a GitHub App.
 type AppConfig struct {
 	ID            *int64     `json:"id,omitempty"`
+	Slug          *string    `json:"slug,omitempty"`
 	NodeID        *string    `json:"node_id,omitempty"`
 	Owner         *User      `json:"owner,omitempty"`
 	Name          *string    `json:"name,omitempty"`

--- a/github/apps_manifest_test.go
+++ b/github/apps_manifest_test.go
@@ -72,6 +72,7 @@ func TestAppConfig_Marshal(t *testing.T) {
 
 	u := &AppConfig{
 		ID:     Int64(1),
+		Slug:   String("s"),
 		NodeID: String("nid"),
 		Owner: &User{
 			Login:           String("l"),
@@ -107,6 +108,7 @@ func TestAppConfig_Marshal(t *testing.T) {
 
 	want := `{
 		"id": 1,
+		"slug": "s",
 		"node_id": "nid",
 		"owner": {
 			"login": "l",

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -460,6 +460,14 @@ func (a *AppConfig) GetPEM() string {
 	return *a.PEM
 }
 
+// GetSlug returns the Slug field if it's non-nil, zero value otherwise.
+func (a *AppConfig) GetSlug() string {
+	if a == nil || a.Slug == nil {
+		return ""
+	}
+	return *a.Slug
+}
+
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (a *AppConfig) GetUpdatedAt() Timestamp {
 	if a == nil || a.UpdatedAt == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -519,6 +519,16 @@ func TestAppConfig_GetPEM(tt *testing.T) {
 	a.GetPEM()
 }
 
+func TestAppConfig_GetSlug(tt *testing.T) {
+	var zeroValue string
+	a := &AppConfig{Slug: &zeroValue}
+	a.GetSlug()
+	a = &AppConfig{}
+	a.GetSlug()
+	a = nil
+	a.GetSlug()
+}
+
 func TestAppConfig_GetUpdatedAt(tt *testing.T) {
 	var zeroValue Timestamp
 	a := &AppConfig{UpdatedAt: &zeroValue}


### PR DESCRIPTION
Add the `slug` field from the [GitHub manifest response](https://docs.github.com/en/rest/reference/apps#create-a-github-app-from-a-manifest) to `AppConfig`