### PR TITLE
feat: Add CreatedAt and UpdatedAt to Ruleset

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -21150,6 +21150,14 @@ func (r *Ruleset) GetConditions() *RulesetConditions {
 	return r.Conditions
 }
 
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (r *Ruleset) GetCreatedAt() Timestamp {
+	if r == nil || r.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *r.CreatedAt
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (r *Ruleset) GetID() int64 {
 	if r == nil || r.ID == nil {
@@ -21188,6 +21196,14 @@ func (r *Ruleset) GetTarget() string {
 		return ""
 	}
 	return *r.Target
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (r *Ruleset) GetUpdatedAt() Timestamp {
+	if r == nil || r.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *r.UpdatedAt
 }
 
 // GetRefName returns the RefName field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -27208,6 +27208,17 @@ func TestRuleset_GetConditions(tt *testing.T) {
 	r.GetConditions()
 }
 
+func TestRuleset_GetCreatedAt(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue Timestamp
+	r := &Ruleset{CreatedAt: &zeroValue}
+	r.GetCreatedAt()
+	r = &Ruleset{}
+	r.GetCreatedAt()
+	r = nil
+	r.GetCreatedAt()
+}
+
 func TestRuleset_GetID(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int64
@@ -27258,6 +27269,17 @@ func TestRuleset_GetTarget(tt *testing.T) {
 	r.GetTarget()
 	r = nil
 	r.GetTarget()
+}
+
+func TestRuleset_GetUpdatedAt(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue Timestamp
+	r := &Ruleset{UpdatedAt: &zeroValue}
+	r.GetUpdatedAt()
+	r = &Ruleset{}
+	r.GetUpdatedAt()
+	r = nil
+	r.GetUpdatedAt()
 }
 
 func TestRulesetConditions_GetRefName(tt *testing.T) {

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -548,6 +548,8 @@ type Ruleset struct {
 	Links        *RulesetLinks      `json:"_links,omitempty"`
 	Conditions   *RulesetConditions `json:"conditions,omitempty"`
 	Rules        []*RepositoryRule  `json:"rules,omitempty"`
+	UpdatedAt    *Timestamp         `json:"updated_at,omitempty"`
+	CreatedAt    *Timestamp         `json:"created_at,omitempty"`
 }
 
 // rulesetNoOmitBypassActors represents a GitHub ruleset object. The struct does not omit bypassActors if the field is nil or an empty array is passed.

--- a/github/repos_rules_test.go
+++ b/github/repos_rules_test.go
@@ -489,14 +489,18 @@ func TestRepositoriesService_GetAllRulesets(t *testing.T) {
 			  "name": "ruleset",
 			  "source_type": "Repository",
 			  "source": "o/repo",
-			  "enforcement": "enabled"
+			  "enforcement": "enabled",
+			  "created_at": `+referenceTimeStr+`,
+			  "updated_at": `+referenceTimeStr+`
 			},
 			{
 			  "id": 314,
 			  "name": "Another ruleset",
 			  "source_type": "Repository",
 			  "source": "o/repo",
-			  "enforcement": "enabled"
+			  "enforcement": "enabled",
+			  "created_at": `+referenceTimeStr+`,
+			  "updated_at": `+referenceTimeStr+`
 			}
 		]`)
 	})
@@ -514,6 +518,8 @@ func TestRepositoriesService_GetAllRulesets(t *testing.T) {
 			SourceType:  String("Repository"),
 			Source:      "o/repo",
 			Enforcement: "enabled",
+			CreatedAt:   &Timestamp{referenceTime},
+			UpdatedAt:   &Timestamp{referenceTime},
 		},
 		{
 			ID:          Int64(314),
@@ -521,6 +527,8 @@ func TestRepositoriesService_GetAllRulesets(t *testing.T) {
 			SourceType:  String("Repository"),
 			Source:      "o/repo",
 			Enforcement: "enabled",
+			CreatedAt:   &Timestamp{referenceTime},
+			UpdatedAt:   &Timestamp{referenceTime},
 		},
 	}
 	if !cmp.Equal(ruleSet, want) {
@@ -683,7 +691,9 @@ func TestRepositoriesService_GetRuleset(t *testing.T) {
 			"name": "ruleset",
 			"source_type": "Organization",
 			"source": "o",
-			"enforcement": "enabled"
+			"enforcement": "enabled",
+			"created_at": `+referenceTimeStr+`,
+			"updated_at": `+referenceTimeStr+`
 		}`)
 	})
 
@@ -699,6 +709,8 @@ func TestRepositoriesService_GetRuleset(t *testing.T) {
 		SourceType:  String("Organization"),
 		Source:      "o",
 		Enforcement: "enabled",
+		CreatedAt:   &Timestamp{referenceTime},
+		UpdatedAt:   &Timestamp{referenceTime},
 	}
 	if !cmp.Equal(ruleSet, want) {
 		t.Errorf("Repositories.GetRuleset returned %+v, want %+v", ruleSet, want)


### PR DESCRIPTION
This PR will expose fields `CreatedAt` and `UpdatedAt` for `Ruleset`

Closes https://github.com/google/go-github/issues/3315