### PR TITLE
Fix SecretScanning API by switching arguments from url to json

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -20046,6 +20046,30 @@ func (s *SecretScanningAlertEvent) GetSender() *User {
 	return s.Sender
 }
 
+// GetResolution returns the Resolution field if it's non-nil, zero value otherwise.
+func (s *SecretScanningAlertListOptions) GetResolution() string {
+	if s == nil || s.Resolution == nil {
+		return ""
+	}
+	return *s.Resolution
+}
+
+// GetSecretType returns the SecretType field if it's non-nil, zero value otherwise.
+func (s *SecretScanningAlertListOptions) GetSecretType() string {
+	if s == nil || s.SecretType == nil {
+		return ""
+	}
+	return *s.SecretType
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (s *SecretScanningAlertListOptions) GetState() string {
+	if s == nil || s.State == nil {
+		return ""
+	}
+	return *s.State
+}
+
 // GetDetails returns the Details field.
 func (s *SecretScanningAlertLocation) GetDetails() *SecretScanningAlertLocationDetails {
 	if s == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -23381,6 +23381,36 @@ func TestSecretScanningAlertEvent_GetSender(tt *testing.T) {
 	s.GetSender()
 }
 
+func TestSecretScanningAlertListOptions_GetResolution(tt *testing.T) {
+	var zeroValue string
+	s := &SecretScanningAlertListOptions{Resolution: &zeroValue}
+	s.GetResolution()
+	s = &SecretScanningAlertListOptions{}
+	s.GetResolution()
+	s = nil
+	s.GetResolution()
+}
+
+func TestSecretScanningAlertListOptions_GetSecretType(tt *testing.T) {
+	var zeroValue string
+	s := &SecretScanningAlertListOptions{SecretType: &zeroValue}
+	s.GetSecretType()
+	s = &SecretScanningAlertListOptions{}
+	s.GetSecretType()
+	s = nil
+	s.GetSecretType()
+}
+
+func TestSecretScanningAlertListOptions_GetState(tt *testing.T) {
+	var zeroValue string
+	s := &SecretScanningAlertListOptions{State: &zeroValue}
+	s.GetState()
+	s = &SecretScanningAlertListOptions{}
+	s.GetState()
+	s = nil
+	s.GetState()
+}
+
 func TestSecretScanningAlertLocation_GetDetails(tt *testing.T) {
 	s := &SecretScanningAlertLocation{}
 	s.GetDetails()

--- a/github/secret_scanning.go
+++ b/github/secret_scanning.go
@@ -53,14 +53,14 @@ type SecretScanningAlertLocationDetails struct {
 // SecretScanningAlertListOptions specifies optional parameters to the SecretScanningService.ListAlertsForEnterprise method.
 type SecretScanningAlertListOptions struct {
 	// State of the secret scanning alerts to list. Set to open or resolved to only list secret scanning alerts in a specific state.
-	State string `json:"state,omitempty"`
+	State *string `json:"state,omitempty"`
 
 	// A comma-separated list of secret types to return. By default all secret types are returned.
-	SecretType string `json:"secret_type,omitempty"`
+	SecretType *string `json:"secret_type,omitempty"`
 
 	// A comma-separated list of resolutions. Only secret scanning alerts with one of these resolutions are listed.
 	// Valid resolutions are false_positive, wont_fix, revoked, pattern_edited, pattern_deleted or used_in_tests.
-	Resolution string `json:"resolution,omitempty"`
+	Resolution *string `json:"resolution,omitempty"`
 
 	ListCursorOptions
 

--- a/github/secret_scanning.go
+++ b/github/secret_scanning.go
@@ -53,14 +53,14 @@ type SecretScanningAlertLocationDetails struct {
 // SecretScanningAlertListOptions specifies optional parameters to the SecretScanningService.ListAlertsForEnterprise method.
 type SecretScanningAlertListOptions struct {
 	// State of the secret scanning alerts to list. Set to open or resolved to only list secret scanning alerts in a specific state.
-	State string `url:"state,omitempty"`
+	State string `json:"state,omitempty"`
 
 	// A comma-separated list of secret types to return. By default all secret types are returned.
-	SecretType string `url:"secret_type,omitempty"`
+	SecretType string `json:"secret_type,omitempty"`
 
 	// A comma-separated list of resolutions. Only secret scanning alerts with one of these resolutions are listed.
 	// Valid resolutions are false_positive, wont_fix, revoked, pattern_edited, pattern_deleted or used_in_tests.
-	Resolution string `url:"resolution,omitempty"`
+	Resolution string `json:"resolution,omitempty"`
 
 	ListCursorOptions
 
@@ -77,14 +77,14 @@ type SecretScanningAlertListOptions struct {
 type SecretScanningAlertUpdateOptions struct {
 	// Required. Sets the state of the secret scanning alert. Can be either open or resolved.
 	// You must provide resolution when you set the state to resolved.
-	State *string `url:"state,omitempty"`
+	State *string `json:"state,omitempty"`
 
 	// A comma-separated list of secret types to return. By default all secret types are returned.
-	SecretType *string `url:"secret_type,omitempty"`
+	SecretType *string `json:"secret_type,omitempty"`
 
 	// Required when the state is resolved. The reason for resolving the alert. Can be one of false_positive,
 	// wont_fix, revoked, or used_in_tests.
-	Resolution *string `url:"resolution,omitempty"`
+	Resolution *string `json:"resolution,omitempty"`
 }
 
 // Lists secret scanning alerts for eligible repositories in an enterprise, from newest to oldest.


### PR DESCRIPTION
These structs were incorrectly defined with `url` parameters, instead these need to be encoded into `json` for the request.