### PR TITLE
scrape: refactor tests with t.Fatal

### DIFF
--- a/scrape/apps_test.go
+++ b/scrape/apps_test.go
@@ -37,7 +37,7 @@ func Test_AppRestrictionsEnabled(t *testing.T) {
 
 			got, err := client.AppRestrictionsEnabled("o")
 			if err != nil {
-				t.Errorf("AppRestrictionsEnabled returned err: %v", err)
+				t.Fatalf("AppRestrictionsEnabled returned err: %v", err)
 			}
 			if want := tt.want; got != want {
 				t.Errorf("AppRestrictionsEnabled returned %t, want %t", got, want)
@@ -55,7 +55,7 @@ func Test_ListOAuthApps(t *testing.T) {
 
 	got, err := client.ListOAuthApps("e")
 	if err != nil {
-		t.Errorf("ListOAuthApps(e) returned err: %v", err)
+		t.Fatalf("ListOAuthApps(e) returned err: %v", err)
 	}
 	want := []OAuthApp{
 		{

--- a/scrape/forms_test.go
+++ b/scrape/forms_test.go
@@ -73,7 +73,7 @@ func Test_ParseForms(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			node, err := html.Parse(strings.NewReader(tt.html))
 			if err != nil {
-				t.Errorf("error parsing html: %v", err)
+				t.Fatalf("error parsing html: %v", err)
 			}
 			if got, want := parseForms(node), tt.forms; !cmp.Equal(got, want) {
 				t.Errorf("parseForms(%q) returned %+v, want %+v", tt.html, got, want)
@@ -95,7 +95,7 @@ func Test_FetchAndSumbitForm(t *testing.T) {
 	mux.HandleFunc("/submit", func(w http.ResponseWriter, r *http.Request) {
 		err := r.ParseForm()
 		if err != nil {
-			t.Errorf("error parsing form: %v", err)
+			t.Fatalf("error parsing form: %v", err)
 		}
 		want := url.Values{"hidden": {"h"}, "name": {"n"}}
 		if got := r.Form; !cmp.Equal(got, want) {
@@ -107,7 +107,7 @@ func Test_FetchAndSumbitForm(t *testing.T) {
 	setValues := func(values url.Values) { values.Set("name", "n") }
 	_, err := fetchAndSubmitForm(client.Client, client.baseURL.String()+"/", setValues)
 	if err != nil {
-		t.Errorf("fetchAndSubmitForm returned err: %v", err)
+		t.Fatalf("fetchAndSubmitForm returned err: %v", err)
 	}
 	if !submitted {
 		t.Error("form was never submitted")

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -27,9 +28,9 @@ func setup(t *testing.T) (client *Client, mux *http.ServeMux) {
 
 func copyTestFile(t *testing.T, w io.Writer, filename string) {
 	t.Helper()
-	f, err := os.Open("testdata/" + filename)
+	f, err := os.Open(filepath.Join("testdata", filename))
 	if err != nil {
-		t.Errorf("unable to open test file: %v", err)
+		t.Fatalf("unable to open test file: %v", err)
 	}
 	_, err = io.Copy(w, f)
 	if err != nil {


### PR DESCRIPTION
The PR replaces `t.Errorf` with `t.Fatalf` in `scrape` tests where there is no need to continue execution if an `err` occurs. Additionally, it uses `filepath.Join` instead of a hard-coded separator `/`.