### PR TITLE
Add fields to RateLimits struct

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -13510,6 +13510,22 @@ func (p *PushEventRepository) GetWatchersCount() int {
 	return *p.WatchersCount
 }
 
+// GetActionsRunnerRegistration returns the ActionsRunnerRegistration field.
+func (r *RateLimits) GetActionsRunnerRegistration() *Rate {
+	if r == nil {
+		return nil
+	}
+	return r.ActionsRunnerRegistration
+}
+
+// GetCodeScanningUpload returns the CodeScanningUpload field.
+func (r *RateLimits) GetCodeScanningUpload() *Rate {
+	if r == nil {
+		return nil
+	}
+	return r.CodeScanningUpload
+}
+
 // GetCore returns the Core field.
 func (r *RateLimits) GetCore() *Rate {
 	if r == nil {
@@ -13518,12 +13534,44 @@ func (r *RateLimits) GetCore() *Rate {
 	return r.Core
 }
 
+// GetGraphQL returns the GraphQL field.
+func (r *RateLimits) GetGraphQL() *Rate {
+	if r == nil {
+		return nil
+	}
+	return r.GraphQL
+}
+
+// GetIntegrationManifest returns the IntegrationManifest field.
+func (r *RateLimits) GetIntegrationManifest() *Rate {
+	if r == nil {
+		return nil
+	}
+	return r.IntegrationManifest
+}
+
+// GetSCIM returns the SCIM field.
+func (r *RateLimits) GetSCIM() *Rate {
+	if r == nil {
+		return nil
+	}
+	return r.SCIM
+}
+
 // GetSearch returns the Search field.
 func (r *RateLimits) GetSearch() *Rate {
 	if r == nil {
 		return nil
 	}
 	return r.Search
+}
+
+// GetSourceImport returns the SourceImport field.
+func (r *RateLimits) GetSourceImport() *Rate {
+	if r == nil {
+		return nil
+	}
+	return r.SourceImport
 }
 
 // GetContent returns the Content field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -15724,6 +15724,20 @@ func TestPushEventRepository_GetWatchersCount(tt *testing.T) {
 	p.GetWatchersCount()
 }
 
+func TestRateLimits_GetActionsRunnerRegistration(tt *testing.T) {
+	r := &RateLimits{}
+	r.GetActionsRunnerRegistration()
+	r = nil
+	r.GetActionsRunnerRegistration()
+}
+
+func TestRateLimits_GetCodeScanningUpload(tt *testing.T) {
+	r := &RateLimits{}
+	r.GetCodeScanningUpload()
+	r = nil
+	r.GetCodeScanningUpload()
+}
+
 func TestRateLimits_GetCore(tt *testing.T) {
 	r := &RateLimits{}
 	r.GetCore()
@@ -15731,11 +15745,39 @@ func TestRateLimits_GetCore(tt *testing.T) {
 	r.GetCore()
 }
 
+func TestRateLimits_GetGraphQL(tt *testing.T) {
+	r := &RateLimits{}
+	r.GetGraphQL()
+	r = nil
+	r.GetGraphQL()
+}
+
+func TestRateLimits_GetIntegrationManifest(tt *testing.T) {
+	r := &RateLimits{}
+	r.GetIntegrationManifest()
+	r = nil
+	r.GetIntegrationManifest()
+}
+
+func TestRateLimits_GetSCIM(tt *testing.T) {
+	r := &RateLimits{}
+	r.GetSCIM()
+	r = nil
+	r.GetSCIM()
+}
+
 func TestRateLimits_GetSearch(tt *testing.T) {
 	r := &RateLimits{}
 	r.GetSearch()
 	r = nil
 	r.GetSearch()
+}
+
+func TestRateLimits_GetSourceImport(tt *testing.T) {
+	r := &RateLimits{}
+	r.GetSourceImport()
+	r = nil
+	r.GetSourceImport()
 }
 
 func TestReaction_GetContent(tt *testing.T) {

--- a/github/github.go
+++ b/github/github.go
@@ -1113,12 +1113,12 @@ type rateLimitCategory uint8
 const (
 	coreCategory rateLimitCategory = iota
 	searchCategory
-	graphqlCategory                   //nolint:deadcode,varcheck
-	integrationManifestCategory       //nolint:deadcode,varcheck
-	sourceImportCategory              //nolint:deadcode,varcheck
-	codeScanningUploadCategory        //nolint:deadcode,varcheck
-	actionsRunnerRegistrationCategory //nolint:deadcode,varcheck
-	scimCategory                      //nolint:deadcode,varcheck
+	graphqlCategory
+	integrationManifestCategory
+	sourceImportCategory
+	codeScanningUploadCategory
+	actionsRunnerRegistrationCategory
+	scimCategory
 
 	categories // An array of this length will be able to contain all rate limit categories.
 )
@@ -1158,6 +1158,24 @@ func (c *Client) RateLimits(ctx context.Context) (*RateLimits, *Response, error)
 		}
 		if response.Resources.Search != nil {
 			c.rateLimits[searchCategory] = *response.Resources.Search
+		}
+		if response.Resources.GraphQL != nil {
+			c.rateLimits[graphqlCategory] = *response.Resources.GraphQL
+		}
+		if response.Resources.IntegrationManifest != nil {
+			c.rateLimits[integrationManifestCategory] = *response.Resources.IntegrationManifest
+		}
+		if response.Resources.SourceImport != nil {
+			c.rateLimits[sourceImportCategory] = *response.Resources.SourceImport
+		}
+		if response.Resources.CodeScanningUpload != nil {
+			c.rateLimits[codeScanningUploadCategory] = *response.Resources.CodeScanningUpload
+		}
+		if response.Resources.ActionsRunnerRegistration != nil {
+			c.rateLimits[actionsRunnerRegistrationCategory] = *response.Resources.ActionsRunnerRegistration
+		}
+		if response.Resources.SCIM != nil {
+			c.rateLimits[scimCategory] = *response.Resources.SCIM
 		}
 		c.rateMu.Unlock()
 	}

--- a/github/github.go
+++ b/github/github.go
@@ -1113,12 +1113,12 @@ type rateLimitCategory uint8
 const (
 	coreCategory rateLimitCategory = iota
 	searchCategory
-	graphqlCategory
-	integrationManifestCategory
-	sourceImportCategory
-	codeScanningUploadCategory
-	actionsRunnerRegistrationCategory
-	scimCategory
+	graphqlCategory                   //nolint:deadcode,varcheck
+	integrationManifestCategory       //nolint:deadcode,varcheck
+	sourceImportCategory              //nolint:deadcode,varcheck
+	codeScanningUploadCategory        //nolint:deadcode,varcheck
+	actionsRunnerRegistrationCategory //nolint:deadcode,varcheck
+	scimCategory                      //nolint:deadcode,varcheck
 
 	categories // An array of this length will be able to contain all rate limit categories.
 )

--- a/github/github.go
+++ b/github/github.go
@@ -1082,15 +1082,26 @@ type RateLimits struct {
 	// requests are limited to 60 per hour. Authenticated requests are
 	// limited to 5,000 per hour.
 	//
-	// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/#rate-limiting
+	// GitHub API docs: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
 	Core *Rate `json:"core"`
 
 	// The rate limit for search API requests. Unauthenticated requests
 	// are limited to 10 requests per minutes. Authenticated requests are
 	// limited to 30 per minute.
 	//
-	// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/search/#rate-limit
+	// GitHub API docs: https://docs.github.com/en/rest/search#rate-limit
 	Search *Rate `json:"search"`
+
+	// GitHub API docs: https://docs.github.com/en/graphql/overview/resource-limitations#rate-limit
+	Graphql *Rate `json:"graphql"`
+
+	// GitHub API dos: https://docs.github.com/en/rest/rate-limit
+	IntegrationManifest *Rate `json:"integration_manifest"`
+
+	SourceImport              *Rate `json:"source_import"`
+	CodeScanningUpload        *Rate `json:"code_scanning_upload"`
+	ActionsRunnerRegistration *Rate `json:"actions_runner_registration"`
+	Scim                      *Rate `json:"scim"`
 }
 
 func (r RateLimits) String() string {
@@ -1102,6 +1113,12 @@ type rateLimitCategory uint8
 const (
 	coreCategory rateLimitCategory = iota
 	searchCategory
+	graphqlCategory
+	integrationManifestCategory
+	sourceImportCategory
+	codeScanningUploadCategory
+	actionsRunnerRegistrationCategory
+	scimCategory
 
 	categories // An array of this length will be able to contain all rate limit categories.
 )

--- a/github/github.go
+++ b/github/github.go
@@ -1093,7 +1093,7 @@ type RateLimits struct {
 	Search *Rate `json:"search"`
 
 	// GitHub API docs: https://docs.github.com/en/graphql/overview/resource-limitations#rate-limit
-	Graphql *Rate `json:"graphql"`
+	GraphQL *Rate `json:"graphql"`
 
 	// GitHub API dos: https://docs.github.com/en/rest/rate-limit
 	IntegrationManifest *Rate `json:"integration_manifest"`
@@ -1101,7 +1101,7 @@ type RateLimits struct {
 	SourceImport              *Rate `json:"source_import"`
 	CodeScanningUpload        *Rate `json:"code_scanning_upload"`
 	ActionsRunnerRegistration *Rate `json:"actions_runner_registration"`
-	Scim                      *Rate `json:"scim"`
+	SCIM                      *Rate `json:"scim"`
 }
 
 func (r RateLimits) String() string {

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -474,10 +474,16 @@ func TestClient_rateLimits(t *testing.T) {
 
 func TestRateLimits_String(t *testing.T) {
 	v := RateLimits{
-		Core:   &Rate{},
-		Search: &Rate{},
+		Core:                      &Rate{},
+		Search:                    &Rate{},
+		Graphql:                   &Rate{},
+		IntegrationManifest:       &Rate{},
+		SourceImport:              &Rate{},
+		CodeScanningUpload:        &Rate{},
+		ActionsRunnerRegistration: &Rate{},
+		Scim:                      &Rate{},
 	}
-	want := `github.RateLimits{Core:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, Search:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}}`
+	want := `github.RateLimits{Core:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, Search:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, Graphql:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, IntegrationManifest:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, SourceImport:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, CodeScanningUpload:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, ActionsRunnerRegistration:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, Scim:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}}`
 	if got := v.String(); got != want {
 		t.Errorf("RateLimits.String = %v, want %v", got, want)
 	}
@@ -2394,6 +2400,36 @@ func TestRateLimits_Marshal(t *testing.T) {
 			Remaining: 1,
 			Reset:     Timestamp{referenceTime},
 		},
+		Graphql: &Rate{
+			Limit:     1,
+			Remaining: 1,
+			Reset:     Timestamp{referenceTime},
+		},
+		IntegrationManifest: &Rate{
+			Limit:     1,
+			Remaining: 1,
+			Reset:     Timestamp{referenceTime},
+		},
+		SourceImport: &Rate{
+			Limit:     1,
+			Remaining: 1,
+			Reset:     Timestamp{referenceTime},
+		},
+		CodeScanningUpload: &Rate{
+			Limit:     1,
+			Remaining: 1,
+			Reset:     Timestamp{referenceTime},
+		},
+		ActionsRunnerRegistration: &Rate{
+			Limit:     1,
+			Remaining: 1,
+			Reset:     Timestamp{referenceTime},
+		},
+		Scim: &Rate{
+			Limit:     1,
+			Remaining: 1,
+			Reset:     Timestamp{referenceTime},
+		},
 	}
 
 	want := `{
@@ -2403,6 +2439,36 @@ func TestRateLimits_Marshal(t *testing.T) {
 			"reset": ` + referenceTimeStr + `
 		},
 		"search": {
+			"limit": 1,
+			"remaining": 1,
+			"reset": ` + referenceTimeStr + `
+		},
+		"graphql": {
+			"limit": 1,
+			"remaining": 1,
+			"reset": ` + referenceTimeStr + `
+		},
+		"integration_manifest": {
+			"limit": 1,
+			"remaining": 1,
+			"reset": ` + referenceTimeStr + `
+		},
+		"source_import": {
+			"limit": 1,
+			"remaining": 1,
+			"reset": ` + referenceTimeStr + `
+		},
+		"code_scanning_upload": {
+			"limit": 1,
+			"remaining": 1,
+			"reset": ` + referenceTimeStr + `
+		},
+		"actions_runner_registration": {
+			"limit": 1,
+			"remaining": 1,
+			"reset": ` + referenceTimeStr + `
+		},
+		"scim": {
 			"limit": 1,
 			"remaining": 1,
 			"reset": ` + referenceTimeStr + `

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1868,7 +1868,13 @@ func TestRateLimits(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"resources":{
 			"core": {"limit":2,"remaining":1,"reset":1372700873},
-			"search": {"limit":3,"remaining":2,"reset":1372700874}
+			"search": {"limit":3,"remaining":2,"reset":1372700874},
+			"graphql": {"limit":4,"remaining":3,"reset":1372700875},
+			"integration_manifest": {"limit":5,"remaining":4,"reset":1372700876},
+			"source_import": {"limit":6,"remaining":5,"reset":1372700877},
+			"code_scanning_upload": {"limit":7,"remaining":6,"reset":1372700878},
+			"actions_runner_registration": {"limit":8,"remaining":7,"reset":1372700879},
+			"scim": {"limit":9,"remaining":8,"reset":1372700880}
 		}}`)
 	})
 
@@ -1889,6 +1895,36 @@ func TestRateLimits(t *testing.T) {
 			Remaining: 2,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 54, 0, time.UTC).Local()},
 		},
