### PR TITLE
Add parents field to timeline events

### DIFF
--- a/github/issues_timeline.go
+++ b/github/issues_timeline.go
@@ -35,6 +35,8 @@ type Timeline struct {
 	SHA *string `json:"sha,omitempty"`
 	// The commit message.
 	Message *string `json:"message,omitempty"`
+	// The commit parents.
+	Parents []*Commit `json:"parents,omitempty"`
 
 	// Event identifies the actual type of Event that occurred. Possible values
 	// are:

--- a/github/issues_timeline.go
+++ b/github/issues_timeline.go
@@ -35,7 +35,7 @@ type Timeline struct {
 	SHA *string `json:"sha,omitempty"`
 	// The commit message.
 	Message *string `json:"message,omitempty"`
-	// The commit parents.
+	// A list of parent commits.
 	Parents []*Commit `json:"parents,omitempty"`
 
 	// Event identifies the actual type of Event that occurred. Possible values


### PR DESCRIPTION
The `committed` events from the timeline API can have a `parents` field containing the parent commits:
```json
    "parents": [
      {
        "sha": "29480ba555d614487fddba278d32d19102e86527",
        "url": "https://api.github.com/repos/google/go-github/git/commits/29480ba555d614487fddba278d32d19102e86527",
        "html_url": "https://github.com/google/go-github/commit/29480ba555d614487fddba278d32d19102e86527"
      }
    ],
```
This is also documented on the `issue` event payload: https://docs.github.com/en/developers/webhooks-and-events/events/issue-event-types#event-object-properties-7