### PR TITLE
Add BranchProtectionRuleEvent Installation field

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -20,12 +20,13 @@ type RequestedAction struct {
 //
 // GitHub API docs: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#branch_protection_rule
 type BranchProtectionRuleEvent struct {
-	Action  *string               `json:"action,omitempty"`
-	Rule    *BranchProtectionRule `json:"rule,omitempty"`
-	Changes *ProtectionChanges    `json:"changes,omitempty"`
-	Repo    *Repository           `json:"repository,omitempty"`
-	Org     *Organization         `json:"organization,omitempty"`
-	Sender  *User                 `json:"sender,omitempty"`
+	Action       *string               `json:"action,omitempty"`
+	Rule         *BranchProtectionRule `json:"rule,omitempty"`
+	Changes      *ProtectionChanges    `json:"changes,omitempty"`
+	Repo         *Repository           `json:"repository,omitempty"`
+	Org          *Organization         `json:"organization,omitempty"`
+	Sender       *User                 `json:"sender,omitempty"`
+	Installation *Installation         `json:"installation,omitempty"`
 }
 
 // CheckRunEvent is triggered when a check run is "created", "completed", or "rerequested".

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1636,6 +1636,14 @@ func (b *BranchProtectionRuleEvent) GetSender() *User {
 	return b.Sender
 }
 
+// GetInstallation returns the Installation field.
+func (b *BranchProtectionRuleEvent) GetInstallation() *Installation {
+	if b == nil {
+		return nil
+	}
+	return b.Installation
+}
+
 // GetApp returns the App field.
 func (c *CheckRun) GetApp() *App {
 	if c == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1604,6 +1604,14 @@ func (b *BranchProtectionRuleEvent) GetChanges() *ProtectionChanges {
 	return b.Changes
 }
 
+// GetInstallation returns the Installation field.
+func (b *BranchProtectionRuleEvent) GetInstallation() *Installation {
+	if b == nil {
+		return nil
+	}
+	return b.Installation
+}
+
 // GetOrg returns the Org field.
 func (b *BranchProtectionRuleEvent) GetOrg() *Organization {
 	if b == nil {
@@ -1634,14 +1642,6 @@ func (b *BranchProtectionRuleEvent) GetSender() *User {
 		return nil
 	}
 	return b.Sender
-}
-
-// GetInstallation returns the Installation field.
-func (b *BranchProtectionRuleEvent) GetInstallation() *Installation {
-	if b == nil {
-		return nil
-	}
-	return b.Installation
 }
 
 // GetApp returns the App field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -1956,6 +1956,13 @@ func TestBranchProtectionRuleEvent_GetSender(tt *testing.T) {
 	b.GetSender()
 }
 
+func TestBranchProtectionRuleEvent_GetInstallation(tt *testing.T) {
+	b := &BranchProtectionRuleEvent{}
+	b.GetInstallation()
+	b = nil
+	b.GetInstallation()
+}
+
 func TestCheckRun_GetApp(tt *testing.T) {
 	c := &CheckRun{}
 	c.GetApp()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -1928,6 +1928,13 @@ func TestBranchProtectionRuleEvent_GetChanges(tt *testing.T) {
 	b.GetChanges()
 }
 
+func TestBranchProtectionRuleEvent_GetInstallation(tt *testing.T) {
+	b := &BranchProtectionRuleEvent{}
+	b.GetInstallation()
+	b = nil
+	b.GetInstallation()
+}
+
 func TestBranchProtectionRuleEvent_GetOrg(tt *testing.T) {
 	b := &BranchProtectionRuleEvent{}
 	b.GetOrg()
@@ -1954,13 +1961,6 @@ func TestBranchProtectionRuleEvent_GetSender(tt *testing.T) {
 	b.GetSender()
 	b = nil
 	b.GetSender()
-}
-
-func TestBranchProtectionRuleEvent_GetInstallation(tt *testing.T) {
-	b := &BranchProtectionRuleEvent{}
-	b.GetInstallation()
-	b = nil
-	b.GetInstallation()
 }
 
 func TestCheckRun_GetApp(tt *testing.T) {

--- a/scrape/testdata/access-restrictions-disabled.html
+++ b/scrape/testdata/access-restrictions-disabled.html
@@ -2,16 +2,16 @@
      Some extraneous markup removed to keep the file size smaller -->
 <html lang="en">
   <body class="logged-in env-production min-width-lg">
-    
+
   <div class="application-main " data-commit-hovercards-enabled>
       <main id="js-pjax-container" data-pjax-container>
-        
+
 <div itemscope itemtype="http://schema.org/Organization">
 
   <div class="container-lg px-3 d-flex">
 
     <div class="col-9">
-      
+
   <div class="boxed-group oauth-application-whitelist ">
     <h3>Third-party application access policy</h3>
     <div class="boxed-group-inner">

--- a/scrape/testdata/access-restrictions-enabled.html
+++ b/scrape/testdata/access-restrictions-enabled.html
@@ -2,10 +2,10 @@
      Some extraneous markup removed to keep the file size smaller -->
 <html lang="en">
   <body class="logged-in env-production min-width-lg">
-    
+
   <div class="application-main " data-commit-hovercards-enabled>
       <main id="js-pjax-container" data-pjax-container>
-        
+
 
 
 <div itemscope itemtype="http://schema.org/Organization">
@@ -13,7 +13,7 @@
   <div class="container-lg px-3 d-flex">
 
     <div class="col-9">
-      
+
   <div class="boxed-group oauth-application-whitelist is-selectable">
     <h3>Third-party application access policy</h3>
     <div class="boxed-group-inner">
@@ -23,24 +23,24 @@
         <p>
           Only approved applications can access data in this organization. Applications owned by <strong>google-test</strong> always have access.
         </p>
-        
+
 <details
   class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark d-inline-block text-left"
   >
   <summary
       class="btn btn-danger"
-     
-      
-      
-      
+
+
+
+
       >
-    
+
     Remove restrictions
   </summary>
   <details-dialog
     aria-label="Are you sure?"
     class="Box Box--overlay d-flex flex-column anim-fade-in fast "
-    
+
     >
     <div class="Box-header">
       <button class="Box-btn-octicon btn-octicon float-right" type="button" aria-label="Close dialog" data-close-dialog>
@@ -48,7 +48,7 @@
       </button>
       <h3 class="Box-title ">Are you sure?</h3>
     </div>
-    
+
           <div class="flash flash-full flash-warn">
             You’re about to remove all third-party application restrictions. Please read this carefully.
           </div>
@@ -69,7 +69,7 @@
           <ul class="boxed-group-list">
             <li>
               <div class="float-right request-indicator">
-                Approval requested by <a class="requestor" href="/willnorris">willnorris</a> &#8212; 
+                Approval requested by <a class="requestor" href="/willnorris">willnorris</a> &#8212;
                 <a href="/orgs/google-test/policies/applications/22222">Review</a>
               </div>
               <img class="avatar float-left" src="https://avatars3.githubusercontent.com/oa/22222?s=40&amp;u=90a5890234f8061be4c6c0b29b4fa7594f2ba2d7&amp;v=4" height="20" width="20" alt="" />


### PR DESCRIPTION
Although it isn't yet documented at github, the BranchProtectionRuleEvent
includes an `installation` field which is crucial for letting Apps reacting to it
to authenticate their requests.

This PR adds that field the event type, along with an accessor for it.

Fixes: #2214.