### PR TITLE
Bump version of go-github to v69.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-github #
 
 [![go-github release (latest SemVer)](https://img.shields.io/github/v/release/google/go-github?sort=semver)](https://github.com/google/go-github/releases)
-[![Go Reference](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/google/go-github/v68/github)
+[![Go Reference](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/google/go-github/v69/github)
 [![Test Status](https://github.com/google/go-github/workflows/tests/badge.svg)](https://github.com/google/go-github/actions?query=workflow%3Atests)
 [![Test Coverage](https://codecov.io/gh/google/go-github/branch/master/graph/badge.svg)](https://codecov.io/gh/google/go-github)
 [![Discuss at go-github@googlegroups.com](https://img.shields.io/badge/discuss-go--github%40googlegroups.com-blue.svg)](https://groups.google.com/group/go-github)
@@ -43,7 +43,7 @@ If you're interested in using the [GraphQL API v4][], the recommended library is
 go-github is compatible with modern Go releases in module mode, with Go installed:
 
 ```bash
-go get github.com/google/go-github/v68
+go get github.com/google/go-github/v69
 ```
 
 will resolve and add the package to the current development module, along with its dependencies.
@@ -51,7 +51,7 @@ will resolve and add the package to the current development module, along with i
 Alternatively the same can be achieved if you use import in a package:
 
 ```go
-import "github.com/google/go-github/v68/github"
+import "github.com/google/go-github/v69/github"
 ```
 
 and run `go get` without parameters.
@@ -59,13 +59,13 @@ and run `go get` without parameters.
 Finally, to use the top-of-trunk version of this repo, use the following command:
 
 ```bash
-go get github.com/google/go-github/v68@master
+go get github.com/google/go-github/v69@master
 ```
 
 ## Usage ##
 
 ```go
-import "github.com/google/go-github/v68/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
+import "github.com/google/go-github/v69/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
 import "github.com/google/go-github/github" // with go modules disabled
 ```
 
@@ -138,7 +138,7 @@ import (
 	"net/http"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 func main() {
@@ -172,7 +172,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"github.com/jferrl/go-githubauth"
 	"golang.org/x/oauth2"
 )
@@ -380,7 +380,7 @@ For complete usage of go-github, see the full [package docs][].
 
 [GitHub API v3]: https://docs.github.com/en/rest
 [personal access token]: https://github.com/blog/1509-personal-api-tokens
-[package docs]: https://pkg.go.dev/github.com/google/go-github/v68/github
+[package docs]: https://pkg.go.dev/github.com/google/go-github/v69/github
 [GraphQL API v4]: https://developer.github.com/v4/
 [shurcooL/githubv4]: https://github.com/shurcooL/githubv4
 [GitHub webhook events]: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads
@@ -454,7 +454,7 @@ Versions prior to 48.2.0 are not listed.
 
 | go-github Version | GitHub v3 API Version |
 | ----------------- | --------------------- |
-| 68.0.0            | 2022-11-28            |
+| 69.0.0            | 2022-11-28            |
 | ...               | 2022-11-28            |
 | 48.2.0            | 2022-11-28            |
 

--- a/example/actionpermissions/main.go
+++ b/example/actionpermissions/main.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 var (

--- a/example/appengine/app.go
+++ b/example/appengine/app.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/log"
 )

--- a/example/basicauth/main.go
+++ b/example/basicauth/main.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"golang.org/x/term"
 )
 

--- a/example/codespaces/newreposecretwithxcrypto/main.go
+++ b/example/codespaces/newreposecretwithxcrypto/main.go
@@ -37,7 +37,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/codespaces/newusersecretwithxcrypto/main.go
+++ b/example/codespaces/newusersecretwithxcrypto/main.go
@@ -38,7 +38,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -33,7 +33,7 @@ import (
 	"time"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 var (

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v68/example
+module github.com/google/go-github/v69/example
 
 go 1.22.0
 
@@ -6,7 +6,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371
 	github.com/bradleyfalzon/ghinstallation/v2 v2.0.4
 	github.com/gofri/go-github-ratelimit v1.0.3
-	github.com/google/go-github/v68 v68.0.0
+	github.com/google/go-github/v69 v69.0.0
 	github.com/sigstore/sigstore-go v0.5.1
 	golang.org/x/crypto v0.31.0
 	golang.org/x/term v0.27.0
@@ -98,4 +98,4 @@ require (
 )
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v68 => ../
+replace github.com/google/go-github/v69 => ../

--- a/example/listenvironments/main.go
+++ b/example/listenvironments/main.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 func main() {

--- a/example/migrations/main.go
+++ b/example/migrations/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 func fetchAllUserMigrations() ([]*github.UserMigration, error) {

--- a/example/newfilewithappauth/main.go
+++ b/example/newfilewithappauth/main.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 func main() {

--- a/example/newrepo/main.go
+++ b/example/newrepo/main.go
@@ -16,7 +16,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 var (

--- a/example/newreposecretwithlibsodium/go.mod
+++ b/example/newreposecretwithlibsodium/go.mod
@@ -4,10 +4,10 @@ go 1.22.0
 
 require (
 	github.com/GoKillers/libsodium-go v0.0.0-20171022220152-dd733721c3cb
-	github.com/google/go-github/v68 v68.0.0
+	github.com/google/go-github/v69 v69.0.0
 )
 
 require github.com/google/go-querystring v1.1.0 // indirect
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v68 => ../..
+replace github.com/google/go-github/v69 => ../..

--- a/example/newreposecretwithlibsodium/main.go
+++ b/example/newreposecretwithlibsodium/main.go
@@ -36,7 +36,7 @@ import (
 	"os"
 
 	sodium "github.com/GoKillers/libsodium-go/cryptobox"
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 var (

--- a/example/newreposecretwithxcrypto/main.go
+++ b/example/newreposecretwithxcrypto/main.go
@@ -37,7 +37,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/ratelimit/main.go
+++ b/example/ratelimit/main.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 
 	"github.com/gofri/go-github-ratelimit/github_ratelimit"
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 func main() {

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 // Fetch all the public organizations' membership of a user.

--- a/example/tokenauth/main.go
+++ b/example/tokenauth/main.go
@@ -15,7 +15,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"golang.org/x/term"
 )
 

--- a/example/topics/main.go
+++ b/example/topics/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 // Fetch and lists all the public topics associated with the specified GitHub topic.

--- a/example/verifyartifact/main.go
+++ b/example/verifyartifact/main.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/verify"

--- a/github/doc.go
+++ b/github/doc.go
@@ -8,7 +8,7 @@ Package github provides a client for using the GitHub API.
 
 Usage:
 
-	import "github.com/google/go-github/v68/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
+	import "github.com/google/go-github/v69/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
 	import "github.com/google/go-github/github"     // with go modules disabled
 
 Construct a new GitHub client, then use the various services on the client to

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 func ExampleMarkdownService_Render() {

--- a/github/github.go
+++ b/github/github.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	Version = "v68.0.0"
+	Version = "v69.0.0"
 
 	defaultAPIVersion = "2022-11-28"
 	defaultBaseURL    = "https://api.github.com/"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v68
+module github.com/google/go-github/v69
 
 go 1.22.0
 

--- a/test/fields/fields.go
+++ b/test/fields/fields.go
@@ -25,7 +25,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 var (

--- a/test/integration/activity_test.go
+++ b/test/integration/activity_test.go
@@ -11,7 +11,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 const (

--- a/test/integration/authorizations_test.go
+++ b/test/integration/authorizations_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 const msgEnvMissing = "Skipping test because the required environment variable (%v) is not present."

--- a/test/integration/github_test.go
+++ b/test/integration/github_test.go
@@ -14,7 +14,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 var (

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 func TestRepositories_CRUD(t *testing.T) {

--- a/test/integration/users_test.go
+++ b/test/integration/users_test.go
@@ -13,7 +13,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 func TestUsers_Get(t *testing.T) {

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v1.7.0
 	github.com/getkin/kin-openapi v0.128.0
 	github.com/google/go-cmp v0.6.0
-	github.com/google/go-github/v68 v68.0.0
+	github.com/google/go-github/v69 v69.0.0
 	golang.org/x/sync v0.10.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -24,4 +24,4 @@ require (
 )
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v68 => ../
+replace github.com/google/go-github/v69 => ../

--- a/tools/metadata/main.go
+++ b/tools/metadata/main.go
@@ -16,7 +16,7 @@ import (
 	"path/filepath"
 
 	"github.com/alecthomas/kong"
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 var helpVars = kong.Vars{

--- a/tools/metadata/main_test.go
+++ b/tools/metadata/main_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 func TestUpdateGo(t *testing.T) {

--- a/tools/metadata/metadata.go
+++ b/tools/metadata/metadata.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"gopkg.in/yaml.v3"
 )
 

--- a/tools/metadata/openapi.go
+++ b/tools/metadata/openapi.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"golang.org/x/sync/errgroup"
 )
 


### PR DESCRIPTION
This release contains the following breaking API changes:

* #3417
  BREAKING CHANGE: `Create*Ruleset` and `Update*Ruleset` now pass `ruleset` parameter by-value instead of by-reference.
* #3444
  BREAKING CHANGE: `Rerequstable`=>`Rerequestable`, `RunsRerequstable`=>`RunsRerequestable`
* #3445
  BREAKING CHANGE: `MergablePulls`=>`MergeablePulls`, `UnmergablePulls`=>`UnmergeablePulls`
* #3446
  BREAKING CHANGE: Some error strings are slightly modified - please do not rely on error text in general.
* #3430
  BREAKING CHANGES: The following types have been renamed:
  - `Ruleset` -> `RepositoryRuleset`
  - `RulesetLink` -> `RepositoryRulesetLink`
  - `RulesetLinks` -> `RepositoryRulesetLinks`
  - `RulesetRefConditionParameters` -> `RepositoryRulesetRefConditionParameters`
  - `RulesetRepositoryNamesConditionParameters` -> `RepositoryRulesetRepositoryNamesConditionParameters`
  - `RulesetRepositoryIDsConditionParameters` -> `RepositoryRulesetRepositoryIDsConditionParameters`
  - `RulesetRepositoryPropertyTargetParameters` -> `Repository`
  - `RulesetRepositoryPropertyConditionParameters` -> `RepositoryRulesetRepositoryPropertyConditionParameters`
  - `RulesetOrganizationNamesConditionParameters` -> `RepositoryRulesetOrganizationNamesConditionParameters`
  - `RulesetOrganizationIDsConditionParameters` -> `RepositoryRulesetOrganizationIDsConditionParameters`
  - `RulesetConditions` -> `RepositoryRulesetConditions`
  - `RepositoryRulesetEditedChanges` -> `RepositoryRulesetChanges`
  - `RepositoryRulesetEditedSource` -> `RepositoryRulesetChangeSource`
  - `RepositoryRulesetEditedSources` -> `RepositoryRulesetChangeSources`
  - `RepositoryRulesetEditedConditions` -> `RepositoryRulesetUpdatedConditions`
  - `RepositoryRulesetUpdatedConditionsEdited` -> `RepositoryRulesetUpdatedCondition`
  - `RepositoryRulesetEditedRules` -> `RepositoryRulesetChangedRules`
  - `RepositoryRulesetUpdatedRules` -> `RepositoryRulesetUpdatedRules`
  - `RepositoryRulesetEditedRuleChanges` -> `RepositoryRulesetChangedRule`
* #3447
  BREAKING CHANGE: `ListOAuthApps` now returns `([]*OAuthApp, error)` instead of `([]OAuthApp, error)`.
* #3460
  BREAKING CHANGE: `User.InheritedFrom` is changed from a `*Team` to a `[]*Team`.

...and the following additional changes:

* #3398
* #3400
* #3401
* #3402
* #3404
* #3408
* #3410
* #3411
* #3419
* #3420
* #3386
* #3424
* #3426
* #3423
* #3428
* #3431
* #3435
* #3437
* #3440
* #3441
* #3442
* #3433
* #3448
* #3449
* #3451
* #3452
* #3453
* #3454
* #3455
* #3396
* #3458
