### PR TITLE
Extend `Rate` and Rate Limiting with `X-Ratelimit-Used` and `X-Ratelimit-Resource` headers

### DIFF
--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1500,9 +1500,11 @@ func TestRate_String(t *testing.T) {
 	v := Rate{
 		Limit:     0,
 		Remaining: 0,
+		Used:	   0,
 		Reset:     Timestamp{},
+		Resource:  "core",
 	}
-	want := `github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}`
+	want := `github.Rate{Limit:0, Remaining:0, Used:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Resource:"core"}`
 	if got := v.String(); got != want {
 		t.Errorf("Rate.String = %v, want %v", got, want)
 	}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1500,11 +1500,11 @@ func TestRate_String(t *testing.T) {
 	v := Rate{
 		Limit:     0,
 		Remaining: 0,
-		Used:	   0,
+		Used:      0,
 		Reset:     Timestamp{},
-		Resource:  "core",
+		Resource:  "",
 	}
-	want := `github.Rate{Limit:0, Remaining:0, Used:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Resource:"core"}`
+	want := `github.Rate{Limit:0, Remaining:0, Used:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Resource:""}`
 	if got := v.String(); got != want {
 		t.Errorf("Rate.String = %v, want %v", got, want)
 	}

--- a/github/github.go
+++ b/github/github.go
@@ -38,7 +38,9 @@ const (
 	headerAPIVersion    = "X-Github-Api-Version"
 	headerRateLimit     = "X-Ratelimit-Limit"
 	headerRateRemaining = "X-Ratelimit-Remaining"
+	headerRateUsed      = "X-Ratelimit-Used"
 	headerRateReset     = "X-Ratelimit-Reset"
+	headerRateResource  = "X-Ratelimit-Resource"
 	headerOTP           = "X-Github-Otp"
 	headerRetryAfter    = "Retry-After"
 
@@ -763,10 +765,16 @@ func parseRate(r *http.Response) Rate {
 	if remaining := r.Header.Get(headerRateRemaining); remaining != "" {
 		rate.Remaining, _ = strconv.Atoi(remaining)
 	}
+	if used := r.Header.Get(headerRateUsed); used != "" {
+		rate.Used, _ = strconv.Atoi(used)
+	}
 	if reset := r.Header.Get(headerRateReset); reset != "" {
 		if v, _ := strconv.ParseInt(reset, 10, 64); v != 0 {
 			rate.Reset = Timestamp{time.Unix(v, 0)}
 		}
+	}
+	if resource := r.Header.Get(headerRateResource); resource != "" {
+		rate.Resource = resource
 	}
 	return rate
 }

--- a/github/rate_limit.go
+++ b/github/rate_limit.go
@@ -12,14 +12,22 @@ type RateLimitService service
 
 // Rate represents the rate limit for the current client.
 type Rate struct {
-	// The number of requests per hour the client is currently limited to.
+	// The maximum number of requests that you can make per hour.
 	Limit int `json:"limit"`
 
-	// The number of remaining requests the client can make this hour.
+	// The number of requests remaining in the current rate limit window.
 	Remaining int `json:"remaining"`
 
-	// The time at which the current rate limit will reset.
+	// The number of requests you have made in the current rate limit window.
+	Used int `json:"used"`
+
+	// The time at which the current rate limit window resets, in UTC epoch seconds.
 	Reset Timestamp `json:"reset"`
+
+	// The rate limit resource that the request counted against.
+	// For more information about the different resources, see REST API endpoints for rate limits.
+	// GitHub API docs: https://docs.github.com/en/rest/rate-limit/rate-limit#get-rate-limit-status-for-the-authenticated-user
+	Resource string `json:"resource,omitempty"`
 }
 
 func (r Rate) String() string {

--- a/github/rate_limit_test.go
+++ b/github/rate_limit_test.go
@@ -30,7 +30,7 @@ func TestRateLimits_String(t *testing.T) {
 		CodeSearch:                &Rate{},
 		AuditLog:                  &Rate{},
 	}
-	want := `github.RateLimits{Core:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, Search:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, GraphQL:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, IntegrationManifest:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, SourceImport:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, CodeScanningUpload:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, ActionsRunnerRegistration:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, SCIM:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, DependencySnapshots:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, CodeSearch:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}, AuditLog:github.Rate{Limit:0, Remaining:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}}`
+	want := `github.RateLimits{Core:github.Rate{Limit:0, Remaining:0, Used:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Resource:""}, Search:github.Rate{Limit:0, Remaining:0, Used:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Resource:""}, GraphQL:github.Rate{Limit:0, Remaining:0, Used:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Resource:""}, IntegrationManifest:github.Rate{Limit:0, Remaining:0, Used:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Resource:""}, SourceImport:github.Rate{Limit:0, Remaining:0, Used:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Resource:""}, CodeScanningUpload:github.Rate{Limit:0, Remaining:0, Used:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Resource:""}, ActionsRunnerRegistration:github.Rate{Limit:0, Remaining:0, Used:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Resource:""}, SCIM:github.Rate{Limit:0, Remaining:0, Used:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Resource:""}, DependencySnapshots:github.Rate{Limit:0, Remaining:0, Used:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Resource:""}, CodeSearch:github.Rate{Limit:0, Remaining:0, Used:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Resource:""}, AuditLog:github.Rate{Limit:0, Remaining:0, Used:0, Reset:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Resource:""}}`
 	if got := v.String(); got != want {
 		t.Errorf("RateLimits.String = %v, want %v", got, want)
 	}
@@ -43,17 +43,17 @@ func TestRateLimits(t *testing.T) {
 	mux.HandleFunc("/rate_limit", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"resources":{
-			"core": {"limit":2,"remaining":1,"reset":1372700873},
-			"search": {"limit":3,"remaining":2,"reset":1372700874},
-			"graphql": {"limit":4,"remaining":3,"reset":1372700875},
-			"integration_manifest": {"limit":5,"remaining":4,"reset":1372700876},
-			"source_import": {"limit":6,"remaining":5,"reset":1372700877},
-			"code_scanning_upload": {"limit":7,"remaining":6,"reset":1372700878},
-			"actions_runner_registration": {"limit":8,"remaining":7,"reset":1372700879},
-			"scim": {"limit":9,"remaining":8,"reset":1372700880},
-			"dependency_snapshots": {"limit":10,"remaining":9,"reset":1372700881},
-			"code_search": {"limit":11,"remaining":10,"reset":1372700882},
-			"audit_log": {"limit": 12,"remaining":11,"reset":1372700883}
+			"core": {"limit":2,"remaining":1,"used":1,"reset":1372700873},
+			"search": {"limit":3,"remaining":2,"used":1,"reset":1372700874},
+			"graphql": {"limit":4,"remaining":3,"used":1,"reset":1372700875},
+			"integration_manifest": {"limit":5,"remaining":4,"used":1,"reset":1372700876},
+			"source_import": {"limit":6,"remaining":5,"used":1,"reset":1372700877},
+			"code_scanning_upload": {"limit":7,"remaining":6,"used":1,"reset":1372700878},
+			"actions_runner_registration": {"limit":8,"remaining":7,"used":1,"reset":1372700879},
+			"scim": {"limit":9,"remaining":8,"used":1,"reset":1372700880},
+			"dependency_snapshots": {"limit":10,"remaining":9,"used":1,"reset":1372700881},
+			"code_search": {"limit":11,"remaining":10,"used":1,"reset":1372700882},
+			"audit_log": {"limit": 12,"remaining":11,"used":1,"reset":1372700883}
 		}}`)
 	})
 
@@ -67,56 +67,67 @@ func TestRateLimits(t *testing.T) {
 		Core: &Rate{
 			Limit:     2,
 			Remaining: 1,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 53, 0, time.UTC).Local()},
 		},
 		Search: &Rate{
 			Limit:     3,
 			Remaining: 2,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 54, 0, time.UTC).Local()},
 		},
 		GraphQL: &Rate{
 			Limit:     4,
 			Remaining: 3,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 55, 0, time.UTC).Local()},
 		},
 		IntegrationManifest: &Rate{
 			Limit:     5,
 			Remaining: 4,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 56, 0, time.UTC).Local()},
 		},
 		SourceImport: &Rate{
 			Limit:     6,
 			Remaining: 5,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 57, 0, time.UTC).Local()},
 		},
 		CodeScanningUpload: &Rate{
 			Limit:     7,
 			Remaining: 6,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 58, 0, time.UTC).Local()},
 		},
 		ActionsRunnerRegistration: &Rate{
 			Limit:     8,
 			Remaining: 7,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 59, 0, time.UTC).Local()},
 		},
 		SCIM: &Rate{
 			Limit:     9,
 			Remaining: 8,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 48, 00, 0, time.UTC).Local()},
 		},
 		DependencySnapshots: &Rate{
 			Limit:     10,
 			Remaining: 9,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 48, 1, 0, time.UTC).Local()},
 		},
 		CodeSearch: &Rate{
 			Limit:     11,
 			Remaining: 10,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 48, 2, 0, time.UTC).Local()},
 		},
 		AuditLog: &Rate{
 			Limit:     12,
 			Remaining: 11,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 48, 3, 0, time.UTC).Local()},
 		},
 	}
@@ -200,21 +211,22 @@ func TestRateLimits_overQuota(t *testing.T) {
 	client.rateLimits[CoreCategory] = Rate{
 		Limit:     1,
 		Remaining: 0,
+		Used:      1,
 		Reset:     Timestamp{time.Now().Add(time.Hour).Local()},
 	}
 	mux.HandleFunc("/rate_limit", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"resources":{
-			"core": {"limit":2,"remaining":1,"reset":1372700873},
-			"search": {"limit":3,"remaining":2,"reset":1372700874},
-			"graphql": {"limit":4,"remaining":3,"reset":1372700875},
-			"integration_manifest": {"limit":5,"remaining":4,"reset":1372700876},
-			"source_import": {"limit":6,"remaining":5,"reset":1372700877},
-			"code_scanning_upload": {"limit":7,"remaining":6,"reset":1372700878},
-			"actions_runner_registration": {"limit":8,"remaining":7,"reset":1372700879},
-			"scim": {"limit":9,"remaining":8,"reset":1372700880},
-			"dependency_snapshots": {"limit":10,"remaining":9,"reset":1372700881},
-			"code_search": {"limit":11,"remaining":10,"reset":1372700882},
-			"audit_log": {"limit":12,"remaining":11,"reset":1372700883}
+			"core": {"limit":2,"remaining":1,"used":1,"reset":1372700873},
+			"search": {"limit":3,"remaining":2,"used":1,"reset":1372700874},
+			"graphql": {"limit":4,"remaining":3,"used":1,"reset":1372700875},
+			"integration_manifest": {"limit":5,"remaining":4,"used":1,"reset":1372700876},
+			"source_import": {"limit":6,"remaining":5,"used":1,"reset":1372700877},
+			"code_scanning_upload": {"limit":7,"remaining":6,"used":1,"reset":1372700878},
+			"actions_runner_registration": {"limit":8,"remaining":7,"used":1,"reset":1372700879},
+			"scim": {"limit":9,"remaining":8,"used":1,"reset":1372700880},
+			"dependency_snapshots": {"limit":10,"remaining":9,"used":1,"reset":1372700881},
+			"code_search": {"limit":11,"remaining":10,"used":1,"reset":1372700882},
+			"audit_log": {"limit":12,"remaining":11,"used":1,"reset":1372700883}
 		}}`)
 	})
 
@@ -228,56 +240,67 @@ func TestRateLimits_overQuota(t *testing.T) {
 		Core: &Rate{
 			Limit:     2,
 			Remaining: 1,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 53, 0, time.UTC).Local()},
 		},
 		Search: &Rate{
 			Limit:     3,
 			Remaining: 2,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 54, 0, time.UTC).Local()},
 		},
 		GraphQL: &Rate{
 			Limit:     4,
 			Remaining: 3,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 55, 0, time.UTC).Local()},
 		},
 		IntegrationManifest: &Rate{
 			Limit:     5,
 			Remaining: 4,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 56, 0, time.UTC).Local()},
 		},
 		SourceImport: &Rate{
 			Limit:     6,
 			Remaining: 5,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 57, 0, time.UTC).Local()},
 		},
 		CodeScanningUpload: &Rate{
 			Limit:     7,
 			Remaining: 6,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 58, 0, time.UTC).Local()},
 		},
 		ActionsRunnerRegistration: &Rate{
 			Limit:     8,
 			Remaining: 7,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 47, 59, 0, time.UTC).Local()},
 		},
 		SCIM: &Rate{
 			Limit:     9,
 			Remaining: 8,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 48, 00, 0, time.UTC).Local()},
 		},
 		DependencySnapshots: &Rate{
 			Limit:     10,
 			Remaining: 9,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 48, 1, 0, time.UTC).Local()},
 		},
 		CodeSearch: &Rate{
 			Limit:     11,
 			Remaining: 10,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 48, 2, 0, time.UTC).Local()},
 		},
 		AuditLog: &Rate{
 			Limit:     12,
 			Remaining: 11,
+			Used:      1,
 			Reset:     Timestamp{time.Date(2013, time.July, 1, 17, 48, 3, 0, time.UTC).Local()},
 		},
 	}
