### PR TITLE
feat!: Fix broken SCIMService.ProvisionAndInviteSCIMUser method

### DIFF
--- a/github/scim.go
+++ b/github/scim.go
@@ -110,19 +110,22 @@ func (s *SCIMService) ListSCIMProvisionedIdentities(ctx context.Context, org str
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/scim/scim#provision-and-invite-a-scim-user
 //
 //meta:operation POST /scim/v2/organizations/{org}/Users
-func (s *SCIMService) ProvisionAndInviteSCIMUser(ctx context.Context, org string, opts *SCIMUserAttributes) (*Response, error) {
+func (s *SCIMService) ProvisionAndInviteSCIMUser(ctx context.Context, org string, opts *SCIMUserAttributes) (*SCIMUserAttributes, *Response, error) {
+
 	u := fmt.Sprintf("scim/v2/organizations/%v/Users", org)
-	u, err := addOptions(u, opts)
+
+	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}	
+
+	user := new(SCIMUserAttributes)
+	resp, err := s.client.Do(ctx, req, user)
+	if err != nil {
+		return nil, resp, err
 	}
 
-	req, err := s.client.NewRequest("POST", u, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.client.Do(ctx, req, nil)
+	return user, resp, nil
 }
 
 // GetSCIMProvisioningInfoForUser returns SCIM provisioning information for a user.

--- a/github/scim.go
+++ b/github/scim.go
@@ -111,13 +111,12 @@ func (s *SCIMService) ListSCIMProvisionedIdentities(ctx context.Context, org str
 //
 //meta:operation POST /scim/v2/organizations/{org}/Users
 func (s *SCIMService) ProvisionAndInviteSCIMUser(ctx context.Context, org string, opts *SCIMUserAttributes) (*SCIMUserAttributes, *Response, error) {
-
 	u := fmt.Sprintf("scim/v2/organizations/%v/Users", org)
 
 	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
 		return nil, nil, err
-	}	
+	}
 
 	user := new(SCIMUserAttributes)
 	resp, err := s.client.Do(ctx, req, user)


### PR DESCRIPTION
Fixes: #3238. 

BREAKING CHANGE: `SCIMService.ProvisionAndInviteSCIMUser` now returns a response.