### PR TITLE
Update comment on ListPullRequestsWithCommit API

### DIFF
--- a/github/pulls.go
+++ b/github/pulls.go
@@ -167,9 +167,10 @@ func (s *PullRequestsService) List(ctx context.Context, owner string, repo strin
 
 // ListPullRequestsWithCommit returns pull requests associated with a commit SHA.
 //
-// The results will include open and closed pull requests.
+// The results may include open and closed pull requests.
+// By default, the PullRequestListOptions State filters for "open".
 //
-// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/repos/#list-pull-requests-associated-with-a-commit
+// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/commits/#list-pull-requests-associated-with-a-commit
 func (s *PullRequestsService) ListPullRequestsWithCommit(ctx context.Context, owner, repo, sha string, opts *PullRequestListOptions) ([]*PullRequest, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/commits/%v/pulls", owner, repo, sha)
 	u, err := addOptions(u, opts)


### PR DESCRIPTION
1. Correct the statement that results include open and closed PRs by default, when it is only `open` by default, per https://github.com/google/go-github/blob/ff33a554ef2c24c1710238b69942fe51e70d89da/github/pulls.go#L120-L123 

2. Correct the URL for the Github API doc, per https://github.com/google/go-github/issues/2227