### PR TITLE
refactor: Replace 'println' with 'fmt.Println'

### DIFF
--- a/example/tokenauth/main.go
+++ b/example/tokenauth/main.go
@@ -22,7 +22,7 @@ import (
 func main() {
 	fmt.Print("GitHub Token: ")
 	token, _ := term.ReadPassword(int(os.Stdin.Fd()))
-	println()
+	fmt.Println()
 
 	ctx := context.Background()
 	client := github.NewClient(nil).WithAuthToken(string(token))


### PR DESCRIPTION
The PR replaces `println` with normal `fmt.Println` in the `example/tokenauth`.

`println` is not guaranteed to stay in the language according to [the spec](https://go.dev/ref/spec#Bootstrapping).