### PR TITLE
Add missing models to SCIM GET methods

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -8190,6 +8190,30 @@ func (l *ListSCIMProvisionedIdentitiesOptions) GetStartIndex() int {
 	return *l.StartIndex
 }
 
+// GetItemsPerPage returns the ItemsPerPage field if it's non-nil, zero value otherwise.
+func (l *ListSCIMProvisionedIdentitiesResult) GetItemsPerPage() int {
+	if l == nil || l.ItemsPerPage == nil {
+		return 0
+	}
+	return *l.ItemsPerPage
+}
+
+// GetStartIndex returns the StartIndex field if it's non-nil, zero value otherwise.
+func (l *ListSCIMProvisionedIdentitiesResult) GetStartIndex() int {
+	if l == nil || l.StartIndex == nil {
+		return 0
+	}
+	return *l.StartIndex
+}
+
+// GetTotalResults returns the TotalResults field if it's non-nil, zero value otherwise.
+func (l *ListSCIMProvisionedIdentitiesResult) GetTotalResults() int {
+	if l == nil || l.TotalResults == nil {
+		return 0
+	}
+	return *l.TotalResults
+}
+
 // GetEndColumn returns the EndColumn field if it's non-nil, zero value otherwise.
 func (l *Location) GetEndColumn() int {
 	if l == nil || l.EndColumn == nil {
@@ -16172,6 +16196,46 @@ func (s *ScanningAnalysis) GetWarning() string {
 		return ""
 	}
 	return *s.Warning
+}
+
+// GetCreated returns the Created field if it's non-nil, zero value otherwise.
+func (s *SCIMMeta) GetCreated() Timestamp {
+	if s == nil || s.Created == nil {
+		return Timestamp{}
+	}
+	return *s.Created
+}
+
+// GetLastModified returns the LastModified field if it's non-nil, zero value otherwise.
+func (s *SCIMMeta) GetLastModified() Timestamp {
+	if s == nil || s.LastModified == nil {
+		return Timestamp{}
+	}
+	return *s.LastModified
+}
+
+// GetLocation returns the Location field if it's non-nil, zero value otherwise.
+func (s *SCIMMeta) GetLocation() string {
+	if s == nil || s.Location == nil {
+		return ""
+	}
+	return *s.Location
+}
+
+// GetResourceType returns the ResourceType field if it's non-nil, zero value otherwise.
+func (s *SCIMMeta) GetResourceType() string {
+	if s == nil || s.ResourceType == nil {
+		return ""
+	}
+	return *s.ResourceType
+}
+
+// GetId returns the Id field if it's non-nil, zero value otherwise.
+func (s *SCIMUser) GetId() string {
+	if s == nil || s.Id == nil {
+		return ""
+	}
+	return *s.Id
 }
 
 // GetActive returns the Active field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -9605,6 +9605,36 @@ func TestListSCIMProvisionedIdentitiesOptions_GetStartIndex(tt *testing.T) {
 	l.GetStartIndex()
 }
 
