### PR TITLE
feat: Add missing values_editable_by field for organization custom properties

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -4718,6 +4718,14 @@ func (c *CustomProperty) GetRequired() bool {
 	return *c.Required
 }
 
+// GetValuesEditableBy returns the ValuesEditableBy field if it's non-nil, zero value otherwise.
+func (c *CustomProperty) GetValuesEditableBy() string {
+	if c == nil || c.ValuesEditableBy == nil {
+		return ""
+	}
+	return *c.ValuesEditableBy
+}
+
 // GetValue returns the Value field if it's non-nil, zero value otherwise.
 func (c *CustomPropertyValue) GetValue() string {
 	if c == nil || c.Value == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -5553,6 +5553,16 @@ func TestCustomProperty_GetRequired(tt *testing.T) {
 	c.GetRequired()
 }
 
+func TestCustomProperty_GetValuesEditableBy(tt *testing.T) {
+	var zeroValue string
+	c := &CustomProperty{ValuesEditableBy: &zeroValue}
+	c.GetValuesEditableBy()
+	c = &CustomProperty{}
+	c.GetValuesEditableBy()
+	c = nil
+	c.GetValuesEditableBy()
+}
+
 func TestCustomPropertyValue_GetValue(tt *testing.T) {
 	var zeroValue string
 	c := &CustomPropertyValue{Value: &zeroValue}

--- a/github/orgs_properties.go
+++ b/github/orgs_properties.go
@@ -15,12 +15,19 @@ type CustomProperty struct {
 	// PropertyName is required for most endpoints except when calling CreateOrUpdateCustomProperty;
 	// where this is sent in the path and thus can be omitted.
 	PropertyName *string `json:"property_name,omitempty"`
-	// Possible values for ValueType are: string, single_select
-	ValueType     string   `json:"value_type"`
-	Required      *bool    `json:"required,omitempty"`
-	DefaultValue  *string  `json:"default_value,omitempty"`
-	Description   *string  `json:"description,omitempty"`
+	// The type of the value for the property. Can be one of: string, single_select.
+	ValueType string `json:"value_type"`
+	// Whether the property is required.
+	Required *bool `json:"required,omitempty"`
+	// Default value of the property.
+	DefaultValue *string `json:"default_value,omitempty"`
+	// Short description of the property.
+	Description *string `json:"description,omitempty"`
+	// An ordered list of the allowed values of the property. The property can have up to 200
+	// allowed values.
 	AllowedValues []string `json:"allowed_values,omitempty"`
+	// Who can edit the values of the property. Can be one of: org_actors, org_and_repo_actors, nil (null).
+	ValuesEditableBy *string `json:"values_editable_by,omitempty"`
 }
 
 // RepoCustomPropertyValue represents a repository custom property value.

--- a/github/orgs_properties_test.go
+++ b/github/orgs_properties_test.go
@@ -30,7 +30,8 @@ func TestOrganizationsService_GetAllCustomProperties(t *testing.T) {
           "allowed_values":[
             "production",
             "development"
-          ]
+          ],
+          "values_editable_by": "org_actors"
         },
         {
           "property_name": "service",
@@ -52,12 +53,13 @@ func TestOrganizationsService_GetAllCustomProperties(t *testing.T) {
 
 	want := []*CustomProperty{
 		{
-			PropertyName:  String("name"),
-			ValueType:     "single_select",
-			Required:      Bool(true),
-			DefaultValue:  String("production"),
-			Description:   String("Prod or dev environment"),
-			AllowedValues: []string{"production", "development"},
+			PropertyName:     String("name"),
+			ValueType:        "single_select",
+			Required:         Bool(true),
+			DefaultValue:     String("production"),
+			Description:      String("Prod or dev environment"),
+			AllowedValues:    []string{"production", "development"},
+			ValuesEditableBy: String("org_actors"),
 		},
 		{
 			PropertyName: String("service"),
@@ -162,7 +164,8 @@ func TestOrganizationsService_GetCustomProperty(t *testing.T) {
 		"allowed_values":[
 		  "production",
 		  "development"
-		]
+		],
+		"values_editable_by": "org_actors"
 	  }`)
 	})
 
@@ -173,12 +176,13 @@ func TestOrganizationsService_GetCustomProperty(t *testing.T) {
 	}
 
 	want := &CustomProperty{
-		PropertyName:  String("name"),
-		ValueType:     "single_select",
-		Required:      Bool(true),
-		DefaultValue:  String("production"),
-		Description:   String("Prod or dev environment"),
-		AllowedValues: []string{"production", "development"},
+		PropertyName:     String("name"),
+		ValueType:        "single_select",
+		Required:         Bool(true),
+		DefaultValue:     String("production"),
+		Description:      String("Prod or dev environment"),
+		AllowedValues:    []string{"production", "development"},
+		ValuesEditableBy: String("org_actors"),
 	}
 	if !cmp.Equal(property, want) {
 		t.Errorf("Organizations.GetCustomProperty returned %+v, want %+v", property, want)
@@ -210,29 +214,32 @@ func TestOrganizationsService_CreateOrUpdateCustomProperty(t *testing.T) {
 		"allowed_values":[
 		  "production",
 		  "development"
-		]
+		],
+		"values_editable_by": "org_actors"
 	  }`)
 	})
 
 	ctx := context.Background()
 	property, _, err := client.Organizations.CreateOrUpdateCustomProperty(ctx, "o", "name", &CustomProperty{
-		ValueType:     "single_select",
-		Required:      Bool(true),
-		DefaultValue:  String("production"),
-		Description:   String("Prod or dev environment"),
-		AllowedValues: []string{"production", "development"},
+		ValueType:        "single_select",
+		Required:         Bool(true),
+		DefaultValue:     String("production"),
+		Description:      String("Prod or dev environment"),
+		AllowedValues:    []string{"production", "development"},
+		ValuesEditableBy: String("org_actors"),
 	})
 	if err != nil {
 		t.Errorf("Organizations.CreateOrUpdateCustomProperty returned error: %v", err)
 	}
 
 	want := &CustomProperty{
-		PropertyName:  String("name"),
-		ValueType:     "single_select",
-		Required:      Bool(true),
-		DefaultValue:  String("production"),
-		Description:   String("Prod or dev environment"),
-		AllowedValues: []string{"production", "development"},
+		PropertyName:     String("name"),
+		ValueType:        "single_select",
+		Required:         Bool(true),
+		DefaultValue:     String("production"),
+		Description:      String("Prod or dev environment"),
+		AllowedValues:    []string{"production", "development"},
+		ValuesEditableBy: String("org_actors"),
 	}
 	if !cmp.Equal(property, want) {
 		t.Errorf("Organizations.CreateOrUpdateCustomProperty returned %+v, want %+v", property, want)
@@ -280,7 +287,7 @@ func TestOrganizationsService_ListCustomPropertyValues(t *testing.T) {
 		fmt.Fprint(w, `[{
 		"repository_id": 1296269,
 		"repository_name": "Hello-World",
-		"repository_full_name": "octocat/Hello-World",	
+		"repository_full_name": "octocat/Hello-World",
 		"properties": [
 		{
           "property_name": "environment",


### PR DESCRIPTION
Adds missing field `values_editable_by` for custom properties, as well as mirrors the field documentation directly from the API documentation for the other fields of custom properties.

Ref: https://docs.github.com/en/rest/orgs/custom-properties?apiVersion=2022-11-28#create-or-update-custom-properties-for-an-organization