### PR TITLE
Update CustomOrgRoles and CustomRepoRoles to include all fields returned by the GitHub API

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -4702,6 +4702,22 @@ func (c *CustomDeploymentProtectionRuleRequest) GetIntegrationID() int64 {
 	return *c.IntegrationID
 }
 
+// GetBaseRole returns the BaseRole field if it's non-nil, zero value otherwise.
+func (c *CustomOrgRoles) GetBaseRole() string {
+	if c == nil || c.BaseRole == nil {
+		return ""
+	}
+	return *c.BaseRole
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (c *CustomOrgRoles) GetCreatedAt() Timestamp {
+	if c == nil || c.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *c.CreatedAt
+}
+
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
 func (c *CustomOrgRoles) GetDescription() string {
 	if c == nil || c.Description == nil {
@@ -4724,6 +4740,30 @@ func (c *CustomOrgRoles) GetName() string {
 		return ""
 	}
 	return *c.Name
+}
+
+// GetOrg returns the Org field.
+func (c *CustomOrgRoles) GetOrg() *Organization {
+	if c == nil {
+		return nil
+	}
+	return c.Org
+}
+
+// GetSource returns the Source field if it's non-nil, zero value otherwise.
+func (c *CustomOrgRoles) GetSource() string {
+	if c == nil || c.Source == nil {
+		return ""
+	}
+	return *c.Source
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (c *CustomOrgRoles) GetUpdatedAt() Timestamp {
+	if c == nil || c.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *c.UpdatedAt
 }
 
 // GetDefaultValue returns the DefaultValue field if it's non-nil, zero value otherwise.
@@ -4782,6 +4822,14 @@ func (c *CustomRepoRoles) GetBaseRole() string {
 	return *c.BaseRole
 }
 
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (c *CustomRepoRoles) GetCreatedAt() Timestamp {
+	if c == nil || c.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *c.CreatedAt
+}
+
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
 func (c *CustomRepoRoles) GetDescription() string {
 	if c == nil || c.Description == nil {
@@ -4804,6 +4852,22 @@ func (c *CustomRepoRoles) GetName() string {
 		return ""
 	}
 	return *c.Name
+}
+
+// GetOrg returns the Org field.
+func (c *CustomRepoRoles) GetOrg() *Organization {
+	if c == nil {
+		return nil
+	}
+	return c.Org
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (c *CustomRepoRoles) GetUpdatedAt() Timestamp {
+	if c == nil || c.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *c.UpdatedAt
 }
 
 // GetQuerySuite returns the QuerySuite field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -5533,6 +5533,26 @@ func TestCustomDeploymentProtectionRuleRequest_GetIntegrationID(tt *testing.T) {
 	c.GetIntegrationID()
 }
 
+func TestCustomOrgRoles_GetBaseRole(tt *testing.T) {
+	var zeroValue string
+	c := &CustomOrgRoles{BaseRole: &zeroValue}
+	c.GetBaseRole()
+	c = &CustomOrgRoles{}
+	c.GetBaseRole()
+	c = nil
+	c.GetBaseRole()
+}
+
+func TestCustomOrgRoles_GetCreatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	c := &CustomOrgRoles{CreatedAt: &zeroValue}
+	c.GetCreatedAt()
+	c = &CustomOrgRoles{}
+	c.GetCreatedAt()
+	c = nil
+	c.GetCreatedAt()
+}
+
 func TestCustomOrgRoles_GetDescription(tt *testing.T) {
 	var zeroValue string
 	c := &CustomOrgRoles{Description: &zeroValue}
@@ -5561,6 +5581,33 @@ func TestCustomOrgRoles_GetName(tt *testing.T) {
 	c.GetName()
 	c = nil
 	c.GetName()
+}
+
+func TestCustomOrgRoles_GetOrg(tt *testing.T) {
+	c := &CustomOrgRoles{}
+	c.GetOrg()
+	c = nil
+	c.GetOrg()
+}
+
+func TestCustomOrgRoles_GetSource(tt *testing.T) {
+	var zeroValue string
+	c := &CustomOrgRoles{Source: &zeroValue}
+	c.GetSource()
+	c = &CustomOrgRoles{}
+	c.GetSource()
+	c = nil
+	c.GetSource()
+}
+
+func TestCustomOrgRoles_GetUpdatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	c := &CustomOrgRoles{UpdatedAt: &zeroValue}
+	c.GetUpdatedAt()
+	c = &CustomOrgRoles{}
+	c.GetUpdatedAt()
+	c = nil
+	c.GetUpdatedAt()
 }
 
 func TestCustomProperty_GetDefaultValue(tt *testing.T) {
@@ -5633,6 +5680,16 @@ func TestCustomRepoRoles_GetBaseRole(tt *testing.T) {
 	c.GetBaseRole()
 }
 
+func TestCustomRepoRoles_GetCreatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	c := &CustomRepoRoles{CreatedAt: &zeroValue}
+	c.GetCreatedAt()
+	c = &CustomRepoRoles{}
+	c.GetCreatedAt()
+	c = nil
+	c.GetCreatedAt()
+}
+
 func TestCustomRepoRoles_GetDescription(tt *testing.T) {
 	var zeroValue string
 	c := &CustomRepoRoles{Description: &zeroValue}
@@ -5661,6 +5718,23 @@ func TestCustomRepoRoles_GetName(tt *testing.T) {
 	c.GetName()
 	c = nil
 	c.GetName()
+}
+
+func TestCustomRepoRoles_GetOrg(tt *testing.T) {
+	c := &CustomRepoRoles{}
+	c.GetOrg()
+	c = nil
+	c.GetOrg()
+}
+
+func TestCustomRepoRoles_GetUpdatedAt(tt *testing.T) {
+	var zeroValue Timestamp
+	c := &CustomRepoRoles{UpdatedAt: &zeroValue}
+	c.GetUpdatedAt()
+	c = &CustomRepoRoles{}
+	c.GetUpdatedAt()
+	c = nil
+	c.GetUpdatedAt()
 }
 
 func TestDefaultSetupConfiguration_GetQuerySuite(tt *testing.T) {

--- a/github/orgs_custom_roles.go
+++ b/github/orgs_custom_roles.go
@@ -18,10 +18,15 @@ type OrganizationCustomRoles struct {
 
 // CustomOrgRoles represents custom organization role available in specified organization.
 type CustomOrgRoles struct {
-	ID          *int64   `json:"id,omitempty"`
-	Name        *string  `json:"name,omitempty"`
-	Description *string  `json:"description,omitempty"`
-	Permissions []string `json:"permissions,omitempty"`
+	ID          *int64        `json:"id,omitempty"`
+	Name        *string       `json:"name,omitempty"`
+	Description *string       `json:"description,omitempty"`
+	Permissions []string      `json:"permissions,omitempty"`
+	Org         *Organization `json:"organization,omitempty"`
+	CreatedAt   *Timestamp    `json:"created_at,omitempty"`
+	UpdatedAt   *Timestamp    `json:"updated_at,omitempty"`
+	Source      *string       `json:"source,omitempty"`
+	BaseRole    *string       `json:"base_role,omitempty"`
 }
 
 // OrganizationCustomRepoRoles represents custom repository roles available in specified organization.
@@ -34,11 +39,14 @@ type OrganizationCustomRepoRoles struct {
 // See https://docs.github.com/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization
 // for more information.
 type CustomRepoRoles struct {
-	ID          *int64   `json:"id,omitempty"`
-	Name        *string  `json:"name,omitempty"`
-	Description *string  `json:"description,omitempty"`
-	BaseRole    *string  `json:"base_role,omitempty"`
-	Permissions []string `json:"permissions,omitempty"`
+	ID          *int64        `json:"id,omitempty"`
+	Name        *string       `json:"name,omitempty"`
+	Description *string       `json:"description,omitempty"`
+	BaseRole    *string       `json:"base_role,omitempty"`
+	Permissions []string      `json:"permissions,omitempty"`
+	Org         *Organization `json:"organization,omitempty"`
+	CreatedAt   *Timestamp    `json:"created_at,omitempty"`
+	UpdatedAt   *Timestamp    `json:"updated_at,omitempty"`
 }
 
 // CreateOrUpdateOrgRoleOptions represents options required to create or update a custom organization role.

--- a/github/orgs_custom_roles_test.go
+++ b/github/orgs_custom_roles_test.go
@@ -39,7 +39,7 @@ func TestOrganizationsService_ListRoles(t *testing.T) {
 					"email": "e"
 				},
 				"created_at": "2024-07-21T19:33:08Z",
-			    "updated_at": "2024-07-21T19:33:08Z",
+				"updated_at": "2024-07-21T19:33:08Z",
 				"source": "Organization",
 				"base_role": "admin"
 			}
@@ -237,7 +237,7 @@ func TestOrganizationsService_ListCustomRepoRoles(t *testing.T) {
 					"email": "e"
 				},
 				"created_at": "2024-07-21T19:33:08Z",
-			    "updated_at": "2024-07-21T19:33:08Z"
+				"updated_at": "2024-07-21T19:33:08Z"
 			}
 		  ]
 		}`)

--- a/github/orgs_custom_roles_test.go
+++ b/github/orgs_custom_roles_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -20,7 +21,30 @@ func TestOrganizationsService_ListRoles(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/organization-roles", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"total_count": 1, "roles": [{ "id": 1, "name": "Auditor", "permissions": ["read_audit_logs"]}]}`)
+		fmt.Fprint(w, `{"total_count": 1, "roles": [
+			{
+				"id": 1,
+				"name": "Auditor",
+				"permissions": ["read_audit_logs"],
+				"organization": {
+					"login": "l",
+					"id": 1,
+					"node_id": "n",
+					"avatar_url": "a",
+					"html_url": "h",
+					"name": "n",
+					"company": "c",
+					"blog": "b",
+					"location": "l",
+					"email": "e"
+				},
+				"created_at": "2024-07-21T19:33:08Z",
+			    "updated_at": "2024-07-21T19:33:08Z",
+				"source": "Organization",
+				"base_role": "admin"
+			}
+			]
+		}`)
 	})
 
 	ctx := context.Background()
