### PR TITLE
Vaidate URLs

### DIFF
--- a/github/actions_artifacts.go
+++ b/github/actions_artifacts.go
@@ -54,8 +54,11 @@ type ArtifactList struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/artifacts#list-artifacts-for-a-repository
 func (s *ActionsService) ListArtifacts(ctx context.Context, owner, repo string, opts *ListOptions) (*ArtifactList, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/artifacts", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/actions/artifacts", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -78,8 +81,11 @@ func (s *ActionsService) ListArtifacts(ctx context.Context, owner, repo string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/artifacts#list-workflow-run-artifacts
 func (s *ActionsService) ListWorkflowRunArtifacts(ctx context.Context, owner, repo string, runID int64, opts *ListOptions) (*ArtifactList, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/artifacts", owner, repo, runID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/actions/runs/%v/artifacts", owner, repo, runID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -102,7 +108,10 @@ func (s *ActionsService) ListWorkflowRunArtifacts(ctx context.Context, owner, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/artifacts#get-an-artifact
 func (s *ActionsService) GetArtifact(ctx context.Context, owner, repo string, artifactID int64) (*Artifact, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/artifacts/%v", owner, repo, artifactID)
+	u, err := newURLString("repos/%v/%v/actions/artifacts/%v", owner, repo, artifactID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -122,7 +131,10 @@ func (s *ActionsService) GetArtifact(ctx context.Context, owner, repo string, ar
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/artifacts#download-an-artifact
 func (s *ActionsService) DownloadArtifact(ctx context.Context, owner, repo string, artifactID int64, followRedirects bool) (*url.URL, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/artifacts/%v/zip", owner, repo, artifactID)
+	u, err := newURLString("repos/%v/%v/actions/artifacts/%v/zip", owner, repo, artifactID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, followRedirects)
 	if err != nil {
@@ -146,7 +158,10 @@ func (s *ActionsService) DownloadArtifact(ctx context.Context, owner, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/artifacts#delete-an-artifact
 func (s *ActionsService) DeleteArtifact(ctx context.Context, owner, repo string, artifactID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/artifacts/%v", owner, repo, artifactID)
+	u, err := newURLString("repos/%v/%v/actions/artifacts/%v", owner, repo, artifactID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/actions_cache.go
+++ b/github/actions_cache.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ActionsCache represents a GitHub action cache.
@@ -79,8 +78,11 @@ type ActionsCacheListOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#list-github-actions-caches-for-a-repository
 func (s *ActionsService) ListCaches(ctx context.Context, owner, repo string, opts *ActionsCacheListOptions) (*ActionsCacheList, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/caches", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/actions/caches", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -109,8 +111,11 @@ func (s *ActionsService) ListCaches(ctx context.Context, owner, repo string, opt
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-github-actions-caches-for-a-repository-using-a-cache-key
 func (s *ActionsService) DeleteCachesByKey(ctx context.Context, owner, repo, key string, ref *string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/caches", owner, repo)
-	u, err := addOptions(u, ActionsCache{Key: &key, Ref: ref})
+	u, err := newURLString("repos/%v/%v/actions/caches", owner, repo)
+	if err != nil {
+		return nil, err
+	}
+	u, err = addOptions(u, ActionsCache{Key: &key, Ref: ref})
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +134,10 @@ func (s *ActionsService) DeleteCachesByKey(ctx context.Context, owner, repo, key
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id
 func (s *ActionsService) DeleteCachesByID(ctx context.Context, owner, repo string, cacheID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/caches/%v", owner, repo, cacheID)
+	u, err := newURLString("repos/%v/%v/actions/caches/%v", owner, repo, cacheID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -146,7 +154,10 @@ func (s *ActionsService) DeleteCachesByID(ctx context.Context, owner, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#get-github-actions-cache-usage-for-a-repository
 func (s *ActionsService) GetCacheUsageForRepo(ctx context.Context, owner, repo string) (*ActionsCacheUsage, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/cache/usage", owner, repo)
+	u, err := newURLString("repos/%v/%v/actions/cache/usage", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -169,8 +180,11 @@ func (s *ActionsService) GetCacheUsageForRepo(ctx context.Context, owner, repo s
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#list-repositories-with-github-actions-cache-usage-for-an-organization
 func (s *ActionsService) ListCacheUsageByRepoForOrg(ctx context.Context, org string, opts *ListOptions) (*ActionsCacheUsageList, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/cache/usage-by-repository", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/actions/cache/usage-by-repository", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -197,7 +211,10 @@ func (s *ActionsService) ListCacheUsageByRepoForOrg(ctx context.Context, org str
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#get-github-actions-cache-usage-for-an-organization
 func (s *ActionsService) GetTotalCacheUsageForOrg(ctx context.Context, org string) (*TotalCacheUsage, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/cache/usage", org)
+	u, err := newURLString("orgs/%v/actions/cache/usage", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -219,7 +236,10 @@ func (s *ActionsService) GetTotalCacheUsageForOrg(ctx context.Context, org strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#get-github-actions-cache-usage-for-an-enterprise
 func (s *ActionsService) GetTotalCacheUsageForEnterprise(ctx context.Context, enterprise string) (*TotalCacheUsage, *Response, error) {
-	u := fmt.Sprintf("enterprises/%v/actions/cache/usage", enterprise)
+	u, err := newURLString("enterprises/%v/actions/cache/usage", enterprise)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/actions_oidc.go
+++ b/github/actions_oidc.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // OIDCSubjectClaimCustomTemplate represents an OIDC subject claim customization template.
@@ -20,7 +19,10 @@ type OIDCSubjectClaimCustomTemplate struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization
 func (s *ActionsService) GetOrgOIDCSubjectClaimCustomTemplate(ctx context.Context, org string) (*OIDCSubjectClaimCustomTemplate, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/oidc/customization/sub", org)
+	u, err := newURLString("orgs/%v/actions/oidc/customization/sub", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getOIDCSubjectClaimCustomTemplate(ctx, u)
 }
 
@@ -28,7 +30,10 @@ func (s *ActionsService) GetOrgOIDCSubjectClaimCustomTemplate(ctx context.Contex
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-a-repository
 func (s *ActionsService) GetRepoOIDCSubjectClaimCustomTemplate(ctx context.Context, owner, repo string) (*OIDCSubjectClaimCustomTemplate, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/oidc/customization/sub", owner, repo)
+	u, err := newURLString("repos/%v/%v/actions/oidc/customization/sub", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getOIDCSubjectClaimCustomTemplate(ctx, u)
 }
 
@@ -51,7 +56,10 @@ func (s *ActionsService) getOIDCSubjectClaimCustomTemplate(ctx context.Context, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-an-organization
 func (s *ActionsService) SetOrgOIDCSubjectClaimCustomTemplate(ctx context.Context, org string, template *OIDCSubjectClaimCustomTemplate) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/oidc/customization/sub", org)
+	u, err := newURLString("orgs/%v/actions/oidc/customization/sub", org)
+	if err != nil {
+		return nil, err
+	}
 	return s.setOIDCSubjectClaimCustomTemplate(ctx, u, template)
 }
 
@@ -59,7 +67,10 @@ func (s *ActionsService) SetOrgOIDCSubjectClaimCustomTemplate(ctx context.Contex
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-a-repository
 func (s *ActionsService) SetRepoOIDCSubjectClaimCustomTemplate(ctx context.Context, owner, repo string, template *OIDCSubjectClaimCustomTemplate) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/oidc/customization/sub", owner, repo)
+	u, err := newURLString("repos/%v/%v/actions/oidc/customization/sub", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 	return s.setOIDCSubjectClaimCustomTemplate(ctx, u, template)
 }
 

--- a/github/actions_required_workflows.go
+++ b/github/actions_required_workflows.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // OrgRequiredWorkflow represents a required workflow object at the org level.
@@ -69,7 +68,10 @@ type RepoRequiredWorkflows struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#list-required-workflows
 func (s *ActionsService) ListOrgRequiredWorkflows(ctx context.Context, org string, opts *ListOptions) (*OrgRequiredWorkflows, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/required_workflows", org)
+	url, err := newURLString("orgs/%v/actions/required_workflows", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	u, err := addOptions(url, opts)
 	if err != nil {
 		return nil, nil, err
@@ -93,7 +95,10 @@ func (s *ActionsService) ListOrgRequiredWorkflows(ctx context.Context, org strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#create-a-required-workflow
 func (s *ActionsService) CreateRequiredWorkflow(ctx context.Context, org string, createRequiredWorkflowOptions *CreateUpdateRequiredWorkflowOptions) (*OrgRequiredWorkflow, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/required_workflows", org)
+	url, err := newURLString("orgs/%v/actions/required_workflows", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", url, createRequiredWorkflowOptions)
 	if err != nil {
 		return nil, nil, err
@@ -112,7 +117,10 @@ func (s *ActionsService) CreateRequiredWorkflow(ctx context.Context, org string,
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#list-required-workflows
 func (s *ActionsService) GetRequiredWorkflowByID(ctx context.Context, owner string, requiredWorkflowID int64) (*OrgRequiredWorkflow, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/required_workflows/%v", owner, requiredWorkflowID)
+	u, err := newURLString("orgs/%v/actions/required_workflows/%v", owner, requiredWorkflowID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -132,7 +140,10 @@ func (s *ActionsService) GetRequiredWorkflowByID(ctx context.Context, owner stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#update-a-required-workflow
 func (s *ActionsService) UpdateRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID int64, updateRequiredWorkflowOptions *CreateUpdateRequiredWorkflowOptions) (*OrgRequiredWorkflow, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v", org, requiredWorkflowID)
+	url, err := newURLString("orgs/%v/actions/required_workflows/%v", org, requiredWorkflowID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", url, updateRequiredWorkflowOptions)
 	if err != nil {
 		return nil, nil, err
@@ -151,7 +162,10 @@ func (s *ActionsService) UpdateRequiredWorkflow(ctx context.Context, org string,
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#update-a-required-workflow
 func (s *ActionsService) DeleteRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID int64) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v", org, requiredWorkflowID)
+	url, err := newURLString("orgs/%v/actions/required_workflows/%v", org, requiredWorkflowID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", url, nil)
 	if err != nil {
 		return nil, err
@@ -163,7 +177,10 @@ func (s *ActionsService) DeleteRequiredWorkflow(ctx context.Context, org string,
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#list-selected-repositories-for-a-required-workflow
 func (s *ActionsService) ListRequiredWorkflowSelectedRepos(ctx context.Context, org string, requiredWorkflowID int64, opts *ListOptions) (*RequiredWorkflowSelectedRepos, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v/repositories", org, requiredWorkflowID)
+	url, err := newURLString("orgs/%v/actions/required_workflows/%v/repositories", org, requiredWorkflowID)
+	if err != nil {
+		return nil, nil, err
+	}
 	u, err := addOptions(url, opts)
 	if err != nil {
 		return nil, nil, err
@@ -189,7 +206,10 @@ func (s *ActionsService) SetRequiredWorkflowSelectedRepos(ctx context.Context, o
 	type repoIDs struct {
 		SelectedIDs SelectedRepoIDs `json:"selected_repository_ids"`
 	}
-	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v/repositories", org, requiredWorkflowID)
+	url, err := newURLString("orgs/%v/actions/required_workflows/%v/repositories", org, requiredWorkflowID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", url, repoIDs{SelectedIDs: ids})
 	if err != nil {
 		return nil, err
@@ -202,7 +222,10 @@ func (s *ActionsService) SetRequiredWorkflowSelectedRepos(ctx context.Context, o
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#add-a-repository-to-a-required-workflow
 func (s *ActionsService) AddRepoToRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID, repoID int64) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v/repositories/%v", org, requiredWorkflowID, repoID)
+	url, err := newURLString("orgs/%v/actions/required_workflows/%v/repositories/%v", org, requiredWorkflowID, repoID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", url, nil)
 	if err != nil {
 		return nil, err
@@ -214,7 +237,10 @@ func (s *ActionsService) AddRepoToRequiredWorkflow(ctx context.Context, org stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#add-a-repository-to-a-required-workflow
 func (s *ActionsService) RemoveRepoFromRequiredWorkflow(ctx context.Context, org string, requiredWorkflowID, repoID int64) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/required_workflows/%v/repositories/%v", org, requiredWorkflowID, repoID)
+	url, err := newURLString("orgs/%v/actions/required_workflows/%v/repositories/%v", org, requiredWorkflowID, repoID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", url, nil)
 	if err != nil {
 		return nil, err
@@ -226,7 +252,10 @@ func (s *ActionsService) RemoveRepoFromRequiredWorkflow(ctx context.Context, org
 //
 // Github API docs:https://docs.github.com/en/rest/actions/required-workflows?apiVersion=2022-11-28#list-repository-required-workflows
 func (s *ActionsService) ListRepoRequiredWorkflows(ctx context.Context, owner, repo string, opts *ListOptions) (*RepoRequiredWorkflows, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/required_workflows", owner, repo)
+	url, err := newURLString("repos/%v/%v/actions/required_workflows", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	u, err := addOptions(url, opts)
 	if err != nil {
 		return nil, nil, err

--- a/github/actions_runner_groups.go
+++ b/github/actions_runner_groups.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // RunnerGroup represents a self-hosted runner group configured in an organization.
@@ -82,8 +81,11 @@ type ListOrgRunnerGroupOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runner-groups#list-self-hosted-runner-groups-for-an-organization
 func (s *ActionsService) ListOrganizationRunnerGroups(ctx context.Context, org string, opts *ListOrgRunnerGroupOptions) (*RunnerGroups, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runner-groups", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/actions/runner-groups", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -106,7 +108,10 @@ func (s *ActionsService) ListOrganizationRunnerGroups(ctx context.Context, org s
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runner-groups#get-a-self-hosted-runner-group-for-an-organization
 func (s *ActionsService) GetOrganizationRunnerGroup(ctx context.Context, org string, groupID int64) (*RunnerGroup, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v", org, groupID)
+	u, err := newURLString("orgs/%v/actions/runner-groups/%v", org, groupID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -125,7 +130,10 @@ func (s *ActionsService) GetOrganizationRunnerGroup(ctx context.Context, org str
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runner-groups#delete-a-self-hosted-runner-group-from-an-organization
 func (s *ActionsService) DeleteOrganizationRunnerGroup(ctx context.Context, org string, groupID int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v", org, groupID)
+	u, err := newURLString("orgs/%v/actions/runner-groups/%v", org, groupID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -139,7 +147,10 @@ func (s *ActionsService) DeleteOrganizationRunnerGroup(ctx context.Context, org 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runner-groups#create-a-self-hosted-runner-group-for-an-organization
 func (s *ActionsService) CreateOrganizationRunnerGroup(ctx context.Context, org string, createReq CreateRunnerGroupRequest) (*RunnerGroup, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runner-groups", org)
+	u, err := newURLString("orgs/%v/actions/runner-groups", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, createReq)
 	if err != nil {
 		return nil, nil, err
@@ -158,7 +169,10 @@ func (s *ActionsService) CreateOrganizationRunnerGroup(ctx context.Context, org 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runner-groups#update-a-self-hosted-runner-group-for-an-organization
 func (s *ActionsService) UpdateOrganizationRunnerGroup(ctx context.Context, org string, groupID int64, updateReq UpdateRunnerGroupRequest) (*RunnerGroup, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v", org, groupID)
+	u, err := newURLString("orgs/%v/actions/runner-groups/%v", org, groupID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, updateReq)
 	if err != nil {
 		return nil, nil, err
@@ -177,8 +191,11 @@ func (s *ActionsService) UpdateOrganizationRunnerGroup(ctx context.Context, org 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runner-groups#list-repository-access-to-a-self-hosted-runner-group-in-an-organization
 func (s *ActionsService) ListRepositoryAccessRunnerGroup(ctx context.Context, org string, groupID int64, opts *ListOptions) (*ListRepositories, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v/repositories", org, groupID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/actions/runner-groups/%v/repositories", org, groupID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -202,7 +219,10 @@ func (s *ActionsService) ListRepositoryAccessRunnerGroup(ctx context.Context, or
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runner-groups#set-repository-access-for-a-self-hosted-runner-group-in-an-organization
 func (s *ActionsService) SetRepositoryAccessRunnerGroup(ctx context.Context, org string, groupID int64, ids SetRepoAccessRunnerGroupRequest) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v/repositories", org, groupID)
+	u, err := newURLString("orgs/%v/actions/runner-groups/%v/repositories", org, groupID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, ids)
 	if err != nil {
@@ -217,7 +237,10 @@ func (s *ActionsService) SetRepositoryAccessRunnerGroup(ctx context.Context, org
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runner-groups#add-repository-access-to-a-self-hosted-runner-group-in-an-organization
 func (s *ActionsService) AddRepositoryAccessRunnerGroup(ctx context.Context, org string, groupID, repoID int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v/repositories/%v", org, groupID, repoID)
+	u, err := newURLString("orgs/%v/actions/runner-groups/%v/repositories/%v", org, groupID, repoID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
@@ -232,7 +255,10 @@ func (s *ActionsService) AddRepositoryAccessRunnerGroup(ctx context.Context, org
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runner-groups#remove-repository-access-to-a-self-hosted-runner-group-in-an-organization
 func (s *ActionsService) RemoveRepositoryAccessRunnerGroup(ctx context.Context, org string, groupID, repoID int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v/repositories/%v", org, groupID, repoID)
+	u, err := newURLString("orgs/%v/actions/runner-groups/%v/repositories/%v", org, groupID, repoID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -246,8 +272,11 @@ func (s *ActionsService) RemoveRepositoryAccessRunnerGroup(ctx context.Context, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runner-groups#list-self-hosted-runners-in-a-group-for-an-organization
 func (s *ActionsService) ListRunnerGroupRunners(ctx context.Context, org string, groupID int64, opts *ListOptions) (*Runners, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v/runners", org, groupID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/actions/runner-groups/%v/runners", org, groupID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -271,7 +300,10 @@ func (s *ActionsService) ListRunnerGroupRunners(ctx context.Context, org string,
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runner-groups#set-self-hosted-runners-in-a-group-for-an-organization
 func (s *ActionsService) SetRunnerGroupRunners(ctx context.Context, org string, groupID int64, ids SetRunnerGroupRunnersRequest) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v/runners", org, groupID)
+	u, err := newURLString("orgs/%v/actions/runner-groups/%v/runners", org, groupID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, ids)
 	if err != nil {
@@ -285,7 +317,10 @@ func (s *ActionsService) SetRunnerGroupRunners(ctx context.Context, org string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runner-groups#add-a-self-hosted-runner-to-a-group-for-an-organization
 func (s *ActionsService) AddRunnerGroupRunners(ctx context.Context, org string, groupID, runnerID int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v/runners/%v", org, groupID, runnerID)
+	u, err := newURLString("orgs/%v/actions/runner-groups/%v/runners/%v", org, groupID, runnerID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
@@ -300,7 +335,10 @@ func (s *ActionsService) AddRunnerGroupRunners(ctx context.Context, org string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runner-groups#remove-a-self-hosted-runner-from-a-group-for-an-organization
 func (s *ActionsService) RemoveRunnerGroupRunners(ctx context.Context, org string, groupID, runnerID int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v/runners/%v", org, groupID, runnerID)
+	u, err := newURLString("orgs/%v/actions/runner-groups/%v/runners/%v", org, groupID, runnerID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // RunnerApplicationDownload represents a binary for the self-hosted runner application that can be downloaded.
@@ -30,7 +29,10 @@ type ActionsEnabledOnOrgRepos struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#list-runner-applications-for-a-repository
 func (s *ActionsService) ListRunnerApplicationDownloads(ctx context.Context, owner, repo string) ([]*RunnerApplicationDownload, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runners/downloads", owner, repo)
+	u, err := newURLString("repos/%v/%v/actions/runners/downloads", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -66,7 +68,10 @@ type JITRunnerConfig struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-configuration-for-a-just-in-time-runner-for-an-organization
 func (s *ActionsService) GenerateOrgJITConfig(ctx context.Context, owner string, request *GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runners/generate-jitconfig", owner)
+	u, err := newURLString("orgs/%v/actions/runners/generate-jitconfig", owner)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, request)
 	if err != nil {
 		return nil, nil, err
@@ -85,7 +90,10 @@ func (s *ActionsService) GenerateOrgJITConfig(ctx context.Context, owner string,
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-configuration-for-a-just-in-time-runner-for-a-repository
 func (s *ActionsService) GenerateRepoJITConfig(ctx context.Context, owner, repo string, request *GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runners/generate-jitconfig", owner, repo)
+	u, err := newURLString("repos/%v/%v/actions/runners/generate-jitconfig", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, request)
 	if err != nil {
 		return nil, nil, err
@@ -110,7 +118,10 @@ type RegistrationToken struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#create-a-registration-token-for-a-repository
 func (s *ActionsService) CreateRegistrationToken(ctx context.Context, owner, repo string) (*RegistrationToken, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runners/registration-token", owner, repo)
+	u, err := newURLString("repos/%v/%v/actions/runners/registration-token", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -153,8 +164,11 @@ type Runners struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#list-self-hosted-runners-for-a-repository
 func (s *ActionsService) ListRunners(ctx context.Context, owner, repo string, opts *ListOptions) (*Runners, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runners", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/actions/runners", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -177,7 +191,10 @@ func (s *ActionsService) ListRunners(ctx context.Context, owner, repo string, op
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-a-repository
 func (s *ActionsService) GetRunner(ctx context.Context, owner, repo string, runnerID int64) (*Runner, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runners/%v", owner, repo, runnerID)
+	u, err := newURLString("repos/%v/%v/actions/runners/%v", owner, repo, runnerID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -202,7 +219,10 @@ type RemoveToken struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#create-a-remove-token-for-a-repository
 func (s *ActionsService) CreateRemoveToken(ctx context.Context, owner, repo string) (*RemoveToken, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runners/remove-token", owner, repo)
+	u, err := newURLString("repos/%v/%v/actions/runners/remove-token", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -222,7 +242,10 @@ func (s *ActionsService) CreateRemoveToken(ctx context.Context, owner, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-a-repository
 func (s *ActionsService) RemoveRunner(ctx context.Context, owner, repo string, runnerID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runners/%v", owner, repo, runnerID)
+	u, err := newURLString("repos/%v/%v/actions/runners/%v", owner, repo, runnerID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -236,7 +259,10 @@ func (s *ActionsService) RemoveRunner(ctx context.Context, owner, repo string, r
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#list-runner-applications-for-an-organization
 func (s *ActionsService) ListOrganizationRunnerApplicationDownloads(ctx context.Context, owner string) ([]*RunnerApplicationDownload, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runners/downloads", owner)
+	u, err := newURLString("orgs/%v/actions/runners/downloads", owner)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -255,7 +281,10 @@ func (s *ActionsService) ListOrganizationRunnerApplicationDownloads(ctx context.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#create-a-registration-token-for-an-organization
 func (s *ActionsService) CreateOrganizationRegistrationToken(ctx context.Context, owner string) (*RegistrationToken, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runners/registration-token", owner)
+	u, err := newURLString("orgs/%v/actions/runners/registration-token", owner)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -275,8 +304,11 @@ func (s *ActionsService) CreateOrganizationRegistrationToken(ctx context.Context
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#list-self-hosted-runners-for-an-organization
 func (s *ActionsService) ListOrganizationRunners(ctx context.Context, owner string, opts *ListOptions) (*Runners, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runners", owner)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/actions/runners", owner)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -299,8 +331,11 @@ func (s *ActionsService) ListOrganizationRunners(ctx context.Context, owner stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/permissions#list-selected-repositories-enabled-for-github-actions-in-an-organization
 func (s *ActionsService) ListEnabledReposInOrg(ctx context.Context, owner string, opts *ListOptions) (*ActionsEnabledOnOrgRepos, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/permissions/repositories", owner)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/actions/permissions/repositories", owner)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -323,7 +358,10 @@ func (s *ActionsService) ListEnabledReposInOrg(ctx context.Context, owner string
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/permissions#set-selected-repositories-enabled-for-github-actions-in-an-organization
 func (s *ActionsService) SetEnabledReposInOrg(ctx context.Context, owner string, repositoryIDs []int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/permissions/repositories", owner)
+	u, err := newURLString("orgs/%v/actions/permissions/repositories", owner)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, struct {
 		IDs []int64 `json:"selected_repository_ids"`
@@ -344,7 +382,10 @@ func (s *ActionsService) SetEnabledReposInOrg(ctx context.Context, owner string,
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/permissions#enable-a-selected-repository-for-github-actions-in-an-organization
 func (s *ActionsService) AddEnabledReposInOrg(ctx context.Context, owner string, repositoryID int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/permissions/repositories/%v", owner, repositoryID)
+	u, err := newURLString("orgs/%v/actions/permissions/repositories/%v", owner, repositoryID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
@@ -363,7 +404,10 @@ func (s *ActionsService) AddEnabledReposInOrg(ctx context.Context, owner string,
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/permissions#disable-a-selected-repository-for-github-actions-in-an-organization
 func (s *ActionsService) RemoveEnabledRepoInOrg(ctx context.Context, owner string, repositoryID int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/permissions/repositories/%v", owner, repositoryID)
+	u, err := newURLString("orgs/%v/actions/permissions/repositories/%v", owner, repositoryID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -382,7 +426,10 @@ func (s *ActionsService) RemoveEnabledRepoInOrg(ctx context.Context, owner strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-organization
 func (s *ActionsService) GetOrganizationRunner(ctx context.Context, owner string, runnerID int64) (*Runner, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runners/%v", owner, runnerID)
+	u, err := newURLString("orgs/%v/actions/runners/%v", owner, runnerID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -401,7 +448,10 @@ func (s *ActionsService) GetOrganizationRunner(ctx context.Context, owner string
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#create-a-remove-token-for-an-organization
 func (s *ActionsService) CreateOrganizationRemoveToken(ctx context.Context, owner string) (*RemoveToken, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runners/remove-token", owner)
+	u, err := newURLString("orgs/%v/actions/runners/remove-token", owner)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -421,7 +471,10 @@ func (s *ActionsService) CreateOrganizationRemoveToken(ctx context.Context, owne
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-an-organization
 func (s *ActionsService) RemoveOrganizationRunner(ctx context.Context, owner string, runnerID int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/runners/%v", owner, runnerID)
+	u, err := newURLString("orgs/%v/actions/runners/%v", owner, runnerID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -135,11 +135,11 @@ func (s *ActionsService) listSecrets(ctx context.Context, url string, opts *List
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#list-repository-secrets
 func (s *ActionsService) ListRepoSecrets(ctx context.Context, owner, repo string, opts *ListOptions) (*Secrets, *Response, error) {
-	url, err := newURLString("repos/%v/%v/actions/secrets", owner, repo)
+	u, err := newURLString("repos/%v/%v/actions/secrets", owner, repo)
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.listSecrets(ctx, url, opts)
+	return s.listSecrets(ctx, u, opts)
 }
 
 // ListOrgSecrets lists all secrets available in an organization
@@ -147,22 +147,22 @@ func (s *ActionsService) ListRepoSecrets(ctx context.Context, owner, repo string
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#list-organization-secrets
 func (s *ActionsService) ListOrgSecrets(ctx context.Context, org string, opts *ListOptions) (*Secrets, *Response, error) {
-	url, err := newURLString("orgs/%v/actions/secrets", org)
+	u, err := newURLString("orgs/%v/actions/secrets", org)
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.listSecrets(ctx, url, opts)
+	return s.listSecrets(ctx, u, opts)
 }
 
 // ListEnvSecrets lists all secrets available in an environment.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#list-environment-secrets
 func (s *ActionsService) ListEnvSecrets(ctx context.Context, repoID int, env string, opts *ListOptions) (*Secrets, *Response, error) {
-	url, err := newURLString("repositories/%v/environments/%v/secrets", repoID, env)
+	u, err := newURLString("repositories/%v/environments/%v/secrets", repoID, env)
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.listSecrets(ctx, url, opts)
+	return s.listSecrets(ctx, u, opts)
 }
 
 func (s *ActionsService) getSecret(ctx context.Context, url string) (*Secret, *Response, error) {
@@ -343,11 +343,11 @@ func (s *ActionsService) listSelectedReposForSecret(ctx context.Context, url str
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#list-selected-repositories-for-an-organization-secret
 func (s *ActionsService) ListSelectedReposForOrgSecret(ctx context.Context, org, name string, opts *ListOptions) (*SelectedReposList, *Response, error) {
-	url, err := newURLString("orgs/%v/actions/secrets/%v/repositories", org, name)
+	u, err := newURLString("orgs/%v/actions/secrets/%v/repositories", org, name)
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.listSelectedReposForSecret(ctx, url, opts)
+	return s.listSelectedReposForSecret(ctx, u, opts)
 }
 
 func (s *ActionsService) setSelectedReposForSecret(ctx context.Context, url string, ids SelectedRepoIDs) (*Response, error) {

--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -66,7 +66,10 @@ func (s *ActionsService) getPublicKey(ctx context.Context, url string) (*PublicK
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#get-a-repository-public-key
 func (s *ActionsService) GetRepoPublicKey(ctx context.Context, owner, repo string) (*PublicKey, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/secrets/public-key", owner, repo)
+	url, err := newURLString("repos/%v/%v/actions/secrets/public-key", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getPublicKey(ctx, url)
 }
 
@@ -74,7 +77,10 @@ func (s *ActionsService) GetRepoPublicKey(ctx context.Context, owner, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#get-an-organization-public-key
 func (s *ActionsService) GetOrgPublicKey(ctx context.Context, org string) (*PublicKey, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/secrets/public-key", org)
+	url, err := newURLString("orgs/%v/actions/secrets/public-key", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getPublicKey(ctx, url)
 }
 
@@ -82,7 +88,10 @@ func (s *ActionsService) GetOrgPublicKey(ctx context.Context, org string) (*Publ
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#get-an-environment-public-key
 func (s *ActionsService) GetEnvPublicKey(ctx context.Context, repoID int, env string) (*PublicKey, *Response, error) {
-	url := fmt.Sprintf("repositories/%v/environments/%v/secrets/public-key", repoID, env)
+	url, err := newURLString("repositories/%v/environments/%v/secrets/public-key", repoID, env)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getPublicKey(ctx, url)
 }
 
@@ -126,7 +135,10 @@ func (s *ActionsService) listSecrets(ctx context.Context, url string, opts *List
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#list-repository-secrets
 func (s *ActionsService) ListRepoSecrets(ctx context.Context, owner, repo string, opts *ListOptions) (*Secrets, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/secrets", owner, repo)
+	url, err := newURLString("repos/%v/%v/actions/secrets", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.listSecrets(ctx, url, opts)
 }
 
@@ -135,7 +147,10 @@ func (s *ActionsService) ListRepoSecrets(ctx context.Context, owner, repo string
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#list-organization-secrets
 func (s *ActionsService) ListOrgSecrets(ctx context.Context, org string, opts *ListOptions) (*Secrets, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/secrets", org)
+	url, err := newURLString("orgs/%v/actions/secrets", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.listSecrets(ctx, url, opts)
 }
 
@@ -143,7 +158,10 @@ func (s *ActionsService) ListOrgSecrets(ctx context.Context, org string, opts *L
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#list-environment-secrets
 func (s *ActionsService) ListEnvSecrets(ctx context.Context, repoID int, env string, opts *ListOptions) (*Secrets, *Response, error) {
-	url := fmt.Sprintf("repositories/%v/environments/%v/secrets", repoID, env)
+	url, err := newURLString("repositories/%v/environments/%v/secrets", repoID, env)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.listSecrets(ctx, url, opts)
 }
 
@@ -166,7 +184,10 @@ func (s *ActionsService) getSecret(ctx context.Context, url string) (*Secret, *R
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#get-a-repository-secret
 func (s *ActionsService) GetRepoSecret(ctx context.Context, owner, repo, name string) (*Secret, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/secrets/%v", owner, repo, name)
+	url, err := newURLString("repos/%v/%v/actions/secrets/%v", owner, repo, name)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getSecret(ctx, url)
 }
 
@@ -174,7 +195,10 @@ func (s *ActionsService) GetRepoSecret(ctx context.Context, owner, repo, name st
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#get-an-organization-secret
 func (s *ActionsService) GetOrgSecret(ctx context.Context, org, name string) (*Secret, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/secrets/%v", org, name)
+	url, err := newURLString("orgs/%v/actions/secrets/%v", org, name)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getSecret(ctx, url)
 }
 
@@ -182,7 +206,10 @@ func (s *ActionsService) GetOrgSecret(ctx context.Context, org, name string) (*S
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#get-an-environment-secret
 func (s *ActionsService) GetEnvSecret(ctx context.Context, repoID int, env, secretName string) (*Secret, *Response, error) {
-	url := fmt.Sprintf("repositories/%v/environments/%v/secrets/%v", repoID, env, secretName)
+	url, err := newURLString("repositories/%v/environments/%v/secrets/%v", repoID, env, secretName)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getSecret(ctx, url)
 }
 
@@ -215,7 +242,10 @@ func (s *ActionsService) putSecret(ctx context.Context, url string, eSecret *Enc
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#create-or-update-a-repository-secret
 func (s *ActionsService) CreateOrUpdateRepoSecret(ctx context.Context, owner, repo string, eSecret *EncryptedSecret) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/secrets/%v", owner, repo, eSecret.Name)
+	url, err := newURLString("repos/%v/%v/actions/secrets/%v", owner, repo, eSecret.Name)
+	if err != nil {
+		return nil, err
+	}
 	return s.putSecret(ctx, url, eSecret)
 }
 
@@ -223,7 +253,10 @@ func (s *ActionsService) CreateOrUpdateRepoSecret(ctx context.Context, owner, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#create-or-update-an-organization-secret
 func (s *ActionsService) CreateOrUpdateOrgSecret(ctx context.Context, org string, eSecret *EncryptedSecret) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/secrets/%v", org, eSecret.Name)
+	url, err := newURLString("orgs/%v/actions/secrets/%v", org, eSecret.Name)
+	if err != nil {
+		return nil, err
+	}
 	return s.putSecret(ctx, url, eSecret)
 }
 
@@ -231,7 +264,10 @@ func (s *ActionsService) CreateOrUpdateOrgSecret(ctx context.Context, org string
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#create-or-update-an-environment-secret
 func (s *ActionsService) CreateOrUpdateEnvSecret(ctx context.Context, repoID int, env string, eSecret *EncryptedSecret) (*Response, error) {
-	url := fmt.Sprintf("repositories/%v/environments/%v/secrets/%v", repoID, env, eSecret.Name)
+	url, err := newURLString("repositories/%v/environments/%v/secrets/%v", repoID, env, eSecret.Name)
+	if err != nil {
+		return nil, err
+	}
 	return s.putSecret(ctx, url, eSecret)
 }
 
@@ -248,7 +284,10 @@ func (s *ActionsService) deleteSecret(ctx context.Context, url string) (*Respons
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#delete-a-repository-secret
 func (s *ActionsService) DeleteRepoSecret(ctx context.Context, owner, repo, name string) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/secrets/%v", owner, repo, name)
+	url, err := newURLString("repos/%v/%v/actions/secrets/%v", owner, repo, name)
+	if err != nil {
+		return nil, err
+	}
 	return s.deleteSecret(ctx, url)
 }
 
@@ -256,7 +295,10 @@ func (s *ActionsService) DeleteRepoSecret(ctx context.Context, owner, repo, name
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#delete-an-organization-secret
 func (s *ActionsService) DeleteOrgSecret(ctx context.Context, org, name string) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/secrets/%v", org, name)
+	url, err := newURLString("orgs/%v/actions/secrets/%v", org, name)
+	if err != nil {
+		return nil, err
+	}
 	return s.deleteSecret(ctx, url)
 }
 
@@ -264,7 +306,10 @@ func (s *ActionsService) DeleteOrgSecret(ctx context.Context, org, name string) 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#delete-an-environment-secret
 func (s *ActionsService) DeleteEnvSecret(ctx context.Context, repoID int, env, secretName string) (*Response, error) {
-	url := fmt.Sprintf("repositories/%v/environments/%v/secrets/%v", repoID, env, secretName)
+	url, err := newURLString("repositories/%v/environments/%v/secrets/%v", repoID, env, secretName)
+	if err != nil {
+		return nil, err
+	}
 	return s.deleteSecret(ctx, url)
 }
 
@@ -298,7 +343,10 @@ func (s *ActionsService) listSelectedReposForSecret(ctx context.Context, url str
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#list-selected-repositories-for-an-organization-secret
 func (s *ActionsService) ListSelectedReposForOrgSecret(ctx context.Context, org, name string, opts *ListOptions) (*SelectedReposList, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories", org, name)
+	url, err := newURLString("orgs/%v/actions/secrets/%v/repositories", org, name)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.listSelectedReposForSecret(ctx, url, opts)
 }
 
@@ -319,7 +367,10 @@ func (s *ActionsService) setSelectedReposForSecret(ctx context.Context, url stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#set-selected-repositories-for-an-organization-secret
 func (s *ActionsService) SetSelectedReposForOrgSecret(ctx context.Context, org, name string, ids SelectedRepoIDs) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories", org, name)
+	url, err := newURLString("orgs/%v/actions/secrets/%v/repositories", org, name)
+	if err != nil {
+		return nil, err
+	}
 	return s.setSelectedReposForSecret(ctx, url, ids)
 }
 
@@ -336,7 +387,10 @@ func (s *ActionsService) addSelectedRepoToSecret(ctx context.Context, url string
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#add-selected-repository-to-an-organization-secret
 func (s *ActionsService) AddSelectedRepoToOrgSecret(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories/%v", org, name, *repo.ID)
+	url, err := newURLString("orgs/%v/actions/secrets/%v/repositories/%v", org, name, *repo.ID)
+	if err != nil {
+		return nil, err
+	}
 	return s.addSelectedRepoToSecret(ctx, url)
 }
 
@@ -353,6 +407,9 @@ func (s *ActionsService) removeSelectedRepoFromSecret(ctx context.Context, url s
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/secrets#remove-selected-repository-from-an-organization-secret
 func (s *ActionsService) RemoveSelectedRepoFromOrgSecret(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/secrets/%v/repositories/%v", org, name, *repo.ID)
+	url, err := newURLString("orgs/%v/actions/secrets/%v/repositories/%v", org, name, *repo.ID)
+	if err != nil {
+		return nil, err
+	}
 	return s.removeSelectedRepoFromSecret(ctx, url)
 }

--- a/github/actions_variables.go
+++ b/github/actions_variables.go
@@ -52,33 +52,33 @@ func (s *ActionsService) listVariables(ctx context.Context, url string, opts *Li
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#list-repository-variables
 func (s *ActionsService) ListRepoVariables(ctx context.Context, owner, repo string, opts *ListOptions) (*ActionsVariables, *Response, error) {
-	url, err := newURLString("repos/%v/%v/actions/variables", owner, repo)
+	u, err := newURLString("repos/%v/%v/actions/variables", owner, repo)
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.listVariables(ctx, url, opts)
+	return s.listVariables(ctx, u, opts)
 }
 
 // ListOrgVariables lists all variables available in an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#list-organization-variables
 func (s *ActionsService) ListOrgVariables(ctx context.Context, org string, opts *ListOptions) (*ActionsVariables, *Response, error) {
-	url, err := newURLString("orgs/%v/actions/variables", org)
+	u, err := newURLString("orgs/%v/actions/variables", org)
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.listVariables(ctx, url, opts)
+	return s.listVariables(ctx, u, opts)
 }
 
 // ListEnvVariables lists all variables available in an environment.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#list-environment-variables
 func (s *ActionsService) ListEnvVariables(ctx context.Context, repoID int, env string, opts *ListOptions) (*ActionsVariables, *Response, error) {
-	url, err := newURLString("repositories/%v/environments/%v/variables", repoID, env)
+	u, err := newURLString("repositories/%v/environments/%v/variables", repoID, env)
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.listVariables(ctx, url, opts)
+	return s.listVariables(ctx, u, opts)
 }
 
 func (s *ActionsService) getVariable(ctx context.Context, url string) (*ActionsVariable, *Response, error) {
@@ -277,11 +277,11 @@ func (s *ActionsService) listSelectedReposForVariable(ctx context.Context, url s
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#list-selected-repositories-for-an-organization-variable
 func (s *ActionsService) ListSelectedReposForOrgVariable(ctx context.Context, org, name string, opts *ListOptions) (*SelectedReposList, *Response, error) {
-	url, err := newURLString("orgs/%v/actions/variables/%v/repositories", org, name)
+	u, err := newURLString("orgs/%v/actions/variables/%v/repositories", org, name)
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.listSelectedReposForVariable(ctx, url, opts)
+	return s.listSelectedReposForVariable(ctx, u, opts)
 }
 
 func (s *ActionsService) setSelectedReposForVariable(ctx context.Context, url string, ids SelectedRepoIDs) (*Response, error) {

--- a/github/actions_variables.go
+++ b/github/actions_variables.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ActionsVariable represents a repository action variable.
@@ -53,7 +52,10 @@ func (s *ActionsService) listVariables(ctx context.Context, url string, opts *Li
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#list-repository-variables
 func (s *ActionsService) ListRepoVariables(ctx context.Context, owner, repo string, opts *ListOptions) (*ActionsVariables, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/variables", owner, repo)
+	url, err := newURLString("repos/%v/%v/actions/variables", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.listVariables(ctx, url, opts)
 }
 
@@ -61,7 +63,10 @@ func (s *ActionsService) ListRepoVariables(ctx context.Context, owner, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#list-organization-variables
 func (s *ActionsService) ListOrgVariables(ctx context.Context, org string, opts *ListOptions) (*ActionsVariables, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/variables", org)
+	url, err := newURLString("orgs/%v/actions/variables", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.listVariables(ctx, url, opts)
 }
 
@@ -69,7 +74,10 @@ func (s *ActionsService) ListOrgVariables(ctx context.Context, org string, opts 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#list-environment-variables
 func (s *ActionsService) ListEnvVariables(ctx context.Context, repoID int, env string, opts *ListOptions) (*ActionsVariables, *Response, error) {
-	url := fmt.Sprintf("repositories/%v/environments/%v/variables", repoID, env)
+	url, err := newURLString("repositories/%v/environments/%v/variables", repoID, env)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.listVariables(ctx, url, opts)
 }
 
@@ -92,7 +100,10 @@ func (s *ActionsService) getVariable(ctx context.Context, url string) (*ActionsV
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#get-a-repository-variable
 func (s *ActionsService) GetRepoVariable(ctx context.Context, owner, repo, name string) (*ActionsVariable, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/variables/%v", owner, repo, name)
+	url, err := newURLString("repos/%v/%v/actions/variables/%v", owner, repo, name)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getVariable(ctx, url)
 }
 
@@ -100,7 +111,10 @@ func (s *ActionsService) GetRepoVariable(ctx context.Context, owner, repo, name 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#get-an-organization-variable
 func (s *ActionsService) GetOrgVariable(ctx context.Context, org, name string) (*ActionsVariable, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/variables/%v", org, name)
+	url, err := newURLString("orgs/%v/actions/variables/%v", org, name)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getVariable(ctx, url)
 }
 
@@ -108,7 +122,10 @@ func (s *ActionsService) GetOrgVariable(ctx context.Context, org, name string) (
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#get-an-environment-variable
 func (s *ActionsService) GetEnvVariable(ctx context.Context, repoID int, env, variableName string) (*ActionsVariable, *Response, error) {
-	url := fmt.Sprintf("repositories/%v/environments/%v/variables/%v", repoID, env, variableName)
+	url, err := newURLString("repositories/%v/environments/%v/variables/%v", repoID, env, variableName)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getVariable(ctx, url)
 }
 
@@ -124,7 +141,10 @@ func (s *ActionsService) postVariable(ctx context.Context, url string, variable 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#create-a-repository-variable
 func (s *ActionsService) CreateRepoVariable(ctx context.Context, owner, repo string, variable *ActionsVariable) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/variables", owner, repo)
+	url, err := newURLString("repos/%v/%v/actions/variables", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 	return s.postVariable(ctx, url, variable)
 }
 
@@ -132,7 +152,10 @@ func (s *ActionsService) CreateRepoVariable(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#create-an-organization-variable
 func (s *ActionsService) CreateOrgVariable(ctx context.Context, org string, variable *ActionsVariable) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/variables", org)
+	url, err := newURLString("orgs/%v/actions/variables", org)
+	if err != nil {
+		return nil, err
+	}
 	return s.postVariable(ctx, url, variable)
 }
 
@@ -140,7 +163,10 @@ func (s *ActionsService) CreateOrgVariable(ctx context.Context, org string, vari
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#create-an-environment-variable
 func (s *ActionsService) CreateEnvVariable(ctx context.Context, repoID int, env string, variable *ActionsVariable) (*Response, error) {
-	url := fmt.Sprintf("repositories/%v/environments/%v/variables", repoID, env)
+	url, err := newURLString("repositories/%v/environments/%v/variables", repoID, env)
+	if err != nil {
+		return nil, err
+	}
 	return s.postVariable(ctx, url, variable)
 }
 
@@ -156,7 +182,10 @@ func (s *ActionsService) patchVariable(ctx context.Context, url string, variable
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#update-a-repository-variable
 func (s *ActionsService) UpdateRepoVariable(ctx context.Context, owner, repo string, variable *ActionsVariable) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/variables/%v", owner, repo, variable.Name)
+	url, err := newURLString("repos/%v/%v/actions/variables/%v", owner, repo, variable.Name)
+	if err != nil {
+		return nil, err
+	}
 	return s.patchVariable(ctx, url, variable)
 }
 
@@ -164,7 +193,10 @@ func (s *ActionsService) UpdateRepoVariable(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#update-an-organization-variable
 func (s *ActionsService) UpdateOrgVariable(ctx context.Context, org string, variable *ActionsVariable) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/variables/%v", org, variable.Name)
+	url, err := newURLString("orgs/%v/actions/variables/%v", org, variable.Name)
+	if err != nil {
+		return nil, err
+	}
 	return s.patchVariable(ctx, url, variable)
 }
 
@@ -172,7 +204,10 @@ func (s *ActionsService) UpdateOrgVariable(ctx context.Context, org string, vari
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#create-an-environment-variable
 func (s *ActionsService) UpdateEnvVariable(ctx context.Context, repoID int, env string, variable *ActionsVariable) (*Response, error) {
-	url := fmt.Sprintf("repositories/%v/environments/%v/variables/%v", repoID, env, variable.Name)
+	url, err := newURLString("repositories/%v/environments/%v/variables/%v", repoID, env, variable.Name)
+	if err != nil {
+		return nil, err
+	}
 	return s.patchVariable(ctx, url, variable)
 }
 
@@ -189,7 +224,10 @@ func (s *ActionsService) deleteVariable(ctx context.Context, url string) (*Respo
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#delete-a-repository-variable
 func (s *ActionsService) DeleteRepoVariable(ctx context.Context, owner, repo, name string) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/variables/%v", owner, repo, name)
+	url, err := newURLString("repos/%v/%v/actions/variables/%v", owner, repo, name)
+	if err != nil {
+		return nil, err
+	}
 	return s.deleteVariable(ctx, url)
 }
 
@@ -197,7 +235,10 @@ func (s *ActionsService) DeleteRepoVariable(ctx context.Context, owner, repo, na
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#delete-an-organization-variable
 func (s *ActionsService) DeleteOrgVariable(ctx context.Context, org, name string) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/variables/%v", org, name)
+	url, err := newURLString("orgs/%v/actions/variables/%v", org, name)
+	if err != nil {
+		return nil, err
+	}
 	return s.deleteVariable(ctx, url)
 }
 
@@ -205,7 +246,10 @@ func (s *ActionsService) DeleteOrgVariable(ctx context.Context, org, name string
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#delete-an-environment-variable
 func (s *ActionsService) DeleteEnvVariable(ctx context.Context, repoID int, env, variableName string) (*Response, error) {
-	url := fmt.Sprintf("repositories/%v/environments/%v/variables/%v", repoID, env, variableName)
+	url, err := newURLString("repositories/%v/environments/%v/variables/%v", repoID, env, variableName)
+	if err != nil {
+		return nil, err
+	}
 	return s.deleteVariable(ctx, url)
 }
 
@@ -233,7 +277,10 @@ func (s *ActionsService) listSelectedReposForVariable(ctx context.Context, url s
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#list-selected-repositories-for-an-organization-variable
 func (s *ActionsService) ListSelectedReposForOrgVariable(ctx context.Context, org, name string, opts *ListOptions) (*SelectedReposList, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories", org, name)
+	url, err := newURLString("orgs/%v/actions/variables/%v/repositories", org, name)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.listSelectedReposForVariable(ctx, url, opts)
 }
 
@@ -254,7 +301,10 @@ func (s *ActionsService) setSelectedReposForVariable(ctx context.Context, url st
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#set-selected-repositories-for-an-organization-variable
 func (s *ActionsService) SetSelectedReposForOrgVariable(ctx context.Context, org, name string, ids SelectedRepoIDs) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories", org, name)
+	url, err := newURLString("orgs/%v/actions/variables/%v/repositories", org, name)
+	if err != nil {
+		return nil, err
+	}
 	return s.setSelectedReposForVariable(ctx, url, ids)
 }
 
@@ -271,7 +321,10 @@ func (s *ActionsService) addSelectedRepoToVariable(ctx context.Context, url stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#add-selected-repository-to-an-organization-variable
 func (s *ActionsService) AddSelectedRepoToOrgVariable(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories/%v", org, name, *repo.ID)
+	url, err := newURLString("orgs/%v/actions/variables/%v/repositories/%v", org, name, *repo.ID)
+	if err != nil {
+		return nil, err
+	}
 	return s.addSelectedRepoToVariable(ctx, url)
 }
 
@@ -288,6 +341,9 @@ func (s *ActionsService) removeSelectedRepoFromVariable(ctx context.Context, url
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/variables#remove-selected-repository-from-an-organization-variable
 func (s *ActionsService) RemoveSelectedRepoFromOrgVariable(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories/%v", org, name, *repo.ID)
+	url, err := newURLString("orgs/%v/actions/variables/%v/repositories/%v", org, name, *repo.ID)
+	if err != nil {
+		return nil, err
+	}
 	return s.removeSelectedRepoFromVariable(ctx, url)
 }

--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -72,8 +72,11 @@ type ListWorkflowJobsOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run
 func (s *ActionsService) ListWorkflowJobs(ctx context.Context, owner, repo string, runID int64, opts *ListWorkflowJobsOptions) (*Jobs, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/actions/runs/%v/jobs", owner, repo, runID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%s/%s/actions/runs/%v/jobs", owner, repo, runID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -96,7 +99,10 @@ func (s *ActionsService) ListWorkflowJobs(ctx context.Context, owner, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run
 func (s *ActionsService) GetWorkflowJobByID(ctx context.Context, owner, repo string, jobID int64) (*WorkflowJob, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/jobs/%v", owner, repo, jobID)
+	u, err := newURLString("repos/%v/%v/actions/jobs/%v", owner, repo, jobID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -116,7 +122,10 @@ func (s *ActionsService) GetWorkflowJobByID(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-jobs#download-job-logs-for-a-workflow-run
 func (s *ActionsService) GetWorkflowJobLogs(ctx context.Context, owner, repo string, jobID int64, followRedirects bool) (*url.URL, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/jobs/%v/logs", owner, repo, jobID)
+	u, err := newURLString("repos/%v/%v/actions/jobs/%v/logs", owner, repo, jobID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, followRedirects)
 	if err != nil {

--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -128,7 +128,10 @@ func (s *ActionsService) listWorkflowRuns(ctx context.Context, endpoint string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs
 func (s *ActionsService) ListWorkflowRunsByID(ctx context.Context, owner, repo string, workflowID int64, opts *ListWorkflowRunsOptions) (*WorkflowRuns, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/actions/workflows/%v/runs", owner, repo, workflowID)
+	u, err := newURLString("repos/%s/%s/actions/workflows/%v/runs", owner, repo, workflowID)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.listWorkflowRuns(ctx, u, opts)
 }
 
@@ -136,7 +139,10 @@ func (s *ActionsService) ListWorkflowRunsByID(ctx context.Context, owner, repo s
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs
 func (s *ActionsService) ListWorkflowRunsByFileName(ctx context.Context, owner, repo, workflowFileName string, opts *ListWorkflowRunsOptions) (*WorkflowRuns, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/actions/workflows/%v/runs", owner, repo, workflowFileName)
+	u, err := newURLString("repos/%s/%s/actions/workflows/%v/runs", owner, repo, workflowFileName)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.listWorkflowRuns(ctx, u, opts)
 }
 
@@ -144,8 +150,11 @@ func (s *ActionsService) ListWorkflowRunsByFileName(ctx context.Context, owner, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
 func (s *ActionsService) ListRepositoryWorkflowRuns(ctx context.Context, owner, repo string, opts *ListWorkflowRunsOptions) (*WorkflowRuns, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/actions/runs", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%s/%s/actions/runs", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -168,7 +177,10 @@ func (s *ActionsService) ListRepositoryWorkflowRuns(ctx context.Context, owner, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run
 func (s *ActionsService) GetWorkflowRunByID(ctx context.Context, owner, repo string, runID int64) (*WorkflowRun, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v", owner, repo, runID)
+	u, err := newURLString("repos/%v/%v/actions/runs/%v", owner, repo, runID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -188,8 +200,11 @@ func (s *ActionsService) GetWorkflowRunByID(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run-attempt
 func (s *ActionsService) GetWorkflowRunAttempt(ctx context.Context, owner, repo string, runID int64, attemptNumber int, opts *WorkflowRunAttemptOptions) (*WorkflowRun, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/attempts/%v", owner, repo, runID, attemptNumber)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/actions/runs/%v/attempts/%v", owner, repo, runID, attemptNumber)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -212,7 +227,10 @@ func (s *ActionsService) GetWorkflowRunAttempt(ctx context.Context, owner, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#download-workflow-run-attempt-logs
 func (s *ActionsService) GetWorkflowRunAttemptLogs(ctx context.Context, owner, repo string, runID int64, attemptNumber int, followRedirects bool) (*url.URL, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/attempts/%v/logs", owner, repo, runID, attemptNumber)
+	u, err := newURLString("repos/%v/%v/actions/runs/%v/attempts/%v/logs", owner, repo, runID, attemptNumber)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, followRedirects)
 	if err != nil {
@@ -232,7 +250,10 @@ func (s *ActionsService) GetWorkflowRunAttemptLogs(ctx context.Context, owner, r
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#re-run-a-workflow
 func (s *ActionsService) RerunWorkflowByID(ctx context.Context, owner, repo string, runID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/rerun", owner, repo, runID)
+	u, err := newURLString("repos/%v/%v/actions/runs/%v/rerun", owner, repo, runID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -246,7 +267,10 @@ func (s *ActionsService) RerunWorkflowByID(ctx context.Context, owner, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#re-run-failed-jobs-from-a-workflow-run
 func (s *ActionsService) RerunFailedJobsByID(ctx context.Context, owner, repo string, runID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/rerun-failed-jobs", owner, repo, runID)
+	u, err := newURLString("repos/%v/%v/actions/runs/%v/rerun-failed-jobs", owner, repo, runID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -260,7 +284,10 @@ func (s *ActionsService) RerunFailedJobsByID(ctx context.Context, owner, repo st
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#re-run-a-job-from-a-workflow-run
 func (s *ActionsService) RerunJobByID(ctx context.Context, owner, repo string, jobID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/jobs/%v/rerun", owner, repo, jobID)
+	u, err := newURLString("repos/%v/%v/actions/jobs/%v/rerun", owner, repo, jobID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -274,7 +301,10 @@ func (s *ActionsService) RerunJobByID(ctx context.Context, owner, repo string, j
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#cancel-a-workflow-run
 func (s *ActionsService) CancelWorkflowRunByID(ctx context.Context, owner, repo string, runID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/cancel", owner, repo, runID)
+	u, err := newURLString("repos/%v/%v/actions/runs/%v/cancel", owner, repo, runID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -288,7 +318,10 @@ func (s *ActionsService) CancelWorkflowRunByID(ctx context.Context, owner, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#download-workflow-run-logs
 func (s *ActionsService) GetWorkflowRunLogs(ctx context.Context, owner, repo string, runID int64, followRedirects bool) (*url.URL, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/logs", owner, repo, runID)
+	u, err := newURLString("repos/%v/%v/actions/runs/%v/logs", owner, repo, runID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, followRedirects)
 	if err != nil {
@@ -308,7 +341,10 @@ func (s *ActionsService) GetWorkflowRunLogs(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#delete-a-workflow-run
 func (s *ActionsService) DeleteWorkflowRun(ctx context.Context, owner, repo string, runID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v", owner, repo, runID)
+	u, err := newURLString("repos/%v/%v/actions/runs/%v", owner, repo, runID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -322,7 +358,10 @@ func (s *ActionsService) DeleteWorkflowRun(ctx context.Context, owner, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#delete-workflow-run-logs
 func (s *ActionsService) DeleteWorkflowRunLogs(ctx context.Context, owner, repo string, runID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/logs", owner, repo, runID)
+	u, err := newURLString("repos/%v/%v/actions/runs/%v/logs", owner, repo, runID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -336,7 +375,10 @@ func (s *ActionsService) DeleteWorkflowRunLogs(ctx context.Context, owner, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#get-workflow-run-usage
 func (s *ActionsService) GetWorkflowRunUsageByID(ctx context.Context, owner, repo string, runID int64) (*WorkflowRunUsage, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/timing", owner, repo, runID)
+	u, err := newURLString("repos/%v/%v/actions/runs/%v/timing", owner, repo, runID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -356,7 +398,10 @@ func (s *ActionsService) GetWorkflowRunUsageByID(ctx context.Context, owner, rep
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#review-pending-deployments-for-a-workflow-run
 func (s *ActionsService) PendingDeployments(ctx context.Context, owner, repo string, runID int64, request *PendingDeploymentsRequest) ([]*Deployment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/pending_deployments", owner, repo, runID)
+	u, err := newURLString("repos/%v/%v/actions/runs/%v/pending_deployments", owner, repo, runID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, request)
 	if err != nil {

--- a/github/actions_workflows.go
+++ b/github/actions_workflows.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // Workflow represents a repository action workflow.
@@ -60,8 +59,11 @@ type CreateWorkflowDispatchEventRequest struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflows#list-repository-workflows
 func (s *ActionsService) ListWorkflows(ctx context.Context, owner, repo string, opts *ListOptions) (*Workflows, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/actions/workflows", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%s/%s/actions/workflows", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -84,7 +86,10 @@ func (s *ActionsService) ListWorkflows(ctx context.Context, owner, repo string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflows#get-a-workflow
 func (s *ActionsService) GetWorkflowByID(ctx context.Context, owner, repo string, workflowID int64) (*Workflow, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/workflows/%v", owner, repo, workflowID)
+	u, err := newURLString("repos/%v/%v/actions/workflows/%v", owner, repo, workflowID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	return s.getWorkflow(ctx, u)
 }
@@ -93,7 +98,10 @@ func (s *ActionsService) GetWorkflowByID(ctx context.Context, owner, repo string
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflows#get-a-workflow
 func (s *ActionsService) GetWorkflowByFileName(ctx context.Context, owner, repo, workflowFileName string) (*Workflow, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/workflows/%v", owner, repo, workflowFileName)
+	u, err := newURLString("repos/%v/%v/actions/workflows/%v", owner, repo, workflowFileName)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	return s.getWorkflow(ctx, u)
 }
@@ -117,7 +125,10 @@ func (s *ActionsService) getWorkflow(ctx context.Context, url string) (*Workflow
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflows#get-workflow-usage
 func (s *ActionsService) GetWorkflowUsageByID(ctx context.Context, owner, repo string, workflowID int64) (*WorkflowUsage, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/workflows/%v/timing", owner, repo, workflowID)
+	u, err := newURLString("repos/%v/%v/actions/workflows/%v/timing", owner, repo, workflowID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	return s.getWorkflowUsage(ctx, u)
 }
@@ -126,7 +137,10 @@ func (s *ActionsService) GetWorkflowUsageByID(ctx context.Context, owner, repo s
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflows#get-workflow-usage
 func (s *ActionsService) GetWorkflowUsageByFileName(ctx context.Context, owner, repo, workflowFileName string) (*WorkflowUsage, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/workflows/%v/timing", owner, repo, workflowFileName)
+	u, err := newURLString("repos/%v/%v/actions/workflows/%v/timing", owner, repo, workflowFileName)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	return s.getWorkflowUsage(ctx, u)
 }
@@ -150,7 +164,10 @@ func (s *ActionsService) getWorkflowUsage(ctx context.Context, url string) (*Wor
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event
 func (s *ActionsService) CreateWorkflowDispatchEventByID(ctx context.Context, owner, repo string, workflowID int64, event CreateWorkflowDispatchEventRequest) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/workflows/%v/dispatches", owner, repo, workflowID)
+	u, err := newURLString("repos/%v/%v/actions/workflows/%v/dispatches", owner, repo, workflowID)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.createWorkflowDispatchEvent(ctx, u, &event)
 }
@@ -159,7 +176,10 @@ func (s *ActionsService) CreateWorkflowDispatchEventByID(ctx context.Context, ow
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event
 func (s *ActionsService) CreateWorkflowDispatchEventByFileName(ctx context.Context, owner, repo, workflowFileName string, event CreateWorkflowDispatchEventRequest) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/workflows/%v/dispatches", owner, repo, workflowFileName)
+	u, err := newURLString("repos/%v/%v/actions/workflows/%v/dispatches", owner, repo, workflowFileName)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.createWorkflowDispatchEvent(ctx, u, &event)
 }
@@ -177,7 +197,10 @@ func (s *ActionsService) createWorkflowDispatchEvent(ctx context.Context, url st
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflows#enable-a-workflow
 func (s *ActionsService) EnableWorkflowByID(ctx context.Context, owner, repo string, workflowID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/workflows/%v/enable", owner, repo, workflowID)
+	u, err := newURLString("repos/%v/%v/actions/workflows/%v/enable", owner, repo, workflowID)
+	if err != nil {
+		return nil, err
+	}
 	return s.doNewPutRequest(ctx, u)
 }
 
@@ -185,7 +208,10 @@ func (s *ActionsService) EnableWorkflowByID(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflows#enable-a-workflow
 func (s *ActionsService) EnableWorkflowByFileName(ctx context.Context, owner, repo, workflowFileName string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/workflows/%v/enable", owner, repo, workflowFileName)
+	u, err := newURLString("repos/%v/%v/actions/workflows/%v/enable", owner, repo, workflowFileName)
+	if err != nil {
+		return nil, err
+	}
 	return s.doNewPutRequest(ctx, u)
 }
 
@@ -193,7 +219,10 @@ func (s *ActionsService) EnableWorkflowByFileName(ctx context.Context, owner, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflows#disable-a-workflow
 func (s *ActionsService) DisableWorkflowByID(ctx context.Context, owner, repo string, workflowID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/workflows/%v/disable", owner, repo, workflowID)
+	u, err := newURLString("repos/%v/%v/actions/workflows/%v/disable", owner, repo, workflowID)
+	if err != nil {
+		return nil, err
+	}
 	return s.doNewPutRequest(ctx, u)
 }
 
@@ -201,7 +230,10 @@ func (s *ActionsService) DisableWorkflowByID(ctx context.Context, owner, repo st
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflows#disable-a-workflow
 func (s *ActionsService) DisableWorkflowByFileName(ctx context.Context, owner, repo, workflowFileName string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/workflows/%v/disable", owner, repo, workflowFileName)
+	u, err := newURLString("repos/%v/%v/actions/workflows/%v/disable", owner, repo, workflowFileName)
+	if err != nil {
+		return nil, err
+	}
 	return s.doNewPutRequest(ctx, u)
 }
 

--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ListEvents drinks from the firehose of all public events across GitHub.
@@ -37,8 +36,11 @@ func (s *ActivityService) ListEvents(ctx context.Context, opts *ListOptions) ([]
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/events#list-repository-events
 func (s *ActivityService) ListRepositoryEvents(ctx context.Context, owner, repo string, opts *ListOptions) ([]*Event, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/events", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/events", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -61,8 +63,11 @@ func (s *ActivityService) ListRepositoryEvents(ctx context.Context, owner, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/events#list-issue-events-for-a-repository
 func (s *ActivityService) ListIssueEventsForRepository(ctx context.Context, owner, repo string, opts *ListOptions) ([]*IssueEvent, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/events", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/issues/events", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -85,8 +90,11 @@ func (s *ActivityService) ListIssueEventsForRepository(ctx context.Context, owne
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/events#list-public-events-for-a-network-of-repositories
 func (s *ActivityService) ListEventsForRepoNetwork(ctx context.Context, owner, repo string, opts *ListOptions) ([]*Event, *Response, error) {
-	u := fmt.Sprintf("networks/%v/%v/events", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("networks/%v/%v/events", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -109,8 +117,11 @@ func (s *ActivityService) ListEventsForRepoNetwork(ctx context.Context, owner, r
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/events#list-public-organization-events
 func (s *ActivityService) ListEventsForOrganization(ctx context.Context, org string, opts *ListOptions) ([]*Event, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/events", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/events", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -135,13 +146,15 @@ func (s *ActivityService) ListEventsForOrganization(ctx context.Context, org str
 // GitHub API docs: https://docs.github.com/en/rest/activity/events#list-events-for-the-authenticated-user
 // GitHub API docs: https://docs.github.com/en/rest/activity/events#list-public-events-for-a-user
 func (s *ActivityService) ListEventsPerformedByUser(ctx context.Context, user string, publicOnly bool, opts *ListOptions) ([]*Event, *Response, error) {
-	var u string
+	urlFormat := "users/%v/events"
 	if publicOnly {
-		u = fmt.Sprintf("users/%v/events/public", user)
-	} else {
-		u = fmt.Sprintf("users/%v/events", user)
+		urlFormat += "/public"
 	}
-	u, err := addOptions(u, opts)
+	u, err := newURLString(urlFormat, user)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -166,13 +179,15 @@ func (s *ActivityService) ListEventsPerformedByUser(ctx context.Context, user st
 // GitHub API docs: https://docs.github.com/en/rest/activity/events#list-events-received-by-the-authenticated-user
 // GitHub API docs: https://docs.github.com/en/rest/activity/events#list-public-events-received-by-a-user
 func (s *ActivityService) ListEventsReceivedByUser(ctx context.Context, user string, publicOnly bool, opts *ListOptions) ([]*Event, *Response, error) {
-	var u string
+	urlFormat := "users/%v/received_events"
 	if publicOnly {
-		u = fmt.Sprintf("users/%v/received_events/public", user)
-	} else {
-		u = fmt.Sprintf("users/%v/received_events", user)
+		urlFormat += "/public"
 	}
-	u, err := addOptions(u, opts)
+	u, err := newURLString(urlFormat, user)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -196,8 +211,11 @@ func (s *ActivityService) ListEventsReceivedByUser(ctx context.Context, user str
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/events#list-organization-events-for-the-authenticated-user
 func (s *ActivityService) ListUserEventsForOrganization(ctx context.Context, org, user string, opts *ListOptions) ([]*Event, *Response, error) {
-	u := fmt.Sprintf("users/%v/events/orgs/%v", user, org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("users/%v/events/orgs/%v", user, org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -13,7 +13,11 @@ import (
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/events#list-public-events
 func (s *ActivityService) ListEvents(ctx context.Context, opts *ListOptions) ([]*Event, *Response, error) {
-	u, err := addOptions("events", opts)
+	u, err := newURLString("events")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/activity_notifications.go
+++ b/github/activity_notifications.go
@@ -54,10 +54,6 @@ func (s *ActivityService) ListNotifications(ctx context.Context, opts *Notificat
 	if err != nil {
 		return nil, nil, err
 	}
-	u, err = addOptions("notifications", opts)
-	if err != nil {
-		return nil, nil, err
-	}
 	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err

--- a/github/activity_notifications.go
+++ b/github/activity_notifications.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"time"
 )
 
@@ -51,8 +50,15 @@ type NotificationListOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/notifications#list-notifications-for-the-authenticated-user
 func (s *ActivityService) ListNotifications(ctx context.Context, opts *NotificationListOptions) ([]*Notification, *Response, error) {
-	u := "notifications"
-	u, err := addOptions(u, opts)
+	u, err := newURLString("notifications")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions("notifications", opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -76,8 +82,11 @@ func (s *ActivityService) ListNotifications(ctx context.Context, opts *Notificat
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/notifications#list-repository-notifications-for-the-authenticated-user
 func (s *ActivityService) ListRepositoryNotifications(ctx context.Context, owner, repo string, opts *NotificationListOptions) ([]*Notification, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/notifications", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/notifications", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -123,7 +132,10 @@ func (s *ActivityService) MarkRepositoryNotificationsRead(ctx context.Context, o
 	opts := &markReadOptions{
 		LastReadAt: lastRead,
 	}
-	u := fmt.Sprintf("repos/%v/%v/notifications", owner, repo)
+	u, err := newURLString("repos/%v/%v/notifications", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, err
@@ -136,7 +148,10 @@ func (s *ActivityService) MarkRepositoryNotificationsRead(ctx context.Context, o
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/notifications#get-a-thread
 func (s *ActivityService) GetThread(ctx context.Context, id string) (*Notification, *Response, error) {
-	u := fmt.Sprintf("notifications/threads/%v", id)
+	u, err := newURLString("notifications/threads/%v", id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -156,7 +171,10 @@ func (s *ActivityService) GetThread(ctx context.Context, id string) (*Notificati
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/notifications#mark-a-thread-as-read
 func (s *ActivityService) MarkThreadRead(ctx context.Context, id string) (*Response, error) {
-	u := fmt.Sprintf("notifications/threads/%v", id)
+	u, err := newURLString("notifications/threads/%v", id)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PATCH", u, nil)
 	if err != nil {
@@ -171,7 +189,10 @@ func (s *ActivityService) MarkThreadRead(ctx context.Context, id string) (*Respo
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/notifications#get-a-thread-subscription-for-the-authenticated-user
 func (s *ActivityService) GetThreadSubscription(ctx context.Context, id string) (*Subscription, *Response, error) {
-	u := fmt.Sprintf("notifications/threads/%v/subscription", id)
+	u, err := newURLString("notifications/threads/%v/subscription", id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -192,7 +213,10 @@ func (s *ActivityService) GetThreadSubscription(ctx context.Context, id string) 
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/notifications#set-a-thread-subscription
 func (s *ActivityService) SetThreadSubscription(ctx context.Context, id string, subscription *Subscription) (*Subscription, *Response, error) {
-	u := fmt.Sprintf("notifications/threads/%v/subscription", id)
+	u, err := newURLString("notifications/threads/%v/subscription", id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, subscription)
 	if err != nil {
@@ -213,7 +237,10 @@ func (s *ActivityService) SetThreadSubscription(ctx context.Context, id string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/notifications#delete-a-thread-subscription
 func (s *ActivityService) DeleteThreadSubscription(ctx context.Context, id string) (*Response, error) {
-	u := fmt.Sprintf("notifications/threads/%v/subscription", id)
+	u, err := newURLString("notifications/threads/%v/subscription", id)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/activity_star.go
+++ b/github/activity_star.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"strings"
 )
 
@@ -27,8 +26,11 @@ type Stargazer struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/starring#list-stargazers
 func (s *ActivityService) ListStargazers(ctx context.Context, owner, repo string, opts *ListOptions) ([]*Stargazer, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/stargazers", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%s/%s/stargazers", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -71,12 +73,16 @@ type ActivityListStarredOptions struct {
 // GitHub API docs: https://docs.github.com/en/rest/activity/starring#list-repositories-starred-by-a-user
 func (s *ActivityService) ListStarred(ctx context.Context, user string, opts *ActivityListStarredOptions) ([]*StarredRepository, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/starred", user)
+		u, err = newURLString("users/%v/starred", user)
 	} else {
-		u = "user/starred"
+		u, err = newURLString("user/starred")
 	}
-	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -103,7 +109,10 @@ func (s *ActivityService) ListStarred(ctx context.Context, user string, opts *Ac
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/starring#check-if-a-repository-is-starred-by-the-authenticated-user
 func (s *ActivityService) IsStarred(ctx context.Context, owner, repo string) (bool, *Response, error) {
-	u := fmt.Sprintf("user/starred/%v/%v", owner, repo)
+	u, err := newURLString("user/starred/%v/%v", owner, repo)
+	if err != nil {
+		return false, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return false, nil, err
@@ -118,7 +127,10 @@ func (s *ActivityService) IsStarred(ctx context.Context, owner, repo string) (bo
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/starring#star-a-repository-for-the-authenticated-user
 func (s *ActivityService) Star(ctx context.Context, owner, repo string) (*Response, error) {
-	u := fmt.Sprintf("user/starred/%v/%v", owner, repo)
+	u, err := newURLString("user/starred/%v/%v", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
 		return nil, err
@@ -131,7 +143,10 @@ func (s *ActivityService) Star(ctx context.Context, owner, repo string) (*Respon
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/starring#unstar-a-repository-for-the-authenticated-user
 func (s *ActivityService) Unstar(ctx context.Context, owner, repo string) (*Response, error) {
-	u := fmt.Sprintf("user/starred/%v/%v", owner, repo)
+	u, err := newURLString("user/starred/%v/%v", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/activity_watching.go
+++ b/github/activity_watching.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // Subscription identifies a repository or thread subscription.
@@ -29,8 +28,11 @@ type Subscription struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/watching#list-watchers
 func (s *ActivityService) ListWatchers(ctx context.Context, owner, repo string, opts *ListOptions) ([]*User, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/subscribers", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%s/%s/subscribers", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -56,12 +58,16 @@ func (s *ActivityService) ListWatchers(ctx context.Context, owner, repo string, 
 // GitHub API docs: https://docs.github.com/en/rest/activity/watching#list-repositories-watched-by-a-user
 func (s *ActivityService) ListWatched(ctx context.Context, user string, opts *ListOptions) ([]*Repository, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/subscriptions", user)
+		u, err = newURLString("users/%v/subscriptions", user)
 	} else {
-		u = "user/subscriptions"
+		u, err = newURLString("user/subscriptions")
 	}
-	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -86,7 +92,10 @@ func (s *ActivityService) ListWatched(ctx context.Context, user string, opts *Li
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/watching#get-a-repository-subscription
 func (s *ActivityService) GetRepositorySubscription(ctx context.Context, owner, repo string) (*Subscription, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/subscription", owner, repo)
+	u, err := newURLString("repos/%s/%s/subscription", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -113,7 +122,10 @@ func (s *ActivityService) GetRepositorySubscription(ctx context.Context, owner, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/watching#set-a-repository-subscription
 func (s *ActivityService) SetRepositorySubscription(ctx context.Context, owner, repo string, subscription *Subscription) (*Subscription, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/subscription", owner, repo)
+	u, err := newURLString("repos/%s/%s/subscription", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, subscription)
 	if err != nil {
@@ -137,7 +149,10 @@ func (s *ActivityService) SetRepositorySubscription(ctx context.Context, owner, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/activity/watching#delete-a-repository-subscription
 func (s *ActivityService) DeleteRepositorySubscription(ctx context.Context, owner, repo string) (*Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/subscription", owner, repo)
+	u, err := newURLString("repos/%s/%s/subscription", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/admin.go
+++ b/github/admin.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // AdminService handles communication with the admin related methods of the
@@ -84,7 +83,10 @@ func (m Enterprise) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-server/rest/enterprise-admin/ldap#update-ldap-mapping-for-a-user
 func (s *AdminService) UpdateUserLDAPMapping(ctx context.Context, user string, mapping *UserLDAPMapping) (*UserLDAPMapping, *Response, error) {
-	u := fmt.Sprintf("admin/ldap/users/%v/mapping", user)
+	u, err := newURLString("admin/ldap/users/%v/mapping", user)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, mapping)
 	if err != nil {
 		return nil, nil, err
@@ -103,7 +105,10 @@ func (s *AdminService) UpdateUserLDAPMapping(ctx context.Context, user string, m
 //
 // GitHub API docs: https://docs.github.com/en/rest/enterprise/ldap/#update-ldap-mapping-for-a-team
 func (s *AdminService) UpdateTeamLDAPMapping(ctx context.Context, team int64, mapping *TeamLDAPMapping) (*TeamLDAPMapping, *Response, error) {
-	u := fmt.Sprintf("admin/ldap/teams/%v/mapping", team)
+	u, err := newURLString("admin/ldap/teams/%v/mapping", team)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, mapping)
 	if err != nil {
 		return nil, nil, err

--- a/github/admin_orgs.go
+++ b/github/admin_orgs.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // createOrgRequest is a subset of Organization and is used internally
@@ -24,7 +23,10 @@ type createOrgRequest struct {
 //
 // GitHub Enterprise API docs: https://developer.github.com/enterprise/v3/enterprise-admin/orgs/#create-an-organization
 func (s *AdminService) CreateOrg(ctx context.Context, org *Organization, admin string) (*Organization, *Response, error) {
-	u := "admin/organizations"
+	u, err := newURLString("admin/organizations")
+	if err != nil {
+		return nil, nil, err
+	}
 
 	orgReq := &createOrgRequest{
 		Login: org.Login,
@@ -68,7 +70,10 @@ func (s *AdminService) RenameOrg(ctx context.Context, org *Organization, newName
 //
 // GitHub Enterprise API docs: https://developer.github.com/enterprise/v3/enterprise-admin/orgs/#rename-an-organization
 func (s *AdminService) RenameOrgByName(ctx context.Context, org, newName string) (*RenameOrgResponse, *Response, error) {
-	u := fmt.Sprintf("admin/organizations/%v", org)
+	u, err := newURLString("admin/organizations/%v", org)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	orgReq := &renameOrgRequest{
 		Login: &newName,

--- a/github/admin_stats.go
+++ b/github/admin_stats.go
@@ -154,7 +154,10 @@ func (s RepoStats) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/enterprise-admin/admin_stats/
 func (s *AdminService) GetAdminStats(ctx context.Context) (*AdminStats, *Response, error) {
-	u := "enterprise/stats/all"
+	u, err := newURLString("enterprise/stats/all")
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/admin_users.go
+++ b/github/admin_users.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // createUserRequest is a subset of User and is used internally
@@ -21,7 +20,10 @@ type createUserRequest struct {
 //
 // GitHub Enterprise API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#create-a-new-user
 func (s *AdminService) CreateUser(ctx context.Context, login, email string) (*User, *Response, error) {
-	u := "admin/users"
+	u, err := newURLString("admin/users")
+	if err != nil {
+		return nil, nil, err
+	}
 
 	userReq := &createUserRequest{
 		Login: &login,
@@ -46,7 +48,10 @@ func (s *AdminService) CreateUser(ctx context.Context, login, email string) (*Us
 //
 // GitHub Enterprise API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#delete-a-user
 func (s *AdminService) DeleteUser(ctx context.Context, username string) (*Response, error) {
-	u := "admin/users/" + username
+	u, err := newURLString("admin/users/%s", username)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -97,7 +102,10 @@ type UserAuthorization struct {
 //
 // GitHub Enterprise API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#create-an-impersonation-oauth-token
 func (s *AdminService) CreateUserImpersonation(ctx context.Context, username string, opts *ImpersonateUserOptions) (*UserAuthorization, *Response, error) {
-	u := fmt.Sprintf("admin/users/%s/authorizations", username)
+	u, err := newURLString("admin/users/%s/authorizations", username)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
@@ -117,7 +125,10 @@ func (s *AdminService) CreateUserImpersonation(ctx context.Context, username str
 //
 // GitHub Enterprise API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#delete-an-impersonation-oauth-token
 func (s *AdminService) DeleteUserImpersonation(ctx context.Context, username string) (*Response, error) {
-	u := fmt.Sprintf("admin/users/%s/authorizations", username)
+	u, err := newURLString("admin/users/%s/authorizations", username)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/apps.go
+++ b/github/apps.go
@@ -179,7 +179,11 @@ func (s *AppsService) Get(ctx context.Context, appSlug string) (*App, *Response,
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/apps#list-installations-for-the-authenticated-app
 func (s *AppsService) ListInstallations(ctx context.Context, opts *ListOptions) ([]*Installation, *Response, error) {
-	u, err := addOptions("app/installations", opts)
+	u, err := newURLString("app/installations")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -209,7 +213,11 @@ func (s *AppsService) GetInstallation(ctx context.Context, id int64) (*Installat
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/installations#list-app-installations-accessible-to-the-user-access-token
 func (s *AppsService) ListUserInstallations(ctx context.Context, opts *ListOptions) ([]*Installation, *Response, error) {
-	u, err := addOptions("user/installations", opts)
+	u, err := newURLString("user/installations")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/apps.go
+++ b/github/apps.go
@@ -234,7 +234,10 @@ func (s *AppsService) ListUserInstallations(ctx context.Context, opts *ListOptio
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/apps#suspend-an-app-installation
 func (s *AppsService) SuspendInstallation(ctx context.Context, id int64) (*Response, error) {
-	u := fmt.Sprintf("app/installations/%v/suspended", id)
+	u, err := newURLString("app/installations/%v/suspended", id)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
@@ -248,7 +251,10 @@ func (s *AppsService) SuspendInstallation(ctx context.Context, id int64) (*Respo
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/apps#unsuspend-an-app-installation
 func (s *AppsService) UnsuspendInstallation(ctx context.Context, id int64) (*Response, error) {
-	u := fmt.Sprintf("app/installations/%v/suspended", id)
+	u, err := newURLString("app/installations/%v/suspended", id)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -262,7 +268,10 @@ func (s *AppsService) UnsuspendInstallation(ctx context.Context, id int64) (*Res
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/apps#delete-an-installation-for-the-authenticated-app
 func (s *AppsService) DeleteInstallation(ctx context.Context, id int64) (*Response, error) {
-	u := fmt.Sprintf("app/installations/%v", id)
+	u, err := newURLString("app/installations/%v", id)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -276,7 +285,10 @@ func (s *AppsService) DeleteInstallation(ctx context.Context, id int64) (*Respon
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app
 func (s *AppsService) CreateInstallationToken(ctx context.Context, id int64, opts *InstallationTokenOptions) (*InstallationToken, *Response, error) {
-	u := fmt.Sprintf("app/installations/%v/access_tokens", id)
+	u, err := newURLString("app/installations/%v/access_tokens", id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
@@ -296,7 +308,10 @@ func (s *AppsService) CreateInstallationToken(ctx context.Context, id int64, opt
 //
 // TODO: Find GitHub API docs.
 func (s *AppsService) CreateAttachment(ctx context.Context, contentReferenceID int64, title, body string) (*Attachment, *Response, error) {
-	u := fmt.Sprintf("content_references/%v/attachments", contentReferenceID)
+	u, err := newURLString("content_references/%v/attachments", contentReferenceID)
+	if err != nil {
+		return nil, nil, err
+	}
 	payload := &Attachment{Title: String(title), Body: String(body)}
 	req, err := s.client.NewRequest("POST", u, payload)
 	if err != nil {

--- a/github/apps.go
+++ b/github/apps.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // AppsService provides access to the installation related functions
@@ -155,10 +154,14 @@ func (i Installation) String() string {
 // GitHub API docs: https://docs.github.com/en/rest/apps/apps#get-an-app
 func (s *AppsService) Get(ctx context.Context, appSlug string) (*App, *Response, error) {
 	var u string
+	var err error
 	if appSlug != "" {
-		u = fmt.Sprintf("apps/%v", appSlug)
+		u, err = newURLString("apps/%v", appSlug)
 	} else {
-		u = "app"
+		u, err = newURLString("app")
+	}
+	if err != nil {
+		return nil, nil, err
 	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -206,7 +209,11 @@ func (s *AppsService) ListInstallations(ctx context.Context, opts *ListOptions) 
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/apps#get-an-installation-for-the-authenticated-app
 func (s *AppsService) GetInstallation(ctx context.Context, id int64) (*Installation, *Response, error) {
-	return s.getInstallation(ctx, fmt.Sprintf("app/installations/%v", id))
+	u, err := newURLString("app/installations/%v", id)
+	if err != nil {
+		return nil, nil, err
+	}
+	return s.getInstallation(ctx, u)
 }
 
 // ListUserInstallations lists installations that are accessible to the authenticated user.
@@ -342,28 +349,44 @@ func (s *AppsService) CreateAttachment(ctx context.Context, contentReferenceID i
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/apps#get-an-organization-installation-for-the-authenticated-app
 func (s *AppsService) FindOrganizationInstallation(ctx context.Context, org string) (*Installation, *Response, error) {
-	return s.getInstallation(ctx, fmt.Sprintf("orgs/%v/installation", org))
+	u, err := newURLString("orgs/%v/installation", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	return s.getInstallation(ctx, u)
 }
 
 // FindRepositoryInstallation finds the repository's installation information.
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app
 func (s *AppsService) FindRepositoryInstallation(ctx context.Context, owner, repo string) (*Installation, *Response, error) {
-	return s.getInstallation(ctx, fmt.Sprintf("repos/%v/%v/installation", owner, repo))
+	u, err := newURLString("repos/%v/%v/installation", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	return s.getInstallation(ctx, u)
 }
 
 // FindRepositoryInstallationByID finds the repository's installation information.
 //
 // Note: FindRepositoryInstallationByID uses the undocumented GitHub API endpoint /repositories/:id/installation.
 func (s *AppsService) FindRepositoryInstallationByID(ctx context.Context, id int64) (*Installation, *Response, error) {
-	return s.getInstallation(ctx, fmt.Sprintf("repositories/%d/installation", id))
+	u, err := newURLString("repositories/%v/installation", id)
+	if err != nil {
+		return nil, nil, err
+	}
+	return s.getInstallation(ctx, u)
 }
 
 // FindUserInstallation finds the user's installation information.
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/apps#get-a-user-installation-for-the-authenticated-app
 func (s *AppsService) FindUserInstallation(ctx context.Context, user string) (*Installation, *Response, error) {
-	return s.getInstallation(ctx, fmt.Sprintf("users/%v/installation", user))
+	u, err := newURLString("users/%v/installation", user)
+	if err != nil {
+		return nil, nil, err
+	}
+	return s.getInstallation(ctx, u)
 }
 
 func (s *AppsService) getInstallation(ctx context.Context, url string) (*Installation, *Response, error) {

--- a/github/apps_hooks_deliveries.go
+++ b/github/apps_hooks_deliveries.go
@@ -13,7 +13,11 @@ import (
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/webhooks#list-deliveries-for-an-app-webhook
 func (s *AppsService) ListHookDeliveries(ctx context.Context, opts *ListCursorOptions) ([]*HookDelivery, *Response, error) {
-	u, err := addOptions("app/hook/deliveries", opts)
+	u, err := newURLString("app/hook/deliveries")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/apps_hooks_deliveries.go
+++ b/github/apps_hooks_deliveries.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ListHookDeliveries lists deliveries of an App webhook.
@@ -37,7 +36,10 @@ func (s *AppsService) ListHookDeliveries(ctx context.Context, opts *ListCursorOp
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/webhooks#get-a-delivery-for-an-app-webhook
 func (s *AppsService) GetHookDelivery(ctx context.Context, deliveryID int64) (*HookDelivery, *Response, error) {
-	u := fmt.Sprintf("app/hook/deliveries/%v", deliveryID)
+	u, err := newURLString("app/hook/deliveries/%v", deliveryID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -56,7 +58,10 @@ func (s *AppsService) GetHookDelivery(ctx context.Context, deliveryID int64) (*H
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/webhooks#redeliver-a-delivery-for-an-app-webhook
 func (s *AppsService) RedeliverHookDelivery(ctx context.Context, deliveryID int64) (*HookDelivery, *Response, error) {
-	u := fmt.Sprintf("app/hook/deliveries/%v/attempts", deliveryID)
+	u, err := newURLString("app/hook/deliveries/%v/attempts", deliveryID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -20,7 +20,11 @@ type ListRepositories struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/installations#list-repositories-accessible-to-the-app-installation
 func (s *AppsService) ListRepos(ctx context.Context, opts *ListOptions) (*ListRepositories, *Response, error) {
-	u, err := addOptions("installation/repositories", opts)
+	u, err := newURLString("installation/repositories")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"strings"
 )
 
@@ -54,8 +53,11 @@ func (s *AppsService) ListRepos(ctx context.Context, opts *ListOptions) (*ListRe
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/installations#list-repositories-accessible-to-the-user-access-token
 func (s *AppsService) ListUserRepos(ctx context.Context, id int64, opts *ListOptions) (*ListRepositories, *Response, error) {
-	u := fmt.Sprintf("user/installations/%v/repositories", id)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("user/installations/%v/repositories", id)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -86,7 +88,10 @@ func (s *AppsService) ListUserRepos(ctx context.Context, id int64, opts *ListOpt
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/installations#add-a-repository-to-an-app-installation
 func (s *AppsService) AddRepository(ctx context.Context, instID, repoID int64) (*Repository, *Response, error) {
-	u := fmt.Sprintf("user/installations/%v/repositories/%v", instID, repoID)
+	u, err := newURLString("user/installations/%v/repositories/%v", instID, repoID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -105,7 +110,10 @@ func (s *AppsService) AddRepository(ctx context.Context, instID, repoID int64) (
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/installations#remove-a-repository-from-an-app-installation
 func (s *AppsService) RemoveRepository(ctx context.Context, instID, repoID int64) (*Response, error) {
-	u := fmt.Sprintf("user/installations/%v/repositories/%v", instID, repoID)
+	u, err := newURLString("user/installations/%v/repositories/%v", instID, repoID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -118,7 +126,10 @@ func (s *AppsService) RemoveRepository(ctx context.Context, instID, repoID int64
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/installations#revoke-an-installation-access-token
 func (s *AppsService) RevokeInstallationToken(ctx context.Context) (*Response, error) {
-	u := "installation/token"
+	u, err := newURLString("installation/token")
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/apps_manifest.go
+++ b/github/apps_manifest.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // AppConfig describes the configuration of a GitHub App.
@@ -33,7 +32,10 @@ type AppConfig struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/apps#create-a-github-app-from-a-manifest
 func (s *AppsService) CompleteAppManifest(ctx context.Context, code string) (*AppConfig, *Response, error) {
-	u := fmt.Sprintf("app-manifests/%s/conversions", code)
+	u, err := newURLString("app-manifests/%s/conversions", code)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/apps_marketplace.go
+++ b/github/apps_marketplace.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // MarketplaceService handles communication with the marketplace related
@@ -91,7 +90,11 @@ type MarketplacePurchaseAccount struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps#list-plans
 func (s *MarketplaceService) ListPlans(ctx context.Context, opts *ListOptions) ([]*MarketplacePlan, *Response, error) {
-	u, err := s.marketplaceURI("plans")
+	u, err := newURLString("plans")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = s.marketplaceURI(u)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -118,7 +121,11 @@ func (s *MarketplaceService) ListPlans(ctx context.Context, opts *ListOptions) (
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps#list-accounts-for-a-plan
 func (s *MarketplaceService) ListPlanAccountsForPlan(ctx context.Context, planID int64, opts *ListOptions) ([]*MarketplacePlanAccount, *Response, error) {
-	u, err := s.marketplaceURI(fmt.Sprintf("plans/%v/accounts", planID))
+	u, err := newURLString("plans/%v/accounts", planID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = s.marketplaceURI(u)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -145,12 +152,16 @@ func (s *MarketplaceService) ListPlanAccountsForPlan(ctx context.Context, planID
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps#get-a-subscription-plan-for-an-account
 func (s *MarketplaceService) GetPlanAccountForAccount(ctx context.Context, accountID int64) (*MarketplacePlanAccount, *Response, error) {
-	uri, err := s.marketplaceURI(fmt.Sprintf("accounts/%v", accountID))
+	u, err := newURLString("accounts/%v", accountID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = s.marketplaceURI(u)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", uri, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -203,6 +214,5 @@ func (s *MarketplaceService) marketplaceURI(endpoint string) (string, error) {
 	if s.Stubbed {
 		url = "marketplace_listing/stubbed"
 	}
-	url += "/" + endpoint
-	return newURLString(url)
+	return newURLString(url + "/" + endpoint)
 }

--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // Scope models a GitHub authorization scope.
@@ -145,7 +144,10 @@ func (a AuthorizationUpdateRequest) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/oauth-applications#check-a-token
 func (s *AuthorizationsService) Check(ctx context.Context, clientID, accessToken string) (*Authorization, *Response, error) {
-	u := fmt.Sprintf("applications/%v/token", clientID)
+	u, err := newURLString("applications/%v/token", clientID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	reqBody := &struct {
 		AccessToken string `json:"access_token"`
@@ -178,7 +180,10 @@ func (s *AuthorizationsService) Check(ctx context.Context, clientID, accessToken
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/oauth-applications#reset-a-token
 func (s *AuthorizationsService) Reset(ctx context.Context, clientID, accessToken string) (*Authorization, *Response, error) {
-	u := fmt.Sprintf("applications/%v/token", clientID)
+	u, err := newURLString("applications/%v/token", clientID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	reqBody := &struct {
 		AccessToken string `json:"access_token"`
@@ -207,7 +212,10 @@ func (s *AuthorizationsService) Reset(ctx context.Context, clientID, accessToken
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/oauth-applications#delete-an-app-token
 func (s *AuthorizationsService) Revoke(ctx context.Context, clientID, accessToken string) (*Response, error) {
-	u := fmt.Sprintf("applications/%v/token", clientID)
+	u, err := newURLString("applications/%v/token", clientID)
+	if err != nil {
+		return nil, err
+	}
 
 	reqBody := &struct {
 		AccessToken string `json:"access_token"`
@@ -228,7 +236,10 @@ func (s *AuthorizationsService) Revoke(ctx context.Context, clientID, accessToke
 //
 // GitHub API docs: https://docs.github.com/en/rest/apps/oauth-applications#delete-an-app-authorization
 func (s *AuthorizationsService) DeleteGrant(ctx context.Context, clientID, accessToken string) (*Response, error) {
-	u := fmt.Sprintf("applications/%v/grant", clientID)
+	u, err := newURLString("applications/%v/grant", clientID)
+	if err != nil {
+		return nil, err
+	}
 
 	reqBody := &struct {
 		AccessToken string `json:"access_token"`
@@ -251,7 +262,10 @@ func (s *AuthorizationsService) DeleteGrant(ctx context.Context, clientID, acces
 //
 // GitHub API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#create-an-impersonation-oauth-token
 func (s *AuthorizationsService) CreateImpersonation(ctx context.Context, username string, authReq *AuthorizationRequest) (*Authorization, *Response, error) {
-	u := fmt.Sprintf("admin/users/%v/authorizations", username)
+	u, err := newURLString("admin/users/%v/authorizations", username)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, authReq)
 	if err != nil {
 		return nil, nil, err
@@ -271,7 +285,10 @@ func (s *AuthorizationsService) CreateImpersonation(ctx context.Context, usernam
 //
 // GitHub API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#delete-an-impersonation-oauth-token
 func (s *AuthorizationsService) DeleteImpersonation(ctx context.Context, username string) (*Response, error) {
-	u := fmt.Sprintf("admin/users/%v/authorizations", username)
+	u, err := newURLString("admin/users/%v/authorizations", username)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/billing.go
+++ b/github/billing.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // BillingService provides access to the billing related functions
@@ -64,7 +63,10 @@ type AdvancedSecurityCommittersBreakdown struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/billing#get-github-actions-billing-for-an-organization
 func (s *BillingService) GetActionsBillingOrg(ctx context.Context, org string) (*ActionBilling, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/settings/billing/actions", org)
+	u, err := newURLString("orgs/%v/settings/billing/actions", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -83,7 +85,10 @@ func (s *BillingService) GetActionsBillingOrg(ctx context.Context, org string) (
 //
 // GitHub API docs: https://docs.github.com/en/rest/billing#get-github-packages-billing-for-an-organization
 func (s *BillingService) GetPackagesBillingOrg(ctx context.Context, org string) (*PackageBilling, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/settings/billing/packages", org)
+	u, err := newURLString("orgs/%v/settings/billing/packages", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -103,7 +108,10 @@ func (s *BillingService) GetPackagesBillingOrg(ctx context.Context, org string) 
 //
 // GitHub API docs: https://docs.github.com/en/rest/billing#get-shared-storage-billing-for-an-organization
 func (s *BillingService) GetStorageBillingOrg(ctx context.Context, org string) (*StorageBilling, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/settings/billing/shared-storage", org)
+	u, err := newURLString("orgs/%v/settings/billing/shared-storage", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -122,8 +130,11 @@ func (s *BillingService) GetStorageBillingOrg(ctx context.Context, org string) (
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/billing?apiVersion=2022-11-28#get-github-advanced-security-active-committers-for-an-organization
 func (s *BillingService) GetAdvancedSecurityActiveCommittersOrg(ctx context.Context, org string, opts *ListOptions) (*ActiveCommitters, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/settings/billing/advanced-security", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/settings/billing/advanced-security", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -146,7 +157,10 @@ func (s *BillingService) GetAdvancedSecurityActiveCommittersOrg(ctx context.Cont
 //
 // GitHub API docs: https://docs.github.com/en/rest/billing#get-github-actions-billing-for-a-user
 func (s *BillingService) GetActionsBillingUser(ctx context.Context, user string) (*ActionBilling, *Response, error) {
-	u := fmt.Sprintf("users/%v/settings/billing/actions", user)
+	u, err := newURLString("users/%v/settings/billing/actions", user)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -165,7 +179,10 @@ func (s *BillingService) GetActionsBillingUser(ctx context.Context, user string)
 //
 // GitHub API docs: https://docs.github.com/en/rest/billing#get-github-packages-billing-for-a-user
 func (s *BillingService) GetPackagesBillingUser(ctx context.Context, user string) (*PackageBilling, *Response, error) {
-	u := fmt.Sprintf("users/%v/settings/billing/packages", user)
+	u, err := newURLString("users/%v/settings/billing/packages", user)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -185,7 +202,10 @@ func (s *BillingService) GetPackagesBillingUser(ctx context.Context, user string
 //
 // GitHub API docs: https://docs.github.com/en/rest/billing#get-shared-storage-billing-for-a-user
 func (s *BillingService) GetStorageBillingUser(ctx context.Context, user string) (*StorageBilling, *Response, error) {
-	u := fmt.Sprintf("users/%v/settings/billing/shared-storage", user)
+	u, err := newURLString("users/%v/settings/billing/shared-storage", user)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/checks.go
+++ b/github/checks.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ChecksService provides access to the Checks API in the
@@ -100,7 +99,10 @@ func (c CheckSuite) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/checks/runs#get-a-check-run
 func (s *ChecksService) GetCheckRun(ctx context.Context, owner, repo string, checkRunID int64) (*CheckRun, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/check-runs/%v", owner, repo, checkRunID)
+	u, err := newURLString("repos/%v/%v/check-runs/%v", owner, repo, checkRunID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -121,7 +123,10 @@ func (s *ChecksService) GetCheckRun(ctx context.Context, owner, repo string, che
 //
 // GitHub API docs: https://docs.github.com/en/rest/checks/suites#get-a-check-suite
 func (s *ChecksService) GetCheckSuite(ctx context.Context, owner, repo string, checkSuiteID int64) (*CheckSuite, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/check-suites/%v", owner, repo, checkSuiteID)
+	u, err := newURLString("repos/%v/%v/check-suites/%v", owner, repo, checkSuiteID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -163,7 +168,10 @@ type CheckRunAction struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/checks/runs#create-a-check-run
 func (s *ChecksService) CreateCheckRun(ctx context.Context, owner, repo string, opts CreateCheckRunOptions) (*CheckRun, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/check-runs", owner, repo)
+	u, err := newURLString("repos/%v/%v/check-runs", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -196,7 +204,10 @@ type UpdateCheckRunOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/checks/runs#update-a-check-run
 func (s *ChecksService) UpdateCheckRun(ctx context.Context, owner, repo string, checkRunID int64, opts UpdateCheckRunOptions) (*CheckRun, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/check-runs/%v", owner, repo, checkRunID)
+	u, err := newURLString("repos/%v/%v/check-runs/%v", owner, repo, checkRunID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -217,8 +228,11 @@ func (s *ChecksService) UpdateCheckRun(ctx context.Context, owner, repo string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/checks/runs#list-check-run-annotations
 func (s *ChecksService) ListCheckRunAnnotations(ctx context.Context, owner, repo string, checkRunID int64, opts *ListOptions) ([]*CheckRunAnnotation, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/check-runs/%v/annotations", owner, repo, checkRunID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/check-runs/%v/annotations", owner, repo, checkRunID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -259,8 +273,11 @@ type ListCheckRunsResults struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference
 func (s *ChecksService) ListCheckRunsForRef(ctx context.Context, owner, repo, ref string, opts *ListCheckRunsOptions) (*ListCheckRunsResults, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/commits/%v/check-runs", owner, repo, refURLEscape(ref))
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/commits/%v/check-runs", owner, repo, refURLEscape(ref))
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -285,8 +302,11 @@ func (s *ChecksService) ListCheckRunsForRef(ctx context.Context, owner, repo, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/checks/runs#list-check-runs-in-a-check-suite
 func (s *ChecksService) ListCheckRunsCheckSuite(ctx context.Context, owner, repo string, checkSuiteID int64, opts *ListCheckRunsOptions) (*ListCheckRunsResults, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/check-suites/%v/check-runs", owner, repo, checkSuiteID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/check-suites/%v/check-runs", owner, repo, checkSuiteID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -311,7 +331,10 @@ func (s *ChecksService) ListCheckRunsCheckSuite(ctx context.Context, owner, repo
 //
 // GitHub API docs: https://docs.github.com/en/rest/checks/runs#rerequest-a-check-run
 func (s *ChecksService) ReRequestCheckRun(ctx context.Context, owner, repo string, checkRunID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/check-runs/%v/rerequest", owner, repo, checkRunID)
+	u, err := newURLString("repos/%v/%v/check-runs/%v/rerequest", owner, repo, checkRunID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -341,8 +364,11 @@ type ListCheckSuiteResults struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/checks/suites#list-check-suites-for-a-git-reference
 func (s *ChecksService) ListCheckSuitesForRef(ctx context.Context, owner, repo, ref string, opts *ListCheckSuiteOptions) (*ListCheckSuiteResults, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/commits/%v/check-suites", owner, repo, refURLEscape(ref))
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/commits/%v/check-suites", owner, repo, refURLEscape(ref))
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -389,7 +415,10 @@ type PreferenceList struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/checks/suites#update-repository-preferences-for-check-suites
 func (s *ChecksService) SetCheckSuitePreferences(ctx context.Context, owner, repo string, opts CheckSuitePreferenceOptions) (*CheckSuitePreferenceResults, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/check-suites/preferences", owner, repo)
+	u, err := newURLString("repos/%v/%v/check-suites/preferences", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -416,7 +445,10 @@ type CreateCheckSuiteOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/checks/suites#create-a-check-suite
 func (s *ChecksService) CreateCheckSuite(ctx context.Context, owner, repo string, opts CreateCheckSuiteOptions) (*CheckSuite, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/check-suites", owner, repo)
+	u, err := newURLString("repos/%v/%v/check-suites", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -437,7 +469,10 @@ func (s *ChecksService) CreateCheckSuite(ctx context.Context, owner, repo string
 //
 // GitHub API docs: https://docs.github.com/en/rest/checks/suites#rerequest-a-check-suite
 func (s *ChecksService) ReRequestCheckSuite(ctx context.Context, owner, repo string, checkSuiteID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/check-suites/%v/rerequest", owner, repo, checkSuiteID)
+	u, err := newURLString("repos/%v/%v/check-suites/%v/rerequest", owner, repo, checkSuiteID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {

--- a/github/code-scanning.go
+++ b/github/code-scanning.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 )
@@ -210,8 +209,11 @@ type SarifID struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/code-scanning#list-code-scanning-alerts-for-an-organization
 func (s *CodeScanningService) ListAlertsForOrg(ctx context.Context, org string, opts *AlertListOptions) ([]*Alert, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/code-scanning/alerts", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/code-scanning/alerts", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -238,8 +240,11 @@ func (s *CodeScanningService) ListAlertsForOrg(ctx context.Context, org string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/code-scanning#list-code-scanning-alerts-for-a-repository
 func (s *CodeScanningService) ListAlertsForRepo(ctx context.Context, owner, repo string, opts *AlertListOptions) ([]*Alert, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/code-scanning/alerts", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/code-scanning/alerts", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -267,7 +272,10 @@ func (s *CodeScanningService) ListAlertsForRepo(ctx context.Context, owner, repo
 //
 // GitHub API docs: https://docs.github.com/en/rest/code-scanning#get-a-code-scanning-alert
 func (s *CodeScanningService) GetAlert(ctx context.Context, owner, repo string, id int64) (*Alert, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/code-scanning/alerts/%v", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/code-scanning/alerts/%v", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -292,7 +300,10 @@ func (s *CodeScanningService) GetAlert(ctx context.Context, owner, repo string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/code-scanning?apiVersion=2022-11-28#update-a-code-scanning-alert
 func (s *CodeScanningService) UpdateAlert(ctx context.Context, owner, repo string, id int64, stateInfo *CodeScanningAlertState) (*Alert, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/code-scanning/alerts/%v", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/code-scanning/alerts/%v", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PATCH", u, stateInfo)
 	if err != nil {
@@ -316,7 +327,10 @@ func (s *CodeScanningService) UpdateAlert(ctx context.Context, owner, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/code-scanning#upload-an-analysis-as-sarif-data
 func (s *CodeScanningService) UploadSarif(ctx context.Context, owner, repo string, sarif *SarifAnalysis) (*SarifID, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/code-scanning/sarifs", owner, repo)
+	u, err := newURLString("repos/%v/%v/code-scanning/sarifs", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, sarif)
 	if err != nil {
@@ -340,8 +354,11 @@ func (s *CodeScanningService) UploadSarif(ctx context.Context, owner, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/code-scanning#list-code-scanning-analyses-for-a-repository
 func (s *CodeScanningService) ListAnalysesForRepo(ctx context.Context, owner, repo string, opts *AnalysesListOptions) ([]*ScanningAnalysis, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/code-scanning/analyses", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/code-scanning/analyses", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -369,7 +386,10 @@ func (s *CodeScanningService) ListAnalysesForRepo(ctx context.Context, owner, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/code-scanning#get-a-code-scanning-analysis-for-a-repository
 func (s *CodeScanningService) GetAnalysis(ctx context.Context, owner, repo string, id int64) (*ScanningAnalysis, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/code-scanning/analyses/%v", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/code-scanning/analyses/%v", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -401,7 +421,10 @@ type DefaultSetupConfiguration struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/code-scanning#get-a-code-scanning-default-setup-configuration
 func (s *CodeScanningService) GetDefaultSetupConfiguration(ctx context.Context, owner, repo string) (*DefaultSetupConfiguration, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/code-scanning/default-setup", owner, repo)
+	u, err := newURLString("repos/%s/%s/code-scanning/default-setup", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -442,7 +465,10 @@ type UpdateDefaultSetupConfigurationResponse struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/code-scanning#update-a-code-scanning-default-setup-configuration
 func (s *CodeScanningService) UpdateDefaultSetupConfiguration(ctx context.Context, owner, repo string, options *UpdateDefaultSetupConfigurationOptions) (*UpdateDefaultSetupConfigurationResponse, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/code-scanning/default-setup", owner, repo)
+	u, err := newURLString("repos/%s/%s/code-scanning/default-setup", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PATCH", u, options)
 	if err != nil {

--- a/github/codespaces.go
+++ b/github/codespaces.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // CodespacesService handles communication with the Codespaces related
@@ -92,8 +91,11 @@ type ListCodespaces struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/codespaces?apiVersion=2022-11-28#list-codespaces-in-a-repository-for-the-authenticated-user
 func (s *CodespacesService) ListInRepo(ctx context.Context, owner, repo string, opts *ListOptions) (*ListCodespaces, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/codespaces", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/codespaces", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -126,8 +128,11 @@ type ListCodespacesOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/codespaces?apiVersion=2022-11-28#list-codespaces-for-the-authenticated-user
 func (s *CodespacesService) List(ctx context.Context, opts *ListCodespacesOptions) (*ListCodespaces, *Response, error) {
-	u := "user/codespaces"
-	u, err := addOptions(u, opts)
+	u, err := newURLString("user/codespaces")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -174,7 +179,10 @@ type CreateCodespaceOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/codespaces?apiVersion=2022-11-28#create-a-codespace-in-a-repository
 func (s *CodespacesService) CreateInRepo(ctx context.Context, owner, repo string, request *CreateCodespaceOptions) (*Codespace, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/codespaces", owner, repo)
+	u, err := newURLString("repos/%v/%v/codespaces", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, request)
 	if err != nil {
@@ -197,7 +205,10 @@ func (s *CodespacesService) CreateInRepo(ctx context.Context, owner, repo string
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/codespaces?apiVersion=2022-11-28#start-a-codespace-for-the-authenticated-user
 func (s *CodespacesService) Start(ctx context.Context, codespaceName string) (*Codespace, *Response, error) {
-	u := fmt.Sprintf("user/codespaces/%v/start", codespaceName)
+	u, err := newURLString("user/codespaces/%v/start", codespaceName)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -220,7 +231,10 @@ func (s *CodespacesService) Start(ctx context.Context, codespaceName string) (*C
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/codespaces?apiVersion=2022-11-28#stop-a-codespace-for-the-authenticated-user
 func (s *CodespacesService) Stop(ctx context.Context, codespaceName string) (*Codespace, *Response, error) {
-	u := fmt.Sprintf("user/codespaces/%v/stop", codespaceName)
+	u, err := newURLString("user/codespaces/%v/stop", codespaceName)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -243,7 +257,10 @@ func (s *CodespacesService) Stop(ctx context.Context, codespaceName string) (*Co
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/codespaces?apiVersion=2022-11-28#delete-a-codespace-for-the-authenticated-user
 func (s *CodespacesService) Delete(ctx context.Context, codespaceName string) (*Response, error) {
-	u := fmt.Sprintf("user/codespaces/%v", codespaceName)
+	u, err := newURLString("user/codespaces/%v", codespaceName)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/codespaces_secrets.go
+++ b/github/codespaces_secrets.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ListUserSecrets list all secrets available for a users codespace
@@ -95,7 +94,11 @@ func (s *CodespacesService) GetUserPublicKey(ctx context.Context) (*PublicKey, *
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/organization-secrets?apiVersion=2022-11-28#get-an-organization-public-key
 func (s *CodespacesService) GetOrgPublicKey(ctx context.Context, org string) (*PublicKey, *Response, error) {
-	return s.getPublicKey(ctx, fmt.Sprintf("orgs/%v/codespaces/secrets/public-key", org))
+	u, err := newURLString("orgs/%v/codespaces/secrets/public-key", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	return s.getPublicKey(ctx, u)
 }
 
 // GetRepoPublicKey gets the repo public key for encrypting codespace secrets
@@ -104,7 +107,11 @@ func (s *CodespacesService) GetOrgPublicKey(ctx context.Context, org string) (*P
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/repository-secrets?apiVersion=2022-11-28#get-a-repository-public-key
 func (s *CodespacesService) GetRepoPublicKey(ctx context.Context, owner, repo string) (*PublicKey, *Response, error) {
-	return s.getPublicKey(ctx, fmt.Sprintf("repos/%v/%v/codespaces/secrets/public-key", owner, repo))
+	u, err := newURLString("repos/%v/%v/codespaces/secrets/public-key", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	return s.getPublicKey(ctx, u)
 }
 
 func (s *CodespacesService) getPublicKey(ctx context.Context, url string) (*PublicKey, *Response, error) {

--- a/github/codespaces_secrets.go
+++ b/github/codespaces_secrets.go
@@ -31,8 +31,11 @@ func (s *CodespacesService) ListUserSecrets(ctx context.Context, opts *ListOptio
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/organization-secrets?apiVersion=2022-11-28#list-organization-secrets
 func (s *CodespacesService) ListOrgSecrets(ctx context.Context, org string, opts *ListOptions) (*Secrets, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/codespaces/secrets", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/codespaces/secrets", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -45,8 +48,11 @@ func (s *CodespacesService) ListOrgSecrets(ctx context.Context, org string, opts
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/repository-secrets?apiVersion=2022-11-28#list-repository-secrets
 func (s *CodespacesService) ListRepoSecrets(ctx context.Context, owner, repo string, opts *ListOptions) (*Secrets, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/codespaces/secrets", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/codespaces/secrets", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -120,7 +126,10 @@ func (s *CodespacesService) getPublicKey(ctx context.Context, url string) (*Publ
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/secrets?apiVersion=2022-11-28#get-a-secret-for-the-authenticated-user
 func (s *CodespacesService) GetUserSecret(ctx context.Context, name string) (*Secret, *Response, error) {
-	u := fmt.Sprintf("user/codespaces/secrets/%v", name)
+	u, err := newURLString("user/codespaces/secrets/%v", name)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getSecret(ctx, u)
 }
 
@@ -130,7 +139,10 @@ func (s *CodespacesService) GetUserSecret(ctx context.Context, name string) (*Se
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/organization-secrets?apiVersion=2022-11-28#get-an-organization-secret
 func (s *CodespacesService) GetOrgSecret(ctx context.Context, org, name string) (*Secret, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/codespaces/secrets/%v", org, name)
+	u, err := newURLString("orgs/%v/codespaces/secrets/%v", org, name)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getSecret(ctx, u)
 }
 
@@ -140,7 +152,10 @@ func (s *CodespacesService) GetOrgSecret(ctx context.Context, org, name string) 
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/repository-secrets?apiVersion=2022-11-28#get-a-repository-secret
 func (s *CodespacesService) GetRepoSecret(ctx context.Context, owner, repo, name string) (*Secret, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/codespaces/secrets/%v", owner, repo, name)
+	u, err := newURLString("repos/%v/%v/codespaces/secrets/%v", owner, repo, name)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getSecret(ctx, u)
 }
 
@@ -167,7 +182,10 @@ func (s *CodespacesService) getSecret(ctx context.Context, url string) (*Secret,
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/secrets?apiVersion=2022-11-28#create-or-update-a-secret-for-the-authenticated-user
 func (s *CodespacesService) CreateOrUpdateUserSecret(ctx context.Context, eSecret *EncryptedSecret) (*Response, error) {
-	u := fmt.Sprintf("user/codespaces/secrets/%v", eSecret.Name)
+	u, err := newURLString("user/codespaces/secrets/%v", eSecret.Name)
+	if err != nil {
+		return nil, err
+	}
 	return s.createOrUpdateSecret(ctx, u, eSecret)
 }
 
@@ -177,7 +195,10 @@ func (s *CodespacesService) CreateOrUpdateUserSecret(ctx context.Context, eSecre
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/organization-secrets?apiVersion=2022-11-28#create-or-update-an-organization-secret
 func (s *CodespacesService) CreateOrUpdateOrgSecret(ctx context.Context, org string, eSecret *EncryptedSecret) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/codespaces/secrets/%v", org, eSecret.Name)
+	u, err := newURLString("orgs/%v/codespaces/secrets/%v", org, eSecret.Name)
+	if err != nil {
+		return nil, err
+	}
 	return s.createOrUpdateSecret(ctx, u, eSecret)
 }
 
@@ -187,7 +208,10 @@ func (s *CodespacesService) CreateOrUpdateOrgSecret(ctx context.Context, org str
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/repository-secrets?apiVersion=2022-11-28#create-or-update-a-repository-secret
 func (s *CodespacesService) CreateOrUpdateRepoSecret(ctx context.Context, owner, repo string, eSecret *EncryptedSecret) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/codespaces/secrets/%v", owner, repo, eSecret.Name)
+	u, err := newURLString("repos/%v/%v/codespaces/secrets/%v", owner, repo, eSecret.Name)
+	if err != nil {
+		return nil, err
+	}
 	return s.createOrUpdateSecret(ctx, u, eSecret)
 }
 
@@ -213,7 +237,10 @@ func (s *CodespacesService) createOrUpdateSecret(ctx context.Context, url string
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/secrets?apiVersion=2022-11-28#delete-a-secret-for-the-authenticated-user
 func (s *CodespacesService) DeleteUserSecret(ctx context.Context, name string) (*Response, error) {
-	u := fmt.Sprintf("user/codespaces/secrets/%v", name)
+	u, err := newURLString("user/codespaces/secrets/%v", name)
+	if err != nil {
+		return nil, err
+	}
 	return s.deleteSecret(ctx, u)
 }
 
@@ -223,7 +250,10 @@ func (s *CodespacesService) DeleteUserSecret(ctx context.Context, name string) (
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/organization-secrets?apiVersion=2022-11-28#delete-an-organization-secret
 func (s *CodespacesService) DeleteOrgSecret(ctx context.Context, org, name string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/codespaces/secrets/%v", org, name)
+	u, err := newURLString("orgs/%v/codespaces/secrets/%v", org, name)
+	if err != nil {
+		return nil, err
+	}
 	return s.deleteSecret(ctx, u)
 }
 
@@ -233,7 +263,10 @@ func (s *CodespacesService) DeleteOrgSecret(ctx context.Context, org, name strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/repository-secrets?apiVersion=2022-11-28#delete-a-repository-secret
 func (s *CodespacesService) DeleteRepoSecret(ctx context.Context, owner, repo, name string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/codespaces/secrets/%v", owner, repo, name)
+	u, err := newURLString("repos/%v/%v/codespaces/secrets/%v", owner, repo, name)
+	if err != nil {
+		return nil, err
+	}
 	return s.deleteSecret(ctx, u)
 }
 
@@ -258,8 +291,11 @@ func (s *CodespacesService) deleteSecret(ctx context.Context, url string) (*Resp
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/secrets?apiVersion=2022-11-28#list-selected-repositories-for-a-user-secret
 func (s *CodespacesService) ListSelectedReposForUserSecret(ctx context.Context, name string, opts *ListOptions) (*SelectedReposList, *Response, error) {
-	u := fmt.Sprintf("user/codespaces/secrets/%v/repositories", name)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("user/codespaces/secrets/%v/repositories", name)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -273,8 +309,11 @@ func (s *CodespacesService) ListSelectedReposForUserSecret(ctx context.Context, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/organization-secrets?apiVersion=2022-11-28#list-selected-repositories-for-an-organization-secret
 func (s *CodespacesService) ListSelectedReposForOrgSecret(ctx context.Context, org, name string, opts *ListOptions) (*SelectedReposList, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/codespaces/secrets/%v/repositories", org, name)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/codespaces/secrets/%v/repositories", org, name)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -304,7 +343,10 @@ func (s *CodespacesService) listSelectedReposForSecret(ctx context.Context, url 
 //
 // Github API docs: https://docs.github.com/en/rest/codespaces/secrets?apiVersion=2022-11-28#set-selected-repositories-for-a-user-secret
 func (s *CodespacesService) SetSelectedReposForUserSecret(ctx context.Context, name string, ids SelectedRepoIDs) (*Response, error) {
-	u := fmt.Sprintf("user/codespaces/secrets/%v/repositories", name)
+	u, err := newURLString("user/codespaces/secrets/%v/repositories", name)
+	if err != nil {
+		return nil, err
+	}
 	return s.setSelectedRepoForSecret(ctx, u, ids)
 }
 
@@ -314,7 +356,10 @@ func (s *CodespacesService) SetSelectedReposForUserSecret(ctx context.Context, n
 //
 // Github API docs: https://docs.github.com/en/rest/codespaces/secrets?apiVersion=2022-11-28#set-selected-repositories-for-a-user-secret
 func (s *CodespacesService) SetSelectedReposForOrgSecret(ctx context.Context, org, name string, ids SelectedRepoIDs) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/codespaces/secrets/%v/repositories", org, name)
+	u, err := newURLString("orgs/%v/codespaces/secrets/%v/repositories", org, name)
+	if err != nil {
+		return nil, err
+	}
 	return s.setSelectedRepoForSecret(ctx, u, ids)
 }
 
@@ -342,7 +387,10 @@ func (s *CodespacesService) setSelectedRepoForSecret(ctx context.Context, url st
 //
 // Github API docs: https://docs.github.com/en/rest/codespaces/secrets?apiVersion=2022-11-28#add-a-selected-repository-to-a-user-secret
 func (s *CodespacesService) AddSelectedRepoToUserSecret(ctx context.Context, name string, repo *Repository) (*Response, error) {
-	u := fmt.Sprintf("user/codespaces/secrets/%v/repositories/%v", name, *repo.ID)
+	u, err := newURLString("user/codespaces/secrets/%v/repositories/%v", name, *repo.ID)
+	if err != nil {
+		return nil, err
+	}
 	return s.addSelectedRepoToSecret(ctx, u)
 }
 
@@ -352,7 +400,10 @@ func (s *CodespacesService) AddSelectedRepoToUserSecret(ctx context.Context, nam
 //
 // Github API docs: https://docs.github.com/en/rest/codespaces/organization-secrets?apiVersion=2022-11-28#add-selected-repository-to-an-organization-secret
 func (s *CodespacesService) AddSelectedRepoToOrgSecret(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/codespaces/secrets/%v/repositories/%v", org, name, *repo.ID)
+	u, err := newURLString("orgs/%v/codespaces/secrets/%v/repositories/%v", org, name, *repo.ID)
+	if err != nil {
+		return nil, err
+	}
 	return s.addSelectedRepoToSecret(ctx, u)
 }
 
@@ -376,7 +427,10 @@ func (s *CodespacesService) addSelectedRepoToSecret(ctx context.Context, url str
 //
 // Github API docs: https://docs.github.com/en/rest/codespaces/secrets?apiVersion=2022-11-28#remove-a-selected-repository-from-a-user-secret
 func (s *CodespacesService) RemoveSelectedRepoFromUserSecret(ctx context.Context, name string, repo *Repository) (*Response, error) {
-	u := fmt.Sprintf("user/codespaces/secrets/%v/repositories/%v", name, *repo.ID)
+	u, err := newURLString("user/codespaces/secrets/%v/repositories/%v", name, *repo.ID)
+	if err != nil {
+		return nil, err
+	}
 	return s.removeSelectedRepoFromSecret(ctx, u)
 }
 
@@ -386,7 +440,10 @@ func (s *CodespacesService) RemoveSelectedRepoFromUserSecret(ctx context.Context
 //
 // Github API docs: https://docs.github.com/en/rest/codespaces/organization-secrets?apiVersion=2022-11-28#remove-selected-repository-from-an-organization-secret
 func (s *CodespacesService) RemoveSelectedRepoFromOrgSecret(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/codespaces/secrets/%v/repositories/%v", org, name, *repo.ID)
+	u, err := newURLString("orgs/%v/codespaces/secrets/%v/repositories/%v", org, name, *repo.ID)
+	if err != nil {
+		return nil, err
+	}
 	return s.removeSelectedRepoFromSecret(ctx, u)
 }
 

--- a/github/codespaces_secrets.go
+++ b/github/codespaces_secrets.go
@@ -18,7 +18,11 @@ import (
 //
 // GitHub API docs: https://docs.github.com/en/rest/codespaces/secrets?apiVersion=2022-11-28#list-secrets-for-the-authenticated-user
 func (s *CodespacesService) ListUserSecrets(ctx context.Context, opts *ListOptions) (*Secrets, *Response, error) {
-	u, err := addOptions("user/codespaces/secrets", opts)
+	u, err := newURLString("user/codespaces/secrets")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/dependabot_alerts.go
+++ b/github/dependabot_alerts.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // Dependency reprensents the vulnerable dependency.
@@ -104,7 +103,10 @@ func (s *DependabotService) listAlerts(ctx context.Context, url string, opts *Li
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/alerts#list-dependabot-alerts-for-a-repository
 func (s *DependabotService) ListRepoAlerts(ctx context.Context, owner, repo string, opts *ListAlertsOptions) ([]*DependabotAlert, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/dependabot/alerts", owner, repo)
+	url, err := newURLString("repos/%v/%v/dependabot/alerts", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.listAlerts(ctx, url, opts)
 }
 
@@ -112,7 +114,10 @@ func (s *DependabotService) ListRepoAlerts(ctx context.Context, owner, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/alerts#list-dependabot-alerts-for-an-organization
 func (s *DependabotService) ListOrgAlerts(ctx context.Context, org string, opts *ListAlertsOptions) ([]*DependabotAlert, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/dependabot/alerts", org)
+	url, err := newURLString("orgs/%v/dependabot/alerts", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.listAlerts(ctx, url, opts)
 }
 
@@ -120,7 +125,10 @@ func (s *DependabotService) ListOrgAlerts(ctx context.Context, org string, opts 
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/alerts#get-a-dependabot-alert
 func (s *DependabotService) GetRepoAlert(ctx context.Context, owner, repo string, number int) (*DependabotAlert, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/dependabot/alerts/%v", owner, repo, number)
+	url, err := newURLString("repos/%v/%v/dependabot/alerts/%v", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/dependabot_alerts.go
+++ b/github/dependabot_alerts.go
@@ -103,22 +103,22 @@ func (s *DependabotService) listAlerts(ctx context.Context, url string, opts *Li
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/alerts#list-dependabot-alerts-for-a-repository
 func (s *DependabotService) ListRepoAlerts(ctx context.Context, owner, repo string, opts *ListAlertsOptions) ([]*DependabotAlert, *Response, error) {
-	url, err := newURLString("repos/%v/%v/dependabot/alerts", owner, repo)
+	u, err := newURLString("repos/%v/%v/dependabot/alerts", owner, repo)
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.listAlerts(ctx, url, opts)
+	return s.listAlerts(ctx, u, opts)
 }
 
 // ListOrgAlerts lists all Dependabot alerts of an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/alerts#list-dependabot-alerts-for-an-organization
 func (s *DependabotService) ListOrgAlerts(ctx context.Context, org string, opts *ListAlertsOptions) ([]*DependabotAlert, *Response, error) {
-	url, err := newURLString("orgs/%v/dependabot/alerts", org)
+	u, err := newURLString("orgs/%v/dependabot/alerts", org)
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.listAlerts(ctx, url, opts)
+	return s.listAlerts(ctx, u, opts)
 }
 
 // GetRepoAlert gets a single repository Dependabot alert.

--- a/github/dependabot_secrets.go
+++ b/github/dependabot_secrets.go
@@ -72,11 +72,11 @@ func (s *DependabotService) listSecrets(ctx context.Context, url string, opts *L
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#list-repository-secrets
 func (s *DependabotService) ListRepoSecrets(ctx context.Context, owner, repo string, opts *ListOptions) (*Secrets, *Response, error) {
-	url, err := newURLString("repos/%v/%v/dependabot/secrets", owner, repo)
+	u, err := newURLString("repos/%v/%v/dependabot/secrets", owner, repo)
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.listSecrets(ctx, url, opts)
+	return s.listSecrets(ctx, u, opts)
 }
 
 // ListOrgSecrets lists all Dependabot secrets available in an organization
@@ -84,11 +84,11 @@ func (s *DependabotService) ListRepoSecrets(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#list-organization-secrets
 func (s *DependabotService) ListOrgSecrets(ctx context.Context, org string, opts *ListOptions) (*Secrets, *Response, error) {
-	url, err := newURLString("orgs/%v/dependabot/secrets", org)
+	u, err := newURLString("orgs/%v/dependabot/secrets", org)
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.listSecrets(ctx, url, opts)
+	return s.listSecrets(ctx, u, opts)
 }
 
 func (s *DependabotService) getSecret(ctx context.Context, url string) (*Secret, *Response, error) {
@@ -224,11 +224,11 @@ func (s *DependabotService) DeleteOrgSecret(ctx context.Context, org, name strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#list-selected-repositories-for-an-organization-secret
 func (s *DependabotService) ListSelectedReposForOrgSecret(ctx context.Context, org, name string, opts *ListOptions) (*SelectedReposList, *Response, error) {
-	url, err := newURLString("orgs/%v/dependabot/secrets/%v/repositories", org, name)
+	u, err := newURLString("orgs/%v/dependabot/secrets/%v/repositories", org, name)
 	if err != nil {
 		return nil, nil, err
 	}
-	u, err := addOptions(url, opts)
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/dependabot_secrets.go
+++ b/github/dependabot_secrets.go
@@ -29,7 +29,10 @@ func (s *DependabotService) getPublicKey(ctx context.Context, url string) (*Publ
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#get-a-repository-public-key
 func (s *DependabotService) GetRepoPublicKey(ctx context.Context, owner, repo string) (*PublicKey, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/dependabot/secrets/public-key", owner, repo)
+	url, err := newURLString("repos/%v/%v/dependabot/secrets/public-key", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getPublicKey(ctx, url)
 }
 
@@ -37,7 +40,10 @@ func (s *DependabotService) GetRepoPublicKey(ctx context.Context, owner, repo st
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#get-an-organization-public-key
 func (s *DependabotService) GetOrgPublicKey(ctx context.Context, org string) (*PublicKey, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/public-key", org)
+	url, err := newURLString("orgs/%v/dependabot/secrets/public-key", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getPublicKey(ctx, url)
 }
 
@@ -66,7 +72,10 @@ func (s *DependabotService) listSecrets(ctx context.Context, url string, opts *L
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#list-repository-secrets
 func (s *DependabotService) ListRepoSecrets(ctx context.Context, owner, repo string, opts *ListOptions) (*Secrets, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/dependabot/secrets", owner, repo)
+	url, err := newURLString("repos/%v/%v/dependabot/secrets", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.listSecrets(ctx, url, opts)
 }
 
@@ -75,7 +84,10 @@ func (s *DependabotService) ListRepoSecrets(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#list-organization-secrets
 func (s *DependabotService) ListOrgSecrets(ctx context.Context, org string, opts *ListOptions) (*Secrets, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets", org)
+	url, err := newURLString("orgs/%v/dependabot/secrets", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.listSecrets(ctx, url, opts)
 }
 
@@ -98,7 +110,10 @@ func (s *DependabotService) getSecret(ctx context.Context, url string) (*Secret,
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#get-a-repository-secret
 func (s *DependabotService) GetRepoSecret(ctx context.Context, owner, repo, name string) (*Secret, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/dependabot/secrets/%v", owner, repo, name)
+	url, err := newURLString("repos/%v/%v/dependabot/secrets/%v", owner, repo, name)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getSecret(ctx, url)
 }
 
@@ -106,7 +121,10 @@ func (s *DependabotService) GetRepoSecret(ctx context.Context, owner, repo, name
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#get-an-organization-secret
 func (s *DependabotService) GetOrgSecret(ctx context.Context, org, name string) (*Secret, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v", org, name)
+	url, err := newURLString("orgs/%v/dependabot/secrets/%v", org, name)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getSecret(ctx, url)
 }
 
@@ -136,7 +154,10 @@ func (s *DependabotService) putSecret(ctx context.Context, url string, eSecret *
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#create-or-update-a-repository-secret
 func (s *DependabotService) CreateOrUpdateRepoSecret(ctx context.Context, owner, repo string, eSecret *DependabotEncryptedSecret) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/dependabot/secrets/%v", owner, repo, eSecret.Name)
+	url, err := newURLString("repos/%v/%v/dependabot/secrets/%v", owner, repo, eSecret.Name)
+	if err != nil {
+		return nil, err
+	}
 	return s.putSecret(ctx, url, eSecret)
 }
 
@@ -156,7 +177,10 @@ func (s *DependabotService) CreateOrUpdateOrgSecret(ctx context.Context, org str
 		SelectedRepositoryIDs:     repoIDs,
 	}
 
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v", org, eSecret.Name)
+	url, err := newURLString("orgs/%v/dependabot/secrets/%v", org, eSecret.Name)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", url, params)
 	if err != nil {
 		return nil, err
@@ -178,7 +202,10 @@ func (s *DependabotService) deleteSecret(ctx context.Context, url string) (*Resp
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#delete-a-repository-secret
 func (s *DependabotService) DeleteRepoSecret(ctx context.Context, owner, repo, name string) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/dependabot/secrets/%v", owner, repo, name)
+	url, err := newURLString("repos/%v/%v/dependabot/secrets/%v", owner, repo, name)
+	if err != nil {
+		return nil, err
+	}
 	return s.deleteSecret(ctx, url)
 }
 
@@ -186,7 +213,10 @@ func (s *DependabotService) DeleteRepoSecret(ctx context.Context, owner, repo, n
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#delete-an-organization-secret
 func (s *DependabotService) DeleteOrgSecret(ctx context.Context, org, name string) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v", org, name)
+	url, err := newURLString("orgs/%v/dependabot/secrets/%v", org, name)
+	if err != nil {
+		return nil, err
+	}
 	return s.deleteSecret(ctx, url)
 }
 
@@ -194,7 +224,10 @@ func (s *DependabotService) DeleteOrgSecret(ctx context.Context, org, name strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#list-selected-repositories-for-an-organization-secret
 func (s *DependabotService) ListSelectedReposForOrgSecret(ctx context.Context, org, name string, opts *ListOptions) (*SelectedReposList, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v/repositories", org, name)
+	url, err := newURLString("orgs/%v/dependabot/secrets/%v/repositories", org, name)
+	if err != nil {
+		return nil, nil, err
+	}
 	u, err := addOptions(url, opts)
 	if err != nil {
 		return nil, nil, err
@@ -221,7 +254,10 @@ type DependabotSecretsSelectedRepoIDs []int64
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#set-selected-repositories-for-an-organization-secret
 func (s *DependabotService) SetSelectedReposForOrgSecret(ctx context.Context, org, name string, ids DependabotSecretsSelectedRepoIDs) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v/repositories", org, name)
+	url, err := newURLString("orgs/%v/dependabot/secrets/%v/repositories", org, name)
+	if err != nil {
+		return nil, err
+	}
 	type repoIDs struct {
 		SelectedIDs DependabotSecretsSelectedRepoIDs `json:"selected_repository_ids"`
 	}
@@ -238,7 +274,10 @@ func (s *DependabotService) SetSelectedReposForOrgSecret(ctx context.Context, or
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#add-selected-repository-to-an-organization-secret
 func (s *DependabotService) AddSelectedRepoToOrgSecret(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v/repositories/%v", org, name, *repo.ID)
+	url, err := newURLString("orgs/%v/dependabot/secrets/%v/repositories/%v", org, name, *repo.ID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", url, nil)
 	if err != nil {
 		return nil, err
@@ -251,7 +290,10 @@ func (s *DependabotService) AddSelectedRepoToOrgSecret(ctx context.Context, org,
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependabot/secrets#remove-selected-repository-from-an-organization-secret
 func (s *DependabotService) RemoveSelectedRepoFromOrgSecret(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v/repositories/%v", org, name, *repo.ID)
+	url, err := newURLString("orgs/%v/dependabot/secrets/%v/repositories/%v", org, name, *repo.ID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", url, nil)
 	if err != nil {
 		return nil, err

--- a/github/dependency_graph.go
+++ b/github/dependency_graph.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 type DependencyGraphService service
@@ -63,7 +62,10 @@ func (s SBOM) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/dependency-graph/sboms
 func (s *DependencyGraphService) GetSBOM(ctx context.Context, owner, repo string) (*SBOM, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/dependency-graph/sbom", owner, repo)
+	u, err := newURLString("repos/%v/%v/dependency-graph/sbom", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/enterprise_actions_runners.go
+++ b/github/enterprise_actions_runners.go
@@ -7,14 +7,16 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ListRunnerApplicationDownloads lists self-hosted runner application binaries that can be downloaded and run.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#list-runner-applications-for-an-enterprise
 func (s *EnterpriseService) ListRunnerApplicationDownloads(ctx context.Context, enterprise string) ([]*RunnerApplicationDownload, *Response, error) {
-	u := fmt.Sprintf("enterprises/%v/actions/runners/downloads", enterprise)
+	u, err := newURLString("enterprises/%v/actions/runners/downloads", enterprise)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -33,7 +35,10 @@ func (s *EnterpriseService) ListRunnerApplicationDownloads(ctx context.Context, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#create-a-registration-token-for-an-enterprise
 func (s *EnterpriseService) CreateRegistrationToken(ctx context.Context, enterprise string) (*RegistrationToken, *Response, error) {
-	u := fmt.Sprintf("enterprises/%v/actions/runners/registration-token", enterprise)
+	u, err := newURLString("enterprises/%v/actions/runners/registration-token", enterprise)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -53,8 +58,11 @@ func (s *EnterpriseService) CreateRegistrationToken(ctx context.Context, enterpr
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#list-self-hosted-runners-for-an-enterprise
 func (s *EnterpriseService) ListRunners(ctx context.Context, enterprise string, opts *ListOptions) (*Runners, *Response, error) {
-	u := fmt.Sprintf("enterprises/%v/actions/runners", enterprise)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("enterprises/%v/actions/runners", enterprise)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -77,7 +85,10 @@ func (s *EnterpriseService) ListRunners(ctx context.Context, enterprise string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-an-enterprise
 func (s *EnterpriseService) RemoveRunner(ctx context.Context, enterprise string, runnerID int64) (*Response, error) {
-	u := fmt.Sprintf("enterprises/%v/actions/runners/%v", enterprise, runnerID)
+	u, err := newURLString("enterprises/%v/actions/runners/%v", enterprise, runnerID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/enterprise_audit_log.go
+++ b/github/enterprise_audit_log.go
@@ -7,15 +7,17 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // GetAuditLog gets the audit-log entries for an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/enterprise-admin/audit-log#get-the-audit-log-for-an-enterprise
 func (s *EnterpriseService) GetAuditLog(ctx context.Context, enterprise string, opts *GetAuditLogOptions) ([]*AuditEntry, *Response, error) {
-	u := fmt.Sprintf("enterprises/%v/audit-log", enterprise)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("enterprises/%v/audit-log", enterprise)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/enterprise_code_security_and_analysis.go
+++ b/github/enterprise_code_security_and_analysis.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // EnterpriseSecurityAnalysisSettings represents security analysis settings for an enterprise.
@@ -22,7 +21,10 @@ type EnterpriseSecurityAnalysisSettings struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#get-code-security-and-analysis-features-for-an-enterprise
 func (s *EnterpriseService) GetCodeSecurityAndAnalysis(ctx context.Context, enterprise string) (*EnterpriseSecurityAnalysisSettings, *Response, error) {
-	u := fmt.Sprintf("enterprises/%v/code_security_and_analysis", enterprise)
+	u, err := newURLString("enterprises/%v/code_security_and_analysis", enterprise)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -42,7 +44,10 @@ func (s *EnterpriseService) GetCodeSecurityAndAnalysis(ctx context.Context, ente
 //
 // GitHub API docs: https://docs.github.com/en/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#update-code-security-and-analysis-features-for-an-enterprise
 func (s *EnterpriseService) UpdateCodeSecurityAndAnalysis(ctx context.Context, enterprise string, settings *EnterpriseSecurityAnalysisSettings) (*Response, error) {
-	u := fmt.Sprintf("enterprises/%v/code_security_and_analysis", enterprise)
+	u, err := newURLString("enterprises/%v/code_security_and_analysis", enterprise)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, settings)
 	if err != nil {
 		return nil, err
@@ -63,7 +68,10 @@ func (s *EnterpriseService) UpdateCodeSecurityAndAnalysis(ctx context.Context, e
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/code-security-and-analysis?apiVersion=2022-11-28#enable-or-disable-a-security-feature
 func (s *EnterpriseService) EnableDisableSecurityFeature(ctx context.Context, enterprise, securityProduct, enablement string) (*Response, error) {
-	u := fmt.Sprintf("enterprises/%v/%v/%v", enterprise, securityProduct, enablement)
+	u, err := newURLString("enterprises/%v/%v/%v", enterprise, securityProduct, enablement)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/gists.go
+++ b/github/gists.go
@@ -131,7 +131,11 @@ func (s *GistsService) List(ctx context.Context, user string, opts *GistListOpti
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/gists#list-public-gists
 func (s *GistsService) ListAll(ctx context.Context, opts *GistListOptions) ([]*Gist, *Response, error) {
-	u, err := addOptions("gists/public", opts)
+	u, err := newURLString("gists/public")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -154,7 +158,11 @@ func (s *GistsService) ListAll(ctx context.Context, opts *GistListOptions) ([]*G
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/gists#list-starred-gists
 func (s *GistsService) ListStarred(ctx context.Context, opts *GistListOptions) ([]*Gist, *Response, error) {
-	u, err := addOptions("gists/starred", opts)
+	u, err := newURLString("gists/starred")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/gists.go
+++ b/github/gists.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"time"
 )
 
@@ -100,12 +99,16 @@ type GistListOptions struct {
 // GitHub API docs: https://docs.github.com/en/rest/gists/gists#list-gists-for-a-user
 func (s *GistsService) List(ctx context.Context, user string, opts *GistListOptions) ([]*Gist, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/gists", user)
+		u, err = newURLString("users/%v/gists", user)
 	} else {
-		u = "gists"
+		u, err = newURLString("gists")
 	}
-	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -174,7 +177,10 @@ func (s *GistsService) ListStarred(ctx context.Context, opts *GistListOptions) (
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/gists#get-a-gist
 func (s *GistsService) Get(ctx context.Context, id string) (*Gist, *Response, error) {
-	u := fmt.Sprintf("gists/%v", id)
+	u, err := newURLString("gists/%v", id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -193,7 +199,10 @@ func (s *GistsService) Get(ctx context.Context, id string) (*Gist, *Response, er
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/gists#get-a-gist-revision
 func (s *GistsService) GetRevision(ctx context.Context, id, sha string) (*Gist, *Response, error) {
-	u := fmt.Sprintf("gists/%v/%v", id, sha)
+	u, err := newURLString("gists/%v/%v", id, sha)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -212,7 +221,10 @@ func (s *GistsService) GetRevision(ctx context.Context, id, sha string) (*Gist, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/gists#create-a-gist
 func (s *GistsService) Create(ctx context.Context, gist *Gist) (*Gist, *Response, error) {
-	u := "gists"
+	u, err := newURLString("gists")
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, gist)
 	if err != nil {
 		return nil, nil, err
@@ -231,7 +243,10 @@ func (s *GistsService) Create(ctx context.Context, gist *Gist) (*Gist, *Response
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/gists#update-a-gist
 func (s *GistsService) Edit(ctx context.Context, id string, gist *Gist) (*Gist, *Response, error) {
-	u := fmt.Sprintf("gists/%v", id)
+	u, err := newURLString("gists/%v", id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, gist)
 	if err != nil {
 		return nil, nil, err
@@ -250,8 +265,11 @@ func (s *GistsService) Edit(ctx context.Context, id string, gist *Gist) (*Gist, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/gists#list-gist-commits
 func (s *GistsService) ListCommits(ctx context.Context, id string, opts *ListOptions) ([]*GistCommit, *Response, error) {
-	u := fmt.Sprintf("gists/%v/commits", id)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("gists/%v/commits", id)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -274,7 +292,10 @@ func (s *GistsService) ListCommits(ctx context.Context, id string, opts *ListOpt
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/gists#delete-a-gist
 func (s *GistsService) Delete(ctx context.Context, id string) (*Response, error) {
-	u := fmt.Sprintf("gists/%v", id)
+	u, err := newURLString("gists/%v", id)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -287,7 +308,10 @@ func (s *GistsService) Delete(ctx context.Context, id string) (*Response, error)
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/gists#star-a-gist
 func (s *GistsService) Star(ctx context.Context, id string) (*Response, error) {
-	u := fmt.Sprintf("gists/%v/star", id)
+	u, err := newURLString("gists/%v/star", id)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
 		return nil, err
@@ -300,7 +324,10 @@ func (s *GistsService) Star(ctx context.Context, id string) (*Response, error) {
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/gists#unstar-a-gist
 func (s *GistsService) Unstar(ctx context.Context, id string) (*Response, error) {
-	u := fmt.Sprintf("gists/%v/star", id)
+	u, err := newURLString("gists/%v/star", id)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -313,7 +340,10 @@ func (s *GistsService) Unstar(ctx context.Context, id string) (*Response, error)
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/gists#check-if-a-gist-is-starred
 func (s *GistsService) IsStarred(ctx context.Context, id string) (bool, *Response, error) {
-	u := fmt.Sprintf("gists/%v/star", id)
+	u, err := newURLString("gists/%v/star", id)
+	if err != nil {
+		return false, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return false, nil, err
@@ -328,7 +358,10 @@ func (s *GistsService) IsStarred(ctx context.Context, id string) (bool, *Respons
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/gists#fork-a-gist
 func (s *GistsService) Fork(ctx context.Context, id string) (*Gist, *Response, error) {
-	u := fmt.Sprintf("gists/%v/forks", id)
+	u, err := newURLString("gists/%v/forks", id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -347,8 +380,11 @@ func (s *GistsService) Fork(ctx context.Context, id string) (*Gist, *Response, e
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/gists#list-gist-forks
 func (s *GistsService) ListForks(ctx context.Context, id string, opts *ListOptions) ([]*GistFork, *Response, error) {
-	u := fmt.Sprintf("gists/%v/forks", id)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("gists/%v/forks", id)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/gists_comments.go
+++ b/github/gists_comments.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // GistComment represents a Gist comment.
@@ -27,8 +26,11 @@ func (g GistComment) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/comments#list-gist-comments
 func (s *GistsService) ListComments(ctx context.Context, gistID string, opts *ListOptions) ([]*GistComment, *Response, error) {
-	u := fmt.Sprintf("gists/%v/comments", gistID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("gists/%v/comments", gistID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -51,7 +53,10 @@ func (s *GistsService) ListComments(ctx context.Context, gistID string, opts *Li
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/comments#get-a-gist-comment
 func (s *GistsService) GetComment(ctx context.Context, gistID string, commentID int64) (*GistComment, *Response, error) {
-	u := fmt.Sprintf("gists/%v/comments/%v", gistID, commentID)
+	u, err := newURLString("gists/%v/comments/%v", gistID, commentID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -70,7 +75,10 @@ func (s *GistsService) GetComment(ctx context.Context, gistID string, commentID 
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/comments#create-a-gist-comment
 func (s *GistsService) CreateComment(ctx context.Context, gistID string, comment *GistComment) (*GistComment, *Response, error) {
-	u := fmt.Sprintf("gists/%v/comments", gistID)
+	u, err := newURLString("gists/%v/comments", gistID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -89,7 +97,10 @@ func (s *GistsService) CreateComment(ctx context.Context, gistID string, comment
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/comments#update-a-gist-comment
 func (s *GistsService) EditComment(ctx context.Context, gistID string, commentID int64, comment *GistComment) (*GistComment, *Response, error) {
-	u := fmt.Sprintf("gists/%v/comments/%v", gistID, commentID)
+	u, err := newURLString("gists/%v/comments/%v", gistID, commentID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -108,7 +119,10 @@ func (s *GistsService) EditComment(ctx context.Context, gistID string, commentID
 //
 // GitHub API docs: https://docs.github.com/en/rest/gists/comments#delete-a-gist-comment
 func (s *GistsService) DeleteComment(ctx context.Context, gistID string, commentID int64) (*Response, error) {
-	u := fmt.Sprintf("gists/%v/comments/%v", gistID, commentID)
+	u, err := newURLString("gists/%v/comments/%v", gistID, commentID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/git_blobs.go
+++ b/github/git_blobs.go
@@ -8,7 +8,6 @@ package github
 import (
 	"bytes"
 	"context"
-	"fmt"
 )
 
 // Blob represents a blob object.
@@ -25,7 +24,10 @@ type Blob struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/git/blobs#get-a-blob
 func (s *GitService) GetBlob(ctx context.Context, owner string, repo string, sha string) (*Blob, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/git/blobs/%v", owner, repo, sha)
+	u, err := newURLString("repos/%v/%v/git/blobs/%v", owner, repo, sha)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -45,7 +47,10 @@ func (s *GitService) GetBlob(ctx context.Context, owner string, repo string, sha
 //
 // GitHub API docs: https://docs.github.com/en/rest/git/blobs#get-a-blob
 func (s *GitService) GetBlobRaw(ctx context.Context, owner, repo, sha string) ([]byte, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/git/blobs/%v", owner, repo, sha)
+	u, err := newURLString("repos/%v/%v/git/blobs/%v", owner, repo, sha)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -66,7 +71,10 @@ func (s *GitService) GetBlobRaw(ctx context.Context, owner, repo, sha string) ([
 //
 // GitHub API docs: https://docs.github.com/en/rest/git/blobs#create-a-blob
 func (s *GitService) CreateBlob(ctx context.Context, owner string, repo string, blob *Blob) (*Blob, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/git/blobs", owner, repo)
+	u, err := newURLString("repos/%v/%v/git/blobs", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, blob)
 	if err != nil {
 		return nil, nil, err

--- a/github/git_commits.go
+++ b/github/git_commits.go
@@ -71,7 +71,10 @@ func (c CommitAuthor) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/git/commits#get-a-commit
 func (s *GitService) GetCommit(ctx context.Context, owner string, repo string, sha string) (*Commit, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/git/commits/%v", owner, repo, sha)
+	u, err := newURLString("repos/%v/%v/git/commits/%v", owner, repo, sha)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -109,7 +112,10 @@ func (s *GitService) CreateCommit(ctx context.Context, owner string, repo string
 		return nil, nil, fmt.Errorf("commit must be provided")
 	}
 
-	u := fmt.Sprintf("repos/%v/%v/git/commits", owner, repo)
+	u, err := newURLString("repos/%v/%v/git/commits", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	parents := make([]string, len(commit.Parents))
 	for i, parent := range commit.Parents {

--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"strings"
 )
@@ -52,7 +51,10 @@ type updateRefRequest struct {
 // GitHub API docs: https://docs.github.com/en/rest/git/refs#get-a-reference
 func (s *GitService) GetRef(ctx context.Context, owner string, repo string, ref string) (*Reference, *Response, error) {
 	ref = strings.TrimPrefix(ref, "refs/")
-	u := fmt.Sprintf("repos/%v/%v/git/ref/%v", owner, repo, refURLEscape(ref))
+	u, err := newURLString("repos/%v/%v/git/ref/%v", owner, repo, refURLEscape(ref))
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -94,8 +96,11 @@ func (s *GitService) ListMatchingRefs(ctx context.Context, owner, repo string, o
 	if opts != nil {
 		ref = strings.TrimPrefix(opts.Ref, "refs/")
 	}
-	u := fmt.Sprintf("repos/%v/%v/git/matching-refs/%v", owner, repo, refURLEscape(ref))
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/git/matching-refs/%v", owner, repo, refURLEscape(ref))
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -118,7 +123,10 @@ func (s *GitService) ListMatchingRefs(ctx context.Context, owner, repo string, o
 //
 // GitHub API docs: https://docs.github.com/en/rest/git/refs#create-a-reference
 func (s *GitService) CreateRef(ctx context.Context, owner string, repo string, ref *Reference) (*Reference, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/git/refs", owner, repo)
+	u, err := newURLString("repos/%v/%v/git/refs", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, &createRefRequest{
 		// back-compat with previous behavior that didn't require 'refs/' prefix
 		Ref: String("refs/" + strings.TrimPrefix(*ref.Ref, "refs/")),
@@ -142,7 +150,10 @@ func (s *GitService) CreateRef(ctx context.Context, owner string, repo string, r
 // GitHub API docs: https://docs.github.com/en/rest/git/refs#update-a-reference
 func (s *GitService) UpdateRef(ctx context.Context, owner string, repo string, ref *Reference, force bool) (*Reference, *Response, error) {
 	refPath := strings.TrimPrefix(*ref.Ref, "refs/")
-	u := fmt.Sprintf("repos/%v/%v/git/refs/%v", owner, repo, refURLEscape(refPath))
+	u, err := newURLString("repos/%v/%v/git/refs/%v", owner, repo, refURLEscape(refPath))
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, &updateRefRequest{
 		SHA:   ref.Object.SHA,
 		Force: &force,
@@ -165,7 +176,10 @@ func (s *GitService) UpdateRef(ctx context.Context, owner string, repo string, r
 // GitHub API docs: https://docs.github.com/en/rest/git/refs#delete-a-reference
 func (s *GitService) DeleteRef(ctx context.Context, owner string, repo string, ref string) (*Response, error) {
 	ref = strings.TrimPrefix(ref, "refs/")
-	u := fmt.Sprintf("repos/%v/%v/git/refs/%v", owner, repo, refURLEscape(ref))
+	u, err := newURLString("repos/%v/%v/git/refs/%v", owner, repo, refURLEscape(ref))
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/git_tags.go
+++ b/github/git_tags.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // Tag represents a tag object.
@@ -37,7 +36,10 @@ type createTagRequest struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/git/tags#get-a-tag
 func (s *GitService) GetTag(ctx context.Context, owner string, repo string, sha string) (*Tag, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/git/tags/%v", owner, repo, sha)
+	u, err := newURLString("repos/%v/%v/git/tags/%v", owner, repo, sha)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -56,7 +58,10 @@ func (s *GitService) GetTag(ctx context.Context, owner string, repo string, sha 
 //
 // GitHub API docs: https://docs.github.com/en/rest/git/tags#create-a-tag-object
 func (s *GitService) CreateTag(ctx context.Context, owner string, repo string, tag *Tag) (*Tag, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/git/tags", owner, repo)
+	u, err := newURLString("repos/%v/%v/git/tags", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// convert Tag into a createTagRequest
 	tagRequest := &createTagRequest{

--- a/github/git_trees.go
+++ b/github/git_trees.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 )
 
 // Tree represents a GitHub tree.
@@ -95,7 +94,10 @@ func (t *TreeEntry) MarshalJSON() ([]byte, error) {
 //
 // GitHub API docs: https://docs.github.com/en/rest/git/trees#get-a-tree
 func (s *GitService) GetTree(ctx context.Context, owner string, repo string, sha string, recursive bool) (*Tree, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/git/trees/%v", owner, repo, sha)
+	u, err := newURLString("repos/%v/%v/git/trees/%v", owner, repo, sha)
+	if err != nil {
+		return nil, nil, err
+	}
 	if recursive {
 		u += "?recursive=1"
 	}
@@ -126,7 +128,10 @@ type createTree struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/git/trees#create-a-tree
 func (s *GitService) CreateTree(ctx context.Context, owner string, repo string, baseTree string, entries []*TreeEntry) (*Tree, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/git/trees", owner, repo)
+	u, err := newURLString("repos/%v/%v/git/trees", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	newEntries := make([]interface{}, 0, len(entries))
 	for _, entry := range entries {

--- a/github/git_trees.go
+++ b/github/git_trees.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"net/url"
 )
 
 // Tree represents a GitHub tree.
@@ -99,7 +100,10 @@ func (s *GitService) GetTree(ctx context.Context, owner string, repo string, sha
 		return nil, nil, err
 	}
 	if recursive {
-		u += "?recursive=1"
+		u, err = addQueryParams(u, url.Values{"recursive": []string{"1"}})
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	req, err := s.client.NewRequest("GET", u, nil)

--- a/github/github.go
+++ b/github/github.go
@@ -300,16 +300,23 @@ func addOptions(s string, opts interface{}) (string, error) {
 		return s, nil
 	}
 
-	u, err := url.Parse(s)
-	if err != nil {
-		return s, err
-	}
-
 	qs, err := query.Values(opts)
 	if err != nil {
 		return s, err
 	}
+	return addQueryParams(s, qs)
+}
 
+// addQueryParams parses s as a url and adds params to the existing query
+func addQueryParams(s string, params url.Values) (string, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return s, err
+	}
+	qs := u.Query()
+	for k, v := range params {
+		qs[k] = v
+	}
 	u.RawQuery = qs.Encode()
 	return u.String(), nil
 }

--- a/github/github.go
+++ b/github/github.go
@@ -282,6 +282,16 @@ type RawOptions struct {
 	Type RawType
 }
 
+// newURLString uses fmt.Sprintf to build a URL then validates it with url.Parse.
+func newURLString(format string, a ...interface{}) (string, error) {
+	s := fmt.Sprintf(format, a...)
+	_, err := url.Parse(s)
+	if err != nil {
+		return "", err
+	}
+	return s, nil
+}
+
 // addOptions adds the parameters in opts as URL query parameters to s. opts
 // must be a struct whose fields may contain "url" tags.
 func addOptions(s string, opts interface{}) (string, error) {

--- a/github/gitignore.go
+++ b/github/gitignore.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // GitignoresService provides access to the gitignore related functions in the
@@ -48,7 +47,10 @@ func (s *GitignoresService) List(ctx context.Context) ([]string, *Response, erro
 //
 // GitHub API docs: https://docs.github.com/en/rest/gitignore#get-a-gitignore-template
 func (s *GitignoresService) Get(ctx context.Context, name string) (*Gitignore, *Response, error) {
-	u := fmt.Sprintf("gitignore/templates/%v", name)
+	u, err := newURLString("gitignore/templates/%v", name)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/interactions_orgs.go
+++ b/github/interactions_orgs.go
@@ -7,14 +7,16 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // GetRestrictionsForOrg fetches the interaction restrictions for an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/interactions/orgs#get-interaction-restrictions-for-an-organization
 func (s *InteractionsService) GetRestrictionsForOrg(ctx context.Context, organization string) (*InteractionRestriction, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/interaction-limits", organization)
+	u, err := newURLString("orgs/%v/interaction-limits", organization)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -41,7 +43,10 @@ func (s *InteractionsService) GetRestrictionsForOrg(ctx context.Context, organiz
 //
 // GitHub API docs: https://docs.github.com/en/rest/interactions/orgs#set-interaction-restrictions-for-an-organization
 func (s *InteractionsService) UpdateRestrictionsForOrg(ctx context.Context, organization, limit string) (*InteractionRestriction, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/interaction-limits", organization)
+	u, err := newURLString("orgs/%v/interaction-limits", organization)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	interaction := &InteractionRestriction{Limit: String(limit)}
 
@@ -67,7 +72,10 @@ func (s *InteractionsService) UpdateRestrictionsForOrg(ctx context.Context, orga
 //
 // GitHub API docs: https://docs.github.com/en/rest/interactions/orgs#remove-interaction-restrictions-for-an-organization
 func (s *InteractionsService) RemoveRestrictionsFromOrg(ctx context.Context, organization string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/interaction-limits", organization)
+	u, err := newURLString("orgs/%v/interaction-limits", organization)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/interactions_repos.go
+++ b/github/interactions_repos.go
@@ -7,14 +7,16 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // GetRestrictionsForRepo fetches the interaction restrictions for a repository.
 //
 // GitHub API docs: https://docs.github.com/en/rest/interactions/repos#get-interaction-restrictions-for-a-repository
 func (s *InteractionsService) GetRestrictionsForRepo(ctx context.Context, owner, repo string) (*InteractionRestriction, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/interaction-limits", owner, repo)
+	u, err := newURLString("repos/%v/%v/interaction-limits", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -41,7 +43,10 @@ func (s *InteractionsService) GetRestrictionsForRepo(ctx context.Context, owner,
 //
 // GitHub API docs: https://docs.github.com/en/rest/interactions/repos#set-interaction-restrictions-for-a-repository
 func (s *InteractionsService) UpdateRestrictionsForRepo(ctx context.Context, owner, repo, limit string) (*InteractionRestriction, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/interaction-limits", owner, repo)
+	u, err := newURLString("repos/%v/%v/interaction-limits", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	interaction := &InteractionRestriction{Limit: String(limit)}
 
@@ -67,7 +72,10 @@ func (s *InteractionsService) UpdateRestrictionsForRepo(ctx context.Context, own
 //
 // GitHub API docs: https://docs.github.com/en/rest/interactions/repos#remove-interaction-restrictions-for-a-repository
 func (s *InteractionsService) RemoveRestrictionsFromRepo(ctx context.Context, owner, repo string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/interaction-limits", owner, repo)
+	u, err := newURLString("repos/%v/%v/interaction-limits", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/issue_import.go
+++ b/github/issue_import.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 )
 
 // IssueImportService handles communication with the issue import related
@@ -72,7 +71,10 @@ type IssueImportError struct {
 //
 // https://gist.github.com/jonmagic/5282384165e0f86ef105#start-an-issue-import
 func (s *IssueImportService) Create(ctx context.Context, owner, repo string, issue *IssueImportRequest) (*IssueImportResponse, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/import/issues", owner, repo)
+	u, err := newURLString("repos/%v/%v/import/issues", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, issue)
 	if err != nil {
 		return nil, nil, err
@@ -101,7 +103,10 @@ func (s *IssueImportService) Create(ctx context.Context, owner, repo string, iss
 //
 // https://gist.github.com/jonmagic/5282384165e0f86ef105#import-status-request
 func (s *IssueImportService) CheckStatus(ctx context.Context, owner, repo string, issueID int64) (*IssueImportResponse, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/import/issues/%v", owner, repo, issueID)
+	u, err := newURLString("repos/%v/%v/import/issues/%v", owner, repo, issueID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -123,7 +128,10 @@ func (s *IssueImportService) CheckStatus(ctx context.Context, owner, repo string
 //
 // https://gist.github.com/jonmagic/5282384165e0f86ef105#check-status-of-multiple-issues
 func (s *IssueImportService) CheckStatusSince(ctx context.Context, owner, repo string, since Timestamp) ([]*IssueImportResponse, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/import/issues?since=%v", owner, repo, since.Format("2006-01-02"))
+	u, err := newURLString("repos/%v/%v/import/issues?since=%v", owner, repo, since.Format("2006-01-02"))
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/issues.go
+++ b/github/issues.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"time"
 )
 
@@ -149,7 +148,10 @@ func (s *IssuesService) List(ctx context.Context, all bool, opts *IssueListOptio
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/issues#list-organization-issues-assigned-to-the-authenticated-user
 func (s *IssuesService) ListByOrg(ctx context.Context, org string, opts *IssueListOptions) ([]*Issue, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/issues", org)
+	u, err := newURLString("orgs/%v/issues", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.listIssues(ctx, u, opts)
 }
 
@@ -220,8 +222,11 @@ type IssueListByRepoOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/issues#list-repository-issues
 func (s *IssuesService) ListByRepo(ctx context.Context, owner string, repo string, opts *IssueListByRepoOptions) ([]*Issue, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/issues", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -247,7 +252,10 @@ func (s *IssuesService) ListByRepo(ctx context.Context, owner string, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/issues#get-an-issue
 func (s *IssuesService) Get(ctx context.Context, owner string, repo string, number int) (*Issue, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/%d", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/issues/%d", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -269,7 +277,10 @@ func (s *IssuesService) Get(ctx context.Context, owner string, repo string, numb
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/issues#create-an-issue
 func (s *IssuesService) Create(ctx context.Context, owner string, repo string, issue *IssueRequest) (*Issue, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues", owner, repo)
+	u, err := newURLString("repos/%v/%v/issues", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, issue)
 	if err != nil {
 		return nil, nil, err
@@ -288,7 +299,10 @@ func (s *IssuesService) Create(ctx context.Context, owner string, repo string, i
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/issues#update-an-issue
 func (s *IssuesService) Edit(ctx context.Context, owner string, repo string, number int, issue *IssueRequest) (*Issue, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/%d", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/issues/%d", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, issue)
 	if err != nil {
 		return nil, nil, err
@@ -309,7 +323,10 @@ func (s *IssuesService) Edit(ctx context.Context, owner string, repo string, num
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/issues#update-an-issue
 func (s *IssuesService) RemoveMilestone(ctx context.Context, owner, repo string, issueNumber int) (*Issue, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/%v", owner, repo, issueNumber)
+	u, err := newURLString("repos/%v/%v/issues/%v", owner, repo, issueNumber)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, &struct {
 		Milestone *Milestone `json:"milestone"`
 	}{})
@@ -339,7 +356,10 @@ type LockIssueOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/issues#lock-an-issue
 func (s *IssuesService) Lock(ctx context.Context, owner string, repo string, number int, opts *LockIssueOptions) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/%d/lock", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/issues/%d/lock", owner, repo, number)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, err
@@ -352,7 +372,10 @@ func (s *IssuesService) Lock(ctx context.Context, owner string, repo string, num
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/issues#unlock-an-issue
 func (s *IssuesService) Unlock(ctx context.Context, owner string, repo string, number int) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/%d/lock", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/issues/%d/lock", owner, repo, number)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/issues.go
+++ b/github/issues.go
@@ -135,10 +135,14 @@ type PullRequestLinks struct {
 // GitHub API docs: https://docs.github.com/en/rest/issues/issues#list-issues-assigned-to-the-authenticated-user
 func (s *IssuesService) List(ctx context.Context, all bool, opts *IssueListOptions) ([]*Issue, *Response, error) {
 	var u string
+	var err error
 	if all {
-		u = "issues"
+		u, err = newURLString("issues")
 	} else {
-		u = "user/issues"
+		u, err = newURLString("user/issues")
+	}
+	if err != nil {
+		return nil, nil, err
 	}
 	return s.listIssues(ctx, u, opts)
 }

--- a/github/issues_assignees.go
+++ b/github/issues_assignees.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ListAssignees fetches all available assignees (owners and collaborators) to
@@ -15,8 +14,11 @@ import (
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/assignees#list-assignees
 func (s *IssuesService) ListAssignees(ctx context.Context, owner, repo string, opts *ListOptions) ([]*User, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/assignees", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/assignees", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -39,7 +41,10 @@ func (s *IssuesService) ListAssignees(ctx context.Context, owner, repo string, o
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/assignees#check-if-a-user-can-be-assigned
 func (s *IssuesService) IsAssignee(ctx context.Context, owner, repo, user string) (bool, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/assignees/%v", owner, repo, user)
+	u, err := newURLString("repos/%v/%v/assignees/%v", owner, repo, user)
+	if err != nil {
+		return false, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return false, nil, err
@@ -57,7 +62,10 @@ func (s *IssuesService) AddAssignees(ctx context.Context, owner, repo string, nu
 	users := &struct {
 		Assignees []string `json:"assignees,omitempty"`
 	}{Assignees: assignees}
-	u := fmt.Sprintf("repos/%v/%v/issues/%v/assignees", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/issues/%v/assignees", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, users)
 	if err != nil {
 		return nil, nil, err
@@ -79,7 +87,10 @@ func (s *IssuesService) RemoveAssignees(ctx context.Context, owner, repo string,
 	users := &struct {
 		Assignees []string `json:"assignees,omitempty"`
 	}{Assignees: assignees}
-	u := fmt.Sprintf("repos/%v/%v/issues/%v/assignees", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/issues/%v/assignees", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, users)
 	if err != nil {
 		return nil, nil, err

--- a/github/issues_comments.go
+++ b/github/issues_comments.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"time"
 )
 
@@ -54,12 +53,16 @@ type IssueListCommentsOptions struct {
 // GitHub API docs: https://docs.github.com/en/rest/issues/comments#list-issue-comments-for-a-repository
 func (s *IssuesService) ListComments(ctx context.Context, owner string, repo string, number int, opts *IssueListCommentsOptions) ([]*IssueComment, *Response, error) {
 	var u string
+	var err error
 	if number == 0 {
-		u = fmt.Sprintf("repos/%v/%v/issues/comments", owner, repo)
+		u, err = newURLString("repos/%v/%v/issues/comments", owner, repo)
 	} else {
-		u = fmt.Sprintf("repos/%v/%v/issues/%d/comments", owner, repo, number)
+		u, err = newURLString("repos/%v/%v/issues/%d/comments", owner, repo, number)
 	}
-	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -85,7 +88,10 @@ func (s *IssuesService) ListComments(ctx context.Context, owner string, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/comments#get-an-issue-comment
 func (s *IssuesService) GetComment(ctx context.Context, owner string, repo string, commentID int64) (*IssueComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/comments/%d", owner, repo, commentID)
+	u, err := newURLString("repos/%v/%v/issues/comments/%d", owner, repo, commentID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -108,7 +114,10 @@ func (s *IssuesService) GetComment(ctx context.Context, owner string, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/comments#create-an-issue-comment
 func (s *IssuesService) CreateComment(ctx context.Context, owner string, repo string, number int, comment *IssueComment) (*IssueComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/%d/comments", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/issues/%d/comments", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -127,7 +136,10 @@ func (s *IssuesService) CreateComment(ctx context.Context, owner string, repo st
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/comments#update-an-issue-comment
 func (s *IssuesService) EditComment(ctx context.Context, owner string, repo string, commentID int64, comment *IssueComment) (*IssueComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/comments/%d", owner, repo, commentID)
+	u, err := newURLString("repos/%v/%v/issues/comments/%d", owner, repo, commentID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -145,7 +157,10 @@ func (s *IssuesService) EditComment(ctx context.Context, owner string, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/comments#delete-an-issue-comment
 func (s *IssuesService) DeleteComment(ctx context.Context, owner string, repo string, commentID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/comments/%d", owner, repo, commentID)
+	u, err := newURLString("repos/%v/%v/issues/comments/%d", owner, repo, commentID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/issues_events.go
+++ b/github/issues_events.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // IssueEvent represents an event that occurred around an Issue or Pull Request.
@@ -101,8 +100,11 @@ type DismissedReview struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/events#list-issue-events
 func (s *IssuesService) ListIssueEvents(ctx context.Context, owner, repo string, number int, opts *ListOptions) ([]*IssueEvent, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/%v/events", owner, repo, number)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/issues/%v/events", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -127,8 +129,11 @@ func (s *IssuesService) ListIssueEvents(ctx context.Context, owner, repo string,
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/events#list-issue-events-for-a-repository
 func (s *IssuesService) ListRepositoryEvents(ctx context.Context, owner, repo string, opts *ListOptions) ([]*IssueEvent, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/events", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/issues/events", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -151,7 +156,10 @@ func (s *IssuesService) ListRepositoryEvents(ctx context.Context, owner, repo st
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/events#get-an-issue-event
 func (s *IssuesService) GetEvent(ctx context.Context, owner, repo string, id int64) (*IssueEvent, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/events/%v", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/issues/events/%v", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/issues_labels.go
+++ b/github/issues_labels.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // Label represents a GitHub label on an Issue
@@ -29,8 +28,11 @@ func (l Label) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/labels#list-labels-for-a-repository
 func (s *IssuesService) ListLabels(ctx context.Context, owner string, repo string, opts *ListOptions) ([]*Label, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/labels", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/labels", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -53,7 +55,10 @@ func (s *IssuesService) ListLabels(ctx context.Context, owner string, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/labels#get-a-label
 func (s *IssuesService) GetLabel(ctx context.Context, owner string, repo string, name string) (*Label, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/labels/%v", owner, repo, name)
+	u, err := newURLString("repos/%v/%v/labels/%v", owner, repo, name)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -72,7 +77,10 @@ func (s *IssuesService) GetLabel(ctx context.Context, owner string, repo string,
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/labels#create-a-label
 func (s *IssuesService) CreateLabel(ctx context.Context, owner string, repo string, label *Label) (*Label, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/labels", owner, repo)
+	u, err := newURLString("repos/%v/%v/labels", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, label)
 	if err != nil {
 		return nil, nil, err
@@ -91,7 +99,10 @@ func (s *IssuesService) CreateLabel(ctx context.Context, owner string, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/labels#update-a-label
 func (s *IssuesService) EditLabel(ctx context.Context, owner string, repo string, name string, label *Label) (*Label, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/labels/%v", owner, repo, name)
+	u, err := newURLString("repos/%v/%v/labels/%v", owner, repo, name)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, label)
 	if err != nil {
 		return nil, nil, err
@@ -110,7 +121,10 @@ func (s *IssuesService) EditLabel(ctx context.Context, owner string, repo string
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/labels#delete-a-label
 func (s *IssuesService) DeleteLabel(ctx context.Context, owner string, repo string, name string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/labels/%v", owner, repo, name)
+	u, err := newURLString("repos/%v/%v/labels/%v", owner, repo, name)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -122,8 +136,11 @@ func (s *IssuesService) DeleteLabel(ctx context.Context, owner string, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/labels#list-labels-for-an-issue
 func (s *IssuesService) ListLabelsByIssue(ctx context.Context, owner string, repo string, number int, opts *ListOptions) ([]*Label, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels", owner, repo, number)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/issues/%d/labels", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -146,7 +163,10 @@ func (s *IssuesService) ListLabelsByIssue(ctx context.Context, owner string, rep
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/labels#add-labels-to-an-issue
 func (s *IssuesService) AddLabelsToIssue(ctx context.Context, owner string, repo string, number int, labels []string) ([]*Label, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/issues/%d/labels", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, labels)
 	if err != nil {
 		return nil, nil, err
@@ -165,7 +185,10 @@ func (s *IssuesService) AddLabelsToIssue(ctx context.Context, owner string, repo
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/labels#remove-a-label-from-an-issue
 func (s *IssuesService) RemoveLabelForIssue(ctx context.Context, owner string, repo string, number int, label string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels/%v", owner, repo, number, label)
+	u, err := newURLString("repos/%v/%v/issues/%d/labels/%v", owner, repo, number, label)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -178,7 +201,10 @@ func (s *IssuesService) RemoveLabelForIssue(ctx context.Context, owner string, r
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/labels#set-labels-for-an-issue
 func (s *IssuesService) ReplaceLabelsForIssue(ctx context.Context, owner string, repo string, number int, labels []string) ([]*Label, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/issues/%d/labels", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, labels)
 	if err != nil {
 		return nil, nil, err
@@ -197,7 +223,10 @@ func (s *IssuesService) ReplaceLabelsForIssue(ctx context.Context, owner string,
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/labels#remove-all-labels-from-an-issue
 func (s *IssuesService) RemoveLabelsForIssue(ctx context.Context, owner string, repo string, number int) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/issues/%d/labels", owner, repo, number)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -210,8 +239,11 @@ func (s *IssuesService) RemoveLabelsForIssue(ctx context.Context, owner string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/labels#list-labels-for-issues-in-a-milestone
 func (s *IssuesService) ListLabelsForMilestone(ctx context.Context, owner string, repo string, number int, opts *ListOptions) ([]*Label, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/milestones/%d/labels", owner, repo, number)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/milestones/%d/labels", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/issues_milestones.go
+++ b/github/issues_milestones.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // Milestone represents a GitHub repository milestone.
@@ -56,8 +55,11 @@ type MilestoneListOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/milestones#list-milestones
 func (s *IssuesService) ListMilestones(ctx context.Context, owner string, repo string, opts *MilestoneListOptions) ([]*Milestone, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/milestones", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/milestones", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -80,7 +82,10 @@ func (s *IssuesService) ListMilestones(ctx context.Context, owner string, repo s
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/milestones#get-a-milestone
 func (s *IssuesService) GetMilestone(ctx context.Context, owner string, repo string, number int) (*Milestone, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/milestones/%d", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/milestones/%d", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -99,7 +104,10 @@ func (s *IssuesService) GetMilestone(ctx context.Context, owner string, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/milestones#create-a-milestone
 func (s *IssuesService) CreateMilestone(ctx context.Context, owner string, repo string, milestone *Milestone) (*Milestone, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/milestones", owner, repo)
+	u, err := newURLString("repos/%v/%v/milestones", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, milestone)
 	if err != nil {
 		return nil, nil, err
@@ -118,7 +126,10 @@ func (s *IssuesService) CreateMilestone(ctx context.Context, owner string, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/milestones#update-a-milestone
 func (s *IssuesService) EditMilestone(ctx context.Context, owner string, repo string, number int, milestone *Milestone) (*Milestone, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/milestones/%d", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/milestones/%d", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, milestone)
 	if err != nil {
 		return nil, nil, err
@@ -137,7 +148,10 @@ func (s *IssuesService) EditMilestone(ctx context.Context, owner string, repo st
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/milestones#delete-a-milestone
 func (s *IssuesService) DeleteMilestone(ctx context.Context, owner string, repo string, number int) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/milestones/%d", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/milestones/%d", owner, repo, number)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/issues_timeline.go
+++ b/github/issues_timeline.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"strings"
 )
 
@@ -166,8 +165,11 @@ type Source struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/issues/timeline#list-timeline-events-for-an-issue
 func (s *IssuesService) ListIssueTimeline(ctx context.Context, owner, repo string, number int, opts *ListOptions) ([]*Timeline, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/%v/timeline", owner, repo, number)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/issues/%v/timeline", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/licenses.go
+++ b/github/licenses.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // LicensesService handles communication with the license related
@@ -80,7 +79,10 @@ func (s *LicensesService) List(ctx context.Context) ([]*License, *Response, erro
 //
 // GitHub API docs: https://docs.github.com/en/rest/licenses#get-a-license
 func (s *LicensesService) Get(ctx context.Context, licenseName string) (*License, *Response, error) {
-	u := fmt.Sprintf("licenses/%s", licenseName)
+	u, err := newURLString("licenses/%s", licenseName)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/migrations.go
+++ b/github/migrations.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 )
@@ -76,7 +75,10 @@ type startMigration struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/orgs#start-an-organization-migration
 func (s *MigrationService) StartMigration(ctx context.Context, org string, repos []string, opts *MigrationOptions) (*Migration, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/migrations", org)
+	u, err := newURLString("orgs/%v/migrations", org)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	body := &startMigration{Repositories: repos}
 	if opts != nil {
@@ -105,8 +107,11 @@ func (s *MigrationService) StartMigration(ctx context.Context, org string, repos
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/orgs#list-organization-migrations
 func (s *MigrationService) ListMigrations(ctx context.Context, org string, opts *ListOptions) ([]*Migration, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/migrations", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/migrations", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -133,7 +138,10 @@ func (s *MigrationService) ListMigrations(ctx context.Context, org string, opts 
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/orgs#get-an-organization-migration-status
 func (s *MigrationService) MigrationStatus(ctx context.Context, org string, id int64) (*Migration, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/migrations/%v", org, id)
+	u, err := newURLString("orgs/%v/migrations/%v", org, id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -157,7 +165,10 @@ func (s *MigrationService) MigrationStatus(ctx context.Context, org string, id i
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/orgs#download-an-organization-migration-archive
 func (s *MigrationService) MigrationArchiveURL(ctx context.Context, org string, id int64) (url string, err error) {
-	u := fmt.Sprintf("orgs/%v/migrations/%v/archive", org, id)
+	u, err := newURLString("orgs/%v/migrations/%v/archive", org, id)
+	if err != nil {
+		return "", err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -194,7 +205,10 @@ func (s *MigrationService) MigrationArchiveURL(ctx context.Context, org string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/orgs#delete-an-organization-migration-archive
 func (s *MigrationService) DeleteMigration(ctx context.Context, org string, id int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/migrations/%v/archive", org, id)
+	u, err := newURLString("orgs/%v/migrations/%v/archive", org, id)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -214,7 +228,10 @@ func (s *MigrationService) DeleteMigration(ctx context.Context, org string, id i
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/orgs#unlock-an-organization-repository
 func (s *MigrationService) UnlockRepo(ctx context.Context, org string, id int64, repo string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/migrations/%v/repos/%v/lock", org, id, repo)
+	u, err := newURLString("orgs/%v/migrations/%v/repos/%v/lock", org, id, repo)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/migrations_source_import.go
+++ b/github/migrations_source_import.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // Import represents a repository import request.
@@ -148,7 +147,10 @@ func (f LargeFile) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/source-imports#start-an-import
 func (s *MigrationService) StartImport(ctx context.Context, owner, repo string, in *Import) (*Import, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
+	u, err := newURLString("repos/%v/%v/import", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, in)
 	if err != nil {
 		return nil, nil, err
@@ -167,7 +169,10 @@ func (s *MigrationService) StartImport(ctx context.Context, owner, repo string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/source-imports#get-an-import-status
 func (s *MigrationService) ImportProgress(ctx context.Context, owner, repo string) (*Import, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
+	u, err := newURLString("repos/%v/%v/import", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -186,7 +191,10 @@ func (s *MigrationService) ImportProgress(ctx context.Context, owner, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/source-imports#update-an-import
 func (s *MigrationService) UpdateImport(ctx context.Context, owner, repo string, in *Import) (*Import, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
+	u, err := newURLString("repos/%v/%v/import", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, in)
 	if err != nil {
 		return nil, nil, err
@@ -215,7 +223,10 @@ func (s *MigrationService) UpdateImport(ctx context.Context, owner, repo string,
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/source-imports#get-commit-authors
 func (s *MigrationService) CommitAuthors(ctx context.Context, owner, repo string) ([]*SourceImportAuthor, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/import/authors", owner, repo)
+	u, err := newURLString("repos/%v/%v/import/authors", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -236,7 +247,10 @@ func (s *MigrationService) CommitAuthors(ctx context.Context, owner, repo string
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/source-imports#map-a-commit-author
 func (s *MigrationService) MapCommitAuthor(ctx context.Context, owner, repo string, id int64, author *SourceImportAuthor) (*SourceImportAuthor, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/import/authors/%v", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/import/authors/%v", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, author)
 	if err != nil {
 		return nil, nil, err
@@ -257,7 +271,10 @@ func (s *MigrationService) MapCommitAuthor(ctx context.Context, owner, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/source-imports#update-git-lfs-preference
 func (s *MigrationService) SetLFSPreference(ctx context.Context, owner, repo string, in *Import) (*Import, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/import/lfs", owner, repo)
+	u, err := newURLString("repos/%v/%v/import/lfs", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, in)
 	if err != nil {
 		return nil, nil, err
@@ -276,7 +293,10 @@ func (s *MigrationService) SetLFSPreference(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/source-imports#get-large-files
 func (s *MigrationService) LargeFiles(ctx context.Context, owner, repo string) ([]*LargeFile, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/import/large_files", owner, repo)
+	u, err := newURLString("repos/%v/%v/import/large_files", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -295,7 +315,10 @@ func (s *MigrationService) LargeFiles(ctx context.Context, owner, repo string) (
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/source-imports#cancel-an-import
 func (s *MigrationService) CancelImport(ctx context.Context, owner, repo string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
+	u, err := newURLString("repos/%v/%v/import", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/migrations_user.go
+++ b/github/migrations_user.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 )
 
@@ -69,7 +68,10 @@ type startUserMigration struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/users#start-a-user-migration
 func (s *MigrationService) StartUserMigration(ctx context.Context, repos []string, opts *UserMigrationOptions) (*UserMigration, *Response, error) {
-	u := "user/migrations"
+	u, err := newURLString("user/migrations")
+	if err != nil {
+		return nil, nil, err
+	}
 
 	body := &startUserMigration{Repositories: repos}
 	if opts != nil {
@@ -98,8 +100,11 @@ func (s *MigrationService) StartUserMigration(ctx context.Context, repos []strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/users#list-user-migrations
 func (s *MigrationService) ListUserMigrations(ctx context.Context, opts *ListOptions) ([]*UserMigration, *Response, error) {
-	u := "user/migrations"
-	u, err := addOptions(u, opts)
+	u, err := newURLString("user/migrations")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -126,7 +131,10 @@ func (s *MigrationService) ListUserMigrations(ctx context.Context, opts *ListOpt
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/users#get-a-user-migration-status
 func (s *MigrationService) UserMigrationStatus(ctx context.Context, id int64) (*UserMigration, *Response, error) {
-	u := fmt.Sprintf("user/migrations/%v", id)
+	u, err := newURLString("user/migrations/%v", id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -150,7 +158,10 @@ func (s *MigrationService) UserMigrationStatus(ctx context.Context, id int64) (*
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/users#download-a-user-migration-archive
 func (s *MigrationService) UserMigrationArchiveURL(ctx context.Context, id int64) (string, error) {
-	url := fmt.Sprintf("user/migrations/%v/archive", id)
+	url, err := newURLString("user/migrations/%v/archive", id)
+	if err != nil {
+		return "", err
+	}
 
 	req, err := s.client.NewRequest("GET", url, nil)
 	if err != nil {
@@ -184,7 +195,10 @@ func (s *MigrationService) UserMigrationArchiveURL(ctx context.Context, id int64
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/users#delete-a-user-migration-archive
 func (s *MigrationService) DeleteUserMigration(ctx context.Context, id int64) (*Response, error) {
-	url := fmt.Sprintf("user/migrations/%v/archive", id)
+	url, err := newURLString("user/migrations/%v/archive", id)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", url, nil)
 	if err != nil {
@@ -204,7 +218,10 @@ func (s *MigrationService) DeleteUserMigration(ctx context.Context, id int64) (*
 //
 // GitHub API docs: https://docs.github.com/en/rest/migrations/users#unlock-a-user-repository
 func (s *MigrationService) UnlockUserRepo(ctx context.Context, id int64, repo string) (*Response, error) {
-	url := fmt.Sprintf("user/migrations/%v/repos/%v/lock", id, repo)
+	url, err := newURLString("user/migrations/%v/repos/%v/lock", id, repo)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", url, nil)
 	if err != nil {

--- a/github/misc.go
+++ b/github/misc.go
@@ -8,7 +8,6 @@ package github
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net/url"
 )
 
@@ -120,7 +119,10 @@ func (c *Client) ListCodesOfConduct(ctx context.Context) ([]*CodeOfConduct, *Res
 //
 // https://docs.github.com/en/rest/codes_of_conduct/#get-an-individual-code-of-conduct
 func (c *Client) GetCodeOfConduct(ctx context.Context, key string) (*CodeOfConduct, *Response, error) {
-	u := fmt.Sprintf("codes_of_conduct/%s", key)
+	u, err := newURLString("codes_of_conduct/%s", key)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := c.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -209,11 +211,13 @@ func (c *Client) APIMeta(ctx context.Context) (*APIMeta, *Response, error) {
 // Octocat returns an ASCII art octocat with the specified message in a speech
 // bubble. If message is empty, a random zen phrase is used.
 func (c *Client) Octocat(ctx context.Context, message string) (string, *Response, error) {
-	u := "octocat"
-	if message != "" {
-		u = fmt.Sprintf("%s?s=%s", u, url.QueryEscape(message))
+	u, err := newURLString("octocat")
+	if err != nil {
+		return "", nil, err
 	}
-
+	if message != "" {
+		u += "?s=" + url.QueryEscape(message)
+	}
 	req, err := c.NewRequest("GET", u, nil)
 	if err != nil {
 		return "", nil, err
@@ -263,7 +267,10 @@ func (s *ServiceHook) String() string {
 //
 // GitHub API docs: https://developer.github.com/webhooks/#services
 func (c *Client) ListServiceHooks(ctx context.Context) ([]*ServiceHook, *Response, error) {
-	u := "hooks"
+	u, err := newURLString("hooks")
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := c.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/misc.go
+++ b/github/misc.go
@@ -216,7 +216,10 @@ func (c *Client) Octocat(ctx context.Context, message string) (string, *Response
 		return "", nil, err
 	}
 	if message != "" {
-		u += "?s=" + url.QueryEscape(message)
+		u, err = addQueryParams(u, url.Values{"s": []string{message}})
+		if err != nil {
+			return "", nil, err
+		}
 	}
 	req, err := c.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // OrganizationsService provides access to the organization related functions
@@ -175,12 +174,16 @@ func (s *OrganizationsService) ListAll(ctx context.Context, opts *OrganizationsL
 // GitHub API docs: https://docs.github.com/en/rest/orgs/orgs#list-organizations-for-a-user
 func (s *OrganizationsService) List(ctx context.Context, user string, opts *ListOptions) ([]*Organization, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/orgs", user)
+		u, err = newURLString("users/%v/orgs", user)
 	} else {
-		u = "user/orgs"
+		u, err = newURLString("user/orgs")
 	}
-	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -203,7 +206,10 @@ func (s *OrganizationsService) List(ctx context.Context, user string, opts *List
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/orgs#get-an-organization
 func (s *OrganizationsService) Get(ctx context.Context, org string) (*Organization, *Response, error) {
-	u := fmt.Sprintf("orgs/%v", org)
+	u, err := newURLString("orgs/%v", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -225,7 +231,10 @@ func (s *OrganizationsService) Get(ctx context.Context, org string) (*Organizati
 //
 // Note: GetByID uses the undocumented GitHub API endpoint /organizations/:id.
 func (s *OrganizationsService) GetByID(ctx context.Context, id int64) (*Organization, *Response, error) {
-	u := fmt.Sprintf("organizations/%d", id)
+	u, err := newURLString("organizations/%d", id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -244,7 +253,10 @@ func (s *OrganizationsService) GetByID(ctx context.Context, id int64) (*Organiza
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/orgs#update-an-organization
 func (s *OrganizationsService) Edit(ctx context.Context, name string, org *Organization) (*Organization, *Response, error) {
-	u := fmt.Sprintf("orgs/%v", name)
+	u, err := newURLString("orgs/%v", name)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, org)
 	if err != nil {
 		return nil, nil, err
@@ -266,7 +278,10 @@ func (s *OrganizationsService) Edit(ctx context.Context, name string, org *Organ
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/orgs#delete-an-organization
 func (s *OrganizationsService) Delete(ctx context.Context, org string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v", org)
+	u, err := newURLString("orgs/%v", org)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -279,9 +294,12 @@ func (s *OrganizationsService) Delete(ctx context.Context, org string) (*Respons
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/orgs#list-app-installations-for-an-organization
 func (s *OrganizationsService) ListInstallations(ctx context.Context, org string, opts *ListOptions) (*OrganizationInstallations, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/installations", org)
+	u, err := newURLString("orgs/%v/installations", org)
+	if err != nil {
+		return nil, nil, err
+	}
 
-	u, err := addOptions(u, opts)
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -149,7 +149,11 @@ type OrganizationsListOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/orgs#list-organizations
 func (s *OrganizationsService) ListAll(ctx context.Context, opts *OrganizationsListOptions) ([]*Organization, *Response, error) {
-	u, err := addOptions("organizations", opts)
+	u, err := newURLString("organizations")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/orgs_actions_allowed.go
+++ b/github/orgs_actions_allowed.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ActionsAllowed represents selected actions that are allowed.
@@ -27,7 +26,10 @@ func (a ActionsAllowed) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-organization
 func (s *OrganizationsService) GetActionsAllowed(ctx context.Context, org string) (*ActionsAllowed, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/permissions/selected-actions", org)
+	u, err := newURLString("orgs/%v/actions/permissions/selected-actions", org)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -47,7 +49,10 @@ func (s *OrganizationsService) GetActionsAllowed(ctx context.Context, org string
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/permissions#set-allowed-actions-and-reusable-workflows-for-an-organization
 func (s *OrganizationsService) EditActionsAllowed(ctx context.Context, org string, actionsAllowed ActionsAllowed) (*ActionsAllowed, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/permissions/selected-actions", org)
+	u, err := newURLString("orgs/%v/actions/permissions/selected-actions", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, actionsAllowed)
 	if err != nil {
 		return nil, nil, err

--- a/github/orgs_actions_permissions.go
+++ b/github/orgs_actions_permissions.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ActionsPermissions represents a policy for repositories and allowed actions in an organization.
@@ -27,7 +26,10 @@ func (a ActionsPermissions) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/permissions#get-github-actions-permissions-for-an-organization
 func (s *OrganizationsService) GetActionsPermissions(ctx context.Context, org string) (*ActionsPermissions, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/permissions", org)
+	u, err := newURLString("orgs/%v/actions/permissions", org)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -47,7 +49,10 @@ func (s *OrganizationsService) GetActionsPermissions(ctx context.Context, org st
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/permissions#set-github-actions-permissions-for-an-organization
 func (s *OrganizationsService) EditActionsPermissions(ctx context.Context, org string, actionsPermissions ActionsPermissions) (*ActionsPermissions, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/actions/permissions", org)
+	u, err := newURLString("orgs/%v/actions/permissions", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, actionsPermissions)
 	if err != nil {
 		return nil, nil, err

--- a/github/orgs_audit_log.go
+++ b/github/orgs_audit_log.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // GetAuditLogOptions sets up optional parameters to query audit-log endpoint.
@@ -135,8 +134,11 @@ type AuditEntryData struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/orgs#get-the-audit-log-for-an-organization
 func (s *OrganizationsService) GetAuditLog(ctx context.Context, org string, opts *GetAuditLogOptions) ([]*AuditEntry, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/audit-log", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/audit-log", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/orgs_credential_authorizations.go
+++ b/github/orgs_credential_authorizations.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 )
 
@@ -60,8 +59,11 @@ type CredentialAuthorization struct {
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/orgs/orgs?apiVersion=2022-11-28#list-saml-sso-authorizations-for-an-organization
 func (s *OrganizationsService) ListCredentialAuthorizations(ctx context.Context, org string, opts *ListOptions) ([]*CredentialAuthorization, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/credential-authorizations", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/credential-authorizations", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -85,7 +87,10 @@ func (s *OrganizationsService) ListCredentialAuthorizations(ctx context.Context,
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/orgs/orgs?apiVersion=2022-11-28#remove-a-saml-sso-authorization-for-an-organization
 func (s *OrganizationsService) RemoveCredentialAuthorization(ctx context.Context, org string, credentialID int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/credential-authorizations/%v", org, credentialID)
+	u, err := newURLString("orgs/%v/credential-authorizations/%v", org, credentialID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil)
 	if err != nil {
 		return nil, err

--- a/github/orgs_custom_roles.go
+++ b/github/orgs_custom_roles.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // OrganizationCustomRepoRoles represents custom repository roles available in specified organization.
@@ -32,7 +31,10 @@ type CustomRepoRoles struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/custom-roles#list-custom-repository-roles-in-an-organization
 func (s *OrganizationsService) ListCustomRepoRoles(ctx context.Context, org string) (*OrganizationCustomRepoRoles, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/custom-repository-roles", org)
+	u, err := newURLString("orgs/%v/custom-repository-roles", org)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -61,7 +63,10 @@ type CreateOrUpdateCustomRoleOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/custom-roles#create-a-custom-repository-role
 func (s *OrganizationsService) CreateCustomRepoRole(ctx context.Context, org string, opts *CreateOrUpdateCustomRoleOptions) (*CustomRepoRoles, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/custom-repository-roles", org)
+	u, err := newURLString("orgs/%v/custom-repository-roles", org)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
@@ -82,7 +87,10 @@ func (s *OrganizationsService) CreateCustomRepoRole(ctx context.Context, org str
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/custom-roles#update-a-custom-repository-role
 func (s *OrganizationsService) UpdateCustomRepoRole(ctx context.Context, org, roleID string, opts *CreateOrUpdateCustomRoleOptions) (*CustomRepoRoles, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/custom-repository-roles/%v", org, roleID)
+	u, err := newURLString("orgs/%v/custom-repository-roles/%v", org, roleID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PATCH", u, opts)
 	if err != nil {
@@ -103,7 +111,10 @@ func (s *OrganizationsService) UpdateCustomRepoRole(ctx context.Context, org, ro
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/custom-roles#delete-a-custom-repository-role
 func (s *OrganizationsService) DeleteCustomRepoRole(ctx context.Context, org, roleID string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/custom-repository-roles/%v", org, roleID)
+	u, err := newURLString("orgs/%v/custom-repository-roles/%v", org, roleID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/orgs_hooks.go
+++ b/github/orgs_hooks.go
@@ -7,15 +7,17 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ListHooks lists all Hooks for the specified organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/webhooks#list-organization-webhooks
 func (s *OrganizationsService) ListHooks(ctx context.Context, org string, opts *ListOptions) ([]*Hook, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/hooks", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/hooks", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -38,7 +40,10 @@ func (s *OrganizationsService) ListHooks(ctx context.Context, org string, opts *
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/webhooks#get-an-organization-webhook
 func (s *OrganizationsService) GetHook(ctx context.Context, org string, id int64) (*Hook, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/hooks/%d", org, id)
+	u, err := newURLString("orgs/%v/hooks/%d", org, id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -61,7 +66,10 @@ func (s *OrganizationsService) GetHook(ctx context.Context, org string, id int64
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/webhooks#create-an-organization-webhook
 func (s *OrganizationsService) CreateHook(ctx context.Context, org string, hook *Hook) (*Hook, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/hooks", org)
+	u, err := newURLString("orgs/%v/hooks", org)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	hookReq := &createHookRequest{
 		Name:   "web",
@@ -88,7 +96,11 @@ func (s *OrganizationsService) CreateHook(ctx context.Context, org string, hook 
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/webhooks#update-an-organization-webhook
 func (s *OrganizationsService) EditHook(ctx context.Context, org string, id int64, hook *Hook) (*Hook, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/hooks/%d", org, id)
+	u, err := newURLString("orgs/%v/hooks/%d", org, id)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	req, err := s.client.NewRequest("PATCH", u, hook)
 	if err != nil {
 		return nil, nil, err
@@ -107,7 +119,11 @@ func (s *OrganizationsService) EditHook(ctx context.Context, org string, id int6
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/webhooks#ping-an-organization-webhook
 func (s *OrganizationsService) PingHook(ctx context.Context, org string, id int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/hooks/%d/pings", org, id)
+	u, err := newURLString("orgs/%v/hooks/%d/pings", org, id)
+	if err != nil {
+		return nil, err
+	}
+
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
@@ -120,7 +136,11 @@ func (s *OrganizationsService) PingHook(ctx context.Context, org string, id int6
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/webhooks#delete-an-organization-webhook
 func (s *OrganizationsService) DeleteHook(ctx context.Context, org string, id int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/hooks/%d", org, id)
+	u, err := newURLString("orgs/%v/hooks/%d", org, id)
+	if err != nil {
+		return nil, err
+	}
+
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/orgs_hooks_configuration.go
+++ b/github/orgs_hooks_configuration.go
@@ -7,14 +7,16 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // GetHookConfiguration returns the configuration for the specified organization webhook.
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/webhooks?apiVersion=2022-11-28#get-a-webhook-configuration-for-an-organization
 func (s *OrganizationsService) GetHookConfiguration(ctx context.Context, org string, id int64) (*HookConfig, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/hooks/%v/config", org, id)
+	u, err := newURLString("orgs/%v/hooks/%v/config", org, id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -33,7 +35,10 @@ func (s *OrganizationsService) GetHookConfiguration(ctx context.Context, org str
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/webhooks?apiVersion=2022-11-28#update-a-webhook-configuration-for-an-organization
 func (s *OrganizationsService) EditHookConfiguration(ctx context.Context, org string, id int64, config *HookConfig) (*HookConfig, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/hooks/%v/config", org, id)
+	u, err := newURLString("orgs/%v/hooks/%v/config", org, id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, config)
 	if err != nil {
 		return nil, nil, err

--- a/github/orgs_hooks_deliveries.go
+++ b/github/orgs_hooks_deliveries.go
@@ -7,15 +7,17 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ListHookDeliveries lists webhook deliveries for a webhook configured in an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/webhooks#list-deliveries-for-an-organization-webhook
 func (s *OrganizationsService) ListHookDeliveries(ctx context.Context, org string, id int64, opts *ListCursorOptions) ([]*HookDelivery, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/hooks/%v/deliveries", org, id)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/hooks/%v/deliveries", org, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -38,7 +40,10 @@ func (s *OrganizationsService) ListHookDeliveries(ctx context.Context, org strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/webhooks#get-a-webhook-delivery-for-an-organization-webhook
 func (s *OrganizationsService) GetHookDelivery(ctx context.Context, owner string, hookID, deliveryID int64) (*HookDelivery, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/hooks/%v/deliveries/%v", owner, hookID, deliveryID)
+	u, err := newURLString("orgs/%v/hooks/%v/deliveries/%v", owner, hookID, deliveryID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -57,7 +62,10 @@ func (s *OrganizationsService) GetHookDelivery(ctx context.Context, owner string
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/webhooks#redeliver-a-delivery-for-an-organization-webhook
 func (s *OrganizationsService) RedeliverHookDelivery(ctx context.Context, owner string, hookID, deliveryID int64) (*HookDelivery, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/hooks/%v/deliveries/%v/attempts", owner, hookID, deliveryID)
+	u, err := newURLString("orgs/%v/hooks/%v/deliveries/%v/attempts", owner, hookID, deliveryID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // Membership represents the status of a user's membership in an organization or team.
@@ -233,10 +232,14 @@ func (s *OrganizationsService) ListOrgMemberships(ctx context.Context, opts *Lis
 // GitHub API docs: https://docs.github.com/en/rest/orgs/members#get-organization-membership-for-a-user
 func (s *OrganizationsService) GetOrgMembership(ctx context.Context, user, org string) (*Membership, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("orgs/%v/memberships/%v", org, user)
+		u, err = newURLString("orgs/%v/memberships/%v", org, user)
 	} else {
-		u = fmt.Sprintf("user/memberships/orgs/%v", org)
+		u, err = newURLString("user/memberships/orgs/%v", org)
+	}
+	if err != nil {
+		return nil, nil, err
 	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -261,12 +264,17 @@ func (s *OrganizationsService) GetOrgMembership(ctx context.Context, user, org s
 // GitHub API docs: https://docs.github.com/en/rest/orgs/members#set-organization-membership-for-a-user
 func (s *OrganizationsService) EditOrgMembership(ctx context.Context, user, org string, membership *Membership) (*Membership, *Response, error) {
 	var u, method string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("orgs/%v/memberships/%v", org, user)
 		method = "PUT"
+		u, err = newURLString("orgs/%v/memberships/%v", org, user)
+
 	} else {
-		u = fmt.Sprintf("user/memberships/orgs/%v", org)
 		method = "PATCH"
+		u, err = newURLString("user/memberships/orgs/%v", org)
+	}
+	if err != nil {
+		return nil, nil, err
 	}
 
 	req, err := s.client.NewRequest(method, u, membership)

--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -75,12 +75,16 @@ type ListMembersOptions struct {
 // GitHub API docs: https://docs.github.com/en/rest/orgs/members#list-public-organization-members
 func (s *OrganizationsService) ListMembers(ctx context.Context, org string, opts *ListMembersOptions) ([]*User, *Response, error) {
 	var u string
+	var err error
 	if opts != nil && opts.PublicOnly {
-		u = fmt.Sprintf("orgs/%v/public_members", org)
+		u, err = newURLString("orgs/%v/public_members", org)
 	} else {
-		u = fmt.Sprintf("orgs/%v/members", org)
+		u, err = newURLString("orgs/%v/members", org)
 	}
-	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -103,7 +107,10 @@ func (s *OrganizationsService) ListMembers(ctx context.Context, org string, opts
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/members#check-organization-membership-for-a-user
 func (s *OrganizationsService) IsMember(ctx context.Context, org, user string) (bool, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/members/%v", org, user)
+	u, err := newURLString("orgs/%v/members/%v", org, user)
+	if err != nil {
+		return false, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return false, nil, err
@@ -118,7 +125,10 @@ func (s *OrganizationsService) IsMember(ctx context.Context, org, user string) (
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/members#check-public-organization-membership-for-a-user
 func (s *OrganizationsService) IsPublicMember(ctx context.Context, org, user string) (bool, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/public_members/%v", org, user)
+	u, err := newURLString("orgs/%v/public_members/%v", org, user)
+	if err != nil {
+		return false, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return false, nil, err
@@ -133,7 +143,10 @@ func (s *OrganizationsService) IsPublicMember(ctx context.Context, org, user str
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/members#remove-an-organization-member
 func (s *OrganizationsService) RemoveMember(ctx context.Context, org, user string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/members/%v", org, user)
+	u, err := newURLString("orgs/%v/members/%v", org, user)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -147,7 +160,10 @@ func (s *OrganizationsService) RemoveMember(ctx context.Context, org, user strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/members#set-public-organization-membership-for-the-authenticated-user
 func (s *OrganizationsService) PublicizeMembership(ctx context.Context, org, user string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/public_members/%v", org, user)
+	u, err := newURLString("orgs/%v/public_members/%v", org, user)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
 		return nil, err
@@ -160,7 +176,10 @@ func (s *OrganizationsService) PublicizeMembership(ctx context.Context, org, use
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/members#remove-public-organization-membership-for-the-authenticated-user
 func (s *OrganizationsService) ConcealMembership(ctx context.Context, org, user string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/public_members/%v", org, user)
+	u, err := newURLString("orgs/%v/public_members/%v", org, user)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -183,8 +202,11 @@ type ListOrgMembershipsOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/members#list-organization-memberships-for-the-authenticated-user
 func (s *OrganizationsService) ListOrgMemberships(ctx context.Context, opts *ListOrgMembershipsOptions) ([]*Membership, *Response, error) {
-	u := "user/memberships/orgs"
-	u, err := addOptions(u, opts)
+	u, err := newURLString("user/memberships/orgs")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -266,7 +288,10 @@ func (s *OrganizationsService) EditOrgMembership(ctx context.Context, user, org 
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/members#remove-organization-membership-for-a-user
 func (s *OrganizationsService) RemoveOrgMembership(ctx context.Context, user, org string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/memberships/%v", org, user)
+	u, err := newURLString("orgs/%v/memberships/%v", org, user)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -279,8 +304,11 @@ func (s *OrganizationsService) RemoveOrgMembership(ctx context.Context, user, or
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/members#list-pending-organization-invitations
 func (s *OrganizationsService) ListPendingOrgInvitations(ctx context.Context, org string, opts *ListOptions) ([]*Invitation, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/invitations", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/invitations", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -325,7 +353,10 @@ type CreateOrgInvitationOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/members#create-an-organization-invitation
 func (s *OrganizationsService) CreateOrgInvitation(ctx context.Context, org string, opts *CreateOrgInvitationOptions) (*Invitation, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/invitations", org)
+	u, err := newURLString("orgs/%v/invitations", org)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
@@ -346,8 +377,11 @@ func (s *OrganizationsService) CreateOrgInvitation(ctx context.Context, org stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/members#list-organization-invitation-teams
 func (s *OrganizationsService) ListOrgInvitationTeams(ctx context.Context, org, invitationID string, opts *ListOptions) ([]*Team, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/invitations/%v/teams", org, invitationID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/invitations/%v/teams", org, invitationID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -370,8 +404,11 @@ func (s *OrganizationsService) ListOrgInvitationTeams(ctx context.Context, org, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/members#list-failed-organization-invitations
 func (s *OrganizationsService) ListFailedOrgInvitations(ctx context.Context, org string, opts *ListOptions) ([]*Invitation, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/failed_invitations", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/failed_invitations", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/orgs_outside_collaborators.go
+++ b/github/orgs_outside_collaborators.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ListOutsideCollaboratorsOptions specifies optional parameters to the
@@ -29,8 +28,11 @@ type ListOutsideCollaboratorsOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/outside-collaborators#list-outside-collaborators-for-an-organization
 func (s *OrganizationsService) ListOutsideCollaborators(ctx context.Context, org string, opts *ListOutsideCollaboratorsOptions) ([]*User, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/outside_collaborators", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/outside_collaborators", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -54,7 +56,10 @@ func (s *OrganizationsService) ListOutsideCollaborators(ctx context.Context, org
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/outside-collaborators#remove-outside-collaborator-from-an-organization
 func (s *OrganizationsService) RemoveOutsideCollaborator(ctx context.Context, org string, user string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/outside_collaborators/%v", org, user)
+	u, err := newURLString("orgs/%v/outside_collaborators/%v", org, user)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -71,7 +76,10 @@ func (s *OrganizationsService) RemoveOutsideCollaborator(ctx context.Context, or
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/outside-collaborators#convert-an-organization-member-to-outside-collaborator
 func (s *OrganizationsService) ConvertMemberToOutsideCollaborator(ctx context.Context, org string, user string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/outside_collaborators/%v", org, user)
+	u, err := newURLString("orgs/%v/outside_collaborators/%v", org, user)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/orgs_packages.go
+++ b/github/orgs_packages.go
@@ -7,15 +7,17 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // List the packages for an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/packages#list-packages-for-an-organization
 func (s *OrganizationsService) ListPackages(ctx context.Context, org string, opts *PackageListOptions) ([]*Package, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/packages", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/packages", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -38,7 +40,10 @@ func (s *OrganizationsService) ListPackages(ctx context.Context, org string, opt
 //
 // GitHub API docs: https://docs.github.com/en/rest/packages#get-a-package-for-an-organization
 func (s *OrganizationsService) GetPackage(ctx context.Context, org, packageType, packageName string) (*Package, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/packages/%v/%v", org, packageType, packageName)
+	u, err := newURLString("orgs/%v/packages/%v/%v", org, packageType, packageName)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -57,7 +62,10 @@ func (s *OrganizationsService) GetPackage(ctx context.Context, org, packageType,
 //
 // GitHub API docs: https://docs.github.com/en/rest/packages#delete-a-package-for-an-organization
 func (s *OrganizationsService) DeletePackage(ctx context.Context, org, packageType, packageName string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/packages/%v/%v", org, packageType, packageName)
+	u, err := newURLString("orgs/%v/packages/%v/%v", org, packageType, packageName)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -70,7 +78,10 @@ func (s *OrganizationsService) DeletePackage(ctx context.Context, org, packageTy
 //
 // GitHub API docs: https://docs.github.com/en/rest/packages#restore-a-package-for-an-organization
 func (s *OrganizationsService) RestorePackage(ctx context.Context, org, packageType, packageName string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/packages/%v/%v/restore", org, packageType, packageName)
+	u, err := newURLString("orgs/%v/packages/%v/%v/restore", org, packageType, packageName)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
@@ -83,8 +94,11 @@ func (s *OrganizationsService) RestorePackage(ctx context.Context, org, packageT
 //
 // GitHub API docs: https://docs.github.com/en/rest/packages#list-package-versions-for-a-package-owned-by-an-organization
 func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, packageType, packageName string, opts *PackageListOptions) ([]*PackageVersion, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions", org, packageType, packageName)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/packages/%v/%v/versions", org, packageType, packageName)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -107,7 +121,10 @@ func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, p
 //
 // GitHub API docs: https://docs.github.com/en/rest/packages#get-a-package-version-for-an-organization
 func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*PackageVersion, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v", org, packageType, packageName, packageVersionID)
+	u, err := newURLString("orgs/%v/packages/%v/%v/versions/%v", org, packageType, packageName, packageVersionID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -126,7 +143,10 @@ func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packa
 //
 // GitHub API docs: https://docs.github.com/en/rest/packages#delete-package-version-for-an-organization
 func (s *OrganizationsService) PackageDeleteVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v", org, packageType, packageName, packageVersionID)
+	u, err := newURLString("orgs/%v/packages/%v/%v/versions/%v", org, packageType, packageName, packageVersionID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -139,7 +159,10 @@ func (s *OrganizationsService) PackageDeleteVersion(ctx context.Context, org, pa
 //
 // GitHub API docs: https://docs.github.com/en/rest/packages#restore-package-version-for-an-organization
 func (s *OrganizationsService) PackageRestoreVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v/restore", org, packageType, packageName, packageVersionID)
+	u, err := newURLString("orgs/%v/packages/%v/%v/versions/%v/restore", org, packageType, packageName, packageVersionID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/orgs_personal_access_tokens.go
+++ b/github/orgs_personal_access_tokens.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 )
 
@@ -23,7 +22,10 @@ type ReviewPersonalAccessTokenRequestOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/personal-access-tokens?apiVersion=2022-11-28#review-a-request-to-access-organization-resources-with-a-fine-grained-personal-access-token
 func (s *OrganizationsService) ReviewPersonalAccessTokenRequest(ctx context.Context, org string, requestID int64, opts ReviewPersonalAccessTokenRequestOptions) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/personal-access-token-requests/%v", org, requestID)
+	u, err := newURLString("orgs/%v/personal-access-token-requests/%v", org, requestID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest(http.MethodPost, u, &opts)
 	if err != nil {

--- a/github/orgs_projects.go
+++ b/github/orgs_projects.go
@@ -7,15 +7,17 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ListProjects lists the projects for an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/projects#list-organization-projects
 func (s *OrganizationsService) ListProjects(ctx context.Context, org string, opts *ProjectListOptions) ([]*Project, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/projects", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/projects", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -41,7 +43,10 @@ func (s *OrganizationsService) ListProjects(ctx context.Context, org string, opt
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/projects#create-an-organization-project
 func (s *OrganizationsService) CreateProject(ctx context.Context, org string, opts *ProjectOptions) (*Project, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/projects", org)
+	u, err := newURLString("orgs/%v/projects", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
 		return nil, nil, err

--- a/github/orgs_rules.go
+++ b/github/orgs_rules.go
@@ -7,14 +7,16 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // GetAllOrganizationRulesets gets all the rulesets for the specified organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/rules#get-all-organization-repository-rulesets
 func (s *OrganizationsService) GetAllOrganizationRulesets(ctx context.Context, org string) ([]*Ruleset, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/rulesets", org)
+	u, err := newURLString("orgs/%v/rulesets", org)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -34,7 +36,10 @@ func (s *OrganizationsService) GetAllOrganizationRulesets(ctx context.Context, o
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/rules#create-an-organization-repository-ruleset
 func (s *OrganizationsService) CreateOrganizationRuleset(ctx context.Context, org string, rs *Ruleset) (*Ruleset, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/rulesets", org)
+	u, err := newURLString("orgs/%v/rulesets", org)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, rs)
 	if err != nil {
@@ -54,7 +59,10 @@ func (s *OrganizationsService) CreateOrganizationRuleset(ctx context.Context, or
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/rules#get-an-organization-repository-ruleset
 func (s *OrganizationsService) GetOrganizationRuleset(ctx context.Context, org string, rulesetID int64) (*Ruleset, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/rulesets/%v", org, rulesetID)
+	u, err := newURLString("orgs/%v/rulesets/%v", org, rulesetID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -74,7 +82,10 @@ func (s *OrganizationsService) GetOrganizationRuleset(ctx context.Context, org s
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/rules#update-an-organization-repository-ruleset
 func (s *OrganizationsService) UpdateOrganizationRuleset(ctx context.Context, org string, rulesetID int64, rs *Ruleset) (*Ruleset, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/rulesets/%v", org, rulesetID)
+	u, err := newURLString("orgs/%v/rulesets/%v", org, rulesetID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, rs)
 	if err != nil {
@@ -94,7 +105,10 @@ func (s *OrganizationsService) UpdateOrganizationRuleset(ctx context.Context, or
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/rules#delete-an-organization-repository-ruleset
 func (s *OrganizationsService) DeleteOrganizationRuleset(ctx context.Context, org string, rulesetID int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/rulesets/%v", org, rulesetID)
+	u, err := newURLString("orgs/%v/rulesets/%v", org, rulesetID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/orgs_security_managers.go
+++ b/github/orgs_security_managers.go
@@ -7,14 +7,16 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ListSecurityManagerTeams lists all security manager teams for an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/security-managers#list-security-manager-teams
 func (s *OrganizationsService) ListSecurityManagerTeams(ctx context.Context, org string) ([]*Team, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/security-managers", org)
+	u, err := newURLString("orgs/%v/security-managers", org)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -34,7 +36,10 @@ func (s *OrganizationsService) ListSecurityManagerTeams(ctx context.Context, org
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/security-managers#add-a-security-manager-team
 func (s *OrganizationsService) AddSecurityManagerTeam(ctx context.Context, org, team string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/security-managers/teams/%v", org, team)
+	u, err := newURLString("orgs/%v/security-managers/teams/%v", org, team)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
 		return nil, err
@@ -47,7 +52,10 @@ func (s *OrganizationsService) AddSecurityManagerTeam(ctx context.Context, org, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/security-managers#remove-a-security-manager-team
 func (s *OrganizationsService) RemoveSecurityManagerTeam(ctx context.Context, org, team string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/security-managers/teams/%v", org, team)
+	u, err := newURLString("orgs/%v/security-managers/teams/%v", org, team)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/orgs_users_blocking.go
+++ b/github/orgs_users_blocking.go
@@ -7,15 +7,17 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ListBlockedUsers lists all the users blocked by an organization.
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/blocking#list-users-blocked-by-an-organization
 func (s *OrganizationsService) ListBlockedUsers(ctx context.Context, org string, opts *ListOptions) ([]*User, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/blocks", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/blocks", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -41,7 +43,10 @@ func (s *OrganizationsService) ListBlockedUsers(ctx context.Context, org string,
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/blocking#check-if-a-user-is-blocked-by-an-organization
 func (s *OrganizationsService) IsBlocked(ctx context.Context, org string, user string) (bool, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/blocks/%v", org, user)
+	u, err := newURLString("orgs/%v/blocks/%v", org, user)
+	if err != nil {
+		return false, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -60,7 +65,10 @@ func (s *OrganizationsService) IsBlocked(ctx context.Context, org string, user s
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/blocking#block-a-user-from-an-organization
 func (s *OrganizationsService) BlockUser(ctx context.Context, org string, user string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/blocks/%v", org, user)
+	u, err := newURLString("orgs/%v/blocks/%v", org, user)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
@@ -77,7 +85,10 @@ func (s *OrganizationsService) BlockUser(ctx context.Context, org string, user s
 //
 // GitHub API docs: https://docs.github.com/en/rest/orgs/blocking#unblock-a-user-from-an-organization
 func (s *OrganizationsService) UnblockUser(ctx context.Context, org string, user string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/blocks/%v", org, user)
+	u, err := newURLString("orgs/%v/blocks/%v", org, user)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/projects.go
+++ b/github/projects.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ProjectsService provides access to the projects functions in the
@@ -45,7 +44,10 @@ func (p Project) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/projects#get-a-project
 func (s *ProjectsService) GetProject(ctx context.Context, id int64) (*Project, *Response, error) {
-	u := fmt.Sprintf("projects/%v", id)
+	u, err := newURLString("projects/%v", id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -92,7 +94,10 @@ type ProjectOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/projects#update-a-project
 func (s *ProjectsService) UpdateProject(ctx context.Context, id int64, opts *ProjectOptions) (*Project, *Response, error) {
-	u := fmt.Sprintf("projects/%v", id)
+	u, err := newURLString("projects/%v", id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -114,7 +119,10 @@ func (s *ProjectsService) UpdateProject(ctx context.Context, id int64, opts *Pro
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/projects#delete-a-project
 func (s *ProjectsService) DeleteProject(ctx context.Context, id int64) (*Response, error) {
-	u := fmt.Sprintf("projects/%v", id)
+	u, err := newURLString("projects/%v", id)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -144,8 +152,11 @@ type ProjectColumn struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/columns#list-project-columns
 func (s *ProjectsService) ListProjectColumns(ctx context.Context, projectID int64, opts *ListOptions) ([]*ProjectColumn, *Response, error) {
-	u := fmt.Sprintf("projects/%v/columns", projectID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("projects/%v/columns", projectID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -171,7 +182,10 @@ func (s *ProjectsService) ListProjectColumns(ctx context.Context, projectID int6
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/columns#get-a-project-column
 func (s *ProjectsService) GetProjectColumn(ctx context.Context, id int64) (*ProjectColumn, *Response, error) {
-	u := fmt.Sprintf("projects/columns/%v", id)
+	u, err := newURLString("projects/columns/%v", id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -201,7 +215,10 @@ type ProjectColumnOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/columns#create-a-project-column
 func (s *ProjectsService) CreateProjectColumn(ctx context.Context, projectID int64, opts *ProjectColumnOptions) (*ProjectColumn, *Response, error) {
-	u := fmt.Sprintf("projects/%v/columns", projectID)
+	u, err := newURLString("projects/%v/columns", projectID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -223,7 +240,10 @@ func (s *ProjectsService) CreateProjectColumn(ctx context.Context, projectID int
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/columns#update-an-existing-project-column
 func (s *ProjectsService) UpdateProjectColumn(ctx context.Context, columnID int64, opts *ProjectColumnOptions) (*ProjectColumn, *Response, error) {
-	u := fmt.Sprintf("projects/columns/%v", columnID)
+	u, err := newURLString("projects/columns/%v", columnID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -245,7 +265,10 @@ func (s *ProjectsService) UpdateProjectColumn(ctx context.Context, columnID int6
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/columns#delete-a-project-column
 func (s *ProjectsService) DeleteProjectColumn(ctx context.Context, columnID int64) (*Response, error) {
-	u := fmt.Sprintf("projects/columns/%v", columnID)
+	u, err := newURLString("projects/columns/%v", columnID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -269,7 +292,10 @@ type ProjectColumnMoveOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/columns#move-a-project-column
 func (s *ProjectsService) MoveProjectColumn(ctx context.Context, columnID int64, opts *ProjectColumnMoveOptions) (*Response, error) {
-	u := fmt.Sprintf("projects/columns/%v/moves", columnID)
+	u, err := newURLString("projects/columns/%v/moves", columnID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
 		return nil, err
@@ -320,8 +346,11 @@ type ProjectCardListOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/cards#list-project-cards
 func (s *ProjectsService) ListProjectCards(ctx context.Context, columnID int64, opts *ProjectCardListOptions) ([]*ProjectCard, *Response, error) {
-	u := fmt.Sprintf("projects/columns/%v/cards", columnID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("projects/columns/%v/cards", columnID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -347,7 +376,10 @@ func (s *ProjectsService) ListProjectCards(ctx context.Context, columnID int64, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/cards#get-a-project-card
 func (s *ProjectsService) GetProjectCard(ctx context.Context, cardID int64) (*ProjectCard, *Response, error) {
-	u := fmt.Sprintf("projects/columns/cards/%v", cardID)
+	u, err := newURLString("projects/columns/cards/%v", cardID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -385,7 +417,10 @@ type ProjectCardOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/cards#create-a-project-card
 func (s *ProjectsService) CreateProjectCard(ctx context.Context, columnID int64, opts *ProjectCardOptions) (*ProjectCard, *Response, error) {
-	u := fmt.Sprintf("projects/columns/%v/cards", columnID)
+	u, err := newURLString("projects/columns/%v/cards", columnID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -407,7 +442,10 @@ func (s *ProjectsService) CreateProjectCard(ctx context.Context, columnID int64,
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/cards#update-an-existing-project-card
 func (s *ProjectsService) UpdateProjectCard(ctx context.Context, cardID int64, opts *ProjectCardOptions) (*ProjectCard, *Response, error) {
-	u := fmt.Sprintf("projects/columns/cards/%v", cardID)
+	u, err := newURLString("projects/columns/cards/%v", cardID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -429,7 +467,10 @@ func (s *ProjectsService) UpdateProjectCard(ctx context.Context, cardID int64, o
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/cards#delete-a-project-card
 func (s *ProjectsService) DeleteProjectCard(ctx context.Context, cardID int64) (*Response, error) {
-	u := fmt.Sprintf("projects/columns/cards/%v", cardID)
+	u, err := newURLString("projects/columns/cards/%v", cardID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -457,7 +498,10 @@ type ProjectCardMoveOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/cards#move-a-project-card
 func (s *ProjectsService) MoveProjectCard(ctx context.Context, cardID int64, opts *ProjectCardMoveOptions) (*Response, error) {
-	u := fmt.Sprintf("projects/columns/cards/%v/moves", cardID)
+	u, err := newURLString("projects/columns/cards/%v/moves", cardID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
 		return nil, err
@@ -487,7 +531,10 @@ type ProjectCollaboratorOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/collaborators#add-project-collaborator
 func (s *ProjectsService) AddProjectCollaborator(ctx context.Context, id int64, username string, opts *ProjectCollaboratorOptions) (*Response, error) {
-	u := fmt.Sprintf("projects/%v/collaborators/%v", id, username)
+	u, err := newURLString("projects/%v/collaborators/%v", id, username)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, err
@@ -504,7 +551,10 @@ func (s *ProjectsService) AddProjectCollaborator(ctx context.Context, id int64, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/collaborators#remove-user-as-a-collaborator
 func (s *ProjectsService) RemoveProjectCollaborator(ctx context.Context, id int64, username string) (*Response, error) {
-	u := fmt.Sprintf("projects/%v/collaborators/%v", id, username)
+	u, err := newURLString("projects/%v/collaborators/%v", id, username)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -540,8 +590,11 @@ type ListCollaboratorOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/collaborators#list-project-collaborators
 func (s *ProjectsService) ListProjectCollaborators(ctx context.Context, id int64, opts *ListCollaboratorOptions) ([]*User, *Response, error) {
-	u := fmt.Sprintf("projects/%v/collaborators", id)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("projects/%v/collaborators", id)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -578,7 +631,10 @@ type ProjectPermissionLevel struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/collaborators#get-project-permission-for-a-user
 func (s *ProjectsService) ReviewProjectCollaboratorPermission(ctx context.Context, id int64, username string) (*ProjectPermissionLevel, *Response, error) {
-	u := fmt.Sprintf("projects/%v/collaborators/%v/permission", id, username)
+	u, err := newURLString("projects/%v/collaborators/%v/permission", id, username)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -144,8 +144,11 @@ type PullRequestListOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/pulls#list-pull-requests
 func (s *PullRequestsService) List(ctx context.Context, owner string, repo string, opts *PullRequestListOptions) ([]*PullRequest, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/pulls", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -171,8 +174,11 @@ func (s *PullRequestsService) List(ctx context.Context, owner string, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit
 func (s *PullRequestsService) ListPullRequestsWithCommit(ctx context.Context, owner, repo, sha string, opts *ListOptions) ([]*PullRequest, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/commits/%v/pulls", owner, repo, sha)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/commits/%v/pulls", owner, repo, sha)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -197,7 +203,10 @@ func (s *PullRequestsService) ListPullRequestsWithCommit(ctx context.Context, ow
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
 func (s *PullRequestsService) Get(ctx context.Context, owner string, repo string, number int) (*PullRequest, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/pulls/%d", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -216,7 +225,10 @@ func (s *PullRequestsService) Get(ctx context.Context, owner string, repo string
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
 func (s *PullRequestsService) GetRaw(ctx context.Context, owner string, repo string, number int, opts RawOptions) (string, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/pulls/%d", owner, repo, number)
+	if err != nil {
+		return "", nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return "", nil, err
@@ -256,7 +268,10 @@ type NewPullRequest struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/pulls#create-a-pull-request
 func (s *PullRequestsService) Create(ctx context.Context, owner string, repo string, pull *NewPullRequest) (*PullRequest, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls", owner, repo)
+	u, err := newURLString("repos/%v/%v/pulls", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, pull)
 	if err != nil {
 		return nil, nil, err
@@ -295,7 +310,10 @@ type PullRequestBranchUpdateResponse struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request-branch
 func (s *PullRequestsService) UpdateBranch(ctx context.Context, owner, repo string, number int, opts *PullRequestBranchUpdateOptions) (*PullRequestBranchUpdateResponse, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/update-branch", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/pulls/%d/update-branch", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
@@ -334,7 +352,10 @@ func (s *PullRequestsService) Edit(ctx context.Context, owner string, repo strin
 		return nil, nil, fmt.Errorf("pull must be provided")
 	}
 
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/pulls/%d", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	update := &pullRequestUpdate{
 		Title:               pull.Title,
@@ -367,8 +388,11 @@ func (s *PullRequestsService) Edit(ctx context.Context, owner string, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/pulls#list-commits-on-a-pull-request
 func (s *PullRequestsService) ListCommits(ctx context.Context, owner string, repo string, number int, opts *ListOptions) ([]*RepositoryCommit, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/commits", owner, repo, number)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/pulls/%d/commits", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -391,8 +415,11 @@ func (s *PullRequestsService) ListCommits(ctx context.Context, owner string, rep
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
 func (s *PullRequestsService) ListFiles(ctx context.Context, owner string, repo string, number int, opts *ListOptions) ([]*CommitFile, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/files", owner, repo, number)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/pulls/%d/files", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -415,7 +442,10 @@ func (s *PullRequestsService) ListFiles(ctx context.Context, owner string, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/pulls#check-if-a-pull-request-has-been-merged
 func (s *PullRequestsService) IsMerged(ctx context.Context, owner string, repo string, number int) (bool, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/merge", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/pulls/%d/merge", owner, repo, number)
+	if err != nil {
+		return false, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return false, nil, err
@@ -457,7 +487,10 @@ type pullRequestMergeRequest struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request
 func (s *PullRequestsService) Merge(ctx context.Context, owner string, repo string, number int, commitMessage string, options *PullRequestOptions) (*PullRequestMergeResult, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/merge", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/pulls/%d/merge", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	pullRequestBody := &pullRequestMergeRequest{}
 	if commitMessage != "" {

--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 )
@@ -72,12 +71,16 @@ type PullRequestListCommentsOptions struct {
 // GitHub API docs: https://docs.github.com/en/rest/pulls/comments#list-review-comments-in-a-repository
 func (s *PullRequestsService) ListComments(ctx context.Context, owner, repo string, number int, opts *PullRequestListCommentsOptions) ([]*PullRequestComment, *Response, error) {
 	var u string
+	var err error
 	if number == 0 {
-		u = fmt.Sprintf("repos/%v/%v/pulls/comments", owner, repo)
+		u, err = newURLString("repos/%v/%v/pulls/comments", owner, repo)
 	} else {
-		u = fmt.Sprintf("repos/%v/%v/pulls/%d/comments", owner, repo, number)
+		u, err = newURLString("repos/%v/%v/pulls/%d/comments", owner, repo, number)
 	}
-	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -104,7 +107,10 @@ func (s *PullRequestsService) ListComments(ctx context.Context, owner, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/comments#get-a-review-comment-for-a-pull-request
 func (s *PullRequestsService) GetComment(ctx context.Context, owner, repo string, commentID int64) (*PullRequestComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%d", owner, repo, commentID)
+	u, err := newURLString("repos/%v/%v/pulls/comments/%d", owner, repo, commentID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -127,7 +133,10 @@ func (s *PullRequestsService) GetComment(ctx context.Context, owner, repo string
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/comments#create-a-review-comment-for-a-pull-request
 func (s *PullRequestsService) CreateComment(ctx context.Context, owner, repo string, number int, comment *PullRequestComment) (*PullRequestComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/comments", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/pulls/%d/comments", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -156,7 +165,10 @@ func (s *PullRequestsService) CreateCommentInReplyTo(ctx context.Context, owner,
 		Body:      body,
 		InReplyTo: commentID,
 	}
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/comments", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/pulls/%d/comments", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -176,7 +188,10 @@ func (s *PullRequestsService) CreateCommentInReplyTo(ctx context.Context, owner,
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/comments#update-a-review-comment-for-a-pull-request
 func (s *PullRequestsService) EditComment(ctx context.Context, owner, repo string, commentID int64, comment *PullRequestComment) (*PullRequestComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%d", owner, repo, commentID)
+	u, err := newURLString("repos/%v/%v/pulls/comments/%d", owner, repo, commentID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -195,7 +210,10 @@ func (s *PullRequestsService) EditComment(ctx context.Context, owner, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/comments#delete-a-review-comment-for-a-pull-request
 func (s *PullRequestsService) DeleteComment(ctx context.Context, owner, repo string, commentID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%d", owner, repo, commentID)
+	u, err := newURLString("repos/%v/%v/pulls/comments/%d", owner, repo, commentID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/pulls_reviewers.go
+++ b/github/pulls_reviewers.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ReviewersRequest specifies users and teams for a pull request review request.
@@ -27,7 +26,10 @@ type Reviewers struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/review-requests#request-reviewers-for-a-pull-request
 func (s *PullRequestsService) RequestReviewers(ctx context.Context, owner, repo string, number int, reviewers ReviewersRequest) (*PullRequest, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, number)
+	u, err := newURLString("repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, &reviewers)
 	if err != nil {
 		return nil, nil, err
@@ -46,8 +48,11 @@ func (s *PullRequestsService) RequestReviewers(ctx context.Context, owner, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/review-requests#list-requested-reviewers-for-a-pull-request
 func (s *PullRequestsService) ListReviewers(ctx context.Context, owner, repo string, number int, opts *ListOptions) (*Reviewers, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/requested_reviewers", owner, repo, number)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/pulls/%d/requested_reviewers", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -70,7 +75,10 @@ func (s *PullRequestsService) ListReviewers(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/review-requests#remove-requested-reviewers-from-a-pull-request
 func (s *PullRequestsService) RemoveReviewers(ctx context.Context, owner, repo string, number int, reviewers ReviewersRequest) (*Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, number)
+	u, err := newURLString("repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, number)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, &reviewers)
 	if err != nil {
 		return nil, err

--- a/github/pulls_reviews.go
+++ b/github/pulls_reviews.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"errors"
-	"fmt"
 )
 
 var ErrMixedCommentStyles = errors.New("cannot use both position and side/line form comments")
@@ -102,8 +101,11 @@ func (r PullRequestReviewDismissalRequest) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/reviews#list-reviews-for-a-pull-request
 func (s *PullRequestsService) ListReviews(ctx context.Context, owner, repo string, number int, opts *ListOptions) ([]*PullRequestReview, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/reviews", owner, repo, number)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/pulls/%d/reviews", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -126,7 +128,10 @@ func (s *PullRequestsService) ListReviews(ctx context.Context, owner, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/reviews#get-a-review-for-a-pull-request
 func (s *PullRequestsService) GetReview(ctx context.Context, owner, repo string, number int, reviewID int64) (*PullRequestReview, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/reviews/%d", owner, repo, number, reviewID)
+	u, err := newURLString("repos/%v/%v/pulls/%d/reviews/%d", owner, repo, number, reviewID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -146,7 +151,10 @@ func (s *PullRequestsService) GetReview(ctx context.Context, owner, repo string,
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/reviews#delete-a-pending-review-for-a-pull-request
 func (s *PullRequestsService) DeletePendingReview(ctx context.Context, owner, repo string, number int, reviewID int64) (*PullRequestReview, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/reviews/%d", owner, repo, number, reviewID)
+	u, err := newURLString("repos/%v/%v/pulls/%d/reviews/%d", owner, repo, number, reviewID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -166,8 +174,11 @@ func (s *PullRequestsService) DeletePendingReview(ctx context.Context, owner, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/reviews#list-comments-for-a-pull-request-review
 func (s *PullRequestsService) ListReviewComments(ctx context.Context, owner, repo string, number int, reviewID int64, opts *ListOptions) ([]*PullRequestComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/reviews/%d/comments", owner, repo, number, reviewID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/pulls/%d/reviews/%d/comments", owner, repo, number, reviewID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -224,7 +235,10 @@ func (s *PullRequestsService) ListReviewComments(ctx context.Context, owner, rep
 //	It is waaaaaay better.
 //	```
 func (s *PullRequestsService) CreateReview(ctx context.Context, owner, repo string, number int, review *PullRequestReviewRequest) (*PullRequestReview, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/reviews", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/pulls/%d/reviews", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, review)
 	if err != nil {
@@ -256,7 +270,10 @@ func (s *PullRequestsService) UpdateReview(ctx context.Context, owner, repo stri
 	opts := &struct {
 		Body string `json:"body"`
 	}{Body: body}
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/reviews/%d", owner, repo, number, reviewID)
+	u, err := newURLString("repos/%v/%v/pulls/%d/reviews/%d", owner, repo, number, reviewID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
@@ -276,7 +293,10 @@ func (s *PullRequestsService) UpdateReview(ctx context.Context, owner, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/reviews#submit-a-review-for-a-pull-request
 func (s *PullRequestsService) SubmitReview(ctx context.Context, owner, repo string, number int, reviewID int64, review *PullRequestReviewRequest) (*PullRequestReview, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/reviews/%d/events", owner, repo, number, reviewID)
+	u, err := newURLString("repos/%v/%v/pulls/%d/reviews/%d/events", owner, repo, number, reviewID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, review)
 	if err != nil {
@@ -296,7 +316,10 @@ func (s *PullRequestsService) SubmitReview(ctx context.Context, owner, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/pulls/reviews#dismiss-a-review-for-a-pull-request
 func (s *PullRequestsService) DismissReview(ctx context.Context, owner, repo string, number int, reviewID int64, review *PullRequestReviewDismissalRequest) (*PullRequestReview, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/%d/reviews/%d/dismissals", owner, repo, number, reviewID)
+	u, err := newURLString("repos/%v/%v/pulls/%d/reviews/%d/dismissals", owner, repo, number, reviewID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, review)
 	if err != nil {

--- a/github/reactions.go
+++ b/github/reactions.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 )
 
@@ -62,8 +61,11 @@ type ListCommentReactionOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#list-reactions-for-a-commit-comment
 func (s *ReactionsService) ListCommentReactions(ctx context.Context, owner, repo string, id int64, opts *ListCommentReactionOptions) ([]*Reaction, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions", owner, repo, id)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/comments/%v/reactions", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -92,7 +94,10 @@ func (s *ReactionsService) ListCommentReactions(ctx context.Context, owner, repo
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#create-reaction-for-a-commit-comment
 func (s *ReactionsService) CreateCommentReaction(ctx context.Context, owner, repo string, id int64, content string) (*Reaction, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/comments/%v/reactions", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	body := &Reaction{Content: String(content)}
 	req, err := s.client.NewRequest("POST", u, body)
@@ -116,7 +121,10 @@ func (s *ReactionsService) CreateCommentReaction(ctx context.Context, owner, rep
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#delete-a-commit-comment-reaction
 func (s *ReactionsService) DeleteCommentReaction(ctx context.Context, owner, repo string, commentID, reactionID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions/%v", owner, repo, commentID, reactionID)
+	u, err := newURLString("repos/%v/%v/comments/%v/reactions/%v", owner, repo, commentID, reactionID)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.deleteReaction(ctx, u)
 }
@@ -125,7 +133,10 @@ func (s *ReactionsService) DeleteCommentReaction(ctx context.Context, owner, rep
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#delete-a-commit-comment-reaction
 func (s *ReactionsService) DeleteCommentReactionByID(ctx context.Context, repoID, commentID, reactionID int64) (*Response, error) {
-	u := fmt.Sprintf("repositories/%v/comments/%v/reactions/%v", repoID, commentID, reactionID)
+	u, err := newURLString("repositories/%v/comments/%v/reactions/%v", repoID, commentID, reactionID)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.deleteReaction(ctx, u)
 }
@@ -134,8 +145,11 @@ func (s *ReactionsService) DeleteCommentReactionByID(ctx context.Context, repoID
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#list-reactions-for-an-issue
 func (s *ReactionsService) ListIssueReactions(ctx context.Context, owner, repo string, number int, opts *ListOptions) ([]*Reaction, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/%v/reactions", owner, repo, number)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/issues/%v/reactions", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -164,7 +178,10 @@ func (s *ReactionsService) ListIssueReactions(ctx context.Context, owner, repo s
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#create-reaction-for-an-issue
 func (s *ReactionsService) CreateIssueReaction(ctx context.Context, owner, repo string, number int, content string) (*Reaction, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/%v/reactions", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/issues/%v/reactions", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	body := &Reaction{Content: String(content)}
 	req, err := s.client.NewRequest("POST", u, body)
@@ -188,7 +205,10 @@ func (s *ReactionsService) CreateIssueReaction(ctx context.Context, owner, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#delete-an-issue-reaction
 func (s *ReactionsService) DeleteIssueReaction(ctx context.Context, owner, repo string, issueNumber int, reactionID int64) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/issues/%v/reactions/%v", owner, repo, issueNumber, reactionID)
+	url, err := newURLString("repos/%v/%v/issues/%v/reactions/%v", owner, repo, issueNumber, reactionID)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.deleteReaction(ctx, url)
 }
@@ -197,7 +217,10 @@ func (s *ReactionsService) DeleteIssueReaction(ctx context.Context, owner, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#delete-an-issue-reaction
 func (s *ReactionsService) DeleteIssueReactionByID(ctx context.Context, repoID, issueNumber int, reactionID int64) (*Response, error) {
-	url := fmt.Sprintf("repositories/%v/issues/%v/reactions/%v", repoID, issueNumber, reactionID)
+	url, err := newURLString("repositories/%v/issues/%v/reactions/%v", repoID, issueNumber, reactionID)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.deleteReaction(ctx, url)
 }
@@ -206,8 +229,11 @@ func (s *ReactionsService) DeleteIssueReactionByID(ctx context.Context, repoID, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#list-reactions-for-an-issue-comment
 func (s *ReactionsService) ListIssueCommentReactions(ctx context.Context, owner, repo string, id int64, opts *ListOptions) ([]*Reaction, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/comments/%v/reactions", owner, repo, id)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/issues/comments/%v/reactions", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -236,7 +262,10 @@ func (s *ReactionsService) ListIssueCommentReactions(ctx context.Context, owner,
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#create-reaction-for-an-issue-comment
 func (s *ReactionsService) CreateIssueCommentReaction(ctx context.Context, owner, repo string, id int64, content string) (*Reaction, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/issues/comments/%v/reactions", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/issues/comments/%v/reactions", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	body := &Reaction{Content: String(content)}
 	req, err := s.client.NewRequest("POST", u, body)
@@ -260,7 +289,10 @@ func (s *ReactionsService) CreateIssueCommentReaction(ctx context.Context, owner
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#delete-an-issue-comment-reaction
 func (s *ReactionsService) DeleteIssueCommentReaction(ctx context.Context, owner, repo string, commentID, reactionID int64) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/issues/comments/%v/reactions/%v", owner, repo, commentID, reactionID)
+	url, err := newURLString("repos/%v/%v/issues/comments/%v/reactions/%v", owner, repo, commentID, reactionID)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.deleteReaction(ctx, url)
 }
@@ -269,7 +301,10 @@ func (s *ReactionsService) DeleteIssueCommentReaction(ctx context.Context, owner
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#delete-an-issue-comment-reaction
 func (s *ReactionsService) DeleteIssueCommentReactionByID(ctx context.Context, repoID, commentID, reactionID int64) (*Response, error) {
-	url := fmt.Sprintf("repositories/%v/issues/comments/%v/reactions/%v", repoID, commentID, reactionID)
+	url, err := newURLString("repositories/%v/issues/comments/%v/reactions/%v", repoID, commentID, reactionID)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.deleteReaction(ctx, url)
 }
@@ -278,8 +313,11 @@ func (s *ReactionsService) DeleteIssueCommentReactionByID(ctx context.Context, r
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#list-reactions-for-a-pull-request-review-comment
 func (s *ReactionsService) ListPullRequestCommentReactions(ctx context.Context, owner, repo string, id int64, opts *ListOptions) ([]*Reaction, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%v/reactions", owner, repo, id)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/pulls/comments/%v/reactions", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -308,7 +346,10 @@ func (s *ReactionsService) ListPullRequestCommentReactions(ctx context.Context, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#create-reaction-for-a-pull-request-review-comment
 func (s *ReactionsService) CreatePullRequestCommentReaction(ctx context.Context, owner, repo string, id int64, content string) (*Reaction, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%v/reactions", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/pulls/comments/%v/reactions", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	body := &Reaction{Content: String(content)}
 	req, err := s.client.NewRequest("POST", u, body)
@@ -332,7 +373,10 @@ func (s *ReactionsService) CreatePullRequestCommentReaction(ctx context.Context,
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#delete-a-pull-request-comment-reaction
 func (s *ReactionsService) DeletePullRequestCommentReaction(ctx context.Context, owner, repo string, commentID, reactionID int64) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/pulls/comments/%v/reactions/%v", owner, repo, commentID, reactionID)
+	url, err := newURLString("repos/%v/%v/pulls/comments/%v/reactions/%v", owner, repo, commentID, reactionID)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.deleteReaction(ctx, url)
 }
@@ -341,7 +385,10 @@ func (s *ReactionsService) DeletePullRequestCommentReaction(ctx context.Context,
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#delete-a-pull-request-comment-reaction
 func (s *ReactionsService) DeletePullRequestCommentReactionByID(ctx context.Context, repoID, commentID, reactionID int64) (*Response, error) {
-	url := fmt.Sprintf("repositories/%v/pulls/comments/%v/reactions/%v", repoID, commentID, reactionID)
+	url, err := newURLString("repositories/%v/pulls/comments/%v/reactions/%v", repoID, commentID, reactionID)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.deleteReaction(ctx, url)
 }
@@ -350,8 +397,11 @@ func (s *ReactionsService) DeletePullRequestCommentReactionByID(ctx context.Cont
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#list-reactions-for-a-team-discussion-legacy
 func (s *ReactionsService) ListTeamDiscussionReactions(ctx context.Context, teamID int64, discussionNumber int, opts *ListOptions) ([]*Reaction, *Response, error) {
-	u := fmt.Sprintf("teams/%v/discussions/%v/reactions", teamID, discussionNumber)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("teams/%v/discussions/%v/reactions", teamID, discussionNumber)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -377,7 +427,10 @@ func (s *ReactionsService) ListTeamDiscussionReactions(ctx context.Context, team
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#create-reaction-for-a-team-discussion-legacy
 func (s *ReactionsService) CreateTeamDiscussionReaction(ctx context.Context, teamID int64, discussionNumber int, content string) (*Reaction, *Response, error) {
-	u := fmt.Sprintf("teams/%v/discussions/%v/reactions", teamID, discussionNumber)
+	u, err := newURLString("teams/%v/discussions/%v/reactions", teamID, discussionNumber)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	body := &Reaction{Content: String(content)}
 	req, err := s.client.NewRequest("POST", u, body)
@@ -400,7 +453,10 @@ func (s *ReactionsService) CreateTeamDiscussionReaction(ctx context.Context, tea
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#delete-team-discussion-reaction
 func (s *ReactionsService) DeleteTeamDiscussionReaction(ctx context.Context, org, teamSlug string, discussionNumber int, reactionID int64) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/reactions/%v", org, teamSlug, discussionNumber, reactionID)
+	url, err := newURLString("orgs/%v/teams/%v/discussions/%v/reactions/%v", org, teamSlug, discussionNumber, reactionID)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.deleteReaction(ctx, url)
 }
@@ -409,7 +465,10 @@ func (s *ReactionsService) DeleteTeamDiscussionReaction(ctx context.Context, org
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#create-reaction-for-a-team-discussion
 func (s *ReactionsService) DeleteTeamDiscussionReactionByOrgIDAndTeamID(ctx context.Context, orgID, teamID, discussionNumber int, reactionID int64) (*Response, error) {
-	url := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/reactions/%v", orgID, teamID, discussionNumber, reactionID)
+	url, err := newURLString("organizations/%v/team/%v/discussions/%v/reactions/%v", orgID, teamID, discussionNumber, reactionID)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.deleteReaction(ctx, url)
 }
@@ -418,8 +477,11 @@ func (s *ReactionsService) DeleteTeamDiscussionReactionByOrgIDAndTeamID(ctx cont
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#list-reactions-for-a-team-discussion-comment-legacy
 func (s *ReactionsService) ListTeamDiscussionCommentReactions(ctx context.Context, teamID int64, discussionNumber, commentNumber int, opts *ListOptions) ([]*Reaction, *Response, error) {
-	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v/reactions", teamID, discussionNumber, commentNumber)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("teams/%v/discussions/%v/comments/%v/reactions", teamID, discussionNumber, commentNumber)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -444,7 +506,10 @@ func (s *ReactionsService) ListTeamDiscussionCommentReactions(ctx context.Contex
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#create-reaction-for-a-team-discussion-comment-legacy
 func (s *ReactionsService) CreateTeamDiscussionCommentReaction(ctx context.Context, teamID int64, discussionNumber, commentNumber int, content string) (*Reaction, *Response, error) {
-	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v/reactions", teamID, discussionNumber, commentNumber)
+	u, err := newURLString("teams/%v/discussions/%v/comments/%v/reactions", teamID, discussionNumber, commentNumber)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	body := &Reaction{Content: String(content)}
 	req, err := s.client.NewRequest("POST", u, body)
@@ -467,7 +532,10 @@ func (s *ReactionsService) CreateTeamDiscussionCommentReaction(ctx context.Conte
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#delete-team-discussion-comment-reaction
 func (s *ReactionsService) DeleteTeamDiscussionCommentReaction(ctx context.Context, org, teamSlug string, discussionNumber, commentNumber int, reactionID int64) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments/%v/reactions/%v", org, teamSlug, discussionNumber, commentNumber, reactionID)
+	url, err := newURLString("orgs/%v/teams/%v/discussions/%v/comments/%v/reactions/%v", org, teamSlug, discussionNumber, commentNumber, reactionID)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.deleteReaction(ctx, url)
 }
@@ -476,7 +544,10 @@ func (s *ReactionsService) DeleteTeamDiscussionCommentReaction(ctx context.Conte
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#create-reaction-for-a-team-discussion-comment
 func (s *ReactionsService) DeleteTeamDiscussionCommentReactionByOrgIDAndTeamID(ctx context.Context, orgID, teamID, discussionNumber, commentNumber int, reactionID int64) (*Response, error) {
-	url := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/comments/%v/reactions/%v", orgID, teamID, discussionNumber, commentNumber, reactionID)
+	url, err := newURLString("organizations/%v/team/%v/discussions/%v/comments/%v/reactions/%v", orgID, teamID, discussionNumber, commentNumber, reactionID)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.deleteReaction(ctx, url)
 }
@@ -500,7 +571,10 @@ func (s *ReactionsService) deleteReaction(ctx context.Context, url string) (*Res
 //
 // GitHub API docs: https://docs.github.com/en/rest/reactions#create-reaction-for-a-release
 func (s *ReactionsService) CreateReleaseReaction(ctx context.Context, owner, repo string, releaseID int64, content string) (*Reaction, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/releases/%v/reactions", owner, repo, releaseID)
+	u, err := newURLString("repos/%v/%v/releases/%v/reactions", owner, repo, releaseID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	body := &Reaction{Content: String(content)}
 	req, err := s.client.NewRequest("POST", u, body)

--- a/github/repos.go
+++ b/github/repos.go
@@ -438,10 +438,14 @@ type createRepoRequest struct {
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#create-an-organization-repository
 func (s *RepositoriesService) Create(ctx context.Context, org string, repo *Repository) (*Repository, *Response, error) {
 	var u string
+	var err error
 	if org != "" {
-		u = fmt.Sprintf("orgs/%v/repos", org)
+		u, err = newURLString("orgs/%v/repos", org)
 	} else {
-		u = "user/repos"
+		u, err = newURLString("user/repos")
+	}
+	if err != nil {
+		return nil, nil, err
 	}
 
 	repoReq := &createRepoRequest{

--- a/github/repos.go
+++ b/github/repos.go
@@ -360,7 +360,11 @@ type RepositoryListAllOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#list-public-repositories
 func (s *RepositoriesService) ListAll(ctx context.Context, opts *RepositoryListAllOptions) ([]*Repository, *Response, error) {
-	u, err := addOptions("repositories", opts)
+	u, err := newURLString("repositories")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/repos.go
+++ b/github/repos.go
@@ -268,12 +268,16 @@ func (d DependabotSecurityUpdates) String() string {
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#list-repositories-for-a-user
 func (s *RepositoriesService) List(ctx context.Context, user string, opts *RepositoryListOptions) ([]*Repository, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/repos", user)
+		u, err = newURLString("users/%v/repos", user)
 	} else {
-		u = "user/repos"
+		u, err = newURLString("user/repos")
 	}
-	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -318,8 +322,11 @@ type RepositoryListByOrgOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#list-organization-repositories
 func (s *RepositoriesService) ListByOrg(ctx context.Context, org string, opts *RepositoryListByOrgOptions) ([]*Repository, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/repos", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/repos", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -493,7 +500,10 @@ type TemplateRepoRequest struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#create-a-repository-using-a-template
 func (s *RepositoriesService) CreateFromTemplate(ctx context.Context, templateOwner, templateRepo string, templateRepoReq *TemplateRepoRequest) (*Repository, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/generate", templateOwner, templateRepo)
+	u, err := newURLString("repos/%v/%v/generate", templateOwner, templateRepo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, templateRepoReq)
 	if err != nil {
@@ -514,7 +524,10 @@ func (s *RepositoriesService) CreateFromTemplate(ctx context.Context, templateOw
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#get-a-repository
 func (s *RepositoriesService) Get(ctx context.Context, owner, repo string) (*Repository, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v", owner, repo)
+	u, err := newURLString("repos/%v/%v", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -545,7 +558,10 @@ func (s *RepositoriesService) Get(ctx context.Context, owner, repo string) (*Rep
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#update-a-repository
 func (s *RepositoriesService) GetCodeOfConduct(ctx context.Context, owner, repo string) (*CodeOfConduct, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v", owner, repo)
+	u, err := newURLString("repos/%v/%v", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -567,7 +583,10 @@ func (s *RepositoriesService) GetCodeOfConduct(ctx context.Context, owner, repo 
 //
 // Note: GetByID uses the undocumented GitHub API endpoint /repositories/:id.
 func (s *RepositoriesService) GetByID(ctx context.Context, id int64) (*Repository, *Response, error) {
-	u := fmt.Sprintf("repositories/%d", id)
+	u, err := newURLString("repositories/%d", id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -586,7 +605,10 @@ func (s *RepositoriesService) GetByID(ctx context.Context, id int64) (*Repositor
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#update-a-repository
 func (s *RepositoriesService) Edit(ctx context.Context, owner, repo string, repository *Repository) (*Repository, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v", owner, repo)
+	u, err := newURLString("repos/%v/%v", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, repository)
 	if err != nil {
 		return nil, nil, err
@@ -607,7 +629,10 @@ func (s *RepositoriesService) Edit(ctx context.Context, owner, repo string, repo
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#delete-a-repository
 func (s *RepositoriesService) Delete(ctx context.Context, owner, repo string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v", owner, repo)
+	u, err := newURLString("repos/%v/%v", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -654,7 +679,10 @@ type ListContributorsOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#check-if-vulnerability-alerts-are-enabled-for-a-repository
 func (s *RepositoriesService) GetVulnerabilityAlerts(ctx context.Context, owner, repository string) (bool, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/vulnerability-alerts", owner, repository)
+	u, err := newURLString("repos/%v/%v/vulnerability-alerts", owner, repository)
+	if err != nil {
+		return false, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -673,7 +701,10 @@ func (s *RepositoriesService) GetVulnerabilityAlerts(ctx context.Context, owner,
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#enable-vulnerability-alerts
 func (s *RepositoriesService) EnableVulnerabilityAlerts(ctx context.Context, owner, repository string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/vulnerability-alerts", owner, repository)
+	u, err := newURLString("repos/%v/%v/vulnerability-alerts", owner, repository)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
@@ -690,7 +721,10 @@ func (s *RepositoriesService) EnableVulnerabilityAlerts(ctx context.Context, own
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#disable-vulnerability-alerts
 func (s *RepositoriesService) DisableVulnerabilityAlerts(ctx context.Context, owner, repository string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/vulnerability-alerts", owner, repository)
+	u, err := newURLString("repos/%v/%v/vulnerability-alerts", owner, repository)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -707,7 +741,10 @@ func (s *RepositoriesService) DisableVulnerabilityAlerts(ctx context.Context, ow
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#check-if-automated-security-fixes-are-enabled-for-a-repository
 func (s *RepositoriesService) GetAutomatedSecurityFixes(ctx context.Context, owner, repository string) (*AutomatedSecurityFixes, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/automated-security-fixes", owner, repository)
+	u, err := newURLString("repos/%v/%v/automated-security-fixes", owner, repository)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -726,7 +763,10 @@ func (s *RepositoriesService) GetAutomatedSecurityFixes(ctx context.Context, own
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#enable-automated-security-fixes
 func (s *RepositoriesService) EnableAutomatedSecurityFixes(ctx context.Context, owner, repository string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/automated-security-fixes", owner, repository)
+	u, err := newURLString("repos/%v/%v/automated-security-fixes", owner, repository)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
@@ -740,7 +780,10 @@ func (s *RepositoriesService) EnableAutomatedSecurityFixes(ctx context.Context, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#disable-automated-security-fixes
 func (s *RepositoriesService) DisableAutomatedSecurityFixes(ctx context.Context, owner, repository string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/automated-security-fixes", owner, repository)
+	u, err := newURLString("repos/%v/%v/automated-security-fixes", owner, repository)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -754,8 +797,11 @@ func (s *RepositoriesService) DisableAutomatedSecurityFixes(ctx context.Context,
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#list-repository-contributors
 func (s *RepositoriesService) ListContributors(ctx context.Context, owner string, repository string, opts *ListContributorsOptions) ([]*Contributor, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/contributors", owner, repository)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/contributors", owner, repository)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -785,7 +831,10 @@ func (s *RepositoriesService) ListContributors(ctx context.Context, owner string
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#list-repository-languages
 func (s *RepositoriesService) ListLanguages(ctx context.Context, owner string, repo string) (map[string]int, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/languages", owner, repo)
+	u, err := newURLString("repos/%v/%v/languages", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -804,8 +853,11 @@ func (s *RepositoriesService) ListLanguages(ctx context.Context, owner string, r
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#list-repository-teams
 func (s *RepositoriesService) ListTeams(ctx context.Context, owner string, repo string, opts *ListOptions) ([]*Team, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/teams", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/teams", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -836,8 +888,11 @@ type RepositoryTag struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#list-repository-tags
 func (s *RepositoriesService) ListTags(ctx context.Context, owner string, repo string, opts *ListOptions) ([]*RepositoryTag, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/tags", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/tags", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1251,8 +1306,11 @@ type AutomatedSecurityFixes struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branches#list-branches
 func (s *RepositoriesService) ListBranches(ctx context.Context, owner string, repo string, opts *BranchListOptions) ([]*Branch, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/branches", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1275,7 +1333,10 @@ func (s *RepositoriesService) ListBranches(ctx context.Context, owner string, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branches#get-a-branch
 func (s *RepositoriesService) GetBranch(ctx context.Context, owner, repo, branch string, followRedirects bool) (*Branch, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, followRedirects)
 	if err != nil {
@@ -1304,7 +1365,10 @@ type renameBranchRequest struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branches#rename-a-branch
 func (s *RepositoriesService) RenameBranch(ctx context.Context, owner, repo, branch, newName string) (*Branch, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/rename", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/rename", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	r := &renameBranchRequest{NewName: newName}
 	req, err := s.client.NewRequest("POST", u, r)
 	if err != nil {
@@ -1324,7 +1388,10 @@ func (s *RepositoriesService) RenameBranch(ctx context.Context, owner, repo, bra
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#get-branch-protection
 func (s *RepositoriesService) GetBranchProtection(ctx context.Context, owner, repo, branch string) (*Protection, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1349,7 +1416,10 @@ func (s *RepositoriesService) GetBranchProtection(ctx context.Context, owner, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#get-status-checks-protection
 func (s *RepositoriesService) GetRequiredStatusChecks(ctx context.Context, owner, repo, branch string) (*RequiredStatusChecks, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_status_checks", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/required_status_checks", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1371,7 +1441,10 @@ func (s *RepositoriesService) GetRequiredStatusChecks(ctx context.Context, owner
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#get-all-status-check-contexts
 func (s *RepositoriesService) ListRequiredStatusChecksContexts(ctx context.Context, owner, repo, branch string) (contexts []string, resp *Response, err error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_status_checks/contexts", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/required_status_checks/contexts", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1392,7 +1465,10 @@ func (s *RepositoriesService) ListRequiredStatusChecksContexts(ctx context.Conte
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#update-branch-protection
 func (s *RepositoriesService) UpdateBranchProtection(ctx context.Context, owner, repo, branch string, preq *ProtectionRequest) (*Protection, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, preq)
 	if err != nil {
 		return nil, nil, err
@@ -1414,7 +1490,10 @@ func (s *RepositoriesService) UpdateBranchProtection(ctx context.Context, owner,
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#delete-branch-protection
 func (s *RepositoriesService) RemoveBranchProtection(ctx context.Context, owner, repo, branch string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection", owner, repo, branch)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -1427,7 +1506,10 @@ func (s *RepositoriesService) RemoveBranchProtection(ctx context.Context, owner,
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#get-commit-signature-protection
 func (s *RepositoriesService) GetSignaturesProtectedBranch(ctx context.Context, owner, repo, branch string) (*SignaturesProtectedBranch, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_signatures", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/required_signatures", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1450,7 +1532,10 @@ func (s *RepositoriesService) GetSignaturesProtectedBranch(ctx context.Context, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#create-commit-signature-protection
 func (s *RepositoriesService) RequireSignaturesOnProtectedBranch(ctx context.Context, owner, repo, branch string) (*SignaturesProtectedBranch, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_signatures", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/required_signatures", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1472,7 +1557,10 @@ func (s *RepositoriesService) RequireSignaturesOnProtectedBranch(ctx context.Con
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#delete-commit-signature-protection
 func (s *RepositoriesService) OptionalSignaturesOnProtectedBranch(ctx context.Context, owner, repo, branch string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_signatures", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/required_signatures", owner, repo, branch)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -1488,7 +1576,10 @@ func (s *RepositoriesService) OptionalSignaturesOnProtectedBranch(ctx context.Co
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#update-status-check-protection
 func (s *RepositoriesService) UpdateRequiredStatusChecks(ctx context.Context, owner, repo, branch string, sreq *RequiredStatusChecksRequest) (*RequiredStatusChecks, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_status_checks", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/required_status_checks", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, sreq)
 	if err != nil {
 		return nil, nil, err
@@ -1507,7 +1598,10 @@ func (s *RepositoriesService) UpdateRequiredStatusChecks(ctx context.Context, ow
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#remove-status-check-protection
 func (s *RepositoriesService) RemoveRequiredStatusChecks(ctx context.Context, owner, repo, branch string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_status_checks", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/required_status_checks", owner, repo, branch)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -1520,7 +1614,10 @@ func (s *RepositoriesService) RemoveRequiredStatusChecks(ctx context.Context, ow
 //
 // GitHub API docs: https://docs.github.com/en/rest/licenses#get-the-license-for-a-repository
 func (s *RepositoriesService) License(ctx context.Context, owner, repo string) (*RepositoryLicense, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/license", owner, repo)
+	u, err := newURLString("repos/%v/%v/license", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1539,7 +1636,10 @@ func (s *RepositoriesService) License(ctx context.Context, owner, repo string) (
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#get-pull-request-review-protection
 func (s *RepositoriesService) GetPullRequestReviewEnforcement(ctx context.Context, owner, repo, branch string) (*PullRequestReviewsEnforcement, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_pull_request_reviews", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/required_pull_request_reviews", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1562,7 +1662,10 @@ func (s *RepositoriesService) GetPullRequestReviewEnforcement(ctx context.Contex
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#update-pull-request-review-protection
 func (s *RepositoriesService) UpdatePullRequestReviewEnforcement(ctx context.Context, owner, repo, branch string, patch *PullRequestReviewsEnforcementUpdate) (*PullRequestReviewsEnforcement, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_pull_request_reviews", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/required_pull_request_reviews", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, patch)
 	if err != nil {
 		return nil, nil, err
@@ -1585,7 +1688,10 @@ func (s *RepositoriesService) UpdatePullRequestReviewEnforcement(ctx context.Con
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#update-pull-request-review-protection
 func (s *RepositoriesService) DisableDismissalRestrictions(ctx context.Context, owner, repo, branch string) (*PullRequestReviewsEnforcement, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_pull_request_reviews", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/required_pull_request_reviews", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	data := new(struct {
 		DismissalRestrictionsRequest `json:"dismissal_restrictions"`
@@ -1612,7 +1718,10 @@ func (s *RepositoriesService) DisableDismissalRestrictions(ctx context.Context, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#delete-pull-request-review-protection
 func (s *RepositoriesService) RemovePullRequestReviewEnforcement(ctx context.Context, owner, repo, branch string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_pull_request_reviews", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/required_pull_request_reviews", owner, repo, branch)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -1625,7 +1734,10 @@ func (s *RepositoriesService) RemovePullRequestReviewEnforcement(ctx context.Con
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#get-admin-branch-protection
 func (s *RepositoriesService) GetAdminEnforcement(ctx context.Context, owner, repo, branch string) (*AdminEnforcement, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/enforce_admins", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/enforce_admins", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1645,7 +1757,10 @@ func (s *RepositoriesService) GetAdminEnforcement(ctx context.Context, owner, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#set-admin-branch-protection
 func (s *RepositoriesService) AddAdminEnforcement(ctx context.Context, owner, repo, branch string) (*AdminEnforcement, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/enforce_admins", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/enforce_admins", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1664,7 +1779,10 @@ func (s *RepositoriesService) AddAdminEnforcement(ctx context.Context, owner, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#delete-admin-branch-protection
 func (s *RepositoriesService) RemoveAdminEnforcement(ctx context.Context, owner, repo, branch string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/enforce_admins", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/enforce_admins", owner, repo, branch)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -1682,7 +1800,10 @@ type repositoryTopics struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#get-all-repository-topics
 func (s *RepositoriesService) ListAllTopics(ctx context.Context, owner, repo string) ([]string, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/topics", owner, repo)
+	u, err := newURLString("repos/%v/%v/topics", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1704,7 +1825,10 @@ func (s *RepositoriesService) ListAllTopics(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#replace-all-repository-topics
 func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo string, topics []string) ([]string, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/topics", owner, repo)
+	u, err := newURLString("repos/%v/%v/topics", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	t := &repositoryTopics{
 		Names: topics,
 	}
@@ -1735,7 +1859,10 @@ func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo 
 //
 // Deprecated: Please use ListAppRestrictions instead.
 func (s *RepositoriesService) ListApps(ctx context.Context, owner, repo, branch string) ([]*App, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/apps", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/restrictions/apps", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1768,7 +1895,10 @@ func (s *RepositoriesService) ListAppRestrictions(ctx context.Context, owner, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#set-app-access-restrictions
 func (s *RepositoriesService) ReplaceAppRestrictions(ctx context.Context, owner, repo, branch string, apps []string) ([]*App, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/apps", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/restrictions/apps", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, apps)
 	if err != nil {
 		return nil, nil, err
@@ -1790,7 +1920,10 @@ func (s *RepositoriesService) ReplaceAppRestrictions(ctx context.Context, owner,
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#add-app-access-restrictions
 func (s *RepositoriesService) AddAppRestrictions(ctx context.Context, owner, repo, branch string, apps []string) ([]*App, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/apps", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/restrictions/apps", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, apps)
 	if err != nil {
 		return nil, nil, err
@@ -1812,7 +1945,10 @@ func (s *RepositoriesService) AddAppRestrictions(ctx context.Context, owner, rep
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#remove-app-access-restrictions
 func (s *RepositoriesService) RemoveAppRestrictions(ctx context.Context, owner, repo, branch string, apps []string) ([]*App, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/apps", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/restrictions/apps", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, apps)
 	if err != nil {
 		return nil, nil, err
@@ -1832,7 +1968,10 @@ func (s *RepositoriesService) RemoveAppRestrictions(ctx context.Context, owner, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#get-teams-with-access-to-the-protected-branch
 func (s *RepositoriesService) ListTeamRestrictions(ctx context.Context, owner, repo, branch string) ([]*Team, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/teams", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/restrictions/teams", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1855,7 +1994,10 @@ func (s *RepositoriesService) ListTeamRestrictions(ctx context.Context, owner, r
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#set-team-access-restrictions
 func (s *RepositoriesService) ReplaceTeamRestrictions(ctx context.Context, owner, repo, branch string, teams []string) ([]*Team, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/teams", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/restrictions/teams", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, teams)
 	if err != nil {
 		return nil, nil, err
@@ -1877,7 +2019,10 @@ func (s *RepositoriesService) ReplaceTeamRestrictions(ctx context.Context, owner
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#add-team-access-restrictions
 func (s *RepositoriesService) AddTeamRestrictions(ctx context.Context, owner, repo, branch string, teams []string) ([]*Team, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/teams", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/restrictions/teams", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, teams)
 	if err != nil {
 		return nil, nil, err
@@ -1899,7 +2044,10 @@ func (s *RepositoriesService) AddTeamRestrictions(ctx context.Context, owner, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#remove-team-access-restrictions
 func (s *RepositoriesService) RemoveTeamRestrictions(ctx context.Context, owner, repo, branch string, teams []string) ([]*Team, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/teams", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/restrictions/teams", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, teams)
 	if err != nil {
 		return nil, nil, err
@@ -1919,7 +2067,10 @@ func (s *RepositoriesService) RemoveTeamRestrictions(ctx context.Context, owner,
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#get-users-with-access-to-the-protected-branch
 func (s *RepositoriesService) ListUserRestrictions(ctx context.Context, owner, repo, branch string) ([]*User, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/users", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/restrictions/users", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1942,7 +2093,10 @@ func (s *RepositoriesService) ListUserRestrictions(ctx context.Context, owner, r
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#set-team-access-restrictions
 func (s *RepositoriesService) ReplaceUserRestrictions(ctx context.Context, owner, repo, branch string, users []string) ([]*User, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/users", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/restrictions/users", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, users)
 	if err != nil {
 		return nil, nil, err
@@ -1964,7 +2118,10 @@ func (s *RepositoriesService) ReplaceUserRestrictions(ctx context.Context, owner
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#add-team-access-restrictions
 func (s *RepositoriesService) AddUserRestrictions(ctx context.Context, owner, repo, branch string, users []string) ([]*User, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/users", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/restrictions/users", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, users)
 	if err != nil {
 		return nil, nil, err
@@ -1986,7 +2143,10 @@ func (s *RepositoriesService) AddUserRestrictions(ctx context.Context, owner, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branch-protection#remove-team-access-restrictions
 func (s *RepositoriesService) RemoveUserRestrictions(ctx context.Context, owner, repo, branch string, users []string) ([]*User, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/users", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/branches/%v/protection/restrictions/users", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, users)
 	if err != nil {
 		return nil, nil, err
@@ -2018,7 +2178,10 @@ type TransferRequest struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#transfer-a-repository
 func (s *RepositoriesService) Transfer(ctx context.Context, owner, repo string, transfer TransferRequest) (*Repository, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/transfer", owner, repo)
+	u, err := newURLString("repos/%v/%v/transfer", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, &transfer)
 	if err != nil {
@@ -2047,7 +2210,10 @@ type DispatchRequestOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event
 func (s *RepositoriesService) Dispatch(ctx context.Context, owner, repo string, opts DispatchRequestOptions) (*Repository, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/dispatches", owner, repo)
+	u, err := newURLString("repos/%v/%v/dispatches", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, &opts)
 	if err != nil {
@@ -2075,7 +2241,10 @@ func isBranchNotProtected(err error) bool {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#enable-private-vulnerability-reporting-for-a-repository
 func (s *RepositoriesService) EnablePrivateReporting(ctx context.Context, owner, repo string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/private-vulnerability-reporting", owner, repo)
+	u, err := newURLString("repos/%v/%v/private-vulnerability-reporting", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
@@ -2095,7 +2264,10 @@ func (s *RepositoriesService) EnablePrivateReporting(ctx context.Context, owner,
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#disable-private-vulnerability-reporting-for-a-repository
 func (s *RepositoriesService) DisablePrivateReporting(ctx context.Context, owner, repo string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/private-vulnerability-reporting", owner, repo)
+	u, err := newURLString("repos/%v/%v/private-vulnerability-reporting", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/repos_actions_access.go
+++ b/github/repos_actions_access.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // RepositoryActionsAccessLevel represents the repository actions access level.
@@ -25,7 +24,10 @@ type RepositoryActionsAccessLevel struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/permissions#get-the-level-of-access-for-workflows-outside-of-the-repository
 func (s *RepositoriesService) GetActionsAccessLevel(ctx context.Context, owner, repo string) (*RepositoryActionsAccessLevel, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/permissions/access", owner, repo)
+	u, err := newURLString("repos/%v/%v/actions/permissions/access", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -45,7 +47,10 @@ func (s *RepositoriesService) GetActionsAccessLevel(ctx context.Context, owner, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/permissions#set-the-level-of-access-for-workflows-outside-of-the-repository
 func (s *RepositoriesService) EditActionsAccessLevel(ctx context.Context, owner, repo string, repositoryActionsAccessLevel RepositoryActionsAccessLevel) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/permissions/access", owner, repo)
+	u, err := newURLString("repos/%v/%v/actions/permissions/access", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, repositoryActionsAccessLevel)
 	if err != nil {
 		return nil, err

--- a/github/repos_actions_allowed.go
+++ b/github/repos_actions_allowed.go
@@ -7,14 +7,16 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // GetActionsAllowed gets the allowed actions and reusable workflows for a repository.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-a-repository
 func (s *RepositoriesService) GetActionsAllowed(ctx context.Context, org, repo string) (*ActionsAllowed, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/permissions/selected-actions", org, repo)
+	u, err := newURLString("repos/%v/%v/actions/permissions/selected-actions", org, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -33,7 +35,10 @@ func (s *RepositoriesService) GetActionsAllowed(ctx context.Context, org, repo s
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/permissions#set-allowed-actions-and-reusable-workflows-for-a-repository
 func (s *RepositoriesService) EditActionsAllowed(ctx context.Context, org, repo string, actionsAllowed ActionsAllowed) (*ActionsAllowed, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/permissions/selected-actions", org, repo)
+	u, err := newURLString("repos/%v/%v/actions/permissions/selected-actions", org, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, actionsAllowed)
 	if err != nil {
 		return nil, nil, err

--- a/github/repos_actions_permissions.go
+++ b/github/repos_actions_permissions.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ActionsPermissionsRepository represents a policy for repositories and allowed actions in a repository.
@@ -27,7 +26,10 @@ func (a ActionsPermissionsRepository) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/permissions#get-github-actions-permissions-for-a-repository
 func (s *RepositoriesService) GetActionsPermissions(ctx context.Context, owner, repo string) (*ActionsPermissionsRepository, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/permissions", owner, repo)
+	u, err := newURLString("repos/%v/%v/actions/permissions", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -46,7 +48,10 @@ func (s *RepositoriesService) GetActionsPermissions(ctx context.Context, owner, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/permissions#set-github-actions-permissions-for-a-repository
 func (s *RepositoriesService) EditActionsPermissions(ctx context.Context, owner, repo string, actionsPermissionsRepository ActionsPermissionsRepository) (*ActionsPermissionsRepository, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/actions/permissions", owner, repo)
+	u, err := newURLString("repos/%v/%v/actions/permissions", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, actionsPermissionsRepository)
 	if err != nil {
 		return nil, nil, err

--- a/github/repos_autolinks.go
+++ b/github/repos_autolinks.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // AutolinkOptions specifies parameters for RepositoriesService.AddAutolink method.
@@ -30,8 +29,11 @@ type Autolink struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/autolinks#list-all-autolinks-of-a-repository
 func (s *RepositoriesService) ListAutolinks(ctx context.Context, owner, repo string, opts *ListOptions) ([]*Autolink, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/autolinks", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/autolinks", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -55,7 +57,10 @@ func (s *RepositoriesService) ListAutolinks(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/autolinks#create-an-autolink-reference-for-a-repository
 func (s *RepositoriesService) AddAutolink(ctx context.Context, owner, repo string, opts *AutolinkOptions) (*Autolink, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/autolinks", owner, repo)
+	u, err := newURLString("repos/%v/%v/autolinks", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -74,7 +79,10 @@ func (s *RepositoriesService) AddAutolink(ctx context.Context, owner, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/autolinks#get-an-autolink-reference-of-a-repository
 func (s *RepositoriesService) GetAutolink(ctx context.Context, owner, repo string, id int64) (*Autolink, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/autolinks/%v", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/autolinks/%v", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -95,7 +103,10 @@ func (s *RepositoriesService) GetAutolink(ctx context.Context, owner, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/autolinks#delete-an-autolink-reference-from-a-repository
 func (s *RepositoriesService) DeleteAutolink(ctx context.Context, owner, repo string, id int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/autolinks/%v", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/autolinks/%v", owner, repo, id)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/repos_codeowners.go
+++ b/github/repos_codeowners.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // CodeownersErrors represents a list of syntax errors detected in the CODEOWNERS file.
@@ -30,7 +29,10 @@ type CodeownersError struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/repos#list-codeowners-errors
 func (s *RepositoriesService) GetCodeownersErrors(ctx context.Context, owner, repo string) (*CodeownersErrors, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/codeowners/errors", owner, repo)
+	u, err := newURLString("repos/%v/%v/codeowners/errors", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/repos_collaborators.go
+++ b/github/repos_collaborators.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ListCollaboratorsOptions specifies the optional parameters to the
@@ -50,8 +49,11 @@ type CollaboratorInvitation struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/collaborators/collaborators#list-repository-collaborators
 func (s *RepositoriesService) ListCollaborators(ctx context.Context, owner, repo string, opts *ListCollaboratorsOptions) ([]*User, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/collaborators", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/collaborators", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -77,7 +79,10 @@ func (s *RepositoriesService) ListCollaborators(ctx context.Context, owner, repo
 //
 // GitHub API docs: https://docs.github.com/en/rest/collaborators/collaborators#check-if-a-user-is-a-repository-collaborator
 func (s *RepositoriesService) IsCollaborator(ctx context.Context, owner, repo, user string) (bool, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/collaborators/%v", owner, repo, user)
+	u, err := newURLString("repos/%v/%v/collaborators/%v", owner, repo, user)
+	if err != nil {
+		return false, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return false, nil, err
@@ -101,7 +106,10 @@ type RepositoryPermissionLevel struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/collaborators/collaborators#get-repository-permissions-for-a-user
 func (s *RepositoriesService) GetPermissionLevel(ctx context.Context, owner, repo, user string) (*RepositoryPermissionLevel, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/collaborators/%v/permission", owner, repo, user)
+	u, err := newURLString("repos/%v/%v/collaborators/%v/permission", owner, repo, user)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -136,7 +144,10 @@ type RepositoryAddCollaboratorOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/collaborators/collaborators#add-a-repository-collaborator
 func (s *RepositoriesService) AddCollaborator(ctx context.Context, owner, repo, user string, opts *RepositoryAddCollaboratorOptions) (*CollaboratorInvitation, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/collaborators/%v", owner, repo, user)
+	u, err := newURLString("repos/%v/%v/collaborators/%v", owner, repo, user)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -156,7 +167,10 @@ func (s *RepositoriesService) AddCollaborator(ctx context.Context, owner, repo, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/collaborators/collaborators#remove-a-repository-collaborator
 func (s *RepositoriesService) RemoveCollaborator(ctx context.Context, owner, repo, user string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/collaborators/%v", owner, repo, user)
+	u, err := newURLString("repos/%v/%v/collaborators/%v", owner, repo, user)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/repos_comments.go
+++ b/github/repos_comments.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // RepositoryComment represents a comment for a commit, file, or line in a repository.
@@ -37,8 +36,11 @@ func (r RepositoryComment) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/commits/comments#list-commit-comments-for-a-repository
 func (s *RepositoriesService) ListComments(ctx context.Context, owner, repo string, opts *ListOptions) ([]*RepositoryComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/comments", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/comments", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -64,8 +66,11 @@ func (s *RepositoriesService) ListComments(ctx context.Context, owner, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/commits/comments#list-commit-comments
 func (s *RepositoriesService) ListCommitComments(ctx context.Context, owner, repo, sha string, opts *ListOptions) ([]*RepositoryComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/commits/%v/comments", owner, repo, sha)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/commits/%v/comments", owner, repo, sha)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -92,7 +97,10 @@ func (s *RepositoriesService) ListCommitComments(ctx context.Context, owner, rep
 //
 // GitHub API docs: https://docs.github.com/en/rest/commits/comments#create-a-commit-comment
 func (s *RepositoriesService) CreateComment(ctx context.Context, owner, repo, sha string, comment *RepositoryComment) (*RepositoryComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/commits/%v/comments", owner, repo, sha)
+	u, err := newURLString("repos/%v/%v/commits/%v/comments", owner, repo, sha)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -111,7 +119,10 @@ func (s *RepositoriesService) CreateComment(ctx context.Context, owner, repo, sh
 //
 // GitHub API docs: https://docs.github.com/en/rest/commits/comments#get-a-commit-comment
 func (s *RepositoriesService) GetComment(ctx context.Context, owner, repo string, id int64) (*RepositoryComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/comments/%v", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -133,7 +144,10 @@ func (s *RepositoriesService) GetComment(ctx context.Context, owner, repo string
 //
 // GitHub API docs: https://docs.github.com/en/rest/commits/comments#update-a-commit-comment
 func (s *RepositoriesService) UpdateComment(ctx context.Context, owner, repo string, id int64, comment *RepositoryComment) (*RepositoryComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/comments/%v", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -152,7 +166,10 @@ func (s *RepositoriesService) UpdateComment(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/commits/comments#delete-a-commit-comment
 func (s *RepositoriesService) DeleteComment(ctx context.Context, owner, repo string, id int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/comments/%v", owner, repo, id)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -126,8 +126,11 @@ type BranchCommit struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/commits/commits#list-commits
 func (s *RepositoriesService) ListCommits(ctx context.Context, owner, repo string, opts *CommitsListOptions) ([]*RepositoryCommit, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/commits", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/commits", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -151,8 +154,11 @@ func (s *RepositoriesService) ListCommits(ctx context.Context, owner, repo strin
 // GitHub API docs: https://docs.github.com/en/rest/commits/commits#get-a-single-commit
 // GitHub API docs: https://docs.github.com/en/rest/commits/commits#get-a-commit
 func (s *RepositoriesService) GetCommit(ctx context.Context, owner, repo, sha string, opts *ListOptions) (*RepositoryCommit, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/commits/%v", owner, repo, sha)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/commits/%v", owner, repo, sha)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -175,7 +181,10 @@ func (s *RepositoriesService) GetCommit(ctx context.Context, owner, repo, sha st
 //
 // GitHub API docs: https://docs.github.com/en/rest/commits/commits#get-a-commit
 func (s *RepositoriesService) GetCommitRaw(ctx context.Context, owner string, repo string, sha string, opts RawOptions) (string, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/commits/%v", owner, repo, sha)
+	u, err := newURLString("repos/%v/%v/commits/%v", owner, repo, sha)
+	if err != nil {
+		return "", nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return "", nil, err
@@ -204,7 +213,10 @@ func (s *RepositoriesService) GetCommitRaw(ctx context.Context, owner string, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/commits/commits#get-a-commit
 func (s *RepositoriesService) GetCommitSHA1(ctx context.Context, owner, repo, ref, lastSHA string) (string, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/commits/%v", owner, repo, refURLEscape(ref))
+	u, err := newURLString("repos/%v/%v/commits/%v", owner, repo, refURLEscape(ref))
+	if err != nil {
+		return "", nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -232,8 +244,11 @@ func (s *RepositoriesService) CompareCommits(ctx context.Context, owner, repo st
 	escapedBase := url.QueryEscape(base)
 	escapedHead := url.QueryEscape(head)
 
-	u := fmt.Sprintf("repos/%v/%v/compare/%v...%v", owner, repo, escapedBase, escapedHead)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/compare/%v...%v", owner, repo, escapedBase, escapedHead)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -263,7 +278,10 @@ func (s *RepositoriesService) CompareCommitsRaw(ctx context.Context, owner, repo
 	escapedBase := url.QueryEscape(base)
 	escapedHead := url.QueryEscape(head)
 
-	u := fmt.Sprintf("repos/%v/%v/compare/%v...%v", owner, repo, escapedBase, escapedHead)
+	u, err := newURLString("repos/%v/%v/compare/%v...%v", owner, repo, escapedBase, escapedHead)
+	if err != nil {
+		return "", nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -293,7 +311,10 @@ func (s *RepositoriesService) CompareCommitsRaw(ctx context.Context, owner, repo
 //
 // GitHub API docs: https://docs.github.com/en/rest/commits/commits#list-branches-for-head-commit
 func (s *RepositoriesService) ListBranchesHeadCommit(ctx context.Context, owner, repo, sha string) ([]*BranchCommit, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/commits/%v/branches-where-head", owner, repo, sha)
+	u, err := newURLString("repos/%v/%v/commits/%v/branches-where-head", owner, repo, sha)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/repos_community_health.go
+++ b/github/repos_community_health.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // Metric represents the different fields for one file in community health files.
@@ -45,7 +44,10 @@ type CommunityHealthMetrics struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/metrics/community#get-community-profile-metrics
 func (s *RepositoriesService) GetCommunityHealthMetrics(ctx context.Context, owner, repo string) (*CommunityHealthMetrics, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/community/profile", owner, repo)
+	u, err := newURLString("repos/%v/%v/community/profile", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -100,8 +100,11 @@ func (r *RepositoryContent) GetContent() (string, error) {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/contents#get-a-repository-readme
 func (s *RepositoriesService) GetReadme(ctx context.Context, owner, repo string, opts *RepositoryContentGetOptions) (*RepositoryContent, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/readme", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/readme", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -205,7 +208,10 @@ func (s *RepositoriesService) GetContents(ctx context.Context, owner, repo, path
 	}
 
 	escapedPath := (&url.URL{Path: strings.TrimSuffix(path, "/")}).String()
-	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, escapedPath)
+	u, err := newURLString("repos/%s/%s/contents/%s", owner, repo, escapedPath)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, nil, err
@@ -240,7 +246,10 @@ func (s *RepositoriesService) GetContents(ctx context.Context, owner, repo, path
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents
 func (s *RepositoriesService) CreateFile(ctx context.Context, owner, repo, path string, opts *RepositoryContentFileOptions) (*RepositoryContentResponse, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, path)
+	u, err := newURLString("repos/%s/%s/contents/%s", owner, repo, path)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -260,7 +269,10 @@ func (s *RepositoriesService) CreateFile(ctx context.Context, owner, repo, path 
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents
 func (s *RepositoriesService) UpdateFile(ctx context.Context, owner, repo, path string, opts *RepositoryContentFileOptions) (*RepositoryContentResponse, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, path)
+	u, err := newURLString("repos/%s/%s/contents/%s", owner, repo, path)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -280,7 +292,10 @@ func (s *RepositoriesService) UpdateFile(ctx context.Context, owner, repo, path 
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/contents#delete-a-file
 func (s *RepositoriesService) DeleteFile(ctx context.Context, owner, repo, path string, opts *RepositoryContentFileOptions) (*RepositoryContentResponse, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, path)
+	u, err := newURLString("repos/%s/%s/contents/%s", owner, repo, path)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -312,7 +327,10 @@ const (
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/contents/#get-archive-link
 func (s *RepositoriesService) GetArchiveLink(ctx context.Context, owner, repo string, archiveformat ArchiveFormat, opts *RepositoryContentGetOptions, followRedirects bool) (*url.URL, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/%s", owner, repo, archiveformat)
+	u, err := newURLString("repos/%s/%s/%s", owner, repo, archiveformat)
+	if err != nil {
+		return nil, nil, err
+	}
 	if opts != nil && opts.Ref != "" {
 		u += fmt.Sprintf("/%s", opts.Ref)
 	}

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -332,7 +332,10 @@ func (s *RepositoriesService) GetArchiveLink(ctx context.Context, owner, repo st
 		return nil, nil, err
 	}
 	if opts != nil && opts.Ref != "" {
-		u += fmt.Sprintf("/%s", opts.Ref)
+		u, err = url.JoinPath(u, opts.Ref)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, followRedirects)
 	if err != nil {

--- a/github/repos_deployment_branch_policies.go
+++ b/github/repos_deployment_branch_policies.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // DeploymentBranchPolicy represents a single deployment branch policy for an environment.
@@ -32,7 +31,10 @@ type DeploymentBranchPolicyRequest struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/branch-policies#list-deployment-branch-policies
 func (s *RepositoriesService) ListDeploymentBranchPolicies(ctx context.Context, owner, repo, environment string) (*DeploymentBranchPolicyResponse, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment-branch-policies", owner, repo, environment)
+	u, err := newURLString("repos/%v/%v/environments/%v/deployment-branch-policies", owner, repo, environment)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -52,7 +54,10 @@ func (s *RepositoriesService) ListDeploymentBranchPolicies(ctx context.Context, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/branch-policies#get-a-deployment-branch-policy
 func (s *RepositoriesService) GetDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, branchPolicyID int64) (*DeploymentBranchPolicy, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment-branch-policies/%v", owner, repo, environment, branchPolicyID)
+	u, err := newURLString("repos/%v/%v/environments/%v/deployment-branch-policies/%v", owner, repo, environment, branchPolicyID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -72,7 +77,10 @@ func (s *RepositoriesService) GetDeploymentBranchPolicy(ctx context.Context, own
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/branch-policies#create-a-deployment-branch-policy
 func (s *RepositoriesService) CreateDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, request *DeploymentBranchPolicyRequest) (*DeploymentBranchPolicy, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment-branch-policies", owner, repo, environment)
+	u, err := newURLString("repos/%v/%v/environments/%v/deployment-branch-policies", owner, repo, environment)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, request)
 	if err != nil {
@@ -92,7 +100,10 @@ func (s *RepositoriesService) CreateDeploymentBranchPolicy(ctx context.Context, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/branch-policies#update-a-deployment-branch-policy
 func (s *RepositoriesService) UpdateDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, branchPolicyID int64, request *DeploymentBranchPolicyRequest) (*DeploymentBranchPolicy, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment-branch-policies/%v", owner, repo, environment, branchPolicyID)
+	u, err := newURLString("repos/%v/%v/environments/%v/deployment-branch-policies/%v", owner, repo, environment, branchPolicyID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, request)
 	if err != nil {
@@ -112,7 +123,10 @@ func (s *RepositoriesService) UpdateDeploymentBranchPolicy(ctx context.Context, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/branch-policies#delete-a-deployment-branch-policy
 func (s *RepositoriesService) DeleteDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, branchPolicyID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment-branch-policies/%v", owner, repo, environment, branchPolicyID)
+	u, err := newURLString("repos/%v/%v/environments/%v/deployment-branch-policies/%v", owner, repo, environment, branchPolicyID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 )
 
@@ -65,8 +64,11 @@ type DeploymentsListOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/deployments#list-deployments
 func (s *RepositoriesService) ListDeployments(ctx context.Context, owner, repo string, opts *DeploymentsListOptions) ([]*Deployment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/deployments", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/deployments", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -89,7 +91,10 @@ func (s *RepositoriesService) ListDeployments(ctx context.Context, owner, repo s
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/deployments#get-a-deployment
 func (s *RepositoriesService) GetDeployment(ctx context.Context, owner, repo string, deploymentID int64) (*Deployment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/deployments/%v", owner, repo, deploymentID)
+	u, err := newURLString("repos/%v/%v/deployments/%v", owner, repo, deploymentID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -109,7 +114,10 @@ func (s *RepositoriesService) GetDeployment(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/deployments#create-a-deployment
 func (s *RepositoriesService) CreateDeployment(ctx context.Context, owner, repo string, request *DeploymentRequest) (*Deployment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/deployments", owner, repo)
+	u, err := newURLString("repos/%v/%v/deployments", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, request)
 	if err != nil {
@@ -133,7 +141,10 @@ func (s *RepositoriesService) CreateDeployment(ctx context.Context, owner, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/deployments#delete-a-deployment
 func (s *RepositoriesService) DeleteDeployment(ctx context.Context, owner, repo string, deploymentID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/deployments/%v", owner, repo, deploymentID)
+	u, err := newURLString("repos/%v/%v/deployments/%v", owner, repo, deploymentID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -177,8 +188,11 @@ type DeploymentStatusRequest struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/statuses#list-deployment-statuses
 func (s *RepositoriesService) ListDeploymentStatuses(ctx context.Context, owner, repo string, deployment int64, opts *ListOptions) ([]*DeploymentStatus, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/deployments/%v/statuses", owner, repo, deployment)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/deployments/%v/statuses", owner, repo, deployment)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -205,7 +219,10 @@ func (s *RepositoriesService) ListDeploymentStatuses(ctx context.Context, owner,
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/statuses#get-a-deployment-status
 func (s *RepositoriesService) GetDeploymentStatus(ctx context.Context, owner, repo string, deploymentID, deploymentStatusID int64) (*DeploymentStatus, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/deployments/%v/statuses/%v", owner, repo, deploymentID, deploymentStatusID)
+	u, err := newURLString("repos/%v/%v/deployments/%v/statuses/%v", owner, repo, deploymentID, deploymentStatusID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -229,7 +246,10 @@ func (s *RepositoriesService) GetDeploymentStatus(ctx context.Context, owner, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/statuses#create-a-deployment-status
 func (s *RepositoriesService) CreateDeploymentStatus(ctx context.Context, owner, repo string, deployment int64, request *DeploymentStatusRequest) (*DeploymentStatus, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/deployments/%v/statuses", owner, repo, deployment)
+	u, err := newURLString("repos/%v/%v/deployments/%v/statuses", owner, repo, deployment)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, request)
 	if err != nil {

--- a/github/repos_environments.go
+++ b/github/repos_environments.go
@@ -108,8 +108,11 @@ func (r *RequiredReviewer) UnmarshalJSON(data []byte) error {
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/environments#get-all-environments
 func (s *RepositoriesService) ListEnvironments(ctx context.Context, owner, repo string, opts *EnvironmentListOptions) (*EnvResponse, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/environments", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%s/%s/environments", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -131,7 +134,10 @@ func (s *RepositoriesService) ListEnvironments(ctx context.Context, owner, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/environments#get-an-environment
 func (s *RepositoriesService) GetEnvironment(ctx context.Context, owner, repo, name string) (*Environment, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/environments/%s", owner, repo, name)
+	u, err := newURLString("repos/%s/%s/environments/%s", owner, repo, name)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -186,7 +192,10 @@ type createUpdateEnvironmentNoEnterprise struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/environments#create-or-update-an-environment
 func (s *RepositoriesService) CreateUpdateEnvironment(ctx context.Context, owner, repo, name string, environment *CreateUpdateEnvironment) (*Environment, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/environments/%s", owner, repo, name)
+	u, err := newURLString("repos/%s/%s/environments/%s", owner, repo, name)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, environment)
 	if err != nil {
@@ -232,7 +241,10 @@ func (s *RepositoriesService) createNewEnvNoEnterprise(ctx context.Context, u st
 //
 // GitHub API docs: https://docs.github.com/en/rest/deployments/environments#delete-an-environment
 func (s *RepositoriesService) DeleteEnvironment(ctx context.Context, owner, repo, name string) (*Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/environments/%s", owner, repo, name)
+	u, err := newURLString("repos/%s/%s/environments/%s", owner, repo, name)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/repos_forks.go
+++ b/github/repos_forks.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 )
 
 // RepositoryListForksOptions specifies the optional parameters to the
@@ -25,8 +24,11 @@ type RepositoryListForksOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/forks#list-forks
 func (s *RepositoriesService) ListForks(ctx context.Context, owner, repo string, opts *RepositoryListForksOptions) ([]*Repository, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/forks", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/forks", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -68,7 +70,10 @@ type RepositoryCreateForkOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/forks#create-a-fork
 func (s *RepositoriesService) CreateFork(ctx context.Context, owner, repo string, opts *RepositoryCreateForkOptions) (*Repository, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/forks", owner, repo)
+	u, err := newURLString("repos/%v/%v/forks", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {

--- a/github/repos_hooks.go
+++ b/github/repos_hooks.go
@@ -81,7 +81,10 @@ type createHookRequest struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/webhooks/repos#create-a-repository-webhook
 func (s *RepositoriesService) CreateHook(ctx context.Context, owner, repo string, hook *Hook) (*Hook, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks", owner, repo)
+	u, err := newURLString("repos/%v/%v/hooks", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	hookReq := &createHookRequest{
 		Name:   "web",
@@ -108,8 +111,11 @@ func (s *RepositoriesService) CreateHook(ctx context.Context, owner, repo string
 //
 // GitHub API docs: https://docs.github.com/en/rest/webhooks/repos#list-repository-webhooks
 func (s *RepositoriesService) ListHooks(ctx context.Context, owner, repo string, opts *ListOptions) ([]*Hook, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/hooks", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -132,7 +138,10 @@ func (s *RepositoriesService) ListHooks(ctx context.Context, owner, repo string,
 //
 // GitHub API docs: https://docs.github.com/en/rest/webhooks/repos#get-a-repository-webhook
 func (s *RepositoriesService) GetHook(ctx context.Context, owner, repo string, id int64) (*Hook, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%d", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/hooks/%d", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -150,7 +159,10 @@ func (s *RepositoriesService) GetHook(ctx context.Context, owner, repo string, i
 //
 // GitHub API docs: https://docs.github.com/en/rest/webhooks/repos#update-a-repository-webhook
 func (s *RepositoriesService) EditHook(ctx context.Context, owner, repo string, id int64, hook *Hook) (*Hook, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%d", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/hooks/%d", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, hook)
 	if err != nil {
 		return nil, nil, err
@@ -168,7 +180,10 @@ func (s *RepositoriesService) EditHook(ctx context.Context, owner, repo string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/webhooks/repos#delete-a-repository-webhook
 func (s *RepositoriesService) DeleteHook(ctx context.Context, owner, repo string, id int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%d", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/hooks/%d", owner, repo, id)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -180,7 +195,10 @@ func (s *RepositoriesService) DeleteHook(ctx context.Context, owner, repo string
 //
 // GitHub API docs: https://docs.github.com/en/rest/webhooks/repos#ping-a-repository-webhook
 func (s *RepositoriesService) PingHook(ctx context.Context, owner, repo string, id int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%d/pings", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/hooks/%d/pings", owner, repo, id)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
@@ -192,7 +210,10 @@ func (s *RepositoriesService) PingHook(ctx context.Context, owner, repo string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/webhooks/repos#test-the-push-repository-webhook
 func (s *RepositoriesService) TestHook(ctx context.Context, owner, repo string, id int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%d/tests", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/hooks/%d/tests", owner, repo, id)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/repos_hooks.go
+++ b/github/repos_hooks.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -250,12 +249,15 @@ func (s *RepositoriesService) Unsubscribe(ctx context.Context, owner, repo, even
 //
 // See: https://www.w3.org/TR/websub/#subscriber-sends-subscription-request
 func (s *RepositoriesService) createWebSubRequest(hubMode, owner, repo, event, callback string, secret []byte) (*http.Request, error) {
-	topic := fmt.Sprintf(
+	topic, err := newURLString(
 		"https://github.com/%s/%s/events/%s",
 		owner,
 		repo,
 		event,
 	)
+	if err != nil {
+		return nil, err
+	}
 	form := url.Values{}
 	form.Add("hub.mode", hubMode)
 	form.Add("hub.topic", topic)

--- a/github/repos_hooks_configuration.go
+++ b/github/repos_hooks_configuration.go
@@ -7,14 +7,16 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // GetHookConfiguration returns the configuration for the specified repository webhook.
 //
 // GitHub API docs: https://docs.github.com/en/rest/webhooks/repo-config?apiVersion=2022-11-28#get-a-webhook-configuration-for-a-repository
 func (s *RepositoriesService) GetHookConfiguration(ctx context.Context, owner, repo string, id int64) (*HookConfig, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%v/config", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/hooks/%v/config", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -33,7 +35,10 @@ func (s *RepositoriesService) GetHookConfiguration(ctx context.Context, owner, r
 //
 // GitHub API docs: https://docs.github.com/en/rest/webhooks/repo-config?apiVersion=2022-11-28#update-a-webhook-configuration-for-a-repository
 func (s *RepositoriesService) EditHookConfiguration(ctx context.Context, owner, repo string, id int64, config *HookConfig) (*HookConfig, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%v/config", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/hooks/%v/config", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, config)
 	if err != nil {
 		return nil, nil, err

--- a/github/repos_hooks_deliveries.go
+++ b/github/repos_hooks_deliveries.go
@@ -65,8 +65,11 @@ func (r HookResponse) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/webhooks/repo-deliveries#list-deliveries-for-a-repository-webhook
 func (s *RepositoriesService) ListHookDeliveries(ctx context.Context, owner, repo string, id int64, opts *ListCursorOptions) ([]*HookDelivery, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%v/deliveries", owner, repo, id)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/hooks/%v/deliveries", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -89,7 +92,10 @@ func (s *RepositoriesService) ListHookDeliveries(ctx context.Context, owner, rep
 //
 // GitHub API docs: https://docs.github.com/en/rest/webhooks/repo-deliveries#get-a-delivery-for-a-repository-webhook
 func (s *RepositoriesService) GetHookDelivery(ctx context.Context, owner, repo string, hookID, deliveryID int64) (*HookDelivery, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%v/deliveries/%v", owner, repo, hookID, deliveryID)
+	u, err := newURLString("repos/%v/%v/hooks/%v/deliveries/%v", owner, repo, hookID, deliveryID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -108,7 +114,10 @@ func (s *RepositoriesService) GetHookDelivery(ctx context.Context, owner, repo s
 //
 // GitHub API docs: https://docs.github.com/en/rest/webhooks/repo-deliveries#redeliver-a-delivery-for-a-repository-webhook
 func (s *RepositoriesService) RedeliverHookDelivery(ctx context.Context, owner, repo string, hookID, deliveryID int64) (*HookDelivery, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/hooks/%v/deliveries/%v/attempts", owner, repo, hookID, deliveryID)
+	u, err := newURLString("repos/%v/%v/hooks/%v/deliveries/%v/attempts", owner, repo, hookID, deliveryID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/repos_invitations.go
+++ b/github/repos_invitations.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // RepositoryInvitation represents an invitation to collaborate on a repo.
@@ -29,8 +28,11 @@ type RepositoryInvitation struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/collaborators/invitations#list-repository-invitations
 func (s *RepositoriesService) ListInvitations(ctx context.Context, owner, repo string, opts *ListOptions) ([]*RepositoryInvitation, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/invitations", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/invitations", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -53,7 +55,10 @@ func (s *RepositoriesService) ListInvitations(ctx context.Context, owner, repo s
 //
 // GitHub API docs: https://docs.github.com/en/rest/collaborators/invitations#delete-a-repository-invitation
 func (s *RepositoriesService) DeleteInvitation(ctx context.Context, owner, repo string, invitationID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/invitations/%v", owner, repo, invitationID)
+	u, err := newURLString("repos/%v/%v/invitations/%v", owner, repo, invitationID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -73,7 +78,10 @@ func (s *RepositoriesService) UpdateInvitation(ctx context.Context, owner, repo 
 	opts := &struct {
 		Permissions string `json:"permissions"`
 	}{Permissions: permissions}
-	u := fmt.Sprintf("repos/%v/%v/invitations/%v", owner, repo, invitationID)
+	u, err := newURLString("repos/%v/%v/invitations/%v", owner, repo, invitationID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err

--- a/github/repos_keys.go
+++ b/github/repos_keys.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // The Key type is defined in users_keys.go
@@ -16,8 +15,11 @@ import (
 //
 // GitHub API docs: https://docs.github.com/en/rest/deploy-keys#list-deploy-keys
 func (s *RepositoriesService) ListKeys(ctx context.Context, owner string, repo string, opts *ListOptions) ([]*Key, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/keys", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/keys", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -40,7 +42,10 @@ func (s *RepositoriesService) ListKeys(ctx context.Context, owner string, repo s
 //
 // GitHub API docs: https://docs.github.com/en/rest/deploy-keys#get-a-deploy-key
 func (s *RepositoriesService) GetKey(ctx context.Context, owner string, repo string, id int64) (*Key, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/keys/%v", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/keys/%v", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -60,7 +65,10 @@ func (s *RepositoriesService) GetKey(ctx context.Context, owner string, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/deploy-keys#create-a-deploy-key
 func (s *RepositoriesService) CreateKey(ctx context.Context, owner string, repo string, key *Key) (*Key, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/keys", owner, repo)
+	u, err := newURLString("repos/%v/%v/keys", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, key)
 	if err != nil {
@@ -80,7 +88,10 @@ func (s *RepositoriesService) CreateKey(ctx context.Context, owner string, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/deploy-keys#delete-a-deploy-key
 func (s *RepositoriesService) DeleteKey(ctx context.Context, owner string, repo string, id int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/keys/%v", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/keys/%v", owner, repo, id)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/repos_lfs.go
+++ b/github/repos_lfs.go
@@ -7,14 +7,16 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // EnableLFS turns the LFS (Large File Storage) feature ON for the selected repo.
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/lfs#enable-git-lfs-for-a-repository
 func (s *RepositoriesService) EnableLFS(ctx context.Context, owner, repo string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/lfs", owner, repo)
+	u, err := newURLString("repos/%v/%v/lfs", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
@@ -33,7 +35,10 @@ func (s *RepositoriesService) EnableLFS(ctx context.Context, owner, repo string)
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/lfs#disable-git-lfs-for-a-repository
 func (s *RepositoriesService) DisableLFS(ctx context.Context, owner, repo string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/lfs", owner, repo)
+	u, err := newURLString("repos/%v/%v/lfs", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/repos_merging.go
+++ b/github/repos_merging.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // RepositoryMergeRequest represents a request to merge a branch in a
@@ -36,7 +35,10 @@ type RepoMergeUpstreamResult struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branches#merge-a-branch
 func (s *RepositoriesService) Merge(ctx context.Context, owner, repo string, request *RepositoryMergeRequest) (*RepositoryCommit, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/merges", owner, repo)
+	u, err := newURLString("repos/%v/%v/merges", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, request)
 	if err != nil {
 		return nil, nil, err
@@ -56,7 +58,10 @@ func (s *RepositoriesService) Merge(ctx context.Context, owner, repo string, req
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branches#sync-a-fork-branch-with-the-upstream-repository
 func (s *RepositoriesService) MergeUpstream(ctx context.Context, owner, repo string, request *RepoMergeUpstreamRequest) (*RepoMergeUpstreamResult, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/merge-upstream", owner, repo)
+	u, err := newURLString("repos/%v/%v/merge-upstream", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, request)
 	if err != nil {
 		return nil, nil, err

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // Pages represents a GitHub Pages site configuration.
@@ -105,7 +104,10 @@ type createPagesRequest struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/pages#create-a-github-pages-site
 func (s *RepositoriesService) EnablePages(ctx context.Context, owner, repo string, pages *Pages) (*Pages, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
+	u, err := newURLString("repos/%v/%v/pages", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	pagesReq := &createPagesRequest{
 		BuildType: pages.BuildType,
@@ -155,7 +157,10 @@ type PagesUpdate struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/pages#update-information-about-a-github-pages-site
 func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo string, opts *PagesUpdate) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
+	u, err := newURLString("repos/%v/%v/pages", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
@@ -174,7 +179,10 @@ func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/pages#delete-a-github-pages-site
 func (s *RepositoriesService) DisablePages(ctx context.Context, owner, repo string) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
+	u, err := newURLString("repos/%v/%v/pages", owner, repo)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -190,7 +198,10 @@ func (s *RepositoriesService) DisablePages(ctx context.Context, owner, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/pages#get-a-github-pages-site
 func (s *RepositoriesService) GetPagesInfo(ctx context.Context, owner, repo string) (*Pages, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
+	u, err := newURLString("repos/%v/%v/pages", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -209,8 +220,11 @@ func (s *RepositoriesService) GetPagesInfo(ctx context.Context, owner, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/pages#list-github-pages-builds
 func (s *RepositoriesService) ListPagesBuilds(ctx context.Context, owner, repo string, opts *ListOptions) ([]*PagesBuild, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pages/builds", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/pages/builds", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -233,7 +247,10 @@ func (s *RepositoriesService) ListPagesBuilds(ctx context.Context, owner, repo s
 //
 // GitHub API docs: https://docs.github.com/en/rest/pages#get-latest-pages-build
 func (s *RepositoriesService) GetLatestPagesBuild(ctx context.Context, owner, repo string) (*PagesBuild, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pages/builds/latest", owner, repo)
+	u, err := newURLString("repos/%v/%v/pages/builds/latest", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -252,7 +269,10 @@ func (s *RepositoriesService) GetLatestPagesBuild(ctx context.Context, owner, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/pages#get-github-pages-build
 func (s *RepositoriesService) GetPageBuild(ctx context.Context, owner, repo string, id int64) (*PagesBuild, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pages/builds/%v", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/pages/builds/%v", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -271,7 +291,10 @@ func (s *RepositoriesService) GetPageBuild(ctx context.Context, owner, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/pages#request-a-github-pages-build
 func (s *RepositoriesService) RequestPageBuild(ctx context.Context, owner, repo string) (*PagesBuild, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pages/builds", owner, repo)
+	u, err := newURLString("repos/%v/%v/pages/builds", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -290,7 +313,10 @@ func (s *RepositoriesService) RequestPageBuild(ctx context.Context, owner, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/pages#get-a-dns-health-check-for-github-pages
 func (s *RepositoriesService) GetPageHealthCheck(ctx context.Context, owner, repo string) (*PagesHealthCheckResponse, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pages/health", owner, repo)
+	u, err := newURLString("repos/%v/%v/pages/health", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/repos_prereceive_hooks.go
+++ b/github/repos_prereceive_hooks.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // PreReceiveHook represents a GitHub pre-receive hook for a repository.
@@ -26,8 +25,11 @@ func (p PreReceiveHook) String() string {
 //
 // GitHub API docs: https://developer.github.com/enterprise/2.13/v3/repos/pre_receive_hooks/#list-pre-receive-hooks
 func (s *RepositoriesService) ListPreReceiveHooks(ctx context.Context, owner, repo string, opts *ListOptions) ([]*PreReceiveHook, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pre-receive-hooks", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/pre-receive-hooks", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -53,7 +55,10 @@ func (s *RepositoriesService) ListPreReceiveHooks(ctx context.Context, owner, re
 //
 // GitHub API docs: https://developer.github.com/enterprise/2.13/v3/repos/pre_receive_hooks/#get-a-single-pre-receive-hook
 func (s *RepositoriesService) GetPreReceiveHook(ctx context.Context, owner, repo string, id int64) (*PreReceiveHook, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pre-receive-hooks/%d", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/pre-receive-hooks/%d", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -75,7 +80,10 @@ func (s *RepositoriesService) GetPreReceiveHook(ctx context.Context, owner, repo
 //
 // GitHub API docs: https://developer.github.com/enterprise/2.13/v3/repos/pre_receive_hooks/#update-pre-receive-hook-enforcement
 func (s *RepositoriesService) UpdatePreReceiveHook(ctx context.Context, owner, repo string, id int64, hook *PreReceiveHook) (*PreReceiveHook, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pre-receive-hooks/%d", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/pre-receive-hooks/%d", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, hook)
 	if err != nil {
 		return nil, nil, err
@@ -97,7 +105,10 @@ func (s *RepositoriesService) UpdatePreReceiveHook(ctx context.Context, owner, r
 //
 // GitHub API docs: https://developer.github.com/enterprise/2.13/v3/repos/pre_receive_hooks/#remove-enforcement-overrides-for-a-pre-receive-hook
 func (s *RepositoriesService) DeletePreReceiveHook(ctx context.Context, owner, repo string, id int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/pre-receive-hooks/%d", owner, repo, id)
+	u, err := newURLString("repos/%v/%v/pre-receive-hooks/%d", owner, repo, id)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/repos_projects.go
+++ b/github/repos_projects.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ProjectListOptions specifies the optional parameters to the
@@ -23,8 +22,11 @@ type ProjectListOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/projects#list-repository-projects
 func (s *RepositoriesService) ListProjects(ctx context.Context, owner, repo string, opts *ProjectListOptions) ([]*Project, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/projects", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/projects", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -50,7 +52,10 @@ func (s *RepositoriesService) ListProjects(ctx context.Context, owner, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/projects#create-a-repository-project
 func (s *RepositoriesService) CreateProject(ctx context.Context, owner, repo string, opts *ProjectOptions) (*Project, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/projects", owner, repo)
+	u, err := newURLString("repos/%v/%v/projects", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
 		return nil, nil, err

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"mime"
 	"net/http"
@@ -89,8 +88,11 @@ func (r ReleaseAsset) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/releases/releases#list-releases
 func (s *RepositoriesService) ListReleases(ctx context.Context, owner, repo string, opts *ListOptions) ([]*RepositoryRelease, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/releases", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%s/%s/releases", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -112,7 +114,10 @@ func (s *RepositoriesService) ListReleases(ctx context.Context, owner, repo stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/releases/releases#get-a-release
 func (s *RepositoriesService) GetRelease(ctx context.Context, owner, repo string, id int64) (*RepositoryRelease, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/releases/%d", owner, repo, id)
+	u, err := newURLString("repos/%s/%s/releases/%d", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getSingleRelease(ctx, u)
 }
 
@@ -120,7 +125,10 @@ func (s *RepositoriesService) GetRelease(ctx context.Context, owner, repo string
 //
 // GitHub API docs: https://docs.github.com/en/rest/releases/releases#get-the-latest-release
 func (s *RepositoriesService) GetLatestRelease(ctx context.Context, owner, repo string) (*RepositoryRelease, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/releases/latest", owner, repo)
+	u, err := newURLString("repos/%s/%s/releases/latest", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getSingleRelease(ctx, u)
 }
 
@@ -128,7 +136,10 @@ func (s *RepositoriesService) GetLatestRelease(ctx context.Context, owner, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/releases/releases#get-a-release-by-tag-name
 func (s *RepositoriesService) GetReleaseByTag(ctx context.Context, owner, repo, tag string) (*RepositoryRelease, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/releases/tags/%s", owner, repo, tag)
+	u, err := newURLString("repos/%s/%s/releases/tags/%s", owner, repo, tag)
+	if err != nil {
+		return nil, nil, err
+	}
 	return s.getSingleRelease(ctx, u)
 }
 
@@ -136,7 +147,10 @@ func (s *RepositoriesService) GetReleaseByTag(ctx context.Context, owner, repo, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release
 func (s *RepositoriesService) GenerateReleaseNotes(ctx context.Context, owner, repo string, opts *GenerateNotesOptions) (*RepositoryReleaseNotes, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/releases/generate-notes", owner, repo)
+	u, err := newURLString("repos/%s/%s/releases/generate-notes", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -190,7 +204,10 @@ type repositoryReleaseRequest struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/releases/releases#create-a-release
 func (s *RepositoriesService) CreateRelease(ctx context.Context, owner, repo string, release *RepositoryRelease) (*RepositoryRelease, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/releases", owner, repo)
+	u, err := newURLString("repos/%s/%s/releases", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	releaseReq := &repositoryReleaseRequest{
 		TagName:                release.TagName,
@@ -224,7 +241,10 @@ func (s *RepositoriesService) CreateRelease(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/releases/releases#update-a-release
 func (s *RepositoriesService) EditRelease(ctx context.Context, owner, repo string, id int64, release *RepositoryRelease) (*RepositoryRelease, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/releases/%d", owner, repo, id)
+	u, err := newURLString("repos/%s/%s/releases/%d", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	releaseReq := &repositoryReleaseRequest{
 		TagName:                release.TagName,
@@ -254,7 +274,10 @@ func (s *RepositoriesService) EditRelease(ctx context.Context, owner, repo strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/releases/releases#delete-a-release
 func (s *RepositoriesService) DeleteRelease(ctx context.Context, owner, repo string, id int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/releases/%d", owner, repo, id)
+	u, err := newURLString("repos/%s/%s/releases/%d", owner, repo, id)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -267,8 +290,11 @@ func (s *RepositoriesService) DeleteRelease(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/releases/assets#list-release-assets
 func (s *RepositoriesService) ListReleaseAssets(ctx context.Context, owner, repo string, id int64, opts *ListOptions) ([]*ReleaseAsset, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/releases/%d/assets", owner, repo, id)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%s/%s/releases/%d/assets", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -290,7 +316,10 @@ func (s *RepositoriesService) ListReleaseAssets(ctx context.Context, owner, repo
 //
 // GitHub API docs: https://docs.github.com/en/rest/releases/assets#get-a-release-asset
 func (s *RepositoriesService) GetReleaseAsset(ctx context.Context, owner, repo string, id int64) (*ReleaseAsset, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/releases/assets/%d", owner, repo, id)
+	u, err := newURLString("repos/%s/%s/releases/assets/%d", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -319,7 +348,10 @@ func (s *RepositoriesService) GetReleaseAsset(ctx context.Context, owner, repo s
 //
 // GitHub API docs: https://docs.github.com/en/rest/releases/assets#get-a-release-asset
 func (s *RepositoriesService) DownloadReleaseAsset(ctx context.Context, owner, repo string, id int64, followRedirectsClient *http.Client) (rc io.ReadCloser, redirectURL string, err error) {
-	u := fmt.Sprintf("repos/%s/%s/releases/assets/%d", owner, repo, id)
+	u, err := newURLString("repos/%s/%s/releases/assets/%d", owner, repo, id)
+	if err != nil {
+		return nil, "", err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -381,7 +413,10 @@ func (s *RepositoriesService) downloadReleaseAssetFromURL(ctx context.Context, f
 //
 // GitHub API docs: https://docs.github.com/en/rest/releases/assets#update-a-release-asset
 func (s *RepositoriesService) EditReleaseAsset(ctx context.Context, owner, repo string, id int64, release *ReleaseAsset) (*ReleaseAsset, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/releases/assets/%d", owner, repo, id)
+	u, err := newURLString("repos/%s/%s/releases/assets/%d", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PATCH", u, release)
 	if err != nil {
@@ -400,7 +435,10 @@ func (s *RepositoriesService) EditReleaseAsset(ctx context.Context, owner, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/releases/assets#delete-a-release-asset
 func (s *RepositoriesService) DeleteReleaseAsset(ctx context.Context, owner, repo string, id int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/releases/assets/%d", owner, repo, id)
+	u, err := newURLString("repos/%s/%s/releases/assets/%d", owner, repo, id)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -414,8 +452,11 @@ func (s *RepositoriesService) DeleteReleaseAsset(ctx context.Context, owner, rep
 //
 // GitHub API docs: https://docs.github.com/en/rest/releases/assets#upload-a-release-asset
 func (s *RepositoriesService) UploadReleaseAsset(ctx context.Context, owner, repo string, id int64, opts *UploadOptions, file *os.File) (*ReleaseAsset, *Response, error) {
-	u := fmt.Sprintf("repos/%s/%s/releases/%d/assets", owner, repo, id)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%s/%s/releases/%d/assets", owner, repo, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -351,7 +351,10 @@ type Ruleset struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/rules#get-rules-for-a-branch
 func (s *RepositoriesService) GetRulesForBranch(ctx context.Context, owner, repo, branch string) ([]*RepositoryRule, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/rules/branches/%v", owner, repo, branch)
+	u, err := newURLString("repos/%v/%v/rules/branches/%v", owner, repo, branch)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -372,7 +375,10 @@ func (s *RepositoriesService) GetRulesForBranch(ctx context.Context, owner, repo
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/rules#get-all-repository-rulesets
 func (s *RepositoriesService) GetAllRulesets(ctx context.Context, owner, repo string, includesParents bool) ([]*Ruleset, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/rulesets?includes_parents=%v", owner, repo, includesParents)
+	u, err := newURLString("repos/%v/%v/rulesets?includes_parents=%v", owner, repo, includesParents)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -392,7 +398,10 @@ func (s *RepositoriesService) GetAllRulesets(ctx context.Context, owner, repo st
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/rules#create-a-repository-ruleset
 func (s *RepositoriesService) CreateRuleset(ctx context.Context, owner, repo string, rs *Ruleset) (*Ruleset, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/rulesets", owner, repo)
+	u, err := newURLString("repos/%v/%v/rulesets", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, rs)
 	if err != nil {
@@ -413,7 +422,10 @@ func (s *RepositoriesService) CreateRuleset(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/rules#get-a-repository-ruleset
 func (s *RepositoriesService) GetRuleset(ctx context.Context, owner, repo string, rulesetID int64, includesParents bool) (*Ruleset, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/rulesets/%v?includes_parents=%v", owner, repo, rulesetID, includesParents)
+	u, err := newURLString("repos/%v/%v/rulesets/%v?includes_parents=%v", owner, repo, rulesetID, includesParents)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -433,7 +445,10 @@ func (s *RepositoriesService) GetRuleset(ctx context.Context, owner, repo string
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/rules#update-a-repository-ruleset
 func (s *RepositoriesService) UpdateRuleset(ctx context.Context, owner, repo string, rulesetID int64, rs *Ruleset) (*Ruleset, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/rulesets/%v", owner, repo, rulesetID)
+	u, err := newURLString("repos/%v/%v/rulesets/%v", owner, repo, rulesetID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, rs)
 	if err != nil {
@@ -453,7 +468,10 @@ func (s *RepositoriesService) UpdateRuleset(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/rules#delete-a-repository-ruleset
 func (s *RepositoriesService) DeleteRuleset(ctx context.Context, owner, repo string, rulesetID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/rulesets/%v", owner, repo, rulesetID)
+	u, err := newURLString("repos/%v/%v/rulesets/%v", owner, repo, rulesetID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/repos_stats.go
+++ b/github/repos_stats.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"time"
 )
 
@@ -47,7 +46,10 @@ func (w WeeklyStats) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/metrics/statistics#get-all-contributor-commit-activity
 func (s *RepositoriesService) ListContributorsStats(ctx context.Context, owner, repo string) ([]*ContributorStats, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/stats/contributors", owner, repo)
+	u, err := newURLString("repos/%v/%v/stats/contributors", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -86,7 +88,10 @@ func (w WeeklyCommitActivity) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/metrics/statistics#get-the-last-year-of-commit-activity
 func (s *RepositoriesService) ListCommitActivity(ctx context.Context, owner, repo string) ([]*WeeklyCommitActivity, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/stats/commit_activity", owner, repo)
+	u, err := newURLString("repos/%v/%v/stats/commit_activity", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -113,7 +118,10 @@ func (s *RepositoriesService) ListCommitActivity(ctx context.Context, owner, rep
 //
 // GitHub API docs: https://docs.github.com/en/rest/metrics/statistics#get-the-weekly-commit-activity
 func (s *RepositoriesService) ListCodeFrequency(ctx context.Context, owner, repo string) ([]*WeeklyStats, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/stats/code_frequency", owner, repo)
+	u, err := newURLString("repos/%v/%v/stats/code_frequency", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -169,7 +177,10 @@ func (r RepositoryParticipation) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/metrics/statistics#get-the-weekly-commit-count
 func (s *RepositoriesService) ListParticipation(ctx context.Context, owner, repo string) (*RepositoryParticipation, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/stats/participation", owner, repo)
+	u, err := newURLString("repos/%v/%v/stats/participation", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -202,7 +213,10 @@ type PunchCard struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/metrics/statistics#get-the-hourly-commit-count-for-each-day
 func (s *RepositoriesService) ListPunchCard(ctx context.Context, owner, repo string) ([]*PunchCard, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/stats/punch_card", owner, repo)
+	u, err := newURLString("repos/%v/%v/stats/punch_card", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/repos_statuses.go
+++ b/github/repos_statuses.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // RepoStatus represents the status of a repository at a particular reference.
@@ -47,8 +46,11 @@ func (r RepoStatus) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/commits/statuses#list-commit-statuses-for-a-reference
 func (s *RepositoriesService) ListStatuses(ctx context.Context, owner, repo, ref string, opts *ListOptions) ([]*RepoStatus, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/commits/%v/statuses", owner, repo, refURLEscape(ref))
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/commits/%v/statuses", owner, repo, refURLEscape(ref))
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -72,7 +74,10 @@ func (s *RepositoriesService) ListStatuses(ctx context.Context, owner, repo, ref
 //
 // GitHub API docs: https://docs.github.com/en/rest/commits/statuses#create-a-commit-status
 func (s *RepositoriesService) CreateStatus(ctx context.Context, owner, repo, ref string, status *RepoStatus) (*RepoStatus, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/statuses/%v", owner, repo, refURLEscape(ref))
+	u, err := newURLString("repos/%v/%v/statuses/%v", owner, repo, refURLEscape(ref))
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, status)
 	if err != nil {
 		return nil, nil, err
@@ -111,8 +116,11 @@ func (s CombinedStatus) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/commits/statuses#get-the-combined-status-for-a-specific-reference
 func (s *RepositoriesService) GetCombinedStatus(ctx context.Context, owner, repo, ref string, opts *ListOptions) (*CombinedStatus, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/commits/%v/status", owner, repo, refURLEscape(ref))
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/commits/%v/status", owner, repo, refURLEscape(ref))
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/repos_tags.go
+++ b/github/repos_tags.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // TagProtection represents a repository tag protection.
@@ -26,7 +25,10 @@ type tagProtectionRequest struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/tags#list-tag-protection-states-for-a-repository
 func (s *RepositoriesService) ListTagProtection(ctx context.Context, owner, repo string) ([]*TagProtection, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/tags/protection", owner, repo)
+	u, err := newURLString("repos/%v/%v/tags/protection", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -46,7 +48,10 @@ func (s *RepositoriesService) ListTagProtection(ctx context.Context, owner, repo
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/tags#create-a-tag-protection-state-for-a-repository
 func (s *RepositoriesService) CreateTagProtection(ctx context.Context, owner, repo, pattern string) (*TagProtection, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/tags/protection", owner, repo)
+	u, err := newURLString("repos/%v/%v/tags/protection", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	r := &tagProtectionRequest{Pattern: pattern}
 	req, err := s.client.NewRequest("POST", u, r)
 	if err != nil {
@@ -66,7 +71,10 @@ func (s *RepositoriesService) CreateTagProtection(ctx context.Context, owner, re
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/tags#delete-a-tag-protection-state-for-a-repository
 func (s *RepositoriesService) DeleteTagProtection(ctx context.Context, owner, repo string, tagProtectionID int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/tags/protection/%v", owner, repo, tagProtectionID)
+	u, err := newURLString("repos/%v/%v/tags/protection/%v", owner, repo, tagProtectionID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/repos_traffic.go
+++ b/github/repos_traffic.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // TrafficReferrer represent information about traffic from a referrer .
@@ -56,7 +55,10 @@ type TrafficBreakdownOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/metrics/traffic#get-top-referral-sources
 func (s *RepositoriesService) ListTrafficReferrers(ctx context.Context, owner, repo string) ([]*TrafficReferrer, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/traffic/popular/referrers", owner, repo)
+	u, err := newURLString("repos/%v/%v/traffic/popular/referrers", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -76,7 +78,10 @@ func (s *RepositoriesService) ListTrafficReferrers(ctx context.Context, owner, r
 //
 // GitHub API docs: https://docs.github.com/en/rest/metrics/traffic#get-top-referral-paths
 func (s *RepositoriesService) ListTrafficPaths(ctx context.Context, owner, repo string) ([]*TrafficPath, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/traffic/popular/paths", owner, repo)
+	u, err := newURLString("repos/%v/%v/traffic/popular/paths", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -96,8 +101,11 @@ func (s *RepositoriesService) ListTrafficPaths(ctx context.Context, owner, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/metrics/traffic#get-page-views
 func (s *RepositoriesService) ListTrafficViews(ctx context.Context, owner, repo string, opts *TrafficBreakdownOptions) (*TrafficViews, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/traffic/views", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/traffic/views", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -120,8 +128,11 @@ func (s *RepositoriesService) ListTrafficViews(ctx context.Context, owner, repo 
 //
 // GitHub API docs: https://docs.github.com/en/rest/metrics/traffic#get-repository-clones
 func (s *RepositoriesService) ListTrafficClones(ctx context.Context, owner, repo string, opts *TrafficBreakdownOptions) (*TrafficClones, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/traffic/clones", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/traffic/clones", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/scim.go
+++ b/github/scim.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 )
 
 // SCIMService provides access to SCIM related functions in the
@@ -83,8 +82,11 @@ type ListSCIMProvisionedIdentitiesOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/scim#list-scim-provisioned-identities
 func (s *SCIMService) ListSCIMProvisionedIdentities(ctx context.Context, org string, opts *ListSCIMProvisionedIdentitiesOptions) (*SCIMProvisionedIdentities, *Response, error) {
-	u := fmt.Sprintf("scim/v2/organizations/%v/Users", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("scim/v2/organizations/%v/Users", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -107,8 +109,11 @@ func (s *SCIMService) ListSCIMProvisionedIdentities(ctx context.Context, org str
 //
 // GitHub API docs: https://docs.github.com/en/rest/scim#provision-and-invite-a-scim-user
 func (s *SCIMService) ProvisionAndInviteSCIMUser(ctx context.Context, org string, opts *SCIMUserAttributes) (*Response, error) {
-	u := fmt.Sprintf("scim/v2/organizations/%v/Users", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("scim/v2/organizations/%v/Users", org)
+	if err != nil {
+		return nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +130,10 @@ func (s *SCIMService) ProvisionAndInviteSCIMUser(ctx context.Context, org string
 //
 // GitHub API docs: https://docs.github.com/en/rest/scim#supported-scim-user-attributes
 func (s *SCIMService) GetSCIMProvisioningInfoForUser(ctx context.Context, org, scimUserID string) (*SCIMUserAttributes, *Response, error) {
-	u := fmt.Sprintf("scim/v2/organizations/%v/Users/%v", org, scimUserID)
+	u, err := newURLString("scim/v2/organizations/%v/Users/%v", org, scimUserID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -144,8 +152,11 @@ func (s *SCIMService) GetSCIMProvisioningInfoForUser(ctx context.Context, org, s
 //
 // GitHub API docs: https://docs.github.com/en/rest/scim#update-a-provisioned-organization-membership
 func (s *SCIMService) UpdateProvisionedOrgMembership(ctx context.Context, org, scimUserID string, opts *SCIMUserAttributes) (*Response, error) {
-	u := fmt.Sprintf("scim/v2/organizations/%v/Users/%v", org, scimUserID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("scim/v2/organizations/%v/Users/%v", org, scimUserID)
+	if err != nil {
+		return nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -177,8 +188,11 @@ type UpdateAttributeForSCIMUserOperations struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/scim#update-an-attribute-for-a-scim-user
 func (s *SCIMService) UpdateAttributeForSCIMUser(ctx context.Context, org, scimUserID string, opts *UpdateAttributeForSCIMUserOptions) (*Response, error) {
-	u := fmt.Sprintf("scim/v2/organizations/%v/Users/%v", org, scimUserID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("scim/v2/organizations/%v/Users/%v", org, scimUserID)
+	if err != nil {
+		return nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +209,10 @@ func (s *SCIMService) UpdateAttributeForSCIMUser(ctx context.Context, org, scimU
 //
 // GitHub API docs: https://docs.github.com/en/rest/scim#delete-a-scim-user-from-an-organization
 func (s *SCIMService) DeleteSCIMUserFromOrg(ctx context.Context, org, scimUserID string) (*Response, error) {
-	u := fmt.Sprintf("scim/v2/organizations/%v/Users/%v", org, scimUserID)
+	u, err := newURLString("scim/v2/organizations/%v/Users/%v", org, scimUserID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/search.go
+++ b/github/search.go
@@ -295,7 +295,11 @@ func (s *SearchService) search(ctx context.Context, searchType string, parameter
 		params.Set("repository_id", strconv.FormatInt(*parameters.RepositoryID, 10))
 	}
 	params.Set("q", parameters.Query)
-	u, err := newURLString("search/%s?%s", searchType, params.Encode())
+	u, err := newURLString("search/%s", searchType)
+	if err != nil {
+		return nil, err
+	}
+	u, err = addQueryParams(u, params)
 	if err != nil {
 		return nil, err
 	}

--- a/github/search.go
+++ b/github/search.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -296,7 +295,10 @@ func (s *SearchService) search(ctx context.Context, searchType string, parameter
 		params.Set("repository_id", strconv.FormatInt(*parameters.RepositoryID, 10))
 	}
 	params.Set("q", parameters.Query)
-	u := fmt.Sprintf("search/%s?%s", searchType, params.Encode())
+	u, err := newURLString("search/%s?%s", searchType, params.Encode())
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/secret_scanning.go
+++ b/github/secret_scanning.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // SecretScanningService handles communication with the secret scanning related
@@ -94,8 +93,11 @@ type SecretScanningAlertUpdateOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-server@3.5/rest/secret-scanning#list-secret-scanning-alerts-for-an-enterprise
 func (s *SecretScanningService) ListAlertsForEnterprise(ctx context.Context, enterprise string, opts *SecretScanningAlertListOptions) ([]*SecretScanningAlert, *Response, error) {
-	u := fmt.Sprintf("enterprises/%v/secret-scanning/alerts", enterprise)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("enterprises/%v/secret-scanning/alerts", enterprise)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -121,8 +123,11 @@ func (s *SecretScanningService) ListAlertsForEnterprise(ctx context.Context, ent
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-server@3.5/rest/secret-scanning#list-secret-scanning-alerts-for-an-organization
 func (s *SecretScanningService) ListAlertsForOrg(ctx context.Context, org string, opts *SecretScanningAlertListOptions) ([]*SecretScanningAlert, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/secret-scanning/alerts", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/secret-scanning/alerts", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -148,8 +153,11 @@ func (s *SecretScanningService) ListAlertsForOrg(ctx context.Context, org string
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-server@3.5/rest/secret-scanning#list-secret-scanning-alerts-for-a-repository
 func (s *SecretScanningService) ListAlertsForRepo(ctx context.Context, owner, repo string, opts *SecretScanningAlertListOptions) ([]*SecretScanningAlert, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/secret-scanning/alerts", owner, repo)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/secret-scanning/alerts", owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -175,7 +183,10 @@ func (s *SecretScanningService) ListAlertsForRepo(ctx context.Context, owner, re
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-server@3.5/rest/secret-scanning#get-a-secret-scanning-alert
 func (s *SecretScanningService) GetAlert(ctx context.Context, owner, repo string, number int64) (*SecretScanningAlert, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/secret-scanning/alerts/%v", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/secret-scanning/alerts/%v", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -198,7 +209,10 @@ func (s *SecretScanningService) GetAlert(ctx context.Context, owner, repo string
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-server@3.5/rest/secret-scanning#update-a-secret-scanning-alert
 func (s *SecretScanningService) UpdateAlert(ctx context.Context, owner, repo string, number int64, opts *SecretScanningAlertUpdateOptions) (*SecretScanningAlert, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/secret-scanning/alerts/%v", owner, repo, number)
+	u, err := newURLString("repos/%v/%v/secret-scanning/alerts/%v", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PATCH", u, opts)
 	if err != nil {
@@ -221,8 +235,11 @@ func (s *SecretScanningService) UpdateAlert(ctx context.Context, owner, repo str
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-server@3.5/rest/secret-scanning#list-locations-for-a-secret-scanning-alert
 func (s *SecretScanningService) ListLocationsForAlert(ctx context.Context, owner, repo string, number int64, opts *ListOptions) ([]*SecretScanningAlertLocation, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/secret-scanning/alerts/%v/locations", owner, repo, number)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("repos/%v/%v/secret-scanning/alerts/%v/locations", owner, repo, number)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/security_advisories.go
+++ b/github/security_advisories.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 type SecurityAdvisoriesService service
@@ -17,7 +16,10 @@ type SecurityAdvisoriesService service
 //
 // GitHub API docs: https://docs.github.com/en/rest/security-advisories/repository-advisories#request-a-cve-for-a-repository-security-advisory
 func (s *SecurityAdvisoriesService) RequestCVE(ctx context.Context, owner, repo, ghsaID string) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/security-advisories/%v/cve", owner, repo, ghsaID)
+	url, err := newURLString("repos/%v/%v/security-advisories/%v/cve", owner, repo, ghsaID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", url, nil)
 	if err != nil {

--- a/github/teams.go
+++ b/github/teams.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 )
@@ -83,8 +82,11 @@ func (i Invitation) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#list-teams
 func (s *TeamsService) ListTeams(ctx context.Context, org string, opts *ListOptions) ([]*Team, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/teams", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -107,7 +109,10 @@ func (s *TeamsService) ListTeams(ctx context.Context, org string, opts *ListOpti
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#get-a-team-by-name
 func (s *TeamsService) GetTeamByID(ctx context.Context, orgID, teamID int64) (*Team, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v", orgID, teamID)
+	u, err := newURLString("organizations/%v/team/%v", orgID, teamID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -126,7 +131,10 @@ func (s *TeamsService) GetTeamByID(ctx context.Context, orgID, teamID int64) (*T
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#get-a-team-by-name
 func (s *TeamsService) GetTeamBySlug(ctx context.Context, org, slug string) (*Team, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v", org, slug)
+	u, err := newURLString("orgs/%v/teams/%v", org, slug)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -176,7 +184,10 @@ func (s NewTeam) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#create-a-team
 func (s *TeamsService) CreateTeam(ctx context.Context, org string, team NewTeam) (*Team, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams", org)
+	u, err := newURLString("orgs/%v/teams", org)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, team)
 	if err != nil {
 		return nil, nil, err
@@ -222,10 +233,12 @@ func copyNewTeamWithoutParent(team *NewTeam) *newTeamNoParent {
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#update-a-team
 func (s *TeamsService) EditTeamByID(ctx context.Context, orgID, teamID int64, team NewTeam, removeParent bool) (*Team, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v", orgID, teamID)
+	u, err := newURLString("organizations/%v/team/%v", orgID, teamID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	var req *http.Request
-	var err error
 	if removeParent {
 		teamRemoveParent := copyNewTeamWithoutParent(&team)
 		req, err = s.client.NewRequest("PATCH", u, teamRemoveParent)
@@ -249,10 +262,12 @@ func (s *TeamsService) EditTeamByID(ctx context.Context, orgID, teamID int64, te
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#update-a-team
 func (s *TeamsService) EditTeamBySlug(ctx context.Context, org, slug string, team NewTeam, removeParent bool) (*Team, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v", org, slug)
+	u, err := newURLString("orgs/%v/teams/%v", org, slug)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	var req *http.Request
-	var err error
 	if removeParent {
 		teamRemoveParent := copyNewTeamWithoutParent(&team)
 		req, err = s.client.NewRequest("PATCH", u, teamRemoveParent)
@@ -276,7 +291,10 @@ func (s *TeamsService) EditTeamBySlug(ctx context.Context, org, slug string, tea
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#delete-a-team
 func (s *TeamsService) DeleteTeamByID(ctx context.Context, orgID, teamID int64) (*Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v", orgID, teamID)
+	u, err := newURLString("organizations/%v/team/%v", orgID, teamID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -289,7 +307,10 @@ func (s *TeamsService) DeleteTeamByID(ctx context.Context, orgID, teamID int64) 
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#delete-a-team
 func (s *TeamsService) DeleteTeamBySlug(ctx context.Context, org, slug string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v", org, slug)
+	u, err := newURLString("orgs/%v/teams/%v", org, slug)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -302,8 +323,11 @@ func (s *TeamsService) DeleteTeamBySlug(ctx context.Context, org, slug string) (
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#list-child-teams
 func (s *TeamsService) ListChildTeamsByParentID(ctx context.Context, orgID, teamID int64, opts *ListOptions) ([]*Team, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/teams", orgID, teamID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("organizations/%v/team/%v/teams", orgID, teamID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -326,8 +350,11 @@ func (s *TeamsService) ListChildTeamsByParentID(ctx context.Context, orgID, team
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#list-child-teams
 func (s *TeamsService) ListChildTeamsByParentSlug(ctx context.Context, org, slug string, opts *ListOptions) ([]*Team, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/teams", org, slug)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/teams/%v/teams", org, slug)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -350,8 +377,11 @@ func (s *TeamsService) ListChildTeamsByParentSlug(ctx context.Context, org, slug
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#list-team-repositories
 func (s *TeamsService) ListTeamReposByID(ctx context.Context, orgID, teamID int64, opts *ListOptions) ([]*Repository, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/repos", orgID, teamID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("organizations/%v/team/%v/repos", orgID, teamID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -378,8 +408,11 @@ func (s *TeamsService) ListTeamReposByID(ctx context.Context, orgID, teamID int6
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#list-team-repositories
 func (s *TeamsService) ListTeamReposBySlug(ctx context.Context, org, slug string, opts *ListOptions) ([]*Repository, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/repos", org, slug)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/teams/%v/repos", org, slug)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -408,7 +441,10 @@ func (s *TeamsService) ListTeamReposBySlug(ctx context.Context, org, slug string
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#check-team-permissions-for-a-repository
 func (s *TeamsService) IsTeamRepoByID(ctx context.Context, orgID, teamID int64, owner, repo string) (*Repository, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/repos/%v/%v", orgID, teamID, owner, repo)
+	u, err := newURLString("organizations/%v/team/%v/repos/%v/%v", orgID, teamID, owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -432,7 +468,10 @@ func (s *TeamsService) IsTeamRepoByID(ctx context.Context, orgID, teamID int64, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#check-team-permissions-for-a-repository
 func (s *TeamsService) IsTeamRepoBySlug(ctx context.Context, org, slug, owner, repo string) (*Repository, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/repos/%v/%v", org, slug, owner, repo)
+	u, err := newURLString("orgs/%v/teams/%v/repos/%v/%v", org, slug, owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -471,7 +510,10 @@ type TeamAddTeamRepoOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#add-or-update-team-repository-permissions
 func (s *TeamsService) AddTeamRepoByID(ctx context.Context, orgID, teamID int64, owner, repo string, opts *TeamAddTeamRepoOptions) (*Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/repos/%v/%v", orgID, teamID, owner, repo)
+	u, err := newURLString("organizations/%v/team/%v/repos/%v/%v", orgID, teamID, owner, repo)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, err
@@ -486,7 +528,10 @@ func (s *TeamsService) AddTeamRepoByID(ctx context.Context, orgID, teamID int64,
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#add-or-update-team-repository-permissions
 func (s *TeamsService) AddTeamRepoBySlug(ctx context.Context, org, slug, owner, repo string, opts *TeamAddTeamRepoOptions) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/repos/%v/%v", org, slug, owner, repo)
+	u, err := newURLString("orgs/%v/teams/%v/repos/%v/%v", org, slug, owner, repo)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, err
@@ -501,7 +546,10 @@ func (s *TeamsService) AddTeamRepoBySlug(ctx context.Context, org, slug, owner, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#remove-a-repository-from-a-team
 func (s *TeamsService) RemoveTeamRepoByID(ctx context.Context, orgID, teamID int64, owner, repo string) (*Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/repos/%v/%v", orgID, teamID, owner, repo)
+	u, err := newURLString("organizations/%v/team/%v/repos/%v/%v", orgID, teamID, owner, repo)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -516,7 +564,10 @@ func (s *TeamsService) RemoveTeamRepoByID(ctx context.Context, orgID, teamID int
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#remove-a-repository-from-a-team
 func (s *TeamsService) RemoveTeamRepoBySlug(ctx context.Context, org, slug, owner, repo string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/repos/%v/%v", org, slug, owner, repo)
+	u, err := newURLString("orgs/%v/teams/%v/repos/%v/%v", org, slug, owner, repo)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -528,8 +579,11 @@ func (s *TeamsService) RemoveTeamRepoBySlug(ctx context.Context, org, slug, owne
 // ListUserTeams lists a user's teams
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#list-teams-for-the-authenticated-user
 func (s *TeamsService) ListUserTeams(ctx context.Context, opts *ListOptions) ([]*Team, *Response, error) {
-	u := "user/teams"
-	u, err := addOptions(u, opts)
+	u, err := newURLString("user/teams")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -552,7 +606,10 @@ func (s *TeamsService) ListUserTeams(ctx context.Context, opts *ListOptions) ([]
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#list-team-projects
 func (s *TeamsService) ListTeamProjectsByID(ctx context.Context, orgID, teamID int64) ([]*Project, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/projects", orgID, teamID)
+	u, err := newURLString("organizations/%v/team/%v/projects", orgID, teamID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -576,7 +633,10 @@ func (s *TeamsService) ListTeamProjectsByID(ctx context.Context, orgID, teamID i
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#list-team-projects
 func (s *TeamsService) ListTeamProjectsBySlug(ctx context.Context, org, slug string) ([]*Project, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/projects", org, slug)
+	u, err := newURLString("orgs/%v/teams/%v/projects", org, slug)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -601,7 +661,10 @@ func (s *TeamsService) ListTeamProjectsBySlug(ctx context.Context, org, slug str
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#check-team-permissions-for-a-project
 func (s *TeamsService) ReviewTeamProjectsByID(ctx context.Context, orgID, teamID, projectID int64) (*Project, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/projects/%v", orgID, teamID, projectID)
+	u, err := newURLString("organizations/%v/team/%v/projects/%v", orgID, teamID, projectID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -625,7 +688,10 @@ func (s *TeamsService) ReviewTeamProjectsByID(ctx context.Context, orgID, teamID
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#check-team-permissions-for-a-project
 func (s *TeamsService) ReviewTeamProjectsBySlug(ctx context.Context, org, slug string, projectID int64) (*Project, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/projects/%v", org, slug, projectID)
+	u, err := newURLString("orgs/%v/teams/%v/projects/%v", org, slug, projectID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -662,7 +728,10 @@ type TeamProjectOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#add-or-update-team-project-permissions
 func (s *TeamsService) AddTeamProjectByID(ctx context.Context, orgID, teamID, projectID int64, opts *TeamProjectOptions) (*Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/projects/%v", orgID, teamID, projectID)
+	u, err := newURLString("organizations/%v/team/%v/projects/%v", orgID, teamID, projectID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, err
@@ -681,7 +750,10 @@ func (s *TeamsService) AddTeamProjectByID(ctx context.Context, orgID, teamID, pr
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#add-or-update-team-project-permissions
 func (s *TeamsService) AddTeamProjectBySlug(ctx context.Context, org, slug string, projectID int64, opts *TeamProjectOptions) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/projects/%v", org, slug, projectID)
+	u, err := newURLString("orgs/%v/teams/%v/projects/%v", org, slug, projectID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, err
@@ -703,7 +775,10 @@ func (s *TeamsService) AddTeamProjectBySlug(ctx context.Context, org, slug strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#remove-a-project-from-a-team
 func (s *TeamsService) RemoveTeamProjectByID(ctx context.Context, orgID, teamID, projectID int64) (*Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/projects/%v", orgID, teamID, projectID)
+	u, err := newURLString("organizations/%v/team/%v/projects/%v", orgID, teamID, projectID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -725,7 +800,10 @@ func (s *TeamsService) RemoveTeamProjectByID(ctx context.Context, orgID, teamID,
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/teams#remove-a-project-from-a-team
 func (s *TeamsService) RemoveTeamProjectBySlug(ctx context.Context, org, slug string, projectID int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/projects/%v", org, slug, projectID)
+	u, err := newURLString("orgs/%v/teams/%v/projects/%v", org, slug, projectID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -754,8 +832,11 @@ type IDPGroup struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/team-sync#list-idp-groups-for-an-organization
 func (s *TeamsService) ListIDPGroupsInOrganization(ctx context.Context, org string, opts *ListCursorOptions) (*IDPGroupList, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/team-sync/groups", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/team-sync/groups", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -779,7 +860,10 @@ func (s *TeamsService) ListIDPGroupsInOrganization(ctx context.Context, org stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/team-sync#list-idp-groups-for-a-team
 func (s *TeamsService) ListIDPGroupsForTeamByID(ctx context.Context, orgID, teamID int64) (*IDPGroupList, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/team-sync/group-mappings", orgID, teamID)
+	u, err := newURLString("organizations/%v/team/%v/team-sync/group-mappings", orgID, teamID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -800,7 +884,10 @@ func (s *TeamsService) ListIDPGroupsForTeamByID(ctx context.Context, orgID, team
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/team-sync#list-idp-groups-for-a-team
 func (s *TeamsService) ListIDPGroupsForTeamBySlug(ctx context.Context, org, slug string) (*IDPGroupList, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/team-sync/group-mappings", org, slug)
+	u, err := newURLString("orgs/%v/teams/%v/team-sync/group-mappings", org, slug)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -821,7 +908,10 @@ func (s *TeamsService) ListIDPGroupsForTeamBySlug(ctx context.Context, org, slug
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/team-sync#create-or-update-idp-group-connections
 func (s *TeamsService) CreateOrUpdateIDPGroupConnectionsByID(ctx context.Context, orgID, teamID int64, opts IDPGroupList) (*IDPGroupList, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/team-sync/group-mappings", orgID, teamID)
+	u, err := newURLString("organizations/%v/team/%v/team-sync/group-mappings", orgID, teamID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PATCH", u, opts)
 	if err != nil {
@@ -842,7 +932,10 @@ func (s *TeamsService) CreateOrUpdateIDPGroupConnectionsByID(ctx context.Context
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/team-sync#create-or-update-idp-group-connections
 func (s *TeamsService) CreateOrUpdateIDPGroupConnectionsBySlug(ctx context.Context, org, slug string, opts IDPGroupList) (*IDPGroupList, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/team-sync/group-mappings", org, slug)
+	u, err := newURLString("orgs/%v/teams/%v/team-sync/group-mappings", org, slug)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PATCH", u, opts)
 	if err != nil {
@@ -890,7 +983,10 @@ type ExternalGroupList struct {
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/teams/external-groups#get-an-external-group
 func (s *TeamsService) GetExternalGroup(ctx context.Context, org string, groupID int64) (*ExternalGroup, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/external-group/%v", org, groupID)
+	u, err := newURLString("orgs/%v/external-group/%v", org, groupID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -917,8 +1013,11 @@ type ListExternalGroupsOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/teams/external-groups#list-external-groups-in-an-organization
 func (s *TeamsService) ListExternalGroups(ctx context.Context, org string, opts *ListExternalGroupsOptions) (*ExternalGroupList, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/external-groups", org)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/external-groups", org)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -941,7 +1040,10 @@ func (s *TeamsService) ListExternalGroups(ctx context.Context, org string, opts 
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/teams/external-groups#list-a-connection-between-an-external-group-and-a-team
 func (s *TeamsService) ListExternalGroupsForTeamBySlug(ctx context.Context, org, slug string) (*ExternalGroupList, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/external-groups", org, slug)
+	u, err := newURLString("orgs/%v/teams/%v/external-groups", org, slug)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -961,7 +1063,10 @@ func (s *TeamsService) ListExternalGroupsForTeamBySlug(ctx context.Context, org,
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/teams/external-groups#update-the-connection-between-an-external-group-and-a-team
 func (s *TeamsService) UpdateConnectedExternalGroup(ctx context.Context, org, slug string, eg *ExternalGroup) (*ExternalGroup, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/external-groups", org, slug)
+	u, err := newURLString("orgs/%v/teams/%v/external-groups", org, slug)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("PATCH", u, eg)
 	if err != nil {
@@ -981,7 +1086,10 @@ func (s *TeamsService) UpdateConnectedExternalGroup(ctx context.Context, org, sl
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/teams/external-groups#remove-the-connection-between-an-external-group-and-a-team
 func (s *TeamsService) RemoveConnectedExternalGroup(ctx context.Context, org, slug string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/external-groups", org, slug)
+	u, err := newURLString("orgs/%v/teams/%v/external-groups", org, slug)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/teams_discussion_comments.go
+++ b/github/teams_discussion_comments.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // DiscussionComment represents a GitHub dicussion in a team.
@@ -45,8 +44,11 @@ type DiscussionCommentListOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussion-comments#list-discussion-comments
 func (s *TeamsService) ListCommentsByID(ctx context.Context, orgID, teamID int64, discussionNumber int, options *DiscussionCommentListOptions) ([]*DiscussionComment, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/comments", orgID, teamID, discussionNumber)
-	u, err := addOptions(u, options)
+	u, err := newURLString("organizations/%v/team/%v/discussions/%v/comments", orgID, teamID, discussionNumber)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -70,8 +72,11 @@ func (s *TeamsService) ListCommentsByID(ctx context.Context, orgID, teamID int64
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussion-comments#list-discussion-comments
 func (s *TeamsService) ListCommentsBySlug(ctx context.Context, org, slug string, discussionNumber int, options *DiscussionCommentListOptions) ([]*DiscussionComment, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments", org, slug, discussionNumber)
-	u, err := addOptions(u, options)
+	u, err := newURLString("orgs/%v/teams/%v/discussions/%v/comments", org, slug, discussionNumber)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -95,7 +100,10 @@ func (s *TeamsService) ListCommentsBySlug(ctx context.Context, org, slug string,
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussion-comments#get-a-discussion-comment
 func (s *TeamsService) GetCommentByID(ctx context.Context, orgID, teamID int64, discussionNumber, commentNumber int) (*DiscussionComment, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/comments/%v", orgID, teamID, discussionNumber, commentNumber)
+	u, err := newURLString("organizations/%v/team/%v/discussions/%v/comments/%v", orgID, teamID, discussionNumber, commentNumber)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -115,7 +123,10 @@ func (s *TeamsService) GetCommentByID(ctx context.Context, orgID, teamID int64, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussion-comments#get-a-discussion-comment
 func (s *TeamsService) GetCommentBySlug(ctx context.Context, org, slug string, discussionNumber, commentNumber int) (*DiscussionComment, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments/%v", org, slug, discussionNumber, commentNumber)
+	u, err := newURLString("orgs/%v/teams/%v/discussions/%v/comments/%v", org, slug, discussionNumber, commentNumber)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -136,7 +147,10 @@ func (s *TeamsService) GetCommentBySlug(ctx context.Context, org, slug string, d
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussion-comments#create-a-discussion-comment
 func (s *TeamsService) CreateCommentByID(ctx context.Context, orgID, teamID int64, discsusionNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/comments", orgID, teamID, discsusionNumber)
+	u, err := newURLString("organizations/%v/team/%v/discussions/%v/comments", orgID, teamID, discsusionNumber)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -156,7 +170,10 @@ func (s *TeamsService) CreateCommentByID(ctx context.Context, orgID, teamID int6
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussion-comments#create-a-discussion-comment
 func (s *TeamsService) CreateCommentBySlug(ctx context.Context, org, slug string, discsusionNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments", org, slug, discsusionNumber)
+	u, err := newURLString("orgs/%v/teams/%v/discussions/%v/comments", org, slug, discsusionNumber)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -177,7 +194,10 @@ func (s *TeamsService) CreateCommentBySlug(ctx context.Context, org, slug string
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussion-comments#update-a-discussion-comment
 func (s *TeamsService) EditCommentByID(ctx context.Context, orgID, teamID int64, discussionNumber, commentNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/comments/%v", orgID, teamID, discussionNumber, commentNumber)
+	u, err := newURLString("organizations/%v/team/%v/discussions/%v/comments/%v", orgID, teamID, discussionNumber, commentNumber)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -198,7 +218,10 @@ func (s *TeamsService) EditCommentByID(ctx context.Context, orgID, teamID int64,
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussion-comments#update-a-discussion-comment
 func (s *TeamsService) EditCommentBySlug(ctx context.Context, org, slug string, discussionNumber, commentNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments/%v", org, slug, discussionNumber, commentNumber)
+	u, err := newURLString("orgs/%v/teams/%v/discussions/%v/comments/%v", org, slug, discussionNumber, commentNumber)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
@@ -218,7 +241,10 @@ func (s *TeamsService) EditCommentBySlug(ctx context.Context, org, slug string, 
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussion-comments#delete-a-discussion-comment
 func (s *TeamsService) DeleteCommentByID(ctx context.Context, orgID, teamID int64, discussionNumber, commentNumber int) (*Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/comments/%v", orgID, teamID, discussionNumber, commentNumber)
+	u, err := newURLString("organizations/%v/team/%v/discussions/%v/comments/%v", orgID, teamID, discussionNumber, commentNumber)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -232,7 +258,10 @@ func (s *TeamsService) DeleteCommentByID(ctx context.Context, orgID, teamID int6
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussion-comments#delete-a-discussion-comment
 func (s *TeamsService) DeleteCommentBySlug(ctx context.Context, org, slug string, discussionNumber, commentNumber int) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments/%v", org, slug, discussionNumber, commentNumber)
+	u, err := newURLString("orgs/%v/teams/%v/discussions/%v/comments/%v", org, slug, discussionNumber, commentNumber)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/teams_discussions.go
+++ b/github/teams_discussions.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // TeamDiscussion represents a GitHub dicussion in a team.
@@ -51,8 +50,11 @@ type DiscussionListOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussions#list-discussions
 func (s *TeamsService) ListDiscussionsByID(ctx context.Context, orgID, teamID int64, opts *DiscussionListOptions) ([]*TeamDiscussion, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/discussions", orgID, teamID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("organizations/%v/team/%v/discussions", orgID, teamID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -76,8 +78,11 @@ func (s *TeamsService) ListDiscussionsByID(ctx context.Context, orgID, teamID in
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussions#list-discussions
 func (s *TeamsService) ListDiscussionsBySlug(ctx context.Context, org, slug string, opts *DiscussionListOptions) ([]*TeamDiscussion, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/discussions", org, slug)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/teams/%v/discussions", org, slug)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -101,7 +106,10 @@ func (s *TeamsService) ListDiscussionsBySlug(ctx context.Context, org, slug stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussions#get-a-discussion
 func (s *TeamsService) GetDiscussionByID(ctx context.Context, orgID, teamID int64, discussionNumber int) (*TeamDiscussion, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v", orgID, teamID, discussionNumber)
+	u, err := newURLString("organizations/%v/team/%v/discussions/%v", orgID, teamID, discussionNumber)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -121,7 +129,10 @@ func (s *TeamsService) GetDiscussionByID(ctx context.Context, orgID, teamID int6
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussions#get-a-discussion
 func (s *TeamsService) GetDiscussionBySlug(ctx context.Context, org, slug string, discussionNumber int) (*TeamDiscussion, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v", org, slug, discussionNumber)
+	u, err := newURLString("orgs/%v/teams/%v/discussions/%v", org, slug, discussionNumber)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -141,7 +152,10 @@ func (s *TeamsService) GetDiscussionBySlug(ctx context.Context, org, slug string
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussions#create-a-discussion
 func (s *TeamsService) CreateDiscussionByID(ctx context.Context, orgID, teamID int64, discussion TeamDiscussion) (*TeamDiscussion, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/discussions", orgID, teamID)
+	u, err := newURLString("organizations/%v/team/%v/discussions", orgID, teamID)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, discussion)
 	if err != nil {
 		return nil, nil, err
@@ -161,7 +175,10 @@ func (s *TeamsService) CreateDiscussionByID(ctx context.Context, orgID, teamID i
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussions#create-a-discussion
 func (s *TeamsService) CreateDiscussionBySlug(ctx context.Context, org, slug string, discussion TeamDiscussion) (*TeamDiscussion, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/discussions", org, slug)
+	u, err := newURLString("orgs/%v/teams/%v/discussions", org, slug)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, discussion)
 	if err != nil {
 		return nil, nil, err
@@ -182,7 +199,10 @@ func (s *TeamsService) CreateDiscussionBySlug(ctx context.Context, org, slug str
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussions#update-a-discussion
 func (s *TeamsService) EditDiscussionByID(ctx context.Context, orgID, teamID int64, discussionNumber int, discussion TeamDiscussion) (*TeamDiscussion, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v", orgID, teamID, discussionNumber)
+	u, err := newURLString("organizations/%v/team/%v/discussions/%v", orgID, teamID, discussionNumber)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, discussion)
 	if err != nil {
 		return nil, nil, err
@@ -203,7 +223,10 @@ func (s *TeamsService) EditDiscussionByID(ctx context.Context, orgID, teamID int
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussions#update-a-discussion
 func (s *TeamsService) EditDiscussionBySlug(ctx context.Context, org, slug string, discussionNumber int, discussion TeamDiscussion) (*TeamDiscussion, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v", org, slug, discussionNumber)
+	u, err := newURLString("orgs/%v/teams/%v/discussions/%v", org, slug, discussionNumber)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, discussion)
 	if err != nil {
 		return nil, nil, err
@@ -223,7 +246,10 @@ func (s *TeamsService) EditDiscussionBySlug(ctx context.Context, org, slug strin
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussions#delete-a-discussion
 func (s *TeamsService) DeleteDiscussionByID(ctx context.Context, orgID, teamID int64, discussionNumber int) (*Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v", orgID, teamID, discussionNumber)
+	u, err := newURLString("organizations/%v/team/%v/discussions/%v", orgID, teamID, discussionNumber)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -237,7 +263,10 @@ func (s *TeamsService) DeleteDiscussionByID(ctx context.Context, orgID, teamID i
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/discussions#delete-a-discussion
 func (s *TeamsService) DeleteDiscussionBySlug(ctx context.Context, org, slug string, discussionNumber int) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v", org, slug, discussionNumber)
+	u, err := newURLString("orgs/%v/teams/%v/discussions/%v", org, slug, discussionNumber)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/teams_members.go
+++ b/github/teams_members.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // TeamListTeamMembersOptions specifies the optional parameters to the
@@ -25,8 +24,11 @@ type TeamListTeamMembersOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/members#list-team-members
 func (s *TeamsService) ListTeamMembersByID(ctx context.Context, orgID, teamID int64, opts *TeamListTeamMembersOptions) ([]*User, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/members", orgID, teamID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("organizations/%v/team/%v/members", orgID, teamID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -50,8 +52,11 @@ func (s *TeamsService) ListTeamMembersByID(ctx context.Context, orgID, teamID in
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/members#list-team-members
 func (s *TeamsService) ListTeamMembersBySlug(ctx context.Context, org, slug string, opts *TeamListTeamMembersOptions) ([]*User, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/members", org, slug)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/teams/%v/members", org, slug)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,7 +80,10 @@ func (s *TeamsService) ListTeamMembersBySlug(ctx context.Context, org, slug stri
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/members#list-team-members
 func (s *TeamsService) GetTeamMembershipByID(ctx context.Context, orgID, teamID int64, user string) (*Membership, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/memberships/%v", orgID, teamID, user)
+	u, err := newURLString("organizations/%v/team/%v/memberships/%v", orgID, teamID, user)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -95,7 +103,10 @@ func (s *TeamsService) GetTeamMembershipByID(ctx context.Context, orgID, teamID 
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/members#get-team-membership-for-a-user
 func (s *TeamsService) GetTeamMembershipBySlug(ctx context.Context, org, slug, user string) (*Membership, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/memberships/%v", org, slug, user)
+	u, err := newURLString("orgs/%v/teams/%v/memberships/%v", org, slug, user)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -129,7 +140,10 @@ type TeamAddTeamMembershipOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/members#add-or-update-team-membership-for-a-user
 func (s *TeamsService) AddTeamMembershipByID(ctx context.Context, orgID, teamID int64, user string, opts *TeamAddTeamMembershipOptions) (*Membership, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/memberships/%v", orgID, teamID, user)
+	u, err := newURLString("organizations/%v/team/%v/memberships/%v", orgID, teamID, user)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -149,7 +163,10 @@ func (s *TeamsService) AddTeamMembershipByID(ctx context.Context, orgID, teamID 
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/members#add-or-update-team-membership-for-a-user
 func (s *TeamsService) AddTeamMembershipBySlug(ctx context.Context, org, slug, user string, opts *TeamAddTeamMembershipOptions) (*Membership, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/memberships/%v", org, slug, user)
+	u, err := newURLString("orgs/%v/teams/%v/memberships/%v", org, slug, user)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -169,7 +186,10 @@ func (s *TeamsService) AddTeamMembershipBySlug(ctx context.Context, org, slug, u
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/members#remove-team-membership-for-a-user
 func (s *TeamsService) RemoveTeamMembershipByID(ctx context.Context, orgID, teamID int64, user string) (*Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/memberships/%v", orgID, teamID, user)
+	u, err := newURLString("organizations/%v/team/%v/memberships/%v", orgID, teamID, user)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -183,7 +203,10 @@ func (s *TeamsService) RemoveTeamMembershipByID(ctx context.Context, orgID, team
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/members#remove-team-membership-for-a-user
 func (s *TeamsService) RemoveTeamMembershipBySlug(ctx context.Context, org, slug, user string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/memberships/%v", org, slug, user)
+	u, err := newURLString("orgs/%v/teams/%v/memberships/%v", org, slug, user)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -197,8 +220,11 @@ func (s *TeamsService) RemoveTeamMembershipBySlug(ctx context.Context, org, slug
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/members#list-pending-team-invitations
 func (s *TeamsService) ListPendingTeamInvitationsByID(ctx context.Context, orgID, teamID int64, opts *ListOptions) ([]*Invitation, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/team/%v/invitations", orgID, teamID)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("organizations/%v/team/%v/invitations", orgID, teamID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -222,8 +248,11 @@ func (s *TeamsService) ListPendingTeamInvitationsByID(ctx context.Context, orgID
 //
 // GitHub API docs: https://docs.github.com/en/rest/teams/members#list-pending-team-invitations
 func (s *TeamsService) ListPendingTeamInvitationsBySlug(ctx context.Context, org, slug string, opts *ListOptions) ([]*Invitation, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/invitations", org, slug)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("orgs/%v/teams/%v/invitations", org, slug)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/users.go
+++ b/github/users.go
@@ -214,7 +214,11 @@ type UserListOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/users#list-users
 func (s *UsersService) ListAll(ctx context.Context, opts *UserListOptions) ([]*User, *Response, error) {
-	u, err := addOptions("users", opts)
+	u, err := newURLString("users")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -238,7 +242,11 @@ func (s *UsersService) ListAll(ctx context.Context, opts *UserListOptions) ([]*U
 //
 // GitHub API docs: https://docs.github.com/en/rest/collaborators/invitations#list-repository-invitations-for-the-authenticated-user
 func (s *UsersService) ListInvitations(ctx context.Context, opts *ListOptions) ([]*RepositoryInvitation, *Response, error) {
-	u, err := addOptions("user/repository_invitations", opts)
+	u, err := newURLString("user/repository_invitations")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/users.go
+++ b/github/users.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // UsersService handles communication with the user related
@@ -83,10 +82,14 @@ func (u User) String() string {
 // GitHub API docs: https://docs.github.com/en/rest/users/users#get-a-user
 func (s *UsersService) Get(ctx context.Context, user string) (*User, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v", user)
+		u, err = newURLString("users/%v", user)
 	} else {
-		u = "user"
+		u, err = newURLString("user")
+	}
+	if err != nil {
+		return nil, nil, err
 	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/users.go
+++ b/github/users.go
@@ -106,7 +106,10 @@ func (s *UsersService) Get(ctx context.Context, user string) (*User, *Response, 
 //
 // Note: GetByID uses the undocumented GitHub API endpoint /user/:id.
 func (s *UsersService) GetByID(ctx context.Context, id int64) (*User, *Response, error) {
-	u := fmt.Sprintf("user/%d", id)
+	u, err := newURLString("user/%d", id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -125,7 +128,10 @@ func (s *UsersService) GetByID(ctx context.Context, id int64) (*User, *Response,
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/users#update-the-authenticated-user
 func (s *UsersService) Edit(ctx context.Context, user *User) (*User, *Response, error) {
-	u := "user"
+	u, err := newURLString("user")
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, user)
 	if err != nil {
 		return nil, nil, err
@@ -167,8 +173,11 @@ type UserContext struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/users#get-contextual-information-for-a-user
 func (s *UsersService) GetHovercard(ctx context.Context, user string, opts *HovercardOptions) (*Hovercard, *Response, error) {
-	u := fmt.Sprintf("users/%v/hovercard", user)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("users/%v/hovercard", user)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -253,7 +262,10 @@ func (s *UsersService) ListInvitations(ctx context.Context, opts *ListOptions) (
 //
 // GitHub API docs: https://docs.github.com/en/rest/collaborators/invitations#accept-a-repository-invitation
 func (s *UsersService) AcceptInvitation(ctx context.Context, invitationID int64) (*Response, error) {
-	u := fmt.Sprintf("user/repository_invitations/%v", invitationID)
+	u, err := newURLString("user/repository_invitations/%v", invitationID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PATCH", u, nil)
 	if err != nil {
 		return nil, err
@@ -267,7 +279,10 @@ func (s *UsersService) AcceptInvitation(ctx context.Context, invitationID int64)
 //
 // GitHub API docs: https://docs.github.com/en/rest/collaborators/invitations#decline-a-repository-invitation
 func (s *UsersService) DeclineInvitation(ctx context.Context, invitationID int64) (*Response, error) {
-	u := fmt.Sprintf("user/repository_invitations/%v", invitationID)
+	u, err := newURLString("user/repository_invitations/%v", invitationID)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/users_administration.go
+++ b/github/users_administration.go
@@ -7,14 +7,16 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // PromoteSiteAdmin promotes a user to a site administrator of a GitHub Enterprise instance.
 //
 // GitHub API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#promote-an-ordinary-user-to-a-site-administrator
 func (s *UsersService) PromoteSiteAdmin(ctx context.Context, user string) (*Response, error) {
-	u := fmt.Sprintf("users/%v/site_admin", user)
+	u, err := newURLString("users/%v/site_admin", user)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
@@ -28,7 +30,10 @@ func (s *UsersService) PromoteSiteAdmin(ctx context.Context, user string) (*Resp
 //
 // GitHub API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#demote-a-site-administrator-to-an-ordinary-user
 func (s *UsersService) DemoteSiteAdmin(ctx context.Context, user string) (*Response, error) {
-	u := fmt.Sprintf("users/%v/site_admin", user)
+	u, err := newURLString("users/%v/site_admin", user)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -47,7 +52,10 @@ type UserSuspendOptions struct {
 //
 // GitHub API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#suspend-a-user
 func (s *UsersService) Suspend(ctx context.Context, user string, opts *UserSuspendOptions) (*Response, error) {
-	u := fmt.Sprintf("users/%v/suspended", user)
+	u, err := newURLString("users/%v/suspended", user)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
@@ -61,7 +69,10 @@ func (s *UsersService) Suspend(ctx context.Context, user string, opts *UserSuspe
 //
 // GitHub API docs: https://developer.github.com/enterprise/v3/enterprise-admin/users/#unsuspend-a-user
 func (s *UsersService) Unsuspend(ctx context.Context, user string) (*Response, error) {
-	u := fmt.Sprintf("users/%v/suspended", user)
+	u, err := newURLString("users/%v/suspended", user)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/users_blocking.go
+++ b/github/users_blocking.go
@@ -7,15 +7,17 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ListBlockedUsers lists all the blocked users by the authenticated user.
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/blocking#list-users-blocked-by-the-authenticated-user
 func (s *UsersService) ListBlockedUsers(ctx context.Context, opts *ListOptions) ([]*User, *Response, error) {
-	u := "user/blocks"
-	u, err := addOptions(u, opts)
+	u, err := newURLString("user/blocks")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -41,7 +43,10 @@ func (s *UsersService) ListBlockedUsers(ctx context.Context, opts *ListOptions) 
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/blocking#check-if-a-user-is-blocked-by-the-authenticated-user
 func (s *UsersService) IsBlocked(ctx context.Context, user string) (bool, *Response, error) {
-	u := fmt.Sprintf("user/blocks/%v", user)
+	u, err := newURLString("user/blocks/%v", user)
+	if err != nil {
+		return false, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -60,7 +65,10 @@ func (s *UsersService) IsBlocked(ctx context.Context, user string) (bool, *Respo
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/blocking#block-a-user
 func (s *UsersService) BlockUser(ctx context.Context, user string) (*Response, error) {
-	u := fmt.Sprintf("user/blocks/%v", user)
+	u, err := newURLString("user/blocks/%v", user)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
@@ -77,7 +85,10 @@ func (s *UsersService) BlockUser(ctx context.Context, user string) (*Response, e
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/blocking#unblock-a-user
 func (s *UsersService) UnblockUser(ctx context.Context, user string) (*Response, error) {
-	u := fmt.Sprintf("user/blocks/%v", user)
+	u, err := newURLString("user/blocks/%v", user)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/users_emails.go
+++ b/github/users_emails.go
@@ -19,8 +19,11 @@ type UserEmail struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/emails#list-email-addresses-for-the-authenticated-user
 func (s *UsersService) ListEmails(ctx context.Context, opts *ListOptions) ([]*UserEmail, *Response, error) {
-	u := "user/emails"
-	u, err := addOptions(u, opts)
+	u, err := newURLString("user/emails")
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -43,7 +46,10 @@ func (s *UsersService) ListEmails(ctx context.Context, opts *ListOptions) ([]*Us
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/emails#add-an-email-address-for-the-authenticated-user
 func (s *UsersService) AddEmails(ctx context.Context, emails []string) ([]*UserEmail, *Response, error) {
-	u := "user/emails"
+	u, err := newURLString("user/emails")
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, emails)
 	if err != nil {
 		return nil, nil, err
@@ -62,7 +68,10 @@ func (s *UsersService) AddEmails(ctx context.Context, emails []string) ([]*UserE
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/emails#delete-an-email-address-for-the-authenticated-user
 func (s *UsersService) DeleteEmails(ctx context.Context, emails []string) (*Response, error) {
-	u := "user/emails"
+	u, err := newURLString("user/emails")
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, emails)
 	if err != nil {
 		return nil, err
@@ -76,7 +85,10 @@ func (s *UsersService) DeleteEmails(ctx context.Context, emails []string) (*Resp
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/emails#set-primary-email-visibility-for-the-authenticated-user
 func (s *UsersService) SetEmailVisibility(ctx context.Context, visibility string) ([]*UserEmail, *Response, error) {
-	u := "user/email/visibility"
+	u, err := newURLString("user/email/visibility")
+	if err != nil {
+		return nil, nil, err
+	}
 
 	updateVisiblilityReq := &UserEmail{
 		Visibility: &visibility,

--- a/github/users_followers.go
+++ b/github/users_followers.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ListFollowers lists the followers for a user. Passing the empty string will
@@ -87,10 +86,14 @@ func (s *UsersService) ListFollowing(ctx context.Context, user string, opts *Lis
 // GitHub API docs: https://docs.github.com/en/rest/users/followers#check-if-a-user-follows-another-user
 func (s *UsersService) IsFollowing(ctx context.Context, user, target string) (bool, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/following/%v", user, target)
+		u, err = newURLString("users/%v/following/%v", user, target)
 	} else {
-		u = fmt.Sprintf("user/following/%v", target)
+		u, err = newURLString("user/following/%v", target)
+	}
+	if err != nil {
+		return false, nil, err
 	}
 
 	req, err := s.client.NewRequest("GET", u, nil)

--- a/github/users_followers.go
+++ b/github/users_followers.go
@@ -17,12 +17,16 @@ import (
 // GitHub API docs: https://docs.github.com/en/rest/users/followers#list-followers-of-a-user
 func (s *UsersService) ListFollowers(ctx context.Context, user string, opts *ListOptions) ([]*User, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/followers", user)
+		u, err = newURLString("users/%v/followers", user)
 	} else {
-		u = "user/followers"
+		u, err = newURLString("user/followers")
 	}
-	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -48,12 +52,16 @@ func (s *UsersService) ListFollowers(ctx context.Context, user string, opts *Lis
 // GitHub API docs: https://docs.github.com/en/rest/users/followers#list-the-people-a-user-follows
 func (s *UsersService) ListFollowing(ctx context.Context, user string, opts *ListOptions) ([]*User, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/following", user)
+		u, err = newURLString("users/%v/following", user)
 	} else {
-		u = "user/following"
+		u, err = newURLString("user/following")
 	}
-	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -99,7 +107,10 @@ func (s *UsersService) IsFollowing(ctx context.Context, user, target string) (bo
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/followers#follow-a-user
 func (s *UsersService) Follow(ctx context.Context, user string) (*Response, error) {
-	u := fmt.Sprintf("user/following/%v", user)
+	u, err := newURLString("user/following/%v", user)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
 		return nil, err
@@ -112,7 +123,10 @@ func (s *UsersService) Follow(ctx context.Context, user string) (*Response, erro
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/followers#unfollow-a-user
 func (s *UsersService) Unfollow(ctx context.Context, user string) (*Response, error) {
-	u := fmt.Sprintf("user/following/%v", user)
+	u, err := newURLString("user/following/%v", user)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/users_gpg_keys.go
+++ b/github/users_gpg_keys.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // GPGKey represents a GitHub user's public GPG key used to verify GPG signed commits and tags.
@@ -48,12 +47,16 @@ type GPGEmail struct {
 // GitHub API docs: https://docs.github.com/en/rest/users/gpg-keys#list-gpg-keys-for-a-user
 func (s *UsersService) ListGPGKeys(ctx context.Context, user string, opts *ListOptions) ([]*GPGKey, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/gpg_keys", user)
+		u, err = newURLString("users/%v/gpg_keys", user)
 	} else {
-		u = "user/gpg_keys"
+		u, err = newURLString("user/gpg_keys")
 	}
-	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -77,7 +80,10 @@ func (s *UsersService) ListGPGKeys(ctx context.Context, user string, opts *ListO
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/gpg-keys#get-a-gpg-key-for-the-authenticated-user
 func (s *UsersService) GetGPGKey(ctx context.Context, id int64) (*GPGKey, *Response, error) {
-	u := fmt.Sprintf("user/gpg_keys/%v", id)
+	u, err := newURLString("user/gpg_keys/%v", id)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -119,7 +125,10 @@ func (s *UsersService) CreateGPGKey(ctx context.Context, armoredPublicKey string
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/gpg-keys#delete-a-gpg-key-for-the-authenticated-user
 func (s *UsersService) DeleteGPGKey(ctx context.Context, id int64) (*Response, error) {
-	u := fmt.Sprintf("user/gpg_keys/%v", id)
+	u, err := newURLString("user/gpg_keys/%v", id)
+	if err != nil {
+		return nil, err
+	}
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/users_keys.go
+++ b/github/users_keys.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // Key represents a public SSH key used to authenticate a user or deploy script.
@@ -34,12 +33,16 @@ func (k Key) String() string {
 // GitHub API docs: https://docs.github.com/en/rest/users/keys#list-public-keys-for-a-user
 func (s *UsersService) ListKeys(ctx context.Context, user string, opts *ListOptions) ([]*Key, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/keys", user)
+		u, err = newURLString("users/%v/keys", user)
 	} else {
-		u = "user/keys"
+		u, err = newURLString("user/keys")
 	}
-	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -62,7 +65,10 @@ func (s *UsersService) ListKeys(ctx context.Context, user string, opts *ListOpti
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/keys#get-a-public-ssh-key-for-the-authenticated-user
 func (s *UsersService) GetKey(ctx context.Context, id int64) (*Key, *Response, error) {
-	u := fmt.Sprintf("user/keys/%v", id)
+	u, err := newURLString("user/keys/%v", id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -82,7 +88,10 @@ func (s *UsersService) GetKey(ctx context.Context, id int64) (*Key, *Response, e
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/keys#create-a-public-ssh-key-for-the-authenticated-user
 func (s *UsersService) CreateKey(ctx context.Context, key *Key) (*Key, *Response, error) {
-	u := "user/keys"
+	u, err := newURLString("user/keys")
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, key)
 	if err != nil {
@@ -102,7 +111,10 @@ func (s *UsersService) CreateKey(ctx context.Context, key *Key) (*Key, *Response
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/keys#delete-a-public-ssh-key-for-the-authenticated-user
 func (s *UsersService) DeleteKey(ctx context.Context, id int64) (*Response, error) {
-	u := fmt.Sprintf("user/keys/%v", id)
+	u, err := newURLString("user/keys/%v", id)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/users_packages.go
+++ b/github/users_packages.go
@@ -17,12 +17,16 @@ import (
 // GitHub API docs: https://docs.github.com/en/rest/packages#list-packages-for-a-user
 func (s *UsersService) ListPackages(ctx context.Context, user string, opts *PackageListOptions) ([]*Package, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/packages", user)
+		u, err = newURLString("users/%v/packages", user)
 	} else {
-		u = "user/packages"
+		u, err = newURLString("user/packages")
 	}
-	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -117,12 +121,16 @@ func (s *UsersService) RestorePackage(ctx context.Context, user, packageType, pa
 // GitHub API docs: https://docs.github.com/en/rest/packages#get-all-package-versions-for-a-package-owned-by-a-user
 func (s *UsersService) PackageGetAllVersions(ctx context.Context, user, packageType, packageName string, opts *PackageListOptions) ([]*PackageVersion, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/packages/%v/%v/versions", user, packageType, packageName)
+		u, err = newURLString("users/%v/packages/%v/%v/versions", user, packageType, packageName)
 	} else {
-		u = fmt.Sprintf("user/packages/%v/%v/versions", packageType, packageName)
+		u, err = newURLString("user/packages/%v/%v/versions", packageType, packageName)
 	}
-	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/users_packages.go
+++ b/github/users_packages.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // List the packages for a user. Passing the empty string for "user" will
@@ -52,10 +51,14 @@ func (s *UsersService) ListPackages(ctx context.Context, user string, opts *Pack
 // GitHub API docs: https://docs.github.com/en/rest/packages#get-a-package-for-a-user
 func (s *UsersService) GetPackage(ctx context.Context, user, packageType, packageName string) (*Package, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/packages/%v/%v", user, packageType, packageName)
+		u, err = newURLString("users/%v/packages/%v/%v", user, packageType, packageName)
 	} else {
-		u = fmt.Sprintf("user/packages/%v/%v", packageType, packageName)
+		u, err = newURLString("user/packages/%v/%v", packageType, packageName)
+	}
+	if err != nil {
+		return nil, nil, err
 	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -79,10 +82,14 @@ func (s *UsersService) GetPackage(ctx context.Context, user, packageType, packag
 // GitHub API docs: https://docs.github.com/en/rest/packages#delete-a-package-for-a-user
 func (s *UsersService) DeletePackage(ctx context.Context, user, packageType, packageName string) (*Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/packages/%v/%v", user, packageType, packageName)
+		u, err = newURLString("users/%v/packages/%v/%v", user, packageType, packageName)
 	} else {
-		u = fmt.Sprintf("user/packages/%v/%v", packageType, packageName)
+		u, err = newURLString("user/packages/%v/%v", packageType, packageName)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
@@ -100,10 +107,14 @@ func (s *UsersService) DeletePackage(ctx context.Context, user, packageType, pac
 // GitHub API docs: https://docs.github.com/en/rest/packages#restore-a-package-for-a-user
 func (s *UsersService) RestorePackage(ctx context.Context, user, packageType, packageName string) (*Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/packages/%v/%v/restore", user, packageType, packageName)
+		u, err = newURLString("users/%v/packages/%v/%v/restore", user, packageType, packageName)
 	} else {
-		u = fmt.Sprintf("user/packages/%v/%v/restore", packageType, packageName)
+		u, err = newURLString("user/packages/%v/%v/restore", packageType, packageName)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	req, err := s.client.NewRequest("POST", u, nil)
@@ -156,10 +167,14 @@ func (s *UsersService) PackageGetAllVersions(ctx context.Context, user, packageT
 // GitHub API docs: https://docs.github.com/en/rest/packages#get-a-package-version-for-a-user
 func (s *UsersService) PackageGetVersion(ctx context.Context, user, packageType, packageName string, packageVersionID int64) (*PackageVersion, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/packages/%v/%v/versions/%v", user, packageType, packageName, packageVersionID)
+		u, err = newURLString("users/%v/packages/%v/%v/versions/%v", user, packageType, packageName, packageVersionID)
 	} else {
-		u = fmt.Sprintf("user/packages/%v/%v/versions/%v", packageType, packageName, packageVersionID)
+		u, err = newURLString("user/packages/%v/%v/versions/%v", packageType, packageName, packageVersionID)
+	}
+	if err != nil {
+		return nil, nil, err
 	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -183,10 +198,14 @@ func (s *UsersService) PackageGetVersion(ctx context.Context, user, packageType,
 // GitHub API docs: https://docs.github.com/en/rest/packages#delete-package-version-for-a-user
 func (s *UsersService) PackageDeleteVersion(ctx context.Context, user, packageType, packageName string, packageVersionID int64) (*Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/packages/%v/%v/versions/%v", user, packageType, packageName, packageVersionID)
+		u, err = newURLString("users/%v/packages/%v/%v/versions/%v", user, packageType, packageName, packageVersionID)
 	} else {
-		u = fmt.Sprintf("user/packages/%v/%v/versions/%v", packageType, packageName, packageVersionID)
+		u, err = newURLString("user/packages/%v/%v/versions/%v", packageType, packageName, packageVersionID)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
@@ -204,10 +223,14 @@ func (s *UsersService) PackageDeleteVersion(ctx context.Context, user, packageTy
 // GitHub API docs: https://docs.github.com/en/rest/packages#restore-package-version-for-a-user
 func (s *UsersService) PackageRestoreVersion(ctx context.Context, user, packageType, packageName string, packageVersionID int64) (*Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/packages/%v/%v/versions/%v/restore", user, packageType, packageName, packageVersionID)
+		u, err = newURLString("users/%v/packages/%v/%v/versions/%v/restore", user, packageType, packageName, packageVersionID)
 	} else {
-		u = fmt.Sprintf("user/packages/%v/%v/versions/%v/restore", packageType, packageName, packageVersionID)
+		u, err = newURLString("user/packages/%v/%v/versions/%v/restore", packageType, packageName, packageVersionID)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	req, err := s.client.NewRequest("POST", u, nil)

--- a/github/users_projects.go
+++ b/github/users_projects.go
@@ -7,15 +7,17 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // ListProjects lists the projects for the specified user.
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/projects#list-user-projects
 func (s *UsersService) ListProjects(ctx context.Context, user string, opts *ProjectListOptions) ([]*Project, *Response, error) {
-	u := fmt.Sprintf("users/%v/projects", user)
-	u, err := addOptions(u, opts)
+	u, err := newURLString("users/%v/projects", user)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -49,7 +51,10 @@ type CreateUserProjectOptions struct {
 //
 // GitHub API docs: https://docs.github.com/en/rest/projects/projects#create-a-user-project
 func (s *UsersService) CreateProject(ctx context.Context, opts *CreateUserProjectOptions) (*Project, *Response, error) {
-	u := "user/projects"
+	u, err := newURLString("user/projects")
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
 		return nil, nil, err

--- a/github/users_ssh_signing_keys.go
+++ b/github/users_ssh_signing_keys.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 )
 
 // SSHSigningKey represents a public SSH key used to sign git commits.
@@ -29,12 +28,16 @@ func (k SSHSigningKey) String() string {
 // GitHub API docs: https://docs.github.com/en/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-a-user
 func (s *UsersService) ListSSHSigningKeys(ctx context.Context, user string, opts *ListOptions) ([]*SSHSigningKey, *Response, error) {
 	var u string
+	var err error
 	if user != "" {
-		u = fmt.Sprintf("users/%v/ssh_signing_keys", user)
+		u, err = newURLString("users/%v/ssh_signing_keys", user)
 	} else {
-		u = "user/ssh_signing_keys"
+		u, err = newURLString("user/ssh_signing_keys")
 	}
-	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	u, err = addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -57,7 +60,10 @@ func (s *UsersService) ListSSHSigningKeys(ctx context.Context, user string, opts
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/ssh-signing-keys#get-an-ssh-signing-key-for-the-authenticated-user
 func (s *UsersService) GetSSHSigningKey(ctx context.Context, id int64) (*SSHSigningKey, *Response, error) {
-	u := fmt.Sprintf("user/ssh_signing_keys/%v", id)
+	u, err := newURLString("user/ssh_signing_keys/%v", id)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -77,7 +83,10 @@ func (s *UsersService) GetSSHSigningKey(ctx context.Context, id int64) (*SSHSign
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/ssh-signing-keys#create-a-ssh-signing-key-for-the-authenticated-user
 func (s *UsersService) CreateSSHSigningKey(ctx context.Context, key *Key) (*SSHSigningKey, *Response, error) {
-	u := "user/ssh_signing_keys"
+	u, err := newURLString("user/ssh_signing_keys")
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("POST", u, key)
 	if err != nil {
@@ -97,7 +106,10 @@ func (s *UsersService) CreateSSHSigningKey(ctx context.Context, key *Key) (*SSHS
 //
 // GitHub API docs: https://docs.github.com/en/rest/users/ssh-signing-keys#delete-an-ssh-signing-key-for-the-authenticated-user
 func (s *UsersService) DeleteSSHSigningKey(ctx context.Context, id int64) (*Response, error) {
-	u := fmt.Sprintf("user/ssh_signing_keys/%v", id)
+	u, err := newURLString("user/ssh_signing_keys/%v", id)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {


### PR DESCRIPTION
Resolves google/go-github#1203

This addresses the issue raised in google/go-github#1203 by adding a `newURLString` function that builds a url the same way they were previously built with `fmt.Sprintf` but also errors if the result is not valid.

I went this route instead of modifying `addOptions` because it seemed better to validate all urls instead of only the ones that use `addOptions`.

This turned into a pretty big diff, but that is the nature of updating boilerplate that is used in hundreds of methods.
