### PR TITLE
Add `OldLogin` field to `AuditEntryData`

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1598,6 +1598,14 @@ func (a *AuditEntry) GetWorkflowRunID() int64 {
 	return *a.WorkflowRunID
 }
 
+// GetOldLogin returns the OldLogin field if it's non-nil, zero value otherwise.
+func (a *AuditEntryData) GetOldLogin() string {
+	if a == nil || a.OldLogin == nil {
+		return ""
+	}
+	return *a.OldLogin
+}
+
 // GetOldName returns the OldName field if it's non-nil, zero value otherwise.
 func (a *AuditEntryData) GetOldName() string {
 	if a == nil || a.OldName == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -1911,6 +1911,16 @@ func TestAuditEntry_GetWorkflowRunID(tt *testing.T) {
 	a.GetWorkflowRunID()
 }
 
+func TestAuditEntryData_GetOldLogin(tt *testing.T) {
+	var zeroValue string
+	a := &AuditEntryData{OldLogin: &zeroValue}
+	a.GetOldLogin()
+	a = &AuditEntryData{}
+	a.GetOldLogin()
+	a = nil
+	a.GetOldLogin()
+}
+
 func TestAuditEntryData_GetOldName(tt *testing.T) {
 	var zeroValue string
 	a := &AuditEntryData{OldName: &zeroValue}

--- a/github/orgs_audit_log.go
+++ b/github/orgs_audit_log.go
@@ -127,7 +127,8 @@ type AuditEntry struct {
 
 // AuditEntryData represents additional information stuffed into a `data` field.
 type AuditEntryData struct {
-	OldName *string `json:"old_name,omitempty"` // The previous name of the repository, for a name change
+	OldName  *string `json:"old_name,omitempty"`  // The previous name of the repository, for a name change
+	OldLogin *string `json:"old_login,omitempty"` // The previous name of the organization, for a name change
 }
 
 // GetAuditLog gets the audit-log entries for an organization.

--- a/github/orgs_audit_log_test.go
+++ b/github/orgs_audit_log_test.go
@@ -300,7 +300,8 @@ func TestAuditEntry_Marshal(t *testing.T) {
 		WorkflowID:            Int64(1),
 		WorkflowRunID:         Int64(1),
 		Data: &AuditEntryData{
-			OldName: String("on"),
+			OldName:  String("on"),
+			OldLogin: String("ol"),
 		},
 	}
 
@@ -396,7 +397,8 @@ func TestAuditEntry_Marshal(t *testing.T) {
 		"workflow_id": 1,
 		"workflow_run_id": 1,
 		"data": {
-			"old_name": "on"
+			"old_name": "on",
+			"old_login": "ol"
 		}
 	}`
 


### PR DESCRIPTION
When renaming a Github organisation, the audit log entry (with action `org.rename`) will contain `data.old_login` which provides the prior name of the organisation.

This PR builds upon prior work which added support for the `data` field within an Audit Log entry.