### PR TITLE
fix: correct endpoints for custom roles

### DIFF
--- a/github/orgs_custom_roles.go
+++ b/github/orgs_custom_roles.go
@@ -44,4 +44,3 @@ func (s *OrganizationsService) ListCustomRepoRoles(ctx context.Context, org stri
 
 	return customRepoRoles, resp, nil
 }
-diff --git a/github/org_custom_roles.go b/github/org_custom_roles.go

--- a/github/orgs_custom_roles.go
+++ b/github/orgs_custom_roles.go
@@ -29,7 +29,7 @@ type CustomRepoRoles struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/custom-roles
 func (s *OrganizationsService) ListCustomRepoRoles(ctx context.Context, org string) (*OrganizationCustomRepoRoles, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/custom_roles", org)
+	u := fmt.Sprintf("orgs/%v/custom_roles", org)
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -44,3 +44,4 @@ func (s *OrganizationsService) ListCustomRepoRoles(ctx context.Context, org stri
 
 	return customRepoRoles, resp, nil
 }
+diff --git a/github/org_custom_roles.go b/github/org_custom_roles.go

--- a/github/orgs_custom_roles_test.go
+++ b/github/orgs_custom_roles_test.go
@@ -48,4 +48,3 @@ func TestOrganizationsService_ListCustomRepoRoles(t *testing.T) {
 		return resp, err
 	})
 }
-diff --git a/github/org_custom_roles_test.go b/github/org_custom_roles_test.go

--- a/github/orgs_custom_roles_test.go
+++ b/github/orgs_custom_roles_test.go
@@ -18,7 +18,7 @@ func TestOrganizationsService_ListCustomRepoRoles(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/organizations/o/custom_roles", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/custom_roles", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"total_count": 1, "custom_roles": [{ "id": 1, "name": "Developer"}]}`)
 	})
@@ -48,3 +48,4 @@ func TestOrganizationsService_ListCustomRepoRoles(t *testing.T) {
 		return resp, err
 	})
 }
+diff --git a/github/org_custom_roles_test.go b/github/org_custom_roles_test.go


### PR DESCRIPTION
This function was created based on the docs here: 
https://docs.github.com/en/rest/orgs/custom-roles#list-custom-repository-roles-in-an-organization

The docs incorrectly give the endpoint `https://api.github.com/organizations/ORGANIZATION_ID/custom_roles`.

When using this function, I get a 404. 

The correct endpoint for the custom_roles endpoint is `https://api.github.com/orgs/ORGANIZATION_ID/custom_roles` - and this is consistent with other github endpoints under orgs. I have raised a support ticket with github, but I would expect them to change the documentation, not the api endpoint.

Also changed the file names for consistency.