### PR TITLE
Update .gitignore for ignoring goenv .go-version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ vendor/
 .vscode
 # vim temp files
 *.swp
+
+# goenv local version
+.go-version

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ vendor/
 # vim temp files
 *.swp
 
-# goenv local version
+# goenv local version. See https://github.com/syndbg/goenv/blob/master/COMMANDS.md#goenv-local for more info.
 .go-version


### PR DESCRIPTION
Hi reviewers:

I updated the `.gitignore` to ignore the `.go-version` file in this PR.
If merged, it's easy to manage different go version locally for the **goenv** user.
Please help to review it. Thanks!

Reference
https://github.com/syndbg/goenv/blob/master/COMMANDS.md#goenv-local