### PR TITLE
feat: Add do_not_enforce_on_create to required status checks rule params

### DIFF
--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -111,6 +111,7 @@ type RuleRequiredStatusChecks struct {
 
 // RequiredStatusChecksRuleParameters represents the required_status_checks rule parameters.
 type RequiredStatusChecksRuleParameters struct {
+	DoNotEnforceOnCreate             bool                       `json:"do_not_enforce_on_create"`
 	RequiredStatusChecks             []RuleRequiredStatusChecks `json:"required_status_checks"`
 	StrictRequiredStatusChecksPolicy bool                       `json:"strict_required_status_checks_policy"`
 }

--- a/github/repos_rules_test.go
+++ b/github/repos_rules_test.go
@@ -224,7 +224,7 @@ func TestRepositoryRule_UnmarshalJSON(t *testing.T) {
 			wantErr: true,
 		},
 		"Valid required_status_checks params": {
-			data: `{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"test","integration_id":1}],"strict_required_status_checks_policy":true}}`,
+			data: `{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"test","integration_id":1}],"strict_required_status_checks_policy":true,"do_not_enforce_on_create":true}}`,
 			want: NewRequiredStatusChecksRule(&RequiredStatusChecksRuleParameters{
 				DoNotEnforceOnCreate: true,
 				RequiredStatusChecks: []RuleRequiredStatusChecks{

--- a/github/repos_rules_test.go
+++ b/github/repos_rules_test.go
@@ -226,6 +226,7 @@ func TestRepositoryRule_UnmarshalJSON(t *testing.T) {
 		"Valid required_status_checks params": {
 			data: `{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"test","integration_id":1}],"strict_required_status_checks_policy":true}}`,
 			want: NewRequiredStatusChecksRule(&RequiredStatusChecksRuleParameters{
+				DoNotEnforceOnCreate: true,
 				RequiredStatusChecks: []RuleRequiredStatusChecks{
 					{
 						Context:       "test",


### PR DESCRIPTION
Fixes: #3244.

I signed the CLA. The `fmt` `test` and `lint` scripts all passed without warnings.