### PR TITLE
fix: Typos in func parameter, vars, error, and comments

### DIFF
--- a/example/verifyartifact/main.go
+++ b/example/verifyartifact/main.go
@@ -169,7 +169,7 @@ func getPolicyBuilder() (*verify.PolicyBuilder, error) {
 		return nil, err
 	}
 
-	// Set up the articaft policy
+	// Set up the artifact policy
 	artifactDigestBytes, err := hex.DecodeString(*artifactDigest)
 	if err != nil {
 		return nil, err

--- a/github/github.go
+++ b/github/github.go
@@ -987,7 +987,7 @@ func (c *Client) bareDoUntilFound(ctx context.Context, req *http.Request, maxRed
 			if maxRedirects <= 0 && rerr.StatusCode == http.StatusMovedPermanently {
 				return nil, response, fmt.Errorf("reached the maximum amount of redirections: %w", err)
 			}
-			return nil, response, fmt.Errorf("unexepected redirection response: %w", err)
+			return nil, response, fmt.Errorf("unexpected redirection response: %w", err)
 		}
 	}
 

--- a/github/repos_deployments_test.go
+++ b/github/repos_deployments_test.go
@@ -186,14 +186,14 @@ func TestRepositoriesService_ListDeploymentStatuses(t *testing.T) {
 
 	opt := &ListOptions{Page: 2}
 	ctx := context.Background()
-	statutses, _, err := client.Repositories.ListDeploymentStatuses(ctx, "o", "r", 1, opt)
+	statuses, _, err := client.Repositories.ListDeploymentStatuses(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Repositories.ListDeploymentStatuses returned error: %v", err)
 	}
 
 	want := []*DeploymentStatus{{ID: Ptr(int64(1))}, {ID: Ptr(int64(2))}}
-	if !cmp.Equal(statutses, want) {
-		t.Errorf("Repositories.ListDeploymentStatuses returned %+v, want %+v", statutses, want)
+	if !cmp.Equal(statuses, want) {
+		t.Errorf("Repositories.ListDeploymentStatuses returned %+v, want %+v", statuses, want)
 	}
 
 	const methodName = "ListDeploymentStatuses"

--- a/github/teams_discussion_comments.go
+++ b/github/teams_discussion_comments.go
@@ -167,8 +167,8 @@ func (s *TeamsService) CreateCommentByID(ctx context.Context, orgID, teamID int6
 // GitHub API docs: https://docs.github.com/rest/teams/discussion-comments#create-a-discussion-comment
 //
 //meta:operation POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments
-func (s *TeamsService) CreateCommentBySlug(ctx context.Context, org, slug string, discsusionNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
-	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments", org, slug, discsusionNumber)
+func (s *TeamsService) CreateCommentBySlug(ctx context.Context, org, slug string, discussionNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments", org, slug, discussionNumber)
 	req, err := s.client.NewRequest("POST", u, comment)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
The PR corrects grammar mistakes. Changing the parameter name in `CreateCommentBySlug` is backward-compatible.