### PR TITLE
Add missing common event fields.

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -106,10 +106,11 @@ type CreateEvent struct {
 	RefType      *string `json:"ref_type,omitempty"`
 	MasterBranch *string `json:"master_branch,omitempty"`
 	Description  *string `json:"description,omitempty"`
+	PusherType   *string `json:"pusher_type,omitempty"`
 
 	// The following fields are only populated by Webhook events.
-	PusherType   *string       `json:"pusher_type,omitempty"`
 	Repo         *Repository   `json:"repository,omitempty"`
+	Org          *Organization `json:"organization,omitempty"`
 	Sender       *User         `json:"sender,omitempty"`
 	Installation *Installation `json:"installation,omitempty"`
 }
@@ -493,13 +494,14 @@ type IssuesEvent struct {
 type LabelEvent struct {
 	// Action is the action that was performed. Possible values are:
 	// "created", "edited", "deleted"
-	Action *string `json:"action,omitempty"`
-	Label  *Label  `json:"label,omitempty"`
+	Action  *string     `json:"action,omitempty"`
+	Label   *Label      `json:"label,omitempty"`
+	Changes *EditChange `json:"changes,omitempty"`
 
 	// The following fields are only populated by Webhook events.
-	Changes      *EditChange   `json:"changes,omitempty"`
 	Repo         *Repository   `json:"repository,omitempty"`
 	Org          *Organization `json:"organization,omitempty"`
+	Sender       *User         `json:"sender,omitempty"`
 	Installation *Installation `json:"installation,omitempty"`
 }
 
@@ -574,6 +576,9 @@ type MetaEvent struct {
 	Hook *Hook `json:"hook,omitempty"`
 
 	// The following fields are only populated by Webhook events.
+	Repo         *Repository   `json:"repository,omitempty"`
+	Org          *Organization `json:"organization,omitempty"`
+	Sender       *User         `json:"sender,omitempty"`
 	Installation *Installation `json:"installation,omitempty"`
 }
 
@@ -682,7 +687,12 @@ type PingEvent struct {
 	// The ID of the webhook that triggered the ping.
 	HookID *int64 `json:"hook_id,omitempty"`
 	// The webhook configuration.
-	Hook         *Hook         `json:"hook,omitempty"`
+	Hook *Hook `json:"hook,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Repo         *Repository   `json:"repository,omitempty"`
+	Org          *Organization `json:"organization,omitempty"`
+	Sender       *User         `json:"sender,omitempty"`
 	Installation *Installation `json:"installation,omitempty"`
 }
 

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -3438,6 +3438,14 @@ func (c *CreateEvent) GetMasterBranch() string {
 	return *c.MasterBranch
 }
 
+// GetOrg returns the Org field.
+func (c *CreateEvent) GetOrg() *Organization {
+	if c == nil {
+		return nil
+	}
+	return c.Org
+}
+
 // GetPusherType returns the PusherType field if it's non-nil, zero value otherwise.
 func (c *CreateEvent) GetPusherType() string {
 	if c == nil || c.PusherType == nil {
@@ -7902,6 +7910,14 @@ func (l *LabelEvent) GetRepo() *Repository {
 	return l.Repo
 }
 
+// GetSender returns the Sender field.
+func (l *LabelEvent) GetSender() *User {
+	if l == nil {
+		return nil
+	}
+	return l.Sender
+}
+
 // GetColor returns the Color field if it's non-nil, zero value otherwise.
 func (l *LabelResult) GetColor() string {
 	if l == nil || l.Color == nil {
@@ -8740,6 +8756,30 @@ func (m *MetaEvent) GetInstallation() *Installation {
 		return nil
 	}
 	return m.Installation
+}
+
+// GetOrg returns the Org field.
+func (m *MetaEvent) GetOrg() *Organization {
+	if m == nil {
+		return nil
+	}
+	return m.Org
+}
+
+// GetRepo returns the Repo field.
+func (m *MetaEvent) GetRepo() *Repository {
+	if m == nil {
+		return nil
+	}
+	return m.Repo
+}
+
+// GetSender returns the Sender field.
+func (m *MetaEvent) GetSender() *User {
+	if m == nil {
+		return nil
+	}
+	return m.Sender
 }
 
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
@@ -10764,6 +10804,30 @@ func (p *PingEvent) GetInstallation() *Installation {
 		return nil
 	}
 	return p.Installation
+}
+
+// GetOrg returns the Org field.
+func (p *PingEvent) GetOrg() *Organization {
+	if p == nil {
+		return nil
+	}
+	return p.Org
+}
+
+// GetRepo returns the Repo field.
+func (p *PingEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *PingEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
 }
 
 // GetZen returns the Zen field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -4022,6 +4022,13 @@ func TestCreateEvent_GetMasterBranch(tt *testing.T) {
 	c.GetMasterBranch()
 }
 
+func TestCreateEvent_GetOrg(tt *testing.T) {
+	c := &CreateEvent{}
+	c.GetOrg()
+	c = nil
+	c.GetOrg()
+}
+
 func TestCreateEvent_GetPusherType(tt *testing.T) {
 	var zeroValue string
 	c := &CreateEvent{PusherType: &zeroValue}
@@ -9245,6 +9252,13 @@ func TestLabelEvent_GetRepo(tt *testing.T) {
 	l.GetRepo()
 }
 
+func TestLabelEvent_GetSender(tt *testing.T) {
+	l := &LabelEvent{}
+	l.GetSender()
+	l = nil
+	l.GetSender()
+}
+
 func TestLabelResult_GetColor(tt *testing.T) {
 	var zeroValue string
 	l := &LabelResult{Color: &zeroValue}
@@ -10227,6 +10241,27 @@ func TestMetaEvent_GetInstallation(tt *testing.T) {
 	m.GetInstallation()
 	m = nil
 	m.GetInstallation()
+}
+
+func TestMetaEvent_GetOrg(tt *testing.T) {
+	m := &MetaEvent{}
+	m.GetOrg()
+	m = nil
+	m.GetOrg()
+}
+
+func TestMetaEvent_GetRepo(tt *testing.T) {
+	m := &MetaEvent{}
+	m.GetRepo()
+	m = nil
+	m.GetRepo()
+}
+
+func TestMetaEvent_GetSender(tt *testing.T) {
+	m := &MetaEvent{}
+	m.GetSender()
+	m = nil
+	m.GetSender()
 }
 
 func TestMetric_GetHTMLURL(tt *testing.T) {
@@ -12619,6 +12654,27 @@ func TestPingEvent_GetInstallation(tt *testing.T) {
 	p.GetInstallation()
 	p = nil
 	p.GetInstallation()
+}
+
+func TestPingEvent_GetOrg(tt *testing.T) {
+	p := &PingEvent{}
+	p.GetOrg()
+	p = nil
+	p.GetOrg()
+}
+
+func TestPingEvent_GetRepo(tt *testing.T) {
+	p := &PingEvent{}
+	p.GetRepo()
+	p = nil
+	p.GetRepo()
+}
+
+func TestPingEvent_GetSender(tt *testing.T) {
+	p := &PingEvent{}
+	p.GetSender()
+	p = nil
+	p.GetSender()
 }
 
 func TestPingEvent_GetZen(tt *testing.T) {


### PR DESCRIPTION
See
https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-object-common-properties
for the list of common fields.

I may have missed some - but gives better coverage for fields we were
missing before.

Signed-off-by: Billy Lynch <billy@chainguard.dev>