### PR TITLE
Add missing Deployment field to workflow_job event type

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -1787,6 +1787,7 @@ type WorkflowJobEvent struct {
 	Repo         *Repository   `json:"repository,omitempty"`
 	Sender       *User         `json:"sender,omitempty"`
 	Installation *Installation `json:"installation,omitempty"`
+	Deployment   *Deployment   `json:"deployment,omitempty"`
 }
 
 // WorkflowRunEvent is triggered when a GitHub Actions workflow run is requested or completed.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -26574,6 +26574,14 @@ func (w *WorkflowJobEvent) GetAction() string {
 	return *w.Action
 }
 
+// GetDeployment returns the Deployment field.
+func (w *WorkflowJobEvent) GetDeployment() *Deployment {
+	if w == nil {
+		return nil
+	}
+	return w.Deployment
+}
+
 // GetInstallation returns the Installation field.
 func (w *WorkflowJobEvent) GetInstallation() *Installation {
 	if w == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -34093,6 +34093,14 @@ func TestWorkflowJobEvent_GetAction(tt *testing.T) {
 	w.GetAction()
 }
 
+func TestWorkflowJobEvent_GetDeployment(tt *testing.T) {
+	tt.Parallel()
+	w := &WorkflowJobEvent{}
+	w.GetDeployment()
+	w = nil
+	w.GetDeployment()
+}
+
 func TestWorkflowJobEvent_GetInstallation(tt *testing.T) {
 	tt.Parallel()
 	w := &WorkflowJobEvent{}


### PR DESCRIPTION
The `workflow_job` webhook event as described by GitHub documentation contains a `deployment` object. 
https://docs.github.com/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_job

However, the struct that defines the `workflow_job `webhook event type is missing the `deployment` object . This PR adds the missing object to the `WorkflowJobEvent` type.