### PR TITLE
Check for nil pointer in update rule parameters

### DIFF
--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -118,7 +118,7 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 	case "creation", "deletion", "required_linear_history", "required_signatures", "non_fast_forward":
 		r.Parameters = nil
 	case "update":
-		if RepositoryRule.Parameters != nil {
+		if RepositoryRule.Parameters == nil {
 			r.Parameters = nil
 			return nil
 		} else {
@@ -190,13 +190,18 @@ func NewCreationRule() (rule *RepositoryRule) {
 
 // NewUpdateRule creates a rule to only allow users with bypass permission to update matching refs.
 func NewUpdateRule(params *UpdateAllowsFetchAndMergeRuleParameters) (rule *RepositoryRule) {
-	bytes, _ := json.Marshal(params)
+	if params != nil {
+		bytes, _ := json.Marshal(params)
 
-	rawParams := json.RawMessage(bytes)
+		rawParams := json.RawMessage(bytes)
 
+		return &RepositoryRule{
+			Type:       "update",
+			Parameters: &rawParams,
+		}
+	}
 	return &RepositoryRule{
-		Type:       "update",
-		Parameters: &rawParams,
+		Type: "update",
 	}
 }
 

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -121,17 +121,17 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 		if RepositoryRule.Parameters == nil {
 			r.Parameters = nil
 			return nil
-		} else {
-			params := UpdateAllowsFetchAndMergeRuleParameters{}
-			if err := json.Unmarshal(*RepositoryRule.Parameters, &params); err != nil {
-				return err
-			}
-
-			bytes, _ := json.Marshal(params)
-			rawParams := json.RawMessage(bytes)
-
-			r.Parameters = &rawParams
 		}
+		params := UpdateAllowsFetchAndMergeRuleParameters{}
+		if err := json.Unmarshal(*RepositoryRule.Parameters, &params); err != nil {
+			return err
+		}
+
+		bytes, _ := json.Marshal(params)
+		rawParams := json.RawMessage(bytes)
+
+		r.Parameters = &rawParams
+
 	case "required_deployments":
 		params := RequiredDeploymentEnvironmentsRuleParameters{}
 		if err := json.Unmarshal(*RepositoryRule.Parameters, &params); err != nil {

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -118,8 +118,11 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 	case "creation", "deletion", "required_linear_history", "required_signatures", "non_fast_forward":
 		r.Parameters = nil
 	case "update":
-		params := UpdateAllowsFetchAndMergeRuleParameters{}
 		if RepositoryRule.Parameters != nil {
+			r.Parameters = nil
+			return nil
+		} else {
+			params := UpdateAllowsFetchAndMergeRuleParameters{}
 			if err := json.Unmarshal(*RepositoryRule.Parameters, &params); err != nil {
 				return err
 			}
@@ -128,8 +131,6 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 			rawParams := json.RawMessage(bytes)
 
 			r.Parameters = &rawParams
-		} else {
-			r.Parameters = nil
 		}
 	case "required_deployments":
 		params := RequiredDeploymentEnvironmentsRuleParameters{}

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -119,14 +119,18 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 		r.Parameters = nil
 	case "update":
 		params := UpdateAllowsFetchAndMergeRuleParameters{}
-		if err := json.Unmarshal(*RepositoryRule.Parameters, &params); err != nil {
-			return err
+		if RepositoryRule.Parameters != nil {
+			if err := json.Unmarshal(*RepositoryRule.Parameters, &params); err != nil {
+				return err
+			}
+
+			bytes, _ := json.Marshal(params)
+			rawParams := json.RawMessage(bytes)
+
+			r.Parameters = &rawParams
+		} else {
+			r.Parameters = nil
 		}
-
-		bytes, _ := json.Marshal(params)
-		rawParams := json.RawMessage(bytes)
-
-		r.Parameters = &rawParams
 	case "required_deployments":
 		params := RequiredDeploymentEnvironmentsRuleParameters{}
 		if err := json.Unmarshal(*RepositoryRule.Parameters, &params); err != nil {


### PR DESCRIPTION
Since discussing this with the GitHub folks, I’ve been told that the `update_allows_fetch_and_merge` parameter for the update rule only applies to forked repos. **Note: I was told this is still bugged for forked repos when sending a request through the API, but will be fixed in the near future.**

Since it only applies to forked repos, the API returns a ruleset which contains:
```
{
   "type": “update"
}
```

This doesn't have a parameters field, so when we try to unmarshal the JSON we run into a nil pointer dereference error. No functionality is changed here except to check for a nil pointer before we try to unmarshal the JSON, and if it isn’t included then we just set the parameters to nil.

I didn’t think this needed a change in testing because it doesn’t change any functionality, but I’ll be happy to go and add something if you think otherwise.

@gmlewis I’d really appreciate if this can be part of the upcoming release (which I know is short notice) since I’d love for it to be included in https://github.com/integrations/terraform-provider-github/pull/1808. No worries if it’s too late though, I can just keep it out for now. Thanks!!