### PR TITLE
Add support for Dependency Graph Snapshots endpoint

### DIFF
--- a/github/dependency_graph_snapshots.go
+++ b/github/dependency_graph_snapshots.go
@@ -1,0 +1,99 @@
+// Copyright 2023 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+type DependencyRelationship string
+
+const (
+	DIRECT   DependencyRelationship = "direct"
+	INDIRECT                        = "indirect"
+)
+
+type DependencyScope string
+
+const (
+	RUNTIME     DependencyScope = "runtime"
+	DEVELOPMENT                 = "development"
+)
+
+type SnapshotCreationResult string
+
+const (
+	SUCCESS  SnapshotCreationResult = "SUCCESS"
+	ACCEPTED                        = "ACCEPTED"
+	INVALID                         = "INVALID"
+)
+
+type Resolved struct {
+	PackageUrl   *string                `json:"package_url,omitempty"`
+	Relationship DependencyRelationship `json:"relationship,omitempty"`
+	Scope        DependencyScope        `json:"scope,omitempty"`
+	Dependencies []string               `json:"dependencies,omitempty"`
+}
+
+type Job struct {
+	Correlator *string `json:"correlator,omitempty"`
+	ID         *string `json:"id,omitempty"`
+	HtmlUrl    *string `json:"html_url,omitempty"`
+}
+
+type Detector struct {
+	Name    *string `json:"name,omitempty"`
+	Version *string `json:"version,omitempty"`
+	URL     *string `json:"url,omitempty"`
+}
+
+type File struct {
+	SourceLocation *string `json:"source_location,omitempty"`
+}
+
+type Manifest struct {
+	Name     *string              `json:"name,omitempty"`
+	File     *File                `json:"file,omitempty"`
+	Resolved map[string]*Resolved `json:"resolved,omitempty"`
+}
+
+type Snapshot struct {
+	Version   int                  `json:"version"`
+	Sha       *string              `json:"sha,omitempty"`
+	Ref       *string              `json:"ref,omitempty"`
+	Job       *Job                 `json:"job,omitempty"`
+	Detector  *Detector            `json:"detector,omitempty"`
+	Scanned   *Timestamp           `json:"scanned,omitempty"`
+	Manifests map[string]*Manifest `json:"manifests,omitempty"`
+}
+
+type SnapshotCreationData struct {
+	ID        int                    `json:"id"`
+	CreatedAt *Timestamp             `json:"created_at"`
+	Message   *string                `json:"message"`
+	Result    SnapshotCreationResult `json:"result"`
+}
+
+// Create a new snapshot of a repository's dependencies.
+//
+// GitHub API docs: https://docs.github.com/en/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
+func (s *DependencyGraphService) CreateSnapshot(ctx context.Context, owner, repo string, snapshot *Snapshot) (*SnapshotCreationData, *Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/dependency-graph/snapshots", owner, repo)
+
+	req, err := s.client.NewRequest("POST", url, snapshot)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var spanshotCreationData *SnapshotCreationData
+	resp, err := s.client.Do(ctx, req, &spanshotCreationData)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return spanshotCreationData, resp, nil
+}

