### PR TITLE
feat: Add support for network-configurations endpoints

### DIFF
--- a/github/enterprise_network_configurations.go
+++ b/github/enterprise_network_configurations.go
@@ -1,0 +1,177 @@
+// Copyright 2025 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// ComputeService represents a hosted compute service the network configuration supports.
+type ComputeService string
+
+const (
+	ComputeServiceNone    ComputeService = "none"
+	ComputeServiceActions ComputeService = "actions"
+)
+
+// EnterpriseNetworkConfiguration represents a hosted compute network configuration.
+type EnterpriseNetworkConfiguration struct {
+	ID                 *int64          `json:"id,omitempty"`
+	Name               *string         `json:"name,omitempty"`
+	ComputeService     *ComputeService `json:"compute_service,omitempty"`
+	NetworkSettingsIDs []string        `json:"network_settings_ids,omitempty"`
+	CreatedOn          *Timestamp      `json:"created_on,omitempty"`
+}
+
+// EnterpriseNetworkConfigurations represents a hosted compute network configurations.
+type EnterpriseNetworkConfigurations struct {
+	TotalCount            *int64                            `json:"total_count,omitempty"`
+	NetworkConfigurations []*EnterpriseNetworkConfiguration `json:"network_configurations,omitempty"`
+}
+
+// EnterpriseNetworkSettingsResource represents a hosted compute network settings resource.
+type EnterpriseNetworkSettingsResource struct {
+	ID                     *int64  `json:"id,omitempty"`
+	Name                   *string `json:"name,omitempty"`
+	NetworkConfigurationID *string `json:"network_configuration_id,omitempty"`
+	SubnetID               *string `json:"subnet_id,omitempty"`
+	Region                 *string `json:"region,omitempty"`
+}
+
+// CreateEnterpriseNetworkConfigurationRequest represents a request to create a network configuration for an enterprise.
+type CreateEnterpriseNetworkConfigurationRequest struct {
+	Name               *string         `json:"name,omitempty"`
+	ComputeService     *ComputeService `json:"compute_service,omitempty"`
+	NetworkSettingsIDs *[]string       `json:"network_settings_ids,omitempty"`
+}
+
+// UpdateEnterpriseNetworkConfigurationRequest represents a request to update a network configuration for an enterprise
+type UpdateEnterpriseNetworkConfigurationRequest struct {
+	Name               *string         `json:"name,omitempty"`
+	ComputeService     *ComputeService `json:"compute_service,omitempty"`
+	NetworkSettingsIDs *[]string       `json:"network_settings_ids,omitempty"`
+}
+
+// ListEnterpriseNetworkConfigurations lists all hosted compute network configurations configured in an enterprise.
+//
+// GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/network-configurations#list-hosted-compute-network-configurations-for-an-enterprise
+//
+//meta:operation GET /enterprises/{enterprise}/network-configurations
+func (s *EnterpriseService) ListEnterpriseNetworkConfigurations(ctx context.Context, enterprise string, opts *ListOptions) (*EnterpriseNetworkConfigurations, *Response, error) {
+	u := fmt.Sprintf("/enterprises/%v/network-configurations", enterprise)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	networks := &EnterpriseNetworkConfigurations{}
+	resp, err := s.client.Do(ctx, req, networks)
+	if err != nil {
+		return nil, nil, err
+	}
+	return networks, resp, nil
+}
+
+// CreateEnterpriseNetworkConfiguration creates a hosted compute network configuration for an enterprise.
+//
+// GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/network-configurations#create-a-hosted-compute-network-configuration-for-an-enterprise
+//
+//meta:operation POST /enterprises/{enterprise}/network-configurations
+func (s *EnterpriseService) CreateEnterpriseNetworkConfiguration(ctx context.Context, enterprise string, createReq CreateEnterpriseNetworkConfigurationRequest) (*EnterpriseNetworkConfiguration, *Response, error) {
+	u := fmt.Sprintf("/enterprises/%v/network-configurations", enterprise)
+	req, err := s.client.NewRequest("POST", u, createReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	network := &EnterpriseNetworkConfiguration{}
+	resp, err := s.client.Do(ctx, req, network)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return network, resp, nil
+}
+
+// GetEnterpriseNetworkConfiguration gets a hosted compute network configuration configured in an enterprise.
+//
+// GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/network-configurations#get-a-hosted-compute-network-configuration-for-an-enterprise
+//
+//meta:operation GET /enterprises/{enterprise}/network-configurations/{network_configuration_id}
+func (s *EnterpriseService) GetEnterpriseNetworkConfiguration(ctx context.Context, enterprise string, networkID int64) (*EnterpriseNetworkConfiguration, *Response, error) {
+	u := fmt.Sprintf("/enterprises/%v/network-configurations/%v", enterprise, networkID)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	network := &EnterpriseNetworkConfiguration{}
+	resp, err := s.client.Do(ctx, req, network)
+	if err != nil {
+		return nil, nil, err
+	}
+	return network, resp, nil
+}
+
+// UpdateEnterpriseNetworkConfiguration updates a hosted compute network configuration for an enterprise.
+//
+// GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/network-configurations#update-a-hosted-compute-network-configuration-for-an-enterprise
+//
+//meta:operation PATCH /enterprises/{enterprise}/network-configurations/{network_configuration_id}
+func (s *EnterpriseService) UpdateEnterpriseNetworkConfiguration(ctx context.Context, enterprise string, networkID int64, updateReq UpdateEnterpriseNetworkConfigurationRequest) (*EnterpriseNetworkConfiguration, *Response, error) {
+	u := fmt.Sprintf("/enterprises/%v/network-configurations/%v", enterprise, networkID)
+	req, err := s.client.NewRequest("PATCH", u, updateReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	network := &EnterpriseNetworkConfiguration{}
+	resp, err := s.client.Do(ctx, req, network)
+	if err != nil {
+		return nil, nil, err
+	}
+	return network, resp, nil
+}
+
+// DeleteEnterpriseNetworkConfiguration deletes a hosted compute network configuration from an enterprise.
+//
+// GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/network-configurations#delete-a-hosted-compute-network-configuration-from-an-enterprise
+//
+//meta:operation DELETE /enterprises/{enterprise}/network-configurations/{network_configuration_id}
+func (s *EnterpriseService) DeleteEnterpriseNetworkConfiguration(ctx context.Context, enterprise string, networkID int64) (*Response, error) {
+	u := fmt.Sprintf("enterprises/%v/network-configurations/%v", enterprise, networkID)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+}
+
+// GetEnterpriseNetworkSettingsResource gets a hosted compute network settings resource configured for an enterprise.
+//
+// GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/network-configurations#get-a-hosted-compute-network-settings-resource-for-an-enterprise
+//
+//meta:operation GET /enterprises/{enterprise}/network-settings/{network_settings_id}
+func (s *EnterpriseService) GetEnterpriseNetworkSettingsResource(ctx context.Context, enterprise string, networkID int64) (*EnterpriseNetworkSettingsResource, *Response, error) {
+	u := fmt.Sprintf("/enterprises/%v/network-settings/%v", enterprise, networkID)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resource := &EnterpriseNetworkSettingsResource{}
+	resp, err := s.client.Do(ctx, req, resource)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resource, resp, err
+}

--- a/github/enterprise_network_configurations.go
+++ b/github/enterprise_network_configurations.go
@@ -20,7 +20,7 @@ const (
 
 // EnterpriseNetworkConfiguration represents a hosted compute network configuration.
 type EnterpriseNetworkConfiguration struct {
-	ID                 *int64          `json:"id,omitempty"`
+	ID                 *string         `json:"id,omitempty"`
 	Name               *string         `json:"name,omitempty"`
 	ComputeService     *ComputeService `json:"compute_service,omitempty"`
 	NetworkSettingsIDs []string        `json:"network_settings_ids,omitempty"`
@@ -35,22 +35,15 @@ type EnterpriseNetworkConfigurations struct {
 
 // EnterpriseNetworkSettingsResource represents a hosted compute network settings resource.
 type EnterpriseNetworkSettingsResource struct {
-	ID                     *int64  `json:"id,omitempty"`
+	ID                     *string `json:"id,omitempty"`
 	Name                   *string `json:"name,omitempty"`
 	NetworkConfigurationID *string `json:"network_configuration_id,omitempty"`
 	SubnetID               *string `json:"subnet_id,omitempty"`
 	Region                 *string `json:"region,omitempty"`
 }
 
-// CreateEnterpriseNetworkConfigurationRequest represents a request to create a network configuration for an enterprise.
-type CreateEnterpriseNetworkConfigurationRequest struct {
-	Name               *string         `json:"name,omitempty"`
-	ComputeService     *ComputeService `json:"compute_service,omitempty"`
-	NetworkSettingsIDs *[]string       `json:"network_settings_ids,omitempty"`
-}
-
-// UpdateEnterpriseNetworkConfigurationRequest represents a request to update a network configuration for an enterprise
-type UpdateEnterpriseNetworkConfigurationRequest struct {
+// EnterpriseNetworkConfigurationRequest represents a request to create or update a network configuration for an enterprise.
+type EnterpriseNetworkConfigurationRequest struct {
 	Name               *string         `json:"name,omitempty"`
 	ComputeService     *ComputeService `json:"compute_service,omitempty"`
 	NetworkSettingsIDs *[]string       `json:"network_settings_ids,omitempty"`
@@ -62,7 +55,7 @@ type UpdateEnterpriseNetworkConfigurationRequest struct {
 //
 //meta:operation GET /enterprises/{enterprise}/network-configurations
 func (s *EnterpriseService) ListEnterpriseNetworkConfigurations(ctx context.Context, enterprise string, opts *ListOptions) (*EnterpriseNetworkConfigurations, *Response, error) {
-	u := fmt.Sprintf("/enterprises/%v/network-configurations", enterprise)
+	u := fmt.Sprintf("enterprises/%v/network-configurations", enterprise)
 	u, err := addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
@@ -76,7 +69,7 @@ func (s *EnterpriseService) ListEnterpriseNetworkConfigurations(ctx context.Cont
 	networks := &EnterpriseNetworkConfigurations{}
 	resp, err := s.client.Do(ctx, req, networks)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return networks, resp, nil
 }
@@ -86,8 +79,8 @@ func (s *EnterpriseService) ListEnterpriseNetworkConfigurations(ctx context.Cont
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/network-configurations#create-a-hosted-compute-network-configuration-for-an-enterprise
 //
 //meta:operation POST /enterprises/{enterprise}/network-configurations
-func (s *EnterpriseService) CreateEnterpriseNetworkConfiguration(ctx context.Context, enterprise string, createReq CreateEnterpriseNetworkConfigurationRequest) (*EnterpriseNetworkConfiguration, *Response, error) {
-	u := fmt.Sprintf("/enterprises/%v/network-configurations", enterprise)
+func (s *EnterpriseService) CreateEnterpriseNetworkConfiguration(ctx context.Context, enterprise string, createReq EnterpriseNetworkConfigurationRequest) (*EnterpriseNetworkConfiguration, *Response, error) {
+	u := fmt.Sprintf("enterprises/%v/network-configurations", enterprise)
 	req, err := s.client.NewRequest("POST", u, createReq)
 	if err != nil {
 		return nil, nil, err
@@ -96,7 +89,7 @@ func (s *EnterpriseService) CreateEnterpriseNetworkConfiguration(ctx context.Con
 	network := &EnterpriseNetworkConfiguration{}
 	resp, err := s.client.Do(ctx, req, network)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 
 	return network, resp, nil
@@ -107,8 +100,8 @@ func (s *EnterpriseService) CreateEnterpriseNetworkConfiguration(ctx context.Con
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/network-configurations#get-a-hosted-compute-network-configuration-for-an-enterprise
 //
 //meta:operation GET /enterprises/{enterprise}/network-configurations/{network_configuration_id}
-func (s *EnterpriseService) GetEnterpriseNetworkConfiguration(ctx context.Context, enterprise string, networkID int64) (*EnterpriseNetworkConfiguration, *Response, error) {
-	u := fmt.Sprintf("/enterprises/%v/network-configurations/%v", enterprise, networkID)
+func (s *EnterpriseService) GetEnterpriseNetworkConfiguration(ctx context.Context, enterprise string, networkID string) (*EnterpriseNetworkConfiguration, *Response, error) {
+	u := fmt.Sprintf("enterprises/%v/network-configurations/%v", enterprise, networkID)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -117,7 +110,7 @@ func (s *EnterpriseService) GetEnterpriseNetworkConfiguration(ctx context.Contex
 	network := &EnterpriseNetworkConfiguration{}
 	resp, err := s.client.Do(ctx, req, network)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return network, resp, nil
 }
@@ -127,8 +120,8 @@ func (s *EnterpriseService) GetEnterpriseNetworkConfiguration(ctx context.Contex
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/network-configurations#update-a-hosted-compute-network-configuration-for-an-enterprise
 //
 //meta:operation PATCH /enterprises/{enterprise}/network-configurations/{network_configuration_id}
-func (s *EnterpriseService) UpdateEnterpriseNetworkConfiguration(ctx context.Context, enterprise string, networkID int64, updateReq UpdateEnterpriseNetworkConfigurationRequest) (*EnterpriseNetworkConfiguration, *Response, error) {
-	u := fmt.Sprintf("/enterprises/%v/network-configurations/%v", enterprise, networkID)
+func (s *EnterpriseService) UpdateEnterpriseNetworkConfiguration(ctx context.Context, enterprise string, networkID string, updateReq EnterpriseNetworkConfigurationRequest) (*EnterpriseNetworkConfiguration, *Response, error) {
+	u := fmt.Sprintf("enterprises/%v/network-configurations/%v", enterprise, networkID)
 	req, err := s.client.NewRequest("PATCH", u, updateReq)
 	if err != nil {
 		return nil, nil, err
@@ -137,7 +130,7 @@ func (s *EnterpriseService) UpdateEnterpriseNetworkConfiguration(ctx context.Con
 	network := &EnterpriseNetworkConfiguration{}
 	resp, err := s.client.Do(ctx, req, network)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return network, resp, nil
 }
@@ -147,7 +140,7 @@ func (s *EnterpriseService) UpdateEnterpriseNetworkConfiguration(ctx context.Con
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/network-configurations#delete-a-hosted-compute-network-configuration-from-an-enterprise
 //
 //meta:operation DELETE /enterprises/{enterprise}/network-configurations/{network_configuration_id}
-func (s *EnterpriseService) DeleteEnterpriseNetworkConfiguration(ctx context.Context, enterprise string, networkID int64) (*Response, error) {
+func (s *EnterpriseService) DeleteEnterpriseNetworkConfiguration(ctx context.Context, enterprise string, networkID string) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/network-configurations/%v", enterprise, networkID)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -161,8 +154,8 @@ func (s *EnterpriseService) DeleteEnterpriseNetworkConfiguration(ctx context.Con
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/network-configurations#get-a-hosted-compute-network-settings-resource-for-an-enterprise
 //
 //meta:operation GET /enterprises/{enterprise}/network-settings/{network_settings_id}
-func (s *EnterpriseService) GetEnterpriseNetworkSettingsResource(ctx context.Context, enterprise string, networkID int64) (*EnterpriseNetworkSettingsResource, *Response, error) {
-	u := fmt.Sprintf("/enterprises/%v/network-settings/%v", enterprise, networkID)
+func (s *EnterpriseService) GetEnterpriseNetworkSettingsResource(ctx context.Context, enterprise string, networkID string) (*EnterpriseNetworkSettingsResource, *Response, error) {
+	u := fmt.Sprintf("enterprises/%v/network-settings/%v", enterprise, networkID)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -171,7 +164,7 @@ func (s *EnterpriseService) GetEnterpriseNetworkSettingsResource(ctx context.Con
 	resource := &EnterpriseNetworkSettingsResource{}
 	resp, err := s.client.Do(ctx, req, resource)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return resource, resp, err
 }

--- a/github/enterprise_network_configurations.go
+++ b/github/enterprise_network_configurations.go
@@ -46,7 +46,7 @@ type EnterpriseNetworkSettingsResource struct {
 type EnterpriseNetworkConfigurationRequest struct {
 	Name               *string         `json:"name,omitempty"`
 	ComputeService     *ComputeService `json:"compute_service,omitempty"`
-	NetworkSettingsIDs *[]string       `json:"network_settings_ids,omitempty"`
+	NetworkSettingsIDs []string        `json:"network_settings_ids,omitempty"`
 }
 
 // ListEnterpriseNetworkConfigurations lists all hosted compute network configurations configured in an enterprise.
@@ -100,7 +100,7 @@ func (s *EnterpriseService) CreateEnterpriseNetworkConfiguration(ctx context.Con
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/network-configurations#get-a-hosted-compute-network-configuration-for-an-enterprise
 //
 //meta:operation GET /enterprises/{enterprise}/network-configurations/{network_configuration_id}
-func (s *EnterpriseService) GetEnterpriseNetworkConfiguration(ctx context.Context, enterprise string, networkID string) (*EnterpriseNetworkConfiguration, *Response, error) {
+func (s *EnterpriseService) GetEnterpriseNetworkConfiguration(ctx context.Context, enterprise, networkID string) (*EnterpriseNetworkConfiguration, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/network-configurations/%v", enterprise, networkID)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -120,7 +120,7 @@ func (s *EnterpriseService) GetEnterpriseNetworkConfiguration(ctx context.Contex
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/network-configurations#update-a-hosted-compute-network-configuration-for-an-enterprise
 //
 //meta:operation PATCH /enterprises/{enterprise}/network-configurations/{network_configuration_id}
-func (s *EnterpriseService) UpdateEnterpriseNetworkConfiguration(ctx context.Context, enterprise string, networkID string, updateReq EnterpriseNetworkConfigurationRequest) (*EnterpriseNetworkConfiguration, *Response, error) {
+func (s *EnterpriseService) UpdateEnterpriseNetworkConfiguration(ctx context.Context, enterprise, networkID string, updateReq EnterpriseNetworkConfigurationRequest) (*EnterpriseNetworkConfiguration, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/network-configurations/%v", enterprise, networkID)
 	req, err := s.client.NewRequest("PATCH", u, updateReq)
 	if err != nil {
@@ -140,7 +140,7 @@ func (s *EnterpriseService) UpdateEnterpriseNetworkConfiguration(ctx context.Con
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/network-configurations#delete-a-hosted-compute-network-configuration-from-an-enterprise
 //
 //meta:operation DELETE /enterprises/{enterprise}/network-configurations/{network_configuration_id}
-func (s *EnterpriseService) DeleteEnterpriseNetworkConfiguration(ctx context.Context, enterprise string, networkID string) (*Response, error) {
+func (s *EnterpriseService) DeleteEnterpriseNetworkConfiguration(ctx context.Context, enterprise, networkID string) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/network-configurations/%v", enterprise, networkID)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -154,7 +154,7 @@ func (s *EnterpriseService) DeleteEnterpriseNetworkConfiguration(ctx context.Con
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/network-configurations#get-a-hosted-compute-network-settings-resource-for-an-enterprise
 //
 //meta:operation GET /enterprises/{enterprise}/network-settings/{network_settings_id}
-func (s *EnterpriseService) GetEnterpriseNetworkSettingsResource(ctx context.Context, enterprise string, networkID string) (*EnterpriseNetworkSettingsResource, *Response, error) {
+func (s *EnterpriseService) GetEnterpriseNetworkSettingsResource(ctx context.Context, enterprise, networkID string) (*EnterpriseNetworkSettingsResource, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/network-settings/%v", enterprise, networkID)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/enterprise_network_configurations_test.go
+++ b/github/enterprise_network_configurations_test.go
@@ -1,0 +1,335 @@
+// Copyright 2025 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestEnterpriseService_ListEnterpriseNetworkConfigurations(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc(" /enterprises/e/network-configurations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"page": "3", "per_page": "2"})
+		fmt.Fprintf(w, `{
+		  "total_count": 2,
+		  "network_configurations": [
+			{
+			  "id": "123456789ABCDEF",
+			  "name": "configuration_one",
+			  "compute_service": "actions",
+			  "network_settings_ids": [
+				"23456789ABDCEF1",
+				"3456789ABDCEF12"
+			  ],
+			  "created_on": "2024-04-09T17:30:15Z"
+			},
+			{
+			  "id": "456789ABDCEF123",
+			  "name": "configuration_two",
+			  "compute_service": "none",
+			  "network_settings_ids": [
+				"56789ABDCEF1234",
+				"6789ABDCEF12345"
+			  ],
+			  "created_on": "2024-11-02T12:30:30Z"
+			}
+		  ]
+		}`)
+	})
+
+	ctx := context.Background()
+
+	opts := &ListOptions{Page: 3, PerPage: 2}
+	configurations, _, err := client.Enterprise.ListEnterpriseNetworkConfigurations(ctx, "e", opts)
+	if err != nil {
+		t.Errorf("Enterprise.ListEnterpriseNetworkConfigurations returned error: %v", err)
+	}
+
+	want := &EnterpriseNetworkConfigurations{
+		TotalCount: Ptr(int64(2)),
+		NetworkConfigurations: []*EnterpriseNetworkConfiguration{
+			{
+				ID:                 Ptr("123456789ABCDEF"),
+				Name:               Ptr("configuration_one"),
+				ComputeService:     Ptr(ComputeService("actions")),
+				NetworkSettingsIDs: []string{"23456789ABDCEF1", "3456789ABDCEF12"},
+				CreatedOn:          &Timestamp{time.Date(2024, 4, 9, 17, 30, 15, 0, time.UTC)},
+			},
+			{
+				ID:                 Ptr("456789ABDCEF123"),
+				Name:               Ptr("configuration_two"),
+				ComputeService:     Ptr(ComputeService("none")),
+				NetworkSettingsIDs: []string{"56789ABDCEF1234", "6789ABDCEF12345"},
+				CreatedOn:          &Timestamp{time.Date(2024, 11, 2, 12, 30, 30, 0, time.UTC)},
+			},
+		},
+	}
+	if !cmp.Equal(configurations, want) {
+		t.Errorf("Enterprise.ListEnterpriseNetworkConfigurations mismatch (-want +got):\n%s", cmp.Diff(want, configurations))
+	}
+
+	const methodName = "ListEnterpriseNetworkConfigurations"
+	testBadOptions(t, methodName, func() error {
+		_, _, err = client.Enterprise.ListEnterpriseNetworkConfigurations(ctx, "\ne", opts)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Enterprise.ListEnterpriseNetworkConfigurations(ctx, "e", opts)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestEnterpriseService_CreateEnterpriseNetworkConfiguration(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/enterprises/e/network-configurations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprintf(w, `{
+		  "id": "123456789ABCDEF",
+		  "name": "configuration_one",
+		  "compute_service": "actions",
+		  "network_settings_ids": [
+			"23456789ABDCEF1",
+			"3456789ABDCEF12"
+		  ],
+		  "created_on": "2024-04-09T17:30:15Z"
+		}`)
+	})
+
+	ctx := context.Background()
+
+	req := EnterpriseNetworkConfigurationRequest{
+		Name:           Ptr("configuration_one"),
+		ComputeService: Ptr(ComputeService("actions")),
+		NetworkSettingsIDs: &[]string{
+			"23456789ABDCEF1",
+			"3456789ABDCEF12",
+		},
+	}
+	configuration, _, err := client.Enterprise.CreateEnterpriseNetworkConfiguration(ctx, "e", req)
+	if err != nil {
+		t.Errorf("Enterprise.CreateEnterpriseNetworkConfiguration returned error: %v", err)
+	}
+
+	want := &EnterpriseNetworkConfiguration{
+		ID:                 Ptr("123456789ABCDEF"),
+		Name:               Ptr("configuration_one"),
+		ComputeService:     Ptr(ComputeService("actions")),
+		NetworkSettingsIDs: []string{"23456789ABDCEF1", "3456789ABDCEF12"},
+		CreatedOn:          &Timestamp{time.Date(2024, 4, 9, 17, 30, 15, 0, time.UTC)},
+	}
+	if !cmp.Equal(configuration, want) {
+		t.Errorf("Enterprise.CreateEnterpriseNetworkConfiguration mismatch (-want +got):\n%s", cmp.Diff(want, configuration))
+	}
+
+	const methodName = "CreateEnterpriseNetworkConfiguration"
+	testBadOptions(t, methodName, func() error {
+		_, _, err = client.Enterprise.CreateEnterpriseNetworkConfiguration(ctx, "\ne", req)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Enterprise.CreateEnterpriseNetworkConfiguration(ctx, "e", req)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestEnterpriseService_GetEnterpriseNetworkConfiguration(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/enterprises/e/network-configurations/123456789ABCDEF", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprintf(w, `{
+		  "id": "123456789ABCDEF",
+		  "name": "configuration_one",
+		  "compute_service": "actions",
+		  "network_settings_ids": [
+			"23456789ABDCEF1",
+			"3456789ABDCEF12"
+		  ],
+		  "created_on": "2024-12-10T19:00:15Z"
+		}`)
+	})
+
+	ctx := context.Background()
+	configuration, _, err := client.Enterprise.GetEnterpriseNetworkConfiguration(ctx, "e", "123456789ABCDEF")
+	if err != nil {
+		t.Errorf("Enterprise.GetEnterpriseNetworkConfiguration returned err: %v", err)
+	}
+
+	want := &EnterpriseNetworkConfiguration{
+		ID:                 Ptr("123456789ABCDEF"),
+		Name:               Ptr("configuration_one"),
+		ComputeService:     Ptr(ComputeService("actions")),
+		NetworkSettingsIDs: []string{"23456789ABDCEF1", "3456789ABDCEF12"},
+		CreatedOn:          &Timestamp{time.Date(2024, 12, 10, 19, 00, 15, 0, time.UTC)},
+	}
+	if !cmp.Equal(configuration, want) {
+		t.Errorf("Enterprise.GetEnterpriseNetworkConfiguration mismatch (-want +got):\n%s", cmp.Diff(want, configuration))
+	}
+
+	const methodName = "GetEnterpriseNetworkConfiguration"
+	testBadOptions(t, methodName, func() error {
+		_, _, err = client.Enterprise.GetEnterpriseNetworkConfiguration(ctx, "\ne", "123456789ABCDEF")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Enterprise.GetEnterpriseNetworkConfiguration(ctx, "e", "123456789ABCDEF")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestEnterpriseService_UpdateEnterpriseNetworkConfiguration(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/enterprises/e/network-configurations/123456789ABCDEF", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		fmt.Fprintf(w, `{
+		  "id": "123456789ABCDEF",
+		  "name": "updated_configuration_one",
+		  "compute_service": "none",
+		  "network_settings_ids": [
+			"456789ABDCEF123",
+			"56789ABDCEF1234"
+		  ],
+		  "created_on": "2024-12-10T19:00:15Z"
+		}`)
+	})
+
+	ctx := context.Background()
+	req := EnterpriseNetworkConfigurationRequest{
+		Name: Ptr("updated_configuration_one"),
+		NetworkSettingsIDs: &[]string{
+			"456789ABDCEF123",
+			"56789ABDCEF1234",
+		},
+		ComputeService: Ptr(ComputeService("none")),
+	}
+	configuration, _, err := client.Enterprise.UpdateEnterpriseNetworkConfiguration(ctx, "e", "123456789ABCDEF", req)
+	if err != nil {
+		t.Errorf("Enterprise.UpdateEnterpriseNetworkConfiguration returned error %v", err)
+	}
+
+	want := &EnterpriseNetworkConfiguration{
+		ID:                 Ptr("123456789ABCDEF"),
+		Name:               Ptr("updated_configuration_one"),
+		ComputeService:     Ptr(ComputeService("none")),
+		NetworkSettingsIDs: []string{"456789ABDCEF123", "56789ABDCEF1234"},
+		CreatedOn:          &Timestamp{time.Date(2024, 12, 10, 19, 00, 15, 0, time.UTC)},
+	}
+	if !cmp.Equal(configuration, want) {
+		t.Errorf("Enterprise.UpdateEnterpriseNetworkConfiguration mismatch (-want +get)\n%s", cmp.Diff(want, configuration))
+	}
+
+	const methodName = "UpdateEnterpriseNetworkConfiguration"
+	testBadOptions(t, methodName, func() error {
+		_, _, err = client.Enterprise.UpdateEnterpriseNetworkConfiguration(ctx, "\ne", "123456789ABCDEF", req)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Enterprise.UpdateEnterpriseNetworkConfiguration(ctx, "e", "123456789ABCDEF", req)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestEnterpriseService_DeleteEnterpriseNetworkConfiguration(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/enterprises/e/network-configurations/123456789ABCDEF", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	ctx := context.Background()
+	_, err := client.Enterprise.DeleteEnterpriseNetworkConfiguration(ctx, "e", "123456789ABCDEF")
+	if err != nil {
+		t.Errorf("Enterprise.DeleteEnterpriseNetworkConfiguration returned error %v", err)
+	}
+
+	const methodName = "DeleteEnterpriseNetworkConfiguration"
+	testBadOptions(t, methodName, func() error {
+		_, err = client.Enterprise.DeleteEnterpriseNetworkConfiguration(ctx, "\ne", "123456789ABCDEF")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Enterprise.DeleteEnterpriseNetworkConfiguration(ctx, "e", "123456789ABCDEF")
+	})
+}
+
+func TestEnterpriseService_GetEnterpriseNetworkSettingsResource(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/enterprises/e/network-settings/123456789ABCDEF", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprintf(w, `{
+			"id": "220F78DACB92BBFBC5E6F22DE1CCF52309D",
+			"network_configuration_id": "934E208B3EE0BD60CF5F752C426BFB53562",
+			"name": "my_network_settings",
+			"subnet_id": "/subscriptions/14839728-3ad9-43ab-bd2b-fa6ad0f75e2a/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet",
+			"region": "germanywestcentral"
+		}`)
+	})
+
+	ctx := context.Background()
+	resource, _, err := client.Enterprise.GetEnterpriseNetworkSettingsResource(ctx, "e", "123456789ABCDEF")
+	if err != nil {
+		t.Errorf("Enterprise.GetEnterpriseNetworkSettingsResource returned error %v", err)
+	}
+
+	want := &EnterpriseNetworkSettingsResource{
+		ID:                     Ptr("220F78DACB92BBFBC5E6F22DE1CCF52309D"),
+		NetworkConfigurationID: Ptr("934E208B3EE0BD60CF5F752C426BFB53562"),
+		Name:                   Ptr("my_network_settings"),
+		SubnetID:               Ptr("/subscriptions/14839728-3ad9-43ab-bd2b-fa6ad0f75e2a/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet"),
+		Region:                 Ptr("germanywestcentral"),
+	}
+	if !cmp.Equal(resource, want) {
+		t.Errorf("Enterprise.GetEnterpriseNetworkSettingsResource mistach (-want +got):\n%s", cmp.Diff(want, resource))
+	}
+
+	const methodName = "GetEnterpriseNetworkSettingsResource"
+	testBadOptions(t, methodName, func() error {
+		_, _, err = client.Enterprise.GetEnterpriseNetworkSettingsResource(ctx, "\ne", "123456789ABCDEF")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Enterprise.GetEnterpriseNetworkSettingsResource(ctx, "e", "123456789ABCDEF")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}

--- a/github/enterprise_network_configurations_test.go
+++ b/github/enterprise_network_configurations_test.go
@@ -118,7 +118,7 @@ func TestEnterpriseService_CreateEnterpriseNetworkConfiguration(t *testing.T) {
 	req := EnterpriseNetworkConfigurationRequest{
 		Name:           Ptr("configuration_one"),
 		ComputeService: Ptr(ComputeService("actions")),
-		NetworkSettingsIDs: &[]string{
+		NetworkSettingsIDs: []string{
 			"23456789ABDCEF1",
 			"3456789ABDCEF12",
 		},
@@ -225,7 +225,7 @@ func TestEnterpriseService_UpdateEnterpriseNetworkConfiguration(t *testing.T) {
 	ctx := context.Background()
 	req := EnterpriseNetworkConfigurationRequest{
 		Name: Ptr("updated_configuration_one"),
-		NetworkSettingsIDs: &[]string{
+		NetworkSettingsIDs: []string{
 			"456789ABDCEF123",
 			"56789ABDCEF1234",
 		},

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -8654,14 +8654,6 @@ func (e *EnterpriseNetworkConfigurationRequest) GetName() string {
 	return *e.Name
 }
 
-// GetNetworkSettingsIDs returns the NetworkSettingsIDs field if it's non-nil, zero value otherwise.
-func (e *EnterpriseNetworkConfigurationRequest) GetNetworkSettingsIDs() []string {
-	if e == nil || e.NetworkSettingsIDs == nil {
-		return nil
-	}
-	return *e.NetworkSettingsIDs
-}
-
 // GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
 func (e *EnterpriseNetworkConfigurations) GetTotalCount() int64 {
 	if e == nil || e.TotalCount == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -8606,6 +8606,110 @@ func (e *Enterprise) GetWebsiteURL() string {
 	return *e.WebsiteURL
 }
 
+// GetComputeService returns the ComputeService field.
+func (e *EnterpriseNetworkConfiguration) GetComputeService() *ComputeService {
+	if e == nil {
+		return nil
+	}
+	return e.ComputeService
+}
+
+// GetCreatedOn returns the CreatedOn field if it's non-nil, zero value otherwise.
+func (e *EnterpriseNetworkConfiguration) GetCreatedOn() Timestamp {
+	if e == nil || e.CreatedOn == nil {
+		return Timestamp{}
+	}
+	return *e.CreatedOn
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (e *EnterpriseNetworkConfiguration) GetID() string {
+	if e == nil || e.ID == nil {
+		return ""
+	}
+	return *e.ID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (e *EnterpriseNetworkConfiguration) GetName() string {
+	if e == nil || e.Name == nil {
+		return ""
+	}
+	return *e.Name
+}
+
+// GetComputeService returns the ComputeService field.
+func (e *EnterpriseNetworkConfigurationRequest) GetComputeService() *ComputeService {
+	if e == nil {
+		return nil
+	}
+	return e.ComputeService
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (e *EnterpriseNetworkConfigurationRequest) GetName() string {
+	if e == nil || e.Name == nil {
+		return ""
+	}
+	return *e.Name
+}
+
+// GetNetworkSettingsIDs returns the NetworkSettingsIDs field if it's non-nil, zero value otherwise.
+func (e *EnterpriseNetworkConfigurationRequest) GetNetworkSettingsIDs() []string {
+	if e == nil || e.NetworkSettingsIDs == nil {
+		return nil
+	}
+	return *e.NetworkSettingsIDs
+}
+
+// GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
+func (e *EnterpriseNetworkConfigurations) GetTotalCount() int64 {
+	if e == nil || e.TotalCount == nil {
+		return 0
+	}
+	return *e.TotalCount
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (e *EnterpriseNetworkSettingsResource) GetID() string {
+	if e == nil || e.ID == nil {
+		return ""
+	}
+	return *e.ID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (e *EnterpriseNetworkSettingsResource) GetName() string {
+	if e == nil || e.Name == nil {
+		return ""
+	}
+	return *e.Name
+}
+
+// GetNetworkConfigurationID returns the NetworkConfigurationID field if it's non-nil, zero value otherwise.
+func (e *EnterpriseNetworkSettingsResource) GetNetworkConfigurationID() string {
+	if e == nil || e.NetworkConfigurationID == nil {
+		return ""
+	}
+	return *e.NetworkConfigurationID
+}
+
+// GetRegion returns the Region field if it's non-nil, zero value otherwise.
+func (e *EnterpriseNetworkSettingsResource) GetRegion() string {
+	if e == nil || e.Region == nil {
+		return ""
+	}
+	return *e.Region
+}
+
+// GetSubnetID returns the SubnetID field if it's non-nil, zero value otherwise.
+func (e *EnterpriseNetworkSettingsResource) GetSubnetID() string {
+	if e == nil || e.SubnetID == nil {
+		return ""
+	}
+	return *e.SubnetID
+}
+
 // GetAllowsPublicRepositories returns the AllowsPublicRepositories field if it's non-nil, zero value otherwise.
 func (e *EnterpriseRunnerGroup) GetAllowsPublicRepositories() bool {
 	if e == nil || e.AllowsPublicRepositories == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11118,6 +11118,143 @@ func TestEnterprise_GetWebsiteURL(tt *testing.T) {
 	e.GetWebsiteURL()
 }
 
+func TestEnterpriseNetworkConfiguration_GetComputeService(tt *testing.T) {
+	tt.Parallel()
+	e := &EnterpriseNetworkConfiguration{}
+	e.GetComputeService()
+	e = nil
+	e.GetComputeService()
+}
+
+func TestEnterpriseNetworkConfiguration_GetCreatedOn(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue Timestamp
+	e := &EnterpriseNetworkConfiguration{CreatedOn: &zeroValue}
+	e.GetCreatedOn()
+	e = &EnterpriseNetworkConfiguration{}
+	e.GetCreatedOn()
+	e = nil
+	e.GetCreatedOn()
+}
+
+func TestEnterpriseNetworkConfiguration_GetID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	e := &EnterpriseNetworkConfiguration{ID: &zeroValue}
+	e.GetID()
+	e = &EnterpriseNetworkConfiguration{}
+	e.GetID()
+	e = nil
+	e.GetID()
+}
+
+func TestEnterpriseNetworkConfiguration_GetName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	e := &EnterpriseNetworkConfiguration{Name: &zeroValue}
+	e.GetName()
+	e = &EnterpriseNetworkConfiguration{}
+	e.GetName()
+	e = nil
+	e.GetName()
+}
+
+func TestEnterpriseNetworkConfigurationRequest_GetComputeService(tt *testing.T) {
+	tt.Parallel()
+	e := &EnterpriseNetworkConfigurationRequest{}
+	e.GetComputeService()
+	e = nil
+	e.GetComputeService()
+}
+
+func TestEnterpriseNetworkConfigurationRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	e := &EnterpriseNetworkConfigurationRequest{Name: &zeroValue}
+	e.GetName()
+	e = &EnterpriseNetworkConfigurationRequest{}
+	e.GetName()
+	e = nil
+	e.GetName()
+}
+
+func TestEnterpriseNetworkConfigurationRequest_GetNetworkSettingsIDs(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue []string
+	e := &EnterpriseNetworkConfigurationRequest{NetworkSettingsIDs: &zeroValue}
+	e.GetNetworkSettingsIDs()
+	e = &EnterpriseNetworkConfigurationRequest{}
+	e.GetNetworkSettingsIDs()
+	e = nil
+	e.GetNetworkSettingsIDs()
+}
+
+func TestEnterpriseNetworkConfigurations_GetTotalCount(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int64
+	e := &EnterpriseNetworkConfigurations{TotalCount: &zeroValue}
+	e.GetTotalCount()
+	e = &EnterpriseNetworkConfigurations{}
+	e.GetTotalCount()
+	e = nil
+	e.GetTotalCount()
+}
+
+func TestEnterpriseNetworkSettingsResource_GetID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	e := &EnterpriseNetworkSettingsResource{ID: &zeroValue}
+	e.GetID()
+	e = &EnterpriseNetworkSettingsResource{}
+	e.GetID()
+	e = nil
+	e.GetID()
+}
+
+func TestEnterpriseNetworkSettingsResource_GetName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	e := &EnterpriseNetworkSettingsResource{Name: &zeroValue}
+	e.GetName()
+	e = &EnterpriseNetworkSettingsResource{}
+	e.GetName()
+	e = nil
+	e.GetName()
+}
+
+func TestEnterpriseNetworkSettingsResource_GetNetworkConfigurationID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	e := &EnterpriseNetworkSettingsResource{NetworkConfigurationID: &zeroValue}
+	e.GetNetworkConfigurationID()
+	e = &EnterpriseNetworkSettingsResource{}
+	e.GetNetworkConfigurationID()
+	e = nil
+	e.GetNetworkConfigurationID()
+}
+
+func TestEnterpriseNetworkSettingsResource_GetRegion(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	e := &EnterpriseNetworkSettingsResource{Region: &zeroValue}
+	e.GetRegion()
+	e = &EnterpriseNetworkSettingsResource{}
+	e.GetRegion()
+	e = nil
+	e.GetRegion()
+}
+
+func TestEnterpriseNetworkSettingsResource_GetSubnetID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	e := &EnterpriseNetworkSettingsResource{SubnetID: &zeroValue}
+	e.GetSubnetID()
+	e = &EnterpriseNetworkSettingsResource{}
+	e.GetSubnetID()
+	e = nil
+	e.GetSubnetID()
+}
+
 func TestEnterpriseRunnerGroup_GetAllowsPublicRepositories(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11178,17 +11178,6 @@ func TestEnterpriseNetworkConfigurationRequest_GetName(tt *testing.T) {
 	e.GetName()
 }
 
-func TestEnterpriseNetworkConfigurationRequest_GetNetworkSettingsIDs(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue []string
-	e := &EnterpriseNetworkConfigurationRequest{NetworkSettingsIDs: &zeroValue}
-	e.GetNetworkSettingsIDs()
-	e = &EnterpriseNetworkConfigurationRequest{}
-	e.GetNetworkSettingsIDs()
-	e = nil
-	e.GetNetworkSettingsIDs()
-}
-
 func TestEnterpriseNetworkConfigurations_GetTotalCount(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int64


### PR DESCRIPTION
This pull request introduces support for the hosted compute network configurations  in the go-github library, addressing https://github.com/google/go-github/issues/3462.

Changes Include:

Implementation of API endpoints for managing network-configuration endpoints.
Support for the following operations:
* Get, Create, Update, Delete and List network-configuration of an enterprise.
* Get network settings resource.
* Corresponding unit tests for each function.

Additional Information:
API Reference: [GitHub REST API: Network Configurations](https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/network-configurations?apiVersion=2022-11-28).