### PR TITLE
Repo property ruleset conditions

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -20878,6 +20878,14 @@ func (r *RulesetConditions) GetRepositoryName() *RulesetRepositoryNamesCondition
 	return r.RepositoryName
 }
 
+// GetRepositoryProperty returns the RepositoryProperty field.
+func (r *RulesetConditions) GetRepositoryProperty() *RulesetRepositoryPropertyConditionParameters {
+	if r == nil {
+		return nil
+	}
+	return r.RepositoryProperty
+}
+
 // GetHRef returns the HRef field if it's non-nil, zero value otherwise.
 func (r *RulesetLink) GetHRef() string {
 	if r == nil || r.HRef == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -24262,6 +24262,13 @@ func TestRulesetConditions_GetRepositoryName(tt *testing.T) {
 	r.GetRepositoryName()
 }
 
+func TestRulesetConditions_GetRepositoryProperty(tt *testing.T) {
+	r := &RulesetConditions{}
+	r.GetRepositoryProperty()
+	r = nil
+	r.GetRepositoryProperty()
+}
+
 func TestRulesetLink_GetHRef(tt *testing.T) {
 	var zeroValue string
 	r := &RulesetLink{HRef: &zeroValue}

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -48,12 +48,25 @@ type RulesetRepositoryIDsConditionParameters struct {
 	RepositoryIDs []int64 `json:"repository_ids,omitempty"`
 }
 
+// RulesetRepositoryPropertyTargetParameters represents a repository_property name and values to be used for targetting.
+type RulesetRepositoryPropertyTargetParameters struct {
+	Name   string   `json:"name"`
+	Values []string `json:"property_values"`
+}
+
+// RulesetRepositoryPropertyConditionParameters represents the conditions object for repository_property.
+type RulesetRepositoryPropertyConditionParameters struct {
+	Include []RulesetRepositoryPropertyTargetParameters `json:"include,omitempty"`
+	Exclude []RulesetRepositoryPropertyTargetParameters `json:"exclude,omitempty"`
+}
+
 // RulesetConditions represents the conditions object in a ruleset.
-// Set either RepositoryName or RepositoryID, not both.
+// Set either RepositoryName or RepositoryID or RepositoryProperty, not more than one.
 type RulesetConditions struct {
-	RefName        *RulesetRefConditionParameters             `json:"ref_name,omitempty"`
-	RepositoryName *RulesetRepositoryNamesConditionParameters `json:"repository_name,omitempty"`
-	RepositoryID   *RulesetRepositoryIDsConditionParameters   `json:"repository_id,omitempty"`
+	RefName            *RulesetRefConditionParameters                `json:"ref_name,omitempty"`
+	RepositoryName     *RulesetRepositoryNamesConditionParameters    `json:"repository_name,omitempty"`
+	RepositoryID       *RulesetRepositoryIDsConditionParameters      `json:"repository_id,omitempty"`
+	RepositoryProperty *RulesetRepositoryPropertyConditionParameters `json:"repository_property,omitempty"`
 }
 
 // RulePatternParameters represents the rule pattern parameters.

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -48,7 +48,7 @@ type RulesetRepositoryIDsConditionParameters struct {
 	RepositoryIDs []int64 `json:"repository_ids,omitempty"`
 }
 
-// RulesetRepositoryPropertyTargetParameters represents a repository_property name and values to be used for targetting.
+// RulesetRepositoryPropertyTargetParameters represents a repository_property name and values to be used for targeting.
 type RulesetRepositoryPropertyTargetParameters struct {
 	Name   string   `json:"name"`
 	Values []string `json:"property_values"`


### PR DESCRIPTION
Github recently introduced Repository Properties. Rulesets can include or exclude repositories based on these properties.
The PR implements those conditions.

According to Github API docs: 
https://docs.github.com/en/rest/orgs/rules?apiVersion=2022-11-28#create-an-organization-repository-ruleset

Changed comment on `RulesetConditions` struct to say either use Name, ID OR repo property. The docs have not been super clear on this but i assume so because when creating rulesets trough UI you can either select repositories based on name or on property.

Please let me know what you think!