### PR TITLE
fix!: Remove unused `Stats` field from  `Commit` struct

### DIFF
--- a/github/git_commits.go
+++ b/github/git_commits.go
@@ -49,7 +49,6 @@ type Commit struct {
 	Message      *string                `json:"message,omitempty"`
 	Tree         *Tree                  `json:"tree,omitempty"`
 	Parents      []*Commit              `json:"parents,omitempty"`
-	Stats        *CommitStats           `json:"stats,omitempty"`
 	HTMLURL      *string                `json:"html_url,omitempty"`
 	URL          *string                `json:"url,omitempty"`
 	Verification *SignatureVerification `json:"verification,omitempty"`

--- a/github/git_commits_test.go
+++ b/github/git_commits_test.go
@@ -71,11 +71,6 @@ func TestCommit_Marshal(t *testing.T) {
 			Truncated: Ptr(false),
 		},
 		Parents: nil,
-		Stats: &CommitStats{
-			Additions: Ptr(1),
-			Deletions: Ptr(1),
-			Total:     Ptr(1),
-		},
 		HTMLURL: Ptr("h"),
 		URL:     Ptr("u"),
 		Verification: &SignatureVerification{
@@ -117,11 +112,6 @@ func TestCommit_Marshal(t *testing.T) {
 				}
 			],
 			"truncated": false
-		},
-		"stats": {
-			"additions": 1,
-			"deletions": 1,
-			"total": 1
 		},
 		"html_url": "h",
 		"url": "u",

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -3542,14 +3542,6 @@ func (c *Commit) GetSHA() string {
 	return *c.SHA
 }
 
-// GetStats returns the Stats field.
-func (c *Commit) GetStats() *CommitStats {
-	if c == nil {
-		return nil
-	}
-	return c.Stats
-}
-
 // GetTree returns the Tree field.
 func (c *Commit) GetTree() *Tree {
 	if c == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -4614,14 +4614,6 @@ func TestCommit_GetSHA(tt *testing.T) {
 	c.GetSHA()
 }
 
-func TestCommit_GetStats(tt *testing.T) {
-	tt.Parallel()
-	c := &Commit{}
-	c.GetStats()
-	c = nil
-	c.GetStats()
-}
-
 func TestCommit_GetTree(tt *testing.T) {
 	tt.Parallel()
 	c := &Commit{}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -283,14 +283,13 @@ func TestCommit_String(t *testing.T) {
 		Committer:    &CommitAuthor{},
 		Message:      Ptr(""),
 		Tree:         &Tree{},
-		Stats:        &CommitStats{},
 		HTMLURL:      Ptr(""),
 		URL:          Ptr(""),
 		Verification: &SignatureVerification{},
 		NodeID:       Ptr(""),
 		CommentCount: Ptr(0),
 	}
-	want := `github.Commit{SHA:"", Author:github.CommitAuthor{}, Committer:github.CommitAuthor{}, Message:"", Tree:github.Tree{}, Stats:github.CommitStats{}, HTMLURL:"", URL:"", Verification:github.SignatureVerification{}, NodeID:"", CommentCount:0}`
+	want := `github.Commit{SHA:"", Author:github.CommitAuthor{}, Committer:github.CommitAuthor{}, Message:"", Tree:github.Tree{}, HTMLURL:"", URL:"", Verification:github.SignatureVerification{}, NodeID:"", CommentCount:0}`
 	if got := v.String(); got != want {
 		t.Errorf("Commit.String = %v, want %v", got, want)
 	}

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -714,11 +714,6 @@ func TestBranchCommit_Marshal(t *testing.T) {
 				Truncated: Ptr(false),
 			},
 			Parents: nil,
-			Stats: &CommitStats{
-				Additions: Ptr(1),
-				Deletions: Ptr(1),
-				Total:     Ptr(1),
-			},
 			HTMLURL: Ptr("h"),
 			URL:     Ptr("u"),
 			Verification: &SignatureVerification{
@@ -764,11 +759,6 @@ func TestBranchCommit_Marshal(t *testing.T) {
 					}
 				],
 				"truncated": false
-			},
-			"stats": {
-				"additions": 1,
-				"deletions": 1,
-				"total": 1
 			},
 			"html_url": "h",
 			"url": "u",

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -894,11 +894,6 @@ func TestRepositoryContentResponse_Marshal(t *testing.T) {
 				Truncated: Ptr(false),
 			},
 			Parents: nil,
-			Stats: &CommitStats{
-				Additions: Ptr(1),
-				Deletions: Ptr(1),
-				Total:     Ptr(1),
-			},
 			HTMLURL: Ptr("h"),
 			URL:     Ptr("u"),
 			Verification: &SignatureVerification{
@@ -957,11 +952,6 @@ func TestRepositoryContentResponse_Marshal(t *testing.T) {
 					}
 				],
 				"truncated": false
-			},
-			"stats": {
-				"additions": 1,
-				"deletions": 1,
-				"total": 1
 			},
 			"html_url": "h",
 			"url": "u",


### PR DESCRIPTION
BREAKING CHANGE: The unused `Stats` field is removed from the `Commit` struct.

This field appears to never be populated throughout the codebase.

Closes #3394