### PR TITLE
Parse Before/After Links into Response

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -462,7 +462,7 @@ type Response struct {
 	// Set ListCursorOptions.Cursor to this value when calling the endpoint again.
 	Cursor string
 
-	// For APIs that support before/after pagniation, such as OrganizationsService.AuditLog.
+	// For APIs that support before/after pagination, such as OrganizationsService.AuditLog.
 	Before string
 	After  string
 

--- a/github/github.go
+++ b/github/github.go
@@ -462,6 +462,10 @@ type Response struct {
 	// Set ListCursorOptions.Cursor to this value when calling the endpoint again.
 	Cursor string
 
+	// For APIs that support before/after pagniation, such as OrganizationsService.AuditLog.
+	Before string
+	After  string
+
 	// Explicitly specify the Rate type so Rate's String() receiver doesn't
 	// propagate to Response.
 	Rate Rate
@@ -517,7 +521,9 @@ func (r *Response) populatePageValues() {
 			}
 
 			page := q.Get("page")
-			if page == "" {
+			before := q.Get("before")
+			after := q.Get("after")
+			if page == "" && before == "" && after == "" {
 				continue
 			}
 
@@ -527,8 +533,10 @@ func (r *Response) populatePageValues() {
 					if r.NextPage, err = strconv.Atoi(page); err != nil {
 						r.NextPageToken = page
 					}
+					r.After = after
 				case `rel="prev"`:
 					r.PrevPage, _ = strconv.Atoi(page)
+					r.Before = before
 				case `rel="first"`:
 					r.FirstPage, _ = strconv.Atoi(page)
 				case `rel="last"`:

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -688,6 +688,40 @@ func TestResponse_cursorPagination(t *testing.T) {
 	}
 }
 
+func TestResponse_beforeAfterPagination(t *testing.T) {
+	r := http.Response{
+		Header: http.Header{
+			"Link": {`<https://api.github.com/?after=a1b2c3&before=>; rel="next",` +
+				` <https://api.github.com/?after=&before=>; rel="first",` +
+				` <https://api.github.com/?after=&before=d4e5f6>; rel="prev",`,
+			},
+		},
+	}
+
+	response := newResponse(&r)
+	if got, want := response.Before, "d4e5f6"; got != want {
+		t.Errorf("response.Before: %v, want %v", got, want)
+	}
+	if got, want := response.After, "a1b2c3"; got != want {
+		t.Errorf("response.After: %v, want %v", got, want)
+	}
+	if got, want := response.FirstPage, 0; got != want {
+		t.Errorf("response.FirstPage: %v, want %v", got, want)
+	}
+	if got, want := response.PrevPage, 0; want != got {
+		t.Errorf("response.PrevPage: %v, want %v", got, want)
+	}
+	if got, want := response.NextPage, 0; want != got {
+		t.Errorf("response.NextPage: %v, want %v", got, want)
+	}
+	if got, want := response.LastPage, 0; want != got {
+		t.Errorf("response.LastPage: %v, want %v", got, want)
+	}
+	if got, want := response.NextPageToken, ""; want != got {
+		t.Errorf("response.NextPageToken: %v, want %v", got, want)
+	}
+}
+
 func TestResponse_populatePageValues_invalid(t *testing.T) {
 	r := http.Response{
 		Header: http.Header{


### PR DESCRIPTION
* Some Github APIs use `before`/`after` for pagination, rather than `page` or `cursor` pagination. Parse these response values into the github `Response`
* For example, the Organizations GetAuditLog (Enterprise Cloud) https://docs.github.com/en/rest/reference/orgs#get-the-audit-log-for-an-organization

With this change, pagination can be performed

```go
auditParams := &github.GetAuditLogOptions{}
for {
  entries, resp, err := client.Organizations.GetAuditLog(ctx, "myorg", auditParams)
  if err != nil {
    return err
  }

  if resp.After == "" {
    break
  }
  auditParams.After = resp.After
}
```

Rel: https://github.com/google/go-github/issues/1848