### PR TITLE
fix(packages): fix specified user packages api path

### DIFF
--- a/github/users_packages.go
+++ b/github/users_packages.go
@@ -18,7 +18,7 @@ import (
 func (s *UsersService) ListPackages(ctx context.Context, user string, opts *PackageListOptions) ([]*Package, *Response, error) {
 	var u string
 	if user != "" {
-		u = fmt.Sprintf("user/%v/packages", user)
+		u = fmt.Sprintf("users/%v/packages", user)
 	} else {
 		u = "user/packages"
 	}

--- a/github/users_packages_test.go
+++ b/github/users_packages_test.go
@@ -74,7 +74,7 @@ func TestUsersService_specifiedUser_ListPackages(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/user/u/packages", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/users/u/packages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"package_type": "container", "visibility": "public"})
 		fmt.Fprint(w, `[{


### PR DESCRIPTION
fix specified user packages api path

Error in getting specific user repository API path, should be `/users/%v/packages`, not `/user/%v/packages`

https://docs.github.com/en/rest/reference/packages#get-a-package-version-for-a-user

Signed-off-by: ysicing <i@ysicing.me>