### PR TITLE
Add RerunFailedJobsByID and RerunJobByID

### DIFF
--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -211,6 +211,34 @@ func (s *ActionsService) RerunWorkflowByID(ctx context.Context, owner, repo stri
 	return s.client.Do(ctx, req, nil)
 }
 
+// RerunFailedJobsByID re-runs all of the failed jobs and their dependent jobs in a workflow run by ID.
+//
+// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/actions/workflow-runs#re-run-failed-jobs-from-a-workflow-run
+func (s *ActionsService) RerunFailedJobsByID(ctx context.Context, owner, repo string, runID int64) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/rerun-failed-jobs", owner, repo, runID)
+
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// RerunJobByID re-runs a job and its dependent jobs in a workflow run by ID.
+//
+// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/actions/workflow-runs#re-run-a-job-from-a-workflow-run
+func (s *ActionsService) RerunJobByID(ctx context.Context, owner, repo string, jobID int64) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/jobs/%v/rerun", owner, repo, jobID)
+
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
 // CancelWorkflowRunByID cancels a workflow run by ID.
 //
 // GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/actions/#cancel-a-workflow-run

--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -216,6 +216,64 @@ func TestActionsService_RerunWorkflowRunByID(t *testing.T) {
 	})
 }
 
+func TestActionsService_RerunFailedJobsByID(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/runs/3434/rerun-failed-jobs", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Actions.RerunFailedJobsByID(ctx, "o", "r", 3434)
+	if err != nil {
+		t.Errorf("Actions.RerunFailedJobsByID returned error: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("Actions.RerunFailedJobsByID returned status: %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+
+	const methodName = "RerunFailedJobsByID"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.RerunFailedJobsByID(ctx, "\n", "\n", 3434)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.RerunFailedJobsByID(ctx, "o", "r", 3434)
+	})
+}
+
+func TestActionsService_RerunJobByID(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/jobs/3434/rerun", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Actions.RerunJobByID(ctx, "o", "r", 3434)
+	if err != nil {
+		t.Errorf("Actions.RerunJobByID returned error: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("Actions.RerunJobByID returned status: %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+
+	const methodName = "RerunJobByID"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.RerunJobByID(ctx, "\n", "\n", 3434)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.RerunJobByID(ctx, "o", "r", 3434)
+	})
+}
+
 func TestActionsService_CancelWorkflowRunByID(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
Fixes https://github.com/google/go-github/issues/2344

Add support to rerun all failed jobs or a single job from a workflow run
https://docs.github.com/en/rest/actions/workflow-runs#re-run-failed-jobs-from-a-workflow-run
https://docs.github.com/en/rest/actions/workflow-runs#re-run-a-job-from-a-workflow-run