### PR TITLE
Add issue `Type` to `IssueRequest`

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -12406,6 +12406,14 @@ func (i *IssueRequest) GetTitle() string {
 	return *i.Title
 }
 
+// GetType returns the Type field if it's non-nil, zero value otherwise.
+func (i *IssueRequest) GetType() string {
+	if i == nil || i.Type == nil {
+		return ""
+	}
+	return *i.Type
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (i *IssuesEvent) GetAction() string {
 	if i == nil || i.Action == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -16064,6 +16064,17 @@ func TestIssueRequest_GetTitle(tt *testing.T) {
 	i.GetTitle()
 }
 
+func TestIssueRequest_GetType(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &IssueRequest{Type: &zeroValue}
+	i.GetType()
+	i = &IssueRequest{}
+	i.GetType()
+	i = nil
+	i.GetType()
+}
+
 func TestIssuesEvent_GetAction(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/issues.go
+++ b/github/issues.go
@@ -90,6 +90,7 @@ type IssueRequest struct {
 	StateReason *string   `json:"state_reason,omitempty"`
 	Milestone   *int      `json:"milestone,omitempty"`
 	Assignees   *[]string `json:"assignees,omitempty"`
+	Type        *string   `json:"type,omitempty"`
 }
 
 // IssueListOptions specifies the optional parameters to the IssuesService.List

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -314,7 +314,7 @@ func TestIssuesService_Edit(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &IssueRequest{Title: Ptr("t")}
+	input := &IssueRequest{Title: Ptr("t"), Type: Ptr("bug")}
 
 	mux.HandleFunc("/repos/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
 		v := new(IssueRequest)
@@ -325,7 +325,7 @@ func TestIssuesService_Edit(t *testing.T) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
-		fmt.Fprint(w, `{"number":1}`)
+		fmt.Fprint(w, `{"number":1, "type": {"name": "bug"}}`)
 	})
 
 	ctx := context.Background()
@@ -334,7 +334,7 @@ func TestIssuesService_Edit(t *testing.T) {
 		t.Errorf("Issues.Edit returned error: %v", err)
 	}
 
-	want := &Issue{Number: Ptr(1)}
+	want := &Issue{Number: Ptr(1), Type: &IssueType{Name: Ptr("bug")}}
 	if !cmp.Equal(issue, want) {
 		t.Errorf("Issues.Edit returned %+v, want %+v", issue, want)
 	}
@@ -529,6 +529,7 @@ func TestIssueRequest_Marshal(t *testing.T) {
 		State:     Ptr("url"),
 		Milestone: Ptr(1),
 		Assignees: &[]string{"a"},
+		Type:      Ptr("issue_type"),
 	}
 
 	want := `{
@@ -542,7 +543,8 @@ func TestIssueRequest_Marshal(t *testing.T) {
 		"milestone": 1,
 		"assignees": [
 			"a"
-		]
+		],
+		"type": "issue_type"
 	}`
 
 	testJSONMarshal(t, u, want)
@@ -582,6 +584,7 @@ func TestIssue_Marshal(t *testing.T) {
 		NodeID:            Ptr("nid"),
 		TextMatches:       []*TextMatch{{ObjectURL: Ptr("ourl")}},
 		ActiveLockReason:  Ptr("alr"),
+		Type:              &IssueType{Name: Ptr("bug")},
 	}
 
 	want := `{
@@ -639,7 +642,10 @@ func TestIssue_Marshal(t *testing.T) {
 				"object_url": "ourl"
 			}
 		],
-		"active_lock_reason": "alr"
+		"active_lock_reason": "alr",
+		"type": {
+			"name": "bug"
+		}
 	}`
 
 	testJSONMarshal(t, u, want)


### PR DESCRIPTION
With he new field for Issue Type, we can also update that field in the edit method, adding that to be able to use it.
updating the tests to add that as well

https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#update-an-issue

cc @gmlewis 