### PR TITLE
refactor!: Do not capitalize error strings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,8 @@ linters-settings:
     errorf: true
     strconcat: false
   revive:
+    # Set below 0.8 to enable error-strings rule.
+    confidence: 0.6
     rules:
       - name: blank-imports
       - name: bool-literal-in-expr

--- a/example/codespaces/newreposecretwithxcrypto/main.go
+++ b/example/codespaces/newreposecretwithxcrypto/main.go
@@ -134,7 +134,7 @@ func addRepoSecret(ctx context.Context, client *github.Client, owner string, rep
 	}
 
 	if _, err := client.Codespaces.CreateOrUpdateRepoSecret(ctx, owner, repo, encryptedSecret); err != nil {
-		return fmt.Errorf("Codespaces.CreateOrUpdateRepoSecret returned error: %v", err)
+		return fmt.Errorf("client.Codespaces.CreateOrUpdateRepoSecret returned error: %v", err)
 	}
 
 	return nil
@@ -143,7 +143,7 @@ func addRepoSecret(ctx context.Context, client *github.Client, owner string, rep
 func encryptSecretWithPublicKey(publicKey *github.PublicKey, secretName string, secretValue string) (*github.EncryptedSecret, error) {
 	decodedPublicKey, err := base64.StdEncoding.DecodeString(publicKey.GetKey())
 	if err != nil {
-		return nil, fmt.Errorf("base64.StdEncoding.DecodeString was unable to decode public key: %v", err)
+		return nil, fmt.Errorf("unable to decode public key: %v", err)
 	}
 
 	var boxKey [32]byte

--- a/example/codespaces/newusersecretwithxcrypto/main.go
+++ b/example/codespaces/newusersecretwithxcrypto/main.go
@@ -129,17 +129,17 @@ func addUserSecret(ctx context.Context, client *github.Client, secretName, secre
 	}
 
 	if _, err := client.Codespaces.CreateOrUpdateUserSecret(ctx, encryptedSecret); err != nil {
-		return fmt.Errorf("Codespaces.CreateOrUpdateUserSecret returned error: %v", err)
+		return fmt.Errorf("client.Codespaces.CreateOrUpdateUserSecret returned error: %v", err)
 	}
 
 	if owner != "" && repo != "" {
 		r, _, err := client.Repositories.Get(ctx, owner, repo)
 		if err != nil {
-			return fmt.Errorf("Repositories.Get returned error: %v", err)
+			return fmt.Errorf("client.Repositories.Get returned error: %v", err)
 		}
 		_, err = client.Codespaces.AddSelectedRepoToUserSecret(ctx, encryptedSecret.Name, r)
 		if err != nil {
-			return fmt.Errorf("Codespaces.AddSelectedRepoToUserSecret returned error: %v", err)
+			return fmt.Errorf("client.Codespaces.AddSelectedRepoToUserSecret returned error: %v", err)
 		}
 		fmt.Printf("Added secret %q to %v/%v\n", secretName, owner, repo)
 	}

--- a/example/newreposecretwithlibsodium/main.go
+++ b/example/newreposecretwithlibsodium/main.go
@@ -130,7 +130,7 @@ func addRepoSecret(ctx context.Context, client *github.Client, owner string, rep
 	}
 
 	if _, err := client.Actions.CreateOrUpdateRepoSecret(ctx, owner, repo, encryptedSecret); err != nil {
-		return fmt.Errorf("Actions.CreateOrUpdateRepoSecret returned error: %v", err)
+		return fmt.Errorf("client.Actions.CreateOrUpdateRepoSecret returned error: %v", err)
 	}
 
 	return nil

--- a/example/newreposecretwithxcrypto/main.go
+++ b/example/newreposecretwithxcrypto/main.go
@@ -134,7 +134,7 @@ func addRepoSecret(ctx context.Context, client *github.Client, owner string, rep
 	}
 
 	if _, err := client.Actions.CreateOrUpdateRepoSecret(ctx, owner, repo, encryptedSecret); err != nil {
-		return fmt.Errorf("Actions.CreateOrUpdateRepoSecret returned error: %v", err)
+		return fmt.Errorf("client.Actions.CreateOrUpdateRepoSecret returned error: %v", err)
 	}
 
 	return nil

--- a/github/github.go
+++ b/github/github.go
@@ -519,7 +519,7 @@ func WithVersion(version string) RequestOption {
 // request body.
 func (c *Client) NewRequest(method, urlStr string, body interface{}, opts ...RequestOption) (*http.Request, error) {
 	if !strings.HasSuffix(c.BaseURL.Path, "/") {
-		return nil, fmt.Errorf("BaseURL must have a trailing slash, but %q does not", c.BaseURL)
+		return nil, fmt.Errorf("baseURL must have a trailing slash, but %q does not", c.BaseURL)
 	}
 
 	u, err := c.BaseURL.Parse(urlStr)
@@ -565,7 +565,7 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}, opts ...Req
 // Body is sent with Content-Type: application/x-www-form-urlencoded.
 func (c *Client) NewFormRequest(urlStr string, body io.Reader, opts ...RequestOption) (*http.Request, error) {
 	if !strings.HasSuffix(c.BaseURL.Path, "/") {
-		return nil, fmt.Errorf("BaseURL must have a trailing slash, but %q does not", c.BaseURL)
+		return nil, fmt.Errorf("baseURL must have a trailing slash, but %q does not", c.BaseURL)
 	}
 
 	u, err := c.BaseURL.Parse(urlStr)
@@ -597,7 +597,7 @@ func (c *Client) NewFormRequest(urlStr string, body io.Reader, opts ...RequestOp
 // Relative URLs should always be specified without a preceding slash.
 func (c *Client) NewUploadRequest(urlStr string, reader io.Reader, size int64, mediaType string, opts ...RequestOption) (*http.Request, error) {
 	if !strings.HasSuffix(c.UploadURL.Path, "/") {
-		return nil, fmt.Errorf("UploadURL must have a trailing slash, but %q does not", c.UploadURL)
+		return nil, fmt.Errorf("uploadURL must have a trailing slash, but %q does not", c.UploadURL)
 	}
 	u, err := c.UploadURL.Parse(urlStr)
 	if err != nil {

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -2180,7 +2180,7 @@ func TestErrorResponse_Is(t *testing.T) {
 		},
 		"errors have different types": {
 			wantSame:   false,
-			otherError: errors.New("Github"),
+			otherError: errors.New("github"),
 		},
 	}
 
@@ -2250,7 +2250,7 @@ func TestRateLimitError_Is(t *testing.T) {
 		"errors have different types": {
 			wantSame:   false,
 			err:        err,
-			otherError: errors.New("Github"),
+			otherError: errors.New("github"),
 		},
 	}
 
@@ -2337,7 +2337,7 @@ func TestAbuseRateLimitError_Is(t *testing.T) {
 		"errors have different types": {
 			wantSame:   false,
 			err:        err,
-			otherError: errors.New("Github"),
+			otherError: errors.New("github"),
 		},
 	}
 
@@ -2369,7 +2369,7 @@ func TestAcceptedError_Is(t *testing.T) {
 		},
 		"errors have different types": {
 			wantSame:   false,
-			otherError: errors.New("Github"),
+			otherError: errors.New("github"),
 		},
 	}
 

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -567,7 +567,7 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 	default:
 		r.Type = ""
 		r.Parameters = nil
-		return fmt.Errorf("RepositoryRule.Type %q is not yet implemented, unable to unmarshal (%#v)", repositoryRule.Type, repositoryRule)
+		return fmt.Errorf("repositoryRule.Type %q is not yet implemented, unable to unmarshal (%#v)", repositoryRule.Type, repositoryRule)
 	}
 
 	return nil


### PR DESCRIPTION
BREAKING CHANGE: Some error strings are slightly modified - please do not rely on error text in general.

This PR is somewhat of a breaking change because it changes error messages for `Client.NewRequest`, `Client.NewFormRequest`, and `Client.NewUploadRequest`. However, I'm not sure if anyone relies on the word case of an error message.

The PR also configures golangci-lint to detect this in the future.
`revive.error-strings` was already enabled in the lint config but didn't work until we set `confidence: 0.6` in this PR.