### PR TITLE
chore: Fix codecov upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,10 @@ concurrency:
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
     branches:
-    - master
+      - master
 
 name: tests
 env:
@@ -19,6 +19,9 @@ permissions:
 
 jobs:
   test:
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         shell: bash
@@ -39,38 +42,40 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
-      with:
-        go-version: ${{ matrix.go-version }}
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          go-version: ${{ matrix.go-version }}
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    # Get values for cache paths to be used in later steps
-    - id: cache-paths
-      run: |
-        echo "go-cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-        echo "go-mod-cache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+      # Get values for cache paths to be used in later steps
+      - id: cache-paths
+        run: |
+          echo "go-cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod-cache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
 
-    - name: Cache go modules
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-      with:
-        path: |
-          ${{ steps.cache-paths.outputs.go-cache }}
-          ${{ steps.cache-paths.outputs.go-mod-cache }}
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go-
+      - name: Cache go modules
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ${{ steps.cache-paths.outputs.go-cache }}
+            ${{ steps.cache-paths.outputs.go-mod-cache }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
 
-    - name: Run go test
-      run: |
-        if [ -n "${{ matrix.update-coverage }}" ]; then
-          script/test.sh -race -covermode atomic -coverprofile coverage.txt ./...
-          exit
-        fi
-        script/test.sh -race -covermode atomic ./...
+      - name: Run go test
+        run: |
+          if [ -n "${{ matrix.update-coverage }}" ]; then
+            script/test.sh -race -covermode atomic -coverprofile coverage.txt ./...
+            exit
+          fi
+          script/test.sh -race -covermode atomic ./...
 
-    - name: Ensure integration tests build
-      # don't actually run tests since they hit live GitHub API
-      run: go test -v -tags=integration -run=^$ ./test/integration
+      - name: Ensure integration tests build
+        # don't actually run tests since they hit live GitHub API
+        run: go test -v -tags=integration -run=^$ ./test/integration
 
-    - name: Upload coverage to Codecov
-      if: ${{ matrix.update-coverage }}
-      uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
+      - name: Upload coverage to Codecov
+        if: ${{ matrix.update-coverage }}
+        uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
+        with:
+          use_oidc: true


### PR DESCRIPTION
This PR updates the Codecov action to use native GH OIDC support to authenticate pushing coverage from the `master` branch.

Fixes: #3439.
Closes: #3221.