### PR TITLE
Remove unnecessary use of fmt.Sprintf

### DIFF
--- a/github/admin_stats.go
+++ b/github/admin_stats.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // AdminStats represents a variety of stats of a GitHub Enterprise
@@ -155,7 +154,7 @@ func (s RepoStats) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/enterprise-admin/admin_stats/
 func (s *AdminService) GetAdminStats(ctx context.Context) (*AdminStats, *Response, error) {
-	u := fmt.Sprintf("enterprise/stats/all")
+	u := "enterprise/stats/all"
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/codespaces.go
+++ b/github/codespaces.go
@@ -126,7 +126,7 @@ type ListCodespacesOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/codespaces?apiVersion=2022-11-28#list-codespaces-for-the-authenticated-user
 func (s *CodespacesService) List(ctx context.Context, opts *ListCodespacesOptions) (*ListCodespaces, *Response, error) {
-	u := fmt.Sprint("user/codespaces")
+	u := "user/codespaces"
 	u, err := addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
unnecessary use of fmt.Sprint
unnecessary use of fmt.Sprintf