### PR TITLE
Fix branch protection request fields

### DIFF
--- a/github/repos.go
+++ b/github/repos.go
@@ -1055,7 +1055,7 @@ type RequiredStatusChecks struct {
 	Contexts []string `json:"contexts,omitempty"`
 	// The list of status checks to require in order to merge into this
 	// branch.
-	Checks      []*RequiredStatusCheck `json:"checks"`
+	Checks      []*RequiredStatusCheck `json:"checks,omitempty"`
 	ContextsURL *string                `json:"contexts_url,omitempty"`
 	URL         *string                `json:"url,omitempty"`
 }

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -1766,7 +1766,6 @@ func TestRepositoriesService_UpdateBranchProtection_StrictNoChecks(t *testing.T)
 			input := &ProtectionRequest{
 				RequiredStatusChecks: &RequiredStatusChecks{
 					Strict: true,
-					Checks: []*RequiredStatusCheck{},
 				},
 				RequiredPullRequestReviews: &PullRequestReviewsEnforcementRequest{
 					DismissStaleReviews: true,
@@ -1802,8 +1801,7 @@ func TestRepositoriesService_UpdateBranchProtection_StrictNoChecks(t *testing.T)
 				fmt.Fprintf(w, `{
 					"required_status_checks":{
 						"strict":true,
-						"contexts":[],
-						"checks": []
+						"contexts":[]
 					},
 					"required_pull_request_reviews":{
 						"dismissal_restrictions":{
@@ -1847,7 +1845,6 @@ func TestRepositoriesService_UpdateBranchProtection_StrictNoChecks(t *testing.T)
 				RequiredStatusChecks: &RequiredStatusChecks{
 					Strict:   true,
 					Contexts: []string{},
-					Checks:   []*RequiredStatusCheck{},
 				},
 				RequiredPullRequestReviews: &PullRequestReviewsEnforcement{
 					DismissStaleReviews: true,


### PR DESCRIPTION
Fixes #2976 

The property `Checks` on `RequiredStatusChecks` type is not required according to GitHub api, so using the `omitempty` tag