### PR TITLE
refactor: Replace 'print' with 'fmt.Print'

### DIFF
--- a/test/fields/fields.go
+++ b/test/fields/fields.go
@@ -39,7 +39,7 @@ func main() {
 
 	token := os.Getenv("GITHUB_AUTH_TOKEN")
 	if token == "" {
-		print("!!! No OAuth token. Some tests won't run. !!!\n\n")
+		fmt.Print("!!! No OAuth token. Some tests won't run. !!!\n\n")
 		client = github.NewClient(nil)
 	} else {
 		client = github.NewClient(nil).WithAuthToken(token)

--- a/test/integration/github_test.go
+++ b/test/integration/github_test.go
@@ -28,7 +28,7 @@ var (
 func init() {
 	token := os.Getenv("GITHUB_AUTH_TOKEN")
 	if token == "" {
-		print("!!! No OAuth token. Some tests won't run. !!!\n\n")
+		fmt.Print("!!! No OAuth token. Some tests won't run. !!!\n\n")
 		client = github.NewClient(nil)
 	} else {
 		client = github.NewClient(nil).WithAuthToken(token)


### PR DESCRIPTION
The PR replaces `print` with normal `fmt.Print` in the `test` directory.

`print` is not guaranteed to stay in the language according to [the spec](https://go.dev/ref/spec#Bootstrapping).

The same changes as in the #3326.