### PR TITLE
Add generate-jitconfig API for self-hosted runners

### DIFF
--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -45,15 +45,67 @@ func (s *ActionsService) ListRunnerApplicationDownloads(ctx context.Context, own
 	return rads, resp, nil
 }
 
+// GenerateJITConfigRequest specifies body parameters to GenerateJITConfig.
+type GenerateJITConfigRequest struct {
+	Name          string   `json:"name"`
+	RunnerGroupID int      `json:"runner_group_id"`
+	Labels        []string `json:"labels"`
+	WorkFolder    string   `json:"work_folder,omitempty"`
+}
+
+// JITRunnerConfig represents encoded JIT configuration that can be used to bootstrap a self-hosted runner.
+type JITRunnerConfig struct {
+	EncodedJITConfig *string `json:"encoded_jit_config,omitempty"`
+}
+
+// GenerateOrganizationJITConfig generate a just-in-time configuration for an organization.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-configuration-for-a-just-in-time-runner-for-an-organization
+func (s *ActionsService) GenerateOrganizationJITConfig(ctx context.Context, owner string, request *GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/runners/generate-jitconfig", owner)
+	req, err := s.client.NewRequest("POST", u, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	jitConfig := new(JITRunnerConfig)
+	resp, err := s.client.Do(ctx, req, jitConfig)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return jitConfig, resp, nil
+}
+
+// GenerateJITConfig generates a just-in-time configuration for a repository.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-configuration-for-a-just-in-time-runner-for-a-repository
+func (s *ActionsService) GenerateJITConfig(ctx context.Context, owner, repo string, request *GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/runners/generate-jitconfig", owner, repo)
+	req, err := s.client.NewRequest("POST", u, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	jitConfig := new(JITRunnerConfig)
+	resp, err := s.client.Do(ctx, req, jitConfig)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return jitConfig, resp, nil
+}
+
+// CreateRegistrationToken creates a token that can be used to add a self-hosted runner.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#create-a-registration-token-for-a-repository
+
 // RegistrationToken represents a token that can be used to add a self-hosted runner to a repository.
 type RegistrationToken struct {
 	Token     *string    `json:"token,omitempty"`
 	ExpiresAt *Timestamp `json:"expires_at,omitempty"`
 }
 
-// CreateRegistrationToken creates a token that can be used to add a self-hosted runner.
-//
-// GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#create-a-registration-token-for-a-repository
 func (s *ActionsService) CreateRegistrationToken(ctx context.Context, owner, repo string) (*RegistrationToken, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners/registration-token", owner, repo)
 


### PR DESCRIPTION
GitHub recently introduced [just-in-time configuration](https://github.blog/changelog/2023-06-02-github-actions-just-in-time-self-hosted-runners/) for self-hosted runner, so runners do not need to be seeded with privileged tokens. This PR adds those endpoints for orgs + repos. 