### PR TITLE
Remove GenerateReleaseNotes from RepositoriesService.EditRelease

### DIFF
--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -26,7 +26,9 @@ type RepositoryRelease struct {
 	Draft                  *bool   `json:"draft,omitempty"`
 	Prerelease             *bool   `json:"prerelease,omitempty"`
 	DiscussionCategoryName *string `json:"discussion_category_name,omitempty"`
-	GenerateReleaseNotes   *bool   `json:"generate_release_notes,omitempty"`
+
+	// The following fields are not used in EditRelease:
+	GenerateReleaseNotes *bool `json:"generate_release_notes,omitempty"`
 
 	// The following fields are not used in CreateRelease or EditRelease:
 	ID          *int64          `json:"id,omitempty"`
@@ -228,7 +230,6 @@ func (s *RepositoriesService) EditRelease(ctx context.Context, owner, repo strin
 		Draft:                  release.Draft,
 		Prerelease:             release.Prerelease,
 		DiscussionCategoryName: release.DiscussionCategoryName,
-		GenerateReleaseNotes:   release.GenerateReleaseNotes,
 	}
 
 	req, err := s.client.NewRequest("PATCH", u, releaseReq)

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -273,20 +273,20 @@ func TestRepositoriesService_EditRelease(t *testing.T) {
 	input := &RepositoryRelease{
 		Name:                   String("n"),
 		DiscussionCategoryName: String("General"),
-		GenerateReleaseNotes:   Bool(true),
 		// Fields to be removed:
-		ID:          Int64(2),
-		CreatedAt:   &Timestamp{referenceTime},
-		PublishedAt: &Timestamp{referenceTime},
-		URL:         String("http://url/"),
-		HTMLURL:     String("http://htmlurl/"),
-		AssetsURL:   String("http://assetsurl/"),
-		Assets:      []*ReleaseAsset{{ID: Int64(5)}},
-		UploadURL:   String("http://uploadurl/"),
-		ZipballURL:  String("http://zipballurl/"),
-		TarballURL:  String("http://tarballurl/"),
-		Author:      &User{Name: String("octocat")},
-		NodeID:      String("nodeid"),
+		GenerateReleaseNotes: Bool(true),
+		ID:                   Int64(2),
+		CreatedAt:            &Timestamp{referenceTime},
+		PublishedAt:          &Timestamp{referenceTime},
+		URL:                  String("http://url/"),
+		HTMLURL:              String("http://htmlurl/"),
+		AssetsURL:            String("http://assetsurl/"),
+		Assets:               []*ReleaseAsset{{ID: Int64(5)}},
+		UploadURL:            String("http://uploadurl/"),
+		ZipballURL:           String("http://zipballurl/"),
+		TarballURL:           String("http://tarballurl/"),
+		Author:               &User{Name: String("octocat")},
+		NodeID:               String("nodeid"),
 	}
 
 	mux.HandleFunc("/repos/o/r/releases/1", func(w http.ResponseWriter, r *http.Request) {
@@ -297,7 +297,6 @@ func TestRepositoriesService_EditRelease(t *testing.T) {
 		want := &repositoryReleaseRequest{
 			Name:                   String("n"),
 			DiscussionCategoryName: String("General"),
-			GenerateReleaseNotes:   Bool(true),
 		}
 		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)


### PR DESCRIPTION
This PR closes #2444 

According to the [GitHub v3 API reference](https://docs.github.com/en/rest/releases/releases#update-a-release),
`generate_release_notes` is not a recognised body parameter of the endpoint to update a release. If provided to
the API, it will have no effect.

This commit removes the setting of this parameter when updating a release, to avoid confusion in the effect of
setting this parameter.