### PR TITLE
Revert "Remove graduated GitHub v3 API preview header"

### DIFF
--- a/github/checks.go
+++ b/github/checks.go
@@ -106,6 +106,8 @@ func (s *ChecksService) GetCheckRun(ctx context.Context, owner, repo string, che
 		return nil, nil, err
 	}
 
+	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+
 	checkRun := new(CheckRun)
 	resp, err := s.client.Do(ctx, req, checkRun)
 	if err != nil {
@@ -124,6 +126,8 @@ func (s *ChecksService) GetCheckSuite(ctx context.Context, owner, repo string, c
 	if err != nil {
 		return nil, nil, err
 	}
+
+	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
 	checkSuite := new(CheckSuite)
 	resp, err := s.client.Do(ctx, req, checkSuite)
@@ -165,6 +169,8 @@ func (s *ChecksService) CreateCheckRun(ctx context.Context, owner, repo string, 
 		return nil, nil, err
 	}
 
+	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+
 	checkRun := new(CheckRun)
 	resp, err := s.client.Do(ctx, req, checkRun)
 	if err != nil {
@@ -196,6 +202,8 @@ func (s *ChecksService) UpdateCheckRun(ctx context.Context, owner, repo string, 
 		return nil, nil, err
 	}
 
+	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+
 	checkRun := new(CheckRun)
 	resp, err := s.client.Do(ctx, req, checkRun)
 	if err != nil {
@@ -219,6 +227,8 @@ func (s *ChecksService) ListCheckRunAnnotations(ctx context.Context, owner, repo
 	if err != nil {
 		return nil, nil, err
 	}
+
+	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
 	var checkRunAnnotations []*CheckRunAnnotation
 	resp, err := s.client.Do(ctx, req, &checkRunAnnotations)
@@ -260,6 +270,8 @@ func (s *ChecksService) ListCheckRunsForRef(ctx context.Context, owner, repo, re
 		return nil, nil, err
 	}
 
+	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+
 	var checkRunResults *ListCheckRunsResults
 	resp, err := s.client.Do(ctx, req, &checkRunResults)
 	if err != nil {
@@ -283,6 +295,8 @@ func (s *ChecksService) ListCheckRunsCheckSuite(ctx context.Context, owner, repo
 	if err != nil {
 		return nil, nil, err
 	}
+
+	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
 	var checkRunResults *ListCheckRunsResults
 	resp, err := s.client.Do(ctx, req, &checkRunResults)
@@ -321,6 +335,8 @@ func (s *ChecksService) ListCheckSuitesForRef(ctx context.Context, owner, repo, 
 	if err != nil {
 		return nil, nil, err
 	}
+
+	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
 	var checkSuiteResults *ListCheckSuiteResults
 	resp, err := s.client.Do(ctx, req, &checkSuiteResults)
@@ -363,6 +379,8 @@ func (s *ChecksService) SetCheckSuitePreferences(ctx context.Context, owner, rep
 		return nil, nil, err
 	}
 
+	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+
 	var checkSuitePrefResults *CheckSuitePreferenceResults
 	resp, err := s.client.Do(ctx, req, &checkSuitePrefResults)
 	if err != nil {
@@ -388,6 +406,8 @@ func (s *ChecksService) CreateCheckSuite(ctx context.Context, owner, repo string
 		return nil, nil, err
 	}
 
+	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
+
 	checkSuite := new(CheckSuite)
 	resp, err := s.client.Do(ctx, req, checkSuite)
 	if err != nil {
@@ -407,6 +427,8 @@ func (s *ChecksService) ReRequestCheckSuite(ctx context.Context, owner, repo str
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
 	resp, err := s.client.Do(ctx, req, nil)
 	return resp, err

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -21,7 +21,7 @@ func TestChecksService_GetCheckRun(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-runs/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-
+		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
 		fmt.Fprint(w, `{
 			"id": 1,
                         "name":"testCheckRun",
@@ -71,7 +71,7 @@ func TestChecksService_GetCheckSuite(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-suites/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-
+		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
 		fmt.Fprint(w, `{
 			"id": 1,
                         "head_branch":"master",
@@ -120,7 +120,7 @@ func TestChecksService_CreateCheckRun(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-
+		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
 		fmt.Fprint(w, `{
 			"id": 1,
                         "name":"testCreateCheckRun",
@@ -187,7 +187,7 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-runs/1/annotations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-
+		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
 		testFormValues(t, r, values{
 			"page": "1",
 		})
@@ -247,7 +247,7 @@ func TestChecksService_UpdateCheckRun(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-runs/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-
+		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
 		fmt.Fprint(w, `{
 			"id": 1,
                         "name":"testUpdateCheckRun",
@@ -313,7 +313,7 @@ func TestChecksService_ListCheckRunsForRef(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/commits/master/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-
+		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
 		testFormValues(t, r, values{
 			"check_name": "testing",
 			"page":       "1",
@@ -385,7 +385,7 @@ func TestChecksService_ListCheckRunsCheckSuite(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-suites/1/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-
+		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
 		testFormValues(t, r, values{
 			"check_name": "testing",
 			"page":       "1",
@@ -452,7 +452,7 @@ func TestChecksService_ListCheckSuiteForRef(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/commits/master/check-suites", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-
+		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
 		testFormValues(t, r, values{
 			"check_name": "testing",
 			"page":       "1",
@@ -518,7 +518,7 @@ func TestChecksService_SetCheckSuitePreferences(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-suites/preferences", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-
+		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
 		testBody(t, r, `{"auto_trigger_checks":[{"app_id":2,"setting":false}]}`+"\n")
 		fmt.Fprint(w, `{"preferences":{"auto_trigger_checks":[{"app_id": 2,"setting": false}]}}`)
 	})
@@ -565,7 +565,7 @@ func TestChecksService_CreateCheckSuite(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-suites", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-
+		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
 		fmt.Fprint(w, `{
 			"id": 2,
                         "head_branch":"master",
@@ -621,7 +621,7 @@ func TestChecksService_ReRequestCheckSuite(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/check-suites/1/rerequest", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-
+		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
 		w.WriteHeader(http.StatusCreated)
 	})
 	ctx := context.Background()

--- a/github/github.go
+++ b/github/github.go
@@ -100,6 +100,9 @@ const (
 	// https://developer.github.com/changes/2018-03-16-protected-branches-required-approving-reviews/
 	mediaTypeRequiredApprovingReviewsPreview = "application/vnd.github.luke-cage-preview+json"
 
+	// https://developer.github.com/changes/2018-05-07-new-checks-api-public-beta/
+	mediaTypeCheckRunsPreview = "application/vnd.github.antiope-preview+json"
+
 	// https://developer.github.com/enterprise/2.13/v3/repos/pre_receive_hooks/
 	mediaTypePreReceiveHooksPreview = "application/vnd.github.eye-scream-preview"
 


### PR DESCRIPTION
Reverts google/go-github#1636

Fixes #2300 