### PR TITLE
Allow up to maxRedirects upon receiving HTTP 301 status

### DIFF
--- a/github/actions_artifacts.go
+++ b/github/actions_artifacts.go
@@ -121,10 +121,10 @@ func (s *ActionsService) GetArtifact(ctx context.Context, owner, repo string, ar
 // DownloadArtifact gets a redirect URL to download an archive for a repository.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/artifacts#download-an-artifact
-func (s *ActionsService) DownloadArtifact(ctx context.Context, owner, repo string, artifactID int64, followRedirects bool) (*url.URL, *Response, error) {
+func (s *ActionsService) DownloadArtifact(ctx context.Context, owner, repo string, artifactID int64, maxRedirects int) (*url.URL, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/artifacts/%v/zip", owner, repo, artifactID)
 
-	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, followRedirects)
+	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, maxRedirects)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/actions_artifacts_test.go
+++ b/github/actions_artifacts_test.go
@@ -277,7 +277,7 @@ func TestActionsSerivice_DownloadArtifact(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	url, resp, err := client.Actions.DownloadArtifact(ctx, "o", "r", 1, true)
+	url, resp, err := client.Actions.DownloadArtifact(ctx, "o", "r", 1, 1)
 	if err != nil {
 		t.Errorf("Actions.DownloadArtifact returned error: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestActionsSerivice_DownloadArtifact(t *testing.T) {
 
 	const methodName = "DownloadArtifact"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.DownloadArtifact(ctx, "\n", "\n", -1, true)
+		_, _, err = client.Actions.DownloadArtifact(ctx, "\n", "\n", -1, 1)
 		return err
 	})
 
@@ -301,7 +301,7 @@ func TestActionsSerivice_DownloadArtifact(t *testing.T) {
 		return nil, errors.New("failed to download artifact")
 	})
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.DownloadArtifact(ctx, "o", "r", 1, true)
+		_, _, err = client.Actions.DownloadArtifact(ctx, "o", "r", 1, 1)
 		return err
 	})
 }
@@ -311,7 +311,7 @@ func TestActionsService_DownloadArtifact_invalidOwner(t *testing.T) {
 	defer teardown()
 
 	ctx := context.Background()
-	_, _, err := client.Actions.DownloadArtifact(ctx, "%", "r", 1, true)
+	_, _, err := client.Actions.DownloadArtifact(ctx, "%", "r", 1, 1)
 	testURLParseError(t, err)
 }
 
@@ -320,7 +320,7 @@ func TestActionsService_DownloadArtifact_invalidRepo(t *testing.T) {
 	defer teardown()
 
 	ctx := context.Background()
-	_, _, err := client.Actions.DownloadArtifact(ctx, "o", "%", 1, true)
+	_, _, err := client.Actions.DownloadArtifact(ctx, "o", "%", 1, 1)
 	testURLParseError(t, err)
 }
 
@@ -334,7 +334,7 @@ func TestActionsService_DownloadArtifact_StatusMovedPermanently_dontFollowRedire
 	})
 
 	ctx := context.Background()
-	_, resp, _ := client.Actions.DownloadArtifact(ctx, "o", "r", 1, false)
+	_, resp, _ := client.Actions.DownloadArtifact(ctx, "o", "r", 1, 0)
 	if resp.StatusCode != http.StatusMovedPermanently {
 		t.Errorf("Actions.DownloadArtifact return status %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
 	}
@@ -355,7 +355,7 @@ func TestActionsService_DownloadArtifact_StatusMovedPermanently_followRedirects(
 	})
 
 	ctx := context.Background()
-	url, resp, err := client.Actions.DownloadArtifact(ctx, "o", "r", 1, true)
+	url, resp, err := client.Actions.DownloadArtifact(ctx, "o", "r", 1, 1)
 	if err != nil {
 		t.Errorf("Actions.DownloadArtifact return error: %v", err)
 	}

