### PR TITLE
fix!: Typo in field names in the PullStats struct

### DIFF
--- a/github/admin_stats.go
+++ b/github/admin_stats.go
@@ -118,13 +118,13 @@ func (s GistStats) String() string {
 	return Stringify(s)
 }
 
-// PullStats represents the number of total, merged, mergable and unmergeable
+// PullStats represents the number of total, merged, mergeable and unmergeable
 // pull-requests.
 type PullStats struct {
-	TotalPulls      *int `json:"total_pulls,omitempty"`
-	MergedPulls     *int `json:"merged_pulls,omitempty"`
-	MergablePulls   *int `json:"mergeable_pulls,omitempty"`
-	UnmergablePulls *int `json:"unmergeable_pulls,omitempty"`
+	TotalPulls       *int `json:"total_pulls,omitempty"`
+	MergedPulls      *int `json:"merged_pulls,omitempty"`
+	MergeablePulls   *int `json:"mergeable_pulls,omitempty"`
+	UnmergeablePulls *int `json:"unmergeable_pulls,omitempty"`
 }
 
 func (s PullStats) String() string {

--- a/github/admin_stats_test.go
+++ b/github/admin_stats_test.go
@@ -98,7 +98,7 @@ func TestAdminService_GetAdminStats(t *testing.T) {
 
 func TestAdminService_Stringify(t *testing.T) {
 	t.Parallel()
-	want := "github.AdminStats{Issues:github.IssueStats{TotalIssues:179, OpenIssues:83, ClosedIssues:96}, Hooks:github.HookStats{TotalHooks:27, ActiveHooks:23, InactiveHooks:4}, Milestones:github.MilestoneStats{TotalMilestones:7, OpenMilestones:6, ClosedMilestones:1}, Orgs:github.OrgStats{TotalOrgs:33, DisabledOrgs:0, TotalTeams:60, TotalTeamMembers:314}, Comments:github.CommentStats{TotalCommitComments:6, TotalGistComments:28, TotalIssueComments:366, TotalPullRequestComments:30}, Pages:github.PageStats{TotalPages:36}, Users:github.UserStats{TotalUsers:254, AdminUsers:45, SuspendedUsers:21}, Gists:github.GistStats{TotalGists:178, PrivateGists:151, PublicGists:25}, Pulls:github.PullStats{TotalPulls:86, MergedPulls:60, MergablePulls:21, UnmergablePulls:3}, Repos:github.RepoStats{TotalRepos:212, RootRepos:194, ForkRepos:18, OrgRepos:51, TotalPushes:3082, TotalWikis:15}}"
+	want := "github.AdminStats{Issues:github.IssueStats{TotalIssues:179, OpenIssues:83, ClosedIssues:96}, Hooks:github.HookStats{TotalHooks:27, ActiveHooks:23, InactiveHooks:4}, Milestones:github.MilestoneStats{TotalMilestones:7, OpenMilestones:6, ClosedMilestones:1}, Orgs:github.OrgStats{TotalOrgs:33, DisabledOrgs:0, TotalTeams:60, TotalTeamMembers:314}, Comments:github.CommentStats{TotalCommitComments:6, TotalGistComments:28, TotalIssueComments:366, TotalPullRequestComments:30}, Pages:github.PageStats{TotalPages:36}, Users:github.UserStats{TotalUsers:254, AdminUsers:45, SuspendedUsers:21}, Gists:github.GistStats{TotalGists:178, PrivateGists:151, PublicGists:25}, Pulls:github.PullStats{TotalPulls:86, MergedPulls:60, MergeablePulls:21, UnmergeablePulls:3}, Repos:github.RepoStats{TotalRepos:212, RootRepos:194, ForkRepos:18, OrgRepos:51, TotalPushes:3082, TotalWikis:15}}"
 	if got := testAdminStats.String(); got != want {
 		t.Errorf("testAdminStats.String = %q, want %q", got, want)
 	}
@@ -143,7 +143,7 @@ func TestAdminService_Stringify(t *testing.T) {
 		t.Errorf("testAdminStats.Gists.String = %q, want %q", got, want)
 	}
 
-	want = "github.PullStats{TotalPulls:86, MergedPulls:60, MergablePulls:21, UnmergablePulls:3}"
+	want = "github.PullStats{TotalPulls:86, MergedPulls:60, MergeablePulls:21, UnmergeablePulls:3}"
 	if got := testAdminStats.Pulls.String(); got != want {
 		t.Errorf("testAdminStats.Pulls.String = %q, want %q", got, want)
 	}
@@ -183,10 +183,10 @@ var testAdminStats = &AdminStats{
 		SuspendedUsers: Ptr(21),
 	},
 	Pulls: &PullStats{
-		TotalPulls:      Ptr(86),
-		MergedPulls:     Ptr(60),
-		MergablePulls:   Ptr(21),
-		UnmergablePulls: Ptr(3),
+		TotalPulls:       Ptr(86),
+		MergedPulls:      Ptr(60),
+		MergeablePulls:   Ptr(21),
+		UnmergeablePulls: Ptr(3),
 	},
 	Issues: &IssueStats{
 		TotalIssues:  Ptr(179),
@@ -368,10 +368,10 @@ func TestPullStats_Marshal(t *testing.T) {
 	testJSONMarshal(t, &PullStats{}, "{}")
 
 	u := &PullStats{
-		TotalPulls:      Ptr(1),
-		MergedPulls:     Ptr(1),
-		MergablePulls:   Ptr(1),
-		UnmergablePulls: Ptr(1),
+		TotalPulls:       Ptr(1),
+		MergedPulls:      Ptr(1),
+		MergeablePulls:   Ptr(1),
+		UnmergeablePulls: Ptr(1),
 	}
 
 	want := `{
@@ -442,10 +442,10 @@ func TestAdminStats_Marshal(t *testing.T) {
 			SuspendedUsers: Ptr(21),
 		},
 		Pulls: &PullStats{
-			TotalPulls:      Ptr(86),
-			MergedPulls:     Ptr(60),
-			MergablePulls:   Ptr(21),
-			UnmergablePulls: Ptr(3),
+			TotalPulls:       Ptr(86),
+			MergedPulls:      Ptr(60),
+			MergeablePulls:   Ptr(21),
+			UnmergeablePulls: Ptr(3),
 		},
 		Issues: &IssueStats{
 			TotalIssues:  Ptr(179),

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -17902,12 +17902,12 @@ func (p *PullRequestThread) GetNodeID() string {
 	return *p.NodeID
 }
 
-// GetMergablePulls returns the MergablePulls field if it's non-nil, zero value otherwise.
-func (p *PullStats) GetMergablePulls() int {
-	if p == nil || p.MergablePulls == nil {
+// GetMergeablePulls returns the MergeablePulls field if it's non-nil, zero value otherwise.
+func (p *PullStats) GetMergeablePulls() int {
+	if p == nil || p.MergeablePulls == nil {
 		return 0
 	}
-	return *p.MergablePulls
+	return *p.MergeablePulls
 }
 
 // GetMergedPulls returns the MergedPulls field if it's non-nil, zero value otherwise.
@@ -17926,12 +17926,12 @@ func (p *PullStats) GetTotalPulls() int {
 	return *p.TotalPulls
 }
 
-// GetUnmergablePulls returns the UnmergablePulls field if it's non-nil, zero value otherwise.
-func (p *PullStats) GetUnmergablePulls() int {
-	if p == nil || p.UnmergablePulls == nil {
+// GetUnmergeablePulls returns the UnmergeablePulls field if it's non-nil, zero value otherwise.
+func (p *PullStats) GetUnmergeablePulls() int {
+	if p == nil || p.UnmergeablePulls == nil {
 		return 0
 	}
-	return *p.UnmergablePulls
+	return *p.UnmergeablePulls
 }
 
 // GetCommits returns the Commits field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -22964,15 +22964,15 @@ func TestPullRequestThread_GetNodeID(tt *testing.T) {
 	p.GetNodeID()
 }
 
-func TestPullStats_GetMergablePulls(tt *testing.T) {
+func TestPullStats_GetMergeablePulls(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int
-	p := &PullStats{MergablePulls: &zeroValue}
-	p.GetMergablePulls()
+	p := &PullStats{MergeablePulls: &zeroValue}
+	p.GetMergeablePulls()
 	p = &PullStats{}
-	p.GetMergablePulls()
+	p.GetMergeablePulls()
 	p = nil
-	p.GetMergablePulls()
+	p.GetMergeablePulls()
 }
 
 func TestPullStats_GetMergedPulls(tt *testing.T) {
@@ -22997,15 +22997,15 @@ func TestPullStats_GetTotalPulls(tt *testing.T) {
 	p.GetTotalPulls()
 }
 
-func TestPullStats_GetUnmergablePulls(tt *testing.T) {
+func TestPullStats_GetUnmergeablePulls(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int
-	p := &PullStats{UnmergablePulls: &zeroValue}
-	p.GetUnmergablePulls()
+	p := &PullStats{UnmergeablePulls: &zeroValue}
+	p.GetUnmergeablePulls()
 	p = &PullStats{}
-	p.GetUnmergablePulls()
+	p.GetUnmergeablePulls()
 	p = nil
-	p.GetUnmergablePulls()
+	p.GetUnmergeablePulls()
 }
 
 func TestPunchCard_GetCommits(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1454,12 +1454,12 @@ func TestPullRequestThread_String(t *testing.T) {
 func TestPullStats_String(t *testing.T) {
 	t.Parallel()
 	v := PullStats{
-		TotalPulls:      Ptr(0),
-		MergedPulls:     Ptr(0),
-		MergablePulls:   Ptr(0),
-		UnmergablePulls: Ptr(0),
+		TotalPulls:       Ptr(0),
+		MergedPulls:      Ptr(0),
+		MergeablePulls:   Ptr(0),
+		UnmergeablePulls: Ptr(0),
 	}
-	want := `github.PullStats{TotalPulls:0, MergedPulls:0, MergablePulls:0, UnmergablePulls:0}`
+	want := `github.PullStats{TotalPulls:0, MergedPulls:0, MergeablePulls:0, UnmergeablePulls:0}`
 	if got := v.String(); got != want {
 		t.Errorf("PullStats.String = %v, want %v", got, want)
 	}


### PR DESCRIPTION
BREAKING CHANGE: `MergablePulls`=>`MergeablePulls`, `UnmergablePulls`=>`UnmergeablePulls`

This PR corrects field typos in the [`github.PullStats`](https://github.com/google/go-github/blob/v68.0.0/github/admin_stats.go#L126-L127) struct:

- `MergablePulls` -> `MergeablePulls` (because `json:"mergeable_pulls"`)
- `UnmergablePulls` -> `UnmergeablePulls` (because `json:"unmergeable_pulls"`)