### PR TITLE
Add support for workflow_job event's `labels` field

### DIFF
--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -38,7 +38,7 @@ type WorkflowJob struct {
 	Name        *string     `json:"name,omitempty"`
 	Steps       []*TaskStep `json:"steps,omitempty"`
 	CheckRunURL *string     `json:"check_run_url,omitempty"`
-	// Labels is runner labels from the `runs-on:` key from a GitHub Actions workflow
+	// Labels represents runner labels from the `runs-on:` key from a GitHub Actions workflow.
 	Labels []string `json:"labels,omitempty"`
 }
 

--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -38,6 +38,8 @@ type WorkflowJob struct {
 	Name        *string     `json:"name,omitempty"`
 	Steps       []*TaskStep `json:"steps,omitempty"`
 	CheckRunURL *string     `json:"check_run_url,omitempty"`
+	// Labels is runner labels from the `runs-on:` key from a GitHub Actions workflow
+	Labels []string `json:"labels,omitempty"`
 }
 
 // Jobs represents a slice of repository action workflow job.

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -1116,13 +1116,16 @@ type WorkflowDispatchEvent struct {
 
 // WorkflowJobEvent is triggered when a job is queued, started or completed.
 //
-// GitHub API docs: pending
+// GitHub API docs: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_job
 type WorkflowJobEvent struct {
 	WorkflowJob *WorkflowJob `json:"workflow_job,omitempty"`
 
 	Action *string `json:"action,omitempty"`
 
 	// The following fields are only populated by Webhook events.
+
+	// Org is not nil when the webhook is configured for an organization or the event
+	// occurs from activity in a repository owned by an organization.
 	Org          *Organization `json:"organization,omitempty"`
 	Repo         *Repository   `json:"repository,omitempty"`
 	Sender       *User         `json:"sender,omitempty"`


### PR DESCRIPTION
This adds support for new `workflow_job` webhook events' `labels` field announced at https://github.blog/changelog/2021-09-20-github-actions-ephemeral-self-hosted-runners-new-webhooks-for-auto-scaling/.

I've already using go-github with this patch for weeks while [participating in the alpha test](https://github.com/actions-runner-controller/actions-runner-controller/issues/697) of the new webhook event. So I'm pretty confident this works. But I'd do anything I can do if necessary!