### PR TITLE
Add function to delete a workflow run by ID

### DIFF
--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -211,6 +211,18 @@ func (s *ActionsService) GetWorkflowRunLogs(ctx context.Context, owner, repo str
 	return parsedURL, newResponse(resp), err
 }
 
+// DeleteWorkflowRunLogs deletes a workflow run by ID.
+func (s *ActionsService) DeleteWorkflowRun(ctx context.Context, owner, repo string, runID int64) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v", owner, repo, runID)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
 // DeleteWorkflowRunLogs deletes all logs for a workflow run.
 //
 // GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/actions/#delete-workflow-run-logs

--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -211,7 +211,9 @@ func (s *ActionsService) GetWorkflowRunLogs(ctx context.Context, owner, repo str
 	return parsedURL, newResponse(resp), err
 }
 
-// DeleteWorkflowRunLogs deletes a workflow run by ID.
+// DeleteWorkflowRun deletes a workflow run by ID.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/actions#delete-a-workflow-run
 func (s *ActionsService) DeleteWorkflowRun(ctx context.Context, owner, repo string, runID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v", owner, repo, runID)
 

--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -334,6 +334,32 @@ func TestActionService_ListRepositoryWorkflowRuns(t *testing.T) {
 	})
 }
 
+func TestActionService_DeleteWorkflowRun(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/runs/399444496", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := context.Background()
+	if _, err := client.Actions.DeleteWorkflowRun(ctx, "o", "r", 399444496); err != nil {
+		t.Errorf("DeleteWorkflowRun returned error: %v", err)
+	}
+
+	const methodName = "DeleteWorkflowRun"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.DeleteWorkflowRun(ctx, "\n", "\n", 399444496)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.DeleteWorkflowRun(ctx, "o", "r", 399444496)
+	})
+}
+
 func TestActionService_DeleteWorkflowRunLogs(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
This Pull request Adds a new function to delete workflows run from workflow history. The same functionality as this button:
<img width="960" alt="Screenshot 2021-11-22 at 11 43 41" src="https://user-images.githubusercontent.com/6052966/142847721-070de07c-60be-4b84-a8e3-965a43b59246.png">

I cannot reference the documentation in the function comment because is missing the endpoint in the docs