### PR TITLE
Enable secret scanning with the enterprise-level REST API

### DIFF
--- a/github/enterprise_code_security_and_analysis.go
+++ b/github/enterprise_code_security_and_analysis.go
@@ -57,8 +57,10 @@ func (s *EnterpriseService) UpdateCodeSecurityAndAnalysis(ctx context.Context, e
 }
 
 // EnableDisableSecurityFeature enables or disables a security feature for all repositories in an enterprise.
-// Valid values for securityProduct : advanced_security, secret_scanning, secret_scanning_push_protection
-// Valid values for enablement :  enable_all, disable_all
+//
+// Valid values for securityProduct: "advanced_security", "secret_scanning", "secret_scanning_push_protection".
+// Valid values for enablement:  "enable_all", "disable_all".
+//
 // GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
 func (s *EnterpriseService) EnableDisableSecurityFeature(ctx context.Context, enterprise, securityProduct, enablement string) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/%v/%v", enterprise, securityProduct, enablement)

--- a/github/enterprise_code_security_and_analysis.go
+++ b/github/enterprise_code_security_and_analysis.go
@@ -42,7 +42,6 @@ func (s *EnterpriseService) GetCodeSecurityAndAnalysis(ctx context.Context, ente
 //
 // GitHub API docs: https://docs.github.com/en/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#update-code-security-and-analysis-features-for-an-enterprise
 func (s *EnterpriseService) UpdateCodeSecurityAndAnalysis(ctx context.Context, enterprise string, enterpriseSecurityAnalysisSettings *EnterpriseSecurityAnalysisSettings) (*Response, error) {
-
 	u := fmt.Sprintf("enterprises/%v/code_security_and_analysis", enterprise)
 	req, err := s.client.NewRequest("PATCH", u, enterpriseSecurityAnalysisSettings)
 	if err != nil {

--- a/github/enterprise_code_security_and_analysis.go
+++ b/github/enterprise_code_security_and_analysis.go
@@ -1,0 +1,166 @@
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// EnterpriseSecurityAnalysisSettings represents security analysis settings for an enterprise.
+type EnterpriseSecurityAnalysisSettings struct {
+	AdvancedSecurityEnabledForNewRepositories             bool   `json:"advanced_security_enabled_for_new_repositories,omitempty"`
+	SecretScanningEnabledForNewRepositories               bool   `json:"secret_scanning_enabled_for_new_repositories,omitempty"`
+	SecretScanningPushProtectionEnabledForNewRepositories bool   `json:"secret_scanning_push_protection_enabled_for_new_repositories,omitempty"`
+	SecretScanningPushProtectionCustomLink                string `json:"secret_scanning_push_protection_custom_link,omitempty"`
+}
+
+// GetCodeSecurityAndAnalysis gets code security and analysis features for an enterprise.
+//
+// GitHub API docs: https://docs.github.com/en/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#get-code-security-and-analysis-features-for-an-enterprise
+func (s *EnterpriseService) GetCodeSecurityAndAnalysis(ctx context.Context, enterprise string) (*EnterpriseSecurityAnalysisSettings, *Response, error) {
+	u := fmt.Sprintf("enterprises/%v/code_security_and_analysis", enterprise)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	enterpriseSecurityAnalysisSettings := new(EnterpriseSecurityAnalysisSettings)
+	resp, err := s.client.Do(ctx, req, enterpriseSecurityAnalysisSettings)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return enterpriseSecurityAnalysisSettings, resp, nil
+}
+
+// UpdateCodeSecurityAndAnalysis updates code security and analysis features for new repositories in an enterprise.
+//
+// GitHub API docs: https://docs.github.com/en/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#update-code-security-and-analysis-features-for-an-enterprise
+func (s *EnterpriseService) UpdateCodeSecurityAndAnalysis(ctx context.Context, enterprise string, enterpriseSecurityAnalysisSettings *EnterpriseSecurityAnalysisSettings) (*Response, error) {
+
+	u := fmt.Sprintf("enterprises/%v/code_security_and_analysis", enterprise)
+	req, err := s.client.NewRequest("PATCH", u, enterpriseSecurityAnalysisSettings)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// EnableAdvancedSecurity enables advanced security for all repositories in an enterprise.
+//
+// GitHub API docs:https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
+func (s *EnterpriseService) EnableAdvancedSecurity(ctx context.Context, enterprise string) (*Response, error) {
+	u := fmt.Sprintf("enterprises/%v/advanced_security/enable_all", enterprise)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// DisableAdvancedSecurity disables advanced security for all repositories in an enterprise.
+//
+// GitHub API docs:https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
+func (s *EnterpriseService) DisableAdvancedSecurity(ctx context.Context, enterprise string) (*Response, error) {
+	u := fmt.Sprintf("enterprises/%v/advanced_security/disable_all", enterprise)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// EnableSecretScanning enables secret scanning for all repositories in an enterprise.
+//
+// GitHub API docs:https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
+func (s *EnterpriseService) EnableSecretScanning(ctx context.Context, enterprise string) (*Response, error) {
+	u := fmt.Sprintf("enterprises/%v/secret_scanning/enable_all", enterprise)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// DisableSecretScanning disables secret scanning for all repositories in an enterprise.
+//
+// GitHub API docs:https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
+func (s *EnterpriseService) DisableSecretScanning(ctx context.Context, enterprise string) (*Response, error) {
+	u := fmt.Sprintf("enterprises/%v/secret_scanning/disable_all", enterprise)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// EnableSecretScanningPushProtection enables secret scanning push protection for all repositories in an enterprise.
+//
+// GitHub API docs:https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
+func (s *EnterpriseService) EnableSecretScanningPushProtection(ctx context.Context, enterprise string) (*Response, error) {
+	u := fmt.Sprintf("enterprises/%v/secret_scanning_push_protection/enable_all", enterprise)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// DisableSecretScanningPushProtection disables secret scanning push protection for all repositories in an enterprise.
+//
+// GitHub API docs:https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
+func (s *EnterpriseService) DisableSecretScanningPushProtection(ctx context.Context, enterprise string) (*Response, error) {
+	u := fmt.Sprintf("enterprises/%v/secret_scanning_push_protection/disable_all", enterprise)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}

--- a/github/enterprise_code_security_and_analysis.go
+++ b/github/enterprise_code_security_and_analysis.go
@@ -56,7 +56,7 @@ func (s *EnterpriseService) UpdateCodeSecurityAndAnalysis(ctx context.Context, e
 	return resp, nil
 }
 
-// EnableDisableSecurityFeature enables advanced security for all repositories in an enterprise.
+// EnableDisableSecurityFeature enables or disables a security feature for all repositories in an enterprise.
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
 func (s *EnterpriseService) EnableDisableSecurityFeature(ctx context.Context, enterprise string, securityProduct string, enablement string) (*Response, error) {

--- a/github/enterprise_code_security_and_analysis.go
+++ b/github/enterprise_code_security_and_analysis.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The go-github AUTHORS. All rights reserved.
+// Copyright 2022 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
@@ -12,10 +12,10 @@ import (
 
 // EnterpriseSecurityAnalysisSettings represents security analysis settings for an enterprise.
 type EnterpriseSecurityAnalysisSettings struct {
-	AdvancedSecurityEnabledForNewRepositories             bool   `json:"advanced_security_enabled_for_new_repositories,omitempty"`
-	SecretScanningEnabledForNewRepositories               bool   `json:"secret_scanning_enabled_for_new_repositories,omitempty"`
-	SecretScanningPushProtectionEnabledForNewRepositories bool   `json:"secret_scanning_push_protection_enabled_for_new_repositories,omitempty"`
-	SecretScanningPushProtectionCustomLink                string `json:"secret_scanning_push_protection_custom_link,omitempty"`
+	AdvancedSecurityEnabledForNewRepositories             *bool   `json:"advanced_security_enabled_for_new_repositories,omitempty"`
+	SecretScanningEnabledForNewRepositories               *bool   `json:"secret_scanning_enabled_for_new_repositories,omitempty"`
+	SecretScanningPushProtectionEnabledForNewRepositories *bool   `json:"secret_scanning_push_protection_enabled_for_new_repositories,omitempty"`
+	SecretScanningPushProtectionCustomLink                *string `json:"secret_scanning_push_protection_custom_link,omitempty"`
 }
 
 // GetCodeSecurityAndAnalysis gets code security and analysis features for an enterprise.
@@ -29,7 +29,7 @@ func (s *EnterpriseService) GetCodeSecurityAndAnalysis(ctx context.Context, ente
 		return nil, nil, err
 	}
 
-	enterpriseSecurityAnalysisSettings := new(EnterpriseSecurityAnalysisSettings)
+	settings := new(EnterpriseSecurityAnalysisSettings)
 	resp, err := s.client.Do(ctx, req, enterpriseSecurityAnalysisSettings)
 	if err != nil {
 		return nil, resp, err
@@ -41,7 +41,7 @@ func (s *EnterpriseService) GetCodeSecurityAndAnalysis(ctx context.Context, ente
 // UpdateCodeSecurityAndAnalysis updates code security and analysis features for new repositories in an enterprise.
 //
 // GitHub API docs: https://docs.github.com/en/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#update-code-security-and-analysis-features-for-an-enterprise
-func (s *EnterpriseService) UpdateCodeSecurityAndAnalysis(ctx context.Context, enterprise string, enterpriseSecurityAnalysisSettings *EnterpriseSecurityAnalysisSettings) (*Response, error) {
+func (s *EnterpriseService) UpdateCodeSecurityAndAnalysis(ctx context.Context, enterprise string, settings *EnterpriseSecurityAnalysisSettings) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/code_security_and_analysis", enterprise)
 	req, err := s.client.NewRequest("PATCH", u, enterpriseSecurityAnalysisSettings)
 	if err != nil {
@@ -58,7 +58,7 @@ func (s *EnterpriseService) UpdateCodeSecurityAndAnalysis(ctx context.Context, e
 
 // EnableAdvancedSecurity enables advanced security for all repositories in an enterprise.
 //
-// GitHub API docs:https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
+// GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
 func (s *EnterpriseService) EnableAdvancedSecurity(ctx context.Context, enterprise string) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/advanced_security/enable_all", enterprise)
 	req, err := s.client.NewRequest("POST", u, nil)

--- a/github/enterprise_code_security_and_analysis.go
+++ b/github/enterprise_code_security_and_analysis.go
@@ -30,12 +30,12 @@ func (s *EnterpriseService) GetCodeSecurityAndAnalysis(ctx context.Context, ente
 	}
 
 	settings := new(EnterpriseSecurityAnalysisSettings)
-	resp, err := s.client.Do(ctx, req, enterpriseSecurityAnalysisSettings)
+	resp, err := s.client.Do(ctx, req, settings)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return enterpriseSecurityAnalysisSettings, resp, nil
+	return settings, resp, nil
 }
 
 // UpdateCodeSecurityAndAnalysis updates code security and analysis features for new repositories in an enterprise.
@@ -43,7 +43,7 @@ func (s *EnterpriseService) GetCodeSecurityAndAnalysis(ctx context.Context, ente
 // GitHub API docs: https://docs.github.com/en/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#update-code-security-and-analysis-features-for-an-enterprise
 func (s *EnterpriseService) UpdateCodeSecurityAndAnalysis(ctx context.Context, enterprise string, settings *EnterpriseSecurityAnalysisSettings) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/code_security_and_analysis", enterprise)
-	req, err := s.client.NewRequest("PATCH", u, enterpriseSecurityAnalysisSettings)
+	req, err := s.client.NewRequest("PATCH", u, settings)
 	if err != nil {
 		return nil, err
 	}
@@ -56,101 +56,11 @@ func (s *EnterpriseService) UpdateCodeSecurityAndAnalysis(ctx context.Context, e
 	return resp, nil
 }
 
-// EnableAdvancedSecurity enables advanced security for all repositories in an enterprise.
+// EnableDisableSecurityFeature enables advanced security for all repositories in an enterprise.
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
-func (s *EnterpriseService) EnableAdvancedSecurity(ctx context.Context, enterprise string) (*Response, error) {
-	u := fmt.Sprintf("enterprises/%v/advanced_security/enable_all", enterprise)
-	req, err := s.client.NewRequest("POST", u, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := s.client.Do(ctx, req, nil)
-	if err != nil {
-		return resp, err
-	}
-
-	return resp, nil
-}
-
-// DisableAdvancedSecurity disables advanced security for all repositories in an enterprise.
-//
-// GitHub API docs:https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
-func (s *EnterpriseService) DisableAdvancedSecurity(ctx context.Context, enterprise string) (*Response, error) {
-	u := fmt.Sprintf("enterprises/%v/advanced_security/disable_all", enterprise)
-	req, err := s.client.NewRequest("POST", u, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := s.client.Do(ctx, req, nil)
-	if err != nil {
-		return resp, err
-	}
-
-	return resp, nil
-}
-
-// EnableSecretScanning enables secret scanning for all repositories in an enterprise.
-//
-// GitHub API docs:https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
-func (s *EnterpriseService) EnableSecretScanning(ctx context.Context, enterprise string) (*Response, error) {
-	u := fmt.Sprintf("enterprises/%v/secret_scanning/enable_all", enterprise)
-	req, err := s.client.NewRequest("POST", u, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := s.client.Do(ctx, req, nil)
-	if err != nil {
-		return resp, err
-	}
-
-	return resp, nil
-}
-
-// DisableSecretScanning disables secret scanning for all repositories in an enterprise.
-//
-// GitHub API docs:https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
-func (s *EnterpriseService) DisableSecretScanning(ctx context.Context, enterprise string) (*Response, error) {
-	u := fmt.Sprintf("enterprises/%v/secret_scanning/disable_all", enterprise)
-	req, err := s.client.NewRequest("POST", u, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := s.client.Do(ctx, req, nil)
-	if err != nil {
-		return resp, err
-	}
-
-	return resp, nil
-}
-
-// EnableSecretScanningPushProtection enables secret scanning push protection for all repositories in an enterprise.
-//
-// GitHub API docs:https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
-func (s *EnterpriseService) EnableSecretScanningPushProtection(ctx context.Context, enterprise string) (*Response, error) {
-	u := fmt.Sprintf("enterprises/%v/secret_scanning_push_protection/enable_all", enterprise)
-	req, err := s.client.NewRequest("POST", u, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := s.client.Do(ctx, req, nil)
-	if err != nil {
-		return resp, err
-	}
-
-	return resp, nil
-}
-
-// DisableSecretScanningPushProtection disables secret scanning push protection for all repositories in an enterprise.
-//
-// GitHub API docs:https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
-func (s *EnterpriseService) DisableSecretScanningPushProtection(ctx context.Context, enterprise string) (*Response, error) {
-	u := fmt.Sprintf("enterprises/%v/secret_scanning_push_protection/disable_all", enterprise)
+func (s *EnterpriseService) EnableDisableSecurityFeature(ctx context.Context, enterprise string, securityProduct string, enablement string) (*Response, error) {
+	u := fmt.Sprintf("enterprises/%v/%v/%v", enterprise, securityProduct, enablement)
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/enterprise_code_security_and_analysis.go
+++ b/github/enterprise_code_security_and_analysis.go
@@ -57,9 +57,10 @@ func (s *EnterpriseService) UpdateCodeSecurityAndAnalysis(ctx context.Context, e
 }
 
 // EnableDisableSecurityFeature enables or disables a security feature for all repositories in an enterprise.
-//
+// Valid values for securityProduct : advanced_security, secret_scanning, secret_scanning_push_protection
+// Valid values for enablement :  enable_all, disable_all
 // GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
-func (s *EnterpriseService) EnableDisableSecurityFeature(ctx context.Context, enterprise string, securityProduct string, enablement string) (*Response, error) {
+func (s *EnterpriseService) EnableDisableSecurityFeature(ctx context.Context, enterprise, securityProduct, enablement string) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/%v/%v", enterprise, securityProduct, enablement)
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {

--- a/github/enterprise_code_security_and_analysis_test.go
+++ b/github/enterprise_code_security_and_analysis_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The go-github AUTHORS. All rights reserved.
+// Copyright 2022 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/github/enterprise_code_security_and_analysis_test.go
+++ b/github/enterprise_code_security_and_analysis_test.go
@@ -35,7 +35,7 @@ func TestEnterpriseService_GetCodeSecurityAndAnalysis(t *testing.T) {
 
 	const methodName = "GetCodeSecurityAndAnalysis"
 
-	enterpriseSecurityAnalysisSettings, _, err := client.Enterprise.GetCodeSecurityAndAnalysis(ctx, "e")
+	settings, _, err := client.Enterprise.GetCodeSecurityAndAnalysis(ctx, "e")
 	if err != nil {
 		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
 	}
@@ -46,8 +46,8 @@ func TestEnterpriseService_GetCodeSecurityAndAnalysis(t *testing.T) {
 		SecretScanningPushProtectionCustomLink:                String("https://github.com/test-org/test-repo/blob/main/README.md"),
 	}
 
-	if !cmp.Equal(enterpriseSecurityAnalysisSettings, want) {
-		t.Errorf("Enterprise.%v return \ngot: %+v,\nwant:%+v", methodName, enterpriseSecurityAnalysisSettings, want)
+	if !cmp.Equal(settings, want) {
+		t.Errorf("Enterprise.%v return \ngot: %+v,\nwant:%+v", methodName, settings, want)
 	}
 
 	testBadOptions(t, methodName, func() (err error) {

--- a/github/enterprise_code_security_and_analysis_test.go
+++ b/github/enterprise_code_security_and_analysis_test.go
@@ -1,0 +1,261 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"net/http"
+	"testing"
+)
+
+func TestEnterpriseService_GetCodeSecurityAndAnalysis(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/enterprises/e/code_security_and_analysis", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+
+		fmt.Fprint(w, `
+		{
+		  "advanced_security_enabled_for_new_repositories": true,
+		  "secret_scanning_enabled_for_new_repositories": true,
+		  "secret_scanning_push_protection_enabled_for_new_repositories": true,
+		  "secret_scanning_push_protection_custom_link": "https://github.com/test-org/test-repo/blob/main/README.md"
+		}`)
+	})
+
+	ctx := context.Background()
+
+	const methodName = "GetCodeSecurityAndAnalysis"
+
+	enterpriseSecurityAnalysisSettings, _, err := client.Enterprise.GetCodeSecurityAndAnalysis(ctx, "e")
+	if err != nil {
+		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
+	}
+	want := &EnterpriseSecurityAnalysisSettings{
+		AdvancedSecurityEnabledForNewRepositories:             true,
+		SecretScanningEnabledForNewRepositories:               true,
+		SecretScanningPushProtectionEnabledForNewRepositories: true,
+		SecretScanningPushProtectionCustomLink:                "https://github.com/test-org/test-repo/blob/main/README.md",
+	}
+
+	if !cmp.Equal(enterpriseSecurityAnalysisSettings, want) {
+		t.Errorf("Enterprise.%v return \ngot: %+v,\nwant:%+v", methodName, enterpriseSecurityAnalysisSettings, want)
+	}
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Enterprise.GetCodeSecurityAndAnalysis(ctx, "o")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Enterprise.GetCodeSecurityAndAnalysis(ctx, "e")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestEnterpriseService_UpdateCodeSecurityAndAnalysis(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &EnterpriseSecurityAnalysisSettings{
+		AdvancedSecurityEnabledForNewRepositories:             true,
+		SecretScanningEnabledForNewRepositories:               true,
+		SecretScanningPushProtectionEnabledForNewRepositories: true,
+		SecretScanningPushProtectionCustomLink:                "https://github.com/test-org/test-repo/blob/main/README.md",
+	}
+
+	mux.HandleFunc("/enterprises/e/code_security_and_analysis", func(w http.ResponseWriter, r *http.Request) {
+		v := new(EnterpriseSecurityAnalysisSettings)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "PATCH")
+		if !cmp.Equal(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+	})
+
+	ctx := context.Background()
+
+	const methodName = "UpdateCodeSecurityAndAnalysis"
+
+	_, err := client.Enterprise.UpdateCodeSecurityAndAnalysis(ctx, "e", input)
+	if err != nil {
+		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
+	}
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Enterprise.UpdateCodeSecurityAndAnalysis(ctx, "o", input)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Enterprise.UpdateCodeSecurityAndAnalysis(ctx, "e", input)
+	})
+}
+
+func TestEnterpriseService_EnableAdvancedSecurity(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/enterprises/e/advanced_security/enable_all", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	ctx := context.Background()
+
+	const methodName = "EnableAdvancedSecurity"
+
+	_, err := client.Enterprise.EnableAdvancedSecurity(ctx, "e")
+	if err != nil {
+		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
+	}
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Enterprise.EnableAdvancedSecurity(ctx, "o")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Enterprise.EnableAdvancedSecurity(ctx, "e")
+	})
+}
+
+func TestEnterpriseService_DisableAdvancedSecurity(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/enterprises/e/advanced_security/disable_all", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	ctx := context.Background()
+
+	const methodName = "DisableAdvancedSecurity"
+
+	_, err := client.Enterprise.DisableAdvancedSecurity(ctx, "e")
+	if err != nil {
+		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
+	}
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Enterprise.DisableAdvancedSecurity(ctx, "o")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Enterprise.DisableAdvancedSecurity(ctx, "e")
+	})
+}
+
+func TestEnterpriseService_EnableSecretScanning(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/enterprises/e/secret_scanning/enable_all", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	ctx := context.Background()
+
+	const methodName = "EnableSecretScanning"
+
+	_, err := client.Enterprise.EnableSecretScanning(ctx, "e")
+	if err != nil {
+		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
+	}
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Enterprise.EnableSecretScanning(ctx, "o")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Enterprise.EnableSecretScanning(ctx, "e")
+	})
+}
+
+func TestEnterpriseService_DisableSecretScanning(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/enterprises/e/secret_scanning/disable_all", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	ctx := context.Background()
+
+	const methodName = "DisableSecretScanning"
+
+	_, err := client.Enterprise.DisableSecretScanning(ctx, "e")
+	if err != nil {
+		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
+	}
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Enterprise.DisableSecretScanning(ctx, "o")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Enterprise.DisableSecretScanning(ctx, "e")
+	})
+}
+
+func TestEnterpriseService_EnableSecretScanningPushProtection(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/enterprises/e/secret_scanning_push_protection/enable_all", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	ctx := context.Background()
+
+	const methodName = "EnableSecretScanningPushProtection"
+
+	_, err := client.Enterprise.EnableSecretScanningPushProtection(ctx, "e")
+	if err != nil {
+		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
+	}
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Enterprise.EnableSecretScanningPushProtection(ctx, "o")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Enterprise.EnableSecretScanningPushProtection(ctx, "e")
+	})
+}
+
+func TestEnterpriseService_DisableSecretScanningPushProtection(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/enterprises/e/secret_scanning_push_protection/disable_all", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	ctx := context.Background()
+
+	const methodName = "DisableSecretScanningPushProtection"
+
+	_, err := client.Enterprise.DisableSecretScanningPushProtection(ctx, "e")
+	if err != nil {
+		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
+	}
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Enterprise.DisableSecretScanningPushProtection(ctx, "o")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Enterprise.DisableSecretScanningPushProtection(ctx, "e")
+	})
+}

--- a/github/enterprise_code_security_and_analysis_test.go
+++ b/github/enterprise_code_security_and_analysis_test.go
@@ -40,10 +40,10 @@ func TestEnterpriseService_GetCodeSecurityAndAnalysis(t *testing.T) {
 		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
 	}
 	want := &EnterpriseSecurityAnalysisSettings{
-		AdvancedSecurityEnabledForNewRepositories:             true,
-		SecretScanningEnabledForNewRepositories:               true,
-		SecretScanningPushProtectionEnabledForNewRepositories: true,
-		SecretScanningPushProtectionCustomLink:                "https://github.com/test-org/test-repo/blob/main/README.md",
+		AdvancedSecurityEnabledForNewRepositories:             Bool(true),
+		SecretScanningEnabledForNewRepositories:               Bool(true),
+		SecretScanningPushProtectionEnabledForNewRepositories: Bool(true),
+		SecretScanningPushProtectionCustomLink:                String("https://github.com/test-org/test-repo/blob/main/README.md"),
 	}
 
 	if !cmp.Equal(enterpriseSecurityAnalysisSettings, want) {
@@ -69,10 +69,10 @@ func TestEnterpriseService_UpdateCodeSecurityAndAnalysis(t *testing.T) {
 	defer teardown()
 
 	input := &EnterpriseSecurityAnalysisSettings{
-		AdvancedSecurityEnabledForNewRepositories:             true,
-		SecretScanningEnabledForNewRepositories:               true,
-		SecretScanningPushProtectionEnabledForNewRepositories: true,
-		SecretScanningPushProtectionCustomLink:                "https://github.com/test-org/test-repo/blob/main/README.md",
+		AdvancedSecurityEnabledForNewRepositories:             Bool(true),
+		SecretScanningEnabledForNewRepositories:               Bool(true),
+		SecretScanningPushProtectionEnabledForNewRepositories: Bool(true),
+		SecretScanningPushProtectionCustomLink:                String("https://github.com/test-org/test-repo/blob/main/README.md"),
 	}
 
 	mux.HandleFunc("/enterprises/e/code_security_and_analysis", func(w http.ResponseWriter, r *http.Request) {
@@ -114,154 +114,19 @@ func TestEnterpriseService_EnableAdvancedSecurity(t *testing.T) {
 
 	ctx := context.Background()
 
-	const methodName = "EnableAdvancedSecurity"
+	const methodName = "EnableDisableSecurityFeature"
 
-	_, err := client.Enterprise.EnableAdvancedSecurity(ctx, "e")
+	_, err := client.Enterprise.EnableDisableSecurityFeature(ctx, "e", "advanced_security", "enable_all")
 	if err != nil {
 		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
 	}
 
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Enterprise.EnableAdvancedSecurity(ctx, "o")
+		_, err = client.Enterprise.EnableDisableSecurityFeature(ctx, "o", "advanced_security", "enable_all")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Enterprise.EnableAdvancedSecurity(ctx, "e")
-	})
-}
-
-func TestEnterpriseService_DisableAdvancedSecurity(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/enterprises/e/advanced_security/disable_all", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-	})
-
-	ctx := context.Background()
-
-	const methodName = "DisableAdvancedSecurity"
-
-	_, err := client.Enterprise.DisableAdvancedSecurity(ctx, "e")
-	if err != nil {
-		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
-	}
-
-	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Enterprise.DisableAdvancedSecurity(ctx, "o")
-		return err
-	})
-
-	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Enterprise.DisableAdvancedSecurity(ctx, "e")
-	})
-}
-
-func TestEnterpriseService_EnableSecretScanning(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/enterprises/e/secret_scanning/enable_all", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-	})
-
-	ctx := context.Background()
-
-	const methodName = "EnableSecretScanning"
-
-	_, err := client.Enterprise.EnableSecretScanning(ctx, "e")
-	if err != nil {
-		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
-	}
-
-	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Enterprise.EnableSecretScanning(ctx, "o")
-		return err
-	})
-
-	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Enterprise.EnableSecretScanning(ctx, "e")
-	})
-}
-
-func TestEnterpriseService_DisableSecretScanning(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/enterprises/e/secret_scanning/disable_all", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-	})
-
-	ctx := context.Background()
-
-	const methodName = "DisableSecretScanning"
-
-	_, err := client.Enterprise.DisableSecretScanning(ctx, "e")
-	if err != nil {
-		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
-	}
-
-	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Enterprise.DisableSecretScanning(ctx, "o")
-		return err
-	})
-
-	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Enterprise.DisableSecretScanning(ctx, "e")
-	})
-}
-
-func TestEnterpriseService_EnableSecretScanningPushProtection(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/enterprises/e/secret_scanning_push_protection/enable_all", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-	})
-
-	ctx := context.Background()
-
-	const methodName = "EnableSecretScanningPushProtection"
-
-	_, err := client.Enterprise.EnableSecretScanningPushProtection(ctx, "e")
-	if err != nil {
-		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
-	}
-
-	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Enterprise.EnableSecretScanningPushProtection(ctx, "o")
-		return err
-	})
-
-	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Enterprise.EnableSecretScanningPushProtection(ctx, "e")
-	})
-}
-
-func TestEnterpriseService_DisableSecretScanningPushProtection(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/enterprises/e/secret_scanning_push_protection/disable_all", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-	})
-
-	ctx := context.Background()
-
-	const methodName = "DisableSecretScanningPushProtection"
-
-	_, err := client.Enterprise.DisableSecretScanningPushProtection(ctx, "e")
-	if err != nil {
-		t.Errorf("Enterprise.%v returned error: %v", methodName, err)
-	}
-
-	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Enterprise.DisableSecretScanningPushProtection(ctx, "o")
-		return err
-	})
-
-	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Enterprise.DisableSecretScanningPushProtection(ctx, "e")
+		return client.Enterprise.EnableDisableSecurityFeature(ctx, "e", "advanced_security", "enable_all")
 	})
 }

