### PR TITLE
docs: Update minimum Go version in README to 1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ go-github tracks [Go's version support policy][support-policy] supporting any
 minor version of the latest two major releases of Go and the go directive in
 go.mod reflects that.
 We do our best not to break older versions of Go if we don't have to, but we
-don't explicitly test older versions and as of Go 1.21 the go directive in
+don't explicitly test older versions and as of Go 1.23 the go directive in
 go.mod declares a hard required _minimum_ version of Go to use with this module
 and this _must_ be greater than or equal to the go line of all dependencies so
 go-github will require the N-1 major release of Go by default.


### PR DESCRIPTION
Because https://github.com/google/go-github/blob/3c5408e78f96138f004621711cac62db14ea030e/go.mod#L3