### PR TITLE
Add support for Packages API

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -155,6 +155,7 @@ ishan upadhyay <ishanupadhyay412@gmail.com>
 isqua <isqua@isqua.ru>
 Jacob Valdemar <jan@lunar.app>
 Jake Krammer <jake.krammer1@gmail.com>
+Jake White <jake@jwhite.network>
 Jameel Haffejee <RC1140@republiccommandos.co.za>
 James Cockbain <james.cockbain@ibm.com>
 James Loh <github@jloh.co>

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -8852,6 +8852,30 @@ func (p *Package) GetUpdatedAt() Timestamp {
 	return *p.UpdatedAt
 }
 
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (p *Package) GetURL() string {
+	if p == nil || p.URL == nil {
+		return ""
+	}
+	return *p.URL
+}
+
+// GetVersionCount returns the VersionCount field if it's non-nil, zero value otherwise.
+func (p *Package) GetVersionCount() int64 {
+	if p == nil || p.VersionCount == nil {
+		return 0
+	}
+	return *p.VersionCount
+}
+
+// GetVisibility returns the Visibility field if it's non-nil, zero value otherwise.
+func (p *Package) GetVisibility() string {
+	if p == nil || p.Visibility == nil {
+		return ""
+	}
+	return *p.Visibility
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (p *PackageEvent) GetAction() string {
 	if p == nil || p.Action == nil {
@@ -8986,6 +9010,22 @@ func (p *PackageFile) GetUpdatedAt() Timestamp {
 		return Timestamp{}
 	}
 	return *p.UpdatedAt
+}
+
+// GetContainer returns the Container field.
+func (p *PackageMetadata) GetContainer() *PackageContainerMetadata {
+	if p == nil {
+		return nil
+	}
+	return p.Container
+}
+
+// GetPackageType returns the PackageType field if it's non-nil, zero value otherwise.
+func (p *PackageMetadata) GetPackageType() string {
+	if p == nil || p.PackageType == nil {
+		return ""
+	}
+	return *p.PackageType
 }
 
 // GetAboutURL returns the AboutURL field if it's non-nil, zero value otherwise.
@@ -9188,6 +9228,30 @@ func (p *PackageVersion) GetManifest() string {
 	return *p.Manifest
 }
 
+// GetMetadata returns the Metadata field.
+func (p *PackageVersion) GetMetadata() *PackageMetadata {
+	if p == nil {
+		return nil
+	}
+	return p.Metadata
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (p *PackageVersion) GetName() string {
+	if p == nil || p.Name == nil {
+		return ""
+	}
+	return *p.Name
+}
+
+// GetPackageHTMLURL returns the PackageHTMLURL field if it's non-nil, zero value otherwise.
+func (p *PackageVersion) GetPackageHTMLURL() string {
+	if p == nil || p.PackageHTMLURL == nil {
+		return ""
+	}
+	return *p.PackageHTMLURL
+}
+
 // GetPrerelease returns the Prerelease field if it's non-nil, zero value otherwise.
 func (p *PackageVersion) GetPrerelease() bool {
 	if p == nil || p.Prerelease == nil {
@@ -9242,6 +9306,14 @@ func (p *PackageVersion) GetUpdatedAt() Timestamp {
 		return Timestamp{}
 	}
 	return *p.UpdatedAt
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (p *PackageVersion) GetURL() string {
+	if p == nil || p.URL == nil {
+		return ""
+	}
+	return *p.URL
 }
 
 // GetVersion returns the Version field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -8844,6 +8844,14 @@ func (p *Package) GetRegistry() *PackageRegistry {
 	return p.Registry
 }
 
+// GetRepository returns the Repository field.
+func (p *Package) GetRepository() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repository
+}
+
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (p *Package) GetUpdatedAt() Timestamp {
 	if p == nil || p.UpdatedAt == nil {
@@ -9010,6 +9018,30 @@ func (p *PackageFile) GetUpdatedAt() Timestamp {
 		return Timestamp{}
 	}
 	return *p.UpdatedAt
+}
+
+// GetPackageType returns the PackageType field if it's non-nil, zero value otherwise.
+func (p *PackageListOptions) GetPackageType() string {
+	if p == nil || p.PackageType == nil {
+		return ""
+	}
+	return *p.PackageType
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (p *PackageListOptions) GetState() string {
+	if p == nil || p.State == nil {
+		return ""
+	}
+	return *p.State
+}
+
+// GetVisibility returns the Visibility field if it's non-nil, zero value otherwise.
+func (p *PackageListOptions) GetVisibility() string {
+	if p == nil || p.Visibility == nil {
+		return ""
+	}
+	return *p.Visibility
 }
 
 // GetContainer returns the Container field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -10385,6 +10385,36 @@ func TestPackage_GetUpdatedAt(tt *testing.T) {
 	p.GetUpdatedAt()
 }
 
+func TestPackage_GetURL(tt *testing.T) {
+	var zeroValue string
+	p := &Package{URL: &zeroValue}
+	p.GetURL()
+	p = &Package{}
+	p.GetURL()
+	p = nil
+	p.GetURL()
+}
+
+func TestPackage_GetVersionCount(tt *testing.T) {
+	var zeroValue int64
+	p := &Package{VersionCount: &zeroValue}
+	p.GetVersionCount()
+	p = &Package{}
+	p.GetVersionCount()
+	p = nil
+	p.GetVersionCount()
+}
+
+func TestPackage_GetVisibility(tt *testing.T) {
+	var zeroValue string
+	p := &Package{Visibility: &zeroValue}
+	p.GetVisibility()
+	p = &Package{}
+	p.GetVisibility()
+	p = nil
+	p.GetVisibility()
+}
+
 func TestPackageEvent_GetAction(tt *testing.T) {
 	var zeroValue string
 	p := &PackageEvent{Action: &zeroValue}
@@ -10538,6 +10568,23 @@ func TestPackageFile_GetUpdatedAt(tt *testing.T) {
 	p.GetUpdatedAt()
 	p = nil
 	p.GetUpdatedAt()
+}
+
+func TestPackageMetadata_GetContainer(tt *testing.T) {
+	p := &PackageMetadata{}
+	p.GetContainer()
+	p = nil
+	p.GetContainer()
+}
+
+func TestPackageMetadata_GetPackageType(tt *testing.T) {
+	var zeroValue string
+	p := &PackageMetadata{PackageType: &zeroValue}
+	p.GetPackageType()
+	p = &PackageMetadata{}
+	p.GetPackageType()
+	p = nil
+	p.GetPackageType()
 }
 
 func TestPackageRegistry_GetAboutURL(tt *testing.T) {
@@ -10784,6 +10831,33 @@ func TestPackageVersion_GetManifest(tt *testing.T) {
 	p.GetManifest()
 }
 
+func TestPackageVersion_GetMetadata(tt *testing.T) {
+	p := &PackageVersion{}
+	p.GetMetadata()
+	p = nil
+	p.GetMetadata()
+}
+
+func TestPackageVersion_GetName(tt *testing.T) {
+	var zeroValue string
+	p := &PackageVersion{Name: &zeroValue}
+	p.GetName()
+	p = &PackageVersion{}
+	p.GetName()
+	p = nil
+	p.GetName()
+}
+
+func TestPackageVersion_GetPackageHTMLURL(tt *testing.T) {
+	var zeroValue string
+	p := &PackageVersion{PackageHTMLURL: &zeroValue}
+	p.GetPackageHTMLURL()
+	p = &PackageVersion{}
+	p.GetPackageHTMLURL()
+	p = nil
+	p.GetPackageHTMLURL()
+}
+
 func TestPackageVersion_GetPrerelease(tt *testing.T) {
 	var zeroValue bool
 	p := &PackageVersion{Prerelease: &zeroValue}
@@ -10849,6 +10923,16 @@ func TestPackageVersion_GetUpdatedAt(tt *testing.T) {
 	p.GetUpdatedAt()
 	p = nil
 	p.GetUpdatedAt()
+}
+
+func TestPackageVersion_GetURL(tt *testing.T) {
+	var zeroValue string
+	p := &PackageVersion{URL: &zeroValue}
+	p.GetURL()
+	p = &PackageVersion{}
+	p.GetURL()
+	p = nil
+	p.GetURL()
 }
 
 func TestPackageVersion_GetVersion(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -10375,6 +10375,13 @@ func TestPackage_GetRegistry(tt *testing.T) {
 	p.GetRegistry()
 }
 
+func TestPackage_GetRepository(tt *testing.T) {
+	p := &Package{}
+	p.GetRepository()
+	p = nil
+	p.GetRepository()
+}
+
 func TestPackage_GetUpdatedAt(tt *testing.T) {
 	var zeroValue Timestamp
 	p := &Package{UpdatedAt: &zeroValue}
@@ -10568,6 +10575,36 @@ func TestPackageFile_GetUpdatedAt(tt *testing.T) {
 	p.GetUpdatedAt()
 	p = nil
 	p.GetUpdatedAt()
+}
+
+func TestPackageListOptions_GetPackageType(tt *testing.T) {
+	var zeroValue string
+	p := &PackageListOptions{PackageType: &zeroValue}
+	p.GetPackageType()
+	p = &PackageListOptions{}
+	p.GetPackageType()
+	p = nil
+	p.GetPackageType()
+}
+
+func TestPackageListOptions_GetState(tt *testing.T) {
+	var zeroValue string
+	p := &PackageListOptions{State: &zeroValue}
+	p.GetState()
+	p = &PackageListOptions{}
+	p.GetState()
+	p = nil
+	p.GetState()
+}
+
+func TestPackageListOptions_GetVisibility(tt *testing.T) {
+	var zeroValue string
+	p := &PackageListOptions{Visibility: &zeroValue}
+	p.GetVisibility()
+	p = &PackageListOptions{}
+	p.GetVisibility()
+	p = nil
+	p.GetVisibility()
 }
 
 func TestPackageMetadata_GetContainer(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -972,8 +972,9 @@ func TestPackage_String(t *testing.T) {
 		URL:            String(""),
 		VersionCount:   Int64(0),
 		Visibility:     String(""),
+		Repository:     &Repository{},
 	}
-	want := `github.Package{ID:0, Name:"", PackageType:"", HTMLURL:"", CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Owner:github.User{}, PackageVersion:github.PackageVersion{}, Registry:github.PackageRegistry{}, URL:"", VersionCount:0, Visibility:""}`
+	want := `github.Package{ID:0, Name:"", PackageType:"", HTMLURL:"", CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Owner:github.User{}, PackageVersion:github.PackageVersion{}, Registry:github.PackageRegistry{}, URL:"", VersionCount:0, Visibility:"", Repository:github.Repository{}}`
 	if got := v.String(); got != want {
 		t.Errorf("Package.String = %v, want %v", got, want)
 	}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -969,8 +969,11 @@ func TestPackage_String(t *testing.T) {
 		Owner:          &User{},
 		PackageVersion: &PackageVersion{},
 		Registry:       &PackageRegistry{},
+		URL:            String(""),
+		VersionCount:   Int64(0),
+		Visibility:     String(""),
 	}
-	want := `github.Package{ID:0, Name:"", PackageType:"", HTMLURL:"", CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Owner:github.User{}, PackageVersion:github.PackageVersion{}, Registry:github.PackageRegistry{}}`
+	want := `github.Package{ID:0, Name:"", PackageType:"", HTMLURL:"", CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Owner:github.User{}, PackageVersion:github.PackageVersion{}, Registry:github.PackageRegistry{}, URL:"", VersionCount:0, Visibility:""}`
 	if got := v.String(); got != want {
 		t.Errorf("Package.String = %v, want %v", got, want)
 	}
@@ -994,6 +997,17 @@ func TestPackageFile_String(t *testing.T) {
 	want := `github.PackageFile{DownloadURL:"", ID:0, Name:"", SHA256:"", SHA1:"", MD5:"", ContentType:"", State:"", Author:github.User{}, Size:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}`
 	if got := v.String(); got != want {
 		t.Errorf("PackageFile.String = %v, want %v", got, want)
+	}
+}
+
+func TestPackageMetadata_String(t *testing.T) {
+	v := PackageMetadata{
+		PackageType: String(""),
+		Container:   &PackageContainerMetadata{},
+	}
+	want := `github.PackageMetadata{PackageType:"", Container:github.PackageContainerMetadata{}}`
+	if got := v.String(); got != want {
+		t.Errorf("PackageMetadata.String = %v, want %v", got, want)
 	}
 }
 
@@ -1050,8 +1064,12 @@ func TestPackageVersion_String(t *testing.T) {
 		UpdatedAt:           &Timestamp{},
 		Author:              &User{},
 		InstallationCommand: String(""),
+		Metadata:            &PackageMetadata{},
+		PackageHTMLURL:      String(""),
+		Name:                String(""),
+		URL:                 String(""),
 	}
-	want := `github.PackageVersion{ID:0, Version:"", Summary:"", Body:"", BodyHTML:"", Release:github.PackageRelease{}, Manifest:"", HTMLURL:"", TagName:"", TargetCommitish:"", TargetOID:"", Draft:false, Prerelease:false, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Author:github.User{}, InstallationCommand:""}`
+	want := `github.PackageVersion{ID:0, Version:"", Summary:"", Body:"", BodyHTML:"", Release:github.PackageRelease{}, Manifest:"", HTMLURL:"", TagName:"", TargetCommitish:"", TargetOID:"", Draft:false, Prerelease:false, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Author:github.User{}, InstallationCommand:"", Metadata:github.PackageMetadata{}, PackageHTMLURL:"", Name:"", URL:""}`
 	if got := v.String(); got != want {
 		t.Errorf("PackageVersion.String = %v, want %v", got, want)
 	}

--- a/github/orgs_packages.go
+++ b/github/orgs_packages.go
@@ -13,8 +13,12 @@ import (
 // List the packages for an organization
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#list-packages-for-an-organization
-func (s *OrganizationsService) ListPackages(ctx context.Context, org string) ([]*Package, *Response, error) {
+func (s *OrganizationsService) ListPackages(ctx context.Context, org string, opts *PackageListOptions) ([]*Package, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages", org)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -73,7 +77,7 @@ func (s *OrganizationsService) RestorePackage(ctx context.Context, org, packageT
 // Get all versions of a package in an organization
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-all-package-versions-for-a-package-owned-by-an-organization
-func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, packageType, packageName string, opts *ListOptions) ([]*PackageVersion, *Response, error) {
+func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, packageType, packageName string, opts *PackageListOptions) ([]*PackageVersion, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions", org, packageType, packageName)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -95,7 +99,7 @@ func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, p
 // Get a specific version of a package in an organization
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-a-package-version-for-an-organization
-func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packageType, packageName, packageVersionID string) (*PackageVersion, *Response, error) {
+func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*PackageVersion, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v", org, packageType, packageName, packageVersionID)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -113,7 +117,7 @@ func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packa
 // Delete a package version from an organization
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#delete-package-version-for-an-organization
-func (s *OrganizationsService) DeletePackageVersion(ctx context.Context, org, packageType, packageName, packageVersionID string) (*Response, error) {
+func (s *OrganizationsService) PackageDeleteVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v", org, packageType, packageName, packageVersionID)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -126,7 +130,7 @@ func (s *OrganizationsService) DeletePackageVersion(ctx context.Context, org, pa
 // Restore a package version to an organization
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#restore-package-version-for-an-organization
-func (s *OrganizationsService) RestorePackageVersion(ctx context.Context, org, packageType, packageName, packageVersionID string) (*Response, error) {
+func (s *OrganizationsService) PackageRestoreVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v/restore", org, packageType, packageName, packageVersionID)
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {

--- a/github/orgs_packages.go
+++ b/github/orgs_packages.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 )
 
-// List the packages for an organization
+// List the packages for an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#list-packages-for-an-organization
 func (s *OrganizationsService) ListPackages(ctx context.Context, org string, opts *PackageListOptions) ([]*Package, *Response, error) {
@@ -19,19 +19,22 @@ func (s *OrganizationsService) ListPackages(ctx context.Context, org string, opt
 	if err != nil {
 		return nil, nil, err
 	}
+
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var packages []*Package
 	resp, err := s.client.Do(ctx, req, &packages)
 	if err != nil {
 		return nil, resp, err
 	}
+
 	return packages, resp, nil
 }
 
-// Get a package by name from an organization
+// Get a package by name from an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-a-package-for-an-organization
 func (s *OrganizationsService) GetPackage(ctx context.Context, org, packageType, packageName string) (*Package, *Response, error) {
@@ -40,15 +43,17 @@ func (s *OrganizationsService) GetPackage(ctx context.Context, org, packageType,
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var pack *Package
 	resp, err := s.client.Do(ctx, req, &pack)
 	if err != nil {
 		return nil, resp, err
 	}
+
 	return pack, resp, nil
 }
 
-// Delete a package from an organization
+// Delete a package from an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#delete-a-package-for-an-organization
 func (s *OrganizationsService) DeletePackage(ctx context.Context, org, packageType, packageName string) (*Response, error) {
@@ -57,11 +62,11 @@ func (s *OrganizationsService) DeletePackage(ctx context.Context, org, packageTy
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
 
+	return s.client.Do(ctx, req, nil)
 }
 
-// Restore a package to an organization
+// Restore a package to an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#restore-a-package-for-an-organization
 func (s *OrganizationsService) RestorePackage(ctx context.Context, org, packageType, packageName string) (*Response, error) {
@@ -70,11 +75,11 @@ func (s *OrganizationsService) RestorePackage(ctx context.Context, org, packageT
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
 
+	return s.client.Do(ctx, req, nil)
 }
 
-// Get all versions of a package in an organization
+// Get all versions of a package in an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-all-package-versions-for-a-package-owned-by-an-organization
 func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, packageType, packageName string, opts *PackageListOptions) ([]*PackageVersion, *Response, error) {
@@ -83,20 +88,22 @@ func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, p
 	if err != nil {
 		return nil, nil, err
 	}
+
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var versions []*PackageVersion
 	resp, err := s.client.Do(ctx, req, &versions)
 	if err != nil {
 		return nil, resp, err
 	}
-	return versions, resp, nil
 
+	return versions, resp, nil
 }
 
-// Get a specific version of a package in an organization
+// Get a specific version of a package in an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-a-package-version-for-an-organization
 func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*PackageVersion, *Response, error) {
@@ -105,16 +112,17 @@ func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packa
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var version *PackageVersion
 	resp, err := s.client.Do(ctx, req, &version)
 	if err != nil {
 		return nil, resp, err
 	}
-	return version, resp, nil
 
+	return version, resp, nil
 }
 
-// Delete a package version from an organization
+// Delete a package version from an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#delete-package-version-for-an-organization
 func (s *OrganizationsService) PackageDeleteVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*Response, error) {
@@ -123,11 +131,11 @@ func (s *OrganizationsService) PackageDeleteVersion(ctx context.Context, org, pa
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
 
+	return s.client.Do(ctx, req, nil)
 }
 
-// Restore a package version to an organization
+// Restore a package version to an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#restore-package-version-for-an-organization
 func (s *OrganizationsService) PackageRestoreVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*Response, error) {
@@ -136,6 +144,6 @@ func (s *OrganizationsService) PackageRestoreVersion(ctx context.Context, org, p
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
 
+	return s.client.Do(ctx, req, nil)
 }

--- a/github/orgs_packages.go
+++ b/github/orgs_packages.go
@@ -1,0 +1,137 @@
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// List the packages for an organization
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#list-packages-for-an-organization
+func (s *OrganizationsService) ListPackages(ctx context.Context, org string) ([]*Package, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/packages", org)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var packages []*Package
+	resp, err := s.client.Do(ctx, req, &packages)
+	if err != nil {
+		return nil, resp, err
+	}
+	return packages, resp, nil
+}
+
+// Get a package by name from an organization
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-a-package-for-an-organization
+func (s *OrganizationsService) GetPackage(ctx context.Context, org, packageType, packageName string) (*Package, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/packages/%v/%v", org, packageType, packageName)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var pack *Package
+	resp, err := s.client.Do(ctx, req, &pack)
+	if err != nil {
+		return nil, resp, err
+	}
+	return pack, resp, nil
+}
+
+// Delete a package from an organization
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#delete-a-package-for-an-organization
+func (s *OrganizationsService) DeletePackage(ctx context.Context, org, packageType, packageName string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/packages/%v/%v", org, packageType, packageName)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+
+}
+
+// Restore a package to an organization
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#restore-a-package-for-an-organization
+func (s *OrganizationsService) RestorePackage(ctx context.Context, org, packageType, packageName string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/packages/%v/%v/restore", org, packageType, packageName)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+
+}
+
+// Get all versions of a package in an organization
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-all-package-versions-for-a-package-owned-by-an-organization
+func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, packageType, packageName string, opts *ListOptions) ([]*PackageVersion, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions", org, packageType, packageName)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var versions []*PackageVersion
+	resp, err := s.client.Do(ctx, req, &versions)
+	if err != nil {
+		return nil, resp, err
+	}
+	return versions, resp, nil
+
+}
+
+// Get a specific version of a package in an organization
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-a-package-version-for-an-organization
+func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packageType, packageName, packageVersionID string) (*PackageVersion, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v", org, packageType, packageName, packageVersionID)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var version *PackageVersion
+	resp, err := s.client.Do(ctx, req, &version)
+	if err != nil {
+		return nil, resp, err
+	}
+	return version, resp, nil
+
+}
+
+// Delete a package version from an organization
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#delete-package-version-for-an-organization
+func (s *OrganizationsService) DeletePackageVersion(ctx context.Context, org, packageType, packageName, packageVersionID string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v", org, packageType, packageName, packageVersionID)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+
+}
+
+// Restore a package version to an organization
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#restore-package-version-for-an-organization
+func (s *OrganizationsService) RestorePackageVersion(ctx context.Context, org, packageType, packageName, packageVersionID string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v/restore", org, packageType, packageName, packageVersionID)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+
+}

--- a/github/orgs_packages_test.go
+++ b/github/orgs_packages_test.go
@@ -18,7 +18,7 @@ func TestOrganizationsService_ListPackages(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/test/packages", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/packages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{
 			"id": 197,
@@ -55,7 +55,7 @@ func TestOrganizationsService_ListPackages(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	packages, _, err := client.Organizations.ListPackages(ctx, "test", nil)
+	packages, _, err := client.Organizations.ListPackages(ctx, "o", nil)
 	if err != nil {
 		t.Errorf("Organizations.ListPackages returned error: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestOrganizationsService_ListPackages(t *testing.T) {
 
 	const methodName = "ListPackages"
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Organizations.ListPackages(ctx, "test", nil)
+		got, resp, err := client.Organizations.ListPackages(ctx, "o", nil)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -109,7 +109,7 @@ func TestOrganizationsService_GetPackage(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/test/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
 			"id": 197,
@@ -125,7 +125,7 @@ func TestOrganizationsService_GetPackage(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	packages, _, err := client.Organizations.GetPackage(ctx, "test", "container", "hello_docker")
+	packages, _, err := client.Organizations.GetPackage(ctx, "o", "container", "hello_docker")
 	if err != nil {
 		t.Errorf("Organizations.GetPackage returned error: %v", err)
 	}
@@ -159,12 +159,12 @@ func TestOrganizationsService_DeletePackage(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/test/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
 	ctx := context.Background()
-	_, err := client.Organizations.DeletePackage(ctx, "test", "container", "hello_docker")
+	_, err := client.Organizations.DeletePackage(ctx, "o", "container", "hello_docker")
 	if err != nil {
 		t.Errorf("Organizations.DeletePackage returned error: %v", err)
 	}
@@ -183,12 +183,12 @@ func TestOrganizationsService_RestorePackage(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/test/packages/container/hello_docker/restore", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/packages/container/hello_docker/restore", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 
 	ctx := context.Background()
-	_, err := client.Organizations.RestorePackage(ctx, "test", "container", "hello_docker")
+	_, err := client.Organizations.RestorePackage(ctx, "o", "container", "hello_docker")
 	if err != nil {
 		t.Errorf("Organizations.RestorePackage returned error: %v", err)
 	}
@@ -203,9 +203,9 @@ func TestOrganizationsService_ListPackagesVersions(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/test/packages/container/hello_docker/versions", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/packages/container/hello_docker/versions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testFormValues(t, r, values{"per_page": "10", "page": "2", "state": "deleted"})
+		testFormValues(t, r, values{"per_page": "2", "page": "1", "state": "deleted", "visibility": "internal", "package_type": "container"})
 		fmt.Fprint(w, `[
 			{
 			  "id": 45763,
@@ -227,7 +227,10 @@ func TestOrganizationsService_ListPackagesVersions(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	packages, _, err := client.Organizations.PackageGetAllVersions(ctx, "test", "container", "hello_docker", &PackageListOptions{State: String("deleted")})
+	opts := &PackageListOptions{
+		String("internal"), String("container"), String("deleted"), ListOptions{Page: 1, PerPage: 2},
+	}
+	packages, _, err := client.Organizations.PackageGetAllVersions(ctx, "o", "container", "hello_docker", opts)
 	if err != nil {
 		t.Errorf("Organizations.PackageGetAllVersions returned error: %v", err)
 	}
@@ -265,7 +268,7 @@ func TestOrganizationsService_PackageGetVersion(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/test/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `
 			{
@@ -288,7 +291,7 @@ func TestOrganizationsService_PackageGetVersion(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	packages, _, err := client.Organizations.PackageGetVersion(ctx, "test", "container", "hello_docker", 45763)
+	packages, _, err := client.Organizations.PackageGetVersion(ctx, "o", "container", "hello_docker", 45763)
 	if err != nil {
 		t.Errorf("Organizations.PackageGetVersion returned error: %v", err)
 	}
@@ -326,12 +329,12 @@ func TestOrganizationsService_PackageDeleteVersion(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/test/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
 	ctx := context.Background()
-	_, err := client.Organizations.PackageDeleteVersion(ctx, "test", "container", "hello_docker", 45763)
+	_, err := client.Organizations.PackageDeleteVersion(ctx, "o", "container", "hello_docker", 45763)
 	if err != nil {
 		t.Errorf("Organizations.PackageDeleteVersion returned error: %v", err)
 	}
@@ -347,12 +350,12 @@ func TestOrganizationsService_PackageRestoreVersion(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/test/packages/container/hello_docker/versions/45763/restore", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/packages/container/hello_docker/versions/45763/restore", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 
 	ctx := context.Background()
-	_, err := client.Organizations.PackageRestoreVersion(ctx, "test", "container", "hello_docker", 45763)
+	_, err := client.Organizations.PackageRestoreVersion(ctx, "o", "container", "hello_docker", 45763)
 	if err != nil {
 		t.Errorf("Organizations.PackageRestoreVersion returned error: %v", err)
 	}

--- a/github/orgs_packages_test.go
+++ b/github/orgs_packages_test.go
@@ -55,7 +55,7 @@ func TestOrganizationsService_ListPackages(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	packages, _, err := client.Organizations.ListPackages(ctx, "o", nil)
+	packages, _, err := client.Organizations.ListPackages(ctx, "o", &PackageListOptions{})
 	if err != nil {
 		t.Errorf("Organizations.ListPackages returned error: %v", err)
 	}

--- a/github/orgs_packages_test.go
+++ b/github/orgs_packages_test.go
@@ -227,7 +227,7 @@ func TestOrganizationsService_ListPackagesVersions(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	packages, _, err := client.Organizations.PackageGetAllVersions(ctx, "test", "container", "hello_docker", &PackageListOptions{PerPage: 10, Page: 2, State: "deleted"})
+	packages, _, err := client.Organizations.PackageGetAllVersions(ctx, "test", "container", "hello_docker", &PackageListOptions{State: String("deleted")})
 	if err != nil {
 		t.Errorf("Organizations.PackageGetAllVersions returned error: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestOrganizationsService_ListPackagesVersions(t *testing.T) {
 		Metadata: &PackageMetadata{
 			PackageType: String("container"),
 			Container: &PackageContainerMetadata{
-				Tags: []*string{String("latest")},
+				Tags: []string{"latest"},
 			},
 		},
 	}}
@@ -304,7 +304,7 @@ func TestOrganizationsService_PackageGetVersion(t *testing.T) {
 		Metadata: &PackageMetadata{
 			PackageType: String("container"),
 			Container: &PackageContainerMetadata{
-				Tags: []*string{String("latest")},
+				Tags: []string{"latest"},
 			},
 		},
 	}

--- a/github/orgs_packages_test.go
+++ b/github/orgs_packages_test.go
@@ -1,0 +1,365 @@
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestOrganizationsService_ListPackages(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/test/packages", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{
+			"id": 197,
+			"name": "hello_docker",
+			"package_type": "container",
+			"owner": {
+			  "login": "github",
+			  "id": 9919,
+			  "node_id": "MDEyOk9yZ2FuaXphdGlvbjk5MTk=",
+			  "avatar_url": "https://avatars.githubusercontent.com/u/9919?v=4",
+			  "gravatar_id": "",
+			  "url": "https://api.github.com/users/github",
+			  "html_url": "https://github.com/github",
+			  "followers_url": "https://api.github.com/users/github/followers",
+			  "following_url": "https://api.github.com/users/github/following{/other_user}",
+			  "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+			  "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+			  "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+			  "organizations_url": "https://api.github.com/users/github/orgs",
+			  "repos_url": "https://api.github.com/users/github/repos",
+			  "events_url": "https://api.github.com/users/github/events{/privacy}",
+			  "received_events_url": "https://api.github.com/users/github/received_events",
+			  "type": "Organization",
+			  "site_admin": false
+			},
+			"version_count": 1,
+			"visibility": "private",
+			"url": "https://api.github.com/orgs/github/packages/container/hello_docker",
+			"created_at": `+referenceTimeStr+`,
+			"updated_at": `+referenceTimeStr+`,
+			"html_url": "https://github.com/orgs/github/packages/container/package/hello_docker"
+		  }
+		  ]`)
+	})
+
+	ctx := context.Background()
+	packages, _, err := client.Organizations.ListPackages(ctx, "test", nil)
+	if err != nil {
+		t.Errorf("Organizations.ListPackages returned error: %v", err)
+	}
+
+	want := []*Package{{
+		ID:           Int64(197),
+		Name:         String("hello_docker"),
+		PackageType:  String("container"),
+		VersionCount: Int64(1),
+		Visibility:   String("private"),
+		URL:          String("https://api.github.com/orgs/github/packages/container/hello_docker"),
+		HTMLURL:      String("https://github.com/orgs/github/packages/container/package/hello_docker"),
+		CreatedAt:    &Timestamp{referenceTime},
+		UpdatedAt:    &Timestamp{referenceTime},
+		Owner: &User{
+			Login:             String("github"),
+			ID:                Int64(9919),
+			NodeID:            String("MDEyOk9yZ2FuaXphdGlvbjk5MTk="),
+			AvatarURL:         String("https://avatars.githubusercontent.com/u/9919?v=4"),
+			GravatarID:        String(""),
+			URL:               String("https://api.github.com/users/github"),
+			HTMLURL:           String("https://github.com/github"),
+			FollowersURL:      String("https://api.github.com/users/github/followers"),
+			FollowingURL:      String("https://api.github.com/users/github/following{/other_user}"),
+			GistsURL:          String("https://api.github.com/users/github/gists{/gist_id}"),
+			StarredURL:        String("https://api.github.com/users/github/starred{/owner}{/repo}"),
+			SubscriptionsURL:  String("https://api.github.com/users/github/subscriptions"),
+			OrganizationsURL:  String("https://api.github.com/users/github/orgs"),
+			ReposURL:          String("https://api.github.com/users/github/repos"),
+			EventsURL:         String("https://api.github.com/users/github/events{/privacy}"),
+			ReceivedEventsURL: String("https://api.github.com/users/github/received_events"),
+			Type:              String("Organization"),
+			SiteAdmin:         Bool(false),
+		},
+	}}
+	if !cmp.Equal(packages, want) {
+		t.Errorf("Organizations.ListPackages returned %+v, want %+v", packages, want)
+	}
+
+	const methodName = "ListPackages"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Organizations.ListPackages(ctx, "test", nil)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestOrganizationsService_GetPackage(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/test/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"id": 197,
+			"name": "hello_docker",
+			"package_type": "container",
+			"version_count": 1,
+			"visibility": "private",
+			"url": "https://api.github.com/orgs/github/packages/container/hello_docker",
+			"created_at": `+referenceTimeStr+`,
+			"updated_at": `+referenceTimeStr+`,
+			"html_url": "https://github.com/orgs/github/packages/container/package/hello_docker"
+		  }`)
+	})
+
+	ctx := context.Background()
+	packages, _, err := client.Organizations.GetPackage(ctx, "test", "container", "hello_docker")
+	if err != nil {
+		t.Errorf("Organizations.GetPackage returned error: %v", err)
+	}
+
+	want := &Package{
+		ID:           Int64(197),
+		Name:         String("hello_docker"),
+		PackageType:  String("container"),
+		VersionCount: Int64(1),
+		Visibility:   String("private"),
+		URL:          String("https://api.github.com/orgs/github/packages/container/hello_docker"),
+		HTMLURL:      String("https://github.com/orgs/github/packages/container/package/hello_docker"),
+		CreatedAt:    &Timestamp{referenceTime},
+		UpdatedAt:    &Timestamp{referenceTime},
+	}
+	if !cmp.Equal(packages, want) {
+		t.Errorf("Organizations.GetPackage returned %+v, want %+v", packages, want)
+	}
+
+	const methodName = "GetPackage"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Organizations.GetPackage(ctx, "", "", "")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestOrganizationsService_DeletePackage(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/test/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	ctx := context.Background()
+	_, err := client.Organizations.DeletePackage(ctx, "test", "container", "hello_docker")
+	if err != nil {
+		t.Errorf("Organizations.DeletePackage returned error: %v", err)
+	}
+
+	const methodName = "DeletePackage"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Organizations.GetPackage(ctx, "", "", "")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestOrganizationsService_RestorePackage(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/test/packages/container/hello_docker/restore", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	ctx := context.Background()
+	_, err := client.Organizations.RestorePackage(ctx, "test", "container", "hello_docker")
+	if err != nil {
+		t.Errorf("Organizations.RestorePackage returned error: %v", err)
+	}
+
+	const methodName = "RestorePackage"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Organizations.RestorePackage(ctx, "", "container", "hello_docker")
+	})
+}
+
+func TestOrganizationsService_ListPackagesVersions(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/test/packages/container/hello_docker/versions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"per_page": "10", "page": "2", "state": "deleted"})
+		fmt.Fprint(w, `[
+			{
+			  "id": 45763,
+			  "name": "sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9",
+			  "url": "https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763",
+			  "package_html_url": "https://github.com/users/octocat/packages/container/package/hello_docker",
+			  "created_at": `+referenceTimeStr+`,
+			  "updated_at": `+referenceTimeStr+`,
+			  "html_url": "https://github.com/users/octocat/packages/container/hello_docker/45763",
+			  "metadata": {
+				"package_type": "container",
+				"container": {
+				  "tags": [
+					"latest"
+				  ]
+				}
+			  }
+			}]`)
+	})
+
+	ctx := context.Background()
+	packages, _, err := client.Organizations.PackageGetAllVersions(ctx, "test", "container", "hello_docker", &PackageListOptions{PerPage: 10, Page: 2, State: "deleted"})
+	if err != nil {
+		t.Errorf("Organizations.PackageGetAllVersions returned error: %v", err)
+	}
+
+	want := []*PackageVersion{{
+		ID:             Int64(45763),
+		Name:           String("sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9"),
+		URL:            String("https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763"),
+		PackageHTMLURL: String("https://github.com/users/octocat/packages/container/package/hello_docker"),
+		CreatedAt:      &Timestamp{referenceTime},
+		UpdatedAt:      &Timestamp{referenceTime},
+		HTMLURL:        String("https://github.com/users/octocat/packages/container/hello_docker/45763"),
+		Metadata: &PackageMetadata{
+			PackageType: String("container"),
+			Container: &PackageContainerMetadata{
+				Tags: []*string{String("latest")},
+			},
+		},
+	}}
+	if !cmp.Equal(packages, want) {
+		t.Errorf("Organizations.PackageGetAllVersions returned %+v, want %+v", packages, want)
+	}
+
+	const methodName = "PackageGetAllVersions"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Organizations.PackageGetAllVersions(ctx, "", "", "", nil)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestOrganizationsService_PackageGetVersion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/test/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `
+			{
+			  "id": 45763,
+			  "name": "sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9",
+			  "url": "https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763",
+			  "package_html_url": "https://github.com/users/octocat/packages/container/package/hello_docker",
+			  "created_at": `+referenceTimeStr+`,
+			  "updated_at": `+referenceTimeStr+`,
+			  "html_url": "https://github.com/users/octocat/packages/container/hello_docker/45763",
+			  "metadata": {
+				"package_type": "container",
+				"container": {
+				  "tags": [
+					"latest"
+				  ]
+				}
+			  }
+			}`)
+	})
+
+	ctx := context.Background()
+	packages, _, err := client.Organizations.PackageGetVersion(ctx, "test", "container", "hello_docker", 45763)
+	if err != nil {
+		t.Errorf("Organizations.PackageGetVersion returned error: %v", err)
+	}
+
+	want := &PackageVersion{
+		ID:             Int64(45763),
+		Name:           String("sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9"),
+		URL:            String("https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763"),
+		PackageHTMLURL: String("https://github.com/users/octocat/packages/container/package/hello_docker"),
+		CreatedAt:      &Timestamp{referenceTime},
+		UpdatedAt:      &Timestamp{referenceTime},
+		HTMLURL:        String("https://github.com/users/octocat/packages/container/hello_docker/45763"),
+		Metadata: &PackageMetadata{
+			PackageType: String("container"),
+			Container: &PackageContainerMetadata{
+				Tags: []*string{String("latest")},
+			},
+		},
+	}
+	if !cmp.Equal(packages, want) {
+		t.Errorf("Organizations.PackageGetVersion returned %+v, want %+v", packages, want)
+	}
+
+	const methodName = "PackageGetVersion"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Organizations.PackageGetVersion(ctx, "", "", "", 45763)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestOrganizationsService_PackageDeleteVersion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/test/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	ctx := context.Background()
+	_, err := client.Organizations.PackageDeleteVersion(ctx, "test", "container", "hello_docker", 45763)
+	if err != nil {
+		t.Errorf("Organizations.PackageDeleteVersion returned error: %v", err)
+	}
+
+	const methodName = "PackageDeleteVersion"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Organizations.PackageDeleteVersion(ctx, "", "", "", 45763)
+
+	})
+}
+
+func TestOrganizationsService_PackageRestoreVersion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/test/packages/container/hello_docker/versions/45763/restore", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	ctx := context.Background()
+	_, err := client.Organizations.PackageRestoreVersion(ctx, "test", "container", "hello_docker", 45763)
+	if err != nil {
+		t.Errorf("Organizations.PackageRestoreVersion returned error: %v", err)
+	}
+
+	const methodName = "PackageRestoreVersion"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Organizations.PackageRestoreVersion(ctx, "", "", "", 45763)
+
+	})
+}

--- a/github/orgs_packages_test.go
+++ b/github/orgs_packages_test.go
@@ -96,6 +96,11 @@ func TestOrganizationsService_ListPackages(t *testing.T) {
 	}
 
 	const methodName = "ListPackages"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.ListPackages(ctx, "\n", nil)
+		return err
+	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		got, resp, err := client.Organizations.ListPackages(ctx, "o", nil)
 		if got != nil {
@@ -146,6 +151,11 @@ func TestOrganizationsService_GetPackage(t *testing.T) {
 	}
 
 	const methodName = "GetPackage"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.GetPackage(ctx, "\n", "", "")
+		return err
+	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		got, resp, err := client.Organizations.GetPackage(ctx, "", "", "")
 		if got != nil {
@@ -170,6 +180,11 @@ func TestOrganizationsService_DeletePackage(t *testing.T) {
 	}
 
 	const methodName = "DeletePackage"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.GetPackage(ctx, "\n", "", "")
+		return err
+	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		got, resp, err := client.Organizations.GetPackage(ctx, "", "", "")
 		if got != nil {
@@ -194,6 +209,11 @@ func TestOrganizationsService_RestorePackage(t *testing.T) {
 	}
 
 	const methodName = "RestorePackage"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Organizations.RestorePackage(ctx, "\n", "", "")
+		return err
+	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Organizations.RestorePackage(ctx, "", "container", "hello_docker")
 	})
@@ -255,6 +275,11 @@ func TestOrganizationsService_ListPackagesVersions(t *testing.T) {
 	}
 
 	const methodName = "PackageGetAllVersions"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.PackageGetAllVersions(ctx, "\n", "", "", nil)
+		return err
+	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		got, resp, err := client.Organizations.PackageGetAllVersions(ctx, "", "", "", nil)
 		if got != nil {
@@ -316,6 +341,11 @@ func TestOrganizationsService_PackageGetVersion(t *testing.T) {
 	}
 
 	const methodName = "PackageGetVersion"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.PackageGetVersion(ctx, "\n", "", "", 0)
+		return err
+	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		got, resp, err := client.Organizations.PackageGetVersion(ctx, "", "", "", 45763)
 		if got != nil {
@@ -340,6 +370,11 @@ func TestOrganizationsService_PackageDeleteVersion(t *testing.T) {
 	}
 
 	const methodName = "PackageDeleteVersion"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Organizations.PackageDeleteVersion(ctx, "\n", "", "", 0)
+		return err
+	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Organizations.PackageDeleteVersion(ctx, "", "", "", 45763)
 
@@ -361,6 +396,11 @@ func TestOrganizationsService_PackageRestoreVersion(t *testing.T) {
 	}
 
 	const methodName = "PackageRestoreVersion"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Organizations.PackageRestoreVersion(ctx, "\n", "", "", 0)
+		return err
+	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Organizations.PackageRestoreVersion(ctx, "", "", "", 45763)
 

--- a/github/orgs_packages_test.go
+++ b/github/orgs_packages_test.go
@@ -97,12 +97,12 @@ func TestOrganizationsService_ListPackages(t *testing.T) {
 
 	const methodName = "ListPackages"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Organizations.ListPackages(ctx, "\n", nil)
+		_, _, err = client.Organizations.ListPackages(ctx, "\n", &PackageListOptions{})
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Organizations.ListPackages(ctx, "o", nil)
+		got, resp, err := client.Organizations.ListPackages(ctx, "o", &PackageListOptions{})
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -276,12 +276,12 @@ func TestOrganizationsService_ListPackagesVersions(t *testing.T) {
 
 	const methodName = "PackageGetAllVersions"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Organizations.PackageGetAllVersions(ctx, "\n", "", "", nil)
+		_, _, err = client.Organizations.PackageGetAllVersions(ctx, "\n", "", "", &PackageListOptions{})
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Organizations.PackageGetAllVersions(ctx, "", "", "", nil)
+		got, resp, err := client.Organizations.PackageGetAllVersions(ctx, "", "", "", &PackageListOptions{})
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/github/packages.go
+++ b/github/packages.go
@@ -16,6 +16,9 @@ type Package struct {
 	Owner          *User            `json:"owner,omitempty"`
 	PackageVersion *PackageVersion  `json:"package_version,omitempty"`
 	Registry       *PackageRegistry `json:"registry,omitempty"`
+	URL            *string          `json:"url,omitempty"`
+	VersionCount   *int64           `json:"version_count,omitempty"`
+	Visibility     *string          `json:"visibility,omitempty"`
 }
 
 func (p Package) String() string {
@@ -24,24 +27,26 @@ func (p Package) String() string {
 
 // PackageVersion represents a GitHub package version.
 type PackageVersion struct {
-	ID                  *int64          `json:"id,omitempty"`
-	Version             *string         `json:"version,omitempty"`
-	Summary             *string         `json:"summary,omitempty"`
-	Body                *string         `json:"body,omitempty"`
-	BodyHTML            *string         `json:"body_html,omitempty"`
-	Release             *PackageRelease `json:"release,omitempty"`
-	Manifest            *string         `json:"manifest,omitempty"`
-	HTMLURL             *string         `json:"html_url,omitempty"`
-	TagName             *string         `json:"tag_name,omitempty"`
-	TargetCommitish     *string         `json:"target_commitish,omitempty"`
-	TargetOID           *string         `json:"target_oid,omitempty"`
-	Draft               *bool           `json:"draft,omitempty"`
-	Prerelease          *bool           `json:"prerelease,omitempty"`
-	CreatedAt           *Timestamp      `json:"created_at,omitempty"`
-	UpdatedAt           *Timestamp      `json:"updated_at,omitempty"`
-	PackageFiles        []*PackageFile  `json:"package_files,omitempty"`
-	Author              *User           `json:"author,omitempty"`
-	InstallationCommand *string         `json:"installation_command,omitempty"`
+	ID                  *int64           `json:"id,omitempty"`
+	Version             *string          `json:"version,omitempty"`
+	Summary             *string          `json:"summary,omitempty"`
+	Body                *string          `json:"body,omitempty"`
+	BodyHTML            *string          `json:"body_html,omitempty"`
+	Release             *PackageRelease  `json:"release,omitempty"`
+	Manifest            *string          `json:"manifest,omitempty"`
+	HTMLURL             *string          `json:"html_url,omitempty"`
+	TagName             *string          `json:"tag_name,omitempty"`
+	TargetCommitish     *string          `json:"target_commitish,omitempty"`
+	TargetOID           *string          `json:"target_oid,omitempty"`
+	Draft               *bool            `json:"draft,omitempty"`
+	Prerelease          *bool            `json:"prerelease,omitempty"`
+	CreatedAt           *Timestamp       `json:"created_at,omitempty"`
+	UpdatedAt           *Timestamp       `json:"updated_at,omitempty"`
+	PackageFiles        []*PackageFile   `json:"package_files,omitempty"`
+	Author              *User            `json:"author,omitempty"`
+	InstallationCommand *string          `json:"installation_command,omitempty"`
+	Metadata            *PackageMetadata `json:"metadata,omitempty"`
+	PackageHTMLURL      *string          `json:"package_html_url,omitempty"`
 }
 
 func (pv PackageVersion) String() string {
@@ -98,4 +103,15 @@ type PackageRegistry struct {
 
 func (r PackageRegistry) String() string {
 	return Stringify(r)
+}
+
+// PackageMetadata represents metadata from a package
+type PackageMetadata struct {
+	PackageType *string                   `json:"package_type,omitempty"`
+	Container   *PackageContainerMetadata `json:"container,omitempty"`
+}
+
+// PackageContainerMetadata represents container metadata for docker container packages
+type PackageContainerMetadata struct {
+	Tags []*string `json:"tags,omitempty"`
 }

--- a/github/packages.go
+++ b/github/packages.go
@@ -47,6 +47,8 @@ type PackageVersion struct {
 	InstallationCommand *string          `json:"installation_command,omitempty"`
 	Metadata            *PackageMetadata `json:"metadata,omitempty"`
 	PackageHTMLURL      *string          `json:"package_html_url,omitempty"`
+	Name                *string          `json:"name,omitempty"`
+	URL                 *string          `json:"url,omitempty"`
 }
 
 func (pv PackageVersion) String() string {
@@ -105,13 +107,39 @@ func (r PackageRegistry) String() string {
 	return Stringify(r)
 }
 
+// PackageListOptions represents the optional list options for a package
+type PackageListOptions struct {
+	// Visibility of packages public, internal or private
+	Visibility string `url:"visibility,omitempty"`
+
+	// Type of package
+	PackageType string `url:"package_type,omitempty"`
+
+	// State of package either active or deleted
+	State string `url:"state,omitempty"`
+
+	// For paginated result sets, page of results to retrieve.
+	Page int `url:"page,omitempty"`
+
+	// For paginated result sets, the number of results to include per page.
+	PerPage int `url:"per_page,omitempty"`
+}
+
 // PackageMetadata represents metadata from a package
 type PackageMetadata struct {
 	PackageType *string                   `json:"package_type,omitempty"`
 	Container   *PackageContainerMetadata `json:"container,omitempty"`
 }
 
+func (r PackageMetadata) String() string {
+	return Stringify(r)
+}
+
 // PackageContainerMetadata represents container metadata for docker container packages
 type PackageContainerMetadata struct {
 	Tags []*string `json:"tags,omitempty"`
+}
+
+func (r PackageContainerMetadata) String() string {
+	return Stringify(r)
 }

--- a/github/packages.go
+++ b/github/packages.go
@@ -19,6 +19,7 @@ type Package struct {
 	URL            *string          `json:"url,omitempty"`
 	VersionCount   *int64           `json:"version_count,omitempty"`
 	Visibility     *string          `json:"visibility,omitempty"`
+	Repository     *Repository      `json:"repository,omitempty"`
 }
 
 func (p Package) String() string {
@@ -107,25 +108,22 @@ func (r PackageRegistry) String() string {
 	return Stringify(r)
 }
 
-// PackageListOptions represents the optional list options for a package
+// PackageListOptions represents the optional list options for a package.
 type PackageListOptions struct {
-	// Visibility of packages public, internal or private
-	Visibility string `url:"visibility,omitempty"`
+	// Visibility of packages "public", "internal" or "private".
+	Visibility *string `url:"visibility,omitempty"`
 
-	// Type of package
-	PackageType string `url:"package_type,omitempty"`
+	// PackageType represents the type of package.
+	// It can be one of "npm", "maven", "rubygems", "nuget", "docker", or "container".
+	PackageType *string `url:"package_type,omitempty"`
 
-	// State of package either active or deleted
-	State string `url:"state,omitempty"`
+	// State of package either "active" or "deleted".
+	State *string `url:"state,omitempty"`
 
-	// For paginated result sets, page of results to retrieve.
-	Page int `url:"page,omitempty"`
-
-	// For paginated result sets, the number of results to include per page.
-	PerPage int `url:"per_page,omitempty"`
+	ListOptions
 }
 
-// PackageMetadata represents metadata from a package
+// PackageMetadata represents metadata from a package.
 type PackageMetadata struct {
 	PackageType *string                   `json:"package_type,omitempty"`
 	Container   *PackageContainerMetadata `json:"container,omitempty"`
@@ -135,9 +133,9 @@ func (r PackageMetadata) String() string {
 	return Stringify(r)
 }
 
-// PackageContainerMetadata represents container metadata for docker container packages
+// PackageContainerMetadata represents container metadata for docker container packages.
 type PackageContainerMetadata struct {
-	Tags []*string `json:"tags,omitempty"`
+	Tags []string `json:"tags,omitempty"`
 }
 
 func (r PackageContainerMetadata) String() string {

--- a/github/packages_test.go
+++ b/github/packages_test.go
@@ -400,6 +400,7 @@ func TestPackage_Marshal(t *testing.T) {
 		HTMLURL:     String("hurl"),
 		CreatedAt:   &Timestamp{referenceTime},
 		UpdatedAt:   &Timestamp{referenceTime},
+		Visibility:  String("private"),
 		Owner: &User{
 			Login:           String("l"),
 			ID:              Int64(1),
@@ -540,6 +541,7 @@ func TestPackage_Marshal(t *testing.T) {
 		"html_url": "hurl",
 		"created_at": ` + referenceTimeStr + `,
 		"updated_at": ` + referenceTimeStr + `,
+		"visibility": "private",
 		"owner": {
 			"login": "l",
 			"id": 1,

--- a/github/users_packages.go
+++ b/github/users_packages.go
@@ -1,0 +1,193 @@
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// List the packages for a user. Passing the empty string will
+// list packages for the authenticated user.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#list-packages-for-the-authenticated-users-namespace
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#list-packages-for-a-user
+func (s *UsersService) ListPackages(ctx context.Context, user string) ([]*Package, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("user/%v/packages", user)
+	} else {
+		u = "user/packages"
+	}
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var packages []*Package
+	resp, err := s.client.Do(ctx, req, &packages)
+	if err != nil {
+		return nil, resp, err
+	}
+	return packages, resp, nil
+}
+
+// Get a package by name for a user. Passing the empty string will
+// get the package for the authenticated user.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-a-package-for-the-authenticated-user
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-a-package-for-a-user
+func (s *UsersService) GetPackage(ctx context.Context, user, packageType, packageName string) (*Package, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/packages/%v/%v", user, packageType, packageName)
+	} else {
+		u = fmt.Sprintf("user/package/%v/%v", packageType, packageName)
+	}
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var pack *Package
+	resp, err := s.client.Do(ctx, req, &pack)
+	if err != nil {
+		return nil, resp, err
+	}
+	return pack, resp, nil
+}
+
+// Delete a package from a user. Passing the empty string will
+// delete the package for the authenticated user.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#delete-a-package-for-the-authenticated-user
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#delete-a-package-for-a-user
+func (s *UsersService) DeletePackage(ctx context.Context, user, packageType, packageName string) (*Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/packages/%v/%v", user, packageType, packageName)
+	} else {
+		u = fmt.Sprintf("user/package/%v/%v", packageType, packageName)
+	}
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+
+}
+
+// Restore a package to a user. Passing the empty string will
+// restore the package for the authenticated user.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#restore-a-package-for-the-authenticated-user
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#restore-a-package-for-a-user
+func (s *UsersService) RestorePackage(ctx context.Context, user, packageType, packageName string) (*Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/packages/%v/%v/restore", user, packageType, packageName)
+	} else {
+		u = fmt.Sprintf("user/package/%v/%v/restore", packageType, packageName)
+	}
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+
+}
+
+// Get all versions of a package for a user. Passing the empty string will
+// get versions for the authenticated user.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-all-package-versions-for-a-package-owned-by-the-authenticated-user
+// GitHub API docs: https://docs.github.com/en/rest/reference/users#delete-an-email-address-for-the-authenticated-user
+func (s *UsersService) PackageGetAllVersions(ctx context.Context, user, packageType, packageName string, opts *ListOptions) ([]*PackageVersion, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/packages/%v/%v/versions", user, packageType, packageName)
+	} else {
+		u = fmt.Sprintf("user/package/%v/%v/versions", packageType, packageName)
+	}
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var versions []*PackageVersion
+	resp, err := s.client.Do(ctx, req, &versions)
+	if err != nil {
+		return nil, resp, err
+	}
+	return versions, resp, nil
+
+}
+
+// Get a specific version of a package in for a user. Passing the empty string will
+// get the version for the authenticated user.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-a-package-version-for-the-authenticated-user
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-a-package-version-for-a-user
+func (s *UsersService) PackageGetVersion(ctx context.Context, user, packageType, packageName, packageVersionID string) (*PackageVersion, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/packages/%v/%v/versions/%v", user, packageType, packageName, packageVersionID)
+	} else {
+		u = fmt.Sprintf("user/package/%v/%v/versions/%v", packageType, packageName, packageVersionID)
+	}
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var version *PackageVersion
+	resp, err := s.client.Do(ctx, req, &version)
+	if err != nil {
+		return nil, resp, err
+	}
+	return version, resp, nil
+
+}
+
+// Delete a package version for a user. Passing the empty string will
+// delete the version for the authenticated user.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#delete-a-package-version-for-the-authenticated-user
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#delete-package-version-for-a-user
+func (s *UsersService) DeletePackageVersion(ctx context.Context, user, packageType, packageName, packageVersionID string) (*Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/packages/%v/%v/versions/%v", user, packageType, packageName, packageVersionID)
+	} else {
+		u = fmt.Sprintf("user/package/%v/%v/versions/%v", packageType, packageName, packageVersionID)
+	}
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+
+}
+
+// Restore a package version to a user. Passing the empty string will
+// restore the version for the authenticated user.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#restore-a-package-version-for-the-authenticated-user
+// GitHub API docs: https://docs.github.com/en/rest/reference/packages#restore-package-version-for-a-user
+func (s *UsersService) RestorePackageVersion(ctx context.Context, user, packageType, packageName, packageVersionID string) (*Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/packages/%v/%v/versions/%v/restore", user, packageType, packageName, packageVersionID)
+	} else {
+		u = fmt.Sprintf("user/package/%v/%v/versions/%v/restore", packageType, packageName, packageVersionID)
+	}
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+
+}

--- a/github/users_packages.go
+++ b/github/users_packages.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 )
 
-// List the packages for a user. Passing the empty string will
+// List the packages for a user. Passing the empty string for "user" will
 // list packages for the authenticated user.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#list-packages-for-the-authenticated-users-namespace
@@ -26,19 +26,22 @@ func (s *UsersService) ListPackages(ctx context.Context, user string, opts *Pack
 	if err != nil {
 		return nil, nil, err
 	}
+
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var packages []*Package
 	resp, err := s.client.Do(ctx, req, &packages)
 	if err != nil {
 		return nil, resp, err
 	}
+
 	return packages, resp, nil
 }
 
-// Get a package by name for a user. Passing the empty string will
+// Get a package by name for a user. Passing the empty string for "user" will
 // get the package for the authenticated user.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-a-package-for-the-authenticated-user
@@ -50,19 +53,22 @@ func (s *UsersService) GetPackage(ctx context.Context, user, packageType, packag
 	} else {
 		u = fmt.Sprintf("user/packages/%v/%v", packageType, packageName)
 	}
+
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var pack *Package
 	resp, err := s.client.Do(ctx, req, &pack)
 	if err != nil {
 		return nil, resp, err
 	}
+
 	return pack, resp, nil
 }
 
-// Delete a package from a user. Passing the empty string will
+// Delete a package from a user. Passing the empty string for "user" will
 // delete the package for the authenticated user.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#delete-a-package-for-the-authenticated-user
@@ -74,15 +80,16 @@ func (s *UsersService) DeletePackage(ctx context.Context, user, packageType, pac
 	} else {
 		u = fmt.Sprintf("user/packages/%v/%v", packageType, packageName)
 	}
+
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
 
+	return s.client.Do(ctx, req, nil)
 }
 
-// Restore a package to a user. Passing the empty string will
+// Restore a package to a user. Passing the empty string for "user" will
 // restore the package for the authenticated user.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#restore-a-package-for-the-authenticated-user
@@ -94,15 +101,16 @@ func (s *UsersService) RestorePackage(ctx context.Context, user, packageType, pa
 	} else {
 		u = fmt.Sprintf("user/packages/%v/%v/restore", packageType, packageName)
 	}
+
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
 
+	return s.client.Do(ctx, req, nil)
 }
 
-// Get all versions of a package for a user. Passing the empty string will
+// Get all versions of a package for a user. Passing the empty string for "user" will
 // get versions for the authenticated user.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-all-package-versions-for-a-package-owned-by-the-authenticated-user
@@ -114,20 +122,22 @@ func (s *UsersService) PackageGetAllVersions(ctx context.Context, user, packageT
 	} else {
 		u = fmt.Sprintf("user/packages/%v/%v/versions", packageType, packageName)
 	}
+
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var versions []*PackageVersion
 	resp, err := s.client.Do(ctx, req, &versions)
 	if err != nil {
 		return nil, resp, err
 	}
-	return versions, resp, nil
 
+	return versions, resp, nil
 }
 
-// Get a specific version of a package in for a user. Passing the empty string will
+// Get a specific version of a package for a user. Passing the empty string for "user" will
 // get the version for the authenticated user.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-a-package-version-for-the-authenticated-user
@@ -139,20 +149,22 @@ func (s *UsersService) PackageGetVersion(ctx context.Context, user, packageType,
 	} else {
 		u = fmt.Sprintf("user/packages/%v/%v/versions/%v", packageType, packageName, packageVersionID)
 	}
+
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var version *PackageVersion
 	resp, err := s.client.Do(ctx, req, &version)
 	if err != nil {
 		return nil, resp, err
 	}
-	return version, resp, nil
 
+	return version, resp, nil
 }
 
-// Delete a package version for a user. Passing the empty string will
+// Delete a package version for a user. Passing the empty string for "user" will
 // delete the version for the authenticated user.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#delete-a-package-version-for-the-authenticated-user
@@ -164,15 +176,16 @@ func (s *UsersService) PackageDeleteVersion(ctx context.Context, user, packageTy
 	} else {
 		u = fmt.Sprintf("user/packages/%v/%v/versions/%v", packageType, packageName, packageVersionID)
 	}
+
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
 
+	return s.client.Do(ctx, req, nil)
 }
 
-// Restore a package version to a user. Passing the empty string will
+// Restore a package version to a user. Passing the empty string for "user" will
 // restore the version for the authenticated user.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#restore-a-package-version-for-the-authenticated-user
@@ -184,10 +197,11 @@ func (s *UsersService) PackageRestoreVersion(ctx context.Context, user, packageT
 	} else {
 		u = fmt.Sprintf("user/packages/%v/%v/versions/%v/restore", packageType, packageName, packageVersionID)
 	}
+
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
 
+	return s.client.Do(ctx, req, nil)
 }

--- a/github/users_packages.go
+++ b/github/users_packages.go
@@ -15,12 +15,16 @@ import (
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#list-packages-for-the-authenticated-users-namespace
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#list-packages-for-a-user
-func (s *UsersService) ListPackages(ctx context.Context, user string) ([]*Package, *Response, error) {
+func (s *UsersService) ListPackages(ctx context.Context, user string, opts *PackageListOptions) ([]*Package, *Response, error) {
 	var u string
 	if user != "" {
 		u = fmt.Sprintf("user/%v/packages", user)
 	} else {
 		u = "user/packages"
+	}
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
 	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -44,7 +48,7 @@ func (s *UsersService) GetPackage(ctx context.Context, user, packageType, packag
 	if user != "" {
 		u = fmt.Sprintf("users/%v/packages/%v/%v", user, packageType, packageName)
 	} else {
-		u = fmt.Sprintf("user/package/%v/%v", packageType, packageName)
+		u = fmt.Sprintf("user/packages/%v/%v", packageType, packageName)
 	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -68,7 +72,7 @@ func (s *UsersService) DeletePackage(ctx context.Context, user, packageType, pac
 	if user != "" {
 		u = fmt.Sprintf("users/%v/packages/%v/%v", user, packageType, packageName)
 	} else {
-		u = fmt.Sprintf("user/package/%v/%v", packageType, packageName)
+		u = fmt.Sprintf("user/packages/%v/%v", packageType, packageName)
 	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -88,7 +92,7 @@ func (s *UsersService) RestorePackage(ctx context.Context, user, packageType, pa
 	if user != "" {
 		u = fmt.Sprintf("users/%v/packages/%v/%v/restore", user, packageType, packageName)
 	} else {
-		u = fmt.Sprintf("user/package/%v/%v/restore", packageType, packageName)
+		u = fmt.Sprintf("user/packages/%v/%v/restore", packageType, packageName)
 	}
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -103,16 +107,12 @@ func (s *UsersService) RestorePackage(ctx context.Context, user, packageType, pa
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-all-package-versions-for-a-package-owned-by-the-authenticated-user
 // GitHub API docs: https://docs.github.com/en/rest/reference/users#delete-an-email-address-for-the-authenticated-user
-func (s *UsersService) PackageGetAllVersions(ctx context.Context, user, packageType, packageName string, opts *ListOptions) ([]*PackageVersion, *Response, error) {
+func (s *UsersService) PackageGetAllVersions(ctx context.Context, user, packageType, packageName string) ([]*PackageVersion, *Response, error) {
 	var u string
 	if user != "" {
 		u = fmt.Sprintf("users/%v/packages/%v/%v/versions", user, packageType, packageName)
 	} else {
-		u = fmt.Sprintf("user/package/%v/%v/versions", packageType, packageName)
-	}
-	u, err := addOptions(u, opts)
-	if err != nil {
-		return nil, nil, err
+		u = fmt.Sprintf("user/packages/%v/%v/versions", packageType, packageName)
 	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -132,12 +132,12 @@ func (s *UsersService) PackageGetAllVersions(ctx context.Context, user, packageT
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-a-package-version-for-the-authenticated-user
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#get-a-package-version-for-a-user
-func (s *UsersService) PackageGetVersion(ctx context.Context, user, packageType, packageName, packageVersionID string) (*PackageVersion, *Response, error) {
+func (s *UsersService) PackageGetVersion(ctx context.Context, user, packageType, packageName string, packageVersionID int64) (*PackageVersion, *Response, error) {
 	var u string
 	if user != "" {
 		u = fmt.Sprintf("users/%v/packages/%v/%v/versions/%v", user, packageType, packageName, packageVersionID)
 	} else {
-		u = fmt.Sprintf("user/package/%v/%v/versions/%v", packageType, packageName, packageVersionID)
+		u = fmt.Sprintf("user/packages/%v/%v/versions/%v", packageType, packageName, packageVersionID)
 	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -157,12 +157,12 @@ func (s *UsersService) PackageGetVersion(ctx context.Context, user, packageType,
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#delete-a-package-version-for-the-authenticated-user
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#delete-package-version-for-a-user
-func (s *UsersService) DeletePackageVersion(ctx context.Context, user, packageType, packageName, packageVersionID string) (*Response, error) {
+func (s *UsersService) PackageDeleteVersion(ctx context.Context, user, packageType, packageName string, packageVersionID int64) (*Response, error) {
 	var u string
 	if user != "" {
 		u = fmt.Sprintf("users/%v/packages/%v/%v/versions/%v", user, packageType, packageName, packageVersionID)
 	} else {
-		u = fmt.Sprintf("user/package/%v/%v/versions/%v", packageType, packageName, packageVersionID)
+		u = fmt.Sprintf("user/packages/%v/%v/versions/%v", packageType, packageName, packageVersionID)
 	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -177,12 +177,12 @@ func (s *UsersService) DeletePackageVersion(ctx context.Context, user, packageTy
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#restore-a-package-version-for-the-authenticated-user
 // GitHub API docs: https://docs.github.com/en/rest/reference/packages#restore-package-version-for-a-user
-func (s *UsersService) RestorePackageVersion(ctx context.Context, user, packageType, packageName, packageVersionID string) (*Response, error) {
+func (s *UsersService) PackageRestoreVersion(ctx context.Context, user, packageType, packageName string, packageVersionID int64) (*Response, error) {
 	var u string
 	if user != "" {
 		u = fmt.Sprintf("users/%v/packages/%v/%v/versions/%v/restore", user, packageType, packageName, packageVersionID)
 	} else {
-		u = fmt.Sprintf("user/package/%v/%v/versions/%v/restore", packageType, packageName, packageVersionID)
+		u = fmt.Sprintf("user/packages/%v/%v/versions/%v/restore", packageType, packageName, packageVersionID)
 	}
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {

--- a/github/users_packages_test.go
+++ b/github/users_packages_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestUsersService_ListPackages(t *testing.T) {
+func TestUsersService_Authenticated_ListPackages(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -37,7 +37,7 @@ func TestUsersService_ListPackages(t *testing.T) {
 	ctx := context.Background()
 	packages, _, err := client.Users.ListPackages(ctx, "", &PackageListOptions{PackageType: String("container"), Visibility: String("private")})
 	if err != nil {
-		t.Errorf("Users.ListPackages returned error: %v", err)
+		t.Errorf("Users.Authenticated_ListPackages returned error: %v", err)
 	}
 
 	want := []*Package{{
@@ -52,10 +52,14 @@ func TestUsersService_ListPackages(t *testing.T) {
 		UpdatedAt:    &Timestamp{referenceTime},
 	}}
 	if !cmp.Equal(packages, want) {
-		t.Errorf("Users.ListPackages returned %+v, want %+v", packages, want)
+		t.Errorf("Users.Authenticated_ListPackages returned %+v, want %+v", packages, want)
 	}
 
 	const methodName = "ListPackages"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Users.ListPackages(ctx, "\n", nil)
+		return err
+	})
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		got, resp, err := client.Users.ListPackages(ctx, "", nil)
 		if got != nil {
@@ -65,11 +69,67 @@ func TestUsersService_ListPackages(t *testing.T) {
 	})
 }
 
-func TestUsersService_GetPackage(t *testing.T) {
+func TestUsersService_specifiedUser_ListPackages(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/users/test/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/u/packages", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"package_type": "container", "visibility": "public"})
+		fmt.Fprint(w, `[{
+			"id": 197,
+			"name": "hello_docker",
+			"package_type": "container",
+			"version_count": 1,
+			"visibility": "public",
+			"url": "https://api.github.com/orgs/github/packages/container/hello_docker",
+			"created_at": `+referenceTimeStr+`,
+			"updated_at": `+referenceTimeStr+`,
+			"html_url": "https://github.com/orgs/github/packages/container/package/hello_docker"
+		  }]`)
+	})
+
+	ctx := context.Background()
+	packages, _, err := client.Users.ListPackages(ctx, "u", &PackageListOptions{PackageType: String("container"), Visibility: String("public")})
+	if err != nil {
+		t.Errorf("Users.specifiedUser_ListPackages returned error: %v", err)
+	}
+
+	want := []*Package{{
+		ID:           Int64(197),
+		Name:         String("hello_docker"),
+		PackageType:  String("container"),
+		VersionCount: Int64(1),
+		Visibility:   String("public"),
+		URL:          String("https://api.github.com/orgs/github/packages/container/hello_docker"),
+		HTMLURL:      String("https://github.com/orgs/github/packages/container/package/hello_docker"),
+		CreatedAt:    &Timestamp{referenceTime},
+		UpdatedAt:    &Timestamp{referenceTime},
+	}}
+	if !cmp.Equal(packages, want) {
+		t.Errorf("Users.specifiedUser_ListPackages returned %+v, want %+v", packages, want)
+	}
+
+	const methodName = "ListPackages"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Users.ListPackages(ctx, "\n", nil)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Users.ListPackages(ctx, "", nil)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestUsersService_specifiedUser_GetPackage(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/u/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
 			"id": 197,
@@ -85,7 +145,7 @@ func TestUsersService_GetPackage(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	packages, _, err := client.Users.GetPackage(ctx, "test", "container", "hello_docker")
+	packages, _, err := client.Users.GetPackage(ctx, "u", "container", "hello_docker")
 	if err != nil {
 		t.Errorf("Users.GetPackage returned error: %v", err)
 	}
@@ -102,10 +162,15 @@ func TestUsersService_GetPackage(t *testing.T) {
 		UpdatedAt:    &Timestamp{referenceTime},
 	}
 	if !cmp.Equal(packages, want) {
-		t.Errorf("Users.GetPackage returned %+v, want %+v", packages, want)
+		t.Errorf("Users.specifiedUser_GetPackage returned %+v, want %+v", packages, want)
 	}
 
 	const methodName = "GetPackage"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Users.GetPackage(ctx, "\n", "\n", "\n")
+		return err
+	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		got, resp, err := client.Users.GetPackage(ctx, "", "", "")
 		if got != nil {
@@ -115,7 +180,62 @@ func TestUsersService_GetPackage(t *testing.T) {
 	})
 }
 
-func TestUsersService_DeletePackage(t *testing.T) {
+func TestUsersService_Authenticated_GetPackage(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"id": 197,
+			"name": "hello_docker",
+			"package_type": "container",
+			"version_count": 1,
+			"visibility": "private",
+			"url": "https://api.github.com/orgs/github/packages/container/hello_docker",
+			"created_at": `+referenceTimeStr+`,
+			"updated_at": `+referenceTimeStr+`,
+			"html_url": "https://github.com/orgs/github/packages/container/package/hello_docker"
+		  }`)
+	})
+
+	ctx := context.Background()
+	packages, _, err := client.Users.GetPackage(ctx, "", "container", "hello_docker")
+	if err != nil {
+		t.Errorf("Users.Authenticated_GetPackage returned error: %v", err)
+	}
+
+	want := &Package{
+		ID:           Int64(197),
+		Name:         String("hello_docker"),
+		PackageType:  String("container"),
+		VersionCount: Int64(1),
+		Visibility:   String("private"),
+		URL:          String("https://api.github.com/orgs/github/packages/container/hello_docker"),
+		HTMLURL:      String("https://github.com/orgs/github/packages/container/package/hello_docker"),
+		CreatedAt:    &Timestamp{referenceTime},
+		UpdatedAt:    &Timestamp{referenceTime},
+	}
+	if !cmp.Equal(packages, want) {
+		t.Errorf("Users.Authenticated_GetPackage returned %+v, want %+v", packages, want)
+	}
+
+	const methodName = "GetPackage"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Users.GetPackage(ctx, "\n", "\n", "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Users.GetPackage(ctx, "", "", "")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestUsersService_Authenticated_DeletePackage(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -126,20 +246,46 @@ func TestUsersService_DeletePackage(t *testing.T) {
 	ctx := context.Background()
 	_, err := client.Users.DeletePackage(ctx, "", "container", "hello_docker")
 	if err != nil {
-		t.Errorf("Users.DeletePackage returned error: %v", err)
+		t.Errorf("Users.Authenticated_DeletePackage returned error: %v", err)
 	}
 
 	const methodName = "DeletePackage"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Users.DeletePackage(ctx, "\n", "\n", "\n")
+		return err
+	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Users.GetPackage(ctx, "", "", "")
-		if got != nil {
-			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
-		}
-		return resp, err
+		return client.Users.DeletePackage(ctx, "", "", "")
 	})
 }
 
-func TestUsersService_RestorePackage(t *testing.T) {
+func TestUsersService_specifiedUser_DeletePackage(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/u/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	ctx := context.Background()
+	_, err := client.Users.DeletePackage(ctx, "u", "container", "hello_docker")
+	if err != nil {
+		t.Errorf("Users.specifiedUser_DeletePackage returned error: %v", err)
+	}
+
+	const methodName = "DeletePackage"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Users.DeletePackage(ctx, "\n", "\n", "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Users.DeletePackage(ctx, "", "", "")
+	})
+}
+
+func TestUsersService_Authenticated_RestorePackage(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -150,16 +296,46 @@ func TestUsersService_RestorePackage(t *testing.T) {
 	ctx := context.Background()
 	_, err := client.Users.RestorePackage(ctx, "", "container", "hello_docker")
 	if err != nil {
-		t.Errorf("Users.RestorePackage returned error: %v", err)
+		t.Errorf("Users.Authenticated_RestorePackage returned error: %v", err)
 	}
 
 	const methodName = "RestorePackage"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Users.RestorePackage(ctx, "\n", "", "")
+		return err
+	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Users.RestorePackage(ctx, "", "container", "hello_docker")
 	})
 }
 
-func TestUsersService_ListPackagesVersions(t *testing.T) {
+func TestUsersService_specifiedUser_RestorePackage(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/u/packages/container/hello_docker/restore", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	ctx := context.Background()
+	_, err := client.Users.RestorePackage(ctx, "u", "container", "hello_docker")
+	if err != nil {
+		t.Errorf("Users.specifiedUser_RestorePackage returned error: %v", err)
+	}
+
+	const methodName = "RestorePackage"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Users.RestorePackage(ctx, "\n", "", "")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Users.RestorePackage(ctx, "", "container", "hello_docker")
+	})
+}
+
+func TestUsersService_Authenticated_ListPackagesVersions(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -188,7 +364,7 @@ func TestUsersService_ListPackagesVersions(t *testing.T) {
 	ctx := context.Background()
 	packages, _, err := client.Users.PackageGetAllVersions(ctx, "", "container", "hello_docker")
 	if err != nil {
-		t.Errorf("Users.PackageGetAllVersions returned error: %v", err)
+		t.Errorf("Users.Authenticated_PackageGetAllVersions returned error: %v", err)
 	}
 
 	want := []*PackageVersion{{
@@ -211,6 +387,11 @@ func TestUsersService_ListPackagesVersions(t *testing.T) {
 	}
 
 	const methodName = "PackageGetAllVersions"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Users.PackageGetAllVersions(ctx, "\n", "", "")
+		return err
+	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		got, resp, err := client.Users.PackageGetAllVersions(ctx, "", "", "")
 		if got != nil {
@@ -220,7 +401,73 @@ func TestUsersService_ListPackagesVersions(t *testing.T) {
 	})
 }
 
-func TestUsersService_PackageGetVersion(t *testing.T) {
+func TestUsersService_specifiedUser_ListPackagesVersions(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/u/packages/container/hello_docker/versions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[
+			{
+			  "id": 45763,
+			  "name": "sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9",
+			  "url": "https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763",
+			  "package_html_url": "https://github.com/users/octocat/packages/container/package/hello_docker",
+			  "created_at": `+referenceTimeStr+`,
+			  "updated_at": `+referenceTimeStr+`,
+			  "html_url": "https://github.com/users/octocat/packages/container/hello_docker/45763",
+			  "metadata": {
+				"package_type": "container",
+				"container": {
+				  "tags": [
+					"latest"
+				  ]
+				}
+			  }
+			}]`)
+	})
+
+	ctx := context.Background()
+	packages, _, err := client.Users.PackageGetAllVersions(ctx, "u", "container", "hello_docker")
+	if err != nil {
+		t.Errorf("Users.specifiedUser_PackageGetAllVersions returned error: %v", err)
+	}
+
+	want := []*PackageVersion{{
+		ID:             Int64(45763),
+		Name:           String("sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9"),
+		URL:            String("https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763"),
+		PackageHTMLURL: String("https://github.com/users/octocat/packages/container/package/hello_docker"),
+		CreatedAt:      &Timestamp{referenceTime},
+		UpdatedAt:      &Timestamp{referenceTime},
+		HTMLURL:        String("https://github.com/users/octocat/packages/container/hello_docker/45763"),
+		Metadata: &PackageMetadata{
+			PackageType: String("container"),
+			Container: &PackageContainerMetadata{
+				Tags: []string{"latest"},
+			},
+		},
+	}}
+	if !cmp.Equal(packages, want) {
+		t.Errorf("Users.specifiedUser_PackageGetAllVersions returned %+v, want %+v", packages, want)
+	}
+
+	const methodName = "PackageGetAllVersions"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Users.PackageGetAllVersions(ctx, "\n", "", "")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Users.PackageGetAllVersions(ctx, "", "", "")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestUsersService_Authenticated_PackageGetVersion(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -268,10 +515,15 @@ func TestUsersService_PackageGetVersion(t *testing.T) {
 		},
 	}
 	if !cmp.Equal(packages, want) {
-		t.Errorf("Users.PackageGetVersion returned %+v, want %+v", packages, want)
+		t.Errorf("Users.Authenticated_PackageGetVersion returned %+v, want %+v", packages, want)
 	}
 
 	const methodName = "PackageGetVersion"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Users.PackageGetVersion(ctx, "\n", "", "", 0)
+		return err
+	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		got, resp, err := client.Users.PackageGetVersion(ctx, "", "", "", 45763)
 		if got != nil {
@@ -281,7 +533,73 @@ func TestUsersService_PackageGetVersion(t *testing.T) {
 	})
 }
 
-func TestUsersService_PackageDeleteVersion(t *testing.T) {
+func TestUsersService_specifiedUser_PackageGetVersion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/u/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `
+			{
+			  "id": 45763,
+			  "name": "sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9",
+			  "url": "https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763",
+			  "package_html_url": "https://github.com/users/octocat/packages/container/package/hello_docker",
+			  "created_at": `+referenceTimeStr+`,
+			  "updated_at": `+referenceTimeStr+`,
+			  "html_url": "https://github.com/users/octocat/packages/container/hello_docker/45763",
+			  "metadata": {
+				"package_type": "container",
+				"container": {
+				  "tags": [
+					"latest"
+				  ]
+				}
+			  }
+			}`)
+	})
+
+	ctx := context.Background()
+	packages, _, err := client.Users.PackageGetVersion(ctx, "u", "container", "hello_docker", 45763)
+	if err != nil {
+		t.Errorf("Users.specifiedUser_PackageGetVersion returned error: %v", err)
+	}
+
+	want := &PackageVersion{
+		ID:             Int64(45763),
+		Name:           String("sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9"),
+		URL:            String("https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763"),
+		PackageHTMLURL: String("https://github.com/users/octocat/packages/container/package/hello_docker"),
+		CreatedAt:      &Timestamp{referenceTime},
+		UpdatedAt:      &Timestamp{referenceTime},
+		HTMLURL:        String("https://github.com/users/octocat/packages/container/hello_docker/45763"),
+		Metadata: &PackageMetadata{
+			PackageType: String("container"),
+			Container: &PackageContainerMetadata{
+				Tags: []string{"latest"},
+			},
+		},
+	}
+	if !cmp.Equal(packages, want) {
+		t.Errorf("Users.specifiedUser_PackageGetVersion returned %+v, want %+v", packages, want)
+	}
+
+	const methodName = "PackageGetVersion"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Users.PackageGetVersion(ctx, "\n", "", "", 0)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Users.PackageGetVersion(ctx, "", "", "", 45763)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestUsersService_Authenticated_PackageDeleteVersion(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -292,17 +610,48 @@ func TestUsersService_PackageDeleteVersion(t *testing.T) {
 	ctx := context.Background()
 	_, err := client.Users.PackageDeleteVersion(ctx, "", "container", "hello_docker", 45763)
 	if err != nil {
-		t.Errorf("Users.PackageDeleteVersion returned error: %v", err)
+		t.Errorf("Users.Authenticated_PackageDeleteVersion returned error: %v", err)
 	}
 
 	const methodName = "PackageDeleteVersion"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Users.PackageDeleteVersion(ctx, "\n", "", "", 0)
+		return err
+	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Users.PackageDeleteVersion(ctx, "", "", "", 45763)
 
 	})
 }
 
-func TestUsersService_PackageRestoreVersion(t *testing.T) {
+func TestUsersService_specifiedUser_PackageDeleteVersion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/u/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	ctx := context.Background()
+	_, err := client.Users.PackageDeleteVersion(ctx, "u", "container", "hello_docker", 45763)
+	if err != nil {
+		t.Errorf("Users.specifiedUser_PackageDeleteVersion returned error: %v", err)
+	}
+
+	const methodName = "PackageDeleteVersion"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Users.PackageDeleteVersion(ctx, "\n", "", "", 0)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Users.PackageDeleteVersion(ctx, "", "", "", 45763)
+
+	})
+}
+
+func TestUsersService_Authenticated_PackageRestoreVersion(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -313,10 +662,41 @@ func TestUsersService_PackageRestoreVersion(t *testing.T) {
 	ctx := context.Background()
 	_, err := client.Users.PackageRestoreVersion(ctx, "", "container", "hello_docker", 45763)
 	if err != nil {
-		t.Errorf("Users.PackageRestoreVersion returned error: %v", err)
+		t.Errorf("Users.Authenticated_PackageRestoreVersion returned error: %v", err)
 	}
 
 	const methodName = "PackageRestoreVersion"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Users.PackageRestoreVersion(ctx, "\n", "", "", 0)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Users.PackageRestoreVersion(ctx, "", "", "", 45763)
+
+	})
+}
+
+func TestUsersService_specifiedUser_PackageRestoreVersion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/u/packages/container/hello_docker/versions/45763/restore", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	ctx := context.Background()
+	_, err := client.Users.PackageRestoreVersion(ctx, "u", "container", "hello_docker", 45763)
+	if err != nil {
+		t.Errorf("Users.specifiedUser_PackageRestoreVersion returned error: %v", err)
+	}
+
+	const methodName = "PackageRestoreVersion"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Users.PackageRestoreVersion(ctx, "\n", "", "", 0)
+		return err
+	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Users.PackageRestoreVersion(ctx, "", "", "", 45763)
 

--- a/github/users_packages_test.go
+++ b/github/users_packages_test.go
@@ -1,0 +1,324 @@
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestUsersService_ListPackages(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/packages", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"package_type": "container", "visibility": "private"})
+		fmt.Fprint(w, `[{
+			"id": 197,
+			"name": "hello_docker",
+			"package_type": "container",
+			"version_count": 1,
+			"visibility": "private",
+			"url": "https://api.github.com/orgs/github/packages/container/hello_docker",
+			"created_at": `+referenceTimeStr+`,
+			"updated_at": `+referenceTimeStr+`,
+			"html_url": "https://github.com/orgs/github/packages/container/package/hello_docker"
+		  }]`)
+	})
+
+	ctx := context.Background()
+	packages, _, err := client.Users.ListPackages(ctx, "", &PackageListOptions{PackageType: "container", Visibility: "private"})
+	if err != nil {
+		t.Errorf("Users.ListPackages returned error: %v", err)
+	}
+
+	want := []*Package{{
+		ID:           Int64(197),
+		Name:         String("hello_docker"),
+		PackageType:  String("container"),
+		VersionCount: Int64(1),
+		Visibility:   String("private"),
+		URL:          String("https://api.github.com/orgs/github/packages/container/hello_docker"),
+		HTMLURL:      String("https://github.com/orgs/github/packages/container/package/hello_docker"),
+		CreatedAt:    &Timestamp{referenceTime},
+		UpdatedAt:    &Timestamp{referenceTime},
+	}}
+	if !cmp.Equal(packages, want) {
+		t.Errorf("Users.ListPackages returned %+v, want %+v", packages, want)
+	}
+
+	const methodName = "ListPackages"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Users.ListPackages(ctx, "", nil)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestUsersService_GetPackage(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/test/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"id": 197,
+			"name": "hello_docker",
+			"package_type": "container",
+			"version_count": 1,
+			"visibility": "private",
+			"url": "https://api.github.com/orgs/github/packages/container/hello_docker",
+			"created_at": `+referenceTimeStr+`,
+			"updated_at": `+referenceTimeStr+`,
+			"html_url": "https://github.com/orgs/github/packages/container/package/hello_docker"
+		  }`)
+	})
+
+	ctx := context.Background()
+	packages, _, err := client.Users.GetPackage(ctx, "test", "container", "hello_docker")
+	if err != nil {
+		t.Errorf("Users.GetPackage returned error: %v", err)
+	}
+
+	want := &Package{
+		ID:           Int64(197),
+		Name:         String("hello_docker"),
+		PackageType:  String("container"),
+		VersionCount: Int64(1),
+		Visibility:   String("private"),
+		URL:          String("https://api.github.com/orgs/github/packages/container/hello_docker"),
+		HTMLURL:      String("https://github.com/orgs/github/packages/container/package/hello_docker"),
+		CreatedAt:    &Timestamp{referenceTime},
+		UpdatedAt:    &Timestamp{referenceTime},
+	}
+	if !cmp.Equal(packages, want) {
+		t.Errorf("Users.GetPackage returned %+v, want %+v", packages, want)
+	}
+
+	const methodName = "GetPackage"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Users.GetPackage(ctx, "", "", "")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestUsersService_DeletePackage(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	ctx := context.Background()
+	_, err := client.Users.DeletePackage(ctx, "", "container", "hello_docker")
+	if err != nil {
+		t.Errorf("Users.DeletePackage returned error: %v", err)
+	}
+
+	const methodName = "DeletePackage"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Users.GetPackage(ctx, "", "", "")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestUsersService_RestorePackage(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/packages/container/hello_docker/restore", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	ctx := context.Background()
+	_, err := client.Users.RestorePackage(ctx, "", "container", "hello_docker")
+	if err != nil {
+		t.Errorf("Users.RestorePackage returned error: %v", err)
+	}
+
+	const methodName = "RestorePackage"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Users.RestorePackage(ctx, "", "container", "hello_docker")
+	})
+}
+
+func TestUsersService_ListPackagesVersions(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/packages/container/hello_docker/versions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[
+			{
+			  "id": 45763,
+			  "name": "sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9",
+			  "url": "https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763",
+			  "package_html_url": "https://github.com/users/octocat/packages/container/package/hello_docker",
+			  "created_at": `+referenceTimeStr+`,
+			  "updated_at": `+referenceTimeStr+`,
+			  "html_url": "https://github.com/users/octocat/packages/container/hello_docker/45763",
+			  "metadata": {
+				"package_type": "container",
+				"container": {
+				  "tags": [
+					"latest"
+				  ]
+				}
+			  }
+			}]`)
+	})
+
+	ctx := context.Background()
+	packages, _, err := client.Users.PackageGetAllVersions(ctx, "", "container", "hello_docker")
+	if err != nil {
+		t.Errorf("Users.PackageGetAllVersions returned error: %v", err)
+	}
+
+	want := []*PackageVersion{{
+		ID:             Int64(45763),
+		Name:           String("sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9"),
+		URL:            String("https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763"),
+		PackageHTMLURL: String("https://github.com/users/octocat/packages/container/package/hello_docker"),
+		CreatedAt:      &Timestamp{referenceTime},
+		UpdatedAt:      &Timestamp{referenceTime},
+		HTMLURL:        String("https://github.com/users/octocat/packages/container/hello_docker/45763"),
+		Metadata: &PackageMetadata{
+			PackageType: String("container"),
+			Container: &PackageContainerMetadata{
+				Tags: []*string{String("latest")},
+			},
+		},
+	}}
+	if !cmp.Equal(packages, want) {
+		t.Errorf("Users.PackageGetAllVersions returned %+v, want %+v", packages, want)
+	}
+
+	const methodName = "PackageGetAllVersions"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Users.PackageGetAllVersions(ctx, "", "", "")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestUsersService_PackageGetVersion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `
+			{
+			  "id": 45763,
+			  "name": "sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9",
+			  "url": "https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763",
+			  "package_html_url": "https://github.com/users/octocat/packages/container/package/hello_docker",
+			  "created_at": `+referenceTimeStr+`,
+			  "updated_at": `+referenceTimeStr+`,
+			  "html_url": "https://github.com/users/octocat/packages/container/hello_docker/45763",
+			  "metadata": {
+				"package_type": "container",
+				"container": {
+				  "tags": [
+					"latest"
+				  ]
+				}
+			  }
+			}`)
+	})
+
+	ctx := context.Background()
+	packages, _, err := client.Users.PackageGetVersion(ctx, "", "container", "hello_docker", 45763)
+	if err != nil {
+		t.Errorf("Users.PackageGetVersion returned error: %v", err)
+	}
+
+	want := &PackageVersion{
+		ID:             Int64(45763),
+		Name:           String("sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9"),
+		URL:            String("https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763"),
+		PackageHTMLURL: String("https://github.com/users/octocat/packages/container/package/hello_docker"),
+		CreatedAt:      &Timestamp{referenceTime},
+		UpdatedAt:      &Timestamp{referenceTime},
+		HTMLURL:        String("https://github.com/users/octocat/packages/container/hello_docker/45763"),
+		Metadata: &PackageMetadata{
+			PackageType: String("container"),
+			Container: &PackageContainerMetadata{
+				Tags: []*string{String("latest")},
+			},
+		},
+	}
+	if !cmp.Equal(packages, want) {
+		t.Errorf("Users.PackageGetVersion returned %+v, want %+v", packages, want)
+	}
+
+	const methodName = "PackageGetVersion"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Users.PackageGetVersion(ctx, "", "", "", 45763)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestUsersService_PackageDeleteVersion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	ctx := context.Background()
+	_, err := client.Users.PackageDeleteVersion(ctx, "", "container", "hello_docker", 45763)
+	if err != nil {
+		t.Errorf("Users.PackageDeleteVersion returned error: %v", err)
+	}
+
+	const methodName = "PackageDeleteVersion"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Users.PackageDeleteVersion(ctx, "", "", "", 45763)
+
+	})
+}
+
+func TestUsersService_PackageRestoreVersion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/packages/container/hello_docker/versions/45763/restore", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	ctx := context.Background()
+	_, err := client.Users.PackageRestoreVersion(ctx, "", "container", "hello_docker", 45763)
+	if err != nil {
+		t.Errorf("Users.PackageRestoreVersion returned error: %v", err)
+	}
+
+	const methodName = "PackageRestoreVersion"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Users.PackageRestoreVersion(ctx, "", "", "", 45763)
+
+	})
+}

--- a/github/users_packages_test.go
+++ b/github/users_packages_test.go
@@ -35,7 +35,7 @@ func TestUsersService_ListPackages(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	packages, _, err := client.Users.ListPackages(ctx, "", &PackageListOptions{PackageType: "container", Visibility: "private"})
+	packages, _, err := client.Users.ListPackages(ctx, "", &PackageListOptions{PackageType: String("container"), Visibility: String("private")})
 	if err != nil {
 		t.Errorf("Users.ListPackages returned error: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestUsersService_ListPackagesVersions(t *testing.T) {
 		Metadata: &PackageMetadata{
 			PackageType: String("container"),
 			Container: &PackageContainerMetadata{
-				Tags: []*string{String("latest")},
+				Tags: []string{"latest"},
 			},
 		},
 	}}
@@ -263,7 +263,7 @@ func TestUsersService_PackageGetVersion(t *testing.T) {
 		Metadata: &PackageMetadata{
 			PackageType: String("container"),
 			Container: &PackageContainerMetadata{
-				Tags: []*string{String("latest")},
+				Tags: []string{"latest"},
 			},
 		},
 	}

--- a/github/users_packages_test.go
+++ b/github/users_packages_test.go
@@ -60,6 +60,7 @@ func TestUsersService_Authenticated_ListPackages(t *testing.T) {
 		_, _, err = client.Users.ListPackages(ctx, "\n", nil)
 		return err
 	})
+
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		got, resp, err := client.Users.ListPackages(ctx, "", nil)
 		if got != nil {

--- a/github/users_packages_test.go
+++ b/github/users_packages_test.go
@@ -57,12 +57,12 @@ func TestUsersService_Authenticated_ListPackages(t *testing.T) {
 
 	const methodName = "ListPackages"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Users.ListPackages(ctx, "\n", nil)
+		_, _, err = client.Users.ListPackages(ctx, "\n", &PackageListOptions{})
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Users.ListPackages(ctx, "", nil)
+		got, resp, err := client.Users.ListPackages(ctx, "", &PackageListOptions{})
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -113,12 +113,12 @@ func TestUsersService_specifiedUser_ListPackages(t *testing.T) {
 
 	const methodName = "ListPackages"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Users.ListPackages(ctx, "\n", nil)
+		_, _, err = client.Users.ListPackages(ctx, "\n", &PackageListOptions{})
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Users.ListPackages(ctx, "", nil)
+		got, resp, err := client.Users.ListPackages(ctx, "", &PackageListOptions{})
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}


### PR DESCRIPTION
Adds support for [Packages API](https://docs.github.com/en/rest/reference/packages) through expansion of Users and Organization Services.

Would resolve #2075 