--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -115,10 +115,10 @@ func (s *ActionsService) GetWorkflowJobByID(ctx context.Context, owner, repo str
 // GetWorkflowJobLogs gets a redirect URL to download a plain text file of logs for a workflow job.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-jobs#download-job-logs-for-a-workflow-run
-func (s *ActionsService) GetWorkflowJobLogs(ctx context.Context, owner, repo string, jobID int64, followRedirects bool) (*url.URL, *Response, error) {
+func (s *ActionsService) GetWorkflowJobLogs(ctx context.Context, owner, repo string, jobID int64, maxRedirects int) (*url.URL, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/jobs/%v/logs", owner, repo, jobID)
 
-	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, followRedirects)
+	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, maxRedirects)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -138,7 +138,7 @@ func TestActionsService_GetWorkflowJobLogs(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, true)
+	url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 1)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowJobLogs returned error: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestActionsService_GetWorkflowJobLogs(t *testing.T) {
 
 	const methodName = "GetWorkflowJobLogs"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.GetWorkflowJobLogs(ctx, "\n", "\n", 399444496, true)
+		_, _, err = client.Actions.GetWorkflowJobLogs(ctx, "\n", "\n", 399444496, 1)
 		return err
 	})
 
@@ -161,7 +161,7 @@ func TestActionsService_GetWorkflowJobLogs(t *testing.T) {
 		return nil, errors.New("failed to get workflow logs")
 	})
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, true)
+		_, _, err = client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 1)
 		return err
 	})
 }
@@ -176,7 +176,7 @@ func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_dontFollowRedi
 	})
 
 	ctx := context.Background()
-	_, resp, _ := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, false)
+	_, resp, _ := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 0)
 	if resp.StatusCode != http.StatusMovedPermanently {
 		t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
 	}
@@ -199,7 +199,7 @@ func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_followRedirect
 	})
 
 	ctx := context.Background()
-	url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, true)
+	url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 1)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowJobLogs returned error: %v", err)
 	}

--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -211,10 +211,10 @@ func (s *ActionsService) GetWorkflowRunAttempt(ctx context.Context, owner, repo 
 // GetWorkflowRunAttemptLogs gets a redirect URL to download a plain text file of logs for a workflow run for attempt number.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#download-workflow-run-attempt-logs
-func (s *ActionsService) GetWorkflowRunAttemptLogs(ctx context.Context, owner, repo string, runID int64, attemptNumber int, followRedirects bool) (*url.URL, *Response, error) {
+func (s *ActionsService) GetWorkflowRunAttemptLogs(ctx context.Context, owner, repo string, runID int64, attemptNumber int, maxRedirects int) (*url.URL, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/attempts/%v/logs", owner, repo, runID, attemptNumber)
 
-	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, followRedirects)
+	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, maxRedirects)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -287,10 +287,10 @@ func (s *ActionsService) CancelWorkflowRunByID(ctx context.Context, owner, repo 
 // GetWorkflowRunLogs gets a redirect URL to download a plain text file of logs for a workflow run.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/workflow-runs#download-workflow-run-logs
-func (s *ActionsService) GetWorkflowRunLogs(ctx context.Context, owner, repo string, runID int64, followRedirects bool) (*url.URL, *Response, error) {
+func (s *ActionsService) GetWorkflowRunLogs(ctx context.Context, owner, repo string, runID int64, maxRedirects int) (*url.URL, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/logs", owner, repo, runID)
 
-	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, followRedirects)
+	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, maxRedirects)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -198,7 +198,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	url, resp, err := client.Actions.GetWorkflowRunAttemptLogs(ctx, "o", "r", 399444496, 2, true)
+	url, resp, err := client.Actions.GetWorkflowRunAttemptLogs(ctx, "o", "r", 399444496, 2, 1)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowRunAttemptLogs returned error: %v", err)
 	}
@@ -212,7 +212,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs(t *testing.T) {
 
 	const methodName = "GetWorkflowRunAttemptLogs"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.GetWorkflowRunAttemptLogs(ctx, "\n", "\n", 399444496, 2, true)
+		_, _, err = client.Actions.GetWorkflowRunAttemptLogs(ctx, "\n", "\n", 399444496, 2, 1)
 		return err
 	})
 }
@@ -227,7 +227,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs_StatusMovedPermanently_dontFol
 	})
 
 	ctx := context.Background()
