### PR TITLE
Fix ListPullRequestsWithCommit option type

### DIFF
--- a/github/pulls.go
+++ b/github/pulls.go
@@ -170,7 +170,7 @@ func (s *PullRequestsService) List(ctx context.Context, owner string, repo strin
 // By default, the PullRequestListOptions State filters for "open".
 //
 // GitHub API docs: https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit
-func (s *PullRequestsService) ListPullRequestsWithCommit(ctx context.Context, owner, repo, sha string, opts *PullRequestListOptions) ([]*PullRequest, *Response, error) {
+func (s *PullRequestsService) ListPullRequestsWithCommit(ctx context.Context, owner, repo, sha string, opts *ListOptions) ([]*PullRequest, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/commits/%v/pulls", owner, repo, sha)
 	u, err := addOptions(u, opts)
 	if err != nil {

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -69,17 +69,12 @@ func TestPullRequestsService_ListPullRequestsWithCommit(t *testing.T) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeListPullsOrBranchesForCommitPreview)
 		testFormValues(t, r, values{
-			"state":     "closed",
-			"head":      "h",
-			"base":      "b",
-			"sort":      "created",
-			"direction": "desc",
 			"page":      "2",
 		})
 		fmt.Fprint(w, `[{"number":1}]`)
 	})
 
-	opts := &PullRequestListOptions{"closed", "h", "b", "created", "desc", ListOptions{Page: 2}}
+	opts := &ListOptions{Page: 2}
 	ctx := context.Background()
 	pulls, _, err := client.PullRequests.ListPullRequestsWithCommit(ctx, "o", "r", "sha", opts)
 	if err != nil {

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -69,7 +69,7 @@ func TestPullRequestsService_ListPullRequestsWithCommit(t *testing.T) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeListPullsOrBranchesForCommitPreview)
 		testFormValues(t, r, values{
-			"page":      "2",
+			"page": "2",
 		})
 		fmt.Fprint(w, `[{"number":1}]`)
 	})


### PR DESCRIPTION
`ListPullRequestsWithCommit` uses `PullRequestListOptions` as one of it's parameters. This is incorrect because in GitHub's documentation, the endpoint for this function, `repos/%v/%v/commits/%v/pulls`, does not share the same parameters as the ones defined in `ListPullRequestsWithCommit`

https://github.com/google/go-github/blob/96726d8192f34c0d46e7b64b3c400962e8e64898/github/pulls.go#L119-L141

![image](https://github.com/google/go-github/assets/33658638/7d30c9a8-fbe5-45ad-9dae-b682e9884ea9)

This PR simply sets the correct options, ListOptions, for the ListPullRequestWithCommit.


see #2815  for more details