### PR TITLE
Add opt-in rate limit support on endpoints returning 302s

### DIFF
--- a/github/actions_artifacts.go
+++ b/github/actions_artifacts.go
@@ -142,6 +142,14 @@ func (s *ActionsService) GetArtifact(ctx context.Context, owner, repo string, ar
 func (s *ActionsService) DownloadArtifact(ctx context.Context, owner, repo string, artifactID int64, maxRedirects int) (*url.URL, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/artifacts/%v/zip", owner, repo, artifactID)
 
+	if s.client.RateLimitRedirectionalEndpoints {
+		return s.downloadArtifactWithRateLimit(ctx, u, maxRedirects)
+	}
+
+	return s.downloadArtifactWithoutRateLimit(ctx, u, maxRedirects)
+}
+
+func (s *ActionsService) downloadArtifactWithoutRateLimit(ctx context.Context, u string, maxRedirects int) (*url.URL, *Response, error) {
 	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, maxRedirects)
 	if err != nil {
 		return nil, nil, err
@@ -158,6 +166,26 @@ func (s *ActionsService) DownloadArtifact(ctx context.Context, owner, repo strin
 	}
 
 	return parsedURL, newResponse(resp), nil
+}
+
+func (s *ActionsService) downloadArtifactWithRateLimit(ctx context.Context, u string, maxRedirects int) (*url.URL, *Response, error) {
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	url, resp, err := s.client.bareDoUntilFound(ctx, req, maxRedirects)
+	if err != nil {
+		return nil, resp, err
+	}
+	defer resp.Body.Close()
+
+	// If we received a valid Location in a 302 response
+	if url != nil {
+		return url, resp, nil
+	}
+
+	return nil, resp, fmt.Errorf("unexpected status code: %s", resp.Status)
 }
 
 // DeleteArtifact deletes a workflow run artifact.

--- a/github/actions_artifacts.go
+++ b/github/actions_artifacts.go
@@ -157,7 +157,7 @@ func (s *ActionsService) downloadArtifactWithoutRateLimit(ctx context.Context, u
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusFound {
-		return nil, newResponse(resp), fmt.Errorf("unexpected status code: %s", resp.Status)
+		return nil, newResponse(resp), fmt.Errorf("unexpected status code: %v", resp.Status)
 	}
 
 	parsedURL, err := url.Parse(resp.Header.Get("Location"))
@@ -180,12 +180,12 @@ func (s *ActionsService) downloadArtifactWithRateLimit(ctx context.Context, u st
 	}
 	defer resp.Body.Close()
 
-	// If we received a valid Location in a 302 response
-	if url != nil {
-		return url, resp, nil
+	// If we didn't receive a valid Location in a 302 response
+	if url == nil {
+		return nil, resp, fmt.Errorf("unexpected status code: %v", resp.Status)
 	}
 
-	return nil, resp, fmt.Errorf("unexpected status code: %s", resp.Status)
+	return url, resp, nil
 }
 
 // DeleteArtifact deletes a workflow run artifact.

--- a/github/actions_artifacts_test.go
+++ b/github/actions_artifacts_test.go
@@ -272,102 +272,210 @@ func TestActionsService_GetArtifact_notFound(t *testing.T) {
 
 func TestActionsService_DownloadArtifact(t *testing.T) {
 	t.Parallel()
-	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/actions/artifacts/1/zip", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		http.Redirect(w, r, "https://github.com/artifact", http.StatusFound)
-	})
-
-	ctx := context.Background()
-	url, resp, err := client.Actions.DownloadArtifact(ctx, "o", "r", 1, 1)
-	if err != nil {
-		t.Errorf("Actions.DownloadArtifact returned error: %v", err)
-	}
-	if resp.StatusCode != http.StatusFound {
-		t.Errorf("Actions.DownloadArtifact returned status: %d, want %d", resp.StatusCode, http.StatusFound)
-	}
-
-	want := "https://github.com/artifact"
-	if url.String() != want {
-		t.Errorf("Actions.DownloadArtifact returned %+v, want %+v", url.String(), want)
+	tcs := []struct {
+		name              string
+		respectRateLimits bool
+	}{
+		{
+			name:              "withoutRateLimits",
+			respectRateLimits: false,
+		},
+		{
+			name:              "withRateLimits",
+			respectRateLimits: true,
+		},
 	}
 
-	const methodName = "DownloadArtifact"
-	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.DownloadArtifact(ctx, "\n", "\n", -1, 1)
-		return err
-	})
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client, mux, _ := setup(t)
+			client.RateLimitRedirectionalEndpoints = tc.respectRateLimits
 
-	// Add custom round tripper
-	client.client.Transport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-		return nil, errors.New("failed to download artifact")
-	})
-	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.DownloadArtifact(ctx, "o", "r", 1, 1)
-		return err
-	})
+			mux.HandleFunc("/repos/o/r/actions/artifacts/1/zip", func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "GET")
+				http.Redirect(w, r, "https://github.com/artifact", http.StatusFound)
+			})
+
+			ctx := context.Background()
+			url, resp, err := client.Actions.DownloadArtifact(ctx, "o", "r", 1, 1)
+			if err != nil {
+				t.Errorf("Actions.DownloadArtifact returned error: %v", err)
+			}
+			if resp.StatusCode != http.StatusFound {
+				t.Errorf("Actions.DownloadArtifact returned status: %d, want %d", resp.StatusCode, http.StatusFound)
+			}
+
+			want := "https://github.com/artifact"
+			if url.String() != want {
+				t.Errorf("Actions.DownloadArtifact returned %+v, want %+v", url.String(), want)
+			}
+
+			const methodName = "DownloadArtifact"
+			testBadOptions(t, methodName, func() (err error) {
+				_, _, err = client.Actions.DownloadArtifact(ctx, "\n", "\n", -1, 1)
+				return err
+			})
+
+			// Add custom round tripper
+			client.client.Transport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				return nil, errors.New("failed to download artifact")
+			})
+			// propagate custom round tripper to client without CheckRedirect
+			client.initialize()
+			testBadOptions(t, methodName, func() (err error) {
+				_, _, err = client.Actions.DownloadArtifact(ctx, "o", "r", 1, 1)
+				return err
+			})
+		})
+	}
 }
 
 func TestActionsService_DownloadArtifact_invalidOwner(t *testing.T) {
 	t.Parallel()
-	client, _, _ := setup(t)
+	tcs := []struct {
+		name              string
+		respectRateLimits bool
+	}{
+		{
+			name:              "withoutRateLimits",
+			respectRateLimits: false,
+		},
+		{
+			name:              "withRateLimits",
+			respectRateLimits: true,
+		},
+	}
 
-	ctx := context.Background()
-	_, _, err := client.Actions.DownloadArtifact(ctx, "%", "r", 1, 1)
-	testURLParseError(t, err)
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client, _, _ := setup(t)
+			client.RateLimitRedirectionalEndpoints = tc.respectRateLimits
+
+			ctx := context.Background()
+			_, _, err := client.Actions.DownloadArtifact(ctx, "%", "r", 1, 1)
+			testURLParseError(t, err)
+		})
+	}
 }
 
 func TestActionsService_DownloadArtifact_invalidRepo(t *testing.T) {
 	t.Parallel()
-	client, _, _ := setup(t)
+	tcs := []struct {
+		name              string
+		respectRateLimits bool
+	}{
+		{
+			name:              "withoutRateLimits",
+			respectRateLimits: false,
+		},
+		{
+			name:              "withRateLimits",
+			respectRateLimits: true,
+		},
+	}
 
-	ctx := context.Background()
-	_, _, err := client.Actions.DownloadArtifact(ctx, "o", "%", 1, 1)
-	testURLParseError(t, err)
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client, _, _ := setup(t)
+			client.RateLimitRedirectionalEndpoints = tc.respectRateLimits
+
+			ctx := context.Background()
+			_, _, err := client.Actions.DownloadArtifact(ctx, "o", "%", 1, 1)
+			testURLParseError(t, err)
+		})
+	}
 }
 
 func TestActionsService_DownloadArtifact_StatusMovedPermanently_dontFollowRedirects(t *testing.T) {
 	t.Parallel()
-	client, mux, _ := setup(t)
+	tcs := []struct {
+		name              string
+		respectRateLimits bool
+	}{
+		{
+			name:              "withoutRateLimits",
+			respectRateLimits: false,
+		},
+		{
+			name:              "withRateLimits",
+			respectRateLimits: true,
+		},
+	}
 
-	mux.HandleFunc("/repos/o/r/actions/artifacts/1/zip", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		http.Redirect(w, r, "https://github.com/artifact", http.StatusMovedPermanently)
-	})
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client, mux, _ := setup(t)
+			client.RateLimitRedirectionalEndpoints = tc.respectRateLimits
 
