### PR TITLE
Add support for Dependabot alert endpoints

### DIFF
--- a/github/dependabot_alerts.go
+++ b/github/dependabot_alerts.go
@@ -10,22 +10,26 @@ import (
 	"fmt"
 )
 
+// Dependency reprensents the vulnerable dependency.
 type Dependency struct {
 	Package      *VulnerabilityPackage `json:"package,omitempty"`
 	ManifestPath *string               `json:"manifest_path,omitempty"`
 	Scope        *string               `json:"scope,omitempty"`
 }
 
+// AdvisoryCVSs represents the advisory pertaining to the Common Vulnerability Scoring System.
 type AdvisoryCVSs struct {
 	Score        *float64 `json:"score,omitempty"`
 	VectorString *string  `json:"vector_string,omitempty"`
 }
 
+// AdvisoryCWEs reprensent the advisory pertaining to Common Weakness Enumeration.
 type AdvisoryCWEs struct {
 	CWEID *string `json:"cwe_id,omitempty"`
 	Name  *string `json:"name,omitempty"`
 }
 
+// DependabotSecurityAdvisory represents the GitHub Security Advisory.
 type DependabotSecurityAdvisory struct {
 	GHSAID          *string                  `json:"ghsa_id,omitempty"`
 	CVEID           *string                  `json:"cve_id,omitempty"`
@@ -42,7 +46,7 @@ type DependabotSecurityAdvisory struct {
 	WithdrawnAt     *Timestamp               `json:"withdrawn_at,omitempty"`
 }
 
-// DependabotAlert represents a dependabot alert
+// DependabotAlert represents a Dependabot alert.
 type DependabotAlert struct {
 	Number                *int                        `json:"number,omitempty"`
 	State                 *string                     `json:"state,omitempty"`
@@ -60,6 +64,8 @@ type DependabotAlert struct {
 	FixedAt               *Timestamp                  `json:"fixed_at,omitempty"`
 }
 
+// ListAlertsOptions specifies the optional parameters to the DependabotService.ListRepoAlerts
+// and DependabotService.ListOrgAlerts methods.
 type ListAlertsOptions struct {
 	State     *string `url:"state,omitempty"`
 	Severity  *string `url:"severity,omitempty"`

--- a/github/dependabot_alerts.go
+++ b/github/dependabot_alerts.go
@@ -39,7 +39,7 @@ type DependabotSecurityAdvisory struct {
 	References      []*AdvisoryReference     `json:"references,omitempty"`
 	PublishedAt     *Timestamp               `json:"published_at,omitempty"`
 	UpdatedAt       *Timestamp               `json:"updated_at,omitempty"`
-	WithdrawnAt     *Timestamp              `json:"withdrawn_at,omitempty"`
+	WithdrawnAt     *Timestamp               `json:"withdrawn_at,omitempty"`
 }
 
 // DependabotAlert represents a dependabot alert
@@ -53,11 +53,11 @@ type DependabotAlert struct {
 	HtmlURL               *string                     `json:"html_url,omitempty"`
 	CreatedAt             *Timestamp                  `json:"created_at,omitempty"`
 	UpdatedAt             *Timestamp                  `json:"updated_at,omitempty"`
-	DismissedAt           *Timestamp                 `json:"dismissed_at,omitempty"`
-	DismissedBy           *User                      `json:"dismissed_by,omitempty"`
+	DismissedAt           *Timestamp                  `json:"dismissed_at,omitempty"`
+	DismissedBy           *User                       `json:"dismissed_by,omitempty"`
 	DismissedReason       *string                     `json:"dismissed_reason,omitempty"`
 	DismissedComment      *string                     `json:"dismissed_comment,omitempty"`
-	FixedAt               *Timestamp                 `json:"fixed_at,omitempty"`
+	FixedAt               *Timestamp                  `json:"fixed_at,omitempty"`
 }
 
 type ListAlertsOptions struct {

--- a/github/dependabot_alerts.go
+++ b/github/dependabot_alerts.go
@@ -54,7 +54,7 @@ type DependabotAlert struct {
 	SecurityAdvisory      *DependabotSecurityAdvisory `json:"security_advisory,omitempty"`
 	SecurityVulnerability *AdvisoryVulnerability      `json:"security_vulnerability,omitempty"`
 	URL                   *string                     `json:"url,omitempty"`
-	HtmlURL               *string                     `json:"html_url,omitempty"`
+	HTMLURL               *string                     `json:"html_url,omitempty"`
 	CreatedAt             *Timestamp                  `json:"created_at,omitempty"`
 	UpdatedAt             *Timestamp                  `json:"updated_at,omitempty"`
 	DismissedAt           *Timestamp                  `json:"dismissed_at,omitempty"`

--- a/github/dependabot_alerts.go
+++ b/github/dependabot_alerts.go
@@ -1,0 +1,128 @@
+// Copyright 2022 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+type Dependency struct {
+	Package      *VulnerabilityPackage `json:"package,omitempty"`
+	ManifestPath *string               `json:"manifest_path,omitempty"`
+	Scope        *string               `json:"scope,omitempty"`
+}
+
+type AdvisoryCVSs struct {
+	Score        *float64 `json:"score,omitempty"`
+	VectorString *string  `json:"vector_string,omitempty"`
+}
+
+type AdvisoryCWEs struct {
+	CWEID *string `json:"cwe_id,omitempty"`
+	Name  *string `json:"name,omitempty"`
+}
+
+type DependabotSecurityAdvisory struct {
+	GHSAID          *string                  `json:"ghsa_id,omitempty"`
+	CVEID           *string                  `json:"cve_id,omitempty"`
+	Summary         *string                  `json:"summary,omitempty"`
+	Description     *string                  `json:"description,omitempty"`
+	Vulnerabilities []*AdvisoryVulnerability `json:"vulnerabilities,omitempty"`
+	Severity        *string                  `json:"severity,omitempty"`
+	CVSs            *AdvisoryCVSs            `json:"cvss,omitempty"`
+	CWEs            []*AdvisoryCWEs          `json:"cwes,omitempty"`
+	Identifiers     []*AdvisoryIdentifier    `json:"identifiers,omitempty"`
+	References      []*AdvisoryReference     `json:"references,omitempty"`
+	PublishedAt     *Timestamp               `json:"published_at,omitempty"`
+	UpdatedAt       *Timestamp               `json:"updated_at,omitempty"`
+	WithdrawnAt     *Timestamp              `json:"withdrawn_at,omitempty"`
+}
+
+// DependabotAlert represents a dependabot alert
+type DependabotAlert struct {
+	Number                *int                        `json:"number,omitempty"`
+	State                 *string                     `json:"state,omitempty"`
+	Dependency            *Dependency                 `json:"dependency,omitempty"`
+	SecurityAdvisory      *DependabotSecurityAdvisory `json:"security_advisory,omitempty"`
+	SecurityVulnerability *AdvisoryVulnerability      `json:"security_vulnerability,omitempty"`
+	URL                   *string                     `json:"url,omitempty"`
+	HtmlURL               *string                     `json:"html_url,omitempty"`
+	CreatedAt             *Timestamp                  `json:"created_at,omitempty"`
+	UpdatedAt             *Timestamp                  `json:"updated_at,omitempty"`
+	DismissedAt           *Timestamp                 `json:"dismissed_at,omitempty"`
+	DismissedBy           *User                      `json:"dismissed_by,omitempty"`
+	DismissedReason       *string                     `json:"dismissed_reason,omitempty"`
+	DismissedComment      *string                     `json:"dismissed_comment,omitempty"`
+	FixedAt               *Timestamp                 `json:"fixed_at,omitempty"`
+}
+
+type ListAlertsOptions struct {
+	State     *string `url:"state,omitempty"`
+	Severity  *string `url:"severity,omitempty"`
+	Ecosystem *string `url:"ecosystem,omitempty"`
+	Package   *string `url:"package,omitempty"`
+	Scope     *string `url:"scope,omitempty"`
+	Sort      *string `url:"sort,omitempty"`
+	Direction *string `url:"direction,omitempty"`
+
+	ListCursorOptions
+}
+
+func (s *DependabotService) listAlerts(ctx context.Context, url string, opts *ListAlertsOptions) ([]*DependabotAlert, *Response, error) {
+	u, err := addOptions(url, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var alerts []*DependabotAlert
+	resp, err := s.client.Do(ctx, req, &alerts)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return alerts, resp, nil
+}
+
+// ListRepoAlerts lists all Dependabot alerts of a repository.
+//
+// GitHub API docs: https://docs.github.com/en/rest/dependabot/alerts#list-dependabot-alerts-for-a-repository
+func (s *DependabotService) ListRepoAlerts(ctx context.Context, owner, repo string, opts *ListAlertsOptions) ([]*DependabotAlert, *Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/dependabot/alerts", owner, repo)
+	return s.listAlerts(ctx, url, opts)
+}
+
+// ListOrgAlerts lists all Dependabot alerts of an organization.
+//
+// GitHub API docs: https://docs.github.com/en/rest/dependabot/alerts#list-dependabot-alerts-for-an-organization
+func (s *DependabotService) ListOrgAlerts(ctx context.Context, org string, opts *ListAlertsOptions) ([]*DependabotAlert, *Response, error) {
+	url := fmt.Sprintf("orgs/%v/dependabot/alerts", org)
+	return s.listAlerts(ctx, url, opts)
+}
+
+// GetRepoAlert gets a single repository Dependabot alert.
+//
+// GitHub API docs: https://docs.github.com/en/rest/dependabot/alerts#get-a-dependabot-alert
+func (s *DependabotService) GetRepoAlert(ctx context.Context, owner, repo string, number int) (*DependabotAlert, *Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/dependabot/alerts/%v", owner, repo, number)
+	req, err := s.client.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	alert := new(DependabotAlert)
+	resp, err := s.client.Do(ctx, req, alert)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return alert, resp, nil
+}

--- a/github/dependabot_alerts_test.go
+++ b/github/dependabot_alerts_test.go
@@ -1,0 +1,133 @@
+// Copyright 2022 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDependabotService_ListRepoAlerts(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/dependabot/alerts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"state": "open"})
+		fmt.Fprint(w, `[{"number":1,"state":"open"},{"number":42,"state":"fixed"}]`)
+	})
+
+	opts := &ListAlertsOptions{State: String("open")}
+	ctx := context.Background()
+	alerts, _, err := client.Dependabot.ListRepoAlerts(ctx, "o", "r", opts)
+	if err != nil {
+		t.Errorf("Dependabot.ListRepoAlerts returned error: %v", err)
+	}
+
+	want := []*DependabotAlert{
+		{Number: Int(1), State: String("open")},
+		{Number: Int(42), State: String("fixed")},
+	}
+	if !cmp.Equal(alerts, want) {
+		t.Errorf("Dependabot.ListRepoAlerts returned %+v, want %+v", alerts, want)
+	}
+
+	const methodName = "ListRepoAlerts"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Dependabot.ListRepoAlerts(ctx, "\n", "\n", opts)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Dependabot.ListRepoAlerts(ctx, "o", "r", opts)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestDependabotService_GetRepoAlert(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/dependabot/alerts/42", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"number":42,"state":"fixed"}`)
+	})
+
+	ctx := context.Background()
+	alert, _, err := client.Dependabot.GetRepoAlert(ctx, "o", "r", 42)
+	if err != nil {
+		t.Errorf("Dependabot.GetRepoAlert returned error: %v", err)
+	}
+
+	want := &DependabotAlert{
+		Number: Int(42),
+		State:  String("fixed"),
+	}
+	if !cmp.Equal(alert, want) {
+		t.Errorf("Dependabot.GetRepoAlert returned %+v, want %+v", alert, want)
+	}
+
+	const methodName = "GetRepoAlert"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Dependabot.GetRepoAlert(ctx, "\n", "\n", 0)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Dependabot.GetRepoAlert(ctx, "o", "r", 42)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestDependabotService_ListOrgAlerts(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/dependabot/alerts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"state": "open"})
+		fmt.Fprint(w, `[{"number":1,"state":"open"},{"number":42,"state":"fixed"}]`)
+	})
+
+	opts := &ListAlertsOptions{State: String("open")}
+	ctx := context.Background()
+	alerts, _, err := client.Dependabot.ListOrgAlerts(ctx, "o", opts)
+	if err != nil {
+		t.Errorf("Dependabot.ListOrgAlerts returned error: %v", err)
+	}
+
+	want := []*DependabotAlert{
+		{Number: Int(1), State: String("open")},
+		{Number: Int(42), State: String("fixed")},
+	}
+	if !cmp.Equal(alerts, want) {
+		t.Errorf("Dependabot.ListOrgAlerts returned %+v, want %+v", alerts, want)
+	}
+
+	const methodName = "ListOrgAlerts"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Dependabot.ListOrgAlerts(ctx, "\n", opts)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Dependabot.ListOrgAlerts(ctx, "o", opts)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -206,6 +206,38 @@ func (a *AdvancedSecurityCommittersBreakdown) GetUserLogin() string {
 	return *a.UserLogin
 }
 
