### PR TITLE
refactor: Change header keys to be canonical

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
   timeout: 10m
 linters:
   enable:
+    - canonicalheader
     - dogsled
     - dupl
     - gocritic

--- a/github/github.go
+++ b/github/github.go
@@ -35,14 +35,14 @@ const (
 	defaultUserAgent  = "go-github" + "/" + Version
 	uploadBaseURL     = "https://uploads.github.com/"
 
-	headerAPIVersion    = "X-GitHub-Api-Version"
-	headerRateLimit     = "X-RateLimit-Limit"
-	headerRateRemaining = "X-RateLimit-Remaining"
-	headerRateReset     = "X-RateLimit-Reset"
-	headerOTP           = "X-GitHub-OTP"
+	headerAPIVersion    = "X-Github-Api-Version"
+	headerRateLimit     = "X-Ratelimit-Limit"
+	headerRateRemaining = "X-Ratelimit-Remaining"
+	headerRateReset     = "X-Ratelimit-Reset"
+	headerOTP           = "X-Github-Otp"
 	headerRetryAfter    = "Retry-After"
 
-	headerTokenExpiration = "GitHub-Authentication-Token-Expiration"
+	headerTokenExpiration = "Github-Authentication-Token-Expiration"
 
 	mediaTypeV3                = "application/vnd.github.v3+json"
 	defaultMediaType           = "application/octet-stream"


### PR DESCRIPTION
The PR enables the `canonicalheader` linter and changes header key strings to be in canonical form.

This is needed because canonical header keys don't need to be converted to a canonical form via [http.CanonicalHeaderKey](https://pkg.go.dev/net/http#CanonicalHeaderKey), leading to fewer allocations when adding, setting or getting a header.

<details>
<summary>Benchmarks</summary>

```go
func BenchmarkCanonical(b *testing.B) {
	v := http.Header{
		"Canonical-Header": []string{"hello_world"},
	}
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		s := v.Get("Canonical-Header")
		if s != "hello_world" {
			b.Fatal()
		}
	}
}

func BenchmarkNonCanonical(b *testing.B) {
	v := http.Header{
		"Canonical-Header": []string{"hello_world"},
	}
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		s := v.Get("CANONICAL-HEADER")
		if s != "hello_world" {
			b.Fatal()
		}
	}
}
```

```
goos: darwin
goarch: arm64
pkg: github.com/lasiar/canonicalheader
cpu: Apple M1 Pro
BenchmarkNonCanonical
BenchmarkNonCanonical-8   	 1407914	       848.2 ns/op	      16 B/op	       1 allocs/op
BenchmarkCanonical
BenchmarkCanonical-8         11176232	       107.7 ns/op	       0 B/op	       0 allocs/op
PASS
```

</details>