### PR TITLE
Add ListWorkflowJobsAttempt method to ActionsService

### DIFF
--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -94,6 +94,32 @@ func (s *ActionsService) ListWorkflowJobs(ctx context.Context, owner, repo strin
 	return jobs, resp, nil
 }
 
+// ListWorkflowJobsAttempt lists jobs for a workflow run Attempt.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run-attempt
+//
+//meta:operation GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs
+func (s *ActionsService) ListWorkflowJobsAttempt(ctx context.Context, owner, repo string, runID, attemptNumber int64, opts *ListOptions) (*Jobs, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/actions/runs/%v/attempts/%v/jobs", owner, repo, runID, attemptNumber)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	jobs := new(Jobs)
+	resp, err := s.client.Do(ctx, req, &jobs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return jobs, resp, nil
+}
+
 // GetWorkflowJobByID gets a specific job in a workflow run by ID.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -89,6 +89,46 @@ func TestActionsService_ListWorkflowJobs_Filter(t *testing.T) {
 	}
 }
 
+func TestActionsService_ListWorkflowJobsAttempt(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/actions/runs/29679449/attempts/1/jobs", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"per_page": "2", "page": "2"})
+		fmt.Fprint(w, `{"total_count":4,"jobs":[{"id":399444496,"run_id":29679449,"started_at":"2019-01-02T15:04:05Z","completed_at":"2020-01-02T15:04:05Z","run_attempt":2},{"id":399444497,"run_id":29679449,"started_at":"2019-01-02T15:04:05Z","completed_at":"2020-01-02T15:04:05Z","run_attempt":2}]}`)
+	})
+	opts := &ListOptions{Page: 2, PerPage: 2}
+	ctx := context.Background()
+	jobs, _, err := client.Actions.ListWorkflowJobsAttempt(ctx, "o", "r", 29679449, 1, opts)
+	if err != nil {
+		t.Errorf("Actions.ListWorkflowJobsAttempt returned error: %v", err)
+	}
+
+	want := &Jobs{
+		TotalCount: Int(4),
+		Jobs: []*WorkflowJob{
+			{
+				ID:          Int64(399444496),
+				RunID:       Int64(29679449),
+				StartedAt:   &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
+				CompletedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
+				RunAttempt:  Int64(2),
+			},
+			{
+				ID:          Int64(399444497),
+				RunID:       Int64(29679449),
+				StartedAt:   &Timestamp{time.Date(2019, time.January, 02, 15, 04, 05, 0, time.UTC)},
+				CompletedAt: &Timestamp{time.Date(2020, time.January, 02, 15, 04, 05, 0, time.UTC)},
+				RunAttempt:  Int64(2),
+			},
+		},
+	}
+	if !cmp.Equal(jobs, want) {
+		t.Errorf("Actions.ListWorkflowJobsAttempt returned %+v, want %+v", jobs, want)
+	}
+}
+
 func TestActionsService_GetWorkflowJobByID(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -127,6 +127,20 @@ func TestActionsService_ListWorkflowJobsAttempt(t *testing.T) {
 	if !cmp.Equal(jobs, want) {
 		t.Errorf("Actions.ListWorkflowJobsAttempt returned %+v, want %+v", jobs, want)
 	}
+
+	const methodName = "ListWorkflowJobsAttempt"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.ListWorkflowJobsAttempt(ctx, "\n", "\n", 29679449, 1, opts)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.ListWorkflowJobsAttempt(ctx, "o", "r", 29679449, 1, opts)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
 }
 
 func TestActionsService_GetWorkflowJobByID(t *testing.T) {


### PR DESCRIPTION
Fixes: #3059.

Add support ListWorkflowJobsAttempt API. 
https://docs.github.com/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run-attempt