+func TestListSCIMProvisionedIdentitiesResult_GetItemsPerPage(tt *testing.T) {
+	var zeroValue int
+	l := &ListSCIMProvisionedIdentitiesResult{ItemsPerPage: &zeroValue}
+	l.GetItemsPerPage()
+	l = &ListSCIMProvisionedIdentitiesResult{}
+	l.GetItemsPerPage()
+	l = nil
+	l.GetItemsPerPage()
+}
+
+func TestListSCIMProvisionedIdentitiesResult_GetStartIndex(tt *testing.T) {
+	var zeroValue int
+	l := &ListSCIMProvisionedIdentitiesResult{StartIndex: &zeroValue}
+	l.GetStartIndex()
+	l = &ListSCIMProvisionedIdentitiesResult{}
+	l.GetStartIndex()
+	l = nil
+	l.GetStartIndex()
+}
+
+func TestListSCIMProvisionedIdentitiesResult_GetTotalResults(tt *testing.T) {
+	var zeroValue int
+	l := &ListSCIMProvisionedIdentitiesResult{TotalResults: &zeroValue}
+	l.GetTotalResults()
+	l = &ListSCIMProvisionedIdentitiesResult{}
+	l.GetTotalResults()
+	l = nil
+	l.GetTotalResults()
+}
+
 func TestLocation_GetEndColumn(tt *testing.T) {
 	var zeroValue int
 	l := &Location{EndColumn: &zeroValue}
@@ -18908,6 +18938,56 @@ func TestScanningAnalysis_GetWarning(tt *testing.T) {
 	s.GetWarning()
 	s = nil
 	s.GetWarning()
+}
+
+func TestSCIMMeta_GetCreated(tt *testing.T) {
+	var zeroValue Timestamp
+	s := &SCIMMeta{Created: &zeroValue}
+	s.GetCreated()
+	s = &SCIMMeta{}
+	s.GetCreated()
+	s = nil
+	s.GetCreated()
+}
+
+func TestSCIMMeta_GetLastModified(tt *testing.T) {
+	var zeroValue Timestamp
+	s := &SCIMMeta{LastModified: &zeroValue}
+	s.GetLastModified()
+	s = &SCIMMeta{}
+	s.GetLastModified()
+	s = nil
+	s.GetLastModified()
+}
+
+func TestSCIMMeta_GetLocation(tt *testing.T) {
+	var zeroValue string
+	s := &SCIMMeta{Location: &zeroValue}
+	s.GetLocation()
+	s = &SCIMMeta{}
+	s.GetLocation()
+	s = nil
+	s.GetLocation()
+}
+
+func TestSCIMMeta_GetResourceType(tt *testing.T) {
+	var zeroValue string
+	s := &SCIMMeta{ResourceType: &zeroValue}
+	s.GetResourceType()
+	s = &SCIMMeta{}
+	s.GetResourceType()
+	s = nil
+	s.GetResourceType()
+}
+
+func TestSCIMUser_GetId(tt *testing.T) {
+	var zeroValue string
+	s := &SCIMUser{Id: &zeroValue}
+	s.GetId()
+	s = &SCIMUser{}
+	s.GetId()
+	s = nil
+	s.GetId()
 }
 
 func TestSCIMUserAttributes_GetActive(tt *testing.T) {

--- a/github/scim_test.go
+++ b/github/scim_test.go
@@ -7,8 +7,10 @@ package github
 
 import (
 	"context"
+	"github.com/google/go-cmp/cmp"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestSCIMService_ListSCIMProvisionedIdentities(t *testing.T) {
@@ -18,23 +20,108 @@ func TestSCIMService_ListSCIMProvisionedIdentities(t *testing.T) {
 	mux.HandleFunc("/scim/v2/organizations/o/Users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+		  "schemas": [
+			"urn:ietf:params:scim:api:messages:2.0:ListResponse"
+		  ],
+		  "totalResults": 1,
+		  "itemsPerPage": 1,
+		  "startIndex": 1,
+		  "Resources": [
+			{
+			  "schemas": [
+				"urn:ietf:params:scim:schemas:core:2.0:User"
+			  ],
+			  "id": "5fc0c238-1112-11e8-8e45-920c87bdbd75",
+			  "externalId": "00u1dhhb1fkIGP7RL1d8",
+			  "userName": "octocat@github.com",
+			  "displayName": "Mona Octocat",
+			  "name": {
+				"givenName": "Mona",
+				"familyName": "Octocat",
+				"formatted": "Mona Octocat"
+			  },
+			  "emails": [
+				{
+				  "value": "octocat@github.com",
+				  "primary": true
+				}
+			  ],
+			  "active": true,
+			  "meta": {
+				"resourceType": "User",
+				"created": "2018-02-13T15:05:24.000-08:00",
+				"lastModified": "2018-02-13T15:05:24.000-08:00",
+				"location": "https://api.github.com/scim/v2/organizations/octo-org/Users/5fc0c238-1112-11e8-8e45-920c87bdbd75"
+			  }
+			}
+		  ]
+		}`))
 	})
 
 	ctx := context.Background()
 	opts := &ListSCIMProvisionedIdentitiesOptions{}
-	_, err := client.SCIM.ListSCIMProvisionedIdentities(ctx, "o", opts)
+	ids, _, err := client.SCIM.ListSCIMProvisionedIdentities(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("SCIM.ListSCIMProvisionedIdentities returned error: %v", err)
 	}
 
+	tz, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Errorf("Failed to load Pacific Standard Time zone")
+	}
+	date := Timestamp{time.Date(2018, time.February, 13, 15, 5, 24, 0, tz)}
+	want := ListSCIMProvisionedIdentitiesResult{
+		Schemas:      []string{"urn:ietf:params:scim:api:messages:2.0:ListResponse"},
+		TotalResults: Int(1),
+		ItemsPerPage: Int(1),
+		StartIndex:   Int(1),
+		Resources: []*SCIMUser{
+			&SCIMUser{
+				Id: String("5fc0c238-1112-11e8-8e45-920c87bdbd75"),
+				Meta: SCIMMeta{
+					ResourceType: String("User"),
+					Created:      &date,
+					LastModified: &date,
+					Location:     String("https://api.github.com/scim/v2/organizations/octo-org/Users/5fc0c238-1112-11e8-8e45-920c87bdbd75"),
+				},
+				SCIMUserAttributes: SCIMUserAttributes{
+					UserName: "octocat@github.com",
+					Name: SCIMUserName{
+						GivenName:  "Mona",
+						FamilyName: "Octocat",
+						Formatted:  String("Mona Octocat"),
+					},
+					DisplayName: String("Mona Octocat"),
+					Emails: []*SCIMUserEmail{
+						&SCIMUserEmail{
+							Value:   "octocat@github.com",
+							Primary: Bool(true),
+						},
+					},
+					Schemas:    []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
+					ExternalID: String("00u1dhhb1fkIGP7RL1d8"),
+					Groups:     nil,
+					Active:     Bool(true),
+				},
+			},
+		},
+	}
+
+	if !cmp.Equal(ids, &want) {
+		diff := cmp.Diff(ids, want)
+		t.Errorf("SCIM.ListSCIMProvisionedIdentities returned %+v, want %+v: diff %+v", ids, want, diff)
+	}
+
 	const methodName = "ListSCIMProvisionedIdentities"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.SCIM.ListSCIMProvisionedIdentities(ctx, "\n", opts)
+		_, _, err = client.SCIM.ListSCIMProvisionedIdentities(ctx, "\n", opts)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.SCIM.ListSCIMProvisionedIdentities(ctx, "o", opts)
+		_, r, err := client.SCIM.ListSCIMProvisionedIdentities(ctx, "o", opts)
+		return r, err
 	})
 }
 
@@ -83,22 +170,95 @@ func TestSCIMService_GetSCIMProvisioningInfoForUser(t *testing.T) {
 	mux.HandleFunc("/scim/v2/organizations/o/Users/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+		  "schemas": [
+			"urn:ietf:params:scim:schemas:core:2.0:User"
+		  ],
+		  "id": "edefdfedf-050c-11e7-8d32",
+		  "externalId": "a7d0f98382",
+		  "userName": "mona.octocat@okta.example.com",
+		  "displayName": "Monalisa Octocat",
+		  "name": {
+			"givenName": "Monalisa",
+			"familyName": "Octocat",
+			"formatted": "Monalisa Octocat"
+		  },
+		  "emails": [
+			{
+			  "value": "mona.octocat@okta.example.com",
+			  "primary": true
+			},
+			{
+			  "value": "monalisa@octocat.github.com"
+			}
+		  ],
+		  "active": true,
+		  "meta": {
+			"resourceType": "User",
+			"created": "2017-03-09T16:11:13-05:00",
+			"lastModified": "2017-03-09T16:11:13-05:00",
+			"location": "https://api.github.com/scim/v2/organizations/octo-org/Users/edefdfedf-050c-11e7-8d32"
+		  }
+		}`))
 	})
 
 	ctx := context.Background()
