### PR TITLE
Add support for pagination options in rules API methods

### DIFF
--- a/github/orgs_rules.go
+++ b/github/orgs_rules.go
@@ -15,8 +15,13 @@ import (
 // GitHub API docs: https://docs.github.com/rest/orgs/rules#get-all-organization-repository-rulesets
 //
 //meta:operation GET /orgs/{org}/rulesets
-func (s *OrganizationsService) GetAllRepositoryRulesets(ctx context.Context, org string) ([]*RepositoryRuleset, *Response, error) {
+func (s *OrganizationsService) GetAllRepositoryRulesets(ctx context.Context, org string, opts *ListOptions) ([]*RepositoryRuleset, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/rulesets", org)
+
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/orgs_rules_test.go
+++ b/github/orgs_rules_test.go
@@ -20,6 +20,10 @@ func TestOrganizationsService_GetAllRepositoryRulesets(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/rulesets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"page":     "2",
+			"per_page": "35",
+		})
 		fmt.Fprint(w, `[{
 			"id": 21,
 			"name": "test ruleset",
@@ -37,8 +41,9 @@ func TestOrganizationsService_GetAllRepositoryRulesets(t *testing.T) {
 		}]`)
 	})
 
+	opts := &ListOptions{Page: 2, PerPage: 35}
 	ctx := context.Background()
-	rulesets, _, err := client.Organizations.GetAllRepositoryRulesets(ctx, "o")
+	rulesets, _, err := client.Organizations.GetAllRepositoryRulesets(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Organizations.GetAllRepositoryRulesets returned error: %v", err)
 	}
@@ -62,7 +67,7 @@ func TestOrganizationsService_GetAllRepositoryRulesets(t *testing.T) {
 	const methodName = "GetAllRepositoryRulesets"
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Organizations.GetAllRepositoryRulesets(ctx, "o")
+		got, resp, err := client.Organizations.GetAllRepositoryRulesets(ctx, "o", opts)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -38,8 +38,13 @@ type rulesetClearBypassActors struct {
 // GitHub API docs: https://docs.github.com/rest/repos/rules#get-rules-for-a-branch
 //
 //meta:operation GET /repos/{owner}/{repo}/rules/branches/{branch}
-func (s *RepositoriesService) GetRulesForBranch(ctx context.Context, owner, repo, branch string) (*BranchRules, *Response, error) {
+func (s *RepositoriesService) GetRulesForBranch(ctx context.Context, owner, repo, branch string, opts *ListOptions) (*BranchRules, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/rules/branches/%v", owner, repo, branch)
+
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -55,14 +60,28 @@ func (s *RepositoriesService) GetRulesForBranch(ctx context.Context, owner, repo
 	return rules, resp, nil
 }
 
+// RepositoryListRulesetsOptions specifies optional parameters to the
+// RepositoriesService.GetAllRulesets method.
+type RepositoryListRulesetsOptions struct {
+	// IncludesParents indicates whether to include rulesets configured at the organization or enterprise level that apply to the repository.
+	IncludesParents *bool `url:"includes_parents,omitempty"`
+	ListOptions
+}
+
 // GetAllRulesets gets all the repository rulesets for the specified repository.
-// If includesParents is true, rulesets configured at the organization or enterprise level that apply to the repository will be returned.
+// By default, this endpoint will include rulesets configured at the organization or enterprise level that apply to the repository.
+// To exclude those rulesets, set the `RepositoryListRulesetsOptions.IncludesParents` parameter to `false`.
 //
 // GitHub API docs: https://docs.github.com/rest/repos/rules#get-all-repository-rulesets
 //
 //meta:operation GET /repos/{owner}/{repo}/rulesets
-func (s *RepositoriesService) GetAllRulesets(ctx context.Context, owner, repo string, includesParents bool) ([]*RepositoryRuleset, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/rulesets?includes_parents=%v", owner, repo, includesParents)
+func (s *RepositoriesService) GetAllRulesets(ctx context.Context, owner, repo string, opts *RepositoryListRulesetsOptions) ([]*RepositoryRuleset, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/rulesets", owner, repo)
+
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/repos_rules_test.go
+++ b/github/repos_rules_test.go
@@ -20,6 +20,10 @@ func TestRepositoriesService_GetRulesForBranch(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/repo/rules/branches/branch", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"page":     "2",
+			"per_page": "35",
+		})
 		fmt.Fprint(w, `[
 			{
 			  "ruleset_id": 42069,
@@ -39,8 +43,9 @@ func TestRepositoriesService_GetRulesForBranch(t *testing.T) {
 		]`)
 	})
 
+	opts := &ListOptions{Page: 2, PerPage: 35}
 	ctx := context.Background()
-	rules, _, err := client.Repositories.GetRulesForBranch(ctx, "o", "repo", "branch")
+	rules, _, err := client.Repositories.GetRulesForBranch(ctx, "o", "repo", "branch", opts)
 	if err != nil {
 		t.Errorf("Repositories.GetRulesForBranch returned error: %v", err)
 	}
@@ -57,7 +62,7 @@ func TestRepositoriesService_GetRulesForBranch(t *testing.T) {
 	const methodName = "GetRulesForBranch"
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.GetRulesForBranch(ctx, "o", "repo", "branch")
+		got, resp, err := client.Repositories.GetRulesForBranch(ctx, "o", "repo", "branch", opts)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -71,6 +76,11 @@ func TestRepositoriesService_GetAllRulesets(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/repo/rulesets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"includes_parents": "false",
+			"page":             "2",
+			"per_page":         "35",
+		})
 		fmt.Fprintf(w, `[
 			{
 			  "id": 42,
@@ -93,8 +103,15 @@ func TestRepositoriesService_GetAllRulesets(t *testing.T) {
 		]`, referenceTimeStr)
 	})
 
+	opts := &RepositoryListRulesetsOptions{
+		IncludesParents: Ptr(false),
+		ListOptions: ListOptions{
+			Page:    2,
+			PerPage: 35,
+		},
+	}
 	ctx := context.Background()
-	ruleSet, _, err := client.Repositories.GetAllRulesets(ctx, "o", "repo", false)
+	ruleSet, _, err := client.Repositories.GetAllRulesets(ctx, "o", "repo", opts)
 	if err != nil {
 		t.Errorf("Repositories.GetAllRulesets returned error: %v", err)
 	}
@@ -126,7 +143,7 @@ func TestRepositoriesService_GetAllRulesets(t *testing.T) {
 	const methodName = "GetAllRulesets"
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.GetAllRulesets(ctx, "o", "repo", false)
+		got, resp, err := client.Repositories.GetAllRulesets(ctx, "o", "repo", opts)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}


### PR DESCRIPTION
Updated `GetRulesForBranch`, `GetAllRulesets`, and `GetAllRepositoryRulesets` methods to accept optional pagination parameters (`ListOptions`). Enhanced test cases to validate the use of these parameters in API requests.