### PR TITLE
Add support for merge queue ruleset JSON unmarshaling 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -485,3 +485,4 @@ zhouhaibing089 <zhouhaibing089@gmail.com>
 六开箱 <lkxed@outlook.com>
 缘生 <i@ysicing.me>
 蒋航 <hang.jiang@daocloud.io>
+Matthew Reidy <matthewreidy5@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -303,6 +303,7 @@ Matt Gaunt <matt@gauntface.co.uk>
 Matt Landis <landis.matt@gmail.com>
 Matt Moore <mattmoor@vmware.com>
 Matt Simons <mattsimons@ntlworld.com>
+Matthew Reidy <matthewreidy5@gmail.com>
 Maxime Bury <maxime.bury@gmail.com>
 Michael Meng <mmeng@lyft.com>
 Michael Spiegel <michael.m.spiegel@gmail.com>
@@ -485,4 +486,3 @@ zhouhaibing089 <zhouhaibing089@gmail.com>
 六开箱 <lkxed@outlook.com>
 缘生 <i@ysicing.me>
 蒋航 <hang.jiang@daocloud.io>
-Matthew Reidy <matthewreidy5@gmail.com>

--- a/github/orgs_rules_test.go
+++ b/github/orgs_rules_test.go
@@ -124,6 +124,9 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoNames(t *testing.T) 
 				"type": "deletion"
 			  },
 			  {
+				"type": "merge_queue"
+			  },
+			  {
 				"type": "required_linear_history"
 			  },
 			  {
@@ -238,6 +241,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoNames(t *testing.T) 
 				UpdateAllowsFetchAndMerge: true,
 			}),
 			NewDeletionRule(),
+			NewMergeQueueRule(),
 			NewRequiredLinearHistoryRule(),
 			NewRequiredDeploymentsRule(&RequiredDeploymentEnvironmentsRuleParameters{
 				RequiredDeploymentEnvironments: []string{"test"},
@@ -324,6 +328,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoNames(t *testing.T) 
 				UpdateAllowsFetchAndMerge: true,
 			}),
 			NewDeletionRule(),
