### PR TITLE
chore: Change golangci-lint output format due to deprecation

### DIFF
--- a/script/lint.sh
+++ b/script/lint.sh
@@ -33,7 +33,7 @@ for dir in $MOD_DIRS; do
     cd "$dir"
     # github actions output when running in an action
     if [ -n "$GITHUB_ACTIONS" ]; then
-      "$BIN"/golangci-lint run --path-prefix "$dir" --out-format github-actions
+      "$BIN"/golangci-lint run --path-prefix "$dir" --out-format colored-line-number
     else
       "$BIN"/golangci-lint run --path-prefix "$dir"
     fi


### PR DESCRIPTION
As specified in the [GitHub Actions logs for the linter](https://github.com/google/go-github/actions/runs/10973176585/job/30470274170#step:4:9), the ``github-actions`` output format is deprecated, and ``colored-line-number`` should be used instead. Deprecation was done in https://github.com/golangci/golangci-lint/pull/4726