@@ -349,56 +372,67 @@ func TestRateLimits_Marshal(t *testing.T) {
 		Core: &Rate{
 			Limit:     1,
 			Remaining: 1,
+			Used:      0,
 			Reset:     Timestamp{referenceTime},
 		},
 		Search: &Rate{
 			Limit:     1,
 			Remaining: 1,
+			Used:      0,
 			Reset:     Timestamp{referenceTime},
 		},
 		GraphQL: &Rate{
 			Limit:     1,
 			Remaining: 1,
+			Used:      0,
 			Reset:     Timestamp{referenceTime},
 		},
 		IntegrationManifest: &Rate{
 			Limit:     1,
 			Remaining: 1,
+			Used:      0,
 			Reset:     Timestamp{referenceTime},
 		},
 		SourceImport: &Rate{
 			Limit:     1,
 			Remaining: 1,
+			Used:      0,
 			Reset:     Timestamp{referenceTime},
 		},
 		CodeScanningUpload: &Rate{
 			Limit:     1,
 			Remaining: 1,
+			Used:      0,
 			Reset:     Timestamp{referenceTime},
 		},
 		ActionsRunnerRegistration: &Rate{
 			Limit:     1,
 			Remaining: 1,
+			Used:      0,
 			Reset:     Timestamp{referenceTime},
 		},
 		SCIM: &Rate{
 			Limit:     1,
 			Remaining: 1,
+			Used:      0,
 			Reset:     Timestamp{referenceTime},
 		},
 		DependencySnapshots: &Rate{
 			Limit:     1,
 			Remaining: 1,
+			Used:      0,
 			Reset:     Timestamp{referenceTime},
 		},
 		CodeSearch: &Rate{
 			Limit:     1,
 			Remaining: 1,
+			Used:      0,
 			Reset:     Timestamp{referenceTime},
 		},
 		AuditLog: &Rate{
 			Limit:     1,
 			Remaining: 1,
+			Used:      0,
 			Reset:     Timestamp{referenceTime},
 		},
 	}
