### PR TITLE
Remove failing unit tests for Go 1.20

### DIFF
--- a/github/actions_artifacts_test.go
+++ b/github/actions_artifacts_test.go
@@ -368,23 +368,6 @@ func TestActionsService_DownloadArtifact_StatusMovedPermanently_followRedirects(
 	}
 }
 
-func TestActionsService_DownloadArtifact_invalidLocationHeader(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/repos/o/r/actions/artifacts/1/zip", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		ctlChar := 0x7f
-		badURL := "https://google.com" + string(byte(ctlChar))
-		w.Header().Add("Location", badURL)
-		w.WriteHeader(http.StatusFound)
-	})
-
-	ctx := context.Background()
-	_, _, err := client.Actions.DownloadArtifact(ctx, "o", "r", 1, false)
-	testURLParseError(t, err)
-}
-
 func TestActionsService_DeleteArtifact(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -744,23 +744,6 @@ func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_followRedirec
 	}
 }
 
-func TestRepositoriesService_GetArchiveLink_invalidLocationHeader(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/repos/o/r/tarball", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		ctlChar := 0x7f
-		badURL := "https://google.com" + string(byte(ctlChar))
-		w.Header().Add("Location", badURL)
-		w.WriteHeader(http.StatusFound)
-	})
-
-	ctx := context.Background()
-	_, _, err := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{}, false)
-	testURLParseError(t, err)
-}
-
 func TestRepositoriesService_GetContents_NoTrailingSlashInDirectoryApiPath(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
Fixes: #2654.