### PR TITLE
fix: allow removing/unsetting repository custom property

### DIFF
--- a/github/orgs_properties.go
+++ b/github/orgs_properties.go
@@ -41,7 +41,7 @@ type RepoCustomPropertyValue struct {
 // CustomPropertyValue represents a custom property value.
 type CustomPropertyValue struct {
 	PropertyName string  `json:"property_name"`
-	Value        *string `json:"value,omitempty"`
+	Value        *string `json:"value"`
 }
 
 // GetAllCustomProperties gets all custom properties that are defined for the specified organization.


### PR DESCRIPTION
This change will allow a user to set `null` when calling [the create/update repository custom property endpoint](https://docs.github.com/en/enterprise-cloud@latest/rest/repos/custom-properties?apiVersion=2022-11-28#create-or-update-custom-property-values-for-a-repository). As written in the docs doing so will remove/unset the custom property. Currently doing so is not possible

Normally I think this would count as a breaking change, since this will modify the behavior when omitting the `Value`, but I believe this is a straight up bug, as omitting the `Value` should always result in an error. So there shouldn't be any usages that's relying on this behavior. Technically it's possible, but improbable. 