### PR TITLE
Fix secondary rate limits URL and improve related documentation

### DIFF
--- a/github/doc.go
+++ b/github/doc.go
@@ -125,11 +125,15 @@ from the most recent API call. If a recent enough response isn't
 available, you can use RateLimits to fetch the most up-to-date rate
 limit data for the client.
 
-To detect an API rate limit error, you can check if its type is *github.RateLimitError:
+To detect an API rate limit error, you can check if its type is *github.RateLimitError.
+For secondary rate limits, you can check if its type is *github.AbuseRateLimitError:
 
 	repos, _, err := client.Repositories.List(ctx, "", nil)
 	if _, ok := err.(*github.RateLimitError); ok {
 		log.Println("hit rate limit")
+	}
+	if _, ok := err.(*github.AbuseRateLimitError); ok {
+		log.Println("hit secondary rate limit")
 	}
 
 Learn more about GitHub rate limiting at

--- a/github/github.go
+++ b/github/github.go
@@ -884,7 +884,7 @@ func (ae *AcceptedError) Is(target error) bool {
 }
 
 // AbuseRateLimitError occurs when GitHub returns 403 Forbidden response with the
-// "documentation_url" field value equal to "https://docs.github.com/en/free-pro-team@latest/rest/reference/#abuse-rate-limits".
+// "documentation_url" field value equal to "https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#secondary-rate-limits".
 type AbuseRateLimitError struct {
 	Response *http.Response // HTTP response that caused this error
 	Message  string         `json:"message"` // error message
@@ -1003,7 +1003,9 @@ func CheckResponse(r *http.Response) error {
 			Response: errorResponse.Response,
 			Message:  errorResponse.Message,
 		}
-	case r.StatusCode == http.StatusForbidden && strings.HasSuffix(errorResponse.DocumentationURL, "#abuse-rate-limits"):
+	case r.StatusCode == http.StatusForbidden &&
+		(strings.HasSuffix(errorResponse.DocumentationURL, "#abuse-rate-limits") ||
+			strings.HasSuffix(errorResponse.DocumentationURL, "#secondary-rate-limits")):
 		abuseRateLimitError := &AbuseRateLimitError{
 			Response: errorResponse.Response,
 			Message:  errorResponse.Message,


### PR DESCRIPTION
It looks like GitHub is now designating "abuse rate limits" as "secondary rate limits": https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits

The URL returned in the error response also changed, so this PR updates it so that these errors can properly be caught again.
This PR also includes a suggestion to update the main documentation page to mention this error type, to make it more discoverable.