### PR TITLE
Add LockBranch and AllowForkSyncing to repos.go

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -12254,12 +12254,28 @@ func (p *Protection) GetAllowForcePushes() *AllowForcePushes {
 	return p.AllowForcePushes
 }
 
+// GetAllowForkSyncing returns the AllowForkSyncing field if it's non-nil, zero value otherwise.
+func (p *Protection) GetAllowForkSyncing() bool {
+	if p == nil || p.AllowForkSyncing == nil {
+		return false
+	}
+	return *p.AllowForkSyncing
+}
+
 // GetEnforceAdmins returns the EnforceAdmins field.
 func (p *Protection) GetEnforceAdmins() *AdminEnforcement {
 	if p == nil {
 		return nil
 	}
 	return p.EnforceAdmins
+}
+
+// GetLockBranch returns the LockBranch field if it's non-nil, zero value otherwise.
+func (p *Protection) GetLockBranch() bool {
+	if p == nil || p.LockBranch == nil {
+		return false
+	}
+	return *p.LockBranch
 }
 
 // GetRequiredConversationResolution returns the RequiredConversationResolution field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -14310,11 +14310,31 @@ func TestProtection_GetAllowForcePushes(tt *testing.T) {
 	p.GetAllowForcePushes()
 }
 
+func TestProtection_GetAllowForkSyncing(tt *testing.T) {
+	var zeroValue bool
+	p := &Protection{AllowForkSyncing: &zeroValue}
+	p.GetAllowForkSyncing()
+	p = &Protection{}
+	p.GetAllowForkSyncing()
+	p = nil
+	p.GetAllowForkSyncing()
+}
+
 func TestProtection_GetEnforceAdmins(tt *testing.T) {
 	p := &Protection{}
 	p.GetEnforceAdmins()
 	p = nil
 	p.GetEnforceAdmins()
+}
+
+func TestProtection_GetLockBranch(tt *testing.T) {
+	var zeroValue bool
+	p := &Protection{LockBranch: &zeroValue}
+	p.GetLockBranch()
+	p = &Protection{}
+	p.GetLockBranch()
+	p = nil
+	p.GetLockBranch()
 }
 
 func TestProtection_GetRequiredConversationResolution(tt *testing.T) {

--- a/github/repos.go
+++ b/github/repos.go
@@ -841,9 +841,9 @@ type Protection struct {
 	AllowDeletions                 *AllowDeletions                 `json:"allow_deletions"`
 	RequiredConversationResolution *RequiredConversationResolution `json:"required_conversation_resolution"`
 	// LockBranch represents if the branch is marked as read-only. If this is true, users will not be able to push to the branch.
-	LockBranch                     *bool                     `json:"lock_branch,omitempty"`
+	LockBranch *bool `json:"lock_branch,omitempty"`
 	// AllowForkSyncing represents whether users can pull changes from upstream when the branch is locked.
-	AllowForkSyncing               *bool               `json:"allow_fork_syncing,omitempty"`
+	AllowForkSyncing *bool `json:"allow_fork_syncing,omitempty"`
 }
 
 // BranchProtectionRule represents the rule applied to a repositories branch.
@@ -898,19 +898,9 @@ type AdminEnforcedChanges struct {
 	From *bool `json:"from,omitempty"`
 }
 
-// LockBranch represents if the branch is marked as read-only. If this is true, users will not be able to push to the branch.
-type LockBranch struct {
-	From *bool `json:"lock_branch"`
-}
-
 // AllowDeletionsEnforcementLevelChanges represents the changes made to the AllowDeletionsEnforcementLevel policy.
 type AllowDeletionsEnforcementLevelChanges struct {
 	From *string `json:"from,omitempty"`
-}
-
-// AllowForkSyncing represents whether users can pull changes from upstream when the branch is locked.
-type AllowForkSyncing struct {
-	From *bool `json:"allow_fork_syncing"`
 }
 
 // AuthorizedActorNames represents who are authorized to edit the branch protection rules.

--- a/github/repos.go
+++ b/github/repos.go
@@ -840,6 +840,8 @@ type Protection struct {
 	AllowForcePushes               *AllowForcePushes               `json:"allow_force_pushes"`
 	AllowDeletions                 *AllowDeletions                 `json:"allow_deletions"`
 	RequiredConversationResolution *RequiredConversationResolution `json:"required_conversation_resolution"`
+	LockBranch                     *LockBranch                     `json:"lock_branch"`
+	AllowForkSyncing               *AllowForkSyncing               `json:"allow_fork_syncing"`
 }
 
 // BranchProtectionRule represents the rule applied to a repositories branch.
@@ -894,9 +896,19 @@ type AdminEnforcedChanges struct {
 	From *bool `json:"from,omitempty"`
 }
 
+// LockBranch represents if the branch is marked as read-only. If this is true, users will not be able to push to the branch.
+type LockBranch struct {
+	From *bool `json:"lock_branch"`
+}
+
 // AllowDeletionsEnforcementLevelChanges represents the changes made to the AllowDeletionsEnforcementLevel policy.
 type AllowDeletionsEnforcementLevelChanges struct {
 	From *string `json:"from,omitempty"`
+}
+
+// AllowForkSyncing represents whether users can pull changes from upstream when the branch is locked.
+type AllowForkSyncing struct {
+	From *bool `json:"allow_fork_syncing"`
 }
 
 // AuthorizedActorNames represents who are authorized to edit the branch protection rules.

--- a/github/repos.go
+++ b/github/repos.go
@@ -840,8 +840,10 @@ type Protection struct {
 	AllowForcePushes               *AllowForcePushes               `json:"allow_force_pushes"`
 	AllowDeletions                 *AllowDeletions                 `json:"allow_deletions"`
 	RequiredConversationResolution *RequiredConversationResolution `json:"required_conversation_resolution"`
-	LockBranch                     *LockBranch                     `json:"lock_branch"`
-	AllowForkSyncing               *AllowForkSyncing               `json:"allow_fork_syncing"`
+	// LockBranch represents if the branch is marked as read-only. If this is true, users will not be able to push to the branch.
+	LockBranch                     *bool                     `json:"lock_branch,omitempty"`
+	// AllowForkSyncing represents whether users can pull changes from upstream when the branch is locked.
+	AllowForkSyncing               *bool               `json:"allow_fork_syncing,omitempty"`
 }
 
 // BranchProtectionRule represents the rule applied to a repositories branch.


### PR DESCRIPTION
Fixes https://github.com/google/go-github/issues/2574 , and it is mostly a direct, if barebones, implementation of the plan ideated there. Adding references to `LockBranch` and `AllowForkSyncing`. References to `RequireLastPushApproval` were added in cb24cabfacd4bff06727d5b3acea48ba56e5f690 . There might be some changes left to do.