### PR TITLE
feat: Support resolution_comment to update alert API

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -23198,6 +23198,14 @@ func (s *SecretScanningAlertUpdateOptions) GetResolution() string {
 	return *s.Resolution
 }
 
+// GetResolutionComment returns the ResolutionComment field if it's non-nil, zero value otherwise.
+func (s *SecretScanningAlertUpdateOptions) GetResolutionComment() string {
+	if s == nil || s.ResolutionComment == nil {
+		return ""
+	}
+	return *s.ResolutionComment
+}
+
 // GetStatus returns the Status field if it's non-nil, zero value otherwise.
 func (s *SecretScanningPushProtection) GetStatus() string {
 	if s == nil || s.Status == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -29733,6 +29733,17 @@ func TestSecretScanningAlertUpdateOptions_GetResolution(tt *testing.T) {
 	s.GetResolution()
 }
 
+func TestSecretScanningAlertUpdateOptions_GetResolutionComment(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	s := &SecretScanningAlertUpdateOptions{ResolutionComment: &zeroValue}
+	s.GetResolutionComment()
+	s = &SecretScanningAlertUpdateOptions{}
+	s.GetResolutionComment()
+	s = nil
+	s.GetResolutionComment()
+}
+
 func TestSecretScanningPushProtection_GetStatus(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/secret_scanning.go
+++ b/github/secret_scanning.go
@@ -91,8 +91,6 @@ type SecretScanningAlertUpdateOptions struct {
 	Resolution *string `json:"resolution,omitempty"`
 
 	// An optional comment when closing an alert.
-	// Cannot be updated or deleted.
-	// Must be null when changing state to open.
 	ResolutionComment *string `json:"resolution_comment,omitempty"`
 }
 

--- a/github/secret_scanning.go
+++ b/github/secret_scanning.go
@@ -89,6 +89,11 @@ type SecretScanningAlertUpdateOptions struct {
 	// Required when the state is "resolved" and represents the reason for resolving the alert.
 	// Can be one of: "false_positive", "wont_fix", "revoked", or "used_in_tests".
 	Resolution *string `json:"resolution,omitempty"`
+
+	// An optional comment when closing an alert.
+	// Cannot be updated or deleted.
+	// Must be null when changing state to open.
+	ResolutionComment *string `json:"resolution_comment,omitempty"`
 }
 
 // ListAlertsForEnterprise lists secret scanning alerts for eligible repositories in an enterprise, from newest to oldest.

--- a/github/secret_scanning_test.go
+++ b/github/secret_scanning_test.go
@@ -359,7 +359,7 @@ func TestSecretScanningService_UpdateAlert(t *testing.T) {
 		v := new(SecretScanningAlertUpdateOptions)
 		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
 
-		want := &SecretScanningAlertUpdateOptions{State: "resolved", Resolution: String("used_in_tests")}
+		want := &SecretScanningAlertUpdateOptions{State: "resolved", Resolution: String("used_in_tests"), ResolutionComment: String("resolution comment")}
 
 		if !cmp.Equal(v, want) {
 			t.Errorf("Request body = %+v, want %+v", v, want)
@@ -373,6 +373,7 @@ func TestSecretScanningService_UpdateAlert(t *testing.T) {
 			"locations_url": "https://api.github.com/repos/o/r/secret-scanning/alerts/1/locations",
 			"state": "resolved",
 			"resolution": "used_in_tests",
+			"resolution_comment": "resolution comment",
 			"resolved_at": "1996-06-20T00:00:00Z",
 			"resolved_by": null,
 			"secret_type": "mailchimp_api_key",
@@ -381,7 +382,7 @@ func TestSecretScanningService_UpdateAlert(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	opts := &SecretScanningAlertUpdateOptions{State: "resolved", Resolution: String("used_in_tests")}
+	opts := &SecretScanningAlertUpdateOptions{State: "resolved", Resolution: String("used_in_tests"), ResolutionComment: String("resolution comment")}
 
 	alert, _, err := client.SecretScanning.UpdateAlert(ctx, "o", "r", 1, opts)
 	if err != nil {
@@ -390,17 +391,18 @@ func TestSecretScanningService_UpdateAlert(t *testing.T) {
 
 	date := Timestamp{time.Date(1996, time.June, 20, 00, 00, 00, 0, time.UTC)}
 	want := &SecretScanningAlert{
-		Number:       Int(1),
-		CreatedAt:    &date,
-		URL:          String("https://api.github.com/repos/o/r/secret-scanning/alerts/1"),
-		HTMLURL:      String("https://github.com/o/r/security/secret-scanning/1"),
-		LocationsURL: String("https://api.github.com/repos/o/r/secret-scanning/alerts/1/locations"),
-		State:        String("resolved"),
-		Resolution:   String("used_in_tests"),
-		ResolvedAt:   &date,
-		ResolvedBy:   nil,
-		SecretType:   String("mailchimp_api_key"),
-		Secret:       String("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-us2"),
+		Number:            Int(1),
+		CreatedAt:         &date,
+		URL:               String("https://api.github.com/repos/o/r/secret-scanning/alerts/1"),
+		HTMLURL:           String("https://github.com/o/r/security/secret-scanning/1"),
+		LocationsURL:      String("https://api.github.com/repos/o/r/secret-scanning/alerts/1/locations"),
+		State:             String("resolved"),
+		Resolution:        String("used_in_tests"),
+		ResolutionComment: String("resolution comment"),
+		ResolvedAt:        &date,
+		ResolvedBy:        nil,
+		SecretType:        String("mailchimp_api_key"),
+		Secret:            String("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-us2"),
 	}
 
 	if !cmp.Equal(alert, want) {


### PR DESCRIPTION
Support to an optional comment when closing an alert

Per the documentation available here:
https://docs.github.com/en/rest/secret-scanning/secret-scanning?apiVersion=2022-11-28#update-a-secret-scanning-alert