### PR TITLE
Add active committers API implementation

### DIFF
--- a/github/billing.go
+++ b/github/billing.go
@@ -44,6 +44,22 @@ type StorageBilling struct {
 	EstimatedStorageForMonth     int     `json:"estimated_storage_for_month"`
 }
 
+type ActiveCommitters struct {
+	TotalAdvancedSecurityCommitters int          `json:"total_advanced_security_committers"`
+	Repositories                    Repositories `json:"repositories"`
+}
+
+type Repositories struct {
+	Name                                string                              `json:"name"`
+	AdvancedSecurityCommitters          int                                 `json:"advanced_security_committers"`
+	AdvancedSecurityCommittersBreakdown []AdvancedSecurityCommittersBreakdown `json:"advanced_security_committers_breakdown"`
+}
+
+type AdvancedSecurityCommittersBreakdown struct {
+	UserLogin      string `json:"user_login"`
+	LastPushedDate string `json:"last_pushed_date"`
+}
+
 // GetActionsBillingOrg returns the summary of the free and paid GitHub Actions minutes used for an Org.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/billing#get-github-actions-billing-for-an-organization
@@ -85,6 +101,20 @@ func (s *BillingService) GetStorageBillingOrg(ctx context.Context, org string) (
 	storageOrgBilling := new(StorageBilling)
 	resp, err := s.client.Do(ctx, req, storageOrgBilling)
 	return storageOrgBilling, resp, err
+}
+
+// GetAdvancedSecurityActiveCommittersOrg returns the GitHub Advanced Security active committers for an organization per repository.
+//
+// GitHub API docs: https://docs.github.com/en/rest/reference/billing#get-github-advanced-security-active-committers-for-an-organization
+func (s *BillingService) GetAdvancedSecurityActiveCommittersOrg(ctx context.Context, org string) (*ActiveCommitters, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/settings/billing/advanced-security", org)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	ActiveOrgCommitters := new(ActiveCommitters)
+	resp, err := s.client.Do(ctx, req, ActiveOrgCommitters)
+	return ActiveOrgCommitters, resp, err
 }
 
 // GetActionsBillingUser returns the summary of the free and paid GitHub Actions minutes used for a user.

