### PR TITLE
Handle Encoding value of "none"

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -86,7 +86,7 @@ func (r *RepositoryContent) GetContent() (string, error) {
 		}
 		c, err := base64.StdEncoding.DecodeString(*r.Content)
 		return string(c), err
-	case "":
+	case "", "none":
 		if r.Content == nil {
 			return "", nil
 		}


### PR DESCRIPTION
When a file is over 1 MB in a repository, GitHub responds with "none" as the encoding value. Handle this accordingly.