### PR TITLE
feat: add GetCodeownersErrors to RepositoriesService (#2405)

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2286,54 +2286,6 @@ func (c *CodeOfConduct) GetURL() string {
 	return *c.URL
 }
 
-// GetColumn returns the Column field if it's non-nil, zero value otherwise.
-func (c *CodeownersError) GetColumn() int {
-	if c == nil || c.Column == nil {
-		return 0
-	}
-	return *c.Column
-}
-
-// GetKind returns the Kind field if it's non-nil, zero value otherwise.
-func (c *CodeownersError) GetKind() string {
-	if c == nil || c.Kind == nil {
-		return ""
-	}
-	return *c.Kind
-}
-
-// GetLine returns the Line field if it's non-nil, zero value otherwise.
-func (c *CodeownersError) GetLine() int {
-	if c == nil || c.Line == nil {
-		return 0
-	}
-	return *c.Line
-}
-
-// GetMessage returns the Message field if it's non-nil, zero value otherwise.
-func (c *CodeownersError) GetMessage() string {
-	if c == nil || c.Message == nil {
-		return ""
-	}
-	return *c.Message
-}
-
-// GetPath returns the Path field if it's non-nil, zero value otherwise.
-func (c *CodeownersError) GetPath() string {
-	if c == nil || c.Path == nil {
-		return ""
-	}
-	return *c.Path
-}
-
-// GetSource returns the Source field if it's non-nil, zero value otherwise.
-func (c *CodeownersError) GetSource() string {
-	if c == nil || c.Source == nil {
-		return ""
-	}
-	return *c.Source
-}
-
 // GetSuggestion returns the Suggestion field if it's non-nil, zero value otherwise.
 func (c *CodeownersError) GetSuggestion() string {
 	if c == nil || c.Suggestion == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2286,6 +2286,62 @@ func (c *CodeOfConduct) GetURL() string {
 	return *c.URL
 }
 
+// GetColumn returns the Column field if it's non-nil, zero value otherwise.
+func (c *CodeownersError) GetColumn() int {
+	if c == nil || c.Column == nil {
+		return 0
+	}
+	return *c.Column
+}
+
+// GetKind returns the Kind field if it's non-nil, zero value otherwise.
+func (c *CodeownersError) GetKind() string {
+	if c == nil || c.Kind == nil {
+		return ""
+	}
+	return *c.Kind
+}
+
+// GetLine returns the Line field if it's non-nil, zero value otherwise.
+func (c *CodeownersError) GetLine() int {
+	if c == nil || c.Line == nil {
+		return 0
+	}
+	return *c.Line
+}
+
+// GetMessage returns the Message field if it's non-nil, zero value otherwise.
+func (c *CodeownersError) GetMessage() string {
+	if c == nil || c.Message == nil {
+		return ""
+	}
+	return *c.Message
+}
+
+// GetPath returns the Path field if it's non-nil, zero value otherwise.
+func (c *CodeownersError) GetPath() string {
+	if c == nil || c.Path == nil {
+		return ""
+	}
+	return *c.Path
+}
+
+// GetSource returns the Source field if it's non-nil, zero value otherwise.
+func (c *CodeownersError) GetSource() string {
+	if c == nil || c.Source == nil {
+		return ""
+	}
+	return *c.Source
+}
+
+// GetSuggestion returns the Suggestion field if it's non-nil, zero value otherwise.
+func (c *CodeownersError) GetSuggestion() string {
+	if c == nil || c.Suggestion == nil {
+		return ""
+	}
+	return *c.Suggestion
+}
+
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
 func (c *CodeResult) GetHTMLURL() string {
 	if c == nil || c.HTMLURL == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -2699,6 +2699,76 @@ func TestCodeOfConduct_GetURL(tt *testing.T) {
 	c.GetURL()
 }
 
+func TestCodeownersError_GetColumn(tt *testing.T) {
+	var zeroValue int
+	c := &CodeownersError{Column: &zeroValue}
+	c.GetColumn()
+	c = &CodeownersError{}
+	c.GetColumn()
+	c = nil
+	c.GetColumn()
+}
+
+func TestCodeownersError_GetKind(tt *testing.T) {
+	var zeroValue string
+	c := &CodeownersError{Kind: &zeroValue}
+	c.GetKind()
+	c = &CodeownersError{}
+	c.GetKind()
+	c = nil
+	c.GetKind()
+}
+
+func TestCodeownersError_GetLine(tt *testing.T) {
+	var zeroValue int
+	c := &CodeownersError{Line: &zeroValue}
+	c.GetLine()
+	c = &CodeownersError{}
+	c.GetLine()
+	c = nil
+	c.GetLine()
+}
+
+func TestCodeownersError_GetMessage(tt *testing.T) {
+	var zeroValue string
+	c := &CodeownersError{Message: &zeroValue}
+	c.GetMessage()
+	c = &CodeownersError{}
+	c.GetMessage()
+	c = nil
+	c.GetMessage()
+}
+
+func TestCodeownersError_GetPath(tt *testing.T) {
+	var zeroValue string
+	c := &CodeownersError{Path: &zeroValue}
+	c.GetPath()
+	c = &CodeownersError{}
+	c.GetPath()
+	c = nil
+	c.GetPath()
+}
+
+func TestCodeownersError_GetSource(tt *testing.T) {
+	var zeroValue string
+	c := &CodeownersError{Source: &zeroValue}
+	c.GetSource()
+	c = &CodeownersError{}
+	c.GetSource()
+	c = nil
+	c.GetSource()
+}
+
+func TestCodeownersError_GetSuggestion(tt *testing.T) {
+	var zeroValue string
+	c := &CodeownersError{Suggestion: &zeroValue}
+	c.GetSuggestion()
+	c = &CodeownersError{}
+	c.GetSuggestion()
+	c = nil
+	c.GetSuggestion()
+}
+
 func TestCodeResult_GetHTMLURL(tt *testing.T) {
 	var zeroValue string
 	c := &CodeResult{HTMLURL: &zeroValue}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -2699,66 +2699,6 @@ func TestCodeOfConduct_GetURL(tt *testing.T) {
 	c.GetURL()
 }
 
-func TestCodeownersError_GetColumn(tt *testing.T) {
-	var zeroValue int
-	c := &CodeownersError{Column: &zeroValue}
-	c.GetColumn()
-	c = &CodeownersError{}
-	c.GetColumn()
-	c = nil
-	c.GetColumn()
-}
-
-func TestCodeownersError_GetKind(tt *testing.T) {
-	var zeroValue string
-	c := &CodeownersError{Kind: &zeroValue}
-	c.GetKind()
-	c = &CodeownersError{}
-	c.GetKind()
-	c = nil
-	c.GetKind()
-}
-
-func TestCodeownersError_GetLine(tt *testing.T) {
-	var zeroValue int
-	c := &CodeownersError{Line: &zeroValue}
-	c.GetLine()
-	c = &CodeownersError{}
-	c.GetLine()
-	c = nil
-	c.GetLine()
-}
-
-func TestCodeownersError_GetMessage(tt *testing.T) {
-	var zeroValue string
-	c := &CodeownersError{Message: &zeroValue}
-	c.GetMessage()
-	c = &CodeownersError{}
-	c.GetMessage()
-	c = nil
-	c.GetMessage()
-}
-
-func TestCodeownersError_GetPath(tt *testing.T) {
-	var zeroValue string
-	c := &CodeownersError{Path: &zeroValue}
-	c.GetPath()
-	c = &CodeownersError{}
-	c.GetPath()
-	c = nil
-	c.GetPath()
-}
-
-func TestCodeownersError_GetSource(tt *testing.T) {
-	var zeroValue string
-	c := &CodeownersError{Source: &zeroValue}
-	c.GetSource()
-	c = &CodeownersError{}
-	c.GetSource()
-	c = nil
-	c.GetSource()
-}
-
 func TestCodeownersError_GetSuggestion(tt *testing.T) {
 	var zeroValue string
 	c := &CodeownersError{Suggestion: &zeroValue}

--- a/github/repos_codeowners.go
+++ b/github/repos_codeowners.go
@@ -1,0 +1,41 @@
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// CodeownersErrors represents a list of syntax errors detected in the CODEOWNERS file.
+type CodeownersErrors struct {
+	Errors []*CodeownersError `json:"errors"`
+}
+
+// CodeownersError represents a syntax error detected in the CODEOWNERS file.
+type CodeownersError struct {
+	Line       *int    `json:"line"`
+	Column     *int    `json:"column"`
+	Kind       *string `json:"kind"`
+	Source     *string `json:"source"`
+	Suggestion *string `json:"suggestion"`
+	Message    *string `json:"message"`
+	Path       *string `json:"path"`
+}
+
+// GetCodeownersErrors lists any syntax errors that are detected in the CODEOWNERS file.
+//
+// GitHub API docs: https://docs.github.com/en/rest/repos/repos#list-codeowners-errors
+func (s *RepositoriesService) GetCodeownersErrors(ctx context.Context, owner, repo string) (*CodeownersErrors, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/codeowners/errors", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	codeownersErrors := &CodeownersErrors{}
+	resp, err := s.client.Do(ctx, req, codeownersErrors)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return codeownersErrors, resp, nil
+}

--- a/github/repos_codeowners.go
+++ b/github/repos_codeowners.go
@@ -1,3 +1,8 @@
+// Copyright 2022 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package github
 
 import (

--- a/github/repos_codeowners.go
+++ b/github/repos_codeowners.go
@@ -17,13 +17,13 @@ type CodeownersErrors struct {
 
 // CodeownersError represents a syntax error detected in the CODEOWNERS file.
 type CodeownersError struct {
-	Line       *int    `json:"line"`
-	Column     *int    `json:"column"`
-	Kind       *string `json:"kind"`
-	Source     *string `json:"source"`
-	Suggestion *string `json:"suggestion"`
-	Message    *string `json:"message"`
-	Path       *string `json:"path"`
+	Line       int     `json:"line"`
+	Column     int     `json:"column"`
+	Kind       string  `json:"kind"`
+	Source     string  `json:"source"`
+	Suggestion *string `json:"suggestion,omitempty"`
+	Message    string  `json:"message"`
+	Path       string  `json:"path"`
 }
 
 // GetCodeownersErrors lists any syntax errors that are detected in the CODEOWNERS file.

--- a/github/repos_codeowners_test.go
+++ b/github/repos_codeowners_test.go
@@ -3,9 +3,10 @@ package github
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"net/http"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRepositoriesService_GetCodeownersErrors(t *testing.T) {

--- a/github/repos_codeowners_test.go
+++ b/github/repos_codeowners_test.go
@@ -1,0 +1,104 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"net/http"
+	"testing"
+)
+
+func TestRepositoriesService_GetCodeownersErrors(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/codeowners/errors", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeV3)
+		fmt.Fprint(w, `{
+		  "errors": [
+			{
+			  "line": 1,
+			  "column": 1,
+			  "kind": "Invalid pattern",
+			  "source": "***/*.rb @monalisa",
+			  "suggestion": "Did you mean **/*.rb?",
+			  "message": "Invalid pattern on line 3: Did you mean **/*.rb?\n\n  ***/*.rb @monalisa\n  ^",
+			  "path": ".github/CODEOWNERS"
+			}
+		  ]
+		}
+	`)
+	})
+
+	ctx := context.Background()
+	codeownersErrors, _, err := client.Repositories.GetCodeownersErrors(ctx, "o", "r")
+	if err != nil {
+		t.Errorf("Repositories.GetCodeownersErrors returned error: %v", err)
+	}
+
+	want := &CodeownersErrors{
+		Errors: []*CodeownersError{
+			{
+				Line:       Int(1),
+				Column:     Int(1),
+				Kind:       String("Invalid pattern"),
+				Source:     String("***/*.rb @monalisa"),
+				Suggestion: String("Did you mean **/*.rb?"),
+				Message:    String("Invalid pattern on line 3: Did you mean **/*.rb?\n\n  ***/*.rb @monalisa\n  ^"),
+				Path:       String(".github/CODEOWNERS"),
+			},
+		},
+	}
+	if !cmp.Equal(codeownersErrors, want) {
+		t.Errorf("Repositories.GetCodeownersErrors returned %+v, want %+v", codeownersErrors, want)
+	}
+
+	const methodName = "GetCodeownersErrors"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Repositories.GetCodeownersErrors(ctx, "\n", "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Repositories.GetCodeownersErrors(ctx, "o", "r")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestCodeownersErrors_Marshal(t *testing.T) {
+	testJSONMarshal(t, &CodeownersErrors{}, "{}")
+
+	u := &CodeownersErrors{
+		Errors: []*CodeownersError{
+			{
+				Line:       Int(1),
+				Column:     Int(1),
+				Kind:       String("Invalid pattern"),
+				Source:     String("***/*.rb @monalisa"),
+				Suggestion: String("Did you mean **/*.rb?"),
+				Message:    String("Invalid pattern on line 3: Did you mean **/*.rb?\n\n  ***/*.rb @monalisa\n  ^"),
+				Path:       String(".github/CODEOWNERS"),
+			},
+		},
+	}
+
+	want := `{
+	  "errors": [
+		{
+		  "line": 1,
+		  "column": 1,
+		  "kind": "Invalid pattern",
+		  "source": "***/*.rb @monalisa",
+		  "suggestion": "Did you mean **/*.rb?",
+		  "message": "Invalid pattern on line 3: Did you mean **/*.rb?\n\n  ***/*.rb @monalisa\n  ^",
+		  "path": ".github/CODEOWNERS"
+		}
+	  ]
+	}
+`
+	testJSONMarshal(t, u, want)
+}

--- a/github/repos_codeowners_test.go
+++ b/github/repos_codeowners_test.go
@@ -46,13 +46,13 @@ func TestRepositoriesService_GetCodeownersErrors(t *testing.T) {
 	want := &CodeownersErrors{
 		Errors: []*CodeownersError{
 			{
-				Line:       Int(1),
-				Column:     Int(1),
-				Kind:       String("Invalid pattern"),
-				Source:     String("***/*.rb @monalisa"),
+				Line:       1,
+				Column:     1,
+				Kind:       "Invalid pattern",
+				Source:     "***/*.rb @monalisa",
 				Suggestion: String("Did you mean **/*.rb?"),
-				Message:    String("Invalid pattern on line 3: Did you mean **/*.rb?\n\n  ***/*.rb @monalisa\n  ^"),
-				Path:       String(".github/CODEOWNERS"),
+				Message:    "Invalid pattern on line 3: Did you mean **/*.rb?\n\n  ***/*.rb @monalisa\n  ^",
+				Path:       ".github/CODEOWNERS",
 			},
 		},
 	}
@@ -81,13 +81,13 @@ func TestCodeownersErrors_Marshal(t *testing.T) {
 	u := &CodeownersErrors{
 		Errors: []*CodeownersError{
 			{
-				Line:       Int(1),
-				Column:     Int(1),
-				Kind:       String("Invalid pattern"),
-				Source:     String("***/*.rb @monalisa"),
+				Line:       1,
+				Column:     1,
+				Kind:       "Invalid pattern",
+				Source:     "***/*.rb @monalisa",
 				Suggestion: String("Did you mean **/*.rb?"),
-				Message:    String("Invalid pattern on line 3: Did you mean **/*.rb?\n\n  ***/*.rb @monalisa\n  ^"),
-				Path:       String(".github/CODEOWNERS"),
+				Message:    "Invalid pattern on line 3: Did you mean **/*.rb?\n\n  ***/*.rb @monalisa\n  ^",
+				Path:       ".github/CODEOWNERS",
 			},
 		},
 	}

--- a/github/repos_codeowners_test.go
+++ b/github/repos_codeowners_test.go
@@ -1,3 +1,8 @@
+// Copyright 2022 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package github
 
 import (


### PR DESCRIPTION
This PR adds a new function `GetCodeownersErrors` to the `RepositoriesService` struct.
It adds support for the endpoint https://docs.github.com/en/rest/repos/repos#list-codeowners-errors as described in #2405 