### PR TITLE
feat(actions): add support for GitHub-hosted runner API endpoints

### DIFF
--- a/github/actions_hosted_runners.go
+++ b/github/actions_hosted_runners.go
@@ -1,0 +1,333 @@
+// Copyright 2020 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// HostedRunnerPublicIP represents the details of a public IP for github-hosted runner.
+type HostedRunnerPublicIP struct {
+	Enabled bool   `json:"enabled"`
+	Prefix  string `json:"prefix"`
+	Length  int    `json:"length"`
+}
+
+// HostedRunnerMachineSpec represents the details of a particular machine specification for github-hosted runner.
+type HostedRunnerMachineSpec struct {
+	ID        string `json:"id"`
+	CPUCores  int    `json:"cpu_cores"`
+	MemoryGB  int    `json:"memory_gb"`
+	StorageGB int    `json:"storage_gb"`
+}
+
+// HostedRunner represents a single github-hosted runner with additional details.
+type HostedRunner struct {
+	ID                 *int64                   `json:"id,omitempty"`
+	Name               *string                  `json:"name,omitempty"`
+	RunnerGroupID      *int64                   `json:"runner_group_id,omitempty"`
+	Platform           *string                  `json:"platform,omitempty"`
+	Image              *HostedRunnerImageDetail `json:"image,omitempty"`
+	MachineSizeDetails *HostedRunnerMachineSpec `json:"machine_size_details,omitempty"`
+	Status             *string                  `json:"status,omitempty"`
+	MaximumRunners     *int64                   `json:"maximum_runners,omitempty"`
+	PublicIPEnabled    *bool                    `json:"public_ip_enabled,omitempty"`
+	PublicIPs          []*HostedRunnerPublicIP  `json:"public_ips,omitempty"`
+	LastActiveOn       *string                  `json:"last_active_on,omitempty"`
+}
+
+// HostedRunnerImageDetail represents the image details of a github-hosted runners.
+type HostedRunnerImageDetail struct {
+	ID   *string `json:"id,omitempty"`
+	Size *int    `json:"size,omitempty"`
+}
+
+// HostedRunners represents a collection of github-hosted runners for a organization.
+type HostedRunners struct {
+	TotalCount int             `json:"total_count"`
+	Runners    []*HostedRunner `json:"runners"`
+}
+
+// ListHostedRunners lists all the github-hosted runners for a organization.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/hosted-runners#list-github-hosted-runners-for-an-organization
+//
+//meta:operation GET /orgs/{org}/actions/hosted-runners
+func (s *ActionsService) ListHostedRunners(ctx context.Context, org string, opts *ListOptions) (*HostedRunners, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/hosted-runners", org)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	runners := &HostedRunners{}
+	resp, err := s.client.Do(ctx, req, &runners)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return runners, resp, nil
+}
+
+// HostedRunnerImage represents the image of github-hosted runners
+// To list all available images, use GET /actions/hosted-runners/images/github-owned or GET /actions/hosted-runners/images/partner
+type HostedRunnerImage struct {
+	ID      string `json:"id"`
+	Source  string `json:"source"`
+	Version string `json:"version"`
+}
+
+// CreateHostedRunnerRequest specifies body parameters to Hosted Runner configuration.
+type CreateHostedRunnerRequest struct {
+	Name           string            `json:"name"`
+	Image          HostedRunnerImage `json:"image"`
+	RunnerGroupID  int64             `json:"runner_group_id"`
+	Size           string            `json:"size"`
+	MaximumRunners int64             `json:"maximum_runners,omitempty"`
+	EnableStaticIP bool              `json:"enable_static_ip,omitempty"`
+}
+
+// CreateHostedRunner creates a github-hosted runner for an organization.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/hosted-runners#create-a-github-hosted-runner-for-an-organization
+//
+//meta:operation POST /orgs/{org}/actions/hosted-runners
+func (s *ActionsService) CreateHostedRunner(ctx context.Context, org string, request *CreateHostedRunnerRequest) (*HostedRunner, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/hosted-runners", org)
+	req, err := s.client.NewRequest("POST", u, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hostedRunner := new(HostedRunner)
+	resp, err := s.client.Do(ctx, req, hostedRunner)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return hostedRunner, resp, nil
+}
+
+// HostedRunnerImageSpecs represents the details of a github-hosted runner image.
+type HostedRunnerImageSpecs struct {
+	ID          string `json:"id"`
+	Platform    string `json:"platform"`
+	SizeGB      int    `json:"size_gb"`
+	DisplayName string `json:"display_name"`
+	Source      string `json:"source"`
+}
+
+// HostedRunnerImages represents the response containing the total count and details of runner images.
+type HostedRunnerImages struct {
+	TotalCount int                       `json:"total_count"`
+	Images     []*HostedRunnerImageSpecs `json:"images"`
+}
+
+// GetHostedRunnerGithubOwnedImages gets the list of GitHub-owned images available for github-hosted runners for an organization.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/hosted-runners#get-github-owned-images-for-github-hosted-runners-in-an-organization
+//
+//meta:operation GET /orgs/{org}/actions/hosted-runners/images/github-owned
+func (s *ActionsService) GetHostedRunnerGithubOwnedImages(ctx context.Context, org string) (*HostedRunnerImages, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/images/github-owned", org)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hostedRunnerImages := new(HostedRunnerImages)
+	resp, err := s.client.Do(ctx, req, hostedRunnerImages)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return hostedRunnerImages, resp, nil
+}
+
+// GetHostedRunnerPartnerImages gets the list of partner images available for github-hosted runners for an organization.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/hosted-runners#get-partner-images-for-github-hosted-runners-in-an-organization
+//
+//meta:operation GET /orgs/{org}/actions/hosted-runners/images/partner
+func (s *ActionsService) GetHostedRunnerPartnerImages(ctx context.Context, org string) (*HostedRunnerImages, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/images/partner", org)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hostedRunnerImages := new(HostedRunnerImages)
+	resp, err := s.client.Do(ctx, req, hostedRunnerImages)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return hostedRunnerImages, resp, nil
+}
+
+// HostedRunnerPublicIPLimits represents the static public IP limits for github-hosted runners.
+type HostedRunnerPublicIPLimits struct {
+	PublicIPs *PublicIPUsage `json:"public_ips"`
+}
+
+// PublicIPUsage provides details of static public IP limits for github-hosted runners.
+type PublicIPUsage struct {
+	Maximum      int `json:"maximum"`
+	CurrentUsage int `json:"current_usage"`
+}
+
+// GetHostedRunnerLimits gets the github-hosted runners Static public IP Limits for an organization.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/hosted-runners#get-limits-on-github-hosted-runners-for-an-organization
+//
+//meta:operation GET /orgs/{org}/actions/hosted-runners/limits
+func (s *ActionsService) GetHostedRunnerLimits(ctx context.Context, org string) (*HostedRunnerPublicIPLimits, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/limits", org)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	publicIPLimits := new(HostedRunnerPublicIPLimits)
+	resp, err := s.client.Do(ctx, req, publicIPLimits)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return publicIPLimits, resp, nil
+}
+
+// HostedRunnerMachineSpecs represents the response containing the total count and details of machine specs for github-hosted runners.
+type HostedRunnerMachineSpecs struct {
+	TotalCount   int                        `json:"total_count"`
+	MachineSpecs []*HostedRunnerMachineSpec `json:"machine_specs"`
+}
+
+// GetHostedRunnerMachineSpecs gets the list of machine specs available for github-hosted runners for an organization.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/hosted-runners#get-github-hosted-runners-machine-specs-for-an-organization
+//
+//meta:operation GET /orgs/{org}/actions/hosted-runners/machine-sizes
+func (s *ActionsService) GetHostedRunnerMachineSpecs(ctx context.Context, org string) (*HostedRunnerMachineSpecs, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/machine-sizes", org)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	machineSpecs := new(HostedRunnerMachineSpecs)
+	resp, err := s.client.Do(ctx, req, machineSpecs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return machineSpecs, resp, nil
+}
+
+// HostedRunnerPlatforms represents the response containing the total count and platforms for github-hosted runners.
+type HostedRunnerPlatforms struct {
+	TotalCount int      `json:"total_count"`
+	Platforms  []string `json:"platforms"`
+}
+
+// GetHostedRunnerPlatforms gets list of platforms available for github-hosted runners for an organization.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/hosted-runners#get-platforms-for-github-hosted-runners-in-an-organization
+//
+//meta:operation GET /orgs/{org}/actions/hosted-runners/platforms
+func (s *ActionsService) GetHostedRunnerPlatforms(ctx context.Context, org string) (*HostedRunnerPlatforms, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/platforms", org)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	platforms := new(HostedRunnerPlatforms)
+	resp, err := s.client.Do(ctx, req, platforms)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return platforms, resp, nil
+}
+
+// GetHostedRunner gets a github-hosted runner in an organization.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/hosted-runners#get-a-github-hosted-runner-for-an-organization
+//
+//meta:operation GET /orgs/{org}/actions/hosted-runners/{hosted_runner_id}
+func (s *ActionsService) GetHostedRunner(ctx context.Context, org string, runnerID int64) (*HostedRunner, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/%v", org, runnerID)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hostedRunner := new(HostedRunner)
+	resp, err := s.client.Do(ctx, req, hostedRunner)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return hostedRunner, resp, nil
+}
+
+// UpdateHostedRunnerRequest specifies the parameters for updating a runner specifications.
+type UpdateHostedRunnerRequest struct {
+	Name           string `json:"name"`
+	RunnerGroupID  int64  `json:"runner_group_id"`
+	MaximumRunners int64  `json:"maximum_runners"`
+	EnableStaticIP bool   `json:"enable_static_ip"`
+	ImageVersion   string `json:"image_version"`
+}
+
+// UpdateHostedRunner updates a github-hosted runner for an organization.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/hosted-runners#update-a-github-hosted-runner-for-an-organization
+//
+//meta:operation PATCH /orgs/{org}/actions/hosted-runners/{hosted_runner_id}
+func (s *ActionsService) UpdateHostedRunner(ctx context.Context, org string, runnerID int64, updateReq UpdateHostedRunnerRequest) (*HostedRunner, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/%v", org, runnerID)
+	req, err := s.client.NewRequest("PATCH", u, updateReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hostedRunner := new(HostedRunner)
+	resp, err := s.client.Do(ctx, req, hostedRunner)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return hostedRunner, resp, nil
+}
+
+// DeleteHostedRunner deletes github-hosted runner from an organization.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/hosted-runners#delete-a-github-hosted-runner-for-an-organization
+//
+//meta:operation DELETE /orgs/{org}/actions/hosted-runners/{hosted_runner_id}
+func (s *ActionsService) DeleteHostedRunner(ctx context.Context, org string, runnerID int64) (*HostedRunner, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/%v", org, runnerID)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hostedRunner := new(HostedRunner)
+	resp, err := s.client.Do(ctx, req, hostedRunner)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return hostedRunner, resp, nil
+}

--- a/github/actions_hosted_runners_test.go
+++ b/github/actions_hosted_runners_test.go
@@ -1,0 +1,789 @@
+// Copyright 2020 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestActionsService_ListHostedRunners(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/actions/hosted-runners", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"total_count": 2,
+			"runners": [
+				{
+					"id": 5,
+					"name": "My hosted ubuntu runner",
+					"runner_group_id": 2,
+					"platform": "linux-x64",
+					"image": {
+						"id": "ubuntu-20.04",
+						"size": 86
+					},
+					"machine_size_details": {
+						"id": "4-core",
+						"cpu_cores": 4,
+						"memory_gb": 16,
+						"storage_gb": 150
+					},
+					"status": "Ready",
+					"maximum_runners": 10,
+					"public_ip_enabled": true,
+					"public_ips": [
+						{
+							"enabled": true,
+							"prefix": "20.80.208.150",
+							"length": 31
+						}
+					],
+					"last_active_on": "2022-10-09T23:39:01Z"
+				},
+				{
+					"id": 7,
+					"name": "My hosted Windows runner",
+					"runner_group_id": 2,
+					"platform": "win-x64",
+					"image": {
+						"id": "windows-latest",
+						"size": 256
+					},
+					"machine_size_details": {
+						"id": "8-core",
+						"cpu_cores": 8,
+						"memory_gb": 32,
+						"storage_gb": 300
+					},
+					"status": "Ready",
+					"maximum_runners": 20,
+					"public_ip_enabled": false,
+					"public_ips": [],
+					"last_active_on": "2023-04-26T15:23:37Z"
+				}
+			]
+		}`)
+	})
+	opts := &ListOptions{Page: 1, PerPage: 1}
+	ctx := context.Background()
+	hostedRunners, _, err := client.Actions.ListHostedRunners(ctx, "o", opts)
+	if err != nil {
+		t.Errorf("Actions.ListHostedRunners returned error: %v", err)
+	}
+
+	want := &HostedRunners{
+		TotalCount: 2,
+		Runners: []*HostedRunner{
+			{
+				ID:            Ptr(int64(5)),
+				Name:          Ptr("My hosted ubuntu runner"),
+				RunnerGroupID: Ptr(int64(2)),
+				Platform:      Ptr("linux-x64"),
+				Image: &HostedRunnerImageDetail{
+					ID:   Ptr("ubuntu-20.04"),
+					Size: Ptr(86),
+				},
+				MachineSizeDetails: &HostedRunnerMachineSpec{
+					ID:        "4-core",
+					CPUCores:  4,
+					MemoryGB:  16,
+					StorageGB: 150,
+				},
+				Status:          Ptr("Ready"),
+				MaximumRunners:  Ptr(int64(10)),
+				PublicIPEnabled: Ptr(true),
+				PublicIPs: []*HostedRunnerPublicIP{
+					{
+						Enabled: true,
+						Prefix:  "20.80.208.150",
+						Length:  31,
+					},
+				},
+				LastActiveOn: Ptr("2022-10-09T23:39:01Z"),
+			},
+			{
+				ID:            Ptr(int64(7)),
+				Name:          Ptr("My hosted Windows runner"),
+				RunnerGroupID: Ptr(int64(2)),
+				Platform:      Ptr("win-x64"),
+				Image: &HostedRunnerImageDetail{
+					ID:   Ptr("windows-latest"),
+					Size: Ptr(256),
+				},
+				MachineSizeDetails: &HostedRunnerMachineSpec{
+					ID:        "8-core",
+					CPUCores:  8,
+					MemoryGB:  32,
+					StorageGB: 300,
+				},
+				Status:          Ptr("Ready"),
+				MaximumRunners:  Ptr(int64(20)),
+				PublicIPEnabled: Ptr(false),
+				PublicIPs:       []*HostedRunnerPublicIP{},
+				LastActiveOn:    Ptr("2023-04-26T15:23:37Z"),
+			},
+		},
+	}
+	if !cmp.Equal(hostedRunners, want) {
+		t.Errorf("Actions.ListHostedRunners returned %+v, want %+v", hostedRunners, want)
+	}
+
+	const methodName = "ListHostedRunners"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.ListHostedRunners(ctx, "\n", opts)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.ListHostedRunners(ctx, "o", opts)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestActionsService_CreateHostedRunner(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/actions/hosted-runners", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{
+			"id": 5,
+			"name": "My hosted ubuntu runner",
+			"runner_group_id": 2,
+			"platform": "linux-x64",
+			"image": {
+				"id": "ubuntu-20.04",
+				"size": 86
+			},
+			"machine_size_details": {
+				"id": "4-core",
+				"cpu_cores": 4,
+				"memory_gb": 16,
+				"storage_gb": 150
+			},
+			"status": "Ready",
+			"maximum_runners": 10,
+			"public_ip_enabled": true,
+			"public_ips": [
+				{
+					"enabled": true,
+					"prefix": "20.80.208.150",
+					"length": 31
+				}
+			],
+			"last_active_on": "2022-10-09T23:39:01Z"
+			}`)
+	})
+
+	ctx := context.Background()
+	req := &CreateHostedRunnerRequest{
+		Name: "My Hosted runner",
+		Image: HostedRunnerImage{
+			ID:      "ubuntu-latest",
+			Source:  "github",
+			Version: "latest",
+		},
+		RunnerGroupID:  1,
+		Size:           "4-core",
+		MaximumRunners: 50,
+		EnableStaticIP: false,
+	}
+	hostedRunner, _, err := client.Actions.CreateHostedRunner(ctx, "o", req)
+	if err != nil {
+		t.Errorf("Actions.CreateHostedRunner returned error: %v", err)
+	}
+
+	want := &HostedRunner{
+		ID:            Ptr(int64(5)),
+		Name:          Ptr("My hosted ubuntu runner"),
+		RunnerGroupID: Ptr(int64(2)),
+		Platform:      Ptr("linux-x64"),
+		Image: &HostedRunnerImageDetail{
+			ID:   Ptr("ubuntu-20.04"),
+			Size: Ptr(86),
+		},
+		MachineSizeDetails: &HostedRunnerMachineSpec{
+			ID:        "4-core",
+			CPUCores:  4,
+			MemoryGB:  16,
+			StorageGB: 150,
+		},
+		Status:          Ptr("Ready"),
+		MaximumRunners:  Ptr(int64(10)),
+		PublicIPEnabled: Ptr(true),
+		PublicIPs: []*HostedRunnerPublicIP{
+			{
+				Enabled: true,
+				Prefix:  "20.80.208.150",
+				Length:  31,
+			},
+		},
+		LastActiveOn: Ptr("2022-10-09T23:39:01Z"),
+	}
+
+	if !cmp.Equal(hostedRunner, want) {
+		t.Errorf("Actions.CreateHostedRunner returned %+v, want %+v", hostedRunner, want)
+	}
+
+	const methodName = "CreateHostedRunner"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.CreateHostedRunner(ctx, "\n", req)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.CreateHostedRunner(ctx, "o", req)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestActionsService_GetHostedRunnerGithubOwnedImages(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/actions/hosted-runners/images/github-owned", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"total_count": 1,
+			"images": [
+				{
+					"id": "ubuntu-20.04",
+					"platform": "linux-x64",
+					"size_gb": 86,
+					"display_name": "20.04",
+					"source": "github"
+				}
+			]
+			}`)
+	})
+
+	ctx := context.Background()
+	hostedRunnerImages, _, err := client.Actions.GetHostedRunnerGithubOwnedImages(ctx, "o")
+	if err != nil {
+		t.Errorf("Actions.GetHostedRunnerGithubOwnedImages returned error: %v", err)
+	}
+
+	want := &HostedRunnerImages{
+		TotalCount: 1,
+		Images: []*HostedRunnerImageSpecs{
+			{
+				ID:          "ubuntu-20.04",
+				Platform:    "linux-x64",
+				SizeGB:      86,
+				DisplayName: "20.04",
+				Source:      "github",
+			},
+		},
+	}
+
+	if !cmp.Equal(hostedRunnerImages, want) {
+		t.Errorf("Actions.GetHostedRunnerGithubOwnedImages returned %+v, want %+v", hostedRunnerImages, want)
+	}
+
+	const methodName = "GetHostedRunnerGithubOwnedImages"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.GetHostedRunnerGithubOwnedImages(ctx, "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.GetHostedRunnerGithubOwnedImages(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestActionsService_GetHostedRunnerPartnerImages(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/actions/hosted-runners/images/partner", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"total_count": 1,
+			"images": [
+				{
+					"id": "ubuntu-20.04",
+					"platform": "linux-x64",
+					"size_gb": 86,
+					"display_name": "20.04",
+					"source": "partner"
+				}
+			]
+			}`)
+	})
+
+	ctx := context.Background()
+	hostedRunnerImages, _, err := client.Actions.GetHostedRunnerPartnerImages(ctx, "o")
+	if err != nil {
+		t.Errorf("Actions.GetHostedRunnerPartnerImages returned error: %v", err)
+	}
+
+	want := &HostedRunnerImages{
+		TotalCount: 1,
+		Images: []*HostedRunnerImageSpecs{
+			{
+				ID:          "ubuntu-20.04",
+				Platform:    "linux-x64",
+				SizeGB:      86,
+				DisplayName: "20.04",
+				Source:      "partner",
+			},
+		},
+	}
+
+	if !cmp.Equal(hostedRunnerImages, want) {
+		t.Errorf("Actions.GetHostedRunnerPartnerImages returned %+v, want %+v", hostedRunnerImages, want)
+	}
+
+	const methodName = "GetHostedRunnerPartnerImages"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.GetHostedRunnerPartnerImages(ctx, "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.GetHostedRunnerPartnerImages(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestActionsService_GetHostedRunnerLimits(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/actions/hosted-runners/limits", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"public_ips": {
+				"current_usage": 17,
+				"maximum": 50
+			}
+		}`)
+	})
+
+	ctx := context.Background()
+	publicIPLimits, _, err := client.Actions.GetHostedRunnerLimits(ctx, "o")
+	if err != nil {
+		t.Errorf("Actions.GetPartnerImages returned error: %v", err)
+	}
+
+	want := &HostedRunnerPublicIPLimits{
+		PublicIPs: &PublicIPUsage{
+			CurrentUsage: 17,
+			Maximum:      50,
+		},
+	}
+
+	if !cmp.Equal(publicIPLimits, want) {
+		t.Errorf("Actions.GetHostedRunnerLimits returned %+v, want %+v", publicIPLimits, want)
+	}
+
+	const methodName = "GetHostedRunnerLimits"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.GetHostedRunnerLimits(ctx, "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.GetHostedRunnerLimits(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestActionsService_GetHostedRunnerMachineSpecs(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/actions/hosted-runners/machine-sizes", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"total_count": 1,
+			"machine_specs": [
+				{
+					"id": "4-core",
+ 	 				"cpu_cores": 4,
+  					"memory_gb": 16,
+  					"storage_gb": 150
+				}
+			]
+			}`)
+	})
+
+	ctx := context.Background()
+	machineSpecs, _, err := client.Actions.GetHostedRunnerMachineSpecs(ctx, "o")
+	if err != nil {
+		t.Errorf("Actions.GetHostedRunnerMachineSpecs returned error: %v", err)
+	}
+	want := &HostedRunnerMachineSpecs{
+		TotalCount: 1,
+		MachineSpecs: []*HostedRunnerMachineSpec{
+			{
+				ID:        "4-core",
+				CPUCores:  4,
+				MemoryGB:  16,
+				StorageGB: 150,
+			},
+		},
+	}
+
+	if !cmp.Equal(machineSpecs, want) {
+		t.Errorf("Actions.GetHostedRunnerMachineSpecs returned %+v, want %+v", machineSpecs, want)
+	}
+
+	const methodName = "GetHostedRunnerMachineSpecs"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.GetHostedRunnerMachineSpecs(ctx, "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.GetHostedRunnerMachineSpecs(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestActionsService_GetHostedRunnerPlatforms(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/actions/hosted-runners/platforms", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"total_count": 1,
+  			"platforms": [
+    			"linux-x64",
+    			"win-x64"
+  			]
+		}`)
+	})
+
+	ctx := context.Background()
+	platforms, _, err := client.Actions.GetHostedRunnerPlatforms(ctx, "o")
+	if err != nil {
+		t.Errorf("Actions.GetHostedRunnerPlatforms returned error: %v", err)
+	}
+	want := &HostedRunnerPlatforms{
+		TotalCount: 1,
+		Platforms: []string{
+			"linux-x64",
+			"win-x64",
+		},
+	}
+
+	if !cmp.Equal(platforms, want) {
+		t.Errorf("Actions.GetHostedRunnerPlatforms returned %+v, want %+v", platforms, want)
+	}
+
+	const methodName = "GetHostedRunnerPlatforms"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.GetHostedRunnerPlatforms(ctx, "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.GetHostedRunnerPlatforms(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestActionsService_GetHostedRunner(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/actions/hosted-runners/23", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"id": 5,
+			"name": "My hosted ubuntu runner",
+			"runner_group_id": 2,
+			"platform": "linux-x64",
+			"image": {
+				"id": "ubuntu-20.04",
+				"size": 86
+			},
+			"machine_size_details": {
+				"id": "4-core",
+				"cpu_cores": 4,
+				"memory_gb": 16,
+				"storage_gb": 150
+			},
+			"status": "Ready",
+			"maximum_runners": 10,
+			"public_ip_enabled": true,
+			"public_ips": [
+				{
+				"enabled": true,
+				"prefix": "20.80.208.150",
+				"length": 31
+				}
+			],
+			"last_active_on": "2022-10-09T23:39:01Z"
+		}`)
+	})
+
+	ctx := context.Background()
+	hostedRunner, _, err := client.Actions.GetHostedRunner(ctx, "o", 23)
+	if err != nil {
+		t.Errorf("Actions.GetHostedRunner returned error: %v", err)
+	}
+
+	want := &HostedRunner{
+		ID:            Ptr(int64(5)),
+		Name:          Ptr("My hosted ubuntu runner"),
+		RunnerGroupID: Ptr(int64(2)),
+		Platform:      Ptr("linux-x64"),
+		Image: &HostedRunnerImageDetail{
+			ID:   Ptr("ubuntu-20.04"),
+			Size: Ptr(86),
+		},
+		MachineSizeDetails: &HostedRunnerMachineSpec{
+			ID:        "4-core",
+			CPUCores:  4,
+			MemoryGB:  16,
+			StorageGB: 150,
+		},
+		Status:          Ptr("Ready"),
+		MaximumRunners:  Ptr(int64(10)),
+		PublicIPEnabled: Ptr(true),
+		PublicIPs: []*HostedRunnerPublicIP{
+			{
+				Enabled: true,
+				Prefix:  "20.80.208.150",
+				Length:  31,
+			},
+		},
+		LastActiveOn: Ptr("2022-10-09T23:39:01Z"),
+	}
+
+	if !cmp.Equal(hostedRunner, want) {
+		t.Errorf("Actions.GetHostedRunner returned %+v, want %+v", hostedRunner, want)
+	}
+
+	const methodName = "GetHostedRunner"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.GetHostedRunner(ctx, "\n", 23)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.GetHostedRunner(ctx, "o", 23)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestActionsService_UpdateHostedRunner(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/actions/hosted-runners/23", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		fmt.Fprint(w, `{
+			"id": 5,
+			"name": "My hosted ubuntu runner",
+			"runner_group_id": 2,
+			"platform": "linux-x64",
+			"image": {
+				"id": "ubuntu-20.04",
+				"size": 86
+			},
+			"machine_size_details": {
+				"id": "4-core",
+				"cpu_cores": 4,
+				"memory_gb": 16,
+				"storage_gb": 150
+			},
+			"status": "Ready",
+			"maximum_runners": 10,
+			"public_ip_enabled": true,
+			"public_ips": [
+				{
+					"enabled": true,
+					"prefix": "20.80.208.150",
+					"length": 31
+				}
+			],
+			"last_active_on": "2022-10-09T23:39:01Z"
+			}`)
+	})
+
+	ctx := context.Background()
+	req := UpdateHostedRunnerRequest{
+		Name:           "My larger runner",
+		RunnerGroupID:  1,
+		MaximumRunners: 50,
+		EnableStaticIP: false,
+		ImageVersion:   "1.0.0",
+	}
+	hostedRunner, _, err := client.Actions.UpdateHostedRunner(ctx, "o", 23, req)
+	if err != nil {
+		t.Errorf("Actions.UpdateHostedRunner returned error: %v", err)
+	}
+
+	want := &HostedRunner{
+		ID:            Ptr(int64(5)),
+		Name:          Ptr("My hosted ubuntu runner"),
+		RunnerGroupID: Ptr(int64(2)),
+		Platform:      Ptr("linux-x64"),
+		Image: &HostedRunnerImageDetail{
+			ID:   Ptr("ubuntu-20.04"),
+			Size: Ptr(86),
+		},
+		MachineSizeDetails: &HostedRunnerMachineSpec{
+			ID:        "4-core",
+			CPUCores:  4,
+			MemoryGB:  16,
+			StorageGB: 150,
+		},
+		Status:          Ptr("Ready"),
+		MaximumRunners:  Ptr(int64(10)),
+		PublicIPEnabled: Ptr(true),
+		PublicIPs: []*HostedRunnerPublicIP{
+			{
+				Enabled: true,
+				Prefix:  "20.80.208.150",
+				Length:  31,
+			},
+		},
+		LastActiveOn: Ptr("2022-10-09T23:39:01Z"),
+	}
+
+	if !cmp.Equal(hostedRunner, want) {
+		t.Errorf("Actions.UpdateHostedRunner returned %+v, want %+v", hostedRunner, want)
+	}
+
+	const methodName = "UpdateHostedRunner"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.UpdateHostedRunner(ctx, "\n", 23, req)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.UpdateHostedRunner(ctx, "o", 23, req)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestActionsService_DeleteHostedRunner(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/actions/hosted-runners/23", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		fmt.Fprint(w, `{
+			"id": 5,
+			"name": "My hosted ubuntu runner",
+			"runner_group_id": 2,
+			"platform": "linux-x64",
+			"image": {
+				"id": "ubuntu-20.04",
+				"size": 86
+			},
+			"machine_size_details": {
+				"id": "4-core",
+				"cpu_cores": 4,
+				"memory_gb": 16,
+				"storage_gb": 150
+			},
+			"status": "Ready",
+			"maximum_runners": 10,
+			"public_ip_enabled": true,
+			"public_ips": [
+				{
+				"enabled": true,
+				"prefix": "20.80.208.150",
+				"length": 31
+				}
+			],
+			"last_active_on": "2022-10-09T23:39:01Z"
+		}`)
+	})
+
+	ctx := context.Background()
+	hostedRunner, _, err := client.Actions.DeleteHostedRunner(ctx, "o", 23)
+	if err != nil {
+		t.Errorf("Actions.GetHostedRunner returned error: %v", err)
+	}
+
+	want := &HostedRunner{
+		ID:            Ptr(int64(5)),
+		Name:          Ptr("My hosted ubuntu runner"),
+		RunnerGroupID: Ptr(int64(2)),
+		Platform:      Ptr("linux-x64"),
+		Image: &HostedRunnerImageDetail{
+			ID:   Ptr("ubuntu-20.04"),
+			Size: Ptr(86),
+		},
+		MachineSizeDetails: &HostedRunnerMachineSpec{
+			ID:        "4-core",
+			CPUCores:  4,
+			MemoryGB:  16,
+			StorageGB: 150,
+		},
+		Status:          Ptr("Ready"),
+		MaximumRunners:  Ptr(int64(10)),
+		PublicIPEnabled: Ptr(true),
+		PublicIPs: []*HostedRunnerPublicIP{
+			{
+				Enabled: true,
+				Prefix:  "20.80.208.150",
+				Length:  31,
+			},
+		},
+		LastActiveOn: Ptr("2022-10-09T23:39:01Z"),
+	}
+
+	if !cmp.Equal(hostedRunner, want) {
+		t.Errorf("Actions.DeleteHostedRunner returned %+v, want %+v", hostedRunner, want)
+	}
+
+	const methodName = "DeleteHostedRunner"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.DeleteHostedRunner(ctx, "\n", 23)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.DeleteHostedRunner(ctx, "o", 23)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -10182,6 +10182,110 @@ func (h *HookStats) GetTotalHooks() int {
 	return *h.TotalHooks
 }
 
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (h *HostedRunner) GetID() int64 {
+	if h == nil || h.ID == nil {
+		return 0
+	}
+	return *h.ID
+}
+
+// GetImage returns the Image field.
+func (h *HostedRunner) GetImage() *HostedRunnerImageDetail {
+	if h == nil {
+		return nil
+	}
+	return h.Image
+}
+
+// GetLastActiveOn returns the LastActiveOn field if it's non-nil, zero value otherwise.
+func (h *HostedRunner) GetLastActiveOn() string {
+	if h == nil || h.LastActiveOn == nil {
+		return ""
+	}
+	return *h.LastActiveOn
+}
+
+// GetMachineSizeDetails returns the MachineSizeDetails field.
+func (h *HostedRunner) GetMachineSizeDetails() *HostedRunnerMachineSpec {
+	if h == nil {
+		return nil
+	}
+	return h.MachineSizeDetails
+}
+
+// GetMaximumRunners returns the MaximumRunners field if it's non-nil, zero value otherwise.
+func (h *HostedRunner) GetMaximumRunners() int64 {
+	if h == nil || h.MaximumRunners == nil {
+		return 0
+	}
+	return *h.MaximumRunners
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (h *HostedRunner) GetName() string {
+	if h == nil || h.Name == nil {
+		return ""
+	}
+	return *h.Name
+}
+
+// GetPlatform returns the Platform field if it's non-nil, zero value otherwise.
+func (h *HostedRunner) GetPlatform() string {
+	if h == nil || h.Platform == nil {
+		return ""
+	}
+	return *h.Platform
+}
+
+// GetPublicIPEnabled returns the PublicIPEnabled field if it's non-nil, zero value otherwise.
+func (h *HostedRunner) GetPublicIPEnabled() bool {
+	if h == nil || h.PublicIPEnabled == nil {
+		return false
+	}
+	return *h.PublicIPEnabled
+}
+
+// GetRunnerGroupID returns the RunnerGroupID field if it's non-nil, zero value otherwise.
+func (h *HostedRunner) GetRunnerGroupID() int64 {
+	if h == nil || h.RunnerGroupID == nil {
+		return 0
+	}
+	return *h.RunnerGroupID
+}
+
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (h *HostedRunner) GetStatus() string {
+	if h == nil || h.Status == nil {
+		return ""
+	}
+	return *h.Status
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (h *HostedRunnerImageDetail) GetID() string {
+	if h == nil || h.ID == nil {
+		return ""
+	}
+	return *h.ID
+}
+
+// GetSize returns the Size field if it's non-nil, zero value otherwise.
+func (h *HostedRunnerImageDetail) GetSize() int {
+	if h == nil || h.Size == nil {
+		return 0
+	}
+	return *h.Size
+}
+
+// GetPublicIPs returns the PublicIPs field.
+func (h *HostedRunnerPublicIPLimits) GetPublicIPs() *PublicIPUsage {
+	if h == nil {
+		return nil
+	}
+	return h.PublicIPs
+}
+
 // GetGroupDescription returns the GroupDescription field if it's non-nil, zero value otherwise.
 func (i *IDPGroup) GetGroupDescription() string {
 	if i == nil || i.GroupDescription == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -13180,6 +13180,140 @@ func TestHookStats_GetTotalHooks(tt *testing.T) {
 	h.GetTotalHooks()
 }
 
+func TestHostedRunner_GetID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int64
+	h := &HostedRunner{ID: &zeroValue}
+	h.GetID()
+	h = &HostedRunner{}
+	h.GetID()
+	h = nil
+	h.GetID()
+}
+
+func TestHostedRunner_GetImage(tt *testing.T) {
+	tt.Parallel()
+	h := &HostedRunner{}
+	h.GetImage()
+	h = nil
+	h.GetImage()
+}
+
+func TestHostedRunner_GetLastActiveOn(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	h := &HostedRunner{LastActiveOn: &zeroValue}
+	h.GetLastActiveOn()
+	h = &HostedRunner{}
+	h.GetLastActiveOn()
+	h = nil
+	h.GetLastActiveOn()
+}
+
+func TestHostedRunner_GetMachineSizeDetails(tt *testing.T) {
+	tt.Parallel()
+	h := &HostedRunner{}
+	h.GetMachineSizeDetails()
+	h = nil
+	h.GetMachineSizeDetails()
+}
+
+func TestHostedRunner_GetMaximumRunners(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int64
+	h := &HostedRunner{MaximumRunners: &zeroValue}
+	h.GetMaximumRunners()
+	h = &HostedRunner{}
+	h.GetMaximumRunners()
+	h = nil
+	h.GetMaximumRunners()
+}
+
+func TestHostedRunner_GetName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	h := &HostedRunner{Name: &zeroValue}
+	h.GetName()
+	h = &HostedRunner{}
+	h.GetName()
+	h = nil
+	h.GetName()
+}
+
+func TestHostedRunner_GetPlatform(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	h := &HostedRunner{Platform: &zeroValue}
+	h.GetPlatform()
+	h = &HostedRunner{}
+	h.GetPlatform()
+	h = nil
+	h.GetPlatform()
+}
+
+func TestHostedRunner_GetPublicIPEnabled(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	h := &HostedRunner{PublicIPEnabled: &zeroValue}
+	h.GetPublicIPEnabled()
+	h = &HostedRunner{}
+	h.GetPublicIPEnabled()
+	h = nil
+	h.GetPublicIPEnabled()
+}
+
+func TestHostedRunner_GetRunnerGroupID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int64
+	h := &HostedRunner{RunnerGroupID: &zeroValue}
+	h.GetRunnerGroupID()
+	h = &HostedRunner{}
+	h.GetRunnerGroupID()
+	h = nil
+	h.GetRunnerGroupID()
+}
+
+func TestHostedRunner_GetStatus(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	h := &HostedRunner{Status: &zeroValue}
+	h.GetStatus()
+	h = &HostedRunner{}
+	h.GetStatus()
+	h = nil
+	h.GetStatus()
+}
+
+func TestHostedRunnerImageDetail_GetID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	h := &HostedRunnerImageDetail{ID: &zeroValue}
+	h.GetID()
+	h = &HostedRunnerImageDetail{}
+	h.GetID()
+	h = nil
+	h.GetID()
+}
+
+func TestHostedRunnerImageDetail_GetSize(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	h := &HostedRunnerImageDetail{Size: &zeroValue}
+	h.GetSize()
+	h = &HostedRunnerImageDetail{}
+	h.GetSize()
+	h = nil
+	h.GetSize()
+}
+
+func TestHostedRunnerPublicIPLimits_GetPublicIPs(tt *testing.T) {
+	tt.Parallel()
+	h := &HostedRunnerPublicIPLimits{}
+	h.GetPublicIPs()
+	h = nil
+	h.GetPublicIPs()
+}
+
 func TestIDPGroup_GetGroupDescription(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/repos.go
+++ b/github/repos.go
@@ -833,7 +833,7 @@ func (s *RepositoriesService) DisableVulnerabilityAlerts(ctx context.Context, ow
 
 // GetAutomatedSecurityFixes checks if the automated security fixes for a repository are enabled.
 //
-// GitHub API docs: https://docs.github.com/rest/repos/repos#check-if-automated-security-fixes-are-enabled-for-a-repository
+// GitHub API docs: https://docs.github.com/rest/repos/repos#check-if-dependabot-security-updates-are-enabled-for-a-repository
 //
 //meta:operation GET /repos/{owner}/{repo}/automated-security-fixes
 func (s *RepositoriesService) GetAutomatedSecurityFixes(ctx context.Context, owner, repository string) (*AutomatedSecurityFixes, *Response, error) {
@@ -854,7 +854,7 @@ func (s *RepositoriesService) GetAutomatedSecurityFixes(ctx context.Context, own
 
 // EnableAutomatedSecurityFixes enables the automated security fixes for a repository.
 //
-// GitHub API docs: https://docs.github.com/rest/repos/repos#enable-automated-security-fixes
+// GitHub API docs: https://docs.github.com/rest/repos/repos#enable-dependabot-security-updates
 //
 //meta:operation PUT /repos/{owner}/{repo}/automated-security-fixes
 func (s *RepositoriesService) EnableAutomatedSecurityFixes(ctx context.Context, owner, repository string) (*Response, error) {
@@ -870,7 +870,7 @@ func (s *RepositoriesService) EnableAutomatedSecurityFixes(ctx context.Context, 
 
 // DisableAutomatedSecurityFixes disables vulnerability alerts and the dependency graph for a repository.
 //
-// GitHub API docs: https://docs.github.com/rest/repos/repos#disable-automated-security-fixes
+// GitHub API docs: https://docs.github.com/rest/repos/repos#disable-dependabot-security-updates
 //
 //meta:operation DELETE /repos/{owner}/{repo}/automated-security-fixes
 func (s *RepositoriesService) DisableAutomatedSecurityFixes(ctx context.Context, owner, repository string) (*Response, error) {

--- a/openapi_operations.yaml
+++ b/openapi_operations.yaml
@@ -47,7 +47,7 @@ operation_overrides:
     documentation_url: https://docs.github.com/rest/pages/pages#request-a-github-pages-build
   - name: GET /repos/{owner}/{repo}/pages/builds/{build_id}
     documentation_url: https://docs.github.com/rest/pages/pages#get-github-pages-build
-openapi_commit: 8031023b31a852778532c5fa688b8bb6bcbab9d6
+openapi_commit: 2320d61e4c805300787f8551fda53076bb4fae8b
 openapi_operations:
   - name: GET /
     documentation_url: https://docs.github.com/rest/meta/meta#github-api-root
@@ -504,6 +504,46 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-server@3.15/rest/actions/cache#set-github-actions-cache-usage-policy-for-an-enterprise
     openapi_files:
       - descriptions/ghes-3.15/ghes-3.15.json
+  - name: GET /enterprises/{enterprise}/actions/hosted-runners
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/hosted-runners#list-github-hosted-runners-for-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: POST /enterprises/{enterprise}/actions/hosted-runners
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/hosted-runners#create-a-github-hosted-runner-for-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: GET /enterprises/{enterprise}/actions/hosted-runners/images/github-owned
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/hosted-runners#get-github-owned-images-for-github-hosted-runners-in-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: GET /enterprises/{enterprise}/actions/hosted-runners/images/partner
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/hosted-runners#get-partner-images-for-github-hosted-runners-in-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: GET /enterprises/{enterprise}/actions/hosted-runners/limits
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/hosted-runners#get-limits-on-github-hosted-runners-for-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: GET /enterprises/{enterprise}/actions/hosted-runners/machine-sizes
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/hosted-runners#get-github-hosted-runners-machine-specs-for-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: GET /enterprises/{enterprise}/actions/hosted-runners/platforms
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/hosted-runners#get-platforms-for-github-hosted-runners-in-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: DELETE /enterprises/{enterprise}/actions/hosted-runners/{hosted_runner_id}
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/hosted-runners#delete-a-github-hosted-runner-for-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: GET /enterprises/{enterprise}/actions/hosted-runners/{hosted_runner_id}
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/hosted-runners#get-a-github-hosted-runner-for-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: PATCH /enterprises/{enterprise}/actions/hosted-runners/{hosted_runner_id}
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/hosted-runners#update-a-github-hosted-runner-for-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
   - name: PUT /enterprises/{enterprise}/actions/oidc/customization/issuer
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/actions/oidc#set-the-github-actions-oidc-custom-issuer-policy-for-an-enterprise
     openapi_files:
@@ -724,6 +764,10 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/audit-log#update-an-existing-audit-log-stream-configuration
     openapi_files:
       - descriptions/ghec/ghec.json
+  - name: GET /enterprises/{enterprise}/bypass-requests/push-rules
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/bypass-requests#list-push-rule-bypass-requests-within-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
   - name: GET /enterprises/{enterprise}/code-scanning/alerts
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-code-scanning-alerts-for-an-enterprise
     openapi_files:
@@ -810,6 +854,30 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/license#get-a-license-sync-status
     openapi_files:
       - descriptions/ghec/ghec.json
+  - name: GET /enterprises/{enterprise}/network-configurations
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/network-configurations#list-hosted-compute-network-configurations-for-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: POST /enterprises/{enterprise}/network-configurations
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/network-configurations#create-a-hosted-compute-network-configuration-for-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: DELETE /enterprises/{enterprise}/network-configurations/{network_configuration_id}
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/network-configurations#delete-a-hosted-compute-network-configuration-from-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: GET /enterprises/{enterprise}/network-configurations/{network_configuration_id}
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/network-configurations#get-a-hosted-compute-network-configuration-for-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: PATCH /enterprises/{enterprise}/network-configurations/{network_configuration_id}
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/network-configurations#update-a-hosted-compute-network-configuration-for-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: GET /enterprises/{enterprise}/network-settings/{network_settings_id}
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/network-configurations#get-a-hosted-compute-network-settings-resource-for-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
   - name: GET /enterprises/{enterprise}/properties/schema
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/custom-properties#get-custom-properties-for-an-enterprise
     openapi_files:
@@ -844,6 +912,14 @@ openapi_operations:
       - descriptions/ghec/ghec.json
   - name: PUT /enterprises/{enterprise}/rulesets/{ruleset_id}
     documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/rules#update-an-enterprise-repository-ruleset
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: GET /enterprises/{enterprise}/rulesets/{ruleset_id}/history
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/rules#get-enterprise-ruleset-history
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: GET /enterprises/{enterprise}/rulesets/{ruleset_id}/history/{version_id}
+    documentation_url: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/rules#get-enterprise-ruleset-version
     openapi_files:
       - descriptions/ghec/ghec.json
   - name: GET /enterprises/{enterprise}/secret-scanning/alerts
@@ -1296,6 +1372,56 @@ openapi_operations:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.15/ghes-3.15.json
+  - name: GET /orgs/{org}/actions/hosted-runners
+    documentation_url: https://docs.github.com/rest/actions/hosted-runners#list-github-hosted-runners-for-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: POST /orgs/{org}/actions/hosted-runners
+    documentation_url: https://docs.github.com/rest/actions/hosted-runners#create-a-github-hosted-runner-for-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: GET /orgs/{org}/actions/hosted-runners/images/github-owned
+    documentation_url: https://docs.github.com/rest/actions/hosted-runners#get-github-owned-images-for-github-hosted-runners-in-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: GET /orgs/{org}/actions/hosted-runners/images/partner
+    documentation_url: https://docs.github.com/rest/actions/hosted-runners#get-partner-images-for-github-hosted-runners-in-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: GET /orgs/{org}/actions/hosted-runners/limits
+    documentation_url: https://docs.github.com/rest/actions/hosted-runners#get-limits-on-github-hosted-runners-for-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: GET /orgs/{org}/actions/hosted-runners/machine-sizes
+    documentation_url: https://docs.github.com/rest/actions/hosted-runners#get-github-hosted-runners-machine-specs-for-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: GET /orgs/{org}/actions/hosted-runners/platforms
+    documentation_url: https://docs.github.com/rest/actions/hosted-runners#get-platforms-for-github-hosted-runners-in-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: DELETE /orgs/{org}/actions/hosted-runners/{hosted_runner_id}
+    documentation_url: https://docs.github.com/rest/actions/hosted-runners#delete-a-github-hosted-runner-for-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: GET /orgs/{org}/actions/hosted-runners/{hosted_runner_id}
+    documentation_url: https://docs.github.com/rest/actions/hosted-runners#get-a-github-hosted-runner-for-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: PATCH /orgs/{org}/actions/hosted-runners/{hosted_runner_id}
+    documentation_url: https://docs.github.com/rest/actions/hosted-runners#update-a-github-hosted-runner-for-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
   - name: GET /orgs/{org}/actions/oidc/customization/sub
     documentation_url: https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization
     openapi_files:
@@ -1398,6 +1524,11 @@ openapi_operations:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.15/ghes-3.15.json
+  - name: GET /orgs/{org}/actions/runner-groups/{runner_group_id}/hosted-runners
+    documentation_url: https://docs.github.com/rest/actions/self-hosted-runner-groups#list-github-hosted-runners-in-a-group-for-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
   - name: GET /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories
     documentation_url: https://docs.github.com/rest/actions/self-hosted-runner-groups#list-repository-access-to-a-self-hosted-runner-group-in-an-organization
     openapi_files:
@@ -2625,6 +2756,16 @@ openapi_operations:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.15/ghes-3.15.json
+  - name: GET /orgs/{org}/rulesets/{ruleset_id}/history
+    documentation_url: https://docs.github.com/rest/orgs/rules#get-organization-ruleset-history
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: GET /orgs/{org}/rulesets/{ruleset_id}/history/{version_id}
+    documentation_url: https://docs.github.com/rest/orgs/rules#get-organization-ruleset-version
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
   - name: GET /orgs/{org}/secret-scanning/alerts
     documentation_url: https://docs.github.com/rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-an-organization
     openapi_files:
@@ -2671,6 +2812,36 @@ openapi_operations:
       - descriptions/ghec/ghec.json
   - name: GET /orgs/{org}/settings/billing/shared-storage
     documentation_url: https://docs.github.com/rest/billing/billing#get-shared-storage-billing-for-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: GET /orgs/{org}/settings/network-configurations
+    documentation_url: https://docs.github.com/rest/orgs/network-configurations#list-hosted-compute-network-configurations-for-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: POST /orgs/{org}/settings/network-configurations
+    documentation_url: https://docs.github.com/rest/orgs/network-configurations#create-a-hosted-compute-network-configuration-for-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: DELETE /orgs/{org}/settings/network-configurations/{network_configuration_id}
+    documentation_url: https://docs.github.com/rest/orgs/network-configurations#delete-a-hosted-compute-network-configuration-from-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: GET /orgs/{org}/settings/network-configurations/{network_configuration_id}
+    documentation_url: https://docs.github.com/rest/orgs/network-configurations#get-a-hosted-compute-network-configuration-for-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: PATCH /orgs/{org}/settings/network-configurations/{network_configuration_id}
+    documentation_url: https://docs.github.com/rest/orgs/network-configurations#update-a-hosted-compute-network-configuration-for-an-organization
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: GET /orgs/{org}/settings/network-settings/{network_settings_id}
+    documentation_url: https://docs.github.com/rest/orgs/network-configurations#get-a-hosted-compute-network-settings-resource-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
@@ -3558,18 +3729,18 @@ openapi_operations:
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.15/ghes-3.15.json
   - name: DELETE /repos/{owner}/{repo}/automated-security-fixes
-    documentation_url: https://docs.github.com/rest/repos/repos#disable-automated-security-fixes
+    documentation_url: https://docs.github.com/rest/repos/repos#disable-dependabot-security-updates
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
   - name: GET /repos/{owner}/{repo}/automated-security-fixes
-    documentation_url: https://docs.github.com/rest/repos/repos#check-if-automated-security-fixes-are-enabled-for-a-repository
+    documentation_url: https://docs.github.com/rest/repos/repos#check-if-dependabot-security-updates-are-enabled-for-a-repository
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.15/ghes-3.15.json
   - name: PUT /repos/{owner}/{repo}/automated-security-fixes
-    documentation_url: https://docs.github.com/rest/repos/repos#enable-automated-security-fixes
+    documentation_url: https://docs.github.com/rest/repos/repos#enable-dependabot-security-updates
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
@@ -5522,6 +5693,16 @@ openapi_operations:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.15/ghes-3.15.json
+  - name: GET /repos/{owner}/{repo}/rulesets/{ruleset_id}/history
+    documentation_url: https://docs.github.com/rest/repos/rules#get-repository-ruleset-history
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: GET /repos/{owner}/{repo}/rulesets/{ruleset_id}/history/{version_id}
+    documentation_url: https://docs.github.com/rest/repos/rules#get-repository-ruleset-version
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
   - name: GET /repos/{owner}/{repo}/secret-scanning/alerts
     documentation_url: https://docs.github.com/rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-a-repository
     openapi_files:


### PR DESCRIPTION
This pull request introduces support for the GitHub-hosted runner API endpoints in the go-github library, addressing [Issue #3461](https://github.com/google/go-github/issues/3461).

Changes Include:
* Implementation of API endpoints for managing GitHub-hosted runners.
* Support for the following operations:
* Create a new hosted runner.
* Update existing hosted runner details.
* Delete a hosted runner.
* Retrieve details of hosted runners.
* Corresponding unit tests for each operation.

Additional Information:
API Reference: [GitHub REST API: Hosted Runners](https://docs.github.com/en/rest/actions/hosted-runners).

Please let me know if any additional changes or improvements are needed!