-	_, resp, _ := client.Actions.GetWorkflowRunAttemptLogs(ctx, "o", "r", 399444496, 2, false)
+	_, resp, _ := client.Actions.GetWorkflowRunAttemptLogs(ctx, "o", "r", 399444496, 2, 0)
 	if resp.StatusCode != http.StatusMovedPermanently {
 		t.Errorf("Actions.GetWorkflowRunAttemptLogs returned status: %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
 	}
@@ -250,7 +250,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs_StatusMovedPermanently_followR
 	})
 
 	ctx := context.Background()
-	url, resp, err := client.Actions.GetWorkflowRunAttemptLogs(ctx, "o", "r", 399444496, 2, true)
+	url, resp, err := client.Actions.GetWorkflowRunAttemptLogs(ctx, "o", "r", 399444496, 2, 1)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowRunAttemptLogs returned error: %v", err)
 	}
@@ -266,7 +266,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs_StatusMovedPermanently_followR
 
 	const methodName = "GetWorkflowRunAttemptLogs"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.GetWorkflowRunAttemptLogs(ctx, "\n", "\n", 399444496, 2, true)
+		_, _, err = client.Actions.GetWorkflowRunAttemptLogs(ctx, "\n", "\n", 399444496, 2, 1)
 		return err
 	})
 }
@@ -397,7 +397,7 @@ func TestActionsService_GetWorkflowRunLogs(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	url, resp, err := client.Actions.GetWorkflowRunLogs(ctx, "o", "r", 399444496, true)
+	url, resp, err := client.Actions.GetWorkflowRunLogs(ctx, "o", "r", 399444496, 1)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowRunLogs returned error: %v", err)
 	}
@@ -411,7 +411,7 @@ func TestActionsService_GetWorkflowRunLogs(t *testing.T) {
 
 	const methodName = "GetWorkflowRunLogs"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.GetWorkflowRunLogs(ctx, "\n", "\n", 399444496, true)
+		_, _, err = client.Actions.GetWorkflowRunLogs(ctx, "\n", "\n", 399444496, 1)
 		return err
 	})
 }
@@ -426,7 +426,7 @@ func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_dontFollowRedi
 	})
 
 	ctx := context.Background()
-	_, resp, _ := client.Actions.GetWorkflowRunLogs(ctx, "o", "r", 399444496, false)
+	_, resp, _ := client.Actions.GetWorkflowRunLogs(ctx, "o", "r", 399444496, 0)
 	if resp.StatusCode != http.StatusMovedPermanently {
 		t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
 	}
@@ -449,7 +449,7 @@ func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_followRedirect
 	})
 
 	ctx := context.Background()
-	url, resp, err := client.Actions.GetWorkflowRunLogs(ctx, "o", "r", 399444496, true)
+	url, resp, err := client.Actions.GetWorkflowRunLogs(ctx, "o", "r", 399444496, 1)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowJobLogs returned error: %v", err)
 	}
@@ -465,7 +465,7 @@ func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_followRedirect
 
 	const methodName = "GetWorkflowRunLogs"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.GetWorkflowRunLogs(ctx, "\n", "\n", 399444496, true)
+		_, _, err = client.Actions.GetWorkflowRunLogs(ctx, "\n", "\n", 399444496, 1)
 		return err
 	})
 }

