### PR TITLE
feat!: Add login query param support to ListCredentialAuthorizations

### DIFF
--- a/github/orgs_credential_authorizations.go
+++ b/github/orgs_credential_authorizations.go
@@ -57,7 +57,7 @@ type CredentialAuthorization struct {
 
 // CredentialAuthorizationsListOptions adds the Login option as supported by the
 // list SAML SSO authorizations for organizations endpoint alongside paging options
-// such as Page and PerPage
+// such as Page and PerPage.
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/orgs/orgs#list-saml-sso-authorizations-for-an-organization
 type CredentialAuthorizationsListOptions struct {
 	ListOptions

--- a/github/orgs_credential_authorizations.go
+++ b/github/orgs_credential_authorizations.go
@@ -55,13 +55,23 @@ type CredentialAuthorization struct {
 	AuthorizedCredentialExpiresAt *Timestamp `json:"authorized_credential_expires_at,omitempty"`
 }
 
+// CredentialAuthorizationsListOptions adds the Login option as supported by the
+// list SAML SSO authorizations for organizations endpoint alongside paging options
+// such as Page and PerPage
+// GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/orgs/orgs#list-saml-sso-authorizations-for-an-organization
+type CredentialAuthorizationsListOptions struct {
+	ListOptions
+	// For credentials authorizations for an organization, limit the list of authorizations to a specific login (aka github username)
+	Login string `url:"login,omitempty"`
+}
+
 // ListCredentialAuthorizations lists credentials authorized through SAML SSO
 // for a given organization. Only available with GitHub Enterprise Cloud.
 //
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/orgs/orgs#list-saml-sso-authorizations-for-an-organization
 //
 //meta:operation GET /orgs/{org}/credential-authorizations
-func (s *OrganizationsService) ListCredentialAuthorizations(ctx context.Context, org string, opts *ListOptions) ([]*CredentialAuthorization, *Response, error) {
+func (s *OrganizationsService) ListCredentialAuthorizations(ctx context.Context, org string, opts *CredentialAuthorizationsListOptions) ([]*CredentialAuthorization, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/credential-authorizations", org)
 	u, err := addOptions(u, opts)
 	if err != nil {

--- a/github/orgs_credential_authorizations_test.go
+++ b/github/orgs_credential_authorizations_test.go
@@ -21,7 +21,7 @@ func TestOrganizationsService_ListCredentialAuthorizations(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/credential-authorizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		testFormValues(t, r, values{"per_page": "2", "page": "2"})
+		testFormValues(t, r, values{"per_page": "2", "page": "2", "login": "l"})
 		fmt.Fprint(w, `[
 			{
 				"login": "l",
@@ -36,6 +36,7 @@ func TestOrganizationsService_ListCredentialAuthorizations(t *testing.T) {
 
 	opts := &CredentialAuthorizationsListOptions{
 		ListOptions: ListOptions{Page: 2, PerPage: 2},
+		Login:       "l",
 	}
 
 	ctx := context.Background()

--- a/github/orgs_credential_authorizations_test.go
+++ b/github/orgs_credential_authorizations_test.go
@@ -34,7 +34,10 @@ func TestOrganizationsService_ListCredentialAuthorizations(t *testing.T) {
 		]`)
 	})
 
-	opts := &ListOptions{Page: 2, PerPage: 2}
+	opts := &CredentialAuthorizationsListOptions{
+		ListOptions: ListOptions{Page: 2, PerPage: 2},
+	}
+
 	ctx := context.Background()
 	creds, _, err := client.Organizations.ListCredentialAuthorizations(ctx, "o", opts)
 	if err != nil {


### PR DESCRIPTION
BREAKING CHANGE: `ListCredentialAuthorizations` now takes `opts *CredentialAuthorizationsListOptions` instead of `ListOptions`.

As per the docs for the [List SAML SSO authorizations for an organization](https://docs.github.com/en/enterprise-cloud@latest/rest/orgs/orgs?apiVersion=2022-11-28#list-saml-sso-authorizations-for-an-organization) endpoint — it supports a query param named `login` to filter the authorizations by a github user.

This PR adds support for passing this `login` query param via a new struct (`CredentialAuthorizationsListOptions`) which embeds `ListOptions` as `ListOptions` itself only supports `Page` and `PerPage` query params.