### PR TITLE
Add head_sha for ListWorkflowRunsOptions

### DIFF
--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -60,6 +60,7 @@ type ListWorkflowRunsOptions struct {
 	Event   string `url:"event,omitempty"`
 	Status  string `url:"status,omitempty"`
 	Created string `url:"created,omitempty"`
+	HeadSHA string `url:"head_sha,omitempty"`
 	ListOptions
 }
 


### PR DESCRIPTION
## Description

Add head_sha for ListWorkflowRunsOptions (fixes: #2687)

## Why is this needed?

GitHub added this option to the following API:

/repos/{owner}/{repo}/actions/runs

Only returns workflow runs that are associated with the specified head_sha.

See also:

https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository
