### PR TITLE
Bump version of go-github library to v46

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-github #
 
 [![go-github release (latest SemVer)](https://img.shields.io/github/v/release/google/go-github?sort=semver)](https://github.com/google/go-github/releases)
-[![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/google/go-github/v45/github)
+[![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/google/go-github/v46/github)
 [![Test Status](https://github.com/google/go-github/workflows/tests/badge.svg)](https://github.com/google/go-github/actions?query=workflow%3Atests)
 [![Test Coverage](https://codecov.io/gh/google/go-github/branch/master/graph/badge.svg)](https://codecov.io/gh/google/go-github)
 [![Discuss at go-github@googlegroups.com](https://img.shields.io/badge/discuss-go--github%40googlegroups.com-blue.svg)](https://groups.google.com/group/go-github)
@@ -24,7 +24,7 @@ If you're interested in using the [GraphQL API v4][], the recommended library is
 go-github is compatible with modern Go releases in module mode, with Go installed:
 
 ```bash
-go get github.com/google/go-github/v45
+go get github.com/google/go-github/v46
 ```
 
 will resolve and add the package to the current development module, along with its dependencies.
@@ -32,7 +32,7 @@ will resolve and add the package to the current development module, along with i
 Alternatively the same can be achieved if you use import in a package:
 
 ```go
-import "github.com/google/go-github/v45/github"
+import "github.com/google/go-github/v46/github"
 ```
 
 and run `go get` without parameters.
@@ -40,13 +40,13 @@ and run `go get` without parameters.
 Finally, to use the top-of-trunk version of this repo, use the following command:
 
 ```bash
-go get github.com/google/go-github/v45@master
+go get github.com/google/go-github/v46@master
 ```
 
 ## Usage ##
 
 ```go
-import "github.com/google/go-github/v45/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
+import "github.com/google/go-github/v46/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
 import "github.com/google/go-github/github" // with go modules disabled
 ```
 
@@ -135,7 +135,7 @@ import (
 	"net/http"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 )
 
 func main() {
@@ -290,7 +290,7 @@ For complete usage of go-github, see the full [package docs][].
 [oauth2]: https://github.com/golang/oauth2
 [oauth2 docs]: https://godoc.org/golang.org/x/oauth2
 [personal API token]: https://github.com/blog/1509-personal-api-tokens
-[package docs]: https://pkg.go.dev/github.com/google/go-github/v45/github
+[package docs]: https://pkg.go.dev/github.com/google/go-github/v46/github
 [GraphQL API v4]: https://developer.github.com/v4/
 [shurcooL/githubv4]: https://github.com/shurcooL/githubv4
 [GitHub webhook events]: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads

--- a/example/actionpermissions/main.go
+++ b/example/actionpermissions/main.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/appengine/app.go
+++ b/example/appengine/app.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 	"golang.org/x/oauth2"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/log"

--- a/example/basicauth/main.go
+++ b/example/basicauth/main.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 	"golang.org/x/crypto/ssh/terminal"
 )
 

--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -31,7 +31,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,10 +1,10 @@
-module github.com/google/go-github/example
+module github.com/google/go-github/v46/example
 
 go 1.17
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.0.4
-	github.com/google/go-github/v45 v45.0.0
+	github.com/google/go-github/v46 v46.0.0
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 	google.golang.org/appengine v1.6.7
@@ -21,4 +21,4 @@ require (
 )
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v45 => ../
+replace github.com/google/go-github/v46 => ../

--- a/example/go.sum
+++ b/example/go.sum
@@ -7,8 +7,8 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
-github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v41 v41.0.0 h1:HseJrM2JFf2vfiZJ8anY2hqBjdfY1Vlj/K27ueww4gg=
 github.com/google/go-github/v41 v41.0.0/go.mod h1:XgmCA5H323A9rtgExdTcnDkcqp6S30AVACCBDOonIxg=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=

--- a/example/listenvironments/main.go
+++ b/example/listenvironments/main.go
@@ -5,10 +5,11 @@
 
 // listenvironments is an example of how to use ListEnvironments method with EnvironmentListOptions.
 // It's runnable with the following command:
-// 		export GITHUB_TOKEN=your_token
-//		export GITHUB_REPOSITORY_OWNER=your_owner
-//		export GITHUB_REPOSITORY_NAME=your_repo
-//		go run .
+//
+//	export GITHUB_TOKEN=your_token
+//	export GITHUB_REPOSITORY_OWNER=your_owner
+//	export GITHUB_REPOSITORY_NAME=your_repo
+//	go run .
 package main
 
 import (
@@ -17,7 +18,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/migrations/main.go
+++ b/example/migrations/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/newfilewithappauth/main.go
+++ b/example/newfilewithappauth/main.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/newrepo/main.go
+++ b/example/newrepo/main.go
@@ -16,7 +16,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/newreposecretwithlibsodium/go.sum
+++ b/example/newreposecretwithlibsodium/go.sum
@@ -35,7 +35,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoKillers/libsodium-go v0.0.0-20171022220152-dd733721c3cb h1:ilqSFSbR1fq6x88heeHrvAqlg+ES+tZk2ZcaCmiH1gI=
 github.com/GoKillers/libsodium-go v0.0.0-20171022220152-dd733721c3cb/go.mod h1:72TQeEkiDH9QMXZa5nJJvZre0UjqqO67X2QEIoOwCRU=
-github.com/bradleyfalzon/ghinstallation/v2 v2.0.4/go.mod h1:B40qPqJxWE0jDZgOR1JmaMy+4AY1eBP+IByOvqyAKp0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -50,7 +49,6 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -86,12 +84,10 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
-github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
-github.com/google/go-github/v41 v41.0.0/go.mod h1:XgmCA5H323A9rtgExdTcnDkcqp6S30AVACCBDOonIxg=
-github.com/google/go-github/v45 v45.0.0 h1:y+GL7LIsAIF2NZlJ46ZoC/D1W1ivZasT0lnWHMYPZ+U=
-github.com/google/go-github/v45 v45.0.0/go.mod h1:ZkTvvmCXBvsfPpTHXnH/d2hP9Y0cTbvN9kr5xqyXOIc=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v45 v45.0.0 h1:LU0WBjYidxIVyx7PZeWb+FP4JZJ3Wh3FQgdumnGqiLs=
+github.com/google/go-github/v45 v45.0.0/go.mod h1:FObaZJEDSTa/WGCzZ2Z3eoCDXWJKMenWWTrd8jrta28=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -287,7 +283,6 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/example/newreposecretwithlibsodium/main.go
+++ b/example/newreposecretwithlibsodium/main.go
@@ -14,11 +14,13 @@
 // To verify the new secret, navigate to GitHub Repository > Settings > left side options bar > Secrets.
 //
 // Usage:
+//
 //	export GITHUB_AUTH_TOKEN=<auth token from github that has secret create rights>
 //	export SECRET_VARIABLE=<secret value of the secret variable>
 //	go run main.go -owner <owner name> -repo <repository name> SECRET_VARIABLE
 //
 // Example:
+//
 //	export GITHUB_AUTH_TOKEN=0000000000000000
 //	export SECRET_VARIABLE="my-secret"
 //	go run main.go -owner google -repo go-github SECRET_VARIABLE

--- a/example/newreposecretwithxcrypto/main.go
+++ b/example/newreposecretwithxcrypto/main.go
@@ -15,11 +15,13 @@
 // To verify the new secret, navigate to GitHub Repository > Settings > left side options bar > Secrets.
 //
 // Usage:
+//
 //	export GITHUB_AUTH_TOKEN=<auth token from github that has secret create rights>
 //	export SECRET_VARIABLE=<secret value of the secret variable>
 //	go run main.go -owner <owner name> -repo <repository name> SECRET_VARIABLE
 //
 // Example:
+//
 //	export GITHUB_AUTH_TOKEN=0000000000000000
 //	export SECRET_VARIABLE="my-secret"
 //	go run main.go -owner google -repo go-github SECRET_VARIABLE
@@ -34,7 +36,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/oauth2"
 )

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -12,11 +12,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 )
 
 // Fetch all the public organizations' membership of a user.
-//
 func fetchOrganizations(username string) ([]*github.Organization, error) {
 	client := github.NewClient(nil)
 	orgs, _, err := client.Organizations.List(context.Background(), username, nil)

--- a/example/tagprotection/main.go
+++ b/example/tagprotection/main.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/oauth2"
 )

--- a/example/tokenauth/main.go
+++ b/example/tokenauth/main.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"syscall"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/oauth2"
 )

--- a/example/topics/main.go
+++ b/example/topics/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 )
 
 // Fetch and lists all the public topics associated with the specified GitHub topic

--- a/github/activity.go
+++ b/github/activity.go
@@ -45,14 +45,15 @@ type FeedLinks struct {
 // ListFeeds lists all the feeds available to the authenticated user.
 //
 // GitHub provides several timeline resources in Atom format:
-//     Timeline: The GitHub global public timeline
-//     User: The public timeline for any user, using URI template
-//     Current user public: The public timeline for the authenticated user
-//     Current user: The private timeline for the authenticated user
-//     Current user actor: The private timeline for activity created by the
-//         authenticated user
-//     Current user organizations: The private timeline for the organizations
-//         the authenticated user is a member of.
+//
+//	Timeline: The GitHub global public timeline
+//	User: The public timeline for any user, using URI template
+//	Current user public: The public timeline for the authenticated user
+//	Current user: The private timeline for the authenticated user
+//	Current user actor: The private timeline for activity created by the
+//	    authenticated user
+//	Current user organizations: The private timeline for the organizations
+//	    the authenticated user is a member of.
 //
 // Note: Private feeds are only returned when authenticating via Basic Auth
 // since current feed URIs use the older, non revocable auth tokens.

--- a/github/apps.go
+++ b/github/apps.go
@@ -59,8 +59,9 @@ type InstallationTokenOptions struct {
 // InstallationPermissions lists the repository and organization permissions for an installation.
 //
 // Permission names taken from:
-//   https://docs.github.com/en/enterprise-server@3.0/rest/apps#create-an-installation-access-token-for-an-app
-//   https://docs.github.com/en/rest/apps#create-an-installation-access-token-for-an-app
+//
+//	https://docs.github.com/en/enterprise-server@3.0/rest/apps#create-an-installation-access-token-for-an-app
+//	https://docs.github.com/en/rest/apps#create-an-installation-access-token-for-an-app
 type InstallationPermissions struct {
 	Actions                       *string `json:"actions,omitempty"`
 	Administration                *string `json:"administration,omitempty"`

--- a/github/doc.go
+++ b/github/doc.go
@@ -8,7 +8,7 @@ Package github provides a client for using the GitHub API.
 
 Usage:
 
-	import "github.com/google/go-github/v45/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
+	import "github.com/google/go-github/v46/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
 	import "github.com/google/go-github/github"     // with go modules disabled
 
 Construct a new GitHub client, then use the various services on the client to
@@ -38,7 +38,7 @@ can be used as a starting point.
 
 For more sample code snippets, head over to the https://github.com/google/go-github/tree/master/example directory.
 
-Authentication
+# Authentication
 
 The go-github library does not directly handle authentication. Instead, when
 creating a new client, pass an http.Client that can handle authentication for
@@ -110,7 +110,7 @@ To authenticate as an app, using a JWT:
 		// Use client...
 	}
 
-Rate Limiting
+# Rate Limiting
 
 GitHub imposes a rate limit on all API clients. Unauthenticated clients are
 limited to 60 requests per hour, while authenticated clients can make up to
@@ -139,7 +139,7 @@ For secondary rate limits, you can check if its type is *github.AbuseRateLimitEr
 Learn more about GitHub rate limiting at
 https://docs.github.com/en/rest/rate-limit .
 
-Accepted Status
+# Accepted Status
 
 Some endpoints may return a 202 Accepted status code, meaning that the
 information required is not yet ready and was scheduled to be gathered on
@@ -154,7 +154,7 @@ To detect this condition of error, you can check if its type is
 		log.Println("scheduled on GitHub side")
 	}
 
-Conditional Requests
+# Conditional Requests
 
 The GitHub API has good support for conditional requests which will help
 prevent you from burning through your rate limit, as well as help speed up your
@@ -165,7 +165,7 @@ https://github.com/gregjones/httpcache for that.
 Learn more about GitHub conditional requests at
 https://docs.github.com/en/rest/overview/resources-in-the-rest-api#conditional-requests.
 
-Creating and Updating Resources
+# Creating and Updating Resources
 
 All structs for GitHub resources use pointer values for all non-repeated fields.
 This allows distinguishing between unset fields and those set to a zero-value.
@@ -181,7 +181,7 @@ bool, and int values. For example:
 
 Users who have worked with protocol buffers should find this pattern familiar.
 
-Pagination
+# Pagination
 
 All requests for resource collections (repos, pull requests, issues, etc.)
 support pagination. Pagination options are described in the
@@ -208,6 +208,5 @@ github.Response struct.
 		}
 		opt.Page = resp.NextPage
 	}
-
 */
 package github

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 )
 
 func ExampleClient_Markdown() {

--- a/github/github.go
+++ b/github/github.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	Version = "45.2.0"
+	Version = "46.0.0"
 
 	defaultBaseURL   = "https://api.github.com/"
 	defaultUserAgent = "go-github" + "/" + Version
@@ -949,17 +949,17 @@ func sanitizeURL(uri *url.URL) *url.URL {
 An Error reports more details on an individual error in an ErrorResponse.
 These are the possible validation error codes:
 
-    missing:
-        resource does not exist
-    missing_field:
-        a required field on a resource has not been set
-    invalid:
-        the formatting of a field is invalid
-    already_exists:
-        another resource has the same valid as this field
-    custom:
-        some resources return this (e.g. github.User.CreateKey()), additional
-        information is set in the Message field of the Error
+	missing:
+	    resource does not exist
+	missing_field:
+	    a required field on a resource has not been set
+	invalid:
+	    the formatting of a field is invalid
+	already_exists:
+	    another resource has the same valid as this field
+	custom:
+	    some resources return this (e.g. github.User.CreateKey()), additional
+	    information is set in the Message field of the Error
 
 GitHub error responses structure are often undocumented and inconsistent.
 Sometimes error is just a simple string (Issue #540).

--- a/github/messages.go
+++ b/github/messages.go
@@ -157,13 +157,13 @@ func messageMAC(signature string) ([]byte, func() hash.Hash, error) {
 //
 // Example usage:
 //
-//     func (s *GitHubEventMonitor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-//       // read signature from request
-//       signature := ""
-//       payload, err := github.ValidatePayloadFromBody(r.Header.Get("Content-Type"), r.Body, signature, s.webhookSecretKey)
-//       if err != nil { ... }
-//       // Process payload...
-//     }
+//	func (s *GitHubEventMonitor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+//	  // read signature from request
+//	  signature := ""
+//	  payload, err := github.ValidatePayloadFromBody(r.Header.Get("Content-Type"), r.Body, signature, s.webhookSecretKey)
+//	  if err != nil { ... }
+//	  // Process payload...
+//	}
 func ValidatePayloadFromBody(contentType string, readable io.Reader, signature string, secretToken []byte) (payload []byte, err error) {
 	var body []byte // Raw body that GitHub uses to calculate the signature.
 
@@ -221,12 +221,11 @@ func ValidatePayloadFromBody(contentType string, readable io.Reader, signature s
 //
 // Example usage:
 //
-//     func (s *GitHubEventMonitor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-//       payload, err := github.ValidatePayload(r, s.webhookSecretKey)
-//       if err != nil { ... }
-//       // Process payload...
-//     }
-//
+//	func (s *GitHubEventMonitor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+//	  payload, err := github.ValidatePayload(r, s.webhookSecretKey)
+//	  if err != nil { ... }
+//	  // Process payload...
+//	}
 func ValidatePayload(r *http.Request, secretToken []byte) (payload []byte, err error) {
 	signature := r.Header.Get(SHA256SignatureHeader)
 	if signature == "" {
@@ -279,20 +278,19 @@ func DeliveryID(r *http.Request) string {
 //
 // Example usage:
 //
-//     func (s *GitHubEventMonitor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-//       payload, err := github.ValidatePayload(r, s.webhookSecretKey)
-//       if err != nil { ... }
-//       event, err := github.ParseWebHook(github.WebHookType(r), payload)
-//       if err != nil { ... }
-//       switch event := event.(type) {
-//       case *github.CommitCommentEvent:
-//           processCommitCommentEvent(event)
-//       case *github.CreateEvent:
-//           processCreateEvent(event)
-//       ...
-//       }
-//     }
-//
+//	func (s *GitHubEventMonitor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+//	  payload, err := github.ValidatePayload(r, s.webhookSecretKey)
+//	  if err != nil { ... }
+//	  event, err := github.ParseWebHook(github.WebHookType(r), payload)
+//	  if err != nil { ... }
+//	  switch event := event.(type) {
+//	  case *github.CommitCommentEvent:
+//	      processCommitCommentEvent(event)
+//	  case *github.CreateEvent:
+//	      processCreateEvent(event)
+//	  ...
+//	  }
+//	}
 func ParseWebHook(messageType string, payload []byte) (interface{}, error) {
 	eventType, ok := eventTypeMapping[messageType]
 	if !ok {

--- a/github/pulls_reviews.go
+++ b/github/pulls_reviews.go
@@ -193,35 +193,37 @@ func (s *PullRequestsService) ListReviewComments(ctx context.Context, owner, rep
 //
 // In order to use multi-line comments, you must use the "comfort fade" preview.
 // This replaces the use of the "Position" field in comments with 4 new fields:
-//   [Start]Side, and [Start]Line.
+//
+//	[Start]Side, and [Start]Line.
+//
 // These new fields must be used for ALL comments (including single-line),
 // with the following restrictions (empirically observed, so subject to change).
 //
 // For single-line "comfort fade" comments, you must use:
 //
-//    Path:  &path,  // as before
-//    Body:  &body,  // as before
-//    Side:  &"RIGHT" (or "LEFT")
-//    Line:  &123,  // NOT THE SAME AS POSITION, this is an actual line number.
+//	Path:  &path,  // as before
+//	Body:  &body,  // as before
+//	Side:  &"RIGHT" (or "LEFT")
+//	Line:  &123,  // NOT THE SAME AS POSITION, this is an actual line number.
 //
 // If StartSide or StartLine is used with single-line comments, a 422 is returned.
 //
 // For multi-line "comfort fade" comments, you must use:
 //
-//    Path:      &path,  // as before
-//    Body:      &body,  // as before
-//    StartSide: &"RIGHT" (or "LEFT")
-//    Side:      &"RIGHT" (or "LEFT")
-//    StartLine: &120,
-//    Line:      &125,
+//	Path:      &path,  // as before
+//	Body:      &body,  // as before
+//	StartSide: &"RIGHT" (or "LEFT")
+//	Side:      &"RIGHT" (or "LEFT")
+//	StartLine: &120,
+//	Line:      &125,
 //
 // Suggested edits are made by commenting on the lines to replace, and including the
 // suggested edit in a block like this (it may be surrounded in non-suggestion markdown):
 //
-//    ```suggestion
-//    Use this instead.
-//    It is waaaaaay better.
-//    ```
+//	```suggestion
+//	Use this instead.
+//	It is waaaaaay better.
+//	```
 func (s *PullRequestsService) CreateReview(ctx context.Context, owner, repo string, number int, review *PullRequestReviewRequest) (*PullRequestReview, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/reviews", owner, repo, number)
 

--- a/github/repos.go
+++ b/github/repos.go
@@ -725,10 +725,10 @@ func (s *RepositoriesService) ListContributors(ctx context.Context, owner string
 // specifies the languages and the number of bytes of code written in that
 // language. For example:
 //
-//     {
-//       "C": 78769,
-//       "Python": 7769
-//     }
+//	{
+//	  "C": 78769,
+//	  "Python": 7769
+//	}
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#list-repository-languages
 func (s *RepositoriesService) ListLanguages(ctx context.Context, owner string, repo string) (map[string]int, *Response, error) {

--- a/github/scim.go
+++ b/github/scim.go
@@ -38,7 +38,7 @@ type SCIMUserName struct {
 	Formatted  *string `json:"formatted,omitempty"` // (Optional.)
 }
 
-//SCIMUserEmail represents SCIM user email.
+// SCIMUserEmail represents SCIM user email.
 type SCIMUserEmail struct {
 	Value   string  `json:"value"`             // (Required.)
 	Primary *bool   `json:"primary,omitempty"` // (Optional.)

--- a/github/search.go
+++ b/github/search.go
@@ -20,8 +20,10 @@ import (
 // Each method takes a query string defining the search keywords and any search qualifiers.
 // For example, when searching issues, the query "gopher is:issue language:go" will search
 // for issues containing the word "gopher" in Go repositories. The method call
-//   opts :=  &github.SearchOptions{Sort: "created", Order: "asc"}
-//   cl.Search.Issues(ctx, "gopher is:issue language:go", opts)
+//
+//	opts :=  &github.SearchOptions{Sort: "created", Order: "asc"}
+//	cl.Search.Issues(ctx, "gopher is:issue language:go", opts)
+//
 // will search for such issues, sorting by creation date in ascending order
 // (i.e., oldest first).
 //

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v45
+module github.com/google/go-github/v46
 
 require (
 	github.com/google/go-cmp v0.5.8

--- a/test/fields/fields.go
+++ b/test/fields/fields.go
@@ -25,7 +25,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 	"golang.org/x/oauth2"
 )
 

--- a/test/integration/activity_test.go
+++ b/test/integration/activity_test.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 )
 
 const (

--- a/test/integration/authorizations_test.go
+++ b/test/integration/authorizations_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 )
 
 const msgEnvMissing = "Skipping test because the required environment variable (%v) is not present."

--- a/test/integration/github_test.go
+++ b/test/integration/github_test.go
@@ -15,7 +15,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 	"golang.org/x/oauth2"
 )
 

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 )
 
 func TestRepositories_CRUD(t *testing.T) {

--- a/test/integration/users_test.go
+++ b/test/integration/users_test.go
@@ -14,7 +14,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v46/github"
 )
 
 func TestUsers_Get(t *testing.T) {

--- a/update-urls/go.mod
+++ b/update-urls/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/update-urls
+module github.com/google/go-github/v46/update-urls
 
 go 1.16
 

--- a/update-urls/main.go
+++ b/update-urls/main.go
@@ -9,14 +9,16 @@
 // to update stale GitHub Developer v3 API documentation URLs.
 //
 // Usage (from go-github directory):
-//   go run ./update-urls/main.go
-//   go generate ./...
-//   go test ./...
-//   go vet ./...
+//
+//	go run ./update-urls/main.go
+//	go generate ./...
+//	go test ./...
+//	go vet ./...
 //
 // When confronted with "PLEASE CHECK MANUALLY AND FIX", the problematic
 // URL needs to be debugged. To debug a specific file, run like this:
-//   go run ./update-urls/main.go -v -d enterprise_actions_runners.go
+//
+//	go run ./update-urls/main.go -v -d enterprise_actions_runners.go
 package main
 
 import (


### PR DESCRIPTION
This release contains the following breaking API changes:

* #2407
* #2401

and the following additional changes:

* #2395
* #2399
* #2398
* #2411
* #2408
* #2430
* #2427
* #2432
* #2422
* #2429
* #2424
* #2388
* #2392
* #2403
* #2434
* #2435
