### PR TITLE
feature: adding api and web to meta api endpoint.

### DIFF
--- a/github/misc.go
+++ b/github/misc.go
@@ -182,8 +182,8 @@ type APIMeta struct {
 	Web []string `json:"web,omitempty"`
 
 	// An array of IP addresses in CIDR format specifying the addresses
-	// which serve GitHub apis.
-	Api []string `json:"api,omitempty"`
+	// which serve GitHub APIs.
+	API []string `json:"api,omitempty"`
 }
 
 // APIMeta returns information about GitHub.com, the service. Or, if you access

--- a/github/misc.go
+++ b/github/misc.go
@@ -176,6 +176,14 @@ type APIMeta struct {
 
 	// An array of SSH keys.
 	SSHKeys []string `json:"ssh_keys,omitempty"`
+
+	// An array of IP addresses in CIDR format specifying the addresses
+	// which serve GitHub websites.
+	Web []string `json:"web,omitempty"`
+
+	// An array of IP addresses in CIDR format specifying the addresses
+	// which serve GitHub apis.
+	Api []string `json:"api,omitempty"`
 }
 
 // APIMeta returns information about GitHub.com, the service. Or, if you access

--- a/github/misc_test.go
+++ b/github/misc_test.go
@@ -190,7 +190,7 @@ func TestAPIMeta_Marshal(t *testing.T) {
 		Dependabot:                       []string{"d"},
 		SSHKeyFingerprints:               map[string]string{"a": "f"},
 		SSHKeys:                          []string{"k"},
-		Api:                              []string{"a"},
+		API:                              []string{"a"},
 		Web:                              []string{"w"},
 	}
 	want := `{
@@ -232,7 +232,7 @@ func TestAPIMeta(t *testing.T) {
 		Importer:   []string{"i"},
 		Actions:    []string{"a"},
 		Dependabot: []string{"d"},
-		Api:        []string{"a"},
+		API:        []string{"a"},
 		Web:        []string{"w"},
 
 		VerifiablePasswordAuthentication: Bool(true),

--- a/github/misc_test.go
+++ b/github/misc_test.go
@@ -190,6 +190,8 @@ func TestAPIMeta_Marshal(t *testing.T) {
 		Dependabot:                       []string{"d"},
 		SSHKeyFingerprints:               map[string]string{"a": "f"},
 		SSHKeys:                          []string{"k"},
+		Api:                              []string{"a"},
+		Web:                              []string{"w"},
 	}
 	want := `{
 		"hooks":["h"],
@@ -200,7 +202,9 @@ func TestAPIMeta_Marshal(t *testing.T) {
 		"actions":["a"],
 		"dependabot":["d"],
 		"ssh_key_fingerprints":{"a":"f"},
-		"ssh_keys":["k"]
+		"ssh_keys":["k"],
+		"api":["a"],
+		"web":["w"]
 	}`
 
 	testJSONMarshal(t, a, want)
@@ -212,7 +216,7 @@ func TestAPIMeta(t *testing.T) {
 
 	mux.HandleFunc("/meta", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"hooks":["h"], "git":["g"], "pages":["p"], "importer":["i"], "actions":["a"], "dependabot":["d"], "verifiable_password_authentication": true}`)
+		fmt.Fprint(w, `{"web":["w"],"api":["a"],"hooks":["h"], "git":["g"], "pages":["p"], "importer":["i"], "actions":["a"], "dependabot":["d"], "verifiable_password_authentication": true}`)
 	})
 
 	ctx := context.Background()
@@ -228,6 +232,8 @@ func TestAPIMeta(t *testing.T) {
 		Importer:   []string{"i"},
 		Actions:    []string{"a"},
 		Dependabot: []string{"d"},
+		Api:        []string{"a"},
+		Web:        []string{"w"},
 
 		VerifiablePasswordAuthentication: Bool(true),
 	}


### PR DESCRIPTION
The Api and Web lists are returned from the `meta` API but still aren't supported in the Go library. This change exposes them in the same way as the other blocks which are returned. I'm working on a change in the GitHub Terraform provider to also support exposing these API/Web CIDRs so if this is all ok I can continue on with that change as well.