### PR TITLE
Add support for repository actions access level / permission

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -15646,6 +15646,14 @@ func (r *Repository) GetWatchersCount() int {
 	return *r.WatchersCount
 }
 
+// GetAccessLevel returns the AccessLevel field if it's non-nil, zero value otherwise.
+func (r *RepositoryActionsAccessLevel) GetAccessLevel() string {
+	if r == nil || r.AccessLevel == nil {
+		return ""
+	}
+	return *r.AccessLevel
+}
+
 // GetAdvancedSecurityCommitters returns the AdvancedSecurityCommitters field if it's non-nil, zero value otherwise.
 func (r *RepositoryActiveCommitters) GetAdvancedSecurityCommitters() int {
 	if r == nil || r.AdvancedSecurityCommitters == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -18208,6 +18208,16 @@ func TestRepository_GetWatchersCount(tt *testing.T) {
 	r.GetWatchersCount()
 }
 
+func TestRepositoryActionsAccessLevel_GetAccessLevel(tt *testing.T) {
+	var zeroValue string
+	r := &RepositoryActionsAccessLevel{AccessLevel: &zeroValue}
+	r.GetAccessLevel()
+	r = &RepositoryActionsAccessLevel{}
+	r.GetAccessLevel()
+	r = nil
+	r.GetAccessLevel()
+}
+
 func TestRepositoryActiveCommitters_GetAdvancedSecurityCommitters(tt *testing.T) {
 	var zeroValue int
 	r := &RepositoryActiveCommitters{AdvancedSecurityCommitters: &zeroValue}

--- a/github/repos_actions_access.go
+++ b/github/repos_actions_access.go
@@ -1,0 +1,56 @@
+// Copyright 2022 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// RepositoryActionsAccessLevel represents the repository actions access level.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/permissions#set-the-level-of-access-for-workflows-outside-of-the-repository
+type RepositoryActionsAccessLevel struct {
+	// AccessLevel specifies the level of access that workflows outside of the repository have
+	// to actions and reusable workflows within the repository.
+	// Possible values are: "none", "organization" "enterprise"
+	AccessLevel *string `json:"access_level,omitempty"`
+}
+
+// GetActionsAccessLevel gets the level of access that workflows outside of the repository have
+// to actions and reusable workflows in the repository.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/permissions#get-the-level-of-access-for-workflows-outside-of-the-repository
+func (s *RepositoriesService) GetActionsAccessLevel(ctx context.Context, owner, repo string) (*RepositoryActionsAccessLevel, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/permissions/access", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	raal := new(RepositoryActionsAccessLevel)
+	resp, err := s.client.Do(ctx, req, raal)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return raal, resp, nil
+}
+
+// EditActionsAccessLevel sets the level of access that workflows outside of the repository have
+// to actions and reusable workflows in the repository.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/permissions#set-the-level-of-access-for-workflows-outside-of-the-repository
+func (s *RepositoriesService) EditActionsAccessLevel(ctx context.Context, owner, repo string, repositoryActionsAccessLevel RepositoryActionsAccessLevel) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/permissions/access", owner, repo)
+	req, err := s.client.NewRequest("PUT", u, repositoryActionsAccessLevel)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	return resp, err
+}

--- a/github/repos_actions_access.go
+++ b/github/repos_actions_access.go
@@ -16,7 +16,7 @@ import (
 type RepositoryActionsAccessLevel struct {
 	// AccessLevel specifies the level of access that workflows outside of the repository have
 	// to actions and reusable workflows within the repository.
-	// Possible values are: "none", "organization" "enterprise"
+	// Possible values are: "none", "organization" "enterprise".
 	AccessLevel *string `json:"access_level,omitempty"`
 }
 
@@ -51,6 +51,5 @@ func (s *RepositoriesService) EditActionsAccessLevel(ctx context.Context, owner,
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
-	return resp, err
+	return s.client.Do(ctx, req, nil)
 }

--- a/github/repos_actions_access_test.go
+++ b/github/repos_actions_access_test.go
@@ -1,0 +1,98 @@
+// Copyright 2022 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRepositoriesService_GetActionsAccessLevel(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/permissions/access", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprintf(w, `{"access_level": "none"}`)
+	})
+
+	ctx := context.Background()
+	org, _, err := client.Repositories.GetActionsAccessLevel(ctx, "o", "r")
+	if err != nil {
+		t.Errorf("Repositories.GetActionsAccessLevel returned error: %v", err)
+	}
+	want := &RepositoryActionsAccessLevel{AccessLevel: String("none")}
+	if !cmp.Equal(org, want) {
+		t.Errorf("Repositories.GetActionsAccessLevel returned %+v, want %+v", org, want)
+	}
+
+	const methodName = "GetActionsAccessLevel"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Repositories.GetActionsAccessLevel(ctx, "\n", "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Repositories.GetActionsAccessLevel(ctx, "o", "r")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestRepositoriesService_EditActionsAccessLevel(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &RepositoryActionsAccessLevel{AccessLevel: String("organization")}
+
+	mux.HandleFunc("/repos/o/r/actions/permissions/access", func(w http.ResponseWriter, r *http.Request) {
+		v := new(RepositoryActionsAccessLevel)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "PUT")
+		if !cmp.Equal(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+	})
+
+	ctx := context.Background()
+	_, err := client.Repositories.EditActionsAccessLevel(ctx, "o", "r", *input)
+	if err != nil {
+		t.Errorf("Repositories.EditActionsAccessLevel returned error: %v", err)
+	}
+
+	const methodName = "EditActionsAccessLevel"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Repositories.EditActionsAccessLevel(ctx, "\n", "\n", *input)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		resp, err := client.Repositories.EditActionsAccessLevel(ctx, "o", "r", *input)
+		return resp, err
+	})
+}
+
+func TestRepositoryActionsAccessLevel_Marshal(t *testing.T) {
+	testJSONMarshal(t, &ActionsPermissions{}, "{}")
+
+	u := &RepositoryActionsAccessLevel{
+		AccessLevel: String("enterprise"),
+	}
+
+	want := `{
+		"access_level": "enterprise"
+	}`
+
+	testJSONMarshal(t, u, want)
+}


### PR DESCRIPTION
This PR adds support for the following endpoints and closes #2575:  
[`GET` `/repos/{owner}/{repo}/actions/permissions/access`](https://docs.github.com/en/enterprise-cloud@latest/rest/actions/permissions#get-the-level-of-access-for-workflows-outside-of-the-repository)  
[`PUT` `/repos/{owner}/{repo}/actions/permissions/access`](https://docs.github.com/en/enterprise-cloud@latest/rest/actions/permissions#set-the-level-of-access-for-workflows-outside-of-the-repository)