--- a/github/billing.go
+++ b/github/billing.go
@@ -46,7 +46,7 @@ type StorageBilling struct {
 
 // ActiveCommitters represents the total active committers across all repositories in an Organization.
 type ActiveCommitters struct {
-	TotalAdvancedSecurityCommitters int            `json:"total_advanced_security_committers,omitempty"`
+	TotalAdvancedSecurityCommitters int                          `json:"total_advanced_security_committers,omitempty"`
 	Repositories                    []RepositoryActiveCommitters `json:"repositories,omitempty"`
 }
 

--- a/github/billing.go
+++ b/github/billing.go
@@ -18,49 +18,49 @@ type BillingService service
 
 // ActionBilling represents a GitHub Action billing.
 type ActionBilling struct {
-	TotalMinutesUsed     int                  `json:"total_minutes_used,omitempty"`
-	TotalPaidMinutesUsed int                  `json:"total_paid_minutes_used,omitempty"`
-	IncludedMinutes      int                  `json:"included_minutes,omitempty"`
-	MinutesUsedBreakdown MinutesUsedBreakdown `json:"minutes_used_breakdown,omitempty"`
+	TotalMinutesUsed     int                  `json:"total_minutes_used"`
+	TotalPaidMinutesUsed int                  `json:"total_paid_minutes_used"`
+	IncludedMinutes      int                  `json:"included_minutes"`
+	MinutesUsedBreakdown MinutesUsedBreakdown `json:"minutes_used_breakdown"`
 }
 
 type MinutesUsedBreakdown struct {
-	Ubuntu  int `json:"UBUNTU,omitempty"`
-	MacOS   int `json:"MACOS,omitempty"`
-	Windows int `json:"WINDOWS,omitempty"`
+	Ubuntu  int `json:"UBUNTU"`
+	MacOS   int `json:"MACOS"`
+	Windows int `json:"WINDOWS"`
 }
 
 // PackageBilling represents a GitHub Package billing.
 type PackageBilling struct {
-	TotalGigabytesBandwidthUsed     int `json:"total_gigabytes_bandwidth_used,omitempty"`
-	TotalPaidGigabytesBandwidthUsed int `json:"total_paid_gigabytes_bandwidth_used,omitempty"`
-	IncludedGigabytesBandwidth      int `json:"included_gigabytes_bandwidth,omitempty"`
+	TotalGigabytesBandwidthUsed     int `json:"total_gigabytes_bandwidth_used"`
+	TotalPaidGigabytesBandwidthUsed int `json:"total_paid_gigabytes_bandwidth_used"`
+	IncludedGigabytesBandwidth      int `json:"included_gigabytes_bandwidth"`
 }
 
 // StorageBilling represents a GitHub Storage billing.
 type StorageBilling struct {
-	DaysLeftInBillingCycle       int     `json:"days_left_in_billing_cycle,omitempty"`
-	EstimatedPaidStorageForMonth float64 `json:"estimated_paid_storage_for_month,omitempty"`
-	EstimatedStorageForMonth     int     `json:"estimated_storage_for_month,omitempty"`
+	DaysLeftInBillingCycle       int     `json:"days_left_in_billing_cycle"`
+	EstimatedPaidStorageForMonth float64 `json:"estimated_paid_storage_for_month"`
+	EstimatedStorageForMonth     int     `json:"estimated_storage_for_month"`
 }
 
 // ActiveCommitters represents the total active committers across all repositories in an Organization.
 type ActiveCommitters struct {
-	TotalAdvancedSecurityCommitters int                          `json:"total_advanced_security_committers,omitempty"`
-	Repositories                    []RepositoryActiveCommitters `json:"repositories,omitempty"`
+	TotalAdvancedSecurityCommitters int                           `json:"total_advanced_security_committers"`
+	Repositories                    []*RepositoryActiveCommitters `json:"repositories,omitempty"`
 }
 
-// RepositoryActiveCommitters represents active committers on each repository
+// RepositoryActiveCommitters represents active committers on each repository.
 type RepositoryActiveCommitters struct {
-	Name                                string                                `json:"name,omitempty"`
-	AdvancedSecurityCommitters          int                                   `json:"advanced_security_committers,omitempty"`
-	AdvancedSecurityCommittersBreakdown []AdvancedSecurityCommittersBreakdown `json:"advanced_security_committers_breakdown,omitempty"`
+	Name                                *string                                `json:"name,omitempty"`
+	AdvancedSecurityCommitters          *int                                   `json:"advanced_security_committers,omitempty"`
+	AdvancedSecurityCommittersBreakdown []*AdvancedSecurityCommittersBreakdown `json:"advanced_security_committers_breakdown,omitempty"`
 }
 
 // AdvancedSecurityCommittersBreakdown represents the user activity breakdown for ActiveCommitters.
 type AdvancedSecurityCommittersBreakdown struct {
-	UserLogin      string `json:"user_login,omitempty"`
-	LastPushedDate string `json:"last_pushed_date,omitempty"`
+	UserLogin      *string `json:"user_login,omitempty"`
+	LastPushedDate *string `json:"last_pushed_date,omitempty"`
 }
 
 // GetActionsBillingOrg returns the summary of the free and paid GitHub Actions minutes used for an Org.
@@ -131,13 +131,13 @@ func (s *BillingService) GetAdvancedSecurityActiveCommittersOrg(ctx context.Cont
 		return nil, nil, err
 	}
 
-	ActiveOrgCommitters := new(ActiveCommitters)
-	resp, err := s.client.Do(ctx, req, ActiveOrgCommitters)
+	activeOrgCommitters := new(ActiveCommitters)
+	resp, err := s.client.Do(ctx, req, activeOrgCommitters)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return ActiveOrgCommitters, resp, err
+	return activeOrgCommitters, resp, err
 }
 
 // GetActionsBillingUser returns the summary of the free and paid GitHub Actions minutes used for a user.

