### PR TITLE
docs: Add dots at the end of sentences

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
   enable:
     - dogsled
     - dupl
+    - godot
     - gofmt
     - goimports
     - gosec

--- a/example/topics/main.go
+++ b/example/topics/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/go-github/v66/github"
 )
 
-// Fetch and lists all the public topics associated with the specified GitHub topic
+// Fetch and lists all the public topics associated with the specified GitHub topic.
 func fetchTopics(topic string) (*github.TopicsSearchResult, error) {
 	client := github.NewClient(nil)
 	topics, _, err := client.Search.Topics(context.Background(), topic, nil)

--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -15,7 +15,7 @@ import (
 // GitHub API docs: https://docs.github.com/rest/oauth/#scopes
 type Scope string
 
-// This is the set of scopes for GitHub API V3
+// This is the set of scopes for GitHub API V3.
 const (
 	ScopeNone           Scope = "(no scope)" // REVISIT: is this actually returned, or just a documentation artifact?
 	ScopeUser           Scope = "user"

--- a/github/checks.go
+++ b/github/checks.go
@@ -401,7 +401,7 @@ type CheckSuitePreferenceResults struct {
 	Repository  *Repository     `json:"repository,omitempty"`
 }
 
-// PreferenceList represents a list of auto trigger checks for repository
+// PreferenceList represents a list of auto trigger checks for repository.
 type PreferenceList struct {
 	AutoTriggerChecks []*AutoTriggerCheck `json:"auto_trigger_checks,omitempty"` // A slice of auto trigger checks that can be set for a check suite in a repository.
 }
@@ -429,7 +429,7 @@ func (s *ChecksService) SetCheckSuitePreferences(ctx context.Context, owner, rep
 	return checkSuitePrefResults, resp, nil
 }
 
-// CreateCheckSuiteOptions sets up parameters to manually create a check suites
+// CreateCheckSuiteOptions sets up parameters to manually create a check suites.
 type CreateCheckSuiteOptions struct {
 	HeadSHA    string  `json:"head_sha"`              // The sha of the head commit. (Required.)
 	HeadBranch *string `json:"head_branch,omitempty"` // The name of the head branch where the code changes are implemented.

--- a/github/codesofconduct.go
+++ b/github/codesofconduct.go
@@ -50,7 +50,7 @@ func (s *CodesOfConductService) List(ctx context.Context) ([]*CodeOfConduct, *Re
 
 // ListCodesOfConduct returns all codes of conduct.
 //
-// Deprecated: Use CodesOfConductService.List instead
+// Deprecated: Use CodesOfConductService.List instead.
 func (c *Client) ListCodesOfConduct(ctx context.Context) ([]*CodeOfConduct, *Response, error) {
 	return c.CodesOfConduct.List(ctx)
 }
@@ -81,7 +81,7 @@ func (s *CodesOfConductService) Get(ctx context.Context, key string) (*CodeOfCon
 
 // GetCodeOfConduct returns an individual code of conduct.
 //
-// Deprecated: Use CodesOfConductService.Get instead
+// Deprecated: Use CodesOfConductService.Get instead.
 func (c *Client) GetCodeOfConduct(ctx context.Context, key string) (*CodeOfConduct, *Response, error) {
 	return c.CodesOfConduct.Get(ctx, key)
 }

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-// Test invalid JSON responses, valid responses are covered in the other tests
+// Test invalid JSON responses, valid responses are covered in the other tests.
 func TestCopilotSeatDetails_UnmarshalJSON(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/github/emojis.go
+++ b/github/emojis.go
@@ -34,7 +34,7 @@ func (s *EmojisService) List(ctx context.Context) (map[string]string, *Response,
 
 // ListEmojis returns the emojis available to use on GitHub.
 //
-// Deprecated: Use EmojisService.List instead
+// Deprecated: Use EmojisService.List instead.
 func (c *Client) ListEmojis(ctx context.Context) (map[string]string, *Response, error) {
 	return c.Emojis.List(ctx)
 }

--- a/github/github.go
+++ b/github/github.go
@@ -1595,7 +1595,7 @@ func Int64(v int64) *int64 { return &v }
 // to store v and returns a pointer to it.
 func String(v string) *string { return &v }
 
-// roundTripperFunc creates a RoundTripper (transport)
+// roundTripperFunc creates a RoundTripper (transport).
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -212,7 +212,7 @@ func testNewRequestAndDoFailure(t *testing.T, methodName string, client *Client,
 	testNewRequestAndDoFailureCategory(t, methodName, client, CoreCategory, f)
 }
 
-// testNewRequestAndDoFailureCategory works Like testNewRequestAndDoFailure, but allows setting the category
+// testNewRequestAndDoFailureCategory works Like testNewRequestAndDoFailure, but allows setting the category.
 func testNewRequestAndDoFailureCategory(t *testing.T, methodName string, client *Client, category RateLimitCategory, f func() (*Response, error)) {
 	t.Helper()
 	if methodName == "" {
@@ -1235,7 +1235,7 @@ func TestDo_rateLimitCategory(t *testing.T) {
 	}
 }
 
-// ensure rate limit is still parsed, even for error responses
+// Ensure rate limit is still parsed, even for error responses.
 func TestDo_rateLimit_errorResponse(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
@@ -2265,7 +2265,7 @@ func TestAcceptedError_Is(t *testing.T) {
 	}
 }
 
-// ensure that we properly handle API errors that do not contain a response body
+// Ensure that we properly handle API errors that do not contain a response body.
 func TestCheckResponse_noBody(t *testing.T) {
 	t.Parallel()
 	res := &http.Response{

--- a/github/issues_labels.go
+++ b/github/issues_labels.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 )
 
-// Label represents a GitHub label on an Issue
+// Label represents a GitHub label on an Issue.
 type Label struct {
 	ID          *int64  `json:"id,omitempty"`
 	URL         *string `json:"url,omitempty"`

--- a/github/messages.go
+++ b/github/messages.go
@@ -114,9 +114,9 @@ var (
 		"workflow_job":                   &WorkflowJobEvent{},
 		"workflow_run":                   &WorkflowRunEvent{},
 	}
-	// forward mapping of event types to the string names of the structs
+	// Forward mapping of event types to the string names of the structs.
 	messageToTypeName = make(map[string]string, len(eventTypeMapping))
-	// Inverse map of the above
+	// Inverse map of the above.
 	typeToMessageMapping = make(map[string]string, len(eventTypeMapping))
 )
 

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -126,7 +126,7 @@ func TestOrganizationsService_IsMember(t *testing.T) {
 	})
 }
 
-// ensure that a 404 response is interpreted as "false" and not an error
+// Ensure that a 404 response is interpreted as "false" and not an error.
 func TestOrganizationsService_IsMember_notMember(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
@@ -146,8 +146,8 @@ func TestOrganizationsService_IsMember_notMember(t *testing.T) {
 	}
 }
 
-// ensure that a 400 response is interpreted as an actual error, and not simply
-// as "false" like the above case of a 404
+// Ensure that a 400 response is interpreted as an actual error, and not simply
+// as "false" like the above case of a 404.
 func TestOrganizationsService_IsMember_error(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
@@ -209,7 +209,7 @@ func TestOrganizationsService_IsPublicMember(t *testing.T) {
 	})
 }
 
-// ensure that a 404 response is interpreted as "false" and not an error
+// Ensure that a 404 response is interpreted as "false" and not an error.
 func TestOrganizationsService_IsPublicMember_notMember(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
@@ -229,8 +229,8 @@ func TestOrganizationsService_IsPublicMember_notMember(t *testing.T) {
 	}
 }
 
-// ensure that a 400 response is interpreted as an actual error, and not simply
-// as "false" like the above case of a 404
+// Ensure that a 400 response is interpreted as an actual error, and not simply
+// as "false" like the above case of a 404.
 func TestOrganizationsService_IsPublicMember_error(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)

--- a/github/repos.go
+++ b/github/repos.go
@@ -738,7 +738,7 @@ func (s *RepositoriesService) Delete(ctx context.Context, owner, repo string) (*
 	return s.client.Do(ctx, req, nil)
 }
 
-// Contributor represents a repository contributor
+// Contributor represents a repository contributor.
 type Contributor struct {
 	Login             *string `json:"login,omitempty"`
 	ID                *int64  `json:"id,omitempty"`
@@ -998,7 +998,7 @@ func (s *RepositoriesService) ListTags(ctx context.Context, owner string, repo s
 	return tags, resp, nil
 }
 
-// Branch represents a repository branch
+// Branch represents a repository branch.
 type Branch struct {
 	Name      *string           `json:"name,omitempty"`
 	Commit    *RepositoryCommit `json:"commit,omitempty"`

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -62,7 +62,7 @@ type RepositoryContentFileOptions struct {
 }
 
 // RepositoryContentGetOptions represents an optional ref parameter, which can be a SHA,
-// branch, or tag
+// branch, or tag.
 type RepositoryContentGetOptions struct {
 	Ref string `url:"ref,omitempty"`
 }

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-// Deployment represents a deployment in a repo
+// Deployment represents a deployment in a repo.
 type Deployment struct {
 	URL           *string         `json:"url,omitempty"`
 	ID            *int64          `json:"id,omitempty"`
@@ -30,7 +30,7 @@ type Deployment struct {
 	NodeID        *string         `json:"node_id,omitempty"`
 }
 
-// DeploymentRequest represents a deployment request
+// DeploymentRequest represents a deployment request.
 type DeploymentRequest struct {
 	Ref                   *string     `json:"ref,omitempty"`
 	Task                  *string     `json:"task,omitempty"`
@@ -171,7 +171,7 @@ type DeploymentStatus struct {
 	URL            *string    `json:"url,omitempty"`
 }
 
-// DeploymentStatusRequest represents a deployment request
+// DeploymentStatusRequest represents a deployment request.
 type DeploymentStatusRequest struct {
 	State          *string `json:"state,omitempty"`
 	LogURL         *string `json:"log_url,omitempty"`

--- a/github/search.go
+++ b/github/search.go
@@ -209,7 +209,7 @@ type Match struct {
 	Indices []int   `json:"indices,omitempty"`
 }
 
-// TextMatch represents a text match for a SearchResult
+// TextMatch represents a text match for a SearchResult.
 type TextMatch struct {
 	ObjectURL  *string  `json:"object_url,omitempty"`
 	ObjectType *string  `json:"object_type,omitempty"`

--- a/github/timestamp.go
+++ b/github/timestamp.go
@@ -46,7 +46,7 @@ func (t *Timestamp) UnmarshalJSON(data []byte) (err error) {
 	return
 }
 
-// Equal reports whether t and u are equal based on time.Equal
+// Equal reports whether t and u are equal based on time.Equal.
 func (t Timestamp) Equal(u Timestamp) bool {
 	return t.Time.Equal(u.Time)
 }

--- a/github/users_emails.go
+++ b/github/users_emails.go
@@ -7,7 +7,7 @@ package github
 
 import "context"
 
-// UserEmail represents user's email address
+// UserEmail represents user's email address.
 type UserEmail struct {
 	Email      *string `json:"email,omitempty"`
 	Primary    *bool   `json:"primary,omitempty"`

--- a/scrape/apps.go
+++ b/scrape/apps.go
@@ -92,11 +92,11 @@ func intFromLastPathSegment(s string) int {
 type OAuthAppReviewState int
 
 const (
-	// OAuthAppRequested indicates access has been requested, but not reviewed
+	// OAuthAppRequested indicates access has been requested, but not reviewed.
 	OAuthAppRequested OAuthAppReviewState = iota + 1
-	// OAuthAppApproved indicates access has been approved
+	// OAuthAppApproved indicates access has been approved.
 	OAuthAppApproved
-	// OAuthAppDenied indicates access has been denied
+	// OAuthAppDenied indicates access has been denied.
 	OAuthAppDenied
 )
 

--- a/test/integration/audit_log_test.go
+++ b/test/integration/audit_log_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 )
 
-// TestOrganizationAuditLog test that the client can read an org's audit log
-// Note: Org must be part of an enterprise
-// Test requires auth - set env var GITHUB_AUTH_TOKEN
+// TestOrganizationAuditLog test that the client can read an org's audit log.
+// Note: Org must be part of an enterprise.
+// Test requires auth - set env var GITHUB_AUTH_TOKEN.
 func TestOrganizationAuditLog(t *testing.T) {
 	org := "example_org"
 	entries, _, err := client.Organizations.GetAuditLog(context.Background(), org, nil)

--- a/tools/metadata/metadata.go
+++ b/tools/metadata/metadata.go
@@ -102,7 +102,7 @@ func normalizedOpName(name string) string {
 	return strings.TrimSpace(verb + " " + normalizeOpPath(u))
 }
 
-// matches something like "GET /some/path"
+// matches something like "GET /some/path".
 var opNameRe = regexp.MustCompile(`(?i)(\S+)(?:\s+(\S.*))?`)
 
 func parseOpName(id string) (verb, url string) {


### PR DESCRIPTION
This PR enables `godot` linter to ensure comments always end with a full stop. This is for consistency with other comments and to comply with the guidelines at https://go.dev/wiki/CodeReviewComments#comment-sentences:
> Comments should begin with the name of the thing being described and end in a period