### PR TITLE
Comment to keep API preview headers around

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -52,7 +52,7 @@ const (
 	// and used to enable particular features on GitHub API that are still in preview.
 	// After some time, specific media types will be promoted (to a "stable" state).
 	// From then on, the preview headers are not required anymore to activate the additional
-	// feature on GitHub.com's API. However, this API header might still be needed for users to run a GitHub Enterprise Server
+	// feature on GitHub.com's API. However, this API header might still be needed for users
 	// to run a GitHub Enterprise Server on-premise.
 	// It's not uncommon for GitHub Enterprise Server customers to run older versions which
 	// would probably rely on the preview headers for some time.

--- a/github/github.go
+++ b/github/github.go
@@ -48,6 +48,21 @@ const (
 	mediaTypeIssueImportAPI    = "application/vnd.github.golden-comet-preview+json"
 
 	// Media Type values to access preview APIs
+	// These media types will be added to the API request as headers
+	// and used to enable particular features on GitHub API that are still in preview.
+	// After some time, specific media types will be promoted (to a "stable" state).
+	// From then on, the preview headers are not required anymore to activate the additional
+	// feature on GitHub.com's API. However, this API header might still be needed for users to run a GitHub Enterprise Server
+	// on-premise.
+	// It's not uncommon for GitHub Enterprise Server customers to run older versions which
+	// would probably rely on the preview headers for some time.
+	// While the header promotion is going out for GitHub.com, it may be some time before it
+	// even arrives in GitHub Enterprise Server.
+	// We keep those preview headers around to avoid breaking older GitHub Enterprise Server
+	// versions. Additionally, an non-functional (preview) header doesn't create any side effects
+	// on GitHub Cloud version.
+	//
+	// See https://github.com/google/go-github/pull/2125 for full context.
 
 	// https://developer.github.com/changes/2014-12-09-new-attributes-for-stars-api/
 	mediaTypeStarringPreview = "application/vnd.github.v3.star+json"

--- a/github/github.go
+++ b/github/github.go
@@ -53,7 +53,7 @@ const (
 	// After some time, specific media types will be promoted (to a "stable" state).
 	// From then on, the preview headers are not required anymore to activate the additional
 	// feature on GitHub.com's API. However, this API header might still be needed for users to run a GitHub Enterprise Server
-	// on-premise.
+	// to run a GitHub Enterprise Server on-premise.
 	// It's not uncommon for GitHub Enterprise Server customers to run older versions which
 	// would probably rely on the preview headers for some time.
 	// While the header promotion is going out for GitHub.com, it may be some time before it

--- a/github/github.go
+++ b/github/github.go
@@ -59,7 +59,7 @@ const (
 	// While the header promotion is going out for GitHub.com, it may be some time before it
 	// even arrives in GitHub Enterprise Server.
 	// We keep those preview headers around to avoid breaking older GitHub Enterprise Server
-	// versions. Additionally, an non-functional (preview) header doesn't create any side effects
+	// versions. Additionally, non-functional (preview) headers don't create any side effects
 	// on GitHub Cloud version.
 	//
 	// See https://github.com/google/go-github/pull/2125 for full context.


### PR DESCRIPTION
## What type of PR is this?

documentation

## What this PR does / why we need it:

API preview headers (media types) are used to enable new features in GitHub API.
These media types will be added to the API request as headers and used to enable particular features on GitHub API that are still in preview.
After some time, specific media types will be promoted (to a "stable" state).
From then on, the preview headers are not required anymore to activate the additional feature on GitHub.com's API. However, this API header might still be needed for users to run a GitHub Enterprise Server on-premise.
It's not uncommon for GitHub Enterprise Server customers to run older versions which would probably rely on the preview headers for some time.
While the header promotion is going out for GitHub.com, it may be some time before it even arrives in GitHub Enterprise Server.
We keep those preview headers around to avoid breaking older GitHub Enterprise Server versions. Additionally, an non-functional (preview) header doesn't create any side effects on GitHub Cloud version.

See https://github.com/google/go-github/pull/2125 for full context.

## Special notes for your reviewer:

This Pull Request was triggered out of a discussion from https://github.com/google/go-github/pull/2125

### Explicit comment

Personally, I prefer and see value in extensive comments that tell the story and the full context next to the code (like in this PR).
I can understand when this interrupts the code reading flow for others.
I do think that the added advantage (by the additional context) is bigger.

Please let me know what you think about it and if any change is required.

## Additional documentation, usage docs, etc.:

- https://github.com/google/go-github/pull/2125