### PR TITLE
Support HTTP Proxy from environment

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -348,6 +348,11 @@ func NewClient(httpClient *http.Client) *Client {
 	return c
 }
 
+// NewClientWithEnvProxy enhances NewClient with the HttpProxy env.
+func NewClientWithEnvProxy() *Client {
+	return NewClient(&http.Client{Transport: &http.Transport{Proxy: http.ProxyFromEnvironment}})
+}
+
 // NewTokenClient returns a new GitHub API client authenticated with the provided token.
 func NewTokenClient(ctx context.Context, token string) *Client {
 	return NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})))

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -264,6 +264,13 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewClientWithEnvProxy(t *testing.T) {
+	client := NewClientWithEnvProxy()
+	if got, want := client.BaseURL.String(), defaultBaseURL; got != want {
+		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
+	}
+}
+
 func TestClient(t *testing.T) {
 	c := NewClient(nil)
 	c2 := c.Client()


### PR DESCRIPTION
Add the support of http prxoy to `NewClientWithEnvProxy`.

Relates to: #2363.