### PR TITLE
Allow Installation of Custom Properties Permissions

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -77,6 +77,7 @@ type InstallationPermissions struct {
 	Metadata                      *string `json:"metadata,omitempty"`
 	Members                       *string `json:"members,omitempty"`
 	OrganizationAdministration    *string `json:"organization_administration,omitempty"`
+	OrganizationCustomProperties  *string `json:"organization_custom_properties,omitempty"`
 	OrganizationCustomRoles       *string `json:"organization_custom_roles,omitempty"`
 	OrganizationHooks             *string `json:"organization_hooks,omitempty"`
 	OrganizationPackages          *string `json:"organization_packages,omitempty"`

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -8686,6 +8686,14 @@ func (i *InstallationPermissions) GetOrganizationAdministration() string {
 	return *i.OrganizationAdministration
 }
 
+// GetOrganizationCustomProperties returns the OrganizationCustomProperties field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetOrganizationCustomProperties() string {
+	if i == nil || i.OrganizationCustomProperties == nil {
+		return ""
+	}
+	return *i.OrganizationCustomProperties
+}
+
 // GetOrganizationCustomRoles returns the OrganizationCustomRoles field if it's non-nil, zero value otherwise.
 func (i *InstallationPermissions) GetOrganizationCustomRoles() string {
 	if i == nil || i.OrganizationCustomRoles == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -10177,6 +10177,16 @@ func TestInstallationPermissions_GetOrganizationAdministration(tt *testing.T) {
 	i.GetOrganizationAdministration()
 }
 
+func TestInstallationPermissions_GetOrganizationCustomProperties(tt *testing.T) {
+	var zeroValue string
+	i := &InstallationPermissions{OrganizationCustomProperties: &zeroValue}
+	i.GetOrganizationCustomProperties()
+	i = &InstallationPermissions{}
+	i.GetOrganizationCustomProperties()
+	i = nil
+	i.GetOrganizationCustomProperties()
+}
+
 func TestInstallationPermissions_GetOrganizationCustomRoles(tt *testing.T) {
 	var zeroValue string
 	i := &InstallationPermissions{OrganizationCustomRoles: &zeroValue}


### PR DESCRIPTION
## Description
This PR allows app installations to request tokens with access to the Org level Custom Properties APIs

## Refs
1. [GitHub App installation access tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app)
2. [API Docs](https://docs.github.com/en/rest/orgs/custom-properties?apiVersion=2022-11-28#get-a-custom-property-for-an-organization)