### PR TITLE
feat!: Replace ListCursorOptions with ListIDPGroupsOptions in TeamsService.ListIDPGroupsInOrganization

### DIFF
--- a/github/teams.go
+++ b/github/teams.go
@@ -796,6 +796,18 @@ func (s *TeamsService) RemoveTeamProjectBySlug(ctx context.Context, org, slug st
 	return s.client.Do(ctx, req, nil)
 }
 
+// ListIDPGroupsOptions specifies the optional parameters to the ListIDPGroupsInOrganization method.
+type ListIDPGroupsOptions struct {
+	// The number of results to include per page.
+	PerPage int `url:"per_page,omitempty"`
+
+	// Page token.
+	Page string `url:"page,omitempty"`
+
+	// Filters the results to return only those that begin with the value specified by this parameter.
+	Query string `url:"q,omitempty"`
+}
+
 // IDPGroupList represents a list of external identity provider (IDP) groups.
 type IDPGroupList struct {
 	Groups []*IDPGroup `json:"groups"`
@@ -813,7 +825,7 @@ type IDPGroup struct {
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/teams/team-sync#list-idp-groups-for-an-organization
 //
 //meta:operation GET /orgs/{org}/team-sync/groups
-func (s *TeamsService) ListIDPGroupsInOrganization(ctx context.Context, org string, opts *ListCursorOptions) (*IDPGroupList, *Response, error) {
+func (s *TeamsService) ListIDPGroupsInOrganization(ctx context.Context, org string, opts *ListIDPGroupsOptions) (*IDPGroupList, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/team-sync/groups", org)
 	u, err := addOptions(u, opts)
 	if err != nil {

--- a/github/teams.go
+++ b/github/teams.go
@@ -798,14 +798,10 @@ func (s *TeamsService) RemoveTeamProjectBySlug(ctx context.Context, org, slug st
 
 // ListIDPGroupsOptions specifies the optional parameters to the ListIDPGroupsInOrganization method.
 type ListIDPGroupsOptions struct {
-	// The number of results to include per page.
-	PerPage int `url:"per_page,omitempty"`
-
-	// Page token.
-	Page string `url:"page,omitempty"`
-
 	// Filters the results to return only those that begin with the value specified by this parameter.
 	Query string `url:"q,omitempty"`
+
+	ListCursorOptions
 }
 
 // IDPGroupList represents a list of external identity provider (IDP) groups.

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -1302,11 +1302,15 @@ func TestTeamsService_ListIDPGroupsInOrganization(t *testing.T) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{
 			"page": "url-encoded-next-page-token",
+			"q":    "n",
 		})
 		fmt.Fprint(w, `{"groups": [{"group_id": "1",  "group_name": "n", "group_description": "d"}]}`)
 	})
 
-	opt := &ListCursorOptions{Page: "url-encoded-next-page-token"}
+	opt := &ListIDPGroupsOptions{
+		Query: "n",
+		Page:  "url-encoded-next-page-token",
+	}
 	ctx := context.Background()
 	groups, _, err := client.Teams.ListIDPGroupsInOrganization(ctx, "o", opt)
 	if err != nil {

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -1308,8 +1308,8 @@ func TestTeamsService_ListIDPGroupsInOrganization(t *testing.T) {
 	})
 
 	opt := &ListIDPGroupsOptions{
-		Query: "n",
-		Page:  "url-encoded-next-page-token",
+		Query:             "n",
+		ListCursorOptions: ListCursorOptions{Page: "url-encoded-next-page-token"},
 	}
 	ctx := context.Background()
 	groups, _, err := client.Teams.ListIDPGroupsInOrganization(ctx, "o", opt)


### PR DESCRIPTION
Fixes #3196.

BREAKING CHANGE: Replace `ListCursorOptions` with `ListIDPGroupsOptions` in `TeamsService.ListIDPGroupsInOrganization`

I followed the template of this PR, fixing a similar issue: https://github.com/google/go-github/pull/3094. 

Let me know if there is a better way to handle this. And I'm open to better naming suggestions.