### PR TITLE
Fix golangci-lint timeout failures

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -29,4 +29,4 @@ jobs:
       with:
         version: latest
         working-directory: ${{ matrix.working-directory}}
-        args: --verbose
+        args: --verbose --timeout=10m


### PR DESCRIPTION
Ever since #2903 , the golangci-lint GitHub Actions workflow has frequently timed out.
According to this: https://github.com/golangci/golangci-lint-action/issues/308
this PR should fix that problem.