### PR TITLE
Make NewClientWithEnvProxy Deprecated

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -468,6 +468,7 @@ func (c *Client) copy() *Client {
 }
 
 // NewClientWithEnvProxy enhances NewClient with the HttpProxy env.
+// Deprecated: Use NewClient(nil) instead.
 func NewClientWithEnvProxy() *Client {
 	return NewClient(&http.Client{Transport: &http.Transport{Proxy: http.ProxyFromEnvironment}})
 }


### PR DESCRIPTION
The former pr: https://github.com/google/go-github/pull/2686

As this issue https://github.com/google/go-github/issues/2898 says `NewClientWithEnvProxy` is redundant with `NewClient(nil)`.

```
var DefaultTransport RoundTripper = &Transport{
	Proxy: ProxyFromEnvironment,
	DialContext: defaultTransportDialContext(&net.Dialer{
		Timeout:   30 * time.Second,
		KeepAlive: 30 * time.Second,
	}),
	ForceAttemptHTTP2:     true,
	MaxIdleConns:          100,
	IdleConnTimeout:       90 * time.Second,
	TLSHandshakeTimeout:   10 * time.Second,
	ExpectContinueTimeout: 1 * time.Second,
}
```
