### PR TITLE
fix: Resolve '400 Custom domains' error on GitHub Enterprise Server

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -16734,6 +16734,38 @@ func (p *PagesUpdate) GetSource() *PagesSource {
 	return p.Source
 }
 
+// GetBuildType returns the BuildType field if it's non-nil, zero value otherwise.
+func (p *PagesUpdateWithoutCNAME) GetBuildType() string {
+	if p == nil || p.BuildType == nil {
+		return ""
+	}
+	return *p.BuildType
+}
+
+// GetHTTPSEnforced returns the HTTPSEnforced field if it's non-nil, zero value otherwise.
+func (p *PagesUpdateWithoutCNAME) GetHTTPSEnforced() bool {
+	if p == nil || p.HTTPSEnforced == nil {
+		return false
+	}
+	return *p.HTTPSEnforced
+}
+
+// GetPublic returns the Public field if it's non-nil, zero value otherwise.
+func (p *PagesUpdateWithoutCNAME) GetPublic() bool {
+	if p == nil || p.Public == nil {
+		return false
+	}
+	return *p.Public
+}
+
+// GetSource returns the Source field.
+func (p *PagesUpdateWithoutCNAME) GetSource() *PagesSource {
+	if p == nil {
+		return nil
+	}
+	return p.Source
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (p *PatternRuleParameters) GetName() string {
 	if p == nil || p.Name == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -21709,6 +21709,47 @@ func TestPagesUpdate_GetSource(tt *testing.T) {
 	p.GetSource()
 }
 
+func TestPagesUpdateWithoutCNAME_GetBuildType(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PagesUpdateWithoutCNAME{BuildType: &zeroValue}
+	p.GetBuildType()
+	p = &PagesUpdateWithoutCNAME{}
+	p.GetBuildType()
+	p = nil
+	p.GetBuildType()
+}
+
+func TestPagesUpdateWithoutCNAME_GetHTTPSEnforced(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	p := &PagesUpdateWithoutCNAME{HTTPSEnforced: &zeroValue}
+	p.GetHTTPSEnforced()
+	p = &PagesUpdateWithoutCNAME{}
+	p.GetHTTPSEnforced()
+	p = nil
+	p.GetHTTPSEnforced()
+}
+
+func TestPagesUpdateWithoutCNAME_GetPublic(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	p := &PagesUpdateWithoutCNAME{Public: &zeroValue}
+	p.GetPublic()
+	p = &PagesUpdateWithoutCNAME{}
+	p.GetPublic()
+	p = nil
+	p.GetPublic()
+}
+
+func TestPagesUpdateWithoutCNAME_GetSource(tt *testing.T) {
+	tt.Parallel()
+	p := &PagesUpdateWithoutCNAME{}
+	p.GetSource()
+	p = nil
+	p.GetSource()
+}
+
 func TestPatternRuleParameters_GetName(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -174,7 +174,7 @@ func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo strin
 }
 
 // PagesUpdateWithoutCNAME defines parameters for updating a GitHub Pages site on GitHub Enterprise Servers.
-// Sending a request with a CNAME (any value, empty string, or null) results in a 400 error: "Custom domains are not available for GitHub Pages."
+// Sending a request with a CNAME (any value, empty string, or null) results in a 400 error: "Custom domains are not available for GitHub Pages".
 type PagesUpdateWithoutCNAME struct {
 	BuildType     *string      `json:"build_type,omitempty"`
 	Source        *PagesSource `json:"source,omitempty"`

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -7,10 +7,7 @@ package github
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net"
-	"net/http"
 )
 
 // Pages represents a GitHub Pages site configuration.
@@ -163,40 +160,38 @@ type PagesUpdate struct {
 //meta:operation PUT /repos/{owner}/{repo}/pages
 func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo string, opts *PagesUpdate) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
-	// Safety check for opts to avoid nil pointer dereference
-	if opts == nil {
-		return nil, errors.New("body parameters PagesUpdate cannot be nil")
-	}
 
-	var req *http.Request
-	var err error
+	req, err := s.client.NewRequest("PUT", u, opts)
 
-	host, _, err := net.SplitHostPort(s.client.BaseURL.Host)
 	if err != nil {
 		return nil, err
 	}
 
-	// Set CNAME to nil if not using the public GitHub API
-	if host != "api.github.com" && host != "127.0.0.1" {
-		// Create a new struct type that omits CNAME
-		type PagesUpdateWithoutCNAME struct {
-			BuildType     *string      `json:"build_type,omitempty"`
-			Source        *PagesSource `json:"source,omitempty"`
-			Public        *bool        `json:"public,omitempty"`
-			HTTPSEnforced *bool        `json:"https_enforced,omitempty"`
-		}
-
-		// Create new struct and copy all fields except CNAME
-		updatedOpts := PagesUpdateWithoutCNAME{
-			BuildType:     opts.BuildType,
-			Source:        opts.Source,
-			Public:        opts.Public,
-			HTTPSEnforced: opts.HTTPSEnforced,
-		}
-		req, err = s.client.NewRequest("PUT", u, updatedOpts)
-	} else {
-		req, err = s.client.NewRequest("PUT", u, opts)
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
 	}
+	return resp, nil
+}
+
+// PagesUpdateWithoutCNAME defines parameters for updating a GitHub Pages site on GitHub Enterprise Servers.
+// Sending a request with a CNAME (any value, empty string, or null) results in a 400 error: "Custom domains are not available for GitHub Pages."
+type PagesUpdateWithoutCNAME struct {
+	BuildType     *string      `json:"build_type,omitempty"`
+	Source        *PagesSource `json:"source,omitempty"`
+	Public        *bool        `json:"public,omitempty"`
+	HTTPSEnforced *bool        `json:"https_enforced,omitempty"`
+}
+
+// UpdatePagesGHES updates GitHub Pages for the named repo in GitHub Enterprise Servers.
+//
+// GitHub API docs: https://docs.github.com/rest/pages/pages#update-information-about-a-github-pages-site
+//
+//meta:operation PUT /repos/{owner}/{repo}/pages
+func (s *RepositoriesService) UpdatePagesGHES(ctx context.Context, owner, repo string, opts *PagesUpdateWithoutCNAME) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
+
+	req, err := s.client.NewRequest("PUT", u, opts)
 
 	if err != nil {
 		return nil, err

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -162,7 +162,6 @@ func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo strin
 	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
 
 	req, err := s.client.NewRequest("PUT", u, opts)
-
 	if err != nil {
 		return nil, err
 	}

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -161,6 +161,16 @@ type PagesUpdate struct {
 func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo string, opts *PagesUpdate) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
 
+	// Safety check for opts to avoid nil pointer dereference
+	if opts == nil {
+		return nil, fmt.Errorf("PagesUpdate options cannot be nil")
+	}
+
+	// Set CNAME to nil if not using the public GitHub API
+	if s.client.BaseURL.Host != "api.github.com" {
+		opts.CNAME = nil
+	}
+
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, err

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -200,6 +200,44 @@ func TestRepositoriesService_UpdatePagesWorkflow(t *testing.T) {
 	})
 }
 
