### PR TITLE
feat!: Update deprecated endpoints in github/action_variables.go

### DIFF
--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -84,7 +84,7 @@ func (s *ActionsService) GetOrgPublicKey(ctx context.Context, org string) (*Publ
 
 // GetEnvPublicKey gets a public key that should be used for secret encryption.
 //
-// GitHub API docs: https://docs.github.com/rest/actions/secrets#get-an-environment-public-key
+// GitHub API docs: https://docs.github.com/enterprise-server@3.7/rest/actions/secrets#get-an-environment-public-key
 //
 //meta:operation GET /repositories/{repository_id}/environments/{environment_name}/secrets/public-key
 func (s *ActionsService) GetEnvPublicKey(ctx context.Context, repoID int, env string) (*PublicKey, *Response, error) {
@@ -162,7 +162,7 @@ func (s *ActionsService) ListOrgSecrets(ctx context.Context, org string, opts *L
 
 // ListEnvSecrets lists all secrets available in an environment.
 //
-// GitHub API docs: https://docs.github.com/rest/actions/secrets#list-environment-secrets
+// GitHub API docs: https://docs.github.com/enterprise-server@3.7/rest/actions/secrets#list-environment-secrets
 //
 //meta:operation GET /repositories/{repository_id}/environments/{environment_name}/secrets
 func (s *ActionsService) ListEnvSecrets(ctx context.Context, repoID int, env string, opts *ListOptions) (*Secrets, *Response, error) {
@@ -207,7 +207,7 @@ func (s *ActionsService) GetOrgSecret(ctx context.Context, org, name string) (*S
 
 // GetEnvSecret gets a single environment secret without revealing its encrypted value.
 //
-// GitHub API docs: https://docs.github.com/rest/actions/secrets#get-an-environment-secret
+// GitHub API docs: https://docs.github.com/enterprise-server@3.7/rest/actions/secrets#get-an-environment-secret
 //
 //meta:operation GET /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}
 func (s *ActionsService) GetEnvSecret(ctx context.Context, repoID int, env, secretName string) (*Secret, *Response, error) {
@@ -262,7 +262,7 @@ func (s *ActionsService) CreateOrUpdateOrgSecret(ctx context.Context, org string
 
 // CreateOrUpdateEnvSecret creates or updates a single environment secret with an encrypted value.
 //
-// GitHub API docs: https://docs.github.com/rest/actions/secrets#create-or-update-an-environment-secret
+// GitHub API docs: https://docs.github.com/enterprise-server@3.7/rest/actions/secrets#create-or-update-an-environment-secret
 //
 //meta:operation PUT /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}
 func (s *ActionsService) CreateOrUpdateEnvSecret(ctx context.Context, repoID int, env string, eSecret *EncryptedSecret) (*Response, error) {
@@ -301,7 +301,7 @@ func (s *ActionsService) DeleteOrgSecret(ctx context.Context, org, name string) 
 
 // DeleteEnvSecret deletes a secret in an environment using the secret name.
 //
-// GitHub API docs: https://docs.github.com/rest/actions/secrets#delete-an-environment-secret
+// GitHub API docs: https://docs.github.com/enterprise-server@3.7/rest/actions/secrets#delete-an-environment-secret
 //
 //meta:operation DELETE /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}
 func (s *ActionsService) DeleteEnvSecret(ctx context.Context, repoID int, env, secretName string) (*Response, error) {

--- a/github/actions_variables.go
+++ b/github/actions_variables.go
@@ -204,9 +204,9 @@ func (s *ActionsService) UpdateOrgVariable(ctx context.Context, org string, vari
 //
 // GitHub API docs: https://docs.github.com/rest/actions/variables#update-an-environment-variable
 //
-//meta:operation PATCH /repositories/{repository_id}/environments/{environment_name}/variables/{name}
-func (s *ActionsService) UpdateEnvVariable(ctx context.Context, repoID int, env string, variable *ActionsVariable) (*Response, error) {
-	url := fmt.Sprintf("repositories/%v/environments/%v/variables/%v", repoID, env, variable.Name)
+//meta:operation PATCH /repos/{owner}/{repo}/environments/{environment_name}/variables/{name}
+func (s *ActionsService) UpdateEnvVariable(ctx context.Context, owner, repo, env string, variable *ActionsVariable) (*Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/environments/%v/variables/%v", owner, repo, env, variable.Name)
 	return s.patchVariable(ctx, url, variable)
 }
 

--- a/github/actions_variables.go
+++ b/github/actions_variables.go
@@ -243,9 +243,9 @@ func (s *ActionsService) DeleteOrgVariable(ctx context.Context, org, name string
 //
 // GitHub API docs: https://docs.github.com/rest/actions/variables#delete-an-environment-variable
 //
-//meta:operation DELETE /repositories/{repository_id}/environments/{environment_name}/variables/{name}
-func (s *ActionsService) DeleteEnvVariable(ctx context.Context, repoID int, env, variableName string) (*Response, error) {
-	url := fmt.Sprintf("repositories/%v/environments/%v/variables/%v", repoID, env, variableName)
+//meta:operation DELETE /repos/{owner}/{repo}/environments/{environment_name}/variables/{name}
+func (s *ActionsService) DeleteEnvVariable(ctx context.Context, owner, repo, env, variableName string) (*Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/environments/%v/variables/%v", owner, repo, env, variableName)
 	return s.deleteVariable(ctx, url)
 }
 

--- a/github/actions_variables.go
+++ b/github/actions_variables.go
@@ -128,9 +128,9 @@ func (s *ActionsService) GetOrgVariable(ctx context.Context, org, name string) (
 //
 // GitHub API docs: https://docs.github.com/rest/actions/variables#get-an-environment-variable
 //
-//meta:operation GET /repositories/{repository_id}/environments/{environment_name}/variables/{name}
-func (s *ActionsService) GetEnvVariable(ctx context.Context, repoID int, env, variableName string) (*ActionsVariable, *Response, error) {
-	url := fmt.Sprintf("repositories/%v/environments/%v/variables/%v", repoID, env, variableName)
+//meta:operation GET /repos/{owner}/{repo}/environments/{environment_name}/variables/{name}
+func (s *ActionsService) GetEnvVariable(ctx context.Context, org, repo, env, variableName string) (*ActionsVariable, *Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/environments/%v/variables/%v", org, repo, env, variableName)
 	return s.getVariable(ctx, url)
 }
 

--- a/github/actions_variables.go
+++ b/github/actions_variables.go
@@ -84,8 +84,8 @@ func (s *ActionsService) ListOrgVariables(ctx context.Context, org string, opts 
 // GitHub API docs: https://docs.github.com/rest/actions/variables#list-environment-variables
 //
 //meta:operation GET /repos/{owner}/{repo}/environments/{environment_name}/variables
-func (s *ActionsService) ListEnvVariables(ctx context.Context, org, repo, env string, opts *ListOptions) (*ActionsVariables, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/environments/%v/variables", org, repo, env)
+func (s *ActionsService) ListEnvVariables(ctx context.Context, owner, repo, env string, opts *ListOptions) (*ActionsVariables, *Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/environments/%v/variables", owner, repo, env)
 	return s.listVariables(ctx, url, opts)
 }
 
@@ -129,8 +129,8 @@ func (s *ActionsService) GetOrgVariable(ctx context.Context, org, name string) (
 // GitHub API docs: https://docs.github.com/rest/actions/variables#get-an-environment-variable
 //
 //meta:operation GET /repos/{owner}/{repo}/environments/{environment_name}/variables/{name}
-func (s *ActionsService) GetEnvVariable(ctx context.Context, org, repo, env, variableName string) (*ActionsVariable, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/environments/%v/variables/%v", org, repo, env, variableName)
+func (s *ActionsService) GetEnvVariable(ctx context.Context, owner, repo, env, variableName string) (*ActionsVariable, *Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/environments/%v/variables/%v", owner, repo, env, variableName)
 	return s.getVariable(ctx, url)
 }
 
@@ -166,9 +166,9 @@ func (s *ActionsService) CreateOrgVariable(ctx context.Context, org string, vari
 //
 // GitHub API docs: https://docs.github.com/rest/actions/variables#create-an-environment-variable
 //
-//meta:operation POST /repositories/{repository_id}/environments/{environment_name}/variables
-func (s *ActionsService) CreateEnvVariable(ctx context.Context, repoID int, env string, variable *ActionsVariable) (*Response, error) {
-	url := fmt.Sprintf("repositories/%v/environments/%v/variables", repoID, env)
+//meta:operation POST /repos/{owner}/{repo}/environments/{environment_name}/variables
+func (s *ActionsService) CreateEnvVariable(ctx context.Context, owner, repo, env string, variable *ActionsVariable) (*Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/environments/%v/variables", owner, repo, env)
 	return s.postVariable(ctx, url, variable)
 }
 

--- a/github/actions_variables.go
+++ b/github/actions_variables.go
@@ -83,9 +83,9 @@ func (s *ActionsService) ListOrgVariables(ctx context.Context, org string, opts 
 //
 // GitHub API docs: https://docs.github.com/rest/actions/variables#list-environment-variables
 //
-//meta:operation GET /repositories/{repository_id}/environments/{environment_name}/variables
-func (s *ActionsService) ListEnvVariables(ctx context.Context, repoID int, env string, opts *ListOptions) (*ActionsVariables, *Response, error) {
-	url := fmt.Sprintf("repositories/%v/environments/%v/variables", repoID, env)
+//meta:operation GET /repos/{owner}/{repo}/environments/{environment_name}/variables
+func (s *ActionsService) ListEnvVariables(ctx context.Context, org, repo, env string, opts *ListOptions) (*ActionsVariables, *Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/environments/%v/variables", org, repo, env)
 	return s.listVariables(ctx, url, opts)
 }
 

--- a/github/actions_variables_test.go
+++ b/github/actions_variables_test.go
@@ -533,7 +533,7 @@ func TestActionsService_ListEnvVariables(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/repositories/1/environments/e/variables", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/usr/1/environments/e/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"per_page": "2", "page": "2"})
 		fmt.Fprint(w, `{"total_count":4,"variables":[{"name":"A","value":"AA","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"},{"name":"B","value":"BB","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}]}`)
@@ -541,7 +541,7 @@ func TestActionsService_ListEnvVariables(t *testing.T) {
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
 	ctx := context.Background()
-	variables, _, err := client.Actions.ListEnvVariables(ctx, 1, "e", opts)
+	variables, _, err := client.Actions.ListEnvVariables(ctx, "usr", "1", "e", opts)
 	if err != nil {
 		t.Errorf("Actions.ListEnvVariables returned error: %v", err)
 	}
@@ -559,12 +559,12 @@ func TestActionsService_ListEnvVariables(t *testing.T) {
 
 	const methodName = "ListEnvVariables"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.ListEnvVariables(ctx, 0.0, "\n", opts)
+		_, _, err = client.Actions.ListEnvVariables(ctx, "usr", "0", "\n", opts)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.ListEnvVariables(ctx, 1, "e", opts)
+		got, resp, err := client.Actions.ListEnvVariables(ctx, "usr", "1", "e", opts)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/github/actions_variables_test.go
+++ b/github/actions_variables_test.go
@@ -576,13 +576,13 @@ func TestActionsService_GetEnvVariable(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/repositories/1/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/usr/1/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"name":"variable","value":"VAR","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
 	})
 
 	ctx := context.Background()
-	variable, _, err := client.Actions.GetEnvVariable(ctx, 1, "e", "variable")
+	variable, _, err := client.Actions.GetEnvVariable(ctx, "usr", "1", "e", "variable")
 	if err != nil {
 		t.Errorf("Actions.GetEnvVariable returned error: %v", err)
 	}
@@ -599,12 +599,12 @@ func TestActionsService_GetEnvVariable(t *testing.T) {
 
 	const methodName = "GetEnvVariable"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.GetEnvVariable(ctx, 0.0, "\n", "\n")
+		_, _, err = client.Actions.GetEnvVariable(ctx, "usr", "0", "\n", "\n")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.GetEnvVariable(ctx, 1, "e", "variable")
+		got, resp, err := client.Actions.GetEnvVariable(ctx, "usr", "1", "e", "variable")
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/github/actions_variables_test.go
+++ b/github/actions_variables_test.go
@@ -680,24 +680,24 @@ func TestActionsService_DeleteEnvVariable(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/repositories/1/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/usr/1/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
 	ctx := context.Background()
-	_, err := client.Actions.DeleteEnvVariable(ctx, 1, "e", "variable")
+	_, err := client.Actions.DeleteEnvVariable(ctx, "usr", "1", "e", "variable")
 	if err != nil {
 		t.Errorf("Actions.DeleteEnvVariable returned error: %v", err)
 	}
 
 	const methodName = "DeleteEnvVariable"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.DeleteEnvVariable(ctx, 0.0, "\n", "\n")
+		_, err = client.Actions.DeleteEnvVariable(ctx, "usr", "0", "\n", "\n")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.DeleteEnvVariable(ctx, 1, "r", "variable")
+		return client.Actions.DeleteEnvVariable(ctx, "usr", "1", "r", "variable")
 	})
 }
 

--- a/github/actions_variables_test.go
+++ b/github/actions_variables_test.go
@@ -648,7 +648,7 @@ func TestActionsService_UpdateEnvVariable(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/repositories/1/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/usr/1/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
 		testHeader(t, r, "Content-Type", "application/json")
 		testBody(t, r, `{"name":"variable","value":"VAR"}`+"\n")
@@ -660,19 +660,19 @@ func TestActionsService_UpdateEnvVariable(t *testing.T) {
 		Value: "VAR",
 	}
 	ctx := context.Background()
-	_, err := client.Actions.UpdateEnvVariable(ctx, 1, "e", input)
+	_, err := client.Actions.UpdateEnvVariable(ctx, "usr", "1", "e", input)
 	if err != nil {
 		t.Errorf("Actions.UpdateEnvVariable returned error: %v", err)
 	}
 
 	const methodName = "UpdateEnvVariable"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.UpdateEnvVariable(ctx, 0.0, "\n", input)
+		_, err = client.Actions.UpdateEnvVariable(ctx, "usr", "1", "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.UpdateEnvVariable(ctx, 1, "e", input)
+		return client.Actions.UpdateEnvVariable(ctx, "usr", "1", "e", input)
 	})
 }
 

--- a/github/actions_variables_test.go
+++ b/github/actions_variables_test.go
@@ -616,7 +616,7 @@ func TestActionsService_CreateEnvVariable(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/repositories/1/environments/e/variables", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/usr/1/environments/e/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Content-Type", "application/json")
 		testBody(t, r, `{"name":"variable","value":"VAR"}`+"\n")
@@ -628,19 +628,19 @@ func TestActionsService_CreateEnvVariable(t *testing.T) {
 		Value: "VAR",
 	}
 	ctx := context.Background()
-	_, err := client.Actions.CreateEnvVariable(ctx, 1, "e", input)
+	_, err := client.Actions.CreateEnvVariable(ctx, "usr", "1", "e", input)
 	if err != nil {
 		t.Errorf("Actions.CreateEnvVariable returned error: %v", err)
 	}
 
 	const methodName = "CreateEnvVariable"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.CreateEnvVariable(ctx, 0.0, "\n", input)
+		_, err = client.Actions.CreateEnvVariable(ctx, "usr", "0", "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.CreateEnvVariable(ctx, 1, "e", input)
+		return client.Actions.CreateEnvVariable(ctx, "usr", "1", "e", input)
 	})
 }
 

--- a/github/admin.go
+++ b/github/admin.go
@@ -82,7 +82,7 @@ func (m Enterprise) String() string {
 
 // UpdateUserLDAPMapping updates the mapping between a GitHub user and an LDAP user.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/ldap#update-ldap-mapping-for-a-user
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/ldap#update-ldap-mapping-for-a-user
 //
 //meta:operation PATCH /admin/ldap/users/{username}/mapping
 func (s *AdminService) UpdateUserLDAPMapping(ctx context.Context, user string, mapping *UserLDAPMapping) (*UserLDAPMapping, *Response, error) {
@@ -103,7 +103,7 @@ func (s *AdminService) UpdateUserLDAPMapping(ctx context.Context, user string, m
 
 // UpdateTeamLDAPMapping updates the mapping between a GitHub team and an LDAP group.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/ldap#update-ldap-mapping-for-a-team
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/ldap#update-ldap-mapping-for-a-team
 //
 //meta:operation PATCH /admin/ldap/teams/{team_id}/mapping
 func (s *AdminService) UpdateTeamLDAPMapping(ctx context.Context, team int64, mapping *TeamLDAPMapping) (*TeamLDAPMapping, *Response, error) {

--- a/github/admin_orgs.go
+++ b/github/admin_orgs.go
@@ -22,7 +22,7 @@ type createOrgRequest struct {
 // Note that only a subset of the org fields are used and org must
 // not be nil.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/orgs#create-an-organization
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/orgs#create-an-organization
 //
 //meta:operation POST /admin/organizations
 func (s *AdminService) CreateOrg(ctx context.Context, org *Organization, admin string) (*Organization, *Response, error) {
@@ -61,7 +61,7 @@ type RenameOrgResponse struct {
 
 // RenameOrg renames an organization in GitHub Enterprise.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/orgs#update-an-organization-name
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/orgs#update-an-organization-name
 //
 //meta:operation PATCH /admin/organizations/{org}
 func (s *AdminService) RenameOrg(ctx context.Context, org *Organization, newName string) (*RenameOrgResponse, *Response, error) {
@@ -70,7 +70,7 @@ func (s *AdminService) RenameOrg(ctx context.Context, org *Organization, newName
 
 // RenameOrgByName renames an organization in GitHub Enterprise using its current name.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/orgs#update-an-organization-name
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/orgs#update-an-organization-name
 //
 //meta:operation PATCH /admin/organizations/{org}
 func (s *AdminService) RenameOrgByName(ctx context.Context, org, newName string) (*RenameOrgResponse, *Response, error) {

--- a/github/admin_stats.go
+++ b/github/admin_stats.go
@@ -152,7 +152,7 @@ func (s RepoStats) String() string {
 // Please note that this is only available to site administrators,
 // otherwise it will error with a 404 not found (instead of 401 or 403).
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/admin-stats#get-all-statistics
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/admin-stats#get-all-statistics
 //
 //meta:operation GET /enterprise/stats/all
 func (s *AdminService) GetAdminStats(ctx context.Context) (*AdminStats, *Response, error) {

--- a/github/admin_users.go
+++ b/github/admin_users.go
@@ -20,7 +20,7 @@ type CreateUserRequest struct {
 
 // CreateUser creates a new user in GitHub Enterprise.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#create-a-user
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#create-a-user
 //
 //meta:operation POST /admin/users
 func (s *AdminService) CreateUser(ctx context.Context, userReq CreateUserRequest) (*User, *Response, error) {
@@ -42,7 +42,7 @@ func (s *AdminService) CreateUser(ctx context.Context, userReq CreateUserRequest
 
 // DeleteUser deletes a user in GitHub Enterprise.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#delete-a-user
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#delete-a-user
 //
 //meta:operation DELETE /admin/users/{username}
 func (s *AdminService) DeleteUser(ctx context.Context, username string) (*Response, error) {
@@ -95,7 +95,7 @@ type UserAuthorization struct {
 
 // CreateUserImpersonation creates an impersonation OAuth token.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#create-an-impersonation-oauth-token
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#create-an-impersonation-oauth-token
 //
 //meta:operation POST /admin/users/{username}/authorizations
 func (s *AdminService) CreateUserImpersonation(ctx context.Context, username string, opts *ImpersonateUserOptions) (*UserAuthorization, *Response, error) {
@@ -117,7 +117,7 @@ func (s *AdminService) CreateUserImpersonation(ctx context.Context, username str
 
 // DeleteUserImpersonation deletes an impersonation OAuth token.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#delete-an-impersonation-oauth-token
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#delete-an-impersonation-oauth-token
 //
 //meta:operation DELETE /admin/users/{username}/authorizations
 func (s *AdminService) DeleteUserImpersonation(ctx context.Context, username string) (*Response, error) {

--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -257,7 +257,7 @@ func (s *AuthorizationsService) DeleteGrant(ctx context.Context, clientID, acces
 // you can e.g. create or delete a user's public SSH key. NOTE: creating a
 // new token automatically revokes an existing one.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#create-an-impersonation-oauth-token
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#create-an-impersonation-oauth-token
 //
 //meta:operation POST /admin/users/{username}/authorizations
 func (s *AuthorizationsService) CreateImpersonation(ctx context.Context, username string, authReq *AuthorizationRequest) (*Authorization, *Response, error) {
@@ -279,7 +279,7 @@ func (s *AuthorizationsService) CreateImpersonation(ctx context.Context, usernam
 //
 // NOTE: there can be only one at a time.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#delete-an-impersonation-oauth-token
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#delete-an-impersonation-oauth-token
 //
 //meta:operation DELETE /admin/users/{username}/authorizations
 func (s *AuthorizationsService) DeleteImpersonation(ctx context.Context, username string) (*Response, error) {

--- a/github/copilot.go
+++ b/github/copilot.go
@@ -132,7 +132,7 @@ func (cp *CopilotSeatDetails) GetOrganization() (*Organization, bool) {
 
 // GetCopilotBilling gets Copilot for Business billing information and settings for an organization.
 //
-// GitHub API docs: https://docs.github.com/rest/copilot/copilot-business#get-copilot-business-seat-information-and-settings-for-an-organization
+// GitHub API docs: https://docs.github.com/rest/copilot/copilot-user-management#get-copilot-seat-information-and-settings-for-an-organization
 //
 //meta:operation GET /orgs/{org}/copilot/billing
 func (s *CopilotService) GetCopilotBilling(ctx context.Context, org string) (*CopilotOrganizationDetails, *Response, error) {
@@ -156,7 +156,7 @@ func (s *CopilotService) GetCopilotBilling(ctx context.Context, org string) (*Co
 //
 // To paginate through all seats, populate 'Page' with the number of the last page.
 //
-// GitHub API docs: https://docs.github.com/rest/copilot/copilot-business#list-all-copilot-business-seat-assignments-for-an-organization
+// GitHub API docs: https://docs.github.com/rest/copilot/copilot-user-management#list-all-copilot-seat-assignments-for-an-organization
 //
 //meta:operation GET /orgs/{org}/copilot/billing/seats
 func (s *CopilotService) ListCopilotSeats(ctx context.Context, org string, opts *ListOptions) (*ListCopilotSeatsResponse, *Response, error) {
@@ -178,7 +178,7 @@ func (s *CopilotService) ListCopilotSeats(ctx context.Context, org string, opts 
 
 // AddCopilotTeams adds teams to the Copilot for Business subscription for an organization.
 //
-// GitHub API docs: https://docs.github.com/rest/copilot/copilot-business#add-teams-to-the-copilot-business-subscription-for-an-organization
+// GitHub API docs: https://docs.github.com/rest/copilot/copilot-user-management#add-teams-to-the-copilot-subscription-for-an-organization
 //
 //meta:operation POST /orgs/{org}/copilot/billing/selected_teams
 func (s *CopilotService) AddCopilotTeams(ctx context.Context, org string, teamNames []string) (*SeatAssignments, *Response, error) {
@@ -206,7 +206,7 @@ func (s *CopilotService) AddCopilotTeams(ctx context.Context, org string, teamNa
 
 // RemoveCopilotTeams removes teams from the Copilot for Business subscription for an organization.
 //
-// GitHub API docs: https://docs.github.com/rest/copilot/copilot-business#remove-teams-from-the-copilot-business-subscription-for-an-organization
+// GitHub API docs: https://docs.github.com/rest/copilot/copilot-user-management#remove-teams-from-the-copilot-subscription-for-an-organization
 //
 //meta:operation DELETE /orgs/{org}/copilot/billing/selected_teams
 func (s *CopilotService) RemoveCopilotTeams(ctx context.Context, org string, teamNames []string) (*SeatCancellations, *Response, error) {
@@ -234,7 +234,7 @@ func (s *CopilotService) RemoveCopilotTeams(ctx context.Context, org string, tea
 
 // AddCopilotUsers adds users to the Copilot for Business subscription for an organization
 //
-// GitHub API docs: https://docs.github.com/rest/copilot/copilot-business#add-users-to-the-copilot-business-subscription-for-an-organization
+// GitHub API docs: https://docs.github.com/rest/copilot/copilot-user-management#add-users-to-the-copilot-subscription-for-an-organization
 //
 //meta:operation POST /orgs/{org}/copilot/billing/selected_users
 func (s *CopilotService) AddCopilotUsers(ctx context.Context, org string, users []string) (*SeatAssignments, *Response, error) {
@@ -262,7 +262,7 @@ func (s *CopilotService) AddCopilotUsers(ctx context.Context, org string, users 
 
 // RemoveCopilotUsers removes users from the Copilot for Business subscription for an organization.
 //
-// GitHub API docs: https://docs.github.com/rest/copilot/copilot-business#remove-users-from-the-copilot-business-subscription-for-an-organization
+// GitHub API docs: https://docs.github.com/rest/copilot/copilot-user-management#remove-users-from-the-copilot-subscription-for-an-organization
 //
 //meta:operation DELETE /orgs/{org}/copilot/billing/selected_users
 func (s *CopilotService) RemoveCopilotUsers(ctx context.Context, org string, users []string) (*SeatCancellations, *Response, error) {
@@ -290,7 +290,7 @@ func (s *CopilotService) RemoveCopilotUsers(ctx context.Context, org string, use
 
 // GetSeatDetails gets Copilot for Business seat assignment details for a user.
 //
-// GitHub API docs: https://docs.github.com/rest/copilot/copilot-business#get-copilot-business-seat-assignment-details-for-a-user
+// GitHub API docs: https://docs.github.com/rest/copilot/copilot-user-management#get-copilot-seat-assignment-details-for-a-user
 //
 //meta:operation GET /orgs/{org}/members/{username}/copilot
 func (s *CopilotService) GetSeatDetails(ctx context.Context, org, user string) (*CopilotSeatDetails, *Response, error) {

--- a/github/repos_autolinks.go
+++ b/github/repos_autolinks.go
@@ -28,7 +28,7 @@ type Autolink struct {
 // ListAutolinks returns a list of autolinks configured for the given repository.
 // Information about autolinks are only available to repository administrators.
 //
-// GitHub API docs: https://docs.github.com/rest/repos/autolinks#list-all-autolinks-of-a-repository
+// GitHub API docs: https://docs.github.com/rest/repos/autolinks#get-all-autolinks-of-a-repository
 //
 //meta:operation GET /repos/{owner}/{repo}/autolinks
 func (s *RepositoriesService) ListAutolinks(ctx context.Context, owner, repo string, opts *ListOptions) ([]*Autolink, *Response, error) {

--- a/github/repos_prereceive_hooks.go
+++ b/github/repos_prereceive_hooks.go
@@ -24,7 +24,7 @@ func (p PreReceiveHook) String() string {
 
 // ListPreReceiveHooks lists all pre-receive hooks for the specified repository.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/repo-pre-receive-hooks#list-pre-receive-hooks-for-a-repository
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/repo-pre-receive-hooks#list-pre-receive-hooks-for-a-repository
 //
 //meta:operation GET /repos/{owner}/{repo}/pre-receive-hooks
 func (s *RepositoriesService) ListPreReceiveHooks(ctx context.Context, owner, repo string, opts *ListOptions) ([]*PreReceiveHook, *Response, error) {
@@ -53,7 +53,7 @@ func (s *RepositoriesService) ListPreReceiveHooks(ctx context.Context, owner, re
 
 // GetPreReceiveHook returns a single specified pre-receive hook.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/repo-pre-receive-hooks#get-a-pre-receive-hook-for-a-repository
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/repo-pre-receive-hooks#get-a-pre-receive-hook-for-a-repository
 //
 //meta:operation GET /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}
 func (s *RepositoriesService) GetPreReceiveHook(ctx context.Context, owner, repo string, id int64) (*PreReceiveHook, *Response, error) {
@@ -77,7 +77,7 @@ func (s *RepositoriesService) GetPreReceiveHook(ctx context.Context, owner, repo
 
 // UpdatePreReceiveHook updates a specified pre-receive hook.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/repo-pre-receive-hooks#update-pre-receive-hook-enforcement-for-a-repository
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/repo-pre-receive-hooks#update-pre-receive-hook-enforcement-for-a-repository
 //
 //meta:operation PATCH /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}
 func (s *RepositoriesService) UpdatePreReceiveHook(ctx context.Context, owner, repo string, id int64, hook *PreReceiveHook) (*PreReceiveHook, *Response, error) {
@@ -101,7 +101,7 @@ func (s *RepositoriesService) UpdatePreReceiveHook(ctx context.Context, owner, r
 
 // DeletePreReceiveHook deletes a specified pre-receive hook.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/repo-pre-receive-hooks#remove-pre-receive-hook-enforcement-for-a-repository
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/repo-pre-receive-hooks#remove-pre-receive-hook-enforcement-for-a-repository
 //
 //meta:operation DELETE /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}
 func (s *RepositoriesService) DeletePreReceiveHook(ctx context.Context, owner, repo string, id int64) (*Response, error) {

--- a/github/users_administration.go
+++ b/github/users_administration.go
@@ -12,7 +12,7 @@ import (
 
 // PromoteSiteAdmin promotes a user to a site administrator of a GitHub Enterprise instance.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#promote-a-user-to-be-a-site-administrator
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#promote-a-user-to-be-a-site-administrator
 //
 //meta:operation PUT /users/{username}/site_admin
 func (s *UsersService) PromoteSiteAdmin(ctx context.Context, user string) (*Response, error) {
@@ -28,7 +28,7 @@ func (s *UsersService) PromoteSiteAdmin(ctx context.Context, user string) (*Resp
 
 // DemoteSiteAdmin demotes a user from site administrator of a GitHub Enterprise instance.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#demote-a-site-administrator
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#demote-a-site-administrator
 //
 //meta:operation DELETE /users/{username}/site_admin
 func (s *UsersService) DemoteSiteAdmin(ctx context.Context, user string) (*Response, error) {
@@ -49,7 +49,7 @@ type UserSuspendOptions struct {
 
 // Suspend a user on a GitHub Enterprise instance.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#suspend-a-user
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#suspend-a-user
 //
 //meta:operation PUT /users/{username}/suspended
 func (s *UsersService) Suspend(ctx context.Context, user string, opts *UserSuspendOptions) (*Response, error) {
@@ -65,7 +65,7 @@ func (s *UsersService) Suspend(ctx context.Context, user string, opts *UserSuspe
 
 // Unsuspend a user on a GitHub Enterprise instance.
 //
-// GitHub API docs: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#unsuspend-a-user
+// GitHub API docs: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#unsuspend-a-user
 //
 //meta:operation DELETE /users/{username}/suspended
 func (s *UsersService) Unsuspend(ctx context.Context, user string) (*Response, error) {

--- a/openapi_operations.yaml
+++ b/openapi_operations.yaml
@@ -48,260 +48,260 @@ operation_overrides:
     documentation_url: https://docs.github.com/rest/pages/pages#request-a-github-pages-build
   - name: GET /repos/{owner}/{repo}/pages/builds/{build_id}
     documentation_url: https://docs.github.com/rest/pages/pages#get-github-pages-build
-openapi_commit: 6922a6cfe785e1069e93d6e501805cf6e1891076
+openapi_commit: b65cdcaa8a1453dd394cb898b35696a2130f4504
 openapi_operations:
   - name: GET /
     documentation_url: https://docs.github.com/rest/meta/meta#github-api-root
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /admin/hooks
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/global-webhooks#list-global-webhooks
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/global-webhooks#list-global-webhooks
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /admin/hooks
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/global-webhooks#create-a-global-webhook
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/global-webhooks#create-a-global-webhook
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /admin/hooks/{hook_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/global-webhooks#delete-a-global-webhook
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/global-webhooks#delete-a-global-webhook
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /admin/hooks/{hook_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/global-webhooks#get-a-global-webhook
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/global-webhooks#get-a-global-webhook
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /admin/hooks/{hook_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/global-webhooks#update-a-global-webhook
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/global-webhooks#update-a-global-webhook
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /admin/hooks/{hook_id}/pings
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/global-webhooks#ping-a-global-webhook
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/global-webhooks#ping-a-global-webhook
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /admin/keys
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#list-public-keys
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#list-public-keys
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /admin/keys/{key_ids}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#delete-a-public-key
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#delete-a-public-key
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /admin/ldap/teams/{team_id}/mapping
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/ldap#update-ldap-mapping-for-a-team
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/ldap#update-ldap-mapping-for-a-team
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /admin/ldap/teams/{team_id}/sync
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/ldap#sync-ldap-mapping-for-a-team
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/ldap#sync-ldap-mapping-for-a-team
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /admin/ldap/users/{username}/mapping
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/ldap#update-ldap-mapping-for-a-user
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/ldap#update-ldap-mapping-for-a-user
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /admin/ldap/users/{username}/sync
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/ldap#sync-ldap-mapping-for-a-user
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/ldap#sync-ldap-mapping-for-a-user
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /admin/organizations
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/orgs#create-an-organization
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/orgs#create-an-organization
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /admin/organizations/{org}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/orgs#update-an-organization-name
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/orgs#update-an-organization-name
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /admin/pre-receive-environments
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/pre-receive-environments#list-pre-receive-environments
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/pre-receive-environments#list-pre-receive-environments
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /admin/pre-receive-environments
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/pre-receive-environments#create-a-pre-receive-environment
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/pre-receive-environments#create-a-pre-receive-environment
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /admin/pre-receive-environments/{pre_receive_environment_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/pre-receive-environments#delete-a-pre-receive-environment
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/pre-receive-environments#delete-a-pre-receive-environment
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /admin/pre-receive-environments/{pre_receive_environment_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/pre-receive-environments#get-a-pre-receive-environment
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/pre-receive-environments#get-a-pre-receive-environment
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /admin/pre-receive-environments/{pre_receive_environment_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/pre-receive-environments#update-a-pre-receive-environment
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/pre-receive-environments#update-a-pre-receive-environment
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /admin/pre-receive-environments/{pre_receive_environment_id}/downloads
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/pre-receive-environments#start-a-pre-receive-environment-download
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/pre-receive-environments#start-a-pre-receive-environment-download
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /admin/pre-receive-environments/{pre_receive_environment_id}/downloads/latest
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/pre-receive-environments#get-the-download-status-for-a-pre-receive-environment
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/pre-receive-environments#get-the-download-status-for-a-pre-receive-environment
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /admin/pre-receive-hooks
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/pre-receive-hooks#list-pre-receive-hooks
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/pre-receive-hooks#list-pre-receive-hooks
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /admin/pre-receive-hooks
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/pre-receive-hooks#create-a-pre-receive-hook
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/pre-receive-hooks#create-a-pre-receive-hook
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /admin/pre-receive-hooks/{pre_receive_hook_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/pre-receive-hooks#delete-a-pre-receive-hook
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/pre-receive-hooks#delete-a-pre-receive-hook
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /admin/pre-receive-hooks/{pre_receive_hook_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/pre-receive-hooks#get-a-pre-receive-hook
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/pre-receive-hooks#get-a-pre-receive-hook
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /admin/pre-receive-hooks/{pre_receive_hook_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/pre-receive-hooks#update-a-pre-receive-hook
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/pre-receive-hooks#update-a-pre-receive-hook
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /admin/tokens
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#list-personal-access-tokens
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#list-personal-access-tokens
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /admin/tokens/{token_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#delete-a-personal-access-token
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#delete-a-personal-access-token
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /admin/users
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#create-a-user
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#create-a-user
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /admin/users/{username}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#delete-a-user
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#delete-a-user
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /admin/users/{username}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#update-the-username-for-a-user
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#update-the-username-for-a-user
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /admin/users/{username}/authorizations
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#delete-an-impersonation-oauth-token
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#delete-an-impersonation-oauth-token
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /admin/users/{username}/authorizations
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#create-an-impersonation-oauth-token
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#create-an-impersonation-oauth-token
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /advisories
     documentation_url: https://docs.github.com/rest/security-advisories/global-advisories#list-global-security-advisories
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /advisories/{ghsa_id}
     documentation_url: https://docs.github.com/rest/security-advisories/global-advisories#get-a-global-security-advisory
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /app
     documentation_url: https://docs.github.com/rest/apps/apps#get-the-authenticated-app
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /app-manifests/{code}/conversions
     documentation_url: https://docs.github.com/rest/apps/apps#create-a-github-app-from-a-manifest
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /app/hook/config
     documentation_url: https://docs.github.com/rest/apps/webhooks#get-a-webhook-configuration-for-an-app
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /app/hook/config
     documentation_url: https://docs.github.com/rest/apps/webhooks#update-a-webhook-configuration-for-an-app
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /app/hook/deliveries
     documentation_url: https://docs.github.com/rest/apps/webhooks#list-deliveries-for-an-app-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /app/hook/deliveries/{delivery_id}
     documentation_url: https://docs.github.com/rest/apps/webhooks#get-a-delivery-for-an-app-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /app/hook/deliveries/{delivery_id}/attempts
     documentation_url: https://docs.github.com/rest/apps/webhooks#redeliver-a-delivery-for-an-app-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /app/installation-requests
     documentation_url: https://docs.github.com/rest/apps/apps#list-installation-requests-for-the-authenticated-app
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /app/installations
     documentation_url: https://docs.github.com/rest/apps/apps#list-installations-for-the-authenticated-app
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /app/installations/{installation_id}
     documentation_url: https://docs.github.com/rest/apps/apps#delete-an-installation-for-the-authenticated-app
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /app/installations/{installation_id}
     documentation_url: https://docs.github.com/rest/apps/apps#get-an-installation-for-the-authenticated-app
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /app/installations/{installation_id}/access_tokens
     documentation_url: https://docs.github.com/rest/apps/apps#create-an-installation-access-token-for-an-app
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /app/installations/{installation_id}/suspended
     documentation_url: https://docs.github.com/rest/apps/apps#unsuspend-an-app-installation
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /app/installations/{installation_id}/suspended
     documentation_url: https://docs.github.com/rest/apps/apps#suspend-an-app-installation
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /applications/grants
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/oauth-authorizations/oauth-authorizations#list-your-grants
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/oauth-authorizations/oauth-authorizations#list-your-grants
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /applications/grants/{grant_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/oauth-authorizations/oauth-authorizations#delete-a-grant
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/oauth-authorizations/oauth-authorizations#delete-a-grant
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /applications/grants/{grant_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/oauth-authorizations/oauth-authorizations#get-a-single-grant
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/oauth-authorizations/oauth-authorizations#get-a-single-grant
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /applications/{client_id}/grant
     documentation_url: https://docs.github.com/rest/apps/oauth-applications#delete-an-app-authorization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /applications/{client_id}/grants/{access_token}
     documentation_url: https://docs.github.com/enterprise-server@3.3/rest/reference/apps#revoke-a-grant-for-an-application
     openapi_files:
@@ -311,25 +311,25 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /applications/{client_id}/token
     documentation_url: https://docs.github.com/rest/apps/oauth-applications#reset-a-token
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /applications/{client_id}/token
     documentation_url: https://docs.github.com/rest/apps/oauth-applications#check-a-token
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /applications/{client_id}/token/scoped
     documentation_url: https://docs.github.com/rest/apps/apps#create-a-scoped-access-token
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /applications/{client_id}/tokens/{access_token}
     documentation_url: https://docs.github.com/enterprise-server@3.3/rest/reference/apps#revoke-an-authorization-for-an-application
     openapi_files:
@@ -347,7 +347,7 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /assignments/{assignment_id}
     documentation_url: https://docs.github.com/rest/classroom/classroom#get-an-assignment
     openapi_files:
@@ -364,33 +364,33 @@ openapi_operations:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
   - name: GET /authorizations
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/oauth-authorizations/oauth-authorizations#list-your-authorizations
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/oauth-authorizations/oauth-authorizations#list-your-authorizations
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /authorizations
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/oauth-authorizations/oauth-authorizations#create-a-new-authorization
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/oauth-authorizations/oauth-authorizations#create-a-new-authorization
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /authorizations/clients/{client_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/oauth-authorizations/oauth-authorizations#get-or-create-an-authorization-for-a-specific-app
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/oauth-authorizations/oauth-authorizations#get-or-create-an-authorization-for-a-specific-app
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /authorizations/clients/{client_id}/{fingerprint}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/oauth-authorizations/oauth-authorizations#get-or-create-an-authorization-for-a-specific-app-and-fingerprint
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/oauth-authorizations/oauth-authorizations#get-or-create-an-authorization-for-a-specific-app-and-fingerprint
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /authorizations/{authorization_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/oauth-authorizations/oauth-authorizations#delete-an-authorization
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/oauth-authorizations/oauth-authorizations#delete-an-authorization
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /authorizations/{authorization_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/oauth-authorizations/oauth-authorizations#get-a-single-authorization
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/oauth-authorizations/oauth-authorizations#get-a-single-authorization
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /authorizations/{authorization_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/oauth-authorizations/oauth-authorizations#update-an-existing-authorization
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/oauth-authorizations/oauth-authorizations#update-an-existing-authorization
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /classrooms
     documentation_url: https://docs.github.com/rest/classroom/classroom#list-classrooms
     openapi_files:
@@ -411,100 +411,100 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /codes_of_conduct/{key}
     documentation_url: https://docs.github.com/rest/codes-of-conduct/codes-of-conduct#get-a-code-of-conduct
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /emojis
     documentation_url: https://docs.github.com/rest/emojis/emojis#get-emojis
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprise-installation/{enterprise_or_org}/server-statistics
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/admin-stats#get-github-enterprise-server-statistics
     openapi_files:
       - descriptions/ghec/ghec.json
   - name: DELETE /enterprise/announcement
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/announcement#remove-the-global-announcement-banner
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/announcement#remove-the-global-announcement-banner
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprise/announcement
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/announcement#get-the-global-announcement-banner
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/announcement#get-the-global-announcement-banner
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /enterprise/announcement
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/announcement#set-the-global-announcement-banner
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/announcement#set-the-global-announcement-banner
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprise/settings/license
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/license#get-license-information
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/license#get-license-information
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprise/stats/all
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/admin-stats#get-all-statistics
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/admin-stats#get-all-statistics
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprise/stats/comments
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/admin-stats#get-comment-statistics
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/admin-stats#get-comment-statistics
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprise/stats/gists
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/admin-stats#get-gist-statistics
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/admin-stats#get-gist-statistics
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprise/stats/hooks
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/admin-stats#get-hooks-statistics
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/admin-stats#get-hooks-statistics
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprise/stats/issues
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/admin-stats#get-issue-statistics
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/admin-stats#get-issue-statistics
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprise/stats/milestones
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/admin-stats#get-milestone-statistics
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/admin-stats#get-milestone-statistics
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprise/stats/orgs
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/admin-stats#get-organization-statistics
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/admin-stats#get-organization-statistics
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprise/stats/pages
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/admin-stats#get-pages-statistics
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/admin-stats#get-pages-statistics
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprise/stats/pulls
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/admin-stats#get-pull-request-statistics
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/admin-stats#get-pull-request-statistics
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprise/stats/repos
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/admin-stats#get-repository-statistics
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/admin-stats#get-repository-statistics
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprise/stats/security-products
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/admin-stats#get-security-products-statistics
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/admin-stats#get-security-products-statistics
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprise/stats/users
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/admin-stats#get-users-statistics
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/admin-stats#get-users-statistics
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/actions/cache/usage
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#get-github-actions-cache-usage-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/actions/cache/usage-policy
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/actions/cache#get-github-actions-cache-usage-policy-for-an-enterprise
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/actions/cache#get-github-actions-cache-usage-policy-for-an-enterprise
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /enterprises/{enterprise}/actions/cache/usage-policy
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/actions/cache#set-github-actions-cache-usage-policy-for-an-enterprise
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/actions/cache#set-github-actions-cache-usage-policy-for-an-enterprise
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /enterprises/{enterprise}/actions/oidc/customization/issuer
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/oidc#set-the-github-actions-oidc-custom-issuer-policy-for-an-enterprise
     openapi_files:
@@ -513,177 +513,177 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-github-actions-permissions-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /enterprises/{enterprise}/actions/permissions
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#set-github-actions-permissions-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/actions/permissions/organizations
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#list-selected-organizations-enabled-for-github-actions-in-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /enterprises/{enterprise}/actions/permissions/organizations
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#set-selected-organizations-enabled-for-github-actions-in-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /enterprises/{enterprise}/actions/permissions/organizations/{org_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#disable-a-selected-organization-for-github-actions-in-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /enterprises/{enterprise}/actions/permissions/organizations/{org_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#enable-a-selected-organization-for-github-actions-in-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/actions/permissions/selected-actions
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /enterprises/{enterprise}/actions/permissions/selected-actions
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#set-allowed-actions-and-reusable-workflows-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/actions/permissions/workflow
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-default-workflow-permissions-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /enterprises/{enterprise}/actions/permissions/workflow
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#set-default-workflow-permissions-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/actions/runner-groups
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-self-hosted-runner-groups-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /enterprises/{enterprise}/actions/runner-groups
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#create-a-self-hosted-runner-group-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#delete-a-self-hosted-runner-group-from-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#get-a-self-hosted-runner-group-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#update-a-self-hosted-runner-group-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-organization-access-to-a-self-hosted-runner-group-in-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#set-organization-access-for-a-self-hosted-runner-group-in-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#remove-organization-access-to-a-self-hosted-runner-group-in-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#add-organization-access-to-a-self-hosted-runner-group-in-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-self-hosted-runners-in-a-group-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#set-self-hosted-runners-in-a-group-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#remove-a-self-hosted-runner-from-a-group-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#add-a-self-hosted-runner-to-a-group-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/actions/runners
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-self-hosted-runners-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/actions/runners/downloads
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-runner-applications-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /enterprises/{enterprise}/actions/runners/generate-jitconfig
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-configuration-for-a-just-in-time-runner-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /enterprises/{enterprise}/actions/runners/registration-token
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-registration-token-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /enterprises/{enterprise}/actions/runners/remove-token
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-remove-token-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /enterprises/{enterprise}/actions/runners/{runner_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/actions/runners/{runner_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /enterprises/{enterprise}/actions/runners/{runner_id}/labels
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#remove-all-custom-labels-from-a-self-hosted-runner-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/actions/runners/{runner_id}/labels
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-labels-for-a-self-hosted-runner-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /enterprises/{enterprise}/actions/runners/{runner_id}/labels
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#add-custom-labels-to-a-self-hosted-runner-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /enterprises/{enterprise}/actions/runners/{runner_id}/labels
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#set-custom-labels-for-a-self-hosted-runner-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /enterprises/{enterprise}/actions/runners/{runner_id}/labels/{name}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#remove-a-custom-label-from-a-self-hosted-runner-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /enterprises/{enterprise}/announcement
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/enterprises#remove-announcement-banner-from-enterprise
     openapi_files:
@@ -700,22 +700,22 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/audit-log#get-the-audit-log-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/code-scanning/alerts
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-code-scanning-alerts-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/code_security_and_analysis
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/code-security-and-analysis#get-code-security-and-analysis-features-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /enterprises/{enterprise}/code_security_and_analysis
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/code-security-and-analysis#update-code-security-and-analysis-features-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/consumed-licenses
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/license#list-enterprise-consumed-licenses
     openapi_files:
@@ -725,7 +725,7 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/license-sync-status
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/license#get-a-license-sync-status
     openapi_files:
@@ -735,7 +735,7 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/settings/billing/actions
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-github-actions-billing-for-an-enterprise
     openapi_files:
@@ -744,7 +744,7 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-github-advanced-security-active-committers-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /enterprises/{enterprise}/settings/billing/packages
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-github-packages-billing-for-an-enterprise
     openapi_files:
@@ -757,207 +757,247 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/code-security-and-analysis#enable-or-disable-a-security-feature
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /events
     documentation_url: https://docs.github.com/rest/activity/events#list-public-events
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /feeds
     documentation_url: https://docs.github.com/rest/activity/feeds#get-feeds
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /gists
     documentation_url: https://docs.github.com/rest/gists/gists#list-gists-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /gists
     documentation_url: https://docs.github.com/rest/gists/gists#create-a-gist
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /gists/public
     documentation_url: https://docs.github.com/rest/gists/gists#list-public-gists
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /gists/starred
     documentation_url: https://docs.github.com/rest/gists/gists#list-starred-gists
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /gists/{gist_id}
     documentation_url: https://docs.github.com/rest/gists/gists#delete-a-gist
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /gists/{gist_id}
     documentation_url: https://docs.github.com/rest/gists/gists#get-a-gist
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /gists/{gist_id}
     documentation_url: https://docs.github.com/rest/gists/gists#update-a-gist
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /gists/{gist_id}/comments
     documentation_url: https://docs.github.com/rest/gists/comments#list-gist-comments
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /gists/{gist_id}/comments
     documentation_url: https://docs.github.com/rest/gists/comments#create-a-gist-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /gists/{gist_id}/comments/{comment_id}
     documentation_url: https://docs.github.com/rest/gists/comments#delete-a-gist-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /gists/{gist_id}/comments/{comment_id}
     documentation_url: https://docs.github.com/rest/gists/comments#get-a-gist-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /gists/{gist_id}/comments/{comment_id}
     documentation_url: https://docs.github.com/rest/gists/comments#update-a-gist-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /gists/{gist_id}/commits
     documentation_url: https://docs.github.com/rest/gists/gists#list-gist-commits
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /gists/{gist_id}/forks
     documentation_url: https://docs.github.com/rest/gists/gists#list-gist-forks
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /gists/{gist_id}/forks
     documentation_url: https://docs.github.com/rest/gists/gists#fork-a-gist
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /gists/{gist_id}/star
     documentation_url: https://docs.github.com/rest/gists/gists#unstar-a-gist
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /gists/{gist_id}/star
     documentation_url: https://docs.github.com/rest/gists/gists#check-if-a-gist-is-starred
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /gists/{gist_id}/star
     documentation_url: https://docs.github.com/rest/gists/gists#star-a-gist
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /gists/{gist_id}/{sha}
     documentation_url: https://docs.github.com/rest/gists/gists#get-a-gist-revision
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /gitignore/templates
     documentation_url: https://docs.github.com/rest/gitignore/gitignore#get-all-gitignore-templates
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /gitignore/templates/{name}
     documentation_url: https://docs.github.com/rest/gitignore/gitignore#get-a-gitignore-template
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /installation/repositories
     documentation_url: https://docs.github.com/rest/apps/installations#list-repositories-accessible-to-the-app-installation
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /installation/token
     documentation_url: https://docs.github.com/rest/apps/installations#revoke-an-installation-access-token
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /issues
     documentation_url: https://docs.github.com/rest/issues/issues#list-issues-assigned-to-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /licenses
     documentation_url: https://docs.github.com/rest/licenses/licenses#get-all-commonly-used-licenses
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /licenses/{license}
     documentation_url: https://docs.github.com/rest/licenses/licenses#get-a-license
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: DELETE /manage/v1/access/ssh
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/manage-ghes#delete-ssh-key
+    openapi_files:
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: GET /manage/v1/access/ssh
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/manage-ghes#get-ssh-keys
+    openapi_files:
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: POST /manage/v1/access/ssh
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/manage-ghes#set-ssh-key
+    openapi_files:
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: GET /manage/v1/checks/system-requirements
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/manage-ghes#get-system-requirements-check-results-on-configured-nodes
+    openapi_files:
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: POST /manage/v1/config/init
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/manage-ghes#initialize-instance-configuration-with-license-upload
+    openapi_files:
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: GET /manage/v1/config/license
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/manage-ghes#get-the-enterprise-license-information
+    openapi_files:
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: PUT /manage/v1/config/license
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/manage-ghes#upload-an-enterprise-license
+    openapi_files:
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: GET /manage/v1/config/license/check
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/manage-ghes#check-a-license
+    openapi_files:
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /manage/v1/config/nodes
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/manage-ghes#get-ghes-node-metadata-for-all-nodes
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/manage-ghes#get-ghes-node-metadata-for-all-nodes
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: GET /manage/v1/config/settings
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/manage-ghes#get-settings
+    openapi_files:
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: PUT /manage/v1/config/settings
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/manage-ghes#set-settings
+    openapi_files:
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /manage/v1/maintenance
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/manage-ghes#get-the-status-of-maintenance-mode
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/manage-ghes#get-the-status-of-maintenance-mode
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /manage/v1/maintenance
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/manage-ghes#set-the-status-of-maintenance-mode
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/manage-ghes#set-the-status-of-maintenance-mode
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /manage/v1/replication/status
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/manage-ghes#get-the-status-of-services-running-on-all-replica-nodes
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/manage-ghes#get-the-status-of-services-running-on-all-replica-nodes
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /manage/v1/version
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/manage-ghes#get-all-ghes-release-versions-for-all-nodes
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/manage-ghes#get-all-ghes-release-versions-for-all-nodes
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /markdown
     documentation_url: https://docs.github.com/rest/markdown/markdown#render-a-markdown-document
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /markdown/raw
     documentation_url: https://docs.github.com/rest/markdown/markdown#render-a-markdown-document-in-raw-mode
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /marketplace_listing/accounts/{account_id}
     documentation_url: https://docs.github.com/rest/apps/marketplace#get-a-subscription-plan-for-an-account
     openapi_files:
@@ -993,439 +1033,444 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /networks/{owner}/{repo}/events
     documentation_url: https://docs.github.com/rest/activity/events#list-public-events-for-a-network-of-repositories
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /notifications
     documentation_url: https://docs.github.com/rest/activity/notifications#list-notifications-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /notifications
     documentation_url: https://docs.github.com/rest/activity/notifications#mark-notifications-as-read
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: DELETE /notifications/threads/{thread_id}
+    documentation_url: https://docs.github.com/rest/activity/notifications#mark-a-thread-as-done
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
   - name: GET /notifications/threads/{thread_id}
     documentation_url: https://docs.github.com/rest/activity/notifications#get-a-thread
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /notifications/threads/{thread_id}
     documentation_url: https://docs.github.com/rest/activity/notifications#mark-a-thread-as-read
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /notifications/threads/{thread_id}/subscription
     documentation_url: https://docs.github.com/rest/activity/notifications#delete-a-thread-subscription
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /notifications/threads/{thread_id}/subscription
     documentation_url: https://docs.github.com/rest/activity/notifications#get-a-thread-subscription-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /notifications/threads/{thread_id}/subscription
     documentation_url: https://docs.github.com/rest/activity/notifications#set-a-thread-subscription
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /octocat
     documentation_url: https://docs.github.com/rest/meta/meta#get-octocat
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /organizations
     documentation_url: https://docs.github.com/rest/orgs/orgs#list-organizations
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /organizations/{organization_id}/custom_roles
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#deprecated---list-custom-repository-roles-in-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}
     documentation_url: https://docs.github.com/rest/orgs/orgs#delete-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}
     documentation_url: https://docs.github.com/rest/orgs/orgs#get-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /orgs/{org}
     documentation_url: https://docs.github.com/rest/orgs/orgs#update-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/cache/usage
     documentation_url: https://docs.github.com/rest/actions/cache#get-github-actions-cache-usage-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/cache/usage-by-repository
     documentation_url: https://docs.github.com/rest/actions/cache#list-repositories-with-github-actions-cache-usage-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/oidc/customization/sub
     documentation_url: https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/oidc/customization/sub
     documentation_url: https://docs.github.com/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/permissions
     documentation_url: https://docs.github.com/rest/actions/permissions#get-github-actions-permissions-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/permissions
     documentation_url: https://docs.github.com/rest/actions/permissions#set-github-actions-permissions-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/permissions/repositories
     documentation_url: https://docs.github.com/rest/actions/permissions#list-selected-repositories-enabled-for-github-actions-in-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/permissions/repositories
     documentation_url: https://docs.github.com/rest/actions/permissions#set-selected-repositories-enabled-for-github-actions-in-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/actions/permissions/repositories/{repository_id}
     documentation_url: https://docs.github.com/rest/actions/permissions#disable-a-selected-repository-for-github-actions-in-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/permissions/repositories/{repository_id}
     documentation_url: https://docs.github.com/rest/actions/permissions#enable-a-selected-repository-for-github-actions-in-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/permissions/selected-actions
     documentation_url: https://docs.github.com/rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/permissions/selected-actions
     documentation_url: https://docs.github.com/rest/actions/permissions#set-allowed-actions-and-reusable-workflows-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/permissions/workflow
     documentation_url: https://docs.github.com/rest/actions/permissions#get-default-workflow-permissions-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/permissions/workflow
     documentation_url: https://docs.github.com/rest/actions/permissions#set-default-workflow-permissions-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/runner-groups
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-self-hosted-runner-groups-for-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/actions/runner-groups
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#create-a-self-hosted-runner-group-for-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#delete-a-self-hosted-runner-group-from-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/runner-groups/{runner_group_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#get-a-self-hosted-runner-group-for-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /orgs/{org}/actions/runner-groups/{runner_group_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#update-a-self-hosted-runner-group-for-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-repository-access-to-a-self-hosted-runner-group-in-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#set-repository-access-for-a-self-hosted-runner-group-in-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#remove-repository-access-to-a-self-hosted-runner-group-in-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#add-repository-access-to-a-self-hosted-runner-group-in-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/runner-groups/{runner_group_id}/runners
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-self-hosted-runners-in-a-group-for-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/runners
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#set-self-hosted-runners-in-a-group-for-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#remove-a-self-hosted-runner-from-a-group-for-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#add-a-self-hosted-runner-to-a-group-for-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/runners
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#list-self-hosted-runners-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/runners/downloads
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#list-runner-applications-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/actions/runners/generate-jitconfig
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#create-configuration-for-a-just-in-time-runner-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/actions/runners/registration-token
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#create-a-registration-token-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/actions/runners/remove-token
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#create-a-remove-token-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/actions/runners/{runner_id}
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/runners/{runner_id}
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/actions/runners/{runner_id}/labels
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#remove-all-custom-labels-from-a-self-hosted-runner-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/runners/{runner_id}/labels
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#list-labels-for-a-self-hosted-runner-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/actions/runners/{runner_id}/labels
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#add-custom-labels-to-a-self-hosted-runner-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/runners/{runner_id}/labels
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#set-custom-labels-for-a-self-hosted-runner-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/actions/runners/{runner_id}/labels/{name}
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#remove-a-custom-label-from-a-self-hosted-runner-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/secrets
     documentation_url: https://docs.github.com/rest/actions/secrets#list-organization-secrets
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/secrets/public-key
     documentation_url: https://docs.github.com/rest/actions/secrets#get-an-organization-public-key
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/actions/secrets/{secret_name}
     documentation_url: https://docs.github.com/rest/actions/secrets#delete-an-organization-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/secrets/{secret_name}
     documentation_url: https://docs.github.com/rest/actions/secrets#get-an-organization-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/secrets/{secret_name}
     documentation_url: https://docs.github.com/rest/actions/secrets#create-or-update-an-organization-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/secrets/{secret_name}/repositories
     documentation_url: https://docs.github.com/rest/actions/secrets#list-selected-repositories-for-an-organization-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/secrets/{secret_name}/repositories
     documentation_url: https://docs.github.com/rest/actions/secrets#set-selected-repositories-for-an-organization-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}
     documentation_url: https://docs.github.com/rest/actions/secrets#remove-selected-repository-from-an-organization-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}
     documentation_url: https://docs.github.com/rest/actions/secrets#add-selected-repository-to-an-organization-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/variables
     documentation_url: https://docs.github.com/rest/actions/variables#list-organization-variables
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/actions/variables
     documentation_url: https://docs.github.com/rest/actions/variables#create-an-organization-variable
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/actions/variables/{name}
     documentation_url: https://docs.github.com/rest/actions/variables#delete-an-organization-variable
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/variables/{name}
     documentation_url: https://docs.github.com/rest/actions/variables#get-an-organization-variable
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /orgs/{org}/actions/variables/{name}
     documentation_url: https://docs.github.com/rest/actions/variables#update-an-organization-variable
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/actions/variables/{name}/repositories
     documentation_url: https://docs.github.com/rest/actions/variables#list-selected-repositories-for-an-organization-variable
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/variables/{name}/repositories
     documentation_url: https://docs.github.com/rest/actions/variables#set-selected-repositories-for-an-organization-variable
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/actions/variables/{name}/repositories/{repository_id}
     documentation_url: https://docs.github.com/rest/actions/variables#remove-selected-repository-from-an-organization-variable
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/actions/variables/{name}/repositories/{repository_id}
     documentation_url: https://docs.github.com/rest/actions/variables#add-selected-repository-to-an-organization-variable
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/announcement
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/organizations#remove-announcement-banner-from-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/announcement
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/organizations#get-announcement-banner-for-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /orgs/{org}/announcement
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/organizations#set-announcement-banner-for-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/audit-log
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#get-the-audit-log-for-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/blocks
     documentation_url: https://docs.github.com/rest/orgs/blocking#list-users-blocked-by-an-organization
     openapi_files:
@@ -1451,7 +1496,7 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/codespaces
     documentation_url: https://docs.github.com/rest/codespaces/organizations#list-codespaces-for-the-organization
     openapi_files:
@@ -1518,32 +1563,32 @@ openapi_operations:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
   - name: GET /orgs/{org}/copilot/billing
-    documentation_url: https://docs.github.com/rest/copilot/copilot-business#get-copilot-business-seat-information-and-settings-for-an-organization
+    documentation_url: https://docs.github.com/rest/copilot/copilot-user-management#get-copilot-seat-information-and-settings-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
   - name: GET /orgs/{org}/copilot/billing/seats
-    documentation_url: https://docs.github.com/rest/copilot/copilot-business#list-all-copilot-business-seat-assignments-for-an-organization
+    documentation_url: https://docs.github.com/rest/copilot/copilot-user-management#list-all-copilot-seat-assignments-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
   - name: DELETE /orgs/{org}/copilot/billing/selected_teams
-    documentation_url: https://docs.github.com/rest/copilot/copilot-business#remove-teams-from-the-copilot-business-subscription-for-an-organization
+    documentation_url: https://docs.github.com/rest/copilot/copilot-user-management#remove-teams-from-the-copilot-subscription-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
   - name: POST /orgs/{org}/copilot/billing/selected_teams
-    documentation_url: https://docs.github.com/rest/copilot/copilot-business#add-teams-to-the-copilot-business-subscription-for-an-organization
+    documentation_url: https://docs.github.com/rest/copilot/copilot-user-management#add-teams-to-the-copilot-subscription-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
   - name: DELETE /orgs/{org}/copilot/billing/selected_users
-    documentation_url: https://docs.github.com/rest/copilot/copilot-business#remove-users-from-the-copilot-business-subscription-for-an-organization
+    documentation_url: https://docs.github.com/rest/copilot/copilot-user-management#remove-users-from-the-copilot-subscription-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
   - name: POST /orgs/{org}/copilot/billing/selected_users
-    documentation_url: https://docs.github.com/rest/copilot/copilot-business#add-users-to-the-copilot-business-subscription-for-an-organization
+    documentation_url: https://docs.github.com/rest/copilot/copilot-user-management#add-users-to-the-copilot-subscription-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
@@ -1559,27 +1604,27 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#list-custom-repository-roles-in-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/custom-repository-roles
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#create-a-custom-repository-role
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/custom-repository-roles/{role_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#delete-a-custom-repository-role
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/custom-repository-roles/{role_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#get-a-custom-repository-role
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /orgs/{org}/custom-repository-roles/{role_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#update-a-custom-repository-role
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/custom_roles
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#deprecated---create-a-custom-role
     openapi_files:
@@ -1601,83 +1646,83 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/dependabot/secrets
     documentation_url: https://docs.github.com/rest/dependabot/secrets#list-organization-secrets
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/dependabot/secrets/public-key
     documentation_url: https://docs.github.com/rest/dependabot/secrets#get-an-organization-public-key
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/dependabot/secrets/{secret_name}
     documentation_url: https://docs.github.com/rest/dependabot/secrets#delete-an-organization-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/dependabot/secrets/{secret_name}
     documentation_url: https://docs.github.com/rest/dependabot/secrets#get-an-organization-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/dependabot/secrets/{secret_name}
     documentation_url: https://docs.github.com/rest/dependabot/secrets#create-or-update-an-organization-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories
     documentation_url: https://docs.github.com/rest/dependabot/secrets#list-selected-repositories-for-an-organization-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories
     documentation_url: https://docs.github.com/rest/dependabot/secrets#set-selected-repositories-for-an-organization-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}
     documentation_url: https://docs.github.com/rest/dependabot/secrets#remove-selected-repository-from-an-organization-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}
     documentation_url: https://docs.github.com/rest/dependabot/secrets#add-selected-repository-to-an-organization-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/docker/conflicts
     documentation_url: https://docs.github.com/rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/events
     documentation_url: https://docs.github.com/rest/activity/events#list-public-organization-events
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/external-group/{group_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#get-an-external-group
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/external-groups
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#list-external-groups-in-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/failed_invitations
     documentation_url: https://docs.github.com/rest/orgs/members#list-failed-organization-invitations
     openapi_files:
@@ -1692,79 +1737,79 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/hooks
     documentation_url: https://docs.github.com/rest/orgs/webhooks#create-an-organization-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/hooks/{hook_id}
     documentation_url: https://docs.github.com/rest/orgs/webhooks#delete-an-organization-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/hooks/{hook_id}
     documentation_url: https://docs.github.com/rest/orgs/webhooks#get-an-organization-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /orgs/{org}/hooks/{hook_id}
     documentation_url: https://docs.github.com/rest/orgs/webhooks#update-an-organization-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/hooks/{hook_id}/config
     documentation_url: https://docs.github.com/rest/orgs/webhooks#get-a-webhook-configuration-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /orgs/{org}/hooks/{hook_id}/config
     documentation_url: https://docs.github.com/rest/orgs/webhooks#update-a-webhook-configuration-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/hooks/{hook_id}/deliveries
     documentation_url: https://docs.github.com/rest/orgs/webhooks#list-deliveries-for-an-organization-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/hooks/{hook_id}/deliveries/{delivery_id}
     documentation_url: https://docs.github.com/rest/orgs/webhooks#get-a-webhook-delivery-for-an-organization-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/hooks/{hook_id}/deliveries/{delivery_id}/attempts
     documentation_url: https://docs.github.com/rest/orgs/webhooks#redeliver-a-delivery-for-an-organization-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/hooks/{hook_id}/pings
     documentation_url: https://docs.github.com/rest/orgs/webhooks#ping-an-organization-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/installation
     documentation_url: https://docs.github.com/rest/apps/apps#get-an-organization-installation-for-the-authenticated-app
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/installations
     documentation_url: https://docs.github.com/rest/orgs/orgs#list-app-installations-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/interaction-limits
     documentation_url: https://docs.github.com/rest/interactions/orgs#remove-interaction-restrictions-for-an-organization
     openapi_files:
@@ -1805,25 +1850,25 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/members
     documentation_url: https://docs.github.com/rest/orgs/members#list-organization-members
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/members/{username}
     documentation_url: https://docs.github.com/rest/orgs/members#remove-an-organization-member
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/members/{username}
     documentation_url: https://docs.github.com/rest/orgs/members#check-organization-membership-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/members/{username}/codespaces
     documentation_url: https://docs.github.com/rest/codespaces/organizations#list-codespaces-for-a-user-in-organization
     openapi_files:
@@ -1840,7 +1885,7 @@ openapi_operations:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
   - name: GET /orgs/{org}/members/{username}/copilot
-    documentation_url: https://docs.github.com/rest/copilot/copilot-business#get-copilot-business-seat-assignment-details-for-a-user
+    documentation_url: https://docs.github.com/rest/copilot/copilot-user-management#get-copilot-seat-assignment-details-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
@@ -1849,61 +1894,61 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/memberships/{username}
     documentation_url: https://docs.github.com/rest/orgs/members#get-organization-membership-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/memberships/{username}
     documentation_url: https://docs.github.com/rest/orgs/members#set-organization-membership-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/migrations
     documentation_url: https://docs.github.com/rest/migrations/orgs#list-organization-migrations
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/migrations
     documentation_url: https://docs.github.com/rest/migrations/orgs#start-an-organization-migration
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/migrations/{migration_id}
     documentation_url: https://docs.github.com/rest/migrations/orgs#get-an-organization-migration-status
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/migrations/{migration_id}/archive
     documentation_url: https://docs.github.com/rest/migrations/orgs#delete-an-organization-migration-archive
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/migrations/{migration_id}/archive
     documentation_url: https://docs.github.com/rest/migrations/orgs#download-an-organization-migration-archive
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock
     documentation_url: https://docs.github.com/rest/migrations/orgs#unlock-an-organization-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/migrations/{migration_id}/repositories
     documentation_url: https://docs.github.com/rest/migrations/orgs#list-repositories-in-an-organization-migration
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/organization-fine-grained-permissions
     documentation_url: https://docs.github.com/rest/orgs/organization-roles#list-organization-fine-grained-permissions-for-an-organization
     openapi_files:
@@ -1979,143 +2024,143 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/outside_collaborators/{username}
     documentation_url: https://docs.github.com/rest/orgs/outside-collaborators#remove-outside-collaborator-from-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/outside_collaborators/{username}
     documentation_url: https://docs.github.com/rest/orgs/outside-collaborators#convert-an-organization-member-to-outside-collaborator
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/packages
     documentation_url: https://docs.github.com/rest/packages/packages#list-packages-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/packages/{package_type}/{package_name}
     documentation_url: https://docs.github.com/rest/packages/packages#delete-a-package-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/packages/{package_type}/{package_name}
     documentation_url: https://docs.github.com/rest/packages/packages#get-a-package-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/packages/{package_type}/{package_name}/restore
     documentation_url: https://docs.github.com/rest/packages/packages#restore-a-package-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/packages/{package_type}/{package_name}/versions
     documentation_url: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}
     documentation_url: https://docs.github.com/rest/packages/packages#delete-package-version-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}
     documentation_url: https://docs.github.com/rest/packages/packages#get-a-package-version-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore
     documentation_url: https://docs.github.com/rest/packages/packages#restore-package-version-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/personal-access-token-requests
     documentation_url: https://docs.github.com/rest/orgs/personal-access-tokens#list-requests-to-access-organization-resources-with-fine-grained-personal-access-tokens
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/personal-access-token-requests
     documentation_url: https://docs.github.com/rest/orgs/personal-access-tokens#review-requests-to-access-organization-resources-with-fine-grained-personal-access-tokens
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/personal-access-token-requests/{pat_request_id}
     documentation_url: https://docs.github.com/rest/orgs/personal-access-tokens#review-a-request-to-access-organization-resources-with-a-fine-grained-personal-access-token
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/personal-access-token-requests/{pat_request_id}/repositories
     documentation_url: https://docs.github.com/rest/orgs/personal-access-tokens#list-repositories-requested-to-be-accessed-by-a-fine-grained-personal-access-token
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/personal-access-tokens
     documentation_url: https://docs.github.com/rest/orgs/personal-access-tokens#list-fine-grained-personal-access-tokens-with-access-to-organization-resources
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/personal-access-tokens
     documentation_url: https://docs.github.com/rest/orgs/personal-access-tokens#update-the-access-to-organization-resources-via-fine-grained-personal-access-tokens
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/personal-access-tokens/{pat_id}
     documentation_url: https://docs.github.com/rest/orgs/personal-access-tokens#update-the-access-a-fine-grained-personal-access-token-has-to-organization-resources
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/personal-access-tokens/{pat_id}/repositories
     documentation_url: https://docs.github.com/rest/orgs/personal-access-tokens#list-repositories-a-fine-grained-personal-access-token-has-access-to
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/pre-receive-hooks
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/org-pre-receive-hooks#list-pre-receive-hooks-for-an-organization
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/org-pre-receive-hooks#list-pre-receive-hooks-for-an-organization
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/org-pre-receive-hooks#remove-pre-receive-hook-enforcement-for-an-organization
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/org-pre-receive-hooks#remove-pre-receive-hook-enforcement-for-an-organization
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/org-pre-receive-hooks#get-a-pre-receive-hook-for-an-organization
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/org-pre-receive-hooks#get-a-pre-receive-hook-for-an-organization
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/org-pre-receive-hooks#update-pre-receive-hook-enforcement-for-an-organization
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/org-pre-receive-hooks#update-pre-receive-hook-enforcement-for-an-organization
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/projects
     documentation_url: https://docs.github.com/rest/projects/projects#list-organization-projects
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/projects
     documentation_url: https://docs.github.com/rest/projects/projects#create-an-organization-project
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/properties/schema
     documentation_url: https://docs.github.com/rest/orgs/custom-properties#get-all-custom-properties-for-an-organization
     openapi_files:
@@ -2156,88 +2201,90 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/public_members/{username}
     documentation_url: https://docs.github.com/rest/orgs/members#remove-public-organization-membership-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/public_members/{username}
     documentation_url: https://docs.github.com/rest/orgs/members#check-public-organization-membership-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/public_members/{username}
     documentation_url: https://docs.github.com/rest/orgs/members#set-public-organization-membership-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/repos
     documentation_url: https://docs.github.com/rest/repos/repos#list-organization-repositories
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/repos
     documentation_url: https://docs.github.com/rest/repos/repos#create-an-organization-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/repository-fine-grained-permissions
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#list-repository-fine-grained-permissions-for-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/rulesets
     documentation_url: https://docs.github.com/rest/orgs/rules#get-all-organization-repository-rulesets
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/rulesets
     documentation_url: https://docs.github.com/rest/orgs/rules#create-an-organization-repository-ruleset
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/rulesets/rule-suites
     documentation_url: https://docs.github.com/rest/orgs/rule-suites#list-organization-rule-suites
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/rulesets/rule-suites/{rule_suite_id}
     documentation_url: https://docs.github.com/rest/orgs/rule-suites#get-an-organization-rule-suite
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/rulesets/{ruleset_id}
     documentation_url: https://docs.github.com/rest/orgs/rules#delete-an-organization-repository-ruleset
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/rulesets/{ruleset_id}
     documentation_url: https://docs.github.com/rest/orgs/rules#get-an-organization-repository-ruleset
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/rulesets/{ruleset_id}
     documentation_url: https://docs.github.com/rest/orgs/rules#update-an-organization-repository-ruleset
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/secret-scanning/alerts
     documentation_url: https://docs.github.com/rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/security-advisories
     documentation_url: https://docs.github.com/rest/security-advisories/repository-advisories#list-repository-security-advisories-for-an-organization
     openapi_files:
@@ -2248,19 +2295,19 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/security-managers/teams/{team_slug}
     documentation_url: https://docs.github.com/rest/orgs/security-managers#remove-a-security-manager-team
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/security-managers/teams/{team_slug}
     documentation_url: https://docs.github.com/rest/orgs/security-managers#add-a-security-manager-team
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/settings/billing/actions
     documentation_url: https://docs.github.com/rest/billing/billing#get-github-actions-billing-for-an-organization
     openapi_files:
@@ -2270,7 +2317,7 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-advanced-security-active-committers-for-an-organization
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/settings/billing/packages
     documentation_url: https://docs.github.com/rest/billing/billing#get-github-packages-billing-for-an-organization
     openapi_files:
@@ -2290,142 +2337,142 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/teams
     documentation_url: https://docs.github.com/rest/teams/teams#create-a-team
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/teams/{team_slug}
     documentation_url: https://docs.github.com/rest/teams/teams#delete-a-team
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/teams/{team_slug}
     documentation_url: https://docs.github.com/rest/teams/teams#get-a-team-by-name
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /orgs/{org}/teams/{team_slug}
     documentation_url: https://docs.github.com/rest/teams/teams#update-a-team
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/teams/{team_slug}/discussions
     documentation_url: https://docs.github.com/rest/teams/discussions#list-discussions
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/teams/{team_slug}/discussions
     documentation_url: https://docs.github.com/rest/teams/discussions#create-a-discussion
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
     documentation_url: https://docs.github.com/rest/teams/discussions#delete-a-discussion
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
     documentation_url: https://docs.github.com/rest/teams/discussions#get-a-discussion
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
     documentation_url: https://docs.github.com/rest/teams/discussions#update-a-discussion
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments
     documentation_url: https://docs.github.com/rest/teams/discussion-comments#list-discussion-comments
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments
     documentation_url: https://docs.github.com/rest/teams/discussion-comments#create-a-discussion-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
     documentation_url: https://docs.github.com/rest/teams/discussion-comments#delete-a-discussion-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
     documentation_url: https://docs.github.com/rest/teams/discussion-comments#get-a-discussion-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
     documentation_url: https://docs.github.com/rest/teams/discussion-comments#update-a-discussion-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-team-discussion-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}
     documentation_url: https://docs.github.com/rest/reactions/reactions#delete-team-discussion-comment-reaction
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-team-discussion
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}
     documentation_url: https://docs.github.com/rest/reactions/reactions#delete-team-discussion-reaction
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/teams/{team_slug}/external-groups
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#remove-the-connection-between-an-external-group-and-a-team
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/teams/{team_slug}/external-groups
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#list-a-connection-between-an-external-group-and-a-team
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /orgs/{org}/teams/{team_slug}/external-groups
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#update-the-connection-between-an-external-group-and-a-team
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/teams/{team_slug}/invitations
     documentation_url: https://docs.github.com/rest/teams/members#list-pending-team-invitations
     openapi_files:
@@ -2436,73 +2483,73 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}
     documentation_url: https://docs.github.com/rest/teams/members#remove-team-membership-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/teams/{team_slug}/memberships/{username}
     documentation_url: https://docs.github.com/rest/teams/members#get-team-membership-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/teams/{team_slug}/memberships/{username}
     documentation_url: https://docs.github.com/rest/teams/members#add-or-update-team-membership-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/teams/{team_slug}/projects
     documentation_url: https://docs.github.com/rest/teams/teams#list-team-projects
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/teams/{team_slug}/projects/{project_id}
     documentation_url: https://docs.github.com/rest/teams/teams#remove-a-project-from-a-team
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/teams/{team_slug}/projects/{project_id}
     documentation_url: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-project
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}
     documentation_url: https://docs.github.com/rest/teams/teams#add-or-update-team-project-permissions
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/teams/{team_slug}/repos
     documentation_url: https://docs.github.com/rest/teams/teams#list-team-repositories
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
     documentation_url: https://docs.github.com/rest/teams/teams#remove-a-repository-from-a-team
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
     documentation_url: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
     documentation_url: https://docs.github.com/rest/teams/teams#add-or-update-team-repository-permissions
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /orgs/{org}/teams/{team_slug}/team-sync/group-mappings
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#list-idp-groups-for-a-team
     openapi_files:
@@ -2516,133 +2563,133 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /orgs/{org}/{security_product}/{enablement}
     documentation_url: https://docs.github.com/rest/orgs/orgs#enable-or-disable-a-security-feature-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /projects/columns/cards/{card_id}
     documentation_url: https://docs.github.com/rest/projects/cards#delete-a-project-card
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /projects/columns/cards/{card_id}
     documentation_url: https://docs.github.com/rest/projects/cards#get-a-project-card
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /projects/columns/cards/{card_id}
     documentation_url: https://docs.github.com/rest/projects/cards#update-an-existing-project-card
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /projects/columns/cards/{card_id}/moves
     documentation_url: https://docs.github.com/rest/projects/cards#move-a-project-card
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /projects/columns/{column_id}
     documentation_url: https://docs.github.com/rest/projects/columns#delete-a-project-column
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /projects/columns/{column_id}
     documentation_url: https://docs.github.com/rest/projects/columns#get-a-project-column
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /projects/columns/{column_id}
     documentation_url: https://docs.github.com/rest/projects/columns#update-an-existing-project-column
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /projects/columns/{column_id}/cards
     documentation_url: https://docs.github.com/rest/projects/cards#list-project-cards
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /projects/columns/{column_id}/cards
     documentation_url: https://docs.github.com/rest/projects/cards#create-a-project-card
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /projects/columns/{column_id}/moves
     documentation_url: https://docs.github.com/rest/projects/columns#move-a-project-column
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /projects/{project_id}
     documentation_url: https://docs.github.com/rest/projects/projects#delete-a-project
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /projects/{project_id}
     documentation_url: https://docs.github.com/rest/projects/projects#get-a-project
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /projects/{project_id}
     documentation_url: https://docs.github.com/rest/projects/projects#update-a-project
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /projects/{project_id}/collaborators
     documentation_url: https://docs.github.com/rest/projects/collaborators#list-project-collaborators
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /projects/{project_id}/collaborators/{username}
     documentation_url: https://docs.github.com/rest/projects/collaborators#remove-user-as-a-collaborator
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /projects/{project_id}/collaborators/{username}
     documentation_url: https://docs.github.com/rest/projects/collaborators#add-project-collaborator
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /projects/{project_id}/collaborators/{username}/permission
     documentation_url: https://docs.github.com/rest/projects/collaborators#get-project-permission-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /projects/{project_id}/columns
     documentation_url: https://docs.github.com/rest/projects/columns#list-project-columns
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /projects/{project_id}/columns
     documentation_url: https://docs.github.com/rest/projects/columns#create-a-project-column
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /rate_limit
     documentation_url: https://docs.github.com/rest/rate-limit/rate-limit#get-rate-limit-status-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /reactions/{reaction_id}
     documentation_url: https://docs.github.com/enterprise-server@3.4/rest/reference/reactions/#delete-a-reaction-legacy
     openapi_files:
@@ -2652,261 +2699,261 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}
     documentation_url: https://docs.github.com/rest/repos/repos#get-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}
     documentation_url: https://docs.github.com/rest/repos/repos#update-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/artifacts
     documentation_url: https://docs.github.com/rest/actions/artifacts#list-artifacts-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/actions/artifacts/{artifact_id}
     documentation_url: https://docs.github.com/rest/actions/artifacts#delete-an-artifact
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}
     documentation_url: https://docs.github.com/rest/actions/artifacts#get-an-artifact
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}
     documentation_url: https://docs.github.com/rest/actions/artifacts#download-an-artifact
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/cache/usage
     documentation_url: https://docs.github.com/rest/actions/cache#get-github-actions-cache-usage-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/cache/usage-policy
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/actions/cache#get-github-actions-cache-usage-policy-for-a-repository
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/actions/cache#get-github-actions-cache-usage-policy-for-a-repository
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/actions/cache/usage-policy
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/actions/cache#set-github-actions-cache-usage-policy-for-a-repository
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/actions/cache#set-github-actions-cache-usage-policy-for-a-repository
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/actions/caches
     documentation_url: https://docs.github.com/rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/caches
     documentation_url: https://docs.github.com/rest/actions/cache#list-github-actions-caches-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/actions/caches/{cache_id}
     documentation_url: https://docs.github.com/rest/actions/cache#delete-a-github-actions-cache-for-a-repository-using-a-cache-id
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/jobs/{job_id}
     documentation_url: https://docs.github.com/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs
     documentation_url: https://docs.github.com/rest/actions/workflow-jobs#download-job-logs-for-a-workflow-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/actions/jobs/{job_id}/rerun
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#re-run-a-job-from-a-workflow-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/oidc/customization/sub
     documentation_url: https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/actions/oidc/customization/sub
     documentation_url: https://docs.github.com/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/organization-secrets
     documentation_url: https://docs.github.com/rest/actions/secrets#list-repository-organization-secrets
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/organization-variables
     documentation_url: https://docs.github.com/rest/actions/variables#list-repository-organization-variables
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/permissions
     documentation_url: https://docs.github.com/rest/actions/permissions#get-github-actions-permissions-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/actions/permissions
     documentation_url: https://docs.github.com/rest/actions/permissions#set-github-actions-permissions-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/permissions/access
     documentation_url: https://docs.github.com/rest/actions/permissions#get-the-level-of-access-for-workflows-outside-of-the-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/actions/permissions/access
     documentation_url: https://docs.github.com/rest/actions/permissions#set-the-level-of-access-for-workflows-outside-of-the-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/permissions/selected-actions
     documentation_url: https://docs.github.com/rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/actions/permissions/selected-actions
     documentation_url: https://docs.github.com/rest/actions/permissions#set-allowed-actions-and-reusable-workflows-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/permissions/workflow
     documentation_url: https://docs.github.com/rest/actions/permissions#get-default-workflow-permissions-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/actions/permissions/workflow
     documentation_url: https://docs.github.com/rest/actions/permissions#set-default-workflow-permissions-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/runners
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#list-self-hosted-runners-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/runners/downloads
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#list-runner-applications-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/actions/runners/generate-jitconfig
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#create-configuration-for-a-just-in-time-runner-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/actions/runners/registration-token
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#create-a-registration-token-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/actions/runners/remove-token
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#create-a-remove-token-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/runners/{runner_id}
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}/labels
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#remove-all-custom-labels-from-a-self-hosted-runner-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/runners/{runner_id}/labels
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#list-labels-for-a-self-hosted-runner-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/actions/runners/{runner_id}/labels
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#add-custom-labels-to-a-self-hosted-runner-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/actions/runners/{runner_id}/labels
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#set-custom-labels-for-a-self-hosted-runner-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}/labels/{name}
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runners#remove-a-custom-label-from-a-self-hosted-runner-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/runs
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/actions/runs/{run_id}
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#delete-a-workflow-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/runs/{run_id}
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#get-a-workflow-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/runs/{run_id}/approvals
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#get-the-review-history-for-a-workflow-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#approve-a-workflow-run-for-a-fork-pull-request
     openapi_files:
@@ -2917,84 +2964,85 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#get-a-workflow-run-attempt
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs
     documentation_url: https://docs.github.com/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run-attempt
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/logs
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#download-workflow-run-attempt-logs
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#cancel-a-workflow-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/actions/runs/{run_id}/deployment_protection_rule
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#review-custom-deployment-protection-rules-for-a-workflow-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/actions/runs/{run_id}/force-cancel
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#force-cancel-a-workflow-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs
     documentation_url: https://docs.github.com/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/actions/runs/{run_id}/logs
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#delete-workflow-run-logs
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#download-workflow-run-logs
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#get-pending-deployments-for-a-workflow-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#review-pending-deployments-for-a-workflow-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#re-run-a-workflow
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#re-run-failed-jobs-from-a-workflow-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/runs/{run_id}/timing
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#get-workflow-run-usage
     openapi_files:
@@ -3005,97 +3053,97 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/secrets/public-key
     documentation_url: https://docs.github.com/rest/actions/secrets#get-a-repository-public-key
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/actions/secrets/{secret_name}
     documentation_url: https://docs.github.com/rest/actions/secrets#delete-a-repository-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/secrets/{secret_name}
     documentation_url: https://docs.github.com/rest/actions/secrets#get-a-repository-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/actions/secrets/{secret_name}
     documentation_url: https://docs.github.com/rest/actions/secrets#create-or-update-a-repository-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/variables
     documentation_url: https://docs.github.com/rest/actions/variables#list-repository-variables
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/actions/variables
     documentation_url: https://docs.github.com/rest/actions/variables#create-a-repository-variable
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/actions/variables/{name}
     documentation_url: https://docs.github.com/rest/actions/variables#delete-a-repository-variable
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/variables/{name}
     documentation_url: https://docs.github.com/rest/actions/variables#get-a-repository-variable
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/actions/variables/{name}
     documentation_url: https://docs.github.com/rest/actions/variables#update-a-repository-variable
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/workflows
     documentation_url: https://docs.github.com/rest/actions/workflows#list-repository-workflows
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}
     documentation_url: https://docs.github.com/rest/actions/workflows#get-a-workflow
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/disable
     documentation_url: https://docs.github.com/rest/actions/workflows#disable-a-workflow
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches
     documentation_url: https://docs.github.com/rest/actions/workflows#create-a-workflow-dispatch-event
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable
     documentation_url: https://docs.github.com/rest/actions/workflows#enable-a-workflow
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs
     documentation_url: https://docs.github.com/rest/actions/workflow-runs#list-workflow-runs-for-a-workflow
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/timing
     documentation_url: https://docs.github.com/rest/actions/workflows#get-workflow-usage
     openapi_files:
@@ -3106,43 +3154,43 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/assignees
     documentation_url: https://docs.github.com/rest/issues/assignees#list-assignees
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/assignees/{assignee}
     documentation_url: https://docs.github.com/rest/issues/assignees#check-if-a-user-can-be-assigned
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/autolinks
-    documentation_url: https://docs.github.com/rest/repos/autolinks#list-all-autolinks-of-a-repository
+    documentation_url: https://docs.github.com/rest/repos/autolinks#get-all-autolinks-of-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/autolinks
     documentation_url: https://docs.github.com/rest/repos/autolinks#create-an-autolink-reference-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/autolinks/{autolink_id}
     documentation_url: https://docs.github.com/rest/repos/autolinks#delete-an-autolink-reference-from-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/autolinks/{autolink_id}
     documentation_url: https://docs.github.com/rest/repos/autolinks#get-an-autolink-reference-of-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/automated-security-fixes
     documentation_url: https://docs.github.com/rest/repos/repos#disable-automated-security-fixes
     openapi_files:
@@ -3153,7 +3201,7 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/automated-security-fixes
     documentation_url: https://docs.github.com/rest/repos/repos#enable-automated-security-fixes
     openapi_files:
@@ -3164,319 +3212,319 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/branches/{branch}
     documentation_url: https://docs.github.com/rest/branches/branches#get-a-branch
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/branches/{branch}/protection
     documentation_url: https://docs.github.com/rest/branches/branch-protection#delete-branch-protection
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/branches/{branch}/protection
     documentation_url: https://docs.github.com/rest/branches/branch-protection#get-branch-protection
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/branches/{branch}/protection
     documentation_url: https://docs.github.com/rest/branches/branch-protection#update-branch-protection
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
     documentation_url: https://docs.github.com/rest/branches/branch-protection#delete-admin-branch-protection
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
     documentation_url: https://docs.github.com/rest/branches/branch-protection#get-admin-branch-protection
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
     documentation_url: https://docs.github.com/rest/branches/branch-protection#set-admin-branch-protection
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews
     documentation_url: https://docs.github.com/rest/branches/branch-protection#delete-pull-request-review-protection
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews
     documentation_url: https://docs.github.com/rest/branches/branch-protection#get-pull-request-review-protection
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews
     documentation_url: https://docs.github.com/rest/branches/branch-protection#update-pull-request-review-protection
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures
     documentation_url: https://docs.github.com/rest/branches/branch-protection#delete-commit-signature-protection
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures
     documentation_url: https://docs.github.com/rest/branches/branch-protection#get-commit-signature-protection
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures
     documentation_url: https://docs.github.com/rest/branches/branch-protection#create-commit-signature-protection
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks
     documentation_url: https://docs.github.com/rest/branches/branch-protection#remove-status-check-protection
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks
     documentation_url: https://docs.github.com/rest/branches/branch-protection#get-status-checks-protection
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks
     documentation_url: https://docs.github.com/rest/branches/branch-protection#update-status-check-protection
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts
     documentation_url: https://docs.github.com/rest/branches/branch-protection#remove-status-check-contexts
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts
     documentation_url: https://docs.github.com/rest/branches/branch-protection#get-all-status-check-contexts
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts
     documentation_url: https://docs.github.com/rest/branches/branch-protection#add-status-check-contexts
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts
     documentation_url: https://docs.github.com/rest/branches/branch-protection#set-status-check-contexts
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions
     documentation_url: https://docs.github.com/rest/branches/branch-protection#delete-access-restrictions
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions
     documentation_url: https://docs.github.com/rest/branches/branch-protection#get-access-restrictions
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps
     documentation_url: https://docs.github.com/rest/branches/branch-protection#remove-app-access-restrictions
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps
     documentation_url: https://docs.github.com/rest/branches/branch-protection#get-apps-with-access-to-the-protected-branch
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps
     documentation_url: https://docs.github.com/rest/branches/branch-protection#add-app-access-restrictions
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps
     documentation_url: https://docs.github.com/rest/branches/branch-protection#set-app-access-restrictions
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams
     documentation_url: https://docs.github.com/rest/branches/branch-protection#remove-team-access-restrictions
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams
     documentation_url: https://docs.github.com/rest/branches/branch-protection#get-teams-with-access-to-the-protected-branch
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams
     documentation_url: https://docs.github.com/rest/branches/branch-protection#add-team-access-restrictions
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams
     documentation_url: https://docs.github.com/rest/branches/branch-protection#set-team-access-restrictions
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users
     documentation_url: https://docs.github.com/rest/branches/branch-protection#remove-user-access-restrictions
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users
     documentation_url: https://docs.github.com/rest/branches/branch-protection#get-users-with-access-to-the-protected-branch
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users
     documentation_url: https://docs.github.com/rest/branches/branch-protection#add-user-access-restrictions
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users
     documentation_url: https://docs.github.com/rest/branches/branch-protection#set-user-access-restrictions
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/branches/{branch}/rename
     documentation_url: https://docs.github.com/rest/branches/branches#rename-a-branch
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/check-runs
     documentation_url: https://docs.github.com/rest/checks/runs#create-a-check-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/check-runs/{check_run_id}
     documentation_url: https://docs.github.com/rest/checks/runs#get-a-check-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}
     documentation_url: https://docs.github.com/rest/checks/runs#update-a-check-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations
     documentation_url: https://docs.github.com/rest/checks/runs#list-check-run-annotations
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/check-runs/{check_run_id}/rerequest
     documentation_url: https://docs.github.com/rest/checks/runs#rerequest-a-check-run
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/check-suites
     documentation_url: https://docs.github.com/rest/checks/suites#create-a-check-suite
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/check-suites/preferences
     documentation_url: https://docs.github.com/rest/checks/suites#update-repository-preferences-for-check-suites
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/check-suites/{check_suite_id}
     documentation_url: https://docs.github.com/rest/checks/suites#get-a-check-suite
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs
     documentation_url: https://docs.github.com/rest/checks/runs#list-check-runs-in-a-check-suite
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest
     documentation_url: https://docs.github.com/rest/checks/suites#rerequest-a-check-suite
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/code-scanning/alerts
     documentation_url: https://docs.github.com/rest/code-scanning/code-scanning#list-code-scanning-alerts-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}
     documentation_url: https://docs.github.com/rest/code-scanning/code-scanning#get-a-code-scanning-alert
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}
     documentation_url: https://docs.github.com/rest/code-scanning/code-scanning#update-a-code-scanning-alert
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/instances
     documentation_url: https://docs.github.com/rest/code-scanning/code-scanning#list-instances-of-a-code-scanning-alert
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/code-scanning/analyses
     documentation_url: https://docs.github.com/rest/code-scanning/code-scanning#list-code-scanning-analyses-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/code-scanning/analyses/{analysis_id}
     documentation_url: https://docs.github.com/rest/code-scanning/code-scanning#delete-a-code-scanning-analysis-from-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/code-scanning/analyses/{analysis_id}
     documentation_url: https://docs.github.com/rest/code-scanning/code-scanning#get-a-code-scanning-analysis-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/code-scanning/codeql/databases
     documentation_url: https://docs.github.com/rest/code-scanning/code-scanning#list-codeql-databases-for-a-repository
     openapi_files:
@@ -3492,31 +3540,31 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/code-scanning/default-setup
     documentation_url: https://docs.github.com/rest/code-scanning/code-scanning#update-a-code-scanning-default-setup-configuration
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/code-scanning/sarifs
     documentation_url: https://docs.github.com/rest/code-scanning/code-scanning#upload-an-analysis-as-sarif-data
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/code-scanning/sarifs/{sarif_id}
     documentation_url: https://docs.github.com/rest/code-scanning/code-scanning#get-information-about-a-sarif-upload
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/codeowners/errors
     documentation_url: https://docs.github.com/rest/repos/repos#list-codeowners-errors
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/codespaces
     documentation_url: https://docs.github.com/rest/codespaces/codespaces#list-codespaces-in-a-repository-for-the-authenticated-user
     openapi_files:
@@ -3577,133 +3625,133 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/collaborators/{username}
     documentation_url: https://docs.github.com/rest/collaborators/collaborators#remove-a-repository-collaborator
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/collaborators/{username}
     documentation_url: https://docs.github.com/rest/collaborators/collaborators#check-if-a-user-is-a-repository-collaborator
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/collaborators/{username}
     documentation_url: https://docs.github.com/rest/collaborators/collaborators#add-a-repository-collaborator
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/collaborators/{username}/permission
     documentation_url: https://docs.github.com/rest/collaborators/collaborators#get-repository-permissions-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/comments
     documentation_url: https://docs.github.com/rest/commits/comments#list-commit-comments-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/comments/{comment_id}
     documentation_url: https://docs.github.com/rest/commits/comments#delete-a-commit-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/comments/{comment_id}
     documentation_url: https://docs.github.com/rest/commits/comments#get-a-commit-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/comments/{comment_id}
     documentation_url: https://docs.github.com/rest/commits/comments#update-a-commit-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/comments/{comment_id}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-commit-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/comments/{comment_id}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-commit-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}
     documentation_url: https://docs.github.com/rest/reactions/reactions#delete-a-commit-comment-reaction
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/commits
     documentation_url: https://docs.github.com/rest/commits/commits#list-commits
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head
     documentation_url: https://docs.github.com/rest/commits/commits#list-branches-for-head-commit
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/commits/{commit_sha}/comments
     documentation_url: https://docs.github.com/rest/commits/comments#list-commit-comments
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/commits/{commit_sha}/comments
     documentation_url: https://docs.github.com/rest/commits/comments#create-a-commit-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls
     documentation_url: https://docs.github.com/rest/commits/commits#list-pull-requests-associated-with-a-commit
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/commits/{ref}
     documentation_url: https://docs.github.com/rest/commits/commits#get-a-commit
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/commits/{ref}/check-runs
     documentation_url: https://docs.github.com/rest/checks/runs#list-check-runs-for-a-git-reference
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/commits/{ref}/check-suites
     documentation_url: https://docs.github.com/rest/checks/suites#list-check-suites-for-a-git-reference
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/commits/{ref}/status
     documentation_url: https://docs.github.com/rest/commits/statuses#get-the-combined-status-for-a-specific-reference
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/commits/{ref}/statuses
     documentation_url: https://docs.github.com/rest/commits/statuses#list-commit-statuses-for-a-reference
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/community/profile
     documentation_url: https://docs.github.com/rest/metrics/community#get-community-profile-metrics
     openapi_files:
@@ -3714,7 +3762,7 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments
     documentation_url: https://docs.github.com/enterprise-server@3.3/rest/reference/apps#create-a-content-attachment
     openapi_files:
@@ -3724,391 +3772,451 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/contents/{path}
     documentation_url: https://docs.github.com/rest/repos/contents#get-repository-content
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/contents/{path}
     documentation_url: https://docs.github.com/rest/repos/contents#create-or-update-file-contents
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/contributors
     documentation_url: https://docs.github.com/rest/repos/repos#list-repository-contributors
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/dependabot/alerts
     documentation_url: https://docs.github.com/rest/dependabot/alerts#list-dependabot-alerts-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number}
     documentation_url: https://docs.github.com/rest/dependabot/alerts#get-a-dependabot-alert
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number}
     documentation_url: https://docs.github.com/rest/dependabot/alerts#update-a-dependabot-alert
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/dependabot/secrets
     documentation_url: https://docs.github.com/rest/dependabot/secrets#list-repository-secrets
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/dependabot/secrets/public-key
     documentation_url: https://docs.github.com/rest/dependabot/secrets#get-a-repository-public-key
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name}
     documentation_url: https://docs.github.com/rest/dependabot/secrets#delete-a-repository-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name}
     documentation_url: https://docs.github.com/rest/dependabot/secrets#get-a-repository-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name}
     documentation_url: https://docs.github.com/rest/dependabot/secrets#create-or-update-a-repository-secret
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/dependency-graph/compare/{basehead}
     documentation_url: https://docs.github.com/rest/dependency-graph/dependency-review#get-a-diff-of-the-dependencies-between-commits
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/dependency-graph/sbom
     documentation_url: https://docs.github.com/rest/dependency-graph/sboms#export-a-software-bill-of-materials-sbom-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/dependency-graph/snapshots
     documentation_url: https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/deployments
     documentation_url: https://docs.github.com/rest/deployments/deployments#list-deployments
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/deployments
     documentation_url: https://docs.github.com/rest/deployments/deployments#create-a-deployment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/deployments/{deployment_id}
     documentation_url: https://docs.github.com/rest/deployments/deployments#delete-a-deployment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/deployments/{deployment_id}
     documentation_url: https://docs.github.com/rest/deployments/deployments#get-a-deployment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses
     documentation_url: https://docs.github.com/rest/deployments/statuses#list-deployment-statuses
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses
     documentation_url: https://docs.github.com/rest/deployments/statuses#create-a-deployment-status
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}
     documentation_url: https://docs.github.com/rest/deployments/statuses#get-a-deployment-status
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/dispatches
     documentation_url: https://docs.github.com/rest/repos/repos#create-a-repository-dispatch-event
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/environments
     documentation_url: https://docs.github.com/rest/deployments/environments#list-environments
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/environments/{environment_name}
     documentation_url: https://docs.github.com/rest/deployments/environments#delete-an-environment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/environments/{environment_name}
     documentation_url: https://docs.github.com/rest/deployments/environments#get-an-environment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/environments/{environment_name}
     documentation_url: https://docs.github.com/rest/deployments/environments#create-or-update-an-environment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies
     documentation_url: https://docs.github.com/rest/deployments/branch-policies#list-deployment-branch-policies
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies
     documentation_url: https://docs.github.com/rest/deployments/branch-policies#create-a-deployment-branch-policy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies/{branch_policy_id}
     documentation_url: https://docs.github.com/rest/deployments/branch-policies#delete-a-deployment-branch-policy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies/{branch_policy_id}
     documentation_url: https://docs.github.com/rest/deployments/branch-policies#get-a-deployment-branch-policy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies/{branch_policy_id}
     documentation_url: https://docs.github.com/rest/deployments/branch-policies#update-a-deployment-branch-policy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/environments/{environment_name}/deployment_protection_rules
     documentation_url: https://docs.github.com/rest/deployments/protection-rules#get-all-deployment-protection-rules-for-an-environment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/environments/{environment_name}/deployment_protection_rules
     documentation_url: https://docs.github.com/rest/deployments/protection-rules#create-a-custom-deployment-protection-rule-on-an-environment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/environments/{environment_name}/deployment_protection_rules/apps
     documentation_url: https://docs.github.com/rest/deployments/protection-rules#list-custom-deployment-rule-integrations-available-for-an-environment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/environments/{environment_name}/deployment_protection_rules/{protection_rule_id}
     documentation_url: https://docs.github.com/rest/deployments/protection-rules#disable-a-custom-protection-rule-for-an-environment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/environments/{environment_name}/deployment_protection_rules/{protection_rule_id}
     documentation_url: https://docs.github.com/rest/deployments/protection-rules#get-a-custom-deployment-protection-rule
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: GET /repos/{owner}/{repo}/environments/{environment_name}/secrets
+    documentation_url: https://docs.github.com/rest/actions/secrets#list-environment-secrets
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: GET /repos/{owner}/{repo}/environments/{environment_name}/secrets/public-key
+    documentation_url: https://docs.github.com/rest/actions/secrets#get-an-environment-public-key
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: DELETE /repos/{owner}/{repo}/environments/{environment_name}/secrets/{secret_name}
+    documentation_url: https://docs.github.com/rest/actions/secrets#delete-an-environment-secret
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: GET /repos/{owner}/{repo}/environments/{environment_name}/secrets/{secret_name}
+    documentation_url: https://docs.github.com/rest/actions/secrets#get-an-environment-secret
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: PUT /repos/{owner}/{repo}/environments/{environment_name}/secrets/{secret_name}
+    documentation_url: https://docs.github.com/rest/actions/secrets#create-or-update-an-environment-secret
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: GET /repos/{owner}/{repo}/environments/{environment_name}/variables
+    documentation_url: https://docs.github.com/rest/actions/variables#list-environment-variables
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: POST /repos/{owner}/{repo}/environments/{environment_name}/variables
+    documentation_url: https://docs.github.com/rest/actions/variables#create-an-environment-variable
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: DELETE /repos/{owner}/{repo}/environments/{environment_name}/variables/{name}
+    documentation_url: https://docs.github.com/rest/actions/variables#delete-an-environment-variable
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: GET /repos/{owner}/{repo}/environments/{environment_name}/variables/{name}
+    documentation_url: https://docs.github.com/rest/actions/variables#get-an-environment-variable
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: PATCH /repos/{owner}/{repo}/environments/{environment_name}/variables/{name}
+    documentation_url: https://docs.github.com/rest/actions/variables#update-an-environment-variable
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/events
     documentation_url: https://docs.github.com/rest/activity/events#list-repository-events
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/forks
     documentation_url: https://docs.github.com/rest/repos/forks#list-forks
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/forks
     documentation_url: https://docs.github.com/rest/repos/forks#create-a-fork
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/git/blobs
     documentation_url: https://docs.github.com/rest/git/blobs#create-a-blob
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/git/blobs/{file_sha}
     documentation_url: https://docs.github.com/rest/git/blobs#get-a-blob
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/git/commits
     documentation_url: https://docs.github.com/rest/git/commits#create-a-commit
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/git/commits/{commit_sha}
     documentation_url: https://docs.github.com/rest/git/commits#get-a-commit-object
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/git/matching-refs/{ref}
     documentation_url: https://docs.github.com/rest/git/refs#list-matching-references
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/git/ref/{ref}
     documentation_url: https://docs.github.com/rest/git/refs#get-a-reference
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/git/refs
     documentation_url: https://docs.github.com/rest/git/refs#create-a-reference
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/git/refs/{ref}
     documentation_url: https://docs.github.com/rest/git/refs#delete-a-reference
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/git/refs/{ref}
     documentation_url: https://docs.github.com/rest/git/refs#update-a-reference
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/git/tags
     documentation_url: https://docs.github.com/rest/git/tags#create-a-tag-object
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/git/tags/{tag_sha}
     documentation_url: https://docs.github.com/rest/git/tags#get-a-tag
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/git/trees
     documentation_url: https://docs.github.com/rest/git/trees#create-a-tree
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/git/trees/{tree_sha}
     documentation_url: https://docs.github.com/rest/git/trees#get-a-tree
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/hooks
     documentation_url: https://docs.github.com/rest/repos/webhooks#list-repository-webhooks
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/hooks
     documentation_url: https://docs.github.com/rest/repos/webhooks#create-a-repository-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/hooks/{hook_id}
     documentation_url: https://docs.github.com/rest/repos/webhooks#delete-a-repository-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/hooks/{hook_id}
     documentation_url: https://docs.github.com/rest/repos/webhooks#get-a-repository-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/hooks/{hook_id}
     documentation_url: https://docs.github.com/rest/repos/webhooks#update-a-repository-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/hooks/{hook_id}/config
     documentation_url: https://docs.github.com/rest/repos/webhooks#get-a-webhook-configuration-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/hooks/{hook_id}/config
     documentation_url: https://docs.github.com/rest/repos/webhooks#update-a-webhook-configuration-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/hooks/{hook_id}/deliveries
     documentation_url: https://docs.github.com/rest/repos/webhooks#list-deliveries-for-a-repository-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/hooks/{hook_id}/deliveries/{delivery_id}
     documentation_url: https://docs.github.com/rest/repos/webhooks#get-a-delivery-for-a-repository-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/hooks/{hook_id}/deliveries/{delivery_id}/attempts
     documentation_url: https://docs.github.com/rest/repos/webhooks#redeliver-a-delivery-for-a-repository-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/hooks/{hook_id}/pings
     documentation_url: https://docs.github.com/rest/repos/webhooks#ping-a-repository-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/hooks/{hook_id}/tests
     documentation_url: https://docs.github.com/rest/repos/webhooks#test-the-push-repository-webhook
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/import
     documentation_url: https://docs.github.com/rest/migrations/source-imports#cancel-an-import
     openapi_files:
@@ -4154,7 +4262,7 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/interaction-limits
     documentation_url: https://docs.github.com/rest/interactions/repos#remove-interaction-restrictions-for-a-repository
     openapi_files:
@@ -4175,412 +4283,431 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/invitations/{invitation_id}
     documentation_url: https://docs.github.com/rest/collaborators/invitations#delete-a-repository-invitation
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/invitations/{invitation_id}
     documentation_url: https://docs.github.com/rest/collaborators/invitations#update-a-repository-invitation
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/issues
     documentation_url: https://docs.github.com/rest/issues/issues#list-repository-issues
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/issues
     documentation_url: https://docs.github.com/rest/issues/issues#create-an-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/issues/comments
     documentation_url: https://docs.github.com/rest/issues/comments#list-issue-comments-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}
     documentation_url: https://docs.github.com/rest/issues/comments#delete-an-issue-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/issues/comments/{comment_id}
     documentation_url: https://docs.github.com/rest/issues/comments#get-an-issue-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}
     documentation_url: https://docs.github.com/rest/issues/comments#update-an-issue-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#list-reactions-for-an-issue-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#create-reaction-for-an-issue-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}
     documentation_url: https://docs.github.com/rest/reactions/reactions#delete-an-issue-comment-reaction
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/issues/events
     documentation_url: https://docs.github.com/rest/issues/events#list-issue-events-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/issues/events/{event_id}
     documentation_url: https://docs.github.com/rest/issues/events#get-an-issue-event
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/issues/{issue_number}
     documentation_url: https://docs.github.com/rest/issues/issues#get-an-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/issues/{issue_number}
     documentation_url: https://docs.github.com/rest/issues/issues#update-an-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees
     documentation_url: https://docs.github.com/rest/issues/assignees#remove-assignees-from-an-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/issues/{issue_number}/assignees
     documentation_url: https://docs.github.com/rest/issues/assignees#add-assignees-to-an-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/issues/{issue_number}/assignees/{assignee}
     documentation_url: https://docs.github.com/rest/issues/assignees#check-if-a-user-can-be-assigned-to-a-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/issues/{issue_number}/comments
     documentation_url: https://docs.github.com/rest/issues/comments#list-issue-comments
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/issues/{issue_number}/comments
     documentation_url: https://docs.github.com/rest/issues/comments#create-an-issue-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/issues/{issue_number}/events
     documentation_url: https://docs.github.com/rest/issues/events#list-issue-events
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels
     documentation_url: https://docs.github.com/rest/issues/labels#remove-all-labels-from-an-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/issues/{issue_number}/labels
     documentation_url: https://docs.github.com/rest/issues/labels#list-labels-for-an-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/issues/{issue_number}/labels
     documentation_url: https://docs.github.com/rest/issues/labels#add-labels-to-an-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/issues/{issue_number}/labels
     documentation_url: https://docs.github.com/rest/issues/labels#set-labels-for-an-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}
     documentation_url: https://docs.github.com/rest/issues/labels#remove-a-label-from-an-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock
     documentation_url: https://docs.github.com/rest/issues/issues#unlock-an-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/issues/{issue_number}/lock
     documentation_url: https://docs.github.com/rest/issues/issues#lock-an-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/issues/{issue_number}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#list-reactions-for-an-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/issues/{issue_number}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#create-reaction-for-an-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}
     documentation_url: https://docs.github.com/rest/reactions/reactions#delete-an-issue-reaction
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/issues/{issue_number}/timeline
     documentation_url: https://docs.github.com/rest/issues/timeline#list-timeline-events-for-an-issue
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/keys
     documentation_url: https://docs.github.com/rest/deploy-keys/deploy-keys#list-deploy-keys
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/keys
     documentation_url: https://docs.github.com/rest/deploy-keys/deploy-keys#create-a-deploy-key
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/keys/{key_id}
     documentation_url: https://docs.github.com/rest/deploy-keys/deploy-keys#delete-a-deploy-key
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/keys/{key_id}
     documentation_url: https://docs.github.com/rest/deploy-keys/deploy-keys#get-a-deploy-key
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/labels
     documentation_url: https://docs.github.com/rest/issues/labels#list-labels-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/labels
     documentation_url: https://docs.github.com/rest/issues/labels#create-a-label
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/labels/{name}
     documentation_url: https://docs.github.com/rest/issues/labels#delete-a-label
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/labels/{name}
     documentation_url: https://docs.github.com/rest/issues/labels#get-a-label
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/labels/{name}
     documentation_url: https://docs.github.com/rest/issues/labels#update-a-label
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/languages
     documentation_url: https://docs.github.com/rest/repos/repos#list-repository-languages
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/lfs
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/repos/lfs#disable-git-lfs-for-a-repository
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/lfs
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/repos/lfs#enable-git-lfs-for-a-repository
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/license
     documentation_url: https://docs.github.com/rest/licenses/licenses#get-the-license-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/merge-upstream
     documentation_url: https://docs.github.com/rest/branches/branches#sync-a-fork-branch-with-the-upstream-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/merges
     documentation_url: https://docs.github.com/rest/branches/branches#merge-a-branch
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/milestones
     documentation_url: https://docs.github.com/rest/issues/milestones#list-milestones
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/milestones
     documentation_url: https://docs.github.com/rest/issues/milestones#create-a-milestone
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/milestones/{milestone_number}
     documentation_url: https://docs.github.com/rest/issues/milestones#delete-a-milestone
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/milestones/{milestone_number}
     documentation_url: https://docs.github.com/rest/issues/milestones#get-a-milestone
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/milestones/{milestone_number}
     documentation_url: https://docs.github.com/rest/issues/milestones#update-a-milestone
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels
     documentation_url: https://docs.github.com/rest/issues/labels#list-labels-for-issues-in-a-milestone
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/notifications
     documentation_url: https://docs.github.com/rest/activity/notifications#list-repository-notifications-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/notifications
     documentation_url: https://docs.github.com/rest/activity/notifications#mark-repository-notifications-as-read
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/pages
     documentation_url: https://docs.github.com/rest/pages/pages#delete-a-apiname-pages-site
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pages
     documentation_url: https://docs.github.com/rest/pages/pages#get-a-apiname-pages-site
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/pages
     documentation_url: https://docs.github.com/rest/pages/pages#create-a-apiname-pages-site
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/pages
     documentation_url: https://docs.github.com/rest/pages/pages#update-information-about-a-apiname-pages-site
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pages/builds
     documentation_url: https://docs.github.com/rest/pages/pages#list-apiname-pages-builds
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/pages/builds
     documentation_url: https://docs.github.com/rest/pages/pages#request-a-apiname-pages-build
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pages/builds/latest
     documentation_url: https://docs.github.com/rest/pages/pages#get-latest-pages-build
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pages/builds/{build_id}
     documentation_url: https://docs.github.com/rest/pages/pages#get-apiname-pages-build
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/pages/deployment
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/pages/pages#create-a-github-pages-deployment
+    openapi_files:
+      - descriptions/ghes-3.7/ghes-3.7.json
+  - name: POST /repos/{owner}/{repo}/pages/deployments
     documentation_url: https://docs.github.com/rest/pages/pages#create-a-github-pages-deployment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: GET /repos/{owner}/{repo}/pages/deployments/{pages_deployment_id}
+    documentation_url: https://docs.github.com/rest/pages/pages#get-the-status-of-a-github-pages-deployment
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: POST /repos/{owner}/{repo}/pages/deployments/{pages_deployment_id}/cancel
+    documentation_url: https://docs.github.com/rest/pages/pages#cancel-a-github-pages-deployment
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
   - name: GET /repos/{owner}/{repo}/pages/health
     documentation_url: https://docs.github.com/rest/pages/pages#get-a-dns-health-check-for-github-pages
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
   - name: GET /repos/{owner}/{repo}/pre-receive-hooks
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/repo-pre-receive-hooks#list-pre-receive-hooks-for-a-repository
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/repo-pre-receive-hooks#list-pre-receive-hooks-for-a-repository
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/repo-pre-receive-hooks#remove-pre-receive-hook-enforcement-for-a-repository
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/repo-pre-receive-hooks#remove-pre-receive-hook-enforcement-for-a-repository
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/repo-pre-receive-hooks#get-a-pre-receive-hook-for-a-repository
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/repo-pre-receive-hooks#get-a-pre-receive-hook-for-a-repository
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/repo-pre-receive-hooks#update-pre-receive-hook-enforcement-for-a-repository
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/repo-pre-receive-hooks#update-pre-receive-hook-enforcement-for-a-repository
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/private-vulnerability-reporting
     documentation_url: https://docs.github.com/rest/repos/repos#disable-private-vulnerability-reporting-for-a-repository
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: GET /repos/{owner}/{repo}/private-vulnerability-reporting
+    documentation_url: https://docs.github.com/rest/repos/repos#check-if-private-vulnerability-reporting-is-enabled-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
@@ -4594,15 +4721,20 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/projects
     documentation_url: https://docs.github.com/rest/projects/projects#create-a-repository-project
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/properties/values
     documentation_url: https://docs.github.com/rest/repos/custom-properties#get-all-custom-property-values-for-a-repository
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: PATCH /repos/{owner}/{repo}/properties/values
+    documentation_url: https://docs.github.com/rest/repos/custom-properties#create-or-update-custom-property-values-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
@@ -4611,67 +4743,67 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/pulls
     documentation_url: https://docs.github.com/rest/pulls/pulls#create-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pulls/comments
     documentation_url: https://docs.github.com/rest/pulls/comments#list-review-comments-in-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}
     documentation_url: https://docs.github.com/rest/pulls/comments#delete-a-review-comment-for-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pulls/comments/{comment_id}
     documentation_url: https://docs.github.com/rest/pulls/comments#get-a-review-comment-for-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}
     documentation_url: https://docs.github.com/rest/pulls/comments#update-a-review-comment-for-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-pull-request-review-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-pull-request-review-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}
     documentation_url: https://docs.github.com/rest/reactions/reactions#delete-a-pull-request-comment-reaction
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pulls/{pull_number}
     documentation_url: https://docs.github.com/rest/pulls/pulls#get-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/pulls/{pull_number}
     documentation_url: https://docs.github.com/rest/pulls/pulls#update-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/pulls/{pull_number}/codespaces
     documentation_url: https://docs.github.com/rest/codespaces/codespaces#create-a-codespace-from-a-pull-request
     openapi_files:
@@ -4682,297 +4814,299 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/pulls/{pull_number}/comments
     documentation_url: https://docs.github.com/rest/pulls/comments#create-a-review-comment-for-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies
     documentation_url: https://docs.github.com/rest/pulls/comments#create-a-reply-for-a-review-comment
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pulls/{pull_number}/commits
     documentation_url: https://docs.github.com/rest/pulls/pulls#list-commits-on-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pulls/{pull_number}/files
     documentation_url: https://docs.github.com/rest/pulls/pulls#list-pull-requests-files
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pulls/{pull_number}/merge
     documentation_url: https://docs.github.com/rest/pulls/pulls#check-if-a-pull-request-has-been-merged
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
     documentation_url: https://docs.github.com/rest/pulls/pulls#merge-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
     documentation_url: https://docs.github.com/rest/pulls/review-requests#remove-requested-reviewers-from-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
     documentation_url: https://docs.github.com/rest/pulls/review-requests#get-all-requested-reviewers-for-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
     documentation_url: https://docs.github.com/rest/pulls/review-requests#request-reviewers-for-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
     documentation_url: https://docs.github.com/rest/pulls/reviews#list-reviews-for-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews
     documentation_url: https://docs.github.com/rest/pulls/reviews#create-a-review-for-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
     documentation_url: https://docs.github.com/rest/pulls/reviews#delete-a-pending-review-for-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
     documentation_url: https://docs.github.com/rest/pulls/reviews#get-a-review-for-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}
     documentation_url: https://docs.github.com/rest/pulls/reviews#update-a-review-for-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments
     documentation_url: https://docs.github.com/rest/pulls/reviews#list-comments-for-a-pull-request-review
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals
     documentation_url: https://docs.github.com/rest/pulls/reviews#dismiss-a-review-for-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events
     documentation_url: https://docs.github.com/rest/pulls/reviews#submit-a-review-for-a-pull-request
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch
     documentation_url: https://docs.github.com/rest/pulls/pulls#update-a-pull-request-branch
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/readme
     documentation_url: https://docs.github.com/rest/repos/contents#get-a-repository-readme
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/readme/{dir}
     documentation_url: https://docs.github.com/rest/repos/contents#get-a-repository-readme-for-a-directory
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/releases
     documentation_url: https://docs.github.com/rest/releases/releases#list-releases
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/releases
     documentation_url: https://docs.github.com/rest/releases/releases#create-a-release
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}
     documentation_url: https://docs.github.com/rest/releases/assets#delete-a-release-asset
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/releases/assets/{asset_id}
     documentation_url: https://docs.github.com/rest/releases/assets#get-a-release-asset
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}
     documentation_url: https://docs.github.com/rest/releases/assets#update-a-release-asset
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/releases/generate-notes
     documentation_url: https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/releases/latest
     documentation_url: https://docs.github.com/rest/releases/releases#get-the-latest-release
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/releases/tags/{tag}
     documentation_url: https://docs.github.com/rest/releases/releases#get-a-release-by-tag-name
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/releases/{release_id}
     documentation_url: https://docs.github.com/rest/releases/releases#delete-a-release
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/releases/{release_id}
     documentation_url: https://docs.github.com/rest/releases/releases#get-a-release
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/releases/{release_id}
     documentation_url: https://docs.github.com/rest/releases/releases#update-a-release
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/releases/{release_id}/assets
     documentation_url: https://docs.github.com/rest/releases/assets#list-release-assets
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/releases/{release_id}/assets
     documentation_url: https://docs.github.com/rest/releases/assets#upload-a-release-asset
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/releases/{release_id}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-release
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/releases/{release_id}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-release
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/releases/{release_id}/reactions/{reaction_id}
     documentation_url: https://docs.github.com/rest/reactions/reactions#delete-a-release-reaction
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/replicas/caches
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/repos/repos#list-repository-cache-replication-status
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/repos/repos#list-repository-cache-replication-status
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/rules/branches/{branch}
     documentation_url: https://docs.github.com/rest/repos/rules#get-rules-for-a-branch
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/rulesets
     documentation_url: https://docs.github.com/rest/repos/rules#get-all-repository-rulesets
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/rulesets
     documentation_url: https://docs.github.com/rest/repos/rules#create-a-repository-ruleset
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/rulesets/rule-suites
     documentation_url: https://docs.github.com/rest/repos/rule-suites#list-repository-rule-suites
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/rulesets/rule-suites/{rule_suite_id}
     documentation_url: https://docs.github.com/rest/repos/rule-suites#get-a-repository-rule-suite
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/rulesets/{ruleset_id}
     documentation_url: https://docs.github.com/rest/repos/rules#delete-a-repository-ruleset
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/rulesets/{ruleset_id}
     documentation_url: https://docs.github.com/rest/repos/rules#get-a-repository-ruleset
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/rulesets/{ruleset_id}
     documentation_url: https://docs.github.com/rest/repos/rules#update-a-repository-ruleset
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/secret-scanning/alerts
     documentation_url: https://docs.github.com/rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
     documentation_url: https://docs.github.com/rest/secret-scanning/secret-scanning#get-a-secret-scanning-alert
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
     documentation_url: https://docs.github.com/rest/secret-scanning/secret-scanning#update-a-secret-scanning-alert
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations
     documentation_url: https://docs.github.com/rest/secret-scanning/secret-scanning#list-locations-for-a-secret-scanning-alert
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/security-advisories
     documentation_url: https://docs.github.com/rest/security-advisories/repository-advisories#list-repository-security-advisories
     openapi_files:
@@ -5013,115 +5147,115 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/stats/code_frequency
     documentation_url: https://docs.github.com/rest/metrics/statistics#get-the-weekly-commit-activity
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/stats/commit_activity
     documentation_url: https://docs.github.com/rest/metrics/statistics#get-the-last-year-of-commit-activity
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/stats/contributors
     documentation_url: https://docs.github.com/rest/metrics/statistics#get-all-contributor-commit-activity
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/stats/participation
     documentation_url: https://docs.github.com/rest/metrics/statistics#get-the-weekly-commit-count
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/stats/punch_card
     documentation_url: https://docs.github.com/rest/metrics/statistics#get-the-hourly-commit-count-for-each-day
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/statuses/{sha}
     documentation_url: https://docs.github.com/rest/commits/statuses#create-a-commit-status
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/subscribers
     documentation_url: https://docs.github.com/rest/activity/watching#list-watchers
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/subscription
     documentation_url: https://docs.github.com/rest/activity/watching#delete-a-repository-subscription
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/subscription
     documentation_url: https://docs.github.com/rest/activity/watching#get-a-repository-subscription
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/subscription
     documentation_url: https://docs.github.com/rest/activity/watching#set-a-repository-subscription
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/tags
     documentation_url: https://docs.github.com/rest/repos/repos#list-repository-tags
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/tags/protection
     documentation_url: https://docs.github.com/rest/repos/tags#list-tag-protection-states-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{owner}/{repo}/tags/protection
     documentation_url: https://docs.github.com/rest/repos/tags#create-a-tag-protection-state-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/tags/protection/{tag_protection_id}
     documentation_url: https://docs.github.com/rest/repos/tags#delete-a-tag-protection-state-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/tarball/{ref}
     documentation_url: https://docs.github.com/rest/repos/contents#download-a-repository-archive-tar
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/teams
     documentation_url: https://docs.github.com/rest/repos/repos#list-repository-teams
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/topics
     documentation_url: https://docs.github.com/rest/repos/repos#get-all-repository-topics
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/topics
     documentation_url: https://docs.github.com/rest/repos/repos#replace-all-repository-topics
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/traffic/clones
     documentation_url: https://docs.github.com/rest/metrics/traffic#get-repository-clones
     openapi_files:
@@ -5147,163 +5281,171 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /repos/{owner}/{repo}/vulnerability-alerts
     documentation_url: https://docs.github.com/rest/repos/repos#disable-vulnerability-alerts
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/vulnerability-alerts
     documentation_url: https://docs.github.com/rest/repos/repos#check-if-vulnerability-alerts-are-enabled-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /repos/{owner}/{repo}/vulnerability-alerts
     documentation_url: https://docs.github.com/rest/repos/repos#enable-vulnerability-alerts
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repos/{owner}/{repo}/zipball/{ref}
     documentation_url: https://docs.github.com/rest/repos/contents#download-a-repository-archive-zip
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /repos/{template_owner}/{template_repo}/generate
     documentation_url: https://docs.github.com/rest/repos/repos#create-a-repository-using-a-template
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repositories
     documentation_url: https://docs.github.com/rest/repos/repos#list-public-repositories
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /repositories/{repository_id}/environments/{environment_name}/secrets
-    documentation_url: https://docs.github.com/rest/actions/secrets#list-environment-secrets
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/actions/secrets#list-environment-secrets
     openapi_files:
-      - descriptions/api.github.com/api.github.com.json
-      - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.7/ghes-3.7.json
   - name: GET /repositories/{repository_id}/environments/{environment_name}/secrets/public-key
-    documentation_url: https://docs.github.com/rest/actions/secrets#get-an-environment-public-key
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/actions/secrets#get-an-environment-public-key
     openapi_files:
-      - descriptions/api.github.com/api.github.com.json
-      - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.7/ghes-3.7.json
   - name: DELETE /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}
-    documentation_url: https://docs.github.com/rest/actions/secrets#delete-an-environment-secret
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/actions/secrets#delete-an-environment-secret
     openapi_files:
-      - descriptions/api.github.com/api.github.com.json
-      - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.7/ghes-3.7.json
   - name: GET /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}
-    documentation_url: https://docs.github.com/rest/actions/secrets#get-an-environment-secret
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/actions/secrets#get-an-environment-secret
     openapi_files:
-      - descriptions/api.github.com/api.github.com.json
-      - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.7/ghes-3.7.json
   - name: PUT /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}
-    documentation_url: https://docs.github.com/rest/actions/secrets#create-or-update-an-environment-secret
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/actions/secrets#create-or-update-an-environment-secret
     openapi_files:
-      - descriptions/api.github.com/api.github.com.json
-      - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: GET /repositories/{repository_id}/environments/{environment_name}/variables
-    documentation_url: https://docs.github.com/rest/actions/variables#list-environment-variables
-    openapi_files:
-      - descriptions/api.github.com/api.github.com.json
-      - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: POST /repositories/{repository_id}/environments/{environment_name}/variables
-    documentation_url: https://docs.github.com/rest/actions/variables#create-an-environment-variable
-    openapi_files:
-      - descriptions/api.github.com/api.github.com.json
-      - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: DELETE /repositories/{repository_id}/environments/{environment_name}/variables/{name}
-    documentation_url: https://docs.github.com/rest/actions/variables#delete-an-environment-variable
-    openapi_files:
-      - descriptions/api.github.com/api.github.com.json
-      - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: GET /repositories/{repository_id}/environments/{environment_name}/variables/{name}
-    documentation_url: https://docs.github.com/rest/actions/variables#get-an-environment-variable
-    openapi_files:
-      - descriptions/api.github.com/api.github.com.json
-      - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: PATCH /repositories/{repository_id}/environments/{environment_name}/variables/{name}
-    documentation_url: https://docs.github.com/rest/actions/variables#update-an-environment-variable
-    openapi_files:
-      - descriptions/api.github.com/api.github.com.json
-      - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.7/ghes-3.7.json
   - name: GET /scim/v2/Groups
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#list-provisioned-scim-groups-for-an-enterprise
+    openapi_files:
+      - descriptions/ghes-3.7/ghes-3.7.json
+  - name: POST /scim/v2/Groups
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#provision-a-scim-enterprise-group
+    openapi_files:
+      - descriptions/ghes-3.7/ghes-3.7.json
+  - name: DELETE /scim/v2/Groups/{scim_group_id}
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#delete-a-scim-group-from-an-enterprise
+    openapi_files:
+      - descriptions/ghes-3.7/ghes-3.7.json
+  - name: GET /scim/v2/Groups/{scim_group_id}
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-group
+    openapi_files:
+      - descriptions/ghes-3.7/ghes-3.7.json
+  - name: PATCH /scim/v2/Groups/{scim_group_id}
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#update-an-attribute-for-a-scim-enterprise-group
+    openapi_files:
+      - descriptions/ghes-3.7/ghes-3.7.json
+  - name: PUT /scim/v2/Groups/{scim_group_id}
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#set-scim-information-for-a-provisioned-enterprise-group
+    openapi_files:
+      - descriptions/ghes-3.7/ghes-3.7.json
+  - name: GET /scim/v2/Users
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#list-scim-provisioned-identities-for-an-enterprise
+    openapi_files:
+      - descriptions/ghes-3.7/ghes-3.7.json
+  - name: POST /scim/v2/Users
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#provision-a-scim-enterprise-user
+    openapi_files:
+      - descriptions/ghes-3.7/ghes-3.7.json
+  - name: DELETE /scim/v2/Users/{scim_user_id}
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#delete-a-scim-user-from-an-enterprise
+    openapi_files:
+      - descriptions/ghes-3.7/ghes-3.7.json
+  - name: GET /scim/v2/Users/{scim_user_id}
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-user
+    openapi_files:
+      - descriptions/ghes-3.7/ghes-3.7.json
+  - name: PATCH /scim/v2/Users/{scim_user_id}
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#update-an-attribute-for-a-scim-enterprise-user
+    openapi_files:
+      - descriptions/ghes-3.7/ghes-3.7.json
+  - name: PUT /scim/v2/Users/{scim_user_id}
+    documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#set-scim-information-for-a-provisioned-enterprise-user
+    openapi_files:
+      - descriptions/ghes-3.7/ghes-3.7.json
+  - name: GET /scim/v2/enterprises/{enterprise}/Groups
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#list-provisioned-scim-groups-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: POST /scim/v2/Groups
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: POST /scim/v2/enterprises/{enterprise}/Groups
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#provision-a-scim-enterprise-group
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: DELETE /scim/v2/Groups/{scim_group_id}
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: DELETE /scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#delete-a-scim-group-from-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: GET /scim/v2/Groups/{scim_group_id}
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: GET /scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-group
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: PATCH /scim/v2/Groups/{scim_group_id}
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: PATCH /scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#update-an-attribute-for-a-scim-enterprise-group
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: PUT /scim/v2/Groups/{scim_group_id}
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: PUT /scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#set-scim-information-for-a-provisioned-enterprise-group
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: GET /scim/v2/Users
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: GET /scim/v2/enterprises/{enterprise}/Users
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#list-scim-provisioned-identities-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: POST /scim/v2/Users
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: POST /scim/v2/enterprises/{enterprise}/Users
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#provision-a-scim-enterprise-user
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: DELETE /scim/v2/Users/{scim_user_id}
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: DELETE /scim/v2/enterprises/{enterprise}/Users/{scim_user_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#delete-a-scim-user-from-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: GET /scim/v2/Users/{scim_user_id}
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: GET /scim/v2/enterprises/{enterprise}/Users/{scim_user_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-user
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: PATCH /scim/v2/Users/{scim_user_id}
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: PATCH /scim/v2/enterprises/{enterprise}/Users/{scim_user_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#update-an-attribute-for-a-scim-enterprise-user
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
-  - name: PUT /scim/v2/Users/{scim_user_id}
+      - descriptions/ghes-3.12/ghes-3.12.json
+  - name: PUT /scim/v2/enterprises/{enterprise}/Users/{scim_user_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#set-scim-information-for-a-provisioned-enterprise-user
     openapi_files:
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /scim/v2/organizations/{org}/Users
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#list-scim-provisioned-identities
     openapi_files:
@@ -5333,189 +5475,189 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /search/commits
     documentation_url: https://docs.github.com/rest/search/search#search-commits
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /search/issues
     documentation_url: https://docs.github.com/rest/search/search#search-issues-and-pull-requests
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /search/labels
     documentation_url: https://docs.github.com/rest/search/search#search-labels
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /search/repositories
     documentation_url: https://docs.github.com/rest/search/search#search-repositories
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /search/topics
     documentation_url: https://docs.github.com/rest/search/search#search-topics
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /search/users
     documentation_url: https://docs.github.com/rest/search/search#search-users
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /setup/api/configcheck
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/management-console#get-the-configuration-status
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/management-console#get-the-configuration-status
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /setup/api/configure
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/management-console#start-a-configuration-process
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/management-console#start-a-configuration-process
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /setup/api/maintenance
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/management-console#get-the-maintenance-status
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/management-console#get-the-maintenance-status
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /setup/api/maintenance
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/management-console#enable-or-disable-maintenance-mode
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/management-console#enable-or-disable-maintenance-mode
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /setup/api/settings
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/management-console#get-settings
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/management-console#get-settings
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /setup/api/settings
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/management-console#set-settings
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/management-console#set-settings
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /setup/api/settings/authorized-keys
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/management-console#remove-an-authorized-ssh-key
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/management-console#remove-an-authorized-ssh-key
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /setup/api/settings/authorized-keys
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/management-console#get-all-authorized-ssh-keys
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/management-console#get-all-authorized-ssh-keys
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /setup/api/settings/authorized-keys
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/management-console#add-an-authorized-ssh-key
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/management-console#add-an-authorized-ssh-key
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /setup/api/start
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/management-console#create-a-github-license
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/management-console#create-a-github-license
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /setup/api/upgrade
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/management-console#upgrade-a-license
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/management-console#upgrade-a-license
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /teams/{team_id}
     documentation_url: https://docs.github.com/rest/teams/teams#delete-a-team-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /teams/{team_id}
     documentation_url: https://docs.github.com/rest/teams/teams#get-a-team-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /teams/{team_id}
     documentation_url: https://docs.github.com/rest/teams/teams#update-a-team-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /teams/{team_id}/discussions
     documentation_url: https://docs.github.com/rest/teams/discussions#list-discussions-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /teams/{team_id}/discussions
     documentation_url: https://docs.github.com/rest/teams/discussions#create-a-discussion-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /teams/{team_id}/discussions/{discussion_number}
     documentation_url: https://docs.github.com/rest/teams/discussions#delete-a-discussion-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /teams/{team_id}/discussions/{discussion_number}
     documentation_url: https://docs.github.com/rest/teams/discussions#get-a-discussion-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /teams/{team_id}/discussions/{discussion_number}
     documentation_url: https://docs.github.com/rest/teams/discussions#update-a-discussion-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /teams/{team_id}/discussions/{discussion_number}/comments
     documentation_url: https://docs.github.com/rest/teams/discussion-comments#list-discussion-comments-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /teams/{team_id}/discussions/{discussion_number}/comments
     documentation_url: https://docs.github.com/rest/teams/discussion-comments#create-a-discussion-comment-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}
     documentation_url: https://docs.github.com/rest/teams/discussion-comments#delete-a-discussion-comment-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}
     documentation_url: https://docs.github.com/rest/teams/discussion-comments#get-a-discussion-comment-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}
     documentation_url: https://docs.github.com/rest/teams/discussion-comments#update-a-discussion-comment-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion-comment-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-team-discussion-comment-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /teams/{team_id}/discussions/{discussion_number}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /teams/{team_id}/discussions/{discussion_number}/reactions
     documentation_url: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-team-discussion-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /teams/{team_id}/invitations
     documentation_url: https://docs.github.com/rest/teams/members#list-pending-team-invitations-legacy
     openapi_files:
@@ -5526,91 +5668,91 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /teams/{team_id}/members/{username}
     documentation_url: https://docs.github.com/rest/teams/members#remove-team-member-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /teams/{team_id}/members/{username}
     documentation_url: https://docs.github.com/rest/teams/members#get-team-member-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /teams/{team_id}/members/{username}
     documentation_url: https://docs.github.com/rest/teams/members#add-team-member-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /teams/{team_id}/memberships/{username}
     documentation_url: https://docs.github.com/rest/teams/members#remove-team-membership-for-a-user-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /teams/{team_id}/memberships/{username}
     documentation_url: https://docs.github.com/rest/teams/members#get-team-membership-for-a-user-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /teams/{team_id}/memberships/{username}
     documentation_url: https://docs.github.com/rest/teams/members#add-or-update-team-membership-for-a-user-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /teams/{team_id}/projects
     documentation_url: https://docs.github.com/rest/teams/teams#list-team-projects-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /teams/{team_id}/projects/{project_id}
     documentation_url: https://docs.github.com/rest/teams/teams#remove-a-project-from-a-team-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /teams/{team_id}/projects/{project_id}
     documentation_url: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-project-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /teams/{team_id}/projects/{project_id}
     documentation_url: https://docs.github.com/rest/teams/teams#add-or-update-team-project-permissions-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /teams/{team_id}/repos
     documentation_url: https://docs.github.com/rest/teams/teams#list-team-repositories-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /teams/{team_id}/repos/{owner}/{repo}
     documentation_url: https://docs.github.com/rest/teams/teams#remove-a-repository-from-a-team-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /teams/{team_id}/repos/{owner}/{repo}
     documentation_url: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-repository-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /teams/{team_id}/repos/{owner}/{repo}
     documentation_url: https://docs.github.com/rest/teams/teams#add-or-update-team-repository-permissions-legacy
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /teams/{team_id}/team-sync/group-mappings
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#list-idp-groups-for-a-team-legacy
     openapi_files:
@@ -5624,19 +5766,19 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user
     documentation_url: https://docs.github.com/rest/users/users#get-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /user
     documentation_url: https://docs.github.com/rest/users/users#update-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/blocks
     documentation_url: https://docs.github.com/rest/users/blocking#list-users-blocked-by-the-authenticated-user
     openapi_files:
@@ -5762,7 +5904,7 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /user/email/visibility
     documentation_url: https://docs.github.com/rest/users/emails#set-primary-email-visibility-for-the-authenticated-user
     openapi_files:
@@ -5773,97 +5915,97 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/emails
     documentation_url: https://docs.github.com/rest/users/emails#list-email-addresses-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /user/emails
     documentation_url: https://docs.github.com/rest/users/emails#add-an-email-address-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/followers
     documentation_url: https://docs.github.com/rest/users/followers#list-followers-of-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/following
     documentation_url: https://docs.github.com/rest/users/followers#list-the-people-the-authenticated-user-follows
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /user/following/{username}
     documentation_url: https://docs.github.com/rest/users/followers#unfollow-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/following/{username}
     documentation_url: https://docs.github.com/rest/users/followers#check-if-a-person-is-followed-by-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /user/following/{username}
     documentation_url: https://docs.github.com/rest/users/followers#follow-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/gpg_keys
     documentation_url: https://docs.github.com/rest/users/gpg-keys#list-gpg-keys-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /user/gpg_keys
     documentation_url: https://docs.github.com/rest/users/gpg-keys#create-a-gpg-key-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /user/gpg_keys/{gpg_key_id}
     documentation_url: https://docs.github.com/rest/users/gpg-keys#delete-a-gpg-key-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/gpg_keys/{gpg_key_id}
     documentation_url: https://docs.github.com/rest/users/gpg-keys#get-a-gpg-key-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/installations
     documentation_url: https://docs.github.com/rest/apps/installations#list-app-installations-accessible-to-the-user-access-token
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/installations/{installation_id}/repositories
     documentation_url: https://docs.github.com/rest/apps/installations#list-repositories-accessible-to-the-user-access-token
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /user/installations/{installation_id}/repositories/{repository_id}
     documentation_url: https://docs.github.com/rest/apps/installations#remove-a-repository-from-an-app-installation
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /user/installations/{installation_id}/repositories/{repository_id}
     documentation_url: https://docs.github.com/rest/apps/installations#add-a-repository-to-an-app-installation
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /user/interaction-limits
     documentation_url: https://docs.github.com/rest/interactions/user#remove-interaction-restrictions-from-your-public-repositories
     openapi_files:
@@ -5884,31 +6026,31 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/keys
     documentation_url: https://docs.github.com/rest/users/keys#list-public-ssh-keys-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /user/keys
     documentation_url: https://docs.github.com/rest/users/keys#create-a-public-ssh-key-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /user/keys/{key_id}
     documentation_url: https://docs.github.com/rest/users/keys#delete-a-public-ssh-key-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/keys/{key_id}
     documentation_url: https://docs.github.com/rest/users/keys#get-a-public-ssh-key-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/marketplace_purchases
     documentation_url: https://docs.github.com/rest/apps/marketplace#list-subscriptions-for-the-authenticated-user
     openapi_files:
@@ -5924,31 +6066,31 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/memberships/orgs/{org}
     documentation_url: https://docs.github.com/rest/orgs/members#get-an-organization-membership-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /user/memberships/orgs/{org}
     documentation_url: https://docs.github.com/rest/orgs/members#update-an-organization-membership-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/migrations
     documentation_url: https://docs.github.com/rest/migrations/users#list-user-migrations
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /user/migrations
     documentation_url: https://docs.github.com/rest/migrations/users#start-a-user-migration
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/migrations/{migration_id}
     documentation_url: https://docs.github.com/rest/migrations/users#get-a-user-migration-status
     openapi_files:
@@ -5964,7 +6106,7 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /user/migrations/{migration_id}/repos/{repo_name}/lock
     documentation_url: https://docs.github.com/rest/migrations/users#unlock-a-user-repository
     openapi_files:
@@ -5975,343 +6117,343 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/orgs
     documentation_url: https://docs.github.com/rest/orgs/orgs#list-organizations-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/packages
     documentation_url: https://docs.github.com/rest/packages/packages#list-packages-for-the-authenticated-users-namespace
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /user/packages/{package_type}/{package_name}
     documentation_url: https://docs.github.com/rest/packages/packages#delete-a-package-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/packages/{package_type}/{package_name}
     documentation_url: https://docs.github.com/rest/packages/packages#get-a-package-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /user/packages/{package_type}/{package_name}/restore
     documentation_url: https://docs.github.com/rest/packages/packages#restore-a-package-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/packages/{package_type}/{package_name}/versions
     documentation_url: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /user/packages/{package_type}/{package_name}/versions/{package_version_id}
     documentation_url: https://docs.github.com/rest/packages/packages#delete-a-package-version-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/packages/{package_type}/{package_name}/versions/{package_version_id}
     documentation_url: https://docs.github.com/rest/packages/packages#get-a-package-version-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /user/packages/{package_type}/{package_name}/versions/{package_version_id}/restore
     documentation_url: https://docs.github.com/rest/packages/packages#restore-a-package-version-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /user/projects
     documentation_url: https://docs.github.com/rest/projects/projects#create-a-user-project
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/public_emails
     documentation_url: https://docs.github.com/rest/users/emails#list-public-email-addresses-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/repos
     documentation_url: https://docs.github.com/rest/repos/repos#list-repositories-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /user/repos
     documentation_url: https://docs.github.com/rest/repos/repos#create-a-repository-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/repository_invitations
     documentation_url: https://docs.github.com/rest/collaborators/invitations#list-repository-invitations-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /user/repository_invitations/{invitation_id}
     documentation_url: https://docs.github.com/rest/collaborators/invitations#decline-a-repository-invitation
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PATCH /user/repository_invitations/{invitation_id}
     documentation_url: https://docs.github.com/rest/collaborators/invitations#accept-a-repository-invitation
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /user/social_accounts
     documentation_url: https://docs.github.com/rest/users/social-accounts#delete-social-accounts-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/social_accounts
     documentation_url: https://docs.github.com/rest/users/social-accounts#list-social-accounts-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /user/social_accounts
     documentation_url: https://docs.github.com/rest/users/social-accounts#add-social-accounts-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/ssh_signing_keys
     documentation_url: https://docs.github.com/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /user/ssh_signing_keys
     documentation_url: https://docs.github.com/rest/users/ssh-signing-keys#create-a-ssh-signing-key-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /user/ssh_signing_keys/{ssh_signing_key_id}
     documentation_url: https://docs.github.com/rest/users/ssh-signing-keys#delete-an-ssh-signing-key-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/ssh_signing_keys/{ssh_signing_key_id}
     documentation_url: https://docs.github.com/rest/users/ssh-signing-keys#get-an-ssh-signing-key-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/starred
     documentation_url: https://docs.github.com/rest/activity/starring#list-repositories-starred-by-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /user/starred/{owner}/{repo}
     documentation_url: https://docs.github.com/rest/activity/starring#unstar-a-repository-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/starred/{owner}/{repo}
     documentation_url: https://docs.github.com/rest/activity/starring#check-if-a-repository-is-starred-by-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /user/starred/{owner}/{repo}
     documentation_url: https://docs.github.com/rest/activity/starring#star-a-repository-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/subscriptions
     documentation_url: https://docs.github.com/rest/activity/watching#list-repositories-watched-by-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /user/teams
     documentation_url: https://docs.github.com/rest/teams/teams#list-teams-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users
     documentation_url: https://docs.github.com/rest/users/users#list-users
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}
     documentation_url: https://docs.github.com/rest/users/users#get-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/docker/conflicts
     documentation_url: https://docs.github.com/rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/events
     documentation_url: https://docs.github.com/rest/activity/events#list-events-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/events/orgs/{org}
     documentation_url: https://docs.github.com/rest/activity/events#list-organization-events-for-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/events/public
     documentation_url: https://docs.github.com/rest/activity/events#list-public-events-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/followers
     documentation_url: https://docs.github.com/rest/users/followers#list-followers-of-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/following
     documentation_url: https://docs.github.com/rest/users/followers#list-the-people-a-user-follows
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/following/{target_user}
     documentation_url: https://docs.github.com/rest/users/followers#check-if-a-user-follows-another-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/gists
     documentation_url: https://docs.github.com/rest/gists/gists#list-gists-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/gpg_keys
     documentation_url: https://docs.github.com/rest/users/gpg-keys#list-gpg-keys-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/hovercard
     documentation_url: https://docs.github.com/rest/users/users#get-contextual-information-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/installation
     documentation_url: https://docs.github.com/rest/apps/apps#get-a-user-installation-for-the-authenticated-app
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/keys
     documentation_url: https://docs.github.com/rest/users/keys#list-public-keys-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/orgs
     documentation_url: https://docs.github.com/rest/orgs/orgs#list-organizations-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/packages
     documentation_url: https://docs.github.com/rest/packages/packages#list-packages-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /users/{username}/packages/{package_type}/{package_name}
     documentation_url: https://docs.github.com/rest/packages/packages#delete-a-package-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/packages/{package_type}/{package_name}
     documentation_url: https://docs.github.com/rest/packages/packages#get-a-package-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /users/{username}/packages/{package_type}/{package_name}/restore
     documentation_url: https://docs.github.com/rest/packages/packages#restore-a-package-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/packages/{package_type}/{package_name}/versions
     documentation_url: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}
     documentation_url: https://docs.github.com/rest/packages/packages#delete-package-version-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}
     documentation_url: https://docs.github.com/rest/packages/packages#get-a-package-version-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: POST /users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore
     documentation_url: https://docs.github.com/rest/packages/packages#restore-package-version-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/projects
     documentation_url: https://docs.github.com/rest/projects/projects#list-user-projects
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/received_events
     documentation_url: https://docs.github.com/rest/activity/events#list-events-received-by-the-authenticated-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/received_events/public
     documentation_url: https://docs.github.com/rest/activity/events#list-public-events-received-by-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/repos
     documentation_url: https://docs.github.com/rest/repos/repos#list-repositories-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/settings/billing/actions
     documentation_url: https://docs.github.com/rest/billing/billing#get-github-actions-billing-for-a-user
     openapi_files:
@@ -6328,45 +6470,45 @@ openapi_operations:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
   - name: DELETE /users/{username}/site_admin
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#demote-a-site-administrator
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#demote-a-site-administrator
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /users/{username}/site_admin
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#promote-a-user-to-be-a-site-administrator
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#promote-a-user-to-be-a-site-administrator
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/social_accounts
     documentation_url: https://docs.github.com/rest/users/social-accounts#list-social-accounts-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/ssh_signing_keys
     documentation_url: https://docs.github.com/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/starred
     documentation_url: https://docs.github.com/rest/activity/starring#list-repositories-starred-by-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /users/{username}/subscriptions
     documentation_url: https://docs.github.com/rest/activity/watching#list-repositories-watched-by-a-user
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: DELETE /users/{username}/suspended
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#unsuspend-a-user
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#unsuspend-a-user
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: PUT /users/{username}/suspended
-    documentation_url: https://docs.github.com/enterprise-server@3.11/rest/enterprise-admin/users#suspend-a-user
+    documentation_url: https://docs.github.com/enterprise-server@3.12/rest/enterprise-admin/users#suspend-a-user
     openapi_files:
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json
   - name: GET /versions
     documentation_url: https://docs.github.com/rest/meta/meta#get-all-api-versions
     openapi_files:
@@ -6377,4 +6519,4 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
-      - descriptions/ghes-3.11/ghes-3.11.json
+      - descriptions/ghes-3.12/ghes-3.12.json


### PR DESCRIPTION
Fixes:
#3103 

BREAKING-CHANGE: The following endpoints now take `owner` and `repo` names instead of an integer repo ID:
* ActionsService.ListEnvVariables
* ActionsService.GetEnvVariable
* ActionsService.CreateEnvVariable
* ActionsService.UpdateEnvVariable
* ActionsService.DeleteEnvVariable