-	ctx := context.Background()
-	_, resp, _ := client.Actions.DownloadArtifact(ctx, "o", "r", 1, 0)
-	if resp.StatusCode != http.StatusMovedPermanently {
-		t.Errorf("Actions.DownloadArtifact return status %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
+			mux.HandleFunc("/repos/o/r/actions/artifacts/1/zip", func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "GET")
+				http.Redirect(w, r, "https://github.com/artifact", http.StatusMovedPermanently)
+			})
+
+			ctx := context.Background()
+			_, resp, _ := client.Actions.DownloadArtifact(ctx, "o", "r", 1, 0)
+			if resp.StatusCode != http.StatusMovedPermanently {
+				t.Errorf("Actions.DownloadArtifact return status %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
+			}
+		})
 	}
 }
 
 func TestActionsService_DownloadArtifact_StatusMovedPermanently_followRedirects(t *testing.T) {
 	t.Parallel()
-	client, mux, serverURL := setup(t)
-
-	mux.HandleFunc("/repos/o/r/actions/artifacts/1/zip", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		redirectURL, _ := url.Parse(serverURL + baseURLPath + "/redirect")
-		http.Redirect(w, r, redirectURL.String(), http.StatusMovedPermanently)
-	})
-	mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		http.Redirect(w, r, "http://github.com/artifact", http.StatusFound)
-	})
-
-	ctx := context.Background()
-	url, resp, err := client.Actions.DownloadArtifact(ctx, "o", "r", 1, 1)
-	if err != nil {
-		t.Errorf("Actions.DownloadArtifact return error: %v", err)
+	tcs := []struct {
+		name              string
+		respectRateLimits bool
+	}{
+		{
+			name:              "withoutRateLimits",
+			respectRateLimits: false,
+		},
+		{
+			name:              "withRateLimits",
+			respectRateLimits: true,
+		},
 	}
-	if resp.StatusCode != http.StatusFound {
-		t.Errorf("Actions.DownloadArtifact return status %d, want %d", resp.StatusCode, http.StatusFound)
-	}
-	want := "http://github.com/artifact"
-	if url.String() != want {
-		t.Errorf("Actions.DownloadArtifact returned %+v, want %+v", url.String(), want)
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client, mux, serverURL := setup(t)
+			client.RateLimitRedirectionalEndpoints = tc.respectRateLimits
+
+			mux.HandleFunc("/repos/o/r/actions/artifacts/1/zip", func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "GET")
+				redirectURL, _ := url.Parse(serverURL + baseURLPath + "/redirect")
+				http.Redirect(w, r, redirectURL.String(), http.StatusMovedPermanently)
+			})
+			mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "GET")
+				http.Redirect(w, r, "http://github.com/artifact", http.StatusFound)
+			})
+
+			ctx := context.Background()
+			url, resp, err := client.Actions.DownloadArtifact(ctx, "o", "r", 1, 1)
+			if err != nil {
+				t.Errorf("Actions.DownloadArtifact return error: %v", err)
+			}
+			if resp.StatusCode != http.StatusFound {
+				t.Errorf("Actions.DownloadArtifact return status %d, want %d", resp.StatusCode, http.StatusFound)
+			}
+			want := "http://github.com/artifact"
+			if url.String() != want {
+				t.Errorf("Actions.DownloadArtifact returned %+v, want %+v", url.String(), want)
+			}
+		})
 	}
 }
 

