### PR TITLE
Add Runner to generate-jitconfig method

### DIFF
--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -58,6 +58,7 @@ type GenerateJITConfigRequest struct {
 
 // JITRunnerConfig represents encoded JIT configuration that can be used to bootstrap a self-hosted runner.
 type JITRunnerConfig struct {
+	Runner           *Runner `json:"runner,omitempty"`
 	EncodedJITConfig *string `json:"encoded_jit_config,omitempty"`
 }
 

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9398,6 +9398,14 @@ func (i *IssueStats) GetTotalIssues() int {
 	return *i.TotalIssues
 }
 
+// GetRunner returns the Runner field.
+func (j *JITRunnerConfig) GetRunner() *Runner {
+	if j == nil || j.Runner == nil {
+		return nil
+	}
+	return j.Runner
+}
+
 // GetEncodedJITConfig returns the EncodedJITConfig field if it's non-nil, zero value otherwise.
 func (j *JITRunnerConfig) GetEncodedJITConfig() string {
 	if j == nil || j.EncodedJITConfig == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9398,20 +9398,20 @@ func (i *IssueStats) GetTotalIssues() int {
 	return *i.TotalIssues
 }
 
-// GetRunner returns the Runner field.
-func (j *JITRunnerConfig) GetRunner() *Runner {
-	if j == nil || j.Runner == nil {
-		return nil
-	}
-	return j.Runner
-}
-
 // GetEncodedJITConfig returns the EncodedJITConfig field if it's non-nil, zero value otherwise.
 func (j *JITRunnerConfig) GetEncodedJITConfig() string {
 	if j == nil || j.EncodedJITConfig == nil {
 		return ""
 	}
 	return *j.EncodedJITConfig
+}
+
+// GetRunner returns the Runner field.
+func (j *JITRunnerConfig) GetRunner() *Runner {
+	if j == nil {
+		return nil
+	}
+	return j.Runner
 }
 
 // GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11029,6 +11029,13 @@ func TestJITRunnerConfig_GetEncodedJITConfig(tt *testing.T) {
 	j.GetEncodedJITConfig()
 }
 
+func TestJITRunnerConfig_GetRunner(tt *testing.T) {
+	j := &JITRunnerConfig{}
+	j.GetRunner()
+	j = nil
+	j.GetRunner()
+}
+
 func TestJobs_GetTotalCount(tt *testing.T) {
 	var zeroValue int
 	j := &Jobs{TotalCount: &zeroValue}


### PR DESCRIPTION
Provide full response for generate-jitconfig method instead of `encoded_jit_config` only. According to the [doc](https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-configuration-for-a-just-in-time-runner-for-a-repository) there is a `runner` object in the API response.

why do we need it? since the generate-jitconfig API is just not generating jitconfig but also creating new self-hosted runner to the github so there is no way we can get the newly created runner id other than from this response.

cc @mkulke @gmlewis 