### PR TITLE
feat: Support baseRole option for custom organization roles

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -4414,6 +4414,14 @@ func (c *CreateOrUpdateCustomRepoRoleOptions) GetName() string {
 	return *c.Name
 }
 
+// GetBaseRole returns the BaseRole field if it's non-nil, zero value otherwise.
+func (c *CreateOrUpdateOrgRoleOptions) GetBaseRole() string {
+	if c == nil || c.BaseRole == nil {
+		return ""
+	}
+	return *c.BaseRole
+}
+
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
 func (c *CreateOrUpdateOrgRoleOptions) GetDescription() string {
 	if c == nil || c.Description == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -5179,6 +5179,16 @@ func TestCreateOrUpdateCustomRepoRoleOptions_GetName(tt *testing.T) {
 	c.GetName()
 }
 
+func TestCreateOrUpdateOrgRoleOptions_GetBaseRole(tt *testing.T) {
+	var zeroValue string
+	c := &CreateOrUpdateOrgRoleOptions{BaseRole: &zeroValue}
+	c.GetBaseRole()
+	c = &CreateOrUpdateOrgRoleOptions{}
+	c.GetBaseRole()
+	c = nil
+	c.GetBaseRole()
+}
+
 func TestCreateOrUpdateOrgRoleOptions_GetDescription(tt *testing.T) {
 	var zeroValue string
 	c := &CreateOrUpdateOrgRoleOptions{Description: &zeroValue}

--- a/github/orgs_custom_roles.go
+++ b/github/orgs_custom_roles.go
@@ -54,6 +54,7 @@ type CreateOrUpdateOrgRoleOptions struct {
 	Name        *string  `json:"name,omitempty"`
 	Description *string  `json:"description,omitempty"`
 	Permissions []string `json:"permissions"`
+	BaseRole    *string  `json:"base_role,omitempty"`
 }
 
 // CreateOrUpdateCustomRepoRoleOptions represents options required to create or update a custom repository role.


### PR DESCRIPTION
Resolves #3283 

Exactly the same as [the custom repo role](https://github.com/google/go-github/blob/46f1127c50024fd92c7bb10992e1baaf607ee5e7/github/orgs_custom_roles.go#L63). 

[Docs for the endpoint](https://docs.github.com/en/enterprise-cloud@latest/rest/orgs/organization-roles?apiVersion=2022-11-28#create-a-custom-organization-role)