### PR TITLE
Add test cases for JSON resource marshaling

### DIFF
--- a/github/secret_scanning_test.go
+++ b/github/secret_scanning_test.go
@@ -475,3 +475,113 @@ func TestSecretScanningService_ListLocationsForAlert(t *testing.T) {
 		return resp, err
 	})
 }
+
+func TestSecretScanningAlert_Marshal(t *testing.T) {
+	testJSONMarshal(t, &SecretScanningAlert{}, `{}`)
+
+	u := &SecretScanningAlert{
+		Number:       Int(1),
+		CreatedAt:    &Timestamp{referenceTime},
+		URL:          String("https://api.github.com/teams/2/discussions/3/comments"),
+		HTMLURL:      String("https://api.github.com/teams/2/discussions/3/comments"),
+		LocationsURL: String("https://api.github.com/teams/2/discussions/3/comments"),
+		State:        String("test_state"),
+		Resolution:   String("test_resolution"),
+		ResolvedAt:   &Timestamp{referenceTime},
+		ResolvedBy: &User{
+			Login:     String("test"),
+			ID:        Int64(10),
+			NodeID:    String("A123"),
+			AvatarURL: String("https://api.github.com/teams/2/discussions/3/comments"),
+		},
+		SecretType: String("test"),
+		Secret:     String("test"),
+	}
+
+	want := `{
+		"number": 1,
+		"created_at": ` + referenceTimeStr + `,
+		"url": "https://api.github.com/teams/2/discussions/3/comments",
+		"html_url": "https://api.github.com/teams/2/discussions/3/comments",
+		"locations_url": "https://api.github.com/teams/2/discussions/3/comments",
+		"state": "test_state",
+		"resolution": "test_resolution",
+		"resolved_at": ` + referenceTimeStr + `,
+		"resolved_by": {
+			"login": "test",
+			"id": 10,
+			"node_id": "A123",
+			"avatar_url": "https://api.github.com/teams/2/discussions/3/comments"
+		},
+		"secret_type": "test",
+		"secret": "test"
+	}`
+
+	testJSONMarshal(t, u, want)
+}
+
+func TestSecretScanningAlertLocation_Marshal(t *testing.T) {
+	testJSONMarshal(t, &SecretScanningAlertLocation{}, `{}`)
+
+	u := &SecretScanningAlertLocation{
+		Type: String("test"),
+		Details: &SecretScanningAlertLocationDetails{
+			Path:        String("test_path"),
+			Startline:   Int(10),
+			EndLine:     Int(20),
+			StartColumn: Int(30),
+			EndColumn:   Int(40),
+			BlobSHA:     String("test_sha"),
+			BlobURL:     String("https://api.github.com/repos/o/r/git/commits/f14d7debf9775f957cf4f1e8176da0786431f72b"),
+			CommitSHA:   String("test_sha"),
+			CommitURL:   String("https://api.github.com/repos/o/r/git/commits/f14d7debf9775f957cf4f1e8176da0786431f72b"),
+		},
+	}
+
+	want := `{
+		"type": "test",
+		"details": {
+			"path": "test_path",
+			"start_line": 10,
+			"end_line": 20,
+			"start_column": 30,
+			"end_column": 40,
+			"blob_sha": "test_sha",
+			"blob_url": "https://api.github.com/repos/o/r/git/commits/f14d7debf9775f957cf4f1e8176da0786431f72b",
+			"commit_sha": "test_sha",
+			"commit_url": "https://api.github.com/repos/o/r/git/commits/f14d7debf9775f957cf4f1e8176da0786431f72b"
+		} 
+	}`
+
+	testJSONMarshal(t, u, want)
+}
+
+func TestSecretScanningAlertLocationDetails_Marshal(t *testing.T) {
+	testJSONMarshal(t, &SecretScanningAlertLocationDetails{}, `{}`)
+
+	u := &SecretScanningAlertLocationDetails{
+		Path:        String("test_path"),
+		Startline:   Int(10),
+		EndLine:     Int(20),
+		StartColumn: Int(30),
+		EndColumn:   Int(40),
+		BlobSHA:     String("test_sha"),
+		BlobURL:     String("https://api.github.com/repos/o/r/git/commits/f14d7debf9775f957cf4f1e8176da0786431f72b"),
+		CommitSHA:   String("test_sha"),
+		CommitURL:   String("https://api.github.com/repos/o/r/git/commits/f14d7debf9775f957cf4f1e8176da0786431f72b"),
+	}
+
+	want := `{
+		"path": "test_path",
+		"start_line": 10,
+		"end_line": 20,
+		"start_column": 30,
+		"end_column": 40,
+		"blob_sha": "test_sha",
+		"blob_url": "https://api.github.com/repos/o/r/git/commits/f14d7debf9775f957cf4f1e8176da0786431f72b",
+		"commit_sha": "test_sha",
+		"commit_url": "https://api.github.com/repos/o/r/git/commits/f14d7debf9775f957cf4f1e8176da0786431f72b"	
+	}`
+
+	testJSONMarshal(t, u, want)
+}


### PR DESCRIPTION
Added test cases for JSON resource marshaling -  github/secret_scanning.go (file)

1. SecretScanningAlertLocationDetails
2.  SecretScanningAlertLocation
3.  SecretScanningAlert 

contribution to https://github.com/google/go-github/issues/55
Kindly add a Hacktoberfest label for the same