### PR TITLE
Update custom repo roles URL

### DIFF
--- a/github/orgs_custom_roles.go
+++ b/github/orgs_custom_roles.go
@@ -32,7 +32,7 @@ type CustomRepoRoles struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/custom-roles#list-custom-repository-roles-in-an-organization
 func (s *OrganizationsService) ListCustomRepoRoles(ctx context.Context, org string) (*OrganizationCustomRepoRoles, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/custom_roles", org)
+	u := fmt.Sprintf("orgs/%v/custom-repository-roles", org)
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -59,9 +59,9 @@ type CreateOrUpdateCustomRoleOptions struct {
 // CreateCustomRepoRole creates a custom repository role in this organization.
 // In order to create custom repository roles in an organization, the authenticated user must be an organization owner.
 //
-// GitHub API docs: https://docs.github.com/en/rest/orgs/custom-roles#create-a-custom-role
+// GitHub API docs: https://docs.github.com/en/rest/orgs/custom-roles#create-a-custom-repository-role
 func (s *OrganizationsService) CreateCustomRepoRole(ctx context.Context, org string, opts *CreateOrUpdateCustomRoleOptions) (*CustomRepoRoles, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/custom_roles", org)
+	u := fmt.Sprintf("orgs/%v/custom-repository-roles", org)
 
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
@@ -80,9 +80,9 @@ func (s *OrganizationsService) CreateCustomRepoRole(ctx context.Context, org str
 // UpdateCustomRepoRole updates a custom repository role in this organization.
 // In order to update custom repository roles in an organization, the authenticated user must be an organization owner.
 //
-// GitHub API docs: https://docs.github.com/en/rest/orgs/custom-roles#update-a-custom-role
+// GitHub API docs: https://docs.github.com/en/rest/orgs/custom-roles#update-a-custom-repository-role
 func (s *OrganizationsService) UpdateCustomRepoRole(ctx context.Context, org, roleID string, opts *CreateOrUpdateCustomRoleOptions) (*CustomRepoRoles, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/custom_roles/%v", org, roleID)
+	u := fmt.Sprintf("orgs/%v/custom-repository-roles/%v", org, roleID)
 
 	req, err := s.client.NewRequest("PATCH", u, opts)
 	if err != nil {
@@ -101,9 +101,9 @@ func (s *OrganizationsService) UpdateCustomRepoRole(ctx context.Context, org, ro
 // DeleteCustomRepoRole deletes an existing custom repository role in this organization.
 // In order to delete custom repository roles in an organization, the authenticated user must be an organization owner.
 //
-// GitHub API docs: https://docs.github.com/en/rest/orgs/custom-roles#delete-a-custom-role
+// GitHub API docs: https://docs.github.com/en/rest/orgs/custom-roles#delete-a-custom-repository-role
 func (s *OrganizationsService) DeleteCustomRepoRole(ctx context.Context, org, roleID string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/custom_roles/%v", org, roleID)
+	u := fmt.Sprintf("orgs/%v/custom-repository-roles/%v", org, roleID)
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/orgs_custom_roles_test.go
+++ b/github/orgs_custom_roles_test.go
@@ -18,7 +18,7 @@ func TestOrganizationsService_ListCustomRepoRoles(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/o/custom_roles", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/custom-repository-roles", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"total_count": 1, "custom_roles": [{ "id": 1, "name": "Developer", "base_role": "write", "permissions": ["delete_alerts_code_scanning"]}]}`)
 	})
@@ -53,7 +53,7 @@ func TestOrganizationsService_CreateCustomRepoRole(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/o/custom_roles", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/custom-repository-roles", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{"id":8030,"name":"Labeler","description":"A role for issue and PR labelers","base_role":"read","permissions":["add_label"]}`)
 	})
@@ -96,7 +96,7 @@ func TestOrganizationsService_UpdateCustomRepoRole(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/o/custom_roles/8030", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/custom-repository-roles/8030", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
 		fmt.Fprint(w, `{"id":8030,"name":"Updated Name","description":"Updated Description","base_role":"read","permissions":["add_label"]}`)
 	})
@@ -137,7 +137,7 @@ func TestOrganizationsService_DeleteCustomRepoRole(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/o/custom_roles/8030", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/custom-repository-roles/8030", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		w.WriteHeader(http.StatusNoContent)
 	})


### PR DESCRIPTION
Update the API routes, from `/orgs/{org}/custom_roles` to `/orgs/{org}/custom-repository-roles`, and some documentation references.

Fixes: #2700 