### PR TITLE
Support query parameter `visible_to_repository` in ListOrganizationRunnerGroups

### DIFF
--- a/github/actions_runner_groups.go
+++ b/github/actions_runner_groups.go
@@ -61,7 +61,7 @@ type SetRunnerGroupRunnersRequest struct {
 	Runners []int64 `json:"runners"`
 }
 
-// ListOrgRunnerGroupOptions extend ListOptions to have the optional parameters VisibleToRepository
+// ListOrgRunnerGroupOptions extend ListOptions to have the optional parameters VisibleToRepository.
 type ListOrgRunnerGroupOptions struct {
 	ListOptions
 

--- a/github/actions_runner_groups.go
+++ b/github/actions_runner_groups.go
@@ -70,7 +70,7 @@ type ListOrgRunnerGroupOptions struct {
 }
 
 // ListOrganizationRunnerGroups is a wrapper around ListOrganizationRunnerGroupsWithOptions to avoid breaking existing client's code.
-func (s *ActionsService) ListOrganizationRunnerGroups(ctx context.Context, org string, opts *ListOptions) (*RunnerGroups, *Response, error) {
+func (s *ActionsService) ListOrganizationRunnerGroups(ctx context.Context, org string, opts *ListOrgRunnerGroupOptions) (*RunnerGroups, *Response, error) {
 	listOpts := &ListOrgRunnerGroupOptions{}
 	if opts != nil {
 		listOpts.ListOptions = *opts

--- a/github/actions_runner_groups.go
+++ b/github/actions_runner_groups.go
@@ -61,10 +61,26 @@ type SetRunnerGroupRunnersRequest struct {
 	Runners []int64 `json:"runners"`
 }
 
-// ListOrganizationRunnerGroups lists all self-hosted runner groups configured in an organization.
+// ListOrgRunnerGroupOptions extend ListOptions to have the optional parameters VisibleToRepository
+type ListOrgRunnerGroupOptions struct {
+	ListOptions
+
+	// Only return runner groups that are allowed to be used by this repository.
+	VisibleToRepository string `url:"visible_to_repository,omitempty"`
+}
+
+// ListOrganizationRunnerGroups is a wrapper around ListOrganizationRunnerGroupsWithOptions to avoid breaking existing client's code.
+func (s *ActionsService) ListOrganizationRunnerGroups(ctx context.Context, org string, opts *ListOptions) (*RunnerGroups, *Response, error) {
+	listOpts := &ListOrgRunnerGroupOptions{
+		ListOptions: *opts,
+	}
+	return s.ListOrganizationRunnerGroupsWithOptions(ctx, org, listOpts)
+}
+
+// ListOrganizationRunnerGroupsWithOptions lists all self-hosted runner groups configured in an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/actions#list-self-hosted-runner-groups-for-an-organization
-func (s *ActionsService) ListOrganizationRunnerGroups(ctx context.Context, org string, opts *ListOptions) (*RunnerGroups, *Response, error) {
+func (s *ActionsService) ListOrganizationRunnerGroupsWithOptions(ctx context.Context, org string, opts *ListOrgRunnerGroupOptions) (*RunnerGroups, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runner-groups", org)
 	u, err := addOptions(u, opts)
 	if err != nil {

--- a/github/actions_runner_groups.go
+++ b/github/actions_runner_groups.go
@@ -69,19 +69,10 @@ type ListOrgRunnerGroupOptions struct {
 	VisibleToRepository string `url:"visible_to_repository,omitempty"`
 }
 
-// ListOrganizationRunnerGroups is a wrapper around ListOrganizationRunnerGroupsWithOptions to avoid breaking existing client's code.
-func (s *ActionsService) ListOrganizationRunnerGroups(ctx context.Context, org string, opts *ListOrgRunnerGroupOptions) (*RunnerGroups, *Response, error) {
-	listOpts := &ListOrgRunnerGroupOptions{}
-	if opts != nil {
-		listOpts.ListOptions = *opts
-	}
-	return s.ListOrganizationRunnerGroupsWithOptions(ctx, org, listOpts)
-}
-
-// ListOrganizationRunnerGroupsWithOptions lists all self-hosted runner groups configured in an organization.
+// ListOrganizationRunnerGroups lists all self-hosted runner groups configured in an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/reference/actions#list-self-hosted-runner-groups-for-an-organization
-func (s *ActionsService) ListOrganizationRunnerGroupsWithOptions(ctx context.Context, org string, opts *ListOrgRunnerGroupOptions) (*RunnerGroups, *Response, error) {
+func (s *ActionsService) ListOrganizationRunnerGroups(ctx context.Context, org string, opts *ListOrgRunnerGroupOptions) (*RunnerGroups, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runner-groups", org)
 	u, err := addOptions(u, opts)
 	if err != nil {

--- a/github/actions_runner_groups.go
+++ b/github/actions_runner_groups.go
@@ -71,8 +71,9 @@ type ListOrgRunnerGroupOptions struct {
 
 // ListOrganizationRunnerGroups is a wrapper around ListOrganizationRunnerGroupsWithOptions to avoid breaking existing client's code.
 func (s *ActionsService) ListOrganizationRunnerGroups(ctx context.Context, org string, opts *ListOptions) (*RunnerGroups, *Response, error) {
-	listOpts := &ListOrgRunnerGroupOptions{
-		ListOptions: *opts,
+	listOpts := &ListOrgRunnerGroupOptions{}
+	if opts != nil {
+		listOpts.ListOptions = *opts
 	}
 	return s.ListOrganizationRunnerGroupsWithOptions(ctx, org, listOpts)
 }

--- a/github/actions_runner_groups_test.go
+++ b/github/actions_runner_groups_test.go
@@ -58,6 +58,50 @@ func TestActionsService_ListOrganizationRunnerGroups(t *testing.T) {
 	})
 }
 
+func TestActionsService_ListOrganizationRunnerGroupsWithOptions(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/actions/runner-groups", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"per_page": "2", "page": "2", "visible_to_repository": "github"})
+		fmt.Fprint(w, `{"total_count":3,"runner_groups":[{"id":1,"name":"Default","visibility":"all","default":true,"runners_url":"https://api.github.com/orgs/octo-org/actions/runner_groups/1/runners","inherited":false,"allows_public_repositories":true},{"id":2,"name":"octo-runner-group","visibility":"selected","default":false,"selected_repositories_url":"https://api.github.com/orgs/octo-org/actions/runner_groups/2/repositories","runners_url":"https://api.github.com/orgs/octo-org/actions/runner_groups/2/runners","inherited":true,"allows_public_repositories":true},{"id":3,"name":"expensive-hardware","visibility":"private","default":false,"runners_url":"https://api.github.com/orgs/octo-org/actions/runner_groups/3/runners","inherited":false,"allows_public_repositories":true}]}`)
+	})
+
+	opts := &ListOrgRunnerGroupOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}, VisibleToRepository: "github"}
+	ctx := context.Background()
+	groups, _, err := client.Actions.ListOrganizationRunnerGroupsWithOptions(ctx, "o", opts)
+	if err != nil {
+		t.Errorf("Actions.ListOrganizationRunnerGroupsWithOptions returned error: %v", err)
+	}
+
+	want := &RunnerGroups{
+		TotalCount: 3,
+		RunnerGroups: []*RunnerGroup{
+			{ID: Int64(1), Name: String("Default"), Visibility: String("all"), Default: Bool(true), RunnersURL: String("https://api.github.com/orgs/octo-org/actions/runner_groups/1/runners"), Inherited: Bool(false), AllowsPublicRepositories: Bool(true)},
+			{ID: Int64(2), Name: String("octo-runner-group"), Visibility: String("selected"), Default: Bool(false), SelectedRepositoriesURL: String("https://api.github.com/orgs/octo-org/actions/runner_groups/2/repositories"), RunnersURL: String("https://api.github.com/orgs/octo-org/actions/runner_groups/2/runners"), Inherited: Bool(true), AllowsPublicRepositories: Bool(true)},
+			{ID: Int64(3), Name: String("expensive-hardware"), Visibility: String("private"), Default: Bool(false), RunnersURL: String("https://api.github.com/orgs/octo-org/actions/runner_groups/3/runners"), Inherited: Bool(false), AllowsPublicRepositories: Bool(true)},
+		},
+	}
+	if !cmp.Equal(groups, want) {
+		t.Errorf("Actions.ListOrganizationRunnerGroupsWithOptions returned %+v, want %+v", groups, want)
+	}
+
+	const methodName = "ListOrganizationRunnerGroupsWithOptions"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.ListOrganizationRunnerGroupsWithOptions(ctx, "\n", opts)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.ListOrganizationRunnerGroupsWithOptions(ctx, "o", opts)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
 func TestActionsService_GetOrganizationRunnerGroup(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()

--- a/github/actions_runner_groups_test.go
+++ b/github/actions_runner_groups_test.go
@@ -24,7 +24,7 @@ func TestActionsService_ListOrganizationRunnerGroups(t *testing.T) {
 		fmt.Fprint(w, `{"total_count":3,"runner_groups":[{"id":1,"name":"Default","visibility":"all","default":true,"runners_url":"https://api.github.com/orgs/octo-org/actions/runner_groups/1/runners","inherited":false,"allows_public_repositories":true},{"id":2,"name":"octo-runner-group","visibility":"selected","default":false,"selected_repositories_url":"https://api.github.com/orgs/octo-org/actions/runner_groups/2/repositories","runners_url":"https://api.github.com/orgs/octo-org/actions/runner_groups/2/runners","inherited":true,"allows_public_repositories":true},{"id":3,"name":"expensive-hardware","visibility":"private","default":false,"runners_url":"https://api.github.com/orgs/octo-org/actions/runner_groups/3/runners","inherited":false,"allows_public_repositories":true}]}`)
 	})
 
-	opts := &ListOptions{Page: 2, PerPage: 2}
+	opts := &ListOrgRunnerGroupOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
 	ctx := context.Background()
 	groups, _, err := client.Actions.ListOrganizationRunnerGroups(ctx, "o", opts)
 	if err != nil {
@@ -58,7 +58,7 @@ func TestActionsService_ListOrganizationRunnerGroups(t *testing.T) {
 	})
 }
 
-func TestActionsService_ListOrganizationRunnerGroupsWithOptions(t *testing.T) {
+func TestActionsService_ListOrganizationRunnerGroupsVisibleToRepo(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -70,9 +70,9 @@ func TestActionsService_ListOrganizationRunnerGroupsWithOptions(t *testing.T) {
 
 	opts := &ListOrgRunnerGroupOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}, VisibleToRepository: "github"}
 	ctx := context.Background()
-	groups, _, err := client.Actions.ListOrganizationRunnerGroupsWithOptions(ctx, "o", opts)
+	groups, _, err := client.Actions.ListOrganizationRunnerGroups(ctx, "o", opts)
 	if err != nil {
-		t.Errorf("Actions.ListOrganizationRunnerGroupsWithOptions returned error: %v", err)
+		t.Errorf("Actions.ListOrganizationRunnerGroups returned error: %v", err)
 	}
 
 	want := &RunnerGroups{
@@ -84,17 +84,17 @@ func TestActionsService_ListOrganizationRunnerGroupsWithOptions(t *testing.T) {
 		},
 	}
 	if !cmp.Equal(groups, want) {
-		t.Errorf("Actions.ListOrganizationRunnerGroupsWithOptions returned %+v, want %+v", groups, want)
+		t.Errorf("Actions.ListOrganizationRunnerGroups returned %+v, want %+v", groups, want)
 	}
 
-	const methodName = "ListOrganizationRunnerGroupsWithOptions"
+	const methodName = "ListOrganizationRunnerGroups"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.ListOrganizationRunnerGroupsWithOptions(ctx, "\n", opts)
+		_, _, err = client.Actions.ListOrganizationRunnerGroups(ctx, "\n", opts)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.ListOrganizationRunnerGroupsWithOptions(ctx, "o", opts)
+		got, resp, err := client.Actions.ListOrganizationRunnerGroups(ctx, "o", opts)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}


### PR DESCRIPTION
Fixing https://github.com/google/go-github/issues/2328 

Support `visible_to_repository` query parameter in `ListOrganizationRunnerGroups`.