### PR TITLE
Change the CreateRequiredWorkflow method from PUT to POST

### DIFF
--- a/github/actions_required_workflows.go
+++ b/github/actions_required_workflows.go
@@ -94,7 +94,7 @@ func (s *ActionsService) ListOrgRequiredWorkflows(ctx context.Context, org strin
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#create-a-required-workflow
 func (s *ActionsService) CreateRequiredWorkflow(ctx context.Context, org string, createRequiredWorkflowOptions *CreateUpdateRequiredWorkflowOptions) (*OrgRequiredWorkflow, *Response, error) {
 	url := fmt.Sprintf("orgs/%v/actions/required_workflows", org)
-	req, err := s.client.NewRequest("PUT", url, createRequiredWorkflowOptions)
+	req, err := s.client.NewRequest("POST", url, createRequiredWorkflowOptions)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/actions_required_workflows_test.go
+++ b/github/actions_required_workflows_test.go
@@ -83,7 +83,7 @@ func TestActionsService_CreateRequiredWorkflow(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 	mux.HandleFunc("/orgs/o/actions/required_workflows", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
+		testMethod(t, r, "POST")
 		testHeader(t, r, "Content-Type", "application/json")
 		testBody(t, r, `{"workflow_file_path":".github/workflows/ci.yaml","repository_id":53,"scope":"selected","selected_repository_ids":[32,91]}`+"\n")
 		fmt.Fprint(w, `{


### PR DESCRIPTION
Fixes: #2770

Changed the method from PUT to POST, by following the github REST API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#create-a-required-workflow