### PR TITLE
Add raw_key field to GPGKey struct

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -4708,6 +4708,14 @@ func (g *GPGKey) GetPublicKey() string {
 	return *g.PublicKey
 }
 
+// GetRawKey returns the RawKey field if it's non-nil, zero value otherwise.
+func (g *GPGKey) GetRawKey() string {
+	if g == nil || g.RawKey == nil {
+		return ""
+	}
+	return *g.RawKey
+}
+
 // GetApp returns the App field.
 func (g *Grant) GetApp() *AuthorizationApp {
 	if g == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -5502,6 +5502,16 @@ func TestGPGKey_GetPublicKey(tt *testing.T) {
 	g.GetPublicKey()
 }
 
+func TestGPGKey_GetRawKey(tt *testing.T) {
+	var zeroValue string
+	g := &GPGKey{RawKey: &zeroValue}
+	g.GetRawKey()
+	g = &GPGKey{}
+	g.GetRawKey()
+	g = nil
+	g.GetRawKey()
+}
+
 func TestGrant_GetApp(tt *testing.T) {
 	g := &Grant{}
 	g.GetApp()

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -375,13 +375,14 @@ func TestGPGKey_String(t *testing.T) {
 		ID:                Int64(0),
 		PrimaryKeyID:      Int64(0),
 		KeyID:             String(""),
+		RawKey:            String(""),
 		PublicKey:         String(""),
 		CanSign:           Bool(false),
 		CanEncryptComms:   Bool(false),
 		CanEncryptStorage: Bool(false),
 		CanCertify:        Bool(false),
 	}
-	want := `github.GPGKey{ID:0, PrimaryKeyID:0, KeyID:"", PublicKey:"", CanSign:false, CanEncryptComms:false, CanEncryptStorage:false, CanCertify:false}`
+	want := `github.GPGKey{ID:0, PrimaryKeyID:0, KeyID:"", RawKey:"", PublicKey:"", CanSign:false, CanEncryptComms:false, CanEncryptStorage:false, CanCertify:false}`
 	if got := v.String(); got != want {
 		t.Errorf("GPGKey.String = %v, want %v", got, want)
 	}

--- a/github/users_gpg_keys.go
+++ b/github/users_gpg_keys.go
@@ -18,6 +18,7 @@ type GPGKey struct {
 	ID                *int64      `json:"id,omitempty"`
 	PrimaryKeyID      *int64      `json:"primary_key_id,omitempty"`
 	KeyID             *string     `json:"key_id,omitempty"`
+	RawKey            *string     `json:"raw_key,omitempty"`
 	PublicKey         *string     `json:"public_key,omitempty"`
 	Emails            []*GPGEmail `json:"emails,omitempty"`
 	Subkeys           []*GPGKey   `json:"subkeys,omitempty"`


### PR DESCRIPTION
This pull request adds the `raw_key` field to `GPGKey`. This field is exposed by github.com, for example: https://api.github.com/users/brekelj1/gpg_keys
