### PR TITLE
Add options for listing workflow runs

### DIFF
--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -55,12 +55,14 @@ type WorkflowRuns struct {
 
 // ListWorkflowRunsOptions specifies optional parameters to ListWorkflowRuns.
 type ListWorkflowRunsOptions struct {
-	Actor   string `url:"actor,omitempty"`
-	Branch  string `url:"branch,omitempty"`
-	Event   string `url:"event,omitempty"`
-	Status  string `url:"status,omitempty"`
-	Created string `url:"created,omitempty"`
-	HeadSHA string `url:"head_sha,omitempty"`
+	Actor               string `url:"actor,omitempty"`
+	Branch              string `url:"branch,omitempty"`
+	Event               string `url:"event,omitempty"`
+	Status              string `url:"status,omitempty"`
+	Created             string `url:"created,omitempty"`
+	HeadSHA             string `url:"head_sha,omitempty"`
+	ExcludePullRequests bool   `url:"exclude_pull_requests,omitempty"`
+	CheckSuiteID        int64  `url:"check_suite_id,omitempty"`
 	ListOptions
 }
 


### PR DESCRIPTION
## Description
I add some options for `ListRepositoryWorkflowRuns`.
 In particular, `exclude_pull_requests` is very useful, as mentioned in the gh command implementation. (https://github.com/cli/cli/blob/trunk/pkg/cmd/run/shared/shared.go#L338)

Document: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository