### PR TITLE
Fix `CreateOrUpdateOrgSecret` regression introduced in v53

### DIFF
--- a/github/dependabot_secrets.go
+++ b/github/dependabot_secrets.go
@@ -146,7 +146,7 @@ func (s *DependabotService) CreateOrUpdateRepoSecret(ctx context.Context, owner,
 func (s *DependabotService) CreateOrUpdateOrgSecret(ctx context.Context, org string, eSecret *DependabotEncryptedSecret) (*Response, error) {
 	repoIDs := make([]string, len(eSecret.SelectedRepositoryIDs))
 	for i, secret := range eSecret.SelectedRepositoryIDs {
-		repoIDs[i] = fmt.Sprintf("%d", secret)
+		repoIDs[i] = fmt.Sprintf("%v", secret)
 	}
 	params := struct {
 		*DependabotEncryptedSecret

--- a/github/dependabot_secrets.go
+++ b/github/dependabot_secrets.go
@@ -144,8 +144,25 @@ func (s *DependabotService) CreateOrUpdateRepoSecret(ctx context.Context, owner,
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#create-or-update-an-organization-secret
 func (s *DependabotService) CreateOrUpdateOrgSecret(ctx context.Context, org string, eSecret *DependabotEncryptedSecret) (*Response, error) {
+	repoIDs := make([]string, len(eSecret.SelectedRepositoryIDs))
+	for i, secret := range eSecret.SelectedRepositoryIDs {
+		repoIDs[i] = fmt.Sprintf("%d", secret)
+	}
+	params := struct {
+		*DependabotEncryptedSecret
+		SelectedRepositoryIDs []string `json:"selected_repository_ids,omitempty"`
+	}{
+		DependabotEncryptedSecret: eSecret,
+		SelectedRepositoryIDs:     repoIDs,
+	}
+
 	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v", org, eSecret.Name)
-	return s.putSecret(ctx, url, eSecret)
+	req, err := s.client.NewRequest("PUT", url, params)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
 }
 
 func (s *DependabotService) deleteSecret(ctx context.Context, url string) (*Response, error) {

--- a/github/dependabot_secrets_test.go
+++ b/github/dependabot_secrets_test.go
@@ -352,7 +352,7 @@ func TestDependabotService_CreateOrUpdateOrgSecret(t *testing.T) {
 	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
-		testBody(t, r, `{"key_id":"1234","encrypted_value":"QIv=","visibility":"selected","selected_repository_ids":[1296269,1269280]}`+"\n")
+		testBody(t, r, `{"key_id":"1234","encrypted_value":"QIv=","visibility":"selected","selected_repository_ids":["1296269","1269280"]}`+"\n")
 		w.WriteHeader(http.StatusCreated)
 	})
 


### PR DESCRIPTION
`CreateOrUpdateOrgSecret`'s API uses `string` for selected repository IDS while other APIs use `int`. This fixes the issue locally by implementing its own type.

fixes https://github.com/google/go-github/issues/2816