### PR TITLE
Allow querying rule set information by ID with information returned from GetRulesFromBranch

### DIFF
--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -112,8 +112,11 @@ type RequiredWorkflowsRuleParameters struct {
 
 // RepositoryRule represents a GitHub Rule.
 type RepositoryRule struct {
-	Type       string           `json:"type"`
-	Parameters *json.RawMessage `json:"parameters,omitempty"`
+	Type              string           `json:"type"`
+	Parameters        *json.RawMessage `json:"parameters,omitempty"`
+	RulesetSourceType string           `json:"ruleset_source_type"`
+	RulesetSource     string           `json:"ruleset_source"`
+	RulesetID         int64            `json:"ruleset_id"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
@@ -125,6 +128,9 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	r.RulesetID = RepositoryRule.RulesetID
+	r.RulesetSourceType = RepositoryRule.RulesetSourceType
+	r.RulesetSource = RepositoryRule.RulesetSource
 	r.Type = RepositoryRule.Type
 
 	switch RepositoryRule.Type {

--- a/github/repos_rules_test.go
+++ b/github/repos_rules_test.go
@@ -28,6 +28,20 @@ func TestRepositoryRule_UnmarshalJSON(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		"With Metadata": {
+			data: `{
+                    "type": "creation",
+					"ruleset_source_type": "Repository",
+					"ruleset_source": "google",
+					"ruleset_id": 1984
+           		   }`,
+			want: &RepositoryRule{
+				RulesetSource:     "google",
+				RulesetSourceType: "Repository",
+				RulesetID:         1984,
+				Type:              "creation",
+			},
+		},
 		"Valid creation": {
 			data: `{"type":"creation"}`,
 			want: NewCreationRule(),
@@ -262,9 +276,15 @@ func TestRepositoriesService_GetRulesForBranch(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[
 			{
+			  "ruleset_id": 42069,
+			  "ruleset_source_type": "Repository",
+			  "ruleset_source": "google",
 			  "type": "creation"
 			},
 			{
+			  "ruleset_id": 42069,
+			  "ruleset_source_type": "Organization",
+			  "ruleset_source": "google",
 			  "type": "update",
 			  "parameters": {
 			    "update_allows_fetch_and_merge": true
@@ -280,9 +300,15 @@ func TestRepositoriesService_GetRulesForBranch(t *testing.T) {
 	}
 
 	creationRule := NewCreationRule()
+	creationRule.RulesetID = 42069
+	creationRule.RulesetSource = "google"
+	creationRule.RulesetSourceType = "Repository"
 	updateRule := NewUpdateRule(&UpdateAllowsFetchAndMergeRuleParameters{
 		UpdateAllowsFetchAndMerge: true,
 	})
+	updateRule.RulesetID = 42069
+	updateRule.RulesetSource = "google"
+	updateRule.RulesetSourceType = "Organization"
 
 	want := []*RepositoryRule{
 		creationRule,


### PR DESCRIPTION
The purpose of this commit is to allow further querying of rulesets for a specific branch, at the organization or the repository level.
To achieve this, this commit adds the `ruleset_id` and `ruleset_source_type` fields to the RepositoryRule object according to the returned information from the github API.
