### PR TITLE
GitHub Actions Billing returns total_paid_minutes_used as float64

### DIFF
--- a/github/billing.go
+++ b/github/billing.go
@@ -19,7 +19,7 @@ type BillingService service
 // ActionBilling represents a GitHub Action billing.
 type ActionBilling struct {
 	TotalMinutesUsed     int                  `json:"total_minutes_used"`
-	TotalPaidMinutesUsed int                  `json:"total_paid_minutes_used"`
+	TotalPaidMinutesUsed float64              `json:"total_paid_minutes_used"`
 	IncludedMinutes      int                  `json:"included_minutes"`
 	MinutesUsedBreakdown MinutesUsedBreakdown `json:"minutes_used_breakdown"`
 }

--- a/github/billing_test.go
+++ b/github/billing_test.go
@@ -22,7 +22,7 @@ func TestBillingService_GetActionsBillingOrg(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
 				"total_minutes_used": 305,
-				"total_paid_minutes_used": 0,
+				"total_paid_minutes_used": 0.0,
 				"included_minutes": 3000,
 				"minutes_used_breakdown": {
 					"UBUNTU": 205,


### PR DESCRIPTION
Fixes #2283 

GitHub Actions returns total_paid_minutes_used as floating point value.
The Implementation should accept this floating point value as float64.


## Example
```bash
curl -H "Authorization: Bearer <TOKEN>" \
-H "Accept: application/vnd.github.v3+json"  \
https://api.github.com/orgs/{org}/settings/billing/actions
```
```json
{
  "total_minutes_used": 1234,
  "total_paid_minutes_used": 3959.0,
  "included_minutes": 3000,
  "minutes_used_breakdown": {
    "UBUNTU": 1234,
    "MACOS": 1234,
    "WINDOWS": 1234
  }
}
```