### PR TITLE
Add org struct fields

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9430,6 +9430,14 @@ func (o *OAuthAPP) GetURL() string {
 	return *o.URL
 }
 
+// GetAdvancedSecurityEnabledForNewRepos returns the AdvancedSecurityEnabledForNewRepos field if it's non-nil, zero value otherwise.
+func (o *Organization) GetAdvancedSecurityEnabledForNewRepos() bool {
+	if o == nil || o.AdvancedSecurityEnabledForNewRepos == nil {
+		return false
+	}
+	return *o.AdvancedSecurityEnabledForNewRepos
+}
+
 // GetAvatarURL returns the AvatarURL field if it's non-nil, zero value otherwise.
 func (o *Organization) GetAvatarURL() string {
 	if o == nil || o.AvatarURL == nil {
@@ -9492,6 +9500,30 @@ func (o *Organization) GetDefaultRepoSettings() string {
 		return ""
 	}
 	return *o.DefaultRepoSettings
+}
+
+// GetDependabotAlertsEnabledForNewRepos returns the DependabotAlertsEnabledForNewRepos field if it's non-nil, zero value otherwise.
+func (o *Organization) GetDependabotAlertsEnabledForNewRepos() bool {
+	if o == nil || o.DependabotAlertsEnabledForNewRepos == nil {
+		return false
+	}
+	return *o.DependabotAlertsEnabledForNewRepos
+}
+
+// GetDependabotSecurityUpdatesEnabledForNewRepos returns the DependabotSecurityUpdatesEnabledForNewRepos field if it's non-nil, zero value otherwise.
+func (o *Organization) GetDependabotSecurityUpdatesEnabledForNewRepos() bool {
+	if o == nil || o.DependabotSecurityUpdatesEnabledForNewRepos == nil {
+		return false
+	}
+	return *o.DependabotSecurityUpdatesEnabledForNewRepos
+}
+
+// GetDependencyGraphEnabledForNewRepos returns the DependencyGraphEnabledForNewRepos field if it's non-nil, zero value otherwise.
+func (o *Organization) GetDependencyGraphEnabledForNewRepos() bool {
+	if o == nil || o.DependencyGraphEnabledForNewRepos == nil {
+		return false
+	}
+	return *o.DependencyGraphEnabledForNewRepos
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
@@ -9766,6 +9798,22 @@ func (o *Organization) GetReposURL() string {
 	return *o.ReposURL
 }
 
+// GetSecretScanningEnabledForNewRepos returns the SecretScanningEnabledForNewRepos field if it's non-nil, zero value otherwise.
+func (o *Organization) GetSecretScanningEnabledForNewRepos() bool {
+	if o == nil || o.SecretScanningEnabledForNewRepos == nil {
+		return false
+	}
+	return *o.SecretScanningEnabledForNewRepos
+}
+
+// GetSecretScanningPushProtectionEnabledForNewRepos returns the SecretScanningPushProtectionEnabledForNewRepos field if it's non-nil, zero value otherwise.
+func (o *Organization) GetSecretScanningPushProtectionEnabledForNewRepos() bool {
+	if o == nil || o.SecretScanningPushProtectionEnabledForNewRepos == nil {
+		return false
+	}
+	return *o.SecretScanningPushProtectionEnabledForNewRepos
+}
+
 // GetTotalPrivateRepos returns the TotalPrivateRepos field if it's non-nil, zero value otherwise.
 func (o *Organization) GetTotalPrivateRepos() int {
 	if o == nil || o.TotalPrivateRepos == nil {
@@ -9812,6 +9860,14 @@ func (o *Organization) GetURL() string {
 		return ""
 	}
 	return *o.URL
+}
+
+// GetWebCommitSignoffRequired returns the WebCommitSignoffRequired field if it's non-nil, zero value otherwise.
+func (o *Organization) GetWebCommitSignoffRequired() bool {
+	if o == nil || o.WebCommitSignoffRequired == nil {
+		return false
+	}
+	return *o.WebCommitSignoffRequired
 }
 
 // GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11041,6 +11041,16 @@ func TestOAuthAPP_GetURL(tt *testing.T) {
 	o.GetURL()
 }
 
+func TestOrganization_GetAdvancedSecurityEnabledForNewRepos(tt *testing.T) {
+	var zeroValue bool
+	o := &Organization{AdvancedSecurityEnabledForNewRepos: &zeroValue}
+	o.GetAdvancedSecurityEnabledForNewRepos()
+	o = &Organization{}
+	o.GetAdvancedSecurityEnabledForNewRepos()
+	o = nil
+	o.GetAdvancedSecurityEnabledForNewRepos()
+}
+
 func TestOrganization_GetAvatarURL(tt *testing.T) {
 	var zeroValue string
 	o := &Organization{AvatarURL: &zeroValue}
@@ -11119,6 +11129,36 @@ func TestOrganization_GetDefaultRepoSettings(tt *testing.T) {
 	o.GetDefaultRepoSettings()
 	o = nil
 	o.GetDefaultRepoSettings()
+}
+
+func TestOrganization_GetDependabotAlertsEnabledForNewRepos(tt *testing.T) {
+	var zeroValue bool
+	o := &Organization{DependabotAlertsEnabledForNewRepos: &zeroValue}
+	o.GetDependabotAlertsEnabledForNewRepos()
+	o = &Organization{}
+	o.GetDependabotAlertsEnabledForNewRepos()
+	o = nil
+	o.GetDependabotAlertsEnabledForNewRepos()
+}
+
+func TestOrganization_GetDependabotSecurityUpdatesEnabledForNewRepos(tt *testing.T) {
+	var zeroValue bool
+	o := &Organization{DependabotSecurityUpdatesEnabledForNewRepos: &zeroValue}
+	o.GetDependabotSecurityUpdatesEnabledForNewRepos()
+	o = &Organization{}
+	o.GetDependabotSecurityUpdatesEnabledForNewRepos()
+	o = nil
+	o.GetDependabotSecurityUpdatesEnabledForNewRepos()
+}
+
+func TestOrganization_GetDependencyGraphEnabledForNewRepos(tt *testing.T) {
+	var zeroValue bool
+	o := &Organization{DependencyGraphEnabledForNewRepos: &zeroValue}
+	o.GetDependencyGraphEnabledForNewRepos()
+	o = &Organization{}
+	o.GetDependencyGraphEnabledForNewRepos()
+	o = nil
+	o.GetDependencyGraphEnabledForNewRepos()
 }
 
 func TestOrganization_GetDescription(tt *testing.T) {
@@ -11458,6 +11498,26 @@ func TestOrganization_GetReposURL(tt *testing.T) {
 	o.GetReposURL()
 }
 
+func TestOrganization_GetSecretScanningEnabledForNewRepos(tt *testing.T) {
+	var zeroValue bool
+	o := &Organization{SecretScanningEnabledForNewRepos: &zeroValue}
+	o.GetSecretScanningEnabledForNewRepos()
+	o = &Organization{}
+	o.GetSecretScanningEnabledForNewRepos()
+	o = nil
+	o.GetSecretScanningEnabledForNewRepos()
+}
+
+func TestOrganization_GetSecretScanningPushProtectionEnabledForNewRepos(tt *testing.T) {
+	var zeroValue bool
+	o := &Organization{SecretScanningPushProtectionEnabledForNewRepos: &zeroValue}
+	o.GetSecretScanningPushProtectionEnabledForNewRepos()
+	o = &Organization{}
+	o.GetSecretScanningPushProtectionEnabledForNewRepos()
+	o = nil
+	o.GetSecretScanningPushProtectionEnabledForNewRepos()
+}
+
 func TestOrganization_GetTotalPrivateRepos(tt *testing.T) {
 	var zeroValue int
 	o := &Organization{TotalPrivateRepos: &zeroValue}
@@ -11516,6 +11576,16 @@ func TestOrganization_GetURL(tt *testing.T) {
 	o.GetURL()
 	o = nil
 	o.GetURL()
+}
+
+func TestOrganization_GetWebCommitSignoffRequired(tt *testing.T) {
+	var zeroValue bool
+	o := &Organization{WebCommitSignoffRequired: &zeroValue}
+	o.GetWebCommitSignoffRequired()
+	o = &Organization{}
+	o.GetWebCommitSignoffRequired()
+	o = nil
+	o.GetWebCommitSignoffRequired()
 }
 
 func TestOrganizationCustomRepoRoles_GetTotalCount(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -997,15 +997,22 @@ func TestOrganization_String(t *testing.T) {
 		MembersCanCreatePages:                Bool(false),
 		MembersCanCreatePublicPages:          Bool(false),
 		MembersCanCreatePrivatePages:         Bool(false),
-		URL:                                  String(""),
-		EventsURL:                            String(""),
-		HooksURL:                             String(""),
-		IssuesURL:                            String(""),
-		MembersURL:                           String(""),
-		PublicMembersURL:                     String(""),
-		ReposURL:                             String(""),
+		WebCommitSignoffRequired:             Bool(false),
+		AdvancedSecurityEnabledForNewRepos:   Bool(false),
+		DependabotAlertsEnabledForNewRepos:   Bool(false),
+		DependabotSecurityUpdatesEnabledForNewRepos:    Bool(false),
+		DependencyGraphEnabledForNewRepos:              Bool(false),
+		SecretScanningEnabledForNewRepos:               Bool(false),
+		SecretScanningPushProtectionEnabledForNewRepos: Bool(false),
+		URL:              String(""),
+		EventsURL:        String(""),
+		HooksURL:         String(""),
+		IssuesURL:        String(""),
+		MembersURL:       String(""),
+		PublicMembersURL: String(""),
+		ReposURL:         String(""),
 	}
-	want := `github.Organization{Login:"", ID:0, NodeID:"", AvatarURL:"", HTMLURL:"", Name:"", Company:"", Blog:"", Location:"", Email:"", TwitterUsername:"", Description:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, BillingEmail:"", Type:"", Plan:github.Plan{}, TwoFactorRequirementEnabled:false, IsVerified:false, HasOrganizationProjects:false, HasRepositoryProjects:false, DefaultRepoPermission:"", DefaultRepoSettings:"", MembersCanCreateRepos:false, MembersCanCreatePublicRepos:false, MembersCanCreatePrivateRepos:false, MembersCanCreateInternalRepos:false, MembersCanForkPrivateRepos:false, MembersAllowedRepositoryCreationType:"", MembersCanCreatePages:false, MembersCanCreatePublicPages:false, MembersCanCreatePrivatePages:false, URL:"", EventsURL:"", HooksURL:"", IssuesURL:"", MembersURL:"", PublicMembersURL:"", ReposURL:""}`
+	want := `github.Organization{Login:"", ID:0, NodeID:"", AvatarURL:"", HTMLURL:"", Name:"", Company:"", Blog:"", Location:"", Email:"", TwitterUsername:"", Description:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, BillingEmail:"", Type:"", Plan:github.Plan{}, TwoFactorRequirementEnabled:false, IsVerified:false, HasOrganizationProjects:false, HasRepositoryProjects:false, DefaultRepoPermission:"", DefaultRepoSettings:"", MembersCanCreateRepos:false, MembersCanCreatePublicRepos:false, MembersCanCreatePrivateRepos:false, MembersCanCreateInternalRepos:false, MembersCanForkPrivateRepos:false, MembersAllowedRepositoryCreationType:"", MembersCanCreatePages:false, MembersCanCreatePublicPages:false, MembersCanCreatePrivatePages:false, WebCommitSignoffRequired:false, AdvancedSecurityEnabledForNewRepos:false, DependabotAlertsEnabledForNewRepos:false, DependabotSecurityUpdatesEnabledForNewRepos:false, DependencyGraphEnabledForNewRepos:false, SecretScanningEnabledForNewRepos:false, SecretScanningPushProtectionEnabledForNewRepos:false, URL:"", EventsURL:"", HooksURL:"", IssuesURL:"", MembersURL:"", PublicMembersURL:"", ReposURL:""}`
 	if got := v.String(); got != want {
 		t.Errorf("Organization.String = %v, want %v", got, want)
 	}

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -82,6 +82,20 @@ type Organization struct {
 	MembersCanCreatePublicPages *bool `json:"members_can_create_public_pages,omitempty"`
 	// MembersCanCreatePrivatePages toggles whether organization members can create private GitHub Pages sites.
 	MembersCanCreatePrivatePages *bool `json:"members_can_create_private_pages,omitempty"`
+	// WebCommitSignoffRequire toggles
+	WebCommitSignoffRequired *bool `json:"web_commit_signoff_required,omitempty"`
+	// AdvancedSecurityAuditLogEnabled toggles whether the advanced security audit log is enabled.
+	AdvancedSecurityEnabledForNewRepos *bool `json:"advanced_security_enabled_for_new_repositories,omitempty"`
+	// DependabotAlertsEnabled toggles whether dependabot alerts are enabled.
+	DependabotAlertsEnabledForNewRepos *bool `json:"dependabot_alerts_enabled_for_new_repositories,omitempty"`
+	// DependabotSecurityUpdatesEnabled toggles whether dependabot security updates are enabled.
+	DependabotSecurityUpdatesEnabledForNewRepos *bool `json:"dependabot_security_updates_enabled_for_new_repositories,omitempty"`
+	// DependabotGraphEnabledForNewRepos toggles whether dependabot graph is enabled on new repositories.
+	DependencyGraphEnabledForNewRepos *bool `json:"dependency_graph_enabled_for_new_repositories,omitempty"`
+	// SecretScanningEnabled toggles whether secret scanning is enabled on new repositories.
+	SecretScanningEnabledForNewRepos *bool `json:"secret_scanning_enabled_for_new_repositories,omitempty"`
+	// SecretScanningPushProtectionEnabledForNewRepos toggles whether secret scanning push protection is enabled on new repositories.
+	SecretScanningPushProtectionEnabledForNewRepos *bool `json:"secret_scanning_push_protection_enabled_for_new_repositories,omitempty"`
 
 	// API URLs
 	URL              *string `json:"url,omitempty"`


### PR DESCRIPTION
The [update an organization](https://docs.github.com/en/rest/orgs/orgs#update-an-organization) API has additional configurable fields that the Organization struct does not support:

WebCommitSignoffRequired
AdvancedSecurityEnabledForNewRepos
DependabotAlertsEnabledForNewRepos
DependabotSecurityUpdatesEnabledForNewRepos
DependencyGraphEnabledForNewRepos
SecretScanningEnabledForNewRepos
SecretScanningPushProtectionEnabledForNewRepos

Proposing adding these fields to enable them to be configurable with Organization.Edit