### PR TITLE
Update Create/Update methods to return the workflow

### DIFF
--- a/github/actions_required_workflows.go
+++ b/github/actions_required_workflows.go
@@ -98,11 +98,13 @@ func (s *ActionsService) CreateRequiredWorkflow(ctx context.Context, org string,
 	if err != nil {
 		return nil, nil, err
 	}
+
 	orgRequiredWorkflow := new(OrgRequiredWorkflow)
 	resp, err := s.client.Do(ctx, req, orgRequiredWorkflow)
 	if err != nil {
 		return nil, resp, err
 	}
+
 	return orgRequiredWorkflow, resp, nil
 }
 
@@ -135,11 +137,13 @@ func (s *ActionsService) UpdateRequiredWorkflow(ctx context.Context, org string,
 	if err != nil {
 		return nil, nil, err
 	}
+
 	orgRequiredWorkflow := new(OrgRequiredWorkflow)
 	resp, err := s.client.Do(ctx, req, orgRequiredWorkflow)
 	if err != nil {
 		return nil, resp, err
 	}
+
 	return orgRequiredWorkflow, resp, nil
 }
 

--- a/github/actions_required_workflows.go
+++ b/github/actions_required_workflows.go
@@ -92,13 +92,18 @@ func (s *ActionsService) ListOrgRequiredWorkflows(ctx context.Context, org strin
 // CreateRequiredWorkflow creates the required workflow in an org.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#create-a-required-workflow
-func (s *ActionsService) CreateRequiredWorkflow(ctx context.Context, org string, createRequiredWorkflowOptions *CreateUpdateRequiredWorkflowOptions) (*Response, error) {
+func (s *ActionsService) CreateRequiredWorkflow(ctx context.Context, org string, createRequiredWorkflowOptions *CreateUpdateRequiredWorkflowOptions) (*OrgRequiredWorkflow, *Response, error) {
 	url := fmt.Sprintf("orgs/%v/actions/required_workflows", org)
 	req, err := s.client.NewRequest("PUT", url, createRequiredWorkflowOptions)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	orgRequiredWorkflow := new(OrgRequiredWorkflow)
+	resp, err := s.client.Do(ctx, req, orgRequiredWorkflow)
+	if err != nil {
+		return nil, resp, err
+	}
+	return orgRequiredWorkflow, resp, nil
 }
 
 // GetRequiredWorkflowByID get the RequiredWorkflows for an org by its ID.
@@ -124,13 +129,18 @@ func (s *ActionsService) GetRequiredWorkflowByID(ctx context.Context, owner stri
 // UpdateRequiredWorkflow updates a required workflow in an org.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#update-a-required-workflow
-func (s *ActionsService) UpdateRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID int64, updateRequiredWorkflowOptions *CreateUpdateRequiredWorkflowOptions) (*Response, error) {
+func (s *ActionsService) UpdateRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID int64, updateRequiredWorkflowOptions *CreateUpdateRequiredWorkflowOptions) (*OrgRequiredWorkflow, *Response, error) {
 	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v", org, requiredWorkflowID)
 	req, err := s.client.NewRequest("PATCH", url, updateRequiredWorkflowOptions)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	orgRequiredWorkflow := new(OrgRequiredWorkflow)
+	resp, err := s.client.Do(ctx, req, orgRequiredWorkflow)
+	if err != nil {
+		return nil, resp, err
+	}
+	return orgRequiredWorkflow, resp, nil
 }
 
 // DeleteRequiredWorkflow deletes a required workflow in an org.

--- a/github/actions_required_workflows_test.go
+++ b/github/actions_required_workflows_test.go
@@ -86,7 +86,20 @@ func TestActionsService_CreateRequiredWorkflow(t *testing.T) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
 		testBody(t, r, `{"workflow_file_path":".github/workflows/ci.yaml","repository_id":53,"scope":"selected","selected_repository_ids":[32,91]}`+"\n")
-		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{
+			"id": 2,
+			"name": "Required CI",
+			"path": ".github/workflows/ci.yml",
+			"scope": "selected",
+			"ref": "refs/head/main",
+			"state": "active",
+			"selected_repositories_url": "https://api.github.com/orgs/octo-org/actions/required_workflows/2/repositories",
+			"created_at": "2020-01-22T19:33:08Z",
+			"updated_at": "2020-01-22T19:33:08Z",
+			"repository": {
+				"id": 53,
+				"name": "Hello-World",
+				"url": "https://api.github.com/repos/o/Hello-World"}}`)
 	})
 	input := &CreateUpdateRequiredWorkflowOptions{
 		WorkflowFilePath:      String(".github/workflows/ci.yaml"),
@@ -95,20 +108,39 @@ func TestActionsService_CreateRequiredWorkflow(t *testing.T) {
 		SelectedRepositoryIDs: &SelectedRepoIDs{32, 91},
 	}
 	ctx := context.Background()
-	_, err := client.Actions.CreateRequiredWorkflow(ctx, "o", input)
-
+	requiredWokflow, _, err := client.Actions.CreateRequiredWorkflow(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Actions.CreateRequiredWorkflow returned error: %v", err)
+	}
+	want := &OrgRequiredWorkflow{
+		ID:                      Int64(2),
+		Name:                    String("Required CI"),
+		Path:                    String(".github/workflows/ci.yml"),
+		Scope:                   String("selected"),
+		Ref:                     String("refs/head/main"),
+		State:                   String("active"),
+		SelectedRepositoriesURL: String("https://api.github.com/orgs/octo-org/actions/required_workflows/2/repositories"),
+		CreatedAt:               &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)},
+		UpdatedAt:               &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)},
+		Repository:              &Repository{ID: Int64(53), URL: String("https://api.github.com/repos/o/Hello-World"), Name: String("Hello-World")},
+	}
+
+	if !cmp.Equal(requiredWokflow, want) {
+		t.Errorf("Actions.CreateRequiredWorkflow returned %+v, want %+v", requiredWokflow, want)
 	}
 
 	const methodName = "CreateRequiredWorkflow"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.CreateRequiredWorkflow(ctx, "\n", input)
+		_, _, err = client.Actions.CreateRequiredWorkflow(ctx, "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.CreateRequiredWorkflow(ctx, "o", input)
+		got, resp, err := client.Actions.CreateRequiredWorkflow(ctx, "o", input)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
 	})
 }
 
@@ -169,7 +201,20 @@ func TestActionsService_UpdateRequiredWorkflow(t *testing.T) {
 		testMethod(t, r, "PATCH")
 		testHeader(t, r, "Content-Type", "application/json")
 		testBody(t, r, `{"workflow_file_path":".github/workflows/ci.yaml","repository_id":53,"scope":"selected","selected_repository_ids":[32,91]}`+"\n")
-		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"id": 12345,
+			"name": "Required CI",
+			"path": ".github/workflows/ci.yml",
+			"scope": "selected",
+			"ref": "refs/head/main",
+			"state": "active",
+			"selected_repositories_url": "https://api.github.com/orgs/octo-org/actions/required_workflows/12345/repositories",
+			"created_at": "2020-01-22T19:33:08Z",
+			"updated_at": "2020-01-22T19:33:08Z",
+			"repository": {
+				"id": 53,
+				"name": "Hello-World",
+				"url": "https://api.github.com/repos/o/Hello-World"}}`)
 	})
 	input := &CreateUpdateRequiredWorkflowOptions{
 		WorkflowFilePath:      String(".github/workflows/ci.yaml"),
@@ -178,20 +223,41 @@ func TestActionsService_UpdateRequiredWorkflow(t *testing.T) {
 		SelectedRepositoryIDs: &SelectedRepoIDs{32, 91},
 	}
 	ctx := context.Background()
-	_, err := client.Actions.UpdateRequiredWorkflow(ctx, "o", 12345, input)
+
+	requiredWokflow, _, err := client.Actions.UpdateRequiredWorkflow(ctx, "o", 12345, input)
 
 	if err != nil {
 		t.Errorf("Actions.UpdateRequiredWorkflow returned error: %v", err)
 	}
+	want := &OrgRequiredWorkflow{
+		ID:                      Int64(12345),
+		Name:                    String("Required CI"),
+		Path:                    String(".github/workflows/ci.yml"),
+		Scope:                   String("selected"),
+		Ref:                     String("refs/head/main"),
+		State:                   String("active"),
+		SelectedRepositoriesURL: String("https://api.github.com/orgs/octo-org/actions/required_workflows/12345/repositories"),
+		CreatedAt:               &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)},
+		UpdatedAt:               &Timestamp{time.Date(2020, time.January, 22, 19, 33, 8, 0, time.UTC)},
+		Repository:              &Repository{ID: Int64(53), URL: String("https://api.github.com/repos/o/Hello-World"), Name: String("Hello-World")},
+	}
+
+	if !cmp.Equal(requiredWokflow, want) {
+		t.Errorf("Actions.UpdateRequiredWorkflow returned %+v, want %+v", requiredWokflow, want)
+	}
 
 	const methodName = "UpdateRequiredWorkflow"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.UpdateRequiredWorkflow(ctx, "\n", 12345, input)
+		_, _, err = client.Actions.UpdateRequiredWorkflow(ctx, "\n", 12345, input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.UpdateRequiredWorkflow(ctx, "o", 12345, input)
+		got, resp, err := client.Actions.UpdateRequiredWorkflow(ctx, "o", 12345, input)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
 	})
 }
 


### PR DESCRIPTION
Updated create and update org required workflow methods to return the required workflow object returned by the github api.
Merging this Fixes https://github.com/google/go-github/issues/2756