--- a/github/github.go
+++ b/github/github.go
@@ -1558,7 +1558,7 @@ func formatRateReset(d time.Duration) string {
 
 // When using roundTripWithOptionalFollowRedirect, note that it
 // is the responsibility of the caller to close the response body.
-func (c *Client) roundTripWithOptionalFollowRedirect(ctx context.Context, u string, followRedirects bool, opts ...RequestOption) (*http.Response, error) {
+func (c *Client) roundTripWithOptionalFollowRedirect(ctx context.Context, u string, maxRedirects int, opts ...RequestOption) (*http.Response, error) {
 	req, err := c.NewRequest("GET", u, nil, opts...)
 	if err != nil {
 		return nil, err
@@ -1577,10 +1577,10 @@ func (c *Client) roundTripWithOptionalFollowRedirect(ctx context.Context, u stri
 	}
 
 	// If redirect response is returned, follow it
-	if followRedirects && resp.StatusCode == http.StatusMovedPermanently {
+	if maxRedirects > 0 && resp.StatusCode == http.StatusMovedPermanently {
 		_ = resp.Body.Close()
 		u = resp.Header.Get("Location")
-		resp, err = c.roundTripWithOptionalFollowRedirect(ctx, u, false, opts...)
+		resp, err = c.roundTripWithOptionalFollowRedirect(ctx, u, maxRedirects-1, opts...)
 	}
 	return resp, err
 }

--- a/github/repos.go
+++ b/github/repos.go
@@ -1274,10 +1274,10 @@ func (s *RepositoriesService) ListBranches(ctx context.Context, owner string, re
 // GetBranch gets the specified branch for a repository.
 //
 // GitHub API docs: https://docs.github.com/en/rest/branches/branches#get-a-branch
-func (s *RepositoriesService) GetBranch(ctx context.Context, owner, repo, branch string, followRedirects bool) (*Branch, *Response, error) {
+func (s *RepositoriesService) GetBranch(ctx context.Context, owner, repo, branch string, maxRedirects int) (*Branch, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v", owner, repo, branch)
 
-	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, followRedirects)
+	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, maxRedirects)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -313,12 +313,12 @@ const (
 // or github.Zipball constant.
 //
 // GitHub API docs: https://docs.github.com/en/rest/repos/contents/#get-archive-link
-func (s *RepositoriesService) GetArchiveLink(ctx context.Context, owner, repo string, archiveformat ArchiveFormat, opts *RepositoryContentGetOptions, followRedirects bool) (*url.URL, *Response, error) {
+func (s *RepositoriesService) GetArchiveLink(ctx context.Context, owner, repo string, archiveformat ArchiveFormat, opts *RepositoryContentGetOptions, maxRedirects int) (*url.URL, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/%s", owner, repo, archiveformat)
 	if opts != nil && opts.Ref != "" {
 		u += fmt.Sprintf("/%s", opts.Ref)
 	}
-	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, followRedirects)
+	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, maxRedirects)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -694,7 +694,7 @@ func TestRepositoriesService_GetArchiveLink(t *testing.T) {
 		http.Redirect(w, r, "http://github.com/a", http.StatusFound)
 	})
 	ctx := context.Background()
-	url, resp, err := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{Ref: "yo"}, true)
+	url, resp, err := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{Ref: "yo"}, 1)
 	if err != nil {
 		t.Errorf("Repositories.GetArchiveLink returned error: %v", err)
 	}
@@ -708,7 +708,7 @@ func TestRepositoriesService_GetArchiveLink(t *testing.T) {
 
 	const methodName = "GetArchiveLink"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Repositories.GetArchiveLink(ctx, "\n", "\n", Tarball, &RepositoryContentGetOptions{}, true)
+		_, _, err = client.Repositories.GetArchiveLink(ctx, "\n", "\n", Tarball, &RepositoryContentGetOptions{}, 1)
 		return err
 	})
 
@@ -717,7 +717,7 @@ func TestRepositoriesService_GetArchiveLink(t *testing.T) {
 		return nil, errors.New("failed to get archive link")
 	})
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{}, true)
+		_, _, err = client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{}, 1)
 		return err
 	})
 }
@@ -730,7 +730,7 @@ func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_dontFollowRed
 		http.Redirect(w, r, "http://github.com/a", http.StatusMovedPermanently)
 	})
 	ctx := context.Background()
-	_, resp, _ := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{}, false)
+	_, resp, _ := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{}, 0)
 	if resp.StatusCode != http.StatusMovedPermanently {
 		t.Errorf("Repositories.GetArchiveLink returned status: %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
 	}
@@ -750,7 +750,7 @@ func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_followRedirec
 		http.Redirect(w, r, "http://github.com/a", http.StatusFound)
 	})
 	ctx := context.Background()
-	url, resp, err := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{}, true)
+	url, resp, err := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{}, 1)
 	if err != nil {
 		t.Errorf("Repositories.GetArchiveLink returned error: %v", err)
 	}

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -925,7 +925,7 @@ func TestRepositoriesService_GetBranch(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	branch, _, err := client.Repositories.GetBranch(ctx, "o", "r", "b", false)
+	branch, _, err := client.Repositories.GetBranch(ctx, "o", "r", "b", 0)
 	if err != nil {
 		t.Errorf("Repositories.GetBranch returned error: %v", err)
 	}
@@ -947,7 +947,7 @@ func TestRepositoriesService_GetBranch(t *testing.T) {
 
 	const methodName = "GetBranch"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Repositories.GetBranch(ctx, "\n", "\n", "\n", false)
+		_, _, err = client.Repositories.GetBranch(ctx, "\n", "\n", "\n", 0)
 		return err
 	})
 }
