### PR TITLE
Fix new golangci-lint errors

### DIFF
--- a/github/orgs_packages_test.go
+++ b/github/orgs_packages_test.go
@@ -377,7 +377,6 @@ func TestOrganizationsService_PackageDeleteVersion(t *testing.T) {
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Organizations.PackageDeleteVersion(ctx, "", "", "", 45763)
-
 	})
 }
 
@@ -403,6 +402,5 @@ func TestOrganizationsService_PackageRestoreVersion(t *testing.T) {
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Organizations.PackageRestoreVersion(ctx, "", "", "", 45763)
-
 	})
 }

--- a/github/users_packages_test.go
+++ b/github/users_packages_test.go
@@ -622,7 +622,6 @@ func TestUsersService_Authenticated_PackageDeleteVersion(t *testing.T) {
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Users.PackageDeleteVersion(ctx, "", "", "", 45763)
-
 	})
 }
 
@@ -648,7 +647,6 @@ func TestUsersService_specifiedUser_PackageDeleteVersion(t *testing.T) {
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Users.PackageDeleteVersion(ctx, "", "", "", 45763)
-
 	})
 }
 
@@ -674,7 +672,6 @@ func TestUsersService_Authenticated_PackageRestoreVersion(t *testing.T) {
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Users.PackageRestoreVersion(ctx, "", "", "", 45763)
-
 	})
 }
 
@@ -700,6 +697,5 @@ func TestUsersService_specifiedUser_PackageRestoreVersion(t *testing.T) {
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Users.PackageRestoreVersion(ctx, "", "", "", 45763)
-
 	})
 }

--- a/scrape/apps_test.go
+++ b/scrape/apps_test.go
@@ -43,7 +43,6 @@ func Test_AppRestrictionsEnabled(t *testing.T) {
 			if want := tt.want; got != want {
 				t.Errorf("AppRestrictionsEnabled returned %t, want %t", got, want)
 			}
-
 		})
 	}
 }
@@ -83,7 +82,6 @@ func Test_ListOAuthApps(t *testing.T) {
 	if !cmp.Equal(got, want) {
 		t.Errorf("ListOAuthApps(o) returned %v, want %v", got, want)
 	}
-
 }
 
 func Test_CreateApp(t *testing.T) {

--- a/update-urls/main.go
+++ b/update-urls/main.go
@@ -199,10 +199,10 @@ func validateRewriteURLs(usedHelpers usedHelpersMap, endpointsByFilename endpoin
 				path = strings.ReplaceAll(path, "%s", "%v")
 
 				// Check the overrides.
-				endpoint.checkHttpMethodOverride(path)
+				endpoint.checkHTTPMethodOverride(path)
 
 				methodAndPath := fmt.Sprintf("%v %v", endpoint.httpMethod, path)
-				url, ok := docCache.UrlByMethodAndPath(methodAndPath)
+				url, ok := docCache.URLByMethodAndPath(methodAndPath)
 				if !ok {
 					if i := len(endpoint.endpointComments); i > 0 {
 						pos := fileRewriter.Position(endpoint.endpointComments[i-1].Pos())
@@ -529,7 +529,7 @@ func resolveHelpersAndCacheDocs(endpoints endpointsMap, docCache documentCacheWr
 }
 
 type documentCacheReader interface {
-	UrlByMethodAndPath(string) (string, bool)
+	URLByMethodAndPath(string) (string, bool)
 }
 
 type documentCacheWriter interface {
@@ -542,7 +542,7 @@ type documentCache struct {
 	urlByMethodAndPath map[string]string
 }
 
-func (dc *documentCache) UrlByMethodAndPath(methodAndPath string) (string, bool) {
+func (dc *documentCache) URLByMethodAndPath(methodAndPath string) (string, bool) {
 	url, ok := dc.urlByMethodAndPath[methodAndPath]
 	return url, ok
 }
@@ -657,7 +657,7 @@ func (e *Endpoint) String() string {
 	return b.String()
 }
 
-func (e *Endpoint) checkHttpMethodOverride(path string) {
+func (e *Endpoint) checkHTTPMethodOverride(path string) {
 	lookupOverride := fmt.Sprintf("%v.%v: %v %v", e.serviceName, e.endpointName, e.httpMethod, path)
 	logf("Looking up override for %q", lookupOverride)
 	if v, ok := methodOverrides[lookupOverride]; ok {
@@ -747,7 +747,7 @@ func processAST(filename string, f *ast.File, services servicesMap, endpoints en
 				stdRefLines:        stdRefLines,
 				endpointComments:   endpointComments,
 			}
-			// ep.checkHttpMethodOverride("")
+			// ep.checkHTTPMethodOverride("")
 			endpoints[fullName] = ep
 			logf("endpoints[%q] = %#v", fullName, endpoints[fullName])
 			if ep.httpMethod == "" && (ep.helperMethod == "" || len(ep.urlFormats) == 0) {

--- a/update-urls/main_test.go
+++ b/update-urls/main_test.go
@@ -233,7 +233,7 @@ type fakeDocCache struct {
 	endpoints endpointsByFragmentID
 }
 
-func (f *fakeDocCache) UrlByMethodAndPath(methodAndPath string) (string, bool) {
+func (f *fakeDocCache) URLByMethodAndPath(methodAndPath string) (string, bool) {
 	f.t.Helper()
 	for fragmentID, endpoints := range f.endpoints {
 		for _, endpoint := range endpoints {
@@ -241,13 +241,13 @@ func (f *fakeDocCache) UrlByMethodAndPath(methodAndPath string) (string, bool) {
 				key := fmt.Sprintf("%v %v", endpoint.httpMethod, urlFormat)
 				if key == methodAndPath {
 					url := fmt.Sprintf("%v#%v", f.baseURL, fragmentID)
-					// log.Printf("UrlByMethodAndPath(%q) = (%q, true)", methodAndPath, url)
+					// log.Printf("URLByMethodAndPath(%q) = (%q, true)", methodAndPath, url)
 					return url, true
 				}
 			}
 		}
 	}
-	f.t.Fatalf("fakeDocCache.UrlByMethodAndPath: unable to find method %v", methodAndPath)
+	f.t.Fatalf("fakeDocCache.URLByMethodAndPath: unable to find method %v", methodAndPath)
 	return "", false
 }
 


### PR DESCRIPTION
#2104 added some linter flags that caused in-flight PRs to fail testing after being merged.
This PR fixes those errors.