### PR TITLE
Improve DownloadContents and DownloadContentsWithMeta methods

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -140,11 +140,8 @@ func (s *RepositoriesService) DownloadContents(ctx context.Context, owner, repo,
 	dir := path.Dir(filepath)
 	filename := path.Base(filepath)
 	fileContent, _, resp, err := s.GetContents(ctx, owner, repo, filepath, opts)
-	if err != nil {
-		return nil, resp, err
-	}
 
-	if fileContent != nil {
+	if err == nil && fileContent != nil {
 		content, err := fileContent.GetContent()
 		if err == nil && content != "" {
 			return io.NopCloser(strings.NewReader(content)), resp, nil
@@ -194,11 +191,8 @@ func (s *RepositoriesService) DownloadContentsWithMeta(ctx context.Context, owne
 	dir := path.Dir(filepath)
 	filename := path.Base(filepath)
 	fileContent, _, resp, err := s.GetContents(ctx, owner, repo, filepath, opts)
-	if err != nil {
-		return nil, nil, resp, err
-	}
 
-	if fileContent != nil {
+	if err == nil && fileContent != nil {
 		content, err := fileContent.GetContent()
 		if err == nil && content != "" {
 			return io.NopCloser(strings.NewReader(content)), fileContent, resp, nil

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -140,7 +140,6 @@ func (s *RepositoriesService) DownloadContents(ctx context.Context, owner, repo,
 	dir := path.Dir(filepath)
 	filename := path.Base(filepath)
 	fileContent, _, resp, err := s.GetContents(ctx, owner, repo, filepath, opts)
-
 	if err == nil && fileContent != nil {
 		content, err := fileContent.GetContent()
 		if err == nil && content != "" {
@@ -158,7 +157,6 @@ func (s *RepositoriesService) DownloadContents(ctx context.Context, owner, repo,
 			if contents.GetDownloadURL() == "" {
 				return nil, resp, fmt.Errorf("no download link found for %s", filepath)
 			}
-
 			dlReq, err := http.NewRequestWithContext(ctx, http.MethodGet, *contents.DownloadURL, nil)
 			if err != nil {
 				return nil, resp, err
@@ -191,7 +189,6 @@ func (s *RepositoriesService) DownloadContentsWithMeta(ctx context.Context, owne
 	dir := path.Dir(filepath)
 	filename := path.Base(filepath)
 	fileContent, _, resp, err := s.GetContents(ctx, owner, repo, filepath, opts)
-
 	if err == nil && fileContent != nil {
 		content, err := fileContent.GetContent()
 		if err == nil && content != "" {
@@ -209,7 +206,6 @@ func (s *RepositoriesService) DownloadContentsWithMeta(ctx context.Context, owne
 			if contents.GetDownloadURL() == "" {
 				return nil, contents, resp, fmt.Errorf("no download link found for %s", filepath)
 			}
-
 			dlReq, err := http.NewRequestWithContext(ctx, http.MethodGet, *contents.DownloadURL, nil)
 			if err != nil {
 				return nil, contents, resp, err

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -303,13 +303,17 @@ func TestRepositoriesService_DownloadContents_NoDownloadURL(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	_, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
+	reader, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err == nil {
 		t.Errorf("Repositories.DownloadContents did not return expected error")
 	}
 
 	if resp == nil {
 		t.Errorf("Repositories.DownloadContents did not return expected response")
+	}
+
+	if reader != nil {
+		t.Errorf("Repositories.DownloadContents did not return expected reader")
 	}
 }
 
@@ -332,13 +336,17 @@ func TestRepositoriesService_DownloadContents_NoFile(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	_, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
+	reader, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err == nil {
 		t.Errorf("Repositories.DownloadContents did not return expected error")
 	}
 
 	if resp == nil {
 		t.Errorf("Repositories.DownloadContents did not return expected response")
+	}
+
+	if reader != nil {
+		t.Errorf("Repositories.DownloadContents did not return expected reader")
 	}
 }
 
@@ -516,23 +524,31 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoDownloadURL(t *testing.T
 		  "name": "f",
 		}`)
 	})
-
 	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{
 		  "type": "file",
 		  "name": "f",
+		  "content": ""
 		}]`)
 	})
 
 	ctx := context.Background()
-	_, _, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
+	reader, contents, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
 	if err == nil {
 		t.Errorf("Repositories.DownloadContentsWithMeta did not return expected error")
 	}
 
+	if reader != nil {
+		t.Errorf("Repositories.DownloadContentsWithMeta did not return expected reader")
+	}
+
 	if resp == nil {
 		t.Errorf("Repositories.DownloadContentsWithMeta did not return expected response")
+	}
+
+	if contents == nil {
+		t.Errorf("Repositories.DownloadContentsWithMeta did not return expected content")
 	}
 }
 

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -265,13 +265,14 @@ func TestRepositoriesService_DownloadContentsWithMeta_Success(t *testing.T) {
 	t.Parallel()
 	client, mux, serverURL := setup(t)
 
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
+		fmt.Fprint(w, `{
 		  "type": "file",
 		  "name": "f",
-		  "download_url": "`+serverURL+baseURLPath+`/download/f"
-		}]`)
+		  "download_url": "`+serverURL+baseURLPath+`/download/f",
+          "content": "foo"
+		}`)
 	})
 	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -328,13 +329,13 @@ func TestRepositoriesService_DownloadContentsWithMeta_FailedResponse(t *testing.
 	t.Parallel()
 	client, mux, serverURL := setup(t)
 
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
+		fmt.Fprint(w, `{
 			"type": "file",
 			"name": "f",
 			"download_url": "`+serverURL+baseURLPath+`/download/f"
-		  }]`)
+		  }`)
 	})
 	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -329,18 +329,28 @@ func TestRepositoriesService_DownloadContentsWithMeta_FailedResponse(t *testing.
 	t.Parallel()
 	client, mux, serverURL := setup(t)
 
+	downloadURL := fmt.Sprintf("%s%s/download/f", serverURL, baseURLPath)
+
 	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
 			"type": "file",
 			"name": "f",
-			"download_url": "`+serverURL+baseURLPath+`/download/f"
+			"download_url": "`+downloadURL+`"
 		  }`)
 	})
 	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(w, "foo error")
+	})
+	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{
+			"type": "file",
+			"name": "f",
+			"download_url": "`+downloadURL+`"
+		  }]`)
 	})
 
 	ctx := context.Background()
@@ -375,6 +385,14 @@ func TestRepositoriesService_DownloadContentsWithMeta_FailedResponse(t *testing.
 func TestRepositoriesService_DownloadContentsWithMeta_NoDownloadURL(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+		  "type": "file",
+		  "name": "f",
+		}`)
+	})
 
 	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")


### PR DESCRIPTION
Fixes: #3566. 
By parsing the content field from the response, we can retrieve the most recent state of the file without making an additional request. Only when the content field is empty—such as [for object format and files exceeding the 1 MB ](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content) limit (see GitHub API docs) — do we fall back to the previous approach, which involves directory parsing and fetching the content via download_url or as raw data.
Additional tests were added to cover various cases.