### PR TITLE
Return proper responses for SCIM provisioned identities

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -16582,6 +16582,62 @@ func (s *ScanningAnalysis) GetWarning() string {
 	return *s.Warning
 }
 
+// GetCreated returns the Created field if it's non-nil, zero value otherwise.
+func (s *SCIMMeta) GetCreated() Timestamp {
+	if s == nil || s.Created == nil {
+		return Timestamp{}
+	}
+	return *s.Created
+}
+
+// GetLastModified returns the LastModified field if it's non-nil, zero value otherwise.
+func (s *SCIMMeta) GetLastModified() Timestamp {
+	if s == nil || s.LastModified == nil {
+		return Timestamp{}
+	}
+	return *s.LastModified
+}
+
+// GetLocation returns the Location field if it's non-nil, zero value otherwise.
+func (s *SCIMMeta) GetLocation() string {
+	if s == nil || s.Location == nil {
+		return ""
+	}
+	return *s.Location
+}
+
+// GetResourceType returns the ResourceType field if it's non-nil, zero value otherwise.
+func (s *SCIMMeta) GetResourceType() string {
+	if s == nil || s.ResourceType == nil {
+		return ""
+	}
+	return *s.ResourceType
+}
+
+// GetItemsPerPage returns the ItemsPerPage field if it's non-nil, zero value otherwise.
+func (s *SCIMProvisionedIdentities) GetItemsPerPage() int {
+	if s == nil || s.ItemsPerPage == nil {
+		return 0
+	}
+	return *s.ItemsPerPage
+}
+
+// GetStartIndex returns the StartIndex field if it's non-nil, zero value otherwise.
+func (s *SCIMProvisionedIdentities) GetStartIndex() int {
+	if s == nil || s.StartIndex == nil {
+		return 0
+	}
+	return *s.StartIndex
+}
+
+// GetTotalResults returns the TotalResults field if it's non-nil, zero value otherwise.
+func (s *SCIMProvisionedIdentities) GetTotalResults() int {
+	if s == nil || s.TotalResults == nil {
+		return 0
+	}
+	return *s.TotalResults
+}
+
 // GetActive returns the Active field if it's non-nil, zero value otherwise.
 func (s *SCIMUserAttributes) GetActive() bool {
 	if s == nil || s.Active == nil {
@@ -16604,6 +16660,22 @@ func (s *SCIMUserAttributes) GetExternalID() string {
 		return ""
 	}
 	return *s.ExternalID
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (s *SCIMUserAttributes) GetID() string {
+	if s == nil || s.ID == nil {
+		return ""
+	}
+	return *s.ID
+}
+
+// GetMeta returns the Meta field.
+func (s *SCIMUserAttributes) GetMeta() *SCIMMeta {
+	if s == nil {
+		return nil
+	}
+	return s.Meta
 }
 
 // GetPrimary returns the Primary field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -19351,6 +19351,76 @@ func TestScanningAnalysis_GetWarning(tt *testing.T) {
 	s.GetWarning()
 }
 
+func TestSCIMMeta_GetCreated(tt *testing.T) {
+	var zeroValue Timestamp
+	s := &SCIMMeta{Created: &zeroValue}
+	s.GetCreated()
+	s = &SCIMMeta{}
+	s.GetCreated()
+	s = nil
+	s.GetCreated()
+}
+
+func TestSCIMMeta_GetLastModified(tt *testing.T) {
+	var zeroValue Timestamp
+	s := &SCIMMeta{LastModified: &zeroValue}
+	s.GetLastModified()
+	s = &SCIMMeta{}
+	s.GetLastModified()
+	s = nil
+	s.GetLastModified()
+}
+
+func TestSCIMMeta_GetLocation(tt *testing.T) {
+	var zeroValue string
+	s := &SCIMMeta{Location: &zeroValue}
+	s.GetLocation()
+	s = &SCIMMeta{}
+	s.GetLocation()
+	s = nil
+	s.GetLocation()
+}
+
+func TestSCIMMeta_GetResourceType(tt *testing.T) {
+	var zeroValue string
+	s := &SCIMMeta{ResourceType: &zeroValue}
+	s.GetResourceType()
+	s = &SCIMMeta{}
+	s.GetResourceType()
+	s = nil
+	s.GetResourceType()
+}
+
+func TestSCIMProvisionedIdentities_GetItemsPerPage(tt *testing.T) {
+	var zeroValue int
+	s := &SCIMProvisionedIdentities{ItemsPerPage: &zeroValue}
+	s.GetItemsPerPage()
+	s = &SCIMProvisionedIdentities{}
+	s.GetItemsPerPage()
+	s = nil
+	s.GetItemsPerPage()
+}
+
+func TestSCIMProvisionedIdentities_GetStartIndex(tt *testing.T) {
+	var zeroValue int
+	s := &SCIMProvisionedIdentities{StartIndex: &zeroValue}
+	s.GetStartIndex()
+	s = &SCIMProvisionedIdentities{}
+	s.GetStartIndex()
+	s = nil
+	s.GetStartIndex()
+}
+
+func TestSCIMProvisionedIdentities_GetTotalResults(tt *testing.T) {
+	var zeroValue int
+	s := &SCIMProvisionedIdentities{TotalResults: &zeroValue}
+	s.GetTotalResults()
+	s = &SCIMProvisionedIdentities{}
+	s.GetTotalResults()
+	s = nil
+	s.GetTotalResults()
+}
+
 func TestSCIMUserAttributes_GetActive(tt *testing.T) {
 	var zeroValue bool
 	s := &SCIMUserAttributes{Active: &zeroValue}
@@ -19379,6 +19449,23 @@ func TestSCIMUserAttributes_GetExternalID(tt *testing.T) {
 	s.GetExternalID()
 	s = nil
 	s.GetExternalID()
+}
+
+func TestSCIMUserAttributes_GetID(tt *testing.T) {
+	var zeroValue string
+	s := &SCIMUserAttributes{ID: &zeroValue}
+	s.GetID()
+	s = &SCIMUserAttributes{}
+	s.GetID()
+	s = nil
+	s.GetID()
+}
+
+func TestSCIMUserAttributes_GetMeta(tt *testing.T) {
+	s := &SCIMUserAttributes{}
+	s.GetMeta()
+	s = nil
+	s.GetMeta()
 }
 
 func TestSCIMUserEmail_GetPrimary(tt *testing.T) {

--- a/github/scim.go
+++ b/github/scim.go
@@ -112,10 +112,12 @@ func (s *SCIMService) ProvisionAndInviteSCIMUser(ctx context.Context, org string
 	if err != nil {
 		return nil, err
 	}
+
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	return s.client.Do(ctx, req, nil)
 }
 
@@ -147,10 +149,12 @@ func (s *SCIMService) UpdateProvisionedOrgMembership(ctx context.Context, org, s
 	if err != nil {
 		return nil, err
 	}
+
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	return s.client.Do(ctx, req, nil)
 }
 
@@ -178,10 +182,12 @@ func (s *SCIMService) UpdateAttributeForSCIMUser(ctx context.Context, org, scimU
 	if err != nil {
 		return nil, err
 	}
+
 	req, err := s.client.NewRequest("PATCH", u, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	return s.client.Do(ctx, req, nil)
 }
 
@@ -194,5 +200,6 @@ func (s *SCIMService) DeleteSCIMUserFromOrg(ctx context.Context, org, scimUserID
 	if err != nil {
 		return nil, err
 	}
+
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/scim.go
+++ b/github/scim.go
@@ -88,15 +88,18 @@ func (s *SCIMService) ListSCIMProvisionedIdentities(ctx context.Context, org str
 	if err != nil {
 		return nil, nil, err
 	}
+
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	identities := new(SCIMProvisionedIdentities)
 	resp, err := s.client.Do(ctx, req, identities)
 	if err != nil {
 		return nil, resp, err
 	}
+
 	return identities, resp, nil
 }
 
@@ -125,11 +128,13 @@ func (s *SCIMService) GetSCIMProvisioningInfoForUser(ctx context.Context, org, s
 	if err != nil {
 		return nil, nil, err
 	}
+
 	user := new(SCIMUserAttributes)
 	resp, err := s.client.Do(ctx, req, &user)
 	if err != nil {
 		return nil, resp, err
 	}
+
 	return user, resp, nil
 }
 

--- a/github/scim.go
+++ b/github/scim.go
@@ -29,6 +29,9 @@ type SCIMUserAttributes struct {
 	ExternalID  *string          `json:"externalId,omitempty"`  // (Optional.)
 	Groups      []string         `json:"groups,omitempty"`      // (Optional.)
 	Active      *bool            `json:"active,omitempty"`      // (Optional.)
+	// Only populated as a result of calling ListSCIMProvisionedIdentitiesOptions or GetSCIMProvisioningInfoForUser:
+	ID   *string   `json:"id,omitempty"`
+	Meta *SCIMMeta `json:"meta,omitempty"`
 }
 
 // SCIMUserName represents SCIM user information.
@@ -43,6 +46,23 @@ type SCIMUserEmail struct {
 	Value   string  `json:"value"`             // (Required.)
 	Primary *bool   `json:"primary,omitempty"` // (Optional.)
 	Type    *string `json:"type,omitempty"`    // (Optional.)
+}
+
+// SCIMMeta represents metadata about the SCIM resource.
+type SCIMMeta struct {
+	ResourceType *string    `json:"resourceType,omitempty"`
+	Created      *Timestamp `json:"created,omitempty"`
+	LastModified *Timestamp `json:"lastModified,omitempty"`
+	Location     *string    `json:"location,omitempty"`
+}
+
+// SCIMProvisionedIdentities represents the result of calling ListSCIMProvisionedIdentities.
+type SCIMProvisionedIdentities struct {
+	Schemas      []string              `json:"schemas,omitempty"`
+	TotalResults *int                  `json:"totalResults,omitempty"`
+	ItemsPerPage *int                  `json:"itemsPerPage,omitempty"`
+	StartIndex   *int                  `json:"startIndex,omitempty"`
+	Resources    []*SCIMUserAttributes `json:"Resources,omitempty"`
 }
 
 // ListSCIMProvisionedIdentitiesOptions represents options for ListSCIMProvisionedIdentities.
@@ -62,17 +82,22 @@ type ListSCIMProvisionedIdentitiesOptions struct {
 // ListSCIMProvisionedIdentities lists SCIM provisioned identities.
 //
 // GitHub API docs: https://docs.github.com/en/rest/scim#list-scim-provisioned-identities
-func (s *SCIMService) ListSCIMProvisionedIdentities(ctx context.Context, org string, opts *ListSCIMProvisionedIdentitiesOptions) (*Response, error) {
+func (s *SCIMService) ListSCIMProvisionedIdentities(ctx context.Context, org string, opts *ListSCIMProvisionedIdentitiesOptions) (*SCIMProvisionedIdentities, *Response, error) {
 	u := fmt.Sprintf("scim/v2/organizations/%v/Users", org)
 	u, err := addOptions(u, opts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	identities := new(SCIMProvisionedIdentities)
+	resp, err := s.client.Do(ctx, req, identities)
+	if err != nil {
+		return nil, resp, err
+	}
+	return identities, resp, nil
 }
 
 // ProvisionAndInviteSCIMUser provisions organization membership for a user, and sends an activation email to the email address.
@@ -94,13 +119,18 @@ func (s *SCIMService) ProvisionAndInviteSCIMUser(ctx context.Context, org string
 // GetSCIMProvisioningInfoForUser returns SCIM provisioning information for a user.
 //
 // GitHub API docs: https://docs.github.com/en/rest/scim#supported-scim-user-attributes
-func (s *SCIMService) GetSCIMProvisioningInfoForUser(ctx context.Context, org, scimUserID string) (*Response, error) {
+func (s *SCIMService) GetSCIMProvisioningInfoForUser(ctx context.Context, org, scimUserID string) (*SCIMUserAttributes, *Response, error) {
 	u := fmt.Sprintf("scim/v2/organizations/%v/Users/%v", org, scimUserID)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	user := new(SCIMUserAttributes)
+	resp, err := s.client.Do(ctx, req, &user)
+	if err != nil {
+		return nil, resp, err
+	}
+	return user, resp, nil
 }
 
 // UpdateProvisionedOrgMembership updates a provisioned organization membership.


### PR DESCRIPTION
This PR adds return responses to `ListSCIMProvisionedIdentities` and `GetSCIMProvisioningInfoForUser`, as before it was not possible to get the output of those calls.
Fixes https://github.com/google/go-github/issues/2338