### PR TITLE
feat!: Change AuditEntry.Org and AuditEntry.OrgID to json.RawMessage

### DIFF
--- a/github/enterprise_audit_log_test.go
+++ b/github/enterprise_audit_log_test.go
@@ -7,6 +7,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -60,7 +61,7 @@ func TestEnterpriseService_GetAuditLog(t *testing.T) {
 			Action:     Ptr("workflows.completed_workflow_run"),
 			Actor:      Ptr("testactor"),
 			CreatedAt:  &Timestamp{timestamp},
-			Org:        Ptr("o"),
+			Org:        json.RawMessage(`"o"`),
 			AdditionalFields: map[string]interface{}{
 				"completed_at":    "2021-03-07T00:35:08.000Z",
 				"conclusion":      "success",

--- a/github/gen-accessors.go
+++ b/github/gen-accessors.go
@@ -45,6 +45,8 @@ var (
 		"ErrorResponse.GetResponse":       true,
 		"RateLimitError.GetResponse":      true,
 		"AbuseRateLimitError.GetResponse": true,
+		"AuditEntry.GetOrgID":             true,
+		"AuditEntry.GetOrg":               true,
 	}
 	// skipStructs lists structs to skip.
 	skipStructs = map[string]bool{

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1166,22 +1166,6 @@ func (a *AuditEntry) GetHashedToken() string {
 	return *a.HashedToken
 }
 
-// GetOrg returns the Org field if it's non-nil, zero value otherwise.
-func (a *AuditEntry) GetOrg() string {
-	if a == nil || a.Org == nil {
-		return ""
-	}
-	return *a.Org
-}
-
-// GetOrgID returns the OrgID field if it's non-nil, zero value otherwise.
-func (a *AuditEntry) GetOrgID() int64 {
-	if a == nil || a.OrgID == nil {
-		return 0
-	}
-	return *a.OrgID
-}
-
 // GetTimestamp returns the Timestamp field if it's non-nil, zero value otherwise.
 func (a *AuditEntry) GetTimestamp() Timestamp {
 	if a == nil || a.Timestamp == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -1518,28 +1518,6 @@ func TestAuditEntry_GetHashedToken(tt *testing.T) {
 	a.GetHashedToken()
 }
 
-func TestAuditEntry_GetOrg(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	a := &AuditEntry{Org: &zeroValue}
-	a.GetOrg()
-	a = &AuditEntry{}
-	a.GetOrg()
-	a = nil
-	a.GetOrg()
-}
-
-func TestAuditEntry_GetOrgID(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue int64
-	a := &AuditEntry{OrgID: &zeroValue}
-	a.GetOrgID()
-	a = &AuditEntry{}
-	a.GetOrgID()
-	a = nil
-	a.GetOrgID()
-}
-
 func TestAuditEntry_GetTimestamp(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp

--- a/github/orgs_audit_log.go
+++ b/github/orgs_audit_log.go
@@ -30,24 +30,24 @@ type ActorLocation struct {
 // in AdditionalFields.
 // For a list of actions see - https://docs.github.com/github/setting-up-and-managing-organizations-and-teams/reviewing-the-audit-log-for-your-organization#audit-log-actions
 type AuditEntry struct {
-	Action                   *string        `json:"action,omitempty"` // The name of the action that was performed, for example `user.login` or `repo.create`.
-	Actor                    *string        `json:"actor,omitempty"`  // The actor who performed the action.
-	ActorID                  *int64         `json:"actor_id,omitempty"`
-	ActorLocation            *ActorLocation `json:"actor_location,omitempty"`
-	Business                 *string        `json:"business,omitempty"`
-	BusinessID               *int64         `json:"business_id,omitempty"`
-	CreatedAt                *Timestamp     `json:"created_at,omitempty"`
-	DocumentID               *string        `json:"_document_id,omitempty"`
-	ExternalIdentityNameID   *string        `json:"external_identity_nameid,omitempty"`
-	ExternalIdentityUsername *string        `json:"external_identity_username,omitempty"`
-	HashedToken              *string        `json:"hashed_token,omitempty"`
-	Org                      *string        `json:"org,omitempty"`
-	OrgID                    *int64         `json:"org_id,omitempty"`
-	Timestamp                *Timestamp     `json:"@timestamp,omitempty"` // The time the audit log event occurred, given as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time).
-	TokenID                  *int64         `json:"token_id,omitempty"`
-	TokenScopes              *string        `json:"token_scopes,omitempty"`
-	User                     *string        `json:"user,omitempty"` // The user that was affected by the action performed (if available).
-	UserID                   *int64         `json:"user_id,omitempty"`
+	Action                   *string         `json:"action,omitempty"` // The name of the action that was performed, for example `user.login` or `repo.create`.
+	Actor                    *string         `json:"actor,omitempty"`  // The actor who performed the action.
+	ActorID                  *int64          `json:"actor_id,omitempty"`
+	ActorLocation            *ActorLocation  `json:"actor_location,omitempty"`
+	Business                 *string         `json:"business,omitempty"`
+	BusinessID               *int64          `json:"business_id,omitempty"`
+	CreatedAt                *Timestamp      `json:"created_at,omitempty"`
+	DocumentID               *string         `json:"_document_id,omitempty"`
+	ExternalIdentityNameID   *string         `json:"external_identity_nameid,omitempty"`
+	ExternalIdentityUsername *string         `json:"external_identity_username,omitempty"`
+	HashedToken              *string         `json:"hashed_token,omitempty"`
+	Org                      json.RawMessage `json:"org,omitempty"`
+	OrgID                    json.RawMessage `json:"org_id,omitempty"`
+	Timestamp                *Timestamp      `json:"@timestamp,omitempty"` // The time the audit log event occurred, given as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time).
+	TokenID                  *int64          `json:"token_id,omitempty"`
+	TokenScopes              *string         `json:"token_scopes,omitempty"`
+	User                     *string         `json:"user,omitempty"` // The user that was affected by the action performed (if available).
+	UserID                   *int64          `json:"user_id,omitempty"`
 
 	// Some events types have a data field that contains additional information about the event.
 	Data map[string]interface{} `json:"data,omitempty"`

--- a/github/orgs_audit_log_test.go
+++ b/github/orgs_audit_log_test.go
@@ -7,6 +7,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -93,6 +94,8 @@ func TestOrganizationService_GetAuditLog(t *testing.T) {
 	}
 	timestamp := time.Unix(0, 1615077308538*1e6)
 
+	orgID, _ := json.Marshal(Ptr(int64(1)))
+
 	want := []*AuditEntry{
 		{
 			Timestamp:  &Timestamp{timestamp},
@@ -104,8 +107,8 @@ func TestOrganizationService_GetAuditLog(t *testing.T) {
 			},
 			CreatedAt:   &Timestamp{timestamp},
 			HashedToken: Ptr("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="),
-			Org:         Ptr("o"),
-			OrgID:       Ptr(int64(1)),
+			Org:         json.RawMessage(`"o"`),
+			OrgID:       orgID,
 			TokenID:     Ptr(int64(1)),
 			TokenScopes: Ptr("gist,repo:read"),
 			AdditionalFields: map[string]interface{}{
@@ -225,6 +228,8 @@ func TestAuditEntry_Marshal(t *testing.T) {
 	t.Parallel()
 	testJSONMarshal(t, &AuditEntry{}, "{}")
 
+	orgID, _ := json.Marshal(Ptr(int64(1)))
+
 	u := &AuditEntry{
 		Action:                   Ptr("a"),
 		Actor:                    Ptr("ac"),
@@ -235,8 +240,8 @@ func TestAuditEntry_Marshal(t *testing.T) {
 		ExternalIdentityNameID:   Ptr("ein"),
 		ExternalIdentityUsername: Ptr("eiu"),
 		HashedToken:              Ptr("ht"),
-		Org:                      Ptr("o"),
-		OrgID:                    Ptr(int64(1)),
+		Org:                      json.RawMessage(`"o"`),
+		OrgID:                    orgID,
 		Timestamp:                &Timestamp{referenceTime},
 		TokenID:                  Ptr(int64(1)),
 		TokenScopes:              Ptr("ts"),


### PR DESCRIPTION
This PR is meant to resolve the issues around https://github.com/google/go-github/issues/3488

I am modifying `AuditEntry.Org` and `AuditEntry.OrgID` from `*string` and `*int64`, respectively, to both be `json.RawMessage` types this is meant to allow the consumer of this client to test the fields for being a string/int64 or being a []string/[]int64 and handle it accordingly.

This PR also modifies the tests `TestOrganizationService_GetAuditLog` `TestAuditEntry_Marshal` and `TestEnterpriseService_GetAuditLog` to ensure functionality remains after changing the above mentioned fields to `json.RawMessage`

I have also added two methods, `AuditEntry.GetOrgID` and `AuditEntry.GetOrg`,  to `skipStructMethods` and ran the code gen to remove the tests and methods to make sure we do not need to modify the generated tests/accessor methods. 