### PR TITLE
Change actions billing structs to maps

### DIFF
--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -70,6 +70,7 @@ type WorkflowRunUsage struct {
 }
 
 // WorkflowRunBillMap represents different runner environments available for a workflow run.
+// Its key is the name of its environment, e.g. "UBUNTU", "MACOS", "WINDOWS", etc.
 type WorkflowRunBillMap map[string]*WorkflowRunBill
 
 // WorkflowRunBill specifies billable time for a specific environment in a workflow run.

--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -65,16 +65,12 @@ type ListWorkflowRunsOptions struct {
 
 // WorkflowRunUsage represents a usage of a specific workflow run.
 type WorkflowRunUsage struct {
-	Billable      *WorkflowRunEnvironment `json:"billable,omitempty"`
-	RunDurationMS *int64                  `json:"run_duration_ms,omitempty"`
+	Billable      *WorkflowRunBillMap `json:"billable,omitempty"`
+	RunDurationMS *int64              `json:"run_duration_ms,omitempty"`
 }
 
-// WorkflowRunEnvironment represents different runner environments available for a workflow run.
-type WorkflowRunEnvironment struct {
-	Ubuntu  *WorkflowRunBill `json:"UBUNTU,omitempty"`
-	MacOS   *WorkflowRunBill `json:"MACOS,omitempty"`
-	Windows *WorkflowRunBill `json:"WINDOWS,omitempty"`
-}
+// WorkflowRunBillMap represents different runner environments available for a workflow run.
+type WorkflowRunBillMap map[string]*WorkflowRunBill
 
 // WorkflowRunBill specifies billable time for a specific environment in a workflow run.
 type WorkflowRunBill struct {

--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -403,7 +403,6 @@ func TestActionService_ListRepositoryWorkflowRuns(t *testing.T) {
 	opts := &ListWorkflowRunsOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
 	ctx := context.Background()
 	runs, _, err := client.Actions.ListRepositoryWorkflowRuns(ctx, "o", "r", opts)
-
 	if err != nil {
 		t.Errorf("Actions.ListRepositoryWorkflowRuns returned error: %v", err)
 	}
@@ -505,8 +504,8 @@ func TestActionsService_GetWorkflowRunUsageByID(t *testing.T) {
 	}
 
 	want := &WorkflowRunUsage{
-		Billable: &WorkflowRunEnvironment{
-			Ubuntu: &WorkflowRunBill{
+		Billable: &WorkflowRunBillMap{
+			"UBUNTU": &WorkflowRunBill{
 				TotalMS: Int64(180000),
 				Jobs:    Int(1),
 				JobRuns: []*WorkflowRunJobRun{
@@ -516,7 +515,7 @@ func TestActionsService_GetWorkflowRunUsageByID(t *testing.T) {
 					},
 				},
 			},
-			MacOS: &WorkflowRunBill{
+			"MACOS": &WorkflowRunBill{
 				TotalMS: Int64(240000),
 				Jobs:    Int(2),
 				JobRuns: []*WorkflowRunJobRun{
@@ -530,7 +529,7 @@ func TestActionsService_GetWorkflowRunUsageByID(t *testing.T) {
 					},
 				},
 			},
-			Windows: &WorkflowRunBill{
+			"WINDOWS": &WorkflowRunBill{
 				TotalMS: Int64(300000),
 				Jobs:    Int(2),
 			},
@@ -975,7 +974,7 @@ func TestWorkflowRuns_Marshal(t *testing.T) {
 					"created_at": ` + referenceTimeStr + `,
 					"suspended_at": ` + referenceTimeStr + `,
 					"url": "u"
-				}		
+				}
 			}
 		]
 	}`
@@ -999,19 +998,19 @@ func TestWorkflowRunBill_Marshal(t *testing.T) {
 	testJSONMarshal(t, u, want)
 }
 
-func TestWorkflowRunEnvironment_Marshal(t *testing.T) {
-	testJSONMarshal(t, &WorkflowRunEnvironment{}, "{}")
+func TestWorkflowRunBillMap_Marshal(t *testing.T) {
+	testJSONMarshal(t, &WorkflowRunBillMap{}, "{}")
 
-	u := &WorkflowRunEnvironment{
-		Ubuntu: &WorkflowRunBill{
+	u := &WorkflowRunBillMap{
+		"UBUNTU": &WorkflowRunBill{
 			TotalMS: Int64(1),
 			Jobs:    Int(1),
 		},
-		MacOS: &WorkflowRunBill{
+		"MACOS": &WorkflowRunBill{
 			TotalMS: Int64(1),
 			Jobs:    Int(1),
 		},
-		Windows: &WorkflowRunBill{
+		"WINDOWS": &WorkflowRunBill{
 			TotalMS: Int64(1),
 			Jobs:    Int(1),
 		},
@@ -1039,16 +1038,16 @@ func TestWorkflowRunUsage_Marshal(t *testing.T) {
 	testJSONMarshal(t, &WorkflowRunUsage{}, "{}")
 
 	u := &WorkflowRunUsage{
-		Billable: &WorkflowRunEnvironment{
-			Ubuntu: &WorkflowRunBill{
+		Billable: &WorkflowRunBillMap{
+			"UBUNTU": &WorkflowRunBill{
 				TotalMS: Int64(1),
 				Jobs:    Int(1),
 			},
-			MacOS: &WorkflowRunBill{
+			"MACOS": &WorkflowRunBill{
 				TotalMS: Int64(1),
 				Jobs:    Int(1),
 			},
-			Windows: &WorkflowRunBill{
+			"WINDOWS": &WorkflowRunBill{
 				TotalMS: Int64(1),
 				Jobs:    Int(1),
 			},

--- a/github/actions_workflows.go
+++ b/github/actions_workflows.go
@@ -36,6 +36,7 @@ type WorkflowUsage struct {
 }
 
 // WorkflowBillMap represents different runner environments available for a workflow.
+// Its key is the name of its environment, e.g. "UBUNTU", "MACOS", "WINDOWS", etc.
 type WorkflowBillMap map[string]*WorkflowBill
 
 // WorkflowBill specifies billable time for a specific environment in a workflow.

--- a/github/actions_workflows.go
+++ b/github/actions_workflows.go
@@ -32,15 +32,11 @@ type Workflows struct {
 
 // WorkflowUsage represents a usage of a specific workflow.
 type WorkflowUsage struct {
-	Billable *WorkflowEnvironment `json:"billable,omitempty"`
+	Billable *WorkflowBillMap `json:"billable,omitempty"`
 }
 
-// WorkflowEnvironment represents different runner environments available for a workflow.
-type WorkflowEnvironment struct {
-	Ubuntu  *WorkflowBill `json:"UBUNTU,omitempty"`
-	MacOS   *WorkflowBill `json:"MACOS,omitempty"`
-	Windows *WorkflowBill `json:"WINDOWS,omitempty"`
-}
+// WorkflowBillMap represents different runner environments available for a workflow.
+type WorkflowBillMap map[string]*WorkflowBill
 
 // WorkflowBill specifies billable time for a specific environment in a workflow.
 type WorkflowBill struct {

--- a/github/actions_workflows_test.go
+++ b/github/actions_workflows_test.go
@@ -153,14 +153,14 @@ func TestActionsService_GetWorkflowUsageByID(t *testing.T) {
 	}
 
 	want := &WorkflowUsage{
-		Billable: &WorkflowEnvironment{
-			Ubuntu: &WorkflowBill{
+		Billable: &WorkflowBillMap{
+			"UBUNTU": &WorkflowBill{
 				TotalMS: Int64(180000),
 			},
-			MacOS: &WorkflowBill{
+			"MACOS": &WorkflowBill{
 				TotalMS: Int64(240000),
 			},
-			Windows: &WorkflowBill{
+			"WINDOWS": &WorkflowBill{
 				TotalMS: Int64(300000),
 			},
 		},
@@ -200,14 +200,14 @@ func TestActionsService_GetWorkflowUsageByFileName(t *testing.T) {
 	}
 
 	want := &WorkflowUsage{
-		Billable: &WorkflowEnvironment{
-			Ubuntu: &WorkflowBill{
+		Billable: &WorkflowBillMap{
+			"UBUNTU": &WorkflowBill{
 				TotalMS: Int64(180000),
 			},
-			MacOS: &WorkflowBill{
+			"MACOS": &WorkflowBill{
 				TotalMS: Int64(240000),
 			},
-			Windows: &WorkflowBill{
+			"WINDOWS": &WorkflowBill{
 				TotalMS: Int64(300000),
 			},
 		},
@@ -545,17 +545,17 @@ func TestWorkflowBill_Marshal(t *testing.T) {
 	testJSONMarshal(t, u, want)
 }
 
-func TestWorkflowEnvironment_Marshal(t *testing.T) {
-	testJSONMarshal(t, &WorkflowEnvironment{}, "{}")
+func TestWorkflowBillMap_Marshal(t *testing.T) {
+	testJSONMarshal(t, &WorkflowBillMap{}, "{}")
 
-	u := &WorkflowEnvironment{
-		Ubuntu: &WorkflowBill{
+	u := &WorkflowBillMap{
+		"UBUNTU": &WorkflowBill{
 			TotalMS: Int64(1),
 		},
-		MacOS: &WorkflowBill{
+		"MACOS": &WorkflowBill{
 			TotalMS: Int64(1),
 		},
-		Windows: &WorkflowBill{
+		"WINDOWS": &WorkflowBill{
 			TotalMS: Int64(1),
 		},
 	}
@@ -579,14 +579,14 @@ func TestWorkflowUsage_Marshal(t *testing.T) {
 	testJSONMarshal(t, &WorkflowUsage{}, "{}")
 
 	u := &WorkflowUsage{
-		Billable: &WorkflowEnvironment{
-			Ubuntu: &WorkflowBill{
+		Billable: &WorkflowBillMap{
+			"UBUNTU": &WorkflowBill{
 				TotalMS: Int64(1),
 			},
-			MacOS: &WorkflowBill{
+			"MACOS": &WorkflowBill{
 				TotalMS: Int64(1),
 			},
-			Windows: &WorkflowBill{
+			"WINDOWS": &WorkflowBill{
 				TotalMS: Int64(1),
 			},
 		},

--- a/github/billing.go
+++ b/github/billing.go
@@ -24,11 +24,7 @@ type ActionBilling struct {
 	MinutesUsedBreakdown MinutesUsedBreakdown `json:"minutes_used_breakdown"`
 }
 
-type MinutesUsedBreakdown struct {
-	Ubuntu  int `json:"UBUNTU"`
-	MacOS   int `json:"MACOS"`
-	Windows int `json:"WINDOWS"`
-}
+type MinutesUsedBreakdown = map[string]int
 
 // PackageBilling represents a GitHub Package billing.
 type PackageBilling struct {

--- a/github/billing.go
+++ b/github/billing.go
@@ -24,6 +24,7 @@ type ActionBilling struct {
 	MinutesUsedBreakdown MinutesUsedBreakdown `json:"minutes_used_breakdown"`
 }
 
+// MinutesUsedBreakdown counts the actions minutes used by machine type (e.g. UBUNTU, WINDOWS, MACOS).
 type MinutesUsedBreakdown = map[string]int
 
 // PackageBilling represents a GitHub Package billing.

--- a/github/billing_test.go
+++ b/github/billing_test.go
@@ -43,9 +43,9 @@ func TestBillingService_GetActionsBillingOrg(t *testing.T) {
 		TotalPaidMinutesUsed: 0,
 		IncludedMinutes:      3000,
 		MinutesUsedBreakdown: MinutesUsedBreakdown{
-			Ubuntu:  205,
-			MacOS:   10,
-			Windows: 90,
+			"UBUNTU":  205,
+			"MACOS":   10,
+			"WINDOWS": 90,
 		},
 	}
 	if !cmp.Equal(hook, want) {
@@ -209,9 +209,9 @@ func TestBillingService_GetActionsBillingUser(t *testing.T) {
 		TotalPaidMinutesUsed: 0,
 		IncludedMinutes:      3000,
 		MinutesUsedBreakdown: MinutesUsedBreakdown{
-			Ubuntu:  205,
-			MacOS:   10,
-			Windows: 90,
+			"UBUNTU":  205,
+			"MACOS":   10,
+			"WINDOWS": 90,
 		},
 	}
 	if !cmp.Equal(hook, want) {
@@ -350,9 +350,9 @@ func TestMinutesUsedBreakdown_Marshal(t *testing.T) {
 	testJSONMarshal(t, &MinutesUsedBreakdown{}, "{}")
 
 	u := &MinutesUsedBreakdown{
-		Ubuntu:  1,
-		MacOS:   1,
-		Windows: 1,
+		"UBUNTU":  1,
+		"MACOS":   1,
+		"WINDOWS": 1,
 	}
 
 	want := `{
@@ -372,9 +372,9 @@ func TestActionBilling_Marshal(t *testing.T) {
 		TotalPaidMinutesUsed: 1,
 		IncludedMinutes:      1,
 		MinutesUsedBreakdown: MinutesUsedBreakdown{
-			Ubuntu:  1,
-			MacOS:   1,
-			Windows: 1,
+			"UBUNTU":  1,
+			"MACOS":   1,
+			"WINDOWS": 1,
 		},
 	}
 

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -20566,30 +20566,6 @@ func (w *WorkflowDispatchEvent) GetWorkflow() string {
 	return *w.Workflow
 }
 
-// GetMacOS returns the MacOS field.
-func (w *WorkflowEnvironment) GetMacOS() *WorkflowBill {
-	if w == nil {
-		return nil
-	}
-	return w.MacOS
-}
-
-// GetUbuntu returns the Ubuntu field.
-func (w *WorkflowEnvironment) GetUbuntu() *WorkflowBill {
-	if w == nil {
-		return nil
-	}
-	return w.Ubuntu
-}
-
-// GetWindows returns the Windows field.
-func (w *WorkflowEnvironment) GetWindows() *WorkflowBill {
-	if w == nil {
-		return nil
-	}
-	return w.Windows
-}
-
 // GetCheckRunURL returns the CheckRunURL field if it's non-nil, zero value otherwise.
 func (w *WorkflowJob) GetCheckRunURL() string {
 	if w == nil || w.CheckRunURL == nil {
@@ -21046,30 +21022,6 @@ func (w *WorkflowRunBill) GetTotalMS() int64 {
 	return *w.TotalMS
 }
 
-// GetMacOS returns the MacOS field.
-func (w *WorkflowRunEnvironment) GetMacOS() *WorkflowRunBill {
-	if w == nil {
-		return nil
-	}
-	return w.MacOS
-}
-
-// GetUbuntu returns the Ubuntu field.
-func (w *WorkflowRunEnvironment) GetUbuntu() *WorkflowRunBill {
-	if w == nil {
-		return nil
-	}
-	return w.Ubuntu
-}
-
-// GetWindows returns the Windows field.
-func (w *WorkflowRunEnvironment) GetWindows() *WorkflowRunBill {
-	if w == nil {
-		return nil
-	}
-	return w.Windows
-}
-
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (w *WorkflowRunEvent) GetAction() string {
 	if w == nil || w.Action == nil {
@@ -21151,7 +21103,7 @@ func (w *WorkflowRuns) GetTotalCount() int {
 }
 
 // GetBillable returns the Billable field.
-func (w *WorkflowRunUsage) GetBillable() *WorkflowRunEnvironment {
+func (w *WorkflowRunUsage) GetBillable() *WorkflowRunBillMap {
 	if w == nil {
 		return nil
 	}
@@ -21175,7 +21127,7 @@ func (w *Workflows) GetTotalCount() int {
 }
 
 // GetBillable returns the Billable field.
-func (w *WorkflowUsage) GetBillable() *WorkflowEnvironment {
+func (w *WorkflowUsage) GetBillable() *WorkflowBillMap {
 	if w == nil {
 		return nil
 	}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -24022,27 +24022,6 @@ func TestWorkflowDispatchEvent_GetWorkflow(tt *testing.T) {
 	w.GetWorkflow()
 }
 
-func TestWorkflowEnvironment_GetMacOS(tt *testing.T) {
-	w := &WorkflowEnvironment{}
-	w.GetMacOS()
-	w = nil
-	w.GetMacOS()
-}
-
-func TestWorkflowEnvironment_GetUbuntu(tt *testing.T) {
-	w := &WorkflowEnvironment{}
-	w.GetUbuntu()
-	w = nil
-	w.GetUbuntu()
-}
-
-func TestWorkflowEnvironment_GetWindows(tt *testing.T) {
-	w := &WorkflowEnvironment{}
-	w.GetWindows()
-	w = nil
-	w.GetWindows()
-}
-
 func TestWorkflowJob_GetCheckRunURL(tt *testing.T) {
 	var zeroValue string
 	w := &WorkflowJob{CheckRunURL: &zeroValue}
@@ -24584,27 +24563,6 @@ func TestWorkflowRunBill_GetTotalMS(tt *testing.T) {
 	w.GetTotalMS()
 	w = nil
 	w.GetTotalMS()
-}
-
-func TestWorkflowRunEnvironment_GetMacOS(tt *testing.T) {
-	w := &WorkflowRunEnvironment{}
-	w.GetMacOS()
-	w = nil
-	w.GetMacOS()
-}
-
-func TestWorkflowRunEnvironment_GetUbuntu(tt *testing.T) {
-	w := &WorkflowRunEnvironment{}
-	w.GetUbuntu()
-	w = nil
-	w.GetUbuntu()
-}
-
-func TestWorkflowRunEnvironment_GetWindows(tt *testing.T) {
-	w := &WorkflowRunEnvironment{}
-	w.GetWindows()
-	w = nil
-	w.GetWindows()
 }
 
 func TestWorkflowRunEvent_GetAction(tt *testing.T) {


### PR DESCRIPTION
Fixes #2595.

The structs hardcode the three machine types that Github Actions supported until recently. However, we now have a lot more different types of machines, with the potential for more to be added at any time. Using maps instead of structs will allow us to transparently support more machine classes in the future.

I've done this pretty naively instead of creating safe access methods or anything like that, and kept the map values as pointers for consistency with other maps in the codebase. Can't think of any tests that would be necessary (beyond the generated ones) but open to suggestions.