### PR TITLE
Fix dropped test error

### DIFF
--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -498,9 +498,12 @@ func TestRepositoriesService_DownloadReleaseAsset_FollowRedirect(t *testing.T) {
 
 	ctx := context.Background()
 	reader, _, err := client.Repositories.DownloadReleaseAsset(ctx, "o", "r", 1, http.DefaultClient)
-	content, err := io.ReadAll(reader)
 	if err != nil {
 		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
+	}
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		t.Errorf("Reading Repositories.DownloadReleaseAsset returned error: %v", err)
 	}
 	reader.Close()
 	want := []byte("Hello World")


### PR DESCRIPTION
This picks up a dropped `err` variable in tests and clarifies the error message.