### PR TITLE
feat!: Add name query parameter to ActionsService.ListArtifacts

### DIFF
--- a/github/actions_artifacts.go
+++ b/github/actions_artifacts.go
@@ -50,12 +50,22 @@ type ArtifactList struct {
 	Artifacts  []*Artifact `json:"artifacts,omitempty"`
 }
 
+// ListArtifactsOptions specifies the optional parameters to the
+// ActionsService.ListArtifacts method.
+type ListArtifactsOptions struct {
+	// Name represents the name field of an artifact.
+	// When specified, only artifacts with this name will be returned.
+	Name *string `url:"name,omitempty"`
+
+	ListOptions
+}
+
 // ListArtifacts lists all artifacts that belong to a repository.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/artifacts#list-artifacts-for-a-repository
 //
 //meta:operation GET /repos/{owner}/{repo}/actions/artifacts
-func (s *ActionsService) ListArtifacts(ctx context.Context, owner, repo string, opts *ListOptions) (*ArtifactList, *Response, error) {
+func (s *ActionsService) ListArtifacts(ctx context.Context, owner, repo string, opts *ListArtifactsOptions) (*ArtifactList, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/artifacts", owner, repo)
 	u, err := addOptions(u, opts)
 	if err != nil {

--- a/github/actions_artifacts_test.go
+++ b/github/actions_artifacts_test.go
@@ -22,7 +22,7 @@ func TestActionsService_ListArtifacts(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/actions/artifacts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testFormValues(t, r, values{"page": "2"})
+		testFormValues(t, r, values{"page": "2", "name": "TheArtifact"})
 		fmt.Fprint(w,
 			`{
 				"total_count":1,
@@ -31,7 +31,10 @@ func TestActionsService_ListArtifacts(t *testing.T) {
 		)
 	})
 
-	opts := &ListOptions{Page: 2}
+	opts := &ListArtifactsOptions{
+		Name:        String("TheArtifact"),
+		ListOptions: ListOptions{Page: 2},
+	}
 	ctx := context.Background()
 	artifacts, _, err := client.Actions.ListArtifacts(ctx, "o", "r", opts)
 	if err != nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11238,6 +11238,14 @@ func (l *ListAlertsOptions) GetState() string {
 	return *l.State
 }
 
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (l *ListArtifactsOptions) GetName() string {
+	if l == nil || l.Name == nil {
+		return ""
+	}
+	return *l.Name
+}
+
 // GetAppID returns the AppID field if it's non-nil, zero value otherwise.
 func (l *ListCheckRunsOptions) GetAppID() int64 {
 	if l == nil || l.AppID == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -14527,6 +14527,17 @@ func TestListAlertsOptions_GetState(tt *testing.T) {
 	l.GetState()
 }
 
+func TestListArtifactsOptions_GetName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	l := &ListArtifactsOptions{Name: &zeroValue}
+	l.GetName()
+	l = &ListArtifactsOptions{}
+	l.GetName()
+	l = nil
+	l.GetName()
+}
+
 func TestListCheckRunsOptions_GetAppID(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int64


### PR DESCRIPTION
Fixes: #3328.

BREAKING CHANGE: `opts` argument to `ActionsService.ListArtifacts` changed from `ListOptions` to `ListArtifactsOptions`.