--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -165,7 +165,7 @@ func (s *ActionsService) getWorkflowJobLogsWithoutRateLimit(ctx context.Context,
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusFound {
-		return nil, newResponse(resp), fmt.Errorf("unexpected status code: %s", resp.Status)
+		return nil, newResponse(resp), fmt.Errorf("unexpected status code: %v", resp.Status)
 	}
 
 	parsedURL, err := url.Parse(resp.Header.Get("Location"))
@@ -184,10 +184,10 @@ func (s *ActionsService) getWorkflowJobLogsWithRateLimit(ctx context.Context, u 
 	}
 	defer resp.Body.Close()
 
-	// If we received a valid Location in a 302 response
-	if url != nil {
-		return url, resp, nil
+	// If we didn't receive a valid Location in a 302 response
+	if url == nil {
+		return nil, resp, fmt.Errorf("unexpected status code: %v", resp.Status)
 	}
 
-	return nil, resp, fmt.Errorf("unexpected status code: %s", resp.Status)
+	return url, resp, nil
 }

--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -150,6 +150,14 @@ func (s *ActionsService) GetWorkflowJobByID(ctx context.Context, owner, repo str
 func (s *ActionsService) GetWorkflowJobLogs(ctx context.Context, owner, repo string, jobID int64, maxRedirects int) (*url.URL, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/jobs/%v/logs", owner, repo, jobID)
 
+	if s.client.RateLimitRedirectionalEndpoints {
+		return s.getWorkflowJobLogsWithRateLimit(ctx, u, maxRedirects)
+	}
+
+	return s.getWorkflowJobLogsWithoutRateLimit(ctx, u, maxRedirects)
+}
+
+func (s *ActionsService) getWorkflowJobLogsWithoutRateLimit(ctx context.Context, u string, maxRedirects int) (*url.URL, *Response, error) {
 	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, maxRedirects)
 	if err != nil {
 		return nil, nil, err
@@ -162,4 +170,24 @@ func (s *ActionsService) GetWorkflowJobLogs(ctx context.Context, owner, repo str
 
 	parsedURL, err := url.Parse(resp.Header.Get("Location"))
 	return parsedURL, newResponse(resp), err
+}
+
+func (s *ActionsService) getWorkflowJobLogsWithRateLimit(ctx context.Context, u string, maxRedirects int) (*url.URL, *Response, error) {
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	url, resp, err := s.client.bareDoUntilFound(ctx, req, maxRedirects)
+	if err != nil {
+		return nil, resp, err
+	}
+	defer resp.Body.Close()
+
+	// If we received a valid Location in a 302 response
+	if url != nil {
+		return url, resp, nil
+	}
+
+	return nil, resp, fmt.Errorf("unexpected status code: %s", resp.Status)
 }

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -184,87 +184,152 @@ func TestActionsService_GetWorkflowJobByID(t *testing.T) {
 
 func TestActionsService_GetWorkflowJobLogs(t *testing.T) {
 	t.Parallel()
-	client, mux, _ := setup(t)
-
-	mux.HandleFunc("/repos/o/r/actions/jobs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		http.Redirect(w, r, "http://github.com/a", http.StatusFound)
-	})
-
-	ctx := context.Background()
-	url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 1)
-	if err != nil {
-		t.Errorf("Actions.GetWorkflowJobLogs returned error: %v", err)
-	}
-	if resp.StatusCode != http.StatusFound {
-		t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusFound)
-	}
-	want := "http://github.com/a"
-	if url.String() != want {
-		t.Errorf("Actions.GetWorkflowJobLogs returned %+v, want %+v", url.String(), want)
+	tcs := []struct {
+		name              string
+		respectRateLimits bool
+	}{
+		{
+			name:              "withoutRateLimits",
+			respectRateLimits: false,
+		},
+		{
+			name:              "withRateLimits",
+			respectRateLimits: true,
+		},
 	}
 
-	const methodName = "GetWorkflowJobLogs"
-	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.GetWorkflowJobLogs(ctx, "\n", "\n", 399444496, 1)
-		return err
-	})
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client, mux, _ := setup(t)
+			client.RateLimitRedirectionalEndpoints = tc.respectRateLimits
 
-	// Add custom round tripper
-	client.client.Transport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-		return nil, errors.New("failed to get workflow logs")
-	})
-	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 1)
-		return err
-	})
+			mux.HandleFunc("/repos/o/r/actions/jobs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "GET")
+				http.Redirect(w, r, "http://github.com/a", http.StatusFound)
+			})
+
+			ctx := context.Background()
+			url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 1)
+			if err != nil {
+				t.Errorf("Actions.GetWorkflowJobLogs returned error: %v", err)
+			}
+			if resp.StatusCode != http.StatusFound {
+				t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusFound)
+			}
+			want := "http://github.com/a"
+			if url.String() != want {
+				t.Errorf("Actions.GetWorkflowJobLogs returned %+v, want %+v", url.String(), want)
+			}
+
+			const methodName = "GetWorkflowJobLogs"
+			testBadOptions(t, methodName, func() (err error) {
+				_, _, err = client.Actions.GetWorkflowJobLogs(ctx, "\n", "\n", 399444496, 1)
+				return err
+			})
+
+			// Add custom round tripper
+			client.client.Transport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				return nil, errors.New("failed to get workflow logs")
+			})
+			// propagate custom round tripper to client without CheckRedirect
+			client.initialize()
+			testBadOptions(t, methodName, func() (err error) {
+				_, _, err = client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 1)
+				return err
+			})
+		})
+	}
 }
 
 func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_dontFollowRedirects(t *testing.T) {
 	t.Parallel()
-	client, mux, _ := setup(t)
+	tcs := []struct {
+		name              string
+		respectRateLimits bool
+	}{
+		{
+			name:              "withoutRateLimits",
+			respectRateLimits: false,
+		},
+		{
+			name:              "withRateLimits",
+			respectRateLimits: true,
+		},
+	}
 
-	mux.HandleFunc("/repos/o/r/actions/jobs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		http.Redirect(w, r, "http://github.com/a", http.StatusMovedPermanently)
-	})
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client, mux, _ := setup(t)
+			client.RateLimitRedirectionalEndpoints = tc.respectRateLimits
 