+		GraphQL: &Rate{
+			Limit:     4,
+			Remaining: 3,
+			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 55, 0, time.UTC).Local()},
+		},
+		IntegrationManifest: &Rate{
+			Limit:     5,
+			Remaining: 4,
+			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 56, 0, time.UTC).Local()},
+		},
+		SourceImport: &Rate{
+			Limit:     6,
+			Remaining: 5,
+			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 57, 0, time.UTC).Local()},
+		},
+		CodeScanningUpload: &Rate{
+			Limit:     7,
+			Remaining: 6,
+			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 58, 0, time.UTC).Local()},
+		},
+		ActionsRunnerRegistration: &Rate{
+			Limit:     8,
+			Remaining: 7,
+			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 59, 0, time.UTC).Local()},
+		},
+		SCIM: &Rate{
+			Limit:     9,
+			Remaining: 8,
+			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 48, 00, 0, time.UTC).Local()},
+		},
 	}
 	if !cmp.Equal(rate, want) {
 		t.Errorf("RateLimits returned %+v, want %+v", rate, want)
@@ -1899,6 +1935,24 @@ func TestRateLimits(t *testing.T) {
 	}
 	if got, want := client.rateLimits[searchCategory], *want.Search; got != want {
 		t.Errorf("client.rateLimits[searchCategory] is %+v, want %+v", got, want)
+	}
+	if got, want := client.rateLimits[graphqlCategory], *want.GraphQL; got != want {
+		t.Errorf("client.rateLimits[graphqlCategory] is %+v, want %+v", got, want)
+	}
+	if got, want := client.rateLimits[integrationManifestCategory], *want.IntegrationManifest; got != want {
+		t.Errorf("client.rateLimits[integrationManifestCategory] is %+v, want %+v", got, want)
+	}
+	if got, want := client.rateLimits[sourceImportCategory], *want.SourceImport; got != want {
+		t.Errorf("client.rateLimits[sourceImportCategory] is %+v, want %+v", got, want)
+	}
+	if got, want := client.rateLimits[codeScanningUploadCategory], *want.CodeScanningUpload; got != want {
+		t.Errorf("client.rateLimits[codeScanningUploadCategory] is %+v, want %+v", got, want)
+	}
+	if got, want := client.rateLimits[actionsRunnerRegistrationCategory], *want.ActionsRunnerRegistration; got != want {
+		t.Errorf("client.rateLimits[actionsRunnerRegistrationCategory] is %+v, want %+v", got, want)
+	}
+	if got, want := client.rateLimits[scimCategory], *want.SCIM; got != want {
+		t.Errorf("client.rateLimits[scimCategory] is %+v, want %+v", got, want)
 	}
 }
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -476,14 +476,14 @@ func TestRateLimits_String(t *testing.T) {
 	v := RateLimits{
 		Core:                      &Rate{},
 		Search:                    &Rate{},
-		Graphql:                   &Rate{},
+		GraphQL:                   &Rate{},
 		IntegrationManifest:       &Rate{},
 		SourceImport:              &Rate{},
 		CodeScanningUpload:        &Rate{},
 		ActionsRunnerRegistration: &Rate{},
-		Scim:                      &Rate{},
+		SCIM:                      &Rate{},
 	}
-	want := `github.RateLimits{Core:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, Search:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, Graphql:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, IntegrationManifest:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, SourceImport:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, CodeScanningUpload:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, ActionsRunnerRegistration:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, Scim:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}}`
+	want := `github.RateLimits{Core:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, Search:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, GraphQL:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, IntegrationManifest:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, SourceImport:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, CodeScanningUpload:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, ActionsRunnerRegistration:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, SCIM:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}}`
 	if got := v.String(); got != want {
 		t.Errorf("RateLimits.String = %v, want %v", got, want)
 	}
@@ -2400,7 +2400,7 @@ func TestRateLimits_Marshal(t *testing.T) {
 			Remaining: 1,
 			Reset:     Timestamp{referenceTime},
 		},
-		Graphql: &Rate{
+		GraphQL: &Rate{
 			Limit:     1,
 			Remaining: 1,
 			Reset:     Timestamp{referenceTime},
@@ -2425,7 +2425,7 @@ func TestRateLimits_Marshal(t *testing.T) {
 			Remaining: 1,
 			Reset:     Timestamp{referenceTime},
 		},
-		Scim: &Rate{
+		SCIM: &Rate{
 			Limit:     1,
 			Remaining: 1,
 			Reset:     Timestamp{referenceTime},


### PR DESCRIPTION
Fixes: https://github.com/google/go-github/issues/2339

#### What this PR does / why we need it:
I added fields to `RateLimits` struct to get rate limits other than `core` and `search`

#### Special notes for your reviewer:
Since there is no documentation for `source_import`, `code_scanning_upload`, `actions_runner_registration`, and `scim`, I did not know which endpoints had the rate limit set, so I did not fix `category` function. 
https://github.com/google/go-github/blob/942d33d1d76e64a53d4d50ac0c95d54c907ba0e1/github/github.go#L1126-L1134