+func TestRepositoriesService_UpdatePagesGHES(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	input := &PagesUpdateWithoutCNAME{
+		BuildType: Ptr("workflow"),
+	}
+
+	mux.HandleFunc("/repos/o/r/pages", func(w http.ResponseWriter, r *http.Request) {
+		v := new(PagesUpdate)
+		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
+
+		testMethod(t, r, "PUT")
+		want := &PagesUpdate{BuildType: Ptr("workflow")}
+		if !cmp.Equal(v, want) {
+			t.Errorf("Request body = %+v, want %+v", v, want)
+		}
+
+		fmt.Fprint(w, `{"build_type":"workflow"}`)
+	})
+
+	ctx := context.Background()
+	_, err := client.Repositories.UpdatePagesGHES(ctx, "o", "r", input)
+	if err != nil {
+		t.Errorf("Repositories.UpdatePagesGHES returned error: %v", err)
+	}
+
+	const methodName = "UpdatePagesGHES"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Repositories.UpdatePagesGHES(ctx, "\n", "\n", input)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Repositories.UpdatePagesGHES(ctx, "o", "r", input)
+	})
+}
+
 func TestRepositoriesService_UpdatePages_NullCNAME(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)


### PR DESCRIPTION
This PR fixes an issue with the UpdatePages method, which caused the error: "400 Custom domains are not available for GitHub Pages" on GHES. The issue occurred because the update struct didn't specify the omitempty tag for JSON marshalling, which resulted in explicit null values being sent. As a result, GHES returned the error.

To resolve this, the fix adds a check for the client URL. If the URL differs from the public GitHub API, a new struct is created without the CNAME field to avoid sending null values.

Question: Should we add the omitempty tag directly to the CNAME field of the PagesUpdate struct instead of this workaround?

References:
- Issue: https://github.com/google/go-github/issues/3466

Fixes: #3466.
