### PR TITLE
Add Repository struct to SecretScanningAlert

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -19510,6 +19510,14 @@ func (s *SecretScanningAlert) GetNumber() int {
 	return *s.Number
 }
 
+// GetRepository returns the Repository field.
+func (s *SecretScanningAlert) GetRepository() *Repository {
+	if s == nil {
+		return nil
+	}
+	return s.Repository
+}
+
 // GetResolution returns the Resolution field if it's non-nil, zero value otherwise.
 func (s *SecretScanningAlert) GetResolution() string {
 	if s == nil || s.Resolution == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -22792,6 +22792,13 @@ func TestSecretScanningAlert_GetNumber(tt *testing.T) {
 	s.GetNumber()
 }
 
+func TestSecretScanningAlert_GetRepository(tt *testing.T) {
+	s := &SecretScanningAlert{}
+	s.GetRepository()
+	s = nil
+	s.GetRepository()
+}
+
 func TestSecretScanningAlert_GetResolution(tt *testing.T) {
 	var zeroValue string
 	s := &SecretScanningAlert{Resolution: &zeroValue}

--- a/github/secret_scanning.go
+++ b/github/secret_scanning.go
@@ -16,17 +16,18 @@ type SecretScanningService service
 
 // SecretScanningAlert represents a GitHub secret scanning alert.
 type SecretScanningAlert struct {
-	Number       *int       `json:"number,omitempty"`
-	CreatedAt    *Timestamp `json:"created_at,omitempty"`
-	URL          *string    `json:"url,omitempty"`
-	HTMLURL      *string    `json:"html_url,omitempty"`
-	LocationsURL *string    `json:"locations_url,omitempty"`
-	State        *string    `json:"state,omitempty"`
-	Resolution   *string    `json:"resolution,omitempty"`
-	ResolvedAt   *Timestamp `json:"resolved_at,omitempty"`
-	ResolvedBy   *User      `json:"resolved_by,omitempty"`
-	SecretType   *string    `json:"secret_type,omitempty"`
-	Secret       *string    `json:"secret,omitempty"`
+	Number       *int        `json:"number,omitempty"`
+	CreatedAt    *Timestamp  `json:"created_at,omitempty"`
+	URL          *string     `json:"url,omitempty"`
+	HTMLURL      *string     `json:"html_url,omitempty"`
+	LocationsURL *string     `json:"locations_url,omitempty"`
+	State        *string     `json:"state,omitempty"`
+	Resolution   *string     `json:"resolution,omitempty"`
+	ResolvedAt   *Timestamp  `json:"resolved_at,omitempty"`
+	ResolvedBy   *User       `json:"resolved_by,omitempty"`
+	SecretType   *string     `json:"secret_type,omitempty"`
+	Secret       *string     `json:"secret,omitempty"`
+	Repository   *Repository `json:"repository,omitempty"`
 }
 
 // SecretScanningAlertLocation represents the location for a secret scanning alert.

--- a/github/secret_scanning_test.go
+++ b/github/secret_scanning_test.go
@@ -35,7 +35,12 @@ func TestSecretScanningService_ListAlertsForEnterprise(t *testing.T) {
 			"resolved_at": null,
 			"resolved_by": null,
 			"secret_type": "mailchimp_api_key",
-			"secret": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-us2"
+			"secret": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-us2",
+			"repository": {
+				"id": 1,
+				"name": "n",
+				"url": "url"
+			}
 		}]`)
 	})
 
@@ -61,6 +66,11 @@ func TestSecretScanningService_ListAlertsForEnterprise(t *testing.T) {
 			ResolvedBy:   nil,
 			SecretType:   String("mailchimp_api_key"),
 			Secret:       String("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-us2"),
+			Repository: &Repository{
+				ID:   Int64(1),
+				URL:  String("url"),
+				Name: String("n"),
+			},
 		},
 	}
 


### PR DESCRIPTION
Add support for getting Repository when [listing secret scanning alerts for enterprise](https://docs.github.com/en/rest/secret-scanning/secret-scanning?apiVersion=2022-11-28#list-secret-scanning-alerts-for-an-enterprise)

There is no easy way of getting the org/repo when listing secret scanning alerts for enterprise in the current struct. The API returns the Repository field, and with this change it will be included in the SecretScanningAlert struct