-	_, err := client.SCIM.GetSCIMProvisioningInfoForUser(ctx, "o", "123")
+	user, _, err := client.SCIM.GetSCIMProvisioningInfoForUser(ctx, "o", "123")
 	if err != nil {
 		t.Errorf("SCIM.GetSCIMProvisioningInfoForUser returned error: %v", err)
 	}
 
+	tz, err := time.LoadLocation("America/Toronto")
+	if err != nil {
+		t.Errorf("Failed to load Eastern Standard Time zone")
+	}
+	date := Timestamp{time.Date(2017, time.March, 9, 16, 11, 13, 0, tz)}
+	want := SCIMUser{
+		Id: String("edefdfedf-050c-11e7-8d32"),
+		Meta: SCIMMeta{
+			ResourceType: String("User"),
+			Created:      &date,
+			LastModified: &date,
+			Location:     String("https://api.github.com/scim/v2/organizations/octo-org/Users/edefdfedf-050c-11e7-8d32"),
+		},
+		SCIMUserAttributes: SCIMUserAttributes{
+			UserName: "mona.octocat@okta.example.com",
+			Name: SCIMUserName{
+				GivenName:  "Monalisa",
+				FamilyName: "Octocat",
+				Formatted:  String("Monalisa Octocat"),
+			},
+			DisplayName: String("Monalisa Octocat"),
+			Emails: []*SCIMUserEmail{
+				&SCIMUserEmail{
+					Value:   "mona.octocat@okta.example.com",
+					Primary: Bool(true),
+				},
+				&SCIMUserEmail{
+					Value: "monalisa@octocat.github.com",
+				},
+			},
+			Schemas:    []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
+			ExternalID: String("a7d0f98382"),
+			Groups:     nil,
+			Active:     Bool(true),
+		},
+	}
+
+	if !cmp.Equal(user, &want) {
+		diff := cmp.Diff(user, want)
+		t.Errorf("SCIM.ListSCIMProvisionedIdentities returned %+v, want %+v: diff %+v", user, want, diff)
+	}
+
 	const methodName = "GetSCIMProvisioningInfoForUser"
 	testBadOptions(t, methodName, func() error {
-		_, err := client.SCIM.GetSCIMProvisioningInfoForUser(ctx, "\n", "123")
+		_, _, err := client.SCIM.GetSCIMProvisioningInfoForUser(ctx, "\n", "123")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.SCIM.GetSCIMProvisioningInfoForUser(ctx, "o", "123")
+		_, r, err := client.SCIM.GetSCIMProvisioningInfoForUser(ctx, "o", "123")
+		return r, err
 	})
 }
 


### PR DESCRIPTION
The previous PR implementing the GitHub SCIM API lacked a way to access the models returned by the API calls. This commit adds those missing models along with tests. References Issue [2338](https://github.com/google/go-github/issues/2338)