### PR TITLE
Change `PushEvent.Pusher` type to `CommitAuthor`

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -1282,7 +1282,7 @@ type PushEvent struct {
 	Compare      *string              `json:"compare,omitempty"`
 	Repo         *PushEventRepository `json:"repository,omitempty"`
 	HeadCommit   *HeadCommit          `json:"head_commit,omitempty"`
-	Pusher       *User                `json:"pusher,omitempty"`
+	Pusher       *CommitAuthor        `json:"pusher,omitempty"`
 	Sender       *User                `json:"sender,omitempty"`
 	Installation *Installation        `json:"installation,omitempty"`
 

--- a/github/event_types_test.go
+++ b/github/event_types_test.go
@@ -3777,14 +3777,11 @@ func TestPushEvent_Marshal(t *testing.T) {
 		Compare:      String("a"),
 		Repo:         &PushEventRepository{ID: Int64(1)},
 		HeadCommit:   &HeadCommit{ID: String("id")},
-		Pusher: &User{
-			Login:     String("l"),
-			ID:        Int64(1),
-			NodeID:    String("n"),
-			URL:       String("u"),
-			ReposURL:  String("r"),
-			EventsURL: String("e"),
-			AvatarURL: String("a"),
+		Pusher: &CommitAuthor{
+			Login: String("l"),
+			Date:  &Timestamp{referenceTime},
+			Name:  String("n"),
+			Email: String("e"),
 		},
 		Sender: &User{
 			Login:     String("l"),
@@ -3937,13 +3934,10 @@ func TestPushEvent_Marshal(t *testing.T) {
 			"id": "id"
 		},
 		"pusher": {
-			"login": "l",
-			"id": 1,
-			"node_id": "n",
-			"avatar_url": "a",
-			"url": "u",
-			"events_url": "e",
-			"repos_url": "r"
+			"date": ` + referenceTimeStr + `,
+			"name": "n",
+			"email": "e",
+			"username": "l"
 		},
 		"sender": {
 			"login": "l",

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -17231,7 +17231,7 @@ func (p *PushEvent) GetOrganization() *Organization {
 }
 
 // GetPusher returns the Pusher field.
-func (p *PushEvent) GetPusher() *User {
+func (p *PushEvent) GetPusher() *CommitAuthor {
 	if p == nil {
 		return nil
 	}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1426,12 +1426,12 @@ func TestPushEvent_String(t *testing.T) {
 		Compare:      String(""),
 		Repo:         &PushEventRepository{},
 		HeadCommit:   &HeadCommit{},
-		Pusher:       &User{},
+		Pusher:       &CommitAuthor{},
 		Sender:       &User{},
 		Installation: &Installation{},
 		Organization: &Organization{},
 	}
-	want := `github.PushEvent{PushID:0, Head:"", Ref:"", Size:0, Before:"", DistinctSize:0, Action:"", After:"", Created:false, Deleted:false, Forced:false, BaseRef:"", Compare:"", Repo:github.PushEventRepository{}, HeadCommit:github.HeadCommit{}, Pusher:github.User{}, Sender:github.User{}, Installation:github.Installation{}, Organization:github.Organization{}}`
+	want := `github.PushEvent{PushID:0, Head:"", Ref:"", Size:0, Before:"", DistinctSize:0, Action:"", After:"", Created:false, Deleted:false, Forced:false, BaseRef:"", Compare:"", Repo:github.PushEventRepository{}, HeadCommit:github.HeadCommit{}, Pusher:github.CommitAuthor{}, Sender:github.User{}, Installation:github.Installation{}, Organization:github.Organization{}}`
 	if got := v.String(); got != want {
 		t.Errorf("PushEvent.String = %v, want %v", got, want)
 	}

--- a/github/repos_hooks_test.go
+++ b/github/repos_hooks_test.go
@@ -357,9 +357,8 @@ func TestBranchWebHookPayload_Marshal(t *testing.T) {
 		Organization: &Organization{
 			ID: Int64(22),
 		},
-		Pusher: &User{
+		Pusher: &CommitAuthor{
 			Login: String("rd@yahoo.com"),
-			ID:    Int64(112),
 		},
 		Repo: &PushEventRepository{
 			ID:     Int64(321),
@@ -421,8 +420,7 @@ func TestBranchWebHookPayload_Marshal(t *testing.T) {
 			"id" : 22
 		},
 		"pusher":{
-			"login": "rd@yahoo.com",
-			"id": 112
+			"username": "rd@yahoo.com"
 		},
 		"repository":{
 			"id": 321,


### PR DESCRIPTION
Fixes https://github.com/google/go-github/issues/2998

`CommitAuthor` currently has the exact fields that the push event's `Pusher` provides and is more correct than using `User` for the reasons laid out in the linked issue.

<img width="383" alt="image" src="https://github.com/google/go-github/assets/16676170/36e08b9a-09fe-4483-bd03-533d17601ff1">
