### PR TITLE
add team.html_url

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -16156,6 +16156,14 @@ func (t *Team) GetDescription() string {
 	return *t.Description
 }
 
+// GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
+func (t *Team) GetHTMLURL() string {
+	if t == nil || t.HTMLURL == nil {
+		return ""
+	}
+	return *t.HTMLURL
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (t *Team) GetID() int64 {
 	if t == nil || t.ID == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -18900,6 +18900,16 @@ func TestTeam_GetDescription(tt *testing.T) {
 	t.GetDescription()
 }
 
+func TestTeam_GetHTMLURL(tt *testing.T) {
+	var zeroValue string
+	t := &Team{HTMLURL: &zeroValue}
+	t.GetHTMLURL()
+	t = &Team{}
+	t.GetHTMLURL()
+	t = nil
+	t.GetHTMLURL()
+}
+
 func TestTeam_GetID(tt *testing.T) {
 	var zeroValue int64
 	t := &Team{ID: &zeroValue}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1672,12 +1672,13 @@ func TestTeam_String(t *testing.T) {
 		MembersCount:    Int(0),
 		ReposCount:      Int(0),
 		Organization:    &Organization{},
+		HTMLURL:         String(""),
 		MembersURL:      String(""),
 		RepositoriesURL: String(""),
 		Parent:          &Team{},
 		LDAPDN:          String(""),
 	}
-	want := `github.Team{ID:0, NodeID:"", Name:"", Description:"", URL:"", Slug:"", Permission:"", Privacy:"", MembersCount:0, ReposCount:0, Organization:github.Organization{}, MembersURL:"", RepositoriesURL:"", Parent:github.Team{}, LDAPDN:""}`
+	want := `github.Team{ID:0, NodeID:"", Name:"", Description:"", URL:"", Slug:"", Permission:"", Privacy:"", MembersCount:0, ReposCount:0, Organization:github.Organization{}, HTMLURL:"", MembersURL:"", RepositoriesURL:"", Parent:github.Team{}, LDAPDN:""}`
 	if got := v.String(); got != want {
 		t.Errorf("Team.String = %v, want %v", got, want)
 	}

--- a/github/teams.go
+++ b/github/teams.go
@@ -46,6 +46,7 @@ type Team struct {
 	MembersCount    *int          `json:"members_count,omitempty"`
 	ReposCount      *int          `json:"repos_count,omitempty"`
 	Organization    *Organization `json:"organization,omitempty"`
+	HTMLURL         *string       `json:"html_url,omitempty"`
 	MembersURL      *string       `json:"members_url,omitempty"`
 	RepositoriesURL *string       `json:"repositories_url,omitempty"`
 	Parent          *Team         `json:"parent,omitempty"`


### PR DESCRIPTION
When performing an edit of a team, the html_url is required `invalid: [status.html_url: Required value]`

However, that field is missing from the struct, so the previous GET does not marshal this data (even though it is included in the response)
```
gh api orgs/testing-org/teams/test-secret-team
{
  "name": "test-secret-team",
  "id": 152,
  "node_id": "hmmm==",
  "slug": "test-secret-team",
  "description": "",
  "privacy": "secret",
  "url": "https://github.myorg.com/api/v3/organizations/63/team/152",
  "html_url": "https://github.myorg.com/orgs/testing-org/teams/test-secret-team",
  "members_url": "https://github.myorg.com/api/v3/organizations/63/team/152/members{/member}",
  "repositories_url": "https://github.myorg.com/api/v3/organizations/63/team/152/repos",
}
```

Signed-off-by: Jake Plimack <jplimack@tesla.com>