-	ctx := context.Background()
-	_, resp, _ := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 0)
-	if resp.StatusCode != http.StatusMovedPermanently {
-		t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
+			mux.HandleFunc("/repos/o/r/actions/jobs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "GET")
+				http.Redirect(w, r, "http://github.com/a", http.StatusMovedPermanently)
+			})
+
+			ctx := context.Background()
+			_, resp, _ := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 0)
+			if resp.StatusCode != http.StatusMovedPermanently {
+				t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
+			}
+		})
 	}
 }
 
 func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_followRedirects(t *testing.T) {
 	t.Parallel()
-	client, mux, serverURL := setup(t)
-
-	// Mock a redirect link, which leads to an archive link
-	mux.HandleFunc("/repos/o/r/actions/jobs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		redirectURL, _ := url.Parse(serverURL + baseURLPath + "/redirect")
-		http.Redirect(w, r, redirectURL.String(), http.StatusMovedPermanently)
-	})
-
-	mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		http.Redirect(w, r, "http://github.com/a", http.StatusFound)
-	})
-
-	ctx := context.Background()
-	url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 1)
-	if err != nil {
-		t.Errorf("Actions.GetWorkflowJobLogs returned error: %v", err)
+	tcs := []struct {
+		name              string
+		respectRateLimits bool
+	}{
+		{
+			name:              "withoutRateLimits",
+			respectRateLimits: false,
+		},
+		{
+			name:              "withRateLimits",
+			respectRateLimits: true,
+		},
 	}
 
-	if resp.StatusCode != http.StatusFound {
-		t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusFound)
-	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client, mux, serverURL := setup(t)
+			client.RateLimitRedirectionalEndpoints = tc.respectRateLimits
 
-	want := "http://github.com/a"
-	if url.String() != want {
-		t.Errorf("Actions.GetWorkflowJobLogs returned %+v, want %+v", url.String(), want)
+			// Mock a redirect link, which leads to an archive link
+			mux.HandleFunc("/repos/o/r/actions/jobs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "GET")
+				redirectURL, _ := url.Parse(serverURL + baseURLPath + "/redirect")
+				http.Redirect(w, r, redirectURL.String(), http.StatusMovedPermanently)
+			})
+
+			mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "GET")
+				http.Redirect(w, r, "http://github.com/a", http.StatusFound)
+			})
+
+			ctx := context.Background()
+			url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 1)
+			if err != nil {
+				t.Errorf("Actions.GetWorkflowJobLogs returned error: %v", err)
+			}
+
+			if resp.StatusCode != http.StatusFound {
+				t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusFound)
+			}
+
+			want := "http://github.com/a"
+			if url.String() != want {
+				t.Errorf("Actions.GetWorkflowJobLogs returned %+v, want %+v", url.String(), want)
+			}
+		})
 	}
 }
 

