### PR TITLE
feat!: Add support for multi-select Custom Properties

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -4766,14 +4766,6 @@ func (c *CustomProperty) GetValuesEditableBy() string {
 	return *c.ValuesEditableBy
 }
 
-// GetValue returns the Value field if it's non-nil, zero value otherwise.
-func (c *CustomPropertyValue) GetValue() string {
-	if c == nil || c.Value == nil {
-		return ""
-	}
-	return *c.Value
-}
-
 // GetBaseRole returns the BaseRole field if it's non-nil, zero value otherwise.
 func (c *CustomRepoRoles) GetBaseRole() string {
 	if c == nil || c.BaseRole == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -5613,16 +5613,6 @@ func TestCustomProperty_GetValuesEditableBy(tt *testing.T) {
 	c.GetValuesEditableBy()
 }
 
-func TestCustomPropertyValue_GetValue(tt *testing.T) {
-	var zeroValue string
-	c := &CustomPropertyValue{Value: &zeroValue}
-	c.GetValue()
-	c = &CustomPropertyValue{}
-	c.GetValue()
-	c = nil
-	c.GetValue()
-}
-
 func TestCustomRepoRoles_GetBaseRole(tt *testing.T) {
 	var zeroValue string
 	c := &CustomRepoRoles{BaseRole: &zeroValue}

--- a/github/orgs_properties.go
+++ b/github/orgs_properties.go
@@ -7,6 +7,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
@@ -40,8 +41,42 @@ type RepoCustomPropertyValue struct {
 
 // CustomPropertyValue represents a custom property value.
 type CustomPropertyValue struct {
-	PropertyName string  `json:"property_name"`
-	Value        *string `json:"value,omitempty"`
+	PropertyName string      `json:"property_name"`
+	Value        interface{} `json:"value,omitempty"`
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// This helps us handle the fact that Value can be either a string, []string, or nil.
+func (cpv *CustomPropertyValue) UnmarshalJSON(data []byte) error {
+	type aliasCustomPropertyValue CustomPropertyValue
+	aux := &struct {
+		*aliasCustomPropertyValue
+	}{
+		aliasCustomPropertyValue: (*aliasCustomPropertyValue)(cpv),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	switch v := aux.Value.(type) {
+	case nil:
+		cpv.Value = nil
+	case string:
+		cpv.Value = v
+	case []interface{}:
+		strSlice := make([]string, len(v))
+		for i, item := range v {
+			if str, ok := item.(string); ok {
+				strSlice[i] = str
+			} else {
+				return fmt.Errorf("non-string value in string array")
+			}
+		}
+		cpv.Value = strSlice
+	default:
+		return fmt.Errorf("unexpected value type: %T", v)
+	}
+	return nil
 }
 
 // GetAllCustomProperties gets all custom properties that are defined for the specified organization.

--- a/github/orgs_properties_test.go
+++ b/github/orgs_properties_test.go
@@ -296,6 +296,14 @@ func TestOrganizationsService_ListCustomPropertyValues(t *testing.T) {
         {
           "property_name": "service",
           "value": "web"
+        },
+        {
+          "property_name": "languages",
+          "value": ["Go", "JavaScript"]
+        },
+        {
+          "property_name": "null_property",
+          "value": null
         }
 		]
         }]`)
@@ -318,11 +326,19 @@ func TestOrganizationsService_ListCustomPropertyValues(t *testing.T) {
 			Properties: []*CustomPropertyValue{
 				{
 					PropertyName: "environment",
-					Value:        String("production"),
+					Value:        "production",
 				},
 				{
 					PropertyName: "service",
-					Value:        String("web"),
+					Value:        "web",
+				},
+				{
+					PropertyName: "languages",
+					Value:        []string{"Go", "JavaScript"},
+				},
+				{
+					PropertyName: "null_property",
+					Value:        nil,
 				},
 			},
 		},

--- a/github/repos_properties_test.go
+++ b/github/repos_properties_test.go
@@ -28,6 +28,14 @@ func TestRepositoriesService_GetAllCustomPropertyValues(t *testing.T) {
         {
           "property_name": "service",
           "value": "web"
+        },
+        {
+          "property_name": "languages",
+          "value": ["Go", "JavaScript"]
+        },
+        {
+          "property_name": "null_property",
+          "value": null
         }
 		]`)
 	})
@@ -41,11 +49,19 @@ func TestRepositoriesService_GetAllCustomPropertyValues(t *testing.T) {
 	want := []*CustomPropertyValue{
 		{
 			PropertyName: "environment",
-			Value:        String("production"),
+			Value:        "production",
 		},
 		{
 			PropertyName: "service",
-			Value:        String("web"),
+			Value:        "web",
+		},
+		{
+			PropertyName: "languages",
+			Value:        []string{"Go", "JavaScript"},
+		},
+		{
+			PropertyName: "null_property",
+			Value:        nil,
 		},
 	}
 
@@ -77,7 +93,7 @@ func TestRepositoriesService_CreateOrUpdateCustomProperties(t *testing.T) {
 	RepoCustomProperty := []*CustomPropertyValue{
 		{
 			PropertyName: "environment",
-			Value:        String("production"),
+			Value:        "production",
 		},
 	}
 	_, err := client.Repositories.CreateOrUpdateCustomProperties(ctx, "usr", "r", RepoCustomProperty)


### PR DESCRIPTION
Fixes #3198.

BREAKING CHANGE: `CustomPropertyValue.Value` is changed from `*string` to `interface{}` to support `string` and `[]string` values.

So the problem here is that the GitHub custom properties `value` can come in either as a `string` (for all non `multi_select` properties), or as a `[]string` in a `multi_select` property.

The issue is happening because we were trying to unmarshal it but always expecting a `string` for the Value.

My solution was to make value an `interface{}` type that implements a `UnmarshalJSON` to handle both scenarios. While this works, we end up losing the auto generated `GetValue()` accessor. Another thing I was unsure is that I saw on other places and on the tests for this that we use a pointer to the value, but I changed it to the value itself on the Unmarshal call since we lose the accessor, not sure if this is correct.

Another solution I played with was using `json.RawMessage`, I could not make it fully work (I can give it another try), but at least we did lose the auto generated `GetValue` accessor there, would this be a more adequate solution?