### PR TITLE
Update docs for CreateWorkflowDispatchEventRequest.Ref

### DIFF
--- a/github/actions_workflows.go
+++ b/github/actions_workflows.go
@@ -50,7 +50,7 @@ type WorkflowBill struct {
 // CreateWorkflowDispatchEventRequest represents a request to create a workflow dispatch event.
 type CreateWorkflowDispatchEventRequest struct {
 	// Ref represents the reference of the workflow run.
-	// The reference can be a branch, tag, or a commit SHA.
+	// The reference can be a branch or a tag.
 	// Ref is required when creating a workflow dispatch event.
 	Ref string `json:"ref"`
 	// Inputs represents input keys and values configured in the workflow file.


### PR DESCRIPTION
go-github documentation on GitHub Actions Workflow parameters indicated
support for branch, tag or SHA, while the official docs indicated only
branch and tag are supported (which was verified by attempting to pass a
SHA to the workflow and seeing it ignored). This small changeset simply
aligns the documentation.