### PR TITLE
Fix pagination for ListCopilotSeats

### DIFF
--- a/github/copilot.go
+++ b/github/copilot.go
@@ -161,8 +161,12 @@ func (s *CopilotService) GetCopilotBilling(ctx context.Context, org string) (*Co
 //meta:operation GET /orgs/{org}/copilot/billing/seats
 func (s *CopilotService) ListCopilotSeats(ctx context.Context, org string, opts *ListOptions) (*ListCopilotSeatsResponse, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/copilot/billing/seats", org)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 
-	req, err := s.client.NewRequest("GET", u, opts)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -584,8 +584,9 @@ func TestCopilotService_ListCopilotSeats(t *testing.T) {
 
 	const methodName = "ListCopilotSeats"
 
+	opts := &ListOptions{Page: 2}
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Copilot.ListCopilotSeats(ctx, "\n", nil)
+		_, _, err = client.Copilot.ListCopilotSeats(ctx, "\n", opts)
 		return err
 	})
 


### PR DESCRIPTION
The pagination must be passed as query parameters instead of request [body according to the docs](https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#list-all-copilot-seat-assignments-for-an-organization).

Currently this is silently failing but the pagination is broken if you've got lots of Copilot users.