### PR TITLE
Query identities associated with organization roles

### DIFF
--- a/github/orgs_custom_roles.go
+++ b/github/orgs_custom_roles.go
@@ -127,14 +127,18 @@ func (s *OrganizationsService) DeleteCustomRepoRole(ctx context.Context, org, ro
 	return resp, nil
 }
 
-// ListTeamsAssignedToOrgRole returns all teams assigned to as specific organization role.
+// ListTeamsAssignedToOrgRole returns all teams assigned to a specific organization role.
 // In order to list teams assigned to an organization role, the authenticated user must be an organization owner.
 //
 // GitHub API docs: https://docs.github.com/rest/orgs/organization-roles#list-teams-that-are-assigned-to-an-organization-role
 //
 //meta:operation GET /orgs/{org}/organization-roles/{role_id}/teams
-func (s *OrganizationsService) ListTeamsAssignedToOrgRole(ctx context.Context, org string, roleID int64) ([]*Team, *Response, error) {
+func (s *OrganizationsService) ListTeamsAssignedToOrgRole(ctx context.Context, org string, roleID int64, opts *ListOptions) ([]*Team, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/organization-roles/%v/teams", org, roleID)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -150,14 +154,18 @@ func (s *OrganizationsService) ListTeamsAssignedToOrgRole(ctx context.Context, o
 	return teams, resp, nil
 }
 
-// ListUsersAssignedToOrgRole returns all users assigned to as specific organization role.
+// ListUsersAssignedToOrgRole returns all users assigned to a specific organization role.
 // In order to list users assigned to an organization role, the authenticated user must be an organization owner.
 //
 // GitHub API docs: https://docs.github.com/rest/orgs/organization-roles#list-users-that-are-assigned-to-an-organization-role
 //
 //meta:operation GET /orgs/{org}/organization-roles/{role_id}/users
-func (s *OrganizationsService) ListUsersAssignedToOrgRole(ctx context.Context, org string, roleID int64) ([]*User, *Response, error) {
+func (s *OrganizationsService) ListUsersAssignedToOrgRole(ctx context.Context, org string, roleID int64, opts *ListOptions) ([]*User, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/organization-roles/%v/users", org, roleID)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/orgs_custom_roles.go
+++ b/github/orgs_custom_roles.go
@@ -126,3 +126,49 @@ func (s *OrganizationsService) DeleteCustomRepoRole(ctx context.Context, org, ro
 
 	return resp, nil
 }
+
+// ListTeamsAssignedToOrgRole returns all teams assigned to as specific organization role.
+// In order to list teams assigned to an organization role, the authenticated user must be an organization owner.
+//
+// GitHub API docs: https://docs.github.com/rest/orgs/organization-roles#list-teams-that-are-assigned-to-an-organization-role
+//
+//meta:operation GET /orgs/{org}/organization-roles/{role_id}/teams
+func (s *OrganizationsService) ListTeamsAssignedToOrgRole(ctx context.Context, org string, roleID int64) ([]*Team, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/organization-roles/%v/teams", org, roleID)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var teams []*Team
+	resp, err := s.client.Do(ctx, req, &teams)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return teams, resp, nil
+}
+
+// ListUsersAssignedToOrgRole returns all users assigned to as specific organization role.
+// In order to list users assigned to an organization role, the authenticated user must be an organization owner.
+//
+// GitHub API docs: https://docs.github.com/rest/orgs/organization-roles#list-users-that-are-assigned-to-an-organization-role
+//
+//meta:operation GET /orgs/{org}/organization-roles/{role_id}/users
+func (s *OrganizationsService) ListUsersAssignedToOrgRole(ctx context.Context, org string, roleID int64) ([]*User, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/organization-roles/%v/users", org, roleID)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var users []*User
+	resp, err := s.client.Do(ctx, req, &users)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return users, resp, nil
+}

--- a/github/orgs_custom_roles_test.go
+++ b/github/orgs_custom_roles_test.go
@@ -168,8 +168,9 @@ func TestOrganizationsService_ListTeamsAssignedToOrgRole(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
+	opt := &ListOptions{Page: 2}
 	ctx := context.Background()
-	apps, _, err := client.Organizations.ListTeamsAssignedToOrgRole(ctx, "o", 1729)
+	apps, _, err := client.Organizations.ListTeamsAssignedToOrgRole(ctx, "o", 1729, opt)
 	if err != nil {
 		t.Errorf("Organizations.ListTeamsAssignedToOrgRole returned error: %v", err)
 	}
@@ -181,12 +182,12 @@ func TestOrganizationsService_ListTeamsAssignedToOrgRole(t *testing.T) {
 
 	const methodName = "ListTeamsAssignedToOrgRole"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Organizations.ListTeamsAssignedToOrgRole(ctx, "\no", 1729)
+		_, _, err = client.Organizations.ListTeamsAssignedToOrgRole(ctx, "\no", 1729, opt)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Organizations.ListTeamsAssignedToOrgRole(ctx, "o", 1729)
+		got, resp, err := client.Organizations.ListTeamsAssignedToOrgRole(ctx, "o", 1729, opt)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -202,8 +203,9 @@ func TestOrganizationsService_ListUsersAssignedToOrgRole(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
+	opt := &ListOptions{Page: 2}
 	ctx := context.Background()
-	apps, _, err := client.Organizations.ListUsersAssignedToOrgRole(ctx, "o", 1729)
+	apps, _, err := client.Organizations.ListUsersAssignedToOrgRole(ctx, "o", 1729, opt)
 	if err != nil {
 		t.Errorf("Organizations.ListUsersAssignedToOrgRole returned error: %v", err)
 	}
@@ -215,12 +217,12 @@ func TestOrganizationsService_ListUsersAssignedToOrgRole(t *testing.T) {
 
 	const methodName = "ListUsersAssignedToOrgRole"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Organizations.ListUsersAssignedToOrgRole(ctx, "\no", 1729)
+		_, _, err = client.Organizations.ListUsersAssignedToOrgRole(ctx, "\no", 1729, opt)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Organizations.ListUsersAssignedToOrgRole(ctx, "o", 1729)
+		got, resp, err := client.Organizations.ListUsersAssignedToOrgRole(ctx, "o", 1729, opt)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/github/orgs_custom_roles_test.go
+++ b/github/orgs_custom_roles_test.go
@@ -159,3 +159,71 @@ func TestOrganizationsService_DeleteCustomRepoRole(t *testing.T) {
 		return err
 	})
 }
+
+func TestOrganizationsService_ListTeamsAssignedToOrgRole(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/organization-roles/1729/teams", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{"id":1}]`)
+	})
+	ctx := context.Background()
+	apps, _, err := client.Organizations.ListTeamsAssignedToOrgRole(ctx, "o", 1729)
+	if err != nil {
+		t.Errorf("Organizations.ListTeamsAssignedToOrgRole returned error: %v", err)
+	}
+
+	want := []*Team{{ID: Int64(1)}}
+	if !cmp.Equal(apps, want) {
+		t.Errorf("Organizations.ListTeamsAssignedToOrgRole returned %+v, want %+v", apps, want)
+	}
+
+	const methodName = "ListTeamsAssignedToOrgRole"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.ListTeamsAssignedToOrgRole(ctx, "\no", 1729)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Organizations.ListTeamsAssignedToOrgRole(ctx, "o", 1729)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestOrganizationsService_ListUsersAssignedToOrgRole(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/organization-roles/1729/users", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{"id":1}]`)
+	})
+	ctx := context.Background()
+	apps, _, err := client.Organizations.ListUsersAssignedToOrgRole(ctx, "o", 1729)
+	if err != nil {
+		t.Errorf("Organizations.ListUsersAssignedToOrgRole returned error: %v", err)
+	}
+
+	want := []*User{{ID: Int64(1)}}
+	if !cmp.Equal(apps, want) {
+		t.Errorf("Organizations.ListUsersAssignedToOrgRole returned %+v, want %+v", apps, want)
+	}
+
+	const methodName = "ListUsersAssignedToOrgRole"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.ListUsersAssignedToOrgRole(ctx, "\no", 1729)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Organizations.ListUsersAssignedToOrgRole(ctx, "o", 1729)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}


### PR DESCRIPTION
Wrap queries to return the teams and users associated with a specific organization role