### PR TITLE
Add support for parsing code_scanning_alerts in webhooks

### DIFF
--- a/github/event.go
+++ b/github/event.go
@@ -36,6 +36,8 @@ func (e *Event) ParsePayload() (payload interface{}, err error) {
 		payload = &CheckRunEvent{}
 	case "CheckSuiteEvent":
 		payload = &CheckSuiteEvent{}
+	case "CodeScanningAlertEvent":
+		payload = &CodeScanningAlertEvent{}
 	case "CommitCommentEvent":
 		payload = &CommitCommentEvent{}
 	case "ContentReferenceEvent":

--- a/github/messages.go
+++ b/github/messages.go
@@ -48,6 +48,7 @@ var (
 		"branch_protection_rule":         "BranchProtectionRuleEvent",
 		"check_run":                      "CheckRunEvent",
 		"check_suite":                    "CheckSuiteEvent",
+		"code_scanning_alert":            "CodeScanningAlertEvent",
 		"commit_comment":                 "CommitCommentEvent",
 		"content_reference":              "ContentReferenceEvent",
 		"create":                         "CreateEvent",

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -274,6 +274,10 @@ func TestParseWebHook(t *testing.T) {
 			messageType: "check_suite",
 		},
 		{
+			payload:     &CodeScanningAlertEvent{},
+			messageType: "code_scanning_alert",
+		},
+		{
 			payload:     &CommitCommentEvent{},
 			messageType: "commit_comment",
 		},

--- a/github/repos_hooks_deliveries_test.go
+++ b/github/repos_hooks_deliveries_test.go
@@ -145,6 +145,7 @@ func TestRepositoriesService_RedeliverHookDelivery(t *testing.T) {
 var hookDeliveryPayloadTypeToStruct = map[string]interface{}{
 	"check_run":                      &CheckRunEvent{},
 	"check_suite":                    &CheckSuiteEvent{},
+	"code_scanning_alert":            &CodeScanningAlertEvent{},
 	"commit_comment":                 &CommitCommentEvent{},
 	"content_reference":              &ContentReferenceEvent{},
 	"create":                         &CreateEvent{},


### PR DESCRIPTION
Following up on the issue I created https://github.com/google/go-github/issues/2391. 

Let me know if there is anything missing or needs fixing. I just tried to follow the patterns from the other types.

Cheers,

emil

Fixes: #2391.