### PR TITLE
fix!: Typo in field names in the CheckSuite struct

### DIFF
--- a/github/checks.go
+++ b/github/checks.go
@@ -87,8 +87,8 @@ type CheckSuite struct {
 	// The following fields are only populated by Webhook events.
 	HeadCommit           *Commit `json:"head_commit,omitempty"`
 	LatestCheckRunsCount *int64  `json:"latest_check_runs_count,omitempty"`
-	Rerequstable         *bool   `json:"rerequestable,omitempty"`
-	RunsRerequstable     *bool   `json:"runs_rerequestable,omitempty"`
+	Rerequestable        *bool   `json:"rerequestable,omitempty"`
+	RunsRerequestable    *bool   `json:"runs_rerequestable,omitempty"`
 }
 
 func (c CheckRun) String() string {

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -891,8 +891,8 @@ func Test_CheckSuiteMarshal(t *testing.T) {
 			SHA: Ptr("s"),
 		},
 		LatestCheckRunsCount: Ptr(int64(1)),
-		Rerequstable:         Ptr(true),
-		RunsRerequstable:     Ptr(true),
+		Rerequestable:        Ptr(true),
+		RunsRerequestable:    Ptr(true),
 	}
 
 	w := fmt.Sprintf(`{

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2358,20 +2358,20 @@ func (c *CheckSuite) GetRepository() *Repository {
 	return c.Repository
 }
 
-// GetRerequstable returns the Rerequstable field if it's non-nil, zero value otherwise.
-func (c *CheckSuite) GetRerequstable() bool {
-	if c == nil || c.Rerequstable == nil {
+// GetRerequestable returns the Rerequestable field if it's non-nil, zero value otherwise.
+func (c *CheckSuite) GetRerequestable() bool {
+	if c == nil || c.Rerequestable == nil {
 		return false
 	}
-	return *c.Rerequstable
+	return *c.Rerequestable
 }
 
-// GetRunsRerequstable returns the RunsRerequstable field if it's non-nil, zero value otherwise.
-func (c *CheckSuite) GetRunsRerequstable() bool {
-	if c == nil || c.RunsRerequstable == nil {
+// GetRunsRerequestable returns the RunsRerequestable field if it's non-nil, zero value otherwise.
+func (c *CheckSuite) GetRunsRerequestable() bool {
+	if c == nil || c.RunsRerequestable == nil {
 		return false
 	}
-	return *c.RunsRerequstable
+	return *c.RunsRerequestable
 }
 
 // GetStatus returns the Status field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -3073,26 +3073,26 @@ func TestCheckSuite_GetRepository(tt *testing.T) {
 	c.GetRepository()
 }
 
-func TestCheckSuite_GetRerequstable(tt *testing.T) {
+func TestCheckSuite_GetRerequestable(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
-	c := &CheckSuite{Rerequstable: &zeroValue}
-	c.GetRerequstable()
+	c := &CheckSuite{Rerequestable: &zeroValue}
+	c.GetRerequestable()
 	c = &CheckSuite{}
-	c.GetRerequstable()
+	c.GetRerequestable()
 	c = nil
-	c.GetRerequstable()
+	c.GetRerequestable()
 }
 
-func TestCheckSuite_GetRunsRerequstable(tt *testing.T) {
+func TestCheckSuite_GetRunsRerequestable(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
-	c := &CheckSuite{RunsRerequstable: &zeroValue}
-	c.GetRunsRerequstable()
+	c := &CheckSuite{RunsRerequestable: &zeroValue}
+	c.GetRunsRerequestable()
 	c = &CheckSuite{}
-	c.GetRunsRerequstable()
+	c.GetRunsRerequestable()
 	c = nil
-	c.GetRunsRerequstable()
+	c.GetRunsRerequestable()
 }
 
 func TestCheckSuite_GetStatus(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -207,10 +207,10 @@ func TestCheckSuite_String(t *testing.T) {
 		Repository:           &Repository{},
 		HeadCommit:           &Commit{},
 		LatestCheckRunsCount: Ptr(int64(0)),
-		Rerequstable:         Ptr(false),
-		RunsRerequstable:     Ptr(false),
+		Rerequestable:        Ptr(false),
+		RunsRerequestable:    Ptr(false),
 	}
-	want := `github.CheckSuite{ID:0, NodeID:"", HeadBranch:"", HeadSHA:"", URL:"", BeforeSHA:"", AfterSHA:"", Status:"", Conclusion:"", CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, App:github.App{}, Repository:github.Repository{}, HeadCommit:github.Commit{}, LatestCheckRunsCount:0, Rerequstable:false, RunsRerequstable:false}`
+	want := `github.CheckSuite{ID:0, NodeID:"", HeadBranch:"", HeadSHA:"", URL:"", BeforeSHA:"", AfterSHA:"", Status:"", Conclusion:"", CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, App:github.App{}, Repository:github.Repository{}, HeadCommit:github.Commit{}, LatestCheckRunsCount:0, Rerequestable:false, RunsRerequestable:false}`
 	if got := v.String(); got != want {
 		t.Errorf("CheckSuite.String = %v, want %v", got, want)
 	}


### PR DESCRIPTION
BREAKING CHANGE: `Rerequstable`=>`Rerequestable`, `RunsRerequstable`=>`RunsRerequestable`

Fixes: #3443.