### PR TITLE
Add case-instensitive GetHeader for HookRequest & HookResponse

### DIFF
--- a/github/repos_hooks_deliveries.go
+++ b/github/repos_hooks_deliveries.go
@@ -40,6 +40,16 @@ func (d HookDelivery) String() string {
 	return Stringify(d)
 }
 
+// getHeader common function for GetHeader funcs of HookRequest & HookResponse.
+func getHeader(headers map[string]string, key string) string {
+	for k, v := range headers {
+		if strings.EqualFold(k, key) {
+			return v
+		}
+	}
+	return ""
+}
+
 // HookRequest is a part of HookDelivery that contains
 // the HTTP headers and the JSON payload of the webhook request.
 type HookRequest struct {
@@ -49,12 +59,7 @@ type HookRequest struct {
 
 // GetHeader gets the value associated with the given key (ignoring key case).
 func (r *HookRequest) GetHeader(key string) string {
-	for k, v := range r.Headers {
-		if strings.EqualFold(k, key) {
-			return v
-		}
-	}
-	return ""
+	return getHeader(r.Headers, key)
 }
 
 func (r HookRequest) String() string {
@@ -70,12 +75,7 @@ type HookResponse struct {
 
 // GetHeader gets the value associated with the given key (ignoring key case).
 func (r *HookResponse) GetHeader(key string) string {
-	for k, v := range r.Headers {
-		if strings.EqualFold(k, key) {
-			return v
-		}
-	}
-	return ""
+	return getHeader(r.Headers, key)
 }
 
 func (r HookResponse) String() string {

--- a/github/repos_hooks_deliveries.go
+++ b/github/repos_hooks_deliveries.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // HookDelivery represents the data that is received from GitHub's Webhook Delivery API
@@ -46,6 +47,16 @@ type HookRequest struct {
 	RawPayload *json.RawMessage  `json:"payload,omitempty"`
 }
 
+// GetHeader gets the value associated with the given key (ignoring key case).
+func (r *HookRequest) GetHeader(key string) string {
+	for k, v := range r.Headers {
+		if strings.EqualFold(k, key) {
+			return v
+		}
+	}
+	return ""
+}
+
 func (r HookRequest) String() string {
 	return Stringify(r)
 }
@@ -55,6 +66,16 @@ func (r HookRequest) String() string {
 type HookResponse struct {
 	Headers    map[string]string `json:"headers,omitempty"`
 	RawPayload *json.RawMessage  `json:"payload,omitempty"`
+}
+
+// GetHeader gets the value associated with the given key (ignoring key case).
+func (r *HookResponse) GetHeader(key string) string {
+	for k, v := range r.Headers {
+		if strings.EqualFold(k, key) {
+			return v
+		}
+	}
+	return ""
 }
 
 func (r HookResponse) String() string {

--- a/github/repos_hooks_deliveries_test.go
+++ b/github/repos_hooks_deliveries_test.go
@@ -307,6 +307,7 @@ func TestHookRequest_GetHeader(t *testing.T) {
 		Headers: header,
 	}
 
+	// Checking positive cases
 	testPrefixes := []string{"key", "Key", "kEy", "KEY"}
 	for hdrKey, hdrValue := range header {
 		for _, prefix := range testPrefixes {
@@ -315,6 +316,16 @@ func TestHookRequest_GetHeader(t *testing.T) {
 				t.Errorf("GetHeader(%q) is not working: %q != %q", key, val, hdrValue)
 			}
 		}
+	}
+
+	// Checking negative case
+	key := "asd"
+	if val := r.GetHeader(key); val != "" {
+		t.Errorf("GetHeader(%q) should return empty value: %q != %q", key, val, "")
+	}
+	key = "kay1"
+	if val := r.GetHeader(key); val != "" {
+		t.Errorf("GetHeader(%q) should return empty value: %q != %q", key, val, "")
 	}
 }
 
@@ -357,6 +368,7 @@ func TestHookResponse_GetHeader(t *testing.T) {
 		Headers: header,
 	}
 
+	// Checking positive cases
 	testPrefixes := []string{"key", "Key", "kEy", "KEY"}
 	for hdrKey, hdrValue := range header {
 		for _, prefix := range testPrefixes {
@@ -365,6 +377,16 @@ func TestHookResponse_GetHeader(t *testing.T) {
 				t.Errorf("GetHeader(%q) is not working: %q != %q", key, val, hdrValue)
 			}
 		}
+	}
+
+	// Checking negative case
+	key := "asd"
+	if val := r.GetHeader(key); val != "" {
+		t.Errorf("GetHeader(%q) should return empty value: %q != %q", key, val, "")
+	}
+	key = "kay1"
+	if val := r.GetHeader(key); val != "" {
+		t.Errorf("GetHeader(%q) should return empty value: %q != %q", key, val, "")
 	}
 }
 

--- a/github/repos_hooks_deliveries_test.go
+++ b/github/repos_hooks_deliveries_test.go
@@ -294,6 +294,30 @@ func TestHookRequest_Marshal(t *testing.T) {
 	testJSONMarshal(t, r, want)
 }
 
+func TestHookRequest_GetHeader(t *testing.T) {
+	t.Parallel()
+
+	header := make(map[string]string)
+	header["key1"] = "value1"
+	header["Key+2"] = "value2"
+	header["kEy-3"] = "value3"
+	header["KEY_4"] = "value4"
+
+	r := &HookRequest{
+		Headers: header,
+	}
+
+	testPrefixes := []string{"key", "Key", "kEy", "KEY"}
+	for hdrKey, hdrValue := range header {
+		for _, prefix := range testPrefixes {
+			key := prefix + hdrKey[3:]
+			if val := r.GetHeader(key); val != hdrValue {
+				t.Errorf("GetHeader(%q) is not working: %q != %q", key, val, hdrValue)
+			}
+		}
+	}
+}
+
 func TestHookResponse_Marshal(t *testing.T) {
 	t.Parallel()
 	testJSONMarshal(t, &HookResponse{}, "{}")
@@ -318,6 +342,30 @@ func TestHookResponse_Marshal(t *testing.T) {
 	}`
 
 	testJSONMarshal(t, r, want)
+}
+
+func TestHookResponse_GetHeader(t *testing.T) {
+	t.Parallel()
+
+	header := make(map[string]string)
+	header["key1"] = "value1"
+	header["Key+2"] = "value2"
+	header["kEy-3"] = "value3"
+	header["KEY_4"] = "value4"
+
+	r := &HookResponse{
+		Headers: header,
+	}
+
+	testPrefixes := []string{"key", "Key", "kEy", "KEY"}
+	for hdrKey, hdrValue := range header {
+		for _, prefix := range testPrefixes {
+			key := prefix + hdrKey[3:]
+			if val := r.GetHeader(key); val != hdrValue {
+				t.Errorf("GetHeader(%q) is not working: %q != %q", key, val, hdrValue)
+			}
+		}
+	}
 }
 
 func TestHookDelivery_Marshal(t *testing.T) {


### PR DESCRIPTION
Simple implementation for case-insensitive GetHeader. I thought about caching the keys, but it seems too complicated for now with additional not predictable memory consumption. Tests are included.

Fixes #3555