### PR TITLE
Add CommitID, InReplyTo, and SubjectType to DraftReviewComment

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6510,6 +6510,22 @@ func (d *DraftReviewComment) GetBody() string {
 	return *d.Body
 }
 
+// GetCommitID returns the CommitID field if it's non-nil, zero value otherwise.
+func (d *DraftReviewComment) GetCommitID() string {
+	if d == nil || d.CommitID == nil {
+		return ""
+	}
+	return *d.CommitID
+}
+
+// GetInReplyTo returns the InReplyTo field if it's non-nil, zero value otherwise.
+func (d *DraftReviewComment) GetInReplyTo() int64 {
+	if d == nil || d.InReplyTo == nil {
+		return 0
+	}
+	return *d.InReplyTo
+}
+
 // GetLine returns the Line field if it's non-nil, zero value otherwise.
 func (d *DraftReviewComment) GetLine() int {
 	if d == nil || d.Line == nil {
@@ -6556,6 +6572,14 @@ func (d *DraftReviewComment) GetStartSide() string {
 		return ""
 	}
 	return *d.StartSide
+}
+
+// GetSubjectType returns the SubjectType field if it's non-nil, zero value otherwise.
+func (d *DraftReviewComment) GetSubjectType() string {
+	if d == nil || d.SubjectType == nil {
+		return ""
+	}
+	return *d.SubjectType
 }
 
 // GetRef returns the Ref field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -7613,6 +7613,26 @@ func TestDraftReviewComment_GetBody(tt *testing.T) {
 	d.GetBody()
 }
 
+func TestDraftReviewComment_GetCommitID(tt *testing.T) {
+	var zeroValue string
+	d := &DraftReviewComment{CommitID: &zeroValue}
+	d.GetCommitID()
+	d = &DraftReviewComment{}
+	d.GetCommitID()
+	d = nil
+	d.GetCommitID()
+}
+
+func TestDraftReviewComment_GetInReplyTo(tt *testing.T) {
+	var zeroValue int64
+	d := &DraftReviewComment{InReplyTo: &zeroValue}
+	d.GetInReplyTo()
+	d = &DraftReviewComment{}
+	d.GetInReplyTo()
+	d = nil
+	d.GetInReplyTo()
+}
+
 func TestDraftReviewComment_GetLine(tt *testing.T) {
 	var zeroValue int
 	d := &DraftReviewComment{Line: &zeroValue}
@@ -7671,6 +7691,16 @@ func TestDraftReviewComment_GetStartSide(tt *testing.T) {
 	d.GetStartSide()
 	d = nil
 	d.GetStartSide()
+}
+
+func TestDraftReviewComment_GetSubjectType(tt *testing.T) {
+	var zeroValue string
+	d := &DraftReviewComment{SubjectType: &zeroValue}
+	d.GetSubjectType()
+	d = &DraftReviewComment{}
+	d.GetSubjectType()
+	d = nil
+	d.GetSubjectType()
 }
 
 func TestEditBase_GetRef(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -388,15 +388,18 @@ func TestDiscussionComment_String(t *testing.T) {
 
 func TestDraftReviewComment_String(t *testing.T) {
 	v := DraftReviewComment{
-		Path:      String(""),
-		Position:  Int(0),
-		Body:      String(""),
-		StartSide: String(""),
-		Side:      String(""),
-		StartLine: Int(0),
-		Line:      Int(0),
+		Path:        String(""),
+		Position:    Int(0),
+		Body:        String(""),
+		CommitID:    String(""),
+		InReplyTo:   Int64(0),
+		SubjectType: String(""),
+		StartSide:   String(""),
+		Side:        String(""),
+		StartLine:   Int(0),
+		Line:        Int(0),
 	}
-	want := `github.DraftReviewComment{Path:"", Position:0, Body:"", StartSide:"", Side:"", StartLine:0, Line:0}`
+	want := `github.DraftReviewComment{Path:"", Position:0, Body:"", CommitID:"", InReplyTo:0, SubjectType:"", StartSide:"", Side:"", StartLine:0, Line:0}`
 	if got := v.String(); got != want {
 		t.Errorf("DraftReviewComment.String = %v, want %v", got, want)
 	}

--- a/github/pulls_reviews.go
+++ b/github/pulls_reviews.go
@@ -35,9 +35,12 @@ func (p PullRequestReview) String() string {
 
 // DraftReviewComment represents a comment part of the review.
 type DraftReviewComment struct {
-	Path     *string `json:"path,omitempty"`
-	Position *int    `json:"position,omitempty"`
-	Body     *string `json:"body,omitempty"`
+	Path        *string `json:"path,omitempty"`
+	Position    *int    `json:"position,omitempty"`
+	Body        *string `json:"body,omitempty"`
+	CommitID    *string `json:"commit_id,omitempty"`
+	InReplyTo   *int64  `json:"in_reply_to,omitempty"`
+	SubjectType *string `json:"subject_type,omitempty"`
 
 	// The new comfort-fade-preview fields
 	StartSide *string `json:"start_side,omitempty"`


### PR DESCRIPTION
closes #3168 

Made InReplyTo an int64 following the established type in https://pkg.go.dev/github.com/google/go-github/v62/github#PullRequestComment but happy to change if that or anything else is incorrect.