### PR TITLE
Add deprecation messages to security managers APIs

### DIFF
--- a/github/orgs_security_managers.go
+++ b/github/orgs_security_managers.go
@@ -12,6 +12,8 @@ import (
 
 // ListSecurityManagerTeams lists all security manager teams for an organization.
 //
+// Deprecated: Please use `client.Organizations.ListTeamsAssignedToOrgRole` instead.
+//
 // GitHub API docs: https://docs.github.com/rest/orgs/security-managers#list-security-manager-teams
 //
 //meta:operation GET /orgs/{org}/security-managers
@@ -34,6 +36,8 @@ func (s *OrganizationsService) ListSecurityManagerTeams(ctx context.Context, org
 
 // AddSecurityManagerTeam adds a team to the list of security managers for an organization.
 //
+// Deprecated: Please use `client.Organizations.AssignOrgRoleToTeam` instead.
+//
 // GitHub API docs: https://docs.github.com/rest/orgs/security-managers#add-a-security-manager-team
 //
 //meta:operation PUT /orgs/{org}/security-managers/teams/{team_slug}
@@ -48,6 +52,8 @@ func (s *OrganizationsService) AddSecurityManagerTeam(ctx context.Context, org, 
 }
 
 // RemoveSecurityManagerTeam removes a team from the list of security managers for an organization.
+//
+// Deprecated: Please use `client.Organizations.RemoveOrgRoleFromTeam` instead.
 //
 // GitHub API docs: https://docs.github.com/rest/orgs/security-managers#remove-a-security-manager-team
 //


### PR DESCRIPTION
The [organization security manager role REST APIs](https://docs.github.com/en/rest/orgs/security-managers) are being sunset (https://gh.io/security-managers-rest-api-sunset) in favor of the [organization roles REST APIs](https://docs.github.com/en/rest/orgs/organization-roles).

This change adds deprecation messages to tell consumers which client operations to use instead going forward.