@@ -29,7 +53,32 @@ func TestOrganizationsService_ListRoles(t *testing.T) {
 		t.Errorf("Organizations.ListRoles returned error: %v", err)
 	}
 
-	want := &OrganizationCustomRoles{TotalCount: Int(1), CustomRepoRoles: []*CustomOrgRoles{{ID: Int64(1), Name: String("Auditor"), Permissions: []string{"read_audit_logs"}}}}
+	want := &OrganizationCustomRoles{
+		TotalCount: Int(1),
+		CustomRepoRoles: []*CustomOrgRoles{
+			{
+				ID:          Int64(1),
+				Name:        String("Auditor"),
+				Permissions: []string{"read_audit_logs"},
+				Org: &Organization{
+					Login:     String("l"),
+					ID:        Int64(1),
+					NodeID:    String("n"),
+					AvatarURL: String("a"),
+					HTMLURL:   String("h"),
+					Name:      String("n"),
+					Company:   String("c"),
+					Blog:      String("b"),
+					Location:  String("l"),
+					Email:     String("e"),
+				},
+				CreatedAt: &Timestamp{time.Date(2024, time.July, 21, 19, 33, 8, 0, time.UTC)},
+				UpdatedAt: &Timestamp{time.Date(2024, time.July, 21, 19, 33, 8, 0, time.UTC)},
+				Source:    String("Organization"),
+				BaseRole:  String("admin"),
+			},
+		},
+	}
 	if !cmp.Equal(apps, want) {
 		t.Errorf("Organizations.ListRoles returned %+v, want %+v", apps, want)
 	}
