### PR TITLE
Fix GitHub docs links

### DIFF
--- a/github/doc.go
+++ b/github/doc.go
@@ -112,7 +112,7 @@ To detect an API rate limit error, you can check if its type is *github.RateLimi
 	}
 
 Learn more about GitHub rate limiting at
-https://docs.github.com/en/free-pro-team@latest/rest/reference/#rate-limiting.
+https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#rate-limiting.
 
 Accepted Status
 
@@ -138,7 +138,7 @@ instead designed to work with a caching http.Transport. We recommend using
 https://github.com/gregjones/httpcache for that.
 
 Learn more about GitHub conditional requests at
-https://docs.github.com/en/free-pro-team@latest/rest/reference/#conditional-requests.
+https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#conditional-requests.
 
 Creating and Updating Resources
 


### PR DESCRIPTION
It looks like the links to GitHub rate limiting and conditional requests docs are now redirected to the docs home page.
It seems like these sections have moved to `Overview > Resources in the REST API`, this PR updates the links accordingly