### PR TITLE
Fix repo rules bypass settings

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2238,6 +2238,14 @@ func (b *BypassActor) GetActorType() string {
 	return *b.ActorType
 }
 
+// GetBypassMode returns the BypassMode field if it's non-nil, zero value otherwise.
+func (b *BypassActor) GetBypassMode() string {
+	if b == nil || b.BypassMode == nil {
+		return ""
+	}
+	return *b.BypassMode
+}
+
 // GetApp returns the App field.
 func (c *CheckRun) GetApp() *App {
 	if c == nil {
@@ -18894,20 +18902,20 @@ func (r *RuleRequiredStatusChecks) GetIntegrationID() int64 {
 	return *r.IntegrationID
 }
 
-// GetBypassMode returns the BypassMode field if it's non-nil, zero value otherwise.
-func (r *Ruleset) GetBypassMode() string {
-	if r == nil || r.BypassMode == nil {
-		return ""
-	}
-	return *r.BypassMode
-}
-
 // GetConditions returns the Conditions field.
 func (r *Ruleset) GetConditions() *RulesetConditions {
 	if r == nil {
 		return nil
 	}
 	return r.Conditions
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (r *Ruleset) GetID() int64 {
+	if r == nil || r.ID == nil {
+		return 0
+	}
+	return *r.ID
 }
 
 // GetLinks returns the Links field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -2684,6 +2684,16 @@ func TestBypassActor_GetActorType(tt *testing.T) {
 	b.GetActorType()
 }
 
+func TestBypassActor_GetBypassMode(tt *testing.T) {
+	var zeroValue string
+	b := &BypassActor{BypassMode: &zeroValue}
+	b.GetBypassMode()
+	b = &BypassActor{}
+	b.GetBypassMode()
+	b = nil
+	b.GetBypassMode()
+}
+
 func TestCheckRun_GetApp(tt *testing.T) {
 	c := &CheckRun{}
 	c.GetApp()
@@ -22043,21 +22053,21 @@ func TestRuleRequiredStatusChecks_GetIntegrationID(tt *testing.T) {
 	r.GetIntegrationID()
 }
 
-func TestRuleset_GetBypassMode(tt *testing.T) {
-	var zeroValue string
-	r := &Ruleset{BypassMode: &zeroValue}
-	r.GetBypassMode()
-	r = &Ruleset{}
-	r.GetBypassMode()
-	r = nil
-	r.GetBypassMode()
-}
-
 func TestRuleset_GetConditions(tt *testing.T) {
 	r := &Ruleset{}
 	r.GetConditions()
 	r = nil
 	r.GetConditions()
+}
+
+func TestRuleset_GetID(tt *testing.T) {
+	var zeroValue int64
+	r := &Ruleset{ID: &zeroValue}
+	r.GetID()
+	r = &Ruleset{}
+	r.GetID()
+	r = nil
+	r.GetID()
 }
 
 func TestRuleset_GetLinks(tt *testing.T) {

--- a/github/orgs_rules_test.go
+++ b/github/orgs_rules_test.go
@@ -523,7 +523,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoIDs(t *testing.T) {
 
 	ctx := context.Background()
 	ruleset, _, err := client.Organizations.CreateOrganizationRuleset(ctx, "o", &Ruleset{
-		ID:          21,
+		ID:          Int64(21),
 		Name:        "ruleset",
 		Target:      String("branch"),
 		SourceType:  String("Organization"),
@@ -607,7 +607,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoIDs(t *testing.T) {
 	}
 
 	want := &Ruleset{
-		ID:          21,
+		ID:          Int64(21),
 		Name:        "ruleset",
 		Target:      String("branch"),
 		SourceType:  String("Organization"),

--- a/github/orgs_rules_test.go
+++ b/github/orgs_rules_test.go
@@ -44,13 +44,12 @@ func TestOrganizationsService_GetAllOrganizationRulesets(t *testing.T) {
 	}
 
 	want := []*Ruleset{{
-		ID:          26110,
+		ID:          Int64(26110),
 		Name:        "test ruleset",
 		Target:      String("branch"),
 		SourceType:  String("Organization"),
 		Source:      "o",
 		Enforcement: "active",
-		BypassMode:  String("none"),
 		NodeID:      String("nid"),
 		Links: &RulesetLinks{
 			Self: &RulesetLink{HRef: String("https://api.github.com/orgs/o/rulesets/26110")},
@@ -210,7 +209,7 @@ func TestOrganizationsService_CreateOrganizationRuleset(t *testing.T) {
 
 	ctx := context.Background()
 	ruleset, _, err := client.Organizations.CreateOrganizationRuleset(ctx, "o", &Ruleset{
-		ID:          21,
+		ID:          Int64(21),
 		Name:        "ruleset",
 		Target:      String("branch"),
 		SourceType:  String("Organization"),
@@ -296,7 +295,7 @@ func TestOrganizationsService_CreateOrganizationRuleset(t *testing.T) {
 	}
 
 	want := &Ruleset{
-		ID:          21,
+		ID:          Int64(21),
 		Name:        "ruleset",
 		Target:      String("branch"),
 		SourceType:  String("Organization"),
@@ -448,13 +447,12 @@ func TestOrganizationsService_GetOrganizationRuleset(t *testing.T) {
 	}
 
 	want := &Ruleset{
-		ID:          26110,
+		ID:          Int64(26110),
 		Name:        "test ruleset",
 		Target:      String("branch"),
 		SourceType:  String("Organization"),
 		Source:      "o",
 		Enforcement: "active",
-		BypassMode:  String("none"),
 		NodeID:      String("nid"),
 		Links: &RulesetLinks{
 			Self: &RulesetLink{HRef: String("https://api.github.com/orgs/o/rulesets/26110")},
@@ -543,7 +541,6 @@ func TestOrganizationsService_UpdateOrganizationRuleset(t *testing.T) {
 		Name:        "test ruleset",
 		Target:      String("branch"),
 		Enforcement: "active",
-		BypassMode:  String("none"),
 		Conditions: &RulesetConditions{
 			RefName: &RulesetRefConditionParameters{
 				Include: []string{"refs/heads/main", "refs/heads/master"},
@@ -565,13 +562,12 @@ func TestOrganizationsService_UpdateOrganizationRuleset(t *testing.T) {
 	}
 
 	want := &Ruleset{
-		ID:          26110,
+		ID:          Int64(26110),
 		Name:        "test ruleset",
 		Target:      String("branch"),
 		SourceType:  String("Organization"),
 		Source:      "o",
 		Enforcement: "active",
-		BypassMode:  String("none"),
 		NodeID:      String("nid"),
 		Links: &RulesetLinks{
 			Self: &RulesetLink{HRef: String("https://api.github.com/orgs/o/rulesets/26110")},

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -14,8 +14,10 @@ import (
 // BypassActor represents the bypass actors from a ruleset.
 type BypassActor struct {
 	ActorID *int64 `json:"actor_id,omitempty"`
-	// Possible values for ActorType are: Team, Integration
+	// Possible values for ActorType are: RepositoryRole, Team, Integration, OrganizationAdmin
 	ActorType *string `json:"actor_type,omitempty"`
+	// Possible values for BypassMode are: always, pull_request
+	BypassMode *string `json:"bypass_mode,omitempty"`
 }
 
 // RulesetLink represents a single link object from GitHub ruleset request _links.
@@ -312,7 +314,7 @@ func NewTagNamePatternRule(params *RulePatternParameters) (rule *RepositoryRule)
 
 // Ruleset represents a GitHub ruleset object.
 type Ruleset struct {
-	ID   int64  `json:"id"`
+	ID   *int64 `json:"id,omitempty"`
 	Name string `json:"name"`
 	// Possible values for Target are branch, tag
 	Target *string `json:"target,omitempty"`
@@ -320,9 +322,7 @@ type Ruleset struct {
 	SourceType *string `json:"source_type,omitempty"`
 	Source     string  `json:"source"`
 	// Possible values for Enforcement are: disabled, active, evaluate
-	Enforcement string `json:"enforcement"`
-	// Possible values for BypassMode are: none, repository, organization
-	BypassMode   *string            `json:"bypass_mode,omitempty"`
+	Enforcement  string             `json:"enforcement"`
 	BypassActors []*BypassActor     `json:"bypass_actors,omitempty"`
 	NodeID       *string            `json:"node_id,omitempty"`
 	Links        *RulesetLinks      `json:"_links,omitempty"`

--- a/github/repos_rules_test.go
+++ b/github/repos_rules_test.go
@@ -324,14 +324,14 @@ func TestRepositoriesService_GetAllRulesets(t *testing.T) {
 
 	want := []*Ruleset{
 		{
-			ID:          42,
+			ID:          Int64(42),
 			Name:        "ruleset",
 			SourceType:  String("Repository"),
 			Source:      "o/repo",
 			Enforcement: "enabled",
 		},
 		{
-			ID:          314,
+			ID:          Int64(314),
 			Name:        "Another ruleset",
 			SourceType:  String("Repository"),
 			Source:      "o/repo",
@@ -378,7 +378,7 @@ func TestRepositoriesService_CreateRuleset(t *testing.T) {
 	}
 
 	want := &Ruleset{
-		ID:          42,
+		ID:          Int64(42),
 		Name:        "ruleset",
 		SourceType:  String("Repository"),
 		Source:      "o/repo",
@@ -421,7 +421,7 @@ func TestRepositoriesService_GetRuleset(t *testing.T) {
 	}
 
 	want := &Ruleset{
-		ID:          42,
+		ID:          Int64(42),
 		Name:        "ruleset",
 		SourceType:  String("Organization"),
 		Source:      "o",
@@ -467,7 +467,7 @@ func TestRepositoriesService_UpdateRuleset(t *testing.T) {
 	}
 
 	want := &Ruleset{
-		ID:          42,
+		ID:          Int64(42),
 		Name:        "ruleset",
 		SourceType:  String("Repository"),
 		Source:      "o/repo",


### PR DESCRIPTION
This PR reconciles library with GitHub API for the following regarding [repo rulesets](https://docs.github.com/en/rest/repos/rules?apiVersion=2022-11-28#create-a-repository-ruleset):
- `BypassMode` should be part of `BypassActor`.
- `ActorType` possible values documentation updated to match API docs.
- `BypassMode possible values documentation updated to match API docs.
- `Ruleset` ID field changed to `Int64` pointer and added `omitempty` to allow for nil, ruleset ID is unknown prior to creation and is not required when sending a POST request to create ruleset. 