### PR TITLE
Escape package names to support names which include a slash

### DIFF
--- a/github/orgs_packages.go
+++ b/github/orgs_packages.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"net/url"
 )
 
 // ListPackages lists the packages for an organization.
@@ -63,7 +64,7 @@ func (s *OrganizationsService) GetPackage(ctx context.Context, org, packageType,
 //
 //meta:operation DELETE /orgs/{org}/packages/{package_type}/{package_name}
 func (s *OrganizationsService) DeletePackage(ctx context.Context, org, packageType, packageName string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/packages/%v/%v", org, packageType, packageName)
+	u := fmt.Sprintf("orgs/%v/packages/%v/%v", org, packageType, url.PathEscape(packageName))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -78,7 +79,7 @@ func (s *OrganizationsService) DeletePackage(ctx context.Context, org, packageTy
 //
 //meta:operation POST /orgs/{org}/packages/{package_type}/{package_name}/restore
 func (s *OrganizationsService) RestorePackage(ctx context.Context, org, packageType, packageName string) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/packages/%v/%v/restore", org, packageType, packageName)
+	u := fmt.Sprintf("orgs/%v/packages/%v/%v/restore", org, packageType, url.PathEscape(packageName))
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
@@ -93,7 +94,7 @@ func (s *OrganizationsService) RestorePackage(ctx context.Context, org, packageT
 //
 //meta:operation GET /orgs/{org}/packages/{package_type}/{package_name}/versions
 func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, packageType, packageName string, opts *PackageListOptions) ([]*PackageVersion, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions", org, packageType, packageName)
+	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions", org, packageType, url.PathEscape(packageName))
 	u, err := addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -119,7 +120,7 @@ func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, p
 //
 //meta:operation GET /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}
 func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*PackageVersion, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v", org, packageType, packageName, packageVersionID)
+	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v", org, packageType, url.PathEscape(packageName), packageVersionID)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -140,7 +141,7 @@ func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packa
 //
 //meta:operation DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}
 func (s *OrganizationsService) PackageDeleteVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v", org, packageType, packageName, packageVersionID)
+	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v", org, packageType, url.PathEscape(packageName), packageVersionID)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -155,7 +156,7 @@ func (s *OrganizationsService) PackageDeleteVersion(ctx context.Context, org, pa
 //
 //meta:operation POST /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore
 func (s *OrganizationsService) PackageRestoreVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*Response, error) {
-	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v/restore", org, packageType, packageName, packageVersionID)
+	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v/restore", org, packageType, url.PathEscape(packageName), packageVersionID)
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/orgs_packages.go
+++ b/github/orgs_packages.go
@@ -45,7 +45,7 @@ func (s *OrganizationsService) ListPackages(ctx context.Context, org string, opt
 //
 //meta:operation GET /orgs/{org}/packages/{package_type}/{package_name}
 func (s *OrganizationsService) GetPackage(ctx context.Context, org, packageType, packageName string) (*Package, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/packages/%v/%v", org, packageType, packageName)
+	u := fmt.Sprintf("orgs/%v/packages/%v/%v", org, packageType, url.PathEscape(packageName))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/github/orgs_packages.go
+++ b/github/orgs_packages.go
@@ -41,6 +41,8 @@ func (s *OrganizationsService) ListPackages(ctx context.Context, org string, opt
 //
 // GitHub API docs: https://docs.github.com/rest/packages/packages#get-a-package-for-an-organization
 //
+// Note that packageName is escaped for the URL path so that you don't need to.
+//
 //meta:operation GET /orgs/{org}/packages/{package_type}/{package_name}
 func (s *OrganizationsService) GetPackage(ctx context.Context, org, packageType, packageName string) (*Package, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages/%v/%v", org, packageType, packageName)
@@ -62,6 +64,8 @@ func (s *OrganizationsService) GetPackage(ctx context.Context, org, packageType,
 //
 // GitHub API docs: https://docs.github.com/rest/packages/packages#delete-a-package-for-an-organization
 //
+// Note that packageName is escaped for the URL path so that you don't need to.
+//
 //meta:operation DELETE /orgs/{org}/packages/{package_type}/{package_name}
 func (s *OrganizationsService) DeletePackage(ctx context.Context, org, packageType, packageName string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages/%v/%v", org, packageType, url.PathEscape(packageName))
@@ -77,6 +81,8 @@ func (s *OrganizationsService) DeletePackage(ctx context.Context, org, packageTy
 //
 // GitHub API docs: https://docs.github.com/rest/packages/packages#restore-a-package-for-an-organization
 //
+// Note that packageName is escaped for the URL path so that you don't need to.
+//
 //meta:operation POST /orgs/{org}/packages/{package_type}/{package_name}/restore
 func (s *OrganizationsService) RestorePackage(ctx context.Context, org, packageType, packageName string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages/%v/%v/restore", org, packageType, url.PathEscape(packageName))
@@ -91,6 +97,8 @@ func (s *OrganizationsService) RestorePackage(ctx context.Context, org, packageT
 // PackageGetAllVersions gets all versions of a package in an organization.
 //
 // GitHub API docs: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization
+//
+// Note that packageName is escaped for the URL path so that you don't need to.
 //
 //meta:operation GET /orgs/{org}/packages/{package_type}/{package_name}/versions
 func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, packageType, packageName string, opts *PackageListOptions) ([]*PackageVersion, *Response, error) {
@@ -118,6 +126,8 @@ func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, p
 //
 // GitHub API docs: https://docs.github.com/rest/packages/packages#get-a-package-version-for-an-organization
 //
+// Note that packageName is escaped for the URL path so that you don't need to.
+//
 //meta:operation GET /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}
 func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*PackageVersion, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v", org, packageType, url.PathEscape(packageName), packageVersionID)
@@ -139,6 +149,8 @@ func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packa
 //
 // GitHub API docs: https://docs.github.com/rest/packages/packages#delete-package-version-for-an-organization
 //
+// Note that packageName is escaped for the URL path so that you don't need to.
+//
 //meta:operation DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}
 func (s *OrganizationsService) PackageDeleteVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v", org, packageType, url.PathEscape(packageName), packageVersionID)
@@ -153,6 +165,8 @@ func (s *OrganizationsService) PackageDeleteVersion(ctx context.Context, org, pa
 // PackageRestoreVersion restores a package version to an organization.
 //
 // GitHub API docs: https://docs.github.com/rest/packages/packages#restore-package-version-for-an-organization
+//
+// Note that packageName is escaped for the URL path so that you don't need to.
 //
 //meta:operation POST /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore
 func (s *OrganizationsService) PackageRestoreVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*Response, error) {

--- a/github/orgs_packages.go
+++ b/github/orgs_packages.go
@@ -39,9 +39,9 @@ func (s *OrganizationsService) ListPackages(ctx context.Context, org string, opt
 
 // GetPackage gets a package by name from an organization.
 //
-// GitHub API docs: https://docs.github.com/rest/packages/packages#get-a-package-for-an-organization
-//
 // Note that packageName is escaped for the URL path so that you don't need to.
+//
+// GitHub API docs: https://docs.github.com/rest/packages/packages#get-a-package-for-an-organization
 //
 //meta:operation GET /orgs/{org}/packages/{package_type}/{package_name}
 func (s *OrganizationsService) GetPackage(ctx context.Context, org, packageType, packageName string) (*Package, *Response, error) {
@@ -62,9 +62,9 @@ func (s *OrganizationsService) GetPackage(ctx context.Context, org, packageType,
 
 // DeletePackage deletes a package from an organization.
 //
-// GitHub API docs: https://docs.github.com/rest/packages/packages#delete-a-package-for-an-organization
-//
 // Note that packageName is escaped for the URL path so that you don't need to.
+//
+// GitHub API docs: https://docs.github.com/rest/packages/packages#delete-a-package-for-an-organization
 //
 //meta:operation DELETE /orgs/{org}/packages/{package_type}/{package_name}
 func (s *OrganizationsService) DeletePackage(ctx context.Context, org, packageType, packageName string) (*Response, error) {
@@ -79,9 +79,9 @@ func (s *OrganizationsService) DeletePackage(ctx context.Context, org, packageTy
 
 // RestorePackage restores a package to an organization.
 //
-// GitHub API docs: https://docs.github.com/rest/packages/packages#restore-a-package-for-an-organization
-//
 // Note that packageName is escaped for the URL path so that you don't need to.
+//
+// GitHub API docs: https://docs.github.com/rest/packages/packages#restore-a-package-for-an-organization
 //
 //meta:operation POST /orgs/{org}/packages/{package_type}/{package_name}/restore
 func (s *OrganizationsService) RestorePackage(ctx context.Context, org, packageType, packageName string) (*Response, error) {
@@ -96,9 +96,9 @@ func (s *OrganizationsService) RestorePackage(ctx context.Context, org, packageT
 
 // PackageGetAllVersions gets all versions of a package in an organization.
 //
-// GitHub API docs: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization
-//
 // Note that packageName is escaped for the URL path so that you don't need to.
+//
+// GitHub API docs: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization
 //
 //meta:operation GET /orgs/{org}/packages/{package_type}/{package_name}/versions
 func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, packageType, packageName string, opts *PackageListOptions) ([]*PackageVersion, *Response, error) {
@@ -124,9 +124,9 @@ func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, p
 
 // PackageGetVersion gets a specific version of a package in an organization.
 //
-// GitHub API docs: https://docs.github.com/rest/packages/packages#get-a-package-version-for-an-organization
-//
 // Note that packageName is escaped for the URL path so that you don't need to.
+//
+// GitHub API docs: https://docs.github.com/rest/packages/packages#get-a-package-version-for-an-organization
 //
 //meta:operation GET /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}
 func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*PackageVersion, *Response, error) {
@@ -147,9 +147,9 @@ func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packa
 
 // PackageDeleteVersion deletes a package version from an organization.
 //
-// GitHub API docs: https://docs.github.com/rest/packages/packages#delete-package-version-for-an-organization
-//
 // Note that packageName is escaped for the URL path so that you don't need to.
+//
+// GitHub API docs: https://docs.github.com/rest/packages/packages#delete-package-version-for-an-organization
 //
 //meta:operation DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}
 func (s *OrganizationsService) PackageDeleteVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*Response, error) {
@@ -164,9 +164,9 @@ func (s *OrganizationsService) PackageDeleteVersion(ctx context.Context, org, pa
 
 // PackageRestoreVersion restores a package version to an organization.
 //
-// GitHub API docs: https://docs.github.com/rest/packages/packages#restore-package-version-for-an-organization
-//
 // Note that packageName is escaped for the URL path so that you don't need to.
+//
+// GitHub API docs: https://docs.github.com/rest/packages/packages#restore-package-version-for-an-organization
 //
 //meta:operation POST /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore
 func (s *OrganizationsService) PackageRestoreVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*Response, error) {

--- a/github/orgs_packages_test.go
+++ b/github/orgs_packages_test.go
@@ -7,7 +7,7 @@ package github
 
 import (
 	"context"
-	"fmt"
+	"io"
 	"net/http"
 	"testing"
 
@@ -20,7 +20,7 @@ func TestOrganizationsService_ListPackages(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/packages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
+		io.WriteString(w, `[{
 			"id": 197,
 			"name": "hello_docker",
 			"package_type": "container",
@@ -114,35 +114,36 @@ func TestOrganizationsService_GetPackage(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/o/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
+	// don't url escape the package name here since mux will convert it to a slash automatically
+	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{
+		io.WriteString(w, `{
 			"id": 197,
-			"name": "hello_docker",
+			"name": "hello/hello_docker",
 			"package_type": "container",
 			"version_count": 1,
 			"visibility": "private",
-			"url": "https://api.github.com/orgs/github/packages/container/hello_docker",
+			"url": "https://api.github.com/orgs/github/packages/container/hello%2Fhello_docker",
 			"created_at": `+referenceTimeStr+`,
 			"updated_at": `+referenceTimeStr+`,
-			"html_url": "https://github.com/orgs/github/packages/container/package/hello_docker"
+			"html_url": "https://github.com/orgs/github/packages/container/package/hello%2Fhello_docker"
 		  }`)
 	})
 
 	ctx := context.Background()
-	packages, _, err := client.Organizations.GetPackage(ctx, "o", "container", "hello_docker")
+	packages, _, err := client.Organizations.GetPackage(ctx, "o", "container", "hello/hello_docker")
 	if err != nil {
 		t.Errorf("Organizations.GetPackage returned error: %v", err)
 	}
 
 	want := &Package{
 		ID:           Int64(197),
-		Name:         String("hello_docker"),
+		Name:         String("hello/hello_docker"),
 		PackageType:  String("container"),
 		VersionCount: Int64(1),
 		Visibility:   String("private"),
-		URL:          String("https://api.github.com/orgs/github/packages/container/hello_docker"),
-		HTMLURL:      String("https://github.com/orgs/github/packages/container/package/hello_docker"),
+		URL:          String("https://api.github.com/orgs/github/packages/container/hello%2Fhello_docker"),
+		HTMLURL:      String("https://github.com/orgs/github/packages/container/package/hello%2Fhello_docker"),
 		CreatedAt:    &Timestamp{referenceTime},
 		UpdatedAt:    &Timestamp{referenceTime},
 	}
@@ -169,12 +170,13 @@ func TestOrganizationsService_DeletePackage(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/o/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
+	// don't url escape the package name here since mux will convert it to a slash automatically
+	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
 	ctx := context.Background()
-	_, err := client.Organizations.DeletePackage(ctx, "o", "container", "hello_docker")
+	_, err := client.Organizations.DeletePackage(ctx, "o", "container", "hello/hello_docker")
 	if err != nil {
 		t.Errorf("Organizations.DeletePackage returned error: %v", err)
 	}
@@ -198,12 +200,13 @@ func TestOrganizationsService_RestorePackage(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/o/packages/container/hello_docker/restore", func(w http.ResponseWriter, r *http.Request) {
+	// don't url escape the package name here since mux will convert it to a slash automatically
+	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker/restore", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 
 	ctx := context.Background()
-	_, err := client.Organizations.RestorePackage(ctx, "o", "container", "hello_docker")
+	_, err := client.Organizations.RestorePackage(ctx, "o", "container", "hello/hello_docker")
 	if err != nil {
 		t.Errorf("Organizations.RestorePackage returned error: %v", err)
 	}
@@ -215,7 +218,7 @@ func TestOrganizationsService_RestorePackage(t *testing.T) {
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Organizations.RestorePackage(ctx, "", "container", "hello_docker")
+		return client.Organizations.RestorePackage(ctx, "", "container", "hello/hello_docker")
 	})
 }
 
@@ -223,18 +226,19 @@ func TestOrganizationsService_ListPackagesVersions(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/o/packages/container/hello_docker/versions", func(w http.ResponseWriter, r *http.Request) {
+	// don't url escape the package name here since mux will convert it to a slash automatically
+	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker/versions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"per_page": "2", "page": "1", "state": "deleted", "visibility": "internal", "package_type": "container"})
-		fmt.Fprint(w, `[
+		io.WriteString(w, `[
 			{
 			  "id": 45763,
 			  "name": "sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9",
-			  "url": "https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763",
-			  "package_html_url": "https://github.com/users/octocat/packages/container/package/hello_docker",
+			  "url": "https://api.github.com/users/octocat/packages/container/hello%2Fhello_docker/versions/45763",
+			  "package_html_url": "https://github.com/users/octocat/packages/container/package/hello%2Fhello_docker",
 			  "created_at": `+referenceTimeStr+`,
 			  "updated_at": `+referenceTimeStr+`,
-			  "html_url": "https://github.com/users/octocat/packages/container/hello_docker/45763",
+			  "html_url": "https://github.com/users/octocat/packages/container/hello%2Fhello_docker/45763",
 			  "metadata": {
 				"package_type": "container",
 				"container": {
@@ -250,7 +254,7 @@ func TestOrganizationsService_ListPackagesVersions(t *testing.T) {
 	opts := &PackageListOptions{
 		String("internal"), String("container"), String("deleted"), ListOptions{Page: 1, PerPage: 2},
 	}
-	packages, _, err := client.Organizations.PackageGetAllVersions(ctx, "o", "container", "hello_docker", opts)
+	packages, _, err := client.Organizations.PackageGetAllVersions(ctx, "o", "container", "hello/hello_docker", opts)
 	if err != nil {
 		t.Errorf("Organizations.PackageGetAllVersions returned error: %v", err)
 	}
@@ -258,11 +262,11 @@ func TestOrganizationsService_ListPackagesVersions(t *testing.T) {
 	want := []*PackageVersion{{
 		ID:             Int64(45763),
 		Name:           String("sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9"),
-		URL:            String("https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763"),
-		PackageHTMLURL: String("https://github.com/users/octocat/packages/container/package/hello_docker"),
+		URL:            String("https://api.github.com/users/octocat/packages/container/hello%2Fhello_docker/versions/45763"),
+		PackageHTMLURL: String("https://github.com/users/octocat/packages/container/package/hello%2Fhello_docker"),
 		CreatedAt:      &Timestamp{referenceTime},
 		UpdatedAt:      &Timestamp{referenceTime},
-		HTMLURL:        String("https://github.com/users/octocat/packages/container/hello_docker/45763"),
+		HTMLURL:        String("https://github.com/users/octocat/packages/container/hello%2Fhello_docker/45763"),
 		Metadata: &PackageMetadata{
 			PackageType: String("container"),
 			Container: &PackageContainerMetadata{
@@ -293,17 +297,18 @@ func TestOrganizationsService_PackageGetVersion(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/o/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
+	// don't url escape the package name here since mux will convert it to a slash automatically
+	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `
+		io.WriteString(w, `
 			{
 			  "id": 45763,
 			  "name": "sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9",
-			  "url": "https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763",
-			  "package_html_url": "https://github.com/users/octocat/packages/container/package/hello_docker",
+			  "url": "https://api.github.com/users/octocat/packages/container/hello%2Fhello_docker/versions/45763",
+			  "package_html_url": "https://github.com/users/octocat/packages/container/package/hello%2Fhello_docker",
 			  "created_at": `+referenceTimeStr+`,
 			  "updated_at": `+referenceTimeStr+`,
-			  "html_url": "https://github.com/users/octocat/packages/container/hello_docker/45763",
+			  "html_url": "https://github.com/users/octocat/packages/container/hello%2Fhello_docker/45763",
 			  "metadata": {
 				"package_type": "container",
 				"container": {
@@ -316,7 +321,7 @@ func TestOrganizationsService_PackageGetVersion(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	packages, _, err := client.Organizations.PackageGetVersion(ctx, "o", "container", "hello_docker", 45763)
+	packages, _, err := client.Organizations.PackageGetVersion(ctx, "o", "container", "hello/hello_docker", 45763)
 	if err != nil {
 		t.Errorf("Organizations.PackageGetVersion returned error: %v", err)
 	}
@@ -324,11 +329,11 @@ func TestOrganizationsService_PackageGetVersion(t *testing.T) {
 	want := &PackageVersion{
 		ID:             Int64(45763),
 		Name:           String("sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9"),
-		URL:            String("https://api.github.com/users/octocat/packages/container/hello_docker/versions/45763"),
-		PackageHTMLURL: String("https://github.com/users/octocat/packages/container/package/hello_docker"),
+		URL:            String("https://api.github.com/users/octocat/packages/container/hello%2Fhello_docker/versions/45763"),
+		PackageHTMLURL: String("https://github.com/users/octocat/packages/container/package/hello%2Fhello_docker"),
 		CreatedAt:      &Timestamp{referenceTime},
 		UpdatedAt:      &Timestamp{referenceTime},
-		HTMLURL:        String("https://github.com/users/octocat/packages/container/hello_docker/45763"),
+		HTMLURL:        String("https://github.com/users/octocat/packages/container/hello%2Fhello_docker/45763"),
 		Metadata: &PackageMetadata{
 			PackageType: String("container"),
 			Container: &PackageContainerMetadata{
@@ -359,12 +364,13 @@ func TestOrganizationsService_PackageDeleteVersion(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/o/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
+	// don't url escape the package name here since mux will convert it to a slash automatically
+	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
 	ctx := context.Background()
-	_, err := client.Organizations.PackageDeleteVersion(ctx, "o", "container", "hello_docker", 45763)
+	_, err := client.Organizations.PackageDeleteVersion(ctx, "o", "container", "hello/hello_docker", 45763)
 	if err != nil {
 		t.Errorf("Organizations.PackageDeleteVersion returned error: %v", err)
 	}
@@ -384,12 +390,13 @@ func TestOrganizationsService_PackageRestoreVersion(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/o/packages/container/hello_docker/versions/45763/restore", func(w http.ResponseWriter, r *http.Request) {
+	// don't url escape the package name here since mux will convert it to a slash automatically
+	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker/versions/45763/restore", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 
 	ctx := context.Background()
-	_, err := client.Organizations.PackageRestoreVersion(ctx, "o", "container", "hello_docker", 45763)
+	_, err := client.Organizations.PackageRestoreVersion(ctx, "o", "container", "hello/hello_docker", 45763)
 	if err != nil {
 		t.Errorf("Organizations.PackageRestoreVersion returned error: %v", err)
 	}

--- a/github/orgs_packages_test.go
+++ b/github/orgs_packages_test.go
@@ -20,7 +20,7 @@ func TestOrganizationsService_ListPackages(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/packages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		io.WriteString(w, `[{
+		_, err := io.WriteString(w, `[{
 			"id": 197,
 			"name": "hello_docker",
 			"package_type": "container",
@@ -52,6 +52,9 @@ func TestOrganizationsService_ListPackages(t *testing.T) {
 			"html_url": "https://github.com/orgs/github/packages/container/package/hello_docker"
 		  }
 		  ]`)
+		if err != nil {
+			t.Fatal("Failed to write test response: ", err)
+		}
 	})
 
 	ctx := context.Background()
@@ -117,7 +120,7 @@ func TestOrganizationsService_GetPackage(t *testing.T) {
 	// don't url escape the package name here since mux will convert it to a slash automatically
 	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		io.WriteString(w, `{
+		_, err := io.WriteString(w, `{
 			"id": 197,
 			"name": "hello/hello_docker",
 			"package_type": "container",
@@ -128,6 +131,9 @@ func TestOrganizationsService_GetPackage(t *testing.T) {
 			"updated_at": `+referenceTimeStr+`,
 			"html_url": "https://github.com/orgs/github/packages/container/package/hello%2Fhello_docker"
 		  }`)
+		if err != nil {
+			t.Fatal("Failed to write test response: ", err)
+		}
 	})
 
 	ctx := context.Background()
@@ -230,7 +236,7 @@ func TestOrganizationsService_ListPackagesVersions(t *testing.T) {
 	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker/versions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"per_page": "2", "page": "1", "state": "deleted", "visibility": "internal", "package_type": "container"})
-		io.WriteString(w, `[
+		_, err := io.WriteString(w, `[
 			{
 			  "id": 45763,
 			  "name": "sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9",
@@ -248,6 +254,9 @@ func TestOrganizationsService_ListPackagesVersions(t *testing.T) {
 				}
 			  }
 			}]`)
+		if err != nil {
+			t.Fatal("Failed to write test response: ", err)
+		}
 	})
 
 	ctx := context.Background()
@@ -300,7 +309,7 @@ func TestOrganizationsService_PackageGetVersion(t *testing.T) {
 	// don't url escape the package name here since mux will convert it to a slash automatically
 	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		io.WriteString(w, `
+		_, err := io.WriteString(w, `
 			{
 			  "id": 45763,
 			  "name": "sha256:08a44bab0bddaddd8837a8b381aebc2e4b933768b981685a9e088360af0d3dd9",
@@ -318,6 +327,9 @@ func TestOrganizationsService_PackageGetVersion(t *testing.T) {
 				}
 			  }
 			}`)
+		if err != nil {
+			t.Fatal("Failed to write test response: ", err)
+		}
 	})
 
 	ctx := context.Background()


### PR DESCRIPTION
Package names aren't escaped before being added to the url.
E.g. `orgs/foo/packages/container/foo/bar` instead of `orgs/foo/packages/container/foo%2Fbar`

This causes 404 errors for such packages.