### PR TITLE
chore: Remove deprecated build constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 
 go-github is a Go client library for accessing the [GitHub API v3][].
 
-Currently, **go-github tests against Go version 1.22 and greater**.  go-github tracks
+**go-github requires Go version 1.17 and greater** and
+the library is tested against Go version 1.22 and greater.  go-github tracks
 [Go's version support policy][support-policy].  We do our best not to break
 older versions of Go if we don't have to, but due to tooling constraints, we
 don't always test older versions.

--- a/github/gen-accessors.go
+++ b/github/gen-accessors.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 // gen-accessors generates accessor methods for structs with pointer fields.
 //

--- a/github/gen-stringify-test.go
+++ b/github/gen-stringify-test.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 // gen-stringify-test generates test methods to test the String methods.
 //

--- a/github/with_appengine.go
+++ b/github/with_appengine.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build appengine
-// +build appengine
 
 // This file provides glue for making github work on App Engine.
 

--- a/github/without_appengine.go
+++ b/github/without_appengine.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !appengine
-// +build !appengine
 
 // This file provides glue for making github work without App Engine.
 

--- a/test/integration/activity_test.go
+++ b/test/integration/activity_test.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build integration
-// +build integration
 
 package integration
 

--- a/test/integration/audit_log_test.go
+++ b/test/integration/audit_log_test.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build integration
-// +build integration
 
 package integration
 

--- a/test/integration/authorizations_test.go
+++ b/test/integration/authorizations_test.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build integration
-// +build integration
 
 package integration
 

--- a/test/integration/github_test.go
+++ b/test/integration/github_test.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build integration
-// +build integration
 
 package integration
 

--- a/test/integration/issues_test.go
+++ b/test/integration/issues_test.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build integration
-// +build integration
 
 package integration
 

--- a/test/integration/misc_test.go
+++ b/test/integration/misc_test.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build integration
-// +build integration
 
 package integration
 

--- a/test/integration/pulls_test.go
+++ b/test/integration/pulls_test.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build integration
-// +build integration
 
 package integration
 

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build integration
-// +build integration
 
 package integration
 

--- a/test/integration/users_test.go
+++ b/test/integration/users_test.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build integration
-// +build integration
 
 package integration
 


### PR DESCRIPTION
This PR removes outdated `// +build` comments. The ["Build constraints"](https://pkg.go.dev/cmd/go#hdr-Build_constraints) says:

> Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix. The gofmt command will add an equivalent //go:build constraint when encountering the older syntax.

**NOTE:** This change breaks compatibility with Go 1.16. The library will compile only with Go 1.17+.