### PR TITLE
Remove REST API preview headers that have been promoted out of preview

### DIFF
--- a/github/activity_star.go
+++ b/github/activity_star.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"strings"
 )
 
 // StarredRepository is returned by ListStarred.
@@ -82,10 +81,6 @@ func (s *ActivityService) ListStarred(ctx context.Context, user string, opts *Ac
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when APIs fully launch
-	acceptHeaders := []string{mediaTypeTopicsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var repos []*StarredRepository
 	resp, err := s.client.Do(ctx, req, &repos)

--- a/github/activity_star.go
+++ b/github/activity_star.go
@@ -38,9 +38,6 @@ func (s *ActivityService) ListStargazers(ctx context.Context, owner, repo string
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeStarringPreview)
-
 	var stargazers []*Stargazer
 	resp, err := s.client.Do(ctx, req, &stargazers)
 	if err != nil {
@@ -87,7 +84,7 @@ func (s *ActivityService) ListStarred(ctx context.Context, user string, opts *Ac
 	}
 
 	// TODO: remove custom Accept header when APIs fully launch
-	acceptHeaders := []string{mediaTypeStarringPreview, mediaTypeTopicsPreview}
+	acceptHeaders := []string{mediaTypeTopicsPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var repos []*StarredRepository

--- a/github/activity_star_test.go
+++ b/github/activity_star_test.go
@@ -22,7 +22,6 @@ func TestActivityService_ListStargazers(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/stargazers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeStarringPreview)
 		testFormValues(t, r, values{
 			"page": "2",
 		})
@@ -62,7 +61,7 @@ func TestActivityService_ListStarred_authenticatedUser(t *testing.T) {
 
 	mux.HandleFunc("/user/starred", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join([]string{mediaTypeStarringPreview, mediaTypeTopicsPreview}, ", "))
+		testHeader(t, r, "Accept", strings.Join([]string{mediaTypeTopicsPreview}, ", "))
 		fmt.Fprint(w, `[{"starred_at":"2002-02-10T15:30:00Z","repo":{"id":1}}]`)
 	})
 
@@ -98,7 +97,7 @@ func TestActivityService_ListStarred_specifiedUser(t *testing.T) {
 
 	mux.HandleFunc("/users/u/starred", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join([]string{mediaTypeStarringPreview, mediaTypeTopicsPreview}, ", "))
+		testHeader(t, r, "Accept", strings.Join([]string{mediaTypeTopicsPreview}, ", "))
 		testFormValues(t, r, values{
 			"sort":      "created",
 			"direction": "asc",

--- a/github/activity_star_test.go
+++ b/github/activity_star_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -61,7 +60,6 @@ func TestActivityService_ListStarred_authenticatedUser(t *testing.T) {
 
 	mux.HandleFunc("/user/starred", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join([]string{mediaTypeTopicsPreview}, ", "))
 		fmt.Fprint(w, `[{"starred_at":"2002-02-10T15:30:00Z","repo":{"id":1}}]`)
 	})
 
@@ -97,7 +95,6 @@ func TestActivityService_ListStarred_specifiedUser(t *testing.T) {
 
 	mux.HandleFunc("/users/u/starred", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join([]string{mediaTypeTopicsPreview}, ", "))
 		testFormValues(t, r, values{
 			"sort":      "created",
 			"direction": "asc",

--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -34,7 +34,6 @@ func (s *AppsService) ListRepos(ctx context.Context, opts *ListOptions) (*ListRe
 	// TODO: remove custom Accept headers when APIs fully launch.
 	acceptHeaders := []string{
 		mediaTypeRepositoryVisibilityPreview,
-		mediaTypeRepositoryTemplatePreview,
 	}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
@@ -67,7 +66,6 @@ func (s *AppsService) ListUserRepos(ctx context.Context, id int64, opts *ListOpt
 	// TODO: remove custom Accept headers when APIs fully launch.
 	acceptHeaders := []string{
 		mediaTypeRepositoryVisibilityPreview,
-		mediaTypeRepositoryTemplatePreview,
 	}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 

--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"strings"
 )
 
 // ListRepositories represents the response from the list repos endpoints.
@@ -30,12 +29,6 @@ func (s *AppsService) ListRepos(ctx context.Context, opts *ListOptions) (*ListRe
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{
-		mediaTypeRepositoryVisibilityPreview,
-	}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var r *ListRepositories
 
@@ -62,12 +55,6 @@ func (s *AppsService) ListUserRepos(ctx context.Context, id int64, opts *ListOpt
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{
-		mediaTypeRepositoryVisibilityPreview,
-	}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var r *ListRepositories
 	resp, err := s.client.Do(ctx, req, &r)

--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -33,7 +33,6 @@ func (s *AppsService) ListRepos(ctx context.Context, opts *ListOptions) (*ListRe
 
 	// TODO: remove custom Accept headers when APIs fully launch.
 	acceptHeaders := []string{
-		mediaTypeTopicsPreview,
 		mediaTypeRepositoryVisibilityPreview,
 		mediaTypeRepositoryTemplatePreview,
 	}
@@ -67,7 +66,6 @@ func (s *AppsService) ListUserRepos(ctx context.Context, id int64, opts *ListOpt
 
 	// TODO: remove custom Accept headers when APIs fully launch.
 	acceptHeaders := []string{
-		mediaTypeTopicsPreview,
 		mediaTypeRepositoryVisibilityPreview,
 		mediaTypeRepositoryTemplatePreview,
 	}

--- a/github/apps_installation_test.go
+++ b/github/apps_installation_test.go
@@ -20,7 +20,6 @@ func TestAppsService_ListRepos(t *testing.T) {
 	defer teardown()
 
 	wantAcceptHeaders := []string{
-		mediaTypeTopicsPreview,
 		mediaTypeRepositoryVisibilityPreview,
 		mediaTypeRepositoryTemplatePreview,
 	}
@@ -61,7 +60,6 @@ func TestAppsService_ListUserRepos(t *testing.T) {
 	defer teardown()
 
 	wantAcceptHeaders := []string{
-		mediaTypeTopicsPreview,
 		mediaTypeRepositoryVisibilityPreview,
 		mediaTypeRepositoryTemplatePreview,
 	}

--- a/github/apps_installation_test.go
+++ b/github/apps_installation_test.go
@@ -21,7 +21,6 @@ func TestAppsService_ListRepos(t *testing.T) {
 
 	wantAcceptHeaders := []string{
 		mediaTypeRepositoryVisibilityPreview,
-		mediaTypeRepositoryTemplatePreview,
 	}
 	mux.HandleFunc("/installation/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -61,7 +60,6 @@ func TestAppsService_ListUserRepos(t *testing.T) {
 
 	wantAcceptHeaders := []string{
 		mediaTypeRepositoryVisibilityPreview,
-		mediaTypeRepositoryTemplatePreview,
 	}
 	mux.HandleFunc("/user/installations/1/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/apps_installation_test.go
+++ b/github/apps_installation_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -19,12 +18,8 @@ func TestAppsService_ListRepos(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{
-		mediaTypeRepositoryVisibilityPreview,
-	}
 	mux.HandleFunc("/installation/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"page":     "1",
 			"per_page": "2",
@@ -58,12 +53,8 @@ func TestAppsService_ListUserRepos(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{
-		mediaTypeRepositoryVisibilityPreview,
-	}
 	mux.HandleFunc("/user/installations/1/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"page":     "1",
 			"per_page": "2",

--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -155,7 +155,6 @@ func (s *AuthorizationsService) Check(ctx context.Context, clientID, accessToken
 	if err != nil {
 		return nil, nil, err
 	}
-	req.Header.Set("Accept", mediaTypeOAuthAppPreview)
 
 	a := new(Authorization)
 	resp, err := s.client.Do(ctx, req, a)
@@ -188,7 +187,6 @@ func (s *AuthorizationsService) Reset(ctx context.Context, clientID, accessToken
 	if err != nil {
 		return nil, nil, err
 	}
-	req.Header.Set("Accept", mediaTypeOAuthAppPreview)
 
 	a := new(Authorization)
 	resp, err := s.client.Do(ctx, req, a)
@@ -217,7 +215,6 @@ func (s *AuthorizationsService) Revoke(ctx context.Context, clientID, accessToke
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Accept", mediaTypeOAuthAppPreview)
 
 	return s.client.Do(ctx, req, nil)
 }
@@ -238,7 +235,6 @@ func (s *AuthorizationsService) DeleteGrant(ctx context.Context, clientID, acces
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Accept", mediaTypeOAuthAppPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/authorizations_test.go
+++ b/github/authorizations_test.go
@@ -21,7 +21,6 @@ func TestAuthorizationsService_Check(t *testing.T) {
 	mux.HandleFunc("/applications/id/token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testBody(t, r, `{"access_token":"a"}`+"\n")
-		testHeader(t, r, "Accept", mediaTypeOAuthAppPreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -58,7 +57,6 @@ func TestAuthorizationsService_Reset(t *testing.T) {
 	mux.HandleFunc("/applications/id/token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
 		testBody(t, r, `{"access_token":"a"}`+"\n")
-		testHeader(t, r, "Accept", mediaTypeOAuthAppPreview)
 		fmt.Fprint(w, `{"ID":1}`)
 	})
 
@@ -95,7 +93,6 @@ func TestAuthorizationsService_Revoke(t *testing.T) {
 	mux.HandleFunc("/applications/id/token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		testBody(t, r, `{"access_token":"a"}`+"\n")
-		testHeader(t, r, "Accept", mediaTypeOAuthAppPreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -123,7 +120,6 @@ func TestDeleteGrant(t *testing.T) {
 	mux.HandleFunc("/applications/id/grant", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		testBody(t, r, `{"access_token":"a"}`+"\n")
-		testHeader(t, r, "Accept", mediaTypeOAuthAppPreview)
 	})
 
 	ctx := context.Background()

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://developer.github.com/changes/2019-06-04-automated-security-fixes/
-	mediaTypeRequiredAutomatedSecurityFixesPreview = "application/vnd.github.london-preview+json"
-
 	// https://developer.github.com/changes/2019-05-29-update-branch-api/
 	mediaTypeUpdatePullRequestBranchPreview = "application/vnd.github.lydian-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -49,9 +49,6 @@ const (
 
 	// Media Type values to access preview APIs
 
-	// https://developer.github.com/changes/2016-05-12-reactions-api-preview/
-	mediaTypeReactionsPreview = "application/vnd.github.squirrel-girl-preview"
-
 	// https://developer.github.com/changes/2016-05-23-timeline-preview-api/
 	mediaTypeTimelinePreview = "application/vnd.github.mockingbird-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://developer.github.com/changes/2019-12-03-internal-visibility-changes/
-	mediaTypeRepositoryVisibilityPreview = "application/vnd.github.nebula-preview+json"
-
 	// https://developer.github.com/changes/2018-12-10-content-attachments-api/
 	mediaTypeContentAttachmentsPreview = "application/vnd.github.corsair-preview+json"
 )

--- a/github/github.go
+++ b/github/github.go
@@ -49,9 +49,6 @@ const (
 
 	// Media Type values to access preview APIs
 
-	// https://developer.github.com/changes/2016-04-06-deployment-and-deployment-status-enhancements/
-	mediaTypeDeploymentStatusPreview = "application/vnd.github.ant-man-preview+json"
-
 	// https://developer.github.com/changes/2018-10-16-deployments-environments-states-and-auto-inactive-updates/
 	mediaTypeExpandDeploymentStatusPreview = "application/vnd.github.flash-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://docs.github.com/en/free-pro-team@latest/rest/reference/previews/#create-and-use-repository-templates
-	mediaTypeRepositoryTemplatePreview = "application/vnd.github.baptiste-preview+json"
-
 	// https://developer.github.com/changes/2019-10-03-multi-line-comments/
 	mediaTypeMultiLineCommentsPreview = "application/vnd.github.comfort-fade-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://developer.github.com/changes/2019-05-29-update-branch-api/
-	mediaTypeUpdatePullRequestBranchPreview = "application/vnd.github.lydian-preview+json"
-
 	// https://developer.github.com/changes/2019-04-11-pulls-branches-for-commit/
 	mediaTypeListPullsOrBranchesForCommitPreview = "application/vnd.github.groot-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://developer.github.com/changes/2018-03-16-protected-branches-required-approving-reviews/
-	mediaTypeRequiredApprovingReviewsPreview = "application/vnd.github.luke-cage-preview+json"
-
 	// https://developer.github.com/enterprise/2.13/v3/repos/pre_receive_hooks/
 	mediaTypePreReceiveHooksPreview = "application/vnd.github.eye-scream-preview"
 

--- a/github/github.go
+++ b/github/github.go
@@ -49,9 +49,6 @@ const (
 
 	// Media Type values to access preview APIs
 
-	// https://developer.github.com/changes/2014-12-09-new-attributes-for-stars-api/
-	mediaTypeStarringPreview = "application/vnd.github.v3.star+json"
-
 	// https://help.github.com/enterprise/2.4/admin/guides/migrations/exporting-the-github-com-organization-s-repositories/
 	mediaTypeMigrationsPreview = "application/vnd.github.wyandotte-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://developer.github.com/changes/2019-10-03-multi-line-comments/
-	mediaTypeMultiLineCommentsPreview = "application/vnd.github.comfort-fade-preview+json"
-
 	// https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/
 	mediaTypeOAuthAppPreview = "application/vnd.github.doctor-strange-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -49,9 +49,6 @@ const (
 
 	// Media Type values to access preview APIs
 
-	// https://developer.github.com/changes/2017-02-28-user-blocking-apis-and-webhook/
-	mediaTypeBlockUsersPreview = "application/vnd.github.giant-sentry-fist-preview+json"
-
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://developer.github.com/changes/2018-12-18-interactions-preview/
-	mediaTypeInteractionRestrictionsPreview = "application/vnd.github.sombra-preview+json"
-
 	// https://developer.github.com/changes/2019-03-14-enabling-disabling-pages/
 	mediaTypeEnablePagesAPIPreview = "application/vnd.github.switcheroo-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://developer.github.com/changes/2019-03-14-enabling-disabling-pages/
-	mediaTypeEnablePagesAPIPreview = "application/vnd.github.switcheroo-preview+json"
-
 	// https://developer.github.com/changes/2019-04-24-vulnerability-alerts/
 	mediaTypeRequiredVulnerabilityAlertsPreview = "application/vnd.github.dorian-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -49,9 +49,6 @@ const (
 
 	// Media Type values to access preview APIs
 
-	// https://developer.github.com/changes/2016-05-23-timeline-preview-api/
-	mediaTypeTimelinePreview = "application/vnd.github.mockingbird-preview+json"
-
 	// https://developer.github.com/changes/2016-09-14-projects-api/
 	mediaTypeProjectsPreview = "application/vnd.github.inertia-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://developer.github.com/changes/2018-02-22-protected-branches-required-signatures/
-	mediaTypeSignaturePreview = "application/vnd.github.zzzax-preview+json"
-
 	// https://developer.github.com/changes/2018-09-05-project-card-events/
 	mediaTypeProjectCardDetailsPreview = "application/vnd.github.starfox-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://developer.github.com/changes/2017-07-17-update-topics-on-repositories/
-	mediaTypeTopicsPreview = "application/vnd.github.mercy-preview+json"
-
 	// https://developer.github.com/changes/2018-03-16-protected-branches-required-approving-reviews/
 	mediaTypeRequiredApprovingReviewsPreview = "application/vnd.github.luke-cage-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://docs.github.com/en/free-pro-team@latest/rest/reference/previews/#repository-creation-permissions
-	mediaTypeMemberAllowedRepoCreationTypePreview = "application/vnd.github.surtur-preview+json"
-
 	// https://docs.github.com/en/free-pro-team@latest/rest/reference/previews/#create-and-use-repository-templates
 	mediaTypeRepositoryTemplatePreview = "application/vnd.github.baptiste-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://developer.github.com/changes/2018-09-05-project-card-events/
-	mediaTypeProjectCardDetailsPreview = "application/vnd.github.starfox-preview+json"
-
 	// https://developer.github.com/changes/2018-12-18-interactions-preview/
 	mediaTypeInteractionRestrictionsPreview = "application/vnd.github.sombra-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://developer.github.com/changes/2019-04-11-pulls-branches-for-commit/
-	mediaTypeListPullsOrBranchesForCommitPreview = "application/vnd.github.groot-preview+json"
-
 	// https://docs.github.com/en/free-pro-team@latest/rest/reference/previews/#repository-creation-permissions
 	mediaTypeMemberAllowedRepoCreationTypePreview = "application/vnd.github.surtur-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/
-	mediaTypeOAuthAppPreview = "application/vnd.github.doctor-strange-preview+json"
-
 	// https://developer.github.com/changes/2019-12-03-internal-visibility-changes/
 	mediaTypeRepositoryVisibilityPreview = "application/vnd.github.nebula-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -49,9 +49,6 @@ const (
 
 	// Media Type values to access preview APIs
 
-	// https://developer.github.com/changes/2016-09-14-projects-api/
-	mediaTypeProjectsPreview = "application/vnd.github.inertia-preview+json"
-
 	// https://developer.github.com/changes/2017-01-05-commit-search-api/
 	mediaTypeCommitSearchPreview = "application/vnd.github.cloak-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://developer.github.com/enterprise/2.13/v3/repos/pre_receive_hooks/
-	mediaTypePreReceiveHooksPreview = "application/vnd.github.eye-scream-preview"
-
 	// https://developer.github.com/changes/2018-02-22-protected-branches-required-signatures/
 	mediaTypeSignaturePreview = "application/vnd.github.zzzax-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -49,9 +49,6 @@ const (
 
 	// Media Type values to access preview APIs
 
-	// https://developer.github.com/changes/2018-10-16-deployments-environments-states-and-auto-inactive-updates/
-	mediaTypeExpandDeploymentStatusPreview = "application/vnd.github.flash-preview+json"
-
 	// https://developer.github.com/changes/2016-05-12-reactions-api-preview/
 	mediaTypeReactionsPreview = "application/vnd.github.squirrel-girl-preview"
 

--- a/github/github.go
+++ b/github/github.go
@@ -49,9 +49,6 @@ const (
 
 	// Media Type values to access preview APIs
 
-	// https://developer.github.com/changes/2017-01-05-commit-search-api/
-	mediaTypeCommitSearchPreview = "application/vnd.github.cloak-preview+json"
-
 	// https://developer.github.com/changes/2017-02-28-user-blocking-apis-and-webhook/
 	mediaTypeBlockUsersPreview = "application/vnd.github.giant-sentry-fist-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -49,9 +49,6 @@ const (
 
 	// Media Type values to access preview APIs
 
-	// https://help.github.com/enterprise/2.4/admin/guides/migrations/exporting-the-github-com-organization-s-repositories/
-	mediaTypeMigrationsPreview = "application/vnd.github.wyandotte-preview+json"
-
 	// https://developer.github.com/changes/2016-04-06-deployment-and-deployment-status-enhancements/
 	mediaTypeDeploymentStatusPreview = "application/vnd.github.ant-man-preview+json"
 

--- a/github/github.go
+++ b/github/github.go
@@ -52,9 +52,6 @@ const (
 	// https://developer.github.com/changes/2017-05-23-coc-api/
 	mediaTypeCodesOfConductPreview = "application/vnd.github.scarlet-witch-preview+json"
 
-	// https://developer.github.com/changes/2019-04-24-vulnerability-alerts/
-	mediaTypeRequiredVulnerabilityAlertsPreview = "application/vnd.github.dorian-preview+json"
-
 	// https://developer.github.com/changes/2019-06-04-automated-security-fixes/
 	mediaTypeRequiredAutomatedSecurityFixesPreview = "application/vnd.github.london-preview+json"
 

--- a/github/interactions_orgs.go
+++ b/github/interactions_orgs.go
@@ -20,9 +20,6 @@ func (s *InteractionsService) GetRestrictionsForOrg(ctx context.Context, organiz
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeInteractionRestrictionsPreview)
-
 	organizationInteractions := new(InteractionRestriction)
 
 	resp, err := s.client.Do(ctx, req, organizationInteractions)
@@ -50,9 +47,6 @@ func (s *InteractionsService) UpdateRestrictionsForOrg(ctx context.Context, orga
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeInteractionRestrictionsPreview)
-
 	organizationInteractions := new(InteractionRestriction)
 
 	resp, err := s.client.Do(ctx, req, organizationInteractions)
@@ -72,9 +66,6 @@ func (s *InteractionsService) RemoveRestrictionsFromOrg(ctx context.Context, org
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeInteractionRestrictionsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/interactions_orgs_test.go
+++ b/github/interactions_orgs_test.go
@@ -21,7 +21,6 @@ func TestInteractionsService_GetRestrictionsForOrgs(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/interaction-limits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeInteractionRestrictionsPreview)
 		fmt.Fprint(w, `{"origin":"organization"}`)
 	})
 
@@ -62,7 +61,6 @@ func TestInteractionsService_UpdateRestrictionsForOrg(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeInteractionRestrictionsPreview)
 		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -101,7 +99,6 @@ func TestInteractionsService_RemoveRestrictionsFromOrg(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/interaction-limits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeInteractionRestrictionsPreview)
 	})
 
 	ctx := context.Background()

--- a/github/interactions_repos.go
+++ b/github/interactions_repos.go
@@ -20,9 +20,6 @@ func (s *InteractionsService) GetRestrictionsForRepo(ctx context.Context, owner,
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeInteractionRestrictionsPreview)
-
 	repositoryInteractions := new(InteractionRestriction)
 
 	resp, err := s.client.Do(ctx, req, repositoryInteractions)
@@ -50,9 +47,6 @@ func (s *InteractionsService) UpdateRestrictionsForRepo(ctx context.Context, own
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeInteractionRestrictionsPreview)
-
 	repositoryInteractions := new(InteractionRestriction)
 
 	resp, err := s.client.Do(ctx, req, repositoryInteractions)
@@ -72,9 +66,6 @@ func (s *InteractionsService) RemoveRestrictionsFromRepo(ctx context.Context, ow
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeInteractionRestrictionsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/interactions_repos_test.go
+++ b/github/interactions_repos_test.go
@@ -21,7 +21,6 @@ func TestInteractionsService_GetRestrictionsForRepo(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/interaction-limits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeInteractionRestrictionsPreview)
 		fmt.Fprint(w, `{"origin":"repository"}`)
 	})
 
@@ -62,7 +61,6 @@ func TestInteractionsService_UpdateRestrictionsForRepo(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeInteractionRestrictionsPreview)
 		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -101,7 +99,6 @@ func TestInteractionsService_RemoveRestrictionsFromRepo(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/interaction-limits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeInteractionRestrictionsPreview)
 	})
 
 	ctx := context.Background()

--- a/github/issues.go
+++ b/github/issues.go
@@ -160,9 +160,6 @@ func (s *IssuesService) listIssues(ctx context.Context, u string, opts *IssueLis
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var issues []*Issue
 	resp, err := s.client.Do(ctx, req, &issues)
 	if err != nil {
@@ -227,9 +224,6 @@ func (s *IssuesService) ListByRepo(ctx context.Context, owner string, repo strin
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var issues []*Issue
 	resp, err := s.client.Do(ctx, req, &issues)
 	if err != nil {
@@ -248,9 +242,6 @@ func (s *IssuesService) Get(ctx context.Context, owner string, repo string, numb
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	issue := new(Issue)
 	resp, err := s.client.Do(ctx, req, issue)

--- a/github/issues_comments.go
+++ b/github/issues_comments.go
@@ -69,9 +69,6 @@ func (s *IssuesService) ListComments(ctx context.Context, owner string, repo str
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var comments []*IssueComment
 	resp, err := s.client.Do(ctx, req, &comments)
 	if err != nil {
@@ -91,9 +88,6 @@ func (s *IssuesService) GetComment(ctx context.Context, owner string, repo strin
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	comment := new(IssueComment)
 	resp, err := s.client.Do(ctx, req, comment)

--- a/github/issues_comments_test.go
+++ b/github/issues_comments_test.go
@@ -22,7 +22,6 @@ func TestIssuesService_ListComments_allIssues(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		testFormValues(t, r, values{
 			"sort":      "updated",
 			"direction": "desc",
@@ -71,7 +70,6 @@ func TestIssuesService_ListComments_specificIssue(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
@@ -116,7 +114,6 @@ func TestIssuesService_GetComment(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 

--- a/github/issues_events.go
+++ b/github/issues_events.go
@@ -113,8 +113,6 @@ func (s *IssuesService) ListIssueEvents(ctx context.Context, owner, repo string,
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeProjectCardDetailsPreview)
-
 	var events []*IssueEvent
 	resp, err := s.client.Do(ctx, req, &events)
 	if err != nil {

--- a/github/issues_events_test.go
+++ b/github/issues_events_test.go
@@ -20,7 +20,6 @@ func TestIssuesService_ListIssueEvents(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/1/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectCardDetailsPreview)
 		testFormValues(t, r, values{
 			"page":     "1",
 			"per_page": "2",

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -22,7 +22,6 @@ func TestIssuesService_List_all(t *testing.T) {
 
 	mux.HandleFunc("/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		testFormValues(t, r, values{
 			"filter":    "all",
 			"state":     "closed",
@@ -68,7 +67,6 @@ func TestIssuesService_List_owned(t *testing.T) {
 
 	mux.HandleFunc("/user/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		fmt.Fprint(w, `[{"number":1}]`)
 	})
 
@@ -90,7 +88,6 @@ func TestIssuesService_ListByOrg(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		fmt.Fprint(w, `[{"number":1}]`)
 	})
 
@@ -135,7 +132,6 @@ func TestIssuesService_ListByRepo(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		testFormValues(t, r, values{
 			"milestone": "*",
 			"state":     "closed",
@@ -196,7 +192,6 @@ func TestIssuesService_Get(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		fmt.Fprint(w, `{"number":1, "author_association": "MEMBER","labels": [{"url": "u", "name": "n", "color": "c"}]}`)
 	})
 

--- a/github/issues_timeline.go
+++ b/github/issues_timeline.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 )
 
@@ -150,10 +149,6 @@ func (s *IssuesService) ListIssueTimeline(ctx context.Context, owner, repo strin
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectCardDetailsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var events []*Timeline
 	resp, err := s.client.Do(ctx, req, &events)

--- a/github/issues_timeline.go
+++ b/github/issues_timeline.go
@@ -152,7 +152,7 @@ func (s *IssuesService) ListIssueTimeline(ctx context.Context, owner, repo strin
 	}
 
 	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeTimelinePreview, mediaTypeProjectCardDetailsPreview}
+	acceptHeaders := []string{mediaTypeProjectCardDetailsPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var events []*Timeline

--- a/github/issues_timeline_test.go
+++ b/github/issues_timeline_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -19,10 +18,8 @@ func TestIssuesService_ListIssueTimeline(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeProjectCardDetailsPreview}
 	mux.HandleFunc("/repos/o/r/issues/1/timeline", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"page":     "1",
 			"per_page": "2",

--- a/github/issues_timeline_test.go
+++ b/github/issues_timeline_test.go
@@ -19,7 +19,7 @@ func TestIssuesService_ListIssueTimeline(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeTimelinePreview, mediaTypeProjectCardDetailsPreview}
+	wantAcceptHeaders := []string{mediaTypeProjectCardDetailsPreview}
 	mux.HandleFunc("/repos/o/r/issues/1/timeline", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))

--- a/github/migrations.go
+++ b/github/migrations.go
@@ -89,9 +89,6 @@ func (s *MigrationService) StartMigration(ctx context.Context, org string, repos
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeMigrationsPreview)
-
 	m := &Migration{}
 	resp, err := s.client.Do(ctx, req, m)
 	if err != nil {
@@ -116,9 +113,6 @@ func (s *MigrationService) ListMigrations(ctx context.Context, org string, opts 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeMigrationsPreview)
-
 	var m []*Migration
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -140,9 +134,6 @@ func (s *MigrationService) MigrationStatus(ctx context.Context, org string, id i
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeMigrationsPreview)
-
 	m := &Migration{}
 	resp, err := s.client.Do(ctx, req, m)
 	if err != nil {
@@ -163,9 +154,6 @@ func (s *MigrationService) MigrationArchiveURL(ctx context.Context, org string, 
 	if err != nil {
 		return "", err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
 	s.client.clientMu.Lock()
 	defer s.client.clientMu.Unlock()
@@ -201,9 +189,6 @@ func (s *MigrationService) DeleteMigration(ctx context.Context, org string, id i
 		return nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeMigrationsPreview)
-
 	return s.client.Do(ctx, req, nil)
 }
 
@@ -220,9 +205,6 @@ func (s *MigrationService) UnlockRepo(ctx context.Context, org string, id int64,
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/migrations_test.go
+++ b/github/migrations_test.go
@@ -21,7 +21,6 @@ func TestMigrationService_StartMigration(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/migrations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeMigrationsPreview)
 
 		w.WriteHeader(http.StatusCreated)
 		w.Write(migrationJSON)
@@ -61,7 +60,6 @@ func TestMigrationService_ListMigrations(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/migrations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeMigrationsPreview)
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(fmt.Sprintf("[%s]", migrationJSON)))
@@ -97,7 +95,6 @@ func TestMigrationService_MigrationStatus(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/migrations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeMigrationsPreview)
 
 		w.WriteHeader(http.StatusOK)
 		w.Write(migrationJSON)
@@ -133,7 +130,6 @@ func TestMigrationService_MigrationArchiveURL(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/migrations/1/archive", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeMigrationsPreview)
 
 		http.Redirect(w, r, "/yo", http.StatusFound)
 	})
@@ -166,7 +162,6 @@ func TestMigrationService_DeleteMigration(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/migrations/1/archive", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeMigrationsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -193,7 +188,6 @@ func TestMigrationService_UnlockRepo(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/migrations/1/repos/r/lock", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeMigrationsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/github/migrations_user.go
+++ b/github/migrations_user.go
@@ -82,9 +82,6 @@ func (s *MigrationService) StartUserMigration(ctx context.Context, repos []strin
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeMigrationsPreview)
-
 	m := &UserMigration{}
 	resp, err := s.client.Do(ctx, req, m)
 	if err != nil {
@@ -104,9 +101,6 @@ func (s *MigrationService) ListUserMigrations(ctx context.Context) ([]*UserMigra
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
 	var m []*UserMigration
 	resp, err := s.client.Do(ctx, req, &m)
@@ -129,9 +123,6 @@ func (s *MigrationService) UserMigrationStatus(ctx context.Context, id int64) (*
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeMigrationsPreview)
-
 	m := &UserMigration{}
 	resp, err := s.client.Do(ctx, req, m)
 	if err != nil {
@@ -152,9 +143,6 @@ func (s *MigrationService) UserMigrationArchiveURL(ctx context.Context, id int64
 	if err != nil {
 		return "", err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
 	m := &UserMigration{}
 
@@ -187,9 +175,6 @@ func (s *MigrationService) DeleteUserMigration(ctx context.Context, id int64) (*
 		return nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeMigrationsPreview)
-
 	return s.client.Do(ctx, req, nil)
 }
 
@@ -206,9 +191,6 @@ func (s *MigrationService) UnlockUserRepo(ctx context.Context, id int64, repo st
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/migrations_user_test.go
+++ b/github/migrations_user_test.go
@@ -21,7 +21,6 @@ func TestMigrationService_StartUserMigration(t *testing.T) {
 
 	mux.HandleFunc("/user/migrations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeMigrationsPreview)
 
 		w.WriteHeader(http.StatusCreated)
 		w.Write(userMigrationJSON)
@@ -59,7 +58,6 @@ func TestMigrationService_ListUserMigrations(t *testing.T) {
 
 	mux.HandleFunc("/user/migrations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeMigrationsPreview)
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(fmt.Sprintf("[%s]", userMigrationJSON)))
@@ -92,7 +90,6 @@ func TestMigrationService_UserMigrationStatus(t *testing.T) {
 
 	mux.HandleFunc("/user/migrations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeMigrationsPreview)
 
 		w.WriteHeader(http.StatusOK)
 		w.Write(userMigrationJSON)
@@ -125,7 +122,6 @@ func TestMigrationService_UserMigrationArchiveURL(t *testing.T) {
 
 	mux.HandleFunc("/user/migrations/1/archive", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeMigrationsPreview)
 
 		http.Redirect(w, r, "/go-github", http.StatusFound)
 	})
@@ -154,7 +150,6 @@ func TestMigrationService_DeleteUserMigration(t *testing.T) {
 
 	mux.HandleFunc("/user/migrations/1/archive", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeMigrationsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -186,7 +181,6 @@ func TestMigrationService_UnlockUserRepo(t *testing.T) {
 
 	mux.HandleFunc("/user/migrations/1/repos/r/lock", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeMigrationsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -193,9 +193,6 @@ func (s *OrganizationsService) Get(ctx context.Context, org string) (*Organizati
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeMemberAllowedRepoCreationTypePreview)
-
 	organization := new(Organization)
 	resp, err := s.client.Do(ctx, req, organization)
 	if err != nil {
@@ -233,9 +230,6 @@ func (s *OrganizationsService) Edit(ctx context.Context, name string, org *Organ
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeMemberAllowedRepoCreationTypePreview)
 
 	o := new(Organization)
 	resp, err := s.client.Do(ctx, req, o)

--- a/github/orgs_projects.go
+++ b/github/orgs_projects.go
@@ -25,9 +25,6 @@ func (s *OrganizationsService) ListProjects(ctx context.Context, org string, opt
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
-
 	var projects []*Project
 	resp, err := s.client.Do(ctx, req, &projects)
 	if err != nil {
@@ -46,9 +43,6 @@ func (s *OrganizationsService) CreateProject(ctx context.Context, org string, op
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	project := &Project{}
 	resp, err := s.client.Do(ctx, req, project)

--- a/github/orgs_projects_test.go
+++ b/github/orgs_projects_test.go
@@ -21,7 +21,6 @@ func TestOrganizationsService_ListProjects(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		testFormValues(t, r, values{"state": "open", "page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -61,7 +60,6 @@ func TestOrganizationsService_CreateProject(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 
 		v := &ProjectOptions{}
 		json.NewDecoder(r.Body).Decode(v)

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -187,7 +187,6 @@ func TestOrganizationsService_Get(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeMemberAllowedRepoCreationTypePreview)
 		fmt.Fprint(w, `{"id":1, "login":"l", "url":"u", "avatar_url": "a", "location":"l"}`)
 	})
 
@@ -271,7 +270,6 @@ func TestOrganizationsService_Edit(t *testing.T) {
 		v := new(Organization)
 		json.NewDecoder(r.Body).Decode(v)
 
-		testHeader(t, r, "Accept", mediaTypeMemberAllowedRepoCreationTypePreview)
 		testMethod(t, r, "PATCH")
 		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)

--- a/github/orgs_users_blocking.go
+++ b/github/orgs_users_blocking.go
@@ -25,9 +25,6 @@ func (s *OrganizationsService) ListBlockedUsers(ctx context.Context, org string,
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
-
 	var blockedUsers []*User
 	resp, err := s.client.Do(ctx, req, &blockedUsers)
 	if err != nil {
@@ -48,9 +45,6 @@ func (s *OrganizationsService) IsBlocked(ctx context.Context, org string, user s
 		return false, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
-
 	resp, err := s.client.Do(ctx, req, nil)
 	isBlocked, err := parseBoolResponse(err)
 	return isBlocked, resp, err
@@ -67,9 +61,6 @@ func (s *OrganizationsService) BlockUser(ctx context.Context, org string, user s
 		return nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
-
 	return s.client.Do(ctx, req, nil)
 }
 
@@ -83,9 +74,6 @@ func (s *OrganizationsService) UnblockUser(ctx context.Context, org string, user
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/orgs_users_blocking_test.go
+++ b/github/orgs_users_blocking_test.go
@@ -20,7 +20,6 @@ func TestOrganizationsService_ListBlockedUsers(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/blocks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeBlockUsersPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{
 			"login": "octocat"
@@ -60,7 +59,6 @@ func TestOrganizationsService_IsBlocked(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/blocks/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeBlockUsersPreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -94,7 +92,6 @@ func TestOrganizationsService_BlockUser(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/blocks/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeBlockUsersPreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -121,7 +118,6 @@ func TestOrganizationsService_UnblockUser(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/blocks/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeBlockUsersPreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 

--- a/github/projects.go
+++ b/github/projects.go
@@ -49,9 +49,6 @@ func (s *ProjectsService) GetProject(ctx context.Context, id int64) (*Project, *
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
-
 	project := &Project{}
 	resp, err := s.client.Do(ctx, req, project)
 	if err != nil {
@@ -96,9 +93,6 @@ func (s *ProjectsService) UpdateProject(ctx context.Context, id int64, opts *Pro
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
-
 	project := &Project{}
 	resp, err := s.client.Do(ctx, req, project)
 	if err != nil {
@@ -117,9 +111,6 @@ func (s *ProjectsService) DeleteProject(ctx context.Context, id int64) (*Respons
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }
@@ -153,9 +144,6 @@ func (s *ProjectsService) ListProjectColumns(ctx context.Context, projectID int6
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
-
 	columns := []*ProjectColumn{}
 	resp, err := s.client.Do(ctx, req, &columns)
 	if err != nil {
@@ -174,9 +162,6 @@ func (s *ProjectsService) GetProjectColumn(ctx context.Context, id int64) (*Proj
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	column := &ProjectColumn{}
 	resp, err := s.client.Do(ctx, req, column)
@@ -205,9 +190,6 @@ func (s *ProjectsService) CreateProjectColumn(ctx context.Context, projectID int
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
-
 	column := &ProjectColumn{}
 	resp, err := s.client.Do(ctx, req, column)
 	if err != nil {
@@ -227,9 +209,6 @@ func (s *ProjectsService) UpdateProjectColumn(ctx context.Context, columnID int6
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
-
 	column := &ProjectColumn{}
 	resp, err := s.client.Do(ctx, req, column)
 	if err != nil {
@@ -248,9 +227,6 @@ func (s *ProjectsService) DeleteProjectColumn(ctx context.Context, columnID int6
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }
@@ -272,9 +248,6 @@ func (s *ProjectsService) MoveProjectColumn(ctx context.Context, columnID int64,
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }
@@ -329,9 +302,6 @@ func (s *ProjectsService) ListProjectCards(ctx context.Context, columnID int64, 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
-
 	cards := []*ProjectCard{}
 	resp, err := s.client.Do(ctx, req, &cards)
 	if err != nil {
@@ -350,9 +320,6 @@ func (s *ProjectsService) GetProjectCard(ctx context.Context, cardID int64) (*Pr
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	card := &ProjectCard{}
 	resp, err := s.client.Do(ctx, req, card)
@@ -389,9 +356,6 @@ func (s *ProjectsService) CreateProjectCard(ctx context.Context, columnID int64,
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
-
 	card := &ProjectCard{}
 	resp, err := s.client.Do(ctx, req, card)
 	if err != nil {
@@ -411,9 +375,6 @@ func (s *ProjectsService) UpdateProjectCard(ctx context.Context, cardID int64, o
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
-
 	card := &ProjectCard{}
 	resp, err := s.client.Do(ctx, req, card)
 	if err != nil {
@@ -432,9 +393,6 @@ func (s *ProjectsService) DeleteProjectCard(ctx context.Context, cardID int64) (
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }
@@ -460,9 +418,6 @@ func (s *ProjectsService) MoveProjectCard(ctx context.Context, cardID int64, opt
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }
@@ -491,9 +446,6 @@ func (s *ProjectsService) AddProjectCollaborator(ctx context.Context, id int64, 
 		return nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
-
 	return s.client.Do(ctx, req, nil)
 }
 
@@ -507,9 +459,6 @@ func (s *ProjectsService) RemoveProjectCollaborator(ctx context.Context, id int6
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }
@@ -549,9 +498,6 @@ func (s *ProjectsService) ListProjectCollaborators(ctx context.Context, id int64
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
-
 	var users []*User
 	resp, err := s.client.Do(ctx, req, &users)
 	if err != nil {
@@ -581,9 +527,6 @@ func (s *ProjectsService) ReviewProjectCollaboratorPermission(ctx context.Contex
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	ppl := new(ProjectPermissionLevel)
 	resp, err := s.client.Do(ctx, req, ppl)

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -99,7 +98,6 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 
 	mux.HandleFunc("/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 
 		v := &ProjectOptions{}
 		json.NewDecoder(r.Body).Decode(v)
@@ -142,7 +140,6 @@ func TestProjectsService_GetProject(t *testing.T) {
 
 	mux.HandleFunc("/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -178,7 +175,6 @@ func TestProjectsService_DeleteProject(t *testing.T) {
 
 	mux.HandleFunc("/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 	})
 
 	ctx := context.Background()
@@ -202,10 +198,8 @@ func TestProjectsService_ListProjectColumns(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/projects/1/columns", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -243,7 +237,6 @@ func TestProjectsService_GetProjectColumn(t *testing.T) {
 
 	mux.HandleFunc("/projects/columns/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -281,7 +274,6 @@ func TestProjectsService_CreateProjectColumn(t *testing.T) {
 
 	mux.HandleFunc("/projects/1/columns", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 
 		v := &ProjectColumnOptions{}
 		json.NewDecoder(r.Body).Decode(v)
@@ -326,7 +318,6 @@ func TestProjectsService_UpdateProjectColumn(t *testing.T) {
 
 	mux.HandleFunc("/projects/columns/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 
 		v := &ProjectColumnOptions{}
 		json.NewDecoder(r.Body).Decode(v)
@@ -369,7 +360,6 @@ func TestProjectsService_DeleteProjectColumn(t *testing.T) {
 
 	mux.HandleFunc("/projects/columns/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 	})
 
 	ctx := context.Background()
@@ -397,7 +387,6 @@ func TestProjectsService_MoveProjectColumn(t *testing.T) {
 
 	mux.HandleFunc("/projects/columns/1/moves", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 
 		v := &ProjectColumnMoveOptions{}
 		json.NewDecoder(r.Body).Decode(v)
@@ -429,7 +418,6 @@ func TestProjectsService_ListProjectCards(t *testing.T) {
 
 	mux.HandleFunc("/projects/columns/1/cards", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		testFormValues(t, r, values{
 			"archived_state": "all",
 			"page":           "2"})
@@ -471,7 +459,6 @@ func TestProjectsService_GetProjectCard(t *testing.T) {
 
 	mux.HandleFunc("/projects/columns/cards/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -512,7 +499,6 @@ func TestProjectsService_CreateProjectCard(t *testing.T) {
 
 	mux.HandleFunc("/projects/columns/1/cards", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 
 		v := &ProjectCardOptions{}
 		json.NewDecoder(r.Body).Decode(v)
@@ -560,7 +546,6 @@ func TestProjectsService_UpdateProjectCard(t *testing.T) {
 
 	mux.HandleFunc("/projects/columns/cards/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 
 		v := &ProjectCardOptions{}
 		json.NewDecoder(r.Body).Decode(v)
@@ -603,7 +588,6 @@ func TestProjectsService_DeleteProjectCard(t *testing.T) {
 
 	mux.HandleFunc("/projects/columns/cards/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 	})
 
 	ctx := context.Background()
@@ -631,7 +615,6 @@ func TestProjectsService_MoveProjectCard(t *testing.T) {
 
 	mux.HandleFunc("/projects/columns/cards/1/moves", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 
 		v := &ProjectCardMoveOptions{}
 		json.NewDecoder(r.Body).Decode(v)
@@ -667,7 +650,6 @@ func TestProjectsService_AddProjectCollaborator(t *testing.T) {
 
 	mux.HandleFunc("/projects/1/collaborators/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 
 		v := &ProjectCollaboratorOptions{}
 		json.NewDecoder(r.Body).Decode(v)
@@ -710,7 +692,6 @@ func TestProjectsService_RemoveCollaborator(t *testing.T) {
 
 	mux.HandleFunc("/projects/1/collaborators/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -746,7 +727,6 @@ func TestProjectsService_ListCollaborators(t *testing.T) {
 
 	mux.HandleFunc("/projects/1/collaborators", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprintf(w, `[{"id":1}, {"id":2}]`)
 	})
@@ -786,7 +766,6 @@ func TestProjectsService_ListCollaborators_withAffiliation(t *testing.T) {
 
 	mux.HandleFunc("/projects/1/collaborators", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		testFormValues(t, r, values{"affiliation": "all", "page": "2"})
 		fmt.Fprintf(w, `[{"id":1}, {"id":2}]`)
 	})
@@ -813,7 +792,6 @@ func TestProjectsService_ReviewProjectCollaboratorPermission(t *testing.T) {
 
 	mux.HandleFunc("/projects/1/collaborators/u/permission", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		fmt.Fprintf(w, `{"permission":"admin","user":{"login":"u"}}`)
 	})
 

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -301,9 +301,6 @@ func (s *PullRequestsService) UpdateBranch(ctx context.Context, owner, repo stri
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeUpdatePullRequestBranchPreview)
-
 	p := new(PullRequestBranchUpdateResponse)
 	resp, err := s.client.Do(ctx, req, p)
 	if err != nil {

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -182,8 +182,6 @@ func (s *PullRequestsService) ListPullRequestsWithCommit(ctx context.Context, ow
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeListPullsOrBranchesForCommitPreview)
 	var pulls []*PullRequest
 	resp, err := s.client.Do(ctx, req, &pulls)
 	if err != nil {

--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -86,7 +86,7 @@ func (s *PullRequestsService) ListComments(ctx context.Context, owner, repo stri
 	}
 
 	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeMultiLineCommentsPreview}
+	acceptHeaders := []string{mediaTypeMultiLineCommentsPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var comments []*PullRequestComment
@@ -109,7 +109,7 @@ func (s *PullRequestsService) GetComment(ctx context.Context, owner, repo string
 	}
 
 	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeMultiLineCommentsPreview}
+	acceptHeaders := []string{mediaTypeMultiLineCommentsPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	comment := new(PullRequestComment)
@@ -131,7 +131,7 @@ func (s *PullRequestsService) CreateComment(ctx context.Context, owner, repo str
 		return nil, nil, err
 	}
 	// TODO: remove custom Accept headers when their respective API fully launches.
-	acceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeMultiLineCommentsPreview}
+	acceptHeaders := []string{mediaTypeMultiLineCommentsPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	c := new(PullRequestComment)

--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 )
 
@@ -85,10 +84,6 @@ func (s *PullRequestsService) ListComments(ctx context.Context, owner, repo stri
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeMultiLineCommentsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
-
 	var comments []*PullRequestComment
 	resp, err := s.client.Do(ctx, req, &comments)
 	if err != nil {
@@ -108,10 +103,6 @@ func (s *PullRequestsService) GetComment(ctx context.Context, owner, repo string
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeMultiLineCommentsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
-
 	comment := new(PullRequestComment)
 	resp, err := s.client.Do(ctx, req, comment)
 	if err != nil {
@@ -130,9 +121,6 @@ func (s *PullRequestsService) CreateComment(ctx context.Context, owner, repo str
 	if err != nil {
 		return nil, nil, err
 	}
-	// TODO: remove custom Accept headers when their respective API fully launches.
-	acceptHeaders := []string{mediaTypeMultiLineCommentsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	c := new(PullRequestComment)
 	resp, err := s.client.Do(ctx, req, c)

--- a/github/pulls_comments_test.go
+++ b/github/pulls_comments_test.go
@@ -137,7 +137,7 @@ func TestPullRequestsService_ListComments_allPulls(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeMultiLineCommentsPreview}
+	wantAcceptHeaders := []string{mediaTypeMultiLineCommentsPreview}
 	mux.HandleFunc("/repos/o/r/pulls/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
@@ -186,7 +186,7 @@ func TestPullRequestsService_ListComments_specificPull(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeMultiLineCommentsPreview}
+	wantAcceptHeaders := []string{mediaTypeMultiLineCommentsPreview}
 	mux.HandleFunc("/repos/o/r/pulls/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
@@ -218,7 +218,7 @@ func TestPullRequestsService_GetComment(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeMultiLineCommentsPreview}
+	wantAcceptHeaders := []string{mediaTypeMultiLineCommentsPreview}
 	mux.HandleFunc("/repos/o/r/pulls/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
@@ -266,7 +266,7 @@ func TestPullRequestsService_CreateComment(t *testing.T) {
 
 	input := &PullRequestComment{Body: String("b")}
 
-	wantAcceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeMultiLineCommentsPreview}
+	wantAcceptHeaders := []string{mediaTypeMultiLineCommentsPreview}
 	mux.HandleFunc("/repos/o/r/pulls/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		v := new(PullRequestComment)
 		json.NewDecoder(r.Body).Decode(v)

--- a/github/pulls_comments_test.go
+++ b/github/pulls_comments_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -137,10 +136,8 @@ func TestPullRequestsService_ListComments_allPulls(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeMultiLineCommentsPreview}
 	mux.HandleFunc("/repos/o/r/pulls/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"sort":      "updated",
 			"direction": "desc",
@@ -186,10 +183,8 @@ func TestPullRequestsService_ListComments_specificPull(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeMultiLineCommentsPreview}
 	mux.HandleFunc("/repos/o/r/pulls/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		fmt.Fprint(w, `[{"id":1, "pull_request_review_id":42}]`)
 	})
 
@@ -218,10 +213,8 @@ func TestPullRequestsService_GetComment(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeMultiLineCommentsPreview}
 	mux.HandleFunc("/repos/o/r/pulls/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -266,13 +259,10 @@ func TestPullRequestsService_CreateComment(t *testing.T) {
 
 	input := &PullRequestComment{Body: String("b")}
 
-	wantAcceptHeaders := []string{mediaTypeMultiLineCommentsPreview}
 	mux.HandleFunc("/repos/o/r/pulls/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		v := new(PullRequestComment)
 		json.NewDecoder(r.Body).Decode(v)
 
-		// TODO: remove custom Accept header assertion when the API fully launches.
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testMethod(t, r, "POST")
 		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)

--- a/github/pulls_reviews.go
+++ b/github/pulls_reviews.go
@@ -231,12 +231,8 @@ func (s *PullRequestsService) CreateReview(ctx context.Context, owner, repo stri
 	}
 
 	// Detect which style of review comment is being used.
-	if isCF, err := review.isComfortFadePreview(); err != nil {
+	if _, err := review.isComfortFadePreview(); err != nil {
 		return nil, nil, err
-	} else if isCF {
-		// If the review comments are using the comfort fade preview fields,
-		// then pass the comfort fade header.
-		req.Header.Set("Accept", mediaTypeMultiLineCommentsPreview)
 	}
 
 	r := new(PullRequestReview)

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -417,7 +417,6 @@ func TestPullRequestsService_UpdateBranch(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pulls/1/update-branch", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeUpdatePullRequestBranchPreview)
 		fmt.Fprint(w, `
 			{
 			  "message": "Updating pull request branch.",

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -67,7 +67,6 @@ func TestPullRequestsService_ListPullRequestsWithCommit(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/commits/sha/pulls", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeListPullsOrBranchesForCommitPreview)
 		testFormValues(t, r, values{
 			"state":     "closed",
 			"head":      "h",

--- a/github/reactions.go
+++ b/github/reactions.go
@@ -73,9 +73,6 @@ func (s *ReactionsService) ListCommentReactions(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -99,9 +96,6 @@ func (s *ReactionsService) CreateCommentReaction(ctx context.Context, owner, rep
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -145,9 +139,6 @@ func (s *ReactionsService) ListIssueReactions(ctx context.Context, owner, repo s
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -171,9 +162,6 @@ func (s *ReactionsService) CreateIssueReaction(ctx context.Context, owner, repo 
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -217,9 +205,6 @@ func (s *ReactionsService) ListIssueCommentReactions(ctx context.Context, owner,
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -243,9 +228,6 @@ func (s *ReactionsService) CreateIssueCommentReaction(ctx context.Context, owner
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -289,9 +271,6 @@ func (s *ReactionsService) ListPullRequestCommentReactions(ctx context.Context, 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -315,9 +294,6 @@ func (s *ReactionsService) CreatePullRequestCommentReaction(ctx context.Context,
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -361,8 +337,6 @@ func (s *ReactionsService) ListTeamDiscussionReactions(ctx context.Context, team
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -384,8 +358,6 @@ func (s *ReactionsService) CreateTeamDiscussionReaction(ctx context.Context, tea
 	if err != nil {
 		return nil, nil, err
 	}
-
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -429,8 +401,6 @@ func (s *ReactionsService) ListTeamDiscussionCommentReactions(ctx context.Contex
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -451,8 +421,6 @@ func (s *ReactionsService) CreateTeamDiscussionCommentReaction(ctx context.Conte
 	if err != nil {
 		return nil, nil, err
 	}
-
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -486,9 +454,6 @@ func (s *ReactionsService) deleteReaction(ctx context.Context, url string) (*Res
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/reactions_test.go
+++ b/github/reactions_test.go
@@ -58,7 +58,7 @@ func TestReactions_Marshal(t *testing.T) {
 		"heart": 1,
 		"hooray": 1,
 		"rocket": 1,
-		"eyes": 1,		
+		"eyes": 1,
 		"url": "u"
 	}`
 
@@ -71,7 +71,6 @@ func TestReactionsService_ListCommentReactions(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		testFormValues(t, r, values{"content": "+1"})
 		fmt.Fprint(w, `[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`)
@@ -109,7 +108,6 @@ func TestReactionsService_CreateCommentReaction(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
@@ -146,7 +144,6 @@ func TestReactionsService_ListIssueReactions(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
@@ -190,7 +187,6 @@ func TestReactionsService_CreateIssueReaction(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
@@ -227,7 +223,6 @@ func TestReactionsService_ListIssueCommentReactions(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
@@ -271,7 +266,6 @@ func TestReactionsService_CreateIssueCommentReaction(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
@@ -308,7 +302,6 @@ func TestReactionsService_ListPullRequestCommentReactions(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pulls/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
@@ -352,7 +345,6 @@ func TestReactionsService_CreatePullRequestCommentReaction(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pulls/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
@@ -389,7 +381,6 @@ func TestReactionsService_ListTeamDiscussionReactions(t *testing.T) {
 
 	mux.HandleFunc("/teams/1/discussions/2/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
@@ -433,7 +424,6 @@ func TestReactionsService_CreateTeamDiscussionReaction(t *testing.T) {
 
 	mux.HandleFunc("/teams/1/discussions/2/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
@@ -470,7 +460,6 @@ func TestReactionService_ListTeamDiscussionCommentReactions(t *testing.T) {
 
 	mux.HandleFunc("/teams/1/discussions/2/comments/3/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
@@ -514,7 +503,6 @@ func TestReactionService_CreateTeamDiscussionCommentReaction(t *testing.T) {
 
 	mux.HandleFunc("/teams/1/discussions/2/comments/3/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
@@ -551,7 +539,6 @@ func TestReactionsService_DeleteCommitCommentReaction(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/comments/1/reactions/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -578,7 +565,6 @@ func TestReactionsService_DeleteCommitCommentReactionByRepoID(t *testing.T) {
 
 	mux.HandleFunc("/repositories/1/comments/2/reactions/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -605,7 +591,6 @@ func TestReactionsService_DeleteIssueReaction(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/1/reactions/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -632,7 +617,6 @@ func TestReactionsService_DeleteIssueReactionByRepoID(t *testing.T) {
 
 	mux.HandleFunc("/repositories/1/issues/2/reactions/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -659,7 +643,6 @@ func TestReactionsService_DeleteIssueCommentReaction(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/comments/1/reactions/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -686,7 +669,6 @@ func TestReactionsService_DeleteIssueCommentReactionByRepoID(t *testing.T) {
 
 	mux.HandleFunc("/repositories/1/issues/comments/2/reactions/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -713,7 +695,6 @@ func TestReactionsService_DeletePullRequestCommentReaction(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pulls/comments/1/reactions/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -740,7 +721,6 @@ func TestReactionsService_DeletePullRequestCommentReactionByRepoID(t *testing.T)
 
 	mux.HandleFunc("/repositories/1/pulls/comments/2/reactions/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -767,7 +747,6 @@ func TestReactionsService_DeleteTeamDiscussionReaction(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/teams/s/discussions/1/reactions/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -794,7 +773,6 @@ func TestReactionsService_DeleteTeamDiscussionReactionByTeamIDAndOrgID(t *testin
 
 	mux.HandleFunc("/organizations/1/team/2/discussions/3/reactions/4", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -821,7 +799,6 @@ func TestReactionsService_DeleteTeamDiscussionCommentReaction(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/teams/s/discussions/1/comments/2/reactions/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -848,7 +825,6 @@ func TestReactionsService_DeleteTeamDiscussionCommentReactionByTeamIDAndOrgID(t 
 
 	mux.HandleFunc("/organizations/1/team/2/discussions/3/comments/4/reactions/5", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/github/repos.go
+++ b/github/repos.go
@@ -373,7 +373,7 @@ func (s *RepositoriesService) Create(ctx context.Context, org string, repo *Repo
 		return nil, nil, err
 	}
 
-	acceptHeaders := []string{mediaTypeRepositoryTemplatePreview, mediaTypeRepositoryVisibilityPreview}
+	acceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 	r := new(Repository)
 	resp, err := s.client.Do(ctx, req, r)
@@ -406,7 +406,6 @@ func (s *RepositoriesService) CreateFromTemplate(ctx context.Context, templateOw
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeRepositoryTemplatePreview)
 	r := new(Repository)
 	resp, err := s.client.Do(ctx, req, r)
 	if err != nil {
@@ -430,7 +429,6 @@ func (s *RepositoriesService) Get(ctx context.Context, owner, repo string) (*Rep
 	// https://docs.github.com/en/free-pro-team@latest/rest/reference/licenses/#get-a-repositorys-license
 	acceptHeaders := []string{
 		mediaTypeCodesOfConductPreview,
-		mediaTypeRepositoryTemplatePreview,
 		mediaTypeRepositoryVisibilityPreview,
 	}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
@@ -495,7 +493,7 @@ func (s *RepositoriesService) Edit(ctx context.Context, owner, repo string, repo
 		return nil, nil, err
 	}
 
-	acceptHeaders := []string{mediaTypeRepositoryTemplatePreview, mediaTypeRepositoryVisibilityPreview}
+	acceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 	r := new(Repository)
 	resp, err := s.client.Do(ctx, req, r)

--- a/github/repos.go
+++ b/github/repos.go
@@ -1134,9 +1134,6 @@ func (s *RepositoriesService) GetSignaturesProtectedBranch(ctx context.Context, 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeSignaturePreview)
-
 	p := new(SignaturesProtectedBranch)
 	resp, err := s.client.Do(ctx, req, p)
 	if err != nil {
@@ -1157,9 +1154,6 @@ func (s *RepositoriesService) RequireSignaturesOnProtectedBranch(ctx context.Con
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeSignaturePreview)
-
 	r := new(SignaturesProtectedBranch)
 	resp, err := s.client.Do(ctx, req, r)
 	if err != nil {
@@ -1178,9 +1172,6 @@ func (s *RepositoriesService) OptionalSignaturesOnProtectedBranch(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeSignaturePreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/repos.go
+++ b/github/repos.go
@@ -609,9 +609,6 @@ func (s *RepositoriesService) EnableAutomatedSecurityFixes(ctx context.Context, 
 		return nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeRequiredAutomatedSecurityFixesPreview)
-
 	return s.client.Do(ctx, req, nil)
 }
 
@@ -625,9 +622,6 @@ func (s *RepositoriesService) DisableAutomatedSecurityFixes(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeRequiredAutomatedSecurityFixesPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/repos.go
+++ b/github/repos.go
@@ -206,7 +206,7 @@ func (s *RepositoriesService) List(ctx context.Context, user string, opts *Repos
 	}
 
 	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
+	acceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var repos []*Repository
@@ -252,7 +252,7 @@ func (s *RepositoriesService) ListByOrg(ctx context.Context, org string, opts *R
 	}
 
 	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
+	acceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var repos []*Repository
@@ -430,7 +430,6 @@ func (s *RepositoriesService) Get(ctx context.Context, owner, repo string) (*Rep
 	// https://docs.github.com/en/free-pro-team@latest/rest/reference/licenses/#get-a-repositorys-license
 	acceptHeaders := []string{
 		mediaTypeCodesOfConductPreview,
-		mediaTypeTopicsPreview,
 		mediaTypeRepositoryTemplatePreview,
 		mediaTypeRepositoryVisibilityPreview,
 	}
@@ -1396,9 +1395,6 @@ func (s *RepositoriesService) ListAllTopics(ctx context.Context, owner, repo str
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeTopicsPreview)
-
 	topics := new(repositoryTopics)
 	resp, err := s.client.Do(ctx, req, topics)
 	if err != nil {
@@ -1423,9 +1419,6 @@ func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo 
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeTopicsPreview)
 
 	t = new(repositoryTopics)
 	resp, err := s.client.Do(ctx, req, t)

--- a/github/repos.go
+++ b/github/repos.go
@@ -564,9 +564,6 @@ func (s *RepositoriesService) GetVulnerabilityAlerts(ctx context.Context, owner,
 		return false, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeRequiredVulnerabilityAlertsPreview)
-
 	resp, err := s.client.Do(ctx, req, nil)
 	vulnerabilityAlertsEnabled, err := parseBoolResponse(err)
 
@@ -584,9 +581,6 @@ func (s *RepositoriesService) EnableVulnerabilityAlerts(ctx context.Context, own
 		return nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeRequiredVulnerabilityAlertsPreview)
-
 	return s.client.Do(ctx, req, nil)
 }
 
@@ -600,9 +594,6 @@ func (s *RepositoriesService) DisableVulnerabilityAlerts(ctx context.Context, ow
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeRequiredVulnerabilityAlertsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/repos.go
+++ b/github/repos.go
@@ -205,10 +205,6 @@ func (s *RepositoriesService) List(ctx context.Context, user string, opts *Repos
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
-
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)
 	if err != nil {
@@ -250,10 +246,6 @@ func (s *RepositoriesService) ListByOrg(ctx context.Context, org string, opts *R
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)
@@ -373,8 +365,6 @@ func (s *RepositoriesService) Create(ctx context.Context, org string, repo *Repo
 		return nil, nil, err
 	}
 
-	acceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 	r := new(Repository)
 	resp, err := s.client.Do(ctx, req, r)
 	if err != nil {
@@ -429,7 +419,6 @@ func (s *RepositoriesService) Get(ctx context.Context, owner, repo string) (*Rep
 	// https://docs.github.com/en/free-pro-team@latest/rest/reference/licenses/#get-a-repositorys-license
 	acceptHeaders := []string{
 		mediaTypeCodesOfConductPreview,
-		mediaTypeRepositoryVisibilityPreview,
 	}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
@@ -493,8 +482,6 @@ func (s *RepositoriesService) Edit(ctx context.Context, owner, repo string, repo
 		return nil, nil, err
 	}
 
-	acceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 	r := new(Repository)
 	resp, err := s.client.Do(ctx, req, r)
 	if err != nil {

--- a/github/repos.go
+++ b/github/repos.go
@@ -1046,9 +1046,6 @@ func (s *RepositoriesService) GetBranchProtection(ctx context.Context, owner, re
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeRequiredApprovingReviewsPreview)
-
 	p := new(Protection)
 	resp, err := s.client.Do(ctx, req, p)
 	if err != nil {
@@ -1104,9 +1101,6 @@ func (s *RepositoriesService) UpdateBranchProtection(ctx context.Context, owner,
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeRequiredApprovingReviewsPreview)
 
 	p := new(Protection)
 	resp, err := s.client.Do(ctx, req, p)
@@ -1252,9 +1246,6 @@ func (s *RepositoriesService) GetPullRequestReviewEnforcement(ctx context.Contex
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeRequiredApprovingReviewsPreview)
-
 	r := new(PullRequestReviewsEnforcement)
 	resp, err := s.client.Do(ctx, req, r)
 	if err != nil {
@@ -1274,9 +1265,6 @@ func (s *RepositoriesService) UpdatePullRequestReviewEnforcement(ctx context.Con
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeRequiredApprovingReviewsPreview)
 
 	r := new(PullRequestReviewsEnforcement)
 	resp, err := s.client.Do(ctx, req, r)
@@ -1302,9 +1290,6 @@ func (s *RepositoriesService) DisableDismissalRestrictions(ctx context.Context, 
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeRequiredApprovingReviewsPreview)
 
 	r := new(PullRequestReviewsEnforcement)
 	resp, err := s.client.Do(ctx, req, r)

--- a/github/repos_comments.go
+++ b/github/repos_comments.go
@@ -49,9 +49,6 @@ func (s *RepositoriesService) ListComments(ctx context.Context, owner, repo stri
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var comments []*RepositoryComment
 	resp, err := s.client.Do(ctx, req, &comments)
 	if err != nil {
@@ -75,9 +72,6 @@ func (s *RepositoriesService) ListCommitComments(ctx context.Context, owner, rep
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var comments []*RepositoryComment
 	resp, err := s.client.Do(ctx, req, &comments)
@@ -117,9 +111,6 @@ func (s *RepositoriesService) GetComment(ctx context.Context, owner, repo string
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	c := new(RepositoryComment)
 	resp, err := s.client.Do(ctx, req, c)

--- a/github/repos_comments_test.go
+++ b/github/repos_comments_test.go
@@ -21,7 +21,6 @@ func TestRepositoriesService_ListComments(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
@@ -68,7 +67,6 @@ func TestRepositoriesService_ListCommitComments(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/commits/s/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
@@ -168,7 +166,6 @@ func TestRepositoriesService_GetComment(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 

--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -300,8 +300,6 @@ func (s *RepositoriesService) ListBranchesHeadCommit(ctx context.Context, owner,
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeListPullsOrBranchesForCommitPreview)
 	var branchCommits []*BranchCommit
 	resp, err := s.client.Do(ctx, req, &branchCommits)
 	if err != nil {

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -117,7 +117,7 @@ func (s *RepositoriesService) CreateDeployment(ctx context.Context, owner, repo 
 	}
 
 	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeExpandDeploymentStatusPreview}
+	acceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	d := new(Deployment)
@@ -189,7 +189,7 @@ func (s *RepositoriesService) ListDeploymentStatuses(ctx context.Context, owner,
 	}
 
 	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeExpandDeploymentStatusPreview}
+	acceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var statuses []*DeploymentStatus
@@ -213,7 +213,7 @@ func (s *RepositoriesService) GetDeploymentStatus(ctx context.Context, owner, re
 	}
 
 	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeExpandDeploymentStatusPreview}
+	acceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	d := new(DeploymentStatus)
@@ -237,7 +237,7 @@ func (s *RepositoriesService) CreateDeploymentStatus(ctx context.Context, owner,
 	}
 
 	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeExpandDeploymentStatusPreview}
+	acceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	d := new(DeploymentStatus)

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 )
 
 // Deployment represents a deployment in a repo
@@ -116,10 +115,6 @@ func (s *RepositoriesService) CreateDeployment(ctx context.Context, owner, repo 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
-
 	d := new(Deployment)
 	resp, err := s.client.Do(ctx, req, d)
 	if err != nil {
@@ -188,10 +183,6 @@ func (s *RepositoriesService) ListDeploymentStatuses(ctx context.Context, owner,
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
-
 	var statuses []*DeploymentStatus
 	resp, err := s.client.Do(ctx, req, &statuses)
 	if err != nil {
@@ -212,10 +203,6 @@ func (s *RepositoriesService) GetDeploymentStatus(ctx context.Context, owner, re
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
-
 	d := new(DeploymentStatus)
 	resp, err := s.client.Do(ctx, req, d)
 	if err != nil {
@@ -235,10 +222,6 @@ func (s *RepositoriesService) CreateDeploymentStatus(ctx context.Context, owner,
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	d := new(DeploymentStatus)
 	resp, err := s.client.Do(ctx, req, d)

--- a/github/repos_deployments_test.go
+++ b/github/repos_deployments_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -100,8 +99,6 @@ func TestRepositoriesService_CreateDeployment(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		wantAcceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -176,10 +173,8 @@ func TestRepositoriesService_ListDeploymentStatuses(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
 	mux.HandleFunc("/repos/o/r/deployments/1/statuses", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
@@ -215,10 +210,8 @@ func TestRepositoriesService_GetDeploymentStatus(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
 	mux.HandleFunc("/repos/o/r/deployments/3/statuses/4", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		fmt.Fprint(w, `{"id":4}`)
 	})
 
@@ -259,8 +252,6 @@ func TestRepositoriesService_CreateDeploymentStatus(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		wantAcceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}

--- a/github/repos_deployments_test.go
+++ b/github/repos_deployments_test.go
@@ -100,7 +100,7 @@ func TestRepositoriesService_CreateDeployment(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		wantAcceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeExpandDeploymentStatusPreview}
+		wantAcceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
@@ -176,7 +176,7 @@ func TestRepositoriesService_ListDeploymentStatuses(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeExpandDeploymentStatusPreview}
+	wantAcceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
 	mux.HandleFunc("/repos/o/r/deployments/1/statuses", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
@@ -215,7 +215,7 @@ func TestRepositoriesService_GetDeploymentStatus(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeExpandDeploymentStatusPreview}
+	wantAcceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
 	mux.HandleFunc("/repos/o/r/deployments/3/statuses/4", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
@@ -259,7 +259,7 @@ func TestRepositoriesService_CreateDeploymentStatus(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		wantAcceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeExpandDeploymentStatusPreview}
+		wantAcceptHeaders := []string{mediaTypeExpandDeploymentStatusPreview}
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)

--- a/github/repos_forks.go
+++ b/github/repos_forks.go
@@ -37,9 +37,6 @@ func (s *RepositoriesService) ListForks(ctx context.Context, owner, repo string,
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when topics API fully launches.
-	req.Header.Set("Accept", mediaTypeTopicsPreview)
-
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)
 	if err != nil {

--- a/github/repos_forks_test.go
+++ b/github/repos_forks_test.go
@@ -20,7 +20,6 @@ func TestRepositoriesService_ListForks(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/forks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeTopicsPreview)
 		testFormValues(t, r, values{
 			"sort": "newest",
 			"page": "3",

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -64,8 +64,6 @@ func (s *RepositoriesService) EnablePages(ctx context.Context, owner, repo strin
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeEnablePagesAPIPreview)
-
 	enable := new(Pages)
 	resp, err := s.client.Do(ctx, req, enable)
 	if err != nil {
@@ -113,9 +111,6 @@ func (s *RepositoriesService) DisablePages(ctx context.Context, owner, repo stri
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeEnablePagesAPIPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -34,7 +34,6 @@ func TestRepositoriesService_EnablePages(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeEnablePagesAPIPreview)
 		want := &createPagesRequest{Source: &PagesSource{Branch: String("master"), Path: String("/")}}
 		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
@@ -144,7 +143,6 @@ func TestRepositoriesService_DisablePages(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeEnablePagesAPIPreview)
 	})
 
 	ctx := context.Background()

--- a/github/repos_prereceive_hooks.go
+++ b/github/repos_prereceive_hooks.go
@@ -37,9 +37,6 @@ func (s *RepositoriesService) ListPreReceiveHooks(ctx context.Context, owner, re
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypePreReceiveHooksPreview)
-
 	var hooks []*PreReceiveHook
 	resp, err := s.client.Do(ctx, req, &hooks)
 	if err != nil {
@@ -58,9 +55,6 @@ func (s *RepositoriesService) GetPreReceiveHook(ctx context.Context, owner, repo
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypePreReceiveHooksPreview)
 
 	h := new(PreReceiveHook)
 	resp, err := s.client.Do(ctx, req, h)
@@ -81,9 +75,6 @@ func (s *RepositoriesService) UpdatePreReceiveHook(ctx context.Context, owner, r
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypePreReceiveHooksPreview)
-
 	h := new(PreReceiveHook)
 	resp, err := s.client.Do(ctx, req, h)
 	if err != nil {
@@ -102,9 +93,6 @@ func (s *RepositoriesService) DeletePreReceiveHook(ctx context.Context, owner, r
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypePreReceiveHooksPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/repos_prereceive_hooks_test.go
+++ b/github/repos_prereceive_hooks_test.go
@@ -21,7 +21,6 @@ func TestRepositoriesService_ListPreReceiveHooks(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pre-receive-hooks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypePreReceiveHooksPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
@@ -69,7 +68,6 @@ func TestRepositoriesService_GetPreReceiveHook(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pre-receive-hooks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypePreReceiveHooksPreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 

--- a/github/repos_projects.go
+++ b/github/repos_projects.go
@@ -34,9 +34,6 @@ func (s *RepositoriesService) ListProjects(ctx context.Context, owner, repo stri
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
-
 	var projects []*Project
 	resp, err := s.client.Do(ctx, req, &projects)
 	if err != nil {
@@ -55,9 +52,6 @@ func (s *RepositoriesService) CreateProject(ctx context.Context, owner, repo str
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	project := &Project{}
 	resp, err := s.client.Do(ctx, req, project)

--- a/github/repos_projects_test.go
+++ b/github/repos_projects_test.go
@@ -21,7 +21,6 @@ func TestRepositoriesService_ListProjects(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -61,7 +60,6 @@ func TestRepositoriesService_CreateProject(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 
 		v := &ProjectOptions{}
 		json.NewDecoder(r.Body).Decode(v)

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -990,8 +990,6 @@ func TestRepositoriesService_GetBranchProtection(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "GET")
-		// TODO: remove custom Accept header when this API fully launches
-		testHeader(t, r, "Accept", mediaTypeRequiredApprovingReviewsPreview)
 		fmt.Fprintf(w, `{
 				"required_status_checks":{
 					"strict":true,
@@ -1091,8 +1089,6 @@ func TestRepositoriesService_GetBranchProtection_noDismissalRestrictions(t *test
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		// TODO: remove custom Accept header when this API fully launches
-		testHeader(t, r, "Accept", mediaTypeRequiredApprovingReviewsPreview)
 		fmt.Fprintf(w, `{
 				"required_status_checks":{
 					"strict":true,
@@ -1181,8 +1177,6 @@ func TestRepositoriesService_UpdateBranchProtection(t *testing.T) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
-		// TODO: remove custom Accept header when this API fully launches
-		testHeader(t, r, "Accept", mediaTypeRequiredApprovingReviewsPreview)
 		fmt.Fprintf(w, `{
 			"required_status_checks":{
 				"strict":true,
@@ -1507,8 +1501,6 @@ func TestRepositoriesService_GetPullRequestReviewEnforcement(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/required_pull_request_reviews", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		// TODO: remove custom Accept header when this API fully launches
-		testHeader(t, r, "Accept", mediaTypeRequiredApprovingReviewsPreview)
 		fmt.Fprintf(w, `{
 			"dismissal_restrictions":{
 				"users":[{"id":1,"login":"u"}],
@@ -1578,8 +1570,6 @@ func TestRepositoriesService_UpdatePullRequestReviewEnforcement(t *testing.T) {
 		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		// TODO: remove custom Accept header when this API fully launches
-		testHeader(t, r, "Accept", mediaTypeRequiredApprovingReviewsPreview)
 		fmt.Fprintf(w, `{
 			"dismissal_restrictions":{
 				"users":[{"id":1,"login":"u"}],
@@ -1635,8 +1625,6 @@ func TestRepositoriesService_DisableDismissalRestrictions(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/required_pull_request_reviews", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		// TODO: remove custom Accept header when this API fully launches
-		testHeader(t, r, "Accept", mediaTypeRequiredApprovingReviewsPreview)
 		testBody(t, r, `{"dismissal_restrictions":{}}`+"\n")
 		fmt.Fprintf(w, `{"dismiss_stale_reviews":true,"require_code_owner_reviews":true,"required_approving_review_count":1}`)
 	})

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -22,10 +21,8 @@ func TestRepositoriesService_List_authenticatedUser(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
@@ -59,10 +56,8 @@ func TestRepositoriesService_List_specifiedUser(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/users/u/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"visibility":  "public",
 			"affiliation": "owner,collaborator",
@@ -96,10 +91,8 @@ func TestRepositoriesService_List_specifiedUser_type(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/users/u/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"type": "owner",
 		})
@@ -134,10 +127,8 @@ func TestRepositoriesService_ListByOrg(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/orgs/o/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"type": "forks",
 			"page": "2",
@@ -227,13 +218,11 @@ func TestRepositoriesService_Create_user(t *testing.T) {
 		Archived: Bool(true), // not passed along.
 	}
 
-	wantAcceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, r *http.Request) {
 		v := new(createRepoRequest)
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		want := &createRepoRequest{Name: String("n")}
 		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
@@ -277,13 +266,11 @@ func TestRepositoriesService_Create_org(t *testing.T) {
 		Archived: Bool(true), // not passed along.
 	}
 
-	wantAcceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/orgs/o/repos", func(w http.ResponseWriter, r *http.Request) {
 		v := new(createRepoRequest)
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		want := &createRepoRequest{Name: String("n")}
 		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
@@ -355,10 +342,8 @@ func TestRepositoriesService_Get(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeCodesOfConductPreview, mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		fmt.Fprint(w, `{"id":1,"name":"n","description":"d","owner":{"login":"l"},"license":{"key":"mit"}}`)
 	})
 
@@ -472,13 +457,11 @@ func TestRepositoriesService_Edit(t *testing.T) {
 	i := true
 	input := &Repository{HasIssues: &i}
 
-	wantAcceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		v := new(Repository)
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -1795,7 +1795,6 @@ func TestRepositoriesService_GetSignaturesProtectedBranch(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/required_signatures", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeSignaturePreview)
 		fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/required_signatures","enabled":false}`)
 	})
 
@@ -1835,7 +1834,6 @@ func TestRepositoriesService_RequireSignaturesOnProtectedBranch(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/required_signatures", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeSignaturePreview)
 		fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/required_signatures","enabled":true}`)
 	})
 
@@ -1875,7 +1873,6 @@ func TestRepositoriesService_OptionalSignaturesOnProtectedBranch(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/branches/b/protection/required_signatures", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeSignaturePreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -648,7 +648,6 @@ func TestRepositoriesService_EnableAutomatedSecurityFixes(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/automated-security-fixes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeRequiredAutomatedSecurityFixesPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -665,7 +664,6 @@ func TestRepositoriesService_DisableAutomatedSecurityFixes(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/automated-security-fixes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeRequiredAutomatedSecurityFixesPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -561,7 +561,6 @@ func TestRepositoriesService_GetVulnerabilityAlerts(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/vulnerability-alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeRequiredVulnerabilityAlertsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -597,7 +596,6 @@ func TestRepositoriesService_EnableVulnerabilityAlerts(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/vulnerability-alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeRequiredVulnerabilityAlertsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -624,7 +622,6 @@ func TestRepositoriesService_DisableVulnerabilityAlerts(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/vulnerability-alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeRequiredVulnerabilityAlertsPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -227,7 +227,7 @@ func TestRepositoriesService_Create_user(t *testing.T) {
 		Archived: Bool(true), // not passed along.
 	}
 
-	wantAcceptHeaders := []string{mediaTypeRepositoryTemplatePreview, mediaTypeRepositoryVisibilityPreview}
+	wantAcceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, r *http.Request) {
 		v := new(createRepoRequest)
 		json.NewDecoder(r.Body).Decode(v)
@@ -277,7 +277,7 @@ func TestRepositoriesService_Create_org(t *testing.T) {
 		Archived: Bool(true), // not passed along.
 	}
 
-	wantAcceptHeaders := []string{mediaTypeRepositoryTemplatePreview, mediaTypeRepositoryVisibilityPreview}
+	wantAcceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/orgs/o/repos", func(w http.ResponseWriter, r *http.Request) {
 		v := new(createRepoRequest)
 		json.NewDecoder(r.Body).Decode(v)
@@ -317,7 +317,6 @@ func TestRepositoriesService_CreateFromTemplate(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeRepositoryTemplatePreview)
 		want := &TemplateRepoRequest{Name: String("n")}
 		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
@@ -356,7 +355,7 @@ func TestRepositoriesService_Get(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeCodesOfConductPreview, mediaTypeRepositoryTemplatePreview, mediaTypeRepositoryVisibilityPreview}
+	wantAcceptHeaders := []string{mediaTypeCodesOfConductPreview, mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
@@ -473,7 +472,7 @@ func TestRepositoriesService_Edit(t *testing.T) {
 	i := true
 	input := &Repository{HasIssues: &i}
 
-	wantAcceptHeaders := []string{mediaTypeRepositoryTemplatePreview, mediaTypeRepositoryVisibilityPreview}
+	wantAcceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		v := new(Repository)
 		json.NewDecoder(r.Body).Decode(v)

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -22,7 +22,7 @@ func TestRepositoriesService_List_authenticatedUser(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
+	wantAcceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
@@ -59,7 +59,7 @@ func TestRepositoriesService_List_specifiedUser(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
+	wantAcceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/users/u/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
@@ -96,7 +96,7 @@ func TestRepositoriesService_List_specifiedUser_type(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
+	wantAcceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/users/u/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
@@ -134,7 +134,7 @@ func TestRepositoriesService_ListByOrg(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
+	wantAcceptHeaders := []string{mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/orgs/o/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
@@ -356,7 +356,7 @@ func TestRepositoriesService_Get(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeCodesOfConductPreview, mediaTypeTopicsPreview, mediaTypeRepositoryTemplatePreview, mediaTypeRepositoryVisibilityPreview}
+	wantAcceptHeaders := []string{mediaTypeCodesOfConductPreview, mediaTypeRepositoryTemplatePreview, mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
@@ -1959,7 +1959,6 @@ func TestRepositoriesService_ListAllTopics(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/topics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeTopicsPreview)
 		fmt.Fprint(w, `{"names":["go", "go-github", "github"]}`)
 	})
 
@@ -1995,7 +1994,6 @@ func TestRepositoriesService_ListAllTopics_emptyTopics(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/topics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeTopicsPreview)
 		fmt.Fprint(w, `{"names":[]}`)
 	})
 
@@ -2017,7 +2015,6 @@ func TestRepositoriesService_ReplaceAllTopics(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/topics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeTopicsPreview)
 		fmt.Fprint(w, `{"names":["go", "go-github", "github"]}`)
 	})
 
@@ -2053,7 +2050,6 @@ func TestRepositoriesService_ReplaceAllTopics_nilSlice(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/topics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeTopicsPreview)
 		testBody(t, r, `{"names":[]}`+"\n")
 		fmt.Fprint(w, `{"names":[]}`)
 	})
@@ -2076,7 +2072,6 @@ func TestRepositoriesService_ReplaceAllTopics_emptySlice(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/topics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeTopicsPreview)
 		testBody(t, r, `{"names":[]}`+"\n")
 		fmt.Fprint(w, `{"names":[]}`)
 	})

--- a/github/search.go
+++ b/github/search.go
@@ -272,10 +272,6 @@ func (s *SearchService) search(ctx context.Context, searchType string, parameter
 	}
 
 	switch {
-	case searchType == "commits":
-		// Accept header for search commits preview endpoint
-		// TODO: remove custom Accept header when this API fully launches.
-		req.Header.Set("Accept", mediaTypeCommitSearchPreview)
 	case searchType == "topics":
 		// Accept header for search repositories based on topics preview endpoint
 		// TODO: remove custom Accept header when this API fully launches.

--- a/github/search.go
+++ b/github/search.go
@@ -284,10 +284,6 @@ func (s *SearchService) search(ctx context.Context, searchType string, parameter
 		// Accept header for search repositories based on topics preview endpoint
 		// TODO: remove custom Accept header when this API fully launches.
 		req.Header.Set("Accept", mediaTypeTopicsPreview)
-	case searchType == "issues":
-		// Accept header for search issues based on reactions preview endpoint
-		// TODO: remove custom Accept header when this API fully launches.
-		req.Header.Set("Accept", mediaTypeReactionsPreview)
 	case opts != nil && opts.TextMatch:
 		// Accept header defaults to "application/vnd.github.v3+json"
 		// We change it here to fetch back text-match metadata

--- a/github/search.go
+++ b/github/search.go
@@ -272,14 +272,6 @@ func (s *SearchService) search(ctx context.Context, searchType string, parameter
 	}
 
 	switch {
-	case searchType == "topics":
-		// Accept header for search repositories based on topics preview endpoint
-		// TODO: remove custom Accept header when this API fully launches.
-		req.Header.Set("Accept", mediaTypeTopicsPreview)
-	case searchType == "repositories":
-		// Accept header for search repositories based on topics preview endpoint
-		// TODO: remove custom Accept header when this API fully launches.
-		req.Header.Set("Accept", mediaTypeTopicsPreview)
 	case opts != nil && opts.TextMatch:
 		// Accept header defaults to "application/vnd.github.v3+json"
 		// We change it here to fetch back text-match metadata

--- a/github/teams.go
+++ b/github/teams.go
@@ -559,10 +559,6 @@ func (s *TeamsService) ListTeamProjectsByID(ctx context.Context, orgID, teamID i
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
-
 	var projects []*Project
 	resp, err := s.client.Do(ctx, req, &projects)
 	if err != nil {
@@ -582,10 +578,6 @@ func (s *TeamsService) ListTeamProjectsBySlug(ctx context.Context, org, slug str
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var projects []*Project
 	resp, err := s.client.Do(ctx, req, &projects)
@@ -607,10 +599,6 @@ func (s *TeamsService) ReviewTeamProjectsByID(ctx context.Context, orgID, teamID
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
-
 	projects := &Project{}
 	resp, err := s.client.Do(ctx, req, &projects)
 	if err != nil {
@@ -630,10 +618,6 @@ func (s *TeamsService) ReviewTeamProjectsBySlug(ctx context.Context, org, slug s
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	projects := &Project{}
 	resp, err := s.client.Do(ctx, req, &projects)
@@ -668,10 +652,6 @@ func (s *TeamsService) AddTeamProjectByID(ctx context.Context, orgID, teamID, pr
 		return nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
-
 	return s.client.Do(ctx, req, nil)
 }
 
@@ -686,10 +666,6 @@ func (s *TeamsService) AddTeamProjectBySlug(ctx context.Context, org, slug strin
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	return s.client.Do(ctx, req, nil)
 }
@@ -709,10 +685,6 @@ func (s *TeamsService) RemoveTeamProjectByID(ctx context.Context, orgID, teamID,
 		return nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
-
 	return s.client.Do(ctx, req, nil)
 }
 
@@ -730,10 +702,6 @@ func (s *TeamsService) RemoveTeamProjectBySlug(ctx context.Context, org, slug st
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/teams.go
+++ b/github/teams.go
@@ -361,10 +361,6 @@ func (s *TeamsService) ListTeamReposByID(ctx context.Context, orgID, teamID int6
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when topics API fully launches.
-	headers := []string{mediaTypeTopicsPreview}
-	req.Header.Set("Accept", strings.Join(headers, ", "))
-
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)
 	if err != nil {
@@ -388,10 +384,6 @@ func (s *TeamsService) ListTeamReposBySlug(ctx context.Context, org, slug string
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when topics API fully launches.
-	headers := []string{mediaTypeTopicsPreview}
-	req.Header.Set("Accept", strings.Join(headers, ", "))
 
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -1016,10 +1016,8 @@ func TestTeamsService_ListProjectsByID(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/organizations/1/team/1/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
@@ -1053,10 +1051,8 @@ func TestTeamsService_ListProjectsBySlug(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/orgs/o/teams/s/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
@@ -1090,10 +1086,8 @@ func TestTeamsService_ReviewProjectsByID(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/organizations/1/team/1/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -1127,10 +1121,8 @@ func TestTeamsService_ReviewProjectsBySlug(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/orgs/o/teams/s/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -1168,10 +1160,8 @@ func TestTeamsService_AddTeamProjectByID(t *testing.T) {
 		Permission: String("admin"),
 	}
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/organizations/1/team/1/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 
 		v := &TeamProjectOptions{}
 		json.NewDecoder(r.Body).Decode(v)
@@ -1207,10 +1197,8 @@ func TestTeamsService_AddTeamProjectBySlug(t *testing.T) {
 		Permission: String("admin"),
 	}
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/orgs/o/teams/s/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 
 		v := &TeamProjectOptions{}
 		json.NewDecoder(r.Body).Decode(v)
@@ -1242,10 +1230,8 @@ func TestTeamsService_RemoveTeamProjectByID(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/organizations/1/team/1/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -1270,10 +1256,8 @@ func TestTeamsService_RemoveTeamProjectBySlug(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/orgs/o/teams/s/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -1666,7 +1650,7 @@ func TestTeams_Marshal(t *testing.T) {
 			"members_count": 1,
 			"repos_count": 1
 		},
-		"ldap_dn": "l"	
+		"ldap_dn": "l"
 	}`
 
 	testJSONMarshal(t, u, want)

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -538,8 +538,6 @@ func TestTeamsService_ListTeamReposByID(t *testing.T) {
 
 	mux.HandleFunc("/organizations/1/team/1/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		wantAcceptHeaders := []string{mediaTypeTopicsPreview}
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -577,8 +575,6 @@ func TestTeamsService_ListTeamReposBySlug(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/teams/s/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		wantAcceptHeaders := []string{mediaTypeTopicsPreview}
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})

--- a/github/users_blocking.go
+++ b/github/users_blocking.go
@@ -25,9 +25,6 @@ func (s *UsersService) ListBlockedUsers(ctx context.Context, opts *ListOptions) 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
-
 	var blockedUsers []*User
 	resp, err := s.client.Do(ctx, req, &blockedUsers)
 	if err != nil {
@@ -48,9 +45,6 @@ func (s *UsersService) IsBlocked(ctx context.Context, user string) (bool, *Respo
 		return false, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
-
 	resp, err := s.client.Do(ctx, req, nil)
 	isBlocked, err := parseBoolResponse(err)
 	return isBlocked, resp, err
@@ -67,9 +61,6 @@ func (s *UsersService) BlockUser(ctx context.Context, user string) (*Response, e
 		return nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
-
 	return s.client.Do(ctx, req, nil)
 }
 
@@ -83,9 +74,6 @@ func (s *UsersService) UnblockUser(ctx context.Context, user string) (*Response,
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/users_blocking_test.go
+++ b/github/users_blocking_test.go
@@ -20,7 +20,6 @@ func TestUsersService_ListBlockedUsers(t *testing.T) {
 
 	mux.HandleFunc("/user/blocks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeBlockUsersPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{
 			"login": "octocat"
@@ -55,7 +54,6 @@ func TestUsersService_IsBlocked(t *testing.T) {
 
 	mux.HandleFunc("/user/blocks/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeBlockUsersPreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -89,7 +87,6 @@ func TestUsersService_BlockUser(t *testing.T) {
 
 	mux.HandleFunc("/user/blocks/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeBlockUsersPreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -116,7 +113,6 @@ func TestUsersService_UnblockUser(t *testing.T) {
 
 	mux.HandleFunc("/user/blocks/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeBlockUsersPreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 

--- a/github/users_projects.go
+++ b/github/users_projects.go
@@ -25,9 +25,6 @@ func (s *UsersService) ListProjects(ctx context.Context, user string, opts *Proj
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
-
 	var projects []*Project
 	resp, err := s.client.Do(ctx, req, &projects)
 	if err != nil {
@@ -54,9 +51,6 @@ func (s *UsersService) CreateProject(ctx context.Context, opts *CreateUserProjec
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches.
-	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	project := &Project{}
 	resp, err := s.client.Do(ctx, req, project)

--- a/github/users_projects_test.go
+++ b/github/users_projects_test.go
@@ -21,7 +21,6 @@ func TestUsersService_ListProjects(t *testing.T) {
 
 	mux.HandleFunc("/users/u/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		testFormValues(t, r, values{"state": "open", "page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -61,7 +60,6 @@ func TestUsersService_CreateProject(t *testing.T) {
 
 	mux.HandleFunc("/user/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 
 		v := &CreateUserProjectOptions{}
 		json.NewDecoder(r.Body).Decode(v)

--- a/update-urls/reactions_test.go
+++ b/update-urls/reactions_test.go
@@ -140,46 +140,46 @@ var reactionsTestWebPage = `
   <meta name="site.data.ui.search.placeholder" content="Search topics, products...">
   <!-- end localized data -->
 
-  
+
 
   <!-- hreflangs -->
-  
+
     <link
       rel="alternate"
       hreflang="en"
       href="https://docs.github.com/en/free-pro-team@latest/rest/reference/reactions"
     />
-  
+
     <link
       rel="alternate"
       hreflang="zh-Hans"
       href="https://docs.github.com/cn/rest/reference/reactions"
     />
-  
+
     <link
       rel="alternate"
       hreflang="ja"
       href="https://docs.github.com/ja/rest/reference/reactions"
     />
-  
+
     <link
       rel="alternate"
       hreflang="es"
       href="https://docs.github.com/es/rest/reference/reactions"
     />
-  
+
     <link
       rel="alternate"
       hreflang="pt"
       href="https://docs.github.com/pt/rest/reference/reactions"
     />
-  
+
     <link
       rel="alternate"
       hreflang="de"
       href="https://docs.github.com/de/rest/reference/reactions"
     />
-  
+
 
   <link rel="stylesheet" href="/dist/index.css">
   <link rel="alternate icon" type="image/png" href="/assets/images/site/favicon.png">
@@ -198,7 +198,7 @@ var reactionsTestWebPage = `
     <a href="/en" class="h4-mktg text-white no-underline no-wrap pl-2 flex-auto">GitHub Docs</a>
   </div>
 
-    
+
     <ul class="sidebar-products">
       <!--
   Styling note:
@@ -219,8 +219,8 @@ var reactionsTestWebPage = `
   <a href="/en/rest" class="pl-4 pr-5 pb-1 f4">REST API</a>
 </li>
 <ul class="sidebar-categories list-style-none">
-  
-  
+
+
 
   <li class="sidebar-category py-1 ">
     <details class="dropdown-withArrow details details-reset" open>
@@ -231,50 +231,50 @@ var reactionsTestWebPage = `
         </div>
       </summary>
       <!-- some categories have maptopics with child articles -->
-      
+
       <ul class="sidebar-articles list-style-none">
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api" class="pl-4 pr-5 py-1">Resources in the REST API</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/overview/media-types" class="pl-4 pr-5 py-1">Media types</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/overview/other-authentication-methods" class="pl-4 pr-5 py-1">Other authentication methods</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/overview/troubleshooting" class="pl-4 pr-5 py-1">Troubleshooting</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/overview/api-previews" class="pl-4 pr-5 py-1">API previews</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/overview/libraries" class="pl-4 pr-5 py-1">Libraries</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/overview/endpoints-available-for-github-apps" class="pl-4 pr-5 py-1 pb-2">Endpoints available for GitHub Apps</a>
         </li>
-        
+
       </ul>
-      
+
     </details>
   </li>
-  
-  
+
+
 
   <li class="sidebar-category py-1 active ">
     <details class="dropdown-withArrow details details-reset" open>
@@ -285,165 +285,165 @@ var reactionsTestWebPage = `
         </div>
       </summary>
       <!-- some categories have maptopics with child articles -->
-      
+
       <ul class="sidebar-articles list-style-none">
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/actions" class="pl-4 pr-5 py-1">Actions</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/activity" class="pl-4 pr-5 py-1">Activity</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/apps" class="pl-4 pr-5 py-1">Apps</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/billing" class="pl-4 pr-5 py-1">Billing</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/checks" class="pl-4 pr-5 py-1">Checks</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/code-scanning" class="pl-4 pr-5 py-1">Code Scanning</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/codes-of-conduct" class="pl-4 pr-5 py-1">Codes of conduct</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/emojis" class="pl-4 pr-5 py-1">Emojis</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/enterprise-admin" class="pl-4 pr-5 py-1">GitHub Enterprise administration</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/gists" class="pl-4 pr-5 py-1">Gists</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/git" class="pl-4 pr-5 py-1">Git database</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/gitignore" class="pl-4 pr-5 py-1">Gitignore</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/interactions" class="pl-4 pr-5 py-1">Interactions</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/issues" class="pl-4 pr-5 py-1">Issues</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/licenses" class="pl-4 pr-5 py-1">Licenses</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/markdown" class="pl-4 pr-5 py-1">Markdown</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/meta" class="pl-4 pr-5 py-1">Meta</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/migrations" class="pl-4 pr-5 py-1">Migrations</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/oauth-authorizations" class="pl-4 pr-5 py-1">OAuth Authorizations</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/orgs" class="pl-4 pr-5 py-1">Organizations</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/projects" class="pl-4 pr-5 py-1">Projects</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/pulls" class="pl-4 pr-5 py-1">Pulls</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/rate-limit" class="pl-4 pr-5 py-1">Rate limit</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article active is-current-page">
           <a href="/en/free-pro-team@latest/rest/reference/reactions" class="pl-4 pr-5 py-1">Reactions</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/repos" class="pl-4 pr-5 py-1">Repositories</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/scim" class="pl-4 pr-5 py-1">SCIM</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/search" class="pl-4 pr-5 py-1">Search</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/teams" class="pl-4 pr-5 py-1">Teams</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/users" class="pl-4 pr-5 py-1">Users</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/reference/permissions-required-for-github-apps" class="pl-4 pr-5 py-1 pb-2">Permissions required for GitHub Apps</a>
         </li>
-        
+
       </ul>
-      
+
     </details>
   </li>
-  
-  
+
+
 
   <li class="sidebar-category py-1 ">
     <details class="dropdown-withArrow details details-reset" open>
@@ -454,82 +454,82 @@ var reactionsTestWebPage = `
         </div>
       </summary>
       <!-- some categories have maptopics with child articles -->
-      
+
       <ul class="sidebar-articles list-style-none">
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/guides/getting-started-with-the-rest-api" class="pl-4 pr-5 py-1">Getting started with the REST API</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/guides/basics-of-authentication" class="pl-4 pr-5 py-1">Basics of authentication</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/guides/discovering-resources-for-a-user" class="pl-4 pr-5 py-1">Discovering resources for a user</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/guides/delivering-deployments" class="pl-4 pr-5 py-1">Delivering deployments</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/guides/rendering-data-as-graphs" class="pl-4 pr-5 py-1">Rendering data as graphs</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/guides/working-with-comments" class="pl-4 pr-5 py-1">Working with comments</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/guides/traversing-with-pagination" class="pl-4 pr-5 py-1">Traversing with pagination</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/guides/building-a-ci-server" class="pl-4 pr-5 py-1">Building a CI server</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/guides/best-practices-for-integrators" class="pl-4 pr-5 py-1">Best practices for integrators</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/guides/getting-started-with-the-git-database-api" class="pl-4 pr-5 py-1">Getting started with the Git Database API</a>
         </li>
-        
-        
+
+
         <li class="sidebar-article ">
           <a href="/en/free-pro-team@latest/rest/guides/getting-started-with-the-checks-api" class="pl-4 pr-5 py-1 pb-2">Getting started with the Checks API</a>
         </li>
-        
+
       </ul>
-      
+
     </details>
   </li>
-  
+
 </ul>
 
     </ul>
-    
+
 </div>
 
 
     <main class="width-full">
       <div class="border-bottom border-gray-light no-print">
 
-  
 
-  
+
+
 
     <header class="container-xl px-3 px-md-6 pt-3 pb-2 position-relative d-flex flex-justify-between width-full ">
 
@@ -559,165 +559,165 @@ var reactionsTestWebPage = `
                     </div>
                   </summary>
                   <div id="homepages" class="position-md-absolute nav-desktop-productDropdown p-md-4 left-md-n4 top-md-6" style="z-index: 6;">
-                    
+
                     <a href="/en/github"
                        class="d-block py-2 link-gray-dark no-underline">
                        GitHub.com
-                       
+
                     </a>
-                    
+
                     <a href="/en/enterprise/admin"
                        class="d-block py-2 link-gray-dark no-underline">
                        Enterprise Server
-                       
+
                     </a>
-                    
+
                     <a href="/en/actions"
                        class="d-block py-2 link-gray-dark no-underline">
                        GitHub Actions
-                       
+
                     </a>
-                    
+
                     <a href="/en/packages"
                        class="d-block py-2 link-gray-dark no-underline">
                        GitHub Packages
-                       
+
                     </a>
-                    
+
                     <a href="/en/developers"
                        class="d-block py-2 link-gray-dark no-underline">
                        Developers
-                       
+
                     </a>
-                    
+
                     <a href="/en/rest"
                        class="d-block py-2 text-blue-mktg text-underline active">
                        REST API
-                       
+
                     </a>
-                    
+
                     <a href="/en/graphql"
                        class="d-block py-2 link-gray-dark no-underline">
                        GraphQL API
-                       
+
                     </a>
-                    
+
                     <a href="/en/insights"
                        class="d-block py-2 link-gray-dark no-underline">
                        GitHub Insights
-                       
+
                     </a>
-                    
+
                     <a href="/en/desktop"
                        class="d-block py-2 link-gray-dark no-underline">
                        GitHub Desktop
-                       
+
                     </a>
-                    
+
                     <a href="https://atom.io/docs"
                        class="d-block py-2 link-gray-dark no-underline">
                        Atom
-                       
+
                        <span class="ml-1"><svg width="9" height="10" viewBox="0 0 9 10" fill="none" xmlns="http://www.w3.org/2000/svg"><path stroke="#24292e" d="M.646 8.789l8-8M8.5 9V1M1 .643h8"/></svg></span>
-                       
+
                     </a>
-                    
+
                     <a href="https://electronjs.org/docs"
                        class="d-block py-2 link-gray-dark no-underline">
                        Electron
-                       
+
                        <span class="ml-1"><svg width="9" height="10" viewBox="0 0 9 10" fill="none" xmlns="http://www.w3.org/2000/svg"><path stroke="#24292e" d="M.646 8.789l8-8M8.5 9V1M1 .643h8"/></svg></span>
-                       
+
                     </a>
-                    
+
                   </div>
                 </details>
               </div>
               <div class="d-md-inline-block">
 
-                
+
                   <div class="border-top border-md-top-0 py-2 py-md-0 d-md-inline-block">
                     <details class="dropdown-withArrow position-relative details details-reset mr-md-3 close-when-clicked-outside">
                       <summary class="py-2 text-gray-dark" role="button" aria-label="Toggle languages list">
                         <div class="d-flex flex-items-center flex-justify-between">
                           <!-- Language switcher - 'English', 'Japanese', etc -->
-                          
+
                             English
-                          
+
                           <svg class="arrow ml-md-1" width="14px" height="8px" viewBox="0 0 14 8" xml:space="preserve" fill="none" stroke="#1B1F23"><path d="M1,1l6.2,6L13,1"></path></svg>
                         </div>
                       </summary>
                       <div id="languages-selector" class="position-md-absolute nav-desktop-langDropdown p-md-4 right-md-n4 top-md-6" style="z-index: 6;">
-                      
-                        
+
+
                           <a
                             href="/en/free-pro-team@latest/rest/reference/reactions"
                             class="d-block py-2 no-underline active link-gray"
                             style="white-space: nowrap"
                           >
-                            
+
                               English
-                            
+
                           </a>
-                        
-                      
-                        
+
+
+
                           <a
                             href="/cn/rest/reference/reactions"
                             class="d-block py-2 no-underline link-gray-dark"
                             style="white-space: nowrap"
                           >
-                            
+
                               简体中文 (Simplified Chinese)
-                            
+
                           </a>
-                        
-                      
-                        
+
+
+
                           <a
                             href="/ja/rest/reference/reactions"
                             class="d-block py-2 no-underline link-gray-dark"
                             style="white-space: nowrap"
                           >
-                            
+
                               日本語 (Japanese)
-                            
+
                           </a>
-                        
-                      
-                        
+
+
+
                           <a
                             href="/es/rest/reference/reactions"
                             class="d-block py-2 no-underline link-gray-dark"
                             style="white-space: nowrap"
                           >
-                            
+
                               Español (Spanish)
-                            
+
                           </a>
-                        
-                      
-                        
+
+
+
                           <a
                             href="/pt/rest/reference/reactions"
                             class="d-block py-2 no-underline link-gray-dark"
                             style="white-space: nowrap"
                           >
-                            
+
                               Português do Brasil (Portuguese)
-                            
+
                           </a>
-                        
-                      
-                        
-                      
+
+
+
+
                       </div>
                     </details>
                   </div>
-                
+
 
                 <!-- GitHub.com homepage and 404 page has a stylized search; Enterprise homepages do not -->
-                
+
                 <div class="pt-3 pt-md-0 d-md-inline-block ml-md-3 bord'er-top border-md-top-0">
                   <!--
   This form is used in two places:
@@ -735,7 +735,7 @@ var reactionsTestWebPage = `
                   <div id="search-results-container"></div>
                   <div class="search-overlay-desktop"></div>
                 </div>
-                
+
 
               </div>
             </div>
@@ -745,15 +745,15 @@ var reactionsTestWebPage = `
     </header>
   </div>
 
-      
+
         <main class="container-xl px-3 px-md-6 my-4 my-lg-4 d-lg-flex">
   <article class="markdown-body width-full">
-    
+
 
 
     <div class="article-grid-container">
       <div class="article-grid-toc">
-        
+
   <details id="article-versions" class="dropdown-withArrow d-inline-block details details-reset mb-4 mb-md-0 position-relative close-when-clicked-outside">
     <summary class="d-flex flex-items-center flex-justify-between f4 h5-mktg btn-outline-mktg btn-mktg p-2">
       <!-- GitHub.com, Enterprise Server 2.16, etc -->
@@ -762,27 +762,27 @@ var reactionsTestWebPage = `
     </summary>
 
     <div class="nav-dropdown position-md-absolute bg-white rounded-1 px-4 py-3 top-7 box-shadow-large" style="z-index: 6; width: 210px;">
-      
+
       <a
       href="/en/free-pro-team@latest/rest/reference/reactions"
       class="d-block py-2 link-blue active"
       >GitHub.com</a>
-      
+
       <a
       href="/en/enterprise/2.21/user/rest/reference/reactions"
       class="d-block py-2 link-gray-dark no-underline"
       >Enterprise Server 2.21</a>
-      
+
       <a
       href="/en/enterprise/2.20/user/rest/reference/reactions"
       class="d-block py-2 link-gray-dark no-underline"
       >Enterprise Server 2.20</a>
-      
+
       <a
       href="/en/enterprise/2.19/user/rest/reference/reactions"
       class="d-block py-2 link-gray-dark no-underline"
       >Enterprise Server 2.19</a>
-      
+
     </div>
   </details>
 
@@ -790,16 +790,16 @@ var reactionsTestWebPage = `
       </div>
       <div class="article-grid-body d-flex flex-items-center" style="height: 39px;">
         <nav class="breadcrumbs f5" aria-label="Breadcrumb">
-  
+
   <a title="product: REST API" href="/en/rest" class="d-inline-block ">
     REST API</a>
-  
+
   <a title="category: Reference" href="/en/free-pro-team@latest/rest/reference" class="d-inline-block ">
     Reference</a>
-  
+
   <a title="article: Reactions" href="/en/free-pro-team@latest/rest/reference/reactions" class="d-inline-block text-gray-light">
     Reactions</a>
-  
+
 </nav>
 
       </div>
@@ -818,118 +818,118 @@ var reactionsTestWebPage = `
         </div>
       </div>
 
-      
 
-      
 
-      
 
-      
+
+
+
+
     </div>
     <div class="article-grid-toc border-bottom border-xl-0 pb-4 mb-5 pb-xl-0 mb-xl-0">
       <div class="article-grid-toc-content">
-        
+
         <h3 id="in-this-article" class="f5 mb-2"><a class="link-gray-dark" href="#in-this-article">In this article</a></h3>
         <ul class="list-style-none pl-0 f5 mb-0">
-          
+
           <li class="ml-0  mb-2 lh-condensed"><a href="#reaction-types">Reaction types</a></li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#list-reactions-for-a-team-discussion-comment">List reactions for a team discussion comment</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#create-reaction-for-a-team-discussion-comment">Create reaction for a team discussion comment</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#delete-team-discussion-comment-reaction">Delete team discussion comment reaction</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#list-reactions-for-a-team-discussion">List reactions for a team discussion</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#create-reaction-for-a-team-discussion">Create reaction for a team discussion</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#delete-team-discussion-reaction">Delete team discussion reaction</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#delete-a-reaction-legacy">Delete a reaction (Legacy)</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#list-reactions-for-a-commit-comment">List reactions for a commit comment</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#create-reaction-for-a-commit-comment">Create reaction for a commit comment</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#delete-a-commit-comment-reaction">Delete a commit comment reaction</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#list-reactions-for-an-issue-comment">List reactions for an issue comment</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#create-reaction-for-an-issue-comment">Create reaction for an issue comment</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#delete-an-issue-comment-reaction">Delete an issue comment reaction</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#list-reactions-for-an-issue">List reactions for an issue</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#create-reaction-for-an-issue">Create reaction for an issue</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#delete-an-issue-reaction">Delete an issue reaction</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#list-reactions-for-a-pull-request-review-comment">List reactions for a pull request review comment</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#create-reaction-for-a-pull-request-review-comment">Create reaction for a pull request review comment</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#delete-a-pull-request-comment-reaction">Delete a pull request comment reaction</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#list-reactions-for-a-team-discussion-comment-legacy">List reactions for a team discussion comment (Legacy)</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#create-reaction-for-a-team-discussion-comment-legacy">Create reaction for a team discussion comment (Legacy)</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#list-reactions-for-a-team-discussion-legacy">List reactions for a team discussion (Legacy)</a>
     </li>
-          
+
           <li class="ml-0  mb-2 lh-condensed">
       <a href="#create-reaction-for-a-team-discussion-legacy">Create reaction for a team discussion (Legacy)</a>
     </li>
-          
+
         </ul>
-        
+
         <div class="d-none d-xl-block border-top border-gray-light mt-4">
-          
+
           <form class="js-helpfulness mt-4 f5" id="helpfulness-xl">
   <h4
     data-help-start
@@ -1069,7 +1069,7 @@ var reactionsTestWebPage = `
       </div>
     </div>
     <div id="article-contents" class="article-grid-body">
-      
+
       <h3 id="reaction-types"><a href="#reaction-types">Reaction types</a></h3>
 <p>When creating a reaction, the allowed values for the <code>content</code> parameter are as follows (with the corresponding emoji for reference):</p>
 
@@ -1124,7 +1124,7 @@ var reactionsTestWebPage = `
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">get</span> /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions</code></pre>
   <div>
-    
+
       <h4 id="list-reactions-for-a-team-discussion-comment--parameters">
         <a href="#list-reactions-for-a-team-discussion-comment--parameters">Parameters</a>
       </h4>
@@ -1138,118 +1138,118 @@ var reactionsTestWebPage = `
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#list-reactions-for-a-team-discussion-comment-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>org</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>team_slug</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>discussion_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>comment_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>content</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Returns a single <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a>. Omit this parameter to list all reactions to a team discussion comment.</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>per_page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Results per page (max 100)</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Page number of the results to fetch.</p>
-                
+
               </td>
             </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="list-reactions-for-a-team-discussion-comment--code-samples">
         <a href="#list-reactions-for-a-team-discussion-comment--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -H &quot;Accept: application/vnd.github.squirrel-girl-preview+json&quot; \
   https://api.github.com/orgs/ORG/teams/TEAM_SLUG/discussions/42/comments/42/reactions
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions&apos;</span>, {
   <span class="hljs-attr">org</span>: <span class="hljs-string">&apos;org&apos;</span>,
@@ -1263,10 +1263,10 @@ var reactionsTestWebPage = `
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 200 OK</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">[
@@ -1298,22 +1298,22 @@ var reactionsTestWebPage = `
   }
 ]
 </code></pre></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="list-reactions-for-a-team-discussion-comment-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -1336,8 +1336,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -1351,7 +1351,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">post</span> /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions</code></pre>
   <div>
-    
+
       <h4 id="create-reaction-for-a-team-discussion-comment--parameters">
         <a href="#create-reaction-for-a-team-discussion-comment--parameters">Parameters</a>
       </h4>
@@ -1365,87 +1365,87 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#create-reaction-for-a-team-discussion-comment-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>org</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>team_slug</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>discussion_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>comment_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
-          
+
+
           <tr>
             <td><code>content</code></td>
             <td class="opacity-70">string</td>
             <td class="opacity-70">body</td>
             <td class="opacity-70">
               <p><strong>Required</strong>. The <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a> to add to the team discussion comment.</p>
-              
+
             </td>
           </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="create-reaction-for-a-team-discussion-comment--code-samples">
         <a href="#create-reaction-for-a-team-discussion-comment--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -X POST \
@@ -1453,13 +1453,13 @@ and creating</a> reactions.</p>
   https://api.github.com/orgs/ORG/teams/TEAM_SLUG/discussions/42/comments/42/reactions \
   -d &apos;{&quot;content&quot;:&quot;content&quot;}&apos;
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions&apos;</span>, {
   <span class="hljs-attr">org</span>: <span class="hljs-string">&apos;org&apos;</span>,
@@ -1474,10 +1474,10 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 201 Created</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">{
@@ -1507,22 +1507,22 @@ and creating</a> reactions.</p>
   <span class="hljs-attr">&quot;created_at&quot;</span>: <span class="hljs-string">&quot;2016-05-20T20:09:31Z&quot;</span>
 }
 </code></pre></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="create-reaction-for-a-team-discussion-comment-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -1545,8 +1545,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -1560,7 +1560,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">delete</span> /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}</code></pre>
   <div>
-    
+
       <h4 id="delete-team-discussion-comment-reaction--parameters">
         <a href="#delete-team-discussion-comment-reaction--parameters">Parameters</a>
       </h4>
@@ -1574,99 +1574,99 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#delete-team-discussion-comment-reaction-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>org</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>team_slug</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>discussion_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>comment_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>reaction_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="delete-team-discussion-comment-reaction--code-samples">
         <a href="#delete-team-discussion-comment-reaction--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -X DELETE \
   -H &quot;Accept: application/vnd.github.squirrel-girl-preview+json&quot; \
   https://api.github.com/orgs/ORG/teams/TEAM_SLUG/discussions/42/comments/42/reactions/42
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}&apos;</span>, {
   <span class="hljs-attr">org</span>: <span class="hljs-string">&apos;org&apos;</span>,
@@ -1681,29 +1681,29 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default Response</h4>
       <pre><code>Status: 204 No Content</code></pre>
       <div class="height-constrained-code-block"></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="delete-team-discussion-comment-reaction-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -1726,8 +1726,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -1741,7 +1741,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">get</span> /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions</code></pre>
   <div>
-    
+
       <h4 id="list-reactions-for-a-team-discussion--parameters">
         <a href="#list-reactions-for-a-team-discussion--parameters">Parameters</a>
       </h4>
@@ -1755,108 +1755,108 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#list-reactions-for-a-team-discussion-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>org</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>team_slug</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>discussion_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>content</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Returns a single <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a>. Omit this parameter to list all reactions to a team discussion.</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>per_page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Results per page (max 100)</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Page number of the results to fetch.</p>
-                
+
               </td>
             </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="list-reactions-for-a-team-discussion--code-samples">
         <a href="#list-reactions-for-a-team-discussion--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -H &quot;Accept: application/vnd.github.squirrel-girl-preview+json&quot; \
   https://api.github.com/orgs/ORG/teams/TEAM_SLUG/discussions/42/reactions
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions&apos;</span>, {
   <span class="hljs-attr">org</span>: <span class="hljs-string">&apos;org&apos;</span>,
@@ -1869,10 +1869,10 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 200 OK</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">[
@@ -1904,22 +1904,22 @@ and creating</a> reactions.</p>
   }
 ]
 </code></pre></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="list-reactions-for-a-team-discussion-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -1942,8 +1942,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -1957,7 +1957,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">post</span> /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions</code></pre>
   <div>
-    
+
       <h4 id="create-reaction-for-a-team-discussion--parameters">
         <a href="#create-reaction-for-a-team-discussion--parameters">Parameters</a>
       </h4>
@@ -1971,77 +1971,77 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#create-reaction-for-a-team-discussion-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>org</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>team_slug</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>discussion_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
-          
+
+
           <tr>
             <td><code>content</code></td>
             <td class="opacity-70">string</td>
             <td class="opacity-70">body</td>
             <td class="opacity-70">
               <p><strong>Required</strong>. The <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a> to add to the team discussion.</p>
-              
+
             </td>
           </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="create-reaction-for-a-team-discussion--code-samples">
         <a href="#create-reaction-for-a-team-discussion--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -X POST \
@@ -2049,13 +2049,13 @@ and creating</a> reactions.</p>
   https://api.github.com/orgs/ORG/teams/TEAM_SLUG/discussions/42/reactions \
   -d &apos;{&quot;content&quot;:&quot;content&quot;}&apos;
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions&apos;</span>, {
   <span class="hljs-attr">org</span>: <span class="hljs-string">&apos;org&apos;</span>,
@@ -2069,10 +2069,10 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 201 Created</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">{
@@ -2102,15 +2102,15 @@ and creating</a> reactions.</p>
   <span class="hljs-attr">&quot;created_at&quot;</span>: <span class="hljs-string">&quot;2016-05-20T20:09:31Z&quot;</span>
 }
 </code></pre></div>
-    
-    
-    
+
+
+
       <h4 id="create-reaction-for-a-team-discussion-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -2133,8 +2133,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -2148,7 +2148,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">delete</span> /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}</code></pre>
   <div>
-    
+
       <h4 id="delete-team-discussion-reaction--parameters">
         <a href="#delete-team-discussion-reaction--parameters">Parameters</a>
       </h4>
@@ -2162,89 +2162,89 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#delete-team-discussion-reaction-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>org</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>team_slug</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>discussion_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>reaction_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="delete-team-discussion-reaction--code-samples">
         <a href="#delete-team-discussion-reaction--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -X DELETE \
   -H &quot;Accept: application/vnd.github.squirrel-girl-preview+json&quot; \
   https://api.github.com/orgs/ORG/teams/TEAM_SLUG/discussions/42/reactions/42
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}&apos;</span>, {
   <span class="hljs-attr">org</span>: <span class="hljs-string">&apos;org&apos;</span>,
@@ -2258,29 +2258,29 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default Response</h4>
       <pre><code>Status: 204 No Content</code></pre>
       <div class="height-constrained-code-block"></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="delete-team-discussion-reaction-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -2303,8 +2303,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -2318,7 +2318,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">delete</span> /reactions/{reaction_id}</code></pre>
   <div>
-    
+
       <h4 id="delete-a-reaction-legacy--parameters">
         <a href="#delete-a-reaction-legacy--parameters">Parameters</a>
       </h4>
@@ -2332,59 +2332,59 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#delete-a-reaction-legacy-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>reaction_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="delete-a-reaction-legacy--code-samples">
         <a href="#delete-a-reaction-legacy--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -X DELETE \
   -H &quot;Accept: application/vnd.github.squirrel-girl-preview+json&quot; \
   https://api.github.com/reactions/42
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;DELETE /reactions/{reaction_id}&apos;</span>, {
   <span class="hljs-attr">reaction_id</span>: <span class="hljs-number">42</span>,
@@ -2395,29 +2395,29 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default Response</h4>
       <pre><code>Status: 204 No Content</code></pre>
       <div class="height-constrained-code-block"></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="delete-a-reaction-legacy-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -2440,8 +2440,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -2454,7 +2454,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">get</span> /repos/{owner}/{repo}/comments/{comment_id}/reactions</code></pre>
   <div>
-    
+
       <h4 id="list-reactions-for-a-commit-comment--parameters">
         <a href="#list-reactions-for-a-commit-comment--parameters">Parameters</a>
       </h4>
@@ -2468,108 +2468,108 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#list-reactions-for-a-commit-comment-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>owner</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>repo</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>comment_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>content</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Returns a single <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a>. Omit this parameter to list all reactions to a commit comment.</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>per_page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Results per page (max 100)</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Page number of the results to fetch.</p>
-                
+
               </td>
             </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="list-reactions-for-a-commit-comment--code-samples">
         <a href="#list-reactions-for-a-commit-comment--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -H &quot;Accept: application/vnd.github.squirrel-girl-preview+json&quot; \
   https://api.github.com/repos/octocat/hello-world/comments/42/reactions
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;GET /repos/{owner}/{repo}/comments/{comment_id}/reactions&apos;</span>, {
   <span class="hljs-attr">owner</span>: <span class="hljs-string">&apos;octocat&apos;</span>,
@@ -2582,10 +2582,10 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 200 OK</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">[
@@ -2617,22 +2617,22 @@ and creating</a> reactions.</p>
   }
 ]
 </code></pre></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="list-reactions-for-a-commit-comment-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -2655,8 +2655,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -2669,7 +2669,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">post</span> /repos/{owner}/{repo}/comments/{comment_id}/reactions</code></pre>
   <div>
-    
+
       <h4 id="create-reaction-for-a-commit-comment--parameters">
         <a href="#create-reaction-for-a-commit-comment--parameters">Parameters</a>
       </h4>
@@ -2683,77 +2683,77 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#create-reaction-for-a-commit-comment-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>owner</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>repo</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>comment_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
-          
+
+
           <tr>
             <td><code>content</code></td>
             <td class="opacity-70">string</td>
             <td class="opacity-70">body</td>
             <td class="opacity-70">
               <p><strong>Required</strong>. The <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a> to add to the commit comment.</p>
-              
+
             </td>
           </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="create-reaction-for-a-commit-comment--code-samples">
         <a href="#create-reaction-for-a-commit-comment--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -X POST \
@@ -2761,13 +2761,13 @@ and creating</a> reactions.</p>
   https://api.github.com/repos/octocat/hello-world/comments/42/reactions \
   -d &apos;{&quot;content&quot;:&quot;content&quot;}&apos;
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;POST /repos/{owner}/{repo}/comments/{comment_id}/reactions&apos;</span>, {
   <span class="hljs-attr">owner</span>: <span class="hljs-string">&apos;octocat&apos;</span>,
@@ -2781,10 +2781,10 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 201 Created</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">{
@@ -2814,22 +2814,22 @@ and creating</a> reactions.</p>
   <span class="hljs-attr">&quot;created_at&quot;</span>: <span class="hljs-string">&quot;2016-05-20T20:09:31Z&quot;</span>
 }
 </code></pre></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="create-reaction-for-a-commit-comment-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -2852,8 +2852,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -2867,7 +2867,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">delete</span> /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}</code></pre>
   <div>
-    
+
       <h4 id="delete-a-commit-comment-reaction--parameters">
         <a href="#delete-a-commit-comment-reaction--parameters">Parameters</a>
       </h4>
@@ -2881,89 +2881,89 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#delete-a-commit-comment-reaction-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>owner</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>repo</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>comment_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>reaction_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="delete-a-commit-comment-reaction--code-samples">
         <a href="#delete-a-commit-comment-reaction--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -X DELETE \
   -H &quot;Accept: application/vnd.github.squirrel-girl-preview+json&quot; \
   https://api.github.com/repos/octocat/hello-world/comments/42/reactions/42
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}&apos;</span>, {
   <span class="hljs-attr">owner</span>: <span class="hljs-string">&apos;octocat&apos;</span>,
@@ -2977,29 +2977,29 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default Response</h4>
       <pre><code>Status: 204 No Content</code></pre>
       <div class="height-constrained-code-block"></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="delete-a-commit-comment-reaction-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -3022,8 +3022,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -3036,7 +3036,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">get</span> /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions</code></pre>
   <div>
-    
+
       <h4 id="list-reactions-for-an-issue-comment--parameters">
         <a href="#list-reactions-for-an-issue-comment--parameters">Parameters</a>
       </h4>
@@ -3050,108 +3050,108 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#list-reactions-for-an-issue-comment-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>owner</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>repo</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>comment_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>content</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Returns a single <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a>. Omit this parameter to list all reactions to an issue comment.</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>per_page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Results per page (max 100)</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Page number of the results to fetch.</p>
-                
+
               </td>
             </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="list-reactions-for-an-issue-comment--code-samples">
         <a href="#list-reactions-for-an-issue-comment--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -H &quot;Accept: application/vnd.github.squirrel-girl-preview+json&quot; \
   https://api.github.com/repos/octocat/hello-world/issues/comments/42/reactions
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions&apos;</span>, {
   <span class="hljs-attr">owner</span>: <span class="hljs-string">&apos;octocat&apos;</span>,
@@ -3164,10 +3164,10 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 200 OK</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">[
@@ -3199,22 +3199,22 @@ and creating</a> reactions.</p>
   }
 ]
 </code></pre></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="list-reactions-for-an-issue-comment-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -3237,8 +3237,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -3251,7 +3251,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">post</span> /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions</code></pre>
   <div>
-    
+
       <h4 id="create-reaction-for-an-issue-comment--parameters">
         <a href="#create-reaction-for-an-issue-comment--parameters">Parameters</a>
       </h4>
@@ -3265,77 +3265,77 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#create-reaction-for-an-issue-comment-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>owner</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>repo</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>comment_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
-          
+
+
           <tr>
             <td><code>content</code></td>
             <td class="opacity-70">string</td>
             <td class="opacity-70">body</td>
             <td class="opacity-70">
               <p><strong>Required</strong>. The <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a> to add to the issue comment.</p>
-              
+
             </td>
           </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="create-reaction-for-an-issue-comment--code-samples">
         <a href="#create-reaction-for-an-issue-comment--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -X POST \
@@ -3343,13 +3343,13 @@ and creating</a> reactions.</p>
   https://api.github.com/repos/octocat/hello-world/issues/comments/42/reactions \
   -d &apos;{&quot;content&quot;:&quot;content&quot;}&apos;
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions&apos;</span>, {
   <span class="hljs-attr">owner</span>: <span class="hljs-string">&apos;octocat&apos;</span>,
@@ -3363,10 +3363,10 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 201 Created</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">{
@@ -3396,22 +3396,22 @@ and creating</a> reactions.</p>
   <span class="hljs-attr">&quot;created_at&quot;</span>: <span class="hljs-string">&quot;2016-05-20T20:09:31Z&quot;</span>
 }
 </code></pre></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="create-reaction-for-an-issue-comment-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -3434,8 +3434,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -3449,7 +3449,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">delete</span> /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}</code></pre>
   <div>
-    
+
       <h4 id="delete-an-issue-comment-reaction--parameters">
         <a href="#delete-an-issue-comment-reaction--parameters">Parameters</a>
       </h4>
@@ -3463,89 +3463,89 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#delete-an-issue-comment-reaction-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>owner</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>repo</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>comment_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>reaction_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="delete-an-issue-comment-reaction--code-samples">
         <a href="#delete-an-issue-comment-reaction--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -X DELETE \
   -H &quot;Accept: application/vnd.github.squirrel-girl-preview+json&quot; \
   https://api.github.com/repos/octocat/hello-world/issues/comments/42/reactions/42
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}&apos;</span>, {
   <span class="hljs-attr">owner</span>: <span class="hljs-string">&apos;octocat&apos;</span>,
@@ -3559,29 +3559,29 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default Response</h4>
       <pre><code>Status: 204 No Content</code></pre>
       <div class="height-constrained-code-block"></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="delete-an-issue-comment-reaction-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -3604,8 +3604,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -3618,7 +3618,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">get</span> /repos/{owner}/{repo}/issues/{issue_number}/reactions</code></pre>
   <div>
-    
+
       <h4 id="list-reactions-for-an-issue--parameters">
         <a href="#list-reactions-for-an-issue--parameters">Parameters</a>
       </h4>
@@ -3632,108 +3632,108 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#list-reactions-for-an-issue-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>owner</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>repo</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>issue_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>content</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Returns a single <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a>. Omit this parameter to list all reactions to an issue.</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>per_page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Results per page (max 100)</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Page number of the results to fetch.</p>
-                
+
               </td>
             </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="list-reactions-for-an-issue--code-samples">
         <a href="#list-reactions-for-an-issue--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -H &quot;Accept: application/vnd.github.squirrel-girl-preview+json&quot; \
   https://api.github.com/repos/octocat/hello-world/issues/42/reactions
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;GET /repos/{owner}/{repo}/issues/{issue_number}/reactions&apos;</span>, {
   <span class="hljs-attr">owner</span>: <span class="hljs-string">&apos;octocat&apos;</span>,
@@ -3746,10 +3746,10 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 200 OK</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">[
@@ -3781,22 +3781,22 @@ and creating</a> reactions.</p>
   }
 ]
 </code></pre></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="list-reactions-for-an-issue-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -3819,8 +3819,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -3833,7 +3833,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">post</span> /repos/{owner}/{repo}/issues/{issue_number}/reactions</code></pre>
   <div>
-    
+
       <h4 id="create-reaction-for-an-issue--parameters">
         <a href="#create-reaction-for-an-issue--parameters">Parameters</a>
       </h4>
@@ -3847,77 +3847,77 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#create-reaction-for-an-issue-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>owner</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>repo</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>issue_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
-          
+
+
           <tr>
             <td><code>content</code></td>
             <td class="opacity-70">string</td>
             <td class="opacity-70">body</td>
             <td class="opacity-70">
               <p><strong>Required</strong>. The <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a> to add to the issue.</p>
-              
+
             </td>
           </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="create-reaction-for-an-issue--code-samples">
         <a href="#create-reaction-for-an-issue--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -X POST \
@@ -3925,13 +3925,13 @@ and creating</a> reactions.</p>
   https://api.github.com/repos/octocat/hello-world/issues/42/reactions \
   -d &apos;{&quot;content&quot;:&quot;content&quot;}&apos;
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;POST /repos/{owner}/{repo}/issues/{issue_number}/reactions&apos;</span>, {
   <span class="hljs-attr">owner</span>: <span class="hljs-string">&apos;octocat&apos;</span>,
@@ -3945,10 +3945,10 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 201 Created</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">{
@@ -3978,15 +3978,15 @@ and creating</a> reactions.</p>
   <span class="hljs-attr">&quot;created_at&quot;</span>: <span class="hljs-string">&quot;2016-05-20T20:09:31Z&quot;</span>
 }
 </code></pre></div>
-    
-    
-    
+
+
+
       <h4 id="create-reaction-for-an-issue-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -4009,8 +4009,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -4024,7 +4024,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">delete</span> /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}</code></pre>
   <div>
-    
+
       <h4 id="delete-an-issue-reaction--parameters">
         <a href="#delete-an-issue-reaction--parameters">Parameters</a>
       </h4>
@@ -4038,89 +4038,89 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#delete-an-issue-reaction-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>owner</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>repo</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>issue_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>reaction_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="delete-an-issue-reaction--code-samples">
         <a href="#delete-an-issue-reaction--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -X DELETE \
   -H &quot;Accept: application/vnd.github.squirrel-girl-preview+json&quot; \
   https://api.github.com/repos/octocat/hello-world/issues/42/reactions/42
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}&apos;</span>, {
   <span class="hljs-attr">owner</span>: <span class="hljs-string">&apos;octocat&apos;</span>,
@@ -4134,29 +4134,29 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default Response</h4>
       <pre><code>Status: 204 No Content</code></pre>
       <div class="height-constrained-code-block"></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="delete-an-issue-reaction-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -4179,8 +4179,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -4193,7 +4193,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">get</span> /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions</code></pre>
   <div>
-    
+
       <h4 id="list-reactions-for-a-pull-request-review-comment--parameters">
         <a href="#list-reactions-for-a-pull-request-review-comment--parameters">Parameters</a>
       </h4>
@@ -4207,108 +4207,108 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#list-reactions-for-a-pull-request-review-comment-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>owner</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>repo</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>comment_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>content</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Returns a single <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a>. Omit this parameter to list all reactions to a pull request review comment.</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>per_page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Results per page (max 100)</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Page number of the results to fetch.</p>
-                
+
               </td>
             </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="list-reactions-for-a-pull-request-review-comment--code-samples">
         <a href="#list-reactions-for-a-pull-request-review-comment--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -H &quot;Accept: application/vnd.github.squirrel-girl-preview+json&quot; \
   https://api.github.com/repos/octocat/hello-world/pulls/comments/42/reactions
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions&apos;</span>, {
   <span class="hljs-attr">owner</span>: <span class="hljs-string">&apos;octocat&apos;</span>,
@@ -4321,10 +4321,10 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 200 OK</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">[
@@ -4356,22 +4356,22 @@ and creating</a> reactions.</p>
   }
 ]
 </code></pre></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="list-reactions-for-a-pull-request-review-comment-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -4394,8 +4394,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -4408,7 +4408,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">post</span> /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions</code></pre>
   <div>
-    
+
       <h4 id="create-reaction-for-a-pull-request-review-comment--parameters">
         <a href="#create-reaction-for-a-pull-request-review-comment--parameters">Parameters</a>
       </h4>
@@ -4422,77 +4422,77 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#create-reaction-for-a-pull-request-review-comment-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>owner</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>repo</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>comment_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
-          
+
+
           <tr>
             <td><code>content</code></td>
             <td class="opacity-70">string</td>
             <td class="opacity-70">body</td>
             <td class="opacity-70">
               <p><strong>Required</strong>. The <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a> to add to the pull request review comment.</p>
-              
+
             </td>
           </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="create-reaction-for-a-pull-request-review-comment--code-samples">
         <a href="#create-reaction-for-a-pull-request-review-comment--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -X POST \
@@ -4500,13 +4500,13 @@ and creating</a> reactions.</p>
   https://api.github.com/repos/octocat/hello-world/pulls/comments/42/reactions \
   -d &apos;{&quot;content&quot;:&quot;content&quot;}&apos;
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions&apos;</span>, {
   <span class="hljs-attr">owner</span>: <span class="hljs-string">&apos;octocat&apos;</span>,
@@ -4520,10 +4520,10 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 201 Created</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">{
@@ -4553,22 +4553,22 @@ and creating</a> reactions.</p>
   <span class="hljs-attr">&quot;created_at&quot;</span>: <span class="hljs-string">&quot;2016-05-20T20:09:31Z&quot;</span>
 }
 </code></pre></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="create-reaction-for-a-pull-request-review-comment-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -4591,8 +4591,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -4606,7 +4606,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">delete</span> /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}</code></pre>
   <div>
-    
+
       <h4 id="delete-a-pull-request-comment-reaction--parameters">
         <a href="#delete-a-pull-request-comment-reaction--parameters">Parameters</a>
       </h4>
@@ -4620,89 +4620,89 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#delete-a-pull-request-comment-reaction-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>owner</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>repo</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>comment_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>reaction_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="delete-a-pull-request-comment-reaction--code-samples">
         <a href="#delete-a-pull-request-comment-reaction--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -X DELETE \
   -H &quot;Accept: application/vnd.github.squirrel-girl-preview+json&quot; \
   https://api.github.com/repos/octocat/hello-world/pulls/comments/42/reactions/42
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}&apos;</span>, {
   <span class="hljs-attr">owner</span>: <span class="hljs-string">&apos;octocat&apos;</span>,
@@ -4716,29 +4716,29 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default Response</h4>
       <pre><code>Status: 204 No Content</code></pre>
       <div class="height-constrained-code-block"></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="delete-a-pull-request-comment-reaction-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -4761,8 +4761,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -4776,7 +4776,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">get</span> /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions</code></pre>
   <div>
-    
+
       <h4 id="list-reactions-for-a-team-discussion-comment-legacy--parameters">
         <a href="#list-reactions-for-a-team-discussion-comment-legacy--parameters">Parameters</a>
       </h4>
@@ -4790,108 +4790,108 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#list-reactions-for-a-team-discussion-comment-legacy-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>team_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>discussion_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>comment_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>content</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Returns a single <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a>. Omit this parameter to list all reactions to a team discussion comment.</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>per_page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Results per page (max 100)</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Page number of the results to fetch.</p>
-                
+
               </td>
             </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="list-reactions-for-a-team-discussion-comment-legacy--code-samples">
         <a href="#list-reactions-for-a-team-discussion-comment-legacy--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -H &quot;Accept: application/vnd.github.squirrel-girl-preview+json&quot; \
   https://api.github.com/teams/42/discussions/42/comments/42/reactions
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;GET /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions&apos;</span>, {
   <span class="hljs-attr">team_id</span>: <span class="hljs-number">42</span>,
@@ -4904,10 +4904,10 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 200 OK</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">[
@@ -4939,22 +4939,22 @@ and creating</a> reactions.</p>
   }
 ]
 </code></pre></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="list-reactions-for-a-team-discussion-comment-legacy-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -4977,8 +4977,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -4992,7 +4992,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">post</span> /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions</code></pre>
   <div>
-    
+
       <h4 id="create-reaction-for-a-team-discussion-comment-legacy--parameters">
         <a href="#create-reaction-for-a-team-discussion-comment-legacy--parameters">Parameters</a>
       </h4>
@@ -5006,77 +5006,77 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#create-reaction-for-a-team-discussion-comment-legacy-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>team_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>discussion_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>comment_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
-          
+
+
           <tr>
             <td><code>content</code></td>
             <td class="opacity-70">string</td>
             <td class="opacity-70">body</td>
             <td class="opacity-70">
               <p><strong>Required</strong>. The <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a> to add to the team discussion comment.</p>
-              
+
             </td>
           </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="create-reaction-for-a-team-discussion-comment-legacy--code-samples">
         <a href="#create-reaction-for-a-team-discussion-comment-legacy--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -X POST \
@@ -5084,13 +5084,13 @@ and creating</a> reactions.</p>
   https://api.github.com/teams/42/discussions/42/comments/42/reactions \
   -d &apos;{&quot;content&quot;:&quot;content&quot;}&apos;
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;POST /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions&apos;</span>, {
   <span class="hljs-attr">team_id</span>: <span class="hljs-number">42</span>,
@@ -5104,10 +5104,10 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 201 Created</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">{
@@ -5137,22 +5137,22 @@ and creating</a> reactions.</p>
   <span class="hljs-attr">&quot;created_at&quot;</span>: <span class="hljs-string">&quot;2016-05-20T20:09:31Z&quot;</span>
 }
 </code></pre></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="create-reaction-for-a-team-discussion-comment-legacy-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -5175,8 +5175,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -5190,7 +5190,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">get</span> /teams/{team_id}/discussions/{discussion_number}/reactions</code></pre>
   <div>
-    
+
       <h4 id="list-reactions-for-a-team-discussion-legacy--parameters">
         <a href="#list-reactions-for-a-team-discussion-legacy--parameters">Parameters</a>
       </h4>
@@ -5204,98 +5204,98 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#list-reactions-for-a-team-discussion-legacy-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>team_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>discussion_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>content</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Returns a single <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a>. Omit this parameter to list all reactions to a team discussion.</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>per_page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Results per page (max 100)</p>
-                
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>page</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">query</td>
               <td class="opacity-70">
                 <p>Page number of the results to fetch.</p>
-                
+
               </td>
             </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="list-reactions-for-a-team-discussion-legacy--code-samples">
         <a href="#list-reactions-for-a-team-discussion-legacy--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -H &quot;Accept: application/vnd.github.squirrel-girl-preview+json&quot; \
   https://api.github.com/teams/42/discussions/42/reactions
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;GET /teams/{team_id}/discussions/{discussion_number}/reactions&apos;</span>, {
   <span class="hljs-attr">team_id</span>: <span class="hljs-number">42</span>,
@@ -5307,10 +5307,10 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 200 OK</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">[
@@ -5342,22 +5342,22 @@ and creating</a> reactions.</p>
   }
 ]
 </code></pre></div>
-    
-    
+
+
       <h4>Notes</h4>
       <ul class="mt-2">
-      
+
         <li><a href="/en/developers/apps">Works with GitHub Apps</a></li>
-      
+
       </ul>
-    
-    
+
+
       <h4 id="list-reactions-for-a-team-discussion-legacy-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -5380,8 +5380,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -5395,7 +5395,7 @@ and creating</a> reactions.</p>
   </div>
   <pre><code><span class="bg-blue text-white rounded-1 px-2 py-1" style="text-transform: uppercase">post</span> /teams/{team_id}/discussions/{discussion_number}/reactions</code></pre>
   <div>
-    
+
       <h4 id="create-reaction-for-a-team-discussion-legacy--parameters">
         <a href="#create-reaction-for-a-team-discussion-legacy--parameters">Parameters</a>
       </h4>
@@ -5409,67 +5409,67 @@ and creating</a> reactions.</p>
           </tr>
         </thead>
         <tbody>
-          
+
             <tr>
               <td><code>accept</code></td>
               <td class="opacity-70">string</td>
               <td class="opacity-70">header</td>
               <td class="opacity-70">
                 <p>This API is under preview and subject to change.</p>
-                
+
                   <a href="#create-reaction-for-a-team-discussion-legacy-preview-notices">
-                    
+
                       See preview notice.
-                    
-                  </a>                
+
+                  </a>
               </td>
             </tr>
-          
+
             <tr>
               <td><code>team_id</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
+
             <tr>
               <td><code>discussion_number</code></td>
               <td class="opacity-70">integer</td>
               <td class="opacity-70">path</td>
               <td class="opacity-70">
-                
-                
+
+
               </td>
             </tr>
-          
-          
+
+
           <tr>
             <td><code>content</code></td>
             <td class="opacity-70">string</td>
             <td class="opacity-70">body</td>
             <td class="opacity-70">
               <p><strong>Required</strong>. The <a href="https://developer.github.com/v3/reactions/#reaction-types">reaction type</a> to add to the team discussion.</p>
-              
+
             </td>
           </tr>
-          
-          
+
+
         </tbody>
       </table>
-    
-    
+
+
       <h4 id="create-reaction-for-a-team-discussion-legacy--code-samples">
         <a href="#create-reaction-for-a-team-discussion-legacy--code-samples">Code samples</a>
       </h4>
-      
-        
+
+
           <h5>
-            
+
               Shell
-            
+
           </h5>
           <pre><code class="hljs language-shell">curl \
   -X POST \
@@ -5477,13 +5477,13 @@ and creating</a> reactions.</p>
   https://api.github.com/teams/42/discussions/42/reactions \
   -d &apos;{&quot;content&quot;:&quot;content&quot;}&apos;
 </code></pre>
-        
-      
-        
+
+
+
           <h5>
-            
+
               JavaScript (<a href="https://github.com/octokit/core.js#readme">@octokit/core.js</a>)
-            
+
           </h5>
           <pre><code class="hljs language-javascript"><span class="hljs-keyword">await</span> octokit.request(<span class="hljs-string">&apos;POST /teams/{team_id}/discussions/{discussion_number}/reactions&apos;</span>, {
   <span class="hljs-attr">team_id</span>: <span class="hljs-number">42</span>,
@@ -5496,10 +5496,10 @@ and creating</a> reactions.</p>
   }
 })
 </code></pre>
-        
-      
-    
-    
+
+
+
+
       <h4>Default response</h4>
       <pre><code>Status: 201 Created</code></pre>
       <div class="height-constrained-code-block"><pre><code class="hljs language-json">{
@@ -5529,15 +5529,15 @@ and creating</a> reactions.</p>
   <span class="hljs-attr">&quot;created_at&quot;</span>: <span class="hljs-string">&quot;2016-05-20T20:09:31Z&quot;</span>
 }
 </code></pre></div>
-    
-    
-    
+
+
+
       <h4 id="create-reaction-for-a-team-discussion-legacy-preview-notices">
-        
+
           Preview notice
-        
+
       </h4>
-      
+
         <div class="extended-markdown note border rounded-1 mb-4 p-3 border-blue bg-blue-light f5">
           <p>An additional <code>reactions</code> object in the issue comment payload is currently available for developers to preview. During
 the preview period, the APIs may change without advance notice. Please see the <a href="https://developer.github.com/changes/2016-05-12-reactions-api-preview">blog
@@ -5560,8 +5560,8 @@ and creating</a> reactions.</p>
 </code></pre>
           &#x261D;&#xFE0F; This header is <strong>required</strong>.
         </div>
-      
-    
+
+
   </div>
   <hr>
 </div>
@@ -5569,7 +5569,7 @@ and creating</a> reactions.</p>
     </div>
   </article>
   <div class="d-block d-xl-none border-top border-gray-light mt-4 markdown-body">
-    
+
     <form class="js-helpfulness mt-4 f5" id="helpfulness-sm">
   <h4
     data-help-start
@@ -5708,7 +5708,7 @@ and creating</a> reactions.</p>
   </div>
 </main>
 
-      
+
       <!-- Contact support banner -->
 <section class="mt-lg-9 py-7 no-print" style="background-color: #fafbfc;">
   <div class="container-xl px-3 px-md-6">
@@ -5892,9 +5892,6 @@ func (s *ReactionsService) ListCommentReactions(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -5918,9 +5915,6 @@ func (s *ReactionsService) CreateCommentReaction(ctx context.Context, owner, rep
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -5964,9 +5958,6 @@ func (s *ReactionsService) ListIssueReactions(ctx context.Context, owner, repo s
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -5990,9 +5981,6 @@ func (s *ReactionsService) CreateIssueReaction(ctx context.Context, owner, repo 
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -6036,9 +6024,6 @@ func (s *ReactionsService) ListIssueCommentReactions(ctx context.Context, owner,
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -6062,9 +6047,6 @@ func (s *ReactionsService) CreateIssueCommentReaction(ctx context.Context, owner
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -6108,9 +6090,6 @@ func (s *ReactionsService) ListPullRequestCommentReactions(ctx context.Context, 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -6134,9 +6113,6 @@ func (s *ReactionsService) CreatePullRequestCommentReaction(ctx context.Context,
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -6180,8 +6156,6 @@ func (s *ReactionsService) ListTeamDiscussionReactions(ctx context.Context, team
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -6203,8 +6177,6 @@ func (s *ReactionsService) CreateTeamDiscussionReaction(ctx context.Context, tea
 	if err != nil {
 		return nil, nil, err
 	}
-
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -6248,8 +6220,6 @@ func (s *ReactionsService) ListTeamDiscussionCommentReactions(ctx context.Contex
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -6270,8 +6240,6 @@ func (s *ReactionsService) CreateTeamDiscussionCommentReaction(ctx context.Conte
 	if err != nil {
 		return nil, nil, err
 	}
-
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -6305,9 +6273,6 @@ func (s *ReactionsService) deleteReaction(ctx context.Context, url string) (*Res
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }
@@ -6384,9 +6349,6 @@ func (s *ReactionsService) ListCommentReactions(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -6410,9 +6372,6 @@ func (s *ReactionsService) CreateCommentReaction(ctx context.Context, owner, rep
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -6456,9 +6415,6 @@ func (s *ReactionsService) ListIssueReactions(ctx context.Context, owner, repo s
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -6482,9 +6438,6 @@ func (s *ReactionsService) CreateIssueReaction(ctx context.Context, owner, repo 
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -6528,9 +6481,6 @@ func (s *ReactionsService) ListIssueCommentReactions(ctx context.Context, owner,
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -6554,9 +6504,6 @@ func (s *ReactionsService) CreateIssueCommentReaction(ctx context.Context, owner
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -6600,9 +6547,6 @@ func (s *ReactionsService) ListPullRequestCommentReactions(ctx context.Context, 
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -6626,9 +6570,6 @@ func (s *ReactionsService) CreatePullRequestCommentReaction(ctx context.Context,
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -6672,8 +6613,6 @@ func (s *ReactionsService) ListTeamDiscussionReactions(ctx context.Context, team
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -6695,8 +6634,6 @@ func (s *ReactionsService) CreateTeamDiscussionReaction(ctx context.Context, tea
 	if err != nil {
 		return nil, nil, err
 	}
-
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -6740,8 +6677,6 @@ func (s *ReactionsService) ListTeamDiscussionCommentReactions(ctx context.Contex
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
-
 	var m []*Reaction
 	resp, err := s.client.Do(ctx, req, &m)
 	if err != nil {
@@ -6762,8 +6697,6 @@ func (s *ReactionsService) CreateTeamDiscussionCommentReaction(ctx context.Conte
 	if err != nil {
 		return nil, nil, err
 	}
-
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	m := &Reaction{}
 	resp, err := s.client.Do(ctx, req, m)
@@ -6797,9 +6730,6 @@ func (s *ReactionsService) deleteReaction(ctx context.Context, url string) (*Res
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }


### PR DESCRIPTION
## What type of PR is this?

cleanup

## What this PR does / why we need it:

On October 14, 2021, GitHub has promoted 23 preview headers. See [October 14, 2021: REST API preview promotions @ GitHub Changelog blog](https://github.blog/changelog/2021-10-14-rest-api-preview-promotions/).

This PR will remove 25 (!) preview headers from the codebase, but we keep the two headers that are still in preview by GitHub (mentioned in the blog post):

* `application/vnd.github.corsair-preview+json`
* `application/vnd.github.scarlet-witch-preview+json`

Removed headers:

* `application/vnd.github.v3.star+json`
* `application/vnd.github.wyandotte-preview+json`
* `application/vnd.github.ant-man-preview+json`
* `application/vnd.github.flash-preview+json`
* `application/vnd.github.squirrel-girl-preview`
* `application/vnd.github.mockingbird-preview+json`
* `application/vnd.github.inertia-preview+json`
* `application/vnd.github.cloak-preview+json`
* `application/vnd.github.giant-sentry-fist-preview+json`
* `application/vnd.github.mercy-preview+json`
* `application/vnd.github.luke-cage-preview+json`
* `application/vnd.github.eye-scream-preview`
* `application/vnd.github.zzzax-preview+json`
* `application/vnd.github.starfox-preview+json`
* `application/vnd.github.sombra-preview+json`
* `application/vnd.github.switcheroo-preview+json`
* `application/vnd.github.dorian-preview+json`
* `application/vnd.github.london-preview+json`
* `application/vnd.github.lydian-preview+json`
* `application/vnd.github.groot-preview+json`
* `application/vnd.github.surtur-preview+json`
* `application/vnd.github.baptiste-preview+json`
* `application/vnd.github.comfort-fade-preview+json`
* `application/vnd.github.doctor-strange-preview+json`
* `application/vnd.github.nebula-preview+json`

Why there is a difference of 2 (this PR removes 25 previews, the blog post is mentioning 23)?

Sadly there is no complete list provided in the blogpost of previews that have been removed.
My assumption is that this codebase contained preview headers that have been graduated before.

## Special notes for your reviewer:

### Size of the Pull Request

This Pull Request is very big and (IMO) hard to review.
Every commit is atomic and removes only one preview.
If you wish to receive 25 Pull Requests (one PR for each preview header), please let me know.

### Other obsolete code

By removing the preview headers, I found the following code to be also obsolete:

`isComfortFadePreview` (incl. tests)
https://github.com/google/go-github/blob/f6640949b0de67474e3987b3e014b2e818386c52/github/pulls_reviews.go#L67

`DraftReviewComment` fields
https://github.com/google/go-github/blob/f6640949b0de67474e3987b3e014b2e818386c52/github/pulls_reviews.go#L43-L47

For now, I kept this code in the codebase to not blow it up even more.
Please let me know what you think about it.

## Additional documentation, usage docs, etc.:

- [October 14, 2021: REST API preview promotions @ GitHub Changelog blog](https://github.blog/changelog/2021-10-14-rest-api-preview-promotions/)
- [GitHub Developer Changes](https://developer.github.com/changes/)