### PR TITLE
fix!: Differentiate merge method of pull request and merge queue

### DIFF
--- a/github/enterprise_rules_test.go
+++ b/github/enterprise_rules_test.go
@@ -212,7 +212,7 @@ func TestEnterpriseService_CreateRepositoryRuleset_OrgNameRepoName(t *testing.T)
 			},
 			RequiredSignatures: &EmptyRuleParameters{},
 			PullRequest: &PullRequestRuleParameters{
-				AllowedMergeMethods:            []MergeMethod{MergeMethodRebase, MergeMethodSquash},
+				AllowedMergeMethods:            []PullRequestMergeMethod{PullRequestMergeMethodRebase, PullRequestMergeMethodSquash},
 				DismissStaleReviewsOnPush:      true,
 				RequireCodeOwnerReview:         true,
 				RequireLastPushApproval:        true,
@@ -313,7 +313,7 @@ func TestEnterpriseService_CreateRepositoryRuleset_OrgNameRepoName(t *testing.T)
 			},
 			RequiredSignatures: &EmptyRuleParameters{},
 			PullRequest: &PullRequestRuleParameters{
-				AllowedMergeMethods:            []MergeMethod{MergeMethodRebase, MergeMethodSquash},
+				AllowedMergeMethods:            []PullRequestMergeMethod{PullRequestMergeMethodRebase, PullRequestMergeMethodSquash},
 				DismissStaleReviewsOnPush:      true,
 				RequireCodeOwnerReview:         true,
 				RequireLastPushApproval:        true,
@@ -602,7 +602,7 @@ func TestEnterpriseService_CreateRepositoryRuleset_OrgNameRepoProperty(t *testin
 			},
 			RequiredSignatures: &EmptyRuleParameters{},
 			PullRequest: &PullRequestRuleParameters{
-				AllowedMergeMethods:            []MergeMethod{MergeMethodRebase, MergeMethodSquash},
+				AllowedMergeMethods:            []PullRequestMergeMethod{PullRequestMergeMethodRebase, PullRequestMergeMethodSquash},
 				DismissStaleReviewsOnPush:      true,
 				RequireCodeOwnerReview:         true,
 				RequireLastPushApproval:        true,
@@ -713,7 +713,7 @@ func TestEnterpriseService_CreateRepositoryRuleset_OrgNameRepoProperty(t *testin
 			},
 			RequiredSignatures: &EmptyRuleParameters{},
 			PullRequest: &PullRequestRuleParameters{
-				AllowedMergeMethods:            []MergeMethod{MergeMethodRebase, MergeMethodSquash},
+				AllowedMergeMethods:            []PullRequestMergeMethod{PullRequestMergeMethodRebase, PullRequestMergeMethodSquash},
 				DismissStaleReviewsOnPush:      true,
 				RequireCodeOwnerReview:         true,
 				RequireLastPushApproval:        true,
@@ -976,7 +976,7 @@ func TestEnterpriseService_CreateRepositoryRuleset_OrgIdRepoName(t *testing.T) {
 			},
 			RequiredSignatures: &EmptyRuleParameters{},
 			PullRequest: &PullRequestRuleParameters{
-				AllowedMergeMethods:            []MergeMethod{MergeMethodRebase, MergeMethodSquash},
+				AllowedMergeMethods:            []PullRequestMergeMethod{PullRequestMergeMethodRebase, PullRequestMergeMethodSquash},
 				DismissStaleReviewsOnPush:      true,
 				RequireCodeOwnerReview:         true,
 				RequireLastPushApproval:        true,
@@ -1076,7 +1076,7 @@ func TestEnterpriseService_CreateRepositoryRuleset_OrgIdRepoName(t *testing.T) {
 			},
 			RequiredSignatures: &EmptyRuleParameters{},
 			PullRequest: &PullRequestRuleParameters{
-				AllowedMergeMethods:            []MergeMethod{MergeMethodRebase, MergeMethodSquash},
+				AllowedMergeMethods:            []PullRequestMergeMethod{PullRequestMergeMethodRebase, PullRequestMergeMethodSquash},
 				DismissStaleReviewsOnPush:      true,
 				RequireCodeOwnerReview:         true,
 				RequireLastPushApproval:        true,
@@ -1358,7 +1358,7 @@ func TestEnterpriseService_CreateRepositoryRuleset_OrgIdRepoProperty(t *testing.
 			},
 			RequiredSignatures: &EmptyRuleParameters{},
 			PullRequest: &PullRequestRuleParameters{
-				AllowedMergeMethods:            []MergeMethod{MergeMethodRebase, MergeMethodSquash},
+				AllowedMergeMethods:            []PullRequestMergeMethod{PullRequestMergeMethodRebase, PullRequestMergeMethodSquash},
 				DismissStaleReviewsOnPush:      true,
 				RequireCodeOwnerReview:         true,
 				RequireLastPushApproval:        true,
@@ -1468,7 +1468,7 @@ func TestEnterpriseService_CreateRepositoryRuleset_OrgIdRepoProperty(t *testing.
 			},
 			RequiredSignatures: &EmptyRuleParameters{},
 			PullRequest: &PullRequestRuleParameters{
-				AllowedMergeMethods:            []MergeMethod{MergeMethodRebase, MergeMethodSquash},
+				AllowedMergeMethods:            []PullRequestMergeMethod{PullRequestMergeMethodRebase, PullRequestMergeMethodSquash},
 				DismissStaleReviewsOnPush:      true,
 				RequireCodeOwnerReview:         true,
 				RequireLastPushApproval:        true,

--- a/github/event_types_test.go
+++ b/github/event_types_test.go
@@ -9761,10 +9761,10 @@ func TestRepositoryRulesetEvent_Unmarshal(t *testing.T) {
 						Deletion:              &EmptyRuleParameters{},
 						RequiredLinearHistory: &EmptyRuleParameters{},
 						PullRequest: &PullRequestRuleParameters{
-							AllowedMergeMethods: []MergeMethod{
-								MergeMethodSquash,
-								MergeMethodRebase,
-								MergeMethodMerge,
+							AllowedMergeMethods: []PullRequestMergeMethod{
+								PullRequestMergeMethodSquash,
+								PullRequestMergeMethodRebase,
+								PullRequestMergeMethodMerge,
 							},
 							AutomaticCopilotCodeReviewEnabled: Ptr(false),
 							DismissStaleReviewsOnPush:         false,
@@ -9825,9 +9825,9 @@ func TestRepositoryRulesetEvent_Unmarshal(t *testing.T) {
 						Deletion:           &EmptyRuleParameters{},
 						RequiredSignatures: &EmptyRuleParameters{},
 						PullRequest: &PullRequestRuleParameters{
-							AllowedMergeMethods: []MergeMethod{
-								MergeMethodSquash,
-								MergeMethodRebase,
+							AllowedMergeMethods: []PullRequestMergeMethod{
+								PullRequestMergeMethodSquash,
+								PullRequestMergeMethodRebase,
 							},
 							AutomaticCopilotCodeReviewEnabled: Ptr(false),
 							DismissStaleReviewsOnPush:         false,
@@ -9880,9 +9880,9 @@ func TestRepositoryRulesetEvent_Unmarshal(t *testing.T) {
 								Rule: &RepositoryRule{
 									Type: RulesetRuleTypePullRequest,
 									Parameters: &PullRequestRuleParameters{
-										AllowedMergeMethods: []MergeMethod{
-											MergeMethodSquash,
-											MergeMethodRebase,
+										AllowedMergeMethods: []PullRequestMergeMethod{
+											PullRequestMergeMethodSquash,
+											PullRequestMergeMethodRebase,
 										},
 										AutomaticCopilotCodeReviewEnabled: Ptr(false),
 										DismissStaleReviewsOnPush:         false,

--- a/github/orgs_rules_test.go
+++ b/github/orgs_rules_test.go
@@ -255,7 +255,7 @@ func TestOrganizationsService_CreateRepositoryRuleset_RepoNames(t *testing.T) {
 			},
 			RequiredSignatures: &EmptyRuleParameters{},
 			PullRequest: &PullRequestRuleParameters{
-				AllowedMergeMethods:            []MergeMethod{MergeMethodRebase, MergeMethodSquash},
+				AllowedMergeMethods:            []PullRequestMergeMethod{PullRequestMergeMethodRebase, PullRequestMergeMethodSquash},
 				DismissStaleReviewsOnPush:      true,
 				RequireCodeOwnerReview:         true,
 				RequireLastPushApproval:        true,
@@ -352,7 +352,7 @@ func TestOrganizationsService_CreateRepositoryRuleset_RepoNames(t *testing.T) {
 			},
 			RequiredSignatures: &EmptyRuleParameters{},
 			PullRequest: &PullRequestRuleParameters{
-				AllowedMergeMethods:            []MergeMethod{MergeMethodRebase, MergeMethodSquash},
+				AllowedMergeMethods:            []PullRequestMergeMethod{PullRequestMergeMethodRebase, PullRequestMergeMethodSquash},
 				DismissStaleReviewsOnPush:      true,
 				RequireCodeOwnerReview:         true,
 				RequireLastPushApproval:        true,
@@ -615,7 +615,7 @@ func TestOrganizationsService_CreateRepositoryRuleset_RepoProperty(t *testing.T)
 			},
 			RequiredSignatures: &EmptyRuleParameters{},
 			PullRequest: &PullRequestRuleParameters{
-				AllowedMergeMethods:            []MergeMethod{MergeMethodRebase, MergeMethodSquash},
+				AllowedMergeMethods:            []PullRequestMergeMethod{PullRequestMergeMethodRebase, PullRequestMergeMethodSquash},
 				DismissStaleReviewsOnPush:      true,
 				RequireCodeOwnerReview:         true,
 				RequireLastPushApproval:        true,
@@ -718,7 +718,7 @@ func TestOrganizationsService_CreateRepositoryRuleset_RepoProperty(t *testing.T)
 			},
 			RequiredSignatures: &EmptyRuleParameters{},
 			PullRequest: &PullRequestRuleParameters{
-				AllowedMergeMethods:            []MergeMethod{MergeMethodRebase, MergeMethodSquash},
+				AllowedMergeMethods:            []PullRequestMergeMethod{PullRequestMergeMethodRebase, PullRequestMergeMethodSquash},
 				DismissStaleReviewsOnPush:      true,
 				RequireCodeOwnerReview:         true,
 				RequireLastPushApproval:        true,
@@ -966,7 +966,7 @@ func TestOrganizationsService_CreateRepositoryRuleset_RepoIDs(t *testing.T) {
 			},
 			RequiredSignatures: &EmptyRuleParameters{},
 			PullRequest: &PullRequestRuleParameters{
-				AllowedMergeMethods:            []MergeMethod{MergeMethodRebase, MergeMethodSquash},
+				AllowedMergeMethods:            []PullRequestMergeMethod{PullRequestMergeMethodRebase, PullRequestMergeMethodSquash},
 				DismissStaleReviewsOnPush:      true,
 				RequireCodeOwnerReview:         true,
 				RequireLastPushApproval:        true,
@@ -1061,7 +1061,7 @@ func TestOrganizationsService_CreateRepositoryRuleset_RepoIDs(t *testing.T) {
 			},
 			RequiredSignatures: &EmptyRuleParameters{},
 			PullRequest: &PullRequestRuleParameters{
-				AllowedMergeMethods:            []MergeMethod{MergeMethodRebase, MergeMethodSquash},
+				AllowedMergeMethods:            []PullRequestMergeMethod{PullRequestMergeMethodRebase, PullRequestMergeMethodSquash},
 				DismissStaleReviewsOnPush:      true,
 				RequireCodeOwnerReview:         true,
 				RequireLastPushApproval:        true,

--- a/github/rules.go
+++ b/github/rules.go
@@ -99,14 +99,34 @@ const (
 	MergeGroupingStrategyHeadGreen MergeGroupingStrategy = "HEADGREEN"
 )
 
-// MergeMethod models a GitHub merge method.
-type MergeMethod string
+// PullRequestMergeMethod is used in PullRequestRuleParameters,
+// where the GitHub API expects lowercase merge method values: "merge", "rebase", "squash".
+//
+// NOTE: GitHub's API inconsistently uses different casing for the same logical values
+// across different rules.
+//
+// TODO: Unify with MergeQueueMergeMethod once the GitHub API uses consistent casing.
+type PullRequestMergeMethod string
 
-// This is the set of GitHub merge methods.
 const (
-	MergeMethodMerge  MergeMethod = "merge"
-	MergeMethodRebase MergeMethod = "rebase"
-	MergeMethodSquash MergeMethod = "squash"
+	PullRequestMergeMethodMerge  PullRequestMergeMethod = "merge"
+	PullRequestMergeMethodRebase PullRequestMergeMethod = "rebase"
+	PullRequestMergeMethodSquash PullRequestMergeMethod = "squash"
+)
+
+// MergeQueueMergeMethod is used in MergeQueueRuleParameters,
+// where the GitHub API expects uppercase merge method values: "MERGE", "REBASE", "SQUASH".
+//
+// NOTE: This type exists alongside PullRequestMergeMethod solely due to API casing inconsistencies.
+// It enforces the correct usage by API context.
+//
+// TODO: Unify with PullRequestMergeMethod once the GitHub API uses consistent casing.
+type MergeQueueMergeMethod string
+
+const (
+	MergeQueueMergeMethodMerge  MergeQueueMergeMethod = "MERGE"
+	MergeQueueMergeMethodRebase MergeQueueMergeMethod = "REBASE"
+	MergeQueueMergeMethodSquash MergeQueueMergeMethod = "SQUASH"
 )
 
 // PatternRuleOperator models a GitHub pattern rule operator.
@@ -383,7 +403,7 @@ type MergeQueueRuleParameters struct {
 	GroupingStrategy             MergeGroupingStrategy `json:"grouping_strategy"`
 	MaxEntriesToBuild            int                   `json:"max_entries_to_build"`
 	MaxEntriesToMerge            int                   `json:"max_entries_to_merge"`
-	MergeMethod                  MergeMethod           `json:"merge_method"`
+	MergeMethod                  MergeQueueMergeMethod `json:"merge_method"`
 	MinEntriesToMerge            int                   `json:"min_entries_to_merge"`
 	MinEntriesToMergeWaitMinutes int                   `json:"min_entries_to_merge_wait_minutes"`
 }
@@ -395,13 +415,13 @@ type RequiredDeploymentsRuleParameters struct {
 
 // PullRequestRuleParameters represents the pull_request rule parameters.
 type PullRequestRuleParameters struct {
-	AllowedMergeMethods               []MergeMethod `json:"allowed_merge_methods"`
-	AutomaticCopilotCodeReviewEnabled *bool         `json:"automatic_copilot_code_review_enabled,omitempty"`
-	DismissStaleReviewsOnPush         bool          `json:"dismiss_stale_reviews_on_push"`
-	RequireCodeOwnerReview            bool          `json:"require_code_owner_review"`
-	RequireLastPushApproval           bool          `json:"require_last_push_approval"`
-	RequiredApprovingReviewCount      int           `json:"required_approving_review_count"`
-	RequiredReviewThreadResolution    bool          `json:"required_review_thread_resolution"`
+	AllowedMergeMethods               []PullRequestMergeMethod `json:"allowed_merge_methods"`
+	AutomaticCopilotCodeReviewEnabled *bool                    `json:"automatic_copilot_code_review_enabled,omitempty"`
+	DismissStaleReviewsOnPush         bool                     `json:"dismiss_stale_reviews_on_push"`
+	RequireCodeOwnerReview            bool                     `json:"require_code_owner_review"`
+	RequireLastPushApproval           bool                     `json:"require_last_push_approval"`
+	RequiredApprovingReviewCount      int                      `json:"required_approving_review_count"`
+	RequiredReviewThreadResolution    bool                     `json:"required_review_thread_resolution"`
 }
 
 // RequiredStatusChecksRuleParameters represents the required status checks rule parameters.

--- a/github/rules_test.go
+++ b/github/rules_test.go
@@ -46,7 +46,7 @@ func TestRulesetRules(t *testing.T) {
 					GroupingStrategy:             MergeGroupingStrategyAllGreen,
 					MaxEntriesToBuild:            10,
 					MaxEntriesToMerge:            20,
-					MergeMethod:                  MergeMethodSquash,
+					MergeMethod:                  MergeQueueMergeMethodSquash,
 					MinEntriesToMerge:            1,
 					MinEntriesToMergeWaitMinutes: 15,
 				},
@@ -55,9 +55,9 @@ func TestRulesetRules(t *testing.T) {
 				},
 				RequiredSignatures: &EmptyRuleParameters{},
 				PullRequest: &PullRequestRuleParameters{
-					AllowedMergeMethods: []MergeMethod{
-						MergeMethodSquash,
-						MergeMethodRebase,
+					AllowedMergeMethods: []PullRequestMergeMethod{
+						PullRequestMergeMethodSquash,
+						PullRequestMergeMethodRebase,
 					},
 					AutomaticCopilotCodeReviewEnabled: nil,
 					DismissStaleReviewsOnPush:         true,
@@ -123,7 +123,7 @@ func TestRulesetRules(t *testing.T) {
 					},
 				},
 			},
-			`[{"type":"creation"},{"type":"update"},{"type":"deletion"},{"type":"required_linear_history"},{"type":"merge_queue","parameters":{"check_response_timeout_minutes":5,"grouping_strategy":"ALLGREEN","max_entries_to_build":10,"max_entries_to_merge":20,"merge_method":"squash","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":15}},{"type":"required_deployments","parameters":{"required_deployment_environments":["test1","test2"]}},{"type":"required_signatures"},{"type":"pull_request","parameters":{"allowed_merge_methods":["squash","rebase"],"dismiss_stale_reviews_on_push":true,"require_code_owner_review":true,"require_last_push_approval":true,"required_approving_review_count":2,"required_review_thread_resolution":true}},{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"test1"},{"context":"test2"}],"strict_required_status_checks_policy":true}},{"type":"non_fast_forward"},{"type":"commit_message_pattern","parameters":{"operator":"starts_with","pattern":"test"}},{"type":"commit_author_email_pattern","parameters":{"operator":"starts_with","pattern":"test"}},{"type":"committer_email_pattern","parameters":{"operator":"starts_with","pattern":"test"}},{"type":"branch_name_pattern","parameters":{"operator":"starts_with","pattern":"test"}},{"type":"tag_name_pattern","parameters":{"operator":"starts_with","pattern":"test"}},{"type":"file_path_restriction","parameters":{"restricted_file_paths":["test1","test2"]}},{"type":"max_file_path_length","parameters":{"max_file_path_length":512}},{"type":"file_extension_restriction","parameters":{"restricted_file_extensions":[".exe",".pkg"]}},{"type":"max_file_size","parameters":{"max_file_size":1024}},{"type":"workflows","parameters":{"workflows":[{"path":".github/workflows/test1.yaml"},{"path":".github/workflows/test2.yaml"}]}},{"type":"code_scanning","parameters":{"code_scanning_tools":[{"alerts_threshold":"all","security_alerts_threshold":"all","tool":"test"},{"alerts_threshold":"none","security_alerts_threshold":"none","tool":"test"}]}}]`,
+			`[{"type":"creation"},{"type":"update"},{"type":"deletion"},{"type":"required_linear_history"},{"type":"merge_queue","parameters":{"check_response_timeout_minutes":5,"grouping_strategy":"ALLGREEN","max_entries_to_build":10,"max_entries_to_merge":20,"merge_method":"SQUASH","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":15}},{"type":"required_deployments","parameters":{"required_deployment_environments":["test1","test2"]}},{"type":"required_signatures"},{"type":"pull_request","parameters":{"allowed_merge_methods":["squash","rebase"],"dismiss_stale_reviews_on_push":true,"require_code_owner_review":true,"require_last_push_approval":true,"required_approving_review_count":2,"required_review_thread_resolution":true}},{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"test1"},{"context":"test2"}],"strict_required_status_checks_policy":true}},{"type":"non_fast_forward"},{"type":"commit_message_pattern","parameters":{"operator":"starts_with","pattern":"test"}},{"type":"commit_author_email_pattern","parameters":{"operator":"starts_with","pattern":"test"}},{"type":"committer_email_pattern","parameters":{"operator":"starts_with","pattern":"test"}},{"type":"branch_name_pattern","parameters":{"operator":"starts_with","pattern":"test"}},{"type":"tag_name_pattern","parameters":{"operator":"starts_with","pattern":"test"}},{"type":"file_path_restriction","parameters":{"restricted_file_paths":["test1","test2"]}},{"type":"max_file_path_length","parameters":{"max_file_path_length":512}},{"type":"file_extension_restriction","parameters":{"restricted_file_extensions":[".exe",".pkg"]}},{"type":"max_file_size","parameters":{"max_file_size":1024}},{"type":"workflows","parameters":{"workflows":[{"path":".github/workflows/test1.yaml"},{"path":".github/workflows/test2.yaml"}]}},{"type":"code_scanning","parameters":{"code_scanning_tools":[{"alerts_threshold":"all","security_alerts_threshold":"all","tool":"test"},{"alerts_threshold":"none","security_alerts_threshold":"none","tool":"test"}]}}]`,
 		},
 		{
 			"all_rules_with_all_params",
@@ -137,7 +137,7 @@ func TestRulesetRules(t *testing.T) {
 					GroupingStrategy:             MergeGroupingStrategyAllGreen,
 					MaxEntriesToBuild:            10,
 					MaxEntriesToMerge:            20,
-					MergeMethod:                  MergeMethodSquash,
+					MergeMethod:                  MergeQueueMergeMethodSquash,
 					MinEntriesToMerge:            1,
 					MinEntriesToMergeWaitMinutes: 15,
 				},
@@ -146,9 +146,9 @@ func TestRulesetRules(t *testing.T) {
 				},
 				RequiredSignatures: &EmptyRuleParameters{},
 				PullRequest: &PullRequestRuleParameters{
-					AllowedMergeMethods: []MergeMethod{
-						MergeMethodSquash,
-						MergeMethodRebase,
+					AllowedMergeMethods: []PullRequestMergeMethod{
+						PullRequestMergeMethodSquash,
+						PullRequestMergeMethodRebase,
 					},
 					AutomaticCopilotCodeReviewEnabled: Ptr(false),
 					DismissStaleReviewsOnPush:         true,
@@ -236,7 +236,7 @@ func TestRulesetRules(t *testing.T) {
 					},
 				},
 			},
-			`[{"type":"creation"},{"type":"update","parameters":{"update_allows_fetch_and_merge":true}},{"type":"deletion"},{"type":"required_linear_history"},{"type":"merge_queue","parameters":{"check_response_timeout_minutes":5,"grouping_strategy":"ALLGREEN","max_entries_to_build":10,"max_entries_to_merge":20,"merge_method":"squash","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":15}},{"type":"required_deployments","parameters":{"required_deployment_environments":["test1","test2"]}},{"type":"required_signatures"},{"type":"pull_request","parameters":{"allowed_merge_methods":["squash","rebase"],"automatic_copilot_code_review_enabled":false,"dismiss_stale_reviews_on_push":true,"require_code_owner_review":true,"require_last_push_approval":true,"required_approving_review_count":2,"required_review_thread_resolution":true}},{"type":"required_status_checks","parameters":{"do_not_enforce_on_create":true,"required_status_checks":[{"context":"test1","integration_id":1},{"context":"test2","integration_id":2}],"strict_required_status_checks_policy":true}},{"type":"non_fast_forward"},{"type":"commit_message_pattern","parameters":{"name":"cmp","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"commit_author_email_pattern","parameters":{"name":"caep","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"committer_email_pattern","parameters":{"name":"cep","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"branch_name_pattern","parameters":{"name":"bp","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"tag_name_pattern","parameters":{"name":"tp","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"file_path_restriction","parameters":{"restricted_file_paths":["test1","test2"]}},{"type":"max_file_path_length","parameters":{"max_file_path_length":512}},{"type":"file_extension_restriction","parameters":{"restricted_file_extensions":[".exe",".pkg"]}},{"type":"max_file_size","parameters":{"max_file_size":1024}},{"type":"workflows","parameters":{"do_not_enforce_on_create":true,"workflows":[{"path":".github/workflows/test1.yaml","ref":"main","repository_id":1,"sha":"aaaa"},{"path":".github/workflows/test2.yaml","ref":"main","repository_id":2,"sha":"bbbb"}]}},{"type":"code_scanning","parameters":{"code_scanning_tools":[{"alerts_threshold":"all","security_alerts_threshold":"all","tool":"test"},{"alerts_threshold":"none","security_alerts_threshold":"none","tool":"test"}]}}]`,
+			`[{"type":"creation"},{"type":"update","parameters":{"update_allows_fetch_and_merge":true}},{"type":"deletion"},{"type":"required_linear_history"},{"type":"merge_queue","parameters":{"check_response_timeout_minutes":5,"grouping_strategy":"ALLGREEN","max_entries_to_build":10,"max_entries_to_merge":20,"merge_method":"SQUASH","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":15}},{"type":"required_deployments","parameters":{"required_deployment_environments":["test1","test2"]}},{"type":"required_signatures"},{"type":"pull_request","parameters":{"allowed_merge_methods":["squash","rebase"],"automatic_copilot_code_review_enabled":false,"dismiss_stale_reviews_on_push":true,"require_code_owner_review":true,"require_last_push_approval":true,"required_approving_review_count":2,"required_review_thread_resolution":true}},{"type":"required_status_checks","parameters":{"do_not_enforce_on_create":true,"required_status_checks":[{"context":"test1","integration_id":1},{"context":"test2","integration_id":2}],"strict_required_status_checks_policy":true}},{"type":"non_fast_forward"},{"type":"commit_message_pattern","parameters":{"name":"cmp","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"commit_author_email_pattern","parameters":{"name":"caep","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"committer_email_pattern","parameters":{"name":"cep","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"branch_name_pattern","parameters":{"name":"bp","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"tag_name_pattern","parameters":{"name":"tp","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"file_path_restriction","parameters":{"restricted_file_paths":["test1","test2"]}},{"type":"max_file_path_length","parameters":{"max_file_path_length":512}},{"type":"file_extension_restriction","parameters":{"restricted_file_extensions":[".exe",".pkg"]}},{"type":"max_file_size","parameters":{"max_file_size":1024}},{"type":"workflows","parameters":{"do_not_enforce_on_create":true,"workflows":[{"path":".github/workflows/test1.yaml","ref":"main","repository_id":1,"sha":"aaaa"},{"path":".github/workflows/test2.yaml","ref":"main","repository_id":2,"sha":"bbbb"}]}},{"type":"code_scanning","parameters":{"code_scanning_tools":[{"alerts_threshold":"all","security_alerts_threshold":"all","tool":"test"},{"alerts_threshold":"none","security_alerts_threshold":"none","tool":"test"}]}}]`,
 		},
 	}
 
@@ -373,7 +373,7 @@ func TestBranchRules(t *testing.T) {
 							GroupingStrategy:             MergeGroupingStrategyAllGreen,
 							MaxEntriesToBuild:            10,
 							MaxEntriesToMerge:            20,
-							MergeMethod:                  MergeMethodSquash,
+							MergeMethod:                  MergeQueueMergeMethodSquash,
 							MinEntriesToMerge:            1,
 							MinEntriesToMergeWaitMinutes: 15,
 						},
@@ -406,9 +406,9 @@ func TestBranchRules(t *testing.T) {
 							RulesetID:         1,
 						},
 						Parameters: PullRequestRuleParameters{
-							AllowedMergeMethods: []MergeMethod{
-								MergeMethodSquash,
-								MergeMethodRebase,
+							AllowedMergeMethods: []PullRequestMergeMethod{
+								PullRequestMergeMethodSquash,
+								PullRequestMergeMethodRebase,
 							},
 							DismissStaleReviewsOnPush:      true,
 							RequireCodeOwnerReview:         true,
@@ -611,7 +611,7 @@ func TestBranchRules(t *testing.T) {
 					},
 				},
 			},
-			`[{"type":"creation","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1},{"type":"update","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"update_allows_fetch_and_merge":true}},{"type":"deletion","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1},{"type":"required_linear_history","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1},{"type":"merge_queue","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"check_response_timeout_minutes":5,"grouping_strategy":"ALLGREEN","max_entries_to_build":10,"max_entries_to_merge":20,"merge_method":"squash","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":15}},{"type":"required_deployments","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"required_deployment_environments":["test1","test2"]}},{"type":"required_signatures","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1},{"type":"pull_request","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"allowed_merge_methods":["squash","rebase"],"dismiss_stale_reviews_on_push":true,"require_code_owner_review":true,"require_last_push_approval":true,"required_approving_review_count":2,"required_review_thread_resolution":true}},{"type":"required_status_checks","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"do_not_enforce_on_create":true,"required_status_checks":[{"context":"test1","integration_id":1},{"context":"test2","integration_id":2}],"strict_required_status_checks_policy":true}},{"type":"non_fast_forward","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1},{"type":"commit_message_pattern","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"name":"cmp","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"commit_author_email_pattern","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"name":"caep","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"committer_email_pattern","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"name":"cep","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"branch_name_pattern","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"name":"bp","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"tag_name_pattern","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"name":"tp","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"file_path_restriction","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"restricted_file_paths":["test1","test2"]}},{"type":"max_file_path_length","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"max_file_path_length":512}},{"type":"file_extension_restriction","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"restricted_file_extensions":[".exe",".pkg"]}},{"type":"max_file_size","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"max_file_size":1024}},{"type":"workflows","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"do_not_enforce_on_create":true,"workflows":[{"path":".github/workflows/test1.yaml","ref":"main","repository_id":1,"sha":"aaaa"},{"path":".github/workflows/test2.yaml","ref":"main","repository_id":2,"sha":"bbbb"}]}},{"type":"code_scanning","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"code_scanning_tools":[{"alerts_threshold":"all","security_alerts_threshold":"all","tool":"test"},{"alerts_threshold":"none","security_alerts_threshold":"none","tool":"test"}]}}]`,
+			`[{"type":"creation","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1},{"type":"update","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"update_allows_fetch_and_merge":true}},{"type":"deletion","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1},{"type":"required_linear_history","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1},{"type":"merge_queue","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"check_response_timeout_minutes":5,"grouping_strategy":"ALLGREEN","max_entries_to_build":10,"max_entries_to_merge":20,"merge_method":"SQUASH","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":15}},{"type":"required_deployments","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"required_deployment_environments":["test1","test2"]}},{"type":"required_signatures","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1},{"type":"pull_request","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"allowed_merge_methods":["squash","rebase"],"dismiss_stale_reviews_on_push":true,"require_code_owner_review":true,"require_last_push_approval":true,"required_approving_review_count":2,"required_review_thread_resolution":true}},{"type":"required_status_checks","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"do_not_enforce_on_create":true,"required_status_checks":[{"context":"test1","integration_id":1},{"context":"test2","integration_id":2}],"strict_required_status_checks_policy":true}},{"type":"non_fast_forward","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1},{"type":"commit_message_pattern","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"name":"cmp","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"commit_author_email_pattern","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"name":"caep","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"committer_email_pattern","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"name":"cep","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"branch_name_pattern","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"name":"bp","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"tag_name_pattern","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"name":"tp","negate":false,"operator":"starts_with","pattern":"test"}},{"type":"file_path_restriction","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"restricted_file_paths":["test1","test2"]}},{"type":"max_file_path_length","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"max_file_path_length":512}},{"type":"file_extension_restriction","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"restricted_file_extensions":[".exe",".pkg"]}},{"type":"max_file_size","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"max_file_size":1024}},{"type":"workflows","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"do_not_enforce_on_create":true,"workflows":[{"path":".github/workflows/test1.yaml","ref":"main","repository_id":1,"sha":"aaaa"},{"path":".github/workflows/test2.yaml","ref":"main","repository_id":2,"sha":"bbbb"}]}},{"type":"code_scanning","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"code_scanning_tools":[{"alerts_threshold":"all","security_alerts_threshold":"all","tool":"test"},{"alerts_threshold":"none","security_alerts_threshold":"none","tool":"test"}]}}]`,
 		},
 	}
 
@@ -695,12 +695,12 @@ func TestRepositoryRule(t *testing.T) {
 					GroupingStrategy:             MergeGroupingStrategyAllGreen,
 					MaxEntriesToBuild:            10,
 					MaxEntriesToMerge:            20,
-					MergeMethod:                  MergeMethodSquash,
+					MergeMethod:                  MergeQueueMergeMethodSquash,
 					MinEntriesToMerge:            1,
 					MinEntriesToMergeWaitMinutes: 15,
 				},
 			},
-			`{"type":"merge_queue","parameters":{"check_response_timeout_minutes":5,"grouping_strategy":"ALLGREEN","max_entries_to_build":10,"max_entries_to_merge":20,"merge_method":"squash","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":15}}`,
+			`{"type":"merge_queue","parameters":{"check_response_timeout_minutes":5,"grouping_strategy":"ALLGREEN","max_entries_to_build":10,"max_entries_to_merge":20,"merge_method":"SQUASH","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":15}}`,
 		},
 		{
 			"required_deployments",
@@ -722,9 +722,9 @@ func TestRepositoryRule(t *testing.T) {
 			&RepositoryRule{
 				Type: RulesetRuleTypePullRequest,
 				Parameters: &PullRequestRuleParameters{
-					AllowedMergeMethods: []MergeMethod{
-						MergeMethodSquash,
-						MergeMethodRebase,
+					AllowedMergeMethods: []PullRequestMergeMethod{
+						PullRequestMergeMethodSquash,
+						PullRequestMergeMethodRebase,
 					},
 					AutomaticCopilotCodeReviewEnabled: Ptr(true),
 					DismissStaleReviewsOnPush:         true,


### PR DESCRIPTION
BREAKING CHANGE: `MergeMethod*` consts have been split into: `PullRequestMergeMethod*` and `MergeQueueMergeMethod*`.

Fixes: #3558

This issue will cause GitHub API return error if user use type MergeMethod in  MergeQueueRuleParameters.MergeMethod: 
```
422 Invalid request. Invalid property /rules/0: data matches no possible input. See `documentation_url`. []
```

