### PR TITLE
Add support for `personal_access_token_request` webhook event type

### DIFF
--- a/github/event.go
+++ b/github/event.go
@@ -93,6 +93,8 @@ func (e *Event) ParsePayload() (payload interface{}, err error) {
 		payload = &PackageEvent{}
 	case "PageBuildEvent":
 		payload = &PageBuildEvent{}
+	case "PersonalAccessTokenRequestEvent":
+		payload = &PersonalAccessTokenRequestEvent{}
 	case "PingEvent":
 		payload = &PingEvent{}
 	case "ProjectEvent":

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -837,9 +837,9 @@ type PersonalAccessTokenRequest struct {
 // PersonalAccessTokenPermissions represents the original or newly requested
 // scope of permissions for a fine-grained personal access token within a PersonalAccessTokenRequest.
 type PersonalAccessTokenPermissions struct {
-	Org   *Organization   `json:"organization,omitempty"`
-	Repo  *Repository     `json:"repository,omitempty"`
-	Other json.RawMessage `json:"other,omitempty"`
+	Org   map[string]string `json:"organization,omitempty"`
+	Repo  map[string]string `json:"repository,omitempty"`
+	Other map[string]string `json:"other,omitempty"`
 }
 
 // PingEvent is triggered when a Webhook is added to GitHub.

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -774,6 +774,71 @@ type PageBuildEvent struct {
 	Installation *Installation `json:"installation,omitempty"`
 }
 
+// PersonalAccessTokenRequestEvent occurs when there is activity relating to a
+// request for a fine-grained personal access token to access resources that
+// belong to a resource owner that requires approval for token access.
+// The webhook event name is "personal_access_token_request".
+//
+// GitHub API docs: https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#personal_access_token_request
+type PersonalAccessTokenRequestEvent struct {
+	// Action is the action that was performed. Possible values are:
+	// "approved", "cancelled", "created" or "denied"
+	Action                     *string                     `json:"action,omitempty"`
+	PersonalAccessTokenRequest *PersonalAccessTokenRequest `json:"personal_access_token_request,omitempty"`
+	Org                        *Organization               `json:"organization,omitempty"`
+	Sender                     *User                       `json:"sender,omitempty"`
+	Installation               *Installation               `json:"installation,omitempty"`
+}
+
+type PersonalAccessTokenRequest struct {
+	// Unique identifier of the request for access via fine-grained personal
+	// access token. Used as the pat_request_id parameter in the list and review
+	// API calls.
+	ID    *int64 `json:"id,omitempty"`
+	Owner *User  `json:"owner,omitempty"`
+
+	// New requested permissions, categorized by type of permission.
+	PermissionsAdded *PersonalAccessTokenPermissions `json:"permissions_added,omitempty"`
+
+	// Requested permissions that elevate access for a previously approved
+	// request for access, categorized by type of permission.
+	PermissionsUpgraded *PersonalAccessTokenPermissions `json:"permissions_upgraded,omitempty"`
+
+	// Permissions requested, categorized by type of permission.
+	// This field incorporates permissions_added and permissions_upgraded.
+	PermissionsResult *PersonalAccessTokenPermissions `json:"permissions_result,omitempty"`
+
+	// Type of repository selection requested. Possible values are:
+	// "none", "all" or "subset"
+	RepositorySelection *string `json:"repository_selection,omitempty"`
+
+	// The number of repositories the token is requesting access to.
+	// This field is only populated when repository_selection is subset.
+	RepositoryCount *int64 `json:"repository_count,omitempty"`
+
+	// An array of repository objects the token is requesting access to.
+	// This field is only populated when repository_selection is subset.
+	Repositories []*Repository `json:"repositories,omitempty"`
+
+	// Date and time when the request for access was created.
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
+
+	// Whether the associated fine-grained personal access token has expired.
+	TokenExpired *bool `json:"token_expired,omitempty"`
+
+	// Date and time when the associated fine-grained personal access token expires.
+	TokenExpiresAt *Timestamp `json:"token_expires_at,omitempty"`
+
+	// Date and time when the associated fine-grained personal access token was last used for authentication.
+	TokenLastUsedAt *Timestamp `json:"token_last_used_at,omitempty"`
+}
+
+type PersonalAccessTokenPermissions struct {
+	Org   *Organization   `json:"organization,omitempty"`
+	Repo  *Repository     `json:"repository,omitempty"`
+	Other json.RawMessage `json:"other,omitempty"`
+}
+
 // PingEvent is triggered when a Webhook is added to GitHub.
 //
 // GitHub API docs: https://developer.github.com/webhooks/#ping-event

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -790,6 +790,7 @@ type PersonalAccessTokenRequestEvent struct {
 	Installation               *Installation               `json:"installation,omitempty"`
 }
 
+// PersonalAccessTokenRequest contains the details of a PersonalAccessTokenRequestEvent.
 type PersonalAccessTokenRequest struct {
 	// Unique identifier of the request for access via fine-grained personal
 	// access token. Used as the pat_request_id parameter in the list and review
@@ -833,6 +834,8 @@ type PersonalAccessTokenRequest struct {
 	TokenLastUsedAt *Timestamp `json:"token_last_used_at,omitempty"`
 }
 
+// PersonalAccessTokenPermissions represents the original or newly requested
+// scope of permissions for a fine-grained personal access token within a PersonalAccessTokenRequest.
 type PersonalAccessTokenPermissions struct {
 	Org   *Organization   `json:"organization,omitempty"`
 	Repo  *Repository     `json:"repository,omitempty"`

--- a/github/event_types_test.go
+++ b/github/event_types_test.go
@@ -7098,10 +7098,8 @@ func TestPersonalAccessTokenRequestEvent_Marshal(t *testing.T) {
 			ID:    Int64(1),
 			Owner: &User{Login: String("l")},
 			PermissionsAdded: &PersonalAccessTokenPermissions{
-				Org: &Organization{Name: String("n")},
-				Repo: &Repository{
-					Name: String("n"),
-				},
+				Org:  map[string]string{"organization_events": "read"},
+				Repo: map[string]string{"security_events": "write"},
 			},
 			CreatedAt:           &Timestamp{referenceTime},
 			TokenExpired:        Bool(false),
@@ -7133,10 +7131,10 @@ func TestPersonalAccessTokenRequestEvent_Marshal(t *testing.T) {
 			},
 			"permissions_added": {
 				"organization": {
-					"name": "n"
+					"organization_events": "read"
 				},
 				"repository": {
-					"name": "n"
+					"security_events": "write"
 				}
 			},
 			"created_at": ` + referenceTimeStr + `,

--- a/github/event_types_test.go
+++ b/github/event_types_test.go
@@ -7089,6 +7089,82 @@ func TestPackageEvent_Marshal(t *testing.T) {
 	testJSONMarshal(t, u, want)
 }
 
+func TestPersonalAccessTokenRequestEvent_Marshal(t *testing.T) {
+	testJSONMarshal(t, &PersonalAccessTokenRequestEvent{}, "{}")
+
+	event := &PersonalAccessTokenRequestEvent{
+		Action: String("a"),
+		PersonalAccessTokenRequest: &PersonalAccessTokenRequest{
+			ID:    Int64(1),
+			Owner: &User{Login: String("l")},
+			PermissionsAdded: &PersonalAccessTokenPermissions{
+				Org: &Organization{Name: String("n")},
+				Repo: &Repository{
+					Name: String("n"),
+				},
+			},
+			CreatedAt:           &Timestamp{referenceTime},
+			TokenExpired:        Bool(false),
+			TokenExpiresAt:      &Timestamp{referenceTime},
+			TokenLastUsedAt:     &Timestamp{referenceTime},
+			RepositoryCount:     Int64(1),
+			RepositorySelection: String("rs"),
+			Repositories: []*Repository{
+				{
+					Name: String("n"),
+				},
+			},
+		},
+		Org: &Organization{Name: String("n")},
+		Sender: &User{
+			Login: String("l"),
+		},
+		Installation: &Installation{
+			ID: Int64(1),
+		},
+	}
+
+	want := `{
+		"action": "a",
+		"personal_access_token_request": {
+			"id": 1,
+			"owner": {
+				"login": "l"
+			},
+			"permissions_added": {
+				"organization": {
+					"name": "n"
+				},
+				"repository": {
+					"name": "n"
+				}
+			},
+			"created_at": ` + referenceTimeStr + `,
+			"token_expired": false,
+			"token_expires_at": ` + referenceTimeStr + `,
+			"token_last_used_at": ` + referenceTimeStr + `,
+			"repository_count": 1,
+			"repository_selection": "rs",
+			"repositories": [
+				{
+					"name": "n"
+				}
+			]
+		},
+		"organization": {
+			"name": "n"
+		},
+		"sender": {
+			"login": "l"
+		},
+		"installation": {
+			"id": 1
+		}
+	}`
+
+	testJSONMarshal(t, event, want)
+}
+
 func TestPingEvent_Marshal(t *testing.T) {
 	testJSONMarshal(t, &PingEvent{}, "{}")
 

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -13134,18 +13134,26 @@ func (p *PagesUpdate) GetSource() *PagesSource {
 	return p.Source
 }
 
-// GetOrg returns the Org field.
-func (p *PersonalAccessTokenPermissions) GetOrg() *Organization {
-	if p == nil {
-		return nil
+// GetOrg returns the Org map if it's non-nil, an empty map otherwise.
+func (p *PersonalAccessTokenPermissions) GetOrg() map[string]string {
+	if p == nil || p.Org == nil {
+		return map[string]string{}
 	}
 	return p.Org
 }
 
-// GetRepo returns the Repo field.
-func (p *PersonalAccessTokenPermissions) GetRepo() *Repository {
-	if p == nil {
-		return nil
+// GetOther returns the Other map if it's non-nil, an empty map otherwise.
+func (p *PersonalAccessTokenPermissions) GetOther() map[string]string {
+	if p == nil || p.Other == nil {
+		return map[string]string{}
+	}
+	return p.Other
+}
+
+// GetRepo returns the Repo map if it's non-nil, an empty map otherwise.
+func (p *PersonalAccessTokenPermissions) GetRepo() map[string]string {
+	if p == nil || p.Repo == nil {
+		return map[string]string{}
 	}
 	return p.Repo
 }

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -13134,6 +13134,150 @@ func (p *PagesUpdate) GetSource() *PagesSource {
 	return p.Source
 }
 
+// GetOrg returns the Org field.
+func (p *PersonalAccessTokenPermissions) GetOrg() *Organization {
+	if p == nil {
+		return nil
+	}
+	return p.Org
+}
+
+// GetRepo returns the Repo field.
+func (p *PersonalAccessTokenPermissions) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (p *PersonalAccessTokenRequest) GetCreatedAt() Timestamp {
+	if p == nil || p.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *p.CreatedAt
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (p *PersonalAccessTokenRequest) GetID() int64 {
+	if p == nil || p.ID == nil {
+		return 0
+	}
+	return *p.ID
+}
+
+// GetOwner returns the Owner field.
+func (p *PersonalAccessTokenRequest) GetOwner() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Owner
+}
+
+// GetPermissionsAdded returns the PermissionsAdded field.
+func (p *PersonalAccessTokenRequest) GetPermissionsAdded() *PersonalAccessTokenPermissions {
+	if p == nil {
+		return nil
+	}
+	return p.PermissionsAdded
+}
+
+// GetPermissionsResult returns the PermissionsResult field.
+func (p *PersonalAccessTokenRequest) GetPermissionsResult() *PersonalAccessTokenPermissions {
+	if p == nil {
+		return nil
+	}
+	return p.PermissionsResult
+}
+
+// GetPermissionsUpgraded returns the PermissionsUpgraded field.
+func (p *PersonalAccessTokenRequest) GetPermissionsUpgraded() *PersonalAccessTokenPermissions {
+	if p == nil {
+		return nil
+	}
+	return p.PermissionsUpgraded
+}
+
+// GetRepositoryCount returns the RepositoryCount field if it's non-nil, zero value otherwise.
+func (p *PersonalAccessTokenRequest) GetRepositoryCount() int64 {
+	if p == nil || p.RepositoryCount == nil {
+		return 0
+	}
+	return *p.RepositoryCount
+}
+
+// GetRepositorySelection returns the RepositorySelection field if it's non-nil, zero value otherwise.
+func (p *PersonalAccessTokenRequest) GetRepositorySelection() string {
+	if p == nil || p.RepositorySelection == nil {
+		return ""
+	}
+	return *p.RepositorySelection
+}
+
+// GetTokenExpired returns the TokenExpired field if it's non-nil, zero value otherwise.
+func (p *PersonalAccessTokenRequest) GetTokenExpired() bool {
+	if p == nil || p.TokenExpired == nil {
+		return false
+	}
+	return *p.TokenExpired
+}
+
+// GetTokenExpiresAt returns the TokenExpiresAt field if it's non-nil, zero value otherwise.
+func (p *PersonalAccessTokenRequest) GetTokenExpiresAt() Timestamp {
+	if p == nil || p.TokenExpiresAt == nil {
+		return Timestamp{}
+	}
+	return *p.TokenExpiresAt
+}
+
+// GetTokenLastUsedAt returns the TokenLastUsedAt field if it's non-nil, zero value otherwise.
+func (p *PersonalAccessTokenRequest) GetTokenLastUsedAt() Timestamp {
+	if p == nil || p.TokenLastUsedAt == nil {
+		return Timestamp{}
+	}
+	return *p.TokenLastUsedAt
+}
+
+// GetAction returns the Action field if it's non-nil, zero value otherwise.
+func (p *PersonalAccessTokenRequestEvent) GetAction() string {
+	if p == nil || p.Action == nil {
+		return ""
+	}
+	return *p.Action
+}
+
+// GetInstallation returns the Installation field.
+func (p *PersonalAccessTokenRequestEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetOrg returns the Org field.
+func (p *PersonalAccessTokenRequestEvent) GetOrg() *Organization {
+	if p == nil {
+		return nil
+	}
+	return p.Org
+}
+
+// GetPersonalAccessTokenRequest returns the PersonalAccessTokenRequest field.
+func (p *PersonalAccessTokenRequestEvent) GetPersonalAccessTokenRequest() *PersonalAccessTokenRequest {
+	if p == nil {
+		return nil
+	}
+	return p.PersonalAccessTokenRequest
+}
+
+// GetSender returns the Sender field.
+func (p *PersonalAccessTokenRequestEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
+}
+
 // GetHook returns the Hook field.
 func (p *PingEvent) GetHook() *Hook {
 	if p == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -15423,14 +15423,30 @@ func TestPagesUpdate_GetSource(tt *testing.T) {
 }
 
 func TestPersonalAccessTokenPermissions_GetOrg(tt *testing.T) {
-	p := &PersonalAccessTokenPermissions{}
+	zeroValue := map[string]string{}
+	p := &PersonalAccessTokenPermissions{Org: zeroValue}
+	p.GetOrg()
+	p = &PersonalAccessTokenPermissions{}
 	p.GetOrg()
 	p = nil
 	p.GetOrg()
 }
 
+func TestPersonalAccessTokenPermissions_GetOther(tt *testing.T) {
+	zeroValue := map[string]string{}
+	p := &PersonalAccessTokenPermissions{Other: zeroValue}
+	p.GetOther()
+	p = &PersonalAccessTokenPermissions{}
+	p.GetOther()
+	p = nil
+	p.GetOther()
+}
+
 func TestPersonalAccessTokenPermissions_GetRepo(tt *testing.T) {
-	p := &PersonalAccessTokenPermissions{}
+	zeroValue := map[string]string{}
+	p := &PersonalAccessTokenPermissions{Repo: zeroValue}
+	p.GetRepo()
+	p = &PersonalAccessTokenPermissions{}
 	p.GetRepo()
 	p = nil
 	p.GetRepo()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -15422,6 +15422,156 @@ func TestPagesUpdate_GetSource(tt *testing.T) {
 	p.GetSource()
 }
 
+func TestPersonalAccessTokenPermissions_GetOrg(tt *testing.T) {
+	p := &PersonalAccessTokenPermissions{}
+	p.GetOrg()
+	p = nil
+	p.GetOrg()
+}
+
+func TestPersonalAccessTokenPermissions_GetRepo(tt *testing.T) {
+	p := &PersonalAccessTokenPermissions{}
+	p.GetRepo()
+	p = nil
+	p.GetRepo()
+}
+
+func TestPersonalAccessTokenRequest_GetCreatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	p := &PersonalAccessTokenRequest{CreatedAt: &zeroValue}
+	p.GetCreatedAt()
+	p = &PersonalAccessTokenRequest{}
+	p.GetCreatedAt()
+	p = nil
+	p.GetCreatedAt()
+}
+
+func TestPersonalAccessTokenRequest_GetID(tt *testing.T) {
+	var zeroValue int64
+	p := &PersonalAccessTokenRequest{ID: &zeroValue}
+	p.GetID()
+	p = &PersonalAccessTokenRequest{}
+	p.GetID()
+	p = nil
+	p.GetID()
+}
+
+func TestPersonalAccessTokenRequest_GetOwner(tt *testing.T) {
+	p := &PersonalAccessTokenRequest{}
+	p.GetOwner()
+	p = nil
+	p.GetOwner()
+}
+
+func TestPersonalAccessTokenRequest_GetPermissionsAdded(tt *testing.T) {
+	p := &PersonalAccessTokenRequest{}
+	p.GetPermissionsAdded()
+	p = nil
+	p.GetPermissionsAdded()
+}
+
+func TestPersonalAccessTokenRequest_GetPermissionsResult(tt *testing.T) {
+	p := &PersonalAccessTokenRequest{}
+	p.GetPermissionsResult()
+	p = nil
+	p.GetPermissionsResult()
+}
+
+func TestPersonalAccessTokenRequest_GetPermissionsUpgraded(tt *testing.T) {
+	p := &PersonalAccessTokenRequest{}
+	p.GetPermissionsUpgraded()
+	p = nil
+	p.GetPermissionsUpgraded()
+}
+
+func TestPersonalAccessTokenRequest_GetRepositoryCount(tt *testing.T) {
+	var zeroValue int64
+	p := &PersonalAccessTokenRequest{RepositoryCount: &zeroValue}
+	p.GetRepositoryCount()
+	p = &PersonalAccessTokenRequest{}
+	p.GetRepositoryCount()
+	p = nil
+	p.GetRepositoryCount()
+}
+
+func TestPersonalAccessTokenRequest_GetRepositorySelection(tt *testing.T) {
+	var zeroValue string
+	p := &PersonalAccessTokenRequest{RepositorySelection: &zeroValue}
+	p.GetRepositorySelection()
+	p = &PersonalAccessTokenRequest{}
+	p.GetRepositorySelection()
+	p = nil
+	p.GetRepositorySelection()
+}
+
+func TestPersonalAccessTokenRequest_GetTokenExpired(tt *testing.T) {
+	var zeroValue bool
+	p := &PersonalAccessTokenRequest{TokenExpired: &zeroValue}
+	p.GetTokenExpired()
+	p = &PersonalAccessTokenRequest{}
+	p.GetTokenExpired()
+	p = nil
+	p.GetTokenExpired()
+}
+
+func TestPersonalAccessTokenRequest_GetTokenExpiresAt(tt *testing.T) {
+	var zeroValue Timestamp
+	p := &PersonalAccessTokenRequest{TokenExpiresAt: &zeroValue}
+	p.GetTokenExpiresAt()
+	p = &PersonalAccessTokenRequest{}
+	p.GetTokenExpiresAt()
+	p = nil
+	p.GetTokenExpiresAt()
+}
+
+func TestPersonalAccessTokenRequest_GetTokenLastUsedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	p := &PersonalAccessTokenRequest{TokenLastUsedAt: &zeroValue}
+	p.GetTokenLastUsedAt()
+	p = &PersonalAccessTokenRequest{}
+	p.GetTokenLastUsedAt()
+	p = nil
+	p.GetTokenLastUsedAt()
+}
+
+func TestPersonalAccessTokenRequestEvent_GetAction(tt *testing.T) {
+	var zeroValue string
+	p := &PersonalAccessTokenRequestEvent{Action: &zeroValue}
+	p.GetAction()
+	p = &PersonalAccessTokenRequestEvent{}
+	p.GetAction()
+	p = nil
+	p.GetAction()
+}
+
+func TestPersonalAccessTokenRequestEvent_GetInstallation(tt *testing.T) {
+	p := &PersonalAccessTokenRequestEvent{}
+	p.GetInstallation()
+	p = nil
+	p.GetInstallation()
+}
+
+func TestPersonalAccessTokenRequestEvent_GetOrg(tt *testing.T) {
+	p := &PersonalAccessTokenRequestEvent{}
+	p.GetOrg()
+	p = nil
+	p.GetOrg()
+}
+
+func TestPersonalAccessTokenRequestEvent_GetPersonalAccessTokenRequest(tt *testing.T) {
+	p := &PersonalAccessTokenRequestEvent{}
+	p.GetPersonalAccessTokenRequest()
+	p = nil
+	p.GetPersonalAccessTokenRequest()
+}
+
+func TestPersonalAccessTokenRequestEvent_GetSender(tt *testing.T) {
+	p := &PersonalAccessTokenRequestEvent{}
+	p.GetSender()
+	p = nil
+	p.GetSender()
+}
+
 func TestPingEvent_GetHook(tt *testing.T) {
 	p := &PingEvent{}
 	p.GetHook()

--- a/github/messages.go
+++ b/github/messages.go
@@ -76,6 +76,7 @@ var (
 		"org_block":                      "OrgBlockEvent",
 		"package":                        "PackageEvent",
 		"page_build":                     "PageBuildEvent",
+		"personal_access_token_request":  "PersonalAccessTokenRequestEvent",
 		"ping":                           "PingEvent",
 		"project":                        "ProjectEvent",
 		"project_card":                   "ProjectCardEvent",

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -381,6 +381,10 @@ func TestParseWebHook(t *testing.T) {
 			messageType: "page_build",
 		},
 		{
+			payload:     &PersonalAccessTokenRequestEvent{},
+			messageType: "personal_access_token_request",
+		},
+		{
 			payload:     &PingEvent{},
 			messageType: "ping",
 		},


### PR DESCRIPTION
This PR adds support for the [`personal_access_token_request`](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#personal_access_token_request) webhook event.

> This event occurs when there is activity relating to a request for a fine-grained personal access token to access resources that belong to a resource owner that requires approval for token access.