### PR TITLE
feat: Add sorting list options for secret scanning

### DIFF
--- a/github/secret_scanning.go
+++ b/github/secret_scanning.go
@@ -68,6 +68,12 @@ type SecretScanningAlertListOptions struct {
 	// Valid resolutions are false_positive, wont_fix, revoked, pattern_edited, pattern_deleted or used_in_tests.
 	Resolution string `url:"resolution,omitempty"`
 
+	// The direction to sort the results by. Possible values are: asc, desc. Default: desc.
+	Direction string `url:"direction,omitempty"`
+
+	// The property by which to sort the results. Possible values are: created, updated. Default: created.
+	Sort string `url:"sort,omitempty"`
+
 	ListCursorOptions
 
 	// List options can vary on the Enterprise type.

--- a/github/secret_scanning_test.go
+++ b/github/secret_scanning_test.go
@@ -22,7 +22,7 @@ func TestSecretScanningService_ListAlertsForEnterprise(t *testing.T) {
 
 	mux.HandleFunc("/enterprises/e/secret-scanning/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testFormValues(t, r, values{"state": "open", "secret_type": "mailchimp_api_key"})
+		testFormValues(t, r, values{"state": "open", "secret_type": "mailchimp_api_key", "sort": "updated", "direction": "asc"})
 
 		fmt.Fprint(w, `[{
 			"number": 1,
@@ -45,7 +45,7 @@ func TestSecretScanningService_ListAlertsForEnterprise(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	opts := &SecretScanningAlertListOptions{State: "open", SecretType: "mailchimp_api_key"}
+	opts := &SecretScanningAlertListOptions{State: "open", SecretType: "mailchimp_api_key", Direction: "asc", Sort: "updated"}
 
 	alerts, _, err := client.SecretScanning.ListAlertsForEnterprise(ctx, "e", opts)
 	if err != nil {
@@ -97,7 +97,7 @@ func TestSecretScanningService_ListAlertsForOrg(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/secret-scanning/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testFormValues(t, r, values{"state": "open", "secret_type": "mailchimp_api_key"})
+		testFormValues(t, r, values{"state": "open", "secret_type": "mailchimp_api_key", "sort": "updated", "direction": "asc"})
 
 		fmt.Fprint(w, `[{
 			"number": 1,
@@ -115,7 +115,7 @@ func TestSecretScanningService_ListAlertsForOrg(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	opts := &SecretScanningAlertListOptions{State: "open", SecretType: "mailchimp_api_key"}
+	opts := &SecretScanningAlertListOptions{State: "open", SecretType: "mailchimp_api_key", Direction: "asc", Sort: "updated"}
 
 	alerts, _, err := client.SecretScanning.ListAlertsForOrg(ctx, "o", opts)
 	if err != nil {
@@ -162,7 +162,7 @@ func TestSecretScanningService_ListAlertsForOrgListOptions(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/secret-scanning/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testFormValues(t, r, values{"state": "open", "secret_type": "mailchimp_api_key", "per_page": "1", "page": "1"})
+		testFormValues(t, r, values{"state": "open", "secret_type": "mailchimp_api_key", "per_page": "1", "page": "1", "sort": "updated", "direction": "asc"})
 
 		fmt.Fprint(w, `[{
 			"number": 1,
@@ -182,7 +182,7 @@ func TestSecretScanningService_ListAlertsForOrgListOptions(t *testing.T) {
 	ctx := context.Background()
 
 	// Testing pagination by index
-	opts := &SecretScanningAlertListOptions{State: "open", SecretType: "mailchimp_api_key", ListOptions: ListOptions{Page: 1, PerPage: 1}}
+	opts := &SecretScanningAlertListOptions{State: "open", SecretType: "mailchimp_api_key", ListOptions: ListOptions{Page: 1, PerPage: 1}, Direction: "asc", Sort: "updated"}
 
 	alerts, _, err := client.SecretScanning.ListAlertsForOrg(ctx, "o", opts)
 	if err != nil {
@@ -229,7 +229,7 @@ func TestSecretScanningService_ListAlertsForRepo(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/secret-scanning/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testFormValues(t, r, values{"state": "open", "secret_type": "mailchimp_api_key"})
+		testFormValues(t, r, values{"state": "open", "secret_type": "mailchimp_api_key", "sort": "updated", "direction": "asc"})
 
 		fmt.Fprint(w, `[{
 			"number": 1,
@@ -247,7 +247,7 @@ func TestSecretScanningService_ListAlertsForRepo(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	opts := &SecretScanningAlertListOptions{State: "open", SecretType: "mailchimp_api_key"}
+	opts := &SecretScanningAlertListOptions{State: "open", SecretType: "mailchimp_api_key", Direction: "asc", Sort: "updated"}
 
 	alerts, _, err := client.SecretScanning.ListAlertsForRepo(ctx, "o", "r", opts)
 	if err != nil {


### PR DESCRIPTION
Similar to https://github.com/google/go-github/pull/3477 this adds the missing sorting options from the `SecretScanningAlertListOptions` struct.

These options are available in the [list-secret-scanning-alerts-for-a-repository](https://docs.github.com/en/rest/secret-scanning/secret-scanning?apiVersion=2022-11-28#list-secret-scanning-alerts-for-a-repository) endpoint and the respective ones for orgs and enterprises.