### PR TITLE
Add support for organization, repository webhook configuration

### DIFF
--- a/github/orgs_hooks_configuration.go
+++ b/github/orgs_hooks_configuration.go
@@ -1,0 +1,49 @@
+// Copyright 2023 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// GetHookConfiguration returns the configuration for the specified organization webhook.
+//
+// GitHub API docs: https://docs.github.com/en/rest/orgs/webhooks?apiVersion=2022-11-28#get-a-webhook-configuration-for-an-organization
+func (s *OrganizationsService) GetHookConfiguration(ctx context.Context, org string, id int64) (*HookConfig, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/hooks/%d/config", org, id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	config := new(HookConfig)
+	resp, err := s.client.Do(ctx, req, config)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return config, resp, nil
+}
+
+// EditHookConfiguration updates the configuration for the specified organization webhook.
+//
+// GitHub API docs: https://docs.github.com/en/rest/orgs/webhooks?apiVersion=2022-11-28#update-a-webhook-configuration-for-an-organization
+func (s *OrganizationsService) EditHookConfiguration(ctx context.Context, org string, id int64, config *HookConfig) (*HookConfig, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/hooks/%d/config", org, id)
+	req, err := s.client.NewRequest("PATCH", u, config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c := new(HookConfig)
+	resp, err := s.client.Do(ctx, req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, nil
+}

--- a/github/orgs_hooks_configuration.go
+++ b/github/orgs_hooks_configuration.go
@@ -14,7 +14,7 @@ import (
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/webhooks?apiVersion=2022-11-28#get-a-webhook-configuration-for-an-organization
 func (s *OrganizationsService) GetHookConfiguration(ctx context.Context, org string, id int64) (*HookConfig, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/hooks/%d/config", org, id)
+	u := fmt.Sprintf("orgs/%v/hooks/%v/config", org, id)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -33,7 +33,7 @@ func (s *OrganizationsService) GetHookConfiguration(ctx context.Context, org str
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/webhooks?apiVersion=2022-11-28#update-a-webhook-configuration-for-an-organization
 func (s *OrganizationsService) EditHookConfiguration(ctx context.Context, org string, id int64, config *HookConfig) (*HookConfig, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/hooks/%d/config", org, id)
+	u := fmt.Sprintf("orgs/%v/hooks/%v/config", org, id)
 	req, err := s.client.NewRequest("PATCH", u, config)
 	if err != nil {
 		return nil, nil, err

--- a/github/orgs_hooks_configuration_test.go
+++ b/github/orgs_hooks_configuration_test.go
@@ -1,0 +1,123 @@
+// Copyright 2023 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestOrganizationsService_GetHookConfiguration(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/hooks/1/config", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"content_type": "json", "insecure_ssl": "0", "secret": "********", "url": "https://example.com/webhook"}`)
+	})
+
+	ctx := context.Background()
+	config, _, err := client.Organizations.GetHookConfiguration(ctx, "o", 1)
+	if err != nil {
+		t.Errorf("Organizations.GetHookConfiguration returned error: %v", err)
+	}
+
+	want := &HookConfig{
+		ContentType: String("json"),
+		InsecureSSL: String("0"),
+		Secret:      String("********"),
+		URL:         String("https://example.com/webhook"),
+	}
+	if !cmp.Equal(config, want) {
+		t.Errorf("Organizations.GetHookConfiguration returned %+v, want %+v", config, want)
+	}
+
+	const methodName = "GetHookConfiguration"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.GetHookConfiguration(ctx, "\n", -1)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Organizations.GetHookConfiguration(ctx, "o", 1)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestOrganizationsService_GetHookConfiguration_invalidOrg(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	ctx := context.Background()
+	_, _, err := client.Organizations.GetHookConfiguration(ctx, "%", 1)
+	testURLParseError(t, err)
+}
+
+func TestOrganizationsService_EditHookConfiguration(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &HookConfig{}
+
+	mux.HandleFunc("/orgs/o/hooks/1/config", func(w http.ResponseWriter, r *http.Request) {
+		v := new(HookConfig)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "PATCH")
+		if !cmp.Equal(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		fmt.Fprint(w, `{"content_type": "json", "insecure_ssl": "0", "secret": "********", "url": "https://example.com/webhook"}`)
+	})
+
+	ctx := context.Background()
+	config, _, err := client.Organizations.EditHookConfiguration(ctx, "o", 1, input)
+	if err != nil {
+		t.Errorf("Organizations.EditHookConfiguration returned error: %v", err)
+	}
+
+	want := &HookConfig{
+		ContentType: String("json"),
+		InsecureSSL: String("0"),
+		Secret:      String("********"),
+		URL:         String("https://example.com/webhook"),
+	}
+	if !cmp.Equal(config, want) {
+		t.Errorf("Organizations.EditHookConfiguration returned %+v, want %+v", config, want)
+	}
+
+	const methodName = "EditHookConfiguration"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.EditHookConfiguration(ctx, "\n", -1, input)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Organizations.EditHookConfiguration(ctx, "o", 1, input)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestOrganizationsService_EditHookConfiguration_invalidOrg(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	ctx := context.Background()
+	_, _, err := client.Organizations.EditHookConfiguration(ctx, "%", 1, nil)
+	testURLParseError(t, err)
+}

--- a/github/repos_hooks_configuration.go
+++ b/github/repos_hooks_configuration.go
@@ -1,0 +1,49 @@
+// Copyright 2023 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// GetHookConfiguration returns the configuration for the specified repository webhook.
+//
+// GitHub API docs: https://docs.github.com/en/rest/webhooks/repo-config?apiVersion=2022-11-28#get-a-webhook-configuration-for-a-repository
+func (s *RepositoriesService) GetHookConfiguration(ctx context.Context, owner, repo string, id int64) (*HookConfig, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/hooks/%d/config", owner, repo, id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	config := new(HookConfig)
+	resp, err := s.client.Do(ctx, req, config)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return config, resp, nil
+}
+
+// EditHookConfiguration updates the configuration for the specified repository webhook.
+//
+// GitHub API docs: https://docs.github.com/en/rest/webhooks/repo-config?apiVersion=2022-11-28#update-a-webhook-configuration-for-a-repository
+func (s *RepositoriesService) EditHookConfiguration(ctx context.Context, owner, repo string, id int64, config *HookConfig) (*HookConfig, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/hooks/%d/config", owner, repo, id)
+	req, err := s.client.NewRequest("PATCH", u, config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c := new(HookConfig)
+	resp, err := s.client.Do(ctx, req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, nil
+}

--- a/github/repos_hooks_configuration.go
+++ b/github/repos_hooks_configuration.go
@@ -14,7 +14,7 @@ import (
 //
 // GitHub API docs: https://docs.github.com/en/rest/webhooks/repo-config?apiVersion=2022-11-28#get-a-webhook-configuration-for-a-repository
 func (s *RepositoriesService) GetHookConfiguration(ctx context.Context, owner, repo string, id int64) (*HookConfig, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%d/config", owner, repo, id)
+	u := fmt.Sprintf("repos/%v/%v/hooks/%v/config", owner, repo, id)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -33,7 +33,7 @@ func (s *RepositoriesService) GetHookConfiguration(ctx context.Context, owner, r
 //
 // GitHub API docs: https://docs.github.com/en/rest/webhooks/repo-config?apiVersion=2022-11-28#update-a-webhook-configuration-for-a-repository
 func (s *RepositoriesService) EditHookConfiguration(ctx context.Context, owner, repo string, id int64, config *HookConfig) (*HookConfig, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%d/config", owner, repo, id)
+	u := fmt.Sprintf("repos/%v/%v/hooks/%v/config", owner, repo, id)
 	req, err := s.client.NewRequest("PATCH", u, config)
 	if err != nil {
 		return nil, nil, err

--- a/github/repos_hooks_configuration_test.go
+++ b/github/repos_hooks_configuration_test.go
@@ -1,0 +1,123 @@
+// Copyright 2023 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRepositoriesService_GetHookConfiguration(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/hooks/1/config", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"content_type": "json", "insecure_ssl": "0", "secret": "********", "url": "https://example.com/webhook"}`)
+	})
+
+	ctx := context.Background()
+	config, _, err := client.Repositories.GetHookConfiguration(ctx, "o", "r", 1)
+	if err != nil {
+		t.Errorf("Repositories.GetHookConfiguration returned error: %v", err)
+	}
+
+	want := &HookConfig{
+		ContentType: String("json"),
+		InsecureSSL: String("0"),
+		Secret:      String("********"),
+		URL:         String("https://example.com/webhook"),
+	}
+	if !cmp.Equal(config, want) {
+		t.Errorf("Repositories.GetHookConfiguration returned %+v, want %+v", config, want)
+	}
+
+	const methodName = "GetHookConfiguration"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Repositories.GetHookConfiguration(ctx, "\n", "\n", -1)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Repositories.GetHookConfiguration(ctx, "o", "r", 1)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestRepositoriesService_GetHookConfiguration_invalidOrg(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	ctx := context.Background()
+	_, _, err := client.Repositories.GetHookConfiguration(ctx, "%", "%", 1)
+	testURLParseError(t, err)
+}
+
+func TestRepositoriesService_EditHookConfiguration(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	input := &HookConfig{}
+
+	mux.HandleFunc("/repos/o/r/hooks/1/config", func(w http.ResponseWriter, r *http.Request) {
+		v := new(HookConfig)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "PATCH")
+		if !cmp.Equal(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		fmt.Fprint(w, `{"content_type": "json", "insecure_ssl": "0", "secret": "********", "url": "https://example.com/webhook"}`)
+	})
+
+	ctx := context.Background()
+	config, _, err := client.Repositories.EditHookConfiguration(ctx, "o", "r", 1, input)
+	if err != nil {
+		t.Errorf("Repositories.EditHookConfiguration returned error: %v", err)
+	}
+
+	want := &HookConfig{
+		ContentType: String("json"),
+		InsecureSSL: String("0"),
+		Secret:      String("********"),
+		URL:         String("https://example.com/webhook"),
+	}
+	if !cmp.Equal(config, want) {
+		t.Errorf("Repositories.EditHookConfiguration returned %+v, want %+v", config, want)
+	}
+
+	const methodName = "EditHookConfiguration"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Repositories.EditHookConfiguration(ctx, "\n", "\n", -1, input)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Repositories.EditHookConfiguration(ctx, "o", "r", 1, input)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestRepositoriesService_EditHookConfiguration_invalidOrg(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	ctx := context.Background()
+	_, _, err := client.Repositories.EditHookConfiguration(ctx, "%", "%", 1, nil)
+	testURLParseError(t, err)
+}


### PR DESCRIPTION
Closes https://github.com/google/go-github/issues/2884

This PR adds support for fetching and updating organization, repository webhook configuration
- [x] go generate
- [x] go test
- [x] go vet