### PR TITLE
Update repo permission level struct

### DIFF
--- a/github/repos_collaborators.go
+++ b/github/repos_collaborators.go
@@ -99,6 +99,8 @@ type RepositoryPermissionLevel struct {
 	Permission *string `json:"permission,omitempty"`
 
 	User *User `json:"user,omitempty"`
+
+	RoleName *string `json:"role_name,omitempty"`
 }
 
 // GetPermissionLevel retrieves the specific permission level a collaborator has for a given repository.


### PR DESCRIPTION
I am currently using this API to fetch what role does a user have on a repository. AFAICS, RepositoryPermissionLevel struct is missing role_name which is provided by the API (https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#get-repository-permissions-for-a-user). Due, to this I am unable to use the library. This PR introduces the field within the RepositoryPermissionLevel struct