### PR TITLE
Fix application of pagination options on ListCopilotSeats endpoint

### DIFF
--- a/github/copilot.go
+++ b/github/copilot.go
@@ -161,8 +161,12 @@ func (s *CopilotService) GetCopilotBilling(ctx context.Context, org string) (*Co
 //meta:operation GET /orgs/{org}/copilot/billing/seats
 func (s *CopilotService) ListCopilotSeats(ctx context.Context, org string, opts *ListOptions) (*ListCopilotSeatsResponse, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/copilot/billing/seats", org)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 
-	req, err := s.client.NewRequest("GET", u, opts)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -336,6 +336,10 @@ func TestCopilotService_ListCopilotSeats(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/copilot/billing/seats", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"per_page": "100",
+			"page":     "1",
+		})
 		fmt.Fprint(w, `{
 				"total_seats": 4,
 				"seats": [
@@ -473,7 +477,7 @@ func TestCopilotService_ListCopilotSeats(t *testing.T) {
 	lastActivityAt2 := Timestamp{tmp}
 
 	ctx := context.Background()
-	got, _, err := client.Copilot.ListCopilotSeats(ctx, "o", nil)
+	got, _, err := client.Copilot.ListCopilotSeats(ctx, "o", &ListOptions{Page: 1, PerPage: 100})
 	if err != nil {
 		t.Errorf("Copilot.ListCopilotSeats returned error: %v", err)
 	}

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -477,7 +477,8 @@ func TestCopilotService_ListCopilotSeats(t *testing.T) {
 	lastActivityAt2 := Timestamp{tmp}
 
 	ctx := context.Background()
-	got, _, err := client.Copilot.ListCopilotSeats(ctx, "o", &ListOptions{Page: 1, PerPage: 100})
+	opts := &ListOptions{Page: 1, PerPage: 100}
+	got, _, err := client.Copilot.ListCopilotSeats(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Copilot.ListCopilotSeats returned error: %v", err)
 	}
@@ -589,12 +590,12 @@ func TestCopilotService_ListCopilotSeats(t *testing.T) {
 	const methodName = "ListCopilotSeats"
 
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Copilot.ListCopilotSeats(ctx, "\n", nil)
+		_, _, err = client.Copilot.ListCopilotSeats(ctx, "\n", opts)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Copilot.ListCopilotSeats(ctx, "", nil)
+		got, resp, err := client.Copilot.ListCopilotSeats(ctx, "o", opts)
 		if got != nil {
 			t.Errorf("Copilot.ListCopilotSeats returned %+v, want nil", got)
 		}


### PR DESCRIPTION
The pagination options were previously being applied as the Request body, instead of applied to the URL as in other `List` endpoints. This PR ensures that these options are correctly applied to the URL and introduces additional parameters in the test case to ensure this. 