### PR TITLE
Allow empty selected_repository_ids for SetSelectedReposForOrgSecret

### DIFF
--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -302,7 +302,7 @@ func (s *ActionsService) SetSelectedReposForOrgSecret(ctx context.Context, org, 
 	u := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories", org, name)
 
 	type repoIDs struct {
-		SelectedIDs SelectedRepoIDs `json:"selected_repository_ids,omitempty"`
+		SelectedIDs SelectedRepoIDs `json:"selected_repository_ids"`
 	}
 
 	req, err := s.client.NewRequest("PUT", u, repoIDs{SelectedIDs: ids})


### PR DESCRIPTION
Fix #2035 - Allow empty selected_repository_ids for SetSelectedReposForOrgSecret