### PR TITLE
feat!: Rename code scanning params from plural to singular

### DIFF
--- a/github/orgs_rules_test.go
+++ b/github/orgs_rules_test.go
@@ -301,7 +301,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoNames(t *testing.T) 
 				Pattern:  "github",
 			}),
 			NewRequiredCodeScanningRule(&RequiredCodeScanningRuleParameters{
-				RequiredCodeScanningTools: []*RuleRequiredCodeScanningTools{
+				RequiredCodeScanningTools: []*RuleRequiredCodeScanningTool{
 					{
 						Tool:                    "CodeQL",
 						SecurityAlertsThreshold: "high_or_higher",
@@ -396,7 +396,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoNames(t *testing.T) 
 				Pattern:  "github",
 			}),
 			NewRequiredCodeScanningRule(&RequiredCodeScanningRuleParameters{
-				RequiredCodeScanningTools: []*RuleRequiredCodeScanningTools{
+				RequiredCodeScanningTools: []*RuleRequiredCodeScanningTool{
 					{
 						Tool:                    "CodeQL",
 						SecurityAlertsThreshold: "high_or_higher",
@@ -660,7 +660,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoProperty(t *testing.
 				Pattern:  "github",
 			}),
 			NewRequiredCodeScanningRule(&RequiredCodeScanningRuleParameters{
-				RequiredCodeScanningTools: []*RuleRequiredCodeScanningTools{
+				RequiredCodeScanningTools: []*RuleRequiredCodeScanningTool{
 					{
 						Tool:                    "CodeQL",
 						SecurityAlertsThreshold: "high_or_higher",
@@ -762,7 +762,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoProperty(t *testing.
 				Pattern:  "github",
 			}),
 			NewRequiredCodeScanningRule(&RequiredCodeScanningRuleParameters{
-				RequiredCodeScanningTools: []*RuleRequiredCodeScanningTools{
+				RequiredCodeScanningTools: []*RuleRequiredCodeScanningTool{
 					{
 						Tool:                    "CodeQL",
 						SecurityAlertsThreshold: "high_or_higher",
@@ -1009,7 +1009,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoIDs(t *testing.T) {
 				Pattern:  "github",
 			}),
 			NewRequiredCodeScanningRule(&RequiredCodeScanningRuleParameters{
-				RequiredCodeScanningTools: []*RuleRequiredCodeScanningTools{
+				RequiredCodeScanningTools: []*RuleRequiredCodeScanningTool{
 					{
 						Tool:                    "CodeQL",
 						SecurityAlertsThreshold: "high_or_higher",
@@ -1102,7 +1102,7 @@ func TestOrganizationsService_CreateOrganizationRuleset_RepoIDs(t *testing.T) {
 				Pattern:  "github",
 			}),
 			NewRequiredCodeScanningRule(&RequiredCodeScanningRuleParameters{
-				RequiredCodeScanningTools: []*RuleRequiredCodeScanningTools{
+				RequiredCodeScanningTools: []*RuleRequiredCodeScanningTool{
 					{
 						Tool:                    "CodeQL",
 						SecurityAlertsThreshold: "high_or_higher",

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -159,8 +159,8 @@ type RequiredWorkflowsRuleParameters struct {
 	RequiredWorkflows    []*RuleRequiredWorkflow `json:"workflows"`
 }
 
-// RuleRequiredCodeScanningTools represents the RequiredCodeScanningTools for the RequiredCodeScanningParameters object.
-type RuleRequiredCodeScanningTools struct {
+// RuleRequiredCodeScanningTool represents the RequiredCodeScanningTools for the RequiredCodeScanningParameters object.
+type RuleRequiredCodeScanningTool struct {
 	AlertsThreshold         string `json:"alerts_threshold"`
 	SecurityAlertsThreshold string `json:"security_alerts_threshold"`
 	Tool                    string `json:"tool"`
@@ -168,7 +168,7 @@ type RuleRequiredCodeScanningTools struct {
 
 // RequiredCodeScanningRuleParameters represents the code_scanning rule parameters.
 type RequiredCodeScanningRuleParameters struct {
-	RequiredCodeScanningTools []*RuleRequiredCodeScanningTools `json:"code_scanning_tools"`
+	RequiredCodeScanningTools []*RuleRequiredCodeScanningTool `json:"code_scanning_tools"`
 }
 
 // RepositoryRule represents a GitHub Rule.

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -159,7 +159,7 @@ type RequiredWorkflowsRuleParameters struct {
 	RequiredWorkflows    []*RuleRequiredWorkflow `json:"workflows"`
 }
 
-// RuleRequiredCodeScanningTool represents the RequiredCodeScanningTools for the RequiredCodeScanningParameters object.
+// RuleRequiredCodeScanningTool represents a single required code-scanning tool for the RequiredCodeScanningParameters object.
 type RuleRequiredCodeScanningTool struct {
 	AlertsThreshold         string `json:"alerts_threshold"`
 	SecurityAlertsThreshold string `json:"security_alerts_threshold"`

--- a/github/repos_rules_test.go
+++ b/github/repos_rules_test.go
@@ -316,7 +316,7 @@ func TestRepositoryRule_UnmarshalJSON(t *testing.T) {
 		"Valid Required code_scanning params": {
 			data: `{"type":"code_scanning","parameters":{"code_scanning_tools":[{"tool": "CodeQL", "security_alerts_threshold": "high_or_higher", "alerts_threshold": "errors"}]}}`,
 			want: NewRequiredCodeScanningRule(&RequiredCodeScanningRuleParameters{
-				RequiredCodeScanningTools: []*RuleRequiredCodeScanningTools{
+				RequiredCodeScanningTools: []*RuleRequiredCodeScanningTool{
 					{
 						Tool:                    "CodeQL",
 						SecurityAlertsThreshold: "high_or_higher",


### PR DESCRIPTION
BREAKING CHANGE: Rename `RuleRequiredCodeScanningTools` to `RuleRequiredCodeScanningTool`.

Some improvements for #3256