+			NewMergeQueueRule(),
 			NewRequiredLinearHistoryRule(),
 			NewRequiredDeploymentsRule(&RequiredDeploymentEnvironmentsRuleParameters{
 				RequiredDeploymentEnvironments: []string{"test"},
@@ -438,6 +443,9 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoIDs(t *testing.T) {
 				"type": "deletion"
 			  },
 			  {
+				"type": "merge_queue"
+			  },
+			  {
 				"type": "required_linear_history"
 			  },
 			  {
@@ -550,6 +558,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoIDs(t *testing.T) {
 				UpdateAllowsFetchAndMerge: true,
 			}),
 			NewDeletionRule(),
+			NewMergeQueueRule(),
 			NewRequiredLinearHistoryRule(),
 			NewRequiredDeploymentsRule(&RequiredDeploymentEnvironmentsRuleParameters{
 				RequiredDeploymentEnvironments: []string{"test"},
@@ -634,6 +643,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoIDs(t *testing.T) {
 				UpdateAllowsFetchAndMerge: true,
 			}),
 			NewDeletionRule(),
+			NewMergeQueueRule(),
 			NewRequiredLinearHistoryRule(),
 			NewRequiredDeploymentsRule(&RequiredDeploymentEnvironmentsRuleParameters{
 				RequiredDeploymentEnvironments: []string{"test"},

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -210,7 +210,7 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// NewMergeQueueRule creates a rule to only allow users with bypass permission to create matching refs.
+// NewMergeQueueRule creates a rule to only allow merges via a merge queue.
 func NewMergeQueueRule() (rule *RepositoryRule) {
 	return &RepositoryRule{
 		Type: "merge_queue",

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -134,7 +134,7 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 	r.Type = RepositoryRule.Type
 
 	switch RepositoryRule.Type {
-	case "creation", "deletion", "required_linear_history", "required_signatures", "non_fast_forward", "merge_queue":
+	case "creation", "deletion", "merge_queue", "non_fast_forward", "required_linear_history", "required_signatures":
 		r.Parameters = nil
 	case "update":
 		if RepositoryRule.Parameters == nil {
@@ -201,7 +201,6 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 		rawParams := json.RawMessage(bytes)
 
 		r.Parameters = &rawParams
-
 	default:
 		r.Type = ""
 		r.Parameters = nil

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -110,6 +110,13 @@ type RequiredWorkflowsRuleParameters struct {
 	RequiredWorkflows []*RuleRequiredWorkflow `json:"workflows"`
 }
 
+type RuleMergeQueue struct {
+}
+
+// RequiredWorkflowsRuleParameters represents the workflows rule parameters.
+type MergeQueueRuleParameters struct {
+}
+
 // RepositoryRule represents a GitHub Rule.
 type RepositoryRule struct {
 	Type              string           `json:"type"`
@@ -201,6 +208,16 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 		rawParams := json.RawMessage(bytes)
 
 		r.Parameters = &rawParams
+	case "merge_queue":
+		params := MergeQueueRuleParameters{}
+		if err := json.Unmarshal(*RepositoryRule.Parameters, &params); err != nil {
+			return err
+		}
+
+		bytes, _ := json.Marshal(params)
+		rawParams := json.RawMessage(bytes)
+
+		r.Parameters = &rawParams
 	default:
 		r.Type = ""
 		r.Parameters = nil
@@ -208,6 +225,18 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+// NewMergeQueueRule creates a rule to only allow users with bypass permission to create matching refs.
+func NewMergeQueueRule(params *RequiredStatusChecksRuleParameters) (rule *RepositoryRule) {
+	bytes, _ := json.Marshal(params)
+
+	rawParams := json.RawMessage(bytes)
+
+	return &RepositoryRule{
+		Type:       "merge_queue",
+		Parameters: &rawParams,
+	}
 }
 
 // NewCreationRule creates a rule to only allow users with bypass permission to create matching refs.

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -110,13 +110,6 @@ type RequiredWorkflowsRuleParameters struct {
 	RequiredWorkflows []*RuleRequiredWorkflow `json:"workflows"`
 }
 
-type RuleMergeQueue struct {
-}
-
-// RequiredWorkflowsRuleParameters represents the workflows rule parameters.
-type MergeQueueRuleParameters struct {
-}
-
 // RepositoryRule represents a GitHub Rule.
 type RepositoryRule struct {
 	Type              string           `json:"type"`
@@ -141,7 +134,7 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 	r.Type = RepositoryRule.Type
 
 	switch RepositoryRule.Type {
-	case "creation", "deletion", "required_linear_history", "required_signatures", "non_fast_forward":
+	case "creation", "deletion", "required_linear_history", "required_signatures", "non_fast_forward", "merge_queue":
 		r.Parameters = nil
 	case "update":
 		if RepositoryRule.Parameters == nil {
@@ -208,16 +201,7 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 		rawParams := json.RawMessage(bytes)
 
 		r.Parameters = &rawParams
-	case "merge_queue":
-		params := MergeQueueRuleParameters{}
-		if err := json.Unmarshal(*RepositoryRule.Parameters, &params); err != nil {
-			return err
-		}
 
-		bytes, _ := json.Marshal(params)
-		rawParams := json.RawMessage(bytes)
-
-		r.Parameters = &rawParams
 	default:
 		r.Type = ""
 		r.Parameters = nil
@@ -228,14 +212,9 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 }
 
 // NewMergeQueueRule creates a rule to only allow users with bypass permission to create matching refs.
-func NewMergeQueueRule(params *RequiredStatusChecksRuleParameters) (rule *RepositoryRule) {
-	bytes, _ := json.Marshal(params)
-
-	rawParams := json.RawMessage(bytes)
-
+func NewMergeQueueRule() (rule *RepositoryRule) {
 	return &RepositoryRule{
-		Type:       "merge_queue",
-		Parameters: &rawParams,
+		Type: "merge_queue",
 	}
 }
 

--- a/github/repos_rules_test.go
+++ b/github/repos_rules_test.go
@@ -67,6 +67,13 @@ func TestRepositoryRule_UnmarshalJSON(t *testing.T) {
 				Parameters: nil,
 			},
 		},
+		"Valid merge_queue": {
+			data: `{"type":"merge_queue"}`,
+			want: &RepositoryRule{
+				Type:       "merge_queue",
+				Parameters: nil,
+			},
+		},
 		"Valid non_fast_forward": {
 			data: `{"type":"non_fast_forward"}`,
 			want: &RepositoryRule{


### PR DESCRIPTION
Fixes: #3098.

Added support for respository ruleset merge_queue in JSON unmarshalling code with accompanying tests 