### PR TITLE
Add SecretScanningPushProtection field to SecurityAndAnalysis struct

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -16894,6 +16894,14 @@ func (s *SecretScanningAlertUpdateOptions) GetState() string {
 	return *s.State
 }
 
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (s *SecretScanningPushProtection) GetStatus() string {
+	if s == nil || s.Status == nil {
+		return ""
+	}
+	return *s.Status
+}
+
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
 func (s *SecurityAdvisory) GetDescription() string {
 	if s == nil || s.Description == nil {
@@ -16980,6 +16988,14 @@ func (s *SecurityAndAnalysis) GetSecretScanning() *SecretScanning {
 		return nil
 	}
 	return s.SecretScanning
+}
+
+// GetSecretScanningPushProtection returns the SecretScanningPushProtection field.
+func (s *SecurityAndAnalysis) GetSecretScanningPushProtection() *SecretScanningPushProtection {
+	if s == nil {
+		return nil
+	}
+	return s.SecretScanningPushProtection
 }
 
 // GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -19717,6 +19717,16 @@ func TestSecretScanningAlertUpdateOptions_GetState(tt *testing.T) {
 	s.GetState()
 }
 
+func TestSecretScanningPushProtection_GetStatus(tt *testing.T) {
+	var zeroValue string
+	s := &SecretScanningPushProtection{Status: &zeroValue}
+	s.GetStatus()
+	s = &SecretScanningPushProtection{}
+	s.GetStatus()
+	s = nil
+	s.GetStatus()
+}
+
 func TestSecurityAdvisory_GetDescription(tt *testing.T) {
 	var zeroValue string
 	s := &SecurityAdvisory{Description: &zeroValue}
@@ -19816,6 +19826,13 @@ func TestSecurityAndAnalysis_GetSecretScanning(tt *testing.T) {
 	s.GetSecretScanning()
 	s = nil
 	s.GetSecretScanning()
+}
+
+func TestSecurityAndAnalysis_GetSecretScanningPushProtection(tt *testing.T) {
+	s := &SecurityAndAnalysis{}
+	s.GetSecretScanningPushProtection()
+	s = nil
+	s.GetSecretScanningPushProtection()
 }
 
 func TestSelectedReposList_GetTotalCount(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1726,10 +1726,11 @@ func TestSecretScanning_String(t *testing.T) {
 
 func TestSecurityAndAnalysis_String(t *testing.T) {
 	v := SecurityAndAnalysis{
-		AdvancedSecurity: &AdvancedSecurity{},
-		SecretScanning:   &SecretScanning{},
+		AdvancedSecurity:             &AdvancedSecurity{},
+		SecretScanning:               &SecretScanning{},
+		SecretScanningPushProtection: &SecretScanningPushProtection{},
 	}
-	want := `github.SecurityAndAnalysis{AdvancedSecurity:github.AdvancedSecurity{}, SecretScanning:github.SecretScanning{}}`
+	want := `github.SecurityAndAnalysis{AdvancedSecurity:github.AdvancedSecurity{}, SecretScanning:github.SecretScanning{}, SecretScanningPushProtection:github.SecretScanningPushProtection{}}`
 	if got := v.String(); got != want {
 		t.Errorf("SecurityAndAnalysis.String = %v, want %v", got, want)
 	}

--- a/github/repos.go
+++ b/github/repos.go
@@ -205,8 +205,9 @@ type RepositoryListOptions struct {
 // SecurityAndAnalysis specifies the optional advanced security features
 // that are enabled on a given repository.
 type SecurityAndAnalysis struct {
-	AdvancedSecurity *AdvancedSecurity `json:"advanced_security,omitempty"`
-	SecretScanning   *SecretScanning   `json:"secret_scanning,omitempty"`
+	AdvancedSecurity             *AdvancedSecurity             `json:"advanced_security,omitempty"`
+	SecretScanning               *SecretScanning               `json:"secret_scanning,omitempty"`
+	SecretScanningPushProtection *SecretScanningPushProtection `json:"secret_scanning_push_protection,omitempty"`
 }
 
 func (s SecurityAndAnalysis) String() string {
@@ -233,6 +234,13 @@ type SecretScanning struct {
 
 func (s SecretScanning) String() string {
 	return Stringify(s)
+}
+
+// SecretScanningPushProtection specifies the state of secret scanning push protection on a repository.
+//
+// Github API docs: https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning#about-secret-scanning-for-partner-patterns
+type SecretScanningPushProtection struct {
+	Status *string `json:"status,omitempty"`
 }
 
 // List the repositories for a user. Passing the empty string will list

--- a/github/repos.go
+++ b/github/repos.go
@@ -238,7 +238,7 @@ func (s SecretScanning) String() string {
 
 // SecretScanningPushProtection specifies the state of secret scanning push protection on a repository.
 //
-// Github API docs: https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning#about-secret-scanning-for-partner-patterns
+// GitHub API docs: https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning#about-secret-scanning-for-partner-patterns
 type SecretScanningPushProtection struct {
 	Status *string `json:"status,omitempty"`
 }

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -360,7 +360,7 @@ func TestRepositoriesService_Get(t *testing.T) {
 	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		fmt.Fprint(w, `{"id":1,"name":"n","description":"d","owner":{"login":"l"},"license":{"key":"mit"},"security_and_analysis":{"advanced_security":{"status":"enabled"},"secret_scanning":{"status":"enabled"}}}`)
+		fmt.Fprint(w, `{"id":1,"name":"n","description":"d","owner":{"login":"l"},"license":{"key":"mit"},"security_and_analysis":{"advanced_security":{"status":"enabled"},"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"}}}`)
 	})
 
 	ctx := context.Background()
@@ -369,7 +369,7 @@ func TestRepositoriesService_Get(t *testing.T) {
 		t.Errorf("Repositories.Get returned error: %v", err)
 	}
 
-	want := &Repository{ID: Int64(1), Name: String("n"), Description: String("d"), Owner: &User{Login: String("l")}, License: &License{Key: String("mit")}, SecurityAndAnalysis: &SecurityAndAnalysis{AdvancedSecurity: &AdvancedSecurity{Status: String("enabled")}, SecretScanning: &SecretScanning{String("enabled")}}}
+	want := &Repository{ID: Int64(1), Name: String("n"), Description: String("d"), Owner: &User{Login: String("l")}, License: &License{Key: String("mit")}, SecurityAndAnalysis: &SecurityAndAnalysis{AdvancedSecurity: &AdvancedSecurity{Status: String("enabled")}, SecretScanning: &SecretScanning{String("enabled")}, SecretScanningPushProtection: &SecretScanningPushProtection{String("enabled")}}}
 	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.Get returned %+v, want %+v", got, want)
 	}


### PR DESCRIPTION
The [Update a repository](https://docs.github.com/en/rest/repos/repos#update-a-repository) endpoint in the GitHub API has added an additional field to the security and analysis object to configure secret scanning push protection for a repository. Proposing adding additional fields in SecurityAndAnalysis struct to support configuration with Repositories.Edit
Closes:
#2475