### PR TITLE
Add InstallationsCount to App

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -18,18 +18,19 @@ type AppsService service
 
 // App represents a GitHub App.
 type App struct {
-	ID          *int64                   `json:"id,omitempty"`
-	Slug        *string                  `json:"slug,omitempty"`
-	NodeID      *string                  `json:"node_id,omitempty"`
-	Owner       *User                    `json:"owner,omitempty"`
-	Name        *string                  `json:"name,omitempty"`
-	Description *string                  `json:"description,omitempty"`
-	ExternalURL *string                  `json:"external_url,omitempty"`
-	HTMLURL     *string                  `json:"html_url,omitempty"`
-	CreatedAt   *Timestamp               `json:"created_at,omitempty"`
-	UpdatedAt   *Timestamp               `json:"updated_at,omitempty"`
-	Permissions *InstallationPermissions `json:"permissions,omitempty"`
-	Events      []string                 `json:"events,omitempty"`
+	ID                 *int64                   `json:"id,omitempty"`
+	Slug               *string                  `json:"slug,omitempty"`
+	NodeID             *string                  `json:"node_id,omitempty"`
+	Owner              *User                    `json:"owner,omitempty"`
+	Name               *string                  `json:"name,omitempty"`
+	Description        *string                  `json:"description,omitempty"`
+	ExternalURL        *string                  `json:"external_url,omitempty"`
+	HTMLURL            *string                  `json:"html_url,omitempty"`
+	CreatedAt          *Timestamp               `json:"created_at,omitempty"`
+	UpdatedAt          *Timestamp               `json:"updated_at,omitempty"`
+	Permissions        *InstallationPermissions `json:"permissions,omitempty"`
+	Events             []string                 `json:"events,omitempty"`
+	InstallationsCount *int                     `json:"installations_count,omitempty"`
 }
 
 // InstallationToken represents an installation token.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -678,6 +678,14 @@ func (a *App) GetID() int64 {
 	return *a.ID
 }
 
+// GetInstallationsCount returns the InstallationsCount field if it's non-nil, zero value otherwise.
+func (a *App) GetInstallationsCount() int {
+	if a == nil || a.InstallationsCount == nil {
+		return 0
+	}
+	return *a.InstallationsCount
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (a *App) GetName() string {
 	if a == nil || a.Name == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -785,6 +785,16 @@ func TestApp_GetID(tt *testing.T) {
 	a.GetID()
 }
 
+func TestApp_GetInstallationsCount(tt *testing.T) {
+	var zeroValue int
+	a := &App{InstallationsCount: &zeroValue}
+	a.GetInstallationsCount()
+	a = &App{}
+	a.GetInstallationsCount()
+	a = nil
+	a.GetInstallationsCount()
+}
+
 func TestApp_GetName(tt *testing.T) {
 	var zeroValue string
 	a := &App{Name: &zeroValue}


### PR DESCRIPTION
It's not in the official github documentation yet but exposed to the API.

```
% curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer $T" https://api.github.com/app|grep installations_count
  "installations_count": 3
  ```