### PR TITLE
feat!: Add support for creating GitHub App with organizations

### DIFF
--- a/scrape/apps.go
+++ b/scrape/apps.go
@@ -149,11 +149,11 @@ type AppConfig struct {
 }
 
 // CreateApp creates a new GitHub App with the given manifest configuration.
-func (c *Client) CreateApp(m *AppManifest, accType *AppConfig) (*http.Response, error) {
+func (c *Client) CreateApp(m *AppManifest, appConfig *AppConfig) (*http.Response, error) {
 	path := "/settings/apps/new"
 
-	if accType.OwnerType == "organizational" {
-		path = fmt.Sprintf("/organizations/%s/settings/apps/new", accType.OrgName)
+	if appConfig.OwnerType == "organizational" {
+		path = fmt.Sprintf("/organizations/%s/settings/apps/new", appConfig.OrgName)
 	}
 
 	u, err := c.baseURL.Parse(path)
@@ -162,7 +162,6 @@ func (c *Client) CreateApp(m *AppManifest, accType *AppConfig) (*http.Response, 
 	}
 
 	body, err := json.Marshal(map[string]*AppManifest{"manifest": m})
-
 	if err != nil {
 		return nil, err
 	}

--- a/scrape/apps.go
+++ b/scrape/apps.go
@@ -148,12 +148,11 @@ type AppConfig struct {
 	OrgName string
 }
 
-// CreateApp creates a new GitHub App with the given manifest configuration.
-func (c *Client) CreateApp(m *AppManifest, appConfig *AppConfig) (*http.Response, error) {
+func (c *Client) CreateApp(m *AppManifest, ac *AppConfig) (*http.Response, error) {
 	path := "/settings/apps/new"
 
-	if appConfig.OwnerType == "organizational" {
-		path = fmt.Sprintf("/organizations/%s/settings/apps/new", appConfig.OrgName)
+	if ac.OwnerType == "organizational" {
+		path = fmt.Sprintf("/organizations/%s/settings/apps/new", ac.OrgName)
 	}
 
 	u, err := c.baseURL.Parse(path)

--- a/scrape/apps.go
+++ b/scrape/apps.go
@@ -152,7 +152,7 @@ func (c *Client) CreateApp(m *AppManifest, ac *AppConfig) (*http.Response, error
 	url := "/settings/apps/new"
 
 	if ac.OwnerType == "organizational" {
-		path = fmt.Sprintf("/organizations/%s/settings/apps/new", ac.OrgName)
+		path = fmt.Sprintf("/organizations/%v/settings/apps/new", ac.OrgName)
 	}
 
 	u, err := c.baseURL.Parse(path)

--- a/scrape/apps.go
+++ b/scrape/apps.go
@@ -149,7 +149,7 @@ type AppConfig struct {
 }
 
 func (c *Client) CreateApp(m *AppManifest, ac *AppConfig) (*http.Response, error) {
-	path := "/settings/apps/new"
+	url := "/settings/apps/new"
 
 	if ac.OwnerType == "organizational" {
 		path = fmt.Sprintf("/organizations/%s/settings/apps/new", ac.OrgName)

--- a/scrape/apps.go
+++ b/scrape/apps.go
@@ -134,28 +134,16 @@ type AppManifest struct {
 	DefaultPermissions *github.InstallationPermissions `json:"default_permissions,omitempty"`
 }
 
-type OwnerType string
-
-const (
-	OwnerTypePersonal     OwnerType = "personal"
-	OwnerTypeOrganization OwnerType = "organizational"
-)
-
-type AppConfig struct {
-	// OwnerType specifies the type of GitHub account owner (personal or organizational).
-	OwnerType OwnerType
-	// OrgName is the name of the organization if the OwnerType is organizational.
-	OrgName string
-}
-
-func (c *Client) CreateApp(m *AppManifest, ac *AppConfig) (*http.Response, error) {
+// CreateApp creates a new GitHub App with the given manifest configuration.
+// orgName is optional, and if provided, the App will be created within the specified organization.
+func (c *Client) CreateApp(m *AppManifest, orgName string) (*http.Response, error) {
 	url := "/settings/apps/new"
 
-	if ac.OwnerType == "organizational" {
-		path = fmt.Sprintf("/organizations/%v/settings/apps/new", ac.OrgName)
+	if orgName != "" {
+		url = fmt.Sprintf("/organizations/%v/settings/apps/new", orgName)
 	}
 
-	u, err := c.baseURL.Parse(path)
+	u, err := c.baseURL.Parse(url)
 	if err != nil {
 		return nil, err
 	}

--- a/scrape/apps.go
+++ b/scrape/apps.go
@@ -142,33 +142,27 @@ const (
 )
 
 type AppConfig struct {
+	// OwnerType specifies the type of GitHub account owner (personal or organizational).
 	OwnerType OwnerType
-	OrgName   string
+	// OrgName is the name of the organization if the OwnerType is organizational.
+	OrgName string
 }
 
 // CreateApp creates a new GitHub App with the given manifest configuration.
-// If the account type is "organizational", the path is set to "/organizations/{orgName}/settings/apps/new",
-// where {orgName} is the name of the organization specified in the AppConfig.
-// Otherwise, the path is set to "/settings/apps/new".
-
 func (c *Client) CreateApp(m *AppManifest, accType *AppConfig) (*http.Response, error) {
-
 	path := "/settings/apps/new"
 
 	if accType.OwnerType == "organizational" {
 		path = fmt.Sprintf("/organizations/%s/settings/apps/new", accType.OrgName)
 	}
 
-	fmt.Println(path)
-
 	u, err := c.baseURL.Parse(path)
 	if err != nil {
 		return nil, err
 	}
 
-	fmt.Println(u)
-
 	body, err := json.Marshal(map[string]*AppManifest{"manifest": m})
+
 	if err != nil {
 		return nil, err
 	}

--- a/scrape/apps_test.go
+++ b/scrape/apps_test.go
@@ -97,9 +97,7 @@ func Test_CreateApp(t *testing.T) {
 		HookAttributes: map[string]string{
 			"url": "https://example.com/hook",
 		},
-	}, &AppConfig{
-		OwnerType: OwnerTypePersonal,
-	}); err != nil {
+	}, ""); err != nil {
 		t.Fatalf("CreateApp: %v", err)
 	}
 }
@@ -118,10 +116,7 @@ func Test_CreateAppWithOrg(t *testing.T) {
 		HookAttributes: map[string]string{
 			"url": "https://example.com/hook",
 		},
-	}, &AppConfig{
-		OwnerType: OwnerTypeOrganization,
-		OrgName:   "example",
-	}); err != nil {
+	}, "example"); err != nil {
 		t.Fatalf("CreateAppWithOrg: %v", err)
 	}
 }

--- a/scrape/apps_test.go
+++ b/scrape/apps_test.go
@@ -97,7 +97,31 @@ func Test_CreateApp(t *testing.T) {
 		HookAttributes: map[string]string{
 			"url": "https://example.com/hook",
 		},
+	}, &AppConfig{
+		OwnerType: OwnerTypePersonal,
 	}); err != nil {
 		t.Fatalf("CreateApp: %v", err)
+	}
+}
+
+func Test_CreateAppWithOrg(t *testing.T) {
+	client, mux, cleanup := setup()
+
+	defer cleanup()
+
+	mux.HandleFunc("/organizations/example/apps/settings/new", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	if _, err := client.CreateApp(&AppManifest{
+		URL: github.String("https://example.com"),
+		HookAttributes: map[string]string{
+			"url": "https://example.com/hook",
+		},
+	}, &AppConfig{
+		OwnerType: OwnerTypeOrganization,
+		OrgName:   "example",
+	}); err != nil {
+		t.Fatalf("CreateAppWithOrg: %v", err)
 	}
 }

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -128,6 +128,7 @@ func (c *Client) Authenticate(username, password, otpseed string) error {
 		values.Set("password", password)
 	}
 	resp, err := fetchAndSubmitForm(c.Client, "https://github.com/login", setPassword)
+
 	if err != nil {
 		return err
 	}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -128,7 +128,6 @@ func (c *Client) Authenticate(username, password, otpseed string) error {
 		values.Set("password", password)
 	}
 	resp, err := fetchAndSubmitForm(c.Client, "https://github.com/login", setPassword)
-
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes: #3210.

**BREAKING CHANGE:** The `CreateApp` function now requires two arguments: `AppManifest` and `orgName`, to support creating apps with organizations.

The issue occurred because the create app URL path was only set up for creating personal GitHub apps.

My solution was to add an additional argument to the function to provide the necessary information for creating organizational GitHub Apps. The second argument, `AppConfig`, now includes configuration structs with an `OwnerType` that can be either personal or organizational, and you can provide the organization name by passing `OrgName` in the `AppConfig` struct.

For more details, see the issue: [https://github.com/google/go-github/issues/3210](https://github.com/google/go-github/issues/3210).
