### PR TITLE
feat!: Add pagination to Repository/Organization Rules Get methods

### DIFF
--- a/github/orgs_rules.go
+++ b/github/orgs_rules.go
@@ -15,8 +15,13 @@ import (
 // GitHub API docs: https://docs.github.com/rest/orgs/rules#get-all-organization-repository-rulesets
 //
 //meta:operation GET /orgs/{org}/rulesets
-func (s *OrganizationsService) GetAllOrganizationRulesets(ctx context.Context, org string) ([]*Ruleset, *Response, error) {
+func (s *OrganizationsService) GetAllOrganizationRulesets(ctx context.Context, org string, opts *ListOptions) ([]*Ruleset, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/rulesets", org)
+
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/orgs_rules_test.go
+++ b/github/orgs_rules_test.go
@@ -20,6 +20,7 @@ func TestOrganizationsService_GetAllOrganizationRulesets(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/rulesets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"per_page": "2", "page": "2"})
 		fmt.Fprint(w, `[{
 			"id": 26110,
 			"name": "test ruleset",
@@ -38,7 +39,7 @@ func TestOrganizationsService_GetAllOrganizationRulesets(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	rulesets, _, err := client.Organizations.GetAllOrganizationRulesets(ctx, "o")
+	rulesets, _, err := client.Organizations.GetAllOrganizationRulesets(ctx, "o", &ListOptions{Page: 2, PerPage: 2})
 	if err != nil {
 		t.Errorf("Organizations.GetAllOrganizationRulesets returned error: %v", err)
 	}
@@ -62,7 +63,7 @@ func TestOrganizationsService_GetAllOrganizationRulesets(t *testing.T) {
 	const methodName = "GetAllOrganizationRulesets"
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Organizations.GetAllOrganizationRulesets(ctx, "o")
+		got, resp, err := client.Organizations.GetAllOrganizationRulesets(ctx, "o", nil)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -431,8 +431,13 @@ type rulesetNoOmitBypassActors struct {
 // GitHub API docs: https://docs.github.com/rest/repos/rules#get-rules-for-a-branch
 //
 //meta:operation GET /repos/{owner}/{repo}/rules/branches/{branch}
-func (s *RepositoriesService) GetRulesForBranch(ctx context.Context, owner, repo, branch string) ([]*RepositoryRule, *Response, error) {
+func (s *RepositoriesService) GetRulesForBranch(ctx context.Context, owner, repo, branch string, opts *ListOptions) ([]*RepositoryRule, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/rules/branches/%v", owner, repo, branch)
+
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -454,8 +459,13 @@ func (s *RepositoriesService) GetRulesForBranch(ctx context.Context, owner, repo
 // GitHub API docs: https://docs.github.com/rest/repos/rules#get-all-repository-rulesets
 //
 //meta:operation GET /repos/{owner}/{repo}/rulesets
-func (s *RepositoriesService) GetAllRulesets(ctx context.Context, owner, repo string, includesParents bool) ([]*Ruleset, *Response, error) {
+func (s *RepositoriesService) GetAllRulesets(ctx context.Context, owner, repo string, includesParents bool, opts *ListOptions) ([]*Ruleset, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/rulesets?includes_parents=%v", owner, repo, includesParents)
+
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/repos_rules_test.go
+++ b/github/repos_rules_test.go
@@ -281,6 +281,7 @@ func TestRepositoriesService_GetRulesForBranch(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/repo/rules/branches/branch", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"per_page": "2", "page": "2"})
 		fmt.Fprint(w, `[
 			{
 			  "ruleset_id": 42069,
@@ -301,7 +302,7 @@ func TestRepositoriesService_GetRulesForBranch(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	rules, _, err := client.Repositories.GetRulesForBranch(ctx, "o", "repo", "branch")
+	rules, _, err := client.Repositories.GetRulesForBranch(ctx, "o", "repo", "branch", &ListOptions{Page: 2, PerPage: 2})
 	if err != nil {
 		t.Errorf("Repositories.GetRulesForBranch returned error: %v", err)
 	}
@@ -328,7 +329,7 @@ func TestRepositoriesService_GetRulesForBranch(t *testing.T) {
 	const methodName = "GetRulesForBranch"
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.GetRulesForBranch(ctx, "o", "repo", "branch")
+		got, resp, err := client.Repositories.GetRulesForBranch(ctx, "o", "repo", "branch", nil)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -342,6 +343,7 @@ func TestRepositoriesService_GetRulesForBranchEmptyUpdateRule(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/repo/rules/branches/branch", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"per_page": "2", "page": "2"})
 		fmt.Fprint(w, `[
 			{
 			  "type": "update"
@@ -350,7 +352,7 @@ func TestRepositoriesService_GetRulesForBranchEmptyUpdateRule(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	rules, _, err := client.Repositories.GetRulesForBranch(ctx, "o", "repo", "branch")
+	rules, _, err := client.Repositories.GetRulesForBranch(ctx, "o", "repo", "branch", &ListOptions{Page: 2, PerPage: 2})
 	if err != nil {
 		t.Errorf("Repositories.GetRulesForBranch returned error: %v", err)
 	}
@@ -367,7 +369,7 @@ func TestRepositoriesService_GetRulesForBranchEmptyUpdateRule(t *testing.T) {
 	const methodName = "GetRulesForBranch"
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.GetRulesForBranch(ctx, "o", "repo", "branch")
+		got, resp, err := client.Repositories.GetRulesForBranch(ctx, "o", "repo", "branch", nil)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -381,6 +383,7 @@ func TestRepositoriesService_GetAllRulesets(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/repo/rulesets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"per_page": "2", "page": "2"})
 		fmt.Fprint(w, `[
 			{
 			  "id": 42,
@@ -400,7 +403,7 @@ func TestRepositoriesService_GetAllRulesets(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	ruleSet, _, err := client.Repositories.GetAllRulesets(ctx, "o", "repo", false)
+	ruleSet, _, err := client.Repositories.GetAllRulesets(ctx, "o", "repo", false, &ListOptions{Page: 2, PerPage: 2})
 	if err != nil {
 		t.Errorf("Repositories.GetAllRulesets returned error: %v", err)
 	}
@@ -428,7 +431,7 @@ func TestRepositoriesService_GetAllRulesets(t *testing.T) {
 	const methodName = "GetAllRulesets"
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.GetAllRulesets(ctx, "o", "repo", false)
+		got, resp, err := client.Repositories.GetAllRulesets(ctx, "o", "repo", false, nil)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}


### PR DESCRIPTION
BREAKING CHANGE: `OrganizationsService.GetAllOrganizationRulesets`, `RepositoriesService.GetRulesForBranch`, and `RepositoriesService.GetAllRulesets` now have `opts *ListOptions`.

The Organization and Repository Rules APIs support pagination (`page` and `per_page`):
* https://docs.github.com/en/rest/orgs/rules?apiVersion=2022-11-28#get-all-organization-repository-rulesets
* https://docs.github.com/en/rest/repos/rules?apiVersion=2022-11-28#get-rules-for-a-branch
* https://docs.github.com/en/rest/repos/rules?apiVersion=2022-11-28#get-all-repository-rulesets

This PR adds the standard `ListOptions` parameter to each method so pagination can be used when listing rules.