### PR TITLE
Fix `old_name` field in `AuditEntry`

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1278,14 +1278,6 @@ func (a *AuditEntry) GetOAuthApplicationID() int64 {
 	return *a.OAuthApplicationID
 }
 
-// GetOldName returns the OldName field if it's non-nil, zero value otherwise.
-func (a *AuditEntry) GetOldName() string {
-	if a == nil || a.OldName == nil {
-		return ""
-	}
-	return *a.OldName
-}
-
 // GetOldPermission returns the OldPermission field if it's non-nil, zero value otherwise.
 func (a *AuditEntry) GetOldPermission() string {
 	if a == nil || a.OldPermission == nil {
@@ -1596,6 +1588,14 @@ func (a *AuditEntry) GetWorkflowRunID() int64 {
 		return 0
 	}
 	return *a.WorkflowRunID
+}
+
+// GetOldName returns the OldName field if it's non-nil, zero value otherwise.
+func (a *AuditEntryData) GetOldName() string {
+	if a == nil || a.OldName == nil {
+		return ""
+	}
+	return *a.OldName
 }
 
 // GetApp returns the App field.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1134,6 +1134,14 @@ func (a *AuditEntry) GetCreatedAt() Timestamp {
 	return *a.CreatedAt
 }
 
+// GetData returns the Data field.
+func (a *AuditEntry) GetData() *AuditEntryData {
+	if a == nil {
+		return nil
+	}
+	return a.Data
+}
+
 // GetDeployKeyFingerprint returns the DeployKeyFingerprint field if it's non-nil, zero value otherwise.
 func (a *AuditEntry) GetDeployKeyFingerprint() string {
 	if a == nil || a.DeployKeyFingerprint == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -1334,6 +1334,13 @@ func TestAuditEntry_GetCreatedAt(tt *testing.T) {
 	a.GetCreatedAt()
 }
 
+func TestAuditEntry_GetData(tt *testing.T) {
+	a := &AuditEntry{}
+	a.GetData()
+	a = nil
+	a.GetData()
+}
+
 func TestAuditEntry_GetDeployKeyFingerprint(tt *testing.T) {
 	var zeroValue string
 	a := &AuditEntry{DeployKeyFingerprint: &zeroValue}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -1514,16 +1514,6 @@ func TestAuditEntry_GetOAuthApplicationID(tt *testing.T) {
 	a.GetOAuthApplicationID()
 }
 
-func TestAuditEntry_GetOldName(tt *testing.T) {
-	var zeroValue string
-	a := &AuditEntry{OldName: &zeroValue}
-	a.GetOldName()
-	a = &AuditEntry{}
-	a.GetOldName()
-	a = nil
-	a.GetOldName()
-}
-
 func TestAuditEntry_GetOldPermission(tt *testing.T) {
 	var zeroValue string
 	a := &AuditEntry{OldPermission: &zeroValue}
@@ -1912,6 +1902,16 @@ func TestAuditEntry_GetWorkflowRunID(tt *testing.T) {
 	a.GetWorkflowRunID()
 	a = nil
 	a.GetWorkflowRunID()
+}
+
+func TestAuditEntryData_GetOldName(tt *testing.T) {
+	var zeroValue string
+	a := &AuditEntryData{OldName: &zeroValue}
+	a.GetOldName()
+	a = &AuditEntryData{}
+	a.GetOldName()
+	a = nil
+	a.GetOldName()
 }
 
 func TestAuthorization_GetApp(tt *testing.T) {

--- a/github/orgs_audit_log.go
+++ b/github/orgs_audit_log.go
@@ -125,7 +125,7 @@ type AuditEntry struct {
 	AuditEntryData `json:"data,omitempty"`
 }
 
-// Some audit entries have additional information stuffed into a `data` field.
+// AuditEntryData represents additional information stuffed into a `data` field.
 type AuditEntryData struct {
 	OldName *string `json:"old_name,omitempty"` // The previous name of the repository, for a name change
 }

--- a/github/orgs_audit_log.go
+++ b/github/orgs_audit_log.go
@@ -78,7 +78,6 @@ type AuditEntry struct {
 	Message                *string                 `json:"message,omitempty"`
 	Name                   *string                 `json:"name,omitempty"`
 	OAuthApplicationID     *int64                  `json:"oauth_application_id,omitempty"`
-	OldName                *string                 `json:"old_name,omitempty"` // The previous name of the repository, for a name change
 	OldUser                *string                 `json:"old_user,omitempty"`
 	OldPermission          *string                 `json:"old_permission,omitempty"` // The permission level for membership changes, for example `admin` or `read`.
 	OpenSSHPublicKey       *string                 `json:"openssh_public_key,omitempty"`
@@ -122,6 +121,13 @@ type AuditEntry struct {
 	Visibility             *string                 `json:"visibility,omitempty"` // The repository visibility, for example `public` or `private`.
 	WorkflowID             *int64                  `json:"workflow_id,omitempty"`
 	WorkflowRunID          *int64                  `json:"workflow_run_id,omitempty"`
+
+	AuditEntryData `json:"data,omitempty"`
+}
+
+// Some audit entries have additional information stuffed into a `data` field.
+type AuditEntryData struct {
+	OldName *string `json:"old_name,omitempty"` // The previous name of the repository, for a name change
 }
 
 // GetAuditLog gets the audit-log entries for an organization.

--- a/github/orgs_audit_log.go
+++ b/github/orgs_audit_log.go
@@ -122,7 +122,7 @@ type AuditEntry struct {
 	WorkflowID             *int64                  `json:"workflow_id,omitempty"`
 	WorkflowRunID          *int64                  `json:"workflow_run_id,omitempty"`
 
-	AuditEntryData `json:"data,omitempty"`
+	Data  *AuditEntryData `json:"data,omitempty"`
 }
 
 // AuditEntryData represents additional information stuffed into a `data` field.

--- a/github/orgs_audit_log.go
+++ b/github/orgs_audit_log.go
@@ -122,7 +122,7 @@ type AuditEntry struct {
 	WorkflowID             *int64                  `json:"workflow_id,omitempty"`
 	WorkflowRunID          *int64                  `json:"workflow_run_id,omitempty"`
 
-	Data  *AuditEntryData `json:"data,omitempty"`
+	Data *AuditEntryData `json:"data,omitempty"`
 }
 
 // AuditEntryData represents additional information stuffed into a `data` field.

--- a/github/orgs_audit_log_test.go
+++ b/github/orgs_audit_log_test.go
@@ -256,7 +256,6 @@ func TestAuditEntry_Marshal(t *testing.T) {
 		LimitedAvailability:    Bool(false),
 		Message:                String("m"),
 		Name:                   String("n"),
-		OldName:                String("on"),
 		OldPermission:          String("op"),
 		OldUser:                String("ou"),
 		OpenSSHPublicKey:       String("osshpk"),
@@ -300,6 +299,9 @@ func TestAuditEntry_Marshal(t *testing.T) {
 		Visibility:            String("v"),
 		WorkflowID:            Int64(1),
 		WorkflowRunID:         Int64(1),
+		AuditEntryData: AuditEntryData{
+			OldName: String("on"),
+		},
 	}
 
 	want := `{
@@ -346,7 +348,6 @@ func TestAuditEntry_Marshal(t *testing.T) {
 		"limited_availability": false,
 		"message": "m",
 		"name": "n",
-                "old_name": "on",
 		"old_permission": "op",
 		"old_user": "ou",
 		"openssh_public_key": "osshpk",
@@ -393,7 +394,10 @@ func TestAuditEntry_Marshal(t *testing.T) {
 		"user_agent": "ua",
 		"visibility": "v",
 		"workflow_id": 1,
-		"workflow_run_id": 1
+		"workflow_run_id": 1,
+		"data": {
+			"old_name": "on"
+		}
 	}`
 
 	testJSONMarshal(t, u, want)

--- a/github/orgs_audit_log_test.go
+++ b/github/orgs_audit_log_test.go
@@ -299,7 +299,7 @@ func TestAuditEntry_Marshal(t *testing.T) {
 		Visibility:            String("v"),
 		WorkflowID:            Int64(1),
 		WorkflowRunID:         Int64(1),
-		AuditEntryData: AuditEntryData{
+		Data: &AuditEntryData{
 			OldName: String("on"),
 		},
 	}


### PR DESCRIPTION
Much to my chagrin, the audit log view in the site manager does not follow the shape of the API response.

I previously raised a PR #2843 which was merged yesterday. Unfortunately, it does not work with the payload returned from the API.

My sincere apologies about this.