### PR TITLE
Addressing issues raised by staticcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,10 +18,10 @@ linters:
   disable:
     - errcheck
     - gosimple
-    - staticcheck
     - ineffassign
+    - staticcheck
     - unused
-issues: 
+issues:
   exclude-rules:
   - linters:
     - dogsled
@@ -30,3 +30,15 @@ issues:
   - linters:
     - dupl
     path: _test\.go
+  - linters:
+    - staticcheck
+    path: github/github_test\.go
+    text: 'SA1012'
+  - linters:
+    - staticcheck
+    path: _test\.go
+    text: 'SA1019'
+  - linters:
+    - staticcheck
+    path: github/git_commits\.go
+    text: 'SA1019'

--- a/example/basicauth/main.go
+++ b/example/basicauth/main.go
@@ -23,7 +23,7 @@ import (
 	"syscall"
 
 	"github.com/google/go-github/v42/github"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 func main() {
@@ -32,7 +32,7 @@ func main() {
 	username, _ := r.ReadString('\n')
 
 	fmt.Print("GitHub Password: ")
-	bytePassword, _ := terminal.ReadPassword(int(syscall.Stdin))
+	bytePassword, _ := term.ReadPassword(int(syscall.Stdin))
 	password := string(bytePassword)
 
 	tp := github.BasicAuthTransport{

--- a/example/tokenauth/main.go
+++ b/example/tokenauth/main.go
@@ -15,13 +15,13 @@ import (
 	"syscall"
 
 	"github.com/google/go-github/v42/github"
-	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/oauth2"
+	"golang.org/x/term"
 )
 
 func main() {
 	fmt.Print("GitHub Token: ")
-	byteToken, _ := terminal.ReadPassword(int(syscall.Stdin))
+	byteToken, _ := term.ReadPassword(int(syscall.Stdin))
 	println()
 	token := string(byteToken)
 

--- a/github/actions_artifacts.go
+++ b/github/actions_artifacts.go
@@ -119,6 +119,9 @@ func (s *ActionsService) DownloadArtifact(ctx context.Context, owner, repo strin
 		return nil, newResponse(resp), fmt.Errorf("unexpected status code: %s", resp.Status)
 	}
 	parsedURL, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		return nil, newResponse(resp), err
+	}
 	return parsedURL, newResponse(resp), nil
 }
 

--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -23,7 +23,7 @@ type PublicKey struct {
 // do not error out when unmarshaling.
 func (p *PublicKey) UnmarshalJSON(data []byte) error {
 	var pk struct {
-		KeyID interface{} `json:"key_id,string"`
+		KeyID interface{} `json:"key_id"`
 		Key   *string     `json:"key"`
 	}
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -887,6 +887,8 @@ func TestDo_nilContext(t *testing.T) {
 	defer teardown()
 
 	req, _ := client.NewRequest("GET", ".", nil)
+
+	//lint:ignore SA1012 we want to make sure that a nil context is handled correctly
 	_, err := client.Do(nil, req, nil)
 
 	if !errors.Is(err, errNonNilContext) {

--- a/github/issue_import.go
+++ b/github/issue_import.go
@@ -89,7 +89,7 @@ func (s *IssueImportService) Create(ctx context.Context, owner, repo string, iss
 		if ok {
 			decErr := json.Unmarshal(aerr.Raw, i)
 			if decErr != nil {
-				err = decErr
+				return nil, resp, decErr
 			}
 
 			return i, resp, nil

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -243,7 +243,7 @@ func TestRepositoriesService_GetCommitSHA1(t *testing.T) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeV3SHA)
 
-		fmt.Fprintf(w, sha1)
+		fmt.Fprint(w, sha1)
 	})
 
 	ctx := context.Background()
@@ -299,7 +299,7 @@ func TestRepositoriesService_NonAlphabetCharacter_GetCommitSHA1(t *testing.T) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeV3SHA)
 
-		fmt.Fprintf(w, sha1)
+		fmt.Fprint(w, sha1)
 	})
 
 	ctx := context.Background()
@@ -339,7 +339,7 @@ func TestRepositoriesService_TrailingPercent_GetCommitSHA1(t *testing.T) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeV3SHA)
 
-		fmt.Fprintf(w, sha1)
+		fmt.Fprint(w, sha1)
 	})
 
 	ctx := context.Background()

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -499,9 +499,12 @@ func TestRepositoriesService_DownloadReleaseAsset_FollowRedirect(t *testing.T) {
 
 	ctx := context.Background()
 	reader, _, err := client.Repositories.DownloadReleaseAsset(ctx, "o", "r", 1, http.DefaultClient)
-	content, err := ioutil.ReadAll(reader)
 	if err != nil {
 		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
+	}
+	content, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Errorf("Failed to read from Repositories.DownloadReleaseAsset result: %v", err)
 	}
 	reader.Close()
 	want := []byte("Hello World")


### PR DESCRIPTION
I've disabled the checks for switch from go's openpgp implementation to a community fork because it seems like it's not a drop in replacement and needs some extra work.

```
github/git_commits.go:16:2: SA1019: package golang.org/x/crypto/openpgp is deprecated: this package is unmaintained except for security fixes. New applications should consider a more focused, modern alternative to OpenPGP for their specific task. If you are required to interoperate with OpenPGP systems and need a maintained package, consider a community fork. See https://golang.org/issue/44226. (staticcheck)
        "golang.org/x/crypto/openpgp"
```

Original issue: #2260