### PR TITLE
fix: DownloadReleaseAsset handles renamed repository

### DIFF
--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -333,9 +333,10 @@ func (s *RepositoriesService) GetReleaseAsset(ctx context.Context, owner, repo s
 // of the io.ReadCloser. Exactly one of rc and redirectURL will be zero.
 //
 // followRedirectsClient can be passed to download the asset from a redirected
-// location. Passing http.DefaultClient is recommended unless special circumstances
-// exist, but it's possible to pass any http.Client. If nil is passed the
-// redirectURL will be returned instead.
+// location. Specifying any http.Client is possible, but passing http.DefaultClient
+// is recommended, except when the specified repository is private, in which case
+// it's necessary to pass an http.Client that performs authenticated requests.
+// If nil is passed the redirectURL will be returned instead.
 //
 // GitHub API docs: https://docs.github.com/rest/releases/assets#get-a-release-asset
 //

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -387,7 +387,7 @@ func (s *RepositoriesService) downloadReleaseAssetFromURL(ctx context.Context, f
 		return nil, err
 	}
 	req = withContext(ctx, req)
-	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Accept", defaultMediaType)
 	resp, err := followRedirectsClient.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes issue #3081, such that `Repositories.DownloadReleaseAsset` correctly handles scenarios where a non-`nil` `followRedirectsClient` argument has been passed, and the specified repository has been renamed to a new name.

Previously, in such scenarios...

1. The initial `GET /repos/<OWNER>/<REPO>/releases/assets/<ASSET ID>` responds 301 w/ a `Location: <GH API HOST>/repositories/<REPO ID>/releases/assets/<ASSET ID>`.
2. The `followRedirectsClient` issues a `GET <GH API HOST>/repositories/<REPO ID>/releases/assets/<ASSET ID>` with a `Accept: */*` header.
3. `GET <GH API HOST>/repositories/<REPO ID>/releases/assets/<ASSET ID>` responds 200 with a JSON response body (rather than 302 w/ a `Location: <MEDIA SERVER ASSET URL>` header) due to the presence of the `Accept: */*` header (and the absence of a `Accept: application/octet-stream` header) from step 2.

The following `curl` offers an example of correct redirect follows & correct `Accept: application/octet-stream`-preservation in this scenario:

```
curl \
  --verbose \
  --location \
  --header "Accept: application/octet-stream" \
  https://api.github.com/repos/mterwill/go-github-issue-demo/releases/assets/151970555
```

Now, as per this change:

1. The initial `GET /repos/<OWNER>/<REPO>/releases/assets/<ASSET ID>` responds 301 w/ a `Location: <GH API HOST>/repositories/<REPO ID>/releases/assets/<ASSET ID>`.
2. The `followRedirectsClient` issues a `GET <GH API HOST>/repositories/<REPO ID>/releases/assets/<ASSET ID>` with a `Accept: application/octet-stream` header [as required by the GH API](https://docs.github.com/en/enterprise-cloud@latest/rest/releases/assets?apiVersion=2022-11-28).
3. `GET <GH API HOST>/repositories/<REPO ID>/releases/assets/<ASSET ID>` responds 302 w/ a `Location: <MEDIA SERVER ASSET URL>`.
4. The `followRedirectsClient` follows the redirects to `GET <MEDIA SERVER ASSET URL>` w/ a `Accept: application/octet-stream` header, and `GET <MEDIA SERVER ASSET URL>` responds 200 w/ the asset contents.