### PR TITLE
Deprecate RepositoriesService.List

### DIFF
--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -49,14 +49,14 @@ func ExampleRepositoriesService_GetReadme() {
 	fmt.Printf("google/go-github README:\n%v\n", content)
 }
 
-func ExampleRepositoriesService_List() {
+func ExampleRepositoriesService_ListByUser() {
 	client := github.NewClient(nil)
 
 	user := "willnorris"
-	opt := &github.RepositoryListOptions{Type: "owner", Sort: "updated", Direction: "desc"}
+	opt := &github.RepositoryListByUserOptions{Type: "owner", Sort: "updated", Direction: "desc"}
 
 	ctx := context.Background()
-	repos, _, err := client.Repositories.List(ctx, user, opt)
+	repos, _, err := client.Repositories.ListByUser(ctx, user, opt)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -81,7 +81,7 @@ func TestRepositoriesService_ListByUser(t *testing.T) {
 
 	const methodName = "ListByUser"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Repositories.ListByUser(ctx, "\n", nil)
+		_, _, err = client.Repositories.ListByUser(ctx, "\n", &RepositoryListByUserOptions{})
 		return err
 	})
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -18,36 +18,30 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestRepositoriesService_List_authenticatedUser(t *testing.T) {
+func TestRepositoriesService_ListByAuthenticatedUser(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
 	ctx := context.Background()
-	got, _, err := client.Repositories.List(ctx, "", nil)
+	got, _, err := client.Repositories.ListByAuthenticatedUser(ctx, nil)
 	if err != nil {
 		t.Errorf("Repositories.List returned error: %v", err)
 	}
 
 	want := []*Repository{{ID: Int64(1)}, {ID: Int64(2)}}
 	if !cmp.Equal(got, want) {
-		t.Errorf("Repositories.List returned %+v, want %+v", got, want)
+		t.Errorf("Repositories.ListByAuthenticatedUser returned %+v, want %+v", got, want)
 	}
 
-	const methodName = "List"
-	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Repositories.List(ctx, "\n", &RepositoryListOptions{})
-		return err
-	})
+	const methodName = "ListByAuthenticatedUser"
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.List(ctx, "", nil)
+		got, resp, err := client.Repositories.ListByAuthenticatedUser(ctx, nil)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -55,78 +49,84 @@ func TestRepositoriesService_List_authenticatedUser(t *testing.T) {
 	})
 }
 
-func TestRepositoriesService_List_specifiedUser(t *testing.T) {
+func TestRepositoriesService_ListByUser(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/users/u/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{
-			"visibility":  "public",
-			"affiliation": "owner,collaborator",
-			"sort":        "created",
-			"direction":   "asc",
-			"page":        "2",
+			"sort":      "created",
+			"direction": "asc",
+			"page":      "2",
 		})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	opt := &RepositoryListOptions{
-		Visibility:  "public",
-		Affiliation: "owner,collaborator",
+	opt := &RepositoryListByUserOptions{
 		Sort:        "created",
 		Direction:   "asc",
 		ListOptions: ListOptions{Page: 2},
 	}
 	ctx := context.Background()
-	repos, _, err := client.Repositories.List(ctx, "u", opt)
+	repos, _, err := client.Repositories.ListByUser(ctx, "u", opt)
 	if err != nil {
 		t.Errorf("Repositories.List returned error: %v", err)
 	}
 
 	want := []*Repository{{ID: Int64(1)}}
 	if !cmp.Equal(repos, want) {
-		t.Errorf("Repositories.List returned %+v, want %+v", repos, want)
+		t.Errorf("Repositories.ListByUser returned %+v, want %+v", repos, want)
 	}
+
+	const methodName = "ListByUser"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Repositories.ListByUser(ctx, "\n", nil)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Repositories.ListByUser(ctx, "u", nil)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
 }
 
-func TestRepositoriesService_List_specifiedUser_type(t *testing.T) {
+func TestRepositoriesService_ListByUser_type(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/users/u/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"type": "owner",
 		})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	opt := &RepositoryListOptions{
+	opt := &RepositoryListByUserOptions{
 		Type: "owner",
 	}
 	ctx := context.Background()
-	repos, _, err := client.Repositories.List(ctx, "u", opt)
+	repos, _, err := client.Repositories.ListByUser(ctx, "u", opt)
 	if err != nil {
-		t.Errorf("Repositories.List returned error: %v", err)
+		t.Errorf("Repositories.ListByUser returned error: %v", err)
 	}
 
 	want := []*Repository{{ID: Int64(1)}}
 	if !cmp.Equal(repos, want) {
-		t.Errorf("Repositories.List returned %+v, want %+v", repos, want)
+		t.Errorf("Repositories.ListByUser returned %+v, want %+v", repos, want)
 	}
 }
 
-func TestRepositoriesService_List_invalidUser(t *testing.T) {
+func TestRepositoriesService_ListByUser_invalidUser(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
 	ctx := context.Background()
-	_, _, err := client.Repositories.List(ctx, "%", nil)
+	_, _, err := client.Repositories.ListByUser(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -157,29 +157,31 @@ func TestRepositories_EditBranches(t *testing.T) {
 	}
 }
 
-func TestRepositories_List(t *testing.T) {
-	if !checkAuth("TestRepositories_List") {
+func TestRepositories_ListByAuthenticatedUser(t *testing.T) {
+	if !checkAuth("TestRepositories_ListByAuthenticatedUser") {
 		return
 	}
 
-	_, _, err := client.Repositories.List(context.Background(), "", nil)
+	_, _, err := client.Repositories.ListByAuthenticatedUser(context.Background(), nil)
 	if err != nil {
-		t.Fatalf("Repositories.List('') returned error: %v", err)
+		t.Fatalf("Repositories.ListByAuthenticatedUser() returned error: %v", err)
+	}
+}
+
+func TestRepositories_ListByUser(t *testing.T) {
+	_, _, err := client.Repositories.ListByUser(context.Background(), "google", nil)
+	if err != nil {
+		t.Fatalf("Repositories.ListByUser('google') returned error: %v", err)
 	}
 
-	_, _, err = client.Repositories.List(context.Background(), "google", nil)
-	if err != nil {
-		t.Fatalf("Repositories.List('google') returned error: %v", err)
-	}
-
-	opt := github.RepositoryListOptions{Sort: "created"}
-	repos, _, err := client.Repositories.List(context.Background(), "google", &opt)
+	opt := github.RepositoryListByUserOptions{Sort: "created"}
+	repos, _, err := client.Repositories.ListByUser(context.Background(), "google", &opt)
 	if err != nil {
 		t.Fatalf("Repositories.List('google') with Sort opt returned error: %v", err)
 	}
 	for i, repo := range repos {
 		if i > 0 && (*repos[i-1].CreatedAt).Time.Before((*repo.CreatedAt).Time) {
-			t.Fatalf("Repositories.List('google') with default descending Sort returned incorrect order")
+			t.Fatalf("Repositories.ListByUser('google') with default descending Sort returned incorrect order")
 		}
 	}
 }


### PR DESCRIPTION
Closes #2987

This deprecates `RepositoriesService.List` and replaces it with two new methods: `RepositoriesService.ListByUser` and `RepositoriesService.ListByAuthenticatedUser`. See #2987 for the justification.