### PR TITLE
Remove params from repo rulesets update rule

### DIFF
--- a/github/orgs_rules_test.go
+++ b/github/orgs_rules_test.go
@@ -115,10 +115,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoNames(t *testing.T) 
 				"type": "creation"
 			  },
 			  {
-				"type": "update",
-				"parameters": {
-				  "update_allows_fetch_and_merge": true
-				}
+				"type": "update"
 			  },
 			  {
 				"type": "deletion"
@@ -234,9 +231,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoNames(t *testing.T) 
 		},
 		Rules: []*RepositoryRule{
 			NewCreationRule(),
-			NewUpdateRule(&UpdateAllowsFetchAndMergeRuleParameters{
-				UpdateAllowsFetchAndMerge: true,
-			}),
+			NewUpdateRule(),
 			NewDeletionRule(),
 			NewRequiredLinearHistoryRule(),
 			NewRequiredDeploymentsRule(&RequiredDeploymentEnvironmentsRuleParameters{
@@ -320,9 +315,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoNames(t *testing.T) 
 		},
 		Rules: []*RepositoryRule{
 			NewCreationRule(),
-			NewUpdateRule(&UpdateAllowsFetchAndMergeRuleParameters{
-				UpdateAllowsFetchAndMerge: true,
-			}),
+			NewUpdateRule(),
 			NewDeletionRule(),
 			NewRequiredLinearHistoryRule(),
 			NewRequiredDeploymentsRule(&RequiredDeploymentEnvironmentsRuleParameters{
@@ -429,10 +422,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoIDs(t *testing.T) {
 				"type": "creation"
 			  },
 			  {
-				"type": "update",
-				"parameters": {
-				  "update_allows_fetch_and_merge": true
-				}
+				"type": "update"
 			  },
 			  {
 				"type": "deletion"
@@ -546,9 +536,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoIDs(t *testing.T) {
 		},
 		Rules: []*RepositoryRule{
 			NewCreationRule(),
-			NewUpdateRule(&UpdateAllowsFetchAndMergeRuleParameters{
-				UpdateAllowsFetchAndMerge: true,
-			}),
+			NewUpdateRule(),
 			NewDeletionRule(),
 			NewRequiredLinearHistoryRule(),
 			NewRequiredDeploymentsRule(&RequiredDeploymentEnvironmentsRuleParameters{
@@ -630,9 +618,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoIDs(t *testing.T) {
 		},
 		Rules: []*RepositoryRule{
 			NewCreationRule(),
-			NewUpdateRule(&UpdateAllowsFetchAndMergeRuleParameters{
-				UpdateAllowsFetchAndMerge: true,
-			}),
+			NewUpdateRule(),
 			NewDeletionRule(),
 			NewRequiredLinearHistoryRule(),
 			NewRequiredDeploymentsRule(&RequiredDeploymentEnvironmentsRuleParameters{

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -66,11 +66,6 @@ type RulePatternParameters struct {
 	Pattern  string `json:"pattern"`
 }
 
-// UpdateAllowsFetchAndMergeRuleParameters represents the update rule parameters.
-type UpdateAllowsFetchAndMergeRuleParameters struct {
-	UpdateAllowsFetchAndMerge bool `json:"update_allows_fetch_and_merge"`
-}
-
 // RequiredDeploymentEnvironmentsRuleParameters represents the required_deployments rule parameters.
 type RequiredDeploymentEnvironmentsRuleParameters struct {
 	RequiredDeploymentEnvironments []string `json:"required_deployment_environments"`
@@ -115,18 +110,8 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 	r.Type = RepositoryRule.Type
 
 	switch RepositoryRule.Type {
-	case "creation", "deletion", "required_linear_history", "required_signatures", "non_fast_forward":
+	case "creation", "update", "deletion", "required_linear_history", "required_signatures", "non_fast_forward":
 		r.Parameters = nil
-	case "update":
-		params := UpdateAllowsFetchAndMergeRuleParameters{}
-		if err := json.Unmarshal(*RepositoryRule.Parameters, &params); err != nil {
-			return err
-		}
-
-		bytes, _ := json.Marshal(params)
-		rawParams := json.RawMessage(bytes)
-
-		r.Parameters = &rawParams
 	case "required_deployments":
 		params := RequiredDeploymentEnvironmentsRuleParameters{}
 		if err := json.Unmarshal(*RepositoryRule.Parameters, &params); err != nil {
@@ -184,14 +169,9 @@ func NewCreationRule() (rule *RepositoryRule) {
 }
 
 // NewUpdateRule creates a rule to only allow users with bypass permission to update matching refs.
-func NewUpdateRule(params *UpdateAllowsFetchAndMergeRuleParameters) (rule *RepositoryRule) {
-	bytes, _ := json.Marshal(params)
-
-	rawParams := json.RawMessage(bytes)
-
+func NewUpdateRule() (rule *RepositoryRule) {
 	return &RepositoryRule{
-		Type:       "update",
-		Parameters: &rawParams,
+		Type: "update",
 	}
 }
 

--- a/github/repos_rules_test.go
+++ b/github/repos_rules_test.go
@@ -60,17 +60,12 @@ func TestRepositoryRule_UnmarshalJSON(t *testing.T) {
 				Parameters: nil,
 			},
 		},
-		"Valid update params": {
-			data: `{"type":"update","parameters":{"update_allows_fetch_and_merge":true}}`,
-			want: NewUpdateRule(&UpdateAllowsFetchAndMergeRuleParameters{UpdateAllowsFetchAndMerge: true}),
-		},
-		"Invalid update params": {
-			data: `{"type":"update","parameters":{"update_allows_fetch_and_merge":"true"}}`,
+		"Valid update": {
+			data: `{"type":"update"}`,
 			want: &RepositoryRule{
 				Type:       "update",
 				Parameters: nil,
 			},
-			wantErr: true,
 		},
 		"Valid required_deployments params": {
 			data: `{"type":"required_deployments","parameters":{"required_deployment_environments":["test"]}}`,
@@ -254,10 +249,7 @@ func TestRepositoriesService_GetRulesForBranch(t *testing.T) {
 			  "type": "creation"
 			},
 			{
-			  "type": "update",
-			  "parameters": {
-			    "update_allows_fetch_and_merge": true
-			  }
+			  "type": "update"
 			}
 		]`)
 	})
@@ -269,9 +261,7 @@ func TestRepositoriesService_GetRulesForBranch(t *testing.T) {
 	}
 
 	creationRule := NewCreationRule()
-	updateRule := NewUpdateRule(&UpdateAllowsFetchAndMergeRuleParameters{
-		UpdateAllowsFetchAndMerge: true,
-	})
+	updateRule := NewUpdateRule()
 
 	want := []*RepositoryRule{
 		creationRule,


### PR DESCRIPTION
I was testing out this functionality and noticed that I can send a request with params set for update rule which is fine since it seems the GitHub API doesn’t actually check parameters with this rule as it doesn’t expect any. 

However, if I try reading a ruleset which contains an update rule, it returns an object with `”type”: “update"`  and no parameters. This is also the same behaviour as the GitHub UI where you cannot set parameters for update rules or see any parameters for it. I looked at the request to read rulesets as sent by the frontend and found:

```
{
        "type": "update",
        "target": "branch",
        "displayName": "Restrict updates",
        "description": "Only allow users with bypass permission to update matching refs.",
        "parameterSchema": {
          "type": "object",
          "name": null,
          "display_name": null,
          "description": null,
          "required": true,
          "root": true,
          "internal": false,
          "org_only": false,
          "supported_plan": null,
          "default_value": null,
          "validator": null,
          "ui_control": null,
          "visibility_fn": null,
          "fields": []
        },
        "metadataPatternSchema": null
}
```

Leads me to think there was an undocumented change in behaviour in the API.