### PR TITLE
Add ability to dump GitHub API requests as curl commands using RoundTripper

### DIFF
--- a/example/tokenauth/main.go
+++ b/example/tokenauth/main.go
@@ -6,6 +6,9 @@
 // The tokenauth command demonstrates using the oauth2.StaticTokenSource.
 // You can test out a GitHub Personal Access Token using this simple example.
 // You can generate them here: https://github.com/settings/tokens
+//
+// It also demonstrates how to debug a GitHub v3 API call by dumping
+// its `curl` equivalent using the DebugCurlTransport RoundTripper.
 package main
 
 import (
@@ -31,7 +34,10 @@ func main() {
 	)
 	tc := oauth2.NewClient(ctx, ts)
 
-	client := github.NewClient(tc)
+	tp := &github.DebugCurlTransport{Transport: tc.Transport}
+	// To remove the debug curl transport, change the following line to:
+	// client := github.NewClient(tc)
+	client := github.NewClient(tp.Client())
 
 	user, resp, err := client.Users.Get(ctx, "")
 	if err != nil {

--- a/example/topics/main.go
+++ b/example/topics/main.go
@@ -6,6 +6,9 @@
 // The simple command demonstrates the functionality that
 // prompts the user for a GitHub topic and lists all the entities
 // that are related to the specified topic or subject.
+//
+// It also demonstrates how to debug a GitHub v3 API call by dumping
+// its `curl` equivalent using the DebugCurlTransport RoundTripper.
 package main
 
 import (
@@ -17,8 +20,10 @@ import (
 
 // Fetch and lists all the public topics associated with the specified GitHub topic
 func fetchTopics(topic string) (*github.TopicsSearchResult, error) {
-	client := github.NewClient(nil)
-	topics, _, err := client.Search.Topics(context.Background(), topic, nil)
+	tp := &github.DebugCurlTransport{}
+	client := github.NewClient(tp.Client()) // pass nil instead of tp.Client() to stop curl debug info logging.
+	ctx := context.Background()
+	topics, _, err := client.Search.Topics(ctx, topic, nil)
 	return topics, err
 }
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -2317,11 +2318,11 @@ func TestBareDo_GoodDebugRequestWithCustomTransport(t *testing.T) {
 		fmt.Fprint(w, expectedBody)
 	})
 
-	utp := &UnauthenticatedRateLimitedTransport{
-		ClientID:     "ID",
-		ClientSecret: "Secret",
-	}
-	tp := &DebugCurlTransport{Transport: utp.Transport}
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: "SECRET"},
+	)
+	tc := oauth2.NewClient(oauth2.NoContext, ts)
+	tp := &DebugCurlTransport{Transport: tc.Transport}
 	client := NewClient(tp.Client())
 	client.BaseURL = c.BaseURL
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -2294,6 +2294,42 @@ func TestBareDo_GoodDebugRequestStringButBodyError(t *testing.T) {
 	}
 }
 
+func TestBareDo_GoodDebugRequestWithCustomTransport(t *testing.T) {
+	_, mux, _, teardown := setup()
+	defer teardown()
+
+	expectedBody := "Hello from the other side !"
+
+	mux.HandleFunc("/test-url", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, expectedBody)
+	})
+
+	utp := &UnauthenticatedRateLimitedTransport{
+		ClientID:     "ID",
+		ClientSecret: "Secret",
+	}
+	tp := &DebugCurlTransport{Transport: utp.Transport}
+	client := NewClient(tp.Client())
+
+	ctx := context.Background()
+	req, err := client.NewRequest("GET", "test-url", nil)
+	if err != nil {
+		t.Fatalf("client.NewRequest returned error: %v", err)
+	}
+	want := "custom error"
+	req.Body = ioutil.NopCloser(iotest.ErrReader(errors.New(want)))
+
+	if _, err = client.BareDo(ctx, req); err == nil {
+		t.Fatal("client.BareDo expected error but got nil")
+	}
+
+	got := err.Error()
+	if !strings.Contains(got, want) {
+		t.Errorf("error = %q, want %q", got, want)
+	}
+}
+
 // roundTripperFunc creates a mock RoundTripper (transport)
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -2295,7 +2295,7 @@ func TestBareDo_GoodDebugRequestStringButBodyError(t *testing.T) {
 }
 
 func TestBareDo_GoodDebugRequestWithCustomTransport(t *testing.T) {
-	_, mux, _, teardown := setup()
+	c, mux, _, teardown := setup()
 	defer teardown()
 
 	expectedBody := "Hello from the other side !"
@@ -2311,22 +2311,16 @@ func TestBareDo_GoodDebugRequestWithCustomTransport(t *testing.T) {
 	}
 	tp := &DebugCurlTransport{Transport: utp.Transport}
 	client := NewClient(tp.Client())
+	client.BaseURL = c.BaseURL
 
 	ctx := context.Background()
 	req, err := client.NewRequest("GET", "test-url", nil)
 	if err != nil {
 		t.Fatalf("client.NewRequest returned error: %v", err)
 	}
-	want := "custom error"
-	req.Body = ioutil.NopCloser(iotest.ErrReader(errors.New(want)))
 
-	if _, err = client.BareDo(ctx, req); err == nil {
-		t.Fatal("client.BareDo expected error but got nil")
-	}
-
-	got := err.Error()
-	if !strings.Contains(got, want) {
-		t.Errorf("error = %q, want %q", got, want)
+	if _, err = client.BareDo(ctx, req); err != nil {
+		t.Fatalf("client.BareDo = %v, want nil", err)
 	}
 }
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -2257,8 +2257,20 @@ func TestBareDo_GoodDebugRequestString(t *testing.T) {
 		t.Fatalf("client.NewRequest returned error: %v", err)
 	}
 
-	if _, err = client.BareDo(ctx, req); err != nil {
+	resp, err := client.BareDo(ctx, req)
+	if err != nil {
 		t.Fatalf("client.BareDo = %v, want nil", err)
+	}
+
+	got, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ioutil.ReadAll returned error: %v", err)
+	}
+	if string(got) != expectedBody {
+		t.Fatalf("Expected %q, got %q", expectedBody, string(got))
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("resp.Body.Close() returned error: %v", err)
 	}
 }
 
@@ -2319,8 +2331,20 @@ func TestBareDo_GoodDebugRequestWithCustomTransport(t *testing.T) {
 		t.Fatalf("client.NewRequest returned error: %v", err)
 	}
 
-	if _, err = client.BareDo(ctx, req); err != nil {
+	resp, err := client.BareDo(ctx, req)
+	if err != nil {
 		t.Fatalf("client.BareDo = %v, want nil", err)
+	}
+
+	got, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ioutil.ReadAll returned error: %v", err)
+	}
+	if string(got) != expectedBody {
+		t.Fatalf("Expected %q, got %q", expectedBody, string(got))
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("resp.Body.Close() returned error: %v", err)
 	}
 }
 


### PR DESCRIPTION
This is a feature that I have wanted for many years, and #2292 finally caused me to write it.
By adding a RoundTripper like this (when using a custom `Transport`):

```go
	tp := &github.DebugCurlTransport{Transport: tc.Transport}
	client := github.NewClient(tp.Client())
```

or like this (when using a `DefaultTransport`):

```go
	tp := &github.DebugCurlTransport{}
	client := github.NewClient(tp.Client())
```

this client will now dump the equivalent `curl` command for every call that is being attempted, which is useful for debugging.

This is an alternative implementation to #2295 in order to see which is better.