### PR TITLE
Add new field for issue state reason

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -7470,6 +7470,14 @@ func (i *Issue) GetState() string {
 	return *i.State
 }
 
+// GetStateReason returns the StateReason field if it's non-nil, zero value otherwise.
+func (i *Issue) GetStateReason() string {
+	if i == nil || i.StateReason == nil {
+		return ""
+	}
+	return *i.StateReason
+}
+
 // GetTitle returns the Title field if it's non-nil, zero value otherwise.
 func (i *Issue) GetTitle() string {
 	if i == nil || i.Title == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -8780,6 +8780,16 @@ func TestIssue_GetState(tt *testing.T) {
 	i.GetState()
 }
 
+func TestIssue_GetStateReason(tt *testing.T) {
+	var zeroValue string
+	i := &Issue{StateReason: &zeroValue}
+	i.GetStateReason()
+	i = &Issue{}
+	i.GetStateReason()
+	i = nil
+	i.GetStateReason()
+}
+
 func TestIssue_GetTitle(tt *testing.T) {
 	var zeroValue string
 	i := &Issue{Title: &zeroValue}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -713,6 +713,7 @@ func TestIssue_String(t *testing.T) {
 		ID:                Int64(0),
 		Number:            Int(0),
 		State:             String(""),
+		StateReason:       String(""),
 		Locked:            Bool(false),
 		Title:             String(""),
 		Body:              String(""),
@@ -734,7 +735,7 @@ func TestIssue_String(t *testing.T) {
 		NodeID:            String(""),
 		ActiveLockReason:  String(""),
 	}
-	want := `github.Issue{ID:0, Number:0, State:"", Locked:false, Title:"", Body:"", AuthorAssociation:"", User:github.User{}, Assignee:github.User{}, Comments:0, ClosedBy:github.User{}, URL:"", HTMLURL:"", CommentsURL:"", EventsURL:"", LabelsURL:"", RepositoryURL:"", Milestone:github.Milestone{}, PullRequestLinks:github.PullRequestLinks{}, Repository:github.Repository{}, Reactions:github.Reactions{}, NodeID:"", ActiveLockReason:""}`
+	want := `github.Issue{ID:0, Number:0, State:"", StateReason:"", Locked:false, Title:"", Body:"", AuthorAssociation:"", User:github.User{}, Assignee:github.User{}, Comments:0, ClosedBy:github.User{}, URL:"", HTMLURL:"", CommentsURL:"", EventsURL:"", LabelsURL:"", RepositoryURL:"", Milestone:github.Milestone{}, PullRequestLinks:github.PullRequestLinks{}, Repository:github.Repository{}, Reactions:github.Reactions{}, NodeID:"", ActiveLockReason:""}`
 	if got := v.String(); got != want {
 		t.Errorf("Issue.String = %v, want %v", got, want)
 	}

--- a/github/issues.go
+++ b/github/issues.go
@@ -28,6 +28,7 @@ type Issue struct {
 	ID                *int64            `json:"id,omitempty"`
 	Number            *int              `json:"number,omitempty"`
 	State             *string           `json:"state,omitempty"`
+	// StateReason can be one of: "completed", "not_planned", "reopened".
 	StateReason       *string           `json:"state_reason,omitempty"`
 	Locked            *bool             `json:"locked,omitempty"`
 	Title             *string           `json:"title,omitempty"`

--- a/github/issues.go
+++ b/github/issues.go
@@ -28,6 +28,7 @@ type Issue struct {
 	ID                *int64            `json:"id,omitempty"`
 	Number            *int              `json:"number,omitempty"`
 	State             *string           `json:"state,omitempty"`
+	StateReason       *string           `json:"state_reason,omitempty"`
 	Locked            *bool             `json:"locked,omitempty"`
 	Title             *string           `json:"title,omitempty"`
 	Body              *string           `json:"body,omitempty"`

--- a/github/issues.go
+++ b/github/issues.go
@@ -25,9 +25,9 @@ type IssuesService service
 // this is an issue, and if PullRequestLinks is not nil, this is a pull request.
 // The IsPullRequest helper method can be used to check that.
 type Issue struct {
-	ID                *int64            `json:"id,omitempty"`
-	Number            *int              `json:"number,omitempty"`
-	State             *string           `json:"state,omitempty"`
+	ID     *int64  `json:"id,omitempty"`
+	Number *int    `json:"number,omitempty"`
+	State  *string `json:"state,omitempty"`
 	// StateReason can be one of: "completed", "not_planned", "reopened".
 	StateReason       *string           `json:"state_reason,omitempty"`
 	Locked            *bool             `json:"locked,omitempty"`


### PR DESCRIPTION
Adds new field `state_reason` for GitHub Issue struct.
reference on the field: https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#update-an-issue