--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -274,7 +274,7 @@ func (s *ActionsService) getWorkflowRunAttemptLogsWithoutRateLimit(ctx context.C
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusFound {
-		return nil, newResponse(resp), fmt.Errorf("unexpected status code: %s", resp.Status)
+		return nil, newResponse(resp), fmt.Errorf("unexpected status code: %v", resp.Status)
 	}
 
 	parsedURL, err := url.Parse(resp.Header.Get("Location"))
@@ -293,12 +293,12 @@ func (s *ActionsService) getWorkflowRunAttemptLogsWithRateLimit(ctx context.Cont
 	}
 	defer resp.Body.Close()
 
-	// If we received a valid Location in a 302 response
-	if url != nil {
-		return url, resp, nil
+	// If we didn't receive a valid Location in a 302 response
+	if url == nil {
+		return nil, resp, fmt.Errorf("unexpected status code: %v", resp.Status)
 	}
 
-	return nil, resp, fmt.Errorf("unexpected status code: %s", resp.Status)
+	return url, resp, nil
 }
 
 // RerunWorkflowByID re-runs a workflow by ID.
@@ -407,12 +407,12 @@ func (s *ActionsService) getWorkflowRunLogsWithRateLimit(ctx context.Context, u 
 	}
 	defer resp.Body.Close()
 
-	// If we received a valid Location in a 302 response
-	if url != nil {
-		return url, resp, nil
+	// If we didn't receive a valid Location in a 302 response
+	if url == nil {
+		return nil, resp, fmt.Errorf("unexpected status code: %v", resp.Status)
 	}
 
-	return nil, resp, fmt.Errorf("unexpected status code: %s", resp.Status)
+	return url, resp, nil
 }
 
 // DeleteWorkflowRun deletes a workflow run by ID.

--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -259,6 +259,14 @@ func (s *ActionsService) GetWorkflowRunAttempt(ctx context.Context, owner, repo 
 func (s *ActionsService) GetWorkflowRunAttemptLogs(ctx context.Context, owner, repo string, runID int64, attemptNumber int, maxRedirects int) (*url.URL, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/attempts/%v/logs", owner, repo, runID, attemptNumber)
 
+	if s.client.RateLimitRedirectionalEndpoints {
+		return s.getWorkflowRunAttemptLogsWithRateLimit(ctx, u, maxRedirects)
+	}
+
+	return s.getWorkflowRunAttemptLogsWithoutRateLimit(ctx, u, maxRedirects)
+}
+
+func (s *ActionsService) getWorkflowRunAttemptLogsWithoutRateLimit(ctx context.Context, u string, maxRedirects int) (*url.URL, *Response, error) {
 	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, maxRedirects)
 	if err != nil {
 		return nil, nil, err
@@ -271,6 +279,26 @@ func (s *ActionsService) GetWorkflowRunAttemptLogs(ctx context.Context, owner, r
 
 	parsedURL, err := url.Parse(resp.Header.Get("Location"))
 	return parsedURL, newResponse(resp), err
+}
+
+func (s *ActionsService) getWorkflowRunAttemptLogsWithRateLimit(ctx context.Context, u string, maxRedirects int) (*url.URL, *Response, error) {
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	url, resp, err := s.client.bareDoUntilFound(ctx, req, maxRedirects)
+	if err != nil {
+		return nil, resp, err
+	}
+	defer resp.Body.Close()
+
+	// If we received a valid Location in a 302 response
+	if url != nil {
+		return url, resp, nil
+	}
+
+	return nil, resp, fmt.Errorf("unexpected status code: %s", resp.Status)
 }
 
 // RerunWorkflowByID re-runs a workflow by ID.
@@ -345,6 +373,14 @@ func (s *ActionsService) CancelWorkflowRunByID(ctx context.Context, owner, repo 
 func (s *ActionsService) GetWorkflowRunLogs(ctx context.Context, owner, repo string, runID int64, maxRedirects int) (*url.URL, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/logs", owner, repo, runID)
 
+	if s.client.RateLimitRedirectionalEndpoints {
+		return s.getWorkflowRunLogsWithRateLimit(ctx, u, maxRedirects)
+	}
+
+	return s.getWorkflowRunLogsWithoutRateLimit(ctx, u, maxRedirects)
+}
+
+func (s *ActionsService) getWorkflowRunLogsWithoutRateLimit(ctx context.Context, u string, maxRedirects int) (*url.URL, *Response, error) {
 	resp, err := s.client.roundTripWithOptionalFollowRedirect(ctx, u, maxRedirects)
 	if err != nil {
 		return nil, nil, err
@@ -357,6 +393,26 @@ func (s *ActionsService) GetWorkflowRunLogs(ctx context.Context, owner, repo str
 
 	parsedURL, err := url.Parse(resp.Header.Get("Location"))
 	return parsedURL, newResponse(resp), err
+}
+
+func (s *ActionsService) getWorkflowRunLogsWithRateLimit(ctx context.Context, u string, maxRedirects int) (*url.URL, *Response, error) {
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	url, resp, err := s.client.bareDoUntilFound(ctx, req, maxRedirects)
+	if err != nil {
+		return nil, resp, err
+	}
+	defer resp.Body.Close()
+
+	// If we received a valid Location in a 302 response
+	if url != nil {
+		return url, resp, nil
+	}
+
+	return nil, resp, fmt.Errorf("unexpected status code: %s", resp.Status)
 }
 
 // DeleteWorkflowRun deletes a workflow run by ID.

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1925,6 +1925,38 @@ func TestCheckResponse_AbuseRateLimit(t *testing.T) {
 	}
 }
 
+func TestCheckResponse_RedirectionError(t *testing.T) {
+	t.Parallel()
+	urlStr := "/foo/bar"
+
+	res := &http.Response{
+		Request:    &http.Request{},
+		StatusCode: http.StatusFound,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(``)),
+	}
+	res.Header.Set("Location", urlStr)
+	err := CheckResponse(res).(*RedirectionError)
+
+	if err == nil {
+		t.Errorf("Expected error response.")
+	}
+
+	wantedURL, parseErr := url.Parse(urlStr)
+	if parseErr != nil {
+		t.Errorf("Error parsing fixture url: %v", parseErr)
+	}
+
+	want := &RedirectionError{
+		Response:   res,
+		StatusCode: http.StatusFound,
+		Location:   wantedURL,
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("Error = %#v, want %#v", err, want)
+	}
+}
+
 func TestCompareHttpResponse(t *testing.T) {
 	t.Parallel()
 	testcases := map[string]struct {

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1824,6 +1824,48 @@ func TestDo_noContent(t *testing.T) {
 	}
 }
 
+func TestBareDoUntilFound_redirectLoop(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, baseURLPath, http.StatusMovedPermanently)
+	})
+
+	req, _ := client.NewRequest("GET", ".", nil)
+	ctx := context.Background()
+	_, _, err := client.bareDoUntilFound(ctx, req, 1)
+
+	if err == nil {
+		t.Error("Expected error to be returned.")
+	}
+	var rerr *RedirectionError
+	if !errors.As(err, &rerr) {
+		t.Errorf("Expected a Redirection error; got %#v.", err)
+	}
+}
+
+func TestBareDoUntilFound_UnexpectedRedirection(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, baseURLPath, http.StatusSeeOther)
+	})
+
+	req, _ := client.NewRequest("GET", ".", nil)
+	ctx := context.Background()
+	_, _, err := client.bareDoUntilFound(ctx, req, 1)
+
+	if err == nil {
+		t.Error("Expected error to be returned.")
+	}
+	var rerr *RedirectionError
+	if !errors.As(err, &rerr) {
+		t.Errorf("Expected a Redirection error; got %#v.", err)
+	}
+}
+
 func TestSanitizeURL(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -364,7 +364,7 @@ func (s *RepositoriesService) getArchiveLinkWithoutRateLimit(ctx context.Context
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusFound {
-		return nil, newResponse(resp), fmt.Errorf("unexpected status code: %s", resp.Status)
+		return nil, newResponse(resp), fmt.Errorf("unexpected status code: %v", resp.Status)
 	}
 
 	parsedURL, err := url.Parse(resp.Header.Get("Location"))
@@ -387,10 +387,10 @@ func (s *RepositoriesService) getArchiveLinkWithRateLimit(ctx context.Context, u
 	}
 	defer resp.Body.Close()
 
-	// If we received a valid Location in a 302 response
-	if url != nil {
-		return url, resp, nil
+	// If we didn't receive a valid Location in a 302 response
+	if url == nil {
+		return nil, resp, fmt.Errorf("unexpected status code: %v", resp.Status)
 	}
 
-	return nil, resp, fmt.Errorf("unexpected status code: %s", resp.Status)
+	return url, resp, nil
 }


### PR DESCRIPTION
Fixes #3406

Some endpoints of the GitHub HTTP API return a 302 response in successful scenarios, often to redirect to archives or artifacts download links. Because the `net/http` client usually follows 302s when calling `Do`, we instead currently use the `RoundTripper` directly for those endpoint to check after each call if the current redirection is a 302. The problem is that the library supports rate limit headers only in the `Do` type of calls.

This PR adds an opt-in feature flag to enable rate limit headers support on those endpoints which end with a 302 redirection. I refactored `Client` a bit to share the core `BareDo` logic between calls that care about redirection details and calls that don't. I added an unexported `bareDoUntilFound` method that behaves similarly to the old `roundTripWithOptionalFollowRedirect` but with all the rate limit and error handling that other endpoints have.