### PR TITLE
Fix SecretScanning API by switching arguments from url to json

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -20958,22 +20958,6 @@ func (s *SecretScanningAlertUpdateOptions) GetResolution() string {
 	return *s.Resolution
 }
 
-// GetSecretType returns the SecretType field if it's non-nil, zero value otherwise.
-func (s *SecretScanningAlertUpdateOptions) GetSecretType() string {
-	if s == nil || s.SecretType == nil {
-		return ""
-	}
-	return *s.SecretType
-}
-
-// GetState returns the State field if it's non-nil, zero value otherwise.
-func (s *SecretScanningAlertUpdateOptions) GetState() string {
-	if s == nil || s.State == nil {
-		return ""
-	}
-	return *s.State
-}
-
 // GetStatus returns the Status field if it's non-nil, zero value otherwise.
 func (s *SecretScanningPushProtection) GetStatus() string {
 	if s == nil || s.Status == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -24440,26 +24440,6 @@ func TestSecretScanningAlertUpdateOptions_GetResolution(tt *testing.T) {
 	s.GetResolution()
 }
 
-func TestSecretScanningAlertUpdateOptions_GetSecretType(tt *testing.T) {
-	var zeroValue string
-	s := &SecretScanningAlertUpdateOptions{SecretType: &zeroValue}
-	s.GetSecretType()
-	s = &SecretScanningAlertUpdateOptions{}
-	s.GetSecretType()
-	s = nil
-	s.GetSecretType()
-}
-
-func TestSecretScanningAlertUpdateOptions_GetState(tt *testing.T) {
-	var zeroValue string
-	s := &SecretScanningAlertUpdateOptions{State: &zeroValue}
-	s.GetState()
-	s = &SecretScanningAlertUpdateOptions{}
-	s.GetState()
-	s = nil
-	s.GetState()
-}
-
 func TestSecretScanningPushProtection_GetStatus(tt *testing.T) {
 	var zeroValue string
 	s := &SecretScanningPushProtection{Status: &zeroValue}

--- a/github/secret_scanning.go
+++ b/github/secret_scanning.go
@@ -82,14 +82,14 @@ type SecretScanningAlertListOptions struct {
 type SecretScanningAlertUpdateOptions struct {
 	// Required. Sets the state of the secret scanning alert. Can be either open or resolved.
 	// You must provide resolution when you set the state to resolved.
-	State *string `url:"state,omitempty"`
+	State *string `json:"state,omitempty"`
 
 	// A comma-separated list of secret types to return. By default all secret types are returned.
-	SecretType *string `url:"secret_type,omitempty"`
+	SecretType *string `json:"secret_type,omitempty"`
 
 	// Required when the state is resolved. The reason for resolving the alert. Can be one of false_positive,
 	// wont_fix, revoked, or used_in_tests.
-	Resolution *string `url:"resolution,omitempty"`
+	Resolution *string `json:"resolution,omitempty"`
 }
 
 // Lists secret scanning alerts for eligible repositories in an enterprise, from newest to oldest.

--- a/github/secret_scanning.go
+++ b/github/secret_scanning.go
@@ -80,15 +80,13 @@ type SecretScanningAlertListOptions struct {
 
 // SecretScanningAlertUpdateOptions specifies optional parameters to the SecretScanningService.UpdateAlert method.
 type SecretScanningAlertUpdateOptions struct {
-	// Required. Sets the state of the secret scanning alert. Can be either open or resolved.
-	// You must provide resolution when you set the state to resolved.
-	State *string `json:"state,omitempty"`
+	// State is required and sets the state of the secret scanning alert.
+	// Can be either "open" or "resolved".
+	// You must provide resolution when you set the state to "resolved".
+	State string `json:"state"`
 
-	// A comma-separated list of secret types to return. By default all secret types are returned.
-	SecretType *string `json:"secret_type,omitempty"`
-
-	// Required when the state is resolved. The reason for resolving the alert. Can be one of false_positive,
-	// wont_fix, revoked, or used_in_tests.
+	// Required when the state is "resolved" and represents the reason for resolving the alert.
+	// Can be one of: "false_positive", "wont_fix", "revoked", or "used_in_tests".
 	Resolution *string `json:"resolution,omitempty"`
 }
 

--- a/github/secret_scanning_test.go
+++ b/github/secret_scanning_test.go
@@ -359,7 +359,7 @@ func TestSecretScanningService_UpdateAlert(t *testing.T) {
 		v := new(SecretScanningAlertUpdateOptions)
 		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
 
-		want := &SecretScanningAlertUpdateOptions{State: String("resolved"), Resolution: String("used_in_tests")}
+		want := &SecretScanningAlertUpdateOptions{State: "resolved", Resolution: String("used_in_tests")}
 
 		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
@@ -381,7 +381,7 @@ func TestSecretScanningService_UpdateAlert(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	opts := &SecretScanningAlertUpdateOptions{State: String("resolved"), Resolution: String("used_in_tests")}
+	opts := &SecretScanningAlertUpdateOptions{State: "resolved", Resolution: String("used_in_tests")}
 
 	alert, _, err := client.SecretScanning.UpdateAlert(ctx, "o", "r", 1, opts)
 	if err != nil {


### PR DESCRIPTION
Closes: #2871.

This PR fixes the endpoint:
https://docs.github.com/en/enterprise-server@3.5/rest/secret-scanning/secret-scanning#update-a-secret-scanning-alert
by sending its parameters in the body instead of as URL query parameters.

I was unable to edit #2871 directly, so this is a replacement.
Thank you, @jentfoo for the bug report and initial PR!