### PR TITLE
feat: Add missing github enterprise importer and domains meta fields

### DIFF
--- a/github/meta.go
+++ b/github/meta.go
@@ -17,11 +17,11 @@ type MetaService service
 
 // APIMeta represents metadata about the GitHub API.
 type APIMeta struct {
-	// An Array of IP addresses in CIDR format specifying the addresses
+	// An array of IP addresses in CIDR format specifying the addresses
 	// that incoming service hooks will originate from on GitHub.com.
 	Hooks []string `json:"hooks,omitempty"`
 
-	// An Array of IP addresses in CIDR format specifying the Git servers
+	// An array of IP addresses in CIDR format specifying the Git servers
 	// for GitHub.com.
 	Git []string `json:"git,omitempty"`
 
@@ -40,9 +40,13 @@ type APIMeta struct {
 	// which serve GitHub Pages websites.
 	Pages []string `json:"pages,omitempty"`
 
-	// An Array of IP addresses specifying the addresses that source imports
+	// An array of IP addresses specifying the addresses that source imports
 	// will originate from on GitHub.com.
 	Importer []string `json:"importer,omitempty"`
+
+	// An array of IP addresses specifying the addresses that source imports
+	// will originate from on GitHub Enterprise Cloud.
+	GithubEnterpriseImporter []string `json:"github_enterprise_importer,omitempty"`
 
 	// An array of IP addresses in CIDR format specifying the IP addresses
 	// GitHub Actions will originate from.
@@ -65,6 +69,10 @@ type APIMeta struct {
 	// An array of IP addresses in CIDR format specifying the addresses
 	// which serve GitHub APIs.
 	API []string `json:"api,omitempty"`
+
+	// A map of GitHub services and their associated domains. Note that many
+	// of these domains are represented as wildcards (e.g. "*.github.com").
+	Domains map[string][]string `json:"domains,omitempty"`
 }
 
 // Get returns information about GitHub.com, the service. Or, if you access

--- a/github/meta_test.go
+++ b/github/meta_test.go
@@ -23,12 +23,16 @@ func TestAPIMeta_Marshal(t *testing.T) {
 		VerifiablePasswordAuthentication: Bool(true),
 		Pages:                            []string{"p"},
 		Importer:                         []string{"i"},
+		GithubEnterpriseImporter:         []string{"gei"},
 		Actions:                          []string{"a"},
 		Dependabot:                       []string{"d"},
 		SSHKeyFingerprints:               map[string]string{"a": "f"},
 		SSHKeys:                          []string{"k"},
 		API:                              []string{"a"},
 		Web:                              []string{"w"},
+		Domains: map[string][]string{
+			"example": {"example.com", "*.example.com"},
+		},
 	}
 	want := `{
 		"hooks":["h"],
@@ -36,12 +40,14 @@ func TestAPIMeta_Marshal(t *testing.T) {
 		"verifiable_password_authentication":true,
 		"pages":["p"],
 		"importer":["i"],
+		"github_enterprise_importer":["gei"],
 		"actions":["a"],
 		"dependabot":["d"],
 		"ssh_key_fingerprints":{"a":"f"},
 		"ssh_keys":["k"],
 		"api":["a"],
-		"web":["w"]
+		"web":["w"],
+		"domains":{"example":["example.com","*.example.com"]}
 	}`
 
 	testJSONMarshal(t, a, want)
@@ -53,7 +59,7 @@ func TestMetaService_Get(t *testing.T) {
 
 	mux.HandleFunc("/meta", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"web":["w"],"api":["a"],"hooks":["h"], "git":["g"], "pages":["p"], "importer":["i"], "actions":["a"], "dependabot":["d"], "verifiable_password_authentication": true}`)
+		fmt.Fprint(w, `{"web":["w"],"api":["a"],"hooks":["h"], "git":["g"], "pages":["p"], "importer":["i"], "github_enterprise_importer": ["gei"], "actions":["a"], "dependabot":["d"], "verifiable_password_authentication": true, "domains":{"example":["example.com","*.example.com"]}}`)
 	})
 
 	ctx := context.Background()
@@ -63,14 +69,18 @@ func TestMetaService_Get(t *testing.T) {
 	}
 
 	want := &APIMeta{
-		Hooks:      []string{"h"},
-		Git:        []string{"g"},
-		Pages:      []string{"p"},
-		Importer:   []string{"i"},
-		Actions:    []string{"a"},
-		Dependabot: []string{"d"},
-		API:        []string{"a"},
-		Web:        []string{"w"},
+		Hooks:                    []string{"h"},
+		Git:                      []string{"g"},
+		Pages:                    []string{"p"},
+		Importer:                 []string{"i"},
+		GithubEnterpriseImporter: []string{"gei"},
+		Actions:                  []string{"a"},
+		Dependabot:               []string{"d"},
+		API:                      []string{"a"},
+		Web:                      []string{"w"},
+		Domains: map[string][]string{
+			"example": {"example.com", "*.example.com"},
+		},
 
 		VerifiablePasswordAuthentication: Bool(true),
 	}


### PR DESCRIPTION
Adds two of the missing fields, `github_enterprise_importer` and `domains`, which are now included with the public meta endpoint. Also fixed some minor capitalization errors.