### PR TITLE
Add created_at field to Reaction

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -20318,6 +20318,14 @@ func (r *Reaction) GetContent() string {
 	return *r.Content
 }
 
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (r *Reaction) GetCreatedAt() Timestamp {
+	if r == nil || r.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *r.CreatedAt
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (r *Reaction) GetID() int64 {
 	if r == nil || r.ID == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -26151,6 +26151,17 @@ func TestReaction_GetContent(tt *testing.T) {
 	r.GetContent()
 }
 
+func TestReaction_GetCreatedAt(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue Timestamp
+	r := &Reaction{CreatedAt: &zeroValue}
+	r.GetCreatedAt()
+	r = &Reaction{}
+	r.GetCreatedAt()
+	r = nil
+	r.GetCreatedAt()
+}
+
 func TestReaction_GetID(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int64

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1513,12 +1513,13 @@ func TestRate_String(t *testing.T) {
 func TestReaction_String(t *testing.T) {
 	t.Parallel()
 	v := Reaction{
-		ID:      Ptr(int64(0)),
-		User:    &User{},
-		NodeID:  Ptr(""),
-		Content: Ptr(""),
+		ID:        Ptr(int64(0)),
+		User:      &User{},
+		NodeID:    Ptr(""),
+		Content:   Ptr(""),
+		CreatedAt: &Timestamp{},
 	}
-	want := `github.Reaction{ID:0, User:github.User{}, NodeID:"", Content:""}`
+	want := `github.Reaction{ID:0, User:github.User{}, NodeID:"", Content:"", CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}`
 	if got := v.String(); got != want {
 		t.Errorf("Reaction.String = %v, want %v", got, want)
 	}

--- a/github/reactions.go
+++ b/github/reactions.go
@@ -26,7 +26,8 @@ type Reaction struct {
 	// Content is the type of reaction.
 	// Possible values are:
 	//     "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", or "eyes".
-	Content *string `json:"content,omitempty"`
+	Content   *string    `json:"content,omitempty"`
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
 }
 
 // Reactions represents a summary of GitHub reactions.


### PR DESCRIPTION
This pull request exposes the `created_at` field for [reactions](https://docs.github.com/en/rest/reactions/reactions?apiVersion=2022-11-28). 