### PR TITLE
Add missing `expires_at` field to `github.Authorization`

### DIFF
--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -67,6 +67,7 @@ type Authorization struct {
 	UpdatedAt      *Timestamp        `json:"updated_at,omitempty"`
 	CreatedAt      *Timestamp        `json:"created_at,omitempty"`
 	Fingerprint    *string           `json:"fingerprint,omitempty"`
+	ExpiresAt      *Timestamp        `json:"expires_at,omitempty"`
 
 	// User is only populated by the Check and Reset methods.
 	User *User `json:"user,omitempty"`


### PR DESCRIPTION
The response of `client.Authorizations.Check(...)` should contain the `expires_at` field.

https://docs.github.com/en/rest/apps/oauth-applications?apiVersion=2022-11-28#check-a-token