### PR TITLE
fix: Add missing NotificationSetting to newTeamNoParent

### DIFF
--- a/github/teams.go
+++ b/github/teams.go
@@ -225,7 +225,6 @@ func copyNewTeamWithoutParent(team *NewTeam) *newTeamNoParent {
 		Description:         team.Description,
 		Maintainers:         team.Maintainers,
 		RepoNames:           team.RepoNames,
-		ParentTeamID:        nil,
 		NotificationSetting: team.NotificationSetting,
 		Privacy:             team.Privacy,
 		LDAPDN:              team.LDAPDN,

--- a/github/teams.go
+++ b/github/teams.go
@@ -206,13 +206,14 @@ func (s *TeamsService) CreateTeam(ctx context.Context, org string, team NewTeam)
 // "parent_team_id" field will be null. It is for internal use
 // only and should not be exported.
 type newTeamNoParent struct {
-	Name         string   `json:"name"`
-	Description  *string  `json:"description,omitempty"`
-	Maintainers  []string `json:"maintainers,omitempty"`
-	RepoNames    []string `json:"repo_names,omitempty"`
-	ParentTeamID *int64   `json:"parent_team_id"` // This will be "null"
-	Privacy      *string  `json:"privacy,omitempty"`
-	LDAPDN       *string  `json:"ldap_dn,omitempty"`
+	Name                string   `json:"name"`
+	Description         *string  `json:"description,omitempty"`
+	Maintainers         []string `json:"maintainers,omitempty"`
+	RepoNames           []string `json:"repo_names,omitempty"`
+	ParentTeamID        *int64   `json:"parent_team_id"` // This will be "null"
+	NotificationSetting *string  `json:"notification_setting,omitempty"`
+	Privacy             *string  `json:"privacy,omitempty"`
+	LDAPDN              *string  `json:"ldap_dn,omitempty"`
 }
 
 // copyNewTeamWithoutParent is used to set the "parent_team_id"
@@ -220,12 +221,14 @@ type newTeamNoParent struct {
 // It is for internal use only and should not be exported.
 func copyNewTeamWithoutParent(team *NewTeam) *newTeamNoParent {
 	return &newTeamNoParent{
-		Name:        team.Name,
-		Description: team.Description,
-		Maintainers: team.Maintainers,
-		RepoNames:   team.RepoNames,
-		Privacy:     team.Privacy,
-		LDAPDN:      team.LDAPDN,
+		Name:                team.Name,
+		Description:         team.Description,
+		Maintainers:         team.Maintainers,
+		RepoNames:           team.RepoNames,
+		ParentTeamID:        nil,
+		NotificationSetting: team.NotificationSetting,
+		Privacy:             team.Privacy,
+		LDAPDN:              team.LDAPDN,
 	}
 }
 

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -277,7 +277,7 @@ func TestTeamsService_EditTeamByID(t *testing.T) {
 func TestTeamsService_EditTeamByID_RemoveParent(t *testing.T) {
 	client, mux, _ := setup(t)
 
-	input := NewTeam{Name: "n", Privacy: String("closed")}
+	input := NewTeam{Name: "n", NotificationSetting: String("notifications_enabled"), Privacy: String("closed")}
 	var body string
 
 	mux.HandleFunc("/organizations/1/team/1", func(w http.ResponseWriter, r *http.Request) {
@@ -308,7 +308,7 @@ func TestTeamsService_EditTeamByID_RemoveParent(t *testing.T) {
 		t.Errorf("Teams.EditTeamByID returned %+v, want %+v", team, want)
 	}
 
-	if want := `{"name":"n","parent_team_id":null,"privacy":"closed"}` + "\n"; body != want {
+	if want := `{"name":"n","parent_team_id":null,"notification_setting":"notifications_enabled","privacy":"closed"}` + "\n"; body != want {
 		t.Errorf("Teams.EditTeamByID body = %+v, want %+v", body, want)
 	}
 }
@@ -359,7 +359,7 @@ func TestTeamsService_EditTeamBySlug(t *testing.T) {
 func TestTeamsService_EditTeamBySlug_RemoveParent(t *testing.T) {
 	client, mux, _ := setup(t)
 
-	input := NewTeam{Name: "n", Privacy: String("closed")}
+	input := NewTeam{Name: "n", NotificationSetting: String("notifications_disabled"), Privacy: String("closed")}
 	var body string
 
 	mux.HandleFunc("/orgs/o/teams/s", func(w http.ResponseWriter, r *http.Request) {
@@ -390,7 +390,7 @@ func TestTeamsService_EditTeamBySlug_RemoveParent(t *testing.T) {
 		t.Errorf("Teams.EditTeam returned %+v, want %+v", team, want)
 	}
 
-	if want := `{"name":"n","parent_team_id":null,"privacy":"closed"}` + "\n"; body != want {
+	if want := `{"name":"n","parent_team_id":null,"notification_setting":"notifications_disabled","privacy":"closed"}` + "\n"; body != want {
 		t.Errorf("Teams.EditTeam body = %+v, want %+v", body, want)
 	}
 }


### PR DESCRIPTION
The `newTeamNoParent` struct is the same as `NewTeam` as the comment states. The PR #3111 added `NotificationSetting` field to the `NewTeam` but forgot to add it to the `newTeamNoParent`.