### PR TITLE
Defer closing body before checking HTTP status code

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -97,15 +97,17 @@ func (c *Client) get(urlStr string, a ...interface{}) (*goquery.Document, error)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URL: %q: %v", urlStr, err)
 	}
+
 	resp, err := c.Client.Get(u.String())
 	if err != nil {
 		return nil, fmt.Errorf("error fetching url %q: %v", u, err)
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("received %v response fetching URL %q", resp.StatusCode, u)
 	}
 
-	defer resp.Body.Close()
 	doc, err := goquery.NewDocumentFromReader(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing response: %v", err)


### PR DESCRIPTION
This is a quote from the [documentation](https://pkg.go.dev/net/http#example-Get) of the `net/http package`:
> When err is nil, resp always contains a non-nil resp.Body. Caller should close resp.Body when done reading from it.

In the current implementation, if the error code is 404, the response body will not close.