### PR TITLE
docs: Clarify ListPullRequestsWithCommit usage

### DIFF
--- a/github/pulls.go
+++ b/github/pulls.go
@@ -169,10 +169,12 @@ func (s *PullRequestsService) List(ctx context.Context, owner string, repo strin
 	return pulls, resp, nil
 }
 
-// ListPullRequestsWithCommit returns pull requests associated with a commit SHA.
+// ListPullRequestsWithCommit returns pull requests associated with a commit SHA
+// or branch name.
 //
-// The results may include open and closed pull requests.
-// By default, the PullRequestListOptions State filters for "open".
+// The results may include open and closed pull requests. If the commit SHA is
+// not present in the repository's default branch, the result will only include
+// open pull requests.
 //
 // GitHub API docs: https://docs.github.com/rest/commits/commits#list-pull-requests-associated-with-a-commit
 //


### PR DESCRIPTION
The docs for `ListPullRequestsWithCommit` mention use of `PullRequestListOptions`, but this method no longer accepts `PullRequestListOptions` per #2815 and #2822.

This pull request updates the method doc comment to remove the outdated reference to `PullRequestListOptions`, and adds some clarifications based on the GitHub docs for the relevant API endpoint.