### PR TITLE
chore: Spell "unmarshal" consistently with one el

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,27 @@ linters-settings:
       - G104
       # int(os.Stdin.Fd())
       - G115
+  misspell:
+    locale: US
+    ignore-words:
+      - "analyses"  # returned by the GitHub API
+      - "cancelled" # returned by the GitHub API
+    # extra words from https://go.dev//wiki/Spelling
+    extra-words:
+      - typo: "marshall"
+        correction: "marshal"
+      - typo: "marshalled"
+        correction: "marshaled"
+      - typo: "marshalling"
+        correction: "marshaling"
+      - typo: "unmarshall"
+        correction: "unmarshal"
+      - typo: "unmarshalling"
+        correction: "unmarshaling"
+      - typo: "unmarshalled"
+        correction: "unmarshaled"
+      - typo: "unmarshalling"
+        correction: "unmarshaling"
   perfsprint:
     errorf: true
     strconcat: false

--- a/github/code_scanning.go
+++ b/github/code_scanning.go
@@ -391,7 +391,7 @@ func (s *CodeScanningService) UploadSarif(ctx context.Context, owner, repo strin
 		return nil, nil, err
 	}
 
-	// This will always return an error without unmarshalling the data
+	// This will always return an error without unmarshaling the data
 	resp, err := s.client.Do(ctx, req, nil)
 	// Even though there was an error, we still return the response
 	// in case the caller wants to inspect it further.

--- a/github/github.go
+++ b/github/github.go
@@ -1311,7 +1311,7 @@ func (r *RedirectionError) Is(target error) bool {
 
 	return r.StatusCode == v.StatusCode &&
 		(r.Location == v.Location || // either both locations are nil or exactly the same pointer
-			r.Location != nil && v.Location != nil && r.Location.String() == v.Location.String()) // or they are both not nil and marshalled identically
+			r.Location != nil && v.Location != nil && r.Location.String() == v.Location.String()) // or they are both not nil and marshaled identically
 }
 
 // sanitizeURL redacts the client_secret parameter from the URL which may be

--- a/github/pulls_reviewers_test.go
+++ b/github/pulls_reviewers_test.go
@@ -130,7 +130,7 @@ func TestRequestReviewers(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	// This returns a PR, unmarshalling of which is tested elsewhere
+	// This returns a PR, unmarshaling of which is tested elsewhere
 	ctx := context.Background()
 	got, _, err := client.PullRequests.RequestReviewers(ctx, "o", "r", 1, ReviewersRequest{Reviewers: []string{"octocat", "googlebot"}, TeamReviewers: []string{"justice-league", "injustice-league"}})
 	if err != nil {

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -254,7 +254,7 @@ func (s *RepositoriesService) GetContents(ctx context.Context, owner, repo, path
 		return nil, directoryContent, resp, nil
 	}
 
-	return nil, nil, resp, fmt.Errorf("unmarshalling failed for both file and directory content: %s and %s", fileUnmarshalError, directoryUnmarshalError)
+	return nil, nil, resp, fmt.Errorf("unmarshaling failed for both file and directory content: %s and %s", fileUnmarshalError, directoryUnmarshalError)
 }
 
 // CreateFile creates a new file in a repository at the given path and returns

--- a/github/timestamp.go
+++ b/github/timestamp.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-// Timestamp represents a time that can be unmarshalled from a JSON string
+// Timestamp represents a time that can be unmarshaled from a JSON string
 // formatted as either an RFC3339 or Unix timestamp. This is necessary for some
 // fields since the GitHub API is inconsistent in how it represents times. All
 // exported methods of time.Time can be called on Timestamp.


### PR DESCRIPTION
The PR updates comments and error messages to use `unmarshal` with one *el*. Also, configures `misspell` linter to detects this in the future.

See https://go.dev//wiki/Spelling