### PR TITLE
Add MakeLatest parameter to support explicitly setting latest release

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -16406,6 +16406,14 @@ func (r *RepositoryRelease) GetID() int64 {
 	return *r.ID
 }
 
+// GetMakeLatest returns the MakeLatest field if it's non-nil, zero value otherwise.
+func (r *RepositoryRelease) GetMakeLatest() string {
+	if r == nil || r.MakeLatest == nil {
+		return ""
+	}
+	return *r.MakeLatest
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (r *RepositoryRelease) GetName() string {
 	if r == nil || r.Name == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -19077,6 +19077,16 @@ func TestRepositoryRelease_GetID(tt *testing.T) {
 	r.GetID()
 }
 
+func TestRepositoryRelease_GetMakeLatest(tt *testing.T) {
+	var zeroValue string
+	r := &RepositoryRelease{MakeLatest: &zeroValue}
+	r.GetMakeLatest()
+	r = &RepositoryRelease{}
+	r.GetMakeLatest()
+	r = nil
+	r.GetMakeLatest()
+}
+
 func TestRepositoryRelease_GetName(tt *testing.T) {
 	var zeroValue string
 	r := &RepositoryRelease{Name: &zeroValue}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1696,6 +1696,7 @@ func TestRepositoryRelease_String(t *testing.T) {
 		Body:                   String(""),
 		Draft:                  Bool(false),
 		Prerelease:             Bool(false),
+		MakeLatest:             String(""),
 		DiscussionCategoryName: String(""),
 		GenerateReleaseNotes:   Bool(false),
 		ID:                     Int64(0),
@@ -1710,7 +1711,7 @@ func TestRepositoryRelease_String(t *testing.T) {
 		Author:                 &User{},
 		NodeID:                 String(""),
 	}
-	want := `github.RepositoryRelease{TagName:"", TargetCommitish:"", Name:"", Body:"", Draft:false, Prerelease:false, DiscussionCategoryName:"", GenerateReleaseNotes:false, ID:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, PublishedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, URL:"", HTMLURL:"", AssetsURL:"", UploadURL:"", ZipballURL:"", TarballURL:"", Author:github.User{}, NodeID:""}`
+	want := `github.RepositoryRelease{TagName:"", TargetCommitish:"", Name:"", Body:"", Draft:false, Prerelease:false, MakeLatest:"", DiscussionCategoryName:"", GenerateReleaseNotes:false, ID:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, PublishedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, URL:"", HTMLURL:"", AssetsURL:"", UploadURL:"", ZipballURL:"", TarballURL:"", Author:github.User{}, NodeID:""}`
 	if got := v.String(); got != want {
 		t.Errorf("RepositoryRelease.String = %v, want %v", got, want)
 	}

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -25,6 +25,7 @@ type RepositoryRelease struct {
 	Body                   *string `json:"body,omitempty"`
 	Draft                  *bool   `json:"draft,omitempty"`
 	Prerelease             *bool   `json:"prerelease,omitempty"`
+	MakeLatest             *string `json:"make_latest,omitempty"`
 	DiscussionCategoryName *string `json:"discussion_category_name,omitempty"`
 
 	// The following fields are not used in EditRelease:
@@ -176,6 +177,7 @@ type repositoryReleaseRequest struct {
 	Body                   *string `json:"body,omitempty"`
 	Draft                  *bool   `json:"draft,omitempty"`
 	Prerelease             *bool   `json:"prerelease,omitempty"`
+	MakeLatest             *string `json:"make_latest,omitempty"`
 	GenerateReleaseNotes   *bool   `json:"generate_release_notes,omitempty"`
 	DiscussionCategoryName *string `json:"discussion_category_name,omitempty"`
 }
@@ -196,6 +198,7 @@ func (s *RepositoriesService) CreateRelease(ctx context.Context, owner, repo str
 		Body:                   release.Body,
 		Draft:                  release.Draft,
 		Prerelease:             release.Prerelease,
+		MakeLatest:             release.MakeLatest,
 		DiscussionCategoryName: release.DiscussionCategoryName,
 		GenerateReleaseNotes:   release.GenerateReleaseNotes,
 	}
@@ -229,6 +232,7 @@ func (s *RepositoriesService) EditRelease(ctx context.Context, owner, repo strin
 		Body:                   release.Body,
 		Draft:                  release.Draft,
 		Prerelease:             release.Prerelease,
+		MakeLatest:             release.MakeLatest,
 		DiscussionCategoryName: release.DiscussionCategoryName,
 	}
 

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -19,12 +19,13 @@ import (
 
 // RepositoryRelease represents a GitHub release in a repository.
 type RepositoryRelease struct {
-	TagName                *string `json:"tag_name,omitempty"`
-	TargetCommitish        *string `json:"target_commitish,omitempty"`
-	Name                   *string `json:"name,omitempty"`
-	Body                   *string `json:"body,omitempty"`
-	Draft                  *bool   `json:"draft,omitempty"`
-	Prerelease             *bool   `json:"prerelease,omitempty"`
+	TagName         *string `json:"tag_name,omitempty"`
+	TargetCommitish *string `json:"target_commitish,omitempty"`
+	Name            *string `json:"name,omitempty"`
+	Body            *string `json:"body,omitempty"`
+	Draft           *bool   `json:"draft,omitempty"`
+	Prerelease      *bool   `json:"prerelease,omitempty"`
+	// MakeLatest can be one of: "true", "false", or "legacy".
 	MakeLatest             *string `json:"make_latest,omitempty"`
 	DiscussionCategoryName *string `json:"discussion_category_name,omitempty"`
 

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -708,6 +708,7 @@ func TestRepositoryReleaseRequest_Marshal(t *testing.T) {
 		Body:                   String("body"),
 		Draft:                  Bool(false),
 		Prerelease:             Bool(false),
+		MakeLatest:             String("legacy"),
 		DiscussionCategoryName: String("dcn"),
 	}
 
@@ -718,6 +719,7 @@ func TestRepositoryReleaseRequest_Marshal(t *testing.T) {
 		"body": "body",
 		"draft": false,
 		"prerelease": false,
+		"make_latest": "legacy",
 		"discussion_category_name": "dcn"
 	}`
 
@@ -774,6 +776,7 @@ func TestRepositoryRelease_Marshal(t *testing.T) {
 		Body:                   String("body"),
 		Draft:                  Bool(false),
 		Prerelease:             Bool(false),
+		MakeLatest:             String("legacy"),
 		DiscussionCategoryName: String("dcn"),
 		ID:                     Int64(1),
 		CreatedAt:              &Timestamp{referenceTime},
@@ -796,6 +799,7 @@ func TestRepositoryRelease_Marshal(t *testing.T) {
 		"body": "body",
 		"draft": false,
 		"prerelease": false,
+		"make_latest": "legacy",
 		"discussion_category_name": "dcn",
 		"id": 1,
 		"created_at": ` + referenceTimeStr + `,


### PR DESCRIPTION
Fixes: #2593

This adds support for the `make_latest` parameter added to the GitHub repositories API for setting explicit releases.

https://github.blog/changelog/2022-10-21-explicitly-set-the-latest-release/
https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#update-a-release