--- a/github/billing.go
+++ b/github/billing.go
@@ -44,17 +44,20 @@ type StorageBilling struct {
 	EstimatedStorageForMonth     int     `json:"estimated_storage_for_month"`
 }
 
+// ActiveCommitters represents the total active committers across all repositories in an Organization.
 type ActiveCommitters struct {
 	TotalAdvancedSecurityCommitters int            `json:"total_advanced_security_committers"`
 	Repositories                    []Repositories `json:"repositories"`
 }
 
+// Repositories represents active committers on each repository
 type Repositories struct {
 	Name                                string                                `json:"name"`
 	AdvancedSecurityCommitters          int                                   `json:"advanced_security_committers"`
 	AdvancedSecurityCommittersBreakdown []AdvancedSecurityCommittersBreakdown `json:"advanced_security_committers_breakdown"`
 }
 
+// AdvancedSecurityCommittersBreakdown represents the user activity breakdown for ActiveCommitters
 type AdvancedSecurityCommittersBreakdown struct {
 	UserLogin      string `json:"user_login"`
 	LastPushedDate string `json:"last_pushed_date"`

--- a/github/billing.go
+++ b/github/billing.go
@@ -50,8 +50,8 @@ type ActiveCommitters struct {
 }
 
 type Repositories struct {
-	Name                                string                              `json:"name"`
-	AdvancedSecurityCommitters          int                                 `json:"advanced_security_committers"`
+	Name                                string                                `json:"name"`
+	AdvancedSecurityCommitters          int                                   `json:"advanced_security_committers"`
 	AdvancedSecurityCommittersBreakdown []AdvancedSecurityCommittersBreakdown `json:"advanced_security_committers_breakdown"`
 }
 

--- a/github/billing.go
+++ b/github/billing.go
@@ -18,49 +18,49 @@ type BillingService service
 
 // ActionBilling represents a GitHub Action billing.
 type ActionBilling struct {
-	TotalMinutesUsed     int                  `json:"total_minutes_used"`
-	TotalPaidMinutesUsed int                  `json:"total_paid_minutes_used"`
-	IncludedMinutes      int                  `json:"included_minutes"`
-	MinutesUsedBreakdown MinutesUsedBreakdown `json:"minutes_used_breakdown"`
+	TotalMinutesUsed     int                  `json:"total_minutes_used,omitempty"`
+	TotalPaidMinutesUsed int                  `json:"total_paid_minutes_used,omitempty"`
+	IncludedMinutes      int                  `json:"included_minutes,omitempty"`
+	MinutesUsedBreakdown MinutesUsedBreakdown `json:"minutes_used_breakdown,omitempty"`
 }
 
 type MinutesUsedBreakdown struct {
-	Ubuntu  int `json:"UBUNTU"`
-	MacOS   int `json:"MACOS"`
-	Windows int `json:"WINDOWS"`
+	Ubuntu  int `json:"UBUNTU,omitempty"`
+	MacOS   int `json:"MACOS,omitempty"`
+	Windows int `json:"WINDOWS,omitempty"`
 }
 
 // PackageBilling represents a GitHub Package billing.
 type PackageBilling struct {
-	TotalGigabytesBandwidthUsed     int `json:"total_gigabytes_bandwidth_used"`
-	TotalPaidGigabytesBandwidthUsed int `json:"total_paid_gigabytes_bandwidth_used"`
-	IncludedGigabytesBandwidth      int `json:"included_gigabytes_bandwidth"`
+	TotalGigabytesBandwidthUsed     int `json:"total_gigabytes_bandwidth_used,omitempty"`
+	TotalPaidGigabytesBandwidthUsed int `json:"total_paid_gigabytes_bandwidth_used,omitempty"`
+	IncludedGigabytesBandwidth      int `json:"included_gigabytes_bandwidth,omitempty"`
 }
 
 // StorageBilling represents a GitHub Storage billing.
 type StorageBilling struct {
-	DaysLeftInBillingCycle       int     `json:"days_left_in_billing_cycle"`
-	EstimatedPaidStorageForMonth float64 `json:"estimated_paid_storage_for_month"`
-	EstimatedStorageForMonth     int     `json:"estimated_storage_for_month"`
+	DaysLeftInBillingCycle       int     `json:"days_left_in_billing_cycle,omitempty"`
+	EstimatedPaidStorageForMonth float64 `json:"estimated_paid_storage_for_month,omitempty"`
+	EstimatedStorageForMonth     int     `json:"estimated_storage_for_month,omitempty"`
 }
 
 // ActiveCommitters represents the total active committers across all repositories in an Organization.
 type ActiveCommitters struct {
-	TotalAdvancedSecurityCommitters int            `json:"total_advanced_security_committers"`
-	Repositories                    []Repositories `json:"repositories"`
+	TotalAdvancedSecurityCommitters int            `json:"total_advanced_security_committers,omitempty"`
+	Repositories                    []RepositoryActiveCommitters `json:"repositories,omitempty"`
 }
 
-// Repositories represents active committers on each repository
-type Repositories struct {
-	Name                                string                                `json:"name"`
-	AdvancedSecurityCommitters          int                                   `json:"advanced_security_committers"`
-	AdvancedSecurityCommittersBreakdown []AdvancedSecurityCommittersBreakdown `json:"advanced_security_committers_breakdown"`
+// RepositoryActiveCommitters represents active committers on each repository
+type RepositoryActiveCommitters struct {
+	Name                                string                                `json:"name,omitempty"`
+	AdvancedSecurityCommitters          int                                   `json:"advanced_security_committers,omitempty"`
+	AdvancedSecurityCommittersBreakdown []AdvancedSecurityCommittersBreakdown `json:"advanced_security_committers_breakdown,omitempty"`
 }
 
-// AdvancedSecurityCommittersBreakdown represents the user activity breakdown for ActiveCommitters
+// AdvancedSecurityCommittersBreakdown represents the user activity breakdown for ActiveCommitters.
 type AdvancedSecurityCommittersBreakdown struct {
-	UserLogin      string `json:"user_login"`
-	LastPushedDate string `json:"last_pushed_date"`
+	UserLogin      string `json:"user_login,omitempty"`
+	LastPushedDate string `json:"last_pushed_date,omitempty"`
 }
 
 // GetActionsBillingOrg returns the summary of the free and paid GitHub Actions minutes used for an Org.
@@ -72,8 +72,13 @@ func (s *BillingService) GetActionsBillingOrg(ctx context.Context, org string) (
 	if err != nil {
 		return nil, nil, err
 	}
+
 	actionsOrgBilling := new(ActionBilling)
 	resp, err := s.client.Do(ctx, req, actionsOrgBilling)
+	if err != nil {
+		return nil, resp, err
+	}
+
 	return actionsOrgBilling, resp, err
 }
 
@@ -86,8 +91,13 @@ func (s *BillingService) GetPackagesBillingOrg(ctx context.Context, org string) 
 	if err != nil {
 		return nil, nil, err
 	}
+
 	packagesOrgBilling := new(PackageBilling)
 	resp, err := s.client.Do(ctx, req, packagesOrgBilling)
+	if err != nil {
+		return nil, resp, err
+	}
+
 	return packagesOrgBilling, resp, err
 }
 
@@ -101,8 +111,13 @@ func (s *BillingService) GetStorageBillingOrg(ctx context.Context, org string) (
 	if err != nil {
 		return nil, nil, err
 	}
+
 	storageOrgBilling := new(StorageBilling)
 	resp, err := s.client.Do(ctx, req, storageOrgBilling)
+	if err != nil {
+		return nil, resp, err
+	}
+
 	return storageOrgBilling, resp, err
 }
 
@@ -115,8 +130,13 @@ func (s *BillingService) GetAdvancedSecurityActiveCommittersOrg(ctx context.Cont
 	if err != nil {
 		return nil, nil, err
 	}
+
 	ActiveOrgCommitters := new(ActiveCommitters)
 	resp, err := s.client.Do(ctx, req, ActiveOrgCommitters)
+	if err != nil {
+		return nil, resp, err
+	}
+
 	return ActiveOrgCommitters, resp, err
 }
 
@@ -129,8 +149,13 @@ func (s *BillingService) GetActionsBillingUser(ctx context.Context, user string)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	actionsUserBilling := new(ActionBilling)
 	resp, err := s.client.Do(ctx, req, actionsUserBilling)
+	if err != nil {
+		return nil, resp, err
+	}
+
 	return actionsUserBilling, resp, err
 }
 
