### PR TITLE
Add list repo org variables and secrets

### DIFF
--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -138,6 +138,17 @@ func (s *ActionsService) ListRepoSecrets(ctx context.Context, owner, repo string
 	return s.listSecrets(ctx, url, opts)
 }
 
+// ListRepoOrgSecrets lists all organization secrets available in a repository
+// without revealing their encrypted values.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/secrets#list-repository-organization-secrets
+//
+//meta:operation GET /repos/{owner}/{repo}/actions/organization-secrets
+func (s *ActionsService) ListRepoOrgSecrets(ctx context.Context, owner, repo string, opts *ListOptions) (*Secrets, *Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/actions/organization-secrets", owner, repo)
+	return s.listSecrets(ctx, url, opts)
+}
+
 // ListOrgSecrets lists all secrets available in an organization
 // without revealing their encrypted values.
 //

--- a/github/actions_variables.go
+++ b/github/actions_variables.go
@@ -59,6 +59,16 @@ func (s *ActionsService) ListRepoVariables(ctx context.Context, owner, repo stri
 	return s.listVariables(ctx, url, opts)
 }
 
+// ListRepoOrgVariables lists all organization variables available in a repository.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/variables#list-repository-organization-variables
+//
+//meta:operation GET /repos/{owner}/{repo}/actions/organization-variables
+func (s *ActionsService) ListRepoOrgVariables(ctx context.Context, owner, repo string, opts *ListOptions) (*ActionsVariables, *Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/actions/organization-variables", owner, repo)
+	return s.listVariables(ctx, url, opts)
+}
+
 // ListOrgVariables lists all variables available in an organization.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/variables#list-organization-variables


### PR DESCRIPTION
This wraps two repository API endpoints which are currently not available in the interface:

- [List repository organization actions secrets ](https://docs.github.com/en/enterprise-cloud@latest/rest/actions/secrets?apiVersion=2022-11-28#list-repository-organization-secrets)
- [List repository organization actions variables](https://docs.github.com/en/rest/actions/variables?apiVersion=2022-11-28#list-repository-organization-variables)