### PR TITLE
Add List Installation Requests API

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -102,6 +102,15 @@ type InstallationPermissions struct {
 	Workflows                     *string `json:"workflows,omitempty"`
 }
 
+// InstallationRequest represents a pending GitHub App installation request.
+type InstallationRequest struct {
+	ID        *int64     `json:"id,omitempty"`
+	NodeID    *string    `json:"node_id,omitempty"`
+	Account   *User      `json:"account,omitempty"`
+	Requester *User      `json:"requester,omitempty"`
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
+}
+
 // Installation represents a GitHub Apps installation.
 type Installation struct {
 	ID                     *int64                   `json:"id,omitempty"`
@@ -173,6 +182,29 @@ func (s *AppsService) Get(ctx context.Context, appSlug string) (*App, *Response,
 	}
 
 	return app, resp, nil
+}
+
+// ListInstallationRequests lists the pending installation requests that the current GitHub App has.
+//
+// GitHub API docs: https://docs.github.com/en/rest/apps/apps#list-installation-requests-for-the-authenticated-app
+func (s *AppsService) ListInstallationRequests(ctx context.Context, opts *ListOptions) ([]*InstallationRequest, *Response, error) {
+	u, err := addOptions("app/installation-requests", opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var i []*InstallationRequest
+	resp, err := s.client.Do(ctx, req, &i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, nil
 }
 
 // ListInstallations lists the installations that the current GitHub App has.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -8910,6 +8910,46 @@ func (i *InstallationRepositoriesEvent) GetSender() *User {
 	return i.Sender
 }
 
+// GetAccount returns the Account field.
+func (i *InstallationRequest) GetAccount() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Account
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (i *InstallationRequest) GetCreatedAt() Timestamp {
+	if i == nil || i.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *i.CreatedAt
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (i *InstallationRequest) GetID() int64 {
+	if i == nil || i.ID == nil {
+		return 0
+	}
+	return *i.ID
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (i *InstallationRequest) GetNodeID() string {
+	if i == nil || i.NodeID == nil {
+		return ""
+	}
+	return *i.NodeID
+}
+
+// GetRequester returns the Requester field.
+func (i *InstallationRequest) GetRequester() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Requester
+}
+
 // GetFrom returns the From field if it's non-nil, zero value otherwise.
 func (i *InstallationSlugChange) GetFrom() string {
 	if i == nil || i.From == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -10487,6 +10487,50 @@ func TestInstallationRepositoriesEvent_GetSender(tt *testing.T) {
 	i.GetSender()
 }
 
+func TestInstallationRequest_GetAccount(tt *testing.T) {
+	i := &InstallationRequest{}
+	i.GetAccount()
+	i = nil
+	i.GetAccount()
+}
+
+func TestInstallationRequest_GetCreatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	i := &InstallationRequest{CreatedAt: &zeroValue}
+	i.GetCreatedAt()
+	i = &InstallationRequest{}
+	i.GetCreatedAt()
+	i = nil
+	i.GetCreatedAt()
+}
+
+func TestInstallationRequest_GetID(tt *testing.T) {
+	var zeroValue int64
+	i := &InstallationRequest{ID: &zeroValue}
+	i.GetID()
+	i = &InstallationRequest{}
+	i.GetID()
+	i = nil
+	i.GetID()
+}
+
+func TestInstallationRequest_GetNodeID(tt *testing.T) {
+	var zeroValue string
+	i := &InstallationRequest{NodeID: &zeroValue}
+	i.GetNodeID()
+	i = &InstallationRequest{}
+	i.GetNodeID()
+	i = nil
+	i.GetNodeID()
+}
+
+func TestInstallationRequest_GetRequester(tt *testing.T) {
+	i := &InstallationRequest{}
+	i.GetRequester()
+	i = nil
+	i.GetRequester()
+}
+
 func TestInstallationSlugChange_GetFrom(tt *testing.T) {
 	var zeroValue string
 	i := &InstallationSlugChange{From: &zeroValue}


### PR DESCRIPTION
The PR adds support for [listing installation requests for the authenticated app](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#list-installation-requests-for-the-authenticated-app).


- [x] Feature addition
- [x] Added Tests
- [x] Run the essential scripts for linting, generation etc.