### PR TITLE
chore: Sort std imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
   enable:
     - dogsled
     - dupl
+    - gci
     - gocritic
     - godot
     - gofmt

--- a/github/orgs_codesecurity_configurations_test.go
+++ b/github/orgs_codesecurity_configurations_test.go
@@ -7,12 +7,11 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
-
-	"encoding/json"
 )
 
 func TestOrganizationsService_GetCodeSecurityConfigurations(t *testing.T) {


### PR DESCRIPTION
This is found with `gci`, so I enabled this linter in golangci-lint's config.