### PR TITLE
Permit toggling rate limit check by consumers

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -801,7 +801,7 @@ func parseTokenExpiration(r *http.Response) Timestamp {
 type requestContext uint8
 
 const (
-	bypassRateLimitCheck requestContext = iota
+	BypassRateLimitCheck requestContext = iota
 	SleepUntilPrimaryRateLimitResetWhenRateLimited
 )
 
@@ -822,7 +822,7 @@ func (c *Client) BareDo(ctx context.Context, req *http.Request) (*Response, erro
 
 	rateLimitCategory := GetRateLimitCategory(req.Method, req.URL.Path)
 
-	if bypass := ctx.Value(bypassRateLimitCheck); bypass == nil {
+	if bypass := ctx.Value(BypassRateLimitCheck); bypass == nil {
 		// If we've hit rate limit, don't make further requests before Reset time.
 		if err := c.checkRateLimitBeforeDo(req, rateLimitCategory); err != nil {
 			return &Response{

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -231,7 +231,7 @@ func testNewRequestAndDoFailureCategory(t *testing.T, methodName string, client 
 	client.BaseURL.Path = "/api-v3/"
 	client.rateLimits[category].Reset.Time = time.Now().Add(10 * time.Minute)
 	resp, err = f()
-	if bypass := resp.Request.Context().Value(bypassRateLimitCheck); bypass != nil {
+	if bypass := resp.Request.Context().Value(BypassRateLimitCheck); bypass != nil {
 		return
 	}
 	if want := http.StatusForbidden; resp == nil || resp.Response.StatusCode != want {

--- a/github/rate_limit.go
+++ b/github/rate_limit.go
@@ -77,7 +77,7 @@ func (s *RateLimitService) Get(ctx context.Context) (*RateLimits, *Response, err
 	})
 
 	// This resource is not subject to rate limits.
-	ctx = context.WithValue(ctx, bypassRateLimitCheck, true)
+	ctx = context.WithValue(ctx, BypassRateLimitCheck, true)
 	resp, err := s.client.Do(ctx, req, response)
 	if err != nil {
 		return nil, resp, err


### PR DESCRIPTION
Export `BypassRateLimitCheck` to allow toggling of rate limit checks by consumers.

I am handling rate-limited retries with my own RoundTripper, and the built-in checks are preventing me from doing so because it simply errors early instead of attempting a request and handling backoff separately.