### PR TITLE
Add alphanumeric param to AutolinkOptions

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1374,6 +1374,14 @@ func (a *Autolink) GetID() int64 {
 	return *a.ID
 }
 
+// GetIsAlphanumeric returns the IsAlphanumeric field if it's non-nil, zero value otherwise.
+func (a *Autolink) GetIsAlphanumeric() bool {
+	if a == nil || a.IsAlphanumeric == nil {
+		return false
+	}
+	return *a.IsAlphanumeric
+}
+
 // GetKeyPrefix returns the KeyPrefix field if it's non-nil, zero value otherwise.
 func (a *Autolink) GetKeyPrefix() string {
 	if a == nil || a.KeyPrefix == nil {
@@ -1388,6 +1396,14 @@ func (a *Autolink) GetURLTemplate() string {
 		return ""
 	}
 	return *a.URLTemplate
+}
+
+// GetIsAlphanumeric returns the IsAlphanumeric field if it's non-nil, zero value otherwise.
+func (a *AutolinkOptions) GetIsAlphanumeric() bool {
+	if a == nil || a.IsAlphanumeric == nil {
+		return false
+	}
+	return *a.IsAlphanumeric
 }
 
 // GetKeyPrefix returns the KeyPrefix field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -1640,6 +1640,16 @@ func TestAutolink_GetID(tt *testing.T) {
 	a.GetID()
 }
 
