### PR TITLE
Replace deprectated crypto/ssh/terminal module in examples

### DIFF
--- a/example/basicauth/main.go
+++ b/example/basicauth/main.go
@@ -23,7 +23,7 @@ import (
 	"syscall"
 
 	"github.com/google/go-github/v53/github"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 func main() {
@@ -32,7 +32,7 @@ func main() {
 	username, _ := r.ReadString('\n')
 
 	fmt.Print("GitHub Password: ")
-	bytePassword, _ := terminal.ReadPassword(int(syscall.Stdin))
+	bytePassword, _ := term.ReadPassword(int(syscall.Stdin))
 	password := string(bytePassword)
 
 	tp := github.BasicAuthTransport{

--- a/example/tagprotection/main.go
+++ b/example/tagprotection/main.go
@@ -20,7 +20,7 @@ import (
 	"syscall"
 
 	"github.com/google/go-github/v53/github"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 func main() {
@@ -39,7 +39,7 @@ func main() {
 	pattern = strings.TrimSpace(pattern)
 
 	fmt.Print("GitHub Token: ")
-	byteToken, _ := terminal.ReadPassword(int(syscall.Stdin))
+	byteToken, _ := term.ReadPassword(int(syscall.Stdin))
 	println()
 	token := string(byteToken)
 

--- a/example/tokenauth/main.go
+++ b/example/tokenauth/main.go
@@ -15,12 +15,12 @@ import (
 	"syscall"
 
 	"github.com/google/go-github/v53/github"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 func main() {
 	fmt.Print("GitHub Token: ")
-	byteToken, _ := terminal.ReadPassword(int(syscall.Stdin))
+	byteToken, _ := term.ReadPassword(int(syscall.Stdin))
 	println()
 	token := string(byteToken)
 


### PR DESCRIPTION
Closes #2875 

Replaces deprecated module `crypto/ssh/terminal` in examples