### PR TITLE
Add support for apps webhook config endpoints

### DIFF
--- a/github/apps_hooks.go
+++ b/github/apps_hooks.go
@@ -1,0 +1,43 @@
+package github
+
+import (
+	"context"
+)
+
+// GetHookConfig returns the webhook configuration for a GitHub App.
+// The underlying transport must be authenticated as an app.
+//
+// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/apps#get-a-webhook-configuration-for-an-app
+func (s *AppsService) GetHookConfig(ctx context.Context) (*HookConfig, *Response, error) {
+	req, err := s.client.NewRequest("GET", "app/hook/config", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	config := new(HookConfig)
+	resp, err := s.client.Do(ctx, req, &config)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return config, resp, nil
+}
+
+// UpdateHookConfig updates the webhook configuration for a GitHub App.
+// The underlying transport must be authenticated as an app.
+//
+// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/apps#update-a-webhook-configuration-for-an-app
+func (s *AppsService) UpdateHookConfig(ctx context.Context, config *HookConfig) (*HookConfig, *Response, error) {
+	req, err := s.client.NewRequest("PATCH", "app/hook/config", config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c := new(HookConfig)
+	resp, err := s.client.Do(ctx, req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, nil
+}

--- a/github/apps_hooks.go
+++ b/github/apps_hooks.go
@@ -1,3 +1,8 @@
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package github
 
 import (

--- a/github/apps_hooks_test.go
+++ b/github/apps_hooks_test.go
@@ -1,0 +1,98 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAppsService_GetHookConfig(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/app/hook/config", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"content_type": "json",
+			"insecure_ssl": "0",
+			"secret": "********",
+			"url": "https://example.com/webhook"
+		}`)
+	})
+
+	ctx := context.Background()
+	config, _, err := client.Apps.GetHookConfig(ctx)
+	if err != nil {
+		t.Errorf("Apps.GetHookConfig returned error: %v", err)
+	}
+
+	want := &HookConfig{
+		ContentType: String("json"),
+		InsecureSSL: String("0"),
+		Secret:      String("********"),
+		URL:         String("https://example.com/webhook"),
+	}
+	if !cmp.Equal(config, want) {
+		t.Errorf("Apps.GetHookConfig returned %+v, want %+v", config, want)
+	}
+
+	const methodName = "GetHookConfig"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Apps.GetHookConfig(ctx)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestAppsService_UpdateHookConfig(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &HookConfig{
+		ContentType: String("json"),
+		InsecureSSL: String("1"),
+		Secret:      String("s"),
+		URL:         String("u"),
+	}
+
+	mux.HandleFunc("/app/hook/config", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		testBody(t, r, `{"content_type":"json","insecure_ssl":"1","url":"u","secret":"s"}`+"\n")
+		fmt.Fprint(w, `{
+			"content_type": "json",
+			"insecure_ssl": "1",
+			"secret": "********",
+			"url": "u"
+		}`)
+	})
+
+	ctx := context.Background()
+	config, _, err := client.Apps.UpdateHookConfig(ctx, input)
+	if err != nil {
+		t.Errorf("Apps.UpdateHookConfig returned error: %v", err)
+	}
+
+	want := &HookConfig{
+		ContentType: String("json"),
+		InsecureSSL: String("1"),
+		Secret:      String("********"),
+		URL:         String("u"),
+	}
+	if !cmp.Equal(config, want) {
+		t.Errorf("Apps.UpdateHookConfig returned %+v, want %+v", config, want)
+	}
+
+	const methodName = "UpdateHookConfig"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Apps.UpdateHookConfig(ctx, input)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}

--- a/github/apps_hooks_test.go
+++ b/github/apps_hooks_test.go
@@ -1,3 +1,8 @@
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package github
 
 import (

--- a/github/doc.go
+++ b/github/doc.go
@@ -73,7 +73,7 @@ BasicAuthTransport.
 
 GitHub Apps authentication can be provided by the
 https://github.com/bradleyfalzon/ghinstallation package.
-It supports both authentication as an installation, using an installation access token
+It supports both authentication as an installation, using an installation access token,
 and as an app, using a JWT.
 
 To authenticate as an installation:

--- a/github/doc.go
+++ b/github/doc.go
@@ -73,6 +73,10 @@ BasicAuthTransport.
 
 GitHub Apps authentication can be provided by the
 https://github.com/bradleyfalzon/ghinstallation package.
+It supports both authentication as an installation, using an installation access token
+and as an app, using a JWT.
+
+To authenticate as an installation:
 
 	import "github.com/bradleyfalzon/ghinstallation"
 
@@ -85,6 +89,23 @@ https://github.com/bradleyfalzon/ghinstallation package.
 
 		// Use installation transport with client
 		client := github.NewClient(&http.Client{Transport: itr})
+
+		// Use client...
+	}
+
+To authenticate as an app, using a JWT:
+
+	import "github.com/bradleyfalzon/ghinstallation"
+
+	func main() {
+		// Wrap the shared transport for use with the application ID 1.
+		atr, err := ghinstallation.NewAppsTransportKeyFromFile(http.DefaultTransport, 1, "2016-10-19.private-key.pem")
+		if err != nil {
+			// Handle error.
+		}
+
+		// Use app transport with client
+		client := github.NewClient(&http.Client{Transport: atr})
 
 		// Use client...
 	}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -4988,6 +4988,14 @@ func (h *HookConfig) GetInsecureSSL() string {
 	return *h.InsecureSSL
 }
 
+// GetSecret returns the Secret field if it's non-nil, zero value otherwise.
+func (h *HookConfig) GetSecret() string {
+	if h == nil || h.Secret == nil {
+		return ""
+	}
+	return *h.Secret
+}
+
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
 func (h *HookConfig) GetURL() string {
 	if h == nil || h.URL == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -5840,6 +5840,16 @@ func TestHookConfig_GetInsecureSSL(tt *testing.T) {
 	h.GetInsecureSSL()
 }
 
+func TestHookConfig_GetSecret(tt *testing.T) {
+	var zeroValue string
+	h := &HookConfig{Secret: &zeroValue}
+	h.GetSecret()
+	h = &HookConfig{}
+	h.GetSecret()
+	h = nil
+	h.GetSecret()
+}
+
 func TestHookConfig_GetURL(tt *testing.T) {
 	var zeroValue string
 	h := &HookConfig{URL: &zeroValue}

--- a/github/orgs_audit_log.go
+++ b/github/orgs_audit_log.go
@@ -24,6 +24,9 @@ type HookConfig struct {
 	ContentType *string `json:"content_type,omitempty"`
 	InsecureSSL *string `json:"insecure_ssl,omitempty"`
 	URL         *string `json:"url,omitempty"`
+
+	// Secret is returned obfuscated by GitHub, but it can be set for outgoing requests
+	Secret *string `json:"secret,omitempty"`
 }
 
 // AuditEntry describes the fields that may be represented by various audit-log "action" entries.

--- a/github/orgs_audit_log.go
+++ b/github/orgs_audit_log.go
@@ -25,7 +25,7 @@ type HookConfig struct {
 	InsecureSSL *string `json:"insecure_ssl,omitempty"`
 	URL         *string `json:"url,omitempty"`
 
-	// Secret is returned obfuscated by GitHub, but it can be set for outgoing requests
+	// Secret is returned obfuscated by GitHub, but it can be set for outgoing requests.
 	Secret *string `json:"secret,omitempty"`
 }
 


### PR DESCRIPTION
This adds support for two Apps API endpoints (see #2095)
- [Get a webhook configuration for an app](https://docs.github.com/en/rest/reference/apps#get-a-webhook-configuration-for-an-app)
- [Update a webhook configuration for an app](https://docs.github.com/en/rest/reference/apps#update-a-webhook-configuration-for-an-app)

Both endpoints require authentication as an app (with a JWT), which can be dealt with by the underlying transport.

A few notes:
- I reused / extended the `HookConfig` struct which was defined in `orgs_audit_logs.go`, since it represents the same object.

- The `InsecureSSL` field of the struct is a `*string`. However, GitHub only returns `"0"` or `"1"` (insecure SSL disabled / enabled), so I think it'd be more user-friendly to use a `*bool`, and write some logic so that boolean values are correctly (un)marshaled from `"0"`/`"1"`. I'd be happy to write the code to deal with this, but that would be a breaking change so I wanted to check with you first.

- This is probably out of scope of this PR, but the [`Hook` struct](https://github.com/google/go-github/blob/master/github/repos_hooks.go#L87) used for repository / organization webhooks endpoints is using a `map[string]interface{}` for the `Config` field, but I think it could be using the `HookConfig` struct as well since it represents the same object. Happy to make that change in a separate PR, but this would be a breaking change as well.