### PR TITLE
feat: Support getting an organization role

### DIFF
--- a/github/orgs_custom_roles.go
+++ b/github/orgs_custom_roles.go
@@ -87,6 +87,29 @@ func (s *OrganizationsService) ListRoles(ctx context.Context, org string) (*Orga
 	return customRepoRoles, resp, nil
 }
 
+// GetOrgRole gets an organization role in this organization.
+// In order to get organization roles in an organization, the authenticated user must be an organization owner, or have access via an organization role.
+//
+// GitHub API docs: https://docs.github.com/rest/orgs/organization-roles#get-an-organization-role
+//
+//meta:operation GET /orgs/{org}/organization-roles/{role_id}
+func (s *OrganizationsService) GetOrgRole(ctx context.Context, org string, roleID int64) (*CustomOrgRoles, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/organization-roles/%v", org, roleID)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resultingRole := new(CustomOrgRoles)
+	resp, err := s.client.Do(ctx, req, resultingRole)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return resultingRole, resp, err
+}
+
 // CreateCustomOrgRole creates a custom role in this organization.
 // In order to create custom roles in an organization, the authenticated user must be an organization owner.
 //

--- a/github/orgs_custom_roles_test.go
+++ b/github/orgs_custom_roles_test.go
@@ -110,8 +110,8 @@ func TestOrganizationsService_GetOrgRole(t *testing.T) {
 			"name": "all_repo_read",
 			"description": "Grants read access to all repositories in the organization.",
 			"permissions": [],
-			"created_at": ` + referenceTimeStr + `,
-			"updated_at": ` + referenceTimeStr + `,
+			"created_at": `+referenceTimeStr+`,
+			"updated_at": `+referenceTimeStr+`,
 			"source": "Predefined",
 			"base_role": "read"
 		}`)
@@ -129,10 +129,10 @@ func TestOrganizationsService_GetOrgRole(t *testing.T) {
 		Name:        String("all_repo_read"),
 		Description: String("Grants read access to all repositories in the organization."),
 		Permissions: []string{},
-		CreatedAt:          &Timestamp{referenceTime},
-		UpdatedAt:          &Timestamp{referenceTime},
-		Source: String("Predefined"),
-		BaseRole: String("read"),
+		CreatedAt:   &Timestamp{referenceTime},
+		UpdatedAt:   &Timestamp{referenceTime},
+		Source:      String("Predefined"),
+		BaseRole:    String("read"),
 	}
 
 	if !cmp.Equal(gotBuiltInRole, wantBuiltInRole) {
@@ -151,8 +151,8 @@ func TestOrganizationsService_GetOrgRole(t *testing.T) {
 				"read_organization_custom_repo_role",
 				"write_organization_custom_org_role"
 			],
-			"created_at": ` + referenceTimeStr + `,
-			"updated_at": ` + referenceTimeStr + `,
+			"created_at": `+referenceTimeStr+`,
+			"updated_at": `+referenceTimeStr+`,
 			"source": "Organization",
 			"base_role": null
 			}`)
@@ -172,10 +172,10 @@ func TestOrganizationsService_GetOrgRole(t *testing.T) {
 			"read_organization_custom_repo_role",
 			"write_organization_custom_org_role",
 		},
-		CreatedAt:          &Timestamp{referenceTime},
-		UpdatedAt:          &Timestamp{referenceTime},
-		Source: String("Organization"),
-		BaseRole: nil,
+		CreatedAt: &Timestamp{referenceTime},
+		UpdatedAt: &Timestamp{referenceTime},
+		Source:    String("Organization"),
+		BaseRole:  nil,
 	}
 
 	if !cmp.Equal(gotCustomRole, wantCustomRole) {

--- a/github/orgs_custom_roles_test.go
+++ b/github/orgs_custom_roles_test.go
@@ -98,6 +98,105 @@ func TestOrganizationsService_ListRoles(t *testing.T) {
 	})
 }
 
+func TestOrganizationsService_GetOrgRole(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	// Test built-in org role
+	mux.HandleFunc("/orgs/o/organization-roles/8132", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"id": 8132,
+			"name": "all_repo_read",
+			"description": "Grants read access to all repositories in the organization.",
+			"permissions": [],
+			"created_at": ` + referenceTimeStr + `,
+			"updated_at": ` + referenceTimeStr + `,
+			"source": "Predefined",
+			"base_role": "read"
+		}`)
+	})
+
+	ctx := context.Background()
+
+	gotBuiltInRole, _, err := client.Organizations.GetOrgRole(ctx, "o", 8132)
+	if err != nil {
+		t.Errorf("Organizations.GetOrgRole returned error: %v", err)
+	}
+
+	wantBuiltInRole := &CustomOrgRoles{
+		ID:          Int64(8132),
+		Name:        String("all_repo_read"),
+		Description: String("Grants read access to all repositories in the organization."),
+		Permissions: []string{},
+		CreatedAt:          &Timestamp{referenceTime},
+		UpdatedAt:          &Timestamp{referenceTime},
+		Source: String("Predefined"),
+		BaseRole: String("read"),
+	}
+
+	if !cmp.Equal(gotBuiltInRole, wantBuiltInRole) {
+		t.Errorf("Organizations.GetOrgRole returned %+v, want %+v", gotBuiltInRole, wantBuiltInRole)
+	}
+
+	// Test custom org role
+	mux.HandleFunc("/orgs/o/organization-roles/123456", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"id": 123456,
+			"name": "test-role",
+			"description": "test-role",
+			"permissions": [
+				"read_organization_custom_org_role",
+				"read_organization_custom_repo_role",
+				"write_organization_custom_org_role"
+			],
+			"created_at": ` + referenceTimeStr + `,
+			"updated_at": ` + referenceTimeStr + `,
+			"source": "Organization",
+			"base_role": null
+			}`)
+	})
+
+	gotCustomRole, _, err := client.Organizations.GetOrgRole(ctx, "o", 123456)
+	if err != nil {
+		t.Errorf("Organizations.GetOrgRole returned error: %v", err)
+	}
+
+	wantCustomRole := &CustomOrgRoles{
+		ID:          Int64(123456),
+		Name:        String("test-role"),
+		Description: String("test-role"),
+		Permissions: []string{
+			"read_organization_custom_org_role",
+			"read_organization_custom_repo_role",
+			"write_organization_custom_org_role",
+		},
+		CreatedAt:          &Timestamp{referenceTime},
+		UpdatedAt:          &Timestamp{referenceTime},
+		Source: String("Organization"),
+		BaseRole: nil,
+	}
+
+	if !cmp.Equal(gotCustomRole, wantCustomRole) {
+		t.Errorf("Organizations.GetOrgRole returned %+v, want %+v", gotCustomRole, wantCustomRole)
+	}
+
+	const methodName = "GetOrgRole"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Organizations.GetOrgRole(ctx, "\no", -8132)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Organizations.GetOrgRole(ctx, "o", 8132)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
 func TestOrganizationsService_CreateCustomOrgRole(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
Resolves #3282 

It was only possible to list organization roles before, this makes it possible to get a specific one. 

I might have went overboard with the test-cases (testing both a custom role and a built-in one). I haven't written mocks before, so I'm not sure what the best practices are here 😅