### PR TITLE
Change total_minutes_used and included_minutes from int to float64

### DIFF
--- a/github/billing.go
+++ b/github/billing.go
@@ -18,9 +18,9 @@ type BillingService service
 
 // ActionBilling represents a GitHub Action billing.
 type ActionBilling struct {
-	TotalMinutesUsed     int                  `json:"total_minutes_used"`
+	TotalMinutesUsed     float64              `json:"total_minutes_used"`
 	TotalPaidMinutesUsed float64              `json:"total_paid_minutes_used"`
-	IncludedMinutes      int                  `json:"included_minutes"`
+	IncludedMinutes      float64              `json:"included_minutes"`
 	MinutesUsedBreakdown MinutesUsedBreakdown `json:"minutes_used_breakdown"`
 }
 

--- a/github/billing.go
+++ b/github/billing.go
@@ -29,9 +29,9 @@ type MinutesUsedBreakdown = map[string]int
 
 // PackageBilling represents a GitHub Package billing.
 type PackageBilling struct {
-	TotalGigabytesBandwidthUsed     int `json:"total_gigabytes_bandwidth_used"`
-	TotalPaidGigabytesBandwidthUsed int `json:"total_paid_gigabytes_bandwidth_used"`
-	IncludedGigabytesBandwidth      int `json:"included_gigabytes_bandwidth"`
+	TotalGigabytesBandwidthUsed     int     `json:"total_gigabytes_bandwidth_used"`
+	TotalPaidGigabytesBandwidthUsed int     `json:"total_paid_gigabytes_bandwidth_used"`
+	IncludedGigabytesBandwidth      float64 `json:"included_gigabytes_bandwidth"`
 }
 
 // StorageBilling represents a GitHub Storage billing.

--- a/github/billing.go
+++ b/github/billing.go
@@ -38,7 +38,7 @@ type PackageBilling struct {
 type StorageBilling struct {
 	DaysLeftInBillingCycle       int     `json:"days_left_in_billing_cycle"`
 	EstimatedPaidStorageForMonth float64 `json:"estimated_paid_storage_for_month"`
-	EstimatedStorageForMonth     int     `json:"estimated_storage_for_month"`
+	EstimatedStorageForMonth     float64 `json:"estimated_storage_for_month"`
 }
 
 // ActiveCommitters represents the total active committers across all repositories in an Organization.

--- a/github/billing_test.go
+++ b/github/billing_test.go
@@ -21,9 +21,9 @@ func TestBillingService_GetActionsBillingOrg(t *testing.T) {
 	mux.HandleFunc("/orgs/o/settings/billing/actions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
-				"total_minutes_used": 305,
+				"total_minutes_used": 305.0,
 				"total_paid_minutes_used": 0.0,
-				"included_minutes": 3000,
+				"included_minutes": 3000.0,
 				"minutes_used_breakdown": {
 					"UBUNTU": 205,
 					"MACOS": 10,
@@ -39,9 +39,9 @@ func TestBillingService_GetActionsBillingOrg(t *testing.T) {
 	}
 
 	want := &ActionBilling{
-		TotalMinutesUsed:     305,
-		TotalPaidMinutesUsed: 0,
-		IncludedMinutes:      3000,
+		TotalMinutesUsed:     305.0,
+		TotalPaidMinutesUsed: 0.0,
+		IncludedMinutes:      3000.0,
 		MinutesUsedBreakdown: MinutesUsedBreakdown{
 			"UBUNTU":  205,
 			"MACOS":   10,


### PR DESCRIPTION
Fixes https://github.com/google/go-github/issues/2642

GitHub Actions returns total_minutes_used and included_minutes as floating point value.
The Implementation should accept this floating point value as float64.

Example

```
curl -H "Authorization: Bearer <TOKEN>" \
-H "Accept: application/vnd.github.v3+json"  \
https://api.github.com/orgs/{org}/settings/billing/actions
```

```json
{
  "total_minutes_used": 1234.0,
  "total_paid_minutes_used": 3959.0,
  "included_minutes": 3000.0,
  "minutes_used_breakdown": {
    "UBUNTU": 1234,
    "MACOS": 1234,
    "WINDOWS": 0
  }
}
```