--- a/github/dependency_graph_snapshots.go
+++ b/github/dependency_graph_snapshots.go
@@ -33,7 +33,7 @@ type DependencyGraphSnapshotResolvedDependencyScope string
 type DependencyGraphSnapshotCreationResult string
 
 type DependencyGraphSnapshotResolvedDependency struct {
-	PackageUrl   *string                                               `json:"package_url,omitempty"`
+	PackageURL   *string                                               `json:"package_url,omitempty"`
 	Relationship DependencyGraphSnapshotResolvedDependencyRelationship `json:"relationship,omitempty"`
 	Scope        DependencyGraphSnapshotResolvedDependencyScope        `json:"scope,omitempty"`
 	Dependencies []string                                              `json:"dependencies,omitempty"`
@@ -42,7 +42,7 @@ type DependencyGraphSnapshotResolvedDependency struct {
 type DependencyGraphSnapshotJob struct {
 	Correlator *string `json:"correlator,omitempty"`
 	ID         *string `json:"id,omitempty"`
-	HtmlUrl    *string `json:"html_url,omitempty"`
+	HTMLURL    *string `json:"html_url,omitempty"`
 }
 
 type DependencyGraphSnapshotDetector struct {

--- a/github/dependency_graph_snapshots.go
+++ b/github/dependency_graph_snapshots.go
@@ -10,57 +10,61 @@ import (
 	"fmt"
 )
 
-// DependencyGraphSnapshotResolvedDependencyRelationship represents whether the dependency is requested directly by the manifest or is a dependency of another dependency.
+// DependencyGraphSnapshotResolvedDependency represents a resolved dependency in a dependency graph snapshot.
 //
-// Can have the following values:
-//   - "direct": indicates that the dependency is requested directly by the manifest.
-//   - "indirect": indicates that the dependency is a dependency of another dependency.
-type DependencyGraphSnapshotResolvedDependencyRelationship string
-
-// DependencyGraphSnapshotResolvedDependencyScope represents whether the dependency is required for the primary build artifact or is only used for development.
-//
-// Can have the following values:
-//   - "runtime": indicates that the dependency is required for the primary build artifact.
-//   - "development": indicates that the dependency is only used for development.
-type DependencyGraphSnapshotResolvedDependencyScope string
-
-// DependencyGraphSnapshotCreationResult represents the snapshot creation result.
-//
-// Can have the following values:
-//   - "SUCCESS": indicates that the snapshot was successfully created and the repository's dependencies were updated.
-//   - "ACCEPTED": indicates that the snapshot was successfully created, but the repository's dependencies were not updated.
-//   - "INVALID": indicates that the snapshot was malformed.
-type DependencyGraphSnapshotCreationResult string
-
+// GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
 type DependencyGraphSnapshotResolvedDependency struct {
-	PackageURL   *string                                               `json:"package_url,omitempty"`
-	Relationship DependencyGraphSnapshotResolvedDependencyRelationship `json:"relationship,omitempty"`
-	Scope        DependencyGraphSnapshotResolvedDependencyScope        `json:"scope,omitempty"`
-	Dependencies []string                                              `json:"dependencies,omitempty"`
+	PackageURL *string `json:"package_url,omitempty"`
+	// Represents whether the dependency is requested directly by the manifest or is a dependency of another dependency.
+	// Can have the following values:
+	//   - "direct": indicates that the dependency is requested directly by the manifest.
+	//   - "indirect": indicates that the dependency is a dependency of another dependency.
+	Relationship *string `json:"relationship,omitempty"`
+	// Represents whether the dependency is required for the primary build artifact or is only used for development.
+	// Can have the following values:
+	//   - "runtime": indicates that the dependency is required for the primary build artifact.
+	//   - "development": indicates that the dependency is only used for development.
+	Scope        *string  `json:"scope,omitempty"`
+	Dependencies []string `json:"dependencies,omitempty"`
 }
 
+// DependencyGraphSnapshotJob represents the job that created the snapshot.
+//
+// GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
 type DependencyGraphSnapshotJob struct {
 	Correlator *string `json:"correlator,omitempty"`
 	ID         *string `json:"id,omitempty"`
 	HTMLURL    *string `json:"html_url,omitempty"`
 }
 
+// DependencyGraphSnapshotDetector represents a description of the detector used.
+//
+// GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
 type DependencyGraphSnapshotDetector struct {
 	Name    *string `json:"name,omitempty"`
 	Version *string `json:"version,omitempty"`
 	URL     *string `json:"url,omitempty"`
 }
 
+// DependencyGraphSnapshotManifestFile represents the file declaring the repository's dependencies.
+//
+// GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
 type DependencyGraphSnapshotManifestFile struct {
 	SourceLocation *string `json:"source_location,omitempty"`
 }
 
+// DependencyGraphSnapshotManifest represents a collection of related dependencies declared in a file or representing a logical group of dependencies.
+//
+// GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
 type DependencyGraphSnapshotManifest struct {
 	Name     *string                                               `json:"name,omitempty"`
 	File     *DependencyGraphSnapshotManifestFile                  `json:"file,omitempty"`
 	Resolved map[string]*DependencyGraphSnapshotResolvedDependency `json:"resolved,omitempty"`
 }
 
+// DependencyGraphSnapshot represent a snapshot of a repository's dependencies.
+//
+// GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
 type DependencyGraphSnapshot struct {
 	Version   int                                         `json:"version"`
 	Sha       *string                                     `json:"sha,omitempty"`
@@ -71,16 +75,26 @@ type DependencyGraphSnapshot struct {
 	Manifests map[string]*DependencyGraphSnapshotManifest `json:"manifests,omitempty"`
 }
 
+// DependencyGraphSnapshotCreationData represents the dependency snapshot's creation result.
+//
+// GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
 type DependencyGraphSnapshotCreationData struct {
-	ID        int                                   `json:"id"`
-	CreatedAt *Timestamp                            `json:"created_at"`
-	Message   *string                               `json:"message"`
-	Result    DependencyGraphSnapshotCreationResult `json:"result"`
+	ID        int        `json:"id"`
+	CreatedAt *Timestamp `json:"created_at"`
+	Message   *string    `json:"message"`
+	// Represents the snapshot creation result.
+	// Can have the following values:
+	//   - "SUCCESS": indicates that the snapshot was successfully created and the repository's dependencies were updated.
+	//   - "ACCEPTED": indicates that the snapshot was successfully created, but the repository's dependencies were not updated.
+	//   - "INVALID": indicates that the snapshot was malformed.
+	Result *string `json:"result"`
 }
 
 // CreateSnapshot creates a new snapshot of a repository's dependencies.
 //
-// GitHub API docs: https://docs.github.com/en/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
+// GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
+//
+//meta:operation POST /repos/{owner}/{repo}/dependency-graph/snapshots
 func (s *DependencyGraphService) CreateSnapshot(ctx context.Context, owner, repo string, dependencyGraphSnapshot *DependencyGraphSnapshot) (*DependencyGraphSnapshotCreationData, *Response, error) {
 	url := fmt.Sprintf("repos/%v/%v/dependency-graph/snapshots", owner, repo)
 

--- a/github/dependency_graph_snapshots.go
+++ b/github/dependency_graph_snapshots.go
@@ -10,90 +10,90 @@ import (
 	"fmt"
 )
 
-type DependencyRelationship string
+// DependencyGraphSnapshotResolvedDependencyRelationship represents whether the dependency is requested directly by the manifest or is a dependency of another dependency.
+//
+// Can have the following values:
+//   - "direct": indicates that the dependency is requested directly by the manifest.
+//   - "indirect": indicates that the dependency is a dependency of another dependency.
+type DependencyGraphSnapshotResolvedDependencyRelationship string
 
-const (
-	DIRECT   DependencyRelationship = "direct"
-	INDIRECT                        = "indirect"
-)
+// DependencyGraphSnapshotResolvedDependencyScope represents whether the dependency is required for the primary build artifact or is only used for development.
+//
+// Can have the following values:
+//   - "runtime": indicates that the dependency is required for the primary build artifact.
+//   - "development": indicates that the dependency is only used for development.
+type DependencyGraphSnapshotResolvedDependencyScope string
 
-type DependencyScope string
+// DependencyGraphSnapshotCreationResult represents the snapshot creation result.
+//
+// Can have the following values:
+//   - "SUCCESS": indicates that the snapshot was successfully created and the repository's dependencies were updated.
+//   - "ACCEPTED": indicates that the snapshot was successfully created, but the repository's dependencies were not updated.
+//   - "INVALID": indicates that the snapshot was malformed.
+type DependencyGraphSnapshotCreationResult string
 
-const (
-	RUNTIME     DependencyScope = "runtime"
-	DEVELOPMENT                 = "development"
-)
-
-type SnapshotCreationResult string
-
-const (
-	SUCCESS  SnapshotCreationResult = "SUCCESS"
-	ACCEPTED                        = "ACCEPTED"
-	INVALID                         = "INVALID"
-)
-
-type Resolved struct {
-	PackageUrl   *string                `json:"package_url,omitempty"`
-	Relationship DependencyRelationship `json:"relationship,omitempty"`
-	Scope        DependencyScope        `json:"scope,omitempty"`
-	Dependencies []string               `json:"dependencies,omitempty"`
+type DependencyGraphSnapshotResolvedDependency struct {
+	PackageUrl   *string                                               `json:"package_url,omitempty"`
+	Relationship DependencyGraphSnapshotResolvedDependencyRelationship `json:"relationship,omitempty"`
+	Scope        DependencyGraphSnapshotResolvedDependencyScope        `json:"scope,omitempty"`
+	Dependencies []string                                              `json:"dependencies,omitempty"`
 }
 
-type Job struct {
+type DependencyGraphSnapshotJob struct {
 	Correlator *string `json:"correlator,omitempty"`
 	ID         *string `json:"id,omitempty"`
 	HtmlUrl    *string `json:"html_url,omitempty"`
 }
 
-type Detector struct {
+type DependencyGraphSnapshotDetector struct {
 	Name    *string `json:"name,omitempty"`
 	Version *string `json:"version,omitempty"`
 	URL     *string `json:"url,omitempty"`
 }
 
-type File struct {
+type DependencyGraphSnapshotManifestFile struct {
 	SourceLocation *string `json:"source_location,omitempty"`
 }
 
-type Manifest struct {
-	Name     *string              `json:"name,omitempty"`
-	File     *File                `json:"file,omitempty"`
-	Resolved map[string]*Resolved `json:"resolved,omitempty"`
+type DependencyGraphSnapshotManifest struct {
+	Name     *string                                               `json:"name,omitempty"`
+	File     *DependencyGraphSnapshotManifestFile                  `json:"file,omitempty"`
+	Resolved map[string]*DependencyGraphSnapshotResolvedDependency `json:"resolved,omitempty"`
 }
 
-type Snapshot struct {
-	Version   int                  `json:"version"`
-	Sha       *string              `json:"sha,omitempty"`
-	Ref       *string              `json:"ref,omitempty"`
-	Job       *Job                 `json:"job,omitempty"`
-	Detector  *Detector            `json:"detector,omitempty"`
-	Scanned   *Timestamp           `json:"scanned,omitempty"`
-	Manifests map[string]*Manifest `json:"manifests,omitempty"`
+type DependencyGraphSnapshot struct {
+	Version   int                                         `json:"version"`
+	Sha       *string                                     `json:"sha,omitempty"`
+	Ref       *string                                     `json:"ref,omitempty"`
+	Job       *DependencyGraphSnapshotJob                 `json:"job,omitempty"`
+	Detector  *DependencyGraphSnapshotDetector            `json:"detector,omitempty"`
+	Scanned   *Timestamp                                  `json:"scanned,omitempty"`
+	Manifests map[string]*DependencyGraphSnapshotManifest `json:"manifests,omitempty"`
 }
 
-type SnapshotCreationData struct {
-	ID        int                    `json:"id"`
-	CreatedAt *Timestamp             `json:"created_at"`
-	Message   *string                `json:"message"`
-	Result    SnapshotCreationResult `json:"result"`
+type DependencyGraphSnapshotCreationData struct {
+	ID        int                                   `json:"id"`
+	CreatedAt *Timestamp                            `json:"created_at"`
+	Message   *string                               `json:"message"`
+	Result    DependencyGraphSnapshotCreationResult `json:"result"`
 }
 
-// Create a new snapshot of a repository's dependencies.
+// CreateSnapshot creates a new snapshot of a repository's dependencies.
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
-func (s *DependencyGraphService) CreateSnapshot(ctx context.Context, owner, repo string, snapshot *Snapshot) (*SnapshotCreationData, *Response, error) {
+func (s *DependencyGraphService) CreateSnapshot(ctx context.Context, owner, repo string, dependencyGraphSnapshot *DependencyGraphSnapshot) (*DependencyGraphSnapshotCreationData, *Response, error) {
 	url := fmt.Sprintf("repos/%v/%v/dependency-graph/snapshots", owner, repo)
 
-	req, err := s.client.NewRequest("POST", url, snapshot)
+	req, err := s.client.NewRequest("POST", url, dependencyGraphSnapshot)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var spanshotCreationData *SnapshotCreationData
-	resp, err := s.client.Do(ctx, req, &spanshotCreationData)
+	var snapshotCreationData *DependencyGraphSnapshotCreationData
+	resp, err := s.client.Do(ctx, req, &snapshotCreationData)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return spanshotCreationData, resp, nil
+	return snapshotCreationData, resp, nil
 }

--- a/github/dependency_graph_snapshots.go
+++ b/github/dependency_graph_snapshots.go
@@ -79,15 +79,15 @@ type DependencyGraphSnapshot struct {
 //
 // GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
 type DependencyGraphSnapshotCreationData struct {
-	ID        int        `json:"id"`
-	CreatedAt *Timestamp `json:"created_at"`
-	Message   *string    `json:"message"`
+	ID        int64        `json:"id"`
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
+	Message   *string    `json:"message,omitempty"`
 	// Represents the snapshot creation result.
 	// Can have the following values:
 	//   - "SUCCESS": indicates that the snapshot was successfully created and the repository's dependencies were updated.
 	//   - "ACCEPTED": indicates that the snapshot was successfully created, but the repository's dependencies were not updated.
 	//   - "INVALID": indicates that the snapshot was malformed.
-	Result *string `json:"result"`
+	Result *string `json:"result,omitempty"`
 }
 
 // CreateSnapshot creates a new snapshot of a repository's dependencies.

--- a/github/dependency_graph_snapshots.go
+++ b/github/dependency_graph_snapshots.go
@@ -79,7 +79,7 @@ type DependencyGraphSnapshot struct {
 //
 // GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
 type DependencyGraphSnapshotCreationData struct {
-	ID        int64        `json:"id"`
+	ID        int64      `json:"id"`
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 	Message   *string    `json:"message,omitempty"`
 	// Represents the snapshot creation result.

--- a/github/dependency_graph_snapshots_test.go
+++ b/github/dependency_graph_snapshots_test.go
@@ -26,42 +26,42 @@ func TestDependencyGraphService_CreateSnapshot(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	snapshot := &Snapshot{
+	snapshot := &DependencyGraphSnapshot{
 		Version: 0,
 		Sha:     String("ce587453ced02b1526dfb4cb910479d431683101"),
 		Ref:     String("refs/heads/main"),
-		Job: &Job{
+		Job: &DependencyGraphSnapshotJob{
 			Correlator: String("yourworkflowname_youractionname"),
 			ID:         String("yourrunid"),
 			HtmlUrl:    String("https://example.com"),
 		},
-		Detector: &Detector{
+		Detector: &DependencyGraphSnapshotDetector{
 			Name:    String("octo-detector"),
 			Version: String("0.0.1"),
 			URL:     String("https://github.com/octo-org/octo-repo"),
 		},
 		Scanned: &Timestamp{time.Date(2022, time.June, 14, 20, 25, 00, 0, time.UTC)},
-		Manifests: map[string]*Manifest{
-			"package-lock.json": &Manifest{
+		Manifests: map[string]*DependencyGraphSnapshotManifest{
+			"package-lock.json": &DependencyGraphSnapshotManifest{
 				Name: String("package-lock.json"),
-				File: &File{SourceLocation: String("src/package-lock.json")},
-				Resolved: map[string]*Resolved{
-					"@actions/core": &Resolved{
+				File: &DependencyGraphSnapshotManifestFile{SourceLocation: String("src/package-lock.json")},
+				Resolved: map[string]*DependencyGraphSnapshotResolvedDependency{
+					"@actions/core": &DependencyGraphSnapshotResolvedDependency{
 						PackageUrl:   String("pkg:/npm/%40actions/core@1.1.9"),
-						Relationship: DIRECT,
-						Scope:        RUNTIME,
+						Relationship: "direct",
+						Scope:        "runtime",
 						Dependencies: []string{"@actions/http-client"},
 					},
-					"@actions/http-client": &Resolved{
+					"@actions/http-client": &DependencyGraphSnapshotResolvedDependency{
 						PackageUrl:   String("pkg:/npm/%40actions/http-client@1.0.7"),
-						Relationship: INDIRECT,
-						Scope:        RUNTIME,
+						Relationship: "indirect",
+						Scope:        "runtime",
 						Dependencies: []string{"tunnel"},
 					},
-					"tunnel": &Resolved{
+					"tunnel": &DependencyGraphSnapshotResolvedDependency{
 						PackageUrl:   String("pkg:/npm/tunnel@0.0.6"),
-						Relationship: INDIRECT,
-						Scope:        RUNTIME,
+						Relationship: "indirect",
+						Scope:        "runtime",
 					},
 				},
 			},
@@ -73,11 +73,11 @@ func TestDependencyGraphService_CreateSnapshot(t *testing.T) {
 		t.Errorf("DependencyGraph.CreateSnapshot returned error: %v", err)
 	}
 
-	want := &SnapshotCreationData{
+	want := &DependencyGraphSnapshotCreationData{
 		ID:        12345,
 		CreatedAt: &Timestamp{time.Date(2022, time.June, 14, 20, 25, 01, 0, time.UTC)},
 		Message:   String("Dependency results for the repo have been successfully updated."),
-		Result:    SUCCESS,
+		Result:    "SUCCESS",
 	}
 	if !cmp.Equal(snapshotCreationData, want) {
 		t.Errorf("DependencyGraph.CreateSnapshot returned %+v, want %+v", snapshotCreationData, want)

--- a/github/dependency_graph_snapshots_test.go
+++ b/github/dependency_graph_snapshots_test.go
@@ -42,23 +42,23 @@ func TestDependencyGraphService_CreateSnapshot(t *testing.T) {
 		},
 		Scanned: &Timestamp{time.Date(2022, time.June, 14, 20, 25, 00, 0, time.UTC)},
 		Manifests: map[string]*DependencyGraphSnapshotManifest{
-			"package-lock.json": &DependencyGraphSnapshotManifest{
+			"package-lock.json": {
 				Name: String("package-lock.json"),
 				File: &DependencyGraphSnapshotManifestFile{SourceLocation: String("src/package-lock.json")},
 				Resolved: map[string]*DependencyGraphSnapshotResolvedDependency{
-					"@actions/core": &DependencyGraphSnapshotResolvedDependency{
+					"@actions/core": {
 						PackageUrl:   String("pkg:/npm/%40actions/core@1.1.9"),
 						Relationship: "direct",
 						Scope:        "runtime",
 						Dependencies: []string{"@actions/http-client"},
 					},
-					"@actions/http-client": &DependencyGraphSnapshotResolvedDependency{
+					"@actions/http-client": {
 						PackageUrl:   String("pkg:/npm/%40actions/http-client@1.0.7"),
 						Relationship: "indirect",
 						Scope:        "runtime",
 						Dependencies: []string{"tunnel"},
 					},
-					"tunnel": &DependencyGraphSnapshotResolvedDependency{
+					"tunnel": {
 						PackageUrl:   String("pkg:/npm/tunnel@0.0.6"),
 						Relationship: "indirect",
 						Scope:        "runtime",

--- a/github/dependency_graph_snapshots_test.go
+++ b/github/dependency_graph_snapshots_test.go
@@ -33,7 +33,7 @@ func TestDependencyGraphService_CreateSnapshot(t *testing.T) {
 		Job: &DependencyGraphSnapshotJob{
 			Correlator: String("yourworkflowname_youractionname"),
 			ID:         String("yourrunid"),
-			HtmlUrl:    String("https://example.com"),
+			HTMLURL:    String("https://example.com"),
 		},
 		Detector: &DependencyGraphSnapshotDetector{
 			Name:    String("octo-detector"),
@@ -47,19 +47,19 @@ func TestDependencyGraphService_CreateSnapshot(t *testing.T) {
 				File: &DependencyGraphSnapshotManifestFile{SourceLocation: String("src/package-lock.json")},
 				Resolved: map[string]*DependencyGraphSnapshotResolvedDependency{
 					"@actions/core": {
-						PackageUrl:   String("pkg:/npm/%40actions/core@1.1.9"),
+						PackageURL:   String("pkg:/npm/%40actions/core@1.1.9"),
 						Relationship: "direct",
 						Scope:        "runtime",
 						Dependencies: []string{"@actions/http-client"},
 					},
 					"@actions/http-client": {
-						PackageUrl:   String("pkg:/npm/%40actions/http-client@1.0.7"),
+						PackageURL:   String("pkg:/npm/%40actions/http-client@1.0.7"),
 						Relationship: "indirect",
 						Scope:        "runtime",
 						Dependencies: []string{"tunnel"},
 					},
 					"tunnel": {
-						PackageUrl:   String("pkg:/npm/tunnel@0.0.6"),
+						PackageURL:   String("pkg:/npm/tunnel@0.0.6"),
 						Relationship: "indirect",
 						Scope:        "runtime",
 					},

--- a/github/dependency_graph_snapshots_test.go
+++ b/github/dependency_graph_snapshots_test.go
@@ -1,0 +1,94 @@
+// Copyright 2023 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDependencyGraphService_CreateSnapshot(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/dependency-graph/snapshots", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testBody(t, r, `{"version":0,"sha":"ce587453ced02b1526dfb4cb910479d431683101","ref":"refs/heads/main","job":{"correlator":"yourworkflowname_youractionname","id":"yourrunid","html_url":"https://example.com"},"detector":{"name":"octo-detector","version":"0.0.1","url":"https://github.com/octo-org/octo-repo"},"scanned":"2022-06-14T20:25:00Z","manifests":{"package-lock.json":{"name":"package-lock.json","file":{"source_location":"src/package-lock.json"},"resolved":{"@actions/core":{"package_url":"pkg:/npm/%40actions/core@1.1.9","relationship":"direct","scope":"runtime","dependencies":["@actions/http-client"]},"@actions/http-client":{"package_url":"pkg:/npm/%40actions/http-client@1.0.7","relationship":"indirect","scope":"runtime","dependencies":["tunnel"]},"tunnel":{"package_url":"pkg:/npm/tunnel@0.0.6","relationship":"indirect","scope":"runtime"}}}}}`+"\n")
+		fmt.Fprint(w, `{"id":12345,"created_at":"2022-06-14T20:25:01Z","message":"Dependency results for the repo have been successfully updated.","result":"SUCCESS"}`)
+	})
+
+	ctx := context.Background()
+	snapshot := &Snapshot{
+		Version: 0,
+		Sha:     String("ce587453ced02b1526dfb4cb910479d431683101"),
+		Ref:     String("refs/heads/main"),
+		Job: &Job{
+			Correlator: String("yourworkflowname_youractionname"),
+			ID:         String("yourrunid"),
+			HtmlUrl:    String("https://example.com"),
+		},
+		Detector: &Detector{
+			Name:    String("octo-detector"),
+			Version: String("0.0.1"),
+			URL:     String("https://github.com/octo-org/octo-repo"),
+		},
+		Scanned: &Timestamp{time.Date(2022, time.June, 14, 20, 25, 00, 0, time.UTC)},
+		Manifests: map[string]*Manifest{
+			"package-lock.json": &Manifest{
+				Name: String("package-lock.json"),
+				File: &File{SourceLocation: String("src/package-lock.json")},
+				Resolved: map[string]*Resolved{
+					"@actions/core": &Resolved{
+						PackageUrl:   String("pkg:/npm/%40actions/core@1.1.9"),
+						Relationship: DIRECT,
+						Scope:        RUNTIME,
+						Dependencies: []string{"@actions/http-client"},
+					},
+					"@actions/http-client": &Resolved{
+						PackageUrl:   String("pkg:/npm/%40actions/http-client@1.0.7"),
+						Relationship: INDIRECT,
+						Scope:        RUNTIME,
+						Dependencies: []string{"tunnel"},
+					},
+					"tunnel": &Resolved{
+						PackageUrl:   String("pkg:/npm/tunnel@0.0.6"),
+						Relationship: INDIRECT,
+						Scope:        RUNTIME,
+					},
+				},
+			},
+		},
+	}
+
+	snapshotCreationData, _, err := client.DependencyGraph.CreateSnapshot(ctx, "o", "r", snapshot)
+	if err != nil {
+		t.Errorf("DependencyGraph.CreateSnapshot returned error: %v", err)
+	}
+
+	want := &SnapshotCreationData{
+		ID:        12345,
+		CreatedAt: &Timestamp{time.Date(2022, time.June, 14, 20, 25, 01, 0, time.UTC)},
+		Message:   String("Dependency results for the repo have been successfully updated."),
+		Result:    SUCCESS,
+	}
+	if !cmp.Equal(snapshotCreationData, want) {
+		t.Errorf("DependencyGraph.CreateSnapshot returned %+v, want %+v", snapshotCreationData, want)
+	}
+
+	const methodName = "CreateSnapshot"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.DependencyGraph.CreateSnapshot(ctx, "o", "r", snapshot)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}

--- a/github/dependency_graph_snapshots_test.go
+++ b/github/dependency_graph_snapshots_test.go
@@ -48,20 +48,20 @@ func TestDependencyGraphService_CreateSnapshot(t *testing.T) {
 				Resolved: map[string]*DependencyGraphSnapshotResolvedDependency{
 					"@actions/core": {
 						PackageURL:   String("pkg:/npm/%40actions/core@1.1.9"),
-						Relationship: "direct",
-						Scope:        "runtime",
+						Relationship: String("direct"),
+						Scope:        String("runtime"),
 						Dependencies: []string{"@actions/http-client"},
 					},
 					"@actions/http-client": {
 						PackageURL:   String("pkg:/npm/%40actions/http-client@1.0.7"),
-						Relationship: "indirect",
-						Scope:        "runtime",
+						Relationship: String("indirect"),
+						Scope:        String("runtime"),
 						Dependencies: []string{"tunnel"},
 					},
 					"tunnel": {
 						PackageURL:   String("pkg:/npm/tunnel@0.0.6"),
-						Relationship: "indirect",
-						Scope:        "runtime",
+						Relationship: String("indirect"),
+						Scope:        String("runtime"),
 					},
 				},
 			},
@@ -77,7 +77,7 @@ func TestDependencyGraphService_CreateSnapshot(t *testing.T) {
 		ID:        12345,
 		CreatedAt: &Timestamp{time.Date(2022, time.June, 14, 20, 25, 01, 0, time.UTC)},
 		Message:   String("Dependency results for the repo have been successfully updated."),
-		Result:    "SUCCESS",
+		Result:    String("SUCCESS"),
 	}
 	if !cmp.Equal(snapshotCreationData, want) {
 		t.Errorf("DependencyGraph.CreateSnapshot returned %+v, want %+v", snapshotCreationData, want)

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -5262,6 +5262,14 @@ func (d *DependencyGraphSnapshotCreationData) GetMessage() string {
 	return *d.Message
 }
 
+// GetResult returns the Result field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotCreationData) GetResult() string {
+	if d == nil || d.Result == nil {
+		return ""
+	}
+	return *d.Result
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (d *DependencyGraphSnapshotDetector) GetName() string {
 	if d == nil || d.Name == nil {
@@ -5340,6 +5348,22 @@ func (d *DependencyGraphSnapshotResolvedDependency) GetPackageURL() string {
 		return ""
 	}
 	return *d.PackageURL
+}
+
+// GetRelationship returns the Relationship field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotResolvedDependency) GetRelationship() string {
+	if d == nil || d.Relationship == nil {
+		return ""
+	}
+	return *d.Relationship
+}
+
+// GetScope returns the Scope field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotResolvedDependency) GetScope() string {
+	if d == nil || d.Scope == nil {
+		return ""
+	}
+	return *d.Scope
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -5814,6 +5814,30 @@ func (d *DeploymentStatusRequest) GetState() string {
 	return *d.State
 }
 
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (d *Detector) GetName() string {
+	if d == nil || d.Name == nil {
+		return ""
+	}
+	return *d.Name
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (d *Detector) GetURL() string {
+	if d == nil || d.URL == nil {
+		return ""
+	}
+	return *d.URL
+}
+
+// GetVersion returns the Version field if it's non-nil, zero value otherwise.
+func (d *Detector) GetVersion() string {
+	if d == nil || d.Version == nil {
+		return ""
+	}
+	return *d.Version
+}
+
 // GetActiveLockReason returns the ActiveLockReason field if it's non-nil, zero value otherwise.
 func (d *Discussion) GetActiveLockReason() string {
 	if d == nil || d.ActiveLockReason == nil {
@@ -7116,6 +7140,14 @@ func (f *Feeds) GetUserURL() string {
 		return ""
 	}
 	return *f.UserURL
+}
+
+// GetSourceLocation returns the SourceLocation field if it's non-nil, zero value otherwise.
+func (f *File) GetSourceLocation() string {
+	if f == nil || f.SourceLocation == nil {
+		return ""
+	}
+	return *f.SourceLocation
 }
 
 // GetIdentifier returns the Identifier field if it's non-nil, zero value otherwise.
@@ -10102,6 +10134,30 @@ func (j *JITRunnerConfig) GetRunner() *Runner {
 	return j.Runner
 }
 
+// GetCorrelator returns the Correlator field if it's non-nil, zero value otherwise.
+func (j *Job) GetCorrelator() string {
+	if j == nil || j.Correlator == nil {
+		return ""
+	}
+	return *j.Correlator
+}
+
+// GetHtmlUrl returns the HtmlUrl field if it's non-nil, zero value otherwise.
+func (j *Job) GetHtmlUrl() string {
+	if j == nil || j.HtmlUrl == nil {
+		return ""
+	}
+	return *j.HtmlUrl
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (j *Job) GetID() string {
+	if j == nil || j.ID == nil {
+		return ""
+	}
+	return *j.ID
+}
+
 // GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
 func (j *Jobs) GetTotalCount() int {
 	if j == nil || j.TotalCount == nil {
@@ -10828,6 +10884,22 @@ func (l *LockBranch) GetEnabled() bool {
 		return false
 	}
 	return *l.Enabled
+}
+
+// GetFile returns the File field.
+func (m *Manifest) GetFile() *File {
+	if m == nil {
+		return nil
+	}
+	return m.File
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (m *Manifest) GetName() string {
+	if m == nil || m.Name == nil {
+		return ""
+	}
+	return *m.Name
 }
 
 // GetEffectiveDate returns the EffectiveDate field if it's non-nil, zero value otherwise.
@@ -20398,6 +20470,14 @@ func (r *RequiredWorkflowSelectedRepos) GetTotalCount() int {
 	return *r.TotalCount
 }
 
+// GetPackageUrl returns the PackageUrl field if it's non-nil, zero value otherwise.
+func (r *Resolved) GetPackageUrl() string {
+	if r == nil || r.PackageUrl == nil {
+		return ""
+	}
+	return *r.PackageUrl
+}
+
 // GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
 func (r *ReviewersRequest) GetNodeID() string {
 	if r == nil || r.NodeID == nil {
@@ -21876,6 +21956,62 @@ func (s *SignatureVerification) GetVerified() bool {
 		return false
 	}
 	return *s.Verified
+}
+
+// GetDetector returns the Detector field.
+func (s *Snapshot) GetDetector() *Detector {
+	if s == nil {
+		return nil
+	}
+	return s.Detector
+}
+
+// GetJob returns the Job field.
+func (s *Snapshot) GetJob() *Job {
+	if s == nil {
+		return nil
+	}
+	return s.Job
+}
+
+// GetRef returns the Ref field if it's non-nil, zero value otherwise.
+func (s *Snapshot) GetRef() string {
+	if s == nil || s.Ref == nil {
+		return ""
+	}
+	return *s.Ref
+}
+
+// GetScanned returns the Scanned field if it's non-nil, zero value otherwise.
+func (s *Snapshot) GetScanned() Timestamp {
+	if s == nil || s.Scanned == nil {
+		return Timestamp{}
+	}
+	return *s.Scanned
+}
+
+// GetSha returns the Sha field if it's non-nil, zero value otherwise.
+func (s *Snapshot) GetSha() string {
+	if s == nil || s.Sha == nil {
+		return ""
+	}
+	return *s.Sha
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (s *SnapshotCreationData) GetCreatedAt() Timestamp {
+	if s == nil || s.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *s.CreatedAt
+}
+
+// GetMessage returns the Message field if it's non-nil, zero value otherwise.
+func (s *SnapshotCreationData) GetMessage() string {
+	if s == nil || s.Message == nil {
+		return ""
+	}
+	return *s.Message
 }
 
 // GetActor returns the Actor field.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -5294,12 +5294,12 @@ func (d *DependencyGraphSnapshotJob) GetCorrelator() string {
 	return *d.Correlator
 }
 
-// GetHtmlUrl returns the HtmlUrl field if it's non-nil, zero value otherwise.
-func (d *DependencyGraphSnapshotJob) GetHtmlUrl() string {
-	if d == nil || d.HtmlUrl == nil {
+// GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotJob) GetHTMLURL() string {
+	if d == nil || d.HTMLURL == nil {
 		return ""
 	}
-	return *d.HtmlUrl
+	return *d.HTMLURL
 }
 
 // GetID returns the ID field if it's non-nil, zero value otherwise.
@@ -5334,12 +5334,12 @@ func (d *DependencyGraphSnapshotManifestFile) GetSourceLocation() string {
 	return *d.SourceLocation
 }
 
-// GetPackageUrl returns the PackageUrl field if it's non-nil, zero value otherwise.
-func (d *DependencyGraphSnapshotResolvedDependency) GetPackageUrl() string {
-	if d == nil || d.PackageUrl == nil {
+// GetPackageURL returns the PackageURL field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotResolvedDependency) GetPackageURL() string {
+	if d == nil || d.PackageURL == nil {
 		return ""
 	}
-	return *d.PackageUrl
+	return *d.PackageURL
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -5206,6 +5206,142 @@ func (d *Dependency) GetScope() string {
 	return *d.Scope
 }
 
+// GetDetector returns the Detector field.
+func (d *DependencyGraphSnapshot) GetDetector() *DependencyGraphSnapshotDetector {
+	if d == nil {
+		return nil
+	}
+	return d.Detector
+}
+
+// GetJob returns the Job field.
+func (d *DependencyGraphSnapshot) GetJob() *DependencyGraphSnapshotJob {
+	if d == nil {
+		return nil
+	}
+	return d.Job
+}
+
+// GetRef returns the Ref field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshot) GetRef() string {
+	if d == nil || d.Ref == nil {
+		return ""
+	}
+	return *d.Ref
+}
+
+// GetScanned returns the Scanned field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshot) GetScanned() Timestamp {
+	if d == nil || d.Scanned == nil {
+		return Timestamp{}
+	}
+	return *d.Scanned
+}
+
+// GetSha returns the Sha field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshot) GetSha() string {
+	if d == nil || d.Sha == nil {
+		return ""
+	}
+	return *d.Sha
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotCreationData) GetCreatedAt() Timestamp {
+	if d == nil || d.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *d.CreatedAt
+}
+
+// GetMessage returns the Message field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotCreationData) GetMessage() string {
+	if d == nil || d.Message == nil {
+		return ""
+	}
+	return *d.Message
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotDetector) GetName() string {
+	if d == nil || d.Name == nil {
+		return ""
+	}
+	return *d.Name
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotDetector) GetURL() string {
+	if d == nil || d.URL == nil {
+		return ""
+	}
+	return *d.URL
+}
+
+// GetVersion returns the Version field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotDetector) GetVersion() string {
+	if d == nil || d.Version == nil {
+		return ""
+	}
+	return *d.Version
+}
+
+// GetCorrelator returns the Correlator field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotJob) GetCorrelator() string {
+	if d == nil || d.Correlator == nil {
+		return ""
+	}
+	return *d.Correlator
+}
+
+// GetHtmlUrl returns the HtmlUrl field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotJob) GetHtmlUrl() string {
+	if d == nil || d.HtmlUrl == nil {
+		return ""
+	}
+	return *d.HtmlUrl
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotJob) GetID() string {
+	if d == nil || d.ID == nil {
+		return ""
+	}
+	return *d.ID
+}
+
+// GetFile returns the File field.
+func (d *DependencyGraphSnapshotManifest) GetFile() *DependencyGraphSnapshotManifestFile {
+	if d == nil {
+		return nil
+	}
+	return d.File
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotManifest) GetName() string {
+	if d == nil || d.Name == nil {
+		return ""
+	}
+	return *d.Name
+}
+
+// GetSourceLocation returns the SourceLocation field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotManifestFile) GetSourceLocation() string {
+	if d == nil || d.SourceLocation == nil {
+		return ""
+	}
+	return *d.SourceLocation
+}
+
+// GetPackageUrl returns the PackageUrl field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshotResolvedDependency) GetPackageUrl() string {
+	if d == nil || d.PackageUrl == nil {
+		return ""
+	}
+	return *d.PackageUrl
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (d *DeployKeyEvent) GetAction() string {
 	if d == nil || d.Action == nil {
@@ -5812,30 +5948,6 @@ func (d *DeploymentStatusRequest) GetState() string {
 		return ""
 	}
 	return *d.State
-}
-
-// GetName returns the Name field if it's non-nil, zero value otherwise.
-func (d *Detector) GetName() string {
-	if d == nil || d.Name == nil {
-		return ""
-	}
-	return *d.Name
-}
-
-// GetURL returns the URL field if it's non-nil, zero value otherwise.
-func (d *Detector) GetURL() string {
-	if d == nil || d.URL == nil {
-		return ""
-	}
-	return *d.URL
-}
-
-// GetVersion returns the Version field if it's non-nil, zero value otherwise.
-func (d *Detector) GetVersion() string {
-	if d == nil || d.Version == nil {
-		return ""
-	}
-	return *d.Version
 }
 
 // GetActiveLockReason returns the ActiveLockReason field if it's non-nil, zero value otherwise.
@@ -7140,14 +7252,6 @@ func (f *Feeds) GetUserURL() string {
 		return ""
 	}
 	return *f.UserURL
-}
-
-// GetSourceLocation returns the SourceLocation field if it's non-nil, zero value otherwise.
-func (f *File) GetSourceLocation() string {
-	if f == nil || f.SourceLocation == nil {
-		return ""
-	}
-	return *f.SourceLocation
 }
 
 // GetIdentifier returns the Identifier field if it's non-nil, zero value otherwise.
@@ -10134,30 +10238,6 @@ func (j *JITRunnerConfig) GetRunner() *Runner {
 	return j.Runner
 }
 
-// GetCorrelator returns the Correlator field if it's non-nil, zero value otherwise.
-func (j *Job) GetCorrelator() string {
-	if j == nil || j.Correlator == nil {
-		return ""
-	}
-	return *j.Correlator
-}
-
-// GetHtmlUrl returns the HtmlUrl field if it's non-nil, zero value otherwise.
-func (j *Job) GetHtmlUrl() string {
-	if j == nil || j.HtmlUrl == nil {
-		return ""
-	}
-	return *j.HtmlUrl
-}
-
-// GetID returns the ID field if it's non-nil, zero value otherwise.
-func (j *Job) GetID() string {
-	if j == nil || j.ID == nil {
-		return ""
-	}
-	return *j.ID
-}
-
 // GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
 func (j *Jobs) GetTotalCount() int {
 	if j == nil || j.TotalCount == nil {
@@ -10884,22 +10964,6 @@ func (l *LockBranch) GetEnabled() bool {
 		return false
 	}
 	return *l.Enabled
-}
-
-// GetFile returns the File field.
-func (m *Manifest) GetFile() *File {
-	if m == nil {
-		return nil
-	}
-	return m.File
-}
-
-// GetName returns the Name field if it's non-nil, zero value otherwise.
-func (m *Manifest) GetName() string {
-	if m == nil || m.Name == nil {
-		return ""
-	}
-	return *m.Name
 }
 
 // GetEffectiveDate returns the EffectiveDate field if it's non-nil, zero value otherwise.
@@ -20470,14 +20534,6 @@ func (r *RequiredWorkflowSelectedRepos) GetTotalCount() int {
 	return *r.TotalCount
 }
 
-// GetPackageUrl returns the PackageUrl field if it's non-nil, zero value otherwise.
-func (r *Resolved) GetPackageUrl() string {
-	if r == nil || r.PackageUrl == nil {
-		return ""
-	}
-	return *r.PackageUrl
-}
-
 // GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
 func (r *ReviewersRequest) GetNodeID() string {
 	if r == nil || r.NodeID == nil {
@@ -21956,62 +22012,6 @@ func (s *SignatureVerification) GetVerified() bool {
 		return false
 	}
 	return *s.Verified
-}
-
-// GetDetector returns the Detector field.
-func (s *Snapshot) GetDetector() *Detector {
-	if s == nil {
-		return nil
-	}
-	return s.Detector
-}
-
-// GetJob returns the Job field.
-func (s *Snapshot) GetJob() *Job {
-	if s == nil {
-		return nil
-	}
-	return s.Job
-}
-
-// GetRef returns the Ref field if it's non-nil, zero value otherwise.
-func (s *Snapshot) GetRef() string {
-	if s == nil || s.Ref == nil {
-		return ""
-	}
-	return *s.Ref
-}
-
-// GetScanned returns the Scanned field if it's non-nil, zero value otherwise.
-func (s *Snapshot) GetScanned() Timestamp {
-	if s == nil || s.Scanned == nil {
-		return Timestamp{}
-	}
-	return *s.Scanned
-}
-
-// GetSha returns the Sha field if it's non-nil, zero value otherwise.
-func (s *Snapshot) GetSha() string {
-	if s == nil || s.Sha == nil {
-		return ""
-	}
-	return *s.Sha
-}
-
-// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
-func (s *SnapshotCreationData) GetCreatedAt() Timestamp {
-	if s == nil || s.CreatedAt == nil {
-		return Timestamp{}
-	}
-	return *s.CreatedAt
-}
-
-// GetMessage returns the Message field if it's non-nil, zero value otherwise.
-func (s *SnapshotCreationData) GetMessage() string {
-	if s == nil || s.Message == nil {
-		return ""
-	}
-	return *s.Message
 }
 
 // GetActor returns the Actor field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -6216,14 +6216,14 @@ func TestDependencyGraphSnapshotJob_GetCorrelator(tt *testing.T) {
 	d.GetCorrelator()
 }
 
-func TestDependencyGraphSnapshotJob_GetHtmlUrl(tt *testing.T) {
+func TestDependencyGraphSnapshotJob_GetHTMLURL(tt *testing.T) {
 	var zeroValue string
-	d := &DependencyGraphSnapshotJob{HtmlUrl: &zeroValue}
-	d.GetHtmlUrl()
+	d := &DependencyGraphSnapshotJob{HTMLURL: &zeroValue}
+	d.GetHTMLURL()
 	d = &DependencyGraphSnapshotJob{}
-	d.GetHtmlUrl()
+	d.GetHTMLURL()
 	d = nil
-	d.GetHtmlUrl()
+	d.GetHTMLURL()
 }
 
 func TestDependencyGraphSnapshotJob_GetID(tt *testing.T) {
@@ -6263,14 +6263,14 @@ func TestDependencyGraphSnapshotManifestFile_GetSourceLocation(tt *testing.T) {
 	d.GetSourceLocation()
 }
 
-func TestDependencyGraphSnapshotResolvedDependency_GetPackageUrl(tt *testing.T) {
+func TestDependencyGraphSnapshotResolvedDependency_GetPackageURL(tt *testing.T) {
 	var zeroValue string
-	d := &DependencyGraphSnapshotResolvedDependency{PackageUrl: &zeroValue}
-	d.GetPackageUrl()
+	d := &DependencyGraphSnapshotResolvedDependency{PackageURL: &zeroValue}
+	d.GetPackageURL()
 	d = &DependencyGraphSnapshotResolvedDependency{}
-	d.GetPackageUrl()
+	d.GetPackageURL()
 	d = nil
-	d.GetPackageUrl()
+	d.GetPackageURL()
 }
 
 func TestDeployKeyEvent_GetAction(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -6176,6 +6176,16 @@ func TestDependencyGraphSnapshotCreationData_GetMessage(tt *testing.T) {
 	d.GetMessage()
 }
 
+func TestDependencyGraphSnapshotCreationData_GetResult(tt *testing.T) {
+	var zeroValue string
+	d := &DependencyGraphSnapshotCreationData{Result: &zeroValue}
+	d.GetResult()
+	d = &DependencyGraphSnapshotCreationData{}
+	d.GetResult()
+	d = nil
+	d.GetResult()
+}
+
 func TestDependencyGraphSnapshotDetector_GetName(tt *testing.T) {
 	var zeroValue string
 	d := &DependencyGraphSnapshotDetector{Name: &zeroValue}
@@ -6271,6 +6281,26 @@ func TestDependencyGraphSnapshotResolvedDependency_GetPackageURL(tt *testing.T) 
 	d.GetPackageURL()
 	d = nil
 	d.GetPackageURL()
+}
+
+func TestDependencyGraphSnapshotResolvedDependency_GetRelationship(tt *testing.T) {
+	var zeroValue string
+	d := &DependencyGraphSnapshotResolvedDependency{Relationship: &zeroValue}
+	d.GetRelationship()
+	d = &DependencyGraphSnapshotResolvedDependency{}
+	d.GetRelationship()
+	d = nil
+	d.GetRelationship()
+}
+
+func TestDependencyGraphSnapshotResolvedDependency_GetScope(tt *testing.T) {
+	var zeroValue string
+	d := &DependencyGraphSnapshotResolvedDependency{Scope: &zeroValue}
+	d.GetScope()
+	d = &DependencyGraphSnapshotResolvedDependency{}
+	d.GetScope()
+	d = nil
+	d.GetScope()
 }
 
 func TestDeployKeyEvent_GetAction(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -6112,6 +6112,167 @@ func TestDependency_GetScope(tt *testing.T) {
 	d.GetScope()
 }
 
+func TestDependencyGraphSnapshot_GetDetector(tt *testing.T) {
+	d := &DependencyGraphSnapshot{}
+	d.GetDetector()
+	d = nil
+	d.GetDetector()
+}
+
+func TestDependencyGraphSnapshot_GetJob(tt *testing.T) {
+	d := &DependencyGraphSnapshot{}
+	d.GetJob()
+	d = nil
+	d.GetJob()
+}
+
+func TestDependencyGraphSnapshot_GetRef(tt *testing.T) {
+	var zeroValue string
+	d := &DependencyGraphSnapshot{Ref: &zeroValue}
+	d.GetRef()
+	d = &DependencyGraphSnapshot{}
+	d.GetRef()
+	d = nil
+	d.GetRef()
+}
+
+func TestDependencyGraphSnapshot_GetScanned(tt *testing.T) {
+	var zeroValue Timestamp
+	d := &DependencyGraphSnapshot{Scanned: &zeroValue}
+	d.GetScanned()
+	d = &DependencyGraphSnapshot{}
+	d.GetScanned()
+	d = nil
+	d.GetScanned()
+}
+
+func TestDependencyGraphSnapshot_GetSha(tt *testing.T) {
+	var zeroValue string
+	d := &DependencyGraphSnapshot{Sha: &zeroValue}
+	d.GetSha()
+	d = &DependencyGraphSnapshot{}
+	d.GetSha()
+	d = nil
+	d.GetSha()
+}
+
+func TestDependencyGraphSnapshotCreationData_GetCreatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	d := &DependencyGraphSnapshotCreationData{CreatedAt: &zeroValue}
+	d.GetCreatedAt()
+	d = &DependencyGraphSnapshotCreationData{}
+	d.GetCreatedAt()
+	d = nil
+	d.GetCreatedAt()
+}
+
+func TestDependencyGraphSnapshotCreationData_GetMessage(tt *testing.T) {
+	var zeroValue string
+	d := &DependencyGraphSnapshotCreationData{Message: &zeroValue}
+	d.GetMessage()
+	d = &DependencyGraphSnapshotCreationData{}
+	d.GetMessage()
+	d = nil
+	d.GetMessage()
+}
+
+func TestDependencyGraphSnapshotDetector_GetName(tt *testing.T) {
+	var zeroValue string
+	d := &DependencyGraphSnapshotDetector{Name: &zeroValue}
+	d.GetName()
+	d = &DependencyGraphSnapshotDetector{}
+	d.GetName()
+	d = nil
+	d.GetName()
+}
+
+func TestDependencyGraphSnapshotDetector_GetURL(tt *testing.T) {
+	var zeroValue string
+	d := &DependencyGraphSnapshotDetector{URL: &zeroValue}
+	d.GetURL()
+	d = &DependencyGraphSnapshotDetector{}
+	d.GetURL()
+	d = nil
+	d.GetURL()
+}
+
+func TestDependencyGraphSnapshotDetector_GetVersion(tt *testing.T) {
+	var zeroValue string
+	d := &DependencyGraphSnapshotDetector{Version: &zeroValue}
+	d.GetVersion()
+	d = &DependencyGraphSnapshotDetector{}
+	d.GetVersion()
+	d = nil
+	d.GetVersion()
+}
+
+func TestDependencyGraphSnapshotJob_GetCorrelator(tt *testing.T) {
+	var zeroValue string
+	d := &DependencyGraphSnapshotJob{Correlator: &zeroValue}
+	d.GetCorrelator()
+	d = &DependencyGraphSnapshotJob{}
+	d.GetCorrelator()
+	d = nil
+	d.GetCorrelator()
+}
+
+func TestDependencyGraphSnapshotJob_GetHtmlUrl(tt *testing.T) {
+	var zeroValue string
+	d := &DependencyGraphSnapshotJob{HtmlUrl: &zeroValue}
+	d.GetHtmlUrl()
+	d = &DependencyGraphSnapshotJob{}
+	d.GetHtmlUrl()
+	d = nil
+	d.GetHtmlUrl()
+}
+
+func TestDependencyGraphSnapshotJob_GetID(tt *testing.T) {
+	var zeroValue string
+	d := &DependencyGraphSnapshotJob{ID: &zeroValue}
+	d.GetID()
+	d = &DependencyGraphSnapshotJob{}
+	d.GetID()
+	d = nil
+	d.GetID()
+}
+
+func TestDependencyGraphSnapshotManifest_GetFile(tt *testing.T) {
+	d := &DependencyGraphSnapshotManifest{}
+	d.GetFile()
+	d = nil
+	d.GetFile()
+}
+
+func TestDependencyGraphSnapshotManifest_GetName(tt *testing.T) {
+	var zeroValue string
+	d := &DependencyGraphSnapshotManifest{Name: &zeroValue}
+	d.GetName()
+	d = &DependencyGraphSnapshotManifest{}
+	d.GetName()
+	d = nil
+	d.GetName()
+}
+
+func TestDependencyGraphSnapshotManifestFile_GetSourceLocation(tt *testing.T) {
+	var zeroValue string
+	d := &DependencyGraphSnapshotManifestFile{SourceLocation: &zeroValue}
+	d.GetSourceLocation()
+	d = &DependencyGraphSnapshotManifestFile{}
+	d.GetSourceLocation()
+	d = nil
+	d.GetSourceLocation()
+}
+
+func TestDependencyGraphSnapshotResolvedDependency_GetPackageUrl(tt *testing.T) {
+	var zeroValue string
+	d := &DependencyGraphSnapshotResolvedDependency{PackageUrl: &zeroValue}
+	d.GetPackageUrl()
+	d = &DependencyGraphSnapshotResolvedDependency{}
+	d.GetPackageUrl()
+	d = nil
+	d.GetPackageUrl()
+}
+
 func TestDeployKeyEvent_GetAction(tt *testing.T) {
 	var zeroValue string
 	d := &DeployKeyEvent{Action: &zeroValue}
@@ -6795,36 +6956,6 @@ func TestDeploymentStatusRequest_GetState(tt *testing.T) {
 	d.GetState()
 	d = nil
 	d.GetState()
-}
-
-func TestDetector_GetName(tt *testing.T) {
-	var zeroValue string
-	d := &Detector{Name: &zeroValue}
-	d.GetName()
-	d = &Detector{}
-	d.GetName()
-	d = nil
-	d.GetName()
-}
-
-func TestDetector_GetURL(tt *testing.T) {
-	var zeroValue string
-	d := &Detector{URL: &zeroValue}
-	d.GetURL()
-	d = &Detector{}
-	d.GetURL()
-	d = nil
-	d.GetURL()
-}
-
-func TestDetector_GetVersion(tt *testing.T) {
-	var zeroValue string
-	d := &Detector{Version: &zeroValue}
-	d.GetVersion()
-	d = &Detector{}
-	d.GetVersion()
-	d = nil
-	d.GetVersion()
 }
 
 func TestDiscussion_GetActiveLockReason(tt *testing.T) {
@@ -8341,16 +8472,6 @@ func TestFeeds_GetUserURL(tt *testing.T) {
 	f.GetUserURL()
 	f = nil
 	f.GetUserURL()
-}
-
-func TestFile_GetSourceLocation(tt *testing.T) {
-	var zeroValue string
-	f := &File{SourceLocation: &zeroValue}
-	f.GetSourceLocation()
-	f = &File{}
-	f.GetSourceLocation()
-	f = nil
-	f.GetSourceLocation()
 }
 
 func TestFirstPatchedVersion_GetIdentifier(tt *testing.T) {
@@ -11822,36 +11943,6 @@ func TestJITRunnerConfig_GetRunner(tt *testing.T) {
 	j.GetRunner()
 }
 
-func TestJob_GetCorrelator(tt *testing.T) {
-	var zeroValue string
-	j := &Job{Correlator: &zeroValue}
-	j.GetCorrelator()
-	j = &Job{}
-	j.GetCorrelator()
-	j = nil
-	j.GetCorrelator()
-}
-
-func TestJob_GetHtmlUrl(tt *testing.T) {
-	var zeroValue string
-	j := &Job{HtmlUrl: &zeroValue}
-	j.GetHtmlUrl()
-	j = &Job{}
-	j.GetHtmlUrl()
-	j = nil
-	j.GetHtmlUrl()
-}
-
-func TestJob_GetID(tt *testing.T) {
-	var zeroValue string
-	j := &Job{ID: &zeroValue}
-	j.GetID()
-	j = &Job{}
-	j.GetID()
-	j = nil
-	j.GetID()
-}
-
 func TestJobs_GetTotalCount(tt *testing.T) {
 	var zeroValue int
 	j := &Jobs{TotalCount: &zeroValue}
@@ -12739,23 +12830,6 @@ func TestLockBranch_GetEnabled(tt *testing.T) {
 	l.GetEnabled()
 	l = nil
 	l.GetEnabled()
-}
-
-func TestManifest_GetFile(tt *testing.T) {
-	m := &Manifest{}
-	m.GetFile()
-	m = nil
-	m.GetFile()
-}
-
-func TestManifest_GetName(tt *testing.T) {
-	var zeroValue string
-	m := &Manifest{Name: &zeroValue}
-	m.GetName()
-	m = &Manifest{}
-	m.GetName()
-	m = nil
-	m.GetName()
 }
 
 func TestMarketplacePendingChange_GetEffectiveDate(tt *testing.T) {
@@ -23776,16 +23850,6 @@ func TestRequiredWorkflowSelectedRepos_GetTotalCount(tt *testing.T) {
 	r.GetTotalCount()
 }
 
-func TestResolved_GetPackageUrl(tt *testing.T) {
-	var zeroValue string
-	r := &Resolved{PackageUrl: &zeroValue}
-	r.GetPackageUrl()
-	r = &Resolved{}
-	r.GetPackageUrl()
-	r = nil
-	r.GetPackageUrl()
-}
-
 func TestReviewersRequest_GetNodeID(tt *testing.T) {
 	var zeroValue string
 	r := &ReviewersRequest{NodeID: &zeroValue}
@@ -25502,70 +25566,6 @@ func TestSignatureVerification_GetVerified(tt *testing.T) {
 	s.GetVerified()
 	s = nil
 	s.GetVerified()
-}
-
-func TestSnapshot_GetDetector(tt *testing.T) {
-	s := &Snapshot{}
-	s.GetDetector()
-	s = nil
-	s.GetDetector()
-}
-
-func TestSnapshot_GetJob(tt *testing.T) {
-	s := &Snapshot{}
-	s.GetJob()
-	s = nil
-	s.GetJob()
-}
-
-func TestSnapshot_GetRef(tt *testing.T) {
-	var zeroValue string
-	s := &Snapshot{Ref: &zeroValue}
-	s.GetRef()
-	s = &Snapshot{}
-	s.GetRef()
-	s = nil
-	s.GetRef()
-}
-
-func TestSnapshot_GetScanned(tt *testing.T) {
-	var zeroValue Timestamp
-	s := &Snapshot{Scanned: &zeroValue}
-	s.GetScanned()
-	s = &Snapshot{}
-	s.GetScanned()
-	s = nil
-	s.GetScanned()
-}
-
-func TestSnapshot_GetSha(tt *testing.T) {
-	var zeroValue string
-	s := &Snapshot{Sha: &zeroValue}
-	s.GetSha()
-	s = &Snapshot{}
-	s.GetSha()
-	s = nil
-	s.GetSha()
-}
-
-func TestSnapshotCreationData_GetCreatedAt(tt *testing.T) {
-	var zeroValue Timestamp
-	s := &SnapshotCreationData{CreatedAt: &zeroValue}
-	s.GetCreatedAt()
-	s = &SnapshotCreationData{}
-	s.GetCreatedAt()
-	s = nil
-	s.GetCreatedAt()
-}
-
-func TestSnapshotCreationData_GetMessage(tt *testing.T) {
-	var zeroValue string
-	s := &SnapshotCreationData{Message: &zeroValue}
-	s.GetMessage()
-	s = &SnapshotCreationData{}
-	s.GetMessage()
-	s = nil
-	s.GetMessage()
 }
 
 func TestSource_GetActor(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -6797,6 +6797,36 @@ func TestDeploymentStatusRequest_GetState(tt *testing.T) {
 	d.GetState()
 }
 
+func TestDetector_GetName(tt *testing.T) {
+	var zeroValue string
+	d := &Detector{Name: &zeroValue}
+	d.GetName()
+	d = &Detector{}
+	d.GetName()
+	d = nil
+	d.GetName()
+}
+
+func TestDetector_GetURL(tt *testing.T) {
+	var zeroValue string
+	d := &Detector{URL: &zeroValue}
+	d.GetURL()
+	d = &Detector{}
+	d.GetURL()
+	d = nil
+	d.GetURL()
+}
+
+func TestDetector_GetVersion(tt *testing.T) {
+	var zeroValue string
+	d := &Detector{Version: &zeroValue}
+	d.GetVersion()
+	d = &Detector{}
+	d.GetVersion()
+	d = nil
+	d.GetVersion()
+}
+
 func TestDiscussion_GetActiveLockReason(tt *testing.T) {
 	var zeroValue string
 	d := &Discussion{ActiveLockReason: &zeroValue}
@@ -8311,6 +8341,16 @@ func TestFeeds_GetUserURL(tt *testing.T) {
 	f.GetUserURL()
 	f = nil
 	f.GetUserURL()
+}
+
+func TestFile_GetSourceLocation(tt *testing.T) {
+	var zeroValue string
+	f := &File{SourceLocation: &zeroValue}
+	f.GetSourceLocation()
+	f = &File{}
+	f.GetSourceLocation()
+	f = nil
+	f.GetSourceLocation()
 }
 
 func TestFirstPatchedVersion_GetIdentifier(tt *testing.T) {
@@ -11782,6 +11822,36 @@ func TestJITRunnerConfig_GetRunner(tt *testing.T) {
 	j.GetRunner()
 }
 
+func TestJob_GetCorrelator(tt *testing.T) {
+	var zeroValue string
+	j := &Job{Correlator: &zeroValue}
+	j.GetCorrelator()
+	j = &Job{}
+	j.GetCorrelator()
+	j = nil
+	j.GetCorrelator()
+}
+
+func TestJob_GetHtmlUrl(tt *testing.T) {
+	var zeroValue string
+	j := &Job{HtmlUrl: &zeroValue}
+	j.GetHtmlUrl()
+	j = &Job{}
+	j.GetHtmlUrl()
+	j = nil
+	j.GetHtmlUrl()
+}
+
+func TestJob_GetID(tt *testing.T) {
+	var zeroValue string
+	j := &Job{ID: &zeroValue}
+	j.GetID()
+	j = &Job{}
+	j.GetID()
+	j = nil
+	j.GetID()
+}
+
 func TestJobs_GetTotalCount(tt *testing.T) {
 	var zeroValue int
 	j := &Jobs{TotalCount: &zeroValue}
@@ -12669,6 +12739,23 @@ func TestLockBranch_GetEnabled(tt *testing.T) {
 	l.GetEnabled()
 	l = nil
 	l.GetEnabled()
+}
+
+func TestManifest_GetFile(tt *testing.T) {
+	m := &Manifest{}
+	m.GetFile()
+	m = nil
+	m.GetFile()
+}
+
+func TestManifest_GetName(tt *testing.T) {
+	var zeroValue string
+	m := &Manifest{Name: &zeroValue}
+	m.GetName()
+	m = &Manifest{}
+	m.GetName()
+	m = nil
+	m.GetName()
 }
 
 func TestMarketplacePendingChange_GetEffectiveDate(tt *testing.T) {
@@ -23689,6 +23776,16 @@ func TestRequiredWorkflowSelectedRepos_GetTotalCount(tt *testing.T) {
 	r.GetTotalCount()
 }
 
+func TestResolved_GetPackageUrl(tt *testing.T) {
+	var zeroValue string
+	r := &Resolved{PackageUrl: &zeroValue}
+	r.GetPackageUrl()
+	r = &Resolved{}
+	r.GetPackageUrl()
+	r = nil
+	r.GetPackageUrl()
+}
+
 func TestReviewersRequest_GetNodeID(tt *testing.T) {
 	var zeroValue string
 	r := &ReviewersRequest{NodeID: &zeroValue}
@@ -25405,6 +25502,70 @@ func TestSignatureVerification_GetVerified(tt *testing.T) {
 	s.GetVerified()
 	s = nil
 	s.GetVerified()
+}
+
+func TestSnapshot_GetDetector(tt *testing.T) {
+	s := &Snapshot{}
+	s.GetDetector()
+	s = nil
+	s.GetDetector()
+}
+
+func TestSnapshot_GetJob(tt *testing.T) {
+	s := &Snapshot{}
+	s.GetJob()
+	s = nil
+	s.GetJob()
+}
+
+func TestSnapshot_GetRef(tt *testing.T) {
+	var zeroValue string
+	s := &Snapshot{Ref: &zeroValue}
+	s.GetRef()
+	s = &Snapshot{}
+	s.GetRef()
+	s = nil
+	s.GetRef()
+}
+
+func TestSnapshot_GetScanned(tt *testing.T) {
+	var zeroValue Timestamp
+	s := &Snapshot{Scanned: &zeroValue}
+	s.GetScanned()
+	s = &Snapshot{}
+	s.GetScanned()
+	s = nil
+	s.GetScanned()
+}
+
+func TestSnapshot_GetSha(tt *testing.T) {
+	var zeroValue string
+	s := &Snapshot{Sha: &zeroValue}
+	s.GetSha()
+	s = &Snapshot{}
+	s.GetSha()
+	s = nil
+	s.GetSha()
+}
+
+func TestSnapshotCreationData_GetCreatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	s := &SnapshotCreationData{CreatedAt: &zeroValue}
+	s.GetCreatedAt()
+	s = &SnapshotCreationData{}
+	s.GetCreatedAt()
+	s = nil
+	s.GetCreatedAt()
+}
+
+func TestSnapshotCreationData_GetMessage(tt *testing.T) {
+	var zeroValue string
+	s := &SnapshotCreationData{Message: &zeroValue}
+	s.GetMessage()
+	s = &SnapshotCreationData{}
+	s.GetMessage()
+	s = nil
+	s.GetMessage()
 }
 
 func TestSource_GetActor(tt *testing.T) {


### PR DESCRIPTION
Starts Dependency Graph service support by starting with the [Create Snapshot](https://docs.github.com/en/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#create-a-snapshot-of-dependencies-for-a-repository) endpoint