### PR TITLE
Add Topics to PushEventRepository

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -1062,6 +1062,7 @@ type PushEventRepository struct {
 	SSHURL          *string    `json:"ssh_url,omitempty"`
 	CloneURL        *string    `json:"clone_url,omitempty"`
 	SVNURL          *string    `json:"svn_url,omitempty"`
+	Topics          []string   `json:"topics,omitempty"`
 }
 
 // PushEventRepoOwner is a basic representation of user/org in a PushEvent payload.

--- a/github/event_types_test.go
+++ b/github/event_types_test.go
@@ -12327,10 +12327,7 @@ func TestPushEventRepository_Marshal(t *testing.T) {
 		"ssh_url": "s",
 		"clone_url": "c",
 		"svn_url": "s",
-		"topics": [
-            "octocat",
-            "api"
-        ]
+		"topics": ["octocat","api"]
     }`
 
 	testJSONMarshal(t, u, want)

--- a/github/event_types_test.go
+++ b/github/event_types_test.go
@@ -12271,6 +12271,7 @@ func TestPushEventRepository_Marshal(t *testing.T) {
 		SSHURL:          String("s"),
 		CloneURL:        String("c"),
 		SVNURL:          String("s"),
+		Topics:          []string{"octocat", "api"},
 	}
 
 	want := `{
@@ -12325,7 +12326,11 @@ func TestPushEventRepository_Marshal(t *testing.T) {
 		"git_url": "g",
 		"ssh_url": "s",
 		"clone_url": "c",
-		"svn_url": "s"
+		"svn_url": "s",
+		"topics": [
+      		"octocat",
+      		"api"
+    	]
 	}`
 
 	testJSONMarshal(t, u, want)

--- a/github/event_types_test.go
+++ b/github/event_types_test.go
@@ -12328,10 +12328,10 @@ func TestPushEventRepository_Marshal(t *testing.T) {
 		"clone_url": "c",
 		"svn_url": "s",
 		"topics": [
-      		"octocat",
-      		"api"
-    	]
-	}`
+            "octocat",
+            "api"
+        ]
+    }`
 
 	testJSONMarshal(t, u, want)
 }


### PR DESCRIPTION
Closes https://github.com/google/go-github/issues/2741

Adding the `Topics` field, which is included in push event payloads under `repository`