### PR TITLE
feat: support specifying repository names

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -47,6 +47,10 @@ type InstallationTokenOptions struct {
 	// Providing repository IDs restricts the access of an installation token to specific repositories.
 	RepositoryIDs []int64 `json:"repository_ids,omitempty"`
 
+	// The names of the repositories that the installation token can access.
+	// Providing repository names restricts the access of an installation token to specific repositories.
+	Repositories []string `json:"repositories,omitempty"`
+
 	// The permissions granted to the access token.
 	// The permissions object includes the permission names and their access type.
 	Permissions *InstallationPermissions `json:"permissions,omitempty"`

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -387,6 +387,7 @@ func TestAppsService_CreateInstallationTokenWithOptions(t *testing.T) {
 
 	installationTokenOptions := &InstallationTokenOptions{
 		RepositoryIDs: []int64{1234},
+		Repositories:  []string{"foo"},
 		Permissions: &InstallationPermissions{
 			Contents: String("write"),
 			Issues:   String("read"),


### PR DESCRIPTION
Hey! I noticed that the [installation access token API](https://docs.github.com/en/rest/reference/apps#create-an-installation-access-token-for-an-app) seems to support specifying repository _names_ instead of IDs. This makes restricting the scope of the token a lot easier, as you don't need to look up the repository ID first.

This PR adds the `repositories` field to the `InstallationTokenOptions` struct in order to support this functionality.