### PR TITLE
Fix JSON protection unmarshal error

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -470,6 +470,14 @@ func (a *AllowDeletionsEnforcementLevelChanges) GetFrom() string {
 	return *a.From
 }
 
+// GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
+func (a *AllowForkSyncing) GetEnabled() bool {
+	if a == nil || a.Enabled == nil {
+		return false
+	}
+	return *a.Enabled
+}
+
 // GetRef returns the Ref field if it's non-nil, zero value otherwise.
 func (a *AnalysesListOptions) GetRef() string {
 	if a == nil || a.Ref == nil {
@@ -8742,6 +8750,14 @@ func (l *Location) GetStartLine() int {
 	return *l.StartLine
 }
 
+// GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
+func (l *LockBranch) GetEnabled() bool {
+	if l == nil || l.Enabled == nil {
+		return false
+	}
+	return *l.Enabled
+}
+
 // GetEffectiveDate returns the EffectiveDate field if it's non-nil, zero value otherwise.
 func (m *MarketplacePendingChange) GetEffectiveDate() Timestamp {
 	if m == nil || m.EffectiveDate == nil {
@@ -12262,12 +12278,12 @@ func (p *Protection) GetAllowForcePushes() *AllowForcePushes {
 	return p.AllowForcePushes
 }
 
-// GetAllowForkSyncing returns the AllowForkSyncing field if it's non-nil, zero value otherwise.
-func (p *Protection) GetAllowForkSyncing() bool {
-	if p == nil || p.AllowForkSyncing == nil {
-		return false
+// GetAllowForkSyncing returns the AllowForkSyncing field.
+func (p *Protection) GetAllowForkSyncing() *AllowForkSyncing {
+	if p == nil {
+		return nil
 	}
-	return *p.AllowForkSyncing
+	return p.AllowForkSyncing
 }
 
 // GetEnforceAdmins returns the EnforceAdmins field.
@@ -12278,12 +12294,12 @@ func (p *Protection) GetEnforceAdmins() *AdminEnforcement {
 	return p.EnforceAdmins
 }
 
-// GetLockBranch returns the LockBranch field if it's non-nil, zero value otherwise.
-func (p *Protection) GetLockBranch() bool {
-	if p == nil || p.LockBranch == nil {
-		return false
+// GetLockBranch returns the LockBranch field.
+func (p *Protection) GetLockBranch() *LockBranch {
+	if p == nil {
+		return nil
 	}
-	return *p.LockBranch
+	return p.LockBranch
 }
 
 // GetRequiredConversationResolution returns the RequiredConversationResolution field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -528,6 +528,16 @@ func TestAllowDeletionsEnforcementLevelChanges_GetFrom(tt *testing.T) {
 	a.GetFrom()
 }
 
+func TestAllowForkSyncing_GetEnabled(tt *testing.T) {
+	var zeroValue bool
+	a := &AllowForkSyncing{Enabled: &zeroValue}
+	a.GetEnabled()
+	a = &AllowForkSyncing{}
+	a.GetEnabled()
+	a = nil
+	a.GetEnabled()
+}
+
 func TestAnalysesListOptions_GetRef(tt *testing.T) {
 	var zeroValue string
 	a := &AnalysesListOptions{Ref: &zeroValue}
@@ -10265,6 +10275,16 @@ func TestLocation_GetStartLine(tt *testing.T) {
 	l.GetStartLine()
 }
 
+func TestLockBranch_GetEnabled(tt *testing.T) {
+	var zeroValue bool
+	l := &LockBranch{Enabled: &zeroValue}
+	l.GetEnabled()
+	l = &LockBranch{}
+	l.GetEnabled()
+	l = nil
+	l.GetEnabled()
+}
+
 func TestMarketplacePendingChange_GetEffectiveDate(tt *testing.T) {
 	var zeroValue Timestamp
 	m := &MarketplacePendingChange{EffectiveDate: &zeroValue}
@@ -14321,10 +14341,7 @@ func TestProtection_GetAllowForcePushes(tt *testing.T) {
 }
 
 func TestProtection_GetAllowForkSyncing(tt *testing.T) {
-	var zeroValue bool
-	p := &Protection{AllowForkSyncing: &zeroValue}
-	p.GetAllowForkSyncing()
-	p = &Protection{}
+	p := &Protection{}
 	p.GetAllowForkSyncing()
 	p = nil
 	p.GetAllowForkSyncing()
@@ -14338,10 +14355,7 @@ func TestProtection_GetEnforceAdmins(tt *testing.T) {
 }
 
 func TestProtection_GetLockBranch(tt *testing.T) {
-	var zeroValue bool
-	p := &Protection{LockBranch: &zeroValue}
-	p.GetLockBranch()
-	p = &Protection{}
+	p := &Protection{}
 	p.GetLockBranch()
 	p = nil
 	p.GetLockBranch()

--- a/github/repos.go
+++ b/github/repos.go
@@ -843,10 +843,18 @@ type Protection struct {
 	AllowForcePushes               *AllowForcePushes               `json:"allow_force_pushes"`
 	AllowDeletions                 *AllowDeletions                 `json:"allow_deletions"`
 	RequiredConversationResolution *RequiredConversationResolution `json:"required_conversation_resolution"`
-	// LockBranch represents if the branch is marked as read-only. If this is true, users will not be able to push to the branch.
-	LockBranch *bool `json:"lock_branch,omitempty"`
-	// AllowForkSyncing represents whether users can pull changes from upstream when the branch is locked.
-	AllowForkSyncing *bool `json:"allow_fork_syncing,omitempty"`
+	LockBranch                     *LockBranch                     `json:"lock_branch,omitempty"`
+	AllowForkSyncing               *AllowForkSyncing               `json:"allow_fork_syncing,omitempty"`
+}
+
+// LockBranch represents if the branch is marked as read-only. If this is true, users will not be able to push to the branch.
+type LockBranch struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// AllowForkSyncing represents whether users can pull changes from upstream when the branch is locked.
+type AllowForkSyncing struct {
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 // BranchProtectionRule represents the rule applied to a repositories branch.


### PR DESCRIPTION
## Description of change

Currently when trying to load in protection an error is thrown due to a data structure mismatch resulting in errors:
```bash
json: cannot unmarshal object into Go struct field Protection.lock_branch of type bool 
json: cannot unmarshal object into Go struct field Protection.allow_fork_syncing of type bool
```
This is due to them using an enabled field which the current structure does not understand. This change introduces the relevant structure and has been tested locally.

## API Payload:

```json
{
    "url": "https://api.github.com/repos/sous-chefs/sc_vscode/branches/main/protection",
   ...
    "required_conversation_resolution": {
        "enabled": false
    },
    "lock_branch": {
        "enabled": false
    },
    "allow_fork_syncing": {
        "enabled": false
    }
}
```

As can be seen on the payload above they are under the `enabled` key and are not bool fields directly in their own right. 


Signed-off-by: Jason Field <jason@avon-lea.co.uk>