### PR TITLE
Change StorageBilling.EstimatedPaidStorageForMonth from int to float64

### DIFF
--- a/github/billing.go
+++ b/github/billing.go
@@ -39,9 +39,9 @@ type PackageBilling struct {
 
 // StorageBilling represents a GitHub Storage billing.
 type StorageBilling struct {
-	DaysLeftInBillingCycle       int `json:"days_left_in_billing_cycle"`
-	EstimatedPaidStorageForMonth int `json:"estimated_paid_storage_for_month"`
-	EstimatedStorageForMonth     int `json:"estimated_storage_for_month"`
+	DaysLeftInBillingCycle       int     `json:"days_left_in_billing_cycle"`
+	EstimatedPaidStorageForMonth float64 `json:"estimated_paid_storage_for_month"`
+	EstimatedStorageForMonth     int     `json:"estimated_storage_for_month"`
 }
 
 // GetActionsBillingOrg returns the summary of the free and paid GitHub Actions minutes used for an Org.

--- a/github/billing_test.go
+++ b/github/billing_test.go
@@ -120,7 +120,7 @@ func TestBillingService_GetStorageBillingOrg(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
 				"days_left_in_billing_cycle": 20,
-				"estimated_paid_storage_for_month": 15,
+				"estimated_paid_storage_for_month": 15.25,
 				"estimated_storage_for_month": 40
 			}`)
 	})
@@ -133,7 +133,7 @@ func TestBillingService_GetStorageBillingOrg(t *testing.T) {
 
 	want := &StorageBilling{
 		DaysLeftInBillingCycle:       20,
-		EstimatedPaidStorageForMonth: 15,
+		EstimatedPaidStorageForMonth: 15.25,
 		EstimatedStorageForMonth:     40,
 	}
 	if !cmp.Equal(hook, want) {
@@ -262,7 +262,7 @@ func TestBillingService_GetStorageBillingUser(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
 				"days_left_in_billing_cycle": 20,
-				"estimated_paid_storage_for_month": 15,
+				"estimated_paid_storage_for_month": 15.25,
 				"estimated_storage_for_month": 40
 			}`)
 	})
@@ -275,7 +275,7 @@ func TestBillingService_GetStorageBillingUser(t *testing.T) {
 
 	want := &StorageBilling{
 		DaysLeftInBillingCycle:       20,
-		EstimatedPaidStorageForMonth: 15,
+		EstimatedPaidStorageForMonth: 15.25,
 		EstimatedStorageForMonth:     40,
 	}
 	if !cmp.Equal(hook, want) {


### PR DESCRIPTION
fixes #2203

**Changes:**
Changed the type from int to float64 for EstimatedPaidStorageForMonth in billing.go and updated the testcases for it.

New to this repo. Please do let me know if any updates needed.