### PR TITLE
Add state_reason to IssuesService.Edit 

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -7630,6 +7630,14 @@ func (i *IssueRequest) GetState() string {
 	return *i.State
 }
 
+// GetStateReason returns the StateReason field if it's non-nil, zero value otherwise.
+func (i *IssueRequest) GetStateReason() string {
+	if i == nil || i.StateReason == nil {
+		return ""
+	}
+	return *i.StateReason
+}
+
 // GetTitle returns the Title field if it's non-nil, zero value otherwise.
 func (i *IssueRequest) GetTitle() string {
 	if i == nil || i.Title == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -8938,6 +8938,16 @@ func TestIssueRequest_GetState(tt *testing.T) {
 	i.GetState()
 }
 
+func TestIssueRequest_GetStateReason(tt *testing.T) {
+	var zeroValue string
+	i := &IssueRequest{StateReason: &zeroValue}
+	i.GetStateReason()
+	i = &IssueRequest{}
+	i.GetStateReason()
+	i = nil
+	i.GetStateReason()
+}
+
 func TestIssueRequest_GetTitle(tt *testing.T) {
 	var zeroValue string
 	i := &IssueRequest{Title: &zeroValue}

--- a/github/issues.go
+++ b/github/issues.go
@@ -77,13 +77,15 @@ func (i Issue) IsPullRequest() bool {
 // It is separate from Issue above because otherwise Labels
 // and Assignee fail to serialize to the correct JSON.
 type IssueRequest struct {
-	Title     *string   `json:"title,omitempty"`
-	Body      *string   `json:"body,omitempty"`
-	Labels    *[]string `json:"labels,omitempty"`
-	Assignee  *string   `json:"assignee,omitempty"`
-	State     *string   `json:"state,omitempty"`
-	Milestone *int      `json:"milestone,omitempty"`
-	Assignees *[]string `json:"assignees,omitempty"`
+	Title    *string   `json:"title,omitempty"`
+	Body     *string   `json:"body,omitempty"`
+	Labels   *[]string `json:"labels,omitempty"`
+	Assignee *string   `json:"assignee,omitempty"`
+	State    *string   `json:"state,omitempty"`
+	// StateReason can be 'completed' or 'not_planned'.
+	StateReason *string   `json:"state_reason,omitempty"`
+	Milestone   *int      `json:"milestone,omitempty"`
+	Assignees   *[]string `json:"assignees,omitempty"`
 }
 
 // IssueListOptions specifies the optional parameters to the IssuesService.List


### PR DESCRIPTION
`state_reason` can be 'completed' or 'not_planned'.

I believe we let GitHub document these values, but let me know if you need me to modify this change. Thank you!

Fixes #2393.

/cc @gmlewis 