### PR TITLE
Add ability to dump GitHub API requests as `curl` commands using context.WithValue

### DIFF
--- a/example/topics/main.go
+++ b/example/topics/main.go
@@ -6,6 +6,9 @@
 // The simple command demonstrates the functionality that
 // prompts the user for a GitHub topic and lists all the entities
 // that are related to the specified topic or subject.
+//
+// It also demonstrates how to debug a GitHub v3 API call
+// by dumping its `curl` equivalent.
 package main
 
 import (
@@ -18,7 +21,9 @@ import (
 // Fetch and lists all the public topics associated with the specified GitHub topic
 func fetchTopics(topic string) (*github.TopicsSearchResult, error) {
 	client := github.NewClient(nil)
-	topics, _, err := client.Search.Topics(context.Background(), topic, nil)
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, github.DebugRequest, "curl") // comment out this line to stop debug info.
+	topics, _, err := client.Search.Topics(ctx, topic, nil)
 	return topics, err
 }
 

--- a/github/github.go
+++ b/github/github.go
@@ -1324,9 +1324,7 @@ func dumpRequestAsCurl(req *http.Request) (string, error) {
 		if err != nil {
 			return "", err
 		}
-
 		lines = append(lines, fmt.Sprintf("-d '%s'", buf))
-
 		req.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
 	}
 

--- a/github/github.go
+++ b/github/github.go
@@ -1299,6 +1299,10 @@ func formatRateReset(d time.Duration) string {
 	return fmt.Sprintf("[rate reset in %v]", timeString)
 }
 
+func escapeSingleQuote(s string) string {
+	return strings.ReplaceAll(s, "'", `\'`)
+}
+
 // dumpRequestAsCurl dumps an outbound request as a curl command to a string
 // for debugging purposes. It redacts any "Authorization" string in the
 // header or client secret in the URL in order to prevent logging secrets.
@@ -1314,7 +1318,7 @@ func dumpRequestAsCurl(req *http.Request) (string, error) {
 			headers = append(headers, fmt.Sprintf("-H '%v: <redacted for security>'", k))
 			continue
 		}
-		headers = append(headers, fmt.Sprintf("-H '%v: %v'", k, strings.Join(v, ", ")))
+		headers = append(headers, fmt.Sprintf("-H '%v: %v'", k, escapeSingleQuote(strings.Join(v, ", "))))
 	}
 	sort.Strings(headers)
 	lines = append(lines, headers...)
@@ -1324,7 +1328,7 @@ func dumpRequestAsCurl(req *http.Request) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		lines = append(lines, fmt.Sprintf("-d '%s'", buf))
+		lines = append(lines, fmt.Sprintf("-d '%v'", escapeSingleQuote(string(buf))))
 		req.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
 	}
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -2580,25 +2580,25 @@ func TestDumpRequestAsCurl(t *testing.T) {
 		},
 		{
 			name: "POST request, no auth",
-			req:  mkReq("POST", "/foo", &User{Login: String("l")}),
+			req:  mkReq("POST", "/foo", &User{Login: String("l'a")}),
 			want: `curl -X POST \
   https://api.github.com/foo \
   -H 'Accept: application/vnd.github.v3+json' \
   -H 'Content-Type: application/json' \
   -H 'User-Agent: go-github' \
-  -d '{"login":"l"}
+  -d '{"login":"l\'a"}
 '`,
 		},
 		{
 			name: "GET request, multiple accept, with auth",
 			req:  mkReq("GET", "/foo", nil),
 			header: http.Header{
-				"Accept":        []string{"a1", "a2", "a3"},
+				"Accept":        []string{"a'1", "a2", "a3"},
 				"AuthoRizaTion": []string{"Bearer ABCD0123"},
 			},
 			want: `curl -X GET \
   https://api.github.com/foo \
-  -H 'Accept: a1, a2, a3' \
+  -H 'Accept: a\'1, a2, a3' \
   -H 'AuthoRizaTion: <redacted for security>' \
   -H 'User-Agent: go-github'`,
 		},

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -2236,6 +2236,29 @@ func TestBareDo_returnsOpenBody(t *testing.T) {
 	}
 }
 
+func TestBareDo_GoodDebugRequestString(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	expectedBody := "Hello from the other side !"
+
+	mux.HandleFunc("/test-url", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, expectedBody)
+	})
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, DebugRequest, "curl")
+	req, err := client.NewRequest("GET", "test-url", nil)
+	if err != nil {
+		t.Fatalf("client.NewRequest returned error: %v", err)
+	}
+
+	if _, err = client.BareDo(ctx, req); err != nil {
+		t.Fatalf("client.BareDo = %v, want nil", err)
+	}
+}
+
 func TestBareDo_BadDebugRequestString(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
This is a feature that I have wanted for many years, and #2292 finally caused me to write it.
By adding a context value like this:

```go
ctx = context.WithValue(ctx, github.DebugRequest, "curl")
```

this client will now dump the equivalent `curl` command for every call that is being attempted, which is useful for debugging.

This is an alternative implementation to #2302 in order to see which is better.