### PR TITLE
Add Repo and Action to IssueEvent

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9510,6 +9510,14 @@ func (i *IssueEvent) GetRename() *Rename {
 	return i.Rename
 }
 
+// GetRepository returns the Repository field.
+func (i *IssueEvent) GetRepository() *Repository {
+	if i == nil {
+		return nil
+	}
+	return i.Repository
+}
+
 // GetRequestedReviewer returns the RequestedReviewer field.
 func (i *IssueEvent) GetRequestedReviewer() *User {
 	if i == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11096,6 +11096,13 @@ func TestIssueEvent_GetRename(tt *testing.T) {
 	i.GetRename()
 }
 
+func TestIssueEvent_GetRepository(tt *testing.T) {
+	i := &IssueEvent{}
+	i.GetRepository()
+	i = nil
+	i.GetRepository()
+}
+
 func TestIssueEvent_GetRequestedReviewer(tt *testing.T) {
 	i := &IssueEvent{}
 	i.GetRequestedReviewer()

--- a/github/issues_events.go
+++ b/github/issues_events.go
@@ -18,6 +18,9 @@ type IssueEvent struct {
 	// The User that generated this event.
 	Actor *User `json:"actor,omitempty"`
 
+	// The action corresponding to the event.
+	Action string `json:"action,omitempty"`
+
 	// Event identifies the actual type of Event that occurred. Possible
 	// values are:
 	//
@@ -74,6 +77,7 @@ type IssueEvent struct {
 	Issue     *Issue     `json:"issue,omitempty"`
 
 	// Only present on certain events; see above.
+	Repository            *Repository      `json:"repository,omitempty"`
 	Assignee              *User            `json:"assignee,omitempty"`
 	Assigner              *User            `json:"assigner,omitempty"`
 	CommitID              *string          `json:"commit_id,omitempty"`


### PR DESCRIPTION
# Description
The IssueEvent was missing the details of `action` and `repository`. 

Issue: #3038 
Related Issue: Similar issue was also reported in #768