### PR TITLE
Add Missing Changes Field to Member Event Type.

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -689,14 +689,34 @@ type MarketplacePurchaseEvent struct {
 	Org *Organization `json:"organization,omitempty"`
 }
 
-// MemberEvent is triggered when a user is added as a collaborator to a repository.
+// MemberChangesPermission represents changes to a repository collaborator's permissions.
+type MemberChangesPermission struct {
+	From *string `json:"from,omitempty"`
+	To   *string `json:"to,omitempty"`
+}
+
+// MemberChangesRoleName represents changes to a repository collaborator's role.
+type MemberChangesRoleName struct {
+	From *string `json:"from,omitempty"`
+	To   *string `json:"to,omitempty"`
+}
+
+// MemberChanges represents changes to a repository collaborator's role or permission.
+type MemberChanges struct {
+	Permission *MemberChangesPermission `json:"permission,omitempty"`
+	RoleName   *MemberChangesRoleName   `json:"role_name,omitempty"`
+}
+
+// MemberEvent is triggered when a user's membership as a collaborator to a repository changes.
 // The Webhook event name is "member".
 //
 // GitHub API docs: https://docs.github.com/developers/webhooks-and-events/webhook-events-and-payloads#member
 type MemberEvent struct {
-	// Action is the action that was performed. Possible value is: "added".
-	Action *string `json:"action,omitempty"`
-	Member *User   `json:"member,omitempty"`
+	// Action is the action that was performed. Possible values are:
+	//"added", "edited", "removed".
+	Action  *string        `json:"action,omitempty"`
+	Member  *User          `json:"member,omitempty"`
+	Changes *MemberChanges `json:"changes,omitempty"`
 
 	// The following fields are only populated by Webhook events.
 	Repo         *Repository   `json:"repository,omitempty"`

--- a/github/event_types_test.go
+++ b/github/event_types_test.go
@@ -9106,6 +9106,16 @@ func TestMemberEvent_Marshal(t *testing.T) {
 			EventsURL: String("e"),
 			AvatarURL: String("a"),
 		},
+		Changes: &MemberChanges{
+			Permission: &MemberChangesPermission{
+				From: String("f"),
+				To:   String("t"),
+			},
+			RoleName: &MemberChangesRoleName{
+				From: String("f"),
+				To:   String("t"),
+			},
+		},
 		Repo: &Repository{
 			ID:   Int64(1),
 			URL:  String("s"),
@@ -9225,6 +9235,16 @@ func TestMemberEvent_Marshal(t *testing.T) {
 			"url": "u",
 			"events_url": "e",
 			"repos_url": "r"
+		},
+		"changes": {
+			"permission": {
+				"from": "f",
+				"to": "t"
+			},
+			"role_name": {
+				"from": "f",
+				"to": "t"
+			}
 		},
 		"repository": {
 			"id": 1,

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11206,12 +11206,68 @@ func (m *Match) GetText() string {
 	return *m.Text
 }
 
+// GetPermission returns the Permission field.
+func (m *MemberChanges) GetPermission() *MemberChangesPermission {
+	if m == nil {
+		return nil
+	}
+	return m.Permission
+}
+
+// GetRoleName returns the RoleName field.
+func (m *MemberChanges) GetRoleName() *MemberChangesRoleName {
+	if m == nil {
+		return nil
+	}
+	return m.RoleName
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (m *MemberChangesPermission) GetFrom() string {
+	if m == nil || m.From == nil {
+		return ""
+	}
+	return *m.From
+}
+
+// GetTo returns the To field if it's non-nil, zero value otherwise.
+func (m *MemberChangesPermission) GetTo() string {
+	if m == nil || m.To == nil {
+		return ""
+	}
+	return *m.To
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (m *MemberChangesRoleName) GetFrom() string {
+	if m == nil || m.From == nil {
+		return ""
+	}
+	return *m.From
+}
+
+// GetTo returns the To field if it's non-nil, zero value otherwise.
+func (m *MemberChangesRoleName) GetTo() string {
+	if m == nil || m.To == nil {
+		return ""
+	}
+	return *m.To
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (m *MemberEvent) GetAction() string {
 	if m == nil || m.Action == nil {
 		return ""
 	}
 	return *m.Action
+}
+
+// GetChanges returns the Changes field.
+func (m *MemberEvent) GetChanges() *MemberChanges {
+	if m == nil {
+		return nil
+	}
+	return m.Changes
 }
 
 // GetInstallation returns the Installation field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -13111,6 +13111,60 @@ func TestMatch_GetText(tt *testing.T) {
 	m.GetText()
 }
 
+func TestMemberChanges_GetPermission(tt *testing.T) {
+	m := &MemberChanges{}
+	m.GetPermission()
+	m = nil
+	m.GetPermission()
+}
+
+func TestMemberChanges_GetRoleName(tt *testing.T) {
+	m := &MemberChanges{}
+	m.GetRoleName()
+	m = nil
+	m.GetRoleName()
+}
+
+func TestMemberChangesPermission_GetFrom(tt *testing.T) {
+	var zeroValue string
+	m := &MemberChangesPermission{From: &zeroValue}
+	m.GetFrom()
+	m = &MemberChangesPermission{}
+	m.GetFrom()
+	m = nil
+	m.GetFrom()
+}
+
+func TestMemberChangesPermission_GetTo(tt *testing.T) {
+	var zeroValue string
+	m := &MemberChangesPermission{To: &zeroValue}
+	m.GetTo()
+	m = &MemberChangesPermission{}
+	m.GetTo()
+	m = nil
+	m.GetTo()
+}
+
+func TestMemberChangesRoleName_GetFrom(tt *testing.T) {
+	var zeroValue string
+	m := &MemberChangesRoleName{From: &zeroValue}
+	m.GetFrom()
+	m = &MemberChangesRoleName{}
+	m.GetFrom()
+	m = nil
+	m.GetFrom()
+}
+
+func TestMemberChangesRoleName_GetTo(tt *testing.T) {
+	var zeroValue string
+	m := &MemberChangesRoleName{To: &zeroValue}
+	m.GetTo()
+	m = &MemberChangesRoleName{}
+	m.GetTo()
+	m = nil
+	m.GetTo()
+}
+
 func TestMemberEvent_GetAction(tt *testing.T) {
 	var zeroValue string
 	m := &MemberEvent{Action: &zeroValue}
@@ -13119,6 +13173,13 @@ func TestMemberEvent_GetAction(tt *testing.T) {
 	m.GetAction()
 	m = nil
 	m.GetAction()
+}
+
+func TestMemberEvent_GetChanges(tt *testing.T) {
+	m := &MemberEvent{}
+	m.GetChanges()
+	m = nil
+	m.GetChanges()
 }
 
 func TestMemberEvent_GetInstallation(tt *testing.T) {


### PR DESCRIPTION
Fixes: #3154.

The `member` webhook event as described by github documentation contains a `changes` object. https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#member

However, the struct that defines the `Member` webhook event type is missing the `changes` object . This PR adds the missing `changes` object to the `MemberEvent` type.