@@ -962,7 +962,7 @@ func TestRepositoriesService_GetBranch_BadJSONResponse(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	if _, _, err := client.Repositories.GetBranch(ctx, "o", "r", "b", false); err == nil {
+	if _, _, err := client.Repositories.GetBranch(ctx, "o", "r", "b", 0); err == nil {
 		t.Error("Repositories.GetBranch returned no error; wanted JSON error")
 	}
 }
@@ -981,7 +981,7 @@ func TestRepositoriesService_GetBranch_StatusMovedPermanently_followRedirects(t 
 		fmt.Fprint(w, `{"name":"n", "commit":{"sha":"s","commit":{"message":"m"}}, "protected":true}`)
 	})
 	ctx := context.Background()
-	branch, resp, err := client.Repositories.GetBranch(ctx, "o", "r", "b", true)
+	branch, resp, err := client.Repositories.GetBranch(ctx, "o", "r", "b", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetBranch returned error: %v", err)
 	}
@@ -1013,7 +1013,7 @@ func TestRepositoriesService_GetBranch_notFound(t *testing.T) {
 		http.Error(w, "branch not found", http.StatusNotFound)
 	})
 	ctx := context.Background()
-	_, resp, err := client.Repositories.GetBranch(ctx, "o", "r", "b", true)
+	_, resp, err := client.Repositories.GetBranch(ctx, "o", "r", "b", 1)
 	if err == nil {
 		t.Error("Repositories.GetBranch returned error: nil")
 	}
@@ -1028,7 +1028,7 @@ func TestRepositoriesService_GetBranch_notFound(t *testing.T) {
 
 	const methodName = "GetBranch"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Repositories.GetBranch(ctx, "\n", "\n", "\n", true)
+		_, _, err = client.Repositories.GetBranch(ctx, "\n", "\n", "\n", 1)
 		return err
 	})
 }

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -64,7 +64,7 @@ func TestRepositories_BranchesTags(t *testing.T) {
 		t.Fatalf("Repositories.ListBranches('git', 'git') returned no branches")
 	}
 
-	_, _, err = client.Repositories.GetBranch(context.Background(), "git", "git", *branches[0].Name, false)
+	_, _, err = client.Repositories.GetBranch(context.Background(), "git", "git", *branches[0].Name, 0)
 	if err != nil {
 		t.Fatalf("Repositories.GetBranch() returned error: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestRepositories_EditBranches(t *testing.T) {
 		t.Fatalf("createRandomTestRepository returned error: %v", err)
 	}
 
-	branch, _, err := client.Repositories.GetBranch(context.Background(), *repo.Owner.Login, *repo.Name, "master", false)
+	branch, _, err := client.Repositories.GetBranch(context.Background(), *repo.Owner.Login, *repo.Name, "master", 0)
 	if err != nil {
 		t.Fatalf("Repositories.GetBranch() returned error: %v", err)
 	}


### PR DESCRIPTION
The [`roundTripWithOptionalFollowRedirect()` method](https://github.com/google/go-github/blob/b45ef89f2dd0ec803ab8f27725bdb4941c0cbc99/github/github.go#L1561) currently takes a boolean parameter `followRedirects`, used to support HTTP 301 redirections. However, at most 1 redirection is handled at the moment (the parameter is set to `false` after the first iteration.)

I've stumbled upon multiple repositories where `https://api.github.com/repos/<OWNER>/<PROJECT>/branches/<BRANCH>` redirects twice ; as a result, the [`GetBranch()` method](https://github.com/google/go-github/blob/b45ef89f2dd0ec803ab8f27725bdb4941c0cbc99/github/repos.go#L1277) only follows the first redirection, then returns the 2nd HTTP 301 response.

This MR proposes to generalize the `followRedirects` boolean into a `maxRedirects` integer, to support an arbitrary number of redirections. This impacts multiple methods, not just `GetBranch()`.

:warning: This is a breaking change.