### PR TITLE
chore: capitalize H on event type and delivery id header keys

### DIFF
--- a/github/messages.go
+++ b/github/messages.go
@@ -37,9 +37,9 @@ const (
 	// SHA256SignatureHeader is the GitHub header key used to pass the HMAC-SHA256 hexdigest.
 	SHA256SignatureHeader = "X-Hub-Signature-256"
 	// EventTypeHeader is the GitHub header key used to pass the event type.
-	EventTypeHeader = "X-Github-Event"
+	EventTypeHeader = "X-GitHub-Event"
 	// DeliveryIDHeader is the GitHub header key used to pass the unique ID for the webhook event.
-	DeliveryIDHeader = "X-Github-Delivery"
+	DeliveryIDHeader = "X-GitHub-Delivery"
 )
 
 var (

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -516,26 +516,51 @@ func TestValidatePayloadFromBody_UnsupportedContentType(t *testing.T) {
 	}
 }
 
-func TestDeliveryID(t *testing.T) {
-	id := "8970a780-244e-11e7-91ca-da3aabcb9793"
-	req, err := http.NewRequest("POST", "http://localhost", nil)
-	if err != nil {
-		t.Fatalf("DeliveryID: %v", err)
+func TestMessageHeaders(t *testing.T) {
+	tests := []struct {
+		key string
+		id  string
+	}{
+		{
+			key: DeliveryIDHeader,
+			id:  "8970a780-244e-11e7-91ca-da3aabcb9793",
+		},
+		{
+			key: "X-Github-Delivery",
+			id:  "8970a780-244e-11e7-91ca-da3aabcb9793",
+		},
 	}
-	req.Header.Set("X-Github-Delivery", id)
 
-	got := DeliveryID(req)
-	if got != id {
-		t.Errorf("DeliveryID(%#v) = %q, want %q", req, got, id)
+	for _, test := range tests {
+		r, _ := http.NewRequest("POST", "https://example.com", nil)
+		r.Header.Set(test.key, test.id)
+		if got, want := DeliveryID(r), test.id; got != want {
+			t.Errorf("DeliveryID(%#v) = %#v, want %#v", r, got, want)
+		}
 	}
 }
 
 func TestWebHookType(t *testing.T) {
-	want := "yo"
-	req := &http.Request{
-		Header: http.Header{EventTypeHeader: []string{want}},
+	tests := []struct {
+		key string
+		id  string
+	}{
+		{
+			key: EventTypeHeader,
+			id:  "issues",
+		},
+		{
+			key: "x-github-event",
+			id:  "issues",
+		},
 	}
-	if got := WebHookType(req); got != want {
-		t.Errorf("WebHookType = %q, want %q", got, want)
+
+	for _, test := range tests {
+		r, _ := http.NewRequest("POST", "https://example.com", nil)
+		r.Header.Set(test.key, test.id)
+
+		if got, want := WebHookType(r), test.id; got != want {
+			t.Errorf("WebHookType(%#v) = %#v, want %#v", r, got, want)
+		}
 	}
 }


### PR DESCRIPTION
This pull request introduces the following changes:

- Refactor `Github` to `GitHub` in the message header keys for `EventTypeHeader` and `DeliveryIDHeader`. I found this to be useful because when we use AWS Gateway to process the payload of a GitHub app, we don't receive a HTTP request (see https://github.com/aws/aws-lambda-go/blob/main/events/apigw.go#L6). By using the current constants we will not be able to correctly access those header values as GitHub sends them with a capitalized H.
- Added unit tests to verify that the http header get is case insensitive and doesn't introduce regressions for users that use `WebHookType()` and `DeliveryID()`.