### PR TITLE
Add support for enable/disable private vulnerability reporting on repositories

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -2069,3 +2069,43 @@ func isBranchNotProtected(err error) bool {
 	errorResponse, ok := err.(*ErrorResponse)
 	return ok && errorResponse.Message == githubBranchNotProtected
 }
+
+// EnablePrivateReporting enables private reporting of vulnerabilities for a
+// repository.
+//
+// Github API docs: https://docs.github.com/en/rest/repos/repos#enable-private-vulnerability-reporting-for-a-repository
+func (s *RepositoriesService) EnablePrivateReporting(ctx context.Context, owner string, repo string) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/private-vulnerability-reporting", owner, repo)
+
+	req, err := s.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// DisablePrivateReporting disables private reporting of vulnerabilities for a
+// repository.
+//
+// Github API docs: https://docs.github.com/en/rest/repos/repos#disable-private-vulnerability-reporting-for-a-repository
+func (s *RepositoriesService) DisablePrivateReporting(ctx context.Context, owner string, repo string) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/private-vulnerability-reporting", owner, repo)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}

--- a/github/repos.go
+++ b/github/repos.go
@@ -2073,8 +2073,8 @@ func isBranchNotProtected(err error) bool {
 // EnablePrivateReporting enables private reporting of vulnerabilities for a
 // repository.
 //
-// Github API docs: https://docs.github.com/en/rest/repos/repos#enable-private-vulnerability-reporting-for-a-repository
-func (s *RepositoriesService) EnablePrivateReporting(ctx context.Context, owner string, repo string) (*Response, error) {
+// GitHub API docs: https://docs.github.com/en/rest/repos/repos#enable-private-vulnerability-reporting-for-a-repository
+func (s *RepositoriesService) EnablePrivateReporting(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/private-vulnerability-reporting", owner, repo)
 
 	req, err := s.client.NewRequest("PUT", u, nil)
@@ -2093,8 +2093,8 @@ func (s *RepositoriesService) EnablePrivateReporting(ctx context.Context, owner 
 // DisablePrivateReporting disables private reporting of vulnerabilities for a
 // repository.
 //
-// Github API docs: https://docs.github.com/en/rest/repos/repos#disable-private-vulnerability-reporting-for-a-repository
-func (s *RepositoriesService) DisablePrivateReporting(ctx context.Context, owner string, repo string) (*Response, error) {
+// GitHub API docs: https://docs.github.com/en/rest/repos/repos#disable-private-vulnerability-reporting-for-a-repository
+func (s *RepositoriesService) DisablePrivateReporting(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/private-vulnerability-reporting", owner, repo)
 
 	req, err := s.client.NewRequest("DELETE", u, nil)

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -3569,3 +3569,55 @@ func TestRepositoryTag_Marshal(t *testing.T) {
 
 	testJSONMarshal(t, u, want)
 }
+
+func TestRepositoriesService_EnablePrivateReporting(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/owner/repo/private-vulnerability-reporting", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := context.Background()
+	_, err := client.Repositories.EnablePrivateReporting(ctx, "owner", "repo")
+	if err != nil {
+		t.Errorf("Repositories.EnablePrivateReporting returned error: %v", err)
+	}
+
+	const methodName = "EnablePrivateReporting"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Repositories.EnablePrivateReporting(ctx, "\n", "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Repositories.EnablePrivateReporting(ctx, "owner", "repo")
+	})
+}
+
+func TestRepositoriesService_DisablePrivateReporting(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/owner/repo/private-vulnerability-reporting", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := context.Background()
+	_, err := client.Repositories.DisablePrivateReporting(ctx, "owner", "repo")
+	if err != nil {
+		t.Errorf("Repositories.DisablePrivateReporting returned error: %v", err)
+	}
+
+	const methodName = "DisablePrivateReporting"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Repositories.DisablePrivateReporting(ctx, "\n", "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Repositories.DisablePrivateReporting(ctx, "owner", "repo")
+	})
+}


### PR DESCRIPTION
Closes https://github.com/google/go-github/issues/2883

- [x] go generate
- [x] go vet
- [x] go test

Please let me know if the method names are not descriptive enough or just need to be changed. 

Also, something that's been bugging me. In my previous [PR](https://github.com/google/go-github/pull/2869), I did some actual testing aside from the unit tests. While not present in [CONTRIBUTING.md](https://github.com/google/go-github/blob/master/CONTRIBUTING.md) , is it advisable/necessary/optional to perform actual testing (importing the library, calling the new method and examine response). 