### PR TITLE
Add support for User SSH signing keys

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Beyang Liu <beyang.liu@gmail.com>
 Billy Keyes <bluekeyes@gmail.com>
 Billy Lynch <wlynch92@gmail.com>
 Björn Häuser <b.haeuser@rebuy.de>
+Bjorn Neergaard <bjorn@neersighted.com>
 boljen <bol.christophe@gmail.com>
 Brad Harris <bmharris@gmail.com>
 Brad Moylan <moylan.brad@gmail.com>

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -17230,6 +17230,38 @@ func (s *SourceImportAuthor) GetURL() string {
 	return *s.URL
 }
 
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (s *SSHSigningKey) GetCreatedAt() Timestamp {
+	if s == nil || s.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *s.CreatedAt
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (s *SSHSigningKey) GetID() int64 {
+	if s == nil || s.ID == nil {
+		return 0
+	}
+	return *s.ID
+}
+
+// GetKey returns the Key field if it's non-nil, zero value otherwise.
+func (s *SSHSigningKey) GetKey() string {
+	if s == nil || s.Key == nil {
+		return ""
+	}
+	return *s.Key
+}
+
+// GetTitle returns the Title field if it's non-nil, zero value otherwise.
+func (s *SSHSigningKey) GetTitle() string {
+	if s == nil || s.Title == nil {
+		return ""
+	}
+	return *s.Title
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (s *StarEvent) GetAction() string {
 	if s == nil || s.Action == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -20116,6 +20116,46 @@ func TestSourceImportAuthor_GetURL(tt *testing.T) {
 	s.GetURL()
 }
 
+func TestSSHSigningKey_GetCreatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	s := &SSHSigningKey{CreatedAt: &zeroValue}
+	s.GetCreatedAt()
+	s = &SSHSigningKey{}
+	s.GetCreatedAt()
+	s = nil
+	s.GetCreatedAt()
+}
+
+func TestSSHSigningKey_GetID(tt *testing.T) {
+	var zeroValue int64
+	s := &SSHSigningKey{ID: &zeroValue}
+	s.GetID()
+	s = &SSHSigningKey{}
+	s.GetID()
+	s = nil
+	s.GetID()
+}
+
+func TestSSHSigningKey_GetKey(tt *testing.T) {
+	var zeroValue string
+	s := &SSHSigningKey{Key: &zeroValue}
+	s.GetKey()
+	s = &SSHSigningKey{}
+	s.GetKey()
+	s = nil
+	s.GetKey()
+}
+
+func TestSSHSigningKey_GetTitle(tt *testing.T) {
+	var zeroValue string
+	s := &SSHSigningKey{Title: &zeroValue}
+	s.GetTitle()
+	s = &SSHSigningKey{}
+	s.GetTitle()
+	s = nil
+	s.GetTitle()
+}
+
 func TestStarEvent_GetAction(tt *testing.T) {
 	var zeroValue string
 	s := &StarEvent{Action: &zeroValue}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1714,6 +1714,19 @@ func TestRepositoryRelease_String(t *testing.T) {
 	}
 }
 
+func TestSSHSigningKey_String(t *testing.T) {
+	v := SSHSigningKey{
+		ID:        Int64(0),
+		Key:       String(""),
+		Title:     String(""),
+		CreatedAt: &Timestamp{},
+	}
+	want := `github.SSHSigningKey{ID:0, Key:"", Title:"", CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}`
+	if got := v.String(); got != want {
+		t.Errorf("SSHSigningKey.String = %v, want %v", got, want)
+	}
+}
+
 func TestSecretScanning_String(t *testing.T) {
 	v := SecretScanning{
 		Status: String(""),

--- a/github/users_ssh_signing_keys.go
+++ b/github/users_ssh_signing_keys.go
@@ -1,0 +1,108 @@
+// Copyright 2022 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// SSHSigningKey represents a public SSH key used to sign git commits.
+type SSHSigningKey struct {
+	ID        *int64     `json:"id,omitempty"`
+	Key       *string    `json:"key,omitempty"`
+	Title     *string    `json:"title,omitempty"`
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
+}
+
+func (k SSHSigningKey) String() string {
+	return Stringify(k)
+}
+
+// ListSSHSigningKeys lists the SSH signing keys for a user. Passing an empty
+// username string will fetch SSH signing keys for the authenticated user.
+//
+// GitHub API docs: https://docs.github.com/en/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-the-authenticated-user
+// GitHub API docs: https://docs.github.com/en/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-a-user
+func (s *UsersService) ListSSHSigningKeys(ctx context.Context, user string, opts *ListOptions) ([]*SSHSigningKey, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/ssh_signing_keys", user)
+	} else {
+		u = "user/ssh_signing_keys"
+	}
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var keys []*SSHSigningKey
+	resp, err := s.client.Do(ctx, req, &keys)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return keys, resp, nil
+}
+
+// GetSSHSigningKey fetches a single SSH signing key for the authenticated user.
+//
+// GitHub API docs: https://docs.github.com/en/rest/users/ssh-signing-keys#get-an-ssh-signing-key-for-the-authenticated-user
+func (s *UsersService) GetSSHSigningKey(ctx context.Context, id int64) (*SSHSigningKey, *Response, error) {
+	u := fmt.Sprintf("user/ssh_signing_keys/%v", id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	key := new(SSHSigningKey)
+	resp, err := s.client.Do(ctx, req, key)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return key, resp, nil
+}
+
+// CreateSSHSigningKey adds a SSH signing key for the authenticated user.
+//
+// GitHub API docs: https://docs.github.com/en/rest/users/ssh-signing-keys#create-a-ssh-signing-key-for-the-authenticated-user
+func (s *UsersService) CreateSSHSigningKey(ctx context.Context, key *Key) (*SSHSigningKey, *Response, error) {
+	u := "user/ssh_signing_keys"
+
+	req, err := s.client.NewRequest("POST", u, key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	k := new(SSHSigningKey)
+	resp, err := s.client.Do(ctx, req, k)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return k, resp, nil
+}
+
+// DeleteKey deletes a SSH signing key for the authenticated user.
+//
+// GitHub API docs: https://docs.github.com/en/rest/users/ssh-signing-keys#delete-an-ssh-signing-key-for-the-authenticated-user
+func (s *UsersService) DeleteSSHSigningKey(ctx context.Context, id int64) (*Response, error) {
+	u := fmt.Sprintf("user/ssh_signing_keys/%v", id)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/users_ssh_signing_keys_test.go
+++ b/github/users_ssh_signing_keys_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013 The go-github AUTHORS. All rights reserved.
+// Copyright 2022 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
@@ -15,11 +15,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestUsersService_ListKeys_authenticatedUser(t *testing.T) {
+func TestUsersService_ListSSHSigningKeys_authenticatedUser(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/user/keys", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/ssh_signing_keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
@@ -27,24 +27,24 @@ func TestUsersService_ListKeys_authenticatedUser(t *testing.T) {
 
 	opt := &ListOptions{Page: 2}
 	ctx := context.Background()
-	keys, _, err := client.Users.ListKeys(ctx, "", opt)
+	keys, _, err := client.Users.ListSSHSigningKeys(ctx, "", opt)
 	if err != nil {
-		t.Errorf("Users.ListKeys returned error: %v", err)
+		t.Errorf("Users.ListSSHSigningKeys returned error: %v", err)
 	}
 
-	want := []*Key{{ID: Int64(1)}}
+	want := []*SSHSigningKey{{ID: Int64(1)}}
 	if !cmp.Equal(keys, want) {
-		t.Errorf("Users.ListKeys returned %+v, want %+v", keys, want)
+		t.Errorf("Users.ListSSHSigningKeys returned %+v, want %+v", keys, want)
 	}
 
-	const methodName = "ListKeys"
+	const methodName = "ListSSHSigningKeys"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Users.ListKeys(ctx, "\n", opt)
+		_, _, err = client.Users.ListSSHSigningKeys(ctx, "\n", opt)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Users.ListKeys(ctx, "", opt)
+		got, resp, err := client.Users.ListSSHSigningKeys(ctx, "", opt)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -52,64 +52,64 @@ func TestUsersService_ListKeys_authenticatedUser(t *testing.T) {
 	})
 }
 
-func TestUsersService_ListKeys_specifiedUser(t *testing.T) {
+func TestUsersService_ListSSHSigningKeys_specifiedUser(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/users/u/keys", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/users/u/ssh_signing_keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
 	ctx := context.Background()
-	keys, _, err := client.Users.ListKeys(ctx, "u", nil)
+	keys, _, err := client.Users.ListSSHSigningKeys(ctx, "u", nil)
 	if err != nil {
-		t.Errorf("Users.ListKeys returned error: %v", err)
+		t.Errorf("Users.ListSSHSigningKeys returned error: %v", err)
 	}
 
-	want := []*Key{{ID: Int64(1)}}
+	want := []*SSHSigningKey{{ID: Int64(1)}}
 	if !cmp.Equal(keys, want) {
-		t.Errorf("Users.ListKeys returned %+v, want %+v", keys, want)
+		t.Errorf("Users.ListSSHSigningKeys returned %+v, want %+v", keys, want)
 	}
 }
 
-func TestUsersService_ListKeys_invalidUser(t *testing.T) {
+func TestUsersService_ListSSHSigningKeys_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
 	ctx := context.Background()
-	_, _, err := client.Users.ListKeys(ctx, "%", nil)
+	_, _, err := client.Users.ListSSHSigningKeys(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
-func TestUsersService_GetKey(t *testing.T) {
+func TestUsersService_GetSSHSigningKey(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/user/keys/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/ssh_signing_keys/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
 	ctx := context.Background()
-	key, _, err := client.Users.GetKey(ctx, 1)
+	key, _, err := client.Users.GetSSHSigningKey(ctx, 1)
 	if err != nil {
-		t.Errorf("Users.GetKey returned error: %v", err)
+		t.Errorf("Users.GetSSHSigningKey returned error: %v", err)
 	}
 
-	want := &Key{ID: Int64(1)}
+	want := &SSHSigningKey{ID: Int64(1)}
 	if !cmp.Equal(key, want) {
-		t.Errorf("Users.GetKey returned %+v, want %+v", key, want)
+		t.Errorf("Users.GetSSHSigningKey returned %+v, want %+v", key, want)
 	}
 
-	const methodName = "GetKey"
+	const methodName = "GetSSHSigningKey"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Users.GetKey(ctx, -1)
+		_, _, err = client.Users.GetSSHSigningKey(ctx, -1)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Users.GetKey(ctx, 1)
+		got, resp, err := client.Users.GetSSHSigningKey(ctx, 1)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -117,13 +117,13 @@ func TestUsersService_GetKey(t *testing.T) {
 	})
 }
 
-func TestUsersService_CreateKey(t *testing.T) {
+func TestUsersService_CreateSSHSigningKey(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
 	input := &Key{Key: String("k"), Title: String("t")}
 
-	mux.HandleFunc("/user/keys", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/ssh_signing_keys", func(w http.ResponseWriter, r *http.Request) {
 		v := new(Key)
 		json.NewDecoder(r.Body).Decode(v)
 
@@ -136,14 +136,14 @@ func TestUsersService_CreateKey(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	key, _, err := client.Users.CreateKey(ctx, input)
+	key, _, err := client.Users.CreateSSHSigningKey(ctx, input)
 	if err != nil {
-		t.Errorf("Users.CreateKey returned error: %v", err)
+		t.Errorf("Users.CreateSSHSigningKey returned error: %v", err)
 	}
 
-	want := &Key{ID: Int64(1)}
+	want := &SSHSigningKey{ID: Int64(1)}
 	if !cmp.Equal(key, want) {
-		t.Errorf("Users.CreateKey returned %+v, want %+v", key, want)
+		t.Errorf("Users.CreateSSHSigningKey returned %+v, want %+v", key, want)
 	}
 
 	const methodName = "CreateKey"
@@ -156,51 +156,45 @@ func TestUsersService_CreateKey(t *testing.T) {
 	})
 }
 
-func TestUsersService_DeleteKey(t *testing.T) {
+func TestUsersService_DeleteSSHSigningKey(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/user/keys/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/ssh_signing_keys/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
 	ctx := context.Background()
-	_, err := client.Users.DeleteKey(ctx, 1)
+	_, err := client.Users.DeleteSSHSigningKey(ctx, 1)
 	if err != nil {
-		t.Errorf("Users.DeleteKey returned error: %v", err)
+		t.Errorf("Users.DeleteSSHSigningKey returned error: %v", err)
 	}
 
-	const methodName = "DeleteKey"
+	const methodName = "DeleteSSHSigningKey"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Users.DeleteKey(ctx, -1)
+		_, err = client.Users.DeleteSSHSigningKey(ctx, -1)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Users.DeleteKey(ctx, 1)
+		return client.Users.DeleteSSHSigningKey(ctx, 1)
 	})
 }
 
-func TestKey_Marshal(t *testing.T) {
-	testJSONMarshal(t, &Key{}, "{}")
+func TestSSHSigningKey_Marshal(t *testing.T) {
+	testJSONMarshal(t, &SSHSigningKey{}, "{}")
 
 	u := &Key{
 		ID:        Int64(1),
 		Key:       String("abc"),
-		URL:       String("url"),
 		Title:     String("title"),
-		ReadOnly:  Bool(true),
-		Verified:  Bool(true),
 		CreatedAt: &Timestamp{referenceTime},
 	}
 
 	want := `{
 		"id": 1,
 		"key": "abc",
-		"url": "url",
 		"title": "title",
-		"read_only": true,
-		"verified": true,
 		"created_at": ` + referenceTimeStr + `
 	}`
 


### PR DESCRIPTION
Introduce support for the new [SSH signing key endpoints](https://docs.github.com/en/rest/users/ssh-signing-keys) introduced into the REST API with the [introduction of SSH commit verification](https://github.blog/changelog/2022-08-23-ssh-commit-verification-now-supported/).
