### PR TITLE
Allow RemoveReviewers to remove only teams

### DIFF
--- a/github/pulls_reviewers.go
+++ b/github/pulls_reviewers.go
@@ -92,7 +92,7 @@ func (s *PullRequestsService) RemoveReviewers(ctx context.Context, owner, repo s
 	}
 
 	if removeRequest.Reviewers == nil {
-		// Github accepts the empty list, but rejects null. Removing `omitempty` is not enough - we also have to promote nil to [].
+		// GitHub accepts the empty list, but rejects null. Removing `omitempty` is not enough - we also have to promote nil to [].
 		removeRequest.Reviewers = []string{}
 	}
 

--- a/github/pulls_reviewers.go
+++ b/github/pulls_reviewers.go
@@ -23,6 +23,13 @@ type Reviewers struct {
 	Teams []*Team `json:"teams,omitempty"`
 }
 
+type removeReviewersRequest struct {
+	NodeID *string `json:"node_id,omitempty"`
+	// Note the lack of omitempty! See comment in RemoveReviewers.
+	Reviewers     []string `json:"reviewers"`
+	TeamReviewers []string `json:"team_reviewers,omitempty"`
+}
+
 // RequestReviewers creates a review request for the provided reviewers for the specified pull request.
 //
 // GitHub API docs: https://docs.github.com/rest/pulls/review-requests#request-reviewers-for-a-pull-request
@@ -76,8 +83,21 @@ func (s *PullRequestsService) ListReviewers(ctx context.Context, owner, repo str
 //
 //meta:operation DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
 func (s *PullRequestsService) RemoveReviewers(ctx context.Context, owner, repo string, number int, reviewers ReviewersRequest) (*Response, error) {
+	// reviewers.Reviewers may be empty if the caller wants to remove teams, but not users. Unlike AddReviewers,
+	// "reviewers" is a required param here. Reference: https://github.com/google/go-github/issues/3336
+	removeRequest := removeReviewersRequest{
+		NodeID:        reviewers.NodeID,
+		Reviewers:     reviewers.Reviewers,
+		TeamReviewers: reviewers.TeamReviewers,
+	}
+
+	if removeRequest.Reviewers == nil {
+		// Github accepts the empty list, but rejects null. Removing `omitempty` is not enough - we also have to promote nil to [].
+		removeRequest.Reviewers = []string{}
+	}
+
 	u := fmt.Sprintf("repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, number)
-	req, err := s.client.NewRequest("DELETE", u, &reviewers)
+	req, err := s.client.NewRequest("DELETE", u, &removeRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/github/pulls_reviewers_test.go
+++ b/github/pulls_reviewers_test.go
@@ -172,6 +172,27 @@ func TestRemoveReviewers(t *testing.T) {
 	})
 }
 
+func TestRemoveReviewers_teamsOnly(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/repos/o/r/pulls/1/requested_reviewers", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testBody(t, r, `{"reviewers":[],"team_reviewers":["justice-league"]}`+"\n")
+	})
+
+	ctx := context.Background()
+	_, err := client.PullRequests.RemoveReviewers(ctx, "o", "r", 1, ReviewersRequest{TeamReviewers: []string{"justice-league"}})
+	if err != nil {
+		t.Errorf("PullRequests.RemoveReviewers returned error: %v", err)
+	}
+
+	const methodName = "RemoveReviewers"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.PullRequests.RemoveReviewers(ctx, "o", "r", 1, ReviewersRequest{TeamReviewers: []string{"justice-league"}})
+	})
+}
+
 func TestListReviewers(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)


### PR DESCRIPTION
# What?
Fixes a [JSON marshaling problem](https://github.com/google/go-github/issues/3336#issuecomment-2438435830) that causes spurious 422s when calling RemoveReviewrs with `TeamReviewers` but no `Reviewers`.

# Background
The github API requires `"reviewers"`. It permits `"reviewers": []` but not `"reviewers": null`. Try it:

```
echo "Show the problem"
curl -L \                                                            
  -X DELETE \   
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer ${PAT}" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/${OWNER}/${REPO}/pulls/${NUMBER}/requested_reviewers \
  -d '{"team_reviewers":["the_senate"]}' 
{
  "message": "Invalid request.\n\n\"reviewers\" wasn't supplied.",
  "documentation_url": "https://docs.github.com/rest/pulls/review-requests#remove-requested-reviewers-from-a-pull-request",
  "status": "422"
}

echo "What if we just removed omitempty?"
curl -L \
  -X DELETE \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer ${PAT}" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/${OWNER}/${REPO}/pulls/${NUMBER}/requested_reviewers \
  -d '{"reviewers": null, "team_reviewers":["the_senate"]}'
{
  "message": "Invalid request.\n\nFor 'properties/reviewers', nil is not an array.",
  "documentation_url": "https://docs.github.com/rest/pulls/review-requests#remove-requested-reviewers-from-a-pull-request",
  "status": "422"
}

echo "Does the empty list work?"
curl -L \
  -X DELETE \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer ${PAT}" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/${OWNER}/${REPO}/pulls/${NUMBER}/requested_reviewers \
  -d '{"reviewers": [], "team_reviewers":["the_senate"]}'
{
  "url": ...<spam>,
```

# Testing?
There's a new unit test. Without the 2nd commit, it fails with:

```
    pulls_reviewers_test.go:181: request Body is {"team_reviewers":["justice-league"]}
        , want {"reviewers":[],"team_reviewers":["justice-league"]}
```