### PR TITLE
Include the version of `go-github` in `User-Agent` headers sent to the GitHub API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,3 +127,5 @@ this][modified-comment].
 [git-aliases]: https://github.com/willnorris/dotfiles/blob/d640d010c23b1116bdb3d4dc12088ed26120d87d/git/.gitconfig#L13-L15
 [rebase-comment]: https://github.com/google/go-github/pull/277#issuecomment-183035491
 [modified-comment]: https://github.com/google/go-github/pull/280#issuecomment-184859046
+
+**When creating a release, don't forget to update the `Version` constant in `github.go`.** This is used to send the version in the `User-Agent` header to identify clients to the GitHub API.

--- a/github/github.go
+++ b/github/github.go
@@ -30,9 +30,9 @@ import (
 const (
 	packageVersion = "45.2.0"
 
-	defaultBaseURL = "https://api.github.com/"
-	uploadBaseURL  = "https://uploads.github.com/"
-	userAgent      = "go-github" + "/" + packageVersion
+	defaultBaseURL   = "https://api.github.com/"
+	uploadBaseURL    = "https://uploads.github.com/"
+	defaultUserAgent = "go-github" + "/" + packageVersion
 
 	headerRateLimit     = "X-RateLimit-Limit"
 	headerRateRemaining = "X-RateLimit-Remaining"
@@ -305,7 +305,7 @@ func NewClient(httpClient *http.Client) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
 	uploadURL, _ := url.Parse(uploadBaseURL)
 
-	c := &Client{client: httpClient, BaseURL: baseURL, PackageVersion: packageVersion, UserAgent: userAgent, UploadURL: uploadURL}
+	c := &Client{client: httpClient, BaseURL: baseURL, PackageVersion: packageVersion, UserAgent: defaultUserAgent, UploadURL: uploadURL}
 	c.common.client = c
 	c.Actions = (*ActionsService)(&c.common)
 	c.Activity = (*ActivityService)(&c.common)

--- a/github/github.go
+++ b/github/github.go
@@ -168,8 +168,6 @@ type Client struct {
 	// User agent used when communicating with the GitHub API.
 	UserAgent string
 
-	PackageVersion string
-
 	rateMu     sync.Mutex
 	rateLimits [categories]Rate // Rate limits for the client as determined by the most recent API calls.
 
@@ -304,7 +302,7 @@ func NewClient(httpClient *http.Client) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
 	uploadURL, _ := url.Parse(uploadBaseURL)
 
-	c := &Client{client: httpClient, BaseURL: baseURL, PackageVersion: CurrentVersion, UserAgent: defaultUserAgent, UploadURL: uploadURL}
+	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: defaultUserAgent, UploadURL: uploadURL}
 	c.common.client = c
 	c.Actions = (*ActionsService)(&c.common)
 	c.Activity = (*ActivityService)(&c.common)

--- a/github/github.go
+++ b/github/github.go
@@ -28,9 +28,10 @@ import (
 )
 
 const (
-	CurrentVersion   = "45.2.0"
+	Version = "45.2.0"
+
 	defaultBaseURL   = "https://api.github.com/"
-	defaultUserAgent = "go-github" + "/" + CurrentVersion
+	defaultUserAgent = "go-github" + "/" + Version
 	uploadBaseURL    = "https://uploads.github.com/"
 
 	headerRateLimit     = "X-RateLimit-Limit"

--- a/github/github.go
+++ b/github/github.go
@@ -32,7 +32,7 @@ const (
 
 	defaultBaseURL = "https://api.github.com/"
 	uploadBaseURL  = "https://uploads.github.com/"
-	userAgent      = "go-github"
+	userAgent      = "go-github" + "/" + packageVersion
 
 	headerRateLimit     = "X-RateLimit-Limit"
 	headerRateRemaining = "X-RateLimit-Remaining"

--- a/github/github.go
+++ b/github/github.go
@@ -28,11 +28,10 @@ import (
 )
 
 const (
-	packageVersion = "45.2.0"
-
+	CurrentVersion   = "45.2.0"
 	defaultBaseURL   = "https://api.github.com/"
+	defaultUserAgent = "go-github" + "/" + CurrentVersion
 	uploadBaseURL    = "https://uploads.github.com/"
-	defaultUserAgent = "go-github" + "/" + packageVersion
 
 	headerRateLimit     = "X-RateLimit-Limit"
 	headerRateRemaining = "X-RateLimit-Remaining"
@@ -305,7 +304,7 @@ func NewClient(httpClient *http.Client) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
 	uploadURL, _ := url.Parse(uploadBaseURL)
 
-	c := &Client{client: httpClient, BaseURL: baseURL, PackageVersion: packageVersion, UserAgent: defaultUserAgent, UploadURL: uploadURL}
+	c := &Client{client: httpClient, BaseURL: baseURL, PackageVersion: CurrentVersion, UserAgent: defaultUserAgent, UploadURL: uploadURL}
 	c.common.client = c
 	c.Actions = (*ActionsService)(&c.common)
 	c.Activity = (*ActivityService)(&c.common)

--- a/github/github.go
+++ b/github/github.go
@@ -28,6 +28,8 @@ import (
 )
 
 const (
+	packageVersion = "45.2.0"
+
 	defaultBaseURL = "https://api.github.com/"
 	uploadBaseURL  = "https://uploads.github.com/"
 	userAgent      = "go-github"
@@ -167,6 +169,8 @@ type Client struct {
 	// User agent used when communicating with the GitHub API.
 	UserAgent string
 
+	PackageVersion string
+
 	rateMu     sync.Mutex
 	rateLimits [categories]Rate // Rate limits for the client as determined by the most recent API calls.
 
@@ -301,7 +305,7 @@ func NewClient(httpClient *http.Client) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
 	uploadURL, _ := url.Parse(uploadBaseURL)
 
-	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent, UploadURL: uploadURL}
+	c := &Client{client: httpClient, BaseURL: baseURL, PackageVersion: packageVersion, UserAgent: userAgent, UploadURL: uploadURL}
 	c.common.client = c
 	c.Actions = (*ActionsService)(&c.common)
 	c.Activity = (*ActivityService)(&c.common)

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -248,7 +248,7 @@ func TestNewClient(t *testing.T) {
 	if got, want := c.BaseURL.String(), defaultBaseURL; got != want {
 		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
 	}
-	if got, want := c.UserAgent, userAgent; got != want {
+	if got, want := c.UserAgent, defaultUserAgent; got != want {
 		t.Errorf("NewClient UserAgent is %v, want %v", got, want)
 	}
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -514,8 +514,8 @@ func TestNewRequest(t *testing.T) {
 		t.Errorf("NewRequest() User-Agent is %v, want %v", got, want)
 	}
 
-	if !strings.Contains(userAgent, c.PackageVersion) {
-		t.Errorf("NewRequest() User-Agent should contain %v, found %v", c.PackageVersion, userAgent)
+	if !strings.Contains(userAgent, CurrentVersion) {
+		t.Errorf("NewRequest() User-Agent should contain %v, found %v", CurrentVersion, userAgent)
 	}
 }
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -514,8 +514,8 @@ func TestNewRequest(t *testing.T) {
 		t.Errorf("NewRequest() User-Agent is %v, want %v", got, want)
 	}
 
-	if !strings.Contains(userAgent, CurrentVersion) {
-		t.Errorf("NewRequest() User-Agent should contain %v, found %v", CurrentVersion, userAgent)
+	if !strings.Contains(userAgent, Version) {
+		t.Errorf("NewRequest() User-Agent should contain %v, found %v", Version, userAgent)
 	}
 }
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -507,9 +507,15 @@ func TestNewRequest(t *testing.T) {
 		t.Errorf("NewRequest(%q) Body is %v, want %v", inBody, got, want)
 	}
 
+	userAgent := req.Header.Get("User-Agent")
+
 	// test that default user-agent is attached to the request
-	if got, want := req.Header.Get("User-Agent"), c.UserAgent; got != want {
+	if got, want := userAgent, c.UserAgent; got != want {
 		t.Errorf("NewRequest() User-Agent is %v, want %v", got, want)
+	}
+
+	if !strings.Contains(userAgent, c.PackageVersion) {
+		t.Errorf("NewRequest() User-Agent should contain %v, found %v", c.PackageVersion, userAgent)
 	}
 }
 


### PR DESCRIPTION
👋🏻 Hi there! I'm Tim, and I'm a Product Manager at GitHub. To allow us to better understand how people are using our API, it's super helpful to know what versions of SDKs like `go-github` they are using. 

At the moment, this package sends the `User-Agent` "go-github" in requests, but it doesn't say what version is being used.

This updates the `User-Agent` header to include that information, whilst still maintaining the ability for people to choose their own user agent by setting the `UserAgent` field on `Client`.

It also exports a `Version` constant, so people can use that information - for example to construct custom `User-Agent` headers.

This will mean that someone has to update the `Version` constant with the new version when it is incremented.

This is the first ever Go I've written, so I won't be upset if you tell me that I've done this in a terrible way 😉 

