### PR TITLE
create and update api's should return the workflow object

### DIFF
--- a/github/actions_required_workflows.go
+++ b/github/actions_required_workflows.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The go-github AUTHORS. All rights reserved.
+// Copyright 2023 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
@@ -10,7 +10,7 @@ import (
 	"fmt"
 )
 
-// OrgRequiredWorkflow represents a required workflow object
+// OrgRequiredWorkflow represents a required workflow object at the org level.
 type OrgRequiredWorkflow struct {
 	ID                      *int64      `json:"id,omitempty"`
 	Name                    *string     `json:"name,omitempty"`
@@ -18,17 +18,19 @@ type OrgRequiredWorkflow struct {
 	Scope                   *string     `json:"scope,omitempty"`
 	Ref                     *string     `json:"ref,omitempty"`
 	State                   *string     `json:"state,omitempty"`
-	SelectedRepositoriesUrl *string     `json:"selected_repositories_url,omitempty"`
+	SelectedRepositoriesURL *string     `json:"selected_repositories_url,omitempty"`
 	CreatedAt               *Timestamp  `json:"created_at,omitempty"`
 	UpdatedAt               *Timestamp  `json:"updated_at,omitempty"`
 	Repository              *Repository `json:"repository,omitempty"`
 }
 
+// OrgRequiredWorkflows represents the required workflows for the org.
 type OrgRequiredWorkflows struct {
 	TotalCount        *int                   `json:"total_count,omitempty"`
 	RequiredWorkflows []*OrgRequiredWorkflow `json:"required_workflows,omitempty"`
 }
 
+// CreateUpdateRequiredWorkflowOptions represents the input object used to create or update required workflows.
 type CreateUpdateRequiredWorkflowOptions struct {
 	WorkflowFilepath      *string         `json:"workflow_file_path,omitempty"`
 	RepositoryID          *int64          `json:"repository_id,omitempty"`
@@ -36,11 +38,13 @@ type CreateUpdateRequiredWorkflowOptions struct {
 	SelectedRepositoryIDs SelectedRepoIDs `json:"selected_repository_ids,omitempty"`
 }
 
-type RequiredWorkflowSelectedRepositories struct {
+// RequiredWorkflowSelectedRepos represents the repo's that a required workflow is applied to.
+type RequiredWorkflowSelectedRepos struct {
 	TotalCount   *int          `json:"total_count,omitempty"`
 	Repositories []*Repository `json:"repositories,omitempty"`
 }
 
+// RepoRequiredWorkflow represents a required workflow object at the repo level.
 type RepoRequiredWorkflow struct {
 	ID               *int64      `json:"id,omitempty"`
 	NodeID           *string     `json:"node_id,omitempty"`
@@ -48,13 +52,14 @@ type RepoRequiredWorkflow struct {
 	Path             *string     `json:"path,omitempty"`
 	State            *string     `json:"state,omitempty"`
 	URL              *string     `json:"url,omitempty"`
-	HtmlURL          *string     `json:"html_url,omitempty"`
+	HTMLURL          *string     `json:"html_url,omitempty"`
 	BadgeURL         *string     `json:"badge_url,omitempty"`
 	CreatedAt        *Timestamp  `json:"created_at,omitempty"`
 	UpdatedAt        *Timestamp  `json:"updated_at,omitempty"`
 	SourceRepository *Repository `json:"source_repository,omitempty"`
 }
 
+// RepoRequiredWorkflows represents the required workflows for a repo.
 type RepoRequiredWorkflows struct {
 	TotalCount        *int                    `json:"total_count,omitempty"`
 	RequiredWorkflows []*RepoRequiredWorkflow `json:"required_workflows,omitempty"`
@@ -84,7 +89,7 @@ func (s *ActionsService) ListOrgRequiredWorkflows(ctx context.Context, org strin
 	return requiredWorkflows, resp, nil
 }
 
-// CreateRequiredWorkflow creates the required workflow in an org
+// CreateRequiredWorkflow creates the required workflow in an org.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#create-a-required-workflow
 func (s *ActionsService) CreateRequiredWorkflow(ctx context.Context, org string, createRequiredWorkflowOptions *CreateUpdateRequiredWorkflowOptions) (*Response, error) {
@@ -116,7 +121,7 @@ func (s *ActionsService) GetRequiredWorkflowByID(ctx context.Context, owner stri
 	return requiredWorkflow, resp, nil
 }
 
-// UpdateRequiredWorkflow updates a required workflow in an org
+// UpdateRequiredWorkflow updates a required workflow in an org.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#update-a-required-workflow
 func (s *ActionsService) UpdateRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID int64, updateRequiredWorkflowOptions *CreateUpdateRequiredWorkflowOptions) (*Response, error) {
@@ -128,7 +133,7 @@ func (s *ActionsService) UpdateRequiredWorkflow(ctx context.Context, org string,
 	return s.client.Do(ctx, req, nil)
 }
 
-// DeleteRequiredWorkflow deletes a required workflow in an org
+// DeleteRequiredWorkflow deletes a required workflow in an org.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#update-a-required-workflow
 func (s *ActionsService) DeleteRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID int64) (*Response, error) {
@@ -140,10 +145,10 @@ func (s *ActionsService) DeleteRequiredWorkflow(ctx context.Context, org string,
 	return s.client.Do(ctx, req, nil)
 }
 
-// ListRequiredWorkflowSelectedRepositories lists the Repositories selected for a workflow.
+// ListRequiredWorkflowSelectedRepos lists the Repositories selected for a workflow.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#list-selected-repositories-for-a-required-workflow
-func (s *ActionsService) ListRequiredWorkflowSelectedRepositories(ctx context.Context, org string, requiredWorkflowID int64, opts *ListOptions) (*RequiredWorkflowSelectedRepositories, *Response, error) {
+func (s *ActionsService) ListRequiredWorkflowSelectedRepos(ctx context.Context, org string, requiredWorkflowID int64, opts *ListOptions) (*RequiredWorkflowSelectedRepos, *Response, error) {
 	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v/repositories", org, requiredWorkflowID)
 	u, err := addOptions(url, opts)
 	if err != nil {
@@ -154,19 +159,19 @@ func (s *ActionsService) ListRequiredWorkflowSelectedRepositories(ctx context.Co
 		return nil, nil, err
 	}
 
-	requiredWorkflowRepositories := new(RequiredWorkflowSelectedRepositories)
-	resp, err := s.client.Do(ctx, req, &requiredWorkflowRepositories)
+	requiredWorkflowRepos := new(RequiredWorkflowSelectedRepos)
+	resp, err := s.client.Do(ctx, req, &requiredWorkflowRepos)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return requiredWorkflowRepositories, resp, nil
+	return requiredWorkflowRepos, resp, nil
 }
 
-// SetRequiredWorkflowSelectedRepositories sets the Repositories selected for a workflow.
+// SetRequiredWorkflowSelectedRepos sets the Repositories selected for a workflow.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#sets-repositories-for-a-required-workflow
-func (s *ActionsService) SetRequiredWorkflowSelectedRepositories(ctx context.Context, org string, requiredWorkflowID int64, ids SelectedRepoIDs) (*Response, error) {
+func (s *ActionsService) SetRequiredWorkflowSelectedRepos(ctx context.Context, org string, requiredWorkflowID int64, ids SelectedRepoIDs) (*Response, error) {
 	type repoIDs struct {
 		SelectedIDs SelectedRepoIDs `json:"selected_repository_ids"`
 	}

--- a/github/actions_required_workflows.go
+++ b/github/actions_required_workflows.go
@@ -32,9 +32,9 @@ type OrgRequiredWorkflows struct {
 
 // CreateUpdateRequiredWorkflowOptions represents the input object used to create or update required workflows.
 type CreateUpdateRequiredWorkflowOptions struct {
-	WorkflowFilePath      *string         `json:"workflow_file_path,omitempty"`
-	RepositoryID          *int64          `json:"repository_id,omitempty"`
-	Scope                 *string         `json:"scope,omitempty"`
+	WorkflowFilePath      *string          `json:"workflow_file_path,omitempty"`
+	RepositoryID          *int64           `json:"repository_id,omitempty"`
+	Scope                 *string          `json:"scope,omitempty"`
 	SelectedRepositoryIDs *SelectedRepoIDs `json:"selected_repository_ids,omitempty"`
 }
 

--- a/github/actions_required_workflows.go
+++ b/github/actions_required_workflows.go
@@ -32,13 +32,13 @@ type OrgRequiredWorkflows struct {
 
 // CreateUpdateRequiredWorkflowOptions represents the input object used to create or update required workflows.
 type CreateUpdateRequiredWorkflowOptions struct {
-	WorkflowFilepath      *string         `json:"workflow_file_path,omitempty"`
+	WorkflowFilePath      *string         `json:"workflow_file_path,omitempty"`
 	RepositoryID          *int64          `json:"repository_id,omitempty"`
 	Scope                 *string         `json:"scope,omitempty"`
-	SelectedRepositoryIDs SelectedRepoIDs `json:"selected_repository_ids,omitempty"`
+	SelectedRepositoryIDs *SelectedRepoIDs `json:"selected_repository_ids,omitempty"`
 }
 
-// RequiredWorkflowSelectedRepos represents the repo's that a required workflow is applied to.
+// RequiredWorkflowSelectedRepos represents the repos that a required workflow is applied to.
 type RequiredWorkflowSelectedRepos struct {
 	TotalCount   *int          `json:"total_count,omitempty"`
 	Repositories []*Repository `json:"repositories,omitempty"`
@@ -199,7 +199,7 @@ func (s *ActionsService) AddRepoToRequiredWorkflow(ctx context.Context, org stri
 // RemoveRepoFromRequiredWorkflow removes the Repository from a required workflow.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#add-a-repository-to-a-required-workflow
-func (s *ActionsService) RemoveRepoFromRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID int64, repoID int64) (*Response, error) {
+func (s *ActionsService) RemoveRepoFromRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID, repoID int64) (*Response, error) {
 	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v/repositories/%v", org, requiredWorkflowID, repoID)
 	req, err := s.client.NewRequest("DELETE", url, nil)
 	if err != nil {

--- a/github/actions_required_workflows.go
+++ b/github/actions_required_workflows.go
@@ -92,13 +92,18 @@ func (s *ActionsService) ListOrgRequiredWorkflows(ctx context.Context, org strin
 // CreateRequiredWorkflow creates the required workflow in an org.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#create-a-required-workflow
-func (s *ActionsService) CreateRequiredWorkflow(ctx context.Context, org string, createRequiredWorkflowOptions *CreateUpdateRequiredWorkflowOptions) (*Response, error) {
+func (s *ActionsService) CreateRequiredWorkflow(ctx context.Context, org string, createRequiredWorkflowOptions *CreateUpdateRequiredWorkflowOptions) (*OrgRequiredWorkflow, *Response, error) {
 	url := fmt.Sprintf("orgs/%v/actions/required_workflows", org)
 	req, err := s.client.NewRequest("PUT", url, createRequiredWorkflowOptions)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	orgRequiredWorkflow := new(OrgRequiredWorkflow)
+	resp, err := s.client.Do(ctx, req, orgRequiredWorkflow)
+	if err != nil {
+		return nil, resp, err
+	}
+	return orgRequiredWorkflow, resp, nil
 }
 
 // GetRequiredWorkflowByID get the RequiredWorkflows for an org by its ID.
@@ -124,13 +129,18 @@ func (s *ActionsService) GetRequiredWorkflowByID(ctx context.Context, owner stri
 // UpdateRequiredWorkflow updates a required workflow in an org.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#update-a-required-workflow
-func (s *ActionsService) UpdateRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID int64, updateRequiredWorkflowOptions *CreateUpdateRequiredWorkflowOptions) (*Response, error) {
+func (s *ActionsService) UpdateRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID int64, updateRequiredWorkflowOptions *CreateUpdateRequiredWorkflowOptions) (*OrgRequiredWorkflow, *Response, error) {
 	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v", org, requiredWorkflowID)
 	req, err := s.client.NewRequest("PATCH", url, updateRequiredWorkflowOptions)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	orgRequiredWorkflow := new(OrgRequiredWorkflow)
+	resp, err := s.client.Do(ctx, req, orgRequiredWorkflow)
+	if err != nil {
+		return nil, resp, err
+	}
+	return orgRequiredWorkflow, resp, nil
 }
 
 // DeleteRequiredWorkflow deletes a required workflow in an org.

--- a/github/actions_required_workflows.go
+++ b/github/actions_required_workflows.go
@@ -187,7 +187,7 @@ func (s *ActionsService) SetRequiredWorkflowSelectedRepos(ctx context.Context, o
 // AddRepoToRequiredWorkflow adds the Repository to a required workflow.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#add-a-repository-to-a-required-workflow
-func (s *ActionsService) AddRepoToRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID int64, repoID int64) (*Response, error) {
+func (s *ActionsService) AddRepoToRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID, repoID int64) (*Response, error) {
 	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v/repositories/%v", org, requiredWorkflowID, repoID)
 	req, err := s.client.NewRequest("PUT", url, nil)
 	if err != nil {

--- a/github/actions_required_workflows.go
+++ b/github/actions_required_workflows.go
@@ -1,0 +1,228 @@
+// Copyright 2020 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// OrgRequiredWorkflow represents a required workflow object
+type OrgRequiredWorkflow struct {
+	ID                      *int64      `json:"id,omitempty"`
+	Name                    *string     `json:"name,omitempty"`
+	Path                    *string     `json:"path,omitempty"`
+	Scope                   *string     `json:"scope,omitempty"`
+	Ref                     *string     `json:"ref,omitempty"`
+	State                   *string     `json:"state,omitempty"`
+	SelectedRepositoriesUrl *string     `json:"selected_repositories_url,omitempty"`
+	CreatedAt               *Timestamp  `json:"created_at,omitempty"`
+	UpdatedAt               *Timestamp  `json:"updated_at,omitempty"`
+	Repository              *Repository `json:"repository,omitempty"`
+}
+
+type OrgRequiredWorkflows struct {
+	TotalCount        *int                   `json:"total_count,omitempty"`
+	RequiredWorkflows []*OrgRequiredWorkflow `json:"required_workflows,omitempty"`
+}
+
+type CreateUpdateRequiredWorkflowOptions struct {
+	WorkflowFilepath      *string         `json:"workflow_file_path,omitempty"`
+	RepositoryID          *int64          `json:"repository_id,omitempty"`
+	Scope                 *string         `json:"scope,omitempty"`
+	SelectedRepositoryIDs SelectedRepoIDs `json:"selected_repository_ids,omitempty"`
+}
+
+type RequiredWorkflowSelectedRepositories struct {
+	TotalCount   *int          `json:"total_count,omitempty"`
+	Repositories []*Repository `json:"repositories,omitempty"`
+}
+
+type RepoRequiredWorkflow struct {
+	ID               *int64      `json:"id,omitempty"`
+	NodeID           *string     `json:"node_id,omitempty"`
+	Name             *string     `json:"name,omitempty"`
+	Path             *string     `json:"path,omitempty"`
+	State            *string     `json:"state,omitempty"`
+	URL              *string     `json:"url,omitempty"`
+	HtmlURL          *string     `json:"html_url,omitempty"`
+	BadgeURL         *string     `json:"badge_url,omitempty"`
+	CreatedAt        *Timestamp  `json:"created_at,omitempty"`
+	UpdatedAt        *Timestamp  `json:"updated_at,omitempty"`
+	SourceRepository *Repository `json:"source_repository,omitempty"`
+}
+
+type RepoRequiredWorkflows struct {
+	TotalCount        *int                    `json:"total_count,omitempty"`
+	RequiredWorkflows []*RepoRequiredWorkflow `json:"required_workflows,omitempty"`
+}
+
+// ListOrgRequiredWorkflows lists the RequiredWorkflows for an org.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#list-required-workflows
+func (s *ActionsService) ListOrgRequiredWorkflows(ctx context.Context, org string, opts *ListOptions) (*OrgRequiredWorkflows, *Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/required_workflows", org)
+	u, err := addOptions(url, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	requiredWorkflows := new(OrgRequiredWorkflows)
+	resp, err := s.client.Do(ctx, req, &requiredWorkflows)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return requiredWorkflows, resp, nil
+}
+
+// CreateRequiredWorkflow creates the required workflow in an org
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#create-a-required-workflow
+func (s *ActionsService) CreateRequiredWorkflow(ctx context.Context, org string, createRequiredWorkflowOptions *CreateUpdateRequiredWorkflowOptions) (*Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/required_workflows", org)
+	req, err := s.client.NewRequest("PUT", url, createRequiredWorkflowOptions)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+}
+
+// GetRequiredWorkflowByID get the RequiredWorkflows for an org by its ID.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#list-required-workflows
+func (s *ActionsService) GetRequiredWorkflowByID(ctx context.Context, owner string, requiredWorkflowID int64) (*OrgRequiredWorkflow, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/required_workflows/%v", owner, requiredWorkflowID)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	requiredWorkflow := new(OrgRequiredWorkflow)
+	resp, err := s.client.Do(ctx, req, &requiredWorkflow)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return requiredWorkflow, resp, nil
+}
+
+// UpdateRequiredWorkflow updates a required workflow in an org
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#update-a-required-workflow
+func (s *ActionsService) UpdateRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID int64, updateRequiredWorkflowOptions *CreateUpdateRequiredWorkflowOptions) (*Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v", org, requiredWorkflowID)
+	req, err := s.client.NewRequest("PATCH", url, updateRequiredWorkflowOptions)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+}
+
+// DeleteRequiredWorkflow deletes a required workflow in an org
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#update-a-required-workflow
+func (s *ActionsService) DeleteRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID int64) (*Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v", org, requiredWorkflowID)
+	req, err := s.client.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+}
+
+// ListRequiredWorkflowSelectedRepositories lists the Repositories selected for a workflow.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#list-selected-repositories-for-a-required-workflow
+func (s *ActionsService) ListRequiredWorkflowSelectedRepositories(ctx context.Context, org string, requiredWorkflowID int64, opts *ListOptions) (*RequiredWorkflowSelectedRepositories, *Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v/repositories", org, requiredWorkflowID)
+	u, err := addOptions(url, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	requiredWorkflowRepositories := new(RequiredWorkflowSelectedRepositories)
+	resp, err := s.client.Do(ctx, req, &requiredWorkflowRepositories)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return requiredWorkflowRepositories, resp, nil
+}
+
+// SetRequiredWorkflowSelectedRepositories sets the Repositories selected for a workflow.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#sets-repositories-for-a-required-workflow
+func (s *ActionsService) SetRequiredWorkflowSelectedRepositories(ctx context.Context, org string, requiredWorkflowID int64, ids SelectedRepoIDs) (*Response, error) {
+	type repoIDs struct {
+		SelectedIDs SelectedRepoIDs `json:"selected_repository_ids"`
+	}
+	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v/repositories", org, requiredWorkflowID)
+	req, err := s.client.NewRequest("PUT", url, repoIDs{SelectedIDs: ids})
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// AddRepoToRequiredWorkflow adds the Repository to a required workflow.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#add-a-repository-to-a-required-workflow
+func (s *ActionsService) AddRepoToRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID int64, repoID int64) (*Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v/repositories/%v", org, requiredWorkflowID, repoID)
+	req, err := s.client.NewRequest("PUT", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+}
+
+// RemoveRepoFromRequiredWorkflow removes the Repository from a required workflow.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#add-a-repository-to-a-required-workflow
+func (s *ActionsService) RemoveRepoFromRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID int64, repoID int64) (*Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v/repositories/%v", org, requiredWorkflowID, repoID)
+	req, err := s.client.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+}
+
+// ListRepoRequiredWorkflows lists the RequiredWorkflows for a repo.
+//
+// Github API docs:https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#list-repository-required-workflows
+func (s *ActionsService) ListRepoRequiredWorkflows(ctx context.Context, owner, repo string, opts *ListOptions) (*RepoRequiredWorkflows, *Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/actions/required_workflows", owner, repo)
+	u, err := addOptions(url, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	requiredWorkflows := new(RepoRequiredWorkflows)
+	resp, err := s.client.Do(ctx, req, &requiredWorkflows)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return requiredWorkflows, resp, nil
+}

--- a/github/actions_required_workflows_test.go
+++ b/github/actions_required_workflows_test.go
@@ -1,0 +1,407 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestActionsService_ListOrgRequiredWorkflows(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/orgs/o/actions/required_workflows", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"per_page": "2", "page": "2"})
+		fmt.Fprint(w, `{"total_count":4,"required_workflows": [
+			{
+			  "id": 30433642,
+			  "name": "Required CI",
+			  "path": ".github/workflows/ci.yml",
+			  "scope": "selected",
+			  "ref": "refs/head/main",
+			  "state": "active",
+			  "selected_repositories_url": "https://api.github.com/organizations/org/actions/required_workflows/1/repositories",
+			  "created_at": "2020-01-22T19:33:08Z",
+			  "updated_at": "2020-01-22T19:33:08Z"
+			},
+			{
+			  "id": 30433643,
+			  "name": "Required Linter",
+			  "path": ".github/workflows/lint.yml",
+			  "scope": "all",
+			  "ref": "refs/head/main",
+			  "state": "active",
+			  "created_at": "2020-01-22T19:33:08Z",
+			  "updated_at": "2020-01-22T19:33:08Z"
+			}
+		  ]
+		}`)
+	})
+	opts := &ListOptions{Page: 2, PerPage: 2}
+	ctx := context.Background()
+	jobs, _, err := client.Actions.ListOrgRequiredWorkflows(ctx, "o", opts)
+
+	if err != nil {
+		t.Errorf("Actions.ListOrgRequiredWorkflows returned error: %v", err)
+	}
+
+	want := &OrgRequiredWorkflows{
+		TotalCount: Int(4),
+		RequiredWorkflows: []*OrgRequiredWorkflow{
+			{ID: Int64(30433642), Name: String("Required CI"), Path: String(".github/workflows/ci.yml"), Scope: String("selected"), Ref: String("refs/head/main"), State: String("active"), SelectedRepositoriesUrl: String("https://api.github.com/organizations/org/actions/required_workflows/1/repositories"), CreatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}},
+			{ID: Int64(30433643), Name: String("Required Linter"), Path: String(".github/workflows/lint.yml"), Scope: String("all"), Ref: String("refs/head/main"), State: String("active"), CreatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}},
+		},
+	}
+	if !cmp.Equal(jobs, want) {
+		t.Errorf("Actions.ListOrgRequiredWorkflows returned %+v, want %+v", jobs, want)
+	}
+	const methodName = "ListOrgRequiredWorkflows"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.ListOrgRequiredWorkflows(ctx, "\n", opts)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.ListOrgRequiredWorkflows(ctx, "o", opts)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+
+}
+
+func TestActionsService_GetRequiredWorkflowByID(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/orgs/o/actions/required_workflows/12345", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"id": 12345,
+			"name": "Required CI",
+			"path": ".github/workflows/ci.yml",
+			"scope": "selected",
+			"ref": "refs/head/main",
+			"state": "active",
+			"selected_repositories_url": "https://api.github.com/orgs/o/actions/required_workflows/12345/repositories",
+			"created_at": "2020-01-22T19:33:08Z",
+			"updated_at": "2020-01-22T19:33:08Z",
+			"repository":{
+				"id": 1296269,
+				"url": "https://api.github.com/repos/o/Hello-World",
+				"name": "Hello-World"
+			}
+			}`)
+	})
+	ctx := context.Background()
+	jobs, _, err := client.Actions.GetRequiredWorkflowByID(ctx, "o", 12345)
+
+	if err != nil {
+		t.Errorf("Actions.GetRequiredWorkflowByID returned error: %v", err)
+	}
+
+	want := &OrgRequiredWorkflow{
+		ID: Int64(12345), Name: String("Required CI"), Path: String(".github/workflows/ci.yml"), Scope: String("selected"), Ref: String("refs/head/main"), State: String("active"), SelectedRepositoriesUrl: String("https://api.github.com/orgs/o/actions/required_workflows/12345/repositories"), CreatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, Repository: &Repository{ID: Int64(1296269), URL: String("https://api.github.com/repos/o/Hello-World"), Name: String("Hello-World")},
+	}
+	if !cmp.Equal(jobs, want) {
+		t.Errorf("Actions.GetRequiredWorkflowByID returned %+v, want %+v", jobs, want)
+	}
+	const methodName = "GetRequiredWorkflowByID"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.GetRequiredWorkflowByID(ctx, "\n", 1)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.GetRequiredWorkflowByID(ctx, "o", 12345)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestActionsService_CreateRequiredWorkflow(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/orgs/o/actions/required_workflows", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Content-Type", "application/json")
+		testBody(t, r, `{"workflow_file_path":".github/workflows/ci.yaml","repository_id":53,"scope":"selected","selected_repository_ids":[32,91]}`+"\n")
+		w.WriteHeader(http.StatusCreated)
+	})
+	input := &CreateUpdateRequiredWorkflowOptions{
+		WorkflowFilepath:      String(".github/workflows/ci.yaml"),
+		RepositoryID:          Int64(53),
+		Scope:                 String("selected"),
+		SelectedRepositoryIDs: SelectedRepoIDs{32, 91},
+	}
+	ctx := context.Background()
+	_, err := client.Actions.CreateRequiredWorkflow(ctx, "o", input)
+
+	if err != nil {
+		t.Errorf("Actions.CreateRequiredWorkflow returned error: %v", err)
+	}
+
+	const methodName = "CreateRequiredWorkflow"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.CreateRequiredWorkflow(ctx, "\n", input)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.CreateRequiredWorkflow(ctx, "o", input)
+
+	})
+}
+
+func TestActionsService_UpdateRequiredWorkflow(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/orgs/o/actions/required_workflows/12345", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		testHeader(t, r, "Content-Type", "application/json")
+		testBody(t, r, `{"workflow_file_path":".github/workflows/ci.yaml","repository_id":53,"scope":"selected","selected_repository_ids":[32,91]}`+"\n")
+		w.WriteHeader(http.StatusOK)
+	})
+	input := &CreateUpdateRequiredWorkflowOptions{
+		WorkflowFilepath:      String(".github/workflows/ci.yaml"),
+		RepositoryID:          Int64(53),
+		Scope:                 String("selected"),
+		SelectedRepositoryIDs: SelectedRepoIDs{32, 91},
+	}
+	ctx := context.Background()
+	_, err := client.Actions.UpdateRequiredWorkflow(ctx, "o", 12345, input)
+
+	if err != nil {
+		t.Errorf("Actions.UpdateRequiredWorkflow returned error: %v", err)
+	}
+
+	const methodName = "UpdateRequiredWorkflow"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.UpdateRequiredWorkflow(ctx, "\n", 12345, input)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.UpdateRequiredWorkflow(ctx, "o", 12345, input)
+
+	})
+}
+
+func TestActionsService_DeleteRequiredWorkflow(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/orgs/o/actions/required_workflows/12345", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	ctx := context.Background()
+	_, err := client.Actions.DeleteRequiredWorkflow(ctx, "o", 12345)
+
+	if err != nil {
+		t.Errorf("Actions.DeleteRequiredWorkflow returned error: %v", err)
+	}
+
+	const methodName = "DeleteRequiredWorkflow"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.DeleteRequiredWorkflow(ctx, "\n", 12345)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.DeleteRequiredWorkflow(ctx, "o", 12345)
+
+	})
+}
+
+func TestActionsService_ListRequiredWorkflowSelectedRepositories(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/orgs/o/actions/required_workflows/12345/repositories", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"per_page": "2", "page": "2"})
+		fmt.Fprint(w, `{"total_count":1,
+			"repositories": [{
+				"id": 1296269,
+				"url": "https://api.github.com/repos/o/Hello-World",
+				"name": "Hello-World"
+				}]
+		}`)
+	})
+	opts := &ListOptions{Page: 2, PerPage: 2}
+	ctx := context.Background()
+	jobs, _, err := client.Actions.ListRequiredWorkflowSelectedRepositories(ctx, "o", 12345, opts)
+
+	if err != nil {
+		t.Errorf("Actions.ListRequiredWorkflowSelectedRepositories returned error: %v", err)
+	}
+
+	want := &RequiredWorkflowSelectedRepositories{
+		TotalCount: Int(1),
+		Repositories: []*Repository{
+			{ID: Int64(1296269), URL: String("https://api.github.com/repos/o/Hello-World"), Name: String("Hello-World")},
+		},
+	}
+	if !cmp.Equal(jobs, want) {
+		t.Errorf("Actions.ListRequiredWorkflowSelectedRepositories returned %+v, want %+v", jobs, want)
+	}
+	const methodName = "ListRequiredWorkflowSelectedRepositories"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.ListRequiredWorkflowSelectedRepositories(ctx, "\n", 12345, opts)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.ListRequiredWorkflowSelectedRepositories(ctx, "o", 12345, opts)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+
+}
+
+func TestActionsService_SetRequiredWorkflowSelectedRepositories(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/orgs/o/actions/required_workflows/12345/repositories", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Content-Type", "application/json")
+		testBody(t, r, `{"selected_repository_ids":[32,91]}`+"\n")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	ctx := context.Background()
+	_, err := client.Actions.SetRequiredWorkflowSelectedRepositories(ctx, "o", 12345, SelectedRepoIDs{32, 91})
+
+	if err != nil {
+		t.Errorf("Actions.SetRequiredWorkflowSelectedRepositories returned error: %v", err)
+	}
+
+	const methodName = "SetRequiredWorkflowSelectedRepositories"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.SetRequiredWorkflowSelectedRepositories(ctx, "\n", 12345, SelectedRepoIDs{32, 91})
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.SetRequiredWorkflowSelectedRepositories(ctx, "o", 12345, SelectedRepoIDs{32, 91})
+
+	})
+}
+
+func TestActionsService_AddRepoToRequiredWorkflow(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/orgs/o/actions/required_workflows/12345/repositories/32", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	ctx := context.Background()
+	_, err := client.Actions.AddRepoToRequiredWorkflow(ctx, "o", 12345, 32)
+
+	if err != nil {
+		t.Errorf("Actions.AddRepoToRequiredWorkflow returned error: %v", err)
+	}
+
+	const methodName = "AddRepoToRequiredWorkflow"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.AddRepoToRequiredWorkflow(ctx, "\n", 12345, 32)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.AddRepoToRequiredWorkflow(ctx, "o", 12345, 32)
+
+	})
+}
+
+func TestActionsService_RemoveRepoFromRequiredWorkflow(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/orgs/o/actions/required_workflows/12345/repositories/32", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	ctx := context.Background()
+	_, err := client.Actions.RemoveRepoFromRequiredWorkflow(ctx, "o", 12345, 32)
+
+	if err != nil {
+		t.Errorf("Actions.RemoveRepoFromRequiredWorkflow returned error: %v", err)
+	}
+
+	const methodName = "RemoveRepoFromRequiredWorkflow"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.RemoveRepoFromRequiredWorkflow(ctx, "\n", 12345, 32)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.RemoveRepoFromRequiredWorkflow(ctx, "o", 12345, 32)
+
+	})
+}
+
+func TestActionsService_ListRepoRequiredWorkflows(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/repos/o/r/actions/required_workflows", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"per_page": "2", "page": "2"})
+		fmt.Fprint(w, `{"total_count":1,"required_workflows": [
+			{
+			  "id": 30433642,
+			  "node_id": "MDg6V29ya2Zsb3cxNjEzMzU=",
+			  "name": "Required CI",
+			  "path": ".github/workflows/ci.yml",
+			  "state": "active",
+			  "created_at": "2020-01-22T19:33:08Z",
+			  "updated_at": "2020-01-22T19:33:08Z",
+			  "url": "https://api.github.com/repos/o/r/actions/required_workflows/161335",
+			  "html_url": "https://github.com/o/r/blob/master/o/hello-world/.github/workflows/required_ci.yaml",
+			  "badge_url": "https://github.com/o/r/workflows/required/o/hello-world/.github/workflows/required_ci.yaml/badge.svg",
+			  "source_repository":{
+				"id": 1296269,
+				"url": "https://api.github.com/repos/o/Hello-World",
+				"name": "Hello-World"
+			  }
+			}
+		  ]
+		}`)
+	})
+	opts := &ListOptions{Page: 2, PerPage: 2}
+	ctx := context.Background()
+	jobs, _, err := client.Actions.ListRepoRequiredWorkflows(ctx, "o", "r", opts)
+
+	if err != nil {
+		t.Errorf("Actions.ListRepoRequiredWorkflows returned error: %v", err)
+	}
+
+	want := &RepoRequiredWorkflows{
+		TotalCount: Int(1),
+		RequiredWorkflows: []*RepoRequiredWorkflow{
+			{ID: Int64(30433642), NodeID: String("MDg6V29ya2Zsb3cxNjEzMzU="), Name: String("Required CI"), Path: String(".github/workflows/ci.yml"), State: String("active"), CreatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, URL: String("https://api.github.com/repos/o/r/actions/required_workflows/161335"), BadgeURL: String("https://github.com/o/r/workflows/required/o/hello-world/.github/workflows/required_ci.yaml/badge.svg"), HtmlURL: String("https://github.com/o/r/blob/master/o/hello-world/.github/workflows/required_ci.yaml"), SourceRepository: &Repository{ID: Int64(1296269), URL: String("https://api.github.com/repos/o/Hello-World"), Name: String("Hello-World")}},
+		},
+	}
+	if !cmp.Equal(jobs, want) {
+		t.Errorf("Actions.ListRepoRequiredWorkflows returned %+v, want %+v", jobs, want)
+	}
+	const methodName = "ListRepoRequiredWorkflows"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.ListRepoRequiredWorkflows(ctx, "\n", "\n", opts)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.ListRepoRequiredWorkflows(ctx, "o", "r", opts)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+
+}

--- a/github/actions_required_workflows_test.go
+++ b/github/actions_required_workflows_test.go
@@ -1,3 +1,8 @@
+// Copyright 2023 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package github
 
 import (
@@ -52,7 +57,7 @@ func TestActionsService_ListOrgRequiredWorkflows(t *testing.T) {
 	want := &OrgRequiredWorkflows{
 		TotalCount: Int(4),
 		RequiredWorkflows: []*OrgRequiredWorkflow{
-			{ID: Int64(30433642), Name: String("Required CI"), Path: String(".github/workflows/ci.yml"), Scope: String("selected"), Ref: String("refs/head/main"), State: String("active"), SelectedRepositoriesUrl: String("https://api.github.com/organizations/org/actions/required_workflows/1/repositories"), CreatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}},
+			{ID: Int64(30433642), Name: String("Required CI"), Path: String(".github/workflows/ci.yml"), Scope: String("selected"), Ref: String("refs/head/main"), State: String("active"), SelectedRepositoriesURL: String("https://api.github.com/organizations/org/actions/required_workflows/1/repositories"), CreatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}},
 			{ID: Int64(30433643), Name: String("Required Linter"), Path: String(".github/workflows/lint.yml"), Scope: String("all"), Ref: String("refs/head/main"), State: String("active"), CreatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}},
 		},
 	}
@@ -67,57 +72,6 @@ func TestActionsService_ListOrgRequiredWorkflows(t *testing.T) {
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		got, resp, err := client.Actions.ListOrgRequiredWorkflows(ctx, "o", opts)
-		if got != nil {
-			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
-		}
-		return resp, err
-	})
-
-}
-
-func TestActionsService_GetRequiredWorkflowByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-	mux.HandleFunc("/orgs/o/actions/required_workflows/12345", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{
-			"id": 12345,
-			"name": "Required CI",
-			"path": ".github/workflows/ci.yml",
-			"scope": "selected",
-			"ref": "refs/head/main",
-			"state": "active",
-			"selected_repositories_url": "https://api.github.com/orgs/o/actions/required_workflows/12345/repositories",
-			"created_at": "2020-01-22T19:33:08Z",
-			"updated_at": "2020-01-22T19:33:08Z",
-			"repository":{
-				"id": 1296269,
-				"url": "https://api.github.com/repos/o/Hello-World",
-				"name": "Hello-World"
-			}
-			}`)
-	})
-	ctx := context.Background()
-	jobs, _, err := client.Actions.GetRequiredWorkflowByID(ctx, "o", 12345)
-
-	if err != nil {
-		t.Errorf("Actions.GetRequiredWorkflowByID returned error: %v", err)
-	}
-
-	want := &OrgRequiredWorkflow{
-		ID: Int64(12345), Name: String("Required CI"), Path: String(".github/workflows/ci.yml"), Scope: String("selected"), Ref: String("refs/head/main"), State: String("active"), SelectedRepositoriesUrl: String("https://api.github.com/orgs/o/actions/required_workflows/12345/repositories"), CreatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, Repository: &Repository{ID: Int64(1296269), URL: String("https://api.github.com/repos/o/Hello-World"), Name: String("Hello-World")},
-	}
-	if !cmp.Equal(jobs, want) {
-		t.Errorf("Actions.GetRequiredWorkflowByID returned %+v, want %+v", jobs, want)
-	}
-	const methodName = "GetRequiredWorkflowByID"
-	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.GetRequiredWorkflowByID(ctx, "\n", 1)
-		return err
-	})
-
-	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.GetRequiredWorkflowByID(ctx, "o", 12345)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -155,7 +109,56 @@ func TestActionsService_CreateRequiredWorkflow(t *testing.T) {
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Actions.CreateRequiredWorkflow(ctx, "o", input)
+	})
+}
 
+func TestActionsService_GetRequiredWorkflowByID(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/orgs/o/actions/required_workflows/12345", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"id": 12345,
+			"name": "Required CI",
+			"path": ".github/workflows/ci.yml",
+			"scope": "selected",
+			"ref": "refs/head/main",
+			"state": "active",
+			"selected_repositories_url": "https://api.github.com/orgs/o/actions/required_workflows/12345/repositories",
+			"created_at": "2020-01-22T19:33:08Z",
+			"updated_at": "2020-01-22T19:33:08Z",
+			"repository":{
+				"id": 1296269,
+				"url": "https://api.github.com/repos/o/Hello-World",
+				"name": "Hello-World"
+			}
+			}`)
+	})
+	ctx := context.Background()
+	jobs, _, err := client.Actions.GetRequiredWorkflowByID(ctx, "o", 12345)
+
+	if err != nil {
+		t.Errorf("Actions.GetRequiredWorkflowByID returned error: %v", err)
+	}
+
+	want := &OrgRequiredWorkflow{
+		ID: Int64(12345), Name: String("Required CI"), Path: String(".github/workflows/ci.yml"), Scope: String("selected"), Ref: String("refs/head/main"), State: String("active"), SelectedRepositoriesURL: String("https://api.github.com/orgs/o/actions/required_workflows/12345/repositories"), CreatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, Repository: &Repository{ID: Int64(1296269), URL: String("https://api.github.com/repos/o/Hello-World"), Name: String("Hello-World")},
+	}
+	if !cmp.Equal(jobs, want) {
+		t.Errorf("Actions.GetRequiredWorkflowByID returned %+v, want %+v", jobs, want)
+	}
+	const methodName = "GetRequiredWorkflowByID"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.GetRequiredWorkflowByID(ctx, "\n", 1)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.GetRequiredWorkflowByID(ctx, "o", 12345)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
 	})
 }
 
@@ -189,7 +192,6 @@ func TestActionsService_UpdateRequiredWorkflow(t *testing.T) {
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Actions.UpdateRequiredWorkflow(ctx, "o", 12345, input)
-
 	})
 }
 
@@ -215,11 +217,10 @@ func TestActionsService_DeleteRequiredWorkflow(t *testing.T) {
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Actions.DeleteRequiredWorkflow(ctx, "o", 12345)
-
 	})
 }
 
-func TestActionsService_ListRequiredWorkflowSelectedRepositories(t *testing.T) {
+func TestActionsService_ListRequiredWorkflowSelectedRepos(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 	mux.HandleFunc("/orgs/o/actions/required_workflows/12345/repositories", func(w http.ResponseWriter, r *http.Request) {
@@ -235,13 +236,13 @@ func TestActionsService_ListRequiredWorkflowSelectedRepositories(t *testing.T) {
 	})
 	opts := &ListOptions{Page: 2, PerPage: 2}
 	ctx := context.Background()
-	jobs, _, err := client.Actions.ListRequiredWorkflowSelectedRepositories(ctx, "o", 12345, opts)
+	jobs, _, err := client.Actions.ListRequiredWorkflowSelectedRepos(ctx, "o", 12345, opts)
 
 	if err != nil {
 		t.Errorf("Actions.ListRequiredWorkflowSelectedRepositories returned error: %v", err)
 	}
 
-	want := &RequiredWorkflowSelectedRepositories{
+	want := &RequiredWorkflowSelectedRepos{
 		TotalCount: Int(1),
 		Repositories: []*Repository{
 			{ID: Int64(1296269), URL: String("https://api.github.com/repos/o/Hello-World"), Name: String("Hello-World")},
@@ -252,21 +253,20 @@ func TestActionsService_ListRequiredWorkflowSelectedRepositories(t *testing.T) {
 	}
 	const methodName = "ListRequiredWorkflowSelectedRepositories"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.ListRequiredWorkflowSelectedRepositories(ctx, "\n", 12345, opts)
+		_, _, err = client.Actions.ListRequiredWorkflowSelectedRepos(ctx, "\n", 12345, opts)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.ListRequiredWorkflowSelectedRepositories(ctx, "o", 12345, opts)
+		got, resp, err := client.Actions.ListRequiredWorkflowSelectedRepos(ctx, "o", 12345, opts)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
 		return resp, err
 	})
-
 }
 
-func TestActionsService_SetRequiredWorkflowSelectedRepositories(t *testing.T) {
+func TestActionsService_SetRequiredWorkflowSelectedRepos(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 	mux.HandleFunc("/orgs/o/actions/required_workflows/12345/repositories", func(w http.ResponseWriter, r *http.Request) {
@@ -276,7 +276,7 @@ func TestActionsService_SetRequiredWorkflowSelectedRepositories(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 	ctx := context.Background()
-	_, err := client.Actions.SetRequiredWorkflowSelectedRepositories(ctx, "o", 12345, SelectedRepoIDs{32, 91})
+	_, err := client.Actions.SetRequiredWorkflowSelectedRepos(ctx, "o", 12345, SelectedRepoIDs{32, 91})
 
 	if err != nil {
 		t.Errorf("Actions.SetRequiredWorkflowSelectedRepositories returned error: %v", err)
@@ -284,13 +284,12 @@ func TestActionsService_SetRequiredWorkflowSelectedRepositories(t *testing.T) {
 
 	const methodName = "SetRequiredWorkflowSelectedRepositories"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.SetRequiredWorkflowSelectedRepositories(ctx, "\n", 12345, SelectedRepoIDs{32, 91})
+		_, err = client.Actions.SetRequiredWorkflowSelectedRepos(ctx, "\n", 12345, SelectedRepoIDs{32, 91})
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.SetRequiredWorkflowSelectedRepositories(ctx, "o", 12345, SelectedRepoIDs{32, 91})
-
+		return client.Actions.SetRequiredWorkflowSelectedRepos(ctx, "o", 12345, SelectedRepoIDs{32, 91})
 	})
 }
 
@@ -316,7 +315,6 @@ func TestActionsService_AddRepoToRequiredWorkflow(t *testing.T) {
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Actions.AddRepoToRequiredWorkflow(ctx, "o", 12345, 32)
-
 	})
 }
 
@@ -342,7 +340,6 @@ func TestActionsService_RemoveRepoFromRequiredWorkflow(t *testing.T) {
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		return client.Actions.RemoveRepoFromRequiredWorkflow(ctx, "o", 12345, 32)
-
 	})
 }
 
@@ -384,7 +381,7 @@ func TestActionsService_ListRepoRequiredWorkflows(t *testing.T) {
 	want := &RepoRequiredWorkflows{
 		TotalCount: Int(1),
 		RequiredWorkflows: []*RepoRequiredWorkflow{
-			{ID: Int64(30433642), NodeID: String("MDg6V29ya2Zsb3cxNjEzMzU="), Name: String("Required CI"), Path: String(".github/workflows/ci.yml"), State: String("active"), CreatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, URL: String("https://api.github.com/repos/o/r/actions/required_workflows/161335"), BadgeURL: String("https://github.com/o/r/workflows/required/o/hello-world/.github/workflows/required_ci.yaml/badge.svg"), HtmlURL: String("https://github.com/o/r/blob/master/o/hello-world/.github/workflows/required_ci.yaml"), SourceRepository: &Repository{ID: Int64(1296269), URL: String("https://api.github.com/repos/o/Hello-World"), Name: String("Hello-World")}},
+			{ID: Int64(30433642), NodeID: String("MDg6V29ya2Zsb3cxNjEzMzU="), Name: String("Required CI"), Path: String(".github/workflows/ci.yml"), State: String("active"), CreatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, UpdatedAt: &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)}, URL: String("https://api.github.com/repos/o/r/actions/required_workflows/161335"), BadgeURL: String("https://github.com/o/r/workflows/required/o/hello-world/.github/workflows/required_ci.yaml/badge.svg"), HTMLURL: String("https://github.com/o/r/blob/master/o/hello-world/.github/workflows/required_ci.yaml"), SourceRepository: &Repository{ID: Int64(1296269), URL: String("https://api.github.com/repos/o/Hello-World"), Name: String("Hello-World")}},
 		},
 	}
 	if !cmp.Equal(jobs, want) {

--- a/github/actions_required_workflows_test.go
+++ b/github/actions_required_workflows_test.go
@@ -86,6 +86,20 @@ func TestActionsService_CreateRequiredWorkflow(t *testing.T) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
 		testBody(t, r, `{"workflow_file_path":".github/workflows/ci.yaml","repository_id":53,"scope":"selected","selected_repository_ids":[32,91]}`+"\n")
+		fmt.Fprint(w, `{
+			"id": 2,
+			"name": "Required CI",
+			"path": ".github/workflows/ci.yml",
+			"scope": "selected",
+			"ref": "refs/head/main",
+			"state": "active",
+			"selected_repositories_url": "https://api.github.com/orgs/octo-org/actions/required_workflows/2/repositories",
+			"created_at": "2020-01-22T19:33:08Z",
+			"updated_at": "2020-01-22T19:33:08Z",
+			"repository": {
+				"id": 53,
+				"name": "Hello-World",
+				"url": "https://api.github.com/repos/o/Hello-World"}}`)
 		w.WriteHeader(http.StatusCreated)
 	})
 	input := &CreateUpdateRequiredWorkflowOptions{
@@ -95,20 +109,39 @@ func TestActionsService_CreateRequiredWorkflow(t *testing.T) {
 		SelectedRepositoryIDs: &SelectedRepoIDs{32, 91},
 	}
 	ctx := context.Background()
-	_, err := client.Actions.CreateRequiredWorkflow(ctx, "o", input)
-
+	requiredWokflow, _, err := client.Actions.CreateRequiredWorkflow(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Actions.CreateRequiredWorkflow returned error: %v", err)
+	}
+	want := &OrgRequiredWorkflow{
+		ID:                      Int64(2),
+		Name:                    String("Required CI"),
+		Path:                    String(".github/workflows/ci.yml"),
+		Scope:                   String("selected"),
+		Ref:                     String("refs/head/main"),
+		State:                   String("active"),
+		SelectedRepositoriesURL: String("https://api.github.com/orgs/octo-org/actions/required_workflows/2/repositories"),
+		CreatedAt:               &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)},
+		UpdatedAt:               &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)},
+		Repository:              &Repository{ID: Int64(53), URL: String("https://api.github.com/repos/o/Hello-World"), Name: String("Hello-World")},
+	}
+
+	if !cmp.Equal(requiredWokflow, want) {
+		t.Errorf("Actions.CreateRequiredWorkflow returned %+v, want %+v", requiredWokflow, want)
 	}
 
 	const methodName = "CreateRequiredWorkflow"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.CreateRequiredWorkflow(ctx, "\n", input)
+		_, _, err = client.Actions.CreateRequiredWorkflow(ctx, "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.CreateRequiredWorkflow(ctx, "o", input)
+		got, resp, err := client.Actions.CreateRequiredWorkflow(ctx, "o", input)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
 	})
 }
 
@@ -169,6 +202,20 @@ func TestActionsService_UpdateRequiredWorkflow(t *testing.T) {
 		testMethod(t, r, "PATCH")
 		testHeader(t, r, "Content-Type", "application/json")
 		testBody(t, r, `{"workflow_file_path":".github/workflows/ci.yaml","repository_id":53,"scope":"selected","selected_repository_ids":[32,91]}`+"\n")
+		fmt.Fprint(w, `{
+			"id": 12345,
+			"name": "Required CI",
+			"path": ".github/workflows/ci.yml",
+			"scope": "selected",
+			"ref": "refs/head/main",
+			"state": "active",
+			"selected_repositories_url": "https://api.github.com/orgs/octo-org/actions/required_workflows/12345/repositories",
+			"created_at": "2020-01-22T19:33:08Z",
+			"updated_at": "2020-01-22T19:33:08Z",
+			"repository": {
+				"id": 53,
+				"name": "Hello-World",
+				"url": "https://api.github.com/repos/o/Hello-World"}}`)
 		w.WriteHeader(http.StatusOK)
 	})
 	input := &CreateUpdateRequiredWorkflowOptions{
@@ -178,20 +225,41 @@ func TestActionsService_UpdateRequiredWorkflow(t *testing.T) {
 		SelectedRepositoryIDs: &SelectedRepoIDs{32, 91},
 	}
 	ctx := context.Background()
-	_, err := client.Actions.UpdateRequiredWorkflow(ctx, "o", 12345, input)
+
+	requiredWokflow, _, err := client.Actions.UpdateRequiredWorkflow(ctx, "o", 12345, input)
 
 	if err != nil {
 		t.Errorf("Actions.UpdateRequiredWorkflow returned error: %v", err)
 	}
+	want := &OrgRequiredWorkflow{
+		ID:                      Int64(12345),
+		Name:                    String("Required CI"),
+		Path:                    String(".github/workflows/ci.yml"),
+		Scope:                   String("selected"),
+		Ref:                     String("refs/head/main"),
+		State:                   String("active"),
+		SelectedRepositoriesURL: String("https://api.github.com/orgs/octo-org/actions/required_workflows/12345/repositories"),
+		CreatedAt:               &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)},
+		UpdatedAt:               &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)},
+		Repository:              &Repository{ID: Int64(53), URL: String("https://api.github.com/repos/o/Hello-World"), Name: String("Hello-World")},
+	}
+
+	if !cmp.Equal(requiredWokflow, want) {
+		t.Errorf("Actions.UpdateRequiredWorkflow returned %+v, want %+v", requiredWokflow, want)
+	}
 
 	const methodName = "UpdateRequiredWorkflow"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.UpdateRequiredWorkflow(ctx, "\n", 12345, input)
+		_, _, err = client.Actions.UpdateRequiredWorkflow(ctx, "\n", 12345, input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.UpdateRequiredWorkflow(ctx, "o", 12345, input)
+		got, resp, err := client.Actions.UpdateRequiredWorkflow(ctx, "o", 12345, input)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
 	})
 }
 

--- a/github/actions_required_workflows_test.go
+++ b/github/actions_required_workflows_test.go
@@ -89,10 +89,10 @@ func TestActionsService_CreateRequiredWorkflow(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 	})
 	input := &CreateUpdateRequiredWorkflowOptions{
-		WorkflowFilepath:      String(".github/workflows/ci.yaml"),
+		WorkflowFilePath:      String(".github/workflows/ci.yaml"),
 		RepositoryID:          Int64(53),
 		Scope:                 String("selected"),
-		SelectedRepositoryIDs: SelectedRepoIDs{32, 91},
+		SelectedRepositoryIDs: &SelectedRepoIDs{32, 91},
 	}
 	ctx := context.Background()
 	_, err := client.Actions.CreateRequiredWorkflow(ctx, "o", input)
@@ -172,10 +172,10 @@ func TestActionsService_UpdateRequiredWorkflow(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 	input := &CreateUpdateRequiredWorkflowOptions{
-		WorkflowFilepath:      String(".github/workflows/ci.yaml"),
+		WorkflowFilePath:      String(".github/workflows/ci.yaml"),
 		RepositoryID:          Int64(53),
 		Scope:                 String("selected"),
-		SelectedRepositoryIDs: SelectedRepoIDs{32, 91},
+		SelectedRepositoryIDs: &SelectedRepoIDs{32, 91},
 	}
 	ctx := context.Background()
 	_, err := client.Actions.UpdateRequiredWorkflow(ctx, "o", 12345, input)
@@ -400,5 +400,4 @@ func TestActionsService_ListRepoRequiredWorkflows(t *testing.T) {
 		}
 		return resp, err
 	})
-
 }

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -4062,12 +4062,20 @@ func (c *CreateUpdateRequiredWorkflowOptions) GetScope() string {
 	return *c.Scope
 }
 
-// GetWorkflowFilepath returns the WorkflowFilepath field if it's non-nil, zero value otherwise.
-func (c *CreateUpdateRequiredWorkflowOptions) GetWorkflowFilepath() string {
-	if c == nil || c.WorkflowFilepath == nil {
+// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs field.
+func (c *CreateUpdateRequiredWorkflowOptions) GetSelectedRepositoryIDs() *SelectedRepoIDs {
+	if c == nil {
+		return nil
+	}
+	return c.SelectedRepositoryIDs
+}
+
+// GetWorkflowFilePath returns the WorkflowFilePath field if it's non-nil, zero value otherwise.
+func (c *CreateUpdateRequiredWorkflowOptions) GetWorkflowFilePath() string {
+	if c == nil || c.WorkflowFilePath == nil {
 		return ""
 	}
-	return *c.WorkflowFilepath
+	return *c.WorkflowFilePath
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -4038,6 +4038,30 @@ func (c *CreateUpdateEnvironment) GetWaitTimer() int {
 	return *c.WaitTimer
 }
 
+// GetRepositoryID returns the RepositoryID field if it's non-nil, zero value otherwise.
+func (c *CreateUpdateRequiredWorkflowOptions) GetRepositoryID() int64 {
+	if c == nil || c.RepositoryID == nil {
+		return 0
+	}
+	return *c.RepositoryID
+}
+
+// GetScope returns the Scope field if it's non-nil, zero value otherwise.
+func (c *CreateUpdateRequiredWorkflowOptions) GetScope() string {
+	if c == nil || c.Scope == nil {
+		return ""
+	}
+	return *c.Scope
+}
+
+// GetWorkflowFilepath returns the WorkflowFilepath field if it's non-nil, zero value otherwise.
+func (c *CreateUpdateRequiredWorkflowOptions) GetWorkflowFilepath() string {
+	if c == nil || c.WorkflowFilepath == nil {
+		return ""
+	}
+	return *c.WorkflowFilepath
+}
+
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
 func (c *CreateUserProjectOptions) GetBody() string {
 	if c == nil || c.Body == nil {
@@ -11046,6 +11070,94 @@ func (o *OrgBlockEvent) GetSender() *User {
 	return o.Sender
 }
 
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (o *OrgRequiredWorkflow) GetCreatedAt() Timestamp {
+	if o == nil || o.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *o.CreatedAt
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (o *OrgRequiredWorkflow) GetID() int64 {
+	if o == nil || o.ID == nil {
+		return 0
+	}
+	return *o.ID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (o *OrgRequiredWorkflow) GetName() string {
+	if o == nil || o.Name == nil {
+		return ""
+	}
+	return *o.Name
+}
+
+// GetPath returns the Path field if it's non-nil, zero value otherwise.
+func (o *OrgRequiredWorkflow) GetPath() string {
+	if o == nil || o.Path == nil {
+		return ""
+	}
+	return *o.Path
+}
+
+// GetRef returns the Ref field if it's non-nil, zero value otherwise.
+func (o *OrgRequiredWorkflow) GetRef() string {
+	if o == nil || o.Ref == nil {
+		return ""
+	}
+	return *o.Ref
+}
+
+// GetRepository returns the Repository field.
+func (o *OrgRequiredWorkflow) GetRepository() *Repository {
+	if o == nil {
+		return nil
+	}
+	return o.Repository
+}
+
+// GetScope returns the Scope field if it's non-nil, zero value otherwise.
+func (o *OrgRequiredWorkflow) GetScope() string {
+	if o == nil || o.Scope == nil {
+		return ""
+	}
+	return *o.Scope
+}
+
+// GetSelectedRepositoriesUrl returns the SelectedRepositoriesUrl field if it's non-nil, zero value otherwise.
+func (o *OrgRequiredWorkflow) GetSelectedRepositoriesUrl() string {
+	if o == nil || o.SelectedRepositoriesUrl == nil {
+		return ""
+	}
+	return *o.SelectedRepositoriesUrl
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (o *OrgRequiredWorkflow) GetState() string {
+	if o == nil || o.State == nil {
+		return ""
+	}
+	return *o.State
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (o *OrgRequiredWorkflow) GetUpdatedAt() Timestamp {
+	if o == nil || o.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *o.UpdatedAt
+}
+
+// GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
+func (o *OrgRequiredWorkflows) GetTotalCount() int {
+	if o == nil || o.TotalCount == nil {
+		return 0
+	}
+	return *o.TotalCount
+}
+
 // GetDisabledOrgs returns the DisabledOrgs field if it's non-nil, zero value otherwise.
 func (o *OrgStats) GetDisabledOrgs() int {
 	if o == nil || o.DisabledOrgs == nil {
@@ -15454,6 +15566,102 @@ func (r *RepoName) GetFrom() string {
 	return *r.From
 }
 
+// GetBadgeURL returns the BadgeURL field if it's non-nil, zero value otherwise.
+func (r *RepoRequiredWorkflow) GetBadgeURL() string {
+	if r == nil || r.BadgeURL == nil {
+		return ""
+	}
+	return *r.BadgeURL
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (r *RepoRequiredWorkflow) GetCreatedAt() Timestamp {
+	if r == nil || r.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *r.CreatedAt
+}
+
+// GetHtmlURL returns the HtmlURL field if it's non-nil, zero value otherwise.
+func (r *RepoRequiredWorkflow) GetHtmlURL() string {
+	if r == nil || r.HtmlURL == nil {
+		return ""
+	}
+	return *r.HtmlURL
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (r *RepoRequiredWorkflow) GetID() int64 {
+	if r == nil || r.ID == nil {
+		return 0
+	}
+	return *r.ID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (r *RepoRequiredWorkflow) GetName() string {
+	if r == nil || r.Name == nil {
+		return ""
+	}
+	return *r.Name
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (r *RepoRequiredWorkflow) GetNodeID() string {
+	if r == nil || r.NodeID == nil {
+		return ""
+	}
+	return *r.NodeID
+}
+
+// GetPath returns the Path field if it's non-nil, zero value otherwise.
+func (r *RepoRequiredWorkflow) GetPath() string {
+	if r == nil || r.Path == nil {
+		return ""
+	}
+	return *r.Path
+}
+
+// GetSourceRepository returns the SourceRepository field.
+func (r *RepoRequiredWorkflow) GetSourceRepository() *Repository {
+	if r == nil {
+		return nil
+	}
+	return r.SourceRepository
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (r *RepoRequiredWorkflow) GetState() string {
+	if r == nil || r.State == nil {
+		return ""
+	}
+	return *r.State
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (r *RepoRequiredWorkflow) GetUpdatedAt() Timestamp {
+	if r == nil || r.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *r.UpdatedAt
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (r *RepoRequiredWorkflow) GetURL() string {
+	if r == nil || r.URL == nil {
+		return ""
+	}
+	return *r.URL
+}
+
+// GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
+func (r *RepoRequiredWorkflows) GetTotalCount() int {
+	if r == nil || r.TotalCount == nil {
+		return 0
+	}
+	return *r.TotalCount
+}
+
 // GetIncompleteResults returns the IncompleteResults field if it's non-nil, zero value otherwise.
 func (r *RepositoriesSearchResult) GetIncompleteResults() bool {
 	if r == nil || r.IncompleteResults == nil {
@@ -17468,6 +17676,14 @@ func (r *RequiredStatusChecksRequest) GetStrict() bool {
 		return false
 	}
 	return *r.Strict
+}
+
+// GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
+func (r *RequiredWorkflowSelectedRepositories) GetTotalCount() int {
+	if r == nil || r.TotalCount == nil {
+		return 0
+	}
+	return *r.TotalCount
 }
 
 // GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11158,12 +11158,12 @@ func (o *OrgRequiredWorkflow) GetScope() string {
 	return *o.Scope
 }
 
-// GetSelectedRepositoriesUrl returns the SelectedRepositoriesUrl field if it's non-nil, zero value otherwise.
-func (o *OrgRequiredWorkflow) GetSelectedRepositoriesUrl() string {
-	if o == nil || o.SelectedRepositoriesUrl == nil {
+// GetSelectedRepositoriesURL returns the SelectedRepositoriesURL field if it's non-nil, zero value otherwise.
+func (o *OrgRequiredWorkflow) GetSelectedRepositoriesURL() string {
+	if o == nil || o.SelectedRepositoriesURL == nil {
 		return ""
 	}
-	return *o.SelectedRepositoriesUrl
+	return *o.SelectedRepositoriesURL
 }
 
 // GetState returns the State field if it's non-nil, zero value otherwise.
@@ -15630,12 +15630,12 @@ func (r *RepoRequiredWorkflow) GetCreatedAt() Timestamp {
 	return *r.CreatedAt
 }
 
-// GetHtmlURL returns the HtmlURL field if it's non-nil, zero value otherwise.
-func (r *RepoRequiredWorkflow) GetHtmlURL() string {
-	if r == nil || r.HtmlURL == nil {
+// GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
+func (r *RepoRequiredWorkflow) GetHTMLURL() string {
+	if r == nil || r.HTMLURL == nil {
 		return ""
 	}
-	return *r.HtmlURL
+	return *r.HTMLURL
 }
 
 // GetID returns the ID field if it's non-nil, zero value otherwise.
@@ -17727,7 +17727,7 @@ func (r *RequiredStatusChecksRequest) GetStrict() bool {
 }
 
 // GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
-func (r *RequiredWorkflowSelectedRepositories) GetTotalCount() int {
+func (r *RequiredWorkflowSelectedRepos) GetTotalCount() int {
 	if r == nil || r.TotalCount == nil {
 		return 0
 	}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -4742,6 +4742,36 @@ func TestCreateUpdateEnvironment_GetWaitTimer(tt *testing.T) {
 	c.GetWaitTimer()
 }
 
+func TestCreateUpdateRequiredWorkflowOptions_GetRepositoryID(tt *testing.T) {
+	var zeroValue int64
+	c := &CreateUpdateRequiredWorkflowOptions{RepositoryID: &zeroValue}
+	c.GetRepositoryID()
+	c = &CreateUpdateRequiredWorkflowOptions{}
+	c.GetRepositoryID()
+	c = nil
+	c.GetRepositoryID()
+}
+
+func TestCreateUpdateRequiredWorkflowOptions_GetScope(tt *testing.T) {
+	var zeroValue string
+	c := &CreateUpdateRequiredWorkflowOptions{Scope: &zeroValue}
+	c.GetScope()
+	c = &CreateUpdateRequiredWorkflowOptions{}
+	c.GetScope()
+	c = nil
+	c.GetScope()
+}
+
+func TestCreateUpdateRequiredWorkflowOptions_GetWorkflowFilepath(tt *testing.T) {
+	var zeroValue string
+	c := &CreateUpdateRequiredWorkflowOptions{WorkflowFilepath: &zeroValue}
+	c.GetWorkflowFilepath()
+	c = &CreateUpdateRequiredWorkflowOptions{}
+	c.GetWorkflowFilepath()
+	c = nil
+	c.GetWorkflowFilepath()
+}
+
 func TestCreateUserProjectOptions_GetBody(tt *testing.T) {
 	var zeroValue string
 	c := &CreateUserProjectOptions{Body: &zeroValue}
@@ -12953,6 +12983,113 @@ func TestOrgBlockEvent_GetSender(tt *testing.T) {
 	o.GetSender()
 }
 
+func TestOrgRequiredWorkflow_GetCreatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	o := &OrgRequiredWorkflow{CreatedAt: &zeroValue}
+	o.GetCreatedAt()
+	o = &OrgRequiredWorkflow{}
+	o.GetCreatedAt()
+	o = nil
+	o.GetCreatedAt()
+}
+
+func TestOrgRequiredWorkflow_GetID(tt *testing.T) {
+	var zeroValue int64
+	o := &OrgRequiredWorkflow{ID: &zeroValue}
+	o.GetID()
+	o = &OrgRequiredWorkflow{}
+	o.GetID()
+	o = nil
+	o.GetID()
+}
+
+func TestOrgRequiredWorkflow_GetName(tt *testing.T) {
+	var zeroValue string
+	o := &OrgRequiredWorkflow{Name: &zeroValue}
+	o.GetName()
+	o = &OrgRequiredWorkflow{}
+	o.GetName()
+	o = nil
+	o.GetName()
+}
+
+func TestOrgRequiredWorkflow_GetPath(tt *testing.T) {
+	var zeroValue string
+	o := &OrgRequiredWorkflow{Path: &zeroValue}
+	o.GetPath()
+	o = &OrgRequiredWorkflow{}
+	o.GetPath()
+	o = nil
+	o.GetPath()
+}
+
+func TestOrgRequiredWorkflow_GetRef(tt *testing.T) {
+	var zeroValue string
+	o := &OrgRequiredWorkflow{Ref: &zeroValue}
+	o.GetRef()
+	o = &OrgRequiredWorkflow{}
+	o.GetRef()
+	o = nil
+	o.GetRef()
+}
+
+func TestOrgRequiredWorkflow_GetRepository(tt *testing.T) {
+	o := &OrgRequiredWorkflow{}
+	o.GetRepository()
+	o = nil
+	o.GetRepository()
+}
+
+func TestOrgRequiredWorkflow_GetScope(tt *testing.T) {
+	var zeroValue string
+	o := &OrgRequiredWorkflow{Scope: &zeroValue}
+	o.GetScope()
+	o = &OrgRequiredWorkflow{}
+	o.GetScope()
+	o = nil
+	o.GetScope()
+}
+
+func TestOrgRequiredWorkflow_GetSelectedRepositoriesUrl(tt *testing.T) {
+	var zeroValue string
+	o := &OrgRequiredWorkflow{SelectedRepositoriesUrl: &zeroValue}
+	o.GetSelectedRepositoriesUrl()
+	o = &OrgRequiredWorkflow{}
+	o.GetSelectedRepositoriesUrl()
+	o = nil
+	o.GetSelectedRepositoriesUrl()
+}
+
+func TestOrgRequiredWorkflow_GetState(tt *testing.T) {
+	var zeroValue string
+	o := &OrgRequiredWorkflow{State: &zeroValue}
+	o.GetState()
+	o = &OrgRequiredWorkflow{}
+	o.GetState()
+	o = nil
+	o.GetState()
+}
+
+func TestOrgRequiredWorkflow_GetUpdatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	o := &OrgRequiredWorkflow{UpdatedAt: &zeroValue}
+	o.GetUpdatedAt()
+	o = &OrgRequiredWorkflow{}
+	o.GetUpdatedAt()
+	o = nil
+	o.GetUpdatedAt()
+}
+
+func TestOrgRequiredWorkflows_GetTotalCount(tt *testing.T) {
+	var zeroValue int
+	o := &OrgRequiredWorkflows{TotalCount: &zeroValue}
+	o.GetTotalCount()
+	o = &OrgRequiredWorkflows{}
+	o.GetTotalCount()
+	o = nil
+	o.GetTotalCount()
+}
+
 func TestOrgStats_GetDisabledOrgs(tt *testing.T) {
 	var zeroValue int
 	o := &OrgStats{DisabledOrgs: &zeroValue}
@@ -17944,6 +18081,123 @@ func TestRepoName_GetFrom(tt *testing.T) {
 	r.GetFrom()
 }
 
+func TestRepoRequiredWorkflow_GetBadgeURL(tt *testing.T) {
+	var zeroValue string
+	r := &RepoRequiredWorkflow{BadgeURL: &zeroValue}
+	r.GetBadgeURL()
+	r = &RepoRequiredWorkflow{}
+	r.GetBadgeURL()
+	r = nil
+	r.GetBadgeURL()
+}
+
+func TestRepoRequiredWorkflow_GetCreatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	r := &RepoRequiredWorkflow{CreatedAt: &zeroValue}
+	r.GetCreatedAt()
+	r = &RepoRequiredWorkflow{}
+	r.GetCreatedAt()
+	r = nil
+	r.GetCreatedAt()
+}
+
+func TestRepoRequiredWorkflow_GetHtmlURL(tt *testing.T) {
+	var zeroValue string
+	r := &RepoRequiredWorkflow{HtmlURL: &zeroValue}
+	r.GetHtmlURL()
+	r = &RepoRequiredWorkflow{}
+	r.GetHtmlURL()
+	r = nil
+	r.GetHtmlURL()
+}
+
+func TestRepoRequiredWorkflow_GetID(tt *testing.T) {
+	var zeroValue int64
+	r := &RepoRequiredWorkflow{ID: &zeroValue}
+	r.GetID()
+	r = &RepoRequiredWorkflow{}
+	r.GetID()
+	r = nil
+	r.GetID()
+}
+
+func TestRepoRequiredWorkflow_GetName(tt *testing.T) {
+	var zeroValue string
+	r := &RepoRequiredWorkflow{Name: &zeroValue}
+	r.GetName()
+	r = &RepoRequiredWorkflow{}
+	r.GetName()
+	r = nil
+	r.GetName()
+}
+
+func TestRepoRequiredWorkflow_GetNodeID(tt *testing.T) {
+	var zeroValue string
+	r := &RepoRequiredWorkflow{NodeID: &zeroValue}
+	r.GetNodeID()
+	r = &RepoRequiredWorkflow{}
+	r.GetNodeID()
+	r = nil
+	r.GetNodeID()
+}
+
+func TestRepoRequiredWorkflow_GetPath(tt *testing.T) {
+	var zeroValue string
+	r := &RepoRequiredWorkflow{Path: &zeroValue}
+	r.GetPath()
+	r = &RepoRequiredWorkflow{}
+	r.GetPath()
+	r = nil
+	r.GetPath()
+}
+
+func TestRepoRequiredWorkflow_GetSourceRepository(tt *testing.T) {
+	r := &RepoRequiredWorkflow{}
+	r.GetSourceRepository()
+	r = nil
+	r.GetSourceRepository()
+}
+
+func TestRepoRequiredWorkflow_GetState(tt *testing.T) {
+	var zeroValue string
+	r := &RepoRequiredWorkflow{State: &zeroValue}
+	r.GetState()
+	r = &RepoRequiredWorkflow{}
+	r.GetState()
+	r = nil
+	r.GetState()
+}
+
+func TestRepoRequiredWorkflow_GetUpdatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	r := &RepoRequiredWorkflow{UpdatedAt: &zeroValue}
+	r.GetUpdatedAt()
+	r = &RepoRequiredWorkflow{}
+	r.GetUpdatedAt()
+	r = nil
+	r.GetUpdatedAt()
+}
+
+func TestRepoRequiredWorkflow_GetURL(tt *testing.T) {
+	var zeroValue string
+	r := &RepoRequiredWorkflow{URL: &zeroValue}
+	r.GetURL()
+	r = &RepoRequiredWorkflow{}
+	r.GetURL()
+	r = nil
+	r.GetURL()
+}
+
+func TestRepoRequiredWorkflows_GetTotalCount(tt *testing.T) {
+	var zeroValue int
+	r := &RepoRequiredWorkflows{TotalCount: &zeroValue}
+	r.GetTotalCount()
+	r = &RepoRequiredWorkflows{}
+	r.GetTotalCount()
+	r = nil
+	r.GetTotalCount()
+}
+
 func TestRepositoriesSearchResult_GetIncompleteResults(tt *testing.T) {
 	var zeroValue bool
 	r := &RepositoriesSearchResult{IncompleteResults: &zeroValue}
@@ -20336,6 +20590,16 @@ func TestRequiredStatusChecksRequest_GetStrict(tt *testing.T) {
 	r.GetStrict()
 	r = nil
 	r.GetStrict()
+}
+
+func TestRequiredWorkflowSelectedRepositories_GetTotalCount(tt *testing.T) {
+	var zeroValue int
+	r := &RequiredWorkflowSelectedRepositories{TotalCount: &zeroValue}
+	r.GetTotalCount()
+	r = &RequiredWorkflowSelectedRepositories{}
+	r.GetTotalCount()
+	r = nil
+	r.GetTotalCount()
 }
 
 func TestReviewersRequest_GetNodeID(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -4772,14 +4772,21 @@ func TestCreateUpdateRequiredWorkflowOptions_GetScope(tt *testing.T) {
 	c.GetScope()
 }
 
-func TestCreateUpdateRequiredWorkflowOptions_GetWorkflowFilepath(tt *testing.T) {
-	var zeroValue string
-	c := &CreateUpdateRequiredWorkflowOptions{WorkflowFilepath: &zeroValue}
-	c.GetWorkflowFilepath()
-	c = &CreateUpdateRequiredWorkflowOptions{}
-	c.GetWorkflowFilepath()
+func TestCreateUpdateRequiredWorkflowOptions_GetSelectedRepositoryIDs(tt *testing.T) {
+	c := &CreateUpdateRequiredWorkflowOptions{}
+	c.GetSelectedRepositoryIDs()
 	c = nil
-	c.GetWorkflowFilepath()
+	c.GetSelectedRepositoryIDs()
+}
+
+func TestCreateUpdateRequiredWorkflowOptions_GetWorkflowFilePath(tt *testing.T) {
+	var zeroValue string
+	c := &CreateUpdateRequiredWorkflowOptions{WorkflowFilePath: &zeroValue}
+	c.GetWorkflowFilePath()
+	c = &CreateUpdateRequiredWorkflowOptions{}
+	c.GetWorkflowFilePath()
+	c = nil
+	c.GetWorkflowFilePath()
 }
 
 func TestCreateUserProjectOptions_GetBody(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -13090,14 +13090,14 @@ func TestOrgRequiredWorkflow_GetScope(tt *testing.T) {
 	o.GetScope()
 }
 
-func TestOrgRequiredWorkflow_GetSelectedRepositoriesUrl(tt *testing.T) {
+func TestOrgRequiredWorkflow_GetSelectedRepositoriesURL(tt *testing.T) {
 	var zeroValue string
-	o := &OrgRequiredWorkflow{SelectedRepositoriesUrl: &zeroValue}
-	o.GetSelectedRepositoriesUrl()
+	o := &OrgRequiredWorkflow{SelectedRepositoriesURL: &zeroValue}
+	o.GetSelectedRepositoriesURL()
 	o = &OrgRequiredWorkflow{}
-	o.GetSelectedRepositoriesUrl()
+	o.GetSelectedRepositoriesURL()
 	o = nil
-	o.GetSelectedRepositoriesUrl()
+	o.GetSelectedRepositoriesURL()
 }
 
 func TestOrgRequiredWorkflow_GetState(tt *testing.T) {
@@ -18161,14 +18161,14 @@ func TestRepoRequiredWorkflow_GetCreatedAt(tt *testing.T) {
 	r.GetCreatedAt()
 }
 
-func TestRepoRequiredWorkflow_GetHtmlURL(tt *testing.T) {
+func TestRepoRequiredWorkflow_GetHTMLURL(tt *testing.T) {
 	var zeroValue string
-	r := &RepoRequiredWorkflow{HtmlURL: &zeroValue}
-	r.GetHtmlURL()
+	r := &RepoRequiredWorkflow{HTMLURL: &zeroValue}
+	r.GetHTMLURL()
 	r = &RepoRequiredWorkflow{}
-	r.GetHtmlURL()
+	r.GetHTMLURL()
 	r = nil
-	r.GetHtmlURL()
+	r.GetHTMLURL()
 }
 
 func TestRepoRequiredWorkflow_GetID(tt *testing.T) {
@@ -20652,11 +20652,11 @@ func TestRequiredStatusChecksRequest_GetStrict(tt *testing.T) {
 	r.GetStrict()
 }
 
-func TestRequiredWorkflowSelectedRepositories_GetTotalCount(tt *testing.T) {
+func TestRequiredWorkflowSelectedRepos_GetTotalCount(tt *testing.T) {
 	var zeroValue int
-	r := &RequiredWorkflowSelectedRepositories{TotalCount: &zeroValue}
+	r := &RequiredWorkflowSelectedRepos{TotalCount: &zeroValue}
 	r.GetTotalCount()
-	r = &RequiredWorkflowSelectedRepositories{}
+	r = &RequiredWorkflowSelectedRepos{}
 	r.GetTotalCount()
 	r = nil
 	r.GetTotalCount()


### PR DESCRIPTION
Updated create and update org required workflow methods to return the required workflow object returned by the github api.
Merging this Fixes https://github.com/google/go-github/issues/2756