### PR TITLE
Bump CI version of Go to test versions 1.17.x and 1.16.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.x, 1.15.x]
+        go-version: [1.x, 1.16.x]
         platform: [ubuntu-latest]
         include:
           # include windows, but only with the latest Go version, since there


### PR DESCRIPTION
Fixes #2106.