### PR TITLE
audit log query options should use url tag

### DIFF
--- a/github/orgs_audit_log.go
+++ b/github/orgs_audit_log.go
@@ -12,9 +12,9 @@ import (
 
 // GetAuditLogOptions sets up optional parameters to query audit-log endpoint.
 type GetAuditLogOptions struct {
-	Phrase  *string `json:"phrase,omitempty"`  // A search phrase. (Optional.)
-	Include *string `json:"include,omitempty"` // Event type includes. Can be one of "web", "git", "all". Default: "web". (Optional.)
-	Order   *string `json:"order,omitempty"`   // The order of audit log events. Can be one of "asc" or "desc". Default: "desc". (Optional.)
+	Phrase  *string `url:"phrase,omitempty"`  // A search phrase. (Optional.)
+	Include *string `url:"include,omitempty"` // Event type includes. Can be one of "web", "git", "all". Default: "web". (Optional.)
+	Order   *string `url:"order,omitempty"`   // The order of audit log events. Can be one of "asc" or "desc". Default: "desc". (Optional.)
 
 	ListCursorOptions
 }

--- a/github/orgs_audit_log_test.go
+++ b/github/orgs_audit_log_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,7 +58,7 @@ func TestOrganizationService_GetAuditLog(t *testing.T) {
 		Order:   String("asc"),
 	}
 
-	auditEntries, _, err := client.Organizations.GetAuditLog(ctx, "o", &getOpts)
+	auditEntries, resp, err := client.Organizations.GetAuditLog(ctx, "o", &getOpts)
 	if err != nil {
 		t.Errorf("Organizations.GetAuditLog returned error: %v", err)
 	}
@@ -95,6 +96,12 @@ func TestOrganizationService_GetAuditLog(t *testing.T) {
 
 	if !cmp.Equal(auditEntries, want) {
 		t.Errorf("Organizations.GetAuditLog return \ngot: %+v,\nwant:%+v", auditEntries, want)
+	}
+
+	// assert query string has lower case params
+	requestedQuery := resp.Request.URL.RawQuery
+	if !strings.Contains(requestedQuery, "phrase") {
+		t.Errorf("Organizations.GetAuditLog query string \ngot: %+v,\nwant:%+v", requestedQuery, "phrase")
 	}
 
 	const methodName = "GetAuditLog"


### PR DESCRIPTION
When using the query option params for the audit log I noticed the filters were not working, for example, when setting: 

```
searchPhrase := "actor:sfunkhouser"
include := "all"

opts := &github.GetAuditLogOptions{
		Phrase:  &searchPhrase,
		Include: &include,
	}
```

The results returned contained other activites besides the listed actor. Upon further investigation, I noticed the query string being sent was:

```
Include=all&Phrase=actor%3Asfunkhouser
```

Although, I don't understand why these are case sensitive, when testing with 
```
include=all&phrase=actor%3Asfunkhouser
```

The expected results are returned. 

Looking at the other `...Options` structs in this repo I saw that those all use the `url` tag instead of `json`. Switching to this allowed for the correct string to be used in the the query string and resulting data back was correct. 
