### PR TITLE
Fix: Propagate context with DownloadContents

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -150,7 +150,11 @@ func (s *RepositoriesService) DownloadContents(ctx context.Context, owner, repo,
 				return nil, resp, fmt.Errorf("no download link found for %s", filepath)
 			}
 
-			dlResp, err := s.client.client.Get(*contents.DownloadURL)
+			dlReq, err := http.NewRequestWithContext(ctx, http.MethodGet, *contents.DownloadURL, nil)
+			if err != nil {
+				return nil, resp, err
+			}
+			dlResp, err := s.client.client.Do(dlReq)
 			if err != nil {
 				return nil, &Response{Response: dlResp}, err
 			}
@@ -188,7 +192,11 @@ func (s *RepositoriesService) DownloadContentsWithMeta(ctx context.Context, owne
 				return nil, contents, resp, fmt.Errorf("no download link found for %s", filepath)
 			}
 
-			dlResp, err := s.client.client.Get(*contents.DownloadURL)
+			dlReq, err := http.NewRequestWithContext(ctx, http.MethodGet, *contents.DownloadURL, nil)
+			if err != nil {
+				return nil, contents, resp, err
+			}
+			dlResp, err := s.client.client.Do(dlReq)
 			if err != nil {
 				return nil, contents, &Response{Response: dlResp}, err
 			}


### PR DESCRIPTION
Main motivation is tracing as this can be the most time consuming operation.