### PR TITLE
Bump version of go-github to v69.1.0

### DIFF
--- a/example/go.mod
+++ b/example/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371
 	github.com/bradleyfalzon/ghinstallation/v2 v2.0.4
 	github.com/gofri/go-github-ratelimit v1.0.3
-	github.com/google/go-github/v69 v69.0.0
+	github.com/google/go-github/v69 v69.1.0
 	github.com/sigstore/sigstore-go v0.5.1
 	golang.org/x/crypto v0.31.0
 	golang.org/x/term v0.27.0

--- a/example/newreposecretwithlibsodium/go.mod
+++ b/example/newreposecretwithlibsodium/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 require (
 	github.com/GoKillers/libsodium-go v0.0.0-20171022220152-dd733721c3cb
-	github.com/google/go-github/v69 v69.0.0
+	github.com/google/go-github/v69 v69.1.0
 )
 
 require github.com/google/go-querystring v1.1.0 // indirect

--- a/github/github.go
+++ b/github/github.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	Version = "v69.0.0"
+	Version = "v69.1.0"
 
 	defaultAPIVersion = "2022-11-28"
 	defaultBaseURL    = "https://api.github.com/"

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v1.8.0
 	github.com/getkin/kin-openapi v0.128.0
 	github.com/google/go-cmp v0.6.0
-	github.com/google/go-github/v69 v69.0.0
+	github.com/google/go-github/v69 v69.1.0
 	golang.org/x/sync v0.11.0
 	gopkg.in/yaml.v3 v3.0.1
 )


### PR DESCRIPTION
This minor release contains the following changes:

* #3464
* #3438
* #3465
* #3459
* #3469
* #3472
* #3470
* #3471
* #3474
* #3475
* #3467
* #3477