@@ -407,56 +441,67 @@ func TestRateLimits_Marshal(t *testing.T) {
 		"core": {
 			"limit": 1,
 			"remaining": 1,
+			"used": 0,
 			"reset": ` + referenceTimeStr + `
 		},
 		"search": {
 			"limit": 1,
 			"remaining": 1,
+			"used": 0,
 			"reset": ` + referenceTimeStr + `
 		},
 		"graphql": {
 			"limit": 1,
 			"remaining": 1,
+			"used": 0,
 			"reset": ` + referenceTimeStr + `
 		},
 		"integration_manifest": {
 			"limit": 1,
 			"remaining": 1,
+			"used": 0,
 			"reset": ` + referenceTimeStr + `
 		},
 		"source_import": {
 			"limit": 1,
 			"remaining": 1,
+			"used": 0,
 			"reset": ` + referenceTimeStr + `
 		},
 		"code_scanning_upload": {
 			"limit": 1,
 			"remaining": 1,
+			"used": 0,
 			"reset": ` + referenceTimeStr + `
 		},
 		"actions_runner_registration": {
 			"limit": 1,
 			"remaining": 1,
+			"used": 0,
 			"reset": ` + referenceTimeStr + `
 		},
 		"scim": {
 			"limit": 1,
 			"remaining": 1,
+			"used": 0,
 			"reset": ` + referenceTimeStr + `
 		},
 		"dependency_snapshots": {
 			"limit": 1,
 			"remaining": 1,
+			"used": 0,
 			"reset": ` + referenceTimeStr + `
 		},
 		"code_search": {
 			"limit": 1,
 			"remaining": 1,
+			"used": 0,
 			"reset": ` + referenceTimeStr + `
 		},
 		"audit_log": {
 			"limit": 1,
 			"remaining": 1,
+			"used": 0,
 			"reset": ` + referenceTimeStr + `
 		}
 	}`
@@ -471,13 +516,17 @@ func TestRate_Marshal(t *testing.T) {
 	u := &Rate{
 		Limit:     1,
 		Remaining: 1,
+		Used:      0,
 		Reset:     Timestamp{referenceTime},
+		Resource:  "core",
 	}
 
 	want := `{
 		"limit": 1,
 		"remaining": 1,
-		"reset": ` + referenceTimeStr + `
+		"used": 0,
+		"reset": ` + referenceTimeStr + `,
+		"resource": "core"
 	}`
 
 	testJSONMarshal(t, u, want)


### PR DESCRIPTION
GitHub introduced two new headrs when it comes to rate limiting:
* `X-Ratelimit-Used`
* `X-Ratelimit-Resource`

See https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#checking-the-status-of-your-rate-limit

For which resources are available, see https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user

This Pull Request extends the Rate Limiting Header parsing and adds the two new information into the `Rate` response.
Additionally, the key `used` is added into the response from the `/rate_limit` API endpoint.

For the `Rate` type, the docs have been updated according to the original GitHub API docs.