### PR TITLE
Fix: Preserve HTTP Response in URL Errors

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -841,6 +841,11 @@ func (c *Client) BareDo(ctx context.Context, req *http.Request) (*Response, erro
 	}
 
 	resp, err := c.client.Do(req)
+	var response *Response
+	if resp != nil {
+		response = newResponse(resp)
+	}
+
 	if err != nil {
 		// If we got an error, and the context has been canceled,
 		// the context's error is probably more useful.
@@ -854,14 +859,12 @@ func (c *Client) BareDo(ctx context.Context, req *http.Request) (*Response, erro
 		if e, ok := err.(*url.Error); ok {
 			if url, err := url.Parse(e.URL); err == nil {
 				e.URL = sanitizeURL(url).String()
-				return nil, e
 			}
+			return response, e
 		}
 
-		return nil, err
+		return response, err
 	}
-
-	response := newResponse(resp)
 
 	// Don't update the rate limits if this was a cached response.
 	// X-From-Cache is set by https://github.com/gregjones/httpcache

--- a/github/github.go
+++ b/github/github.go
@@ -851,7 +851,7 @@ func (c *Client) BareDo(ctx context.Context, req *http.Request) (*Response, erro
 		// the context's error is probably more useful.
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return response, ctx.Err()
 		default:
 		}
 

--- a/github/github.go
+++ b/github/github.go
@@ -859,8 +859,8 @@ func (c *Client) BareDo(ctx context.Context, req *http.Request) (*Response, erro
 		if e, ok := err.(*url.Error); ok {
 			if url, err := url.Parse(e.URL); err == nil {
 				e.URL = sanitizeURL(url).String()
+				return response, e
 			}
-			return response, e
 		}
 
 		return response, err

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1106,7 +1106,7 @@ func TestDo_redirectLoop(t *testing.T) {
 	}
 }
 
-func TestDo_preservesResponseInURLError(t *testing.T) {
+func TestDo_preservesResponseInHTTPError(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1106,6 +1106,27 @@ func TestDo_redirectLoop(t *testing.T) {
 	}
 }
 
+func TestDo_preservesResponseInURLError(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Not Found", http.StatusNotFound)
+	})
+
+	req, _ := client.NewRequest("GET", ".", nil)
+	resp, err := client.Do(context.Background(), req, nil)
+
+	if err == nil {
+		t.Fatal("Expected error to be returned")
+	}
+	if resp == nil {
+		t.Fatal("Expected response to be returned even with error")
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("Expected status code 404, got %d", resp.StatusCode)
+	}
+}
+
 // Test that an error caused by the internal http client's Do() function
 // does not leak the client secret.
 func TestDo_sanitizeURL(t *testing.T) {


### PR DESCRIPTION
Fix: Preserve HTTP Response in URL Errors

Fixes #3362

This PR improves error handling in the BareDo method to properly preserve HTTP response information when encountering *url.Error. Changes include:

- Move response creation earlier to avoid code duplication
- Add proper nil response handling
- Preserve HTTP response information in URL errors
- Add test case TestDo_preservesResponseInURLError

The changes allow users to access HTTP status codes (like 404) even when encountering URL errors.

This PR was created with help from Devin: https://preview.devin.ai/sessions/1b2f7ce6e3b44942b3ac1f518eac7c22