### PR TITLE
Bump version of go-github library to v47

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-github #
 
 [![go-github release (latest SemVer)](https://img.shields.io/github/v/release/google/go-github?sort=semver)](https://github.com/google/go-github/releases)
-[![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/google/go-github/v46/github)
+[![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/google/go-github/v47/github)
 [![Test Status](https://github.com/google/go-github/workflows/tests/badge.svg)](https://github.com/google/go-github/actions?query=workflow%3Atests)
 [![Test Coverage](https://codecov.io/gh/google/go-github/branch/master/graph/badge.svg)](https://codecov.io/gh/google/go-github)
 [![Discuss at go-github@googlegroups.com](https://img.shields.io/badge/discuss-go--github%40googlegroups.com-blue.svg)](https://groups.google.com/group/go-github)
@@ -24,7 +24,7 @@ If you're interested in using the [GraphQL API v4][], the recommended library is
 go-github is compatible with modern Go releases in module mode, with Go installed:
 
 ```bash
-go get github.com/google/go-github/v46
+go get github.com/google/go-github/v47
 ```
 
 will resolve and add the package to the current development module, along with its dependencies.
@@ -32,7 +32,7 @@ will resolve and add the package to the current development module, along with i
 Alternatively the same can be achieved if you use import in a package:
 
 ```go
-import "github.com/google/go-github/v46/github"
+import "github.com/google/go-github/v47/github"
 ```
 
 and run `go get` without parameters.
@@ -40,13 +40,13 @@ and run `go get` without parameters.
 Finally, to use the top-of-trunk version of this repo, use the following command:
 
 ```bash
-go get github.com/google/go-github/v46@master
+go get github.com/google/go-github/v47@master
 ```
 
 ## Usage ##
 
 ```go
-import "github.com/google/go-github/v46/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
+import "github.com/google/go-github/v47/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
 import "github.com/google/go-github/github" // with go modules disabled
 ```
 
@@ -135,7 +135,7 @@ import (
 	"net/http"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 )
 
 func main() {
@@ -290,7 +290,7 @@ For complete usage of go-github, see the full [package docs][].
 [oauth2]: https://github.com/golang/oauth2
 [oauth2 docs]: https://godoc.org/golang.org/x/oauth2
 [personal API token]: https://github.com/blog/1509-personal-api-tokens
-[package docs]: https://pkg.go.dev/github.com/google/go-github/v46/github
+[package docs]: https://pkg.go.dev/github.com/google/go-github/v47/github
 [GraphQL API v4]: https://developer.github.com/v4/
 [shurcooL/githubv4]: https://github.com/shurcooL/githubv4
 [GitHub webhook events]: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads

--- a/example/actionpermissions/main.go
+++ b/example/actionpermissions/main.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/appengine/app.go
+++ b/example/appengine/app.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 	"golang.org/x/oauth2"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/log"

--- a/example/basicauth/main.go
+++ b/example/basicauth/main.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 	"golang.org/x/crypto/ssh/terminal"
 )
 

--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -31,7 +31,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,10 +1,10 @@
-module github.com/google/go-github/v46/example
+module github.com/google/go-github/v47/example
 
 go 1.17
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.0.4
-	github.com/google/go-github/v46 v46.0.0
+	github.com/google/go-github/v47 v47.0.0
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 	google.golang.org/appengine v1.6.7
@@ -21,4 +21,4 @@ require (
 )
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v46 => ../
+replace github.com/google/go-github/v47 => ../

--- a/example/listenvironments/main.go
+++ b/example/listenvironments/main.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/migrations/main.go
+++ b/example/migrations/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/newfilewithappauth/main.go
+++ b/example/newfilewithappauth/main.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/newrepo/main.go
+++ b/example/newrepo/main.go
@@ -16,7 +16,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/newreposecretwithlibsodium/go.mod
+++ b/example/newreposecretwithlibsodium/go.mod
@@ -4,9 +4,9 @@ go 1.15
 
 require (
 	github.com/GoKillers/libsodium-go v0.0.0-20171022220152-dd733721c3cb
-	github.com/google/go-github/v46 v46.0.0
+	github.com/google/go-github/v47 v47.0.0
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 )
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v46 => ../..
+replace github.com/google/go-github/v47 => ../..

--- a/example/newreposecretwithlibsodium/main.go
+++ b/example/newreposecretwithlibsodium/main.go
@@ -36,7 +36,7 @@ import (
 	"os"
 
 	sodium "github.com/GoKillers/libsodium-go/cryptobox"
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 	"golang.org/x/oauth2"
 )
 

--- a/example/newreposecretwithxcrypto/main.go
+++ b/example/newreposecretwithxcrypto/main.go
@@ -36,7 +36,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/oauth2"
 )

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 )
 
 // Fetch all the public organizations' membership of a user.

--- a/example/tagprotection/main.go
+++ b/example/tagprotection/main.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/oauth2"
 )

--- a/example/tokenauth/main.go
+++ b/example/tokenauth/main.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"syscall"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/oauth2"
 )

--- a/example/topics/main.go
+++ b/example/topics/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 )
 
 // Fetch and lists all the public topics associated with the specified GitHub topic

--- a/github/doc.go
+++ b/github/doc.go
@@ -8,7 +8,7 @@ Package github provides a client for using the GitHub API.
 
 Usage:
 
-	import "github.com/google/go-github/v46/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
+	import "github.com/google/go-github/v47/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
 	import "github.com/google/go-github/github"     // with go modules disabled
 
 Construct a new GitHub client, then use the various services on the client to

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 )
 
 func ExampleClient_Markdown() {

--- a/github/github.go
+++ b/github/github.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	Version = "46.0.0"
+	Version = "v47.0.0"
 
 	defaultBaseURL   = "https://api.github.com/"
 	defaultUserAgent = "go-github" + "/" + Version

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v46
+module github.com/google/go-github/v47
 
 require (
 	github.com/google/go-cmp v0.5.8

--- a/test/fields/fields.go
+++ b/test/fields/fields.go
@@ -25,7 +25,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 	"golang.org/x/oauth2"
 )
 

--- a/test/integration/activity_test.go
+++ b/test/integration/activity_test.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 )
 
 const (

--- a/test/integration/authorizations_test.go
+++ b/test/integration/authorizations_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 )
 
 const msgEnvMissing = "Skipping test because the required environment variable (%v) is not present."

--- a/test/integration/github_test.go
+++ b/test/integration/github_test.go
@@ -15,7 +15,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 	"golang.org/x/oauth2"
 )
 

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 )
 
 func TestRepositories_CRUD(t *testing.T) {

--- a/test/integration/users_test.go
+++ b/test/integration/users_test.go
@@ -14,7 +14,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/google/go-github/v46/github"
+	"github.com/google/go-github/v47/github"
 )
 
 func TestUsers_Get(t *testing.T) {

--- a/update-urls/go.mod
+++ b/update-urls/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v46/update-urls
+module github.com/google/go-github/v47/update-urls
 
 go 1.16
 


### PR DESCRIPTION
This release contains the following breaking API changes:

* #2417

and the following additional changes:

* #2438
* #2439
* #2397
* #2440
