### PR TITLE
Print the unrecognized repository rule type

### DIFF
--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -204,7 +204,7 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 	default:
 		r.Type = ""
 		r.Parameters = nil
-		return fmt.Errorf("RepositoryRule.Type %T is not yet implemented, unable to unmarshal", RepositoryRule.Type)
+		return fmt.Errorf("RepositoryRule.Type %q is not yet implemented, unable to unmarshal (%#v)", RepositoryRule.Type, RepositoryRule)
 	}
 
 	return nil


### PR DESCRIPTION
When failing to match the type of a repository rule, print the unmatched name.
Previously only the type of the unmatched name was printed, which is always 'string'. This makes it hard to troubleshoot unmarshalling failures.