### PR TITLE
refactor: Do not call teardown manually in tests

### DIFF
--- a/github/actions_artifacts_test.go
+++ b/github/actions_artifacts_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestActionsService_ListArtifacts(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/artifacts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -59,8 +58,7 @@ func TestActionsService_ListArtifacts(t *testing.T) {
 }
 
 func TestActionsService_ListArtifacts_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Actions.ListArtifacts(ctx, "%", "r", nil)
@@ -68,8 +66,7 @@ func TestActionsService_ListArtifacts_invalidOwner(t *testing.T) {
 }
 
 func TestActionsService_ListArtifacts_invalidRepo(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Actions.ListArtifacts(ctx, "o", "%", nil)
@@ -77,8 +74,7 @@ func TestActionsService_ListArtifacts_invalidRepo(t *testing.T) {
 }
 
 func TestActionsService_ListArtifacts_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/artifacts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -99,8 +95,7 @@ func TestActionsService_ListArtifacts_notFound(t *testing.T) {
 }
 
 func TestActionsService_ListWorkflowRunArtifacts(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/1/artifacts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -141,8 +136,7 @@ func TestActionsService_ListWorkflowRunArtifacts(t *testing.T) {
 }
 
 func TestActionsService_ListWorkflowRunArtifacts_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Actions.ListWorkflowRunArtifacts(ctx, "%", "r", 1, nil)
@@ -150,8 +144,7 @@ func TestActionsService_ListWorkflowRunArtifacts_invalidOwner(t *testing.T) {
 }
 
 func TestActionsService_ListWorkflowRunArtifacts_invalidRepo(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Actions.ListWorkflowRunArtifacts(ctx, "o", "%", 1, nil)
@@ -159,8 +152,7 @@ func TestActionsService_ListWorkflowRunArtifacts_invalidRepo(t *testing.T) {
 }
 
 func TestActionsService_ListWorkflowRunArtifacts_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/1/artifacts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -181,8 +173,7 @@ func TestActionsService_ListWorkflowRunArtifacts_notFound(t *testing.T) {
 }
 
 func TestActionsService_GetArtifact(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/artifacts/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -228,8 +219,7 @@ func TestActionsService_GetArtifact(t *testing.T) {
 }
 
 func TestActionsService_GetArtifact_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Actions.GetArtifact(ctx, "%", "r", 1)
@@ -237,8 +227,7 @@ func TestActionsService_GetArtifact_invalidOwner(t *testing.T) {
 }
 
 func TestActionsService_GetArtifact_invalidRepo(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Actions.GetArtifact(ctx, "o", "%", 1)
@@ -246,8 +235,7 @@ func TestActionsService_GetArtifact_invalidRepo(t *testing.T) {
 }
 
 func TestActionsService_GetArtifact_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/artifacts/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -268,8 +256,7 @@ func TestActionsService_GetArtifact_notFound(t *testing.T) {
 }
 
 func TestActionsService_DownloadArtifact(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/artifacts/1/zip", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -307,8 +294,7 @@ func TestActionsService_DownloadArtifact(t *testing.T) {
 }
 
 func TestActionsService_DownloadArtifact_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Actions.DownloadArtifact(ctx, "%", "r", 1, 1)
@@ -316,8 +302,7 @@ func TestActionsService_DownloadArtifact_invalidOwner(t *testing.T) {
 }
 
 func TestActionsService_DownloadArtifact_invalidRepo(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Actions.DownloadArtifact(ctx, "o", "%", 1, 1)
@@ -325,8 +310,7 @@ func TestActionsService_DownloadArtifact_invalidRepo(t *testing.T) {
 }
 
 func TestActionsService_DownloadArtifact_StatusMovedPermanently_dontFollowRedirects(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/artifacts/1/zip", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -341,8 +325,7 @@ func TestActionsService_DownloadArtifact_StatusMovedPermanently_dontFollowRedire
 }
 
 func TestActionsService_DownloadArtifact_StatusMovedPermanently_followRedirects(t *testing.T) {
-	client, mux, serverURL, teardown := setup()
-	defer teardown()
+	client, mux, serverURL := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/artifacts/1/zip", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -369,8 +352,7 @@ func TestActionsService_DownloadArtifact_StatusMovedPermanently_followRedirects(
 }
 
 func TestActionsService_DeleteArtifact(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/artifacts/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -394,8 +376,7 @@ func TestActionsService_DeleteArtifact(t *testing.T) {
 }
 
 func TestActionsService_DeleteArtifact_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Actions.DeleteArtifact(ctx, "%", "r", 1)
@@ -403,8 +384,7 @@ func TestActionsService_DeleteArtifact_invalidOwner(t *testing.T) {
 }
 
 func TestActionsService_DeleteArtifact_invalidRepo(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Actions.DeleteArtifact(ctx, "o", "%", 1)
@@ -412,8 +392,7 @@ func TestActionsService_DeleteArtifact_invalidRepo(t *testing.T) {
 }
 
 func TestActionsService_DeleteArtifact_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/artifacts/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/actions_cache_test.go
+++ b/github/actions_cache_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestActionsService_ListCaches(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/caches", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -57,8 +56,7 @@ func TestActionsService_ListCaches(t *testing.T) {
 }
 
 func TestActionsService_ListCaches_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Actions.ListCaches(ctx, "%", "r", nil)
@@ -66,8 +64,7 @@ func TestActionsService_ListCaches_invalidOwner(t *testing.T) {
 }
 
 func TestActionsService_ListCaches_invalidRepo(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Actions.ListCaches(ctx, "o", "%", nil)
@@ -75,8 +72,7 @@ func TestActionsService_ListCaches_invalidRepo(t *testing.T) {
 }
 
 func TestActionsService_ListCaches_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/caches", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -97,8 +93,7 @@ func TestActionsService_ListCaches_notFound(t *testing.T) {
 }
 
 func TestActionsService_DeleteCachesByKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/caches", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -123,8 +118,7 @@ func TestActionsService_DeleteCachesByKey(t *testing.T) {
 }
 
 func TestActionsService_DeleteCachesByKey_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Actions.DeleteCachesByKey(ctx, "%", "r", "1", String("main"))
@@ -132,16 +126,14 @@ func TestActionsService_DeleteCachesByKey_invalidOwner(t *testing.T) {
 }
 
 func TestActionsService_DeleteCachesByKey_invalidRepo(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Actions.DeleteCachesByKey(ctx, "o", "%", "1", String("main"))
 	testURLParseError(t, err)
 }
 func TestActionsService_DeleteCachesByKey_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/artifacts/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -159,8 +151,7 @@ func TestActionsService_DeleteCachesByKey_notFound(t *testing.T) {
 }
 
 func TestActionsService_DeleteCachesByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/caches/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -184,8 +175,7 @@ func TestActionsService_DeleteCachesByID(t *testing.T) {
 }
 
 func TestActionsService_DeleteCachesByID_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Actions.DeleteCachesByID(ctx, "%", "r", 1)
@@ -193,8 +183,7 @@ func TestActionsService_DeleteCachesByID_invalidOwner(t *testing.T) {
 }
 
 func TestActionsService_DeleteCachesByID_invalidRepo(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Actions.DeleteCachesByID(ctx, "o", "%", 1)
@@ -202,8 +191,7 @@ func TestActionsService_DeleteCachesByID_invalidRepo(t *testing.T) {
 }
 
 func TestActionsService_DeleteCachesByID_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("repos/o/r/actions/caches/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -221,8 +209,7 @@ func TestActionsService_DeleteCachesByID_notFound(t *testing.T) {
 }
 
 func TestActionsService_GetCacheUsageForRepo(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/cache/usage", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -262,8 +249,7 @@ func TestActionsService_GetCacheUsageForRepo(t *testing.T) {
 }
 
 func TestActionsService_GetCacheUsageForRepo_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Actions.GetCacheUsageForRepo(ctx, "%", "r")
@@ -271,8 +257,7 @@ func TestActionsService_GetCacheUsageForRepo_invalidOwner(t *testing.T) {
 }
 
 func TestActionsService_GetCacheUsageForRepo_invalidRepo(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Actions.GetCacheUsageForRepo(ctx, "o", "%")
@@ -280,8 +265,7 @@ func TestActionsService_GetCacheUsageForRepo_invalidRepo(t *testing.T) {
 }
 
 func TestActionsService_GetCacheUsageForRepo_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/cache/usage", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -302,8 +286,7 @@ func TestActionsService_GetCacheUsageForRepo_notFound(t *testing.T) {
 }
 
 func TestActionsService_ListCacheUsageByRepoForOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/cache/usage-by-repository", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -344,8 +327,7 @@ func TestActionsService_ListCacheUsageByRepoForOrg(t *testing.T) {
 }
 
 func TestActionsService_ListCacheUsageByRepoForOrg_invalidOrganization(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Actions.ListCacheUsageByRepoForOrg(ctx, "%", nil)
@@ -353,8 +335,7 @@ func TestActionsService_ListCacheUsageByRepoForOrg_invalidOrganization(t *testin
 }
 
 func TestActionsService_ListCacheUsageByRepoForOrg_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/cache/usage-by-repository", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -375,8 +356,7 @@ func TestActionsService_ListCacheUsageByRepoForOrg_notFound(t *testing.T) {
 }
 
 func TestActionsService_GetCacheUsageForOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/cache/usage", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -415,8 +395,7 @@ func TestActionsService_GetCacheUsageForOrg(t *testing.T) {
 }
 
 func TestActionsService_GetCacheUsageForOrg_invalidOrganization(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Actions.GetTotalCacheUsageForOrg(ctx, "%")
@@ -424,8 +403,7 @@ func TestActionsService_GetCacheUsageForOrg_invalidOrganization(t *testing.T) {
 }
 
 func TestActionsService_GetCacheUsageForOrg_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/cache/usage", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -446,8 +424,7 @@ func TestActionsService_GetCacheUsageForOrg_notFound(t *testing.T) {
 }
 
 func TestActionsService_GetCacheUsageForEnterprise(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/actions/cache/usage", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -486,8 +463,7 @@ func TestActionsService_GetCacheUsageForEnterprise(t *testing.T) {
 }
 
 func TestActionsService_GetCacheUsageForEnterprise_invalidEnterprise(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Actions.GetTotalCacheUsageForEnterprise(ctx, "%")
@@ -495,8 +471,7 @@ func TestActionsService_GetCacheUsageForEnterprise_invalidEnterprise(t *testing.
 }
 
 func TestActionsService_GetCacheUsageForEnterprise_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/actions/cache/usage", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/actions_oidc_test.go
+++ b/github/actions_oidc_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestActionsService_GetOrgOIDCSubjectClaimCustomTemplate(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/oidc/customization/sub", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -50,8 +49,7 @@ func TestActionsService_GetOrgOIDCSubjectClaimCustomTemplate(t *testing.T) {
 }
 
 func TestActionsService_GetRepoOIDCSubjectClaimCustomTemplate(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/oidc/customization/sub", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -85,8 +83,7 @@ func TestActionsService_GetRepoOIDCSubjectClaimCustomTemplate(t *testing.T) {
 }
 
 func TestActionsService_SetOrgOIDCSubjectClaimCustomTemplate(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/oidc/customization/sub", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -117,8 +114,7 @@ func TestActionsService_SetOrgOIDCSubjectClaimCustomTemplate(t *testing.T) {
 }
 
 func TestActionsService_SetRepoOIDCSubjectClaimCustomTemplate(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/oidc/customization/sub", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -150,8 +146,7 @@ func TestActionsService_SetRepoOIDCSubjectClaimCustomTemplate(t *testing.T) {
 }
 
 func TestActionService_SetRepoOIDCSubjectClaimCustomTemplateToDefault(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/oidc/customization/sub", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")

--- a/github/actions_permissions_enterprise_test.go
+++ b/github/actions_permissions_enterprise_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestActionsService_GetActionsPermissionsInEnterprise(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/actions/permissions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -50,8 +49,7 @@ func TestActionsService_GetActionsPermissionsInEnterprise(t *testing.T) {
 }
 
 func TestActionsService_EditActionsPermissionsInEnterprise(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &ActionsPermissionsEnterprise{EnabledOrganizations: String("all"), AllowedActions: String("selected")}
 
@@ -94,8 +92,7 @@ func TestActionsService_EditActionsPermissionsInEnterprise(t *testing.T) {
 }
 
 func TestActionsService_ListEnabledOrgsInEnterprise(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/actions/permissions/organizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -138,8 +135,7 @@ func TestActionsService_ListEnabledOrgsInEnterprise(t *testing.T) {
 }
 
 func TestActionsService_SetEnabledOrgsInEnterprise(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/actions/permissions/organizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -167,8 +163,7 @@ func TestActionsService_SetEnabledOrgsInEnterprise(t *testing.T) {
 }
 
 func TestActionsService_AddEnabledOrgInEnterprise(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/actions/permissions/organizations/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -194,8 +189,7 @@ func TestActionsService_AddEnabledOrgInEnterprise(t *testing.T) {
 }
 
 func TestActionsService_RemoveEnabledOrgInEnterprise(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/actions/permissions/organizations/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -221,8 +215,7 @@ func TestActionsService_RemoveEnabledOrgInEnterprise(t *testing.T) {
 }
 
 func TestActionsService_GetActionsAllowedInEnterprise(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/actions/permissions/selected-actions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -255,8 +248,8 @@ func TestActionsService_GetActionsAllowedInEnterprise(t *testing.T) {
 }
 
 func TestActionsService_EditActionsAllowedInEnterprise(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	input := &ActionsAllowed{GithubOwnedAllowed: Bool(true), VerifiedAllowed: Bool(false), PatternsAllowed: []string{"a/b"}}
 
 	mux.HandleFunc("/enterprises/e/actions/permissions/selected-actions", func(w http.ResponseWriter, r *http.Request) {
@@ -298,8 +291,7 @@ func TestActionsService_EditActionsAllowedInEnterprise(t *testing.T) {
 }
 
 func TestActionsService_GetDefaultWorkflowPermissionsInEnterprise(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/actions/permissions/workflow", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -332,8 +324,8 @@ func TestActionsService_GetDefaultWorkflowPermissionsInEnterprise(t *testing.T) 
 }
 
 func TestActionsService_EditDefaultWorkflowPermissionsInEnterprise(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	input := &DefaultWorkflowPermissionEnterprise{DefaultWorkflowPermissions: String("read"), CanApprovePullRequestReviews: Bool(true)}
 
 	mux.HandleFunc("/enterprises/e/actions/permissions/workflow", func(w http.ResponseWriter, r *http.Request) {

--- a/github/actions_permissions_orgs_test.go
+++ b/github/actions_permissions_orgs_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestActionsService_GetActionsPermissions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/permissions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -50,8 +49,7 @@ func TestActionsService_GetActionsPermissions(t *testing.T) {
 }
 
 func TestActionsService_EditActionsPermissions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &ActionsPermissions{EnabledRepositories: String("all"), AllowedActions: String("selected")}
 
@@ -94,8 +92,7 @@ func TestActionsService_EditActionsPermissions(t *testing.T) {
 }
 
 func TestActionsService_ListEnabledReposInOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/permissions/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -138,8 +135,7 @@ func TestActionsService_ListEnabledReposInOrg(t *testing.T) {
 }
 
 func TestActionsService_SetEnabledReposInOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/permissions/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -167,8 +163,7 @@ func TestActionsService_SetEnabledReposInOrg(t *testing.T) {
 }
 
 func TestActionsService_AddEnabledReposInOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/permissions/repositories/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -194,8 +189,7 @@ func TestActionsService_AddEnabledReposInOrg(t *testing.T) {
 }
 
 func TestActionsService_RemoveEnabledReposInOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/permissions/repositories/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -221,8 +215,7 @@ func TestActionsService_RemoveEnabledReposInOrg(t *testing.T) {
 }
 
 func TestActionsService_GetActionsAllowed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/permissions/selected-actions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -255,8 +248,8 @@ func TestActionsService_GetActionsAllowed(t *testing.T) {
 }
 
 func TestActionsService_EditActionsAllowed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	input := &ActionsAllowed{GithubOwnedAllowed: Bool(true), VerifiedAllowed: Bool(false), PatternsAllowed: []string{"a/b"}}
 
 	mux.HandleFunc("/orgs/o/actions/permissions/selected-actions", func(w http.ResponseWriter, r *http.Request) {
@@ -336,8 +329,7 @@ func TestActionsPermissions_Marshal(t *testing.T) {
 }
 
 func TestActionsService_GetDefaultWorkflowPermissionsInOrganization(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/permissions/workflow", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -370,8 +362,8 @@ func TestActionsService_GetDefaultWorkflowPermissionsInOrganization(t *testing.T
 }
 
 func TestActionsService_EditDefaultWorkflowPermissionsInOrganization(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	input := &DefaultWorkflowPermissionOrganization{DefaultWorkflowPermissions: String("read"), CanApprovePullRequestReviews: Bool(true)}
 
 	mux.HandleFunc("/orgs/o/actions/permissions/workflow", func(w http.ResponseWriter, r *http.Request) {

--- a/github/actions_required_workflows_test.go
+++ b/github/actions_required_workflows_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 func TestActionsService_ListOrgRequiredWorkflows(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/orgs/o/actions/required_workflows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"per_page": "2", "page": "2"})
@@ -80,8 +80,8 @@ func TestActionsService_ListOrgRequiredWorkflows(t *testing.T) {
 }
 
 func TestActionsService_CreateRequiredWorkflow(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/orgs/o/actions/required_workflows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Content-Type", "application/json")
@@ -145,8 +145,8 @@ func TestActionsService_CreateRequiredWorkflow(t *testing.T) {
 }
 
 func TestActionsService_GetRequiredWorkflowByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/orgs/o/actions/required_workflows/12345", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
@@ -195,8 +195,8 @@ func TestActionsService_GetRequiredWorkflowByID(t *testing.T) {
 }
 
 func TestActionsService_UpdateRequiredWorkflow(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/orgs/o/actions/required_workflows/12345", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
 		testHeader(t, r, "Content-Type", "application/json")
@@ -262,8 +262,8 @@ func TestActionsService_UpdateRequiredWorkflow(t *testing.T) {
 }
 
 func TestActionsService_DeleteRequiredWorkflow(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/orgs/o/actions/required_workflows/12345", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		w.WriteHeader(http.StatusNoContent)
@@ -287,8 +287,8 @@ func TestActionsService_DeleteRequiredWorkflow(t *testing.T) {
 }
 
 func TestActionsService_ListRequiredWorkflowSelectedRepos(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/orgs/o/actions/required_workflows/12345/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"per_page": "2", "page": "2"})
@@ -333,8 +333,8 @@ func TestActionsService_ListRequiredWorkflowSelectedRepos(t *testing.T) {
 }
 
 func TestActionsService_SetRequiredWorkflowSelectedRepos(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/orgs/o/actions/required_workflows/12345/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
@@ -360,8 +360,8 @@ func TestActionsService_SetRequiredWorkflowSelectedRepos(t *testing.T) {
 }
 
 func TestActionsService_AddRepoToRequiredWorkflow(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/orgs/o/actions/required_workflows/12345/repositories/32", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		w.WriteHeader(http.StatusNoContent)
@@ -385,8 +385,8 @@ func TestActionsService_AddRepoToRequiredWorkflow(t *testing.T) {
 }
 
 func TestActionsService_RemoveRepoFromRequiredWorkflow(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/orgs/o/actions/required_workflows/12345/repositories/32", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		w.WriteHeader(http.StatusNoContent)
@@ -410,8 +410,8 @@ func TestActionsService_RemoveRepoFromRequiredWorkflow(t *testing.T) {
 }
 
 func TestActionsService_ListRepoRequiredWorkflows(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/actions/required_workflows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"per_page": "2", "page": "2"})

--- a/github/actions_runner_groups_test.go
+++ b/github/actions_runner_groups_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestActionsService_ListOrganizationRunnerGroups(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runner-groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -59,8 +58,7 @@ func TestActionsService_ListOrganizationRunnerGroups(t *testing.T) {
 }
 
 func TestActionsService_ListOrganizationRunnerGroupsVisibleToRepo(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runner-groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -103,8 +101,7 @@ func TestActionsService_ListOrganizationRunnerGroupsVisibleToRepo(t *testing.T) 
 }
 
 func TestActionsService_GetOrganizationRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runner-groups/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -150,8 +147,7 @@ func TestActionsService_GetOrganizationRunnerGroup(t *testing.T) {
 }
 
 func TestActionsService_DeleteOrganizationRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runner-groups/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -175,8 +171,7 @@ func TestActionsService_DeleteOrganizationRunnerGroup(t *testing.T) {
 }
 
 func TestActionsService_CreateOrganizationRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runner-groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -229,8 +224,7 @@ func TestActionsService_CreateOrganizationRunnerGroup(t *testing.T) {
 }
 
 func TestActionsService_UpdateOrganizationRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runner-groups/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -283,8 +277,7 @@ func TestActionsService_UpdateOrganizationRunnerGroup(t *testing.T) {
 }
 
 func TestActionsService_ListRepositoryAccessRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runner-groups/2/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -325,8 +318,7 @@ func TestActionsService_ListRepositoryAccessRunnerGroup(t *testing.T) {
 }
 
 func TestActionsService_SetRepositoryAccessRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runner-groups/2/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -357,8 +349,7 @@ func TestActionsService_SetRepositoryAccessRunnerGroup(t *testing.T) {
 }
 
 func TestActionsService_AddRepositoryAccessRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runner-groups/2/repositories/42", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -382,8 +373,7 @@ func TestActionsService_AddRepositoryAccessRunnerGroup(t *testing.T) {
 }
 
 func TestActionsService_RemoveRepositoryAccessRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runner-groups/2/repositories/42", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -407,8 +397,7 @@ func TestActionsService_RemoveRepositoryAccessRunnerGroup(t *testing.T) {
 }
 
 func TestActionsService_ListRunnerGroupRunners(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runner-groups/2/runners", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -450,8 +439,7 @@ func TestActionsService_ListRunnerGroupRunners(t *testing.T) {
 }
 
 func TestActionsService_SetRunnerGroupRunners(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runner-groups/2/runners", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -482,8 +470,7 @@ func TestActionsService_SetRunnerGroupRunners(t *testing.T) {
 }
 
 func TestActionsService_AddRunnerGroupRunners(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runner-groups/2/runners/42", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -507,8 +494,7 @@ func TestActionsService_AddRunnerGroupRunners(t *testing.T) {
 }
 
 func TestActionsService_RemoveRunnerGroupRunners(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runner-groups/2/runners/42", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -597,7 +583,7 @@ func TestRunnerGroups_Marshal(t *testing.T) {
 			"allows_public_repositories": true,
 			"restricted_to_workflows": false,
 			"selected_workflows": []
-		}]		
+		}]
 	}`
 
 	testJSONMarshal(t, u, want)

--- a/github/actions_runners_test.go
+++ b/github/actions_runners_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestActionsService_ListRunnerApplicationDownloads(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runners/downloads", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -58,8 +57,7 @@ func TestActionsService_ListRunnerApplicationDownloads(t *testing.T) {
 }
 
 func TestActionsService_GenerateOrgJITConfig(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &GenerateJITConfigRequest{Name: "test", RunnerGroupID: 1, Labels: []string{"one", "two"}}
 
@@ -102,8 +100,7 @@ func TestActionsService_GenerateOrgJITConfig(t *testing.T) {
 }
 
 func TestActionsService_GenerateRepoJITConfig(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &GenerateJITConfigRequest{Name: "test", RunnerGroupID: 1, Labels: []string{"one", "two"}}
 
@@ -146,8 +143,7 @@ func TestActionsService_GenerateRepoJITConfig(t *testing.T) {
 }
 
 func TestActionsService_CreateRegistrationToken(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runners/registration-token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -183,8 +179,7 @@ func TestActionsService_CreateRegistrationToken(t *testing.T) {
 }
 
 func TestActionsService_ListRunners(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runners", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -228,8 +223,7 @@ func TestActionsService_ListRunners(t *testing.T) {
 }
 
 func TestActionsService_GetRunner(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runners/23", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -268,8 +262,7 @@ func TestActionsService_GetRunner(t *testing.T) {
 }
 
 func TestActionsService_CreateRemoveToken(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runners/remove-token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -303,8 +296,7 @@ func TestActionsService_CreateRemoveToken(t *testing.T) {
 }
 
 func TestActionsService_RemoveRunner(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runners/21", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -328,8 +320,7 @@ func TestActionsService_RemoveRunner(t *testing.T) {
 }
 
 func TestActionsService_ListOrganizationRunnerApplicationDownloads(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runners/downloads", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -369,8 +360,7 @@ func TestActionsService_ListOrganizationRunnerApplicationDownloads(t *testing.T)
 }
 
 func TestActionsService_CreateOrganizationRegistrationToken(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runners/registration-token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -406,8 +396,7 @@ func TestActionsService_CreateOrganizationRegistrationToken(t *testing.T) {
 }
 
 func TestActionsService_ListOrganizationRunners(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runners", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -451,8 +440,7 @@ func TestActionsService_ListOrganizationRunners(t *testing.T) {
 }
 
 func TestActionsService_GetOrganizationRunner(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runners/23", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -491,8 +479,7 @@ func TestActionsService_GetOrganizationRunner(t *testing.T) {
 }
 
 func TestActionsService_CreateOrganizationRemoveToken(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runners/remove-token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -526,8 +513,7 @@ func TestActionsService_CreateOrganizationRemoveToken(t *testing.T) {
 }
 
 func TestActionsService_RemoveOrganizationRunner(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/runners/21", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/actions_secrets_test.go
+++ b/github/actions_secrets_test.go
@@ -93,8 +93,7 @@ func TestPublicKey_UnmarshalJSON(t *testing.T) {
 }
 
 func TestActionsService_GetRepoPublicKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/secrets/public-key", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -128,8 +127,7 @@ func TestActionsService_GetRepoPublicKey(t *testing.T) {
 }
 
 func TestActionsService_GetRepoPublicKeyNumeric(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/secrets/public-key", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -163,8 +161,7 @@ func TestActionsService_GetRepoPublicKeyNumeric(t *testing.T) {
 }
 
 func TestActionsService_ListRepoSecrets(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/secrets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -206,8 +203,7 @@ func TestActionsService_ListRepoSecrets(t *testing.T) {
 }
 
 func TestActionsService_ListRepoOrgSecrets(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/organization-secrets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -249,8 +245,7 @@ func TestActionsService_ListRepoOrgSecrets(t *testing.T) {
 }
 
 func TestActionsService_GetRepoSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -288,8 +283,7 @@ func TestActionsService_GetRepoSecret(t *testing.T) {
 }
 
 func TestActionsService_CreateOrUpdateRepoSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -321,8 +315,7 @@ func TestActionsService_CreateOrUpdateRepoSecret(t *testing.T) {
 }
 
 func TestActionsService_DeleteRepoSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -346,8 +339,7 @@ func TestActionsService_DeleteRepoSecret(t *testing.T) {
 }
 
 func TestActionsService_GetOrgPublicKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/secrets/public-key", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -381,8 +373,7 @@ func TestActionsService_GetOrgPublicKey(t *testing.T) {
 }
 
 func TestActionsService_ListOrgSecrets(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/secrets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -425,8 +416,7 @@ func TestActionsService_ListOrgSecrets(t *testing.T) {
 }
 
 func TestActionsService_GetOrgSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -466,8 +456,7 @@ func TestActionsService_GetOrgSecret(t *testing.T) {
 }
 
 func TestActionsService_CreateOrUpdateOrgSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -501,8 +490,7 @@ func TestActionsService_CreateOrUpdateOrgSecret(t *testing.T) {
 }
 
 func TestActionsService_ListSelectedReposForOrgSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -542,8 +530,7 @@ func TestActionsService_ListSelectedReposForOrgSecret(t *testing.T) {
 }
 
 func TestActionsService_SetSelectedReposForOrgSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -569,8 +556,7 @@ func TestActionsService_SetSelectedReposForOrgSecret(t *testing.T) {
 }
 
 func TestActionsService_AddSelectedRepoToOrgSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -595,8 +581,7 @@ func TestActionsService_AddSelectedRepoToOrgSecret(t *testing.T) {
 }
 
 func TestActionsService_RemoveSelectedRepoFromOrgSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -621,8 +606,7 @@ func TestActionsService_RemoveSelectedRepoFromOrgSecret(t *testing.T) {
 }
 
 func TestActionsService_DeleteOrgSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -646,8 +630,8 @@ func TestActionsService_DeleteOrgSecret(t *testing.T) {
 }
 
 func TestActionsService_GetEnvPublicKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repositories/1/environments/e/secrets/public-key", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"key_id":"1234","key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
@@ -680,8 +664,7 @@ func TestActionsService_GetEnvPublicKey(t *testing.T) {
 }
 
 func TestActionsService_GetEnvPublicKeyNumeric(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repositories/1/environments/e/secrets/public-key", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -715,8 +698,7 @@ func TestActionsService_GetEnvPublicKeyNumeric(t *testing.T) {
 }
 
 func TestActionsService_ListEnvSecrets(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repositories/1/environments/e/secrets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -758,8 +740,7 @@ func TestActionsService_ListEnvSecrets(t *testing.T) {
 }
 
 func TestActionsService_GetEnvSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repositories/1/environments/e/secrets/secret", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -797,8 +778,7 @@ func TestActionsService_GetEnvSecret(t *testing.T) {
 }
 
 func TestActionsService_CreateOrUpdateEnvSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repositories/1/environments/e/secrets/secret", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -830,8 +810,7 @@ func TestActionsService_CreateOrUpdateEnvSecret(t *testing.T) {
 }
 
 func TestActionsService_DeleteEnvSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repositories/1/environments/e/secrets/secret", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/actions_variables_test.go
+++ b/github/actions_variables_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestActionsService_ListRepoVariables(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -59,8 +58,7 @@ func TestActionsService_ListRepoVariables(t *testing.T) {
 }
 
 func TestActionsService_ListRepoOrgVariables(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/organization-variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -102,8 +100,7 @@ func TestActionsService_ListRepoOrgVariables(t *testing.T) {
 }
 
 func TestActionsService_GetRepoVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/variables/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -142,8 +139,7 @@ func TestActionsService_GetRepoVariable(t *testing.T) {
 }
 
 func TestActionsService_CreateRepoVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -174,8 +170,7 @@ func TestActionsService_CreateRepoVariable(t *testing.T) {
 }
 
 func TestActionsService_UpdateRepoVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/variables/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -206,8 +201,7 @@ func TestActionsService_UpdateRepoVariable(t *testing.T) {
 }
 
 func TestActionsService_DeleteRepoVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/variables/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -231,8 +225,7 @@ func TestActionsService_DeleteRepoVariable(t *testing.T) {
 }
 
 func TestActionsService_ListOrgVariables(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -275,8 +268,7 @@ func TestActionsService_ListOrgVariables(t *testing.T) {
 }
 
 func TestActionsService_GetOrgVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/variables/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -317,8 +309,7 @@ func TestActionsService_GetOrgVariable(t *testing.T) {
 }
 
 func TestActionsService_CreateOrgVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -351,8 +342,7 @@ func TestActionsService_CreateOrgVariable(t *testing.T) {
 }
 
 func TestActionsService_UpdateOrgVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/variables/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -385,8 +375,7 @@ func TestActionsService_UpdateOrgVariable(t *testing.T) {
 }
 
 func TestActionsService_ListSelectedReposForOrgVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/variables/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -426,8 +415,7 @@ func TestActionsService_ListSelectedReposForOrgVariable(t *testing.T) {
 }
 
 func TestActionsService_SetSelectedReposForOrgSVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/variables/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -453,8 +441,7 @@ func TestActionsService_SetSelectedReposForOrgSVariable(t *testing.T) {
 }
 
 func TestActionsService_AddSelectedRepoToOrgVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/variables/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -479,8 +466,7 @@ func TestActionsService_AddSelectedRepoToOrgVariable(t *testing.T) {
 }
 
 func TestActionsService_RemoveSelectedRepoFromOrgVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/variables/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -505,8 +491,7 @@ func TestActionsService_RemoveSelectedRepoFromOrgVariable(t *testing.T) {
 }
 
 func TestActionsService_DeleteOrgVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/variables/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -530,8 +515,7 @@ func TestActionsService_DeleteOrgVariable(t *testing.T) {
 }
 
 func TestActionsService_ListEnvVariables(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/usr/1/environments/e/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -573,8 +557,7 @@ func TestActionsService_ListEnvVariables(t *testing.T) {
 }
 
 func TestActionsService_GetEnvVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/usr/1/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -613,8 +596,7 @@ func TestActionsService_GetEnvVariable(t *testing.T) {
 }
 
 func TestActionsService_CreateEnvVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/usr/1/environments/e/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -645,8 +627,7 @@ func TestActionsService_CreateEnvVariable(t *testing.T) {
 }
 
 func TestActionsService_UpdateEnvVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/usr/1/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -677,8 +658,7 @@ func TestActionsService_UpdateEnvVariable(t *testing.T) {
 }
 
 func TestActionsService_DeleteEnvVariable(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/usr/1/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func TestActionsService_ListWorkflowJobs(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/29679449/jobs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -61,8 +60,7 @@ func TestActionsService_ListWorkflowJobs(t *testing.T) {
 }
 
 func TestActionsService_ListWorkflowJobs_Filter(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/29679449/jobs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -90,8 +88,7 @@ func TestActionsService_ListWorkflowJobs_Filter(t *testing.T) {
 }
 
 func TestActionsService_ListWorkflowJobsAttempt(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/29679449/attempts/1/jobs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -144,8 +141,7 @@ func TestActionsService_ListWorkflowJobsAttempt(t *testing.T) {
 }
 
 func TestActionsService_GetWorkflowJobByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/jobs/399444496", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -183,8 +179,7 @@ func TestActionsService_GetWorkflowJobByID(t *testing.T) {
 }
 
 func TestActionsService_GetWorkflowJobLogs(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/jobs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -221,8 +216,7 @@ func TestActionsService_GetWorkflowJobLogs(t *testing.T) {
 }
 
 func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_dontFollowRedirects(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/jobs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -237,8 +231,7 @@ func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_dontFollowRedi
 }
 
 func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_followRedirects(t *testing.T) {
-	client, mux, serverURL, teardown := setup()
-	defer teardown()
+	client, mux, serverURL := setup(t)
 
 	// Mock a redirect link, which leads to an archive link
 	mux.HandleFunc("/repos/o/r/actions/jobs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {

--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func TestActionsService_ListWorkflowRunsByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/workflows/29679449/runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -61,8 +60,7 @@ func TestActionsService_ListWorkflowRunsByID(t *testing.T) {
 }
 
 func TestActionsService_ListWorkflowRunsFileName(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/workflows/29679449/runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -104,8 +102,7 @@ func TestActionsService_ListWorkflowRunsFileName(t *testing.T) {
 }
 
 func TestActionsService_GetWorkflowRunByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/29679449", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -145,8 +142,7 @@ func TestActionsService_GetWorkflowRunByID(t *testing.T) {
 }
 
 func TestActionsService_GetWorkflowRunAttempt(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/29679449/attempts/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -189,8 +185,7 @@ func TestActionsService_GetWorkflowRunAttempt(t *testing.T) {
 }
 
 func TestActionsService_GetWorkflowRunAttemptLogs(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/399444496/attempts/2/logs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -218,8 +213,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs(t *testing.T) {
 }
 
 func TestActionsService_GetWorkflowRunAttemptLogs_StatusMovedPermanently_dontFollowRedirects(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/399444496/attempts/2/logs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -234,8 +228,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs_StatusMovedPermanently_dontFol
 }
 
 func TestActionsService_GetWorkflowRunAttemptLogs_StatusMovedPermanently_followRedirects(t *testing.T) {
-	client, mux, serverURL, teardown := setup()
-	defer teardown()
+	client, mux, serverURL := setup(t)
 
 	// Mock a redirect link, which leads to an archive link
 	mux.HandleFunc("/repos/o/r/actions/runs/399444496/attempts/2/logs", func(w http.ResponseWriter, r *http.Request) {
@@ -272,8 +265,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs_StatusMovedPermanently_followR
 }
 
 func TestActionsService_RerunWorkflowRunByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/3434/rerun", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -301,8 +293,7 @@ func TestActionsService_RerunWorkflowRunByID(t *testing.T) {
 }
 
 func TestActionsService_RerunFailedJobsByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/3434/rerun-failed-jobs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -330,8 +321,7 @@ func TestActionsService_RerunFailedJobsByID(t *testing.T) {
 }
 
 func TestActionsService_RerunJobByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/jobs/3434/rerun", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -359,8 +349,7 @@ func TestActionsService_RerunJobByID(t *testing.T) {
 }
 
 func TestActionsService_CancelWorkflowRunByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/3434/cancel", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -388,8 +377,7 @@ func TestActionsService_CancelWorkflowRunByID(t *testing.T) {
 }
 
 func TestActionsService_GetWorkflowRunLogs(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -417,8 +405,7 @@ func TestActionsService_GetWorkflowRunLogs(t *testing.T) {
 }
 
 func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_dontFollowRedirects(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -433,8 +420,7 @@ func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_dontFollowRedi
 }
 
 func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_followRedirects(t *testing.T) {
-	client, mux, serverURL, teardown := setup()
-	defer teardown()
+	client, mux, serverURL := setup(t)
 
 	// Mock a redirect link, which leads to an archive link
 	mux.HandleFunc("/repos/o/r/actions/runs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
@@ -471,8 +457,7 @@ func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_followRedirect
 }
 
 func TestActionService_ListRepositoryWorkflowRuns(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -520,8 +505,7 @@ func TestActionService_ListRepositoryWorkflowRuns(t *testing.T) {
 }
 
 func TestActionService_DeleteWorkflowRun(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/399444496", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -546,8 +530,7 @@ func TestActionService_DeleteWorkflowRun(t *testing.T) {
 }
 
 func TestActionService_DeleteWorkflowRunLogs(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -572,8 +555,7 @@ func TestActionService_DeleteWorkflowRunLogs(t *testing.T) {
 }
 
 func TestActionsService_GetWorkflowRunUsageByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/runs/29679449/timing", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1256,8 +1238,7 @@ func TestWorkflowRunUsage_Marshal(t *testing.T) {
 }
 
 func TestActionService_PendingDeployments(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &PendingDeploymentsRequest{EnvironmentIDs: []int64{3, 4}, State: "approved", Comment: ""}
 

--- a/github/actions_workflows_test.go
+++ b/github/actions_workflows_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestActionsService_ListWorkflows(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/workflows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -60,8 +59,7 @@ func TestActionsService_ListWorkflows(t *testing.T) {
 }
 
 func TestActionsService_GetWorkflowByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/workflows/72844", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -99,8 +97,7 @@ func TestActionsService_GetWorkflowByID(t *testing.T) {
 }
 
 func TestActionsService_GetWorkflowByFileName(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/workflows/main.yml", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -138,8 +135,7 @@ func TestActionsService_GetWorkflowByFileName(t *testing.T) {
 }
 
 func TestActionsService_GetWorkflowUsageByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/workflows/72844/timing", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -185,8 +181,7 @@ func TestActionsService_GetWorkflowUsageByID(t *testing.T) {
 }
 
 func TestActionsService_GetWorkflowUsageByFileName(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/workflows/main.yml/timing", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -232,8 +227,7 @@ func TestActionsService_GetWorkflowUsageByFileName(t *testing.T) {
 }
 
 func TestActionsService_CreateWorkflowDispatchEventByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	event := CreateWorkflowDispatchEventRequest{
 		Ref: "d4cfb6e7",
@@ -276,8 +270,7 @@ func TestActionsService_CreateWorkflowDispatchEventByID(t *testing.T) {
 }
 
 func TestActionsService_CreateWorkflowDispatchEventByFileName(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	event := CreateWorkflowDispatchEventRequest{
 		Ref: "d4cfb6e7",
@@ -320,8 +313,7 @@ func TestActionsService_CreateWorkflowDispatchEventByFileName(t *testing.T) {
 }
 
 func TestActionsService_EnableWorkflowByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/workflows/72844/enable", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -355,8 +347,7 @@ func TestActionsService_EnableWorkflowByID(t *testing.T) {
 }
 
 func TestActionsService_EnableWorkflowByFilename(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/workflows/main.yml/enable", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -390,8 +381,7 @@ func TestActionsService_EnableWorkflowByFilename(t *testing.T) {
 }
 
 func TestActionsService_DisableWorkflowByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/workflows/72844/disable", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -425,8 +415,7 @@ func TestActionsService_DisableWorkflowByID(t *testing.T) {
 }
 
 func TestActionsService_DisableWorkflowByFileName(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/workflows/main.yml/disable", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")

--- a/github/activity_events_test.go
+++ b/github/activity_events_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestActivityService_ListEvents(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -50,8 +49,7 @@ func TestActivityService_ListEvents(t *testing.T) {
 }
 
 func TestActivityService_ListRepositoryEvents(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -89,8 +87,7 @@ func TestActivityService_ListRepositoryEvents(t *testing.T) {
 }
 
 func TestActivityService_ListRepositoryEvents_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Activity.ListRepositoryEvents(ctx, "%", "%", nil)
@@ -98,8 +95,7 @@ func TestActivityService_ListRepositoryEvents_invalidOwner(t *testing.T) {
 }
 
 func TestActivityService_ListIssueEventsForRepository(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -137,8 +133,7 @@ func TestActivityService_ListIssueEventsForRepository(t *testing.T) {
 }
 
 func TestActivityService_ListIssueEventsForRepository_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Activity.ListIssueEventsForRepository(ctx, "%", "%", nil)
@@ -146,8 +141,7 @@ func TestActivityService_ListIssueEventsForRepository_invalidOwner(t *testing.T)
 }
 
 func TestActivityService_ListEventsForRepoNetwork(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/networks/o/r/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -185,8 +179,7 @@ func TestActivityService_ListEventsForRepoNetwork(t *testing.T) {
 }
 
 func TestActivityService_ListEventsForRepoNetwork_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Activity.ListEventsForRepoNetwork(ctx, "%", "%", nil)
@@ -194,8 +187,7 @@ func TestActivityService_ListEventsForRepoNetwork_invalidOwner(t *testing.T) {
 }
 
 func TestActivityService_ListEventsForOrganization(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -233,8 +225,7 @@ func TestActivityService_ListEventsForOrganization(t *testing.T) {
 }
 
 func TestActivityService_ListEventsForOrganization_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Activity.ListEventsForOrganization(ctx, "%", nil)
@@ -242,8 +233,7 @@ func TestActivityService_ListEventsForOrganization_invalidOrg(t *testing.T) {
 }
 
 func TestActivityService_ListEventsPerformedByUser_all(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -281,8 +271,7 @@ func TestActivityService_ListEventsPerformedByUser_all(t *testing.T) {
 }
 
 func TestActivityService_ListEventsPerformedByUser_publicOnly(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/events/public", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -302,8 +291,7 @@ func TestActivityService_ListEventsPerformedByUser_publicOnly(t *testing.T) {
 }
 
 func TestActivityService_ListEventsPerformedByUser_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Activity.ListEventsPerformedByUser(ctx, "%", false, nil)
@@ -311,8 +299,7 @@ func TestActivityService_ListEventsPerformedByUser_invalidUser(t *testing.T) {
 }
 
 func TestActivityService_ListEventsReceivedByUser_all(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/received_events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -350,8 +337,7 @@ func TestActivityService_ListEventsReceivedByUser_all(t *testing.T) {
 }
 
 func TestActivityService_ListEventsReceivedByUser_publicOnly(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/received_events/public", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -371,8 +357,7 @@ func TestActivityService_ListEventsReceivedByUser_publicOnly(t *testing.T) {
 }
 
 func TestActivityService_ListEventsReceivedByUser_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Activity.ListEventsReceivedByUser(ctx, "%", false, nil)
@@ -380,8 +365,7 @@ func TestActivityService_ListEventsReceivedByUser_invalidUser(t *testing.T) {
 }
 
 func TestActivityService_ListUserEventsForOrganization(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/events/orgs/o", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/activity_notifications_test.go
+++ b/github/activity_notifications_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestActivityService_ListNotification(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/notifications", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -60,8 +59,7 @@ func TestActivityService_ListNotification(t *testing.T) {
 }
 
 func TestActivityService_ListRepositoryNotifications(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/notifications", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -95,8 +93,7 @@ func TestActivityService_ListRepositoryNotifications(t *testing.T) {
 }
 
 func TestActivityService_MarkNotificationsRead(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/notifications", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -119,8 +116,7 @@ func TestActivityService_MarkNotificationsRead(t *testing.T) {
 }
 
 func TestActivityService_MarkRepositoryNotificationsRead(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/notifications", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -148,8 +144,7 @@ func TestActivityService_MarkRepositoryNotificationsRead(t *testing.T) {
 }
 
 func TestActivityService_GetThread(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/notifications/threads/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -183,8 +178,7 @@ func TestActivityService_GetThread(t *testing.T) {
 }
 
 func TestActivityService_MarkThreadRead(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/notifications/threads/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -209,8 +203,7 @@ func TestActivityService_MarkThreadRead(t *testing.T) {
 }
 
 func TestActivityService_MarkThreadDone(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/notifications/threads/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -235,8 +228,7 @@ func TestActivityService_MarkThreadDone(t *testing.T) {
 }
 
 func TestActivityService_GetThreadSubscription(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/notifications/threads/1/subscription", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -270,8 +262,7 @@ func TestActivityService_GetThreadSubscription(t *testing.T) {
 }
 
 func TestActivityService_SetThreadSubscription(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Subscription{Subscribed: Bool(true)}
 
@@ -314,8 +305,7 @@ func TestActivityService_SetThreadSubscription(t *testing.T) {
 }
 
 func TestActivityService_DeleteThreadSubscription(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/notifications/threads/1/subscription", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/activity_star_test.go
+++ b/github/activity_star_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestActivityService_ListStargazers(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/stargazers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -57,8 +56,7 @@ func TestActivityService_ListStargazers(t *testing.T) {
 }
 
 func TestActivityService_ListStarred_authenticatedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/starred", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -93,8 +91,7 @@ func TestActivityService_ListStarred_authenticatedUser(t *testing.T) {
 }
 
 func TestActivityService_ListStarred_specifiedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/starred", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -135,8 +132,7 @@ func TestActivityService_ListStarred_specifiedUser(t *testing.T) {
 }
 
 func TestActivityService_ListStarred_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Activity.ListStarred(ctx, "%", nil)
@@ -144,8 +140,7 @@ func TestActivityService_ListStarred_invalidUser(t *testing.T) {
 }
 
 func TestActivityService_IsStarred_hasStar(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/starred/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -177,8 +172,7 @@ func TestActivityService_IsStarred_hasStar(t *testing.T) {
 }
 
 func TestActivityService_IsStarred_noStar(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/starred/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -210,8 +204,7 @@ func TestActivityService_IsStarred_noStar(t *testing.T) {
 }
 
 func TestActivityService_IsStarred_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Activity.IsStarred(ctx, "%", "%")
@@ -219,8 +212,7 @@ func TestActivityService_IsStarred_invalidID(t *testing.T) {
 }
 
 func TestActivityService_Star(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/starred/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -244,8 +236,7 @@ func TestActivityService_Star(t *testing.T) {
 }
 
 func TestActivityService_Star_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Activity.Star(ctx, "%", "%")
@@ -253,8 +244,7 @@ func TestActivityService_Star_invalidID(t *testing.T) {
 }
 
 func TestActivityService_Unstar(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/starred/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -278,8 +268,7 @@ func TestActivityService_Unstar(t *testing.T) {
 }
 
 func TestActivityService_Unstar_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Activity.Unstar(ctx, "%", "%")

--- a/github/activity_test.go
+++ b/github/activity_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestActivityService_List(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/feeds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/activity_watching_test.go
+++ b/github/activity_watching_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestActivityService_ListWatchers(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/subscribers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -55,8 +54,7 @@ func TestActivityService_ListWatchers(t *testing.T) {
 }
 
 func TestActivityService_ListWatched_authenticatedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/subscriptions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -93,8 +91,7 @@ func TestActivityService_ListWatched_authenticatedUser(t *testing.T) {
 }
 
 func TestActivityService_ListWatched_specifiedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/subscriptions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -117,8 +114,7 @@ func TestActivityService_ListWatched_specifiedUser(t *testing.T) {
 }
 
 func TestActivityService_GetRepositorySubscription_true(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/subscription", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -152,8 +148,7 @@ func TestActivityService_GetRepositorySubscription_true(t *testing.T) {
 }
 
 func TestActivityService_GetRepositorySubscription_false(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/subscription", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -173,8 +168,7 @@ func TestActivityService_GetRepositorySubscription_false(t *testing.T) {
 }
 
 func TestActivityService_GetRepositorySubscription_error(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/subscription", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -189,8 +183,7 @@ func TestActivityService_GetRepositorySubscription_error(t *testing.T) {
 }
 
 func TestActivityService_SetRepositorySubscription(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Subscription{Subscribed: Bool(true)}
 
@@ -233,8 +226,7 @@ func TestActivityService_SetRepositorySubscription(t *testing.T) {
 }
 
 func TestActivityService_DeleteRepositorySubscription(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/subscription", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/admin_orgs_test.go
+++ b/github/admin_orgs_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestAdminOrgs_Create(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Organization{
 		Login: String("github"),
@@ -58,8 +57,7 @@ func TestAdminOrgs_Create(t *testing.T) {
 }
 
 func TestAdminOrgs_Rename(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Organization{
 		Login: String("o"),
@@ -100,8 +98,7 @@ func TestAdminOrgs_Rename(t *testing.T) {
 }
 
 func TestAdminOrgs_RenameByName(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/admin/organizations/o", func(w http.ResponseWriter, r *http.Request) {
 		v := new(renameOrgRequest)

--- a/github/admin_stats_test.go
+++ b/github/admin_stats_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestAdminService_GetAdminStats(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprise/stats/all", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/admin_test.go
+++ b/github/admin_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestAdminService_UpdateUserLDAPMapping(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &UserLDAPMapping{
 		LDAPDN: String("uid=asdf,ou=users,dc=github,dc=com"),
@@ -64,8 +63,7 @@ func TestAdminService_UpdateUserLDAPMapping(t *testing.T) {
 }
 
 func TestAdminService_UpdateTeamLDAPMapping(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &TeamLDAPMapping{
 		LDAPDN: String("cn=Enterprise Ops,ou=teams,dc=github,dc=com"),

--- a/github/admin_users_test.go
+++ b/github/admin_users_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestAdminUsers_Create(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/admin/users", func(w http.ResponseWriter, r *http.Request) {
 		v := new(CreateUserRequest)
@@ -63,8 +62,7 @@ func TestAdminUsers_Create(t *testing.T) {
 }
 
 func TestAdminUsers_Delete(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/admin/users/github", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -88,8 +86,7 @@ func TestAdminUsers_Delete(t *testing.T) {
 }
 
 func TestUserImpersonation_Create(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/admin/users/github/authorizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -160,8 +157,7 @@ func TestUserImpersonation_Create(t *testing.T) {
 }
 
 func TestUserImpersonation_Delete(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/admin/users/github/authorizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/apps_hooks_deliveries_test.go
+++ b/github/apps_hooks_deliveries_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestAppsService_ListHookDeliveries(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/app/hook/deliveries", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -49,8 +48,7 @@ func TestAppsService_ListHookDeliveries(t *testing.T) {
 }
 
 func TestAppsService_GetHookDelivery(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/app/hook/deliveries/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -84,8 +82,7 @@ func TestAppsService_GetHookDelivery(t *testing.T) {
 }
 
 func TestAppsService_RedeliverHookDelivery(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/app/hook/deliveries/1/attempts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/github/apps_hooks_test.go
+++ b/github/apps_hooks_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestAppsService_GetHookConfig(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/app/hook/config", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -55,8 +54,7 @@ func TestAppsService_GetHookConfig(t *testing.T) {
 }
 
 func TestAppsService_UpdateHookConfig(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &HookConfig{
 		ContentType: String("json"),

--- a/github/apps_installation_test.go
+++ b/github/apps_installation_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestAppsService_ListRepos(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{
 		mediaTypeTopicsPreview,
@@ -57,8 +56,7 @@ func TestAppsService_ListRepos(t *testing.T) {
 }
 
 func TestAppsService_ListUserRepos(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{
 		mediaTypeTopicsPreview,
@@ -103,8 +101,7 @@ func TestAppsService_ListUserRepos(t *testing.T) {
 }
 
 func TestAppsService_AddRepository(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/installations/1/repositories/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -133,8 +130,7 @@ func TestAppsService_AddRepository(t *testing.T) {
 }
 
 func TestAppsService_RemoveRepository(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/installations/1/repositories/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -154,8 +150,7 @@ func TestAppsService_RemoveRepository(t *testing.T) {
 }
 
 func TestAppsService_RevokeInstallationToken(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/installation/token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/apps_manifest_test.go
+++ b/github/apps_manifest_test.go
@@ -26,8 +26,7 @@ const (
 )
 
 func TestGetConfig(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/app-manifests/code/conversions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/github/apps_marketplace_test.go
+++ b/github/apps_marketplace_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestMarketplaceService_ListPlans(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/marketplace_listing/plans", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -51,8 +50,7 @@ func TestMarketplaceService_ListPlans(t *testing.T) {
 }
 
 func TestMarketplaceService_Stubbed_ListPlans(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/marketplace_listing/stubbed/plans", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -74,8 +72,7 @@ func TestMarketplaceService_Stubbed_ListPlans(t *testing.T) {
 }
 
 func TestMarketplaceService_ListPlanAccountsForPlan(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/marketplace_listing/plans/1/accounts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -106,8 +103,7 @@ func TestMarketplaceService_ListPlanAccountsForPlan(t *testing.T) {
 }
 
 func TestMarketplaceService_Stubbed_ListPlanAccountsForPlan(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/marketplace_listing/stubbed/plans/1/accounts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -129,8 +125,7 @@ func TestMarketplaceService_Stubbed_ListPlanAccountsForPlan(t *testing.T) {
 }
 
 func TestMarketplaceService_GetPlanAccountForAccount(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/marketplace_listing/accounts/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -160,8 +155,7 @@ func TestMarketplaceService_GetPlanAccountForAccount(t *testing.T) {
 }
 
 func TestMarketplaceService_Stubbed_GetPlanAccountForAccount(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/marketplace_listing/stubbed/accounts/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -182,8 +176,7 @@ func TestMarketplaceService_Stubbed_GetPlanAccountForAccount(t *testing.T) {
 }
 
 func TestMarketplaceService_ListMarketplacePurchasesForUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/marketplace_purchases", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -214,8 +207,7 @@ func TestMarketplaceService_ListMarketplacePurchasesForUser(t *testing.T) {
 }
 
 func TestMarketplaceService_Stubbed_ListMarketplacePurchasesForUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/marketplace_purchases/stubbed", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestAppsService_Get_authenticatedApp(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/app", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -52,8 +51,7 @@ func TestAppsService_Get_authenticatedApp(t *testing.T) {
 }
 
 func TestAppsService_Get_specifiedApp(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/apps/a", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -73,8 +71,7 @@ func TestAppsService_Get_specifiedApp(t *testing.T) {
 }
 
 func TestAppsService_ListInstallationRequests(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/app/installation-requests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -120,8 +117,7 @@ func TestAppsService_ListInstallationRequests(t *testing.T) {
 }
 
 func TestAppsService_ListInstallations(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/app/installations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -254,8 +250,7 @@ func TestAppsService_ListInstallations(t *testing.T) {
 }
 
 func TestAppsService_GetInstallation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/app/installations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -289,8 +284,7 @@ func TestAppsService_GetInstallation(t *testing.T) {
 }
 
 func TestAppsService_ListUserInstallations(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/installations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -324,8 +318,7 @@ func TestAppsService_ListUserInstallations(t *testing.T) {
 }
 
 func TestAppsService_SuspendInstallation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/app/installations/1/suspended", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -350,8 +343,7 @@ func TestAppsService_SuspendInstallation(t *testing.T) {
 }
 
 func TestAppsService_UnsuspendInstallation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/app/installations/1/suspended", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -376,8 +368,7 @@ func TestAppsService_UnsuspendInstallation(t *testing.T) {
 }
 
 func TestAppsService_DeleteInstallation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/app/installations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -402,8 +393,7 @@ func TestAppsService_DeleteInstallation(t *testing.T) {
 }
 
 func TestAppsService_CreateInstallationToken(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/app/installations/1/access_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -437,8 +427,7 @@ func TestAppsService_CreateInstallationToken(t *testing.T) {
 }
 
 func TestAppsService_CreateInstallationTokenWithOptions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	installationTokenOptions := &InstallationTokenOptions{
 		RepositoryIDs: []int64{1234},
@@ -474,8 +463,7 @@ func TestAppsService_CreateInstallationTokenWithOptions(t *testing.T) {
 }
 
 func TestAppsService_CreateInstallationTokenListReposWithOptions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	installationTokenListRepoOptions := &InstallationTokenListRepoOptions{
 		Repositories: []string{"foo"},
@@ -510,8 +498,7 @@ func TestAppsService_CreateInstallationTokenListReposWithOptions(t *testing.T) {
 }
 
 func TestAppsService_CreateInstallationTokenListReposWithNoOptions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/app/installations/1/access_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -545,8 +532,7 @@ func TestAppsService_CreateInstallationTokenListReposWithNoOptions(t *testing.T)
 }
 
 func TestAppsService_CreateAttachment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/content_references/11/attachments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -583,8 +569,7 @@ func TestAppsService_CreateAttachment(t *testing.T) {
 }
 
 func TestAppsService_FindOrganizationInstallation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/installation", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -618,8 +603,7 @@ func TestAppsService_FindOrganizationInstallation(t *testing.T) {
 }
 
 func TestAppsService_FindRepositoryInstallation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/installation", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -653,8 +637,7 @@ func TestAppsService_FindRepositoryInstallation(t *testing.T) {
 }
 
 func TestAppsService_FindRepositoryInstallationByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repositories/1/installation", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -688,8 +671,7 @@ func TestAppsService_FindRepositoryInstallationByID(t *testing.T) {
 }
 
 func TestAppsService_FindUserInstallation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/installation", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/authorizations_test.go
+++ b/github/authorizations_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestAuthorizationsService_Check(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/applications/id/token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -52,8 +51,7 @@ func TestAuthorizationsService_Check(t *testing.T) {
 }
 
 func TestAuthorizationsService_Reset(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/applications/id/token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -89,8 +87,7 @@ func TestAuthorizationsService_Reset(t *testing.T) {
 }
 
 func TestAuthorizationsService_Revoke(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/applications/id/token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -117,8 +114,7 @@ func TestAuthorizationsService_Revoke(t *testing.T) {
 }
 
 func TestDeleteGrant(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/applications/id/grant", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -144,8 +140,7 @@ func TestDeleteGrant(t *testing.T) {
 }
 
 func TestAuthorizationsService_CreateImpersonation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/admin/users/u/authorizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -180,8 +175,7 @@ func TestAuthorizationsService_CreateImpersonation(t *testing.T) {
 }
 
 func TestAuthorizationsService_DeleteImpersonation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/admin/users/u/authorizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/billing_test.go
+++ b/github/billing_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestBillingService_GetActionsBillingOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/settings/billing/actions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -68,8 +67,7 @@ func TestBillingService_GetActionsBillingOrg(t *testing.T) {
 }
 
 func TestBillingService_GetActionsBillingOrg_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Billing.GetActionsBillingOrg(ctx, "%")
@@ -77,8 +75,7 @@ func TestBillingService_GetActionsBillingOrg_invalidOrg(t *testing.T) {
 }
 
 func TestBillingService_GetPackagesBillingOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/settings/billing/packages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -120,8 +117,7 @@ func TestBillingService_GetPackagesBillingOrg(t *testing.T) {
 }
 
 func TestBillingService_GetPackagesBillingOrg_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Billing.GetPackagesBillingOrg(ctx, "%")
@@ -129,8 +125,7 @@ func TestBillingService_GetPackagesBillingOrg_invalidOrg(t *testing.T) {
 }
 
 func TestBillingService_GetStorageBillingOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/settings/billing/shared-storage", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -172,8 +167,7 @@ func TestBillingService_GetStorageBillingOrg(t *testing.T) {
 }
 
 func TestBillingService_GetStorageBillingOrg_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Billing.GetStorageBillingOrg(ctx, "%")
@@ -181,8 +175,7 @@ func TestBillingService_GetStorageBillingOrg_invalidOrg(t *testing.T) {
 }
 
 func TestBillingService_GetActionsBillingUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/settings/billing/actions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -234,8 +227,7 @@ func TestBillingService_GetActionsBillingUser(t *testing.T) {
 }
 
 func TestBillingService_GetActionsBillingUser_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Billing.GetActionsBillingUser(ctx, "%")
@@ -243,8 +235,7 @@ func TestBillingService_GetActionsBillingUser_invalidUser(t *testing.T) {
 }
 
 func TestBillingService_GetPackagesBillingUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/settings/billing/packages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -286,8 +277,7 @@ func TestBillingService_GetPackagesBillingUser(t *testing.T) {
 }
 
 func TestBillingService_GetPackagesBillingUser_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Billing.GetPackagesBillingUser(ctx, "%")
@@ -295,8 +285,7 @@ func TestBillingService_GetPackagesBillingUser_invalidUser(t *testing.T) {
 }
 
 func TestBillingService_GetStorageBillingUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/settings/billing/shared-storage", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -338,8 +327,7 @@ func TestBillingService_GetStorageBillingUser(t *testing.T) {
 }
 
 func TestBillingService_GetStorageBillingUser_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Billing.GetStorageBillingUser(ctx, "%")
@@ -429,8 +417,7 @@ func TestStorageBilling_Marshal(t *testing.T) {
 }
 
 func TestBillingService_GetAdvancedSecurityActiveCommittersOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/settings/billing/advanced-security", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -443,7 +430,7 @@ func TestBillingService_GetAdvancedSecurityActiveCommittersOrg(t *testing.T) {
     {
       "name": "octocat-org/Hello-World",
       "advanced_security_committers": 2,
-      
+
       "advanced_security_committers_breakdown": [
         {
           "user_login": "octokitten",
@@ -500,8 +487,7 @@ func TestBillingService_GetAdvancedSecurityActiveCommittersOrg(t *testing.T) {
 }
 
 func TestBillingService_GetAdvancedSecurityActiveCommittersOrg_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Billing.GetAdvancedSecurityActiveCommittersOrg(ctx, "%", nil)

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestChecksService_GetCheckRun(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/check-runs/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -66,8 +65,7 @@ func TestChecksService_GetCheckRun(t *testing.T) {
 }
 
 func TestChecksService_GetCheckSuite(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/check-suites/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -115,8 +113,7 @@ func TestChecksService_GetCheckSuite(t *testing.T) {
 }
 
 func TestChecksService_CreateCheckRun(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -182,8 +179,7 @@ func TestChecksService_CreateCheckRun(t *testing.T) {
 }
 
 func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/check-runs/1/annotations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -196,7 +192,7 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 		                           "start_line": 2,
 		                           "end_line": 2,
 		                           "start_column": 1,
-		                           "end_column": 5,									
+		                           "end_column": 5,
 		                           "annotation_level": "warning",
 		                           "message": "Check your spelling for 'banaas'.",
                                            "title": "Spell check",
@@ -242,8 +238,7 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 }
 
 func TestChecksService_UpdateCheckRun(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/check-runs/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -251,7 +246,7 @@ func TestChecksService_UpdateCheckRun(t *testing.T) {
 		fmt.Fprint(w, `{
 			"id": 1,
                         "name":"testUpdateCheckRun",
-			"status": "completed",            
+			"status": "completed",
 			"conclusion": "neutral",
 			"started_at": "2018-05-04T01:14:52Z",
 			"completed_at": "2018-05-04T01:14:52Z",
@@ -308,8 +303,7 @@ func TestChecksService_UpdateCheckRun(t *testing.T) {
 }
 
 func TestChecksService_ListCheckRunsForRef(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/commits/master/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -380,8 +374,7 @@ func TestChecksService_ListCheckRunsForRef(t *testing.T) {
 }
 
 func TestChecksService_ListCheckRunsCheckSuite(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/check-suites/1/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -447,8 +440,7 @@ func TestChecksService_ListCheckRunsCheckSuite(t *testing.T) {
 }
 
 func TestChecksService_ListCheckSuiteForRef(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/commits/master/check-suites", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -513,8 +505,7 @@ func TestChecksService_ListCheckSuiteForRef(t *testing.T) {
 }
 
 func TestChecksService_SetCheckSuitePreferences(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/check-suites/preferences", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -560,8 +551,7 @@ func TestChecksService_SetCheckSuitePreferences(t *testing.T) {
 }
 
 func TestChecksService_CreateCheckSuite(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/check-suites", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -616,8 +606,7 @@ func TestChecksService_CreateCheckSuite(t *testing.T) {
 }
 
 func TestChecksService_ReRequestCheckSuite(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/check-suites/1/rerequest", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -1726,8 +1715,7 @@ func TestCheckSuitePreferenceResults_Marshal(t *testing.T) {
 }
 
 func TestChecksService_ReRequestCheckRun(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/check-runs/1/rerequest", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/github/code-scanning_test.go
+++ b/github/code-scanning_test.go
@@ -55,8 +55,7 @@ func TestCodeScanningService_Alert_ID(t *testing.T) {
 }
 
 func TestCodeScanningService_UploadSarif(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	expectedSarifID := &SarifID{
 		ID:  String("testid"),
@@ -100,8 +99,7 @@ func TestCodeScanningService_UploadSarif(t *testing.T) {
 }
 
 func TestCodeScanningService_GetSARIF(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/code-scanning/sarifs/abc", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -141,8 +139,7 @@ func TestCodeScanningService_GetSARIF(t *testing.T) {
 }
 
 func TestCodeScanningService_ListAlertsForOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/code-scanning/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -345,8 +342,7 @@ func TestCodeScanningService_ListAlertsForOrg(t *testing.T) {
 }
 
 func TestCodeScanningService_ListAlertsForOrgLisCursorOptions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/code-scanning/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -471,8 +467,7 @@ func TestCodeScanningService_ListAlertsForOrgLisCursorOptions(t *testing.T) {
 }
 
 func TestCodeScanningService_ListAlertsForRepo(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/code-scanning/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -665,8 +660,8 @@ func TestCodeScanningService_ListAlertsForRepo(t *testing.T) {
 }
 
 func TestCodeScanningService_UpdateAlert(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/code-scanning/alerts/88", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
 		fmt.Fprint(w, `{"rule_id":"js/useless-expression",
@@ -782,8 +777,7 @@ func TestCodeScanningService_UpdateAlert(t *testing.T) {
 }
 
 func TestCodeScanningService_ListAlertInstances(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/code-scanning/alerts/88/instances", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -861,8 +855,7 @@ func TestCodeScanningService_ListAlertInstances(t *testing.T) {
 }
 
 func TestCodeScanningService_GetAlert(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/code-scanning/alerts/88", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1111,8 +1104,7 @@ func TestMessage_Marshal(t *testing.T) {
 }
 
 func TestCodeScanningService_ListAnalysesForRepo(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/code-scanning/analyses", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1235,8 +1227,7 @@ func TestCodeScanningService_ListAnalysesForRepo(t *testing.T) {
 }
 
 func TestCodeScanningService_GetAnalysis(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/code-scanning/analyses/3602840", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1311,8 +1302,7 @@ func TestCodeScanningService_GetAnalysis(t *testing.T) {
 }
 
 func TestCodeScanningService_DeleteAnalysis(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/code-scanning/analyses/40", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -1352,8 +1342,7 @@ func TestCodeScanningService_DeleteAnalysis(t *testing.T) {
 }
 
 func TestCodeScanningService_ListCodeQLDatabases(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/code-scanning/codeql/databases", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1451,8 +1440,7 @@ func TestCodeScanningService_ListCodeQLDatabases(t *testing.T) {
 }
 
 func TestCodeScanningService_GetCodeQLDatabase(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/code-scanning/codeql/databases/lang", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1546,8 +1534,7 @@ func TestCodeScanningService_GetCodeQLDatabase(t *testing.T) {
 }
 
 func TestCodeScanningService_GetDefaultSetupConfiguration(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/code-scanning/default-setup", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1599,8 +1586,7 @@ func TestCodeScanningService_GetDefaultSetupConfiguration(t *testing.T) {
 }
 
 func TestCodeScanningService_UpdateDefaultSetupConfiguration(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/code-scanning/default-setup", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")

--- a/github/codesofconduct_test.go
+++ b/github/codesofconduct_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestCodesOfConductService_List(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/codes_of_conduct", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -53,8 +52,7 @@ func TestCodesOfConductService_List(t *testing.T) {
 }
 
 func TestCodesOfConductService_Get(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/codes_of_conduct/k", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/codespaces_secrets_test.go
+++ b/github/codespaces_secrets_test.go
@@ -77,8 +77,7 @@ func TestCodespacesService_ListSecrets(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			tt.handleFunc(mux)
 
@@ -175,8 +174,7 @@ func TestCodespacesService_GetSecret(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			tt.handleFunc(mux)
 
@@ -273,8 +271,7 @@ func TestCodespacesService_CreateOrUpdateSecret(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			tt.handleFunc(mux)
 
@@ -358,8 +355,7 @@ func TestCodespacesService_DeleteSecret(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			tt.handleFunc(mux)
 
@@ -442,8 +438,7 @@ func TestCodespacesService_GetPublicKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			tt.handleFunc(mux)
 
@@ -519,8 +514,7 @@ func TestCodespacesService_ListSelectedReposForSecret(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			tt.handleFunc(mux)
 
@@ -604,8 +598,7 @@ func TestCodespacesService_SetSelectedReposForSecret(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			tt.handleFunc(mux)
 
@@ -670,8 +663,7 @@ func TestCodespacesService_AddSelectedReposForSecret(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			tt.handleFunc(mux)
 
@@ -736,8 +728,7 @@ func TestCodespacesService_RemoveSelectedReposFromSecret(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			tt.handleFunc(mux)
 
@@ -762,8 +753,7 @@ func TestCodespacesService_RemoveSelectedReposFromSecret(t *testing.T) {
 }
 
 // func TestActionsService_ListSelectedReposForOrgSecret(t *testing.T) {
-// 	client, mux, _, teardown := setup()
-// 	defer teardown()
+// 	client, mux, _ := setup()
 
 // 	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
 // 		testMethod(t, r, "GET")

--- a/github/codespaces_test.go
+++ b/github/codespaces_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestCodespacesService_ListInRepo(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/owner/repo/codespaces", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -101,8 +100,7 @@ func TestCodespacesService_ListInRepo(t *testing.T) {
 }
 
 func TestCodespacesService_List(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/codespaces", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -144,8 +142,8 @@ func TestCodespacesService_List(t *testing.T) {
 }
 
 func TestCodespacesService_CreateInRepo(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/owner/repo/codespaces", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Content-Type", "application/json")
@@ -190,8 +188,8 @@ func TestCodespacesService_CreateInRepo(t *testing.T) {
 }
 
 func TestCodespacesService_Start(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/user/codespaces/codespace_1/start", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{"id":1, "repository": {"id": 1296269}}`)
@@ -228,8 +226,8 @@ func TestCodespacesService_Start(t *testing.T) {
 }
 
 func TestCodespacesService_Stop(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/user/codespaces/codespace_1/stop", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{"id":1, "repository": {"id": 1296269}}`)
@@ -266,8 +264,7 @@ func TestCodespacesService_Stop(t *testing.T) {
 }
 
 func TestCodespacesService_Delete(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/codespaces/codespace_1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -272,8 +272,7 @@ func TestCopilotService_GetSeatDetailsOrganization(t *testing.T) {
 }
 
 func TestCopilotService_GetCopilotBilling(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/copilot/billing", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -331,8 +330,7 @@ func TestCopilotService_GetCopilotBilling(t *testing.T) {
 }
 
 func TestCopilotService_ListCopilotSeats(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/copilot/billing/seats", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -604,8 +602,7 @@ func TestCopilotService_ListCopilotSeats(t *testing.T) {
 }
 
 func TestCopilotService_AddCopilotTeams(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/copilot/billing/selected_teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -642,8 +639,7 @@ func TestCopilotService_AddCopilotTeams(t *testing.T) {
 }
 
 func TestCopilotService_RemoveCopilotTeams(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/copilot/billing/selected_teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -680,8 +676,7 @@ func TestCopilotService_RemoveCopilotTeams(t *testing.T) {
 }
 
 func TestCopilotService_AddCopilotUsers(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/copilot/billing/selected_users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -718,8 +713,7 @@ func TestCopilotService_AddCopilotUsers(t *testing.T) {
 }
 
 func TestCopilotService_RemoveCopilotUsers(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/copilot/billing/selected_users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -756,8 +750,7 @@ func TestCopilotService_RemoveCopilotUsers(t *testing.T) {
 }
 
 func TestCopilotService_GetSeatDetails(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/members/u/copilot", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/dependabot_alerts_test.go
+++ b/github/dependabot_alerts_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestDependabotService_ListRepoAlerts(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/dependabot/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -55,8 +54,7 @@ func TestDependabotService_ListRepoAlerts(t *testing.T) {
 }
 
 func TestDependabotService_GetRepoAlert(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/dependabot/alerts/42", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -93,8 +91,7 @@ func TestDependabotService_GetRepoAlert(t *testing.T) {
 }
 
 func TestDependabotService_ListOrgAlerts(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/dependabot/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -133,8 +130,7 @@ func TestDependabotService_ListOrgAlerts(t *testing.T) {
 }
 
 func TestDependabotService_UpdateAlert(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	state := String("dismissed")
 	dismissedReason := String("no_bandwidth")

--- a/github/dependabot_secrets_test.go
+++ b/github/dependabot_secrets_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestDependabotService_GetRepoPublicKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/dependabot/secrets/public-key", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -51,8 +50,7 @@ func TestDependabotService_GetRepoPublicKey(t *testing.T) {
 }
 
 func TestDependabotService_GetRepoPublicKeyNumeric(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/dependabot/secrets/public-key", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -86,8 +84,7 @@ func TestDependabotService_GetRepoPublicKeyNumeric(t *testing.T) {
 }
 
 func TestDependabotService_ListRepoSecrets(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/dependabot/secrets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -129,8 +126,7 @@ func TestDependabotService_ListRepoSecrets(t *testing.T) {
 }
 
 func TestDependabotService_GetRepoSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/dependabot/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -168,8 +164,7 @@ func TestDependabotService_GetRepoSecret(t *testing.T) {
 }
 
 func TestDependabotService_CreateOrUpdateRepoSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/dependabot/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -201,8 +196,7 @@ func TestDependabotService_CreateOrUpdateRepoSecret(t *testing.T) {
 }
 
 func TestDependabotService_DeleteRepoSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/dependabot/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -226,8 +220,7 @@ func TestDependabotService_DeleteRepoSecret(t *testing.T) {
 }
 
 func TestDependabotService_GetOrgPublicKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/dependabot/secrets/public-key", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -261,8 +254,7 @@ func TestDependabotService_GetOrgPublicKey(t *testing.T) {
 }
 
 func TestDependabotService_ListOrgSecrets(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/dependabot/secrets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -305,8 +297,7 @@ func TestDependabotService_ListOrgSecrets(t *testing.T) {
 }
 
 func TestDependabotService_GetOrgSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -346,8 +337,7 @@ func TestDependabotService_GetOrgSecret(t *testing.T) {
 }
 
 func TestDependabotService_CreateOrUpdateOrgSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -381,8 +371,7 @@ func TestDependabotService_CreateOrUpdateOrgSecret(t *testing.T) {
 }
 
 func TestDependabotService_ListSelectedReposForOrgSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -422,8 +411,7 @@ func TestDependabotService_ListSelectedReposForOrgSecret(t *testing.T) {
 }
 
 func TestDependabotService_SetSelectedReposForOrgSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -449,8 +437,7 @@ func TestDependabotService_SetSelectedReposForOrgSecret(t *testing.T) {
 }
 
 func TestDependabotService_AddSelectedRepoToOrgSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -475,8 +462,7 @@ func TestDependabotService_AddSelectedRepoToOrgSecret(t *testing.T) {
 }
 
 func TestDependabotService_RemoveSelectedRepoFromOrgSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -501,8 +487,7 @@ func TestDependabotService_RemoveSelectedRepoFromOrgSecret(t *testing.T) {
 }
 
 func TestDependabotService_DeleteOrgSecret(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/dependency_graph_snapshots_test.go
+++ b/github/dependency_graph_snapshots_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestDependencyGraphService_CreateSnapshot(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/dependency-graph/snapshots", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/github/dependency_graph_test.go
+++ b/github/dependency_graph_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestDependencyGraphService_GetSBOM(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/owner/repo/dependency-graph/sbom", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/emojis_test.go
+++ b/github/emojis_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestEmojisService_List(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/emojis", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/enterprise_actions_runner_groups_test.go
+++ b/github/enterprise_actions_runner_groups_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestEnterpriseService_ListRunnerGroups(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runner-groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -59,8 +58,7 @@ func TestEnterpriseService_ListRunnerGroups(t *testing.T) {
 }
 
 func TestEnterpriseService_ListRunnerGroupsVisibleToOrganization(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runner-groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -103,8 +101,7 @@ func TestEnterpriseService_ListRunnerGroupsVisibleToOrganization(t *testing.T) {
 }
 
 func TestEnterpriseService_GetRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runner-groups/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -150,8 +147,7 @@ func TestEnterpriseService_GetRunnerGroup(t *testing.T) {
 }
 
 func TestEnterpriseService_DeleteRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runner-groups/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -175,8 +171,7 @@ func TestEnterpriseService_DeleteRunnerGroup(t *testing.T) {
 }
 
 func TestEnterpriseService_CreateRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runner-groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -229,8 +224,7 @@ func TestEnterpriseService_CreateRunnerGroup(t *testing.T) {
 }
 
 func TestEnterpriseService_UpdateRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runner-groups/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -283,8 +277,7 @@ func TestEnterpriseService_UpdateRunnerGroup(t *testing.T) {
 }
 
 func TestEnterpriseService_ListOrganizationAccessRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/organizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -325,8 +318,7 @@ func TestEnterpriseService_ListOrganizationAccessRunnerGroup(t *testing.T) {
 }
 
 func TestEnterpriseService_SetOrganizationAccessRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/organizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -357,8 +349,7 @@ func TestEnterpriseService_SetOrganizationAccessRunnerGroup(t *testing.T) {
 }
 
 func TestEnterpriseService_AddOrganizationAccessRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/organizations/42", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -382,8 +373,7 @@ func TestEnterpriseService_AddOrganizationAccessRunnerGroup(t *testing.T) {
 }
 
 func TestEnterpriseService_RemoveOrganizationAccessRunnerGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/organizations/42", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -407,8 +397,7 @@ func TestEnterpriseService_RemoveOrganizationAccessRunnerGroup(t *testing.T) {
 }
 
 func TestEnterpriseService_ListEnterpriseRunnerGroupRunners(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/runners", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -450,8 +439,7 @@ func TestEnterpriseService_ListEnterpriseRunnerGroupRunners(t *testing.T) {
 }
 
 func TestEnterpriseService_SetEnterpriseRunnerGroupRunners(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/runners", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -482,8 +470,7 @@ func TestEnterpriseService_SetEnterpriseRunnerGroupRunners(t *testing.T) {
 }
 
 func TestEnterpriseService_AddEnterpriseRunnerGroupRunners(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/runners/42", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -507,8 +494,7 @@ func TestEnterpriseService_AddEnterpriseRunnerGroupRunners(t *testing.T) {
 }
 
 func TestEnterpriseService_RemoveEnterpriseRunnerGroupRunners(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/runners/42", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -597,7 +583,7 @@ func TestEnterpriseRunnerGroups_Marshal(t *testing.T) {
 			"allows_public_repositories": true,
 			"restricted_to_workflows": false,
 			"selected_workflows": []
-		}]		
+		}]
 	}`
 
 	testJSONMarshal(t, u, want)

--- a/github/enterprise_actions_runners_test.go
+++ b/github/enterprise_actions_runners_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestEnterpriseService_GenerateEnterpriseJITConfig(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &GenerateJITConfigRequest{Name: "test", RunnerGroupID: 1, Labels: []string{"one", "two"}}
 
@@ -64,8 +63,7 @@ func TestEnterpriseService_GenerateEnterpriseJITConfig(t *testing.T) {
 }
 
 func TestEnterpriseService_CreateRegistrationToken(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/actions/runners/registration-token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -101,8 +99,7 @@ func TestEnterpriseService_CreateRegistrationToken(t *testing.T) {
 }
 
 func TestEnterpriseService_ListRunners(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/actions/runners", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -146,8 +143,7 @@ func TestEnterpriseService_ListRunners(t *testing.T) {
 }
 
 func TestEnterpriseService_GetRunner(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/actions/runners/23", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -186,8 +182,7 @@ func TestEnterpriseService_GetRunner(t *testing.T) {
 }
 
 func TestEnterpriseService_RemoveRunner(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runners/21", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -211,8 +206,7 @@ func TestEnterpriseService_RemoveRunner(t *testing.T) {
 }
 
 func TestEnterpriseService_ListRunnerApplicationDownloads(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/o/actions/runners/downloads", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/enterprise_audit_log_test.go
+++ b/github/enterprise_audit_log_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestEnterpriseService_GetAuditLog(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/audit-log", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/enterprise_code_security_and_analysis_test.go
+++ b/github/enterprise_code_security_and_analysis_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestEnterpriseService_GetCodeSecurityAndAnalysis(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/code_security_and_analysis", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -67,8 +66,7 @@ func TestEnterpriseService_GetCodeSecurityAndAnalysis(t *testing.T) {
 }
 
 func TestEnterpriseService_UpdateCodeSecurityAndAnalysis(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &EnterpriseSecurityAnalysisSettings{
 		AdvancedSecurityEnabledForNewRepositories:             Bool(true),
@@ -108,8 +106,7 @@ func TestEnterpriseService_UpdateCodeSecurityAndAnalysis(t *testing.T) {
 }
 
 func TestEnterpriseService_EnableAdvancedSecurity(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/advanced_security/enable_all", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/github/gists_comments_test.go
+++ b/github/gists_comments_test.go
@@ -72,8 +72,7 @@ func TestGistComments_Marshal(t *testing.T) {
 	testJSONMarshal(t, u, want)
 }
 func TestGistsService_ListComments(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -109,8 +108,7 @@ func TestGistsService_ListComments(t *testing.T) {
 }
 
 func TestGistsService_ListComments_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Gists.ListComments(ctx, "%", nil)
@@ -118,8 +116,7 @@ func TestGistsService_ListComments_invalidID(t *testing.T) {
 }
 
 func TestGistsService_GetComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists/1/comments/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -153,8 +150,7 @@ func TestGistsService_GetComment(t *testing.T) {
 }
 
 func TestGistsService_GetComment_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Gists.GetComment(ctx, "%", 1)
@@ -162,8 +158,7 @@ func TestGistsService_GetComment_invalidID(t *testing.T) {
 }
 
 func TestGistsService_CreateComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &GistComment{ID: Int64(1), Body: String("b")}
 
@@ -206,8 +201,7 @@ func TestGistsService_CreateComment(t *testing.T) {
 }
 
 func TestGistsService_CreateComment_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Gists.CreateComment(ctx, "%", nil)
@@ -215,8 +209,7 @@ func TestGistsService_CreateComment_invalidID(t *testing.T) {
 }
 
 func TestGistsService_EditComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &GistComment{ID: Int64(1), Body: String("b")}
 
@@ -259,8 +252,7 @@ func TestGistsService_EditComment(t *testing.T) {
 }
 
 func TestGistsService_EditComment_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Gists.EditComment(ctx, "%", 1, nil)
@@ -268,8 +260,7 @@ func TestGistsService_EditComment_invalidID(t *testing.T) {
 }
 
 func TestGistsService_DeleteComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists/1/comments/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -293,8 +284,7 @@ func TestGistsService_DeleteComment(t *testing.T) {
 }
 
 func TestGistsService_DeleteComment_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Gists.DeleteComment(ctx, "%", 1)

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -226,8 +226,7 @@ func TestGistFork_Marshal(t *testing.T) {
 }
 
 func TestGistsService_List_specifiedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	since := "2013-01-01T00:00:00Z"
 
@@ -267,8 +266,7 @@ func TestGistsService_List_specifiedUser(t *testing.T) {
 }
 
 func TestGistsService_List_authenticatedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -302,8 +300,7 @@ func TestGistsService_List_authenticatedUser(t *testing.T) {
 }
 
 func TestGistsService_List_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Gists.List(ctx, "%", nil)
@@ -311,8 +308,7 @@ func TestGistsService_List_invalidUser(t *testing.T) {
 }
 
 func TestGistsService_ListAll(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	since := "2013-01-01T00:00:00Z"
 
@@ -347,8 +343,7 @@ func TestGistsService_ListAll(t *testing.T) {
 }
 
 func TestGistsService_ListStarred(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	since := "2013-01-01T00:00:00Z"
 
@@ -383,8 +378,7 @@ func TestGistsService_ListStarred(t *testing.T) {
 }
 
 func TestGistsService_Get(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -418,8 +412,7 @@ func TestGistsService_Get(t *testing.T) {
 }
 
 func TestGistsService_Get_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Gists.Get(ctx, "%")
@@ -427,8 +420,7 @@ func TestGistsService_Get_invalidID(t *testing.T) {
 }
 
 func TestGistsService_GetRevision(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists/1/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -462,8 +454,7 @@ func TestGistsService_GetRevision(t *testing.T) {
 }
 
 func TestGistsService_GetRevision_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Gists.GetRevision(ctx, "%", "%")
@@ -471,8 +462,7 @@ func TestGistsService_GetRevision_invalidID(t *testing.T) {
 }
 
 func TestGistsService_Create(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Gist{
 		Description: String("Gist description"),
@@ -534,8 +524,7 @@ func TestGistsService_Create(t *testing.T) {
 }
 
 func TestGistsService_Edit(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Gist{
 		Description: String("New description"),
@@ -605,8 +594,7 @@ func TestGistsService_Edit(t *testing.T) {
 }
 
 func TestGistsService_Edit_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Gists.Edit(ctx, "%", nil)
@@ -614,8 +602,7 @@ func TestGistsService_Edit_invalidID(t *testing.T) {
 }
 
 func TestGistsService_ListCommits(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists/1/commits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -676,8 +663,7 @@ func TestGistsService_ListCommits(t *testing.T) {
 }
 
 func TestGistsService_ListCommits_withOptions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists/1/commits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -709,8 +695,7 @@ func TestGistsService_ListCommits_withOptions(t *testing.T) {
 }
 
 func TestGistsService_ListCommits_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Gists.ListCommits(ctx, "%", nil)
@@ -718,8 +703,7 @@ func TestGistsService_ListCommits_invalidID(t *testing.T) {
 }
 
 func TestGistsService_Delete(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -743,8 +727,7 @@ func TestGistsService_Delete(t *testing.T) {
 }
 
 func TestGistsService_Delete_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Gists.Delete(ctx, "%")
@@ -752,8 +735,7 @@ func TestGistsService_Delete_invalidID(t *testing.T) {
 }
 
 func TestGistsService_Star(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists/1/star", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -777,8 +759,7 @@ func TestGistsService_Star(t *testing.T) {
 }
 
 func TestGistsService_Star_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Gists.Star(ctx, "%")
@@ -786,8 +767,7 @@ func TestGistsService_Star_invalidID(t *testing.T) {
 }
 
 func TestGistsService_Unstar(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists/1/star", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -811,8 +791,7 @@ func TestGistsService_Unstar(t *testing.T) {
 }
 
 func TestGistsService_Unstar_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Gists.Unstar(ctx, "%")
@@ -820,8 +799,7 @@ func TestGistsService_Unstar_invalidID(t *testing.T) {
 }
 
 func TestGistsService_IsStarred_hasStar(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists/1/star", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -853,8 +831,7 @@ func TestGistsService_IsStarred_hasStar(t *testing.T) {
 }
 
 func TestGistsService_IsStarred_noStar(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists/1/star", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -886,8 +863,7 @@ func TestGistsService_IsStarred_noStar(t *testing.T) {
 }
 
 func TestGistsService_IsStarred_invalidID(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Gists.IsStarred(ctx, "%")
@@ -895,8 +871,7 @@ func TestGistsService_IsStarred_invalidID(t *testing.T) {
 }
 
 func TestGistsService_Fork(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists/1/forks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -930,8 +905,7 @@ func TestGistsService_Fork(t *testing.T) {
 }
 
 func TestGistsService_ListForks(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists/1/forks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -981,8 +955,7 @@ func TestGistsService_ListForks(t *testing.T) {
 }
 
 func TestGistsService_ListForks_withOptions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gists/1/forks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/git_blobs_test.go
+++ b/github/git_blobs_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestGitService_GetBlob(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/git/blobs/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -60,8 +59,7 @@ func TestGitService_GetBlob(t *testing.T) {
 }
 
 func TestGitService_GetBlob_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Git.GetBlob(ctx, "%", "%", "%")
@@ -69,8 +67,7 @@ func TestGitService_GetBlob_invalidOwner(t *testing.T) {
 }
 
 func TestGitService_GetBlobRaw(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/git/blobs/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -106,8 +103,7 @@ func TestGitService_GetBlobRaw(t *testing.T) {
 }
 
 func TestGitService_CreateBlob(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Blob{
 		SHA:      String("s"),
@@ -163,8 +159,7 @@ func TestGitService_CreateBlob(t *testing.T) {
 }
 
 func TestGitService_CreateBlob_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Git.CreateBlob(ctx, "%", "%", &Blob{})

--- a/github/git_commits_test.go
+++ b/github/git_commits_test.go
@@ -137,8 +137,7 @@ func TestCommit_Marshal(t *testing.T) {
 }
 
 func TestGitService_GetCommit(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/git/commits/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -172,8 +171,7 @@ func TestGitService_GetCommit(t *testing.T) {
 }
 
 func TestGitService_GetCommit_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Git.GetCommit(ctx, "%", "%", "%")
@@ -181,8 +179,7 @@ func TestGitService_GetCommit_invalidOwner(t *testing.T) {
 }
 
 func TestGitService_CreateCommit(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Commit{
 		Message: String("Commit Message."),
@@ -234,8 +231,7 @@ func TestGitService_CreateCommit(t *testing.T) {
 }
 
 func TestGitService_CreateSignedCommit(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	signature := "----- BEGIN PGP SIGNATURE -----\n\naaaa\naaaa\n----- END PGP SIGNATURE -----"
 
@@ -293,8 +289,7 @@ func TestGitService_CreateSignedCommit(t *testing.T) {
 }
 
 func TestGitService_CreateSignedCommitWithInvalidParams(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	input := &Commit{}
 
@@ -307,8 +302,7 @@ func TestGitService_CreateSignedCommitWithInvalidParams(t *testing.T) {
 }
 
 func TestGitService_CreateCommitWithNilCommit(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Git.CreateCommit(ctx, "o", "r", nil, nil)
@@ -318,8 +312,8 @@ func TestGitService_CreateCommitWithNilCommit(t *testing.T) {
 }
 
 func TestGitService_CreateCommit_WithSigner(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	signature := "my voice is my password"
 	date := time.Date(2017, time.May, 4, 0, 3, 43, 0, time.FixedZone("CEST", 2*3600))
 	author := CommitAuthor{
@@ -507,8 +501,7 @@ Commit Message.`
 }
 
 func TestGitService_CreateCommit_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Git.CreateCommit(ctx, "%", "%", &Commit{}, nil)

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestGitService_GetRef_singleRef(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/git/ref/heads/b", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -74,8 +73,7 @@ func TestGitService_GetRef_singleRef(t *testing.T) {
 }
 
 func TestGitService_GetRef_noRefs(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -110,8 +108,7 @@ func TestGitService_GetRef_noRefs(t *testing.T) {
 }
 
 func TestGitService_ListMatchingRefs_singleRef(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/git/matching-refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -172,8 +169,7 @@ func TestGitService_ListMatchingRefs_singleRef(t *testing.T) {
 }
 
 func TestGitService_ListMatchingRefs_multipleRefs(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/git/matching-refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -237,8 +233,7 @@ func TestGitService_ListMatchingRefs_multipleRefs(t *testing.T) {
 }
 
 func TestGitService_ListMatchingRefs_noRefs(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/git/matching-refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -272,8 +267,7 @@ func TestGitService_ListMatchingRefs_noRefs(t *testing.T) {
 }
 
 func TestGitService_ListMatchingRefs_allRefs(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/git/matching-refs/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -346,8 +340,7 @@ func TestGitService_ListMatchingRefs_allRefs(t *testing.T) {
 }
 
 func TestGitService_ListMatchingRefs_options(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/git/matching-refs/t", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -383,8 +376,7 @@ func TestGitService_ListMatchingRefs_options(t *testing.T) {
 }
 
 func TestGitService_CreateRef(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	args := &createRefRequest{
 		Ref: String("refs/heads/b"),
@@ -472,8 +464,7 @@ func TestGitService_CreateRef(t *testing.T) {
 }
 
 func TestGitService_UpdateRef(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	args := &updateRefRequest{
 		SHA:   String("aa218f56b14c9653891f9e74264a383fa43fefbd"),
@@ -553,8 +544,7 @@ func TestGitService_UpdateRef(t *testing.T) {
 }
 
 func TestGitService_DeleteRef(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -583,8 +573,7 @@ func TestGitService_DeleteRef(t *testing.T) {
 }
 
 func TestGitService_GetRef_pathEscape(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/git/ref/heads/b", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -625,8 +614,7 @@ func TestGitService_GetRef_pathEscape(t *testing.T) {
 }
 
 func TestGitService_UpdateRef_pathEscape(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	args := &updateRefRequest{
 		SHA:   String("aa218f56b14c9653891f9e74264a383fa43fefbd"),

--- a/github/git_tags_test.go
+++ b/github/git_tags_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestGitService_GetTag(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/git/tags/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -51,8 +50,7 @@ func TestGitService_GetTag(t *testing.T) {
 }
 
 func TestGitService_CreateTag(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &createTagRequest{Tag: String("t"), Object: String("s")}
 

--- a/github/git_trees_test.go
+++ b/github/git_trees_test.go
@@ -37,8 +37,7 @@ func TestMarshalJSON_withNilContentAndSHA(t *testing.T) {
 }
 
 func TestGitService_GetTree(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/git/trees/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -84,8 +83,7 @@ func TestGitService_GetTree(t *testing.T) {
 }
 
 func TestGitService_GetTree_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Git.GetTree(ctx, "%", "%", "%", false)
@@ -93,8 +91,7 @@ func TestGitService_GetTree_invalidOwner(t *testing.T) {
 }
 
 func TestGitService_CreateTree(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := []*TreeEntry{
 		{
@@ -172,8 +169,7 @@ func TestGitService_CreateTree(t *testing.T) {
 }
 
 func TestGitService_CreateTree_Content(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := []*TreeEntry{
 		{
@@ -253,8 +249,7 @@ func TestGitService_CreateTree_Content(t *testing.T) {
 }
 
 func TestGitService_CreateTree_Delete(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := []*TreeEntry{
 		{
@@ -333,8 +328,7 @@ func TestGitService_CreateTree_Delete(t *testing.T) {
 }
 
 func TestGitService_CreateTree_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Git.CreateTree(ctx, "%", "%", "", nil)

--- a/github/gitignore_test.go
+++ b/github/gitignore_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestGitignoresService_List(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gitignore/templates", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -45,8 +44,7 @@ func TestGitignoresService_List(t *testing.T) {
 }
 
 func TestGitignoresService_Get(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/gitignore/templates/name", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -80,8 +78,7 @@ func TestGitignoresService_Get(t *testing.T) {
 }
 
 func TestGitignoresService_Get_invalidTemplate(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Gitignores.Get(ctx, "%")

--- a/github/interactions_orgs_test.go
+++ b/github/interactions_orgs_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestInteractionsService_GetRestrictionsForOrgs(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/interaction-limits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -52,8 +51,7 @@ func TestInteractionsService_GetRestrictionsForOrgs(t *testing.T) {
 }
 
 func TestInteractionsService_UpdateRestrictionsForOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &InteractionRestriction{Limit: String("existing_users")}
 
@@ -96,8 +94,7 @@ func TestInteractionsService_UpdateRestrictionsForOrg(t *testing.T) {
 }
 
 func TestInteractionsService_RemoveRestrictionsFromOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/interaction-limits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/interactions_repos_test.go
+++ b/github/interactions_repos_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestInteractionsService_GetRestrictionsForRepo(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/interaction-limits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -52,8 +51,7 @@ func TestInteractionsService_GetRestrictionsForRepo(t *testing.T) {
 }
 
 func TestInteractionsService_UpdateRestrictionsForRepo(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &InteractionRestriction{Limit: String("existing_users")}
 
@@ -96,8 +94,7 @@ func TestInteractionsService_UpdateRestrictionsForRepo(t *testing.T) {
 }
 
 func TestInteractionsService_RemoveRestrictionsFromRepo(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/interaction-limits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/issue_import_test.go
+++ b/github/issue_import_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestIssueImportService_Create(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	createdAt := time.Date(2020, time.August, 11, 15, 30, 0, 0, time.UTC)
 	input := &IssueImportRequest{
@@ -75,8 +74,7 @@ func TestIssueImportService_Create(t *testing.T) {
 }
 
 func TestIssueImportService_Create_deferred(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	createdAt := time.Date(2020, time.August, 11, 15, 30, 0, 0, time.UTC)
 	input := &IssueImportRequest{
@@ -121,8 +119,7 @@ func TestIssueImportService_Create_deferred(t *testing.T) {
 }
 
 func TestIssueImportService_Create_badResponse(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	createdAt := time.Date(2020, time.August, 11, 15, 30, 0, 0, time.UTC)
 	input := &IssueImportRequest{
@@ -162,8 +159,7 @@ func TestIssueImportService_Create_badResponse(t *testing.T) {
 }
 
 func TestIssueImportService_Create_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.IssueImport.Create(ctx, "%", "r", nil)
@@ -171,8 +167,7 @@ func TestIssueImportService_Create_invalidOwner(t *testing.T) {
 }
 
 func TestIssueImportService_CheckStatus(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/import/issues/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -208,8 +203,7 @@ func TestIssueImportService_CheckStatus(t *testing.T) {
 }
 
 func TestIssueImportService_CheckStatus_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.IssueImport.CheckStatus(ctx, "%", "r", 1)
@@ -217,8 +211,7 @@ func TestIssueImportService_CheckStatus_invalidOwner(t *testing.T) {
 }
 
 func TestIssueImportService_CheckStatusSince(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/import/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -254,8 +247,7 @@ func TestIssueImportService_CheckStatusSince(t *testing.T) {
 }
 
 func TestIssueImportService_CheckStatusSince_badResponse(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/import/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -271,8 +263,7 @@ func TestIssueImportService_CheckStatusSince_badResponse(t *testing.T) {
 }
 
 func TestIssueImportService_CheckStatusSince_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.IssueImport.CheckStatusSince(ctx, "%", "r", Timestamp{time.Now()})

--- a/github/issues_assignees_test.go
+++ b/github/issues_assignees_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestIssuesService_ListAssignees(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/assignees", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -53,8 +52,7 @@ func TestIssuesService_ListAssignees(t *testing.T) {
 }
 
 func TestIssuesService_ListAssignees_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.ListAssignees(ctx, "%", "r", nil)
@@ -62,8 +60,7 @@ func TestIssuesService_ListAssignees_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_IsAssignee_true(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/assignees/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -94,8 +91,7 @@ func TestIssuesService_IsAssignee_true(t *testing.T) {
 }
 
 func TestIssuesService_IsAssignee_false(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/assignees/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -127,8 +123,7 @@ func TestIssuesService_IsAssignee_false(t *testing.T) {
 }
 
 func TestIssuesService_IsAssignee_error(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/assignees/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -160,8 +155,7 @@ func TestIssuesService_IsAssignee_error(t *testing.T) {
 }
 
 func TestIssuesService_IsAssignee_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.IsAssignee(ctx, "%", "r", "u")
@@ -169,8 +163,7 @@ func TestIssuesService_IsAssignee_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_AddAssignees(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/1/assignees", func(w http.ResponseWriter, r *http.Request) {
 		var assignees struct {
@@ -213,8 +206,7 @@ func TestIssuesService_AddAssignees(t *testing.T) {
 }
 
 func TestIssuesService_RemoveAssignees(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/1/assignees", func(w http.ResponseWriter, r *http.Request) {
 		var assignees struct {

--- a/github/issues_comments_test.go
+++ b/github/issues_comments_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestIssuesService_ListComments_allIssues(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -66,8 +65,7 @@ func TestIssuesService_ListComments_allIssues(t *testing.T) {
 }
 
 func TestIssuesService_ListComments_specificIssue(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -102,8 +100,7 @@ func TestIssuesService_ListComments_specificIssue(t *testing.T) {
 }
 
 func TestIssuesService_ListComments_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.ListComments(ctx, "%", "r", 1, nil)
@@ -111,8 +108,7 @@ func TestIssuesService_ListComments_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_GetComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -147,8 +143,7 @@ func TestIssuesService_GetComment(t *testing.T) {
 }
 
 func TestIssuesService_GetComment_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.GetComment(ctx, "%", "r", 1)
@@ -156,8 +151,7 @@ func TestIssuesService_GetComment_invalidOrg(t *testing.T) {
 }
 
 func TestIssuesService_CreateComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &IssueComment{Body: String("b")}
 
@@ -200,8 +194,7 @@ func TestIssuesService_CreateComment(t *testing.T) {
 }
 
 func TestIssuesService_CreateComment_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.CreateComment(ctx, "%", "r", 1, nil)
@@ -209,8 +202,7 @@ func TestIssuesService_CreateComment_invalidOrg(t *testing.T) {
 }
 
 func TestIssuesService_EditComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &IssueComment{Body: String("b")}
 
@@ -253,8 +245,7 @@ func TestIssuesService_EditComment(t *testing.T) {
 }
 
 func TestIssuesService_EditComment_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.EditComment(ctx, "%", "r", 1, nil)
@@ -262,8 +253,7 @@ func TestIssuesService_EditComment_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_DeleteComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -287,8 +277,7 @@ func TestIssuesService_DeleteComment(t *testing.T) {
 }
 
 func TestIssuesService_DeleteComment_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Issues.DeleteComment(ctx, "%", "r", 1)

--- a/github/issues_events_test.go
+++ b/github/issues_events_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestIssuesService_ListIssueEvents(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/1/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -56,8 +55,7 @@ func TestIssuesService_ListIssueEvents(t *testing.T) {
 }
 
 func TestIssuesService_ListRepositoryEvents(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -96,8 +94,7 @@ func TestIssuesService_ListRepositoryEvents(t *testing.T) {
 }
 
 func TestIssuesService_GetEvent(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/events/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/issues_labels_test.go
+++ b/github/issues_labels_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestIssuesService_ListLabels(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -53,8 +52,7 @@ func TestIssuesService_ListLabels(t *testing.T) {
 }
 
 func TestIssuesService_ListLabels_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.ListLabels(ctx, "%", "%", nil)
@@ -62,8 +60,7 @@ func TestIssuesService_ListLabels_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_GetLabel(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/labels/n", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -97,8 +94,7 @@ func TestIssuesService_GetLabel(t *testing.T) {
 }
 
 func TestIssuesService_GetLabel_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.GetLabel(ctx, "%", "%", "%")
@@ -106,8 +102,7 @@ func TestIssuesService_GetLabel_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_CreateLabel(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Label{Name: String("n")}
 
@@ -150,8 +145,7 @@ func TestIssuesService_CreateLabel(t *testing.T) {
 }
 
 func TestIssuesService_CreateLabel_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.CreateLabel(ctx, "%", "%", nil)
@@ -159,8 +153,7 @@ func TestIssuesService_CreateLabel_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_EditLabel(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Label{Name: String("z")}
 
@@ -203,8 +196,7 @@ func TestIssuesService_EditLabel(t *testing.T) {
 }
 
 func TestIssuesService_EditLabel_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.EditLabel(ctx, "%", "%", "%", nil)
@@ -212,8 +204,7 @@ func TestIssuesService_EditLabel_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_DeleteLabel(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/labels/n", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -237,8 +228,7 @@ func TestIssuesService_DeleteLabel(t *testing.T) {
 }
 
 func TestIssuesService_DeleteLabel_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Issues.DeleteLabel(ctx, "%", "%", "%")
@@ -246,8 +236,7 @@ func TestIssuesService_DeleteLabel_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_ListLabelsByIssue(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -286,8 +275,7 @@ func TestIssuesService_ListLabelsByIssue(t *testing.T) {
 }
 
 func TestIssuesService_ListLabelsByIssue_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.ListLabelsByIssue(ctx, "%", "%", 1, nil)
@@ -295,8 +283,7 @@ func TestIssuesService_ListLabelsByIssue_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_AddLabelsToIssue(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := []string{"a", "b"}
 
@@ -339,8 +326,7 @@ func TestIssuesService_AddLabelsToIssue(t *testing.T) {
 }
 
 func TestIssuesService_AddLabelsToIssue_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.AddLabelsToIssue(ctx, "%", "%", 1, nil)
@@ -348,8 +334,7 @@ func TestIssuesService_AddLabelsToIssue_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_RemoveLabelForIssue(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/1/labels/l", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -373,8 +358,7 @@ func TestIssuesService_RemoveLabelForIssue(t *testing.T) {
 }
 
 func TestIssuesService_RemoveLabelForIssue_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Issues.RemoveLabelForIssue(ctx, "%", "%", 1, "%")
@@ -382,8 +366,7 @@ func TestIssuesService_RemoveLabelForIssue_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_ReplaceLabelsForIssue(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := []string{"a", "b"}
 
@@ -426,8 +409,7 @@ func TestIssuesService_ReplaceLabelsForIssue(t *testing.T) {
 }
 
 func TestIssuesService_ReplaceLabelsForIssue_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.ReplaceLabelsForIssue(ctx, "%", "%", 1, nil)
@@ -435,8 +417,7 @@ func TestIssuesService_ReplaceLabelsForIssue_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_RemoveLabelsForIssue(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -460,8 +441,7 @@ func TestIssuesService_RemoveLabelsForIssue(t *testing.T) {
 }
 
 func TestIssuesService_RemoveLabelsForIssue_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Issues.RemoveLabelsForIssue(ctx, "%", "%", 1)
@@ -469,8 +449,7 @@ func TestIssuesService_RemoveLabelsForIssue_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_ListLabelsForMilestone(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/milestones/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -506,8 +485,7 @@ func TestIssuesService_ListLabelsForMilestone(t *testing.T) {
 }
 
 func TestIssuesService_ListLabelsForMilestone_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.ListLabelsForMilestone(ctx, "%", "%", 1, nil)

--- a/github/issues_milestones_test.go
+++ b/github/issues_milestones_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestIssuesService_ListMilestones(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/milestones", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -58,8 +57,7 @@ func TestIssuesService_ListMilestones(t *testing.T) {
 }
 
 func TestIssuesService_ListMilestones_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.ListMilestones(ctx, "%", "r", nil)
@@ -67,8 +65,7 @@ func TestIssuesService_ListMilestones_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_GetMilestone(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/milestones/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -102,8 +99,7 @@ func TestIssuesService_GetMilestone(t *testing.T) {
 }
 
 func TestIssuesService_GetMilestone_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.GetMilestone(ctx, "%", "r", 1)
@@ -111,8 +107,7 @@ func TestIssuesService_GetMilestone_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_CreateMilestone(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Milestone{Title: String("t")}
 
@@ -155,8 +150,7 @@ func TestIssuesService_CreateMilestone(t *testing.T) {
 }
 
 func TestIssuesService_CreateMilestone_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.CreateMilestone(ctx, "%", "r", nil)
@@ -164,8 +158,7 @@ func TestIssuesService_CreateMilestone_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_EditMilestone(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Milestone{Title: String("t")}
 
@@ -208,8 +201,7 @@ func TestIssuesService_EditMilestone(t *testing.T) {
 }
 
 func TestIssuesService_EditMilestone_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.EditMilestone(ctx, "%", "r", 1, nil)
@@ -217,8 +209,7 @@ func TestIssuesService_EditMilestone_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_DeleteMilestone(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/milestones/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -242,8 +233,7 @@ func TestIssuesService_DeleteMilestone(t *testing.T) {
 }
 
 func TestIssuesService_DeleteMilestone_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Issues.DeleteMilestone(ctx, "%", "r", 1)

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestIssuesService_List_all(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -63,8 +62,7 @@ func TestIssuesService_List_all(t *testing.T) {
 }
 
 func TestIssuesService_List_owned(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -85,8 +83,7 @@ func TestIssuesService_List_owned(t *testing.T) {
 }
 
 func TestIssuesService_ListByOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -121,8 +118,7 @@ func TestIssuesService_ListByOrg(t *testing.T) {
 }
 
 func TestIssuesService_ListByOrg_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.ListByOrg(ctx, "%", nil)
@@ -130,8 +126,7 @@ func TestIssuesService_ListByOrg_invalidOrg(t *testing.T) {
 }
 
 func TestIssuesService_ListByOrg_badOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.ListByOrg(ctx, "\n", nil)
@@ -139,8 +134,7 @@ func TestIssuesService_ListByOrg_badOrg(t *testing.T) {
 }
 
 func TestIssuesService_ListByRepo(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -191,8 +185,7 @@ func TestIssuesService_ListByRepo(t *testing.T) {
 }
 
 func TestIssuesService_ListByRepo_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.ListByRepo(ctx, "%", "r", nil)
@@ -200,8 +193,7 @@ func TestIssuesService_ListByRepo_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_Get(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -244,8 +236,7 @@ func TestIssuesService_Get(t *testing.T) {
 }
 
 func TestIssuesService_Get_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.Get(ctx, "%", "r", 1)
@@ -253,8 +244,7 @@ func TestIssuesService_Get_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_Create(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &IssueRequest{
 		Title:    String("t"),
@@ -302,8 +292,7 @@ func TestIssuesService_Create(t *testing.T) {
 }
 
 func TestIssuesService_Create_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.Create(ctx, "%", "r", nil)
@@ -311,8 +300,7 @@ func TestIssuesService_Create_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_Edit(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &IssueRequest{Title: String("t")}
 
@@ -355,8 +343,8 @@ func TestIssuesService_Edit(t *testing.T) {
 }
 
 func TestIssuesService_RemoveMilestone(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
 		fmt.Fprint(w, `{"number":1}`)
@@ -389,8 +377,7 @@ func TestIssuesService_RemoveMilestone(t *testing.T) {
 }
 
 func TestIssuesService_Edit_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Issues.Edit(ctx, "%", "r", 1, nil)
@@ -398,8 +385,7 @@ func TestIssuesService_Edit_invalidOwner(t *testing.T) {
 }
 
 func TestIssuesService_Lock(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/1/lock", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -424,8 +410,7 @@ func TestIssuesService_Lock(t *testing.T) {
 }
 
 func TestIssuesService_LockWithReason(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/1/lock", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -441,8 +426,7 @@ func TestIssuesService_LockWithReason(t *testing.T) {
 }
 
 func TestIssuesService_Unlock(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/1/lock", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/issues_timeline_test.go
+++ b/github/issues_timeline_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestIssuesService_ListIssueTimeline(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{mediaTypeTimelinePreview, mediaTypeProjectCardDetailsPreview}
 	mux.HandleFunc("/repos/o/r/issues/1/timeline", func(w http.ResponseWriter, r *http.Request) {

--- a/github/licenses_test.go
+++ b/github/licenses_test.go
@@ -109,8 +109,7 @@ func TestLicense_Marshal(t *testing.T) {
 }
 
 func TestLicensesService_List(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/licenses", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -145,8 +144,7 @@ func TestLicensesService_List(t *testing.T) {
 }
 
 func TestLicensesService_Get(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/licenses/mit", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -180,8 +178,7 @@ func TestLicensesService_Get(t *testing.T) {
 }
 
 func TestLicensesService_Get_invalidTemplate(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Licenses.Get(ctx, "%")

--- a/github/markdown_test.go
+++ b/github/markdown_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestMarkdownService_Markdown(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &markdownRenderRequest{
 		Text:    String("# text #"),

--- a/github/meta_test.go
+++ b/github/meta_test.go
@@ -69,8 +69,7 @@ func TestAPIMeta_Marshal(t *testing.T) {
 }
 
 func TestMetaService_Get(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/meta", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -129,8 +128,7 @@ func TestMetaService_Get(t *testing.T) {
 }
 
 func TestMetaService_Octocat(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := "input"
 	output := "sample text"
@@ -163,8 +161,7 @@ func TestMetaService_Octocat(t *testing.T) {
 }
 
 func TestMetaService_Zen(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	output := "sample text"
 

--- a/github/migrations_source_import_test.go
+++ b/github/migrations_source_import_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestMigrationService_StartImport(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Import{
 		VCS:         String("git"),
@@ -65,8 +64,7 @@ func TestMigrationService_StartImport(t *testing.T) {
 }
 
 func TestMigrationService_ImportProgress(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/import", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -99,8 +97,7 @@ func TestMigrationService_ImportProgress(t *testing.T) {
 }
 
 func TestMigrationService_UpdateImport(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Import{
 		VCS:         String("git"),
@@ -148,8 +145,7 @@ func TestMigrationService_UpdateImport(t *testing.T) {
 }
 
 func TestMigrationService_CommitAuthors(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/import/authors", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -185,8 +181,7 @@ func TestMigrationService_CommitAuthors(t *testing.T) {
 }
 
 func TestMigrationService_MapCommitAuthor(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &SourceImportAuthor{Name: String("n"), Email: String("e")}
 
@@ -228,8 +223,7 @@ func TestMigrationService_MapCommitAuthor(t *testing.T) {
 }
 
 func TestMigrationService_SetLFSPreference(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Import{UseLFS: String("opt_in")}
 
@@ -272,8 +266,7 @@ func TestMigrationService_SetLFSPreference(t *testing.T) {
 }
 
 func TestMigrationService_LargeFiles(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/import/large_files", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -309,8 +302,7 @@ func TestMigrationService_LargeFiles(t *testing.T) {
 }
 
 func TestMigrationService_CancelImport(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/import", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/migrations_test.go
+++ b/github/migrations_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestMigrationService_StartMigration(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/migrations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -56,8 +55,7 @@ func TestMigrationService_StartMigration(t *testing.T) {
 }
 
 func TestMigrationService_ListMigrations(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/migrations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -92,8 +90,7 @@ func TestMigrationService_ListMigrations(t *testing.T) {
 }
 
 func TestMigrationService_MigrationStatus(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/migrations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -128,8 +125,7 @@ func TestMigrationService_MigrationStatus(t *testing.T) {
 }
 
 func TestMigrationService_MigrationArchiveURL(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/migrations/1/archive", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -161,8 +157,7 @@ func TestMigrationService_MigrationArchiveURL(t *testing.T) {
 }
 
 func TestMigrationService_DeleteMigration(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/migrations/1/archive", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -188,8 +183,7 @@ func TestMigrationService_DeleteMigration(t *testing.T) {
 }
 
 func TestMigrationService_UnlockRepo(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/migrations/1/repos/r/lock", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/migrations_user_test.go
+++ b/github/migrations_user_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestMigrationService_StartUserMigration(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/migrations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -54,8 +53,7 @@ func TestMigrationService_StartUserMigration(t *testing.T) {
 }
 
 func TestMigrationService_ListUserMigrations(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/migrations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -87,8 +85,7 @@ func TestMigrationService_ListUserMigrations(t *testing.T) {
 }
 
 func TestMigrationService_UserMigrationStatus(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/migrations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -120,8 +117,7 @@ func TestMigrationService_UserMigrationStatus(t *testing.T) {
 }
 
 func TestMigrationService_UserMigrationArchiveURL(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/migrations/1/archive", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -149,8 +145,7 @@ func TestMigrationService_UserMigrationArchiveURL(t *testing.T) {
 }
 
 func TestMigrationService_DeleteUserMigration(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/migrations/1/archive", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -181,8 +176,7 @@ func TestMigrationService_DeleteUserMigration(t *testing.T) {
 }
 
 func TestMigrationService_UnlockUserRepo(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/migrations/1/repos/r/lock", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/orgs_actions_allowed_test.go
+++ b/github/orgs_actions_allowed_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestOrganizationsService_GetActionsAllowed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/permissions/selected-actions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -50,8 +49,8 @@ func TestOrganizationsService_GetActionsAllowed(t *testing.T) {
 }
 
 func TestOrganizationsService_EditActionsAllowed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	input := &ActionsAllowed{GithubOwnedAllowed: Bool(true), VerifiedAllowed: Bool(false), PatternsAllowed: []string{"a/b"}}
 
 	mux.HandleFunc("/orgs/o/actions/permissions/selected-actions", func(w http.ResponseWriter, r *http.Request) {

--- a/github/orgs_actions_permissions_test.go
+++ b/github/orgs_actions_permissions_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestOrganizationsService_GetActionsPermissions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/actions/permissions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -50,8 +49,7 @@ func TestOrganizationsService_GetActionsPermissions(t *testing.T) {
 }
 
 func TestOrganizationsService_EditActionsPermissions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &ActionsPermissions{EnabledRepositories: String("all"), AllowedActions: String("selected")}
 

--- a/github/orgs_audit_log_test.go
+++ b/github/orgs_audit_log_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestOrganizationService_GetAuditLog(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/audit-log", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/orgs_credential_authorizations_test.go
+++ b/github/orgs_credential_authorizations_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestOrganizationsService_ListCredentialAuthorizations(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/credential-authorizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -73,8 +72,7 @@ func TestOrganizationsService_ListCredentialAuthorizations(t *testing.T) {
 }
 
 func TestOrganizationsService_RemoveCredentialAuthorization(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/credential-authorizations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/github/orgs_custom_roles_test.go
+++ b/github/orgs_custom_roles_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestOrganizationsService_ListRoles(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/organization-roles", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -99,8 +98,7 @@ func TestOrganizationsService_ListRoles(t *testing.T) {
 }
 
 func TestOrganizationsService_GetOrgRole(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	// Test built-in org role
 	mux.HandleFunc("/orgs/o/organization-roles/8132", func(w http.ResponseWriter, r *http.Request) {
@@ -198,8 +196,7 @@ func TestOrganizationsService_GetOrgRole(t *testing.T) {
 }
 
 func TestOrganizationsService_CreateCustomOrgRole(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/organization-roles", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -240,8 +237,7 @@ func TestOrganizationsService_CreateCustomOrgRole(t *testing.T) {
 }
 
 func TestOrganizationsService_UpdateCustomOrgRole(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/organization-roles/8030", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -281,8 +277,7 @@ func TestOrganizationsService_UpdateCustomOrgRole(t *testing.T) {
 }
 
 func TestOrganizationsService_DeleteCustomOrgRole(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/organization-roles/8030", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -312,8 +307,7 @@ func TestOrganizationsService_DeleteCustomOrgRole(t *testing.T) {
 }
 
 func TestOrganizationsService_AssignOrgRoleToTeam(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/organization-roles/teams/t/8030", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -341,8 +335,7 @@ func TestOrganizationsService_AssignOrgRoleToTeam(t *testing.T) {
 }
 
 func TestOrganizationsService_RemoveOrgRoleFromTeam(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/organization-roles/teams/t/8030", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -370,8 +363,7 @@ func TestOrganizationsService_RemoveOrgRoleFromTeam(t *testing.T) {
 }
 
 func TestOrganizationsService_AssignOrgRoleToUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/organization-roles/users/t/8030", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -399,8 +391,7 @@ func TestOrganizationsService_AssignOrgRoleToUser(t *testing.T) {
 }
 
 func TestOrganizationsService_RemoveOrgRoleFromUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/organization-roles/users/t/8030", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -428,8 +419,7 @@ func TestOrganizationsService_RemoveOrgRoleFromUser(t *testing.T) {
 }
 
 func TestOrganizationsService_ListCustomRepoRoles(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/custom-repository-roles", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -509,8 +499,7 @@ func TestOrganizationsService_ListCustomRepoRoles(t *testing.T) {
 }
 
 func TestOrganizationsService_CreateCustomRepoRole(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/custom-repository-roles", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -552,8 +541,7 @@ func TestOrganizationsService_CreateCustomRepoRole(t *testing.T) {
 }
 
 func TestOrganizationsService_UpdateCustomRepoRole(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/custom-repository-roles/8030", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -593,8 +581,7 @@ func TestOrganizationsService_UpdateCustomRepoRole(t *testing.T) {
 }
 
 func TestOrganizationsService_DeleteCustomRepoRole(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/custom-repository-roles/8030", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -620,8 +607,7 @@ func TestOrganizationsService_DeleteCustomRepoRole(t *testing.T) {
 }
 
 func TestOrganizationsService_ListTeamsAssignedToOrgRole(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/organization-roles/1729/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -655,8 +641,7 @@ func TestOrganizationsService_ListTeamsAssignedToOrgRole(t *testing.T) {
 }
 
 func TestOrganizationsService_ListUsersAssignedToOrgRole(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/organization-roles/1729/users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/orgs_hooks_configuration_test.go
+++ b/github/orgs_hooks_configuration_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestOrganizationsService_GetHookConfiguration(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/hooks/1/config", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -56,8 +55,7 @@ func TestOrganizationsService_GetHookConfiguration(t *testing.T) {
 }
 
 func TestOrganizationsService_GetHookConfiguration_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.GetHookConfiguration(ctx, "%", 1)
@@ -65,8 +63,7 @@ func TestOrganizationsService_GetHookConfiguration_invalidOrg(t *testing.T) {
 }
 
 func TestOrganizationsService_EditHookConfiguration(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &HookConfig{}
 
@@ -114,8 +111,7 @@ func TestOrganizationsService_EditHookConfiguration(t *testing.T) {
 }
 
 func TestOrganizationsService_EditHookConfiguration_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.EditHookConfiguration(ctx, "%", 1, nil)

--- a/github/orgs_hooks_deliveries_test.go
+++ b/github/orgs_hooks_deliveries_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestOrganizationsService_ListHookDeliveries(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/hooks/1/deliveries", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -53,8 +52,7 @@ func TestOrganizationsService_ListHookDeliveries(t *testing.T) {
 }
 
 func TestOrganizationsService_ListHookDeliveries_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.ListHookDeliveries(ctx, "%", 1, nil)
@@ -62,8 +60,7 @@ func TestOrganizationsService_ListHookDeliveries_invalidOwner(t *testing.T) {
 }
 
 func TestOrganizationsService_GetHookDelivery(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/hooks/1/deliveries/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -97,8 +94,7 @@ func TestOrganizationsService_GetHookDelivery(t *testing.T) {
 }
 
 func TestOrganizationsService_GetHookDelivery_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.GetHookDelivery(ctx, "%", 1, 1)
@@ -106,8 +102,7 @@ func TestOrganizationsService_GetHookDelivery_invalidOwner(t *testing.T) {
 }
 
 func TestOrganizationsService_RedeliverHookDelivery(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/hooks/1/deliveries/1/attempts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -141,8 +136,7 @@ func TestOrganizationsService_RedeliverHookDelivery(t *testing.T) {
 }
 
 func TestOrganizationsService_RedeliverHookDelivery_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.RedeliverHookDelivery(ctx, "%", 1, 1)

--- a/github/orgs_hooks_test.go
+++ b/github/orgs_hooks_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestOrganizationsService_ListHooks(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/hooks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -54,8 +53,7 @@ func TestOrganizationsService_ListHooks(t *testing.T) {
 }
 
 func TestOrganizationsService_ListHooks_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.ListHooks(ctx, "%", nil)
@@ -63,8 +61,7 @@ func TestOrganizationsService_ListHooks_invalidOrg(t *testing.T) {
 }
 
 func TestOrganizationsService_CreateHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Hook{CreatedAt: &Timestamp{referenceTime}}
 
@@ -108,8 +105,7 @@ func TestOrganizationsService_CreateHook(t *testing.T) {
 }
 
 func TestOrganizationsService_GetHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/hooks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -143,8 +139,7 @@ func TestOrganizationsService_GetHook(t *testing.T) {
 }
 
 func TestOrganizationsService_GetHook_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.GetHook(ctx, "%", 1)
@@ -152,8 +147,7 @@ func TestOrganizationsService_GetHook_invalidOrg(t *testing.T) {
 }
 
 func TestOrganizationsService_EditHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Hook{}
 
@@ -196,8 +190,7 @@ func TestOrganizationsService_EditHook(t *testing.T) {
 }
 
 func TestOrganizationsService_EditHook_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.EditHook(ctx, "%", 1, nil)
@@ -205,8 +198,7 @@ func TestOrganizationsService_EditHook_invalidOrg(t *testing.T) {
 }
 
 func TestOrganizationsService_PingHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/hooks/1/pings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -230,8 +222,7 @@ func TestOrganizationsService_PingHook(t *testing.T) {
 }
 
 func TestOrganizationsService_DeleteHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/hooks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -255,8 +246,7 @@ func TestOrganizationsService_DeleteHook(t *testing.T) {
 }
 
 func TestOrganizationsService_DeleteHook_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Organizations.DeleteHook(ctx, "%", 1)

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestOrganizationsService_ListMembers(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/members", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -63,8 +62,7 @@ func TestOrganizationsService_ListMembers(t *testing.T) {
 }
 
 func TestOrganizationsService_ListMembers_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.ListMembers(ctx, "%", nil)
@@ -72,8 +70,7 @@ func TestOrganizationsService_ListMembers_invalidOrg(t *testing.T) {
 }
 
 func TestOrganizationsService_ListMembers_public(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/public_members", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -94,8 +91,7 @@ func TestOrganizationsService_ListMembers_public(t *testing.T) {
 }
 
 func TestOrganizationsService_IsMember(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/members/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -128,8 +124,7 @@ func TestOrganizationsService_IsMember(t *testing.T) {
 
 // ensure that a 404 response is interpreted as "false" and not an error
 func TestOrganizationsService_IsMember_notMember(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/members/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -149,8 +144,7 @@ func TestOrganizationsService_IsMember_notMember(t *testing.T) {
 // ensure that a 400 response is interpreted as an actual error, and not simply
 // as "false" like the above case of a 404
 func TestOrganizationsService_IsMember_error(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/members/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -168,8 +162,7 @@ func TestOrganizationsService_IsMember_error(t *testing.T) {
 }
 
 func TestOrganizationsService_IsMember_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.IsMember(ctx, "%", "u")
@@ -177,8 +170,7 @@ func TestOrganizationsService_IsMember_invalidOrg(t *testing.T) {
 }
 
 func TestOrganizationsService_IsPublicMember(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/public_members/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -211,8 +203,7 @@ func TestOrganizationsService_IsPublicMember(t *testing.T) {
 
 // ensure that a 404 response is interpreted as "false" and not an error
 func TestOrganizationsService_IsPublicMember_notMember(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/public_members/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -232,8 +223,7 @@ func TestOrganizationsService_IsPublicMember_notMember(t *testing.T) {
 // ensure that a 400 response is interpreted as an actual error, and not simply
 // as "false" like the above case of a 404
 func TestOrganizationsService_IsPublicMember_error(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/public_members/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -251,8 +241,7 @@ func TestOrganizationsService_IsPublicMember_error(t *testing.T) {
 }
 
 func TestOrganizationsService_IsPublicMember_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.IsPublicMember(ctx, "%", "u")
@@ -260,8 +249,7 @@ func TestOrganizationsService_IsPublicMember_invalidOrg(t *testing.T) {
 }
 
 func TestOrganizationsService_RemoveMember(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/members/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -285,8 +273,7 @@ func TestOrganizationsService_RemoveMember(t *testing.T) {
 }
 
 func TestOrganizationsService_RemoveMember_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Organizations.RemoveMember(ctx, "%", "u")
@@ -294,8 +281,7 @@ func TestOrganizationsService_RemoveMember_invalidOrg(t *testing.T) {
 }
 
 func TestOrganizationsService_PublicizeMembership(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/public_members/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -319,8 +305,7 @@ func TestOrganizationsService_PublicizeMembership(t *testing.T) {
 }
 
 func TestOrganizationsService_ConcealMembership(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/public_members/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -344,8 +329,7 @@ func TestOrganizationsService_ConcealMembership(t *testing.T) {
 }
 
 func TestOrganizationsService_ListOrgMemberships(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/memberships/orgs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -382,8 +366,7 @@ func TestOrganizationsService_ListOrgMemberships(t *testing.T) {
 }
 
 func TestOrganizationsService_GetOrgMembership_AuthenticatedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/memberships/orgs/o", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -417,8 +400,7 @@ func TestOrganizationsService_GetOrgMembership_AuthenticatedUser(t *testing.T) {
 }
 
 func TestOrganizationsService_GetOrgMembership_SpecifiedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/memberships/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -438,8 +420,7 @@ func TestOrganizationsService_GetOrgMembership_SpecifiedUser(t *testing.T) {
 }
 
 func TestOrganizationsService_EditOrgMembership_AuthenticatedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Membership{State: String("active")}
 
@@ -482,8 +463,7 @@ func TestOrganizationsService_EditOrgMembership_AuthenticatedUser(t *testing.T) 
 }
 
 func TestOrganizationsService_EditOrgMembership_SpecifiedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Membership{State: String("active")}
 
@@ -512,8 +492,7 @@ func TestOrganizationsService_EditOrgMembership_SpecifiedUser(t *testing.T) {
 }
 
 func TestOrganizationsService_RemoveOrgMembership(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/memberships/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -538,8 +517,7 @@ func TestOrganizationsService_RemoveOrgMembership(t *testing.T) {
 }
 
 func TestOrganizationsService_ListPendingOrgInvitations(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -634,8 +612,8 @@ func TestOrganizationsService_ListPendingOrgInvitations(t *testing.T) {
 }
 
 func TestOrganizationsService_CreateOrgInvitation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	input := &CreateOrgInvitationOptions{
 		Email: String("octocat@github.com"),
 		Role:  String("direct_member"),
@@ -684,8 +662,7 @@ func TestOrganizationsService_CreateOrgInvitation(t *testing.T) {
 }
 
 func TestOrganizationsService_ListOrgInvitationTeams(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/invitations/22/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -746,8 +723,7 @@ func TestOrganizationsService_ListOrgInvitationTeams(t *testing.T) {
 }
 
 func TestOrganizationsService_ListFailedOrgInvitations(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/failed_invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/orgs_outside_collaborators_test.go
+++ b/github/orgs_outside_collaborators_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestOrganizationsService_ListOutsideCollaborators(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/outside_collaborators", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -58,8 +57,7 @@ func TestOrganizationsService_ListOutsideCollaborators(t *testing.T) {
 }
 
 func TestOrganizationsService_ListOutsideCollaborators_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.ListOutsideCollaborators(ctx, "%", nil)
@@ -67,8 +65,7 @@ func TestOrganizationsService_ListOutsideCollaborators_invalidOrg(t *testing.T) 
 }
 
 func TestOrganizationsService_RemoveOutsideCollaborator(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -93,8 +90,7 @@ func TestOrganizationsService_RemoveOutsideCollaborator(t *testing.T) {
 }
 
 func TestOrganizationsService_RemoveOutsideCollaborator_NonMember(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -112,8 +108,7 @@ func TestOrganizationsService_RemoveOutsideCollaborator_NonMember(t *testing.T) 
 }
 
 func TestOrganizationsService_RemoveOutsideCollaborator_Member(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -131,8 +126,7 @@ func TestOrganizationsService_RemoveOutsideCollaborator_Member(t *testing.T) {
 }
 
 func TestOrganizationsService_ConvertMemberToOutsideCollaborator(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -157,8 +151,7 @@ func TestOrganizationsService_ConvertMemberToOutsideCollaborator(t *testing.T) {
 }
 
 func TestOrganizationsService_ConvertMemberToOutsideCollaborator_NonMemberOrLastOwner(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")

--- a/github/orgs_packages_test.go
+++ b/github/orgs_packages_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestOrganizationsService_ListPackages(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/packages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -114,8 +113,7 @@ func TestOrganizationsService_ListPackages(t *testing.T) {
 }
 
 func TestOrganizationsService_GetPackage(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	// don't url escape the package name here since mux will convert it to a slash automatically
 	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker", func(w http.ResponseWriter, r *http.Request) {
@@ -173,8 +171,7 @@ func TestOrganizationsService_GetPackage(t *testing.T) {
 }
 
 func TestOrganizationsService_DeletePackage(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	// don't url escape the package name here since mux will convert it to a slash automatically
 	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker", func(w http.ResponseWriter, r *http.Request) {
@@ -203,8 +200,7 @@ func TestOrganizationsService_DeletePackage(t *testing.T) {
 }
 
 func TestOrganizationsService_RestorePackage(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	// don't url escape the package name here since mux will convert it to a slash automatically
 	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker/restore", func(w http.ResponseWriter, r *http.Request) {
@@ -229,8 +225,7 @@ func TestOrganizationsService_RestorePackage(t *testing.T) {
 }
 
 func TestOrganizationsService_ListPackagesVersions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	// don't url escape the package name here since mux will convert it to a slash automatically
 	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker/versions", func(w http.ResponseWriter, r *http.Request) {
@@ -303,8 +298,7 @@ func TestOrganizationsService_ListPackagesVersions(t *testing.T) {
 }
 
 func TestOrganizationsService_PackageGetVersion(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	// don't url escape the package name here since mux will convert it to a slash automatically
 	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
@@ -373,8 +367,7 @@ func TestOrganizationsService_PackageGetVersion(t *testing.T) {
 }
 
 func TestOrganizationsService_PackageDeleteVersion(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	// don't url escape the package name here since mux will convert it to a slash automatically
 	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
@@ -399,8 +392,7 @@ func TestOrganizationsService_PackageDeleteVersion(t *testing.T) {
 }
 
 func TestOrganizationsService_PackageRestoreVersion(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	// don't url escape the package name here since mux will convert it to a slash automatically
 	mux.HandleFunc("/orgs/o/packages/container/hello/hello_docker/versions/45763/restore", func(w http.ResponseWriter, r *http.Request) {

--- a/github/orgs_personal_access_tokens_test.go
+++ b/github/orgs_personal_access_tokens_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestOrganizationsService_ListFineGrainedPersonalAccessTokens(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/personal-access-tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -156,8 +155,7 @@ func TestOrganizationsService_ListFineGrainedPersonalAccessTokens(t *testing.T) 
 }
 
 func TestOrganizationsService_ReviewPersonalAccessTokenRequest(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := ReviewPersonalAccessTokenRequestOptions{
 		Action: "a",

--- a/github/orgs_projects_test.go
+++ b/github/orgs_projects_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestOrganizationsService_ListProjects(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -54,8 +53,7 @@ func TestOrganizationsService_ListProjects(t *testing.T) {
 }
 
 func TestOrganizationsService_CreateProject(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &ProjectOptions{Name: String("Project Name"), Body: String("Project body.")}
 

--- a/github/orgs_properties_test.go
+++ b/github/orgs_properties_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestOrganizationsService_GetAllCustomProperties(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/properties/schema", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -87,8 +86,7 @@ func TestOrganizationsService_GetAllCustomProperties(t *testing.T) {
 }
 
 func TestOrganizationsService_CreateOrUpdateCustomProperties(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/properties/schema", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -150,8 +148,7 @@ func TestOrganizationsService_CreateOrUpdateCustomProperties(t *testing.T) {
 }
 
 func TestOrganizationsService_GetCustomProperty(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/properties/schema/name", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -200,8 +197,7 @@ func TestOrganizationsService_GetCustomProperty(t *testing.T) {
 }
 
 func TestOrganizationsService_CreateOrUpdateCustomProperty(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/properties/schema/name", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -257,8 +253,7 @@ func TestOrganizationsService_CreateOrUpdateCustomProperty(t *testing.T) {
 }
 
 func TestOrganizationsService_RemoveCustomProperty(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/properties/schema/name", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -278,8 +273,7 @@ func TestOrganizationsService_RemoveCustomProperty(t *testing.T) {
 }
 
 func TestOrganizationsService_ListCustomPropertyValues(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/properties/values", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -437,8 +431,7 @@ func TestCustomPropertyValue_UnmarshalJSON(t *testing.T) {
 }
 
 func TestOrganizationsService_CreateOrUpdateRepoCustomPropertyValues(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/properties/values", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")

--- a/github/orgs_rules_test.go
+++ b/github/orgs_rules_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestOrganizationsService_GetAllOrganizationRulesets(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/rulesets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -71,8 +70,7 @@ func TestOrganizationsService_GetAllOrganizationRulesets(t *testing.T) {
 }
 
 func TestOrganizationsService_CreateOrganizationRuleset_RepoNames(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/rulesets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -391,8 +389,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoNames(t *testing.T) 
 	})
 }
 func TestOrganizationsService_CreateOrganizationRuleset_RepoProperty(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/rulesets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -726,8 +723,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoProperty(t *testing.
 	})
 }
 func TestOrganizationsService_CreateOrganizationRuleset_RepoIDs(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/rulesets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -1036,8 +1032,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoIDs(t *testing.T) {
 }
 
 func TestOrganizationsService_GetOrganizationRuleset(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/rulesets/26110", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1132,8 +1127,7 @@ func TestOrganizationsService_GetOrganizationRuleset(t *testing.T) {
 }
 
 func TestOrganizationsService_GetOrganizationRulesetWithRepoPropCondition(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/rulesets/26110", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1221,8 +1215,7 @@ func TestOrganizationsService_GetOrganizationRulesetWithRepoPropCondition(t *tes
 	})
 }
 func TestOrganizationsService_UpdateOrganizationRuleset(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/rulesets/26110", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -1336,8 +1329,7 @@ func TestOrganizationsService_UpdateOrganizationRuleset(t *testing.T) {
 }
 
 func TestOrganizationsService_UpdateOrganizationRulesetWithRepoProp(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/rulesets/26110", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -1445,8 +1437,7 @@ func TestOrganizationsService_UpdateOrganizationRulesetWithRepoProp(t *testing.T
 	})
 }
 func TestOrganizationsService_DeleteOrganizationRuleset(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/rulesets/26110", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/orgs_security_managers_test.go
+++ b/github/orgs_security_managers_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestOrganizationsService_ListSecurityManagerTeams(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/security-managers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -50,8 +49,7 @@ func TestOrganizationsService_ListSecurityManagerTeams(t *testing.T) {
 }
 
 func TestOrganizationsService_ListSecurityManagerTeams_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.ListSecurityManagerTeams(ctx, "%")
@@ -59,8 +57,7 @@ func TestOrganizationsService_ListSecurityManagerTeams_invalidOrg(t *testing.T) 
 }
 
 func TestOrganizationsService_AddSecurityManagerTeam(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/security-managers/teams/t", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -84,8 +81,7 @@ func TestOrganizationsService_AddSecurityManagerTeam(t *testing.T) {
 }
 
 func TestOrganizationsService_AddSecurityManagerTeam_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Organizations.AddSecurityManagerTeam(ctx, "%", "t")
@@ -93,8 +89,7 @@ func TestOrganizationsService_AddSecurityManagerTeam_invalidOrg(t *testing.T) {
 }
 
 func TestOrganizationsService_AddSecurityManagerTeam_invalidTeam(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Organizations.AddSecurityManagerTeam(ctx, "%", "t")
@@ -102,8 +97,7 @@ func TestOrganizationsService_AddSecurityManagerTeam_invalidTeam(t *testing.T) {
 }
 
 func TestOrganizationsService_RemoveSecurityManagerTeam(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/security-managers/teams/t", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -127,8 +121,7 @@ func TestOrganizationsService_RemoveSecurityManagerTeam(t *testing.T) {
 }
 
 func TestOrganizationsService_RemoveSecurityManagerTeam_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Organizations.RemoveSecurityManagerTeam(ctx, "%", "t")
@@ -136,8 +129,7 @@ func TestOrganizationsService_RemoveSecurityManagerTeam_invalidOrg(t *testing.T)
 }
 
 func TestOrganizationsService_RemoveSecurityManagerTeam_invalidTeam(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Organizations.RemoveSecurityManagerTeam(ctx, "%", "t")

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -68,8 +68,7 @@ func TestOrganization_Marshal(t *testing.T) {
 }
 
 func TestOrganizationsService_ListAll(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	since := int64(1342004)
 	mux.HandleFunc("/organizations", func(w http.ResponseWriter, r *http.Request) {
@@ -101,8 +100,7 @@ func TestOrganizationsService_ListAll(t *testing.T) {
 }
 
 func TestOrganizationsService_List_authenticatedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/orgs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -136,8 +134,7 @@ func TestOrganizationsService_List_authenticatedUser(t *testing.T) {
 }
 
 func TestOrganizationsService_List_specifiedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/orgs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -173,8 +170,7 @@ func TestOrganizationsService_List_specifiedUser(t *testing.T) {
 }
 
 func TestOrganizationsService_List_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.List(ctx, "%", nil)
@@ -182,8 +178,7 @@ func TestOrganizationsService_List_invalidUser(t *testing.T) {
 }
 
 func TestOrganizationsService_Get(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -218,8 +213,7 @@ func TestOrganizationsService_Get(t *testing.T) {
 }
 
 func TestOrganizationsService_Get_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.Get(ctx, "%")
@@ -227,8 +221,7 @@ func TestOrganizationsService_Get_invalidOrg(t *testing.T) {
 }
 
 func TestOrganizationsService_GetByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -262,8 +255,7 @@ func TestOrganizationsService_GetByID(t *testing.T) {
 }
 
 func TestOrganizationsService_Edit(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Organization{Login: String("l")}
 
@@ -307,8 +299,7 @@ func TestOrganizationsService_Edit(t *testing.T) {
 }
 
 func TestOrganizationsService_Edit_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.Edit(ctx, "%", nil)
@@ -316,8 +307,7 @@ func TestOrganizationsService_Edit_invalidOrg(t *testing.T) {
 }
 
 func TestOrganizationsService_Delete(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -341,8 +331,7 @@ func TestOrganizationsService_Delete(t *testing.T) {
 }
 
 func TestOrganizationsService_ListInstallations(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/installations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -376,8 +365,7 @@ func TestOrganizationsService_ListInstallations(t *testing.T) {
 }
 
 func TestOrganizationsService_ListInstallations_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Organizations.ListInstallations(ctx, "%", nil)
@@ -385,8 +373,7 @@ func TestOrganizationsService_ListInstallations_invalidOrg(t *testing.T) {
 }
 
 func TestOrganizationsService_ListInstallations_withListOptions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/installations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/orgs_users_blocking_test.go
+++ b/github/orgs_users_blocking_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestOrganizationsService_ListBlockedUsers(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/blocks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -55,8 +54,7 @@ func TestOrganizationsService_ListBlockedUsers(t *testing.T) {
 }
 
 func TestOrganizationsService_IsBlocked(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/blocks/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -89,8 +87,7 @@ func TestOrganizationsService_IsBlocked(t *testing.T) {
 }
 
 func TestOrganizationsService_BlockUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/blocks/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -116,8 +113,7 @@ func TestOrganizationsService_BlockUser(t *testing.T) {
 }
 
 func TestOrganizationsService_UnblockUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/blocks/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -85,8 +85,7 @@ func TestProject_Marshal(t *testing.T) {
 }
 
 func TestProjectsService_UpdateProject(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &ProjectOptions{
 		Name:    String("Project Name"),
@@ -137,8 +136,7 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 }
 
 func TestProjectsService_GetProject(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -173,8 +171,7 @@ func TestProjectsService_GetProject(t *testing.T) {
 }
 
 func TestProjectsService_DeleteProject(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -199,8 +196,7 @@ func TestProjectsService_DeleteProject(t *testing.T) {
 }
 
 func TestProjectsService_ListProjectColumns(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/projects/1/columns", func(w http.ResponseWriter, r *http.Request) {
@@ -238,8 +234,7 @@ func TestProjectsService_ListProjectColumns(t *testing.T) {
 }
 
 func TestProjectsService_GetProjectColumn(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/projects/columns/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -274,8 +269,7 @@ func TestProjectsService_GetProjectColumn(t *testing.T) {
 }
 
 func TestProjectsService_CreateProjectColumn(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &ProjectColumnOptions{Name: "Column Name"}
 
@@ -319,8 +313,7 @@ func TestProjectsService_CreateProjectColumn(t *testing.T) {
 }
 
 func TestProjectsService_UpdateProjectColumn(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &ProjectColumnOptions{Name: "Column Name"}
 
@@ -364,8 +357,7 @@ func TestProjectsService_UpdateProjectColumn(t *testing.T) {
 }
 
 func TestProjectsService_DeleteProjectColumn(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/projects/columns/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -390,8 +382,7 @@ func TestProjectsService_DeleteProjectColumn(t *testing.T) {
 }
 
 func TestProjectsService_MoveProjectColumn(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &ProjectColumnMoveOptions{Position: "after:12345"}
 
@@ -424,8 +415,7 @@ func TestProjectsService_MoveProjectColumn(t *testing.T) {
 }
 
 func TestProjectsService_ListProjectCards(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/projects/columns/1/cards", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -466,8 +456,7 @@ func TestProjectsService_ListProjectCards(t *testing.T) {
 }
 
 func TestProjectsService_GetProjectCard(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/projects/columns/cards/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -502,8 +491,7 @@ func TestProjectsService_GetProjectCard(t *testing.T) {
 }
 
 func TestProjectsService_CreateProjectCard(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &ProjectCardOptions{
 		ContentID:   12345,
@@ -550,8 +538,7 @@ func TestProjectsService_CreateProjectCard(t *testing.T) {
 }
 
 func TestProjectsService_UpdateProjectCard(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &ProjectCardOptions{
 		ContentID:   12345,
@@ -598,8 +585,7 @@ func TestProjectsService_UpdateProjectCard(t *testing.T) {
 }
 
 func TestProjectsService_DeleteProjectCard(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/projects/columns/cards/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -624,8 +610,7 @@ func TestProjectsService_DeleteProjectCard(t *testing.T) {
 }
 
 func TestProjectsService_MoveProjectCard(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &ProjectCardMoveOptions{Position: "after:12345"}
 
@@ -658,8 +643,7 @@ func TestProjectsService_MoveProjectCard(t *testing.T) {
 }
 
 func TestProjectsService_AddProjectCollaborator(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	opt := &ProjectCollaboratorOptions{
 		Permission: String("admin"),
@@ -696,8 +680,7 @@ func TestProjectsService_AddProjectCollaborator(t *testing.T) {
 }
 
 func TestProjectsService_AddCollaborator_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Projects.AddProjectCollaborator(ctx, 1, "%", nil)
@@ -705,8 +688,7 @@ func TestProjectsService_AddCollaborator_invalidUser(t *testing.T) {
 }
 
 func TestProjectsService_RemoveCollaborator(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/projects/1/collaborators/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -732,8 +714,7 @@ func TestProjectsService_RemoveCollaborator(t *testing.T) {
 }
 
 func TestProjectsService_RemoveCollaborator_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Projects.RemoveProjectCollaborator(ctx, 1, "%")
@@ -741,8 +722,7 @@ func TestProjectsService_RemoveCollaborator_invalidUser(t *testing.T) {
 }
 
 func TestProjectsService_ListCollaborators(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/projects/1/collaborators", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -781,8 +761,7 @@ func TestProjectsService_ListCollaborators(t *testing.T) {
 }
 
 func TestProjectsService_ListCollaborators_withAffiliation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/projects/1/collaborators", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -808,8 +787,7 @@ func TestProjectsService_ListCollaborators_withAffiliation(t *testing.T) {
 }
 
 func TestProjectsService_ReviewProjectCollaboratorPermission(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/projects/1/collaborators/u/permission", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/pulls_comments_test.go
+++ b/github/pulls_comments_test.go
@@ -134,8 +134,7 @@ func TestPullComments_Marshal(t *testing.T) {
 }
 
 func TestPullRequestsService_ListComments_allPulls(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeMultiLineCommentsPreview}
 	mux.HandleFunc("/repos/o/r/pulls/comments", func(w http.ResponseWriter, r *http.Request) {
@@ -183,8 +182,7 @@ func TestPullRequestsService_ListComments_allPulls(t *testing.T) {
 }
 
 func TestPullRequestsService_ListComments_specificPull(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeMultiLineCommentsPreview}
 	mux.HandleFunc("/repos/o/r/pulls/1/comments", func(w http.ResponseWriter, r *http.Request) {
@@ -206,8 +204,7 @@ func TestPullRequestsService_ListComments_specificPull(t *testing.T) {
 }
 
 func TestPullRequestsService_ListComments_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.ListComments(ctx, "%", "r", 1, nil)
@@ -215,8 +212,7 @@ func TestPullRequestsService_ListComments_invalidOwner(t *testing.T) {
 }
 
 func TestPullRequestsService_GetComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{mediaTypeReactionsPreview, mediaTypeMultiLineCommentsPreview}
 	mux.HandleFunc("/repos/o/r/pulls/comments/1", func(w http.ResponseWriter, r *http.Request) {
@@ -252,8 +248,7 @@ func TestPullRequestsService_GetComment(t *testing.T) {
 }
 
 func TestPullRequestsService_GetComment_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.GetComment(ctx, "%", "r", 1)
@@ -261,8 +256,7 @@ func TestPullRequestsService_GetComment_invalidOwner(t *testing.T) {
 }
 
 func TestPullRequestsService_CreateComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &PullRequestComment{Body: String("b")}
 
@@ -308,8 +302,7 @@ func TestPullRequestsService_CreateComment(t *testing.T) {
 }
 
 func TestPullRequestsService_CreateComment_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.CreateComment(ctx, "%", "r", 1, nil)
@@ -317,8 +310,7 @@ func TestPullRequestsService_CreateComment_invalidOwner(t *testing.T) {
 }
 
 func TestPullRequestsService_CreateCommentInReplyTo(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &PullRequestComment{Body: String("b")}
 
@@ -361,8 +353,7 @@ func TestPullRequestsService_CreateCommentInReplyTo(t *testing.T) {
 }
 
 func TestPullRequestsService_EditComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &PullRequestComment{Body: String("b")}
 
@@ -405,8 +396,7 @@ func TestPullRequestsService_EditComment(t *testing.T) {
 }
 
 func TestPullRequestsService_EditComment_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.EditComment(ctx, "%", "r", 1, nil)
@@ -414,8 +404,7 @@ func TestPullRequestsService_EditComment_invalidOwner(t *testing.T) {
 }
 
 func TestPullRequestsService_DeleteComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -439,8 +428,7 @@ func TestPullRequestsService_DeleteComment(t *testing.T) {
 }
 
 func TestPullRequestsService_DeleteComment_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.PullRequests.DeleteComment(ctx, "%", "r", 1)

--- a/github/pulls_reviewers_test.go
+++ b/github/pulls_reviewers_test.go
@@ -119,8 +119,7 @@ func TestReviewers_Marshal(t *testing.T) {
 }
 
 func TestRequestReviewers(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1/requested_reviewers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -150,8 +149,7 @@ func TestRequestReviewers(t *testing.T) {
 }
 
 func TestRemoveReviewers(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1/requested_reviewers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -171,8 +169,7 @@ func TestRemoveReviewers(t *testing.T) {
 }
 
 func TestListReviewers(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1/requested_reviewers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -214,8 +211,7 @@ func TestListReviewers(t *testing.T) {
 }
 
 func TestListReviewers_withOptions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1/requested_reviewers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/pulls_reviews_test.go
+++ b/github/pulls_reviews_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestPullRequestsService_ListReviews(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1/reviews", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -58,8 +57,7 @@ func TestPullRequestsService_ListReviews(t *testing.T) {
 }
 
 func TestPullRequestsService_ListReviews_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.ListReviews(ctx, "%", "r", 1, nil)
@@ -67,8 +65,7 @@ func TestPullRequestsService_ListReviews_invalidOwner(t *testing.T) {
 }
 
 func TestPullRequestsService_GetReview(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1/reviews/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -102,8 +99,7 @@ func TestPullRequestsService_GetReview(t *testing.T) {
 }
 
 func TestPullRequestsService_GetReview_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.GetReview(ctx, "%", "r", 1, 1)
@@ -111,8 +107,7 @@ func TestPullRequestsService_GetReview_invalidOwner(t *testing.T) {
 }
 
 func TestPullRequestsService_DeletePendingReview(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1/reviews/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -146,8 +141,7 @@ func TestPullRequestsService_DeletePendingReview(t *testing.T) {
 }
 
 func TestPullRequestsService_DeletePendingReview_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.DeletePendingReview(ctx, "%", "r", 1, 1)
@@ -155,8 +149,7 @@ func TestPullRequestsService_DeletePendingReview_invalidOwner(t *testing.T) {
 }
 
 func TestPullRequestsService_ListReviewComments(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1/reviews/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -193,8 +186,7 @@ func TestPullRequestsService_ListReviewComments(t *testing.T) {
 }
 
 func TestPullRequestsService_ListReviewComments_withOptions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1/reviews/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -345,8 +337,7 @@ func TestPullRequestReviewRequest_isComfortFadePreview(t *testing.T) {
 }
 
 func TestPullRequestsService_ListReviewComments_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.ListReviewComments(ctx, "%", "r", 1, 1, nil)
@@ -354,8 +345,7 @@ func TestPullRequestsService_ListReviewComments_invalidOwner(t *testing.T) {
 }
 
 func TestPullRequestsService_CreateReview(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &PullRequestReviewRequest{
 		CommitID: String("commit_id"),
@@ -402,8 +392,7 @@ func TestPullRequestsService_CreateReview(t *testing.T) {
 }
 
 func TestPullRequestsService_CreateReview_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.CreateReview(ctx, "%", "r", 1, &PullRequestReviewRequest{})
@@ -411,8 +400,7 @@ func TestPullRequestsService_CreateReview_invalidOwner(t *testing.T) {
 }
 
 func TestPullRequestsService_CreateReview_badReview(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 
@@ -440,8 +428,7 @@ func TestPullRequestsService_CreateReview_badReview(t *testing.T) {
 }
 
 func TestPullRequestsService_CreateReview_addHeader(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	path := "path/to/file.go"
 	body := "this is a comment body"
@@ -487,8 +474,7 @@ func TestPullRequestsService_CreateReview_addHeader(t *testing.T) {
 }
 
 func TestPullRequestsService_UpdateReview(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1/reviews/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -522,8 +508,7 @@ func TestPullRequestsService_UpdateReview(t *testing.T) {
 }
 
 func TestPullRequestsService_SubmitReview(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &PullRequestReviewRequest{
 		Body:  String("b"),
@@ -569,8 +554,7 @@ func TestPullRequestsService_SubmitReview(t *testing.T) {
 }
 
 func TestPullRequestsService_SubmitReview_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.SubmitReview(ctx, "%", "r", 1, 1, &PullRequestReviewRequest{})
@@ -578,8 +562,7 @@ func TestPullRequestsService_SubmitReview_invalidOwner(t *testing.T) {
 }
 
 func TestPullRequestsService_DismissReview(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &PullRequestReviewDismissalRequest{Message: String("m")}
 
@@ -622,8 +605,7 @@ func TestPullRequestsService_DismissReview(t *testing.T) {
 }
 
 func TestPullRequestsService_DismissReview_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.DismissReview(ctx, "%", "r", 1, 1, &PullRequestReviewDismissalRequest{})

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func TestPullRequestsService_List(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -62,8 +61,7 @@ func TestPullRequestsService_List(t *testing.T) {
 }
 
 func TestPullRequestsService_ListPullRequestsWithCommit(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/commits/sha/pulls", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -102,8 +100,7 @@ func TestPullRequestsService_ListPullRequestsWithCommit(t *testing.T) {
 }
 
 func TestPullRequestsService_List_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.List(ctx, "%", "r", nil)
@@ -111,8 +108,7 @@ func TestPullRequestsService_List_invalidOwner(t *testing.T) {
 }
 
 func TestPullRequestsService_Get(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -146,8 +142,7 @@ func TestPullRequestsService_Get(t *testing.T) {
 }
 
 func TestPullRequestsService_GetRaw_diff(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	const rawStr = "@@diff content"
 
@@ -183,8 +178,7 @@ func TestPullRequestsService_GetRaw_diff(t *testing.T) {
 }
 
 func TestPullRequestsService_GetRaw_patch(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	const rawStr = "@@patch content"
 
@@ -206,8 +200,7 @@ func TestPullRequestsService_GetRaw_patch(t *testing.T) {
 }
 
 func TestPullRequestsService_GetRaw_invalid(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.GetRaw(ctx, "o", "r", 1, RawOptions{100})
@@ -220,8 +213,7 @@ func TestPullRequestsService_GetRaw_invalid(t *testing.T) {
 }
 
 func TestPullRequestsService_Get_links(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -274,8 +266,7 @@ func TestPullRequestsService_Get_links(t *testing.T) {
 }
 
 func TestPullRequestsService_Get_headAndBase(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -305,8 +296,7 @@ func TestPullRequestsService_Get_headAndBase(t *testing.T) {
 }
 
 func TestPullRequestsService_Get_urlFields(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -345,8 +335,7 @@ func TestPullRequestsService_Get_urlFields(t *testing.T) {
 }
 
 func TestPullRequestsService_Get_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.Get(ctx, "%", "r", 1)
@@ -354,8 +343,7 @@ func TestPullRequestsService_Get_invalidOwner(t *testing.T) {
 }
 
 func TestPullRequestsService_Create(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &NewPullRequest{Title: String("t")}
 
@@ -398,8 +386,7 @@ func TestPullRequestsService_Create(t *testing.T) {
 }
 
 func TestPullRequestsService_Create_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.Create(ctx, "%", "r", nil)
@@ -407,8 +394,7 @@ func TestPullRequestsService_Create_invalidOwner(t *testing.T) {
 }
 
 func TestPullRequestsService_UpdateBranch(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1/update-branch", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -455,8 +441,7 @@ func TestPullRequestsService_UpdateBranch(t *testing.T) {
 }
 
 func TestPullRequestsService_Edit(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	tests := []struct {
 		input        *PullRequest
@@ -516,8 +501,7 @@ func TestPullRequestsService_Edit(t *testing.T) {
 }
 
 func TestPullRequestsService_Edit_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.PullRequests.Edit(ctx, "%", "r", 1, &PullRequest{})
@@ -525,8 +509,7 @@ func TestPullRequestsService_Edit_invalidOwner(t *testing.T) {
 }
 
 func TestPullRequestsService_ListCommits(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1/commits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -597,8 +580,7 @@ func TestPullRequestsService_ListCommits(t *testing.T) {
 }
 
 func TestPullRequestsService_ListFiles(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1/files", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -674,8 +656,7 @@ func TestPullRequestsService_ListFiles(t *testing.T) {
 }
 
 func TestPullRequestsService_IsMerged(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1/merge", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -709,8 +690,7 @@ func TestPullRequestsService_IsMerged(t *testing.T) {
 }
 
 func TestPullRequestsService_Merge(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/1/merge", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -755,8 +735,7 @@ func TestPullRequestsService_Merge(t *testing.T) {
 
 // Test that different merge options produce expected PUT requests. See issue https://github.com/google/go-github/issues/500.
 func TestPullRequestsService_Merge_options(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	tests := []struct {
 		options  *PullRequestOptions
@@ -810,8 +789,8 @@ func TestPullRequestsService_Merge_options(t *testing.T) {
 }
 
 func TestPullRequestsService_Merge_Blank_Message(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	madeRequest := false
 	expectedBody := ""
 	mux.HandleFunc("/repos/o/r/pulls/1/merge", func(w http.ResponseWriter, r *http.Request) {

--- a/github/rate_limit_test.go
+++ b/github/rate_limit_test.go
@@ -36,8 +36,7 @@ func TestRateLimits_String(t *testing.T) {
 }
 
 func TestRateLimits(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/rate_limit", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -180,8 +179,7 @@ func TestRateLimits(t *testing.T) {
 }
 
 func TestRateLimits_coverage(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 
@@ -193,8 +191,7 @@ func TestRateLimits_coverage(t *testing.T) {
 }
 
 func TestRateLimits_overQuota(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	client.rateLimits[CoreCategory] = Rate{
 		Limit:     1,

--- a/github/reactions_test.go
+++ b/github/reactions_test.go
@@ -58,7 +58,7 @@ func TestReactions_Marshal(t *testing.T) {
 		"heart": 1,
 		"hooray": 1,
 		"rocket": 1,
-		"eyes": 1,		
+		"eyes": 1,
 		"url": "u"
 	}`
 
@@ -66,8 +66,7 @@ func TestReactions_Marshal(t *testing.T) {
 }
 
 func TestReactionsService_ListCommentReactions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -104,8 +103,7 @@ func TestReactionsService_ListCommentReactions(t *testing.T) {
 }
 
 func TestReactionsService_CreateCommentReaction(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -141,8 +139,7 @@ func TestReactionsService_CreateCommentReaction(t *testing.T) {
 }
 
 func TestReactionsService_ListIssueReactions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -164,8 +161,7 @@ func TestReactionsService_ListIssueReactions(t *testing.T) {
 }
 
 func TestReactionsService_ListIssueReactions_coverage(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 
@@ -185,8 +181,7 @@ func TestReactionsService_ListIssueReactions_coverage(t *testing.T) {
 }
 
 func TestReactionsService_CreateIssueReaction(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -222,8 +217,7 @@ func TestReactionsService_CreateIssueReaction(t *testing.T) {
 }
 
 func TestReactionsService_ListIssueCommentReactions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -245,8 +239,7 @@ func TestReactionsService_ListIssueCommentReactions(t *testing.T) {
 }
 
 func TestReactionsService_ListIssueCommentReactions_coverage(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 
@@ -266,8 +259,7 @@ func TestReactionsService_ListIssueCommentReactions_coverage(t *testing.T) {
 }
 
 func TestReactionsService_CreateIssueCommentReaction(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -303,8 +295,7 @@ func TestReactionsService_CreateIssueCommentReaction(t *testing.T) {
 }
 
 func TestReactionsService_ListPullRequestCommentReactions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -326,8 +317,7 @@ func TestReactionsService_ListPullRequestCommentReactions(t *testing.T) {
 }
 
 func TestReactionsService_ListPullRequestCommentReactions_coverage(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 
@@ -347,8 +337,7 @@ func TestReactionsService_ListPullRequestCommentReactions_coverage(t *testing.T)
 }
 
 func TestReactionsService_CreatePullRequestCommentReaction(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -384,8 +373,7 @@ func TestReactionsService_CreatePullRequestCommentReaction(t *testing.T) {
 }
 
 func TestReactionsService_ListTeamDiscussionReactions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/teams/1/discussions/2/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -407,8 +395,7 @@ func TestReactionsService_ListTeamDiscussionReactions(t *testing.T) {
 }
 
 func TestReactionsService_ListTeamDiscussionReactions_coverage(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 
@@ -428,8 +415,7 @@ func TestReactionsService_ListTeamDiscussionReactions_coverage(t *testing.T) {
 }
 
 func TestReactionsService_CreateTeamDiscussionReaction(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/teams/1/discussions/2/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -465,8 +451,7 @@ func TestReactionsService_CreateTeamDiscussionReaction(t *testing.T) {
 }
 
 func TestReactionService_ListTeamDiscussionCommentReactions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/teams/1/discussions/2/comments/3/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -488,8 +473,7 @@ func TestReactionService_ListTeamDiscussionCommentReactions(t *testing.T) {
 }
 
 func TestReactionService_ListTeamDiscussionCommentReactions_coverage(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 
@@ -509,8 +493,7 @@ func TestReactionService_ListTeamDiscussionCommentReactions_coverage(t *testing.
 }
 
 func TestReactionService_CreateTeamDiscussionCommentReaction(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/teams/1/discussions/2/comments/3/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -546,8 +529,7 @@ func TestReactionService_CreateTeamDiscussionCommentReaction(t *testing.T) {
 }
 
 func TestReactionsService_DeleteCommitCommentReaction(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/comments/1/reactions/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -573,8 +555,7 @@ func TestReactionsService_DeleteCommitCommentReaction(t *testing.T) {
 }
 
 func TestReactionsService_DeleteCommitCommentReactionByRepoID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repositories/1/comments/2/reactions/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -600,8 +581,7 @@ func TestReactionsService_DeleteCommitCommentReactionByRepoID(t *testing.T) {
 }
 
 func TestReactionsService_DeleteIssueReaction(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/1/reactions/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -627,8 +607,7 @@ func TestReactionsService_DeleteIssueReaction(t *testing.T) {
 }
 
 func TestReactionsService_DeleteIssueReactionByRepoID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repositories/1/issues/2/reactions/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -654,8 +633,7 @@ func TestReactionsService_DeleteIssueReactionByRepoID(t *testing.T) {
 }
 
 func TestReactionsService_DeleteIssueCommentReaction(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/issues/comments/1/reactions/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -681,8 +659,7 @@ func TestReactionsService_DeleteIssueCommentReaction(t *testing.T) {
 }
 
 func TestReactionsService_DeleteIssueCommentReactionByRepoID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repositories/1/issues/comments/2/reactions/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -708,8 +685,7 @@ func TestReactionsService_DeleteIssueCommentReactionByRepoID(t *testing.T) {
 }
 
 func TestReactionsService_DeletePullRequestCommentReaction(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pulls/comments/1/reactions/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -735,8 +711,7 @@ func TestReactionsService_DeletePullRequestCommentReaction(t *testing.T) {
 }
 
 func TestReactionsService_DeletePullRequestCommentReactionByRepoID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repositories/1/pulls/comments/2/reactions/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -762,8 +737,7 @@ func TestReactionsService_DeletePullRequestCommentReactionByRepoID(t *testing.T)
 }
 
 func TestReactionsService_DeleteTeamDiscussionReaction(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s/discussions/1/reactions/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -789,8 +763,7 @@ func TestReactionsService_DeleteTeamDiscussionReaction(t *testing.T) {
 }
 
 func TestReactionsService_DeleteTeamDiscussionReactionByTeamIDAndOrgID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/2/discussions/3/reactions/4", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -816,8 +789,7 @@ func TestReactionsService_DeleteTeamDiscussionReactionByTeamIDAndOrgID(t *testin
 }
 
 func TestReactionsService_DeleteTeamDiscussionCommentReaction(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s/discussions/1/comments/2/reactions/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -843,8 +815,7 @@ func TestReactionsService_DeleteTeamDiscussionCommentReaction(t *testing.T) {
 }
 
 func TestReactionsService_DeleteTeamDiscussionCommentReactionByTeamIDAndOrgID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/2/discussions/3/comments/4/reactions/5", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -870,8 +841,7 @@ func TestReactionsService_DeleteTeamDiscussionCommentReactionByTeamIDAndOrgID(t 
 }
 
 func TestReactionService_CreateReleaseReaction(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/releases/1/reactions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/github/repos_actions_access_test.go
+++ b/github/repos_actions_access_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_GetActionsAccessLevel(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/permissions/access", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -50,8 +49,7 @@ func TestRepositoriesService_GetActionsAccessLevel(t *testing.T) {
 }
 
 func TestRepositoriesService_EditActionsAccessLevel(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &RepositoryActionsAccessLevel{AccessLevel: String("organization")}
 

--- a/github/repos_actions_allowed_test.go
+++ b/github/repos_actions_allowed_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoryService_GetActionsAllowed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/permissions/selected-actions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -50,8 +49,8 @@ func TestRepositoryService_GetActionsAllowed(t *testing.T) {
 }
 
 func TestRepositoriesService_EditActionsAllowed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	input := &ActionsAllowed{GithubOwnedAllowed: Bool(true), VerifiedAllowed: Bool(false), PatternsAllowed: []string{"a/b"}}
 
 	mux.HandleFunc("/repos/o/r/actions/permissions/selected-actions", func(w http.ResponseWriter, r *http.Request) {

--- a/github/repos_actions_permissions_test.go
+++ b/github/repos_actions_permissions_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_GetActionsPermissions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/permissions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -50,8 +49,7 @@ func TestRepositoriesService_GetActionsPermissions(t *testing.T) {
 }
 
 func TestRepositoriesService_EditActionsPermissions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &ActionsPermissionsRepository{Enabled: Bool(true), AllowedActions: String("selected")}
 
@@ -112,8 +110,7 @@ func TestActionsPermissionsRepository_Marshal(t *testing.T) {
 }
 
 func TestRepositoriesService_GetDefaultWorkflowPermissions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/actions/permissions/workflow", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -146,8 +143,7 @@ func TestRepositoriesService_GetDefaultWorkflowPermissions(t *testing.T) {
 }
 
 func TestRepositoriesService_EditDefaultWorkflowPermissions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &DefaultWorkflowPermissionRepository{DefaultWorkflowPermissions: String("read"), CanApprovePullRequestReviews: Bool(true)}
 

--- a/github/repos_autolinks_test.go
+++ b/github/repos_autolinks_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_ListAutolinks(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/autolinks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -59,8 +58,7 @@ func TestRepositoriesService_ListAutolinks(t *testing.T) {
 }
 
 func TestRepositoriesService_AddAutolink(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	opt := &AutolinkOptions{
 		KeyPrefix:      String("TICKET-"),
@@ -114,8 +112,7 @@ func TestRepositoriesService_AddAutolink(t *testing.T) {
 }
 
 func TestRepositoriesService_GetAutolink(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/autolinks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -144,8 +141,7 @@ func TestRepositoriesService_GetAutolink(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteAutolink(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/autolinks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/repos_codeowners_test.go
+++ b/github/repos_codeowners_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestRepositoriesService_GetCodeownersErrors_noRef(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/codeowners/errors", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -76,8 +75,7 @@ func TestRepositoriesService_GetCodeownersErrors_noRef(t *testing.T) {
 }
 
 func TestRepositoriesService_GetCodeownersErrors_specificRef(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/codeowners/errors", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/repos_collaborators_test.go
+++ b/github/repos_collaborators_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_ListCollaborators(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/collaborators", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -55,8 +54,7 @@ func TestRepositoriesService_ListCollaborators(t *testing.T) {
 }
 
 func TestRepositoriesService_ListCollaborators_withAffiliation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/collaborators", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -95,8 +93,7 @@ func TestRepositoriesService_ListCollaborators_withAffiliation(t *testing.T) {
 }
 
 func TestRepositoriesService_ListCollaborators_withPermission(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/collaborators", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -135,8 +132,7 @@ func TestRepositoriesService_ListCollaborators_withPermission(t *testing.T) {
 }
 
 func TestRepositoriesService_ListCollaborators_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.ListCollaborators(ctx, "%", "%", nil)
@@ -144,8 +140,7 @@ func TestRepositoriesService_ListCollaborators_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_IsCollaborator_True(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/collaborators/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -178,8 +173,7 @@ func TestRepositoriesService_IsCollaborator_True(t *testing.T) {
 }
 
 func TestRepositoriesService_IsCollaborator_False(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/collaborators/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -212,8 +206,7 @@ func TestRepositoriesService_IsCollaborator_False(t *testing.T) {
 }
 
 func TestRepositoriesService_IsCollaborator_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.IsCollaborator(ctx, "%", "%", "%")
@@ -221,8 +214,7 @@ func TestRepositoriesService_IsCollaborator_invalidUser(t *testing.T) {
 }
 
 func TestRepositoryService_GetPermissionLevel(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/collaborators/u/permission", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -262,8 +254,7 @@ func TestRepositoryService_GetPermissionLevel(t *testing.T) {
 }
 
 func TestRepositoriesService_AddCollaborator(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	opt := &RepositoryAddCollaboratorOptions{Permission: "admin"}
 	mux.HandleFunc("/repos/o/r/collaborators/u", func(w http.ResponseWriter, r *http.Request) {
@@ -319,8 +310,7 @@ func TestRepositoriesService_AddCollaborator(t *testing.T) {
 }
 
 func TestRepositoriesService_AddCollaborator_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.AddCollaborator(ctx, "%", "%", "%", nil)
@@ -328,8 +318,7 @@ func TestRepositoriesService_AddCollaborator_invalidUser(t *testing.T) {
 }
 
 func TestRepositoriesService_RemoveCollaborator(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/collaborators/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -354,8 +343,7 @@ func TestRepositoriesService_RemoveCollaborator(t *testing.T) {
 }
 
 func TestRepositoriesService_RemoveCollaborator_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Repositories.RemoveCollaborator(ctx, "%", "%", "%")

--- a/github/repos_comments_test.go
+++ b/github/repos_comments_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_ListComments(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -54,8 +53,7 @@ func TestRepositoriesService_ListComments(t *testing.T) {
 }
 
 func TestRepositoriesService_ListComments_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.ListComments(ctx, "%", "%", nil)
@@ -63,8 +61,7 @@ func TestRepositoriesService_ListComments_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_ListCommitComments(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/commits/s/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -101,8 +98,7 @@ func TestRepositoriesService_ListCommitComments(t *testing.T) {
 }
 
 func TestRepositoriesService_ListCommitComments_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.ListCommitComments(ctx, "%", "%", "%", nil)
@@ -110,8 +106,7 @@ func TestRepositoriesService_ListCommitComments_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &RepositoryComment{Body: String("b")}
 
@@ -154,8 +149,7 @@ func TestRepositoriesService_CreateComment(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateComment_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.CreateComment(ctx, "%", "%", "%", nil)
@@ -163,8 +157,7 @@ func TestRepositoriesService_CreateComment_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_GetComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -199,8 +192,7 @@ func TestRepositoriesService_GetComment(t *testing.T) {
 }
 
 func TestRepositoriesService_GetComment_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.GetComment(ctx, "%", "%", 1)
@@ -208,8 +200,7 @@ func TestRepositoriesService_GetComment_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_UpdateComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &RepositoryComment{Body: String("b")}
 
@@ -252,8 +243,7 @@ func TestRepositoriesService_UpdateComment(t *testing.T) {
 }
 
 func TestRepositoriesService_UpdateComment_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.UpdateComment(ctx, "%", "%", 1, nil)
@@ -261,8 +251,7 @@ func TestRepositoriesService_UpdateComment_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -286,8 +275,7 @@ func TestRepositoriesService_DeleteComment(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteComment_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Repositories.DeleteComment(ctx, "%", "%", 1)

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func TestRepositoriesService_ListCommits(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	// given
 	mux.HandleFunc("/repos/o/r/commits", func(w http.ResponseWriter, r *http.Request) {
@@ -69,8 +68,7 @@ func TestRepositoriesService_ListCommits(t *testing.T) {
 }
 
 func TestRepositoriesService_GetCommit(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/commits/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -160,8 +158,7 @@ func TestRepositoriesService_GetCommit(t *testing.T) {
 }
 
 func TestRepositoriesService_GetCommitRaw_diff(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	const rawStr = "@@diff content"
 
@@ -197,8 +194,7 @@ func TestRepositoriesService_GetCommitRaw_diff(t *testing.T) {
 }
 
 func TestRepositoriesService_GetCommitRaw_patch(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	const rawStr = "@@patch content"
 
@@ -220,8 +216,7 @@ func TestRepositoriesService_GetCommitRaw_patch(t *testing.T) {
 }
 
 func TestRepositoriesService_GetCommitRaw_invalid(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.GetCommitRaw(ctx, "o", "r", "s", RawOptions{100})
@@ -234,8 +229,8 @@ func TestRepositoriesService_GetCommitRaw_invalid(t *testing.T) {
 }
 
 func TestRepositoriesService_GetCommitSHA1(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	const sha1 = "01234abcde"
 
 	mux.HandleFunc("/repos/o/r/commits/master", func(w http.ResponseWriter, r *http.Request) {
@@ -290,8 +285,8 @@ func TestRepositoriesService_GetCommitSHA1(t *testing.T) {
 }
 
 func TestRepositoriesService_NonAlphabetCharacter_GetCommitSHA1(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	const sha1 = "01234abcde"
 
 	mux.HandleFunc("/repos/o/r/commits/master%20hash", func(w http.ResponseWriter, r *http.Request) {
@@ -330,8 +325,8 @@ func TestRepositoriesService_NonAlphabetCharacter_GetCommitSHA1(t *testing.T) {
 }
 
 func TestRepositoriesService_TrailingPercent_GetCommitSHA1(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	const sha1 = "01234abcde"
 
 	mux.HandleFunc("/repos/o/r/commits/comm%", func(w http.ResponseWriter, r *http.Request) {
@@ -380,7 +375,7 @@ func TestRepositoriesService_CompareCommits(t *testing.T) {
 	}
 
 	for _, sample := range testCases {
-		client, mux, _, teardown := setup()
+		client, mux, _ := setup(t)
 
 		base := sample.base
 		head := sample.head
@@ -499,8 +494,6 @@ func TestRepositoriesService_CompareCommits(t *testing.T) {
 			}
 			return resp, err
 		})
-
-		teardown()
 	}
 }
 
@@ -515,7 +508,7 @@ func TestRepositoriesService_CompareCommitsRaw_diff(t *testing.T) {
 	}
 
 	for _, sample := range testCases {
-		client, mux, _, teardown := setup()
+		client, mux, _ := setup(t)
 
 		base := sample.base
 		head := sample.head
@@ -551,8 +544,6 @@ func TestRepositoriesService_CompareCommitsRaw_diff(t *testing.T) {
 			}
 			return resp, err
 		})
-
-		teardown()
 	}
 }
 
@@ -567,7 +558,7 @@ func TestRepositoriesService_CompareCommitsRaw_patch(t *testing.T) {
 	}
 
 	for _, sample := range testCases {
-		client, mux, _, teardown := setup()
+		client, mux, _ := setup(t)
 
 		base := sample.base
 		head := sample.head
@@ -589,8 +580,6 @@ func TestRepositoriesService_CompareCommitsRaw_patch(t *testing.T) {
 		if got != want {
 			t.Errorf("Repositories.GetCommitRaw returned %s want %s", got, want)
 		}
-
-		teardown()
 	}
 }
 
@@ -607,7 +596,7 @@ func TestRepositoriesService_CompareCommitsRaw_invalid(t *testing.T) {
 	}
 
 	for _, sample := range testCases {
-		client, _, _, teardown := setup()
+		client, _, _ := setup(t)
 		_, _, err := client.Repositories.CompareCommitsRaw(ctx, "o", "r", sample.base, sample.head, RawOptions{100})
 		if err == nil {
 			t.Fatal("Repositories.GetCommitRaw should return error")
@@ -615,13 +604,11 @@ func TestRepositoriesService_CompareCommitsRaw_invalid(t *testing.T) {
 		if !strings.Contains(err.Error(), "unsupported raw type") {
 			t.Error("Repositories.GetCommitRaw should return unsupported raw type error")
 		}
-		teardown()
 	}
 }
 
 func TestRepositoriesService_ListBranchesHeadCommit(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/commits/s/branches-where-head", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/repos_community_health_test.go
+++ b/github/repos_community_health_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/community/profile", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -88,8 +88,8 @@ func stringOrNil(s *string) string {
 }
 
 func TestRepositoriesService_GetReadme(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/readme", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
@@ -126,8 +126,8 @@ func TestRepositoriesService_GetReadme(t *testing.T) {
 }
 
 func TestRepositoriesService_DownloadContents_Success(t *testing.T) {
-	client, mux, serverURL, teardown := setup()
-	defer teardown()
+	client, mux, serverURL := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{
@@ -177,8 +177,8 @@ func TestRepositoriesService_DownloadContents_Success(t *testing.T) {
 }
 
 func TestRepositoriesService_DownloadContents_FailedResponse(t *testing.T) {
-	client, mux, serverURL, teardown := setup()
-	defer teardown()
+	client, mux, serverURL := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{
@@ -215,8 +215,8 @@ func TestRepositoriesService_DownloadContents_FailedResponse(t *testing.T) {
 }
 
 func TestRepositoriesService_DownloadContents_NoDownloadURL(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{
@@ -237,8 +237,8 @@ func TestRepositoriesService_DownloadContents_NoDownloadURL(t *testing.T) {
 }
 
 func TestRepositoriesService_DownloadContents_NoFile(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[]`)
@@ -256,8 +256,8 @@ func TestRepositoriesService_DownloadContents_NoFile(t *testing.T) {
 }
 
 func TestRepositoriesService_DownloadContentsWithMeta_Success(t *testing.T) {
-	client, mux, serverURL, teardown := setup()
-	defer teardown()
+	client, mux, serverURL := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{
@@ -318,8 +318,8 @@ func TestRepositoriesService_DownloadContentsWithMeta_Success(t *testing.T) {
 }
 
 func TestRepositoriesService_DownloadContentsWithMeta_FailedResponse(t *testing.T) {
-	client, mux, serverURL, teardown := setup()
-	defer teardown()
+	client, mux, serverURL := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{
@@ -364,8 +364,8 @@ func TestRepositoriesService_DownloadContentsWithMeta_FailedResponse(t *testing.
 }
 
 func TestRepositoriesService_DownloadContentsWithMeta_NoDownloadURL(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{
@@ -386,8 +386,8 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoDownloadURL(t *testing.T
 }
 
 func TestRepositoriesService_DownloadContentsWithMeta_NoFile(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[]`)
@@ -405,8 +405,8 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoFile(t *testing.T) {
 }
 
 func TestRepositoriesService_GetContents_File(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/p", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
@@ -443,8 +443,8 @@ func TestRepositoriesService_GetContents_File(t *testing.T) {
 }
 
 func TestRepositoriesService_GetContents_FilenameNeedsEscape(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/p#?%/中.go", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{}`)
@@ -457,8 +457,8 @@ func TestRepositoriesService_GetContents_FilenameNeedsEscape(t *testing.T) {
 }
 
 func TestRepositoriesService_GetContents_DirectoryWithSpaces(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/some directory/file.go", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{}`)
@@ -471,8 +471,8 @@ func TestRepositoriesService_GetContents_DirectoryWithSpaces(t *testing.T) {
 }
 
 func TestRepositoriesService_GetContents_PathWithParent(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/some/../directory/file.go", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{}`)
@@ -485,8 +485,8 @@ func TestRepositoriesService_GetContents_PathWithParent(t *testing.T) {
 }
 
 func TestRepositoriesService_GetContents_DirectoryWithPlusChars(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/some directory+name/file.go", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{}`)
@@ -499,8 +499,8 @@ func TestRepositoriesService_GetContents_DirectoryWithPlusChars(t *testing.T) {
 }
 
 func TestRepositoriesService_GetContents_Directory(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/p", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{
@@ -528,8 +528,8 @@ func TestRepositoriesService_GetContents_Directory(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateFile(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/p", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		fmt.Fprint(w, `{
@@ -581,8 +581,8 @@ func TestRepositoriesService_CreateFile(t *testing.T) {
 }
 
 func TestRepositoriesService_UpdateFile(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/p", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		fmt.Fprint(w, `{
@@ -636,8 +636,8 @@ func TestRepositoriesService_UpdateFile(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteFile(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/p", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		fmt.Fprint(w, `{
@@ -687,8 +687,8 @@ func TestRepositoriesService_DeleteFile(t *testing.T) {
 }
 
 func TestRepositoriesService_GetArchiveLink(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/tarball/yo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		http.Redirect(w, r, "http://github.com/a", http.StatusFound)
@@ -723,8 +723,8 @@ func TestRepositoriesService_GetArchiveLink(t *testing.T) {
 }
 
 func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_dontFollowRedirects(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/tarball", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		http.Redirect(w, r, "http://github.com/a", http.StatusMovedPermanently)
@@ -737,8 +737,8 @@ func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_dontFollowRed
 }
 
 func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_followRedirects(t *testing.T) {
-	client, mux, serverURL, teardown := setup()
-	defer teardown()
+	client, mux, serverURL := setup(t)
+
 	// Mock a redirect link, which leads to an archive link
 	mux.HandleFunc("/repos/o/r/tarball", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -764,8 +764,8 @@ func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_followRedirec
 }
 
 func TestRepositoriesService_GetContents_NoTrailingSlashInDirectoryApiPath(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
+
 	mux.HandleFunc("/repos/o/r/contents/.github", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		query := r.URL.Query()

--- a/github/repos_deployment_branch_policies_test.go
+++ b/github/repos_deployment_branch_policies_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestRepositoriesService_ListDeploymentBranchPolicies(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/environments/e/deployment-branch-policies", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"total_count":2, "branch_policies":[{"id":1}, {"id": 2}]}`)
@@ -49,8 +48,7 @@ func TestRepositoriesService_ListDeploymentBranchPolicies(t *testing.T) {
 }
 
 func TestRepositoriesService_GetDeploymentBranchPolicy(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/environments/e/deployment-branch-policies/1", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"id":1}`)
@@ -78,8 +76,7 @@ func TestRepositoriesService_GetDeploymentBranchPolicy(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateDeploymentBranchPolicy(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/environments/e/deployment-branch-policies", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -108,8 +105,7 @@ func TestRepositoriesService_CreateDeploymentBranchPolicy(t *testing.T) {
 }
 
 func TestRepositoriesService_UpdateDeploymentBranchPolicy(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/environments/e/deployment-branch-policies/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -138,8 +134,7 @@ func TestRepositoriesService_UpdateDeploymentBranchPolicy(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteDeploymentBranchPolicy(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/environments/e/deployment-branch-policies/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/repos_deployment_protection_rules_test.go
+++ b/github/repos_deployment_protection_rules_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestRepositoriesService_GetAllDeploymentProtectionRules(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/environments/e/deployment_protection_rules", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -53,8 +52,7 @@ func TestRepositoriesService_GetAllDeploymentProtectionRules(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateCustomDeploymentProtectionRule(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &CustomDeploymentProtectionRuleRequest{
 		IntegrationID: Int64(5),
@@ -110,8 +108,7 @@ func TestRepositoriesService_CreateCustomDeploymentProtectionRule(t *testing.T) 
 }
 
 func TestRepositoriesService_ListCustomDeploymentRuleIntegrations(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/environments/e/deployment_protection_rules/apps", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -146,8 +143,7 @@ func TestRepositoriesService_ListCustomDeploymentRuleIntegrations(t *testing.T) 
 }
 
 func TestRepositoriesService_GetCustomDeploymentProtectionRule(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/environments/e/deployment_protection_rules/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -187,8 +183,7 @@ func TestRepositoriesService_GetCustomDeploymentProtectionRule(t *testing.T) {
 }
 
 func TestRepositoriesService_DisableCustomDeploymentProtectionRule(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/environments/e/deployment_protection_rules/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/repos_deployments_test.go
+++ b/github/repos_deployments_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestRepositoriesService_ListDeployments(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/deployments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -54,8 +53,7 @@ func TestRepositoriesService_ListDeployments(t *testing.T) {
 }
 
 func TestRepositoriesService_GetDeployment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/deployments/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -90,8 +88,7 @@ func TestRepositoriesService_GetDeployment(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateDeployment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &DeploymentRequest{Ref: String("1111"), Task: String("deploy"), TransientEnvironment: Bool(true)}
 
@@ -136,8 +133,7 @@ func TestRepositoriesService_CreateDeployment(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteDeployment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/deployments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -173,8 +169,7 @@ func TestRepositoriesService_DeleteDeployment(t *testing.T) {
 }
 
 func TestRepositoriesService_ListDeploymentStatuses(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeExpandDeploymentStatusPreview}
 	mux.HandleFunc("/repos/o/r/deployments/1/statuses", func(w http.ResponseWriter, r *http.Request) {
@@ -212,8 +207,7 @@ func TestRepositoriesService_ListDeploymentStatuses(t *testing.T) {
 }
 
 func TestRepositoriesService_GetDeploymentStatus(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{mediaTypeDeploymentStatusPreview, mediaTypeExpandDeploymentStatusPreview}
 	mux.HandleFunc("/repos/o/r/deployments/3/statuses/4", func(w http.ResponseWriter, r *http.Request) {
@@ -249,8 +243,7 @@ func TestRepositoriesService_GetDeploymentStatus(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateDeploymentStatus(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &DeploymentStatusRequest{State: String("inactive"), Description: String("deploy"), AutoInactive: Bool(false)}
 

--- a/github/repos_environments_test.go
+++ b/github/repos_environments_test.go
@@ -100,8 +100,7 @@ func TestCreateUpdateEnvironment_MarshalJSON(t *testing.T) {
 }
 
 func TestRepositoriesService_ListEnvironments(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/environments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -140,8 +139,7 @@ func TestRepositoriesService_ListEnvironments(t *testing.T) {
 }
 
 func TestRepositoriesService_GetEnvironment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/environments/e", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -175,8 +173,7 @@ func TestRepositoriesService_GetEnvironment(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateEnvironment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &CreateUpdateEnvironment{
 		WaitTimer: Int(30),
@@ -221,8 +218,7 @@ func TestRepositoriesService_CreateEnvironment(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateEnvironment_noEnterprise(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &CreateUpdateEnvironment{}
 	callCount := 0
@@ -257,8 +253,7 @@ func TestRepositoriesService_CreateEnvironment_noEnterprise(t *testing.T) {
 }
 
 func TestRepositoriesService_createNewEnvNoEnterprise(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &CreateUpdateEnvironment{
 		DeploymentBranchPolicy: &BranchPolicy{
@@ -325,8 +320,7 @@ func TestRepositoriesService_createNewEnvNoEnterprise(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteEnvironment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/environments/e", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/repos_forks_test.go
+++ b/github/repos_forks_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestRepositoriesService_ListForks(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/forks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -59,8 +58,7 @@ func TestRepositoriesService_ListForks(t *testing.T) {
 }
 
 func TestRepositoriesService_ListForks_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.ListForks(ctx, "%", "r", nil)
@@ -68,8 +66,7 @@ func TestRepositoriesService_ListForks_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateFork(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/forks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -105,8 +102,7 @@ func TestRepositoriesService_CreateFork(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateFork_deferred(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/forks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -130,8 +126,7 @@ func TestRepositoriesService_CreateFork_deferred(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateFork_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.CreateFork(ctx, "%", "r", nil)

--- a/github/repos_hooks_configuration_test.go
+++ b/github/repos_hooks_configuration_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_GetHookConfiguration(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/hooks/1/config", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -56,8 +55,7 @@ func TestRepositoriesService_GetHookConfiguration(t *testing.T) {
 }
 
 func TestRepositoriesService_GetHookConfiguration_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.GetHookConfiguration(ctx, "%", "%", 1)
@@ -65,8 +63,7 @@ func TestRepositoriesService_GetHookConfiguration_invalidOrg(t *testing.T) {
 }
 
 func TestRepositoriesService_EditHookConfiguration(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &HookConfig{}
 
@@ -114,8 +111,7 @@ func TestRepositoriesService_EditHookConfiguration(t *testing.T) {
 }
 
 func TestRepositoriesService_EditHookConfiguration_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.EditHookConfiguration(ctx, "%", "%", 1, nil)

--- a/github/repos_hooks_deliveries_test.go
+++ b/github/repos_hooks_deliveries_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestRepositoriesService_ListHookDeliveries(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/hooks/1/deliveries", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -55,8 +54,7 @@ func TestRepositoriesService_ListHookDeliveries(t *testing.T) {
 }
 
 func TestRepositoriesService_ListHookDeliveries_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.ListHookDeliveries(ctx, "%", "%", 1, nil)
@@ -64,8 +62,7 @@ func TestRepositoriesService_ListHookDeliveries_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_GetHookDelivery(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/hooks/1/deliveries/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -99,8 +96,7 @@ func TestRepositoriesService_GetHookDelivery(t *testing.T) {
 }
 
 func TestRepositoriesService_GetHookDelivery_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.GetHookDelivery(ctx, "%", "%", 1, 1)
@@ -108,8 +104,7 @@ func TestRepositoriesService_GetHookDelivery_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_RedeliverHookDelivery(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/hooks/1/deliveries/1/attempts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/github/repos_hooks_test.go
+++ b/github/repos_hooks_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_CreateHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Hook{CreatedAt: &Timestamp{referenceTime}}
 
@@ -61,8 +60,7 @@ func TestRepositoriesService_CreateHook(t *testing.T) {
 }
 
 func TestRepositoriesService_ListHooks(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/hooks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -99,8 +97,7 @@ func TestRepositoriesService_ListHooks(t *testing.T) {
 }
 
 func TestRepositoriesService_ListHooks_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.ListHooks(ctx, "%", "%", nil)
@@ -116,8 +113,7 @@ func TestRepositoriesService_ListHooks_404_code(t *testing.T) {
 }
 
 func TestRepositoriesService_GetHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/hooks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -151,8 +147,7 @@ func TestRepositoriesService_GetHook(t *testing.T) {
 }
 
 func TestRepositoriesService_GetHook_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.GetHook(ctx, "%", "%", 1)
@@ -160,8 +155,7 @@ func TestRepositoriesService_GetHook_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_EditHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Hook{}
 
@@ -204,8 +198,7 @@ func TestRepositoriesService_EditHook(t *testing.T) {
 }
 
 func TestRepositoriesService_EditHook_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.EditHook(ctx, "%", "%", 1, nil)
@@ -213,8 +206,7 @@ func TestRepositoriesService_EditHook_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/hooks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -238,8 +230,7 @@ func TestRepositoriesService_DeleteHook(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteHook_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Repositories.DeleteHook(ctx, "%", "%", 1)
@@ -247,8 +238,7 @@ func TestRepositoriesService_DeleteHook_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_PingHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/hooks/1/pings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -272,8 +262,7 @@ func TestRepositoriesService_PingHook(t *testing.T) {
 }
 
 func TestRepositoriesService_TestHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/hooks/1/tests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -297,8 +286,7 @@ func TestRepositoriesService_TestHook(t *testing.T) {
 }
 
 func TestRepositoriesService_TestHook_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Repositories.TestHook(ctx, "%", "%", 1)
@@ -386,7 +374,7 @@ func TestBranchWebHookPayload_Marshal(t *testing.T) {
 				"email": "abc@gmail.com",
 				"name": "abc",
 				"username": "abc_12"
-			}, 
+			},
 			"id":       "1",
 			"message":  "WebHookCommit",
 			"modified": ["abc", "efg", "erd"],
@@ -407,7 +395,7 @@ func TestBranchWebHookPayload_Marshal(t *testing.T) {
 			"email": "abc@gmail.com",
 			"name": "abc",
 			"username": "abc_12"
-		}, 
+		},
 		"id":       "1",
 		"message":  "WebHookCommit",
 		"modified": ["abc", "efg", "erd"],
@@ -485,7 +473,7 @@ func TestBranchWebHookCommit_Marshal(t *testing.T) {
 			"email": "abc@gmail.com",
 			"name": "abc",
 			"username": "abc_12"
-		}, 
+		},
 		"id":       "1",
 		"message":  "WebHookCommit",
 		"modified": ["abc", "efg", "erd"],
@@ -553,15 +541,14 @@ func TestBranchHook_Marshal(t *testing.T) {
 			"content_type": "json"
 		},
 		"events": ["1","2","3"],
-		"active": true		
+		"active": true
 	}`
 
 	testJSONMarshal(t, v, want)
 }
 
 func TestRepositoriesService_Subscribe(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/hub", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -593,8 +580,7 @@ func TestRepositoriesService_Subscribe(t *testing.T) {
 }
 
 func TestRepositoriesService_Unsubscribe(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/hub", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)

--- a/github/repos_invitations_test.go
+++ b/github/repos_invitations_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestRepositoriesService_ListInvitations(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -52,8 +51,7 @@ func TestRepositoriesService_ListInvitations(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteInvitation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/invitations/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -78,8 +76,7 @@ func TestRepositoriesService_DeleteInvitation(t *testing.T) {
 }
 
 func TestRepositoriesService_UpdateInvitation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/invitations/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")

--- a/github/repos_keys_test.go
+++ b/github/repos_keys_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_ListKeys(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -53,8 +52,7 @@ func TestRepositoriesService_ListKeys(t *testing.T) {
 }
 
 func TestRepositoriesService_ListKeys_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.ListKeys(ctx, "%", "%", nil)
@@ -62,8 +60,7 @@ func TestRepositoriesService_ListKeys_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_GetKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/keys/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -97,8 +94,7 @@ func TestRepositoriesService_GetKey(t *testing.T) {
 }
 
 func TestRepositoriesService_GetKey_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.GetKey(ctx, "%", "%", 1)
@@ -106,8 +102,7 @@ func TestRepositoriesService_GetKey_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Key{Key: String("k"), Title: String("t")}
 
@@ -150,8 +145,7 @@ func TestRepositoriesService_CreateKey(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateKey_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.CreateKey(ctx, "%", "%", nil)
@@ -159,8 +153,7 @@ func TestRepositoriesService_CreateKey_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/keys/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -184,8 +177,7 @@ func TestRepositoriesService_DeleteKey(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteKey_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Repositories.DeleteKey(ctx, "%", "%", 1)

--- a/github/repos_lfs_test.go
+++ b/github/repos_lfs_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestRepositoriesService_EnableLFS(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/lfs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -38,8 +37,7 @@ func TestRepositoriesService_EnableLFS(t *testing.T) {
 }
 
 func TestRepositoriesService_DisableLFS(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/lfs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/repos_merging_test.go
+++ b/github/repos_merging_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_Merge(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &RepositoryMergeRequest{
 		Base:          String("b"),
@@ -82,8 +81,7 @@ func TestRepositoryMergeRequest_Marshal(t *testing.T) {
 }
 
 func TestRepositoriesService_MergeUpstream(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &RepoMergeUpstreamRequest{
 		Branch: String("b"),

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func TestRepositoriesService_EnablePagesLegacy(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Pages{
 		BuildType: String("legacy"),
@@ -72,8 +71,7 @@ func TestRepositoriesService_EnablePagesLegacy(t *testing.T) {
 }
 
 func TestRepositoriesService_EnablePagesWorkflow(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Pages{
 		BuildType: String("workflow"),
@@ -122,8 +120,7 @@ func TestRepositoriesService_EnablePagesWorkflow(t *testing.T) {
 }
 
 func TestRepositoriesService_UpdatePagesLegacy(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &PagesUpdate{
 		CNAME:     String("www.my-domain.com"),
@@ -162,8 +159,7 @@ func TestRepositoriesService_UpdatePagesLegacy(t *testing.T) {
 }
 
 func TestRepositoriesService_UpdatePagesWorkflow(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &PagesUpdate{
 		CNAME:     String("www.my-domain.com"),
@@ -201,8 +197,7 @@ func TestRepositoriesService_UpdatePagesWorkflow(t *testing.T) {
 }
 
 func TestRepositoriesService_UpdatePages_NullCNAME(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &PagesUpdate{
 		Source: &PagesSource{Branch: String("gh-pages")},
@@ -230,8 +225,7 @@ func TestRepositoriesService_UpdatePages_NullCNAME(t *testing.T) {
 }
 
 func TestRepositoriesService_DisablePages(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -256,8 +250,7 @@ func TestRepositoriesService_DisablePages(t *testing.T) {
 }
 
 func TestRepositoriesService_GetPagesInfo(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -291,8 +284,7 @@ func TestRepositoriesService_GetPagesInfo(t *testing.T) {
 }
 
 func TestRepositoriesService_ListPagesBuilds(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pages/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -326,8 +318,7 @@ func TestRepositoriesService_ListPagesBuilds(t *testing.T) {
 }
 
 func TestRepositoriesService_ListPagesBuilds_withOptions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pages/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -345,8 +336,7 @@ func TestRepositoriesService_ListPagesBuilds_withOptions(t *testing.T) {
 }
 
 func TestRepositoriesService_GetLatestPagesBuild(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pages/builds/latest", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -380,8 +370,7 @@ func TestRepositoriesService_GetLatestPagesBuild(t *testing.T) {
 }
 
 func TestRepositoriesService_GetPageBuild(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pages/builds/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -415,8 +404,7 @@ func TestRepositoriesService_GetPageBuild(t *testing.T) {
 }
 
 func TestRepositoriesService_RequestPageBuild(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pages/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -450,8 +438,7 @@ func TestRepositoriesService_RequestPageBuild(t *testing.T) {
 }
 
 func TestRepositoriesService_GetPageHealthCheck(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pages/health", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/repos_prereceive_hooks_test.go
+++ b/github/repos_prereceive_hooks_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_ListPreReceiveHooks(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pre-receive-hooks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -55,8 +54,7 @@ func TestRepositoriesService_ListPreReceiveHooks(t *testing.T) {
 }
 
 func TestRepositoriesService_ListPreReceiveHooks_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.ListPreReceiveHooks(ctx, "%", "%", nil)
@@ -64,8 +62,7 @@ func TestRepositoriesService_ListPreReceiveHooks_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_GetPreReceiveHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pre-receive-hooks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -100,8 +97,7 @@ func TestRepositoriesService_GetPreReceiveHook(t *testing.T) {
 }
 
 func TestRepositoriesService_GetPreReceiveHook_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.GetPreReceiveHook(ctx, "%", "%", 1)
@@ -109,8 +105,7 @@ func TestRepositoriesService_GetPreReceiveHook_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_UpdatePreReceiveHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &PreReceiveHook{}
 
@@ -153,8 +148,7 @@ func TestRepositoriesService_UpdatePreReceiveHook(t *testing.T) {
 }
 
 func TestRepositoriesService_PreReceiveHook_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.UpdatePreReceiveHook(ctx, "%", "%", 1, nil)
@@ -162,8 +156,7 @@ func TestRepositoriesService_PreReceiveHook_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_DeletePreReceiveHook(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/pre-receive-hooks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -187,8 +180,7 @@ func TestRepositoriesService_DeletePreReceiveHook(t *testing.T) {
 }
 
 func TestRepositoriesService_DeletePreReceiveHook_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Repositories.DeletePreReceiveHook(ctx, "%", "%", 1)

--- a/github/repos_projects_test.go
+++ b/github/repos_projects_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_ListProjects(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -54,8 +53,7 @@ func TestRepositoriesService_ListProjects(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateProject(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &ProjectOptions{Name: String("Project Name"), Body: String("Project body.")}
 

--- a/github/repos_properties_test.go
+++ b/github/repos_properties_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestRepositoriesService_GetAllCustomPropertyValues(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/properties/values", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -81,8 +80,7 @@ func TestRepositoriesService_GetAllCustomPropertyValues(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateOrUpdateCustomProperties(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/usr/r/properties/values", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -20,8 +20,7 @@ import (
 )
 
 func TestRepositoriesService_ListReleases(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/releases", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -56,8 +55,7 @@ func TestRepositoriesService_ListReleases(t *testing.T) {
 }
 
 func TestRepositoriesService_GenerateReleaseNotes(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/releases/generate-notes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -97,8 +95,7 @@ func TestRepositoriesService_GenerateReleaseNotes(t *testing.T) {
 }
 
 func TestRepositoriesService_GetRelease(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/releases/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -132,8 +129,7 @@ func TestRepositoriesService_GetRelease(t *testing.T) {
 }
 
 func TestRepositoriesService_GetLatestRelease(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/releases/latest", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -167,8 +163,7 @@ func TestRepositoriesService_GetLatestRelease(t *testing.T) {
 }
 
 func TestRepositoriesService_GetReleaseByTag(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/releases/tags/foo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -202,8 +197,7 @@ func TestRepositoriesService_GetReleaseByTag(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateRelease(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &RepositoryRelease{
 		Name:                   String("v1.0"),
@@ -267,8 +261,7 @@ func TestRepositoriesService_CreateRelease(t *testing.T) {
 }
 
 func TestRepositoriesService_EditRelease(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &RepositoryRelease{
 		Name:                   String("n"),
@@ -330,8 +323,7 @@ func TestRepositoriesService_EditRelease(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteRelease(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/releases/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -355,8 +347,7 @@ func TestRepositoriesService_DeleteRelease(t *testing.T) {
 }
 
 func TestRepositoriesService_ListReleaseAssets(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/releases/1/assets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -391,8 +382,7 @@ func TestRepositoriesService_ListReleaseAssets(t *testing.T) {
 }
 
 func TestRepositoriesService_GetReleaseAsset(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -425,8 +415,7 @@ func TestRepositoriesService_GetReleaseAsset(t *testing.T) {
 }
 
 func TestRepositoriesService_DownloadReleaseAsset_Stream(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -458,8 +447,7 @@ func TestRepositoriesService_DownloadReleaseAsset_Stream(t *testing.T) {
 }
 
 func TestRepositoriesService_DownloadReleaseAsset_Redirect(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -479,8 +467,7 @@ func TestRepositoriesService_DownloadReleaseAsset_Redirect(t *testing.T) {
 }
 
 func TestRepositoriesService_DownloadReleaseAsset_FollowRedirect(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -513,8 +500,7 @@ func TestRepositoriesService_DownloadReleaseAsset_FollowRedirect(t *testing.T) {
 }
 
 func TestRepositoriesService_DownloadReleaseAsset_FollowRedirectToError(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -543,8 +529,7 @@ func TestRepositoriesService_DownloadReleaseAsset_FollowRedirectToError(t *testi
 }
 
 func TestRepositoriesService_DownloadReleaseAsset_APIError(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -570,8 +555,7 @@ func TestRepositoriesService_DownloadReleaseAsset_APIError(t *testing.T) {
 }
 
 func TestRepositoriesService_EditReleaseAsset(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &ReleaseAsset{Name: String("n")}
 
@@ -612,8 +596,7 @@ func TestRepositoriesService_EditReleaseAsset(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteReleaseAsset(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -692,8 +675,7 @@ func TestRepositoriesService_UploadReleaseAsset(t *testing.T) {
 		},
 	}
 
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	for key, test := range uploadTests {
 		releaseEndpoint := fmt.Sprintf("/repos/o/r/releases/%d/assets", key)

--- a/github/repos_rules_test.go
+++ b/github/repos_rules_test.go
@@ -333,8 +333,7 @@ func TestRepositoryRule_UnmarshalJSON(t *testing.T) {
 }
 
 func TestRepositoriesService_GetRulesForBranch(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/repo/rules/branches/branch", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -394,8 +393,7 @@ func TestRepositoriesService_GetRulesForBranch(t *testing.T) {
 }
 
 func TestRepositoriesService_GetRulesForBranchEmptyUpdateRule(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/repo/rules/branches/branch", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -433,8 +431,7 @@ func TestRepositoriesService_GetRulesForBranchEmptyUpdateRule(t *testing.T) {
 }
 
 func TestRepositoriesService_GetAllRulesets(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/repo/rulesets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -494,8 +491,7 @@ func TestRepositoriesService_GetAllRulesets(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateRuleset(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/repo/rulesets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -540,8 +536,7 @@ func TestRepositoriesService_CreateRuleset(t *testing.T) {
 }
 
 func TestRepositoriesService_GetRuleset(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/repo/rulesets/42", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -583,8 +578,7 @@ func TestRepositoriesService_GetRuleset(t *testing.T) {
 }
 
 func TestRepositoriesService_UpdateRulesetNoBypassActor(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	rs := &Ruleset{
 		Name:        "ruleset",
@@ -635,8 +629,7 @@ func TestRepositoriesService_UpdateRulesetNoBypassActor(t *testing.T) {
 }
 
 func TestRepositoriesService_UpdateRuleset(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/repo/rulesets/42", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -682,8 +675,7 @@ func TestRepositoriesService_UpdateRuleset(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteRuleset(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/repo/rulesets/42", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/repos_stats_test.go
+++ b/github/repos_stats_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_ListContributorsStats(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/stats/contributors", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -87,8 +86,7 @@ func TestRepositoriesService_ListContributorsStats(t *testing.T) {
 }
 
 func TestRepositoriesService_ListCommitActivity(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/stats/commit_activity", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -138,8 +136,7 @@ func TestRepositoriesService_ListCommitActivity(t *testing.T) {
 }
 
 func TestRepositoriesService_ListCodeFrequency(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/stats/code_frequency", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -179,8 +176,7 @@ func TestRepositoriesService_ListCodeFrequency(t *testing.T) {
 }
 
 func TestRepositoriesService_Participation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/stats/participation", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -244,8 +240,7 @@ func TestRepositoriesService_Participation(t *testing.T) {
 }
 
 func TestRepositoriesService_ListPunchCard(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/stats/punch_card", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -289,8 +284,7 @@ func TestRepositoriesService_ListPunchCard(t *testing.T) {
 }
 
 func TestRepositoriesService_AcceptedError(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/stats/contributors", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/repos_statuses_test.go
+++ b/github/repos_statuses_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_ListStatuses(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/commits/r/statuses", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -53,8 +52,7 @@ func TestRepositoriesService_ListStatuses(t *testing.T) {
 }
 
 func TestRepositoriesService_ListStatuses_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.ListStatuses(ctx, "%", "r", "r", nil)
@@ -62,8 +60,7 @@ func TestRepositoriesService_ListStatuses_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateStatus(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &RepoStatus{State: String("s"), TargetURL: String("t"), Description: String("d")}
 
@@ -105,8 +102,7 @@ func TestRepositoriesService_CreateStatus(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateStatus_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.CreateStatus(ctx, "%", "r", "r", nil)
@@ -114,8 +110,7 @@ func TestRepositoriesService_CreateStatus_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_GetCombinedStatus(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/commits/r/status", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/repos_tags_test.go
+++ b/github/repos_tags_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_ListTagProtection(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/tags/protection", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -52,8 +51,7 @@ func TestRepositoriesService_ListTagProtection(t *testing.T) {
 }
 
 func TestRepositoriesService_ListTagProtection_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.ListTagProtection(ctx, "%", "r")
@@ -61,8 +59,7 @@ func TestRepositoriesService_ListTagProtection_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateTagProtection(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	pattern := "tag*"
 
@@ -106,8 +103,7 @@ func TestRepositoriesService_CreateTagProtection(t *testing.T) {
 }
 
 func TestRepositoriesService_DeleteTagProtection(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/tags/protection/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -20,8 +20,7 @@ import (
 )
 
 func TestRepositoriesService_ListByAuthenticatedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -51,8 +50,7 @@ func TestRepositoriesService_ListByAuthenticatedUser(t *testing.T) {
 }
 
 func TestRepositoriesService_ListByUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -96,8 +94,7 @@ func TestRepositoriesService_ListByUser(t *testing.T) {
 }
 
 func TestRepositoriesService_ListByUser_type(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -123,8 +120,7 @@ func TestRepositoriesService_ListByUser_type(t *testing.T) {
 }
 
 func TestRepositoriesService_ListByUser_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.ListByUser(ctx, "%", nil)
@@ -132,8 +128,7 @@ func TestRepositoriesService_ListByUser_invalidUser(t *testing.T) {
 }
 
 func TestRepositoriesService_ListByOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/orgs/o/repos", func(w http.ResponseWriter, r *http.Request) {
@@ -177,8 +172,7 @@ func TestRepositoriesService_ListByOrg(t *testing.T) {
 }
 
 func TestRepositoriesService_ListByOrg_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.ListByOrg(ctx, "%", nil)
@@ -186,8 +180,7 @@ func TestRepositoriesService_ListByOrg_invalidOrg(t *testing.T) {
 }
 
 func TestRepositoriesService_ListAll(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -220,8 +213,7 @@ func TestRepositoriesService_ListAll(t *testing.T) {
 }
 
 func TestRepositoriesService_Create_user(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Repository{
 		Name:     String("n"),
@@ -270,8 +262,7 @@ func TestRepositoriesService_Create_user(t *testing.T) {
 }
 
 func TestRepositoriesService_Create_org(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Repository{
 		Name:     String("n"),
@@ -306,8 +297,7 @@ func TestRepositoriesService_Create_org(t *testing.T) {
 }
 
 func TestRepositoriesService_CreateFromTemplate(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	templateRepoReq := &TemplateRepoRequest{
 		Name: String("n"),
@@ -354,8 +344,7 @@ func TestRepositoriesService_CreateFromTemplate(t *testing.T) {
 }
 
 func TestRepositoriesService_Get(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{mediaTypeCodesOfConductPreview, mediaTypeTopicsPreview, mediaTypeRepositoryTemplatePreview, mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
@@ -391,8 +380,7 @@ func TestRepositoriesService_Get(t *testing.T) {
 }
 
 func TestRepositoriesService_GetCodeOfConduct(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -440,8 +428,7 @@ func TestRepositoriesService_GetCodeOfConduct(t *testing.T) {
 }
 
 func TestRepositoriesService_GetByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repositories/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -470,8 +457,7 @@ func TestRepositoriesService_GetByID(t *testing.T) {
 }
 
 func TestRepositoriesService_Edit(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	i := true
 	input := &Repository{HasIssues: &i}
@@ -516,8 +502,7 @@ func TestRepositoriesService_Edit(t *testing.T) {
 }
 
 func TestRepositoriesService_Delete(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -541,8 +526,7 @@ func TestRepositoriesService_Delete(t *testing.T) {
 }
 
 func TestRepositoriesService_Get_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.Get(ctx, "%", "r")
@@ -550,8 +534,7 @@ func TestRepositoriesService_Get_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_Edit_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.Edit(ctx, "%", "r", nil)
@@ -559,8 +542,7 @@ func TestRepositoriesService_Edit_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_GetVulnerabilityAlerts(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/vulnerability-alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -595,8 +577,7 @@ func TestRepositoriesService_GetVulnerabilityAlerts(t *testing.T) {
 }
 
 func TestRepositoriesService_EnableVulnerabilityAlerts(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/vulnerability-alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -622,8 +603,7 @@ func TestRepositoriesService_EnableVulnerabilityAlerts(t *testing.T) {
 }
 
 func TestRepositoriesService_DisableVulnerabilityAlerts(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/vulnerability-alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -649,8 +629,7 @@ func TestRepositoriesService_DisableVulnerabilityAlerts(t *testing.T) {
 }
 
 func TestRepositoriesService_EnableAutomatedSecurityFixes(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/automated-security-fixes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -665,8 +644,7 @@ func TestRepositoriesService_EnableAutomatedSecurityFixes(t *testing.T) {
 }
 
 func TestRepositoriesService_GetAutomatedSecurityFixes(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/automated-security-fixes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -702,8 +680,7 @@ func TestRepositoriesService_GetAutomatedSecurityFixes(t *testing.T) {
 }
 
 func TestRepositoriesService_DisableAutomatedSecurityFixes(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/automated-security-fixes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -718,8 +695,7 @@ func TestRepositoriesService_DisableAutomatedSecurityFixes(t *testing.T) {
 }
 
 func TestRepositoriesService_ListContributors(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/contributors", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -758,8 +734,7 @@ func TestRepositoriesService_ListContributors(t *testing.T) {
 }
 
 func TestRepositoriesService_ListLanguages(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/languages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -793,8 +768,7 @@ func TestRepositoriesService_ListLanguages(t *testing.T) {
 }
 
 func TestRepositoriesService_ListTeams(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -830,8 +804,7 @@ func TestRepositoriesService_ListTeams(t *testing.T) {
 }
 
 func TestRepositoriesService_ListTags(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/tags", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -877,8 +850,7 @@ func TestRepositoriesService_ListTags(t *testing.T) {
 }
 
 func TestRepositoriesService_ListBranches(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/branches", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -917,8 +889,7 @@ func TestRepositoriesService_ListBranches(t *testing.T) {
 }
 
 func TestRepositoriesService_GetBranch(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	tests := []struct {
 		branch  string
@@ -979,8 +950,7 @@ func TestRepositoriesService_GetBranch_BadJSONResponse(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
@@ -996,8 +966,7 @@ func TestRepositoriesService_GetBranch_BadJSONResponse(t *testing.T) {
 }
 
 func TestRepositoriesService_GetBranch_StatusMovedPermanently_followRedirects(t *testing.T) {
-	client, mux, serverURL, teardown := setup()
-	defer teardown()
+	client, mux, serverURL := setup(t)
 
 	mux.HandleFunc("/repos/o/r/branches/b", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1048,8 +1017,7 @@ func TestRepositoriesService_GetBranch_notFound(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
@@ -1089,8 +1057,7 @@ func TestRepositoriesService_RenameBranch(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			renameBranchReq := "nn"
 
@@ -1147,8 +1114,7 @@ func TestRepositoriesService_GetBranchProtection(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
@@ -1292,8 +1258,7 @@ func TestRepositoriesService_GetBranchProtection(t *testing.T) {
 }
 
 func TestRepositoriesService_GetBranchProtection_noDismissalRestrictions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	tests := []struct {
 		branch               string
@@ -1388,8 +1353,7 @@ func TestRepositoriesService_GetBranchProtection_branchNotProtected(t *testing.T
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
@@ -1426,8 +1390,7 @@ func TestRepositoriesService_UpdateBranchProtection_Contexts(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			input := &ProtectionRequest{
 				RequiredStatusChecks: &RequiredStatusChecks{
@@ -1614,8 +1577,7 @@ func TestRepositoriesService_UpdateBranchProtection_EmptyContexts(t *testing.T) 
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			input := &ProtectionRequest{
 				RequiredStatusChecks: &RequiredStatusChecks{
@@ -1792,8 +1754,7 @@ func TestRepositoriesService_UpdateBranchProtection_Checks(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			input := &ProtectionRequest{
 				RequiredStatusChecks: &RequiredStatusChecks{
@@ -1949,8 +1910,7 @@ func TestRepositoriesService_UpdateBranchProtection_EmptyChecks(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			input := &ProtectionRequest{
 				RequiredStatusChecks: &RequiredStatusChecks{
@@ -2092,8 +2052,7 @@ func TestRepositoriesService_UpdateBranchProtection_StrictNoChecks(t *testing.T)
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			input := &ProtectionRequest{
 				RequiredStatusChecks: &RequiredStatusChecks{
@@ -2234,8 +2193,7 @@ func TestRepositoriesService_UpdateBranchProtection_RequireLastPushApproval(t *t
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			input := &ProtectionRequest{
 				RequiredPullRequestReviews: &PullRequestReviewsEnforcementRequest{
@@ -2288,8 +2246,7 @@ func TestRepositoriesService_RemoveBranchProtection(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "DELETE")
@@ -2316,8 +2273,7 @@ func TestRepositoriesService_RemoveBranchProtection(t *testing.T) {
 }
 
 func TestRepositoriesService_ListLanguages_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Repositories.ListLanguages(ctx, "%", "%")
@@ -2325,8 +2281,7 @@ func TestRepositoriesService_ListLanguages_invalidOwner(t *testing.T) {
 }
 
 func TestRepositoriesService_License(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/license", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -2381,8 +2336,7 @@ func TestRepositoriesService_GetRequiredStatusChecks(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
@@ -2459,8 +2413,7 @@ func TestRepositoriesService_GetRequiredStatusChecks_branchNotProtected(t *testi
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
@@ -2497,8 +2450,7 @@ func TestRepositoriesService_UpdateRequiredStatusChecks_Contexts(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			input := &RequiredStatusChecksRequest{
 				Strict:   Bool(true),
@@ -2573,8 +2525,7 @@ func TestRepositoriesService_UpdateRequiredStatusChecks_Checks(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			appID := int64(123)
 			noAppID := int64(-1)
@@ -2664,8 +2615,7 @@ func TestRepositoriesService_RemoveRequiredStatusChecks(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "DELETE")
@@ -2703,8 +2653,7 @@ func TestRepositoriesService_ListRequiredStatusChecksContexts(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
@@ -2750,8 +2699,7 @@ func TestRepositoriesService_ListRequiredStatusChecksContexts_branchNotProtected
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
@@ -2788,8 +2736,7 @@ func TestRepositoriesService_GetPullRequestReviewEnforcement(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
@@ -2862,8 +2809,7 @@ func TestRepositoriesService_UpdatePullRequestReviewEnforcement(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			input := &PullRequestReviewsEnforcementUpdate{
 				DismissalRestrictionsRequest: &DismissalRestrictionsRequest{
@@ -2949,8 +2895,7 @@ func TestRepositoriesService_DisableDismissalRestrictions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "PATCH")
@@ -3004,8 +2949,7 @@ func TestRepositoriesService_RemovePullRequestReviewEnforcement(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "DELETE")
@@ -3042,8 +2986,7 @@ func TestRepositoriesService_GetAdminEnforcement(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
@@ -3093,8 +3036,7 @@ func TestRepositoriesService_AddAdminEnforcement(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "POST")
@@ -3143,8 +3085,7 @@ func TestRepositoriesService_RemoveAdminEnforcement(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "DELETE")
@@ -3181,8 +3122,7 @@ func TestRepositoriesService_GetSignaturesProtectedBranch(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
@@ -3233,8 +3173,7 @@ func TestRepositoriesService_RequireSignaturesOnProtectedBranch(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "POST")
@@ -3285,8 +3224,7 @@ func TestRepositoriesService_OptionalSignaturesOnProtectedBranch(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "DELETE")
@@ -3361,8 +3299,7 @@ func TestPullRequestReviewsEnforcementRequest_MarshalJSON_nilDismissalRestirctio
 }
 
 func TestRepositoriesService_ListAllTopics(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/topics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -3397,8 +3334,7 @@ func TestRepositoriesService_ListAllTopics(t *testing.T) {
 }
 
 func TestRepositoriesService_ListAllTopics_emptyTopics(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/topics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -3419,8 +3355,7 @@ func TestRepositoriesService_ListAllTopics_emptyTopics(t *testing.T) {
 }
 
 func TestRepositoriesService_ReplaceAllTopics(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/topics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -3455,8 +3390,7 @@ func TestRepositoriesService_ReplaceAllTopics(t *testing.T) {
 }
 
 func TestRepositoriesService_ReplaceAllTopics_nilSlice(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/topics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -3478,8 +3412,7 @@ func TestRepositoriesService_ReplaceAllTopics_nilSlice(t *testing.T) {
 }
 
 func TestRepositoriesService_ReplaceAllTopics_emptySlice(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/topics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -3511,8 +3444,7 @@ func TestRepositoriesService_ListAppRestrictions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
@@ -3552,8 +3484,7 @@ func TestRepositoriesService_ReplaceAppRestrictions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "PUT")
@@ -3602,8 +3533,7 @@ func TestRepositoriesService_AddAppRestrictions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "POST")
@@ -3652,8 +3582,7 @@ func TestRepositoriesService_RemoveAppRestrictions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "DELETE")
@@ -3698,8 +3627,7 @@ func TestRepositoriesService_ListTeamRestrictions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
@@ -3739,8 +3667,7 @@ func TestRepositoriesService_ReplaceTeamRestrictions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "PUT")
@@ -3789,8 +3716,7 @@ func TestRepositoriesService_AddTeamRestrictions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "POST")
@@ -3839,8 +3765,7 @@ func TestRepositoriesService_RemoveTeamRestrictions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "DELETE")
@@ -3885,8 +3810,7 @@ func TestRepositoriesService_ListUserRestrictions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
@@ -3926,8 +3850,7 @@ func TestRepositoriesService_ReplaceUserRestrictions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "PUT")
@@ -3976,8 +3899,7 @@ func TestRepositoriesService_AddUserRestrictions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "POST")
@@ -4026,8 +3948,7 @@ func TestRepositoriesService_RemoveUserRestrictions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.branch, func(t *testing.T) {
-			client, mux, _, teardown := setup()
-			defer teardown()
+			client, mux, _ := setup(t)
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "DELETE")
@@ -4062,8 +3983,7 @@ func TestRepositoriesService_RemoveUserRestrictions(t *testing.T) {
 }
 
 func TestRepositoriesService_Transfer(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := TransferRequest{NewOwner: "a", NewName: String("b"), TeamID: []int64{123}}
 
@@ -4106,8 +4026,7 @@ func TestRepositoriesService_Transfer(t *testing.T) {
 }
 
 func TestRepositoriesService_Dispatch(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	var input DispatchRequestOptions
 
@@ -4381,8 +4300,7 @@ func TestRepositoryTag_Marshal(t *testing.T) {
 }
 
 func TestRepositoriesService_EnablePrivateReporting(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/owner/repo/private-vulnerability-reporting", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -4407,8 +4325,7 @@ func TestRepositoriesService_EnablePrivateReporting(t *testing.T) {
 }
 
 func TestRepositoriesService_DisablePrivateReporting(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/owner/repo/private-vulnerability-reporting", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -4433,8 +4350,7 @@ func TestRepositoriesService_DisablePrivateReporting(t *testing.T) {
 }
 
 func TestRepositoriesService_IsPrivateReportingEnabled(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/owner/repo/private-vulnerability-reporting", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/repos_traffic_test.go
+++ b/github/repos_traffic_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRepositoriesService_ListTrafficReferrers(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/traffic/popular/referrers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -58,8 +57,7 @@ func TestRepositoriesService_ListTrafficReferrers(t *testing.T) {
 }
 
 func TestRepositoriesService_ListTrafficPaths(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/traffic/popular/paths", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -102,8 +100,7 @@ func TestRepositoriesService_ListTrafficPaths(t *testing.T) {
 }
 
 func TestRepositoriesService_ListTrafficViews(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/traffic/views", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -152,8 +149,7 @@ func TestRepositoriesService_ListTrafficViews(t *testing.T) {
 }
 
 func TestRepositoriesService_ListTrafficClones(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/traffic/clones", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -300,7 +296,7 @@ func TestTrafficData_Marshal(t *testing.T) {
 		Uniques:   Int(6),
 	}
 
-	want := `{	
+	want := `{
 			"timestamp": "2016-05-31T16:00:00.000Z",
 			"count": 7,
 			"uniques": 6

--- a/github/scim_test.go
+++ b/github/scim_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestSCIMService_ListSCIMProvisionedIdentities(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/scim/v2/organizations/o/Users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -122,8 +121,7 @@ func TestSCIMService_ListSCIMProvisionedIdentities(t *testing.T) {
 }
 
 func TestSCIMService_ProvisionAndInviteSCIMUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/scim/v2/organizations/o/Users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -173,8 +171,7 @@ func TestSCIMService_ProvisionAndInviteSCIMUser(t *testing.T) {
 }
 
 func TestSCIMService_GetSCIMProvisioningInfoForUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/scim/v2/organizations/o/Users/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -266,8 +263,7 @@ func TestSCIMService_GetSCIMProvisioningInfoForUser(t *testing.T) {
 }
 
 func TestSCIMService_UpdateProvisionedOrgMembership(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/scim/v2/organizations/o/Users/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -304,8 +300,7 @@ func TestSCIMService_UpdateProvisionedOrgMembership(t *testing.T) {
 }
 
 func TestSCIMService_UpdateAttributeForSCIMUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/scim/v2/organizations/o/Users/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -331,8 +326,7 @@ func TestSCIMService_UpdateAttributeForSCIMUser(t *testing.T) {
 }
 
 func TestSCIMService_DeleteSCIMUserFromOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/scim/v2/organizations/o/Users/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -489,7 +483,7 @@ func TestSCIMUserName_Marshal(t *testing.T) {
 	want := `{
 			"givenName": "Name1",
 			"familyName": "Fname",
-			"formatted": "formatted name"	
+			"formatted": "formatted name"
 	}`
 	testJSONMarshal(t, u, want)
 }

--- a/github/search_test.go
+++ b/github/search_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestSearchService_Repositories(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/search/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -50,8 +49,7 @@ func TestSearchService_Repositories(t *testing.T) {
 }
 
 func TestSearchService_Repositories_coverage(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 
@@ -63,8 +61,7 @@ func TestSearchService_Repositories_coverage(t *testing.T) {
 }
 
 func TestSearchService_RepositoriesTextMatch(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/search/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -142,8 +139,7 @@ func TestSearchService_RepositoriesTextMatch(t *testing.T) {
 }
 
 func TestSearchService_Topics(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/search/topics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -174,8 +170,7 @@ func TestSearchService_Topics(t *testing.T) {
 }
 
 func TestSearchService_Topics_coverage(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 
@@ -187,8 +182,7 @@ func TestSearchService_Topics_coverage(t *testing.T) {
 }
 
 func TestSearchService_Commits(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/search/commits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -219,8 +213,7 @@ func TestSearchService_Commits(t *testing.T) {
 }
 
 func TestSearchService_Commits_coverage(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 
@@ -232,8 +225,7 @@ func TestSearchService_Commits_coverage(t *testing.T) {
 }
 
 func TestSearchService_Issues(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -266,8 +258,7 @@ func TestSearchService_Issues(t *testing.T) {
 }
 
 func TestSearchService_Issues_coverage(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 
@@ -279,8 +270,7 @@ func TestSearchService_Issues_coverage(t *testing.T) {
 }
 
 func TestSearchService_Issues_withQualifiersNoOpts(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	const q = "gopher is:issue label:bug language:c++ pushed:>=2018-01-01 stars:>=200"
 
@@ -317,8 +307,7 @@ func TestSearchService_Issues_withQualifiersNoOpts(t *testing.T) {
 }
 
 func TestSearchService_Issues_withQualifiersAndOpts(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	const q = "gopher is:issue label:bug language:c++ pushed:>=2018-01-01 stars:>=200"
 
@@ -356,8 +345,7 @@ func TestSearchService_Issues_withQualifiersAndOpts(t *testing.T) {
 }
 
 func TestSearchService_Users(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/search/users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -390,8 +378,7 @@ func TestSearchService_Users(t *testing.T) {
 }
 
 func TestSearchService_Users_coverage(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 
@@ -403,8 +390,7 @@ func TestSearchService_Users_coverage(t *testing.T) {
 }
 
 func TestSearchService_Code(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/search/code", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -437,8 +423,7 @@ func TestSearchService_Code(t *testing.T) {
 }
 
 func TestSearchService_Code_coverage(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 
@@ -450,8 +435,7 @@ func TestSearchService_Code_coverage(t *testing.T) {
 }
 
 func TestSearchService_CodeTextMatch(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/search/code", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -512,8 +496,7 @@ func TestSearchService_CodeTextMatch(t *testing.T) {
 }
 
 func TestSearchService_Labels(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/search/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -550,8 +533,7 @@ func TestSearchService_Labels(t *testing.T) {
 }
 
 func TestSearchService_Labels_coverage(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 
@@ -759,7 +741,7 @@ func TestSearchOptions_Marshal(t *testing.T) {
 		},
 	}
 
-	want := `{	
+	want := `{
 		"sort": "author-date",
 		"order": "asc",
 		"page": 1,

--- a/github/secret_scanning_test.go
+++ b/github/secret_scanning_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestSecretScanningService_ListAlertsForEnterprise(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/enterprises/e/secret-scanning/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -92,8 +91,7 @@ func TestSecretScanningService_ListAlertsForEnterprise(t *testing.T) {
 }
 
 func TestSecretScanningService_ListAlertsForOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/secret-scanning/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -157,8 +155,7 @@ func TestSecretScanningService_ListAlertsForOrg(t *testing.T) {
 }
 
 func TestSecretScanningService_ListAlertsForOrgListOptions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/secret-scanning/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -224,8 +221,7 @@ func TestSecretScanningService_ListAlertsForOrgListOptions(t *testing.T) {
 }
 
 func TestSecretScanningService_ListAlertsForRepo(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/secret-scanning/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -289,8 +285,7 @@ func TestSecretScanningService_ListAlertsForRepo(t *testing.T) {
 }
 
 func TestSecretScanningService_GetAlert(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/secret-scanning/alerts/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -350,8 +345,7 @@ func TestSecretScanningService_GetAlert(t *testing.T) {
 }
 
 func TestSecretScanningService_UpdateAlert(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/secret-scanning/alerts/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -421,8 +415,7 @@ func TestSecretScanningService_UpdateAlert(t *testing.T) {
 }
 
 func TestSecretScanningService_ListLocationsForAlert(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/secret-scanning/alerts/1/locations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -560,7 +553,7 @@ func TestSecretScanningAlertLocation_Marshal(t *testing.T) {
 			"blob_url": "https://api.github.com/repos/o/r/git/commits/f14d7debf9775f957cf4f1e8176da0786431f72b",
 			"commit_sha": "test_sha",
 			"commit_url": "https://api.github.com/repos/o/r/git/commits/f14d7debf9775f957cf4f1e8176da0786431f72b"
-		} 
+		}
 	}`
 
 	testJSONMarshal(t, u, want)
@@ -590,7 +583,7 @@ func TestSecretScanningAlertLocationDetails_Marshal(t *testing.T) {
 		"blob_sha": "test_sha",
 		"blob_url": "https://api.github.com/repos/o/r/git/commits/f14d7debf9775f957cf4f1e8176da0786431f72b",
 		"commit_sha": "test_sha",
-		"commit_url": "https://api.github.com/repos/o/r/git/commits/f14d7debf9775f957cf4f1e8176da0786431f72b"	
+		"commit_url": "https://api.github.com/repos/o/r/git/commits/f14d7debf9775f957cf4f1e8176da0786431f72b"
 	}`
 
 	testJSONMarshal(t, u, want)

--- a/github/security_advisories_test.go
+++ b/github/security_advisories_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestSecurityAdvisoriesService_RequestCVE(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/security-advisories/ghsa_id_ok/cve", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -57,8 +56,7 @@ func TestSecurityAdvisoriesService_RequestCVE(t *testing.T) {
 }
 
 func TestSecurityAdvisoriesService_CreateTemporaryPrivateFork(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/security-advisories/ghsa_id/forks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -292,8 +290,7 @@ func TestSecurityAdvisoriesService_CreateTemporaryPrivateFork(t *testing.T) {
 }
 
 func TestSecurityAdvisoriesService_CreateTemporaryPrivateFork_deferred(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/security-advisories/ghsa_id/forks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -514,8 +511,7 @@ func TestSecurityAdvisoriesService_CreateTemporaryPrivateFork_deferred(t *testin
 }
 
 func TestSecurityAdvisoriesService_CreateTemporaryPrivateFork_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.SecurityAdvisories.CreateTemporaryPrivateFork(ctx, "%", "r", "ghsa_id")
@@ -523,8 +519,7 @@ func TestSecurityAdvisoriesService_CreateTemporaryPrivateFork_invalidOwner(t *te
 }
 
 func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg_BadRequest(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/security-advisories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -546,8 +541,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg_BadReq
 }
 
 func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg_NotFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/security-advisories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -576,8 +570,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg_NotFou
 }
 
 func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg_UnmarshalError(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/security-advisories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -602,8 +595,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg_Unmars
 }
 
 func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/security-advisories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -654,8 +646,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg(t *tes
 }
 
 func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories_BadRequest(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/security-advisories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -677,8 +668,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories_BadRequest(t
 }
 
 func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories_NotFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/security-advisories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -707,8 +697,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories_NotFound(t *
 }
 
 func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories_UnmarshalError(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/security-advisories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -733,8 +722,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories_UnmarshalErr
 }
 
 func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/security-advisories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -785,8 +773,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories(t *testing.T
 }
 
 func TestListGlobalSecurityAdvisories(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/advisories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -971,8 +958,7 @@ func TestListGlobalSecurityAdvisories(t *testing.T) {
 }
 
 func TestGetGlobalSecurityAdvisories(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/advisories/GHSA-xoxo-1234-xoxo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/teams_discussion_comments_test.go
+++ b/github/teams_discussion_comments_test.go
@@ -35,8 +35,7 @@ func tdcEndpointBySlug(org, slug, discussionNumber, commentNumber string) string
 }
 
 func TestTeamsService_ListComments(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	handleFunc := func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -176,8 +175,7 @@ func TestTeamsService_ListComments(t *testing.T) {
 }
 
 func TestTeamsService_GetComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	handlerFunc := func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -240,8 +238,7 @@ func TestTeamsService_GetComment(t *testing.T) {
 }
 
 func TestTeamsService_CreateComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := DiscussionComment{Body: String("c")}
 
@@ -313,8 +310,7 @@ func TestTeamsService_CreateComment(t *testing.T) {
 }
 
 func TestTeamsService_EditComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := DiscussionComment{Body: String("e")}
 	handlerFunc := func(w http.ResponseWriter, r *http.Request) {
@@ -385,8 +381,7 @@ func TestTeamsService_EditComment(t *testing.T) {
 }
 
 func TestTeamsService_DeleteComment(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	handlerFunc := func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/teams_discussions_test.go
+++ b/github/teams_discussions_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestTeamsService_ListDiscussionsByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/2/discussions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -132,8 +131,7 @@ func TestTeamsService_ListDiscussionsByID(t *testing.T) {
 }
 
 func TestTeamsService_ListDiscussionsBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s/discussions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -247,8 +245,7 @@ func TestTeamsService_ListDiscussionsBySlug(t *testing.T) {
 }
 
 func TestTeamsService_GetDiscussionByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/2/discussions/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -282,8 +279,7 @@ func TestTeamsService_GetDiscussionByID(t *testing.T) {
 }
 
 func TestTeamsService_GetDiscussionBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s/discussions/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -317,8 +313,7 @@ func TestTeamsService_GetDiscussionBySlug(t *testing.T) {
 }
 
 func TestTeamsService_CreateDiscussionByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := TeamDiscussion{Title: String("c_t"), Body: String("c_b")}
 
@@ -361,8 +356,7 @@ func TestTeamsService_CreateDiscussionByID(t *testing.T) {
 }
 
 func TestTeamsService_CreateDiscussionBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := TeamDiscussion{Title: String("c_t"), Body: String("c_b")}
 
@@ -405,8 +399,7 @@ func TestTeamsService_CreateDiscussionBySlug(t *testing.T) {
 }
 
 func TestTeamsService_EditDiscussionByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := TeamDiscussion{Title: String("e_t"), Body: String("e_b")}
 
@@ -449,8 +442,7 @@ func TestTeamsService_EditDiscussionByID(t *testing.T) {
 }
 
 func TestTeamsService_EditDiscussionBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := TeamDiscussion{Title: String("e_t"), Body: String("e_b")}
 
@@ -493,8 +485,7 @@ func TestTeamsService_EditDiscussionBySlug(t *testing.T) {
 }
 
 func TestTeamsService_DeleteDiscussionByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/2/discussions/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -518,8 +509,7 @@ func TestTeamsService_DeleteDiscussionByID(t *testing.T) {
 }
 
 func TestTeamsService_DeleteDiscussionBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s/discussions/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -593,7 +583,7 @@ func TestTeamDiscussion_Marshal(t *testing.T) {
 			"gravatar_id": "",
 			"url": "https://api.github.com/users/author",
 			"created_at": ` + referenceTimeStr + `,
-			"suspended_at": ` + referenceTimeStr + `	
+			"suspended_at": ` + referenceTimeStr + `
 		},
 		"body": "test",
 		"body_html": "<p>test</p>",

--- a/github/teams_members_test.go
+++ b/github/teams_members_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestTeamsService__ListTeamMembersByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/2/members", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -53,8 +52,7 @@ func TestTeamsService__ListTeamMembersByID(t *testing.T) {
 }
 
 func TestTeamsService__ListTeamMembersByID_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/2/members", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -91,8 +89,7 @@ func TestTeamsService__ListTeamMembersByID_notFound(t *testing.T) {
 }
 
 func TestTeamsService__ListTeamMembersBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s/members", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -128,8 +125,7 @@ func TestTeamsService__ListTeamMembersBySlug(t *testing.T) {
 }
 
 func TestTeamsService__ListTeamMembersBySlug_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s/members", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -166,8 +162,7 @@ func TestTeamsService__ListTeamMembersBySlug_notFound(t *testing.T) {
 }
 
 func TestTeamsService__ListTeamMembersBySlug_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Teams.ListTeamMembersBySlug(ctx, "%", "s", nil)
@@ -175,8 +170,7 @@ func TestTeamsService__ListTeamMembersBySlug_invalidOrg(t *testing.T) {
 }
 
 func TestTeamsService__GetTeamMembershipByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/2/memberships/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -210,8 +204,7 @@ func TestTeamsService__GetTeamMembershipByID(t *testing.T) {
 }
 
 func TestTeamsService__GetTeamMembershipByID_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/2/memberships/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -246,8 +239,7 @@ func TestTeamsService__GetTeamMembershipByID_notFound(t *testing.T) {
 }
 
 func TestTeamsService__GetTeamMembershipBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s/memberships/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -281,8 +273,7 @@ func TestTeamsService__GetTeamMembershipBySlug(t *testing.T) {
 }
 
 func TestTeamsService__GetTeamMembershipBySlug_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s/memberships/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -317,8 +308,7 @@ func TestTeamsService__GetTeamMembershipBySlug_notFound(t *testing.T) {
 }
 
 func TestTeamsService__GetTeamMembershipBySlug_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Teams.GetTeamMembershipBySlug(ctx, "%s", "s", "u")
@@ -326,8 +316,7 @@ func TestTeamsService__GetTeamMembershipBySlug_invalidOrg(t *testing.T) {
 }
 
 func TestTeamsService__AddTeamMembershipByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	opt := &TeamAddTeamMembershipOptions{Role: "maintainer"}
 
@@ -370,8 +359,7 @@ func TestTeamsService__AddTeamMembershipByID(t *testing.T) {
 }
 
 func TestTeamsService__AddTeamMembershipByID_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	opt := &TeamAddTeamMembershipOptions{Role: "maintainer"}
 
@@ -415,8 +403,7 @@ func TestTeamsService__AddTeamMembershipByID_notFound(t *testing.T) {
 }
 
 func TestTeamsService__AddTeamMembershipBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	opt := &TeamAddTeamMembershipOptions{Role: "maintainer"}
 
@@ -459,8 +446,7 @@ func TestTeamsService__AddTeamMembershipBySlug(t *testing.T) {
 }
 
 func TestTeamsService__AddTeamMembershipBySlug_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	opt := &TeamAddTeamMembershipOptions{Role: "maintainer"}
 
@@ -504,8 +490,7 @@ func TestTeamsService__AddTeamMembershipBySlug_notFound(t *testing.T) {
 }
 
 func TestTeamsService__AddTeamMembershipBySlug_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Teams.AddTeamMembershipBySlug(ctx, "%", "s", "u", nil)
@@ -513,8 +498,7 @@ func TestTeamsService__AddTeamMembershipBySlug_invalidOrg(t *testing.T) {
 }
 
 func TestTeamsService__RemoveTeamMembershipByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/2/memberships/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -539,8 +523,7 @@ func TestTeamsService__RemoveTeamMembershipByID(t *testing.T) {
 }
 
 func TestTeamsService__RemoveTeamMembershipByID_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/2/memberships/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -568,8 +551,7 @@ func TestTeamsService__RemoveTeamMembershipByID_notFound(t *testing.T) {
 }
 
 func TestTeamsService__RemoveTeamMembershipBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s/memberships/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -594,8 +576,7 @@ func TestTeamsService__RemoveTeamMembershipBySlug(t *testing.T) {
 }
 
 func TestTeamsService__RemoveTeamMembershipBySlug_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s/memberships/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -623,8 +604,7 @@ func TestTeamsService__RemoveTeamMembershipBySlug_notFound(t *testing.T) {
 }
 
 func TestTeamsService__RemoveTeamMembershipBySlug_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Teams.RemoveTeamMembershipBySlug(ctx, "%", "s", "u")
@@ -632,8 +612,7 @@ func TestTeamsService__RemoveTeamMembershipBySlug_invalidOrg(t *testing.T) {
 }
 
 func TestTeamsService__ListPendingTeamInvitationsByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/2/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -669,8 +648,7 @@ func TestTeamsService__ListPendingTeamInvitationsByID(t *testing.T) {
 }
 
 func TestTeamsService__ListPendingTeamInvitationsByID_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/2/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -707,8 +685,7 @@ func TestTeamsService__ListPendingTeamInvitationsByID_notFound(t *testing.T) {
 }
 
 func TestTeamsService__ListPendingTeamInvitationsBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -744,8 +721,7 @@ func TestTeamsService__ListPendingTeamInvitationsBySlug(t *testing.T) {
 }
 
 func TestTeamsService__ListPendingTeamInvitationsBySlug_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -782,8 +758,7 @@ func TestTeamsService__ListPendingTeamInvitationsBySlug_notFound(t *testing.T) {
 }
 
 func TestTeamsService__ListPendingTeamInvitationsBySlug_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Teams.ListPendingTeamInvitationsBySlug(ctx, "%", "s", nil)

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -19,8 +19,7 @@ import (
 )
 
 func TestTeamsService_ListTeams(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -56,8 +55,7 @@ func TestTeamsService_ListTeams(t *testing.T) {
 }
 
 func TestTeamsService_ListTeams_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Teams.ListTeams(ctx, "%", nil)
@@ -65,8 +63,7 @@ func TestTeamsService_ListTeams_invalidOrg(t *testing.T) {
 }
 
 func TestTeamsService_GetTeamByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -100,8 +97,7 @@ func TestTeamsService_GetTeamByID(t *testing.T) {
 }
 
 func TestTeamsService_GetTeamByID_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -122,8 +118,7 @@ func TestTeamsService_GetTeamByID_notFound(t *testing.T) {
 }
 
 func TestTeamsService_GetTeamBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -157,8 +152,7 @@ func TestTeamsService_GetTeamBySlug(t *testing.T) {
 }
 
 func TestTeamsService_GetTeamBySlug_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Teams.GetTeamBySlug(ctx, "%", "s")
@@ -166,8 +160,7 @@ func TestTeamsService_GetTeamBySlug_invalidOrg(t *testing.T) {
 }
 
 func TestTeamsService_GetTeamBySlug_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -188,8 +181,7 @@ func TestTeamsService_GetTeamBySlug_notFound(t *testing.T) {
 }
 
 func TestTeamsService_CreateTeam(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := NewTeam{Name: "n", Privacy: String("closed"), RepoNames: []string{"r"}}
 
@@ -232,8 +224,7 @@ func TestTeamsService_CreateTeam(t *testing.T) {
 }
 
 func TestTeamsService_CreateTeam_invalidOrg(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Teams.CreateTeam(ctx, "%", NewTeam{})
@@ -241,8 +232,7 @@ func TestTeamsService_CreateTeam_invalidOrg(t *testing.T) {
 }
 
 func TestTeamsService_EditTeamByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := NewTeam{Name: "n", Privacy: String("closed")}
 
@@ -285,8 +275,7 @@ func TestTeamsService_EditTeamByID(t *testing.T) {
 }
 
 func TestTeamsService_EditTeamByID_RemoveParent(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := NewTeam{Name: "n", Privacy: String("closed")}
 	var body string
@@ -325,8 +314,7 @@ func TestTeamsService_EditTeamByID_RemoveParent(t *testing.T) {
 }
 
 func TestTeamsService_EditTeamBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := NewTeam{Name: "n", Privacy: String("closed")}
 
@@ -369,8 +357,7 @@ func TestTeamsService_EditTeamBySlug(t *testing.T) {
 }
 
 func TestTeamsService_EditTeamBySlug_RemoveParent(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := NewTeam{Name: "n", Privacy: String("closed")}
 	var body string
@@ -409,8 +396,7 @@ func TestTeamsService_EditTeamBySlug_RemoveParent(t *testing.T) {
 }
 
 func TestTeamsService_DeleteTeamByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -434,8 +420,7 @@ func TestTeamsService_DeleteTeamByID(t *testing.T) {
 }
 
 func TestTeamsService_DeleteTeamBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -459,8 +444,7 @@ func TestTeamsService_DeleteTeamBySlug(t *testing.T) {
 }
 
 func TestTeamsService_ListChildTeamsByParentID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/2/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -496,8 +480,7 @@ func TestTeamsService_ListChildTeamsByParentID(t *testing.T) {
 }
 
 func TestTeamsService_ListChildTeamsByParentSlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -533,8 +516,7 @@ func TestTeamsService_ListChildTeamsByParentSlug(t *testing.T) {
 }
 
 func TestTeamsService_ListTeamReposByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/1/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -572,8 +554,7 @@ func TestTeamsService_ListTeamReposByID(t *testing.T) {
 }
 
 func TestTeamsService_ListTeamReposBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/s/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -611,8 +592,7 @@ func TestTeamsService_ListTeamReposBySlug(t *testing.T) {
 }
 
 func TestTeamsService_IsTeamRepoByID_true(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/1/repos/owner/repo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -648,8 +628,7 @@ func TestTeamsService_IsTeamRepoByID_true(t *testing.T) {
 }
 
 func TestTeamsService_IsTeamRepoBySlug_true(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/org/teams/slug/repos/owner/repo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -685,8 +664,7 @@ func TestTeamsService_IsTeamRepoBySlug_true(t *testing.T) {
 }
 
 func TestTeamsService_IsTeamRepoByID_false(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/1/repos/owner/repo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -707,8 +685,7 @@ func TestTeamsService_IsTeamRepoByID_false(t *testing.T) {
 }
 
 func TestTeamsService_IsTeamRepoBySlug_false(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/org/teams/slug/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -729,8 +706,7 @@ func TestTeamsService_IsTeamRepoBySlug_false(t *testing.T) {
 }
 
 func TestTeamsService_IsTeamRepoByID_error(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/1/repos/owner/repo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -751,8 +727,7 @@ func TestTeamsService_IsTeamRepoByID_error(t *testing.T) {
 }
 
 func TestTeamsService_IsTeamRepoBySlug_error(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/org/teams/slug/repos/owner/repo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -773,8 +748,7 @@ func TestTeamsService_IsTeamRepoBySlug_error(t *testing.T) {
 }
 
 func TestTeamsService_IsTeamRepoByID_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Teams.IsTeamRepoByID(ctx, 1, 1, "%", "r")
@@ -782,8 +756,7 @@ func TestTeamsService_IsTeamRepoByID_invalidOwner(t *testing.T) {
 }
 
 func TestTeamsService_IsTeamRepoBySlug_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Teams.IsTeamRepoBySlug(ctx, "o", "s", "%", "r")
@@ -791,8 +764,7 @@ func TestTeamsService_IsTeamRepoBySlug_invalidOwner(t *testing.T) {
 }
 
 func TestTeamsService_AddTeamRepoByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	opt := &TeamAddTeamRepoOptions{Permission: "admin"}
 
@@ -826,8 +798,7 @@ func TestTeamsService_AddTeamRepoByID(t *testing.T) {
 }
 
 func TestTeamsService_AddTeamRepoBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	opt := &TeamAddTeamRepoOptions{Permission: "admin"}
 
@@ -861,8 +832,7 @@ func TestTeamsService_AddTeamRepoBySlug(t *testing.T) {
 }
 
 func TestTeamsService_AddTeamRepoByID_noAccess(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/1/repos/owner/repo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -877,8 +847,7 @@ func TestTeamsService_AddTeamRepoByID_noAccess(t *testing.T) {
 }
 
 func TestTeamsService_AddTeamRepoBySlug_noAccess(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/org/teams/slug/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -893,8 +862,7 @@ func TestTeamsService_AddTeamRepoBySlug_noAccess(t *testing.T) {
 }
 
 func TestTeamsService_AddTeamRepoByID_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Teams.AddTeamRepoByID(ctx, 1, 1, "%", "r", nil)
@@ -902,8 +870,7 @@ func TestTeamsService_AddTeamRepoByID_invalidOwner(t *testing.T) {
 }
 
 func TestTeamsService_AddTeamRepoBySlug_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Teams.AddTeamRepoBySlug(ctx, "o", "s", "%", "r", nil)
@@ -911,8 +878,7 @@ func TestTeamsService_AddTeamRepoBySlug_invalidOwner(t *testing.T) {
 }
 
 func TestTeamsService_RemoveTeamRepoByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/1/repos/owner/repo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -937,8 +903,7 @@ func TestTeamsService_RemoveTeamRepoByID(t *testing.T) {
 }
 
 func TestTeamsService_RemoveTeamRepoBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/org/teams/slug/repos/owner/repo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -963,8 +928,7 @@ func TestTeamsService_RemoveTeamRepoBySlug(t *testing.T) {
 }
 
 func TestTeamsService_RemoveTeamRepoByID_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Teams.RemoveTeamRepoByID(ctx, 1, 1, "%", "r")
@@ -972,8 +936,7 @@ func TestTeamsService_RemoveTeamRepoByID_invalidOwner(t *testing.T) {
 }
 
 func TestTeamsService_RemoveTeamRepoBySlug_invalidOwner(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Teams.RemoveTeamRepoBySlug(ctx, "o", "s", "%", "r")
@@ -981,8 +944,7 @@ func TestTeamsService_RemoveTeamRepoBySlug_invalidOwner(t *testing.T) {
 }
 
 func TestTeamsService_ListUserTeams(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1013,8 +975,7 @@ func TestTeamsService_ListUserTeams(t *testing.T) {
 }
 
 func TestTeamsService_ListProjectsByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/organizations/1/team/1/projects", func(w http.ResponseWriter, r *http.Request) {
@@ -1050,8 +1011,7 @@ func TestTeamsService_ListProjectsByID(t *testing.T) {
 }
 
 func TestTeamsService_ListProjectsBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/orgs/o/teams/s/projects", func(w http.ResponseWriter, r *http.Request) {
@@ -1087,8 +1047,7 @@ func TestTeamsService_ListProjectsBySlug(t *testing.T) {
 }
 
 func TestTeamsService_ReviewProjectsByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/organizations/1/team/1/projects/1", func(w http.ResponseWriter, r *http.Request) {
@@ -1124,8 +1083,7 @@ func TestTeamsService_ReviewProjectsByID(t *testing.T) {
 }
 
 func TestTeamsService_ReviewProjectsBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/orgs/o/teams/s/projects/1", func(w http.ResponseWriter, r *http.Request) {
@@ -1161,8 +1119,7 @@ func TestTeamsService_ReviewProjectsBySlug(t *testing.T) {
 }
 
 func TestTeamsService_AddTeamProjectByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	opt := &TeamProjectOptions{
 		Permission: String("admin"),
@@ -1200,8 +1157,7 @@ func TestTeamsService_AddTeamProjectByID(t *testing.T) {
 }
 
 func TestTeamsService_AddTeamProjectBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	opt := &TeamProjectOptions{
 		Permission: String("admin"),
@@ -1239,8 +1195,7 @@ func TestTeamsService_AddTeamProjectBySlug(t *testing.T) {
 }
 
 func TestTeamsService_RemoveTeamProjectByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/organizations/1/team/1/projects/1", func(w http.ResponseWriter, r *http.Request) {
@@ -1267,8 +1222,7 @@ func TestTeamsService_RemoveTeamProjectByID(t *testing.T) {
 }
 
 func TestTeamsService_RemoveTeamProjectBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/orgs/o/teams/s/projects/1", func(w http.ResponseWriter, r *http.Request) {
@@ -1295,8 +1249,7 @@ func TestTeamsService_RemoveTeamProjectBySlug(t *testing.T) {
 }
 
 func TestTeamsService_ListIDPGroupsInOrganization(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/team-sync/groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1346,8 +1299,7 @@ func TestTeamsService_ListIDPGroupsInOrganization(t *testing.T) {
 }
 
 func TestTeamsService_ListIDPGroupsForTeamByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/1/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1389,8 +1341,7 @@ func TestTeamsService_ListIDPGroupsForTeamByID(t *testing.T) {
 }
 
 func TestTeamsService_ListIDPGroupsForTeamBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/slug/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1432,8 +1383,7 @@ func TestTeamsService_ListIDPGroupsForTeamBySlug(t *testing.T) {
 }
 
 func TestTeamsService_CreateOrUpdateIDPGroupConnectionsByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/1/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -1485,8 +1435,7 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnectionsByID(t *testing.T) {
 }
 
 func TestTeamsService_CreateOrUpdateIDPGroupConnectionsBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/slug/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -1537,8 +1486,7 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnectionsBySlug(t *testing.T) {
 	})
 }
 func TestTeamsService_CreateOrUpdateIDPGroupConnectionsByID_empty(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/organizations/1/team/1/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -1564,8 +1512,7 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnectionsByID_empty(t *testing.T) 
 }
 
 func TestTeamsService_CreateOrUpdateIDPGroupConnectionsBySlug_empty(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/slug/team-sync/group-mappings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -1753,8 +1700,7 @@ func TestIDPGroup_Marshal(t *testing.T) {
 }
 
 func TestTeamsService_GetExternalGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/external-group/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1844,8 +1790,7 @@ func TestTeamsService_GetExternalGroup(t *testing.T) {
 }
 
 func TestTeamsService_GetExternalGroup_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/external-group/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1866,8 +1811,7 @@ func TestTeamsService_GetExternalGroup_notFound(t *testing.T) {
 }
 
 func TestTeamsService_ListExternalGroups(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/external-groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1920,8 +1864,7 @@ func TestTeamsService_ListExternalGroups(t *testing.T) {
 }
 
 func TestTeamsService_ListExternalGroups_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/external-groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1942,8 +1885,7 @@ func TestTeamsService_ListExternalGroups_notFound(t *testing.T) {
 }
 
 func TestTeamsService_ListExternalGroupsForTeamBySlug(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/t/external-groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -1993,8 +1935,7 @@ func TestTeamsService_ListExternalGroupsForTeamBySlug(t *testing.T) {
 }
 
 func TestTeamsService_ListExternalGroupsForTeamBySlug_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/t/external-groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -2015,8 +1956,7 @@ func TestTeamsService_ListExternalGroupsForTeamBySlug_notFound(t *testing.T) {
 }
 
 func TestTeamsService_UpdateConnectedExternalGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/t/external-groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -2109,8 +2049,7 @@ func TestTeamsService_UpdateConnectedExternalGroup(t *testing.T) {
 }
 
 func TestTeamsService_UpdateConnectedExternalGroup_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/t/external-groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -2134,8 +2073,7 @@ func TestTeamsService_UpdateConnectedExternalGroup_notFound(t *testing.T) {
 }
 
 func TestTeamsService_RemoveConnectedExternalGroup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/t/external-groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -2160,8 +2098,7 @@ func TestTeamsService_RemoveConnectedExternalGroup(t *testing.T) {
 }
 
 func TestTeamsService_RemoveConnectedExternalGroup_notFound(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/teams/t/external-groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/users_administration_test.go
+++ b/github/users_administration_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestUsersService_PromoteSiteAdmin(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/site_admin", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -41,8 +40,7 @@ func TestUsersService_PromoteSiteAdmin(t *testing.T) {
 }
 
 func TestUsersService_DemoteSiteAdmin(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/site_admin", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -67,8 +65,7 @@ func TestUsersService_DemoteSiteAdmin(t *testing.T) {
 }
 
 func TestUsersService_Suspend(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/suspended", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -93,8 +90,7 @@ func TestUsersService_Suspend(t *testing.T) {
 }
 
 func TestUsersServiceReason_Suspend(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &UserSuspendOptions{Reason: String("test")}
 
@@ -118,8 +114,7 @@ func TestUsersServiceReason_Suspend(t *testing.T) {
 }
 
 func TestUsersService_Unsuspend(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/suspended", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/users_blocking_test.go
+++ b/github/users_blocking_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestUsersService_ListBlockedUsers(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/blocks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -50,8 +49,7 @@ func TestUsersService_ListBlockedUsers(t *testing.T) {
 }
 
 func TestUsersService_IsBlocked(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/blocks/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -84,8 +82,7 @@ func TestUsersService_IsBlocked(t *testing.T) {
 }
 
 func TestUsersService_BlockUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/blocks/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -111,8 +108,7 @@ func TestUsersService_BlockUser(t *testing.T) {
 }
 
 func TestUsersService_UnblockUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/blocks/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/users_emails_test.go
+++ b/github/users_emails_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestUsersService_ListEmails(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/emails", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -52,8 +51,7 @@ func TestUsersService_ListEmails(t *testing.T) {
 }
 
 func TestUsersService_AddEmails(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := []string{"new@example.com"}
 
@@ -94,8 +92,7 @@ func TestUsersService_AddEmails(t *testing.T) {
 }
 
 func TestUsersService_DeleteEmails(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := []string{"user@example.com"}
 
@@ -142,8 +139,7 @@ func TestUserEmail_Marshal(t *testing.T) {
 }
 
 func TestUsersService_SetEmailVisibility(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &UserEmail{Visibility: String("private")}
 

--- a/github/users_followers_test.go
+++ b/github/users_followers_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestUsersService_ListFollowers_authenticatedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/followers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -52,8 +51,7 @@ func TestUsersService_ListFollowers_authenticatedUser(t *testing.T) {
 }
 
 func TestUsersService_ListFollowers_specifiedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/followers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -87,8 +85,7 @@ func TestUsersService_ListFollowers_specifiedUser(t *testing.T) {
 }
 
 func TestUsersService_ListFollowers_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Users.ListFollowers(ctx, "%", nil)
@@ -96,8 +93,7 @@ func TestUsersService_ListFollowers_invalidUser(t *testing.T) {
 }
 
 func TestUsersService_ListFollowing_authenticatedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/following", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -133,8 +129,7 @@ func TestUsersService_ListFollowing_authenticatedUser(t *testing.T) {
 }
 
 func TestUsersService_ListFollowing_specifiedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/following", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -168,8 +163,7 @@ func TestUsersService_ListFollowing_specifiedUser(t *testing.T) {
 }
 
 func TestUsersService_ListFollowing_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Users.ListFollowing(ctx, "%", nil)
@@ -177,8 +171,7 @@ func TestUsersService_ListFollowing_invalidUser(t *testing.T) {
 }
 
 func TestUsersService_IsFollowing_authenticatedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/following/t", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -210,8 +203,7 @@ func TestUsersService_IsFollowing_authenticatedUser(t *testing.T) {
 }
 
 func TestUsersService_IsFollowing_specifiedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/following/t", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -243,8 +235,7 @@ func TestUsersService_IsFollowing_specifiedUser(t *testing.T) {
 }
 
 func TestUsersService_IsFollowing_false(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/following/t", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -276,8 +267,7 @@ func TestUsersService_IsFollowing_false(t *testing.T) {
 }
 
 func TestUsersService_IsFollowing_error(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/following/t", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -309,8 +299,7 @@ func TestUsersService_IsFollowing_error(t *testing.T) {
 }
 
 func TestUsersService_IsFollowing_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Users.IsFollowing(ctx, "%", "%")
@@ -318,8 +307,7 @@ func TestUsersService_IsFollowing_invalidUser(t *testing.T) {
 }
 
 func TestUsersService_Follow(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/following/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -343,8 +331,7 @@ func TestUsersService_Follow(t *testing.T) {
 }
 
 func TestUsersService_Follow_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Users.Follow(ctx, "%")
@@ -352,8 +339,7 @@ func TestUsersService_Follow_invalidUser(t *testing.T) {
 }
 
 func TestUsersService_Unfollow(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/following/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -377,8 +363,7 @@ func TestUsersService_Unfollow(t *testing.T) {
 }
 
 func TestUsersService_Unfollow_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, err := client.Users.Unfollow(ctx, "%")

--- a/github/users_gpg_keys_test.go
+++ b/github/users_gpg_keys_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestUsersService_ListGPGKeys_authenticatedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/gpg_keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -53,8 +52,7 @@ func TestUsersService_ListGPGKeys_authenticatedUser(t *testing.T) {
 }
 
 func TestUsersService_ListGPGKeys_specifiedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/gpg_keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -74,8 +72,7 @@ func TestUsersService_ListGPGKeys_specifiedUser(t *testing.T) {
 }
 
 func TestUsersService_ListGPGKeys_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Users.ListGPGKeys(ctx, "%", nil)
@@ -83,8 +80,7 @@ func TestUsersService_ListGPGKeys_invalidUser(t *testing.T) {
 }
 
 func TestUsersService_GetGPGKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/gpg_keys/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -118,8 +114,7 @@ func TestUsersService_GetGPGKey(t *testing.T) {
 }
 
 func TestUsersService_CreateGPGKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := `
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -166,8 +161,7 @@ mQINBFcEd9kBEACo54TDbGhKlXKWMvJgecEUKPPcv7XdnpKdGb3LRw5MvFwT0V0f
 }
 
 func TestUsersService_DeleteGPGKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/gpg_keys/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/users_keys_test.go
+++ b/github/users_keys_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestUsersService_ListKeys_authenticatedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -53,8 +52,7 @@ func TestUsersService_ListKeys_authenticatedUser(t *testing.T) {
 }
 
 func TestUsersService_ListKeys_specifiedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -74,8 +72,7 @@ func TestUsersService_ListKeys_specifiedUser(t *testing.T) {
 }
 
 func TestUsersService_ListKeys_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Users.ListKeys(ctx, "%", nil)
@@ -83,8 +80,7 @@ func TestUsersService_ListKeys_invalidUser(t *testing.T) {
 }
 
 func TestUsersService_GetKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/keys/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -118,8 +114,7 @@ func TestUsersService_GetKey(t *testing.T) {
 }
 
 func TestUsersService_CreateKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Key{Key: String("k"), Title: String("t")}
 
@@ -157,8 +152,7 @@ func TestUsersService_CreateKey(t *testing.T) {
 }
 
 func TestUsersService_DeleteKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/keys/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/users_packages_test.go
+++ b/github/users_packages_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestUsersService_Authenticated_ListPackages(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/packages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -71,8 +70,7 @@ func TestUsersService_Authenticated_ListPackages(t *testing.T) {
 }
 
 func TestUsersService_specifiedUser_ListPackages(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/packages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -127,8 +125,7 @@ func TestUsersService_specifiedUser_ListPackages(t *testing.T) {
 }
 
 func TestUsersService_specifiedUser_GetPackage(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -182,8 +179,7 @@ func TestUsersService_specifiedUser_GetPackage(t *testing.T) {
 }
 
 func TestUsersService_Authenticated_GetPackage(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -237,8 +233,7 @@ func TestUsersService_Authenticated_GetPackage(t *testing.T) {
 }
 
 func TestUsersService_Authenticated_DeletePackage(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -262,8 +257,7 @@ func TestUsersService_Authenticated_DeletePackage(t *testing.T) {
 }
 
 func TestUsersService_specifiedUser_DeletePackage(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -287,8 +281,7 @@ func TestUsersService_specifiedUser_DeletePackage(t *testing.T) {
 }
 
 func TestUsersService_Authenticated_RestorePackage(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/packages/container/hello_docker/restore", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -312,8 +305,7 @@ func TestUsersService_Authenticated_RestorePackage(t *testing.T) {
 }
 
 func TestUsersService_specifiedUser_RestorePackage(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/packages/container/hello_docker/restore", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -337,8 +329,7 @@ func TestUsersService_specifiedUser_RestorePackage(t *testing.T) {
 }
 
 func TestUsersService_Authenticated_ListPackagesVersions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/packages/container/hello_docker/versions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -406,8 +397,7 @@ func TestUsersService_Authenticated_ListPackagesVersions(t *testing.T) {
 }
 
 func TestUsersService_specifiedUser_ListPackagesVersions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/packages/container/hello_docker/versions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -475,8 +465,7 @@ func TestUsersService_specifiedUser_ListPackagesVersions(t *testing.T) {
 }
 
 func TestUsersService_Authenticated_PackageGetVersion(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -541,8 +530,7 @@ func TestUsersService_Authenticated_PackageGetVersion(t *testing.T) {
 }
 
 func TestUsersService_specifiedUser_PackageGetVersion(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -607,8 +595,7 @@ func TestUsersService_specifiedUser_PackageGetVersion(t *testing.T) {
 }
 
 func TestUsersService_Authenticated_PackageDeleteVersion(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -632,8 +619,7 @@ func TestUsersService_Authenticated_PackageDeleteVersion(t *testing.T) {
 }
 
 func TestUsersService_specifiedUser_PackageDeleteVersion(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -657,8 +643,7 @@ func TestUsersService_specifiedUser_PackageDeleteVersion(t *testing.T) {
 }
 
 func TestUsersService_Authenticated_PackageRestoreVersion(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/packages/container/hello_docker/versions/45763/restore", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -682,8 +667,7 @@ func TestUsersService_Authenticated_PackageRestoreVersion(t *testing.T) {
 }
 
 func TestUsersService_specifiedUser_PackageRestoreVersion(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/packages/container/hello_docker/versions/45763/restore", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/github/users_projects_test.go
+++ b/github/users_projects_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestUsersService_ListProjects(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -54,8 +53,7 @@ func TestUsersService_ListProjects(t *testing.T) {
 }
 
 func TestUsersService_CreateProject(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &CreateUserProjectOptions{Name: "Project Name", Body: String("Project body.")}
 

--- a/github/users_ssh_signing_keys_test.go
+++ b/github/users_ssh_signing_keys_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestUsersService_ListSSHSigningKeys_authenticatedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/ssh_signing_keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -53,8 +52,7 @@ func TestUsersService_ListSSHSigningKeys_authenticatedUser(t *testing.T) {
 }
 
 func TestUsersService_ListSSHSigningKeys_specifiedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/ssh_signing_keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -74,8 +72,7 @@ func TestUsersService_ListSSHSigningKeys_specifiedUser(t *testing.T) {
 }
 
 func TestUsersService_ListSSHSigningKeys_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Users.ListSSHSigningKeys(ctx, "%", nil)
@@ -83,8 +80,7 @@ func TestUsersService_ListSSHSigningKeys_invalidUser(t *testing.T) {
 }
 
 func TestUsersService_GetSSHSigningKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/ssh_signing_keys/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -118,8 +114,7 @@ func TestUsersService_GetSSHSigningKey(t *testing.T) {
 }
 
 func TestUsersService_CreateSSHSigningKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &Key{Key: String("k"), Title: String("t")}
 
@@ -157,8 +152,7 @@ func TestUsersService_CreateSSHSigningKey(t *testing.T) {
 }
 
 func TestUsersService_DeleteSSHSigningKey(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/ssh_signing_keys/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/github/users_test.go
+++ b/github/users_test.go
@@ -145,8 +145,7 @@ func TestUser_Marshal(t *testing.T) {
 }
 
 func TestUsersService_Get_authenticatedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -180,8 +179,7 @@ func TestUsersService_Get_authenticatedUser(t *testing.T) {
 }
 
 func TestUsersService_Get_specifiedUser(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -201,8 +199,7 @@ func TestUsersService_Get_specifiedUser(t *testing.T) {
 }
 
 func TestUsersService_Get_invalidUser(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
+	client, _, _ := setup(t)
 
 	ctx := context.Background()
 	_, _, err := client.Users.Get(ctx, "%")
@@ -210,8 +207,7 @@ func TestUsersService_Get_invalidUser(t *testing.T) {
 }
 
 func TestUsersService_GetByID(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -245,8 +241,7 @@ func TestUsersService_GetByID(t *testing.T) {
 }
 
 func TestUsersService_Edit(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	input := &User{Name: String("n")}
 
@@ -284,8 +279,7 @@ func TestUsersService_Edit(t *testing.T) {
 }
 
 func TestUsersService_GetHovercard(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users/u/hovercard", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -321,8 +315,7 @@ func TestUsersService_GetHovercard(t *testing.T) {
 }
 
 func TestUsersService_ListAll(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -353,8 +346,7 @@ func TestUsersService_ListAll(t *testing.T) {
 }
 
 func TestUsersService_ListInvitations(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/repository_invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -383,8 +375,7 @@ func TestUsersService_ListInvitations(t *testing.T) {
 }
 
 func TestUsersService_ListInvitations_withOptions(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/repository_invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -402,8 +393,7 @@ func TestUsersService_ListInvitations_withOptions(t *testing.T) {
 }
 
 func TestUsersService_AcceptInvitation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/repository_invitations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -427,8 +417,7 @@ func TestUsersService_AcceptInvitation(t *testing.T) {
 }
 
 func TestUsersService_DeclineInvitation(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/user/repository_invitations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/scrape/apps_test.go
+++ b/scrape/apps_test.go
@@ -29,8 +29,7 @@ func Test_AppRestrictionsEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client, mux, cleanup := setup()
-			defer cleanup()
+			client, mux := setup(t)
 
 			mux.HandleFunc("/organizations/o/settings/oauth_application_policy", func(w http.ResponseWriter, r *http.Request) {
 				copyTestFile(t, w, tt.testFile)
@@ -48,8 +47,7 @@ func Test_AppRestrictionsEnabled(t *testing.T) {
 }
 
 func Test_ListOAuthApps(t *testing.T) {
-	client, mux, cleanup := setup()
-	defer cleanup()
+	client, mux := setup(t)
 
 	mux.HandleFunc("/organizations/e/settings/oauth_application_policy", func(w http.ResponseWriter, r *http.Request) {
 		copyTestFile(t, w, "access-restrictions-enabled.html")
@@ -85,8 +83,7 @@ func Test_ListOAuthApps(t *testing.T) {
 }
 
 func Test_CreateApp(t *testing.T) {
-	client, mux, cleanup := setup()
-	defer cleanup()
+	client, mux := setup(t)
 
 	mux.HandleFunc("/apps/settings/new", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
@@ -103,9 +100,7 @@ func Test_CreateApp(t *testing.T) {
 }
 
 func Test_CreateAppWithOrg(t *testing.T) {
-	client, mux, cleanup := setup()
-
-	defer cleanup()
+	client, mux := setup(t)
 
 	mux.HandleFunc("/organizations/example/apps/settings/new", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)

--- a/scrape/forms_test.go
+++ b/scrape/forms_test.go
@@ -83,8 +83,7 @@ func Test_ParseForms(t *testing.T) {
 }
 
 func Test_FetchAndSumbitForm(t *testing.T) {
-	client, mux, cleanup := setup()
-	defer cleanup()
+	client, mux := setup(t)
 	var submitted bool
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -20,6 +20,8 @@ func setup(t *testing.T) (client *Client, mux *http.ServeMux) {
 	client = NewClient(nil)
 	client.baseURL, _ = url.Parse(server.URL + "/")
 
+	t.Cleanup(server.Close)
+
 	return client, mux
 }
 

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -12,14 +12,15 @@ import (
 // setup a test HTTP server along with a scrape.Client that is configured to
 // talk to that test server. Tests should register handlers on the mux which
 // provide mock responses for the GitHub pages being tested.
-func setup() (client *Client, mux *http.ServeMux, cleanup func()) {
+func setup(t *testing.T) (client *Client, mux *http.ServeMux) {
+	t.Helper()
 	mux = http.NewServeMux()
 	server := httptest.NewServer(mux)
 
 	client = NewClient(nil)
 	client.baseURL, _ = url.Parse(server.URL + "/")
 
-	return client, mux, server.Close
+	return client, mux
 }
 
 func copyTestFile(t *testing.T, w io.Writer, filename string) {


### PR DESCRIPTION
The PR refactors the [`setup`](https://github.com/google/go-github/blob/2406067865f4b36a5b994868e4bc3f1922bf8a32/github/github_test.go#L37) function by passing `*testing.T` parameter and calling `t.Cleanup(server.Close)` inside. So a test that using `setup` doesn't need to call manually `teardown`.

This leads to removal of 1319 code lines in tests.