### PR TITLE
Update repo community profile API

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2548,6 +2548,14 @@ func (c *CommunityHealthFiles) GetCodeOfConduct() *Metric {
 	return c.CodeOfConduct
 }
 
+// GetCodeOfConductFile returns the CodeOfConductFile field.
+func (c *CommunityHealthFiles) GetCodeOfConductFile() *Metric {
+	if c == nil {
+		return nil
+	}
+	return c.CodeOfConductFile
+}
+
 // GetContributing returns the Contributing field.
 func (c *CommunityHealthFiles) GetContributing() *Metric {
 	if c == nil {
@@ -2586,6 +2594,30 @@ func (c *CommunityHealthFiles) GetReadme() *Metric {
 		return nil
 	}
 	return c.Readme
+}
+
+// GetContentReportsEnabled returns the ContentReportsEnabled field if it's non-nil, zero value otherwise.
+func (c *CommunityHealthMetrics) GetContentReportsEnabled() bool {
+	if c == nil || c.ContentReportsEnabled == nil {
+		return false
+	}
+	return *c.ContentReportsEnabled
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (c *CommunityHealthMetrics) GetDescription() string {
+	if c == nil || c.Description == nil {
+		return ""
+	}
+	return *c.Description
+}
+
+// GetDocumentation returns the Documentation field if it's non-nil, zero value otherwise.
+func (c *CommunityHealthMetrics) GetDocumentation() string {
+	if c == nil || c.Documentation == nil {
+		return ""
+	}
+	return *c.Documentation
 }
 
 // GetFiles returns the Files field.
@@ -7786,6 +7818,22 @@ func (m *Metric) GetName() string {
 		return ""
 	}
 	return *m.Name
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (m *Metric) GetNodeID() string {
+	if m == nil || m.NodeID == nil {
+		return ""
+	}
+	return *m.NodeID
+}
+
+// GetSPDXID returns the SPDXID field if it's non-nil, zero value otherwise.
+func (m *Metric) GetSPDXID() string {
+	if m == nil || m.SPDXID == nil {
+		return ""
+	}
+	return *m.SPDXID
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -2991,6 +2991,13 @@ func TestCommunityHealthFiles_GetCodeOfConduct(tt *testing.T) {
 	c.GetCodeOfConduct()
 }
 
+func TestCommunityHealthFiles_GetCodeOfConductFile(tt *testing.T) {
+	c := &CommunityHealthFiles{}
+	c.GetCodeOfConductFile()
+	c = nil
+	c.GetCodeOfConductFile()
+}
+
 func TestCommunityHealthFiles_GetContributing(tt *testing.T) {
 	c := &CommunityHealthFiles{}
 	c.GetContributing()
@@ -3024,6 +3031,36 @@ func TestCommunityHealthFiles_GetReadme(tt *testing.T) {
 	c.GetReadme()
 	c = nil
 	c.GetReadme()
+}
+
+func TestCommunityHealthMetrics_GetContentReportsEnabled(tt *testing.T) {
+	var zeroValue bool
+	c := &CommunityHealthMetrics{ContentReportsEnabled: &zeroValue}
+	c.GetContentReportsEnabled()
+	c = &CommunityHealthMetrics{}
+	c.GetContentReportsEnabled()
+	c = nil
+	c.GetContentReportsEnabled()
+}
+
+func TestCommunityHealthMetrics_GetDescription(tt *testing.T) {
+	var zeroValue string
+	c := &CommunityHealthMetrics{Description: &zeroValue}
+	c.GetDescription()
+	c = &CommunityHealthMetrics{}
+	c.GetDescription()
+	c = nil
+	c.GetDescription()
+}
+
+func TestCommunityHealthMetrics_GetDocumentation(tt *testing.T) {
+	var zeroValue string
+	c := &CommunityHealthMetrics{Documentation: &zeroValue}
+	c.GetDocumentation()
+	c = &CommunityHealthMetrics{}
+	c.GetDocumentation()
+	c = nil
+	c.GetDocumentation()
 }
 
 func TestCommunityHealthMetrics_GetFiles(tt *testing.T) {
@@ -9125,6 +9162,26 @@ func TestMetric_GetName(tt *testing.T) {
 	m.GetName()
 	m = nil
 	m.GetName()
+}
+
+func TestMetric_GetNodeID(tt *testing.T) {
+	var zeroValue string
+	m := &Metric{NodeID: &zeroValue}
+	m.GetNodeID()
+	m = &Metric{}
+	m.GetNodeID()
+	m = nil
+	m.GetNodeID()
+}
+
+func TestMetric_GetSPDXID(tt *testing.T) {
+	var zeroValue string
+	m := &Metric{SPDXID: &zeroValue}
+	m.GetSPDXID()
+	m = &Metric{}
+	m.GetSPDXID()
+	m = nil
+	m.GetSPDXID()
 }
 
 func TestMetric_GetURL(tt *testing.T) {

--- a/github/github.go
+++ b/github/github.go
@@ -76,9 +76,6 @@ const (
 	// https://developer.github.com/changes/2017-02-28-user-blocking-apis-and-webhook/
 	mediaTypeBlockUsersPreview = "application/vnd.github.giant-sentry-fist-preview+json"
 
-	// https://developer.github.com/changes/2017-02-09-community-health/
-	mediaTypeRepositoryCommunityHealthMetricsPreview = "application/vnd.github.black-panther-preview+json"
-
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 

--- a/github/repos_community_health.go
+++ b/github/repos_community_health.go
@@ -15,13 +15,16 @@ import (
 type Metric struct {
 	Name    *string `json:"name"`
 	Key     *string `json:"key"`
+	SPDXID  *string `json:"spdx_id"`
 	URL     *string `json:"url"`
 	HTMLURL *string `json:"html_url"`
+	NodeID  *string `json:"node_id"`
 }
 
 // CommunityHealthFiles represents the different files in the community health metrics response.
 type CommunityHealthFiles struct {
 	CodeOfConduct       *Metric `json:"code_of_conduct"`
+	CodeOfConductFile   *Metric `json:"code_of_conduct_file"`
 	Contributing        *Metric `json:"contributing"`
 	IssueTemplate       *Metric `json:"issue_template"`
 	PullRequestTemplate *Metric `json:"pull_request_template"`
@@ -31,14 +34,17 @@ type CommunityHealthFiles struct {
 
 // CommunityHealthMetrics represents a response containing the community metrics of a repository.
 type CommunityHealthMetrics struct {
-	HealthPercentage *int                  `json:"health_percentage"`
-	Files            *CommunityHealthFiles `json:"files"`
-	UpdatedAt        *time.Time            `json:"updated_at"`
+	HealthPercentage      *int                  `json:"health_percentage"`
+	Description           *string               `json:"description"`
+	Documentation         *string               `json:"documentation"`
+	Files                 *CommunityHealthFiles `json:"files"`
+	UpdatedAt             *time.Time            `json:"updated_at"`
+	ContentReportsEnabled *bool                 `json:"content_reports_enabled"`
 }
 
 // GetCommunityHealthMetrics retrieves all the community health  metrics for a  repository.
 //
-// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/repos/#get-community-profile-metrics
+// GitHub API docs: https://docs.github.com/en/rest/reference/repos#get-community-profile-metrics
 func (s *RepositoriesService) GetCommunityHealthMetrics(ctx context.Context, owner, repo string) (*CommunityHealthMetrics, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/community/profile", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)

--- a/github/repos_community_health.go
+++ b/github/repos_community_health.go
@@ -52,9 +52,6 @@ func (s *RepositoriesService) GetCommunityHealthMetrics(ctx context.Context, own
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeRepositoryCommunityHealthMetricsPreview)
-
 	metrics := &CommunityHealthMetrics{}
 	resp, err := s.client.Do(ctx, req, metrics)
 	if err != nil {

--- a/github/repos_community_health_test.go
+++ b/github/repos_community_health_test.go
@@ -21,7 +21,6 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/community/profile", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeRepositoryCommunityHealthMetricsPreview)
 		fmt.Fprintf(w, `{
 				"health_percentage": 100,
 				"description": "My first repository on GitHub!",

--- a/github/repos_community_health_test.go
+++ b/github/repos_community_health_test.go
@@ -24,6 +24,8 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeRepositoryCommunityHealthMetricsPreview)
 		fmt.Fprintf(w, `{
 				"health_percentage": 100,
+				"description": "My first repository on GitHub!",
+				"documentation": null,
 				"files": {
 					"code_of_conduct": {
 						"name": "Contributor Covenant",
@@ -31,22 +33,37 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 						"url": null,
 						"html_url": "https://github.com/octocat/Hello-World/blob/master/CODE_OF_CONDUCT.md"
 					},
+					"code_of_conduct_file": {
+						"url": "https://api.github.com/repos/octocat/Hello-World/contents/CODE_OF_CONDUCT.md",
+						"html_url": "https://github.com/octocat/Hello-World/blob/master/CODE_OF_CONDUCT.md"
+					},
 					"contributing": {
 						"url": "https://api.github.com/repos/octocat/Hello-World/contents/CONTRIBUTING",
 						"html_url": "https://github.com/octocat/Hello-World/blob/master/CONTRIBUTING"
 					},
+					"issue_template": {
+						"url": "https://api.github.com/repos/octocat/Hello-World/contents/ISSUE_TEMPLATE",
+						"html_url": "https://github.com/octocat/Hello-World/blob/master/ISSUE_TEMPLATE"
+					},
+					"pull_request_template": {
+						"url": "https://api.github.com/repos/octocat/Hello-World/contents/PULL_REQUEST_TEMPLATE",
+						"html_url": "https://github.com/octocat/Hello-World/blob/master/PULL_REQUEST_TEMPLATE"
+					},
 					"license": {
 						"name": "MIT License",
 						"key": "mit",
+						"spdx_id": "MIT",
 						"url": "https://api.github.com/licenses/mit",
-						"html_url": "https://github.com/octocat/Hello-World/blob/master/LICENSE"
+						"html_url": "https://github.com/octocat/Hello-World/blob/master/LICENSE",
+						"node_id": "MDc6TGljZW5zZW1pdA=="
 					},
 					"readme": {
 						"url": "https://api.github.com/repos/octocat/Hello-World/contents/README.md",
 						"html_url": "https://github.com/octocat/Hello-World/blob/master/README.md"
 					}
 				},
-				"updated_at": "2017-02-28T00:00:00Z"
+				"updated_at": "2017-02-28T00:00:00Z",
+				"content_reports_enabled": true
 			}`)
 	})
 
@@ -58,23 +75,39 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 
 	updatedAt := time.Date(2017, time.February, 28, 0, 0, 0, 0, time.UTC)
 	want := &CommunityHealthMetrics{
-		HealthPercentage: Int(100),
-		UpdatedAt:        &updatedAt,
+		HealthPercentage:      Int(100),
+		Description:           String("My first repository on GitHub!"),
+		UpdatedAt:             &updatedAt,
+		ContentReportsEnabled: Bool(true),
 		Files: &CommunityHealthFiles{
 			CodeOfConduct: &Metric{
 				Name:    String("Contributor Covenant"),
 				Key:     String("contributor_covenant"),
 				HTMLURL: String("https://github.com/octocat/Hello-World/blob/master/CODE_OF_CONDUCT.md"),
 			},
+			CodeOfConductFile: &Metric{
+				URL:     String("https://api.github.com/repos/octocat/Hello-World/contents/CODE_OF_CONDUCT.md"),
+				HTMLURL: String("https://github.com/octocat/Hello-World/blob/master/CODE_OF_CONDUCT.md"),
+			},
 			Contributing: &Metric{
 				URL:     String("https://api.github.com/repos/octocat/Hello-World/contents/CONTRIBUTING"),
 				HTMLURL: String("https://github.com/octocat/Hello-World/blob/master/CONTRIBUTING"),
 			},
+			IssueTemplate: &Metric{
+				URL:     String("https://api.github.com/repos/octocat/Hello-World/contents/ISSUE_TEMPLATE"),
+				HTMLURL: String("https://github.com/octocat/Hello-World/blob/master/ISSUE_TEMPLATE"),
+			},
+			PullRequestTemplate: &Metric{
+				URL:     String("https://api.github.com/repos/octocat/Hello-World/contents/PULL_REQUEST_TEMPLATE"),
+				HTMLURL: String("https://github.com/octocat/Hello-World/blob/master/PULL_REQUEST_TEMPLATE"),
+			},
 			License: &Metric{
 				Name:    String("MIT License"),
 				Key:     String("mit"),
+				SPDXID:  String("MIT"),
 				URL:     String("https://api.github.com/licenses/mit"),
 				HTMLURL: String("https://github.com/octocat/Hello-World/blob/master/LICENSE"),
+				NodeID:  String("MDc6TGljZW5zZW1pdA=="),
 			},
 			Readme: &Metric{
 				URL:     String("https://api.github.com/repos/octocat/Hello-World/contents/README.md"),
@@ -107,15 +140,19 @@ func TestMetric_Marshal(t *testing.T) {
 	r := &Metric{
 		Name:    String("name"),
 		Key:     String("key"),
+		SPDXID:  String("spdx_id"),
 		URL:     String("url"),
 		HTMLURL: String("hurl"),
+		NodeID:  String("node_id"),
 	}
 
 	want := `{
 		"name": "name",
 		"key": "key",
+		"spdx_id": "spdx_id",
 		"url": "url",
-		"html_url": "hurl"
+		"html_url": "hurl",
+		"node_id": "node_id"
 	}`
 
 	testJSONMarshal(t, r, want)
@@ -126,6 +163,12 @@ func TestCommunityHealthFiles_Marshal(t *testing.T) {
 
 	r := &CommunityHealthFiles{
 		CodeOfConduct: &Metric{
+			Name:    String("name"),
+			Key:     String("key"),
+			URL:     String("url"),
+			HTMLURL: String("hurl"),
+		},
+		CodeOfConductFile: &Metric{
 			Name:    String("name"),
 			Key:     String("key"),
 			URL:     String("url"),
@@ -152,8 +195,10 @@ func TestCommunityHealthFiles_Marshal(t *testing.T) {
 		License: &Metric{
 			Name:    String("name"),
 			Key:     String("key"),
+			SPDXID:  String("spdx_id"),
 			URL:     String("url"),
 			HTMLURL: String("hurl"),
+			NodeID:  String("node_id"),
 		},
 		Readme: &Metric{
 			Name:    String("name"),
@@ -170,6 +215,12 @@ func TestCommunityHealthFiles_Marshal(t *testing.T) {
 			"url": "url",
 			"html_url": "hurl"
 		},
+		"code_of_conduct_file": {
+			"name": "name",
+			"key": "key",
+                        "url": "url",
+                        "html_url": "hurl"
+                },
 		"contributing": {
 			"name": "name",
 			"key": "key",
@@ -191,8 +242,10 @@ func TestCommunityHealthFiles_Marshal(t *testing.T) {
 		"license": {
 			"name": "name",
 			"key": "key",
+			"spdx_id": "spdx_id",
 			"url": "url",
-			"html_url": "hurl"
+			"html_url": "hurl",
+			"node_id": "node_id"
 		},
 		"readme": {
 			"name": "name",
@@ -210,8 +263,16 @@ func TestCommunityHealthMetrics_Marshal(t *testing.T) {
 
 	r := &CommunityHealthMetrics{
 		HealthPercentage: Int(1),
+		Description:      String("desc"),
+		Documentation:    String("docs"),
 		Files: &CommunityHealthFiles{
 			CodeOfConduct: &Metric{
+				Name:    String("name"),
+				Key:     String("key"),
+				URL:     String("url"),
+				HTMLURL: String("hurl"),
+			},
+			CodeOfConductFile: &Metric{
 				Name:    String("name"),
 				Key:     String("key"),
 				URL:     String("url"),
@@ -238,8 +299,10 @@ func TestCommunityHealthMetrics_Marshal(t *testing.T) {
 			License: &Metric{
 				Name:    String("name"),
 				Key:     String("key"),
+				SPDXID:  String("spdx_id"),
 				URL:     String("url"),
 				HTMLURL: String("hurl"),
+				NodeID:  String("node_id"),
 			},
 			Readme: &Metric{
 				Name:    String("name"),
@@ -248,11 +311,14 @@ func TestCommunityHealthMetrics_Marshal(t *testing.T) {
 				HTMLURL: String("hurl"),
 			},
 		},
-		UpdatedAt: &referenceTime,
+		UpdatedAt:             &referenceTime,
+		ContentReportsEnabled: Bool(true),
 	}
 
 	want := `{
 		"health_percentage": 1,
+		"description": "desc",
+		"documentation": "docs",
 		"files": {
 			"code_of_conduct": {
 				"name": "name",
@@ -260,6 +326,12 @@ func TestCommunityHealthMetrics_Marshal(t *testing.T) {
 				"url": "url",
 				"html_url": "hurl"
 			},
+			"code_of_conduct_file": {
+                                "name": "name",
+                                "key": "key",
+                                "url": "url",
+                                "html_url": "hurl"
+                        },
 			"contributing": {
 				"name": "name",
 				"key": "key",
@@ -281,8 +353,10 @@ func TestCommunityHealthMetrics_Marshal(t *testing.T) {
 			"license": {
 				"name": "name",
 				"key": "key",
+				"spdx_id": "spdx_id",
 				"url": "url",
-				"html_url": "hurl"
+				"html_url": "hurl",
+				"node_id": "node_id"
 			},
 			"readme": {
 				"name": "name",
@@ -291,7 +365,8 @@ func TestCommunityHealthMetrics_Marshal(t *testing.T) {
 				"html_url": "hurl"
 			}
 		},
-		"updated_at": ` + referenceTimeStr + `
+		"updated_at": ` + referenceTimeStr + `,
+		"content_reports_enabled": true
 	}`
 
 	testJSONMarshal(t, r, want)


### PR DESCRIPTION
Changes to more closely align with the latest version of the docs for the community profile API at: https://docs.github.com/en/rest/reference/repos#community

- Adds CodeOfConductFile to the list of community health files
- Adds SPDXID and NodeID fields to metrics (used by license health file)
- Adds Description and Documentation fields
- Adds ContentReportsEnabled field (returned by organization owned repositories)
- Updates tests to include new fields and more closely match the response shown in the docs example
- Removes the graduated black-panther preview header for the community health api