### PR TITLE
Add test cases for JSON resource marshaling

### DIFF
--- a/github/search_test.go
+++ b/github/search_test.go
@@ -557,3 +557,21 @@ func TestTopicResult_Marshal(t *testing.T) {
 
 	testJSONMarshal(t, u, want)
 }
+
+func TestRepositoriesSearchResult_Marshal(t *testing.T) {
+	testJSONMarshal(t, &RepositoriesSearchResult{}, "{}")
+
+	u := &RepositoriesSearchResult{
+		Total:             Int(0),
+		IncompleteResults: Bool(true),
+		Repositories:      []*Repository{{ID: Int64(1)}},
+	}
+
+	want := `{
+		"total_count" : 0,
+		"incomplete_results" : true,
+		"items" : [{"id":1}]
+	}`
+
+	testJSONMarshal(t, u, want)
+}


### PR DESCRIPTION
Added test cases for JSON Resources :
1. RepositoriesSearchResult
helps: #55 