### PR TITLE
Add missing Sender field in RepositoryVulnerabilityAlertEvent

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -1058,14 +1058,17 @@ type RepositoryVulnerabilityAlertEvent struct {
 	// Action is the action that was performed. Possible values are: "create", "dismiss", "resolve".
 	Action *string `json:"action,omitempty"`
 
-	//The security alert of the vulnerable dependency.
+	// The security alert of the vulnerable dependency.
 	Alert *RepositoryVulnerabilityAlert `json:"alert,omitempty"`
 
-	//The repository of the vulnerable dependency.
+	// The repository of the vulnerable dependency.
 	Repository *Repository `json:"repository,omitempty"`
 
 	// The following fields are only populated by Webhook events.
 	Installation *Installation `json:"installation,omitempty"`
+
+	// The user that triggered the event.
+	Sender *User `json:"sender,omitempty"`
 }
 
 // RepositoryVulnerabilityAlert represents a repository security alert.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -15622,6 +15622,14 @@ func (r *RepositoryVulnerabilityAlertEvent) GetRepository() *Repository {
 	return r.Repository
 }
 
+// GetSender returns the Sender field.
+func (r *RepositoryVulnerabilityAlertEvent) GetSender() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Sender
+}
+
 // GetForkRepos returns the ForkRepos field if it's non-nil, zero value otherwise.
 func (r *RepoStats) GetForkRepos() int {
 	if r == nil || r.ForkRepos == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -18223,6 +18223,13 @@ func TestRepositoryVulnerabilityAlertEvent_GetRepository(tt *testing.T) {
 	r.GetRepository()
 }
 
+func TestRepositoryVulnerabilityAlertEvent_GetSender(tt *testing.T) {
+	r := &RepositoryVulnerabilityAlertEvent{}
+	r.GetSender()
+	r = nil
+	r.GetSender()
+}
+
 func TestRepoStats_GetForkRepos(tt *testing.T) {
 	var zeroValue int
 	r := &RepoStats{ForkRepos: &zeroValue}


### PR DESCRIPTION
Reference: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#repository_vulnerability_alert