### PR TITLE
Update ProtectionChanges to contain the remaining possible return values

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1375,7 +1375,7 @@ func (a *AuthorizationUpdateRequest) GetNoteURL() string {
 }
 
 // GetFrom returns the From field if it's non-nil, zero value otherwise.
-func (a *AuthorizedActorsOnlyChanges) GetFrom() bool {
+func (a *AuthorizedActorsOnly) GetFrom() bool {
 	if a == nil || a.From == nil {
 		return false
 	}
@@ -11871,7 +11871,7 @@ func (p *ProtectionChanges) GetAllowDeletionsEnforcementLevel() *AllowDeletionsE
 }
 
 // GetAuthorizedActorNames returns the AuthorizedActorNames field.
-func (p *ProtectionChanges) GetAuthorizedActorNames() *AuthorizedActorNamesChanges {
+func (p *ProtectionChanges) GetAuthorizedActorNames() *AuthorizedActorNames {
 	if p == nil {
 		return nil
 	}
@@ -11879,7 +11879,7 @@ func (p *ProtectionChanges) GetAuthorizedActorNames() *AuthorizedActorNamesChang
 }
 
 // GetAuthorizedActorsOnly returns the AuthorizedActorsOnly field.
-func (p *ProtectionChanges) GetAuthorizedActorsOnly() *AuthorizedActorsOnlyChanges {
+func (p *ProtectionChanges) GetAuthorizedActorsOnly() *AuthorizedActorsOnly {
 	if p == nil {
 		return nil
 	}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -86,6 +86,14 @@ func (a *ActionsPermissionsRepository) GetSelectedActionsURL() string {
 	return *a.SelectedActionsURL
 }
 
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (a *AdminEnforcedChanges) GetFrom() bool {
+	if a == nil || a.From == nil {
+		return false
+	}
+	return *a.From
+}
+
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
 func (a *AdminEnforcement) GetURL() string {
 	if a == nil || a.URL == nil {
@@ -412,6 +420,14 @@ func (a *Alert) GetURL() string {
 		return ""
 	}
 	return *a.URL
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (a *AllowDeletionsEnforcementLevelChanges) GetFrom() string {
+	if a == nil || a.From == nil {
+		return ""
+	}
+	return *a.From
 }
 
 // GetRef returns the Ref field if it's non-nil, zero value otherwise.
@@ -1359,7 +1375,15 @@ func (a *AuthorizationUpdateRequest) GetNoteURL() string {
 }
 
 // GetFrom returns the From field if it's non-nil, zero value otherwise.
-func (a *AuthorizedActorsOnly) GetFrom() bool {
+func (a *AuthorizedActorsOnlyChanges) GetFrom() bool {
+	if a == nil || a.From == nil {
+		return false
+	}
+	return *a.From
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (a *AuthorizedDismissalActorsOnlyChanges) GetFrom() bool {
 	if a == nil || a.From == nil {
 		return false
 	}
@@ -3542,6 +3566,14 @@ func (c *CreateOrgInvitationOptions) GetRole() string {
 	return *c.Role
 }
 
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (c *CreateProtectedChanges) GetFrom() bool {
+	if c == nil || c.From == nil {
+		return false
+	}
+	return *c.From
+}
+
 // GetAllowsPublicRepositories returns the AllowsPublicRepositories field if it's non-nil, zero value otherwise.
 func (c *CreateRunnerGroupRequest) GetAllowsPublicRepositories() bool {
 	if c == nil || c.AllowsPublicRepositories == nil {
@@ -4532,6 +4564,14 @@ func (d *DismissedReview) GetState() string {
 		return ""
 	}
 	return *d.State
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (d *DismissStaleReviewsOnPushChanges) GetFrom() bool {
+	if d == nil || d.From == nil {
+		return false
+	}
+	return *d.From
 }
 
 // GetClientPayload returns the ClientPayload field if it's non-nil, zero value otherwise.
@@ -8174,6 +8214,14 @@ func (l *License) GetURL() string {
 	return *l.URL
 }
 
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (l *LinearHistoryRequirementEnforcementLevelChanges) GetFrom() string {
+	if l == nil || l.From == nil {
+		return ""
+	}
+	return *l.From
+}
+
 // GetAppID returns the AppID field if it's non-nil, zero value otherwise.
 func (l *ListCheckRunsOptions) GetAppID() int64 {
 	if l == nil || l.AppID == nil {
@@ -11806,8 +11854,24 @@ func (p *Protection) GetRestrictions() *BranchRestrictions {
 	return p.Restrictions
 }
 
+// GetAdminEnforced returns the AdminEnforced field.
+func (p *ProtectionChanges) GetAdminEnforced() *AdminEnforcedChanges {
+	if p == nil {
+		return nil
+	}
+	return p.AdminEnforced
+}
+
+// GetAllowDeletionsEnforcementLevel returns the AllowDeletionsEnforcementLevel field.
+func (p *ProtectionChanges) GetAllowDeletionsEnforcementLevel() *AllowDeletionsEnforcementLevelChanges {
+	if p == nil {
+		return nil
+	}
+	return p.AllowDeletionsEnforcementLevel
+}
+
 // GetAuthorizedActorNames returns the AuthorizedActorNames field.
-func (p *ProtectionChanges) GetAuthorizedActorNames() *AuthorizedActorNames {
+func (p *ProtectionChanges) GetAuthorizedActorNames() *AuthorizedActorNamesChanges {
 	if p == nil {
 		return nil
 	}
@@ -11815,11 +11879,99 @@ func (p *ProtectionChanges) GetAuthorizedActorNames() *AuthorizedActorNames {
 }
 
 // GetAuthorizedActorsOnly returns the AuthorizedActorsOnly field.
-func (p *ProtectionChanges) GetAuthorizedActorsOnly() *AuthorizedActorsOnly {
+func (p *ProtectionChanges) GetAuthorizedActorsOnly() *AuthorizedActorsOnlyChanges {
 	if p == nil {
 		return nil
 	}
 	return p.AuthorizedActorsOnly
+}
+
+// GetAuthorizedDismissalActorsOnly returns the AuthorizedDismissalActorsOnly field.
+func (p *ProtectionChanges) GetAuthorizedDismissalActorsOnly() *AuthorizedDismissalActorsOnlyChanges {
+	if p == nil {
+		return nil
+	}
+	return p.AuthorizedDismissalActorsOnly
+}
+
+// GetCreateProtected returns the CreateProtected field.
+func (p *ProtectionChanges) GetCreateProtected() *CreateProtectedChanges {
+	if p == nil {
+		return nil
+	}
+	return p.CreateProtected
+}
+
+// GetDismissStaleReviewsOnPush returns the DismissStaleReviewsOnPush field.
+func (p *ProtectionChanges) GetDismissStaleReviewsOnPush() *DismissStaleReviewsOnPushChanges {
+	if p == nil {
+		return nil
+	}
+	return p.DismissStaleReviewsOnPush
+}
+
+// GetLinearHistoryRequirementEnforcementLevel returns the LinearHistoryRequirementEnforcementLevel field.
+func (p *ProtectionChanges) GetLinearHistoryRequirementEnforcementLevel() *LinearHistoryRequirementEnforcementLevelChanges {
+	if p == nil {
+		return nil
+	}
+	return p.LinearHistoryRequirementEnforcementLevel
+}
+
+// GetPullRequestReviewsEnforcementLevel returns the PullRequestReviewsEnforcementLevel field.
+func (p *ProtectionChanges) GetPullRequestReviewsEnforcementLevel() *PullRequestReviewsEnforcementLevelChanges {
+	if p == nil {
+		return nil
+	}
+	return p.PullRequestReviewsEnforcementLevel
+}
+
+// GetRequireCodeOwnerReview returns the RequireCodeOwnerReview field.
+func (p *ProtectionChanges) GetRequireCodeOwnerReview() *RequireCodeOwnerReviewChanges {
+	if p == nil {
+		return nil
+	}
+	return p.RequireCodeOwnerReview
+}
+
+// GetRequiredConversationResolutionLevel returns the RequiredConversationResolutionLevel field.
+func (p *ProtectionChanges) GetRequiredConversationResolutionLevel() *RequiredConversationResolutionLevelChanges {
+	if p == nil {
+		return nil
+	}
+	return p.RequiredConversationResolutionLevel
+}
+
+// GetRequiredDeploymentsEnforcementLevel returns the RequiredDeploymentsEnforcementLevel field.
+func (p *ProtectionChanges) GetRequiredDeploymentsEnforcementLevel() *RequiredDeploymentsEnforcementLevelChanges {
+	if p == nil {
+		return nil
+	}
+	return p.RequiredDeploymentsEnforcementLevel
+}
+
+// GetRequiredStatusChecks returns the RequiredStatusChecks field.
+func (p *ProtectionChanges) GetRequiredStatusChecks() *RequiredStatusChecksChanges {
+	if p == nil {
+		return nil
+	}
+	return p.RequiredStatusChecks
+}
+
+// GetRequiredStatusChecksEnforcementLevel returns the RequiredStatusChecksEnforcementLevel field.
+func (p *ProtectionChanges) GetRequiredStatusChecksEnforcementLevel() *RequiredStatusChecksEnforcementLevelChanges {
+	if p == nil {
+		return nil
+	}
+	return p.RequiredStatusChecksEnforcementLevel
+}
+
+// GetSignatureRequirementEnforcementLevel returns the SignatureRequirementEnforcementLevel field.
+func (p *ProtectionChanges) GetSignatureRequirementEnforcementLevel() *SignatureRequirementEnforcementLevelChanges {
+	if p == nil {
+		return nil
+	}
+	return p.SignatureRequirementEnforcementLevel
 }
 
 // GetAllowDeletions returns the AllowDeletions field if it's non-nil, zero value otherwise.
@@ -13012,6 +13164,14 @@ func (p *PullRequestReviewsEnforcement) GetDismissalRestrictions() *DismissalRes
 		return nil
 	}
 	return p.DismissalRestrictions
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (p *PullRequestReviewsEnforcementLevelChanges) GetFrom() string {
+	if p == nil || p.From == nil {
+		return ""
+	}
+	return *p.From
 }
 
 // GetBypassPullRequestAllowancesRequest returns the BypassPullRequestAllowancesRequest field.
@@ -16134,6 +16294,30 @@ func (r *RepoStatus) GetURL() string {
 	return *r.URL
 }
 
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (r *RequireCodeOwnerReviewChanges) GetFrom() bool {
+	if r == nil || r.From == nil {
+		return false
+	}
+	return *r.From
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (r *RequiredConversationResolutionLevelChanges) GetFrom() string {
+	if r == nil || r.From == nil {
+		return ""
+	}
+	return *r.From
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (r *RequiredDeploymentsEnforcementLevelChanges) GetFrom() string {
+	if r == nil || r.From == nil {
+		return ""
+	}
+	return *r.From
+}
+
 // GetType returns the Type field if it's non-nil, zero value otherwise.
 func (r *RequiredReviewer) GetType() string {
 	if r == nil || r.Type == nil {
@@ -16148,6 +16332,14 @@ func (r *RequiredStatusCheck) GetAppID() int64 {
 		return 0
 	}
 	return *r.AppID
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (r *RequiredStatusChecksEnforcementLevelChanges) GetFrom() string {
+	if r == nil || r.From == nil {
+		return ""
+	}
+	return *r.From
 }
 
 // GetStrict returns the Strict field if it's non-nil, zero value otherwise.
@@ -17084,6 +17276,14 @@ func (s *ServiceHook) GetName() string {
 		return ""
 	}
 	return *s.Name
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (s *SignatureRequirementEnforcementLevelChanges) GetFrom() string {
+	if s == nil || s.From == nil {
+		return ""
+	}
+	return *s.From
 }
 
 // GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -1640,11 +1640,11 @@ func TestAuthorizationUpdateRequest_GetNoteURL(tt *testing.T) {
 	a.GetNoteURL()
 }
 
-func TestAuthorizedActorsOnlyChanges_GetFrom(tt *testing.T) {
+func TestAuthorizedActorsOnly_GetFrom(tt *testing.T) {
 	var zeroValue bool
-	a := &AuthorizedActorsOnlyChanges{From: &zeroValue}
+	a := &AuthorizedActorsOnly{From: &zeroValue}
 	a.GetFrom()
-	a = &AuthorizedActorsOnlyChanges{}
+	a = &AuthorizedActorsOnly{}
 	a.GetFrom()
 	a = nil
 	a.GetFrom()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -105,6 +105,16 @@ func TestActionsPermissionsRepository_GetSelectedActionsURL(tt *testing.T) {
 	a.GetSelectedActionsURL()
 }
 
+func TestAdminEnforcedChanges_GetFrom(tt *testing.T) {
+	var zeroValue bool
+	a := &AdminEnforcedChanges{From: &zeroValue}
+	a.GetFrom()
+	a = &AdminEnforcedChanges{}
+	a.GetFrom()
+	a = nil
+	a.GetFrom()
+}
+
 func TestAdminEnforcement_GetURL(tt *testing.T) {
 	var zeroValue string
 	a := &AdminEnforcement{URL: &zeroValue}
@@ -459,6 +469,16 @@ func TestAlert_GetURL(tt *testing.T) {
 	a.GetURL()
 	a = nil
 	a.GetURL()
+}
+
+func TestAllowDeletionsEnforcementLevelChanges_GetFrom(tt *testing.T) {
+	var zeroValue string
+	a := &AllowDeletionsEnforcementLevelChanges{From: &zeroValue}
+	a.GetFrom()
+	a = &AllowDeletionsEnforcementLevelChanges{}
+	a.GetFrom()
+	a = nil
+	a.GetFrom()
 }
 
 func TestAnalysesListOptions_GetRef(tt *testing.T) {
@@ -1620,11 +1640,21 @@ func TestAuthorizationUpdateRequest_GetNoteURL(tt *testing.T) {
 	a.GetNoteURL()
 }
 
-func TestAuthorizedActorsOnly_GetFrom(tt *testing.T) {
+func TestAuthorizedActorsOnlyChanges_GetFrom(tt *testing.T) {
 	var zeroValue bool
-	a := &AuthorizedActorsOnly{From: &zeroValue}
+	a := &AuthorizedActorsOnlyChanges{From: &zeroValue}
 	a.GetFrom()
-	a = &AuthorizedActorsOnly{}
+	a = &AuthorizedActorsOnlyChanges{}
+	a.GetFrom()
+	a = nil
+	a.GetFrom()
+}
+
+func TestAuthorizedDismissalActorsOnlyChanges_GetFrom(tt *testing.T) {
+	var zeroValue bool
+	a := &AuthorizedDismissalActorsOnlyChanges{From: &zeroValue}
+	a.GetFrom()
+	a = &AuthorizedDismissalActorsOnlyChanges{}
 	a.GetFrom()
 	a = nil
 	a.GetFrom()
@@ -4143,6 +4173,16 @@ func TestCreateOrgInvitationOptions_GetRole(tt *testing.T) {
 	c.GetRole()
 }
 
+func TestCreateProtectedChanges_GetFrom(tt *testing.T) {
+	var zeroValue bool
+	c := &CreateProtectedChanges{From: &zeroValue}
+	c.GetFrom()
+	c = &CreateProtectedChanges{}
+	c.GetFrom()
+	c = nil
+	c.GetFrom()
+}
+
 func TestCreateRunnerGroupRequest_GetAllowsPublicRepositories(tt *testing.T) {
 	var zeroValue bool
 	c := &CreateRunnerGroupRequest{AllowsPublicRepositories: &zeroValue}
@@ -5294,6 +5334,16 @@ func TestDismissedReview_GetState(tt *testing.T) {
 	d.GetState()
 	d = nil
 	d.GetState()
+}
+
+func TestDismissStaleReviewsOnPushChanges_GetFrom(tt *testing.T) {
+	var zeroValue bool
+	d := &DismissStaleReviewsOnPushChanges{From: &zeroValue}
+	d.GetFrom()
+	d = &DismissStaleReviewsOnPushChanges{}
+	d.GetFrom()
+	d = nil
+	d.GetFrom()
 }
 
 func TestDispatchRequestOptions_GetClientPayload(tt *testing.T) {
@@ -9576,6 +9626,16 @@ func TestLicense_GetURL(tt *testing.T) {
 	l.GetURL()
 }
 
+func TestLinearHistoryRequirementEnforcementLevelChanges_GetFrom(tt *testing.T) {
+	var zeroValue string
+	l := &LinearHistoryRequirementEnforcementLevelChanges{From: &zeroValue}
+	l.GetFrom()
+	l = &LinearHistoryRequirementEnforcementLevelChanges{}
+	l.GetFrom()
+	l = nil
+	l.GetFrom()
+}
+
 func TestListCheckRunsOptions_GetAppID(tt *testing.T) {
 	var zeroValue int64
 	l := &ListCheckRunsOptions{AppID: &zeroValue}
@@ -13771,6 +13831,20 @@ func TestProtection_GetRestrictions(tt *testing.T) {
 	p.GetRestrictions()
 }
 
+func TestProtectionChanges_GetAdminEnforced(tt *testing.T) {
+	p := &ProtectionChanges{}
+	p.GetAdminEnforced()
+	p = nil
+	p.GetAdminEnforced()
+}
+
+func TestProtectionChanges_GetAllowDeletionsEnforcementLevel(tt *testing.T) {
+	p := &ProtectionChanges{}
+	p.GetAllowDeletionsEnforcementLevel()
+	p = nil
+	p.GetAllowDeletionsEnforcementLevel()
+}
+
 func TestProtectionChanges_GetAuthorizedActorNames(tt *testing.T) {
 	p := &ProtectionChanges{}
 	p.GetAuthorizedActorNames()
@@ -13783,6 +13857,83 @@ func TestProtectionChanges_GetAuthorizedActorsOnly(tt *testing.T) {
 	p.GetAuthorizedActorsOnly()
 	p = nil
 	p.GetAuthorizedActorsOnly()
+}
+
+func TestProtectionChanges_GetAuthorizedDismissalActorsOnly(tt *testing.T) {
+	p := &ProtectionChanges{}
+	p.GetAuthorizedDismissalActorsOnly()
+	p = nil
+	p.GetAuthorizedDismissalActorsOnly()
+}
+
+func TestProtectionChanges_GetCreateProtected(tt *testing.T) {
+	p := &ProtectionChanges{}
+	p.GetCreateProtected()
+	p = nil
+	p.GetCreateProtected()
+}
+
+func TestProtectionChanges_GetDismissStaleReviewsOnPush(tt *testing.T) {
+	p := &ProtectionChanges{}
+	p.GetDismissStaleReviewsOnPush()
+	p = nil
+	p.GetDismissStaleReviewsOnPush()
+}
+
+func TestProtectionChanges_GetLinearHistoryRequirementEnforcementLevel(tt *testing.T) {
+	p := &ProtectionChanges{}
+	p.GetLinearHistoryRequirementEnforcementLevel()
+	p = nil
+	p.GetLinearHistoryRequirementEnforcementLevel()
+}
+
+func TestProtectionChanges_GetPullRequestReviewsEnforcementLevel(tt *testing.T) {
+	p := &ProtectionChanges{}
+	p.GetPullRequestReviewsEnforcementLevel()
+	p = nil
+	p.GetPullRequestReviewsEnforcementLevel()
+}
+
+func TestProtectionChanges_GetRequireCodeOwnerReview(tt *testing.T) {
+	p := &ProtectionChanges{}
+	p.GetRequireCodeOwnerReview()
+	p = nil
+	p.GetRequireCodeOwnerReview()
+}
+
+func TestProtectionChanges_GetRequiredConversationResolutionLevel(tt *testing.T) {
+	p := &ProtectionChanges{}
+	p.GetRequiredConversationResolutionLevel()
+	p = nil
+	p.GetRequiredConversationResolutionLevel()
+}
+
+func TestProtectionChanges_GetRequiredDeploymentsEnforcementLevel(tt *testing.T) {
+	p := &ProtectionChanges{}
+	p.GetRequiredDeploymentsEnforcementLevel()
+	p = nil
+	p.GetRequiredDeploymentsEnforcementLevel()
+}
+
+func TestProtectionChanges_GetRequiredStatusChecks(tt *testing.T) {
+	p := &ProtectionChanges{}
+	p.GetRequiredStatusChecks()
+	p = nil
+	p.GetRequiredStatusChecks()
+}
+
+func TestProtectionChanges_GetRequiredStatusChecksEnforcementLevel(tt *testing.T) {
+	p := &ProtectionChanges{}
+	p.GetRequiredStatusChecksEnforcementLevel()
+	p = nil
+	p.GetRequiredStatusChecksEnforcementLevel()
+}
+
+func TestProtectionChanges_GetSignatureRequirementEnforcementLevel(tt *testing.T) {
+	p := &ProtectionChanges{}
+	p.GetSignatureRequirementEnforcementLevel()
+	p = nil
+	p.GetSignatureRequirementEnforcementLevel()
 }
 
 func TestProtectionRequest_GetAllowDeletions(tt *testing.T) {
@@ -15141,6 +15292,16 @@ func TestPullRequestReviewsEnforcement_GetDismissalRestrictions(tt *testing.T) {
 	p.GetDismissalRestrictions()
 	p = nil
 	p.GetDismissalRestrictions()
+}
+
+func TestPullRequestReviewsEnforcementLevelChanges_GetFrom(tt *testing.T) {
+	var zeroValue string
+	p := &PullRequestReviewsEnforcementLevelChanges{From: &zeroValue}
+	p.GetFrom()
+	p = &PullRequestReviewsEnforcementLevelChanges{}
+	p.GetFrom()
+	p = nil
+	p.GetFrom()
 }
 
 func TestPullRequestReviewsEnforcementRequest_GetBypassPullRequestAllowancesRequest(tt *testing.T) {
@@ -18794,6 +18955,36 @@ func TestRepoStatus_GetURL(tt *testing.T) {
 	r.GetURL()
 }
 
+func TestRequireCodeOwnerReviewChanges_GetFrom(tt *testing.T) {
+	var zeroValue bool
+	r := &RequireCodeOwnerReviewChanges{From: &zeroValue}
+	r.GetFrom()
+	r = &RequireCodeOwnerReviewChanges{}
+	r.GetFrom()
+	r = nil
+	r.GetFrom()
+}
+
+func TestRequiredConversationResolutionLevelChanges_GetFrom(tt *testing.T) {
+	var zeroValue string
+	r := &RequiredConversationResolutionLevelChanges{From: &zeroValue}
+	r.GetFrom()
+	r = &RequiredConversationResolutionLevelChanges{}
+	r.GetFrom()
+	r = nil
+	r.GetFrom()
+}
+
+func TestRequiredDeploymentsEnforcementLevelChanges_GetFrom(tt *testing.T) {
+	var zeroValue string
+	r := &RequiredDeploymentsEnforcementLevelChanges{From: &zeroValue}
+	r.GetFrom()
+	r = &RequiredDeploymentsEnforcementLevelChanges{}
+	r.GetFrom()
+	r = nil
+	r.GetFrom()
+}
+
 func TestRequiredReviewer_GetType(tt *testing.T) {
 	var zeroValue string
 	r := &RequiredReviewer{Type: &zeroValue}
@@ -18812,6 +19003,16 @@ func TestRequiredStatusCheck_GetAppID(tt *testing.T) {
 	r.GetAppID()
 	r = nil
 	r.GetAppID()
+}
+
+func TestRequiredStatusChecksEnforcementLevelChanges_GetFrom(tt *testing.T) {
+	var zeroValue string
+	r := &RequiredStatusChecksEnforcementLevelChanges{From: &zeroValue}
+	r.GetFrom()
+	r = &RequiredStatusChecksEnforcementLevelChanges{}
+	r.GetFrom()
+	r = nil
+	r.GetFrom()
 }
 
 func TestRequiredStatusChecksRequest_GetStrict(tt *testing.T) {
@@ -19940,6 +20141,16 @@ func TestServiceHook_GetName(tt *testing.T) {
 	s.GetName()
 	s = nil
 	s.GetName()
+}
+
+func TestSignatureRequirementEnforcementLevelChanges_GetFrom(tt *testing.T) {
+	var zeroValue string
+	s := &SignatureRequirementEnforcementLevelChanges{From: &zeroValue}
+	s.GetFrom()
+	s = &SignatureRequirementEnforcementLevelChanges{}
+	s.GetFrom()
+	s = nil
+	s.GetFrom()
 }
 
 func TestSignaturesProtectedBranch_GetEnabled(tt *testing.T) {

--- a/github/repos.go
+++ b/github/repos.go
@@ -874,8 +874,8 @@ type BranchProtectionRule struct {
 type ProtectionChanges struct {
 	AdminEnforced                            *AdminEnforcedChanges                            `json:"admin_enforced,omitempty"`
 	AllowDeletionsEnforcementLevel           *AllowDeletionsEnforcementLevelChanges           `json:"allow_deletions_enforcement_level,omitempty"`
-	AuthorizedActorNames                     *AuthorizedActorNamesChanges                     `json:"authorized_actor_names,omitempty"`
-	AuthorizedActorsOnly                     *AuthorizedActorsOnlyChanges                     `json:"authorized_actors_only,omitempty"`
+	AuthorizedActorNames                     *AuthorizedActorNames                            `json:"authorized_actor_names,omitempty"`
+	AuthorizedActorsOnly                     *AuthorizedActorsOnly                            `json:"authorized_actors_only,omitempty"`
 	AuthorizedDismissalActorsOnly            *AuthorizedDismissalActorsOnlyChanges            `json:"authorized_dismissal_actors_only,omitempty"`
 	CreateProtected                          *CreateProtectedChanges                          `json:"create_protected,omitempty"`
 	DismissStaleReviewsOnPush                *DismissStaleReviewsOnPushChanges                `json:"dismiss_stale_reviews_on_push,omitempty"`
@@ -899,13 +899,13 @@ type AllowDeletionsEnforcementLevelChanges struct {
 	From *string `json:"from,omitempty"`
 }
 
-// AuthorizedActorNamesChanges represents who are authorized to edit the branch protection rules.
-type AuthorizedActorNamesChanges struct {
+// AuthorizedActorNames represents who are authorized to edit the branch protection rules.
+type AuthorizedActorNames struct {
 	From []string `json:"from,omitempty"`
 }
 
-// AuthorizedActorsOnlyChanges represents if the branch rule can be edited by authorized actors only.
-type AuthorizedActorsOnlyChanges struct {
+// AuthorizedActorsOnly represents if the branch rule can be edited by authorized actors only.
+type AuthorizedActorsOnly struct {
 	From *bool `json:"from,omitempty"`
 }
 

--- a/github/repos.go
+++ b/github/repos.go
@@ -872,61 +872,21 @@ type BranchProtectionRule struct {
 
 // ProtectionChanges represents the changes to the rule if the BranchProtection was edited.
 type ProtectionChanges struct {
-	PullRequestReviewsEnforcementLevel       *PullRequestReviewsEnforcementLevelChanges       `json:"pull_request_reviews_enforcement_level,omitempty"`
-	DismissStaleReviewsOnPush                *DismissStaleReviewsOnPushChanges                `json:"dismiss_stale_reviews_on_push,omitempty"`
-	RequireCodeOwnerReview                   *RequireCodeOwnerReviewChanges                   `json:"require_code_owner_review,omitempty"`
+	AdminEnforced                            *AdminEnforcedChanges                            `json:"admin_enforced,omitempty"`
+	AllowDeletionsEnforcementLevel           *AllowDeletionsEnforcementLevelChanges           `json:"allow_deletions_enforcement_level,omitempty"`
+	AuthorizedActorNames                     *AuthorizedActorNamesChanges                     `json:"authorized_actor_names,omitempty"`
+	AuthorizedActorsOnly                     *AuthorizedActorsOnlyChanges                     `json:"authorized_actors_only,omitempty"`
 	AuthorizedDismissalActorsOnly            *AuthorizedDismissalActorsOnlyChanges            `json:"authorized_dismissal_actors_only,omitempty"`
+	CreateProtected                          *CreateProtectedChanges                          `json:"create_protected,omitempty"`
+	DismissStaleReviewsOnPush                *DismissStaleReviewsOnPushChanges                `json:"dismiss_stale_reviews_on_push,omitempty"`
+	LinearHistoryRequirementEnforcementLevel *LinearHistoryRequirementEnforcementLevelChanges `json:"linear_history_requirement_enforcement_level,omitempty"`
+	PullRequestReviewsEnforcementLevel       *PullRequestReviewsEnforcementLevelChanges       `json:"pull_request_reviews_enforcement_level,omitempty"`
+	RequireCodeOwnerReview                   *RequireCodeOwnerReviewChanges                   `json:"require_code_owner_review,omitempty"`
+	RequiredConversationResolutionLevel      *RequiredConversationResolutionLevelChanges      `json:"required_conversation_resolution_level,omitempty"`
+	RequiredDeploymentsEnforcementLevel      *RequiredDeploymentsEnforcementLevelChanges      `json:"required_deployments_enforcement_level,omitempty"`
 	RequiredStatusChecks                     *RequiredStatusChecksChanges                     `json:"required_status_checks,omitempty"`
 	RequiredStatusChecksEnforcementLevel     *RequiredStatusChecksEnforcementLevelChanges     `json:"required_status_checks_enforcement_level,omitempty"`
 	SignatureRequirementEnforcementLevel     *SignatureRequirementEnforcementLevelChanges     `json:"signature_requirement_enforcement_level,omitempty"`
-	LinearHistoryRequirementEnforcementLevel *LinearHistoryRequirementEnforcementLevelChanges `json:"linear_history_requirement_enforcement_level,omitempty"`
-	AdminEnforced                            *AdminEnforcedChanges                            `json:"admin_enforced,omitempty"`
-	CreateProtected                          *CreateProtectedChanges                          `json:"create_protected,omitempty"`
-	AllowDeletionsEnforcementLevel           *AllowDeletionsEnforcementLevelChanges           `json:"allow_deletions_enforcement_level,omitempty"`
-	RequiredDeploymentsEnforcementLevel      *RequiredDeploymentsEnforcementLevelChanges      `json:"required_deployments_enforcement_level,omitempty"`
-	RequiredConversationResolutionLevel      *RequiredConversationResolutionLevelChanges      `json:"required_conversation_resolution_level,omitempty"`
-	AuthorizedActorsOnly                     *AuthorizedActorsOnlyChanges                     `json:"authorized_actors_only,omitempty"`
-	AuthorizedActorNames                     *AuthorizedActorNamesChanges                     `json:"authorized_actor_names,omitempty"`
-}
-
-// PullRequestReviewsEnforcementLevelChanges represents the changes made to the PullRequestReviewsEnforcementLevel policy.
-type PullRequestReviewsEnforcementLevelChanges struct {
-	From *string `json:"from,omitempty"`
-}
-
-// DismissStaleReviewsOnPushChanges represents the changes made to the DismissStaleReviewsOnPushChanges policy.
-type DismissStaleReviewsOnPushChanges struct {
-	From *bool `json:"from"`
-}
-
-// RequireCodeOwnerReviewChanges represents the changes made to the RequireCodeOwnerReview policy.
-type RequireCodeOwnerReviewChanges struct {
-	From *bool `json:"from,omitempty"`
-}
-
-// AuthorizedDismissalActorsOnlyChanges represents the changes made to the AuthorizedDismissalActorsOnly policy.
-type AuthorizedDismissalActorsOnlyChanges struct {
-	From *bool `json:"from,omitempty"`
-}
-
-// RequiredStatusChecksChanges represents the changes made to the RequiredStatusChecks policy.
-type RequiredStatusChecksChanges struct {
-	From []string `json:"from,omitempty"`
-}
-
-// RequiredStatusChecksEnforcementLevelChanges represents the changes made to the RequiredStatusChecksEnforcement policy.
-type RequiredStatusChecksEnforcementLevelChanges struct {
-	From *string `json:"from,omitempty"`
-}
-
-// SignatureRequirementEnforcementLevelChanges represents the changes made to the SignatureRequirementEnforcement policy.
-type SignatureRequirementEnforcementLevelChanges struct {
-	From *string `json:"from,omitempty"`
-}
-
-// LinearHistoryRequirementEnforcementLevelChanges represents the changes made to the LinearHistoryRequirementEnforcement policy.
-type LinearHistoryRequirementEnforcementLevelChanges struct {
-	From *string `json:"from,omitempty"`
 }
 
 // AdminEnforcedChanges represents the changes made to the AdminEnforced policy.
@@ -934,23 +894,8 @@ type AdminEnforcedChanges struct {
 	From *bool `json:"from,omitempty"`
 }
 
-// CreateProtectedChanges represents the changes made to the CreateProtected policy.
-type CreateProtectedChanges struct {
-	From *bool `json:"from,omitempty"`
-}
-
-// AllowDeletionsEnforcementLevelChanges represents the changes made to the AllowDeletionsEnforcement policy.
+// AllowDeletionsEnforcementLevelChanges represents the changes made to the AllowDeletionsEnforcementLevel policy.
 type AllowDeletionsEnforcementLevelChanges struct {
-	From *string `json:"from,omitempty"`
-}
-
-// RequiredDeploymentsEnforcementLevelChanges represents the changes made to the RequiredDeploymentsEnforcement policy.
-type RequiredDeploymentsEnforcementLevelChanges struct {
-	From *string `json:"from,omitempty"`
-}
-
-// RequiredConversationResolutionLevelChanges represents the changes made to the RequiredConversationResolution policy.
-type RequiredConversationResolutionLevelChanges struct {
 	From *string `json:"from,omitempty"`
 }
 
@@ -962,6 +907,61 @@ type AuthorizedActorNamesChanges struct {
 // AuthorizedActorsOnlyChanges represents if the branch rule can be edited by authorized actors only.
 type AuthorizedActorsOnlyChanges struct {
 	From *bool `json:"from,omitempty"`
+}
+
+// AuthorizedDismissalActorsOnlyChanges represents the changes made to the AuthorizedDismissalActorsOnly policy.
+type AuthorizedDismissalActorsOnlyChanges struct {
+	From *bool `json:"from,omitempty"`
+}
+
+// CreateProtectedChanges represents the changes made to the CreateProtected policy.
+type CreateProtectedChanges struct {
+	From *bool `json:"from,omitempty"`
+}
+
+// DismissStaleReviewsOnPushChanges represents the changes made to the DismissStaleReviewsOnPushChanges policy.
+type DismissStaleReviewsOnPushChanges struct {
+	From *bool `json:"from,omitempty"`
+}
+
+// LinearHistoryRequirementEnforcementLevelChanges represents the changes made to the LinearHistoryRequirementEnforcementLevel policy.
+type LinearHistoryRequirementEnforcementLevelChanges struct {
+	From *string `json:"from,omitempty"`
+}
+
+// PullRequestReviewsEnforcementLevelChanges represents the changes made to the PullRequestReviewsEnforcementLevel policy.
+type PullRequestReviewsEnforcementLevelChanges struct {
+	From *string `json:"from,omitempty"`
+}
+
+// RequireCodeOwnerReviewChanges represents the changes made to the RequireCodeOwnerReview policy.
+type RequireCodeOwnerReviewChanges struct {
+	From *bool `json:"from,omitempty"`
+}
+
+// RequiredConversationResolutionLevelChanges represents the changes made to the RequiredConversationResolutionLevel policy.
+type RequiredConversationResolutionLevelChanges struct {
+	From *string `json:"from,omitempty"`
+}
+
+// RequiredDeploymentsEnforcementLevelChanges represents the changes made to the RequiredDeploymentsEnforcementLevel policy.
+type RequiredDeploymentsEnforcementLevelChanges struct {
+	From *string `json:"from,omitempty"`
+}
+
+// RequiredStatusChecksChanges represents the changes made to the RequiredStatusChecks policy.
+type RequiredStatusChecksChanges struct {
+	From []string `json:"from,omitempty"`
+}
+
+// RequiredStatusChecksEnforcementLevelChanges represents the changes made to the RequiredStatusChecksEnforcementLevel policy.
+type RequiredStatusChecksEnforcementLevelChanges struct {
+	From *string `json:"from,omitempty"`
+}
+
+// SignatureRequirementEnforcementLevelChanges represents the changes made to the SignatureRequirementEnforcementLevel policy.
+type SignatureRequirementEnforcementLevelChanges struct {
+	From *string `json:"from,omitempty"`
 }
 
 // ProtectionRequest represents a request to create/edit a branch's protection.

--- a/github/repos.go
+++ b/github/repos.go
@@ -872,17 +872,95 @@ type BranchProtectionRule struct {
 
 // ProtectionChanges represents the changes to the rule if the BranchProtection was edited.
 type ProtectionChanges struct {
-	AuthorizedActorsOnly *AuthorizedActorsOnly `json:"authorized_actors_only,omitempty"`
-	AuthorizedActorNames *AuthorizedActorNames `json:"authorized_actor_names,omitempty"`
+	PullRequestReviewsEnforcementLevel       *PullRequestReviewsEnforcementLevelChanges       `json:"pull_request_reviews_enforcement_level,omitempty"`
+	DismissStaleReviewsOnPush                *DismissStaleReviewsOnPushChanges                `json:"dismiss_stale_reviews_on_push,omitempty"`
+	RequireCodeOwnerReview                   *RequireCodeOwnerReviewChanges                   `json:"require_code_owner_review,omitempty"`
+	AuthorizedDismissalActorsOnly            *AuthorizedDismissalActorsOnlyChanges            `json:"authorized_dismissal_actors_only,omitempty"`
+	RequiredStatusChecks                     *RequiredStatusChecksChanges                     `json:"required_status_checks,omitempty"`
+	RequiredStatusChecksEnforcementLevel     *RequiredStatusChecksEnforcementLevelChanges     `json:"required_status_checks_enforcement_level,omitempty"`
+	SignatureRequirementEnforcementLevel     *SignatureRequirementEnforcementLevelChanges     `json:"signature_requirement_enforcement_level,omitempty"`
+	LinearHistoryRequirementEnforcementLevel *LinearHistoryRequirementEnforcementLevelChanges `json:"linear_history_requirement_enforcement_level,omitempty"`
+	AdminEnforced                            *AdminEnforcedChanges                            `json:"admin_enforced,omitempty"`
+	CreateProtected                          *CreateProtectedChanges                          `json:"create_protected,omitempty"`
+	AllowDeletionsEnforcementLevel           *AllowDeletionsEnforcementLevelChanges           `json:"allow_deletions_enforcement_level,omitempty"`
+	RequiredDeploymentsEnforcementLevel      *RequiredDeploymentsEnforcementLevelChanges      `json:"required_deployments_enforcement_level,omitempty"`
+	RequiredConversationResolutionLevel      *RequiredConversationResolutionLevelChanges      `json:"required_conversation_resolution_level,omitempty"`
+	AuthorizedActorsOnly                     *AuthorizedActorsOnlyChanges                     `json:"authorized_actors_only,omitempty"`
+	AuthorizedActorNames                     *AuthorizedActorNamesChanges                     `json:"authorized_actor_names,omitempty"`
 }
 
-// AuthorizedActorNames represents who are authorized to edit the branch protection rules.
-type AuthorizedActorNames struct {
+// PullRequestReviewsEnforcementLevelChanges represents the changes made to the PullRequestReviewsEnforcementLevel policy.
+type PullRequestReviewsEnforcementLevelChanges struct {
+	From *string `json:"from,omitempty"`
+}
+
+// DismissStaleReviewsOnPushChanges represents the changes made to the DismissStaleReviewsOnPushChanges policy.
+type DismissStaleReviewsOnPushChanges struct {
+	From *bool `json:"from"`
+}
+
+// RequireCodeOwnerReviewChanges represents the changes made to the RequireCodeOwnerReview policy.
+type RequireCodeOwnerReviewChanges struct {
+	From *bool `json:"from,omitempty"`
+}
+
+// AuthorizedDismissalActorsOnlyChanges represents the changes made to the AuthorizedDismissalActorsOnly policy.
+type AuthorizedDismissalActorsOnlyChanges struct {
+	From *bool `json:"from,omitempty"`
+}
+
+// RequiredStatusChecksChanges represents the changes made to the RequiredStatusChecks policy.
+type RequiredStatusChecksChanges struct {
 	From []string `json:"from,omitempty"`
 }
 
-// AuthorizedActorsOnly represents if the branche rule can be edited by authorized actors only.
-type AuthorizedActorsOnly struct {
+// RequiredStatusChecksEnforcementLevelChanges represents the changes made to the RequiredStatusChecksEnforcement policy.
+type RequiredStatusChecksEnforcementLevelChanges struct {
+	From *string `json:"from,omitempty"`
+}
+
+// SignatureRequirementEnforcementLevelChanges represents the changes made to the SignatureRequirementEnforcement policy.
+type SignatureRequirementEnforcementLevelChanges struct {
+	From *string `json:"from,omitempty"`
+}
+
+// LinearHistoryRequirementEnforcementLevelChanges represents the changes made to the LinearHistoryRequirementEnforcement policy.
+type LinearHistoryRequirementEnforcementLevelChanges struct {
+	From *string `json:"from,omitempty"`
+}
+
+// AdminEnforcedChanges represents the changes made to the AdminEnforced policy.
+type AdminEnforcedChanges struct {
+	From *bool `json:"from,omitempty"`
+}
+
+// CreateProtectedChanges represents the changes made to the CreateProtected policy.
+type CreateProtectedChanges struct {
+	From *bool `json:"from,omitempty"`
+}
+
+// AllowDeletionsEnforcementLevelChanges represents the changes made to the AllowDeletionsEnforcement policy.
+type AllowDeletionsEnforcementLevelChanges struct {
+	From *string `json:"from,omitempty"`
+}
+
+// RequiredDeploymentsEnforcementLevelChanges represents the changes made to the RequiredDeploymentsEnforcement policy.
+type RequiredDeploymentsEnforcementLevelChanges struct {
+	From *string `json:"from,omitempty"`
+}
+
+// RequiredConversationResolutionLevelChanges represents the changes made to the RequiredConversationResolution policy.
+type RequiredConversationResolutionLevelChanges struct {
+	From *string `json:"from,omitempty"`
+}
+
+// AuthorizedActorNamesChanges represents who are authorized to edit the branch protection rules.
+type AuthorizedActorNamesChanges struct {
+	From []string `json:"from,omitempty"`
+}
+
+// AuthorizedActorsOnlyChanges represents if the branch rule can be edited by authorized actors only.
+type AuthorizedActorsOnlyChanges struct {
 	From *bool `json:"from,omitempty"`
 }
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -2945,9 +2945,9 @@ func TestAdvancedSecurity_Marshal(t *testing.T) {
 }
 
 func TestAuthorizedActorsOnly_Marshal(t *testing.T) {
-	testJSONMarshal(t, &AuthorizedActorsOnly{}, "{}")
+	testJSONMarshal(t, &AuthorizedActorsOnlyChanges{}, "{}")
 
-	u := &AuthorizedActorsOnly{
+	u := &AuthorizedActorsOnlyChanges{
 		From: Bool(true),
 	}
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -2945,9 +2945,9 @@ func TestAdvancedSecurity_Marshal(t *testing.T) {
 }
 
 func TestAuthorizedActorsOnly_Marshal(t *testing.T) {
-	testJSONMarshal(t, &AuthorizedActorsOnlyChanges{}, "{}")
+	testJSONMarshal(t, &AuthorizedActorsOnly{}, "{}")
 
-	u := &AuthorizedActorsOnlyChanges{
+	u := &AuthorizedActorsOnly{
 		From: Bool(true),
 	}
 


### PR DESCRIPTION
Fixes issue https://github.com/google/go-github/issues/2485. The `From` values only seem to come in the variants of `string`, `bool` or `[]string`, so it's possible these objects could be consolidated into something more generic maybe.
e.g.
```go
type FromString struct {
    From *string `json:"from,omitempty"`
}

type FromBool struct {
    From *bool `json:"from,omitempty"`
}

type FromStringSlice struct {
    From []string `json:"from,omitempty"`
}
```
This went against the current pattern so I made everything a `<Value>Changes` struct instead :D