### PR TITLE
add rolename field to user struct

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -18774,6 +18774,14 @@ func (u *User) GetReposURL() string {
 	return *u.ReposURL
 }
 
+// GetRoleName returns the RoleName field if it's non-nil, zero value otherwise.
+func (u *User) GetRoleName() string {
+	if u == nil || u.RoleName == nil {
+		return ""
+	}
+	return *u.RoleName
+}
+
 // GetSiteAdmin returns the SiteAdmin field if it's non-nil, zero value otherwise.
 func (u *User) GetSiteAdmin() bool {
 	if u == nil || u.SiteAdmin == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -21914,6 +21914,16 @@ func TestUser_GetReposURL(tt *testing.T) {
 	u.GetReposURL()
 }
 
+func TestUser_GetRoleName(tt *testing.T) {
+	var zeroValue string
+	u := &User{RoleName: &zeroValue}
+	u.GetRoleName()
+	u = &User{}
+	u.GetRoleName()
+	u = nil
+	u.GetRoleName()
+}
+
 func TestUser_GetSiteAdmin(tt *testing.T) {
 	var zeroValue bool
 	u := &User{SiteAdmin: &zeroValue}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1904,8 +1904,9 @@ func TestUser_String(t *testing.T) {
 		ReposURL:                String(""),
 		StarredURL:              String(""),
 		SubscriptionsURL:        String(""),
+		RoleName:                String(""),
 	}
-	want := `github.User{Login:"", ID:0, NodeID:"", AvatarURL:"", HTMLURL:"", GravatarID:"", Name:"", Company:"", Blog:"", Location:"", Email:"", Hireable:false, Bio:"", TwitterUsername:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, SuspendedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Type:"", SiteAdmin:false, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, TwoFactorAuthentication:false, Plan:github.Plan{}, LdapDn:"", URL:"", EventsURL:"", FollowingURL:"", FollowersURL:"", GistsURL:"", OrganizationsURL:"", ReceivedEventsURL:"", ReposURL:"", StarredURL:"", SubscriptionsURL:""}`
+	want := `github.User{Login:"", ID:0, NodeID:"", AvatarURL:"", HTMLURL:"", GravatarID:"", Name:"", Company:"", Blog:"", Location:"", Email:"", Hireable:false, Bio:"", TwitterUsername:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, SuspendedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Type:"", SiteAdmin:false, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, TwoFactorAuthentication:false, Plan:github.Plan{}, LdapDn:"", URL:"", EventsURL:"", FollowingURL:"", FollowersURL:"", GistsURL:"", OrganizationsURL:"", ReceivedEventsURL:"", ReposURL:"", StarredURL:"", SubscriptionsURL:"", RoleName:""}`
 	if got := v.String(); got != want {
 		t.Errorf("User.String = %v, want %v", got, want)
 	}

--- a/github/users.go
+++ b/github/users.go
@@ -66,9 +66,10 @@ type User struct {
 	// See: search.go and https://docs.github.com/en/rest/search/#text-match-metadata
 	TextMatches []*TextMatch `json:"text_matches,omitempty"`
 
-	// Permissions identifies the permissions that a user has on a given
-	// repository. This is only populated when calling Repositories.ListCollaborators.
+	// Permissions and RoleName identify the permissions and role that a user has on a given
+	// repository. These are only populated when calling Repositories.ListCollaborators.
 	Permissions map[string]bool `json:"permissions,omitempty"`
+	RoleName    *string         `json:"role_name,omitempty"`
 }
 
 func (u User) String() string {


### PR DESCRIPTION
As a follow on from [this PR](https://github.com/google/go-github/pull/2379) - I also need to be able to access the `role_name` returned from the `Repositories.ListCollaborators` endpoint, and therefore have raised this PR to include the field in the user struct.