### PR TITLE
fix: Use stable media type in Starring API

### DIFF
--- a/github/activity_star.go
+++ b/github/activity_star.go
@@ -40,8 +40,7 @@ func (s *ActivityService) ListStargazers(ctx context.Context, owner, repo string
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when this API fully launches
-	req.Header.Set("Accept", mediaTypeStarringPreview)
+	req.Header.Set("Accept", mediaTypeStarring)
 
 	var stargazers []*Stargazer
 	resp, err := s.client.Do(ctx, req, &stargazers)
@@ -91,8 +90,7 @@ func (s *ActivityService) ListStarred(ctx context.Context, user string, opts *Ac
 		return nil, nil, err
 	}
 
-	// TODO: remove custom Accept header when APIs fully launch
-	acceptHeaders := []string{mediaTypeStarringPreview, mediaTypeTopicsPreview}
+	acceptHeaders := []string{mediaTypeStarring, mediaTypeTopicsPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var repos []*StarredRepository

--- a/github/activity_star_test.go
+++ b/github/activity_star_test.go
@@ -22,7 +22,7 @@ func TestActivityService_ListStargazers(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/stargazers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeStarringPreview)
+		testHeader(t, r, "Accept", mediaTypeStarring)
 		testFormValues(t, r, values{
 			"page": "2",
 		})
@@ -62,7 +62,7 @@ func TestActivityService_ListStarred_authenticatedUser(t *testing.T) {
 
 	mux.HandleFunc("/user/starred", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join([]string{mediaTypeStarringPreview, mediaTypeTopicsPreview}, ", "))
+		testHeader(t, r, "Accept", strings.Join([]string{mediaTypeStarring, mediaTypeTopicsPreview}, ", "))
 		fmt.Fprint(w, `[{"starred_at":"2002-02-10T15:30:00Z","repo":{"id":1}}]`)
 	})
 
@@ -98,7 +98,7 @@ func TestActivityService_ListStarred_specifiedUser(t *testing.T) {
 
 	mux.HandleFunc("/users/u/starred", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join([]string{mediaTypeStarringPreview, mediaTypeTopicsPreview}, ", "))
+		testHeader(t, r, "Accept", strings.Join([]string{mediaTypeStarring, mediaTypeTopicsPreview}, ", "))
 		testFormValues(t, r, values{
 			"sort":      "created",
 			"direction": "asc",

--- a/github/github.go
+++ b/github/github.go
@@ -54,6 +54,7 @@ const (
 	mediaTypeV3Patch           = "application/vnd.github.v3.patch"
 	mediaTypeOrgPermissionRepo = "application/vnd.github.v3.repository+json"
 	mediaTypeIssueImportAPI    = "application/vnd.github.golden-comet-preview+json"
+	mediaTypeStarring          = "application/vnd.github.star+json"
 
 	// Media Type values to access preview APIs
 	// These media types will be added to the API request as headers
@@ -71,9 +72,6 @@ const (
 	// on GitHub Cloud version.
 	//
 	// See https://github.com/google/go-github/pull/2125 for full context.
-
-	// https://developer.github.com/changes/2014-12-09-new-attributes-for-stars-api/
-	mediaTypeStarringPreview = "application/vnd.github.v3.star+json"
 
 	// https://help.github.com/enterprise/2.4/admin/guides/migrations/exporting-the-github-com-organization-s-repositories/
 	mediaTypeMigrationsPreview = "application/vnd.github.wyandotte-preview+json"


### PR DESCRIPTION
Starring API is stable, according to the documentation https://docs.github.com/en/rest/activity/starring?apiVersion=2022-11-28