--- a/github/enterprise_code_security_and_analysis_test.go
+++ b/github/enterprise_code_security_and_analysis_test.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"net/http"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestEnterpriseService_GetCodeSecurityAndAnalysis(t *testing.T) {

--- a/github/enterprise_code_security_and_analysis_test.go
+++ b/github/enterprise_code_security_and_analysis_test.go
@@ -1,3 +1,8 @@
+// Copyright 2021 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package github
 
 import (

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -5110,6 +5110,38 @@ func (e *Enterprise) GetWebsiteURL() string {
 	return *e.WebsiteURL
 }
 
+// GetAdvancedSecurityEnabledForNewRepositories returns the AdvancedSecurityEnabledForNewRepositories field if it's non-nil, zero value otherwise.
+func (e *EnterpriseSecurityAnalysisSettings) GetAdvancedSecurityEnabledForNewRepositories() bool {
+	if e == nil || e.AdvancedSecurityEnabledForNewRepositories == nil {
+		return false
+	}
+	return *e.AdvancedSecurityEnabledForNewRepositories
+}
+
+// GetSecretScanningEnabledForNewRepositories returns the SecretScanningEnabledForNewRepositories field if it's non-nil, zero value otherwise.
+func (e *EnterpriseSecurityAnalysisSettings) GetSecretScanningEnabledForNewRepositories() bool {
+	if e == nil || e.SecretScanningEnabledForNewRepositories == nil {
+		return false
+	}
+	return *e.SecretScanningEnabledForNewRepositories
+}
+
+// GetSecretScanningPushProtectionCustomLink returns the SecretScanningPushProtectionCustomLink field if it's non-nil, zero value otherwise.
+func (e *EnterpriseSecurityAnalysisSettings) GetSecretScanningPushProtectionCustomLink() string {
+	if e == nil || e.SecretScanningPushProtectionCustomLink == nil {
+		return ""
+	}
+	return *e.SecretScanningPushProtectionCustomLink
+}
+
+// GetSecretScanningPushProtectionEnabledForNewRepositories returns the SecretScanningPushProtectionEnabledForNewRepositories field if it's non-nil, zero value otherwise.
+func (e *EnterpriseSecurityAnalysisSettings) GetSecretScanningPushProtectionEnabledForNewRepositories() bool {
+	if e == nil || e.SecretScanningPushProtectionEnabledForNewRepositories == nil {
+		return false
+	}
+	return *e.SecretScanningPushProtectionEnabledForNewRepositories
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (e *Environment) GetCreatedAt() Timestamp {
 	if e == nil || e.CreatedAt == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -5974,6 +5974,46 @@ func TestEnterprise_GetWebsiteURL(tt *testing.T) {
 	e.GetWebsiteURL()
 }
 
+func TestEnterpriseSecurityAnalysisSettings_GetAdvancedSecurityEnabledForNewRepositories(tt *testing.T) {
+	var zeroValue bool
+	e := &EnterpriseSecurityAnalysisSettings{AdvancedSecurityEnabledForNewRepositories: &zeroValue}
+	e.GetAdvancedSecurityEnabledForNewRepositories()
+	e = &EnterpriseSecurityAnalysisSettings{}
+	e.GetAdvancedSecurityEnabledForNewRepositories()
+	e = nil
+	e.GetAdvancedSecurityEnabledForNewRepositories()
+}
+
+func TestEnterpriseSecurityAnalysisSettings_GetSecretScanningEnabledForNewRepositories(tt *testing.T) {
+	var zeroValue bool
+	e := &EnterpriseSecurityAnalysisSettings{SecretScanningEnabledForNewRepositories: &zeroValue}
+	e.GetSecretScanningEnabledForNewRepositories()
+	e = &EnterpriseSecurityAnalysisSettings{}
+	e.GetSecretScanningEnabledForNewRepositories()
+	e = nil
+	e.GetSecretScanningEnabledForNewRepositories()
+}
+
+func TestEnterpriseSecurityAnalysisSettings_GetSecretScanningPushProtectionCustomLink(tt *testing.T) {
+	var zeroValue string
+	e := &EnterpriseSecurityAnalysisSettings{SecretScanningPushProtectionCustomLink: &zeroValue}
+	e.GetSecretScanningPushProtectionCustomLink()
+	e = &EnterpriseSecurityAnalysisSettings{}
+	e.GetSecretScanningPushProtectionCustomLink()
+	e = nil
+	e.GetSecretScanningPushProtectionCustomLink()
+}
+
+func TestEnterpriseSecurityAnalysisSettings_GetSecretScanningPushProtectionEnabledForNewRepositories(tt *testing.T) {
+	var zeroValue bool
+	e := &EnterpriseSecurityAnalysisSettings{SecretScanningPushProtectionEnabledForNewRepositories: &zeroValue}
+	e.GetSecretScanningPushProtectionEnabledForNewRepositories()
+	e = &EnterpriseSecurityAnalysisSettings{}
+	e.GetSecretScanningPushProtectionEnabledForNewRepositories()
+	e = nil
+	e.GetSecretScanningPushProtectionEnabledForNewRepositories()
+}
+
 func TestEnvironment_GetCreatedAt(tt *testing.T) {
 	var zeroValue Timestamp
 	e := &Environment{CreatedAt: &zeroValue}


### PR DESCRIPTION
This branch adds support for 
> GitHub Changelog: Enable secret scanning with the enterprise-level REST API

Resolves #2599
[Blog](https://github.blog/changelog/2022-12-13-enable-secret-scanning-with-the-enterprise-level-rest-api/)
[Documentation](https://docs.github.com/en/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28)
