### PR TITLE
Use `go 1.22` to allow building with go1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/go-github/v68
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/script/generate.sh
+++ b/script/generate.sh
@@ -43,6 +43,6 @@ for dir in $MOD_DIRS; do
   (
     cd "$dir"
     go generate ./...
-    GOTOOLCHAIN="go1.22+auto" go mod tidy
+    go mod tidy
   )
 done


### PR DESCRIPTION
When `go.mod` uses `go 1.22.0` (with `.0`), building with `go1.18` or `go1.19` fails.

Before:

```sh
$ go1.18 build ./...
go: errors parsing go.mod:
/Users/Oleksandr_Redko/src/github.com/google/go-github/go.mod:3: invalid go version '1.22.0': must match format 1.23

$ go1.19 build ./...
go: errors parsing go.mod:
/Users/Oleksandr_Redko/src/github.com/google/go-github/go.mod:3: invalid go version '1.22.0': must match format 1.23
```

After:

```sh
$ go1.18 build ./...

$ go1.19 build ./...
```

Follows #3423