### PR TITLE
Add `Draft` to `Issue` type

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9406,6 +9406,14 @@ func (i *Issue) GetCreatedAt() Timestamp {
 	return *i.CreatedAt
 }
 
+// GetDraft returns the Draft field if it's non-nil, zero value otherwise.
+func (i *Issue) GetDraft() bool {
+	if i == nil || i.Draft == nil {
+		return false
+	}
+	return *i.Draft
+}
+
 // GetEventsURL returns the EventsURL field if it's non-nil, zero value otherwise.
 func (i *Issue) GetEventsURL() string {
 	if i == nil || i.EventsURL == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11041,6 +11041,16 @@ func TestIssue_GetCreatedAt(tt *testing.T) {
 	i.GetCreatedAt()
 }
 
+func TestIssue_GetDraft(tt *testing.T) {
+	var zeroValue bool
+	i := &Issue{Draft: &zeroValue}
+	i.GetDraft()
+	i = &Issue{}
+	i.GetDraft()
+	i = nil
+	i.GetDraft()
+}
+
 func TestIssue_GetEventsURL(tt *testing.T) {
 	var zeroValue string
 	i := &Issue{EventsURL: &zeroValue}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -768,9 +768,10 @@ func TestIssue_String(t *testing.T) {
 		Repository:        &Repository{},
 		Reactions:         &Reactions{},
 		NodeID:            String(""),
+		Draft:             Bool(false),
 		ActiveLockReason:  String(""),
 	}
-	want := `github.Issue{ID:0, Number:0, State:"", StateReason:"", Locked:false, Title:"", Body:"", AuthorAssociation:"", User:github.User{}, Assignee:github.User{}, Comments:0, ClosedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, ClosedBy:github.User{}, URL:"", HTMLURL:"", CommentsURL:"", EventsURL:"", LabelsURL:"", RepositoryURL:"", Milestone:github.Milestone{}, PullRequestLinks:github.PullRequestLinks{}, Repository:github.Repository{}, Reactions:github.Reactions{}, NodeID:"", ActiveLockReason:""}`
+	want := `github.Issue{ID:0, Number:0, State:"", StateReason:"", Locked:false, Title:"", Body:"", AuthorAssociation:"", User:github.User{}, Assignee:github.User{}, Comments:0, ClosedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, ClosedBy:github.User{}, URL:"", HTMLURL:"", CommentsURL:"", EventsURL:"", LabelsURL:"", RepositoryURL:"", Milestone:github.Milestone{}, PullRequestLinks:github.PullRequestLinks{}, Repository:github.Repository{}, Reactions:github.Reactions{}, NodeID:"", Draft:false, ActiveLockReason:""}`
 	if got := v.String(); got != want {
 		t.Errorf("Issue.String = %v, want %v", got, want)
 	}

--- a/github/issues.go
+++ b/github/issues.go
@@ -54,6 +54,7 @@ type Issue struct {
 	Reactions         *Reactions        `json:"reactions,omitempty"`
 	Assignees         []*User           `json:"assignees,omitempty"`
 	NodeID            *string           `json:"node_id,omitempty"`
+	Draft             *bool             `json:"draft,omitempty"`
 
 	// TextMatches is only populated from search results that request text matches
 	// See: search.go and https://docs.github.com/rest/search/#text-match-metadata


### PR DESCRIPTION
Fixes https://github.com/google/go-github/issues/2996

Adds `Draft` to the `Issue` type, which is documented to be included with issues - https://docs.github.com/en/webhooks/webhook-events-and-payloads#issue_comment