### PR TITLE
Add new fields for IssueType

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11694,6 +11694,14 @@ func (i *Issue) GetTitle() string {
 	return *i.Title
 }
 
+// GetType returns the Type field.
+func (i *Issue) GetType() *IssueType {
+	if i == nil {
+		return nil
+	}
+	return i.Type
+}
+
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (i *Issue) GetUpdatedAt() Timestamp {
 	if i == nil || i.UpdatedAt == nil {
@@ -12388,6 +12396,62 @@ func (i *IssueStats) GetTotalIssues() int {
 		return 0
 	}
 	return *i.TotalIssues
+}
+
+// GetColor returns the Color field if it's non-nil, zero value otherwise.
+func (i *IssueType) GetColor() string {
+	if i == nil || i.Color == nil {
+		return ""
+	}
+	return *i.Color
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (i *IssueType) GetCreatedAt() Timestamp {
+	if i == nil || i.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *i.CreatedAt
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (i *IssueType) GetDescription() string {
+	if i == nil || i.Description == nil {
+		return ""
+	}
+	return *i.Description
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (i *IssueType) GetID() int64 {
+	if i == nil || i.ID == nil {
+		return 0
+	}
+	return *i.ID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (i *IssueType) GetName() string {
+	if i == nil || i.Name == nil {
+		return ""
+	}
+	return *i.Name
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (i *IssueType) GetNodeID() string {
+	if i == nil || i.NodeID == nil {
+		return ""
+	}
+	return *i.NodeID
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (i *IssueType) GetUpdatedAt() Timestamp {
+	if i == nil || i.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *i.UpdatedAt
 }
 
 // GetEncodedJITConfig returns the EncodedJITConfig field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -15166,6 +15166,14 @@ func TestIssue_GetTitle(tt *testing.T) {
 	i.GetTitle()
 }
 
+func TestIssue_GetType(tt *testing.T) {
+	tt.Parallel()
+	i := &Issue{}
+	i.GetType()
+	i = nil
+	i.GetType()
+}
+
 func TestIssue_GetUpdatedAt(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp
@@ -16025,6 +16033,83 @@ func TestIssueStats_GetTotalIssues(tt *testing.T) {
 	i.GetTotalIssues()
 	i = nil
 	i.GetTotalIssues()
+}
+
+func TestIssueType_GetColor(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &IssueType{Color: &zeroValue}
+	i.GetColor()
+	i = &IssueType{}
+	i.GetColor()
+	i = nil
+	i.GetColor()
+}
+
+func TestIssueType_GetCreatedAt(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue Timestamp
+	i := &IssueType{CreatedAt: &zeroValue}
+	i.GetCreatedAt()
+	i = &IssueType{}
+	i.GetCreatedAt()
+	i = nil
+	i.GetCreatedAt()
+}
+
+func TestIssueType_GetDescription(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &IssueType{Description: &zeroValue}
+	i.GetDescription()
+	i = &IssueType{}
+	i.GetDescription()
+	i = nil
+	i.GetDescription()
+}
+
+func TestIssueType_GetID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int64
+	i := &IssueType{ID: &zeroValue}
+	i.GetID()
+	i = &IssueType{}
+	i.GetID()
+	i = nil
+	i.GetID()
+}
+
+func TestIssueType_GetName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &IssueType{Name: &zeroValue}
+	i.GetName()
+	i = &IssueType{}
+	i.GetName()
+	i = nil
+	i.GetName()
+}
+
+func TestIssueType_GetNodeID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &IssueType{NodeID: &zeroValue}
+	i.GetNodeID()
+	i = &IssueType{}
+	i.GetNodeID()
+	i = nil
+	i.GetNodeID()
+}
+
+func TestIssueType_GetUpdatedAt(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue Timestamp
+	i := &IssueType{UpdatedAt: &zeroValue}
+	i.GetUpdatedAt()
+	i = &IssueType{}
+	i.GetUpdatedAt()
+	i = nil
+	i.GetUpdatedAt()
 }
 
 func TestJITRunnerConfig_GetEncodedJITConfig(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -815,9 +815,10 @@ func TestIssue_String(t *testing.T) {
 		Reactions:         &Reactions{},
 		NodeID:            Ptr(""),
 		Draft:             Ptr(false),
+		Type:              &IssueType{},
 		ActiveLockReason:  Ptr(""),
 	}
-	want := `github.Issue{ID:0, Number:0, State:"", StateReason:"", Locked:false, Title:"", Body:"", AuthorAssociation:"", User:github.User{}, Assignee:github.User{}, Comments:0, ClosedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, ClosedBy:github.User{}, URL:"", HTMLURL:"", CommentsURL:"", EventsURL:"", LabelsURL:"", RepositoryURL:"", Milestone:github.Milestone{}, PullRequestLinks:github.PullRequestLinks{}, Repository:github.Repository{}, Reactions:github.Reactions{}, NodeID:"", Draft:false, ActiveLockReason:""}`
+	want := `github.Issue{ID:0, Number:0, State:"", StateReason:"", Locked:false, Title:"", Body:"", AuthorAssociation:"", User:github.User{}, Assignee:github.User{}, Comments:0, ClosedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, ClosedBy:github.User{}, URL:"", HTMLURL:"", CommentsURL:"", EventsURL:"", LabelsURL:"", RepositoryURL:"", Milestone:github.Milestone{}, PullRequestLinks:github.PullRequestLinks{}, Repository:github.Repository{}, Reactions:github.Reactions{}, NodeID:"", Draft:false, Type:github.IssueType{}, ActiveLockReason:""}`
 	if got := v.String(); got != want {
 		t.Errorf("Issue.String = %v, want %v", got, want)
 	}

--- a/github/issues.go
+++ b/github/issues.go
@@ -55,6 +55,7 @@ type Issue struct {
 	Assignees         []*User           `json:"assignees,omitempty"`
 	NodeID            *string           `json:"node_id,omitempty"`
 	Draft             *bool             `json:"draft,omitempty"`
+	Type              *IssueType        `json:"type,omitempty"`
 
 	// TextMatches is only populated from search results that request text matches
 	// See: search.go and https://docs.github.com/rest/search/#text-match-metadata
@@ -127,6 +128,18 @@ type PullRequestLinks struct {
 	DiffURL  *string    `json:"diff_url,omitempty"`
 	PatchURL *string    `json:"patch_url,omitempty"`
 	MergedAt *Timestamp `json:"merged_at,omitempty"`
+}
+
+// IssueType represents the type of issue.
+// For now it shows up when receiveing an Issue event.
+type IssueType struct {
+	ID          *int64     `json:"id,omitempty"`
+	NodeID      *string    `json:"node_id,omitempty"`
+	Name        *string    `json:"name,omitempty"`
+	Description *string    `json:"description,omitempty"`
+	Color       *string    `json:"color,omitempty"`
+	CreatedAt   *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt   *Timestamp `json:"updated_at,omitempty"`
 }
 
 // List the issues for the authenticated user. If all is true, list issues


### PR DESCRIPTION
Add new fields for Issues Type. In the Rest API this is not available yet when getting an issue information, but that is available in an issue event (webhook)

This is a new feature for issues: https://github.com/orgs/community/discussions/139933

Will be good to have this available in the lib to people can use when dealing with events :)

Fixes: https://github.com/google/go-github/issues/3450

cc @gmlewis 