### PR TITLE
fix: Add missing query params to AlertListOptions

### DIFF
--- a/github/code_scanning.go
+++ b/github/code_scanning.go
@@ -141,6 +141,15 @@ type AlertListOptions struct {
 	// The name of a code scanning tool. Only results by this tool will be listed.
 	ToolName string `url:"tool_name,omitempty"`
 
+	// The GUID of a code scanning tool. Only results by this tool will be listed.
+	ToolGUID string `url:"tool_guid,omitempty"`
+
+	// The direction to sort the results by. Possible values are: asc, desc. Default: desc.
+	Direction string `url:"direction,omitempty"`
+
+	// The property by which to sort the results. Possible values are: created, updated. Default: created.
+	Sort string `url:"sort,omitempty"`
+
 	ListCursorOptions
 
 	// Add ListOptions so offset pagination with integer type "page" query parameter is accepted

--- a/github/code_scanning_test.go
+++ b/github/code_scanning_test.go
@@ -147,7 +147,7 @@ func TestCodeScanningService_ListAlertsForOrg(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/code-scanning/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testFormValues(t, r, values{"state": "open", "ref": "heads/master", "severity": "warning", "tool_name": "CodeQL"})
+		testFormValues(t, r, values{"state": "open", "ref": "heads/master", "severity": "warning", "tool_name": "CodeQL", "tool_guid": "guid", "direction": "asc", "sort": "updated"})
 		fmt.Fprint(w, `[{
 				"repository": {
 					"id": 1,
@@ -159,7 +159,7 @@ func TestCodeScanningService_ListAlertsForOrg(t *testing.T) {
 				"rule_description":"Useless conditional",
 				"tool": {
 					"name": "CodeQL",
-					"guid": null,
+					"guid": "guid",
 					"version": "1.4.0"
 				},
 				"rule": {
@@ -239,7 +239,7 @@ func TestCodeScanningService_ListAlertsForOrg(t *testing.T) {
 				}]`)
 	})
 
-	opts := &AlertListOptions{State: "open", Ref: "heads/master", Severity: "warning", ToolName: "CodeQL"}
+	opts := &AlertListOptions{State: "open", Ref: "heads/master", Severity: "warning", ToolName: "CodeQL", ToolGUID: "guid", Direction: "asc", Sort: "updated"}
 	ctx := context.Background()
 	alerts, _, err := client.CodeScanning.ListAlertsForOrg(ctx, "o", opts)
 	if err != nil {
@@ -257,7 +257,7 @@ func TestCodeScanningService_ListAlertsForOrg(t *testing.T) {
 			RuleID:          Ptr("js/trivial-conditional"),
 			RuleSeverity:    Ptr("warning"),
 			RuleDescription: Ptr("Useless conditional"),
-			Tool:            &Tool{Name: Ptr("CodeQL"), GUID: nil, Version: Ptr("1.4.0")},
+			Tool:            &Tool{Name: Ptr("CodeQL"), GUID: Ptr("guid"), Version: Ptr("1.4.0")},
 			Rule: &Rule{
 				ID:              Ptr("js/trivial-conditional"),
 				Severity:        Ptr("warning"),
@@ -477,14 +477,14 @@ func TestCodeScanningService_ListAlertsForRepo(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/code-scanning/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testFormValues(t, r, values{"state": "open", "ref": "heads/master", "severity": "warning", "tool_name": "CodeQL"})
+		testFormValues(t, r, values{"state": "open", "ref": "heads/master", "severity": "warning", "tool_name": "CodeQL", "tool_guid": "guid", "direction": "asc", "sort": "updated"})
 		fmt.Fprint(w, `[{
 				"rule_id":"js/trivial-conditional",
 				"rule_severity":"warning",
 				"rule_description":"Useless conditional",
 				"tool": {
 					"name": "CodeQL",
-					"guid": null,
+					"guid": "guid",
 					"version": "1.4.0"
 				},
 				"rule": {
@@ -526,7 +526,7 @@ func TestCodeScanningService_ListAlertsForRepo(t *testing.T) {
 				"rule_description":"Expression has no effect",
 				"tool": {
 					"name": "CodeQL",
-					"guid": null,
+					"guid": "guid",
 					"version": "1.4.0"
 				},
 				"rule": {
@@ -564,7 +564,7 @@ func TestCodeScanningService_ListAlertsForRepo(t *testing.T) {
 				}]`)
 	})
 
-	opts := &AlertListOptions{State: "open", Ref: "heads/master", Severity: "warning", ToolName: "CodeQL"}
+	opts := &AlertListOptions{State: "open", Ref: "heads/master", Severity: "warning", ToolName: "CodeQL", ToolGUID: "guid", Direction: "asc", Sort: "updated"}
 	ctx := context.Background()
 	alerts, _, err := client.CodeScanning.ListAlertsForRepo(ctx, "o", "r", opts)
 	if err != nil {
@@ -577,7 +577,7 @@ func TestCodeScanningService_ListAlertsForRepo(t *testing.T) {
 			RuleID:          Ptr("js/trivial-conditional"),
 			RuleSeverity:    Ptr("warning"),
 			RuleDescription: Ptr("Useless conditional"),
-			Tool:            &Tool{Name: Ptr("CodeQL"), GUID: nil, Version: Ptr("1.4.0")},
+			Tool:            &Tool{Name: Ptr("CodeQL"), GUID: Ptr("guid"), Version: Ptr("1.4.0")},
 			Rule: &Rule{
 				ID:              Ptr("js/trivial-conditional"),
 				Severity:        Ptr("warning"),
@@ -613,7 +613,7 @@ func TestCodeScanningService_ListAlertsForRepo(t *testing.T) {
 			RuleID:          Ptr("js/useless-expression"),
 			RuleSeverity:    Ptr("warning"),
 			RuleDescription: Ptr("Expression has no effect"),
-			Tool:            &Tool{Name: Ptr("CodeQL"), GUID: nil, Version: Ptr("1.4.0")},
+			Tool:            &Tool{Name: Ptr("CodeQL"), GUID: Ptr("guid"), Version: Ptr("1.4.0")},
 			Rule: &Rule{
 				ID:              Ptr("js/useless-expression"),
 				Severity:        Ptr("warning"),


### PR DESCRIPTION
As per the official documentation the endpoints to list alerts for both an organization and a repository accept three additional params which are not included in this SDK. Those are: `tool_guid`, `direction` and `sort`.

See:

- https://docs.github.com/en/rest/code-scanning/code-scanning?apiVersion=2022-11-28#list-code-scanning-alerts-for-an-organization
- https://docs.github.com/en/rest/code-scanning/code-scanning?apiVersion=2022-11-28#list-code-scanning-alerts-for-a-repository

This PR adds those fields and extends the tests to cover them as well.