### PR TITLE
Update PersonalAccessToken struct

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -15342,12 +15342,28 @@ func (p *PersonalAccessToken) GetTokenExpiresAt() Timestamp {
 	return *p.TokenExpiresAt
 }
 
+// GetTokenID returns the TokenID field if it's non-nil, zero value otherwise.
+func (p *PersonalAccessToken) GetTokenID() int64 {
+	if p == nil || p.TokenID == nil {
+		return 0
+	}
+	return *p.TokenID
+}
+
 // GetTokenLastUsedAt returns the TokenLastUsedAt field if it's non-nil, zero value otherwise.
 func (p *PersonalAccessToken) GetTokenLastUsedAt() Timestamp {
 	if p == nil || p.TokenLastUsedAt == nil {
 		return Timestamp{}
 	}
 	return *p.TokenLastUsedAt
+}
+
+// GetTokenName returns the TokenName field if it's non-nil, zero value otherwise.
+func (p *PersonalAccessToken) GetTokenName() string {
+	if p == nil || p.TokenName == nil {
+		return ""
+	}
+	return *p.TokenName
 }
 
 // GetOrg returns the Org map if it's non-nil, an empty map otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -19849,6 +19849,17 @@ func TestPersonalAccessToken_GetTokenExpiresAt(tt *testing.T) {
 	p.GetTokenExpiresAt()
 }
 
+func TestPersonalAccessToken_GetTokenID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int64
+	p := &PersonalAccessToken{TokenID: &zeroValue}
+	p.GetTokenID()
+	p = &PersonalAccessToken{}
+	p.GetTokenID()
+	p = nil
+	p.GetTokenID()
+}
+
 func TestPersonalAccessToken_GetTokenLastUsedAt(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp
@@ -19858,6 +19869,17 @@ func TestPersonalAccessToken_GetTokenLastUsedAt(tt *testing.T) {
 	p.GetTokenLastUsedAt()
 	p = nil
 	p.GetTokenLastUsedAt()
+}
+
+func TestPersonalAccessToken_GetTokenName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PersonalAccessToken{TokenName: &zeroValue}
+	p.GetTokenName()
+	p = &PersonalAccessToken{}
+	p.GetTokenName()
+	p = nil
+	p.GetTokenName()
 }
 
 func TestPersonalAccessTokenPermissions_GetOrg(tt *testing.T) {

--- a/github/orgs_personal_access_tokens.go
+++ b/github/orgs_personal_access_tokens.go
@@ -44,6 +44,12 @@ type PersonalAccessToken struct {
 	// Date and time when the associated fine-grained personal access token expires.
 	TokenExpiresAt *Timestamp `json:"token_expires_at"`
 
+	// TokenID
+	TokenID *int64 `json:"token_id"`
+
+	// TokenName
+	TokenName *string `json:"token_name"`
+
 	// Date and time when the associated fine-grained personal access token was last used for authentication.
 	TokenLastUsedAt *Timestamp `json:"token_last_used_at"`
 }


### PR DESCRIPTION
According to REST API: https://docs.github.com/en/rest/orgs/personal-access-tokens?apiVersion=2022-11-28#list-fine-grained-personal-access-tokens-with-access-to-organization-resources

There are some fields which are not getting captured by PersonalAccessToken struct. The fields are:

token_id
token_name

For issue: https://github.com/google/go-github/issues/3403