### PR TITLE
Add ListExternalGroupsForTeamBySlug to Teams API

### DIFF
--- a/github/teams.go
+++ b/github/teams.go
@@ -913,7 +913,7 @@ type ListExternalGroupsOptions struct {
 	ListOptions
 }
 
-// ListExternalGroups lists external groups connected to a team on GitHub.
+// ListExternalGroups lists external groups in an organization on GitHub.
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/teams/external-groups#list-external-groups-in-an-organization
 func (s *TeamsService) ListExternalGroups(ctx context.Context, org string, opts *ListExternalGroupsOptions) (*ExternalGroupList, *Response, error) {
@@ -922,6 +922,26 @@ func (s *TeamsService) ListExternalGroups(ctx context.Context, org string, opts 
 	if err != nil {
 		return nil, nil, err
 	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	externalGroups := new(ExternalGroupList)
+	resp, err := s.client.Do(ctx, req, externalGroups)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return externalGroups, resp, nil
+}
+
+// ListExternalGroupsForTeamBySlug lists external groups connected to a team on GitHub.
+//
+// GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/teams/external-groups#list-a-connection-between-an-external-group-and-a-team
+func (s *TeamsService) ListExternalGroupsForTeamBySlug(ctx context.Context, org, slug string) (*ExternalGroupList, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/teams/%v/external-groups", org, slug)
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {


### PR DESCRIPTION
#2217 added support for the majority of the External Groups API but omitted listing groups for a specific Team within an Organization.

This PR adds the missing method, and corrects the comment on the original `ListExternalGroups` method as that actually returns all external groups within the Organization. I added the `ForTeamBySlug` suffix based on other methods in the source to distinguish it from the original method.

I've added tests based on the original `ListExternalGroups` method and everything passes.