### PR TITLE
Remove omitempty from Content field of RepositoryContentFileOptions

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -51,7 +51,7 @@ type RepositoryContentResponse struct {
 // RepositoryContentFileOptions specifies optional parameters for CreateFile, UpdateFile, and DeleteFile.
 type RepositoryContentFileOptions struct {
 	Message   *string       `json:"message,omitempty"`
-	Content   []byte        `json:"content,omitempty"` // unencoded
+	Content   []byte        `json:"content"` // unencoded
 	SHA       *string       `json:"sha,omitempty"`
 	Branch    *string       `json:"branch,omitempty"`
 	Author    *CommitAuthor `json:"author,omitempty"`


### PR DESCRIPTION
fixes #2427

This removes `omitempty` from `RepositoryContentFileOptions.Content` so that an empty `content` field can be passed in to generate empty files. Before, the `content` field was omitted, which caused the GitHub API to not accept the request as the field is required, even if it is empty.