### PR TITLE
chore: Check and fix license headers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,12 +11,13 @@ linters:
     - gocritic
     - godot
     - gofmt
+    - goheader
     - goimports
     - gosec
     - misspell
     - nakedret
-    - perfsprint
     - paralleltest
+    - perfsprint
     - revive
     - sliceofpointers
     - stylecheck
@@ -35,6 +36,15 @@ linters-settings:
     enabled-checks:
       - commentedOutCode
       - commentFormatting
+  goheader:
+    values:
+      regexp:
+        CopyrightDate: "Copyright \\d{4} "
+    template: |-
+      {{CopyrightDate}}The go-github AUTHORS. All rights reserved.
+      
+      Use of this source code is governed by a BSD-style
+      license that can be found in the LICENSE file.
   gosec:
     excludes:
       # duplicates errcheck

--- a/github/admin_stats_test.go
+++ b/github/admin_stats_test.go
@@ -1,3 +1,8 @@
+// Copyright 2017 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package github
 
 import (

--- a/github/enterprise_audit_log_test.go
+++ b/github/enterprise_audit_log_test.go
@@ -1,6 +1,6 @@
 // Copyright 2021 The go-github AUTHORS. All rights reserved.
 //
-// `Use` of this source code is governed by a BSD-style
+// Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 package github

--- a/github/gists.go
+++ b/github/gists.go
@@ -1,6 +1,6 @@
 // Copyright 2013 The go-github AUTHORS. All rights reserved.
 //
-// Use of this source code is governed by BSD-style
+// Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 package github

--- a/github/orgs_audit_log_test.go
+++ b/github/orgs_audit_log_test.go
@@ -1,6 +1,6 @@
 // Copyright 2021 The go-github AUTHORS. All rights reserved.
 //
-// `Use` of this source code is governed by a BSD-style
+// Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 package github

--- a/github/pulls_reviewers.go
+++ b/github/pulls_reviewers.go
@@ -85,11 +85,7 @@ func (s *PullRequestsService) ListReviewers(ctx context.Context, owner, repo str
 func (s *PullRequestsService) RemoveReviewers(ctx context.Context, owner, repo string, number int, reviewers ReviewersRequest) (*Response, error) {
 	// reviewers.Reviewers may be empty if the caller wants to remove teams, but not users. Unlike AddReviewers,
 	// "reviewers" is a required param here. Reference: https://github.com/google/go-github/issues/3336
-	removeRequest := removeReviewersRequest{
-		NodeID:        reviewers.NodeID,
-		Reviewers:     reviewers.Reviewers,
-		TeamReviewers: reviewers.TeamReviewers,
-	}
+	removeRequest := removeReviewersRequest(reviewers)
 
 	if removeRequest.Reviewers == nil {
 		// GitHub accepts the empty list, but rejects null. Removing `omitempty` is not enough - we also have to promote nil to [].

--- a/github/pulls_reviewers.go
+++ b/github/pulls_reviewers.go
@@ -85,6 +85,7 @@ func (s *PullRequestsService) ListReviewers(ctx context.Context, owner, repo str
 func (s *PullRequestsService) RemoveReviewers(ctx context.Context, owner, repo string, number int, reviewers ReviewersRequest) (*Response, error) {
 	// reviewers.Reviewers may be empty if the caller wants to remove teams, but not users. Unlike AddReviewers,
 	// "reviewers" is a required param here. Reference: https://github.com/google/go-github/issues/3336
+	// The type `removeReviewersRequest` is required because the struct tags are different from `ReviewersRequest`.
 	removeRequest := removeReviewersRequest(reviewers)
 
 	if removeRequest.Reviewers == nil {

--- a/scrape/apps_test.go
+++ b/scrape/apps_test.go
@@ -1,3 +1,8 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package scrape
 
 import (

--- a/scrape/example/scrape/main.go
+++ b/scrape/example/scrape/main.go
@@ -1,3 +1,8 @@
+// Copyright 2019 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // The scrape tool demonstrates use of the github.com/google/go-github/scrape
 // package to fetch data from GitHub.  The tool lists whether third-party app
 // restrictions are enabled for an organization, and lists information about

--- a/scrape/forms_test.go
+++ b/scrape/forms_test.go
@@ -1,3 +1,8 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package scrape
 
 import (

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1,3 +1,8 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package scrape
 
 import (


### PR DESCRIPTION
Add `goheader` to check the file header license.