### PR TITLE
docs: Replace godoc.org with pkg.go.dev

### DIFF
--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -13,7 +13,7 @@
 //
 // Note, if you want to push a single file, you probably prefer to use the
 // content API. An example is available here:
-// https://godoc.org/github.com/google/go-github/github#example-RepositoriesService-CreateFile
+// https://pkg.go.dev/github.com/google/go-github/github#example-RepositoriesService-CreateFile
 //
 // Note, for this to work at least 1 commit is needed, so you if you use this
 // after creating a repository you might want to make sure you set `AutoInit` to
@@ -168,7 +168,7 @@ func pushCommit(ref *github.Reference, tree *github.Tree) (err error) {
 	return err
 }
 
-// createPR creates a pull request. Based on: https://godoc.org/github.com/google/go-github/github#example-PullRequestsService-Create
+// createPR creates a pull request. Based on: https://pkg.go.dev/github.com/google/go-github/github#example-PullRequestsService-Create
 func createPR() (err error) {
 	if *prSubject == "" {
 		return errors.New("missing `-pr-title` flag; skipping PR creation")

--- a/github/doc.go
+++ b/github/doc.go
@@ -31,7 +31,7 @@ The services of a client divide the API into logical chunks and correspond to
 the structure of the GitHub API documentation at
 https://docs.github.com/rest .
 
-NOTE: Using the https://godoc.org/context package, one can easily
+NOTE: Using the https://pkg.go.dev/context package, one can easily
 pass cancelation signals and deadlines to various services of the client for
 handling a request. In case there is no context available, then context.Background()
 can be used as a starting point.

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -72,7 +72,7 @@ func ExampleRepositoriesService_CreateFile() {
 	// so you will need to modify the example to provide an oauth client to
 	// github.NewClient() instead of nil. See the following documentation for more
 	// information on how to authenticate with the client:
-	// https://godoc.org/github.com/google/go-github/github#hdr-Authentication
+	// https://pkg.go.dev/github.com/google/go-github/github#hdr-Authentication
 	client := github.NewClient(nil)
 
 	ctx := context.Background()
@@ -117,7 +117,7 @@ func ExamplePullRequestsService_Create() {
 	// so you will need to modify the example to provide an oauth client to
 	// github.NewClient() instead of nil. See the following documentation for more
 	// information on how to authenticate with the client:
-	// https://godoc.org/github.com/google/go-github/github#hdr-Authentication
+	// https://pkg.go.dev/github.com/google/go-github/github#hdr-Authentication
 	client := github.NewClient(nil)
 
 	newPR := &github.NewPullRequest{
@@ -146,7 +146,7 @@ func ExampleTeamsService_ListTeams() {
 	// the example to provide an oauth client to github.NewClient() instead of nil.
 	// See the following documentation for more information on how to authenticate
 	// with the client:
-	// https://godoc.org/github.com/google/go-github/github#hdr-Authentication
+	// https://pkg.go.dev/github.com/google/go-github/github#hdr-Authentication
 	client := github.NewClient(nil)
 
 	teamName := "Developers team"

--- a/scrape/README.md
+++ b/scrape/README.md
@@ -1,4 +1,4 @@
-[![GoDoc](https://godoc.org/github.com/google/go-github/scrape?status.svg)](https://godoc.org/github.com/google/go-github/scrape)
+[![Go Reference](https://pkg.go.dev/badge/github.com/google/go-github/scrape.svg)](https://pkg.go.dev/github.com/google/go-github/scrape)
 
 The scrape package provides an experimental client for accessing additional
 GitHub data via screen scraping.  It is designed to be a client of last resort


### PR DESCRIPTION
The PR replaces outdated `godoc.org` with `pkg.go.dev`.

See https://github.com/golang/go/issues/49212 for details about the deprecated `godoc`.

The badge is created at https://pkg.go.dev/badge/.