### PR TITLE
Add GetAutomatedSecurityFixes to report status

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1846,6 +1846,22 @@ func (a *AutolinkOptions) GetURLTemplate() string {
 	return *a.URLTemplate
 }
 
+// GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
+func (a *AutomatedSecurityFixes) GetEnabled() bool {
+	if a == nil || a.Enabled == nil {
+		return false
+	}
+	return *a.Enabled
+}
+
+// GetPaused returns the Paused field if it's non-nil, zero value otherwise.
+func (a *AutomatedSecurityFixes) GetPaused() bool {
+	if a == nil || a.Paused == nil {
+		return false
+	}
+	return *a.Paused
+}
+
 // GetAppID returns the AppID field if it's non-nil, zero value otherwise.
 func (a *AutoTriggerCheck) GetAppID() int64 {
 	if a == nil || a.AppID == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -2218,6 +2218,26 @@ func TestAutolinkOptions_GetURLTemplate(tt *testing.T) {
 	a.GetURLTemplate()
 }
 
+func TestAutomatedSecurityFixes_GetEnabled(tt *testing.T) {
+	var zeroValue bool
+	a := &AutomatedSecurityFixes{Enabled: &zeroValue}
+	a.GetEnabled()
+	a = &AutomatedSecurityFixes{}
+	a.GetEnabled()
+	a = nil
+	a.GetEnabled()
+}
+
+func TestAutomatedSecurityFixes_GetPaused(tt *testing.T) {
+	var zeroValue bool
+	a := &AutomatedSecurityFixes{Paused: &zeroValue}
+	a.GetPaused()
+	a = &AutomatedSecurityFixes{}
+	a.GetPaused()
+	a = nil
+	a.GetPaused()
+}
+
 func TestAutoTriggerCheck_GetAppID(tt *testing.T) {
 	var zeroValue int64
 	a := &AutoTriggerCheck{AppID: &zeroValue}

--- a/github/github.go
+++ b/github/github.go
@@ -126,9 +126,6 @@ const (
 	// https://developer.github.com/changes/2019-04-24-vulnerability-alerts/
 	mediaTypeRequiredVulnerabilityAlertsPreview = "application/vnd.github.dorian-preview+json"
 
-	// https://developer.github.com/changes/2019-06-04-automated-security-fixes/
-	mediaTypeRequiredAutomatedSecurityFixesPreview = "application/vnd.github.london-preview+json"
-
 	// https://developer.github.com/changes/2019-05-29-update-branch-api/
 	mediaTypeUpdatePullRequestBranchPreview = "application/vnd.github.lydian-preview+json"
 

--- a/github/repos.go
+++ b/github/repos.go
@@ -687,6 +687,28 @@ func (s *RepositoriesService) DisableVulnerabilityAlerts(ctx context.Context, ow
 	return s.client.Do(ctx, req, nil)
 }
 
+// GetAutomatedSecurityFixes checks if the automated security fixes for a repository are enabled.
+//
+// GitHub API docs: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#check-if-automated-security-fixes-are-enabled-for-a-repository
+func (s *RepositoriesService) GetAutomatedSecurityFixes(ctx context.Context, owner, repository string) (*AutomatedSecurityFixes, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/automated-security-fixes", owner, repository)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeRequiredAutomatedSecurityFixesPreview)
+
+	p := new(AutomatedSecurityFixes)
+	resp, err := s.client.Do(ctx, req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+	return p, resp, nil
+}
+
 // EnableAutomatedSecurityFixes enables the automated security fixes for a repository.
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#enable-automated-security-fixes
@@ -1210,6 +1232,12 @@ type SignaturesProtectedBranch struct {
 	URL *string `json:"url,omitempty"`
 	// Commits pushed to matching branches must have verified signatures.
 	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// AutomatedSecurityFixes represents their status.
+type AutomatedSecurityFixes struct {
+	Enabled *bool `json:"enabled"`
+	Paused  *bool `json:"paused"`
 }
 
 // ListBranches lists branches for the specified repository.

--- a/github/repos.go
+++ b/github/repos.go
@@ -698,9 +698,6 @@ func (s *RepositoriesService) GetAutomatedSecurityFixes(ctx context.Context, own
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeRequiredAutomatedSecurityFixesPreview)
-
 	p := new(AutomatedSecurityFixes)
 	resp, err := s.client.Do(ctx, req, p)
 	if err != nil {
@@ -720,9 +717,6 @@ func (s *RepositoriesService) EnableAutomatedSecurityFixes(ctx context.Context, 
 		return nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeRequiredAutomatedSecurityFixesPreview)
-
 	return s.client.Do(ctx, req, nil)
 }
 
@@ -736,9 +730,6 @@ func (s *RepositoriesService) DisableAutomatedSecurityFixes(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeRequiredAutomatedSecurityFixesPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -664,6 +664,44 @@ func TestRepositoriesService_EnableAutomatedSecurityFixes(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_GetAutomatedSecurityFixes(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/automated-security-fixes", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeRequiredAutomatedSecurityFixesPreview)
+		fmt.Fprint(w, `{"enabled": true, "paused": false}`)
+	})
+
+	ctx := context.Background()
+	fixes, _, err := client.Repositories.GetAutomatedSecurityFixes(ctx, "o", "r")
+	if err != nil {
+		t.Errorf("Repositories.GetAutomatedSecurityFixes returned errpr: #{err}")
+	}
+
+	want := &AutomatedSecurityFixes{
+		Enabled: Bool(true),
+		Paused:  Bool(false),
+	}
+	if !cmp.Equal(fixes, want) {
+		t.Errorf("Repositories.GetAutomatedSecurityFixes returned #{fixes}, want #{want}")
+	}
+
+	const methodName = "GetAutomatedSecurityFixes"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Repositories.GetAutomatedSecurityFixes(ctx, "\n", "\n")
+		return err
+	})
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Repositories.GetAutomatedSecurityFixes(ctx, "o", "r")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
 func TestRepositoriesService_DisableAutomatedSecurityFixes(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -653,7 +653,6 @@ func TestRepositoriesService_EnableAutomatedSecurityFixes(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/automated-security-fixes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeRequiredAutomatedSecurityFixesPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -670,7 +669,6 @@ func TestRepositoriesService_GetAutomatedSecurityFixes(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/automated-security-fixes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeRequiredAutomatedSecurityFixesPreview)
 		fmt.Fprint(w, `{"enabled": true, "paused": false}`)
 	})
 
@@ -708,7 +706,6 @@ func TestRepositoriesService_DisableAutomatedSecurityFixes(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/automated-security-fixes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", mediaTypeRequiredAutomatedSecurityFixesPreview)
 
 		w.WriteHeader(http.StatusNoContent)
 	})


### PR DESCRIPTION
This is an attempt to fix #2080. It is also required by upstream projects such as [terraform-provider-github](https://github.com/integrations/terraform-provider-github), see [issue 1301](https://github.com/integrations/terraform-provider-github/issues/1301)

```
go test github.com/google/go-github/...
ok      github.com/google/go-github/v53/github  1.165s
?       github.com/google/go-github/v53/test/fields     [no test files]
?       github.com/google/go-github/v53/test/integration        [no test files]

```