### PR TITLE
Allow specifying repository name for pull request

### DIFF
--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -123,6 +123,7 @@ func ExamplePullRequestsService_Create() {
 	newPR := &github.NewPullRequest{
 		Title:               github.String("My awesome pull request"),
 		Head:                github.String("branch_to_merge"),
+		HeadRepo:            github.String("my_org/my_repo"),
 		Base:                github.String("master"),
 		Body:                github.String("This is the description of the PR created with the package `github.com/google/go-github/github`"),
 		MaintainerCanModify: github.Bool(true),

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -123,7 +123,7 @@ func ExamplePullRequestsService_Create() {
 	newPR := &github.NewPullRequest{
 		Title:               github.String("My awesome pull request"),
 		Head:                github.String("branch_to_merge"),
-		HeadRepo:            github.String("my_org/my_repo"),
+		HeadRepo:            github.String("my_repo"),
 		Base:                github.String("master"),
 		Body:                github.String("This is the description of the PR created with the package `github.com/google/go-github/github`"),
 		MaintainerCanModify: github.Bool(true),

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9334,6 +9334,14 @@ func (n *NewPullRequest) GetHead() string {
 	return *n.Head
 }
 
+// GetHeadRepo returns the HeadRepo field if it's non-nil, zero value otherwise.
+func (n *NewPullRequest) GetHeadRepo() string {
+	if n == nil || n.HeadRepo == nil {
+		return ""
+	}
+	return *n.HeadRepo
+}
+
 // GetIssue returns the Issue field if it's non-nil, zero value otherwise.
 func (n *NewPullRequest) GetIssue() int {
 	if n == nil || n.Issue == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -10927,6 +10927,16 @@ func TestNewPullRequest_GetHead(tt *testing.T) {
 	n.GetHead()
 }
 
+func TestNewPullRequest_GetHeadRepo(tt *testing.T) {
+	var zeroValue string
+	n := &NewPullRequest{HeadRepo: &zeroValue}
+	n.GetHeadRepo()
+	n = &NewPullRequest{}
+	n.GetHeadRepo()
+	n = nil
+	n.GetHeadRepo()
+}
+
 func TestNewPullRequest_GetIssue(tt *testing.T) {
 	var zeroValue int
 	n := &NewPullRequest{Issue: &zeroValue}

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -245,6 +245,7 @@ func (s *PullRequestsService) GetRaw(ctx context.Context, owner string, repo str
 type NewPullRequest struct {
 	Title               *string `json:"title,omitempty"`
 	Head                *string `json:"head,omitempty"`
+	HeadRepo            *string `json:"head_repo,omitempty"`
 	Base                *string `json:"base,omitempty"`
 	Body                *string `json:"body,omitempty"`
 	Issue               *int    `json:"issue,omitempty"`

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -938,6 +938,7 @@ func TestNewPullRequest_Marshal(t *testing.T) {
 	u := &NewPullRequest{
 		Title:               String("eh"),
 		Head:                String("eh"),
+		HeadRepo:            String("eh"),
 		Base:                String("eh"),
 		Body:                String("eh"),
 		Issue:               Int(1),
@@ -948,6 +949,7 @@ func TestNewPullRequest_Marshal(t *testing.T) {
 	want := `{
 		"title": "eh",
 		"head": "eh",
+		"head_repo": "eh",
 		"base": "eh",
 		"body": "eh",
 		"issue": 1,


### PR DESCRIPTION
This allows to specify forks that have different name from the original repo. One example of a usecase: creating a fork of a repo inside github organization with a different name, and then making a PR from that fork.
