### PR TITLE
refactor: Remove redundant local vars in examples

### DIFF
--- a/example/basicauth/main.go
+++ b/example/basicauth/main.go
@@ -31,12 +31,11 @@ func main() {
 	username, _ := r.ReadString('\n')
 
 	fmt.Print("GitHub Password: ")
-	bytePassword, _ := term.ReadPassword(int(os.Stdin.Fd()))
-	password := string(bytePassword)
+	password, _ := term.ReadPassword(int(os.Stdin.Fd()))
 
 	tp := github.BasicAuthTransport{
 		Username: strings.TrimSpace(username),
-		Password: strings.TrimSpace(password),
+		Password: strings.TrimSpace(string(password)),
 	}
 
 	client := github.NewClient(tp.Client())

--- a/example/codespaces/newreposecretwithxcrypto/main.go
+++ b/example/codespaces/newreposecretwithxcrypto/main.go
@@ -147,8 +147,7 @@ func encryptSecretWithPublicKey(publicKey *github.PublicKey, secretName string, 
 
 	var boxKey [32]byte
 	copy(boxKey[:], decodedPublicKey)
-	secretBytes := []byte(secretValue)
-	encryptedBytes, err := box.SealAnonymous([]byte{}, secretBytes, &boxKey, crypto_rand.Reader)
+	encryptedBytes, err := box.SealAnonymous([]byte{}, []byte(secretValue), &boxKey, crypto_rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("box.SealAnonymous failed with error %w", err)
 	}

--- a/example/codespaces/newusersecretwithxcrypto/main.go
+++ b/example/codespaces/newusersecretwithxcrypto/main.go
@@ -154,8 +154,7 @@ func encryptSecretWithPublicKey(publicKey *github.PublicKey, secretName string, 
 
 	var boxKey [32]byte
 	copy(boxKey[:], decodedPublicKey)
-	secretBytes := []byte(secretValue)
-	encryptedBytes, err := box.SealAnonymous([]byte{}, secretBytes, &boxKey, crypto_rand.Reader)
+	encryptedBytes, err := box.SealAnonymous([]byte{}, []byte(secretValue), &boxKey, crypto_rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("box.SealAnonymous failed with error %w", err)
 	}

--- a/example/newreposecretwithlibsodium/main.go
+++ b/example/newreposecretwithlibsodium/main.go
@@ -142,8 +142,7 @@ func encryptSecretWithPublicKey(publicKey *github.PublicKey, secretName string, 
 		return nil, fmt.Errorf("base64.StdEncoding.DecodeString was unable to decode public key: %v", err)
 	}
 
-	secretBytes := []byte(secretValue)
-	encryptedBytes, exit := sodium.CryptoBoxSeal(secretBytes, decodedPublicKey)
+	encryptedBytes, exit := sodium.CryptoBoxSeal([]byte(secretValue), decodedPublicKey)
 	if exit != 0 {
 		return nil, errors.New("sodium.CryptoBoxSeal exited with non zero exit code")
 	}

--- a/example/newreposecretwithxcrypto/main.go
+++ b/example/newreposecretwithxcrypto/main.go
@@ -147,8 +147,7 @@ func encryptSecretWithPublicKey(publicKey *github.PublicKey, secretName string, 
 
 	var boxKey [32]byte
 	copy(boxKey[:], decodedPublicKey)
-	secretBytes := []byte(secretValue)
-	encryptedBytes, err := box.SealAnonymous([]byte{}, secretBytes, &boxKey, crypto_rand.Reader)
+	encryptedBytes, err := box.SealAnonymous([]byte{}, []byte(secretValue), &boxKey, crypto_rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("box.SealAnonymous failed with error %w", err)
 	}

--- a/example/tagprotection/main.go
+++ b/example/tagprotection/main.go
@@ -38,12 +38,11 @@ func main() {
 	pattern = strings.TrimSpace(pattern)
 
 	fmt.Print("GitHub Token: ")
-	byteToken, _ := term.ReadPassword(int(os.Stdin.Fd()))
+	token, _ := term.ReadPassword(int(os.Stdin.Fd()))
 	println()
-	token := string(byteToken)
 
 	ctx := context.Background()
-	client := github.NewClient(nil).WithAuthToken(token)
+	client := github.NewClient(nil).WithAuthToken(string(token))
 
 	// create new tag protection
 	if pattern != "" {

--- a/example/tokenauth/main.go
+++ b/example/tokenauth/main.go
@@ -21,12 +21,11 @@ import (
 
 func main() {
 	fmt.Print("GitHub Token: ")
-	byteToken, _ := term.ReadPassword(int(os.Stdin.Fd()))
+	token, _ := term.ReadPassword(int(os.Stdin.Fd()))
 	println()
-	token := string(byteToken)
 
 	ctx := context.Background()
-	client := github.NewClient(nil).WithAuthToken(token)
+	client := github.NewClient(nil).WithAuthToken(string(token))
 
 	user, resp, err := client.Users.Get(ctx, "")
 	if err != nil {


### PR DESCRIPTION
The PR proposes removing local variables such as `bytePassword` and `secretBytes` because they do not do not significantly enhance readability.