### PR TITLE
Set Go 1.22 as minimum required version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 go-github is a Go client library for accessing the [GitHub API v3][].
 
-Currently, **go-github requires Go version 1.13 or greater**.  go-github tracks
+Currently, **go-github requires Go version 1.22 or greater**.  go-github tracks
 [Go's version support policy][support-policy].  We do our best not to break
 older versions of Go if we don't have to, but due to tooling constraints, we
 don't always test older versions.

--- a/example/newreposecretwithlibsodium/go.mod
+++ b/example/newreposecretwithlibsodium/go.mod
@@ -1,8 +1,6 @@
 module newreposecretwithlibsodium
 
-go 1.21
-
-toolchain go1.22.0
+go 1.22.0
 
 require (
 	github.com/GoKillers/libsodium-go v0.0.0-20171022220152-dd733721c3cb

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ require (
 	github.com/google/go-querystring v1.1.0
 )
 
-go 1.21
+go 1.22.0

--- a/scrape/go.mod
+++ b/scrape/go.mod
@@ -1,8 +1,6 @@
 module github.com/google/go-github/scrape
 
-go 1.21
-
-toolchain go1.22.0
+go 1.22.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.9.2

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,8 +1,6 @@
 module tools
 
-go 1.21
-
-toolchain go1.22.0
+go 1.22.0
 
 require (
 	github.com/alecthomas/kong v1.2.1


### PR DESCRIPTION
The PR arose from the discussion https://github.com/google/go-github/pull/3300#discussion_r1786805209