### PR TITLE
Add RequestedTeam to issues Timeline type

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -19502,6 +19502,14 @@ func (t *Timeline) GetRename() *Rename {
 	return t.Rename
 }
 
+// GetRequestedTeam returns the RequestedTeam field.
+func (t *Timeline) GetRequestedTeam() *Team {
+	if t == nil {
+		return nil
+	}
+	return t.RequestedTeam
+}
+
 // GetRequester returns the Requester field.
 func (t *Timeline) GetRequester() *User {
 	if t == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -22728,6 +22728,13 @@ func TestTimeline_GetRename(tt *testing.T) {
 	t.GetRename()
 }
 
+func TestTimeline_GetRequestedTeam(tt *testing.T) {
+	t := &Timeline{}
+	t.GetRequestedTeam()
+	t = nil
+	t.GetRequestedTeam()
+}
+
 func TestTimeline_GetRequester(tt *testing.T) {
 	t := &Timeline{}
 	t.GetRequester()

--- a/github/issues_timeline.go
+++ b/github/issues_timeline.go
@@ -143,6 +143,8 @@ type Timeline struct {
 
 	// The person requested to review the pull request.
 	Reviewer *User `json:"requested_reviewer,omitempty"`
+	// RequestedTeam contains the team requested to review the pull request.
+	RequestedTeam *Team `json:"requested_team,omitempty"`
 	// The person who requested a review.
 	Requester *User `json:"review_requester,omitempty"`
 


### PR DESCRIPTION
fixes #2664 

This PR adds the `requested_team` field into the `Timeline` type.