### PR TITLE
feat: Add assignment for org role associations

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -24358,6 +24358,14 @@ func (t *TaskStep) GetStatus() string {
 	return *t.Status
 }
 
+// GetAssignment returns the Assignment field if it's non-nil, zero value otherwise.
+func (t *Team) GetAssignment() string {
+	if t == nil || t.Assignment == nil {
+		return ""
+	}
+	return *t.Assignment
+}
+
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
 func (t *Team) GetDescription() string {
 	if t == nil || t.Description == nil {
@@ -25654,6 +25662,14 @@ func (u *UpdateRunnerGroupRequest) GetVisibility() string {
 	return *u.Visibility
 }
 
+// GetAssignment returns the Assignment field if it's non-nil, zero value otherwise.
+func (u *User) GetAssignment() string {
+	if u == nil || u.Assignment == nil {
+		return ""
+	}
+	return *u.Assignment
+}
+
 // GetAvatarURL returns the AvatarURL field if it's non-nil, zero value otherwise.
 func (u *User) GetAvatarURL() string {
 	if u == nil || u.AvatarURL == nil {
@@ -25796,6 +25812,14 @@ func (u *User) GetID() int64 {
 		return 0
 	}
 	return *u.ID
+}
+
+// GetInheritedFrom returns the InheritedFrom field.
+func (u *User) GetInheritedFrom() *Team {
+	if u == nil {
+		return nil
+	}
+	return u.InheritedFrom
 }
 
 // GetLdapDn returns the LdapDn field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -31190,6 +31190,17 @@ func TestTaskStep_GetStatus(tt *testing.T) {
 	t.GetStatus()
 }
 
+func TestTeam_GetAssignment(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	t := &Team{Assignment: &zeroValue}
+	t.GetAssignment()
+	t = &Team{}
+	t.GetAssignment()
+	t = nil
+	t.GetAssignment()
+}
+
 func TestTeam_GetDescription(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -32858,6 +32869,17 @@ func TestUpdateRunnerGroupRequest_GetVisibility(tt *testing.T) {
 	u.GetVisibility()
 }
 
+func TestUser_GetAssignment(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &User{Assignment: &zeroValue}
+	u.GetAssignment()
+	u = &User{}
+	u.GetAssignment()
+	u = nil
+	u.GetAssignment()
+}
+
 func TestUser_GetAvatarURL(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -33054,6 +33076,14 @@ func TestUser_GetID(tt *testing.T) {
 	u.GetID()
 	u = nil
 	u.GetID()
+}
+
+func TestUser_GetInheritedFrom(tt *testing.T) {
+	tt.Parallel()
+	u := &User{}
+	u.GetInheritedFrom()
+	u = nil
+	u.GetInheritedFrom()
 }
 
 func TestUser_GetLdapDn(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1974,8 +1974,9 @@ func TestTeam_String(t *testing.T) {
 		RepositoriesURL: String(""),
 		Parent:          &Team{},
 		LDAPDN:          String(""),
+		Assignment:      String(""),
 	}
-	want := `github.Team{ID:0, NodeID:"", Name:"", Description:"", URL:"", Slug:"", Permission:"", Privacy:"", MembersCount:0, ReposCount:0, Organization:github.Organization{}, HTMLURL:"", MembersURL:"", RepositoriesURL:"", Parent:github.Team{}, LDAPDN:""}`
+	want := `github.Team{ID:0, NodeID:"", Name:"", Description:"", URL:"", Slug:"", Permission:"", Privacy:"", MembersCount:0, ReposCount:0, Organization:github.Organization{}, HTMLURL:"", MembersURL:"", RepositoriesURL:"", Parent:github.Team{}, LDAPDN:"", Assignment:""}`
 	if got := v.String(); got != want {
 		t.Errorf("Team.String = %v, want %v", got, want)
 	}
@@ -2117,8 +2118,10 @@ func TestUser_String(t *testing.T) {
 		StarredURL:              String(""),
 		SubscriptionsURL:        String(""),
 		RoleName:                String(""),
+		Assignment:              String(""),
+		InheritedFrom:           &Team{},
 	}
-	want := `github.User{Login:"", ID:0, NodeID:"", AvatarURL:"", HTMLURL:"", GravatarID:"", Name:"", Company:"", Blog:"", Location:"", Email:"", Hireable:false, Bio:"", TwitterUsername:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, SuspendedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Type:"", SiteAdmin:false, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, TwoFactorAuthentication:false, Plan:github.Plan{}, LdapDn:"", URL:"", EventsURL:"", FollowingURL:"", FollowersURL:"", GistsURL:"", OrganizationsURL:"", ReceivedEventsURL:"", ReposURL:"", StarredURL:"", SubscriptionsURL:"", RoleName:""}`
+	want := `github.User{Login:"", ID:0, NodeID:"", AvatarURL:"", HTMLURL:"", GravatarID:"", Name:"", Company:"", Blog:"", Location:"", Email:"", Hireable:false, Bio:"", TwitterUsername:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, SuspendedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Type:"", SiteAdmin:false, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, TwoFactorAuthentication:false, Plan:github.Plan{}, LdapDn:"", URL:"", EventsURL:"", FollowingURL:"", FollowersURL:"", GistsURL:"", OrganizationsURL:"", ReceivedEventsURL:"", ReposURL:"", StarredURL:"", SubscriptionsURL:"", RoleName:"", Assignment:"", InheritedFrom:github.Team{}}`
 	if got := v.String(); got != want {
 		t.Errorf("User.String = %v, want %v", got, want)
 	}

--- a/github/teams.go
+++ b/github/teams.go
@@ -30,10 +30,6 @@ type Team struct {
 	// Permission specifies the default permission for repositories owned by the team.
 	Permission *string `json:"permission,omitempty"`
 
-	// Permissions identifies the permissions that a team has on a given
-	// repository. This is only populated when calling Repositories.ListTeams.
-	Permissions map[string]bool `json:"permissions,omitempty"`
-
 	// Privacy identifies the level of privacy this team should have.
 	// Possible values are:
 	//     secret - only visible to organization owners and members of this team
@@ -52,6 +48,15 @@ type Team struct {
 	// LDAPDN is only available in GitHub Enterprise and when the team
 	// membership is synchronized with LDAP.
 	LDAPDN *string `json:"ldap_dn,omitempty"`
+
+	// Permissions identifies the permissions that a team has on a given
+	// repository. This is only populated when calling Repositories.ListTeams.
+	Permissions map[string]bool `json:"permissions,omitempty"`
+
+	// Assignment identifies how a team was assigned to an organization role. Its
+	// possible values are: "direct", "indirect", "mixed". This is only populated when
+	// calling the ListTeamsAssignedToOrgRole method.
+	Assignment *string `json:"assignment,omitempty"`
 }
 
 func (t Team) String() string {

--- a/github/users.go
+++ b/github/users.go
@@ -70,6 +70,14 @@ type User struct {
 	// repository. These are only populated when calling Repositories.ListCollaborators.
 	Permissions map[string]bool `json:"permissions,omitempty"`
 	RoleName    *string         `json:"role_name,omitempty"`
+
+	// Assignment identifies how a user was assigned to an organization role. Its
+	// possible values are: "direct", "indirect", "mixed". This is only populated when
+	// calling the ListUsersAssignedToOrgRole method.
+	Assignment *string `json:"assignment,omitempty"`
+	// InheritedFrom identifies the team that a user inherited their organization role
+	// from. This is only populated when calling the ListUsersAssignedToOrgRole method.
+	InheritedFrom *Team `json:"inherited_from,omitempty"`
 }
 
 func (u User) String() string {


### PR DESCRIPTION
Resolves #3364

This PR adds the `Assignment` field to `Team` & `User` and the `InheritedFrom` field to `User` when accessed in the context of an organization role.