### PR TITLE
Update DependabotSecretsSelectedRepoIDs type to []int64

### DIFF
--- a/github/dependabot_secrets.go
+++ b/github/dependabot_secrets.go
@@ -198,7 +198,7 @@ func (s *DependabotService) ListSelectedReposForOrgSecret(ctx context.Context, o
 }
 
 // DependabotSecretsSelectedRepoIDs are the repository IDs that have access to the dependabot secrets.
-type DependabotSecretsSelectedRepoIDs []string
+type DependabotSecretsSelectedRepoIDs []int64
 
 // SetSelectedReposForOrgSecret sets the repositories that have access to a Dependabot secret.
 //

--- a/github/dependabot_secrets_test.go
+++ b/github/dependabot_secrets_test.go
@@ -352,7 +352,7 @@ func TestDependabotService_CreateOrUpdateOrgSecret(t *testing.T) {
 	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
-		testBody(t, r, `{"key_id":"1234","encrypted_value":"QIv=","visibility":"selected","selected_repository_ids":["1296269","1269280"]}`+"\n")
+		testBody(t, r, `{"key_id":"1234","encrypted_value":"QIv=","visibility":"selected","selected_repository_ids":[1296269,1269280]}`+"\n")
 		w.WriteHeader(http.StatusCreated)
 	})
 
@@ -361,7 +361,7 @@ func TestDependabotService_CreateOrUpdateOrgSecret(t *testing.T) {
 		EncryptedValue:        "QIv=",
 		KeyID:                 "1234",
 		Visibility:            "selected",
-		SelectedRepositoryIDs: DependabotSecretsSelectedRepoIDs{"1296269", "1269280"},
+		SelectedRepositoryIDs: DependabotSecretsSelectedRepoIDs{1296269, 1269280},
 	}
 	ctx := context.Background()
 	_, err := client.Dependabot.CreateOrUpdateOrgSecret(ctx, "o", input)
@@ -428,23 +428,23 @@ func TestDependabotService_SetSelectedReposForOrgSecret(t *testing.T) {
 	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
-		testBody(t, r, `{"selected_repository_ids":["64780797"]}`+"\n")
+		testBody(t, r, `{"selected_repository_ids":[64780797]}`+"\n")
 	})
 
 	ctx := context.Background()
-	_, err := client.Dependabot.SetSelectedReposForOrgSecret(ctx, "o", "NAME", DependabotSecretsSelectedRepoIDs{"64780797"})
+	_, err := client.Dependabot.SetSelectedReposForOrgSecret(ctx, "o", "NAME", DependabotSecretsSelectedRepoIDs{64780797})
 	if err != nil {
 		t.Errorf("Dependabot.SetSelectedReposForOrgSecret returned error: %v", err)
 	}
 
 	const methodName = "SetSelectedReposForOrgSecret"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Dependabot.SetSelectedReposForOrgSecret(ctx, "\n", "\n", DependabotSecretsSelectedRepoIDs{"64780797"})
+		_, err = client.Dependabot.SetSelectedReposForOrgSecret(ctx, "\n", "\n", DependabotSecretsSelectedRepoIDs{64780797})
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Dependabot.SetSelectedReposForOrgSecret(ctx, "o", "NAME", DependabotSecretsSelectedRepoIDs{"64780797"})
+		return client.Dependabot.SetSelectedReposForOrgSecret(ctx, "o", "NAME", DependabotSecretsSelectedRepoIDs{64780797})
 	})
 }
 


### PR DESCRIPTION
According to the docs, the API for setting a repos access to dependabot secrets is expecting an array of integers.

 [https://docs.github.com/en/rest/dependabot/secrets?apiVersion=2022-11-28#set-selected-repositories-for-an-organization-secret](https://docs.github.com/en/rest/dependabot/secrets?apiVersion=2022-11-28#set-selected-repositories-for-an-organization-secret)