### PR TITLE
refactor: Remove unneeded strings.Join calls

### DIFF
--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -203,10 +202,9 @@ func TestProjectsService_ListProjectColumns(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/projects/1/columns", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})

--- a/github/teams.go
+++ b/github/teams.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 )
 
 // TeamsService provides access to the team-related functions
@@ -389,8 +388,7 @@ func (s *TeamsService) ListTeamReposByID(ctx context.Context, orgID, teamID int6
 	}
 
 	// TODO: remove custom Accept header when topics API fully launches.
-	headers := []string{mediaTypeTopicsPreview}
-	req.Header.Set("Accept", strings.Join(headers, ", "))
+	req.Header.Set("Accept", mediaTypeTopicsPreview)
 
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)
@@ -419,8 +417,7 @@ func (s *TeamsService) ListTeamReposBySlug(ctx context.Context, org, slug string
 	}
 
 	// TODO: remove custom Accept header when topics API fully launches.
-	headers := []string{mediaTypeTopicsPreview}
-	req.Header.Set("Accept", strings.Join(headers, ", "))
+	req.Header.Set("Accept", mediaTypeTopicsPreview)
 
 	var repos []*Repository
 	resp, err := s.client.Do(ctx, req, &repos)
@@ -445,8 +442,7 @@ func (s *TeamsService) IsTeamRepoByID(ctx context.Context, orgID, teamID int64, 
 		return nil, nil, err
 	}
 
-	headers := []string{mediaTypeOrgPermissionRepo}
-	req.Header.Set("Accept", strings.Join(headers, ", "))
+	req.Header.Set("Accept", mediaTypeOrgPermissionRepo)
 
 	repository := new(Repository)
 	resp, err := s.client.Do(ctx, req, repository)
@@ -471,8 +467,7 @@ func (s *TeamsService) IsTeamRepoBySlug(ctx context.Context, org, slug, owner, r
 		return nil, nil, err
 	}
 
-	headers := []string{mediaTypeOrgPermissionRepo}
-	req.Header.Set("Accept", strings.Join(headers, ", "))
+	req.Header.Set("Accept", mediaTypeOrgPermissionRepo)
 
 	repository := new(Repository)
 	resp, err := s.client.Do(ctx, req, repository)
@@ -606,8 +601,7 @@ func (s *TeamsService) ListTeamProjectsByID(ctx context.Context, orgID, teamID i
 	}
 
 	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	var projects []*Project
 	resp, err := s.client.Do(ctx, req, &projects)
@@ -632,8 +626,7 @@ func (s *TeamsService) ListTeamProjectsBySlug(ctx context.Context, org, slug str
 	}
 
 	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	var projects []*Project
 	resp, err := s.client.Do(ctx, req, &projects)
@@ -658,8 +651,7 @@ func (s *TeamsService) ReviewTeamProjectsByID(ctx context.Context, orgID, teamID
 	}
 
 	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	projects := &Project{}
 	resp, err := s.client.Do(ctx, req, &projects)
@@ -684,8 +676,7 @@ func (s *TeamsService) ReviewTeamProjectsBySlug(ctx context.Context, org, slug s
 	}
 
 	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	projects := &Project{}
 	resp, err := s.client.Do(ctx, req, &projects)
@@ -723,8 +714,7 @@ func (s *TeamsService) AddTeamProjectByID(ctx context.Context, orgID, teamID, pr
 	}
 
 	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }
@@ -744,8 +734,7 @@ func (s *TeamsService) AddTeamProjectBySlug(ctx context.Context, org, slug strin
 	}
 
 	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }
@@ -768,8 +757,7 @@ func (s *TeamsService) RemoveTeamProjectByID(ctx context.Context, orgID, teamID,
 	}
 
 	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }
@@ -792,8 +780,7 @@ func (s *TeamsService) RemoveTeamProjectBySlug(ctx context.Context, org, slug st
 	}
 
 	// TODO: remove custom Accept header when this API fully launches.
-	acceptHeaders := []string{mediaTypeProjectsPreview}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	return s.client.Do(ctx, req, nil)
 }

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -538,8 +537,7 @@ func TestTeamsService_ListTeamReposByID(t *testing.T) {
 
 	mux.HandleFunc("/organizations/1/team/1/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		wantAcceptHeaders := []string{mediaTypeTopicsPreview}
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+		testHeader(t, r, "Accept", mediaTypeTopicsPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -577,8 +575,7 @@ func TestTeamsService_ListTeamReposBySlug(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/teams/s/repos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		wantAcceptHeaders := []string{mediaTypeTopicsPreview}
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+		testHeader(t, r, "Accept", mediaTypeTopicsPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -616,8 +613,7 @@ func TestTeamsService_IsTeamRepoByID_true(t *testing.T) {
 
 	mux.HandleFunc("/organizations/1/team/1/repos/owner/repo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		wantAcceptHeaders := []string{mediaTypeOrgPermissionRepo}
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+		testHeader(t, r, "Accept", mediaTypeOrgPermissionRepo)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -653,8 +649,7 @@ func TestTeamsService_IsTeamRepoBySlug_true(t *testing.T) {
 
 	mux.HandleFunc("/orgs/org/teams/slug/repos/owner/repo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		wantAcceptHeaders := []string{mediaTypeOrgPermissionRepo}
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+		testHeader(t, r, "Accept", mediaTypeOrgPermissionRepo)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -1016,10 +1011,9 @@ func TestTeamsService_ListProjectsByID(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/organizations/1/team/1/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
@@ -1053,10 +1047,9 @@ func TestTeamsService_ListProjectsBySlug(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/orgs/o/teams/s/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
@@ -1090,10 +1083,9 @@ func TestTeamsService_ReviewProjectsByID(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/organizations/1/team/1/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -1127,10 +1119,9 @@ func TestTeamsService_ReviewProjectsBySlug(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/orgs/o/teams/s/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -1168,10 +1159,9 @@ func TestTeamsService_AddTeamProjectByID(t *testing.T) {
 		Permission: String("admin"),
 	}
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/organizations/1/team/1/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 
 		v := &TeamProjectOptions{}
 		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
@@ -1207,10 +1197,9 @@ func TestTeamsService_AddTeamProjectBySlug(t *testing.T) {
 		Permission: String("admin"),
 	}
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/orgs/o/teams/s/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 
 		v := &TeamProjectOptions{}
 		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
@@ -1242,10 +1231,9 @@ func TestTeamsService_RemoveTeamProjectByID(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/organizations/1/team/1/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -1270,10 +1258,9 @@ func TestTeamsService_RemoveTeamProjectBySlug(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	wantAcceptHeaders := []string{mediaTypeProjectsPreview}
 	mux.HandleFunc("/orgs/o/teams/s/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+		testHeader(t, r, "Accept", mediaTypeProjectsPreview)
 		w.WriteHeader(http.StatusNoContent)
 	})
 


### PR DESCRIPTION
The PR removes unneeded `strings.Join` function calls. The value of `strings.Join([]string{mediaTypeTopicsPreview}, ", ")` is the same as `mediaTypeTopicsPreview`.