### PR TITLE
fix: Add back repository field in Package struct

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -15918,6 +15918,14 @@ func (p *Package) GetRegistry() *PackageRegistry {
 	return p.Registry
 }
 
+// GetRepository returns the Repository field.
+func (p *Package) GetRepository() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repository
+}
+
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (p *Package) GetUpdatedAt() Timestamp {
 	if p == nil || p.UpdatedAt == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -20644,6 +20644,14 @@ func TestPackage_GetRegistry(tt *testing.T) {
 	p.GetRegistry()
 }
 
+func TestPackage_GetRepository(tt *testing.T) {
+	tt.Parallel()
+	p := &Package{}
+	p.GetRepository()
+	p = nil
+	p.GetRepository()
+}
+
 func TestPackage_GetUpdatedAt(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1138,6 +1138,7 @@ func TestPackage_String(t *testing.T) {
 		HTMLURL:        Ptr(""),
 		Visibility:     Ptr(""),
 		Owner:          &User{},
+		Repository:     &Repository{},
 		CreatedAt:      &Timestamp{},
 		UpdatedAt:      &Timestamp{},
 		Namespace:      Ptr(""),
@@ -1148,7 +1149,7 @@ func TestPackage_String(t *testing.T) {
 		URL:            Ptr(""),
 		VersionCount:   Ptr(int64(0)),
 	}
-	want := `github.Package{ID:0, Name:"", PackageType:"", HTMLURL:"", Visibility:"", Owner:github.User{}, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Namespace:"", Description:"", Ecosystem:"", PackageVersion:github.PackageVersion{}, Registry:github.PackageRegistry{}, URL:"", VersionCount:0}`
+	want := `github.Package{ID:0, Name:"", PackageType:"", HTMLURL:"", Visibility:"", Owner:github.User{}, Repository:github.Repository{}, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Namespace:"", Description:"", Ecosystem:"", PackageVersion:github.PackageVersion{}, Registry:github.PackageRegistry{}, URL:"", VersionCount:0}`
 	if got := v.String(); got != want {
 		t.Errorf("Package.String = %v, want %v", got, want)
 	}

--- a/github/packages.go
+++ b/github/packages.go
@@ -11,14 +11,15 @@ import (
 
 // Package represents a GitHub package.
 type Package struct {
-	ID          *int64     `json:"id,omitempty"`
-	Name        *string    `json:"name,omitempty"`
-	PackageType *string    `json:"package_type,omitempty"` // One of "npm", "maven", "rubygems", "docker", "nuget", "container". For webhook events "container" is "CONTAINER"
-	HTMLURL     *string    `json:"html_url,omitempty"`
-	Visibility  *string    `json:"visibility,omitempty"`
-	Owner       *User      `json:"owner,omitempty"`
-	CreatedAt   *Timestamp `json:"created_at,omitempty"`
-	UpdatedAt   *Timestamp `json:"updated_at,omitempty"`
+	ID          *int64      `json:"id,omitempty"`
+	Name        *string     `json:"name,omitempty"`
+	PackageType *string     `json:"package_type,omitempty"` // One of "npm", "maven", "rubygems", "docker", "nuget", "container". For webhook events "container" is "CONTAINER"
+	HTMLURL     *string     `json:"html_url,omitempty"`
+	Visibility  *string     `json:"visibility,omitempty"`
+	Owner       *User       `json:"owner,omitempty"`
+	Repository  *Repository `json:"repository,omitempty"`
+	CreatedAt   *Timestamp  `json:"created_at,omitempty"`
+	UpdatedAt   *Timestamp  `json:"updated_at,omitempty"`
 
 	// The following are only populated for webhook events
 	Namespace      *string          `json:"namespace,omitempty"`

--- a/github/packages_test.go
+++ b/github/packages_test.go
@@ -690,6 +690,7 @@ func TestPackage_Marshal(t *testing.T) {
 			CreatedAt:       &Timestamp{referenceTime},
 			SuspendedAt:     &Timestamp{referenceTime},
 		},
+		Repository:  &Repository{ID: Ptr(int64(1))},
 		CreatedAt:   &Timestamp{referenceTime},
 		UpdatedAt:   &Timestamp{referenceTime},
 		Namespace:   Ptr("n"),
@@ -835,6 +836,9 @@ func TestPackage_Marshal(t *testing.T) {
 			"created_at": ` + referenceTimeStr + `,
 			"suspended_at": ` + referenceTimeStr + `,
 			"url": "u"
+		},
+		"repository": {
+			"id": 1
 		},
 		"created_at": ` + referenceTimeStr + `,
 		"updated_at": ` + referenceTimeStr + `,


### PR DESCRIPTION
Hi,

As mentioned in the [previous reply](https://github.com/google/go-github/pull/3515#issuecomment-2783162924), the `Repository` field was mistakenly removed in `Package` strcuture.

This PR aims to reintroduce it.

cc @gmlewis 