### PR TITLE
Add CancelInvite method to cancel an org invitation by ID

### DIFF
--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -151,6 +151,20 @@ func (s *OrganizationsService) RemoveMember(ctx context.Context, org, user strin
 	return s.client.Do(ctx, req, nil)
 }
 
+// CancelInvite cancels an organization invitation.
+//
+// GitHub API docs: https://docs.github.com/rest/orgs/members#cancel-an-organization-invitation
+//
+//meta:operation DELETE /orgs/{org}/invitations/{invitation_id}
+func (s *OrganizationsService) CancelInvite(ctx context.Context, org string, invitationID int64) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/invitations/%v", org, invitationID)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+}
+
 // PublicizeMembership publicizes a user's membership in an organization. (A
 // user cannot publicize the membership for another user.)
 //

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -284,6 +284,32 @@ func TestOrganizationsService_RemoveMember(t *testing.T) {
 	})
 }
 
+func TestOrganizationsService_CancelInvite(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/o/invitations/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := context.Background()
+	_, err := client.Organizations.CancelInvite(ctx, "o", 1)
+	if err != nil {
+		t.Errorf("Organizations.CancelInvite returned error: %v", err)
+	}
+
+	const methodName = "CancelInvite"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Organizations.CancelInvite(ctx, "\n", 1)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Organizations.CancelInvite(ctx, "o", 1)
+	})
+}
+
 func TestOrganizationsService_RemoveMember_invalidOrg(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
The https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#cancel-an-organization-invitation endpoint was not available, and I needed it for some tooling. 

I tried my best to stick to the standards, and added a quick test. 
Happy to update / change anything if required. 