### PR TITLE
Escape special characters in ref name for update ref

### DIFF
--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -142,7 +142,7 @@ func (s *GitService) CreateRef(ctx context.Context, owner string, repo string, r
 // GitHub API docs: https://docs.github.com/en/rest/git/refs#update-a-reference
 func (s *GitService) UpdateRef(ctx context.Context, owner string, repo string, ref *Reference, force bool) (*Reference, *Response, error) {
 	refPath := strings.TrimPrefix(*ref.Ref, "refs/")
-	u := fmt.Sprintf("repos/%v/%v/git/refs/%v", owner, repo, refPath)
+	u := fmt.Sprintf("repos/%v/%v/git/refs/%v", owner, repo, refURLEscape(refPath))
 	req, err := s.client.NewRequest("PATCH", u, &updateRefRequest{
 		SHA:   ref.Object.SHA,
 		Force: &force,


### PR DESCRIPTION
Closes #2453 

Most of the functions that deal with refs make sure to escape the special characters within the ref's name. The `UpdateRef` function doesn't seem to call the function that does this substitution of special characters with their encodings. This PR solves this problem and should now successfully patch remote refs if the `GetRef` function says the corresponding ref exists.