### PR TITLE
ProjectOptions (public to private) & Project struct (org related fields) fixes 

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -10236,12 +10236,28 @@ func (p *Project) GetNumber() int {
 	return *p.Number
 }
 
+// GetOrganizationPermission returns the OrganizationPermission field if it's non-nil, zero value otherwise.
+func (p *Project) GetOrganizationPermission() string {
+	if p == nil || p.OrganizationPermission == nil {
+		return ""
+	}
+	return *p.OrganizationPermission
+}
+
 // GetOwnerURL returns the OwnerURL field if it's non-nil, zero value otherwise.
 func (p *Project) GetOwnerURL() string {
 	if p == nil || p.OwnerURL == nil {
 		return ""
 	}
 	return *p.OwnerURL
+}
+
+// GetPrivate returns the Private field if it's non-nil, zero value otherwise.
+func (p *Project) GetPrivate() bool {
+	if p == nil || p.Private == nil {
+		return false
+	}
+	return *p.Private
 }
 
 // GetState returns the State field if it's non-nil, zero value otherwise.
@@ -10748,12 +10764,12 @@ func (p *ProjectOptions) GetOrganizationPermission() string {
 	return *p.OrganizationPermission
 }
 
-// GetPublic returns the Public field if it's non-nil, zero value otherwise.
-func (p *ProjectOptions) GetPublic() bool {
-	if p == nil || p.Public == nil {
+// GetPrivate returns the Private field if it's non-nil, zero value otherwise.
+func (p *ProjectOptions) GetPrivate() bool {
+	if p == nil || p.Private == nil {
 		return false
 	}
-	return *p.Public
+	return *p.Private
 }
 
 // GetState returns the State field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11998,6 +11998,16 @@ func TestProject_GetNumber(tt *testing.T) {
 	p.GetNumber()
 }
 
+func TestProject_GetOrganizationPermission(tt *testing.T) {
+	var zeroValue string
+	p := &Project{OrganizationPermission: &zeroValue}
+	p.GetOrganizationPermission()
+	p = &Project{}
+	p.GetOrganizationPermission()
+	p = nil
+	p.GetOrganizationPermission()
+}
+
 func TestProject_GetOwnerURL(tt *testing.T) {
 	var zeroValue string
 	p := &Project{OwnerURL: &zeroValue}
@@ -12006,6 +12016,16 @@ func TestProject_GetOwnerURL(tt *testing.T) {
 	p.GetOwnerURL()
 	p = nil
 	p.GetOwnerURL()
+}
+
+func TestProject_GetPrivate(tt *testing.T) {
+	var zeroValue bool
+	p := &Project{Private: &zeroValue}
+	p.GetPrivate()
+	p = &Project{}
+	p.GetPrivate()
+	p = nil
+	p.GetPrivate()
 }
 
 func TestProject_GetState(tt *testing.T) {
@@ -12569,14 +12589,14 @@ func TestProjectOptions_GetOrganizationPermission(tt *testing.T) {
 	p.GetOrganizationPermission()
 }
 
-func TestProjectOptions_GetPublic(tt *testing.T) {
+func TestProjectOptions_GetPrivate(tt *testing.T) {
 	var zeroValue bool
-	p := &ProjectOptions{Public: &zeroValue}
-	p.GetPublic()
+	p := &ProjectOptions{Private: &zeroValue}
+	p.GetPrivate()
 	p = &ProjectOptions{}
-	p.GetPublic()
+	p.GetPrivate()
 	p = nil
-	p.GetPublic()
+	p.GetPrivate()
 }
 
 func TestProjectOptions_GetState(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1116,21 +1116,23 @@ func TestPreReceiveHook_String(t *testing.T) {
 
 func TestProject_String(t *testing.T) {
 	v := Project{
-		ID:         Int64(0),
-		URL:        String(""),
-		HTMLURL:    String(""),
-		ColumnsURL: String(""),
-		OwnerURL:   String(""),
-		Name:       String(""),
-		Body:       String(""),
-		Number:     Int(0),
-		State:      String(""),
-		CreatedAt:  &Timestamp{},
-		UpdatedAt:  &Timestamp{},
-		NodeID:     String(""),
-		Creator:    &User{},
+		ID:                     Int64(0),
+		URL:                    String(""),
+		HTMLURL:                String(""),
+		ColumnsURL:             String(""),
+		OwnerURL:               String(""),
+		Name:                   String(""),
+		Body:                   String(""),
+		Number:                 Int(0),
+		State:                  String(""),
+		CreatedAt:              &Timestamp{},
+		UpdatedAt:              &Timestamp{},
+		NodeID:                 String(""),
+		OrganizationPermission: String(""),
+		Private:                Bool(false),
+		Creator:                &User{},
 	}
-	want := `github.Project{ID:0, URL:"", HTMLURL:"", ColumnsURL:"", OwnerURL:"", Name:"", Body:"", Number:0, State:"", CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, NodeID:"", Creator:github.User{}}`
+	want := `github.Project{ID:0, URL:"", HTMLURL:"", ColumnsURL:"", OwnerURL:"", Name:"", Body:"", Number:0, State:"", CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, NodeID:"", OrganizationPermission:"", Private:false, Creator:github.User{}}`
 	if got := v.String(); got != want {
 		t.Errorf("Project.String = %v, want %v", got, want)
 	}

--- a/github/projects.go
+++ b/github/projects.go
@@ -18,18 +18,20 @@ type ProjectsService service
 
 // Project represents a GitHub Project.
 type Project struct {
-	ID         *int64     `json:"id,omitempty"`
-	URL        *string    `json:"url,omitempty"`
-	HTMLURL    *string    `json:"html_url,omitempty"`
-	ColumnsURL *string    `json:"columns_url,omitempty"`
-	OwnerURL   *string    `json:"owner_url,omitempty"`
-	Name       *string    `json:"name,omitempty"`
-	Body       *string    `json:"body,omitempty"`
-	Number     *int       `json:"number,omitempty"`
-	State      *string    `json:"state,omitempty"`
-	CreatedAt  *Timestamp `json:"created_at,omitempty"`
-	UpdatedAt  *Timestamp `json:"updated_at,omitempty"`
-	NodeID     *string    `json:"node_id,omitempty"`
+	ID                     *int64     `json:"id,omitempty"`
+	URL                    *string    `json:"url,omitempty"`
+	HTMLURL                *string    `json:"html_url,omitempty"`
+	ColumnsURL             *string    `json:"columns_url,omitempty"`
+	OwnerURL               *string    `json:"owner_url,omitempty"`
+	Name                   *string    `json:"name,omitempty"`
+	Body                   *string    `json:"body,omitempty"`
+	Number                 *int       `json:"number,omitempty"`
+	State                  *string    `json:"state,omitempty"`
+	CreatedAt              *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt              *Timestamp `json:"updated_at,omitempty"`
+	NodeID                 *string    `json:"node_id,omitempty"`
+	OrganizationPermission *string    `json:"organization_permission,omitempty"`
+	Private                *bool      `json:"private,omitempty"`
 
 	// The User object that generated the project.
 	Creator *User `json:"creator,omitempty"`
@@ -83,7 +85,7 @@ type ProjectOptions struct {
 	// Sets visibility of the project within the organization.
 	// Setting visibility is only available
 	// for organization projects.(Optional.)
-	Public *bool `json:"public,omitempty"`
+	Private *bool `json:"private,omitempty"`
 }
 
 // UpdateProject updates a repository project.

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -92,7 +92,7 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 		Name:    String("Project Name"),
 		Body:    String("Project body."),
 		State:   String("open"),
-		Private: Bool(true),
+		Private: Bool(false),
 
 		OrganizationPermission: String("read"),
 	}
@@ -857,7 +857,7 @@ func TestProjectOptions_Marshal(t *testing.T) {
 		Body:                   String("body"),
 		State:                  String("state"),
 		OrganizationPermission: String("op"),
-		Private:                Bool(true),
+		Private:                Bool(false),
 	}
 
 	want := `{
@@ -865,7 +865,7 @@ func TestProjectOptions_Marshal(t *testing.T) {
 		"body": "body",
 		"state": "state",
 		"organization_permission": "op",
-		"private": true
+		"private": false
 	}`
 
 	testJSONMarshal(t, u, want)

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -89,10 +89,10 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 	defer teardown()
 
 	input := &ProjectOptions{
-		Name:   String("Project Name"),
-		Body:   String("Project body."),
-		State:  String("open"),
-		Public: Bool(true),
+		Name:    String("Project Name"),
+		Body:    String("Project body."),
+		State:   String("open"),
+		Private: Bool(true),
 
 		OrganizationPermission: String("read"),
 	}
@@ -857,7 +857,7 @@ func TestProjectOptions_Marshal(t *testing.T) {
 		Body:                   String("body"),
 		State:                  String("state"),
 		OrganizationPermission: String("op"),
-		Public:                 Bool(true),
+		Private:                Bool(true),
 	}
 
 	want := `{
@@ -865,7 +865,7 @@ func TestProjectOptions_Marshal(t *testing.T) {
 		"body": "body",
 		"state": "state",
 		"organization_permission": "op",
-		"public": true
+		"private": true
 	}`
 
 	testJSONMarshal(t, u, want)


### PR DESCRIPTION
This fixes https://github.com/google/go-github/issues/2110

- fixed ProjectOptions: Public -> Private (according to API doc: https://docs.github.com/en/rest/reference/projects#update-a-project)
- added **OrganizationPermission** and **Private** fields to Project struct, which presents during response on Organization Project.

I've done UATs as well, and all API calls looked good:
- Update Org Project with new private field
- Get Org Project (OrganizationPermission and Private presents as expected)
- Get Repo Project (OrganizationPermission and Private not presents as expected)
- Get User Project (OrganizationPermission and Private not presents as expected)