### PR TITLE
Add Action to DeploymentStatusEvent

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -232,6 +232,7 @@ type DeploymentProtectionRuleEvent struct {
 //
 // GitHub API docs: https://docs.github.com/developers/webhooks-and-events/webhook-events-and-payloads#deployment_status
 type DeploymentStatusEvent struct {
+	Action           *string           `json:"action,omitempty"`
 	Deployment       *Deployment       `json:"deployment,omitempty"`
 	DeploymentStatus *DeploymentStatus `json:"deployment_status,omitempty"`
 	Repo             *Repository       `json:"repository,omitempty"`

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -5878,6 +5878,14 @@ func (d *DeploymentStatus) GetURL() string {
 	return *d.URL
 }
 
+// GetAction returns the Action field if it's non-nil, zero value otherwise.
+func (d *DeploymentStatusEvent) GetAction() string {
+	if d == nil || d.Action == nil {
+		return ""
+	}
+	return *d.Action
+}
+
 // GetDeployment returns the Deployment field.
 func (d *DeploymentStatusEvent) GetDeployment() *Deployment {
 	if d == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -6886,6 +6886,16 @@ func TestDeploymentStatus_GetURL(tt *testing.T) {
 	d.GetURL()
 }
 
+func TestDeploymentStatusEvent_GetAction(tt *testing.T) {
+	var zeroValue string
+	d := &DeploymentStatusEvent{Action: &zeroValue}
+	d.GetAction()
+	d = &DeploymentStatusEvent{}
+	d.GetAction()
+	d = nil
+	d.GetAction()
+}
+
 func TestDeploymentStatusEvent_GetDeployment(tt *testing.T) {
 	d := &DeploymentStatusEvent{}
 	d.GetDeployment()


### PR DESCRIPTION
In [GH docs](https://docs.github.com/en/webhooks/webhook-events-and-payloads#deployment_status) we can see that `deployment_status` has a field `action`, that is always set to `created`. This pr adds it to json representation.