### PR TITLE
Add DNS health checks support for GitHub Pages

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -12070,12 +12070,12 @@ func (p *PagesDomain) GetEnforcesHTTPS() bool {
 	return *p.EnforcesHTTPS
 }
 
-// GetHasCNAMERecordPresent returns the HasCNAMERecordPresent field if it's non-nil, zero value otherwise.
-func (p *PagesDomain) GetHasCNAMERecordPresent() bool {
-	if p == nil || p.HasCNAMERecordPresent == nil {
+// GetHasCNAMERecord returns the HasCNAMERecord field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetHasCNAMERecord() bool {
+	if p == nil || p.HasCNAMERecord == nil {
 		return false
 	}
-	return *p.HasCNAMERecordPresent
+	return *p.HasCNAMERecord
 }
 
 // GetHasMXRecordsPresent returns the HasMXRecordsPresent field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -12046,12 +12046,252 @@ func (p *PagesBuild) GetURL() string {
 	return *p.URL
 }
 
+// GetCAAError returns the CAAError field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetCAAError() string {
+	if p == nil || p.CAAError == nil {
+		return ""
+	}
+	return *p.CAAError
+}
+
+// GetDNSResolves returns the DNSResolves field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetDNSResolves() bool {
+	if p == nil || p.DNSResolves == nil {
+		return false
+	}
+	return *p.DNSResolves
+}
+
+// GetEnforcesHTTPS returns the EnforcesHTTPS field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetEnforcesHTTPS() bool {
+	if p == nil || p.EnforcesHTTPS == nil {
+		return false
+	}
+	return *p.EnforcesHTTPS
+}
+
+// GetHasCNAMERecordPresent returns the HasCNAMERecordPresent field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetHasCNAMERecordPresent() bool {
+	if p == nil || p.HasCNAMERecordPresent == nil {
+		return false
+	}
+	return *p.HasCNAMERecordPresent
+}
+
+// GetHasMXRecordsPresent returns the HasMXRecordsPresent field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetHasMXRecordsPresent() bool {
+	if p == nil || p.HasMXRecordsPresent == nil {
+		return false
+	}
+	return *p.HasMXRecordsPresent
+}
+
+// GetHost returns the Host field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetHost() string {
+	if p == nil || p.Host == nil {
+		return ""
+	}
+	return *p.Host
+}
+
+// GetHTTPSError returns the HTTPSError field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetHTTPSError() string {
+	if p == nil || p.HTTPSError == nil {
+		return ""
+	}
+	return *p.HTTPSError
+}
+
+// GetIsApexDomain returns the IsApexDomain field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsApexDomain() bool {
+	if p == nil || p.IsApexDomain == nil {
+		return false
+	}
+	return *p.IsApexDomain
+}
+
+// GetIsARecord returns the IsARecord field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsARecord() bool {
+	if p == nil || p.IsARecord == nil {
+		return false
+	}
+	return *p.IsARecord
+}
+
+// GetIsCloudflareIP returns the IsCloudflareIP field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsCloudflareIP() bool {
+	if p == nil || p.IsCloudflareIP == nil {
+		return false
+	}
+	return *p.IsCloudflareIP
+}
+
+// GetIsCNAMEToFastly returns the IsCNAMEToFastly field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsCNAMEToFastly() bool {
+	if p == nil || p.IsCNAMEToFastly == nil {
+		return false
+	}
+	return *p.IsCNAMEToFastly
+}
+
+// GetIsCNAMEToGithubUserDomain returns the IsCNAMEToGithubUserDomain field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsCNAMEToGithubUserDomain() bool {
+	if p == nil || p.IsCNAMEToGithubUserDomain == nil {
+		return false
+	}
+	return *p.IsCNAMEToGithubUserDomain
+}
+
+// GetIsCNAMEToPagesDotGithubDotCom returns the IsCNAMEToPagesDotGithubDotCom field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsCNAMEToPagesDotGithubDotCom() bool {
+	if p == nil || p.IsCNAMEToPagesDotGithubDotCom == nil {
+		return false
+	}
+	return *p.IsCNAMEToPagesDotGithubDotCom
+}
+
+// GetIsFastlyIP returns the IsFastlyIP field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsFastlyIP() bool {
+	if p == nil || p.IsFastlyIP == nil {
+		return false
+	}
+	return *p.IsFastlyIP
+}
+
+// GetIsHTTPSEligible returns the IsHTTPSEligible field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsHTTPSEligible() bool {
+	if p == nil || p.IsHTTPSEligible == nil {
+		return false
+	}
+	return *p.IsHTTPSEligible
+}
+
+// GetIsNonGithubPagesIPPresent returns the IsNonGithubPagesIPPresent field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsNonGithubPagesIPPresent() bool {
+	if p == nil || p.IsNonGithubPagesIPPresent == nil {
+		return false
+	}
+	return *p.IsNonGithubPagesIPPresent
+}
+
+// GetIsOldIPAddress returns the IsOldIPAddress field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsOldIPAddress() bool {
+	if p == nil || p.IsOldIPAddress == nil {
+		return false
+	}
+	return *p.IsOldIPAddress
+}
+
+// GetIsPagesDomain returns the IsPagesDomain field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsPagesDomain() bool {
+	if p == nil || p.IsPagesDomain == nil {
+		return false
+	}
+	return *p.IsPagesDomain
+}
+
+// GetIsPointedToGithubPagesIP returns the IsPointedToGithubPagesIP field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsPointedToGithubPagesIP() bool {
+	if p == nil || p.IsPointedToGithubPagesIP == nil {
+		return false
+	}
+	return *p.IsPointedToGithubPagesIP
+}
+
+// GetIsProxied returns the IsProxied field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsProxied() bool {
+	if p == nil || p.IsProxied == nil {
+		return false
+	}
+	return *p.IsProxied
+}
+
+// GetIsServedByPages returns the IsServedByPages field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsServedByPages() bool {
+	if p == nil || p.IsServedByPages == nil {
+		return false
+	}
+	return *p.IsServedByPages
+}
+
+// GetIsValid returns the IsValid field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsValid() bool {
+	if p == nil || p.IsValid == nil {
+		return false
+	}
+	return *p.IsValid
+}
+
+// GetIsValidDomain returns the IsValidDomain field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetIsValidDomain() bool {
+	if p == nil || p.IsValidDomain == nil {
+		return false
+	}
+	return *p.IsValidDomain
+}
+
+// GetNameservers returns the Nameservers field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetNameservers() string {
+	if p == nil || p.Nameservers == nil {
+		return ""
+	}
+	return *p.Nameservers
+}
+
+// GetReason returns the Reason field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetReason() string {
+	if p == nil || p.Reason == nil {
+		return ""
+	}
+	return *p.Reason
+}
+
+// GetRespondsToHTTPS returns the RespondsToHTTPS field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetRespondsToHTTPS() bool {
+	if p == nil || p.RespondsToHTTPS == nil {
+		return false
+	}
+	return *p.RespondsToHTTPS
+}
+
+// GetShouldBeARecord returns the ShouldBeARecord field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetShouldBeARecord() bool {
+	if p == nil || p.ShouldBeARecord == nil {
+		return false
+	}
+	return *p.ShouldBeARecord
+}
+
+// GetURI returns the URI field if it's non-nil, zero value otherwise.
+func (p *PagesDomain) GetURI() string {
+	if p == nil || p.URI == nil {
+		return ""
+	}
+	return *p.URI
+}
+
 // GetMessage returns the Message field if it's non-nil, zero value otherwise.
 func (p *PagesError) GetMessage() string {
 	if p == nil || p.Message == nil {
 		return ""
 	}
 	return *p.Message
+}
+
+// GetAltDomain returns the AltDomain field.
+func (p *PagesHealthCheckResponse) GetAltDomain() *PagesDomain {
+	if p == nil {
+		return nil
+	}
+	return p.AltDomain
+}
+
+// GetDomain returns the Domain field.
+func (p *PagesHealthCheckResponse) GetDomain() *PagesDomain {
+	if p == nil {
+		return nil
+	}
+	return p.Domain
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -14128,6 +14128,286 @@ func TestPagesBuild_GetURL(tt *testing.T) {
 	p.GetURL()
 }
 
+func TestPagesDomain_GetCAAError(tt *testing.T) {
+	var zeroValue string
+	p := &PagesDomain{CAAError: &zeroValue}
+	p.GetCAAError()
+	p = &PagesDomain{}
+	p.GetCAAError()
+	p = nil
+	p.GetCAAError()
+}
+
+func TestPagesDomain_GetDNSResolves(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{DNSResolves: &zeroValue}
+	p.GetDNSResolves()
+	p = &PagesDomain{}
+	p.GetDNSResolves()
+	p = nil
+	p.GetDNSResolves()
+}
+
+func TestPagesDomain_GetEnforcesHTTPS(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{EnforcesHTTPS: &zeroValue}
+	p.GetEnforcesHTTPS()
+	p = &PagesDomain{}
+	p.GetEnforcesHTTPS()
+	p = nil
+	p.GetEnforcesHTTPS()
+}
+
+func TestPagesDomain_GetHasCNAMERecordPresent(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{HasCNAMERecordPresent: &zeroValue}
+	p.GetHasCNAMERecordPresent()
+	p = &PagesDomain{}
+	p.GetHasCNAMERecordPresent()
+	p = nil
+	p.GetHasCNAMERecordPresent()
+}
+
+func TestPagesDomain_GetHasMXRecordsPresent(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{HasMXRecordsPresent: &zeroValue}
+	p.GetHasMXRecordsPresent()
+	p = &PagesDomain{}
+	p.GetHasMXRecordsPresent()
+	p = nil
+	p.GetHasMXRecordsPresent()
+}
+
+func TestPagesDomain_GetHost(tt *testing.T) {
+	var zeroValue string
+	p := &PagesDomain{Host: &zeroValue}
+	p.GetHost()
+	p = &PagesDomain{}
+	p.GetHost()
+	p = nil
+	p.GetHost()
+}
+
+func TestPagesDomain_GetHTTPSError(tt *testing.T) {
+	var zeroValue string
+	p := &PagesDomain{HTTPSError: &zeroValue}
+	p.GetHTTPSError()
+	p = &PagesDomain{}
+	p.GetHTTPSError()
+	p = nil
+	p.GetHTTPSError()
+}
+
+func TestPagesDomain_GetIsApexDomain(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsApexDomain: &zeroValue}
+	p.GetIsApexDomain()
+	p = &PagesDomain{}
+	p.GetIsApexDomain()
+	p = nil
+	p.GetIsApexDomain()
+}
+
+func TestPagesDomain_GetIsARecord(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsARecord: &zeroValue}
+	p.GetIsARecord()
+	p = &PagesDomain{}
+	p.GetIsARecord()
+	p = nil
+	p.GetIsARecord()
+}
+
+func TestPagesDomain_GetIsCloudflareIP(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsCloudflareIP: &zeroValue}
+	p.GetIsCloudflareIP()
+	p = &PagesDomain{}
+	p.GetIsCloudflareIP()
+	p = nil
+	p.GetIsCloudflareIP()
+}
+
+func TestPagesDomain_GetIsCNAMEToFastly(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsCNAMEToFastly: &zeroValue}
+	p.GetIsCNAMEToFastly()
+	p = &PagesDomain{}
+	p.GetIsCNAMEToFastly()
+	p = nil
+	p.GetIsCNAMEToFastly()
+}
+
+func TestPagesDomain_GetIsCNAMEToGithubUserDomain(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsCNAMEToGithubUserDomain: &zeroValue}
+	p.GetIsCNAMEToGithubUserDomain()
+	p = &PagesDomain{}
+	p.GetIsCNAMEToGithubUserDomain()
+	p = nil
+	p.GetIsCNAMEToGithubUserDomain()
+}
+
+func TestPagesDomain_GetIsCNAMEToPagesDotGithubDotCom(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsCNAMEToPagesDotGithubDotCom: &zeroValue}
+	p.GetIsCNAMEToPagesDotGithubDotCom()
+	p = &PagesDomain{}
+	p.GetIsCNAMEToPagesDotGithubDotCom()
+	p = nil
+	p.GetIsCNAMEToPagesDotGithubDotCom()
+}
+
+func TestPagesDomain_GetIsFastlyIP(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsFastlyIP: &zeroValue}
+	p.GetIsFastlyIP()
+	p = &PagesDomain{}
+	p.GetIsFastlyIP()
+	p = nil
+	p.GetIsFastlyIP()
+}
+
+func TestPagesDomain_GetIsHTTPSEligible(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsHTTPSEligible: &zeroValue}
+	p.GetIsHTTPSEligible()
+	p = &PagesDomain{}
+	p.GetIsHTTPSEligible()
+	p = nil
+	p.GetIsHTTPSEligible()
+}
+
+func TestPagesDomain_GetIsNonGithubPagesIPPresent(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsNonGithubPagesIPPresent: &zeroValue}
+	p.GetIsNonGithubPagesIPPresent()
+	p = &PagesDomain{}
+	p.GetIsNonGithubPagesIPPresent()
+	p = nil
+	p.GetIsNonGithubPagesIPPresent()
+}
+
+func TestPagesDomain_GetIsOldIPAddress(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsOldIPAddress: &zeroValue}
+	p.GetIsOldIPAddress()
+	p = &PagesDomain{}
+	p.GetIsOldIPAddress()
+	p = nil
+	p.GetIsOldIPAddress()
+}
+
+func TestPagesDomain_GetIsPagesDomain(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsPagesDomain: &zeroValue}
+	p.GetIsPagesDomain()
+	p = &PagesDomain{}
+	p.GetIsPagesDomain()
+	p = nil
+	p.GetIsPagesDomain()
+}
+
+func TestPagesDomain_GetIsPointedToGithubPagesIP(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsPointedToGithubPagesIP: &zeroValue}
+	p.GetIsPointedToGithubPagesIP()
+	p = &PagesDomain{}
+	p.GetIsPointedToGithubPagesIP()
+	p = nil
+	p.GetIsPointedToGithubPagesIP()
+}
+
+func TestPagesDomain_GetIsProxied(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsProxied: &zeroValue}
+	p.GetIsProxied()
+	p = &PagesDomain{}
+	p.GetIsProxied()
+	p = nil
+	p.GetIsProxied()
+}
+
+func TestPagesDomain_GetIsServedByPages(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsServedByPages: &zeroValue}
+	p.GetIsServedByPages()
+	p = &PagesDomain{}
+	p.GetIsServedByPages()
+	p = nil
+	p.GetIsServedByPages()
+}
+
+func TestPagesDomain_GetIsValid(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsValid: &zeroValue}
+	p.GetIsValid()
+	p = &PagesDomain{}
+	p.GetIsValid()
+	p = nil
+	p.GetIsValid()
+}
+
+func TestPagesDomain_GetIsValidDomain(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{IsValidDomain: &zeroValue}
+	p.GetIsValidDomain()
+	p = &PagesDomain{}
+	p.GetIsValidDomain()
+	p = nil
+	p.GetIsValidDomain()
+}
+
+func TestPagesDomain_GetNameservers(tt *testing.T) {
+	var zeroValue string
+	p := &PagesDomain{Nameservers: &zeroValue}
+	p.GetNameservers()
+	p = &PagesDomain{}
+	p.GetNameservers()
+	p = nil
+	p.GetNameservers()
+}
+
+func TestPagesDomain_GetReason(tt *testing.T) {
+	var zeroValue string
+	p := &PagesDomain{Reason: &zeroValue}
+	p.GetReason()
+	p = &PagesDomain{}
+	p.GetReason()
+	p = nil
+	p.GetReason()
+}
+
+func TestPagesDomain_GetRespondsToHTTPS(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{RespondsToHTTPS: &zeroValue}
+	p.GetRespondsToHTTPS()
+	p = &PagesDomain{}
+	p.GetRespondsToHTTPS()
+	p = nil
+	p.GetRespondsToHTTPS()
+}
+
+func TestPagesDomain_GetShouldBeARecord(tt *testing.T) {
+	var zeroValue bool
+	p := &PagesDomain{ShouldBeARecord: &zeroValue}
+	p.GetShouldBeARecord()
+	p = &PagesDomain{}
+	p.GetShouldBeARecord()
+	p = nil
+	p.GetShouldBeARecord()
+}
+
+func TestPagesDomain_GetURI(tt *testing.T) {
+	var zeroValue string
+	p := &PagesDomain{URI: &zeroValue}
+	p.GetURI()
+	p = &PagesDomain{}
+	p.GetURI()
+	p = nil
+	p.GetURI()
+}
+
 func TestPagesError_GetMessage(tt *testing.T) {
 	var zeroValue string
 	p := &PagesError{Message: &zeroValue}
@@ -14136,6 +14416,20 @@ func TestPagesError_GetMessage(tt *testing.T) {
 	p.GetMessage()
 	p = nil
 	p.GetMessage()
+}
+
+func TestPagesHealthCheckResponse_GetAltDomain(tt *testing.T) {
+	p := &PagesHealthCheckResponse{}
+	p.GetAltDomain()
+	p = nil
+	p.GetAltDomain()
+}
+
+func TestPagesHealthCheckResponse_GetDomain(tt *testing.T) {
+	p := &PagesHealthCheckResponse{}
+	p.GetDomain()
+	p = nil
+	p.GetDomain()
 }
 
 func TestPagesHTTPSCertificate_GetDescription(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -14158,14 +14158,14 @@ func TestPagesDomain_GetEnforcesHTTPS(tt *testing.T) {
 	p.GetEnforcesHTTPS()
 }
 
-func TestPagesDomain_GetHasCNAMERecordPresent(tt *testing.T) {
+func TestPagesDomain_GetHasCNAMERecord(tt *testing.T) {
 	var zeroValue bool
-	p := &PagesDomain{HasCNAMERecordPresent: &zeroValue}
-	p.GetHasCNAMERecordPresent()
+	p := &PagesDomain{HasCNAMERecord: &zeroValue}
+	p.GetHasCNAMERecord()
 	p = &PagesDomain{}
-	p.GetHasCNAMERecordPresent()
+	p.GetHasCNAMERecord()
 	p = nil
-	p.GetHasCNAMERecordPresent()
+	p.GetHasCNAMERecord()
 }
 
 func TestPagesDomain_GetHasMXRecordsPresent(tt *testing.T) {

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -47,7 +47,7 @@ type PagesBuild struct {
 	UpdatedAt *Timestamp  `json:"updated_at,omitempty"`
 }
 
-// PagesDomain represents a domain associated with a Github Pages site.
+// PagesDomain represents a domain associated with a GitHub Pages site.
 type PagesDomain struct {
 	Host                          *string `json:"host,omitempty"`
 	URI                           *string `json:"uri,omitempty"`
@@ -58,7 +58,7 @@ type PagesDomain struct {
 	IsFastlyIP                    *bool   `json:"is_fastly_ip,omitempty"`
 	IsOldIPAddress                *bool   `json:"is_old_ip_address,omitempty"`
 	IsARecord                     *bool   `json:"is_a_record,omitempty"`
-	HasCNAMERecordPresent         *bool   `json:"has_cname_record,omitempty"`
+	HasCNAMERecord                *bool   `json:"has_cname_record,omitempty"`
 	HasMXRecordsPresent           *bool   `json:"has_mx_records_present,omitempty"`
 	IsValidDomain                 *bool   `json:"is_valid_domain,omitempty"`
 	IsApexDomain                  *bool   `json:"is_apex_domain,omitempty"`
@@ -79,7 +79,7 @@ type PagesDomain struct {
 	CAAError                      *string `json:"caa_error,omitempty"`
 }
 
-// PagesHealthCheckResponse represents the response given for the health check of a Github Pages site.
+// PagesHealthCheckResponse represents the response given for the health check of a GitHub Pages site.
 type PagesHealthCheckResponse struct {
 	Domain    *PagesDomain `json:"domain,omitempty"`
 	AltDomain *PagesDomain `json:"alt_domain,omitempty"`

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -47,6 +47,44 @@ type PagesBuild struct {
 	UpdatedAt *Timestamp  `json:"updated_at,omitempty"`
 }
 
+// PagesDomain represents a domain associated with a Github Pages site.
+type PagesDomain struct {
+	Host                          *string `json:"host,omitempty"`
+	URI                           *string `json:"uri,omitempty"`
+	Nameservers                   *string `json:"nameservers,omitempty"`
+	DNSResolves                   *bool   `json:"dns_resolves,omitempty"`
+	IsProxied                     *bool   `json:"is_proxied,omitempty"`
+	IsCloudflareIP                *bool   `json:"is_cloudflare_ip,omitempty"`
+	IsFastlyIP                    *bool   `json:"is_fastly_ip,omitempty"`
+	IsOldIPAddress                *bool   `json:"is_old_ip_address,omitempty"`
+	IsARecord                     *bool   `json:"is_a_record,omitempty"`
+	HasCNAMERecordPresent         *bool   `json:"has_cname_record,omitempty"`
+	HasMXRecordsPresent           *bool   `json:"has_mx_records_present,omitempty"`
+	IsValidDomain                 *bool   `json:"is_valid_domain,omitempty"`
+	IsApexDomain                  *bool   `json:"is_apex_domain,omitempty"`
+	ShouldBeARecord               *bool   `json:"should_be_a_record,omitempty"`
+	IsCNAMEToGithubUserDomain     *bool   `json:"is_cname_to_github_user_domain,omitempty"`
+	IsCNAMEToPagesDotGithubDotCom *bool   `json:"is_cname_to_pages_dot_github_dot_com,omitempty"`
+	IsCNAMEToFastly               *bool   `json:"is_cname_to_fastly,omitempty"`
+	IsPointedToGithubPagesIP      *bool   `json:"is_pointed_to_github_pages_ip,omitempty"`
+	IsNonGithubPagesIPPresent     *bool   `json:"is_non_github_pages_ip_present,omitempty"`
+	IsPagesDomain                 *bool   `json:"is_pages_domain,omitempty"`
+	IsServedByPages               *bool   `json:"is_served_by_pages,omitempty"`
+	IsValid                       *bool   `json:"is_valid,omitempty"`
+	Reason                        *string `json:"reason,omitempty"`
+	RespondsToHTTPS               *bool   `json:"responds_to_https,omitempty"`
+	EnforcesHTTPS                 *bool   `json:"enforces_https,omitempty"`
+	HTTPSError                    *string `json:"https_error,omitempty"`
+	IsHTTPSEligible               *bool   `json:"is_https_eligible,omitempty"`
+	CAAError                      *string `json:"caa_error,omitempty"`
+}
+
+// PagesHealthCheckResponse represents the response given for the health check of a Github Pages site.
+type PagesHealthCheckResponse struct {
+	Domain    *PagesDomain `json:"domain,omitempty"`
+	AltDomain *PagesDomain `json:"alt_domain,omitempty"`
+}
+
 // PagesHTTPSCertificate represents the HTTPS Certificate information for a GitHub Pages site.
 type PagesHTTPSCertificate struct {
 	State       *string  `json:"state,omitempty"`
@@ -246,4 +284,23 @@ func (s *RepositoriesService) RequestPageBuild(ctx context.Context, owner, repo 
 	}
 
 	return build, resp, nil
+}
+
+// GetPagesHealthCheck gets a DNS health check for the CNAME record configured for a repository's GitHub Pages.
+//
+// GitHub API docs: https://docs.github.com/en/rest/pages#get-a-dns-health-check-for-github-pages
+func (s *RepositoriesService) GetPageHealthCheck(ctx context.Context, owner, repo string) (*PagesHealthCheckResponse, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pages/health", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	healthCheckResponse := new(PagesHealthCheckResponse)
+	resp, err := s.client.Do(ctx, req, healthCheckResponse)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return healthCheckResponse, resp, nil
 }

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -621,7 +621,7 @@ func TestPagesHealthCheckResponse_Marshal(t *testing.T) {
 			IsFastlyIP:                    Bool(false),
 			IsOldIPAddress:                Bool(false),
 			IsARecord:                     Bool(true),
-			HasCNAMERecordPresent:         Bool(false),
+			HasCNAMERecord:                Bool(false),
 			HasMXRecordsPresent:           Bool(false),
 			IsValidDomain:                 Bool(true),
 			IsApexDomain:                  Bool(true),


### PR DESCRIPTION
Fixes #2745

Allows requesting a DNS health check for the CNAME configured for a repository's GitHub Pages.