+func TestAutolink_GetIsAlphanumeric(tt *testing.T) {
+	var zeroValue bool
+	a := &Autolink{IsAlphanumeric: &zeroValue}
+	a.GetIsAlphanumeric()
+	a = &Autolink{}
+	a.GetIsAlphanumeric()
+	a = nil
+	a.GetIsAlphanumeric()
+}
+
 func TestAutolink_GetKeyPrefix(tt *testing.T) {
 	var zeroValue string
 	a := &Autolink{KeyPrefix: &zeroValue}
@@ -1658,6 +1668,16 @@ func TestAutolink_GetURLTemplate(tt *testing.T) {
 	a.GetURLTemplate()
 	a = nil
 	a.GetURLTemplate()
+}
+
+func TestAutolinkOptions_GetIsAlphanumeric(tt *testing.T) {
+	var zeroValue bool
+	a := &AutolinkOptions{IsAlphanumeric: &zeroValue}
+	a.GetIsAlphanumeric()
+	a = &AutolinkOptions{}
+	a.GetIsAlphanumeric()
+	a = nil
+	a.GetIsAlphanumeric()
 }
 
 func TestAutolinkOptions_GetKeyPrefix(tt *testing.T) {

--- a/github/repos_autolinks.go
+++ b/github/repos_autolinks.go
@@ -12,15 +12,17 @@ import (
 
 // AutolinkOptions specifies parameters for RepositoriesService.AddAutolink method.
 type AutolinkOptions struct {
-	KeyPrefix   *string `json:"key_prefix,omitempty"`
-	URLTemplate *string `json:"url_template,omitempty"`
+	KeyPrefix      *string `json:"key_prefix,omitempty"`
+	URLTemplate    *string `json:"url_template,omitempty"`
+	IsAlphanumeric *bool   `json:"is_alphanumeric,omitempty"`
 }
 
 // Autolink represents autolinks to external resources like JIRA issues and Zendesk tickets.
 type Autolink struct {
-	ID          *int64  `json:"id,omitempty"`
-	KeyPrefix   *string `json:"key_prefix,omitempty"`
-	URLTemplate *string `json:"url_template,omitempty"`
+	ID             *int64  `json:"id,omitempty"`
+	KeyPrefix      *string `json:"key_prefix,omitempty"`
+	URLTemplate    *string `json:"url_template,omitempty"`
+	IsAlphanumeric *bool   `json:"is_alphanumeric,omitempty"`
 }
 
 // ListAutolinks returns a list of autolinks configured for the given repository.

--- a/github/repos_autolinks_test.go
+++ b/github/repos_autolinks_test.go
@@ -62,7 +62,11 @@ func TestRepositoriesService_AddAutolink(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	opt := &AutolinkOptions{KeyPrefix: String("TICKET-"), URLTemplate: String("https://example.com/TICKET?query=<num>")}
+	opt := &AutolinkOptions{
+		KeyPrefix:      String("TICKET-"),
+		URLTemplate:    String("https://example.com/TICKET?query=<num>"),
+		IsAlphanumeric: Bool(true),
+	}
 	mux.HandleFunc("/repos/o/r/autolinks", func(w http.ResponseWriter, r *http.Request) {
 		v := new(AutolinkOptions)
 		json.NewDecoder(r.Body).Decode(v)
@@ -71,7 +75,13 @@ func TestRepositoriesService_AddAutolink(t *testing.T) {
 			t.Errorf("Request body = %+v, want %+v", v, opt)
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"key_prefix": "TICKET-","url_template": "https://example.com/TICKET?query=<num>"}`))
+		w.Write([]byte(`
+			{
+				"key_prefix": "TICKET-",
+				"url_template": "https://example.com/TICKET?query=<num>",
+				"is_alphanumeric": true
+			}
+		`))
 	})
 	ctx := context.Background()
 	autolink, _, err := client.Repositories.AddAutolink(ctx, "o", "r", opt)
@@ -79,8 +89,9 @@ func TestRepositoriesService_AddAutolink(t *testing.T) {
 		t.Errorf("Repositories.AddAutolink returned error: %v", err)
 	}
 	want := &Autolink{
-		KeyPrefix:   String("TICKET-"),
-		URLTemplate: String("https://example.com/TICKET?query=<num>"),
+		KeyPrefix:      String("TICKET-"),
+		URLTemplate:    String("https://example.com/TICKET?query=<num>"),
+		IsAlphanumeric: Bool(true),
 	}
 
 	if !cmp.Equal(autolink, want) {
@@ -157,13 +168,15 @@ func TestAutolinkOptions_Marshal(t *testing.T) {
 	testJSONMarshal(t, &AutolinkOptions{}, "{}")
 
 	r := &AutolinkOptions{
-		KeyPrefix:   String("kp"),
-		URLTemplate: String("URLT"),
+		KeyPrefix:      String("kp"),
+		URLTemplate:    String("URLT"),
+		IsAlphanumeric: Bool(true),
 	}
 
 	want := `{
 		"key_prefix": "kp",
-		"url_template": "URLT"
+		"url_template": "URLT",
+		"is_alphanumeric": true
 	}`
 
 	testJSONMarshal(t, r, want)
@@ -173,15 +186,17 @@ func TestAutolink_Marshal(t *testing.T) {
 	testJSONMarshal(t, &Autolink{}, "{}")
 
 	r := &Autolink{
-		ID:          Int64(1),
-		KeyPrefix:   String("kp"),
-		URLTemplate: String("URLT"),
+		ID:             Int64(1),
+		KeyPrefix:      String("kp"),
+		URLTemplate:    String("URLT"),
+		IsAlphanumeric: Bool(true),
 	}
 
 	want := `{
 		"id": 1,
 		"key_prefix": "kp",
-		"url_template": "URLT"
+		"url_template": "URLT",
+		"is_alphanumeric": true
 	}`
 
 	testJSONMarshal(t, r, want)

--- a/test/README.md
+++ b/test/README.md
@@ -31,6 +31,10 @@ Run tests using:
 
     GITHUB_AUTH_TOKEN=XXX go test -v -tags=integration ./integration
 
+Some tests create repositories. By default, the new repositories will be owned
+by the user identified by the OAuth token. Set the `GITHUB_OWNER='<GH_OWNER>'`
+environment variable to specify a different owner, such as an organization.
+
 Additionally there are a set of integration tests for the Authorizations API.
 These tests require a GitHub user (username and password), and also that a
 [GitHub Application](https://github.com/settings/applications/new) (with

--- a/test/integration/github_test.go
+++ b/test/integration/github_test.go
@@ -60,6 +60,18 @@ func checkAuth(name string) bool {
 }
 
 func createRandomTestRepository(owner string, autoinit bool) (*github.Repository, error) {
+	// determine the owner to use if one wasn't specified
+	if owner == "" {
+		owner = os.Getenv("GITHUB_OWNER")
+		if owner == "" {
+			me, _, err := client.Users.Get(context.Background(), "")
+			if err != nil {
+				return nil, err
+			}
+			owner = *me.Login
+		}
+	}
+
 	// create random repo name that does not currently exist
 	var repoName string
 	for {
@@ -76,7 +88,14 @@ func createRandomTestRepository(owner string, autoinit bool) (*github.Repository
 	}
 
 	// create the repository
-	repo, _, err := client.Repositories.Create(context.Background(), "", &github.Repository{Name: github.String(repoName), AutoInit: github.Bool(autoinit)})
+	repo, _, err := client.Repositories.Create(
+		context.Background(),
+		owner,
+		&github.Repository{
+			Name:     github.String(repoName),
+			AutoInit: github.Bool(autoinit),
+		},
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/github_test.go
+++ b/test/integration/github_test.go
@@ -39,17 +39,6 @@ func init() {
 		client = github.NewClient(tc)
 		auth = true
 	}
-
-	// Environment variables required for Authorization integration tests
-	vars := []string{envKeyGitHubUsername, envKeyGitHubPassword, envKeyClientID, envKeyClientSecret}
-
-	for _, v := range vars {
-		value := os.Getenv(v)
-		if value == "" {
-			print("!!! " + fmt.Sprintf(msgEnvMissing, v) + " !!!\n\n")
-		}
-	}
-
 }
 
 func checkAuth(name string) bool {

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -24,13 +24,8 @@ func TestRepositories_CRUD(t *testing.T) {
 		return
 	}
 
-	// get authenticated user
-	me, _, err := client.Users.Get(context.Background(), "")
-	if err != nil {
-		t.Fatalf("Users.Get('') returned error: %v", err)
-	}
-
-	repo, err := createRandomTestRepository(*me.Login, false)
+	// create a random repository
+	repo, err := createRandomTestRepository("", true)
 	if err != nil {
 		t.Fatalf("createRandomTestRepository returned error: %v", err)
 	}
@@ -91,13 +86,8 @@ func TestRepositories_EditBranches(t *testing.T) {
 		return
 	}
 
-	// get authenticated user
-	me, _, err := client.Users.Get(context.Background(), "")
-	if err != nil {
-		t.Fatalf("Users.Get('') returned error: %v", err)
-	}
-
-	repo, err := createRandomTestRepository(*me.Login, true)
+	// create a random repository
+	repo, err := createRandomTestRepository("", true)
 	if err != nil {
 		t.Fatalf("createRandomTestRepository returned error: %v", err)
 	}

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -188,3 +188,37 @@ func TestRepositories_DownloadReleaseAsset(t *testing.T) {
 		t.Fatalf("Repositories.DownloadReleaseAsset(andersjanmyr, goose, 484892, true) returned error: %v", err)
 	}
 }
+
+func TestRepositories_Autolinks(t *testing.T) {
+	if !checkAuth("TestRepositories_Autolinks") {
+		return
+	}
+
+	// create a random repository
+	repo, err := createRandomTestRepository("", true)
+	if err != nil {
+		t.Fatalf("createRandomTestRepository returned error: %v", err)
+	}
+
+	opts := &github.AutolinkOptions{
+		KeyPrefix:      github.String("TICKET-"),
+		URLTemplate:    github.String("https://example.com/TICKET?query=<num>"),
+		IsAlphanumeric: github.Bool(false),
+	}
+
+	actionlink, _, err := client.Repositories.AddAutolink(context.Background(), *repo.Owner.Login, *repo.Name, opts)
+	if err != nil {
+		t.Fatalf("Repositories.AddAutolink() returned error: %v", err)
+	}
+
+	if !cmp.Equal(actionlink.KeyPrefix, opts.KeyPrefix) ||
+		!cmp.Equal(actionlink.URLTemplate, opts.URLTemplate) ||
+		!cmp.Equal(actionlink.IsAlphanumeric, opts.IsAlphanumeric) {
+		t.Errorf("Repositories.AddAutolink() returned %+v, want %+v", actionlink, opts)
+	}
+
+	_, err = client.Repositories.Delete(context.Background(), *repo.Owner.Login, *repo.Name)
+	if err != nil {
+		t.Fatalf("Repositories.Delete() returned error: %v", err)
+	}
+}


### PR DESCRIPTION
### Summary

Resolves #2449

### Changes

* Adds `IsAlphanumeric` param to `AutolinkOptions` and `Autolink` structs of `github/repos_autolinks.go`
* Adds unit and integration tests for creating and getting autolinks for a repo
* Updates the `createRandomTestRepository` function in `test/integration/github_test.go` to look up the owner to create the repo under if a name isn't specified explicitly. Checks `GITHUB_OWNER` env var else falls back to user the oauth token belongs to.
* Removes redundant env var check from `init` function of `test/integration/github_test.go` because those checks already occur in the `test/integration/authorizations_test.go` file as needed. This made it easier for me to run integrations tests without setting env vars that weren't needed.

### Tests

* `github/repos_autolinks_test.go`
* `test/integration/repos_test.go`

#### Created an alphanumeric autolink

![image](https://user-images.githubusercontent.com/4142577/187864526-ca6cebbb-95d8-4f76-b821-7d900123fc27.png)

#### Created a numeric autolink

![image](https://user-images.githubusercontent.com/4142577/187864539-41991892-193f-4f3d-8fd2-4d3ad650a7d8.png)