@@ -143,8 +168,13 @@ func (s *BillingService) GetPackagesBillingUser(ctx context.Context, user string
 	if err != nil {
 		return nil, nil, err
 	}
+
 	packagesUserBilling := new(PackageBilling)
 	resp, err := s.client.Do(ctx, req, packagesUserBilling)
+	if err != nil {
+		return nil, resp, err
+	}
+
 	return packagesUserBilling, resp, err
 }
 
@@ -158,7 +188,12 @@ func (s *BillingService) GetStorageBillingUser(ctx context.Context, user string)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	storageUserBilling := new(StorageBilling)
 	resp, err := s.client.Do(ctx, req, storageUserBilling)
+	if err != nil {
+		return nil, resp, err
+	}
+
 	return storageUserBilling, resp, err
 }

--- a/github/billing.go
+++ b/github/billing.go
@@ -45,8 +45,8 @@ type StorageBilling struct {
 }
 
 type ActiveCommitters struct {
-	TotalAdvancedSecurityCommitters int          `json:"total_advanced_security_committers"`
-	Repositories                    Repositories `json:"repositories"`
+	TotalAdvancedSecurityCommitters int            `json:"total_advanced_security_committers"`
+	Repositories                    []Repositories `json:"repositories"`
 }
 
 type Repositories struct {

--- a/github/billing_test.go
+++ b/github/billing_test.go
@@ -394,10 +394,6 @@ func TestBillingService_GetAdvancedSecurityActiveCommittersOrg(t *testing.T) {
       "advanced_security_committers": 2,
       "advanced_security_committers_breakdown": [
         {
-          "user_login": "octocat",
-          "last_pushed_date": "2021-11-03"
-        },
-        {
           "user_login": "octokitten",
           "last_pushed_date": "2021-10-25"
         }
@@ -414,14 +410,14 @@ func TestBillingService_GetAdvancedSecurityActiveCommittersOrg(t *testing.T) {
 	}
 
 	want := &ActiveCommitters{
-		TotalAdvancedSecurityCommitters:     2,
+		TotalAdvancedSecurityCommitters: 2,
 		Repositories: Repositories{
-			Name:  "octocat-org/Hello-World",
-			AdvancedSecurityCommitters:   2,
+			Name:                       "octocat-org/Hello-World",
+			AdvancedSecurityCommitters: 2,
 			AdvancedSecurityCommittersBreakdown: []AdvancedSecurityCommittersBreakdown{
 				{
-				UserLogin: "octokitten",
-				LastPushedDate: "2021-10-25",
+					UserLogin:      "octokitten",
+					LastPushedDate: "2021-10-25",
 				},
 			},
 		},

--- a/github/billing_test.go
+++ b/github/billing_test.go
@@ -459,14 +459,14 @@ func TestBillingService_GetAdvancedSecurityActiveCommittersOrg(t *testing.T) {
 
 	want := &ActiveCommitters{
 		TotalAdvancedSecurityCommitters: 2,
-		Repositories: []RepositoryActiveCommitters{
+		Repositories: []*RepositoryActiveCommitters{
 			{
-				Name:                       "octocat-org/Hello-World",
-				AdvancedSecurityCommitters: 2,
-				AdvancedSecurityCommittersBreakdown: []AdvancedSecurityCommittersBreakdown{
+				Name:                       String("octocat-org/Hello-World"),
+				AdvancedSecurityCommitters: Int(2),
+				AdvancedSecurityCommittersBreakdown: []*AdvancedSecurityCommittersBreakdown{
 					{
-						UserLogin:      "octokitten",
-						LastPushedDate: "2021-10-25",
+						UserLogin:      String("octokitten"),
+						LastPushedDate: String("2021-10-25"),
 					},
 				},
 			},

--- a/github/billing_test.go
+++ b/github/billing_test.go
@@ -411,13 +411,15 @@ func TestBillingService_GetAdvancedSecurityActiveCommittersOrg(t *testing.T) {
 
 	want := &ActiveCommitters{
 		TotalAdvancedSecurityCommitters: 2,
-		Repositories: Repositories{
-			Name:                       "octocat-org/Hello-World",
-			AdvancedSecurityCommitters: 2,
-			AdvancedSecurityCommittersBreakdown: []AdvancedSecurityCommittersBreakdown{
-				{
-					UserLogin:      "octokitten",
-					LastPushedDate: "2021-10-25",
+		Repositories: []Repositories{
+			{
+				Name:                       "octocat-org/Hello-World",
+				AdvancedSecurityCommitters: 2,
+				AdvancedSecurityCommittersBreakdown: []AdvancedSecurityCommittersBreakdown{
+					{
+						UserLogin:      "octokitten",
+						LastPushedDate: "2021-10-25",
+					},
 				},
 			},
 		},

--- a/github/billing_test.go
+++ b/github/billing_test.go
@@ -57,6 +57,14 @@ func TestBillingService_GetActionsBillingOrg(t *testing.T) {
 		_, _, err = client.Billing.GetActionsBillingOrg(ctx, "\n")
 		return err
 	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Billing.GetActionsBillingOrg(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
 }
 
 func TestBillingService_GetActionsBillingOrg_invalidOrg(t *testing.T) {
@@ -101,6 +109,14 @@ func TestBillingService_GetPackagesBillingOrg(t *testing.T) {
 		_, _, err = client.Billing.GetPackagesBillingOrg(ctx, "\n")
 		return err
 	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Billing.GetPackagesBillingOrg(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
 }
 
 func TestBillingService_GetPackagesBillingOrg_invalidOrg(t *testing.T) {
@@ -144,6 +160,14 @@ func TestBillingService_GetStorageBillingOrg(t *testing.T) {
 	testBadOptions(t, methodName, func() (err error) {
 		_, _, err = client.Billing.GetStorageBillingOrg(ctx, "\n")
 		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Billing.GetStorageBillingOrg(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
 	})
 }
 
@@ -199,6 +223,14 @@ func TestBillingService_GetActionsBillingUser(t *testing.T) {
 		_, _, err = client.Billing.GetActionsBillingOrg(ctx, "\n")
 		return err
 	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Billing.GetActionsBillingUser(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
 }
 
 func TestBillingService_GetActionsBillingUser_invalidUser(t *testing.T) {
@@ -243,6 +275,14 @@ func TestBillingService_GetPackagesBillingUser(t *testing.T) {
 		_, _, err = client.Billing.GetPackagesBillingUser(ctx, "\n")
 		return err
 	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Billing.GetPackagesBillingUser(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
 }
 
 func TestBillingService_GetPackagesBillingUser_invalidUser(t *testing.T) {
@@ -286,6 +326,14 @@ func TestBillingService_GetStorageBillingUser(t *testing.T) {
 	testBadOptions(t, methodName, func() (err error) {
 		_, _, err = client.Billing.GetStorageBillingUser(ctx, "\n")
 		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Billing.GetStorageBillingUser(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
 	})
 }
 
@@ -411,7 +459,7 @@ func TestBillingService_GetAdvancedSecurityActiveCommittersOrg(t *testing.T) {
 
 	want := &ActiveCommitters{
 		TotalAdvancedSecurityCommitters: 2,
-		Repositories: []Repositories{
+		Repositories: []RepositoryActiveCommitters{
 			{
 				Name:                       "octocat-org/Hello-World",
 				AdvancedSecurityCommitters: 2,
@@ -432,6 +480,14 @@ func TestBillingService_GetAdvancedSecurityActiveCommittersOrg(t *testing.T) {
 	testBadOptions(t, methodName, func() (err error) {
 		_, _, err = client.Billing.GetAdvancedSecurityActiveCommittersOrg(ctx, "\n")
 		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Billing.GetAdvancedSecurityActiveCommittersOrg(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
 	})
 }
 

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -156,6 +156,22 @@ func (a *AdvancedSecurity) GetStatus() string {
 	return *a.Status
 }
 
+// GetLastPushedDate returns the LastPushedDate field if it's non-nil, zero value otherwise.
+func (a *AdvancedSecurityCommittersBreakdown) GetLastPushedDate() string {
+	if a == nil || a.LastPushedDate == nil {
+		return ""
+	}
+	return *a.LastPushedDate
+}
+
+// GetUserLogin returns the UserLogin field if it's non-nil, zero value otherwise.
+func (a *AdvancedSecurityCommittersBreakdown) GetUserLogin() string {
+	if a == nil || a.UserLogin == nil {
+		return ""
+	}
+	return *a.UserLogin
+}
+
 // GetClosedAt returns the ClosedAt field if it's non-nil, zero value otherwise.
 func (a *Alert) GetClosedAt() Timestamp {
 	if a == nil || a.ClosedAt == nil {
@@ -13850,6 +13866,22 @@ func (r *Repository) GetWatchersCount() int {
 		return 0
 	}
 	return *r.WatchersCount
+}
+
+// GetAdvancedSecurityCommitters returns the AdvancedSecurityCommitters field if it's non-nil, zero value otherwise.
+func (r *RepositoryActiveCommitters) GetAdvancedSecurityCommitters() int {
+	if r == nil || r.AdvancedSecurityCommitters == nil {
+		return 0
+	}
+	return *r.AdvancedSecurityCommitters
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (r *RepositoryActiveCommitters) GetName() string {
+	if r == nil || r.Name == nil {
+		return ""
+	}
+	return *r.Name
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -163,6 +163,26 @@ func TestAdvancedSecurity_GetStatus(tt *testing.T) {
 	a.GetStatus()
 }
 
+func TestAdvancedSecurityCommittersBreakdown_GetLastPushedDate(tt *testing.T) {
+	var zeroValue string
+	a := &AdvancedSecurityCommittersBreakdown{LastPushedDate: &zeroValue}
+	a.GetLastPushedDate()
+	a = &AdvancedSecurityCommittersBreakdown{}
+	a.GetLastPushedDate()
+	a = nil
+	a.GetLastPushedDate()
+}
+
+func TestAdvancedSecurityCommittersBreakdown_GetUserLogin(tt *testing.T) {
+	var zeroValue string
+	a := &AdvancedSecurityCommittersBreakdown{UserLogin: &zeroValue}
+	a.GetUserLogin()
+	a = &AdvancedSecurityCommittersBreakdown{}
+	a.GetUserLogin()
+	a = nil
+	a.GetUserLogin()
+}
+
 func TestAlert_GetClosedAt(tt *testing.T) {
 	var zeroValue Timestamp
 	a := &Alert{ClosedAt: &zeroValue}
@@ -16174,6 +16194,26 @@ func TestRepository_GetWatchersCount(tt *testing.T) {
 	r.GetWatchersCount()
 	r = nil
 	r.GetWatchersCount()
+}
+
+func TestRepositoryActiveCommitters_GetAdvancedSecurityCommitters(tt *testing.T) {
+	var zeroValue int
+	r := &RepositoryActiveCommitters{AdvancedSecurityCommitters: &zeroValue}
+	r.GetAdvancedSecurityCommitters()
+	r = &RepositoryActiveCommitters{}
+	r.GetAdvancedSecurityCommitters()
+	r = nil
+	r.GetAdvancedSecurityCommitters()
+}
+
+func TestRepositoryActiveCommitters_GetName(tt *testing.T) {
+	var zeroValue string
+	r := &RepositoryActiveCommitters{Name: &zeroValue}
+	r.GetName()
+	r = &RepositoryActiveCommitters{}
+	r.GetName()
+	r = nil
+	r.GetName()
 }
 
 func TestRepositoryComment_GetBody(tt *testing.T) {


### PR DESCRIPTION
New Method for fetching active committers for an Organization
https://docs.github.com/en/rest/reference/billing#get-github-advanced-security-active-committers-for-an-organization