### PR TITLE
add team.html_url

### DIFF
--- a/github/teams.go
+++ b/github/teams.go
@@ -46,6 +46,7 @@ type Team struct {
 	MembersCount    *int          `json:"members_count,omitempty"`
 	ReposCount      *int          `json:"repos_count,omitempty"`
 	Organization    *Organization `json:"organization,omitempty"`
+	HTMLURL         *string       `json:"html_url,omitempty"`
 	MembersURL      *string       `json:"members_url,omitempty"`
 	RepositoriesURL *string       `json:"repositories_url,omitempty"`
 	Parent          *Team         `json:"parent,omitempty"`


### PR DESCRIPTION
When performing an edit of a team, the `html_url` is required
```
invalid: [status.html_url: Required value]
```
However, that field is missing from the struct, so the previous `GET` does not marshal this data (even though it is included in the response)
```
gh api orgs/testing-org/teams/test-secret-team
{
  "name": "test-secret-team",
  "id": 152,
  "node_id": "hmmm==",
  "slug": "test-secret-team",
  "description": "",
  "privacy": "secret",
  "url": "https://github.myorg.com/api/v3/organizations/63/team/152",
  "html_url": "https://github.myorg.com/orgs/testing-org/teams/test-secret-team",
  "members_url": "https://github.myorg.com/api/v3/organizations/63/team/152/members{/member}",
  "repositories_url": "https://github.myorg.com/api/v3/organizations/63/team/152/repos",
```

Signed-off-by: Jake Plimack <jake.plimack@gmail.com>