### PR TITLE
Rename 'whitelist' to 'allowlist' in oauth class selectors

### DIFF
--- a/scrape/apps.go
+++ b/scrape/apps.go
@@ -28,7 +28,7 @@ func (c *Client) AppRestrictionsEnabled(org string) (bool, error) {
 		return false, err
 	}
 
-	s := doc.Find(".oauth-application-whitelist svg").First()
+	s := doc.Find(".oauth-application-allowlist svg").First()
 	if s.Length() == 0 {
 		return false, errors.New("unable to find expected markup")
 	}
@@ -52,7 +52,7 @@ func (c *Client) ListOAuthApps(org string) ([]OAuthApp, error) {
 	}
 
 	var apps []OAuthApp
-	doc.Find(".oauth-application-whitelist ul > li").Each(func(i int, s *goquery.Selection) {
+	doc.Find(".oauth-application-allowlist ul > li").Each(func(i int, s *goquery.Selection) {
 		var app OAuthApp
 		app.Name = s.Find(".request-info strong").First().Text()
 		app.Description = s.Find(".request-info .application-description").Text()

--- a/scrape/testdata/access-restrictions-disabled.html
+++ b/scrape/testdata/access-restrictions-disabled.html
@@ -12,7 +12,7 @@
 
     <div class="col-9">
 
-  <div class="boxed-group oauth-application-whitelist ">
+  <div class="boxed-group oauth-application-allowlist ">
     <h3>Third-party application access policy</h3>
     <div class="boxed-group-inner">
         <p>

--- a/scrape/testdata/access-restrictions-enabled.html
+++ b/scrape/testdata/access-restrictions-enabled.html
@@ -14,7 +14,7 @@
 
     <div class="col-9">
 
-  <div class="boxed-group oauth-application-whitelist is-selectable">
+  <div class="boxed-group oauth-application-allowlist is-selectable">
     <h3>Third-party application access policy</h3>
     <div class="boxed-group-inner">
         <p>


### PR DESCRIPTION
This PR changes the scrape app checks for oauth_application_policy  to reflect the latest class selectors in github.com/organizations/<org>/settings/oauth_application_policy