### PR TITLE
Add oauth2 TokenSource for application and installation token

### DIFF
--- a/example/go.mod
+++ b/example/go.mod
@@ -15,10 +15,12 @@ require (
 require (
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/golang-jwt/jwt/v4 v4.0.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-github/v41 v41.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/oauth2 v0.20.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/example/go.sum
+++ b/example/go.sum
@@ -10,6 +10,8 @@ github.com/gofri/go-github-ratelimit v1.0.3 h1:Ocs2jaYokZDzgvqaajX+g04dqFyVqL0JQ
 github.com/gofri/go-github-ratelimit v1.0.3/go.mod h1:OnCi5gV+hAG/LMR7llGhU7yHt44se9sYgKPnafoL7RY=
 github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
@@ -44,6 +46,8 @@ golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
 golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/oauth2 v0.20.0 h1:4mQdhULixXKP1rwYBW0vAijoXnkTG0BLCDRzfe1idMo=
+golang.org/x/oauth2 v0.20.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/example/newreposecretwithlibsodium/go.mod
+++ b/example/newreposecretwithlibsodium/go.mod
@@ -9,7 +9,11 @@ require (
 	github.com/google/go-github/v62 v62.0.0
 )
 
-require github.com/google/go-querystring v1.1.0 // indirect
+require (
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
+	golang.org/x/oauth2 v0.20.0 // indirect
+)
 
 // Use version at HEAD, not the latest published.
 replace github.com/google/go-github/v62 => ../..

--- a/example/newreposecretwithlibsodium/go.sum
+++ b/example/newreposecretwithlibsodium/go.sum
@@ -1,8 +1,12 @@
 github.com/GoKillers/libsodium-go v0.0.0-20171022220152-dd733721c3cb h1:ilqSFSbR1fq6x88heeHrvAqlg+ES+tZk2ZcaCmiH1gI=
 github.com/GoKillers/libsodium-go v0.0.0-20171022220152-dd733721c3cb/go.mod h1:72TQeEkiDH9QMXZa5nJJvZre0UjqqO67X2QEIoOwCRU=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+golang.org/x/oauth2 v0.20.0 h1:4mQdhULixXKP1rwYBW0vAijoXnkTG0BLCDRzfe1idMo=
+golang.org/x/oauth2 v0.20.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/github/oauth.go
+++ b/github/oauth.go
@@ -1,0 +1,91 @@
+package github
+
+import (
+	"crypto/rsa"
+	"errors"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v4"
+	"golang.org/x/oauth2"
+)
+
+// DefaultApplicationTokenExpiration is the default expiration time for the GitHub App token.
+// The expiration time of the JWT, after which it can't be used to request an installation token.
+// The time must be no more than 10 minutes into the future.
+const DefaultApplicationTokenExpiration = 10 * time.Minute
+
+// applicationTokenSource represents a GitHub App token.
+// https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
+type applicationTokenSource struct {
+	id         string
+	privateKey *rsa.PrivateKey
+	expiration time.Duration
+}
+
+// ApplicationTokenOpt is a functional option for ApplicationTokenSource.
+type ApplicationTokenOpt func(*applicationTokenSource)
+
+// WithApplicationTokenExpiration sets the expiration for the GitHub App token.
+// The expiration time of the JWT, after which it can't be used to request an installation token.
+// The time must be no more than 10 minutes into the future.
+func WithApplicationTokenExpiration(expiration time.Duration) ApplicationTokenOpt {
+	return func(a *applicationTokenSource) {
+		// The expiration time must be no more than 10 minutes into the future.
+		// Also, the expiration time must be greater than 0.
+		if expiration > DefaultApplicationTokenExpiration || expiration <= 0 {
+			expiration = DefaultApplicationTokenExpiration
+		}
+		a.expiration = expiration
+	}
+}
+
+// NewApplicationTokenSource creates a new GitHub App token source.
+// An application token is used to authenticate as a GitHub App.
+func NewApplicationTokenSource(id string, privateKey []byte, opts ...ApplicationTokenOpt) (oauth2.TokenSource, error) {
+	if id == "" {
+		return nil, errors.New("applicationID is required")
+	}
+
+	privKey, err := jwt.ParseRSAPrivateKeyFromPEM(privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	t := &applicationTokenSource{
+		id:         id,
+		privateKey: privKey,
+		expiration: DefaultApplicationTokenExpiration,
+	}
+
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	return t, nil
+}
+
+// Token creates a new GitHub App token.
+// The token is used to authenticate as a GitHub App.
+// Each token is valid for 10 minutes.
+func (t *applicationTokenSource) Token() (*oauth2.Token, error) {
+	// To protect against clock drift, set this 60 seconds in the past.
+	now := time.Now().Add(-60 * time.Second)
+	expiresAt := now.Add(t.expiration)
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.RegisteredClaims{
+		IssuedAt:  jwt.NewNumericDate(now),
+		ExpiresAt: jwt.NewNumericDate(expiresAt),
+		Issuer:    t.id,
+	})
+
+	tokenString, err := token.SignedString(t.privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &oauth2.Token{
+		AccessToken: tokenString,
+		TokenType:   "Bearer",
+		Expiry:      expiresAt,
+	}, nil
+}

--- a/github/oauth.go
+++ b/github/oauth.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt/v4"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"golang.org/x/oauth2"
 )
 

--- a/github/oauth_test.go
+++ b/github/oauth_test.go
@@ -115,7 +115,6 @@ func Test_installationTokenSource_Token(t *testing.T) {
 	type fields struct {
 		id   int64
 		src  oauth2.TokenSource
-		apps *AppsService
 		opts *InstallationTokenOptions
 	}
 	tests := []struct {

--- a/github/oauth_test.go
+++ b/github/oauth_test.go
@@ -68,6 +68,14 @@ func Test_applicationTokenSource_Token(t *testing.T) {
 				expiration: 5 * time.Minute,
 			},
 		},
+		{
+			name: "should use default expiration when expiration is greater than DefaultApplicationTokenExpiration",
+			fields: fields{
+				id:         "github-app-id",
+				privateKey: []byte(fakePrivateKey),
+				expiration: 15 * time.Minute,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/github/oauth_test.go
+++ b/github/oauth_test.go
@@ -1,0 +1,87 @@
+package github
+
+import (
+	"testing"
+	"time"
+)
+
+const fakePrivateKey = `-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQCBEJcaraGrNm68LstWKMbwalt+n0kaz1pYkBiz+vuFU2K2BkO8
+qrk2VXsJQKtLRJYBsEb5CzbgEPRQFoHbqo7lGlJlT8iLVpd0G0g5A9AfABtMnSCP
+B5onUg3qAy+G16EtsG+5xOddq3CGs3Au17l9xPCinrpjUts+yYDnUdgKhwIDAQAB
+AoGALJT8fRypEak1yw8m8dYYEgfLHwwKhpZFkP4FanYx17YcDOBRGaSnYZtZarLJ
++K/yWRb5DSHQjMmOevOrW6Oow/twOxgt/Qrdmtf7zJCBDuKeIdb5n2Eo1iCeD3jD
+LgdM376i0zfgGOeUQFSjGARmAdXPYuITorXPur+fwqQQosECQQD1dzzLtW63GQSa
+kO4zm8szLQQKtt22PiTMnqIEizb9GV8Ut96yRaqGXOPPW+WVK402OLyGxg8PxGQp
+Pi2+aplxAkEAhpqJMsE/Zedy5mTeyrZ4twDqIlRzkKOOEsPjyvR6zC5kEN3xtE32
+oxt2dh9oAINUabQRl4HsnYdvLkQZ/lKndwJBAIYktnXA3hNzuZ9aisJrZn2+IRJV
+4w4gIe4s1u/SwKdKgTqKTUpxZgJtqxV77Bg8J7y0/tpMTJjaQ76CO29vRBECQBZR
+u5w55PxNw4SmhzbPyPZ3ZVtp63u5Uw6TgssdfNssehU96B1ArDvhiuQNUx56qF2a
+qSwZNBXu5iWizziXlgMCQFodovtv4Wk5WI7BYADWXiHeTCwxuZ4Mp1Z3jD9E7Le6
+vvShKgb038c8wUyjsYYEmSI5SsdLAKrSqXsFKFMTKWg=
+-----END RSA PRIVATE KEY-----`
+
+func Test_applicationTokenSource_Token(t *testing.T) {
+	type fields struct {
+		id         string
+		privateKey []byte
+		expiration time.Duration
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "should error when applicationID is empty",
+			fields: fields{
+				id: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "should error when private key is invalid",
+			fields: fields{
+				id:         "github-app-id",
+				privateKey: []byte("invalid"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return a token",
+			fields: fields{
+				id:         "github-app-id",
+				privateKey: []byte(fakePrivateKey),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr, err := NewApplicationTokenSource(tt.fields.id, tt.fields.privateKey)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewApplicationTokenSource() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tr == nil {
+				return
+			}
+
+			got, err := tr.Token()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("applicationTokenSource.Token() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if got.AccessToken == "" {
+				t.Errorf("applicationTokenSource.Token() = %v, want non-empty AccessToken", got)
+			}
+			if got.TokenType != "Bearer" {
+				t.Errorf("applicationTokenSource.Token() = %v, want TokenType to be Bearer", got)
+			}
+			if got.Expiry.IsZero() {
+				t.Errorf("applicationTokenSource.Token() = %v, want non-zero Expiry", got)
+			}
+		})
+	}
+}

--- a/github/oauth_test.go
+++ b/github/oauth_test.go
@@ -60,10 +60,24 @@ func Test_applicationTokenSource_Token(t *testing.T) {
 				privateKey: []byte(fakePrivateKey),
 			},
 		},
+		{
+			name: "should return a token with custom expiration",
+			fields: fields{
+				id:         "github-app-id",
+				privateKey: []byte(fakePrivateKey),
+				expiration: 5 * time.Minute,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tr, err := NewApplicationTokenSource(tt.fields.id, tt.fields.privateKey)
+			var opts []ApplicationTokenOpt
+			if tt.fields.expiration != 0 {
+				opts = append(opts, WithApplicationTokenExpiration(tt.fields.expiration))
+			}
+
+			tr, err := NewApplicationTokenSource(tt.fields.id, tt.fields.privateKey, opts...)
+
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewApplicationTokenSource() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/google/go-github/v62
 
 require (
+	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-querystring v1.1.0
+	golang.org/x/oauth2 v0.20.0
 )
 
 go 1.21

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/google/go-github/v62
 
 require (
-	github.com/golang-jwt/jwt/v4 v4.5.0
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-querystring v1.1.0
 	golang.org/x/oauth2 v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
+github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+golang.org/x/oauth2 v0.20.0 h1:4mQdhULixXKP1rwYBW0vAijoXnkTG0BLCDRzfe1idMo=
+golang.org/x/oauth2 v0.20.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
-github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -16,12 +16,14 @@ require (
 require (
 	github.com/go-openapi/jsonpointer v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.8 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/invopop/yaml v0.2.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
+	golang.org/x/oauth2 v0.20.0 // indirect
 )
 
 // Use version at HEAD, not the latest published.

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -14,6 +14,8 @@ github.com/go-openapi/swag v0.22.8 h1:/9RjDSQ0vbFR+NyjGMkFTsA1IA0fmhKSThmfGZjicb
 github.com/go-openapi/swag v0.22.8/go.mod h1:6QT22icPLEqAM/z/TChgb4WAveCHF92+2gF0CNjHpPI=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -43,6 +45,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
+golang.org/x/oauth2 v0.20.0 h1:4mQdhULixXKP1rwYBW0vAijoXnkTG0BLCDRzfe1idMo=
+golang.org/x/oauth2 v0.20.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Related to #3178 

This PR introduces a new functionality to support Application and Installation token sources compatible with https://pkg.go.dev/golang.org/x/oauth2