+// GetScore returns the Score field.
+func (a *AdvisoryCVSs) GetScore() *float64 {
+	if a == nil {
+		return nil
+	}
+	return a.Score
+}
+
+// GetVectorString returns the VectorString field if it's non-nil, zero value otherwise.
+func (a *AdvisoryCVSs) GetVectorString() string {
+	if a == nil || a.VectorString == nil {
+		return ""
+	}
+	return *a.VectorString
+}
+
+// GetCWEID returns the CWEID field if it's non-nil, zero value otherwise.
+func (a *AdvisoryCWEs) GetCWEID() string {
+	if a == nil || a.CWEID == nil {
+		return ""
+	}
+	return *a.CWEID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (a *AdvisoryCWEs) GetName() string {
+	if a == nil || a.Name == nil {
+		return ""
+	}
+	return *a.Name
+}
+
 // GetType returns the Type field if it's non-nil, zero value otherwise.
 func (a *AdvisoryIdentifier) GetType() string {
 	if a == nil || a.Type == nil {
@@ -3724,6 +3756,214 @@ func (d *DeleteEvent) GetSender() *User {
 		return nil
 	}
 	return d.Sender
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetCreatedAt() Timestamp {
+	if d == nil || d.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *d.CreatedAt
+}
+
+// GetDependency returns the Dependency field.
+func (d *DependabotAlert) GetDependency() *Dependency {
+	if d == nil {
+		return nil
+	}
+	return d.Dependency
+}
+
+// GetDismissedAt returns the DismissedAt field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetDismissedAt() Timestamp {
+	if d == nil || d.DismissedAt == nil {
+		return Timestamp{}
+	}
+	return *d.DismissedAt
+}
+
+// GetDismissedBy returns the DismissedBy field.
+func (d *DependabotAlert) GetDismissedBy() *User {
+	if d == nil {
+		return nil
+	}
+	return d.DismissedBy
+}
+
+// GetDismissedComment returns the DismissedComment field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetDismissedComment() string {
+	if d == nil || d.DismissedComment == nil {
+		return ""
+	}
+	return *d.DismissedComment
+}
+
+// GetDismissedReason returns the DismissedReason field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetDismissedReason() string {
+	if d == nil || d.DismissedReason == nil {
+		return ""
+	}
+	return *d.DismissedReason
+}
+
+// GetFixedAt returns the FixedAt field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetFixedAt() Timestamp {
+	if d == nil || d.FixedAt == nil {
+		return Timestamp{}
+	}
+	return *d.FixedAt
+}
+
+// GetHtmlURL returns the HtmlURL field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetHtmlURL() string {
+	if d == nil || d.HtmlURL == nil {
+		return ""
+	}
+	return *d.HtmlURL
+}
+
+// GetNumber returns the Number field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetNumber() int {
+	if d == nil || d.Number == nil {
+		return 0
+	}
+	return *d.Number
+}
+
+// GetSecurityAdvisory returns the SecurityAdvisory field.
+func (d *DependabotAlert) GetSecurityAdvisory() *DependabotSecurityAdvisory {
+	if d == nil {
+		return nil
+	}
+	return d.SecurityAdvisory
+}
+
+// GetSecurityVulnerability returns the SecurityVulnerability field.
+func (d *DependabotAlert) GetSecurityVulnerability() *AdvisoryVulnerability {
+	if d == nil {
+		return nil
+	}
+	return d.SecurityVulnerability
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetState() string {
+	if d == nil || d.State == nil {
+		return ""
+	}
+	return *d.State
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetUpdatedAt() Timestamp {
+	if d == nil || d.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *d.UpdatedAt
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetURL() string {
+	if d == nil || d.URL == nil {
+		return ""
+	}
+	return *d.URL
+}
+
+// GetCVEID returns the CVEID field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetCVEID() string {
+	if d == nil || d.CVEID == nil {
+		return ""
+	}
+	return *d.CVEID
+}
+
+// GetCVSs returns the CVSs field.
+func (d *DependabotSecurityAdvisory) GetCVSs() *AdvisoryCVSs {
+	if d == nil {
+		return nil
+	}
+	return d.CVSs
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetDescription() string {
+	if d == nil || d.Description == nil {
+		return ""
+	}
+	return *d.Description
+}
+
+// GetGHSAID returns the GHSAID field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetGHSAID() string {
+	if d == nil || d.GHSAID == nil {
+		return ""
+	}
+	return *d.GHSAID
+}
+
+// GetPublishedAt returns the PublishedAt field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetPublishedAt() Timestamp {
+	if d == nil || d.PublishedAt == nil {
+		return Timestamp{}
+	}
+	return *d.PublishedAt
+}
+
+// GetSeverity returns the Severity field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetSeverity() string {
+	if d == nil || d.Severity == nil {
+		return ""
+	}
+	return *d.Severity
+}
+
+// GetSummary returns the Summary field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetSummary() string {
+	if d == nil || d.Summary == nil {
+		return ""
+	}
+	return *d.Summary
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetUpdatedAt() Timestamp {
+	if d == nil || d.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *d.UpdatedAt
+}
+
+// GetWithdrawnAt returns the WithdrawnAt field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetWithdrawnAt() Timestamp {
+	if d == nil || d.WithdrawnAt == nil {
+		return Timestamp{}
+	}
+	return *d.WithdrawnAt
+}
+
+// GetManifestPath returns the ManifestPath field if it's non-nil, zero value otherwise.
+func (d *Dependency) GetManifestPath() string {
+	if d == nil || d.ManifestPath == nil {
+		return ""
+	}
+	return *d.ManifestPath
+}
+
+// GetPackage returns the Package field.
+func (d *Dependency) GetPackage() *VulnerabilityPackage {
+	if d == nil {
+		return nil
+	}
+	return d.Package
+}
+
+// GetScope returns the Scope field if it's non-nil, zero value otherwise.
+func (d *Dependency) GetScope() string {
+	if d == nil || d.Scope == nil {
+		return ""
+	}
+	return *d.Scope
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
@@ -8268,6 +8508,62 @@ func (l *LinearHistoryRequirementEnforcementLevelChanges) GetFrom() string {
 		return ""
 	}
 	return *l.From
+}
+
+// GetDirection returns the Direction field if it's non-nil, zero value otherwise.
+func (l *ListAlertsOptions) GetDirection() string {
+	if l == nil || l.Direction == nil {
+		return ""
+	}
+	return *l.Direction
+}
+
+// GetEcosystem returns the Ecosystem field if it's non-nil, zero value otherwise.
+func (l *ListAlertsOptions) GetEcosystem() string {
+	if l == nil || l.Ecosystem == nil {
+		return ""
+	}
+	return *l.Ecosystem
+}
+
+// GetPackage returns the Package field if it's non-nil, zero value otherwise.
+func (l *ListAlertsOptions) GetPackage() string {
+	if l == nil || l.Package == nil {
+		return ""
+	}
+	return *l.Package
+}
+
+// GetScope returns the Scope field if it's non-nil, zero value otherwise.
+func (l *ListAlertsOptions) GetScope() string {
+	if l == nil || l.Scope == nil {
+		return ""
+	}
+	return *l.Scope
+}
+
+// GetSeverity returns the Severity field if it's non-nil, zero value otherwise.
+func (l *ListAlertsOptions) GetSeverity() string {
+	if l == nil || l.Severity == nil {
+		return ""
+	}
+	return *l.Severity
+}
+
+// GetSort returns the Sort field if it's non-nil, zero value otherwise.
+func (l *ListAlertsOptions) GetSort() string {
+	if l == nil || l.Sort == nil {
+		return ""
+	}
+	return *l.Sort
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (l *ListAlertsOptions) GetState() string {
+	if l == nil || l.State == nil {
+		return ""
+	}
+	return *l.State
 }
 
 // GetAppID returns the AppID field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -3814,12 +3814,12 @@ func (d *DependabotAlert) GetFixedAt() Timestamp {
 	return *d.FixedAt
 }
 
