### PR TITLE
chore: Enable gosec G602 rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,9 +20,6 @@ linters-settings:
     excludes:
       # duplicates errcheck
       - G104
-      # performance issue: see https://github.com/golangci/golangci-lint/issues/4039
-      # and https://github.com/securego/gosec/issues/1007
-      - G602
       # int(os.Stdin.Fd())
       - G115
 issues:


### PR DESCRIPTION
This PR enables the G602 gosec rule in golangci-lint's config because golangci-lint 1.60.2 doesn't have any problems with gosec's performance. The issues https://github.com/golangci/golangci-lint/issues/4039 and https://github.com/securego/gosec/issues/1007 have been fixed.