### PR TITLE
Omit OpenID Connect customization template claims when none are set

### DIFF
--- a/github/actions_oidc.go
+++ b/github/actions_oidc.go
@@ -13,7 +13,7 @@ import (
 // OIDCSubjectClaimCustomTemplate represents an OIDC subject claim customization template.
 type OIDCSubjectClaimCustomTemplate struct {
 	UseDefault       *bool    `json:"use_default,omitempty"`
-	IncludeClaimKeys []string `json:"include_claim_keys"`
+	IncludeClaimKeys []string `json:"include_claim_keys,omitempty"`
 }
 
 // GetOrgOIDCSubjectClaimCustomTemplate gets the subject claim customization template for an organization.

--- a/github/actions_oidc_test.go
+++ b/github/actions_oidc_test.go
@@ -148,3 +148,35 @@ func TestActionsService_SetRepoOIDCSubjectClaimCustomTemplate(t *testing.T) {
 		return client.Actions.SetRepoOIDCSubjectClaimCustomTemplate(ctx, "o", "r", input)
 	})
 }
+
+func TestActionService_SetRepoOIDCSubjectClaimCustomTemplateToDefault(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/oidc/customization/sub", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Content-Type", "application/json")
+		testBody(t, r, `{"use_default":true}`+"\n")
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	input := &OIDCSubjectClaimCustomTemplate{
+		UseDefault: Bool(true),
+	}
+	ctx := context.Background()
+	_, err := client.Actions.SetRepoOIDCSubjectClaimCustomTemplate(ctx, "o", "r", input)
+	if err != nil {
+		t.Errorf("Actions.SetRepoOIDCSubjectClaimCustomTemplate returned error: %v", err)
+	}
+
+	const methodName = "SetRepoOIDCSubjectClaimCustomTemplate"
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.SetRepoOIDCSubjectClaimCustomTemplate(ctx, "\n", "\n", input)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.SetRepoOIDCSubjectClaimCustomTemplate(ctx, "o", "r", input)
+	})
+}

--- a/github/actions_oidc_test.go
+++ b/github/actions_oidc_test.go
@@ -170,7 +170,6 @@ func TestActionService_SetRepoOIDCSubjectClaimCustomTemplateToDefault(t *testing
 	}
 
 	const methodName = "SetRepoOIDCSubjectClaimCustomTemplate"
-
 	testBadOptions(t, methodName, func() (err error) {
 		_, err = client.Actions.SetRepoOIDCSubjectClaimCustomTemplate(ctx, "\n", "\n", input)
 		return err


### PR DESCRIPTION
There's a bug in the OpenID Connect customization template in #2615  where `included_claim_keys` is set to `nil` and sent to the GitHub API if it is not set. This results in the API returning a `422 Unprocessable Entity` error.

This PR resolves this by setting the JSON annotation of `IncludeClaimKeys` in `OIDCSubjectClaimCustomTemplate` to `omitempty` and adds a test to verify this.