-// GetHtmlURL returns the HtmlURL field if it's non-nil, zero value otherwise.
-func (d *DependabotAlert) GetHtmlURL() string {
-	if d == nil || d.HtmlURL == nil {
+// GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetHTMLURL() string {
+	if d == nil || d.HTMLURL == nil {
 		return ""
 	}
-	return *d.HtmlURL
+	return *d.HTMLURL
 }
 
 // GetNumber returns the Number field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -4462,14 +4462,14 @@ func TestDependabotAlert_GetFixedAt(tt *testing.T) {
 	d.GetFixedAt()
 }
 
-func TestDependabotAlert_GetHtmlURL(tt *testing.T) {
+func TestDependabotAlert_GetHTMLURL(tt *testing.T) {
 	var zeroValue string
-	d := &DependabotAlert{HtmlURL: &zeroValue}
-	d.GetHtmlURL()
+	d := &DependabotAlert{HTMLURL: &zeroValue}
+	d.GetHTMLURL()
 	d = &DependabotAlert{}
-	d.GetHtmlURL()
+	d.GetHTMLURL()
 	d = nil
-	d.GetHtmlURL()
+	d.GetHTMLURL()
 }
 
 func TestDependabotAlert_GetNumber(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -225,6 +225,43 @@ func TestAdvancedSecurityCommittersBreakdown_GetUserLogin(tt *testing.T) {
 	a.GetUserLogin()
 }
 
+func TestAdvisoryCVSs_GetScore(tt *testing.T) {
+	a := &AdvisoryCVSs{}
+	a.GetScore()
+	a = nil
+	a.GetScore()
+}
+
+func TestAdvisoryCVSs_GetVectorString(tt *testing.T) {
+	var zeroValue string
+	a := &AdvisoryCVSs{VectorString: &zeroValue}
+	a.GetVectorString()
+	a = &AdvisoryCVSs{}
+	a.GetVectorString()
+	a = nil
+	a.GetVectorString()
+}
+
+func TestAdvisoryCWEs_GetCWEID(tt *testing.T) {
+	var zeroValue string
+	a := &AdvisoryCWEs{CWEID: &zeroValue}
+	a.GetCWEID()
+	a = &AdvisoryCWEs{}
+	a.GetCWEID()
+	a = nil
+	a.GetCWEID()
+}
+
+func TestAdvisoryCWEs_GetName(tt *testing.T) {
+	var zeroValue string
+	a := &AdvisoryCWEs{Name: &zeroValue}
+	a.GetName()
+	a = &AdvisoryCWEs{}
+	a.GetName()
+	a = nil
+	a.GetName()
+}
+
 func TestAdvisoryIdentifier_GetType(tt *testing.T) {
 	var zeroValue string
 	a := &AdvisoryIdentifier{Type: &zeroValue}
@@ -4359,6 +4396,248 @@ func TestDeleteEvent_GetSender(tt *testing.T) {
 	d.GetSender()
 	d = nil
 	d.GetSender()
+}
+
+func TestDependabotAlert_GetCreatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	d := &DependabotAlert{CreatedAt: &zeroValue}
+	d.GetCreatedAt()
+	d = &DependabotAlert{}
+	d.GetCreatedAt()
+	d = nil
+	d.GetCreatedAt()
+}
+
+func TestDependabotAlert_GetDependency(tt *testing.T) {
+	d := &DependabotAlert{}
+	d.GetDependency()
+	d = nil
+	d.GetDependency()
+}
+
+func TestDependabotAlert_GetDismissedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	d := &DependabotAlert{DismissedAt: &zeroValue}
+	d.GetDismissedAt()
+	d = &DependabotAlert{}
+	d.GetDismissedAt()
+	d = nil
+	d.GetDismissedAt()
+}
+
+func TestDependabotAlert_GetDismissedBy(tt *testing.T) {
+	d := &DependabotAlert{}
+	d.GetDismissedBy()
+	d = nil
+	d.GetDismissedBy()
+}
+
+func TestDependabotAlert_GetDismissedComment(tt *testing.T) {
+	var zeroValue string
+	d := &DependabotAlert{DismissedComment: &zeroValue}
+	d.GetDismissedComment()
+	d = &DependabotAlert{}
+	d.GetDismissedComment()
+	d = nil
+	d.GetDismissedComment()
+}
+
+func TestDependabotAlert_GetDismissedReason(tt *testing.T) {
+	var zeroValue string
+	d := &DependabotAlert{DismissedReason: &zeroValue}
+	d.GetDismissedReason()
+	d = &DependabotAlert{}
+	d.GetDismissedReason()
+	d = nil
+	d.GetDismissedReason()
+}
+
+func TestDependabotAlert_GetFixedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	d := &DependabotAlert{FixedAt: &zeroValue}
+	d.GetFixedAt()
+	d = &DependabotAlert{}
+	d.GetFixedAt()
+	d = nil
+	d.GetFixedAt()
+}
+
+func TestDependabotAlert_GetHtmlURL(tt *testing.T) {
+	var zeroValue string
+	d := &DependabotAlert{HtmlURL: &zeroValue}
+	d.GetHtmlURL()
+	d = &DependabotAlert{}
+	d.GetHtmlURL()
+	d = nil
+	d.GetHtmlURL()
+}
+
+func TestDependabotAlert_GetNumber(tt *testing.T) {
+	var zeroValue int
+	d := &DependabotAlert{Number: &zeroValue}
+	d.GetNumber()
+	d = &DependabotAlert{}
+	d.GetNumber()
+	d = nil
+	d.GetNumber()
+}
+
+func TestDependabotAlert_GetSecurityAdvisory(tt *testing.T) {
+	d := &DependabotAlert{}
+	d.GetSecurityAdvisory()
+	d = nil
+	d.GetSecurityAdvisory()
+}
+
+func TestDependabotAlert_GetSecurityVulnerability(tt *testing.T) {
+	d := &DependabotAlert{}
+	d.GetSecurityVulnerability()
+	d = nil
+	d.GetSecurityVulnerability()
+}
+
+func TestDependabotAlert_GetState(tt *testing.T) {
+	var zeroValue string
+	d := &DependabotAlert{State: &zeroValue}
+	d.GetState()
+	d = &DependabotAlert{}
+	d.GetState()
+	d = nil
+	d.GetState()
+}
+
+func TestDependabotAlert_GetUpdatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	d := &DependabotAlert{UpdatedAt: &zeroValue}
+	d.GetUpdatedAt()
+	d = &DependabotAlert{}
+	d.GetUpdatedAt()
+	d = nil
+	d.GetUpdatedAt()
+}
+
+func TestDependabotAlert_GetURL(tt *testing.T) {
+	var zeroValue string
+	d := &DependabotAlert{URL: &zeroValue}
+	d.GetURL()
+	d = &DependabotAlert{}
+	d.GetURL()
+	d = nil
+	d.GetURL()
+}
+
+func TestDependabotSecurityAdvisory_GetCVEID(tt *testing.T) {
+	var zeroValue string
+	d := &DependabotSecurityAdvisory{CVEID: &zeroValue}
+	d.GetCVEID()
+	d = &DependabotSecurityAdvisory{}
+	d.GetCVEID()
+	d = nil
+	d.GetCVEID()
+}
+
+func TestDependabotSecurityAdvisory_GetCVSs(tt *testing.T) {
+	d := &DependabotSecurityAdvisory{}
+	d.GetCVSs()
+	d = nil
+	d.GetCVSs()
+}
+
+func TestDependabotSecurityAdvisory_GetDescription(tt *testing.T) {
+	var zeroValue string
+	d := &DependabotSecurityAdvisory{Description: &zeroValue}
+	d.GetDescription()
+	d = &DependabotSecurityAdvisory{}
+	d.GetDescription()
+	d = nil
+	d.GetDescription()
+}
+
+func TestDependabotSecurityAdvisory_GetGHSAID(tt *testing.T) {
+	var zeroValue string
+	d := &DependabotSecurityAdvisory{GHSAID: &zeroValue}
+	d.GetGHSAID()
+	d = &DependabotSecurityAdvisory{}
+	d.GetGHSAID()
+	d = nil
+	d.GetGHSAID()
+}
+
+func TestDependabotSecurityAdvisory_GetPublishedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	d := &DependabotSecurityAdvisory{PublishedAt: &zeroValue}
+	d.GetPublishedAt()
+	d = &DependabotSecurityAdvisory{}
+	d.GetPublishedAt()
+	d = nil
+	d.GetPublishedAt()
+}
+
+func TestDependabotSecurityAdvisory_GetSeverity(tt *testing.T) {
+	var zeroValue string
+	d := &DependabotSecurityAdvisory{Severity: &zeroValue}
+	d.GetSeverity()
+	d = &DependabotSecurityAdvisory{}
+	d.GetSeverity()
+	d = nil
+	d.GetSeverity()
+}
+
+func TestDependabotSecurityAdvisory_GetSummary(tt *testing.T) {
+	var zeroValue string
+	d := &DependabotSecurityAdvisory{Summary: &zeroValue}
+	d.GetSummary()
+	d = &DependabotSecurityAdvisory{}
+	d.GetSummary()
+	d = nil
+	d.GetSummary()
+}
+
+func TestDependabotSecurityAdvisory_GetUpdatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	d := &DependabotSecurityAdvisory{UpdatedAt: &zeroValue}
+	d.GetUpdatedAt()
+	d = &DependabotSecurityAdvisory{}
+	d.GetUpdatedAt()
+	d = nil
+	d.GetUpdatedAt()
+}
+
+func TestDependabotSecurityAdvisory_GetWithdrawnAt(tt *testing.T) {
+	var zeroValue Timestamp
+	d := &DependabotSecurityAdvisory{WithdrawnAt: &zeroValue}
+	d.GetWithdrawnAt()
+	d = &DependabotSecurityAdvisory{}
+	d.GetWithdrawnAt()
+	d = nil
+	d.GetWithdrawnAt()
+}
+
+func TestDependency_GetManifestPath(tt *testing.T) {
+	var zeroValue string
+	d := &Dependency{ManifestPath: &zeroValue}
+	d.GetManifestPath()
+	d = &Dependency{}
+	d.GetManifestPath()
+	d = nil
+	d.GetManifestPath()
+}
+
+func TestDependency_GetPackage(tt *testing.T) {
+	d := &Dependency{}
+	d.GetPackage()
+	d = nil
+	d.GetPackage()
+}
+
+func TestDependency_GetScope(tt *testing.T) {
+	var zeroValue string
+	d := &Dependency{Scope: &zeroValue}
+	d.GetScope()
+	d = &Dependency{}
+	d.GetScope()
+	d = nil
+	d.GetScope()
 }
 
 func TestDeployKeyEvent_GetAction(tt *testing.T) {
@@ -9694,6 +9973,76 @@ func TestLinearHistoryRequirementEnforcementLevelChanges_GetFrom(tt *testing.T) 
 	l.GetFrom()
 	l = nil
 	l.GetFrom()
+}
+
+func TestListAlertsOptions_GetDirection(tt *testing.T) {
+	var zeroValue string
+	l := &ListAlertsOptions{Direction: &zeroValue}
+	l.GetDirection()
+	l = &ListAlertsOptions{}
+	l.GetDirection()
+	l = nil
+	l.GetDirection()
+}
+
+func TestListAlertsOptions_GetEcosystem(tt *testing.T) {
+	var zeroValue string
+	l := &ListAlertsOptions{Ecosystem: &zeroValue}
+	l.GetEcosystem()
+	l = &ListAlertsOptions{}
+	l.GetEcosystem()
+	l = nil
+	l.GetEcosystem()
+}
+
+func TestListAlertsOptions_GetPackage(tt *testing.T) {
+	var zeroValue string
+	l := &ListAlertsOptions{Package: &zeroValue}
+	l.GetPackage()
+	l = &ListAlertsOptions{}
+	l.GetPackage()
+	l = nil
+	l.GetPackage()
+}
+
+func TestListAlertsOptions_GetScope(tt *testing.T) {
+	var zeroValue string
+	l := &ListAlertsOptions{Scope: &zeroValue}
+	l.GetScope()
+	l = &ListAlertsOptions{}
+	l.GetScope()
+	l = nil
+	l.GetScope()
+}
+
+func TestListAlertsOptions_GetSeverity(tt *testing.T) {
+	var zeroValue string
+	l := &ListAlertsOptions{Severity: &zeroValue}
+	l.GetSeverity()
+	l = &ListAlertsOptions{}
+	l.GetSeverity()
+	l = nil
+	l.GetSeverity()
+}
+
+func TestListAlertsOptions_GetSort(tt *testing.T) {
+	var zeroValue string
+	l := &ListAlertsOptions{Sort: &zeroValue}
+	l.GetSort()
+	l = &ListAlertsOptions{}
+	l.GetSort()
+	l = nil
+	l.GetSort()
+}
+
+func TestListAlertsOptions_GetState(tt *testing.T) {
+	var zeroValue string
+	l := &ListAlertsOptions{State: &zeroValue}
+	l.GetState()
+	l = &ListAlertsOptions{}
+	l.GetState()
+	l = nil
+	l.GetState()
 }
 
 func TestListCheckRunsOptions_GetAppID(tt *testing.T) {

--- a/github/github.go
+++ b/github/github.go
@@ -237,6 +237,14 @@ type ListCursorOptions struct {
 	// For paginated result sets, the number of results to include per page.
 	PerPage int `url:"per_page,omitempty"`
 
+	// For paginated result sets, the number of results per page (max 100), starting from the first matching result.
+	// This parameter must not be used in combination with last.
+	First int `url:"first,omitempty"`
+
+	// For paginated result sets, the number of results per page (max 100), starting from the last matching result.
+	// This parameter must not be used in combination with first.
+	Last int `url:"last,omitempty"`
+
 	// A cursor, as given in the Link header. If specified, the query only searches for events after this cursor.
 	After string `url:"after,omitempty"`
 


### PR DESCRIPTION
This add support for reading dependabot alerts: https://docs.github.com/en/rest/dependabot/alerts

I added the `First` and `Last` parameters to the `ListCursorOptions`. It seems to replace the `PerPage` parameter.