@@ -169,7 +218,29 @@ func TestOrganizationsService_ListCustomRepoRoles(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/custom-repository-roles", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"total_count": 1, "custom_roles": [{ "id": 1, "name": "Developer", "base_role": "write", "permissions": ["delete_alerts_code_scanning"]}]}`)
+		fmt.Fprint(w, `{"total_count": 1, "custom_roles": [
+			{
+				"id": 1,
+				"name": "Developer",
+				"base_role": "write",
+				"permissions": ["delete_alerts_code_scanning"],
+				"organization": {
+					"login": "l",
+					"id": 1,
+					"node_id": "n",
+					"avatar_url": "a",
+					"html_url": "h",
+					"name": "n",
+					"company": "c",
+					"blog": "b",
+					"location": "l",
+					"email": "e"
+				},
+				"created_at": "2024-07-21T19:33:08Z",
+			    "updated_at": "2024-07-21T19:33:08Z"
+			}
+		  ]
+		}`)
 	})
 
 	ctx := context.Background()
@@ -178,7 +249,31 @@ func TestOrganizationsService_ListCustomRepoRoles(t *testing.T) {
 		t.Errorf("Organizations.ListCustomRepoRoles returned error: %v", err)
 	}
 
-	want := &OrganizationCustomRepoRoles{TotalCount: Int(1), CustomRepoRoles: []*CustomRepoRoles{{ID: Int64(1), Name: String("Developer"), BaseRole: String("write"), Permissions: []string{"delete_alerts_code_scanning"}}}}
+	want := &OrganizationCustomRepoRoles{
+		TotalCount: Int(1),
+		CustomRepoRoles: []*CustomRepoRoles{
+			{
+				ID:          Int64(1),
+				Name:        String("Developer"),
+				BaseRole:    String("write"),
+				Permissions: []string{"delete_alerts_code_scanning"},
+				Org: &Organization{
+					Login:     String("l"),
+					ID:        Int64(1),
+					NodeID:    String("n"),
+					AvatarURL: String("a"),
+					HTMLURL:   String("h"),
+					Name:      String("n"),
+					Company:   String("c"),
+					Blog:      String("b"),
+					Location:  String("l"),
+					Email:     String("e"),
+				},
+				CreatedAt: &Timestamp{time.Date(2024, time.July, 21, 19, 33, 8, 0, time.UTC)},
+				UpdatedAt: &Timestamp{time.Date(2024, time.July, 21, 19, 33, 8, 0, time.UTC)},
+			},
+		},
+	}
 	if !cmp.Equal(apps, want) {
 		t.Errorf("Organizations.ListCustomRepoRoles returned %+v, want %+v", apps, want)
 	}


### PR DESCRIPTION
Fixes: #3214.

`CustomRepoRoles` and `CustomOrgRoles` structures have missing fields, due to which the part of the response from the github API is missed.

Updating the structures as per the github API schema defined.