### PR TITLE
feat: generate release notes support

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -14444,6 +14444,14 @@ func (r *RepositoryRelease) GetDraft() bool {
 	return *r.Draft
 }
 
+// GetGenerateReleaseNotes returns the GenerateReleaseNotes field if it's non-nil, zero value otherwise.
+func (r *RepositoryRelease) GetGenerateReleaseNotes() bool {
+	if r == nil || r.GenerateReleaseNotes == nil {
+		return false
+	}
+	return *r.GenerateReleaseNotes
+}
+
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
 func (r *RepositoryRelease) GetHTMLURL() string {
 	if r == nil || r.HTMLURL == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -16856,6 +16856,16 @@ func TestRepositoryRelease_GetDraft(tt *testing.T) {
 	r.GetDraft()
 }
 
+func TestRepositoryRelease_GetGenerateReleaseNotes(tt *testing.T) {
+	var zeroValue bool
+	r := &RepositoryRelease{GenerateReleaseNotes: &zeroValue}
+	r.GetGenerateReleaseNotes()
+	r = &RepositoryRelease{}
+	r.GetGenerateReleaseNotes()
+	r = nil
+	r.GetGenerateReleaseNotes()
+}
+
 func TestRepositoryRelease_GetHTMLURL(tt *testing.T) {
 	var zeroValue string
 	r := &RepositoryRelease{HTMLURL: &zeroValue}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1589,6 +1589,7 @@ func TestRepositoryRelease_String(t *testing.T) {
 		Draft:                  Bool(false),
 		Prerelease:             Bool(false),
 		DiscussionCategoryName: String(""),
+		GenerateReleaseNotes:   Bool(false),
 		ID:                     Int64(0),
 		CreatedAt:              &Timestamp{},
 		PublishedAt:            &Timestamp{},
@@ -1601,7 +1602,7 @@ func TestRepositoryRelease_String(t *testing.T) {
 		Author:                 &User{},
 		NodeID:                 String(""),
 	}
-	want := `github.RepositoryRelease{TagName:"", TargetCommitish:"", Name:"", Body:"", Draft:false, Prerelease:false, DiscussionCategoryName:"", ID:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, PublishedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, URL:"", HTMLURL:"", AssetsURL:"", UploadURL:"", ZipballURL:"", TarballURL:"", Author:github.User{}, NodeID:""}`
+	want := `github.RepositoryRelease{TagName:"", TargetCommitish:"", Name:"", Body:"", Draft:false, Prerelease:false, DiscussionCategoryName:"", GenerateReleaseNotes:false, ID:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, PublishedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, URL:"", HTMLURL:"", AssetsURL:"", UploadURL:"", ZipballURL:"", TarballURL:"", Author:github.User{}, NodeID:""}`
 	if got := v.String(); got != want {
 		t.Errorf("RepositoryRelease.String = %v, want %v", got, want)
 	}

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -26,6 +26,7 @@ type RepositoryRelease struct {
 	Draft                  *bool   `json:"draft,omitempty"`
 	Prerelease             *bool   `json:"prerelease,omitempty"`
 	DiscussionCategoryName *string `json:"discussion_category_name,omitempty"`
+	GenerateReleaseNotes   *bool   `json:"generate_release_notes,omitempty"`
 
 	// The following fields are not used in CreateRelease or EditRelease:
 	ID          *int64          `json:"id,omitempty"`
@@ -44,6 +45,19 @@ type RepositoryRelease struct {
 
 func (r RepositoryRelease) String() string {
 	return Stringify(r)
+}
+
+// RepositoryReleaseNotes represents a GitHub-generated release notes.
+type RepositoryReleaseNotes struct {
+	Name string `json:"name,omitempty"`
+	Body string `json:"body,omitempty"`
+}
+
+// GenerateNotesOptions represents the options to generate release notes.
+type GenerateNotesOptions struct {
+	TagName         string `json:"tag_name"`
+	PreviousTag     string `json:"previous_tag_name,omitempty"`
+	TargetCommitish string `json:"target_commitish,omitempty"`
 }
 
 // ReleaseAsset represents a GitHub release asset in a repository.
@@ -114,6 +128,25 @@ func (s *RepositoriesService) GetReleaseByTag(ctx context.Context, owner, repo, 
 	return s.getSingleRelease(ctx, u)
 }
 
+// GenerateReleaseNotes generates the release notes for the given tag.
+// TODO: api docs
+// GitHub API docs:
+func (s *RepositoriesService) GenerateReleaseNotes(ctx context.Context, owner, repo string, opts *GenerateNotesOptions) (*RepositoryReleaseNotes, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/releases/generate-notes", owner, repo)
+	req, err := s.client.NewRequest("POST", u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r := new(RepositoryReleaseNotes)
+	resp, err := s.client.Do(ctx, req, r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r, resp, nil
+}
+
 func (s *RepositoriesService) getSingleRelease(ctx context.Context, url string) (*RepositoryRelease, *Response, error) {
 	req, err := s.client.NewRequest("GET", url, nil)
 	if err != nil {
@@ -141,6 +174,7 @@ type repositoryReleaseRequest struct {
 	Body                   *string `json:"body,omitempty"`
 	Draft                  *bool   `json:"draft,omitempty"`
 	Prerelease             *bool   `json:"prerelease,omitempty"`
+	GenerateReleaseNotes   *bool   `json:"generate_release_notes,omitempty"`
 	DiscussionCategoryName *string `json:"discussion_category_name,omitempty"`
 }
 
@@ -161,6 +195,7 @@ func (s *RepositoriesService) CreateRelease(ctx context.Context, owner, repo str
 		Draft:                  release.Draft,
 		Prerelease:             release.Prerelease,
 		DiscussionCategoryName: release.DiscussionCategoryName,
+		GenerateReleaseNotes:   release.GenerateReleaseNotes,
 	}
 
 	req, err := s.client.NewRequest("POST", u, releaseReq)
@@ -193,6 +228,7 @@ func (s *RepositoriesService) EditRelease(ctx context.Context, owner, repo strin
 		Draft:                  release.Draft,
 		Prerelease:             release.Prerelease,
 		DiscussionCategoryName: release.DiscussionCategoryName,
+		GenerateReleaseNotes:   release.GenerateReleaseNotes,
 	}
 
 	req, err := s.client.NewRequest("PATCH", u, releaseReq)

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -55,6 +55,47 @@ func TestRepositoriesService_ListReleases(t *testing.T) {
 	})
 }
 
+func TestRepositoriesService_GenerateReleaseNotes(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/releases/generate-notes", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testBody(t, r, `{"tag_name":"v1.0.0"}`+"\n")
+		fmt.Fprint(w, `{"name":"v1.0.0","body":"**Full Changelog**: https://github.com/o/r/compare/v0.9.0...v1.0.0"}`)
+	})
+
+	opt := &GenerateNotesOptions{
+		TagName: "v1.0.0",
+	}
+	ctx := context.Background()
+	releases, _, err := client.Repositories.GenerateReleaseNotes(ctx, "o", "r", opt)
+	if err != nil {
+		t.Errorf("Repositories.GenerateReleaseNotes returned error: %v", err)
+	}
+	want := &RepositoryReleaseNotes{
+		Name: "v1.0.0",
+		Body: "**Full Changelog**: https://github.com/o/r/compare/v0.9.0...v1.0.0",
+	}
+	if !cmp.Equal(releases, want) {
+		t.Errorf("Repositories.GenerateReleaseNotes returned %+v, want %+v", releases, want)
+	}
+
+	const methodName = "GenerateReleaseNotes"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Repositories.GenerateReleaseNotes(ctx, "\n", "\n", opt)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Repositories.GenerateReleaseNotes(ctx, "o", "r", opt)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
 func TestRepositoriesService_GetRelease(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
@@ -167,6 +208,7 @@ func TestRepositoriesService_CreateRelease(t *testing.T) {
 	input := &RepositoryRelease{
 		Name:                   String("v1.0"),
 		DiscussionCategoryName: String("General"),
+		GenerateReleaseNotes:   Bool(true),
 		// Fields to be removed:
 		ID:          Int64(2),
 		CreatedAt:   &Timestamp{referenceTime},
@@ -190,6 +232,7 @@ func TestRepositoriesService_CreateRelease(t *testing.T) {
 		want := &repositoryReleaseRequest{
 			Name:                   String("v1.0"),
 			DiscussionCategoryName: String("General"),
+			GenerateReleaseNotes:   Bool(true),
 		}
 		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
@@ -230,6 +273,7 @@ func TestRepositoriesService_EditRelease(t *testing.T) {
 	input := &RepositoryRelease{
 		Name:                   String("n"),
 		DiscussionCategoryName: String("General"),
+		GenerateReleaseNotes:   Bool(true),
 		// Fields to be removed:
 		ID:          Int64(2),
 		CreatedAt:   &Timestamp{referenceTime},
@@ -253,6 +297,7 @@ func TestRepositoriesService_EditRelease(t *testing.T) {
 		want := &repositoryReleaseRequest{
 			Name:                   String("n"),
 			DiscussionCategoryName: String("General"),
+			GenerateReleaseNotes:   Bool(true),
 		}
 		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)


### PR DESCRIPTION
supports the new feature github announced today: generate release notes ([link](https://github.blog/2021-10-04-beta-github-releases-improving-release-experience/))

while there are no official docs yet, one of the developers posted a screenshot of it on twitter: https://twitter.com/MylesBorins/status/1445102641214861318

This implements both the new `/releases/generate-notes` endpoint and the new `generate_release_notes` release option.