### PR TITLE
Added iterators section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,25 @@ for {
 }
 ```
 
+#### Iterators (**experimental**)
+
+Go v1.23 introduces the new `iter` package.  
+
+With the `enrichman/gh-iter` package, it is possible to create iterators for `go-github`. The iterator will handle pagination for you, looping through all the available results.
+
+```go
+client := github.NewClient(nil)
+var allRepos []*github.Repository
+
+// create an iterator and start looping through all the results
+repos := ghiter.NewFromFn1(client.Repositories.ListByOrg, "github")
+for repo := range repos.All() {
+	allRepos = append(allRepos, repo)
+}
+```
+
+For complete usage of `enrichman/gh-iter`, see the full [package docs](https://github.com/enrichman/gh-iter).
+
 ### Webhooks ###
 
 `go-github` provides structs for almost all [GitHub webhook events][] as well as functions to validate them and unmarshal JSON payloads from `http.Request` structs.


### PR DESCRIPTION
Fix: https://github.com/google/go-github/issues/3209

As suggested in the issue, this PR adds in the README some information about how to use iterators with the [enrichman/gh-iter](https://github.com/enrichman/gh-iter) package, with a small code snippet.

The feature is still experimental, because it is not available in the standard library yet (Go 1.23 is planned for [August 2024](https://tip.golang.org/doc/go1.23)).