### PR TITLE
chore: Remove redundant in Go 1.22 loop variables

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ run:
 linters:
   enable:
     - canonicalheader
+    - copyloopvar
     - dogsled
     - dupl
     - gci
@@ -42,7 +43,7 @@ linters-settings:
         CopyrightDate: "Copyright \\d{4} "
     template: |-
       {{CopyrightDate}}The go-github AUTHORS. All rights reserved.
-      
+
       Use of this source code is governed by a BSD-style
       license that can be found in the LICENSE file.
   gosec:

--- a/github/actions_artifacts_test.go
+++ b/github/actions_artifacts_test.go
@@ -289,7 +289,6 @@ func TestActionsService_DownloadArtifact(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -351,7 +350,6 @@ func TestActionsService_DownloadArtifact_invalidOwner(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, _, _ := setup(t)
@@ -381,7 +379,6 @@ func TestActionsService_DownloadArtifact_invalidRepo(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, _, _ := setup(t)
@@ -411,7 +408,6 @@ func TestActionsService_DownloadArtifact_StatusMovedPermanently_dontFollowRedire
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -448,7 +444,6 @@ func TestActionsService_DownloadArtifact_StatusMovedPermanently_followRedirects(
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, serverURL := setup(t)
@@ -497,7 +492,6 @@ func TestActionsService_DownloadArtifact_unexpectedCode(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, serverURL := setup(t)

--- a/github/actions_secrets_test.go
+++ b/github/actions_secrets_test.go
@@ -76,7 +76,6 @@ func TestPublicKey_UnmarshalJSON(t *testing.T) {
 	}
 
 	for name, tt := range testCases {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			pk := PublicKey{}

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -200,7 +200,6 @@ func TestActionsService_GetWorkflowJobLogs(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -261,7 +260,6 @@ func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_dontFollowRedi
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -298,7 +296,6 @@ func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_followRedirect
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, serverURL := setup(t)
@@ -351,7 +348,6 @@ func TestActionsService_GetWorkflowJobLogs_unexpectedCode(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, serverURL := setup(t)

--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -206,7 +206,6 @@ func TestActionsService_GetWorkflowRunAttemptLogs(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -256,7 +255,6 @@ func TestActionsService_GetWorkflowRunAttemptLogs_StatusMovedPermanently_dontFol
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -293,7 +291,6 @@ func TestActionsService_GetWorkflowRunAttemptLogs_StatusMovedPermanently_followR
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, serverURL := setup(t)
@@ -352,7 +349,6 @@ func TestActionsService_GetWorkflowRunAttemptLogs_unexpectedCode(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, serverURL := setup(t)
@@ -521,7 +517,6 @@ func TestActionsService_GetWorkflowRunLogs(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -571,7 +566,6 @@ func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_dontFollowRedi
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -608,7 +602,6 @@ func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_followRedirect
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, serverURL := setup(t)
@@ -667,7 +660,6 @@ func TestActionsService_GetWorkflowRunLogs_unexpectedCode(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, serverURL := setup(t)

--- a/github/codespaces_secrets_test.go
+++ b/github/codespaces_secrets_test.go
@@ -77,7 +77,6 @@ func TestCodespacesService_ListSecrets(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -177,7 +176,6 @@ func TestCodespacesService_GetSecret(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -277,7 +275,6 @@ func TestCodespacesService_CreateOrUpdateSecret(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -364,7 +361,6 @@ func TestCodespacesService_DeleteSecret(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -450,7 +446,6 @@ func TestCodespacesService_GetPublicKey(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -529,7 +524,6 @@ func TestCodespacesService_ListSelectedReposForSecret(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -616,7 +610,6 @@ func TestCodespacesService_SetSelectedReposForSecret(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -684,7 +677,6 @@ func TestCodespacesService_AddSelectedReposForSecret(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -752,7 +744,6 @@ func TestCodespacesService_RemoveSelectedReposFromSecret(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -114,7 +114,6 @@ func TestCopilotSeatDetails_UnmarshalJSON(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		seatDetails := &CopilotSeatDetails{}
 
 		t.Run(tc.name, func(t *testing.T) {

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -465,7 +465,6 @@ func TestWithEnterpriseURLs(t *testing.T) {
 			wantUploadURL: "https://cloud-api.custom-upload-url/api/uploads/",
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			validate := func(c *Client, err error) {
@@ -2115,7 +2114,6 @@ func TestCompareHttpResponse(t *testing.T) {
 	}
 
 	for name, tc := range testcases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			v := compareHTTPResponse(tc.h1, tc.h2)
@@ -2274,7 +2272,6 @@ func TestErrorResponse_Is(t *testing.T) {
 	}
 
 	for name, tc := range testcases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if tc.wantSame != err.Is(tc.otherError) {
@@ -2344,7 +2341,6 @@ func TestRateLimitError_Is(t *testing.T) {
 	}
 
 	for name, tc := range testcases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if tc.wantSame != tc.err.Is(tc.otherError) {
@@ -2431,7 +2427,6 @@ func TestAbuseRateLimitError_Is(t *testing.T) {
 	}
 
 	for name, tc := range testcases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if tc.wantSame != tc.err.Is(tc.otherError) {
@@ -2463,7 +2458,6 @@ func TestAcceptedError_Is(t *testing.T) {
 	}
 
 	for name, tc := range testcases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if tc.wantSame != err.Is(tc.otherError) {

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -215,7 +215,6 @@ func TestValidatePayload_BadRequestBody(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		tt := tt
 		t.Run(fmt.Sprintf("test #%v", i), func(t *testing.T) {
 			t.Parallel()
 			req := &http.Request{

--- a/github/orgs_properties_test.go
+++ b/github/orgs_properties_test.go
@@ -423,7 +423,6 @@ func TestCustomPropertyValue_UnmarshalJSON(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			cpv := &CustomPropertyValue{}

--- a/github/pulls_reviews_test.go
+++ b/github/pulls_reviews_test.go
@@ -330,7 +330,6 @@ func TestPullRequestReviewRequest_isComfortFadePreview(t *testing.T) {
 	}}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			gotBool, gotErr := tc.review.isComfortFadePreview()

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -384,7 +384,6 @@ func TestRepositoriesService_CompareCommits(t *testing.T) {
 	}
 
 	for i, sample := range testCases {
-		sample := sample
 		t.Run(fmt.Sprintf("case #%v", i+1), func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -526,7 +525,6 @@ func TestRepositoriesService_CompareCommitsRaw_diff(t *testing.T) {
 	}
 
 	for i, sample := range testCases {
-		sample := sample
 		t.Run(fmt.Sprintf("case #%v", i+1), func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -585,7 +583,6 @@ func TestRepositoriesService_CompareCommitsRaw_patch(t *testing.T) {
 	}
 
 	for i, sample := range testCases {
-		sample := sample
 		t.Run(fmt.Sprintf("case #%v", i+1), func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -632,7 +629,6 @@ func TestRepositoriesService_CompareCommitsRaw_invalid(t *testing.T) {
 	}
 
 	for i, sample := range testCases {
-		sample := sample
 		t.Run(fmt.Sprintf("case #%v", i+1), func(t *testing.T) {
 			t.Parallel()
 			client, _, _ := setup(t)

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -722,7 +722,6 @@ func TestRepositoriesService_GetArchiveLink(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -780,7 +779,6 @@ func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_dontFollowRed
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -816,7 +814,6 @@ func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_followRedirec
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, mux, serverURL := setup(t)

--- a/github/repos_environments_test.go
+++ b/github/repos_environments_test.go
@@ -70,7 +70,6 @@ func TestRequiredReviewer_UnmarshalJSON(t *testing.T) {
 	}
 
 	for name, test := range testCases {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			rule := []*RequiredReviewer{}

--- a/github/repos_hooks_deliveries_test.go
+++ b/github/repos_hooks_deliveries_test.go
@@ -205,7 +205,6 @@ var hookDeliveryPayloadTypeToStruct = map[string]interface{}{
 func TestHookDelivery_ParsePayload(t *testing.T) {
 	t.Parallel()
 	for evt, obj := range hookDeliveryPayloadTypeToStruct {
-		evt, obj := evt, obj
 		t.Run(evt, func(t *testing.T) {
 			t.Parallel()
 			bs, err := json.Marshal(obj)

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -979,7 +979,6 @@ func TestRepositoriesService_GetBranch_BadJSONResponse(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -1050,7 +1049,6 @@ func TestRepositoriesService_GetBranch_notFound(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -1093,7 +1091,6 @@ func TestRepositoriesService_RenameBranch(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -1153,7 +1150,6 @@ func TestRepositoriesService_GetBranchProtection(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -1396,7 +1392,6 @@ func TestRepositoriesService_GetBranchProtection_branchNotProtected(t *testing.T
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -1436,7 +1431,6 @@ func TestRepositoriesService_UpdateBranchProtection_Contexts(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -1626,7 +1620,6 @@ func TestRepositoriesService_UpdateBranchProtection_EmptyContexts(t *testing.T) 
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -1806,7 +1799,6 @@ func TestRepositoriesService_UpdateBranchProtection_Checks(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -1965,7 +1957,6 @@ func TestRepositoriesService_UpdateBranchProtection_EmptyChecks(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -2110,7 +2101,6 @@ func TestRepositoriesService_UpdateBranchProtection_StrictNoChecks(t *testing.T)
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -2254,7 +2244,6 @@ func TestRepositoriesService_UpdateBranchProtection_RequireLastPushApproval(t *t
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -2310,7 +2299,6 @@ func TestRepositoriesService_RemoveBranchProtection(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -2405,7 +2393,6 @@ func TestRepositoriesService_GetRequiredStatusChecks(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -2485,7 +2472,6 @@ func TestRepositoriesService_GetRequiredStatusChecks_branchNotProtected(t *testi
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -2525,7 +2511,6 @@ func TestRepositoriesService_UpdateRequiredStatusChecks_Contexts(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -2603,7 +2588,6 @@ func TestRepositoriesService_UpdateRequiredStatusChecks_Checks(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -2696,7 +2680,6 @@ func TestRepositoriesService_RemoveRequiredStatusChecks(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -2737,7 +2720,6 @@ func TestRepositoriesService_ListRequiredStatusChecksContexts(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -2786,7 +2768,6 @@ func TestRepositoriesService_ListRequiredStatusChecksContexts_branchNotProtected
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -2826,7 +2807,6 @@ func TestRepositoriesService_GetPullRequestReviewEnforcement(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -2902,7 +2882,6 @@ func TestRepositoriesService_UpdatePullRequestReviewEnforcement(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -2991,7 +2970,6 @@ func TestRepositoriesService_DisableDismissalRestrictions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3048,7 +3026,6 @@ func TestRepositoriesService_RemovePullRequestReviewEnforcement(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3088,7 +3065,6 @@ func TestRepositoriesService_GetAdminEnforcement(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3141,7 +3117,6 @@ func TestRepositoriesService_AddAdminEnforcement(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3193,7 +3168,6 @@ func TestRepositoriesService_RemoveAdminEnforcement(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3233,7 +3207,6 @@ func TestRepositoriesService_GetSignaturesProtectedBranch(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3287,7 +3260,6 @@ func TestRepositoriesService_RequireSignaturesOnProtectedBranch(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3341,7 +3313,6 @@ func TestRepositoriesService_OptionalSignaturesOnProtectedBranch(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3570,7 +3541,6 @@ func TestRepositoriesService_ListAppRestrictions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3613,7 +3583,6 @@ func TestRepositoriesService_ReplaceAppRestrictions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3665,7 +3634,6 @@ func TestRepositoriesService_AddAppRestrictions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3717,7 +3685,6 @@ func TestRepositoriesService_RemoveAppRestrictions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3765,7 +3732,6 @@ func TestRepositoriesService_ListTeamRestrictions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3808,7 +3774,6 @@ func TestRepositoriesService_ReplaceTeamRestrictions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3860,7 +3825,6 @@ func TestRepositoriesService_AddTeamRestrictions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3912,7 +3876,6 @@ func TestRepositoriesService_RemoveTeamRestrictions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -3960,7 +3923,6 @@ func TestRepositoriesService_ListUserRestrictions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -4003,7 +3965,6 @@ func TestRepositoriesService_ReplaceUserRestrictions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -4055,7 +4016,6 @@ func TestRepositoriesService_AddUserRestrictions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -4107,7 +4067,6 @@ func TestRepositoriesService_RemoveUserRestrictions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.branch, func(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
@@ -4588,7 +4547,6 @@ func TestRepository_UnmarshalJSON(t *testing.T) {
 	}
 
 	for name, tt := range testCases {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			pk := Repository{}

--- a/scrape/apps_test.go
+++ b/scrape/apps_test.go
@@ -34,7 +34,6 @@ func Test_AppRestrictionsEnabled(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.description, func(t *testing.T) {
 			t.Parallel()
 			client, mux := setup(t)

--- a/scrape/forms_test.go
+++ b/scrape/forms_test.go
@@ -76,7 +76,6 @@ func Test_ParseForms(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.description, func(t *testing.T) {
 			t.Parallel()
 			node, err := html.Parse(strings.NewReader(tt.html))

--- a/tools/metadata/metadata_test.go
+++ b/tools/metadata/metadata_test.go
@@ -19,7 +19,6 @@ func Test_normalizedOpName(t *testing.T) {
 		{name: "get /foo/{id}", want: "GET /foo/*"},
 		{name: "get foo", want: "GET /foo"},
 	} {
-		td := td
 		t.Run(td.name, func(t *testing.T) {
 			t.Parallel()
 			got := normalizedOpName(td.name)


### PR DESCRIPTION
The PR removes `tc := tc` in tests and enables `copyloopvar` to detect such statements in the future. See https://go.dev/blog/loopvar-preview