### PR TITLE
Include response in `ErrorResponse`s that are parsed from the response body

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -1070,11 +1070,12 @@ func CheckResponse(r *http.Response) error {
 		return nil
 	}
 
-	errorResponse := &ErrorResponse{Response: r}
+	errorResponse := &ErrorResponse{}
 	data, err := io.ReadAll(r.Body)
 	if err == nil && data != nil {
 		json.Unmarshal(data, errorResponse)
 	}
+	errorResponse.Response = r
 	// Re-populate error response body because GitHub error responses are often
 	// undocumented and inconsistent.
 	// Issue #1136, #540.


### PR DESCRIPTION
When an error in the response body is successfully parsed, the errorResponse no longer has a `Response` property which leads to panics when calling `errorResponse.Error()`. This PR fixes that by setting the `Response` property after the unmarshal attempt rather than before.