### PR TITLE
fix: Avoid allocation in the stringifyValue

### DIFF
--- a/github/strings.go
+++ b/github/strings.go
@@ -27,7 +27,7 @@ func Stringify(message interface{}) string {
 
 func stringifyValue(w *bytes.Buffer, val reflect.Value) {
 	if val.Kind() == reflect.Ptr && val.IsNil() {
-		w.Write([]byte("<nil>"))
+		w.WriteString("<nil>")
 		return
 	}
 
@@ -37,20 +37,20 @@ func stringifyValue(w *bytes.Buffer, val reflect.Value) {
 	case reflect.String:
 		fmt.Fprintf(w, `"%s"`, v)
 	case reflect.Slice:
-		w.Write([]byte{'['})
+		w.WriteByte('[')
 		for i := 0; i < v.Len(); i++ {
 			if i > 0 {
-				w.Write([]byte{' '})
+				w.WriteByte(' ')
 			}
 
 			stringifyValue(w, v.Index(i))
 		}
 
-		w.Write([]byte{']'})
+		w.WriteByte(']')
 		return
 	case reflect.Struct:
 		if v.Type().Name() != "" {
-			w.Write([]byte(v.Type().String()))
+			w.WriteString(v.Type().String())
 		}
 
 		// special handling of Timestamp values
@@ -59,7 +59,7 @@ func stringifyValue(w *bytes.Buffer, val reflect.Value) {
 			return
 		}
 
-		w.Write([]byte{'{'})
+		w.WriteByte('{')
 
 		var sep bool
 		for i := 0; i < v.NumField(); i++ {
@@ -75,17 +75,17 @@ func stringifyValue(w *bytes.Buffer, val reflect.Value) {
 			}
 
 			if sep {
-				w.Write([]byte(", "))
+				w.WriteString(", ")
 			} else {
 				sep = true
 			}
 
-			w.Write([]byte(v.Type().Field(i).Name))
-			w.Write([]byte{':'})
+			w.WriteString(v.Type().Field(i).Name)
+			w.WriteByte(':')
 			stringifyValue(w, fv)
 		}
 
-		w.Write([]byte{'}'})
+		w.WriteByte('}')
 	default:
 		if v.CanInterface() {
 			fmt.Fprint(w, v.Interface())


### PR DESCRIPTION
The PR refactors implementation of the `stringifyValue` function.

`w.Write([]byte("<nil>"))` may allocate, better is to use `w.WriteString("<nil>")`