### PR TITLE
chore: Deprecate legacy ID-based team methods

### DIFF
--- a/github/teams.go
+++ b/github/teams.go
@@ -106,6 +106,8 @@ func (s *TeamsService) ListTeams(ctx context.Context, org string, opts *ListOpti
 
 // GetTeamByID fetches a team, given a specified organization ID, by ID.
 //
+// Deprecated: Use GetTeamBySlug instead.
+//
 // GitHub API docs: https://docs.github.com/rest/teams/teams#get-a-team-by-name
 //
 //meta:operation GET /orgs/{org}/teams/{team_slug}
@@ -232,6 +234,8 @@ func copyNewTeamWithoutParent(team *NewTeam) *newTeamNoParent {
 
 // EditTeamByID edits a team, given an organization ID, selected by ID.
 //
+// Deprecated: Use EditTeamBySlug instead.
+//
 // GitHub API docs: https://docs.github.com/rest/teams/teams#update-a-team
 //
 //meta:operation PATCH /orgs/{org}/teams/{team_slug}
@@ -290,6 +294,8 @@ func (s *TeamsService) EditTeamBySlug(ctx context.Context, org, slug string, tea
 
 // DeleteTeamByID deletes a team referenced by ID.
 //
+// Deprecated: Use DeleteTeamBySlug instead.
+//
 // GitHub API docs: https://docs.github.com/rest/teams/teams#delete-a-team
 //
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}
@@ -319,6 +325,8 @@ func (s *TeamsService) DeleteTeamBySlug(ctx context.Context, org, slug string) (
 }
 
 // ListChildTeamsByParentID lists child teams for a parent team given parent ID.
+//
+// Deprecated: Use ListChildTeamsByParentSlug instead.
 //
 // GitHub API docs: https://docs.github.com/rest/teams/teams#list-child-teams
 //
@@ -371,6 +379,8 @@ func (s *TeamsService) ListChildTeamsByParentSlug(ctx context.Context, org, slug
 }
 
 // ListTeamReposByID lists the repositories given a team ID that the specified team has access to.
+//
+// Deprecated: Use ListTeamReposBySlug instead.
 //
 // GitHub API docs: https://docs.github.com/rest/teams/teams#list-team-repositories
 //
@@ -431,6 +441,8 @@ func (s *TeamsService) ListTeamReposBySlug(ctx context.Context, org, slug string
 // IsTeamRepoByID checks if a team, given its ID, manages the specified repository. If the
 // repository is managed by team, a Repository is returned which includes the
 // permissions team has for that repo.
+//
+// Deprecated: Use IsTeamRepoBySlug instead.
 //
 // GitHub API docs: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-repository
 //
@@ -497,6 +509,8 @@ type TeamAddTeamRepoOptions struct {
 // The specified repository must be owned by the organization to which the team
 // belongs, or a direct fork of a repository owned by the organization.
 //
+// Deprecated: Use AddTeamRepoBySlug instead.
+//
 // GitHub API docs: https://docs.github.com/rest/teams/teams#add-or-update-team-repository-permissions
 //
 //meta:operation PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
@@ -530,6 +544,8 @@ func (s *TeamsService) AddTeamRepoBySlug(ctx context.Context, org, slug, owner, 
 // RemoveTeamRepoByID removes a repository from being managed by the specified
 // team given the team ID. Note that this does not delete the repository, it
 // just removes it from the team.
+//
+// Deprecated: Use RemoveTeamRepoBySlug instead.
 //
 // GitHub API docs: https://docs.github.com/rest/teams/teams#remove-a-repository-from-a-team
 //
@@ -589,6 +605,8 @@ func (s *TeamsService) ListUserTeams(ctx context.Context, opts *ListOptions) ([]
 
 // ListTeamProjectsByID lists the organization projects for a team given the team ID.
 //
+// Deprecated: Use ListTeamProjectsBySlug instead.
+//
 // GitHub API docs: https://docs.github.com/rest/teams/teams#list-team-projects
 //
 //meta:operation GET /orgs/{org}/teams/{team_slug}/projects
@@ -639,6 +657,8 @@ func (s *TeamsService) ListTeamProjectsBySlug(ctx context.Context, org, slug str
 
 // ReviewTeamProjectsByID checks whether a team, given its ID, has read, write, or admin
 // permissions for an organization project.
+//
+// Deprecated: Use ReviewTeamProjectsBySlug instead.
 //
 // GitHub API docs: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-project
 //
@@ -703,6 +723,8 @@ type TeamProjectOptions struct {
 // To add a project to a team or update the team's permission on a project, the
 // authenticated user must have admin permissions for the project.
 //
+// Deprecated: Use AddTeamProjectBySlug instead.
+//
 // GitHub API docs: https://docs.github.com/rest/teams/teams#add-or-update-team-project-permissions
 //
 //meta:operation PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}
@@ -745,6 +767,8 @@ func (s *TeamsService) AddTeamProjectBySlug(ctx context.Context, org, slug strin
 // must have "read" access to both the team and project, or "admin" access to the team
 // or project.
 // Note: This endpoint removes the project from the team, but does not delete it.
+//
+// Deprecated: Use RemoveTeamProjectBySlug instead.
 //
 // GitHub API docs: https://docs.github.com/rest/teams/teams#remove-a-project-from-a-team
 //
@@ -834,6 +858,8 @@ func (s *TeamsService) ListIDPGroupsInOrganization(ctx context.Context, org stri
 // ListIDPGroupsForTeamByID lists IDP groups connected to a team on GitHub
 // given organization and team IDs.
 //
+// Deprecated: Use ListIDPGroupsForTeamBySlug instead.
+//
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/teams/team-sync#list-idp-groups-for-a-team
 //
 //meta:operation GET /orgs/{org}/teams/{team_slug}/team-sync/group-mappings
@@ -879,6 +905,8 @@ func (s *TeamsService) ListIDPGroupsForTeamBySlug(ctx context.Context, org, slug
 
 // CreateOrUpdateIDPGroupConnectionsByID creates, updates, or removes a connection
 // between a team and an IDP group given organization and team IDs.
+//
+// Deprecated: Use CreateOrUpdateIDPGroupConnectionsBySlug instead.
 //
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/teams/team-sync#create-or-update-idp-group-connections
 //


### PR DESCRIPTION
Resolves #3368

This PR makes all legacy ID based team methods as deprecated based on the [closing down notice](https://docs.github.com/en/enterprise-cloud@latest/rest/teams/teams?apiVersion=2022-11-28#get-a-team-legacy).