### PR TITLE
Add support for additional PagesUpdate parameters

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -10484,6 +10484,22 @@ func (p *PagesUpdate) GetCNAME() string {
 	return *p.CNAME
 }
 
+// GetHTTPSEnforced returns the HTTPSEnforced field if it's non-nil, zero value otherwise.
+func (p *PagesUpdate) GetHTTPSEnforced() bool {
+	if p == nil || p.HTTPSEnforced == nil {
+		return false
+	}
+	return *p.HTTPSEnforced
+}
+
+// GetPublic returns the Public field if it's non-nil, zero value otherwise.
+func (p *PagesUpdate) GetPublic() bool {
+	if p == nil || p.Public == nil {
+		return false
+	}
+	return *p.Public
+}
+
 // GetSource returns the Source field if it's non-nil, zero value otherwise.
 func (p *PagesUpdate) GetSource() string {
 	if p == nil || p.Source == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -12305,6 +12305,26 @@ func TestPagesUpdate_GetCNAME(tt *testing.T) {
 	p.GetCNAME()
 }
 
+func TestPagesUpdate_GetHTTPSEnforced(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesUpdate{HTTPSEnforced: &zeroValue}
+	p.GetHTTPSEnforced()
+	p = &PagesUpdate{}
+	p.GetHTTPSEnforced()
+	p = nil
+	p.GetHTTPSEnforced()
+}
+
+func TestPagesUpdate_GetPublic(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesUpdate{Public: &zeroValue}
+	p.GetPublic()
+	p = &PagesUpdate{}
+	p.GetPublic()
+	p = nil
+	p.GetPublic()
+}
+
 func TestPagesUpdate_GetSource(tt *testing.T) {
 	var zeroValue string
 	p := &PagesUpdate{Source: &zeroValue}

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -95,6 +95,13 @@ type PagesUpdate struct {
 	// Source must include the branch name, and may optionally specify the subdirectory "/docs".
 	// Possible values are: "gh-pages", "master", and "master /docs".
 	Source *string `json:"source,omitempty"`
+	// Public configures access controls for the site.
+	// If "true", the site will be accessible to anyone on the internet. If "false",
+	// the site will be accessible to anyone with read access to the respository that
+	// published the site.
+	Public *bool `json:"public,omitempty"`
+	// HTTPSEnforced specifies whether HTTPS should be enforced for the repository.
+	HTTPSEnforced *bool `json:"https_enforced,omitempty"`
 }
 
 // UpdatePages updates GitHub Pages for the named repo.

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -97,7 +97,7 @@ type PagesUpdate struct {
 	Source *string `json:"source,omitempty"`
 	// Public configures access controls for the site.
 	// If "true", the site will be accessible to anyone on the internet. If "false",
-	// the site will be accessible to anyone with read access to the respository that
+	// the site will be accessible to anyone with read access to the repository that
 	// published the site.
 	Public *bool `json:"public,omitempty"`
 	// HTTPSEnforced specifies whether HTTPS should be enforced for the repository.


### PR DESCRIPTION
Closes #2261 

This change introduces 2 additional parameters provided by the GitHub API to the PagesUpdate type, `Public` and `HTTPSEnforced`. 

Note: I had to open a new PR because the author email for one of the commits in the first PR did not match the email associated with my CLA. 