### PR TITLE
 Add Copilot Usage Summary for Organization

### DIFF
--- a/github/copilot.go
+++ b/github/copilot.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 // CopilotService provides access to the Copilot-related functions
@@ -63,6 +64,13 @@ type SeatCancellations struct {
 	SeatsCancelled int `json:"seats_cancelled"`
 }
 
+type CopilotUsageSummaryListOptions struct {
+	Since time.Time `url:"since,omitempty"`
+	Until time.Time `url:"until,omitempty"`
+
+	ListOptions
+}
+
 type CopilotUsageBreakdown struct {
 	Language         string `json:"language"`
 	Editor           string `json:"editor"`
@@ -74,16 +82,16 @@ type CopilotUsageBreakdown struct {
 }
 
 type CopilotUsageSummary struct {
-	Day                   string                  `json:"day"`
-	TotalSuggestionsCount int                     `json:"total_suggestions_count"`
-	TotalAcceptancesCount int                     `json:"total_acceptances_count"`
-	TotalLinesSuggested   int                     `json:"total_lines_suggested"`
-	TotalLinesAccepted    int                     `json:"total_lines_accepted"`
-	TotalActiveUsers      int                     `json:"total_active_users"`
-	TotalChatAcceptances  int                     `json:"total_chat_acceptances"`
-	TotalChatTurns        int                     `json:"total_chat_turns"`
-	TotalActiveChatUsers  int                     `json:"total_active_chat_users"`
-	Breakdown             []CopilotUsageBreakdown `json:"breakdown"`
+	Day                   string                   `json:"day"`
+	TotalSuggestionsCount int                      `json:"total_suggestions_count"`
+	TotalAcceptancesCount int                      `json:"total_acceptances_count"`
+	TotalLinesSuggested   int                      `json:"total_lines_suggested"`
+	TotalLinesAccepted    int                      `json:"total_lines_accepted"`
+	TotalActiveUsers      int                      `json:"total_active_users"`
+	TotalChatAcceptances  int                      `json:"total_chat_acceptances"`
+	TotalChatTurns        int                      `json:"total_chat_turns"`
+	TotalActiveChatUsers  int                      `json:"total_active_chat_users"`
+	Breakdown             []*CopilotUsageBreakdown `json:"breakdown"`
 }
 
 func (cp *CopilotSeatDetails) UnmarshalJSON(data []byte) error {
@@ -342,8 +350,12 @@ func (s *CopilotService) GetSeatDetails(ctx context.Context, org, user string) (
 // GitHub API docs: https://docs.github.com/en/rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-organization-members
 //
 //meta:operation GET /orgs/{org}/copilot/usage
-func (s *CopilotService) GetOrganizationUsage(ctx context.Context, org string) ([]*CopilotUsageSummary, *Response, error) {
+func (s *CopilotService) GetOrganizationUsage(ctx context.Context, org string, opts *CopilotUsageSummaryListOptions) ([]*CopilotUsageSummary, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/copilot/usage", org)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -883,3 +883,203 @@ func TestCopilotService_GetSeatDetails(t *testing.T) {
 		return resp, err
 	})
 }
+
+func TestCopilotService_GetOrganisationUsage(t *testing.T) {
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/copilot/usage", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[
+			{
+				"day": "2023-10-15",
+				"total_suggestions_count": 1000,
+				"total_acceptances_count": 800,
+				"total_lines_suggested": 1800,
+				"total_lines_accepted": 1200,
+				"total_active_users": 10,
+				"total_chat_acceptances": 32,
+				"total_chat_turns": 200,
+				"total_active_chat_users": 4,
+				"breakdown": [
+				{
+					"language": "python",
+					"editor": "vscode",
+					"suggestions_count": 300,
+					"acceptances_count": 250,
+					"lines_suggested": 900,
+					"lines_accepted": 700,
+					"active_users": 5
+				},
+				{
+					"language": "python",
+					"editor": "jetbrains",
+					"suggestions_count": 300,
+					"acceptances_count": 200,
+					"lines_suggested": 400,
+					"lines_accepted": 300,
+					"active_users": 2
+				},
+				{
+					"language": "ruby",
+					"editor": "vscode",
+					"suggestions_count": 400,
+					"acceptances_count": 350,
+					"lines_suggested": 500,
+					"lines_accepted": 200,
+					"active_users": 3
+				}
+				]
+			},
+			{
+				"day": "2023-10-16",
+				"total_suggestions_count": 800,
+				"total_acceptances_count": 600,
+				"total_lines_suggested": 1100,
+				"total_lines_accepted": 700,
+				"total_active_users": 12,
+				"total_chat_acceptances": 57,
+				"total_chat_turns": 426,
+				"total_active_chat_users": 8,
+				"breakdown": [
+				{
+					"language": "python",
+					"editor": "vscode",
+					"suggestions_count": 300,
+					"acceptances_count": 200,
+					"lines_suggested": 600,
+					"lines_accepted": 300,
+					"active_users": 2
+				},
+				{
+					"language": "python",
+					"editor": "jetbrains",
+					"suggestions_count": 300,
+					"acceptances_count": 150,
+					"lines_suggested": 300,
+					"lines_accepted": 250,
+					"active_users": 6
+				},
+				{
+					"language": "ruby",
+					"editor": "vscode",
+					"suggestions_count": 200,
+					"acceptances_count": 150,
+					"lines_suggested": 200,
+					"lines_accepted": 150,
+					"active_users": 3
+				}
+				]
+			}
+		]`)
+	})
+
+	summaryOne := time.Date(2023, time.October, 15, 0, 0, 0, 0, time.UTC)
+	summaryTwoDate := time.Date(2023, time.October, 16, 0, 0, 0, 0, time.UTC)
+	ctx := context.Background()
+	got, _, err := client.Copilot.GetOrganizationUsage(ctx, "o", &CopilotUsageSummaryListOptions{})
+	if err != nil {
+		t.Errorf("Copilot.GetOrganizationUsage returned error: %v", err)
+	}
+
+	want := []*CopilotUsageSummary{
+		{
+			Day:                   summaryOne.Format("2006-01-02"),
+			TotalSuggestionsCount: 1000,
+			TotalAcceptancesCount: 800,
+			TotalLinesSuggested:   1800,
+			TotalLinesAccepted:    1200,
+			TotalActiveUsers:      10,
+			TotalChatAcceptances:  32,
+			TotalChatTurns:        200,
+			TotalActiveChatUsers:  4,
+			Breakdown: []*CopilotUsageBreakdown{
+				{
+					Language:         "python",
+					Editor:           "vscode",
+					SuggestionsCount: 300,
+					AcceptancesCount: 250,
+					LinesSuggested:   900,
+					LinesAccepted:    700,
+					ActiveUsers:      5,
+				},
+				{
+					Language:         "python",
+					Editor:           "jetbrains",
+					SuggestionsCount: 300,
+					AcceptancesCount: 200,
+					LinesSuggested:   400,
+					LinesAccepted:    300,
+					ActiveUsers:      2,
+				},
+				{
+					Language:         "ruby",
+					Editor:           "vscode",
+					SuggestionsCount: 400,
+					AcceptancesCount: 350,
+					LinesSuggested:   500,
+					LinesAccepted:    200,
+					ActiveUsers:      3,
+				},
+			},
+		},
+		{
+			Day:                   summaryTwoDate.Format("2006-01-02"),
+			TotalSuggestionsCount: 800,
+			TotalAcceptancesCount: 600,
+			TotalLinesSuggested:   1100,
+			TotalLinesAccepted:    700,
+			TotalActiveUsers:      12,
+			TotalChatAcceptances:  57,
+			TotalChatTurns:        426,
+			TotalActiveChatUsers:  8,
+			Breakdown: []*CopilotUsageBreakdown{
+				{
+					Language:         "python",
+					Editor:           "vscode",
+					SuggestionsCount: 300,
+					AcceptancesCount: 200,
+					LinesSuggested:   600,
+					LinesAccepted:    300,
+					ActiveUsers:      2,
+				},
+				{
+					Language:         "python",
+					Editor:           "jetbrains",
+					SuggestionsCount: 300,
+					AcceptancesCount: 150,
+					LinesSuggested:   300,
+					LinesAccepted:    250,
+					ActiveUsers:      6,
+				},
+				{
+					Language:         "ruby",
+					Editor:           "vscode",
+					SuggestionsCount: 200,
+					AcceptancesCount: 150,
+					LinesSuggested:   200,
+					LinesAccepted:    150,
+					ActiveUsers:      3,
+				},
+			},
+		},
+	}
+
+	if !cmp.Equal(got, want) {
+		t.Errorf("Copilot.GetOrganizationUsage returned %+v, want %+v", got, want)
+	}
+
+	const methodName = "GetOrganizationUsage"
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Copilot.GetOrganizationUsage(ctx, "\n", &CopilotUsageSummaryListOptions{})
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Copilot.GetOrganizationUsage(ctx, "o", &CopilotUsageSummaryListOptions{})
+		if got != nil {
+			t.Errorf("Copilot.GetOrganizationUsage returned %+v, want nil", got)
+		}
+		return resp, err
+	})
+}


### PR DESCRIPTION
Github has a Rest API to get the usage summary of Copilot within the organization. This PR implements the functionality to fetch that data.
API Docs: [Here](https://docs.github.com/en/rest/copilot/copilot-usage?apiVersion=2022-11-28#get-a-summary-of-copilot-usage-for-organization-members)

Please let me know what you think!

(Fixup of #3318 due to CLA signing issues) 