### PR TITLE
Add repository query option to ListCustomPropertyValues

### DIFF
--- a/github/orgs_properties.go
+++ b/github/orgs_properties.go
@@ -48,6 +48,13 @@ type CustomPropertyValue struct {
 	Value        any    `json:"value"`
 }
 
+// CustomPropertyValuesListOptions specifies the optional parameters to the
+// OrganizationsService.ListCustomPropertyValues method.
+type CustomPropertyValuesListOptions struct {
+	RepositoryQuery string `url:"repository_query,omitempty"`
+	ListOptions
+}
+
 // UnmarshalJSON implements the json.Unmarshaler interface.
 // This helps us handle the fact that Value can be either a string, []string, or nil.
 func (cpv *CustomPropertyValue) UnmarshalJSON(data []byte) error {
@@ -197,7 +204,7 @@ func (s *OrganizationsService) RemoveCustomProperty(ctx context.Context, org, cu
 // GitHub API docs: https://docs.github.com/rest/orgs/custom-properties#list-custom-property-values-for-organization-repositories
 //
 //meta:operation GET /orgs/{org}/properties/values
-func (s *OrganizationsService) ListCustomPropertyValues(ctx context.Context, org string, opts *ListOptions) ([]*RepoCustomPropertyValue, *Response, error) {
+func (s *OrganizationsService) ListCustomPropertyValues(ctx context.Context, org string, opts *CustomPropertyValuesListOptions) ([]*RepoCustomPropertyValue, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/properties/values", org)
 	u, err := addOptions(u, opts)
 	if err != nil {

--- a/github/orgs_properties_test.go
+++ b/github/orgs_properties_test.go
@@ -283,7 +283,11 @@ func TestOrganizationsService_ListCustomPropertyValues(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/properties/values", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testFormValues(t, r, values{"page": "1", "per_page": "100"})
+		testFormValues(t, r, values{
+			"page":             "1",
+			"per_page":         "100",
+			"repository_query": "repo:octocat/Hello-World",
+		})
 		fmt.Fprint(w, `[{
 		"repository_id": 1296269,
 		"repository_name": "Hello-World",
@@ -310,9 +314,12 @@ func TestOrganizationsService_ListCustomPropertyValues(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	repoPropertyValues, _, err := client.Organizations.ListCustomPropertyValues(ctx, "o", &ListOptions{
-		Page:    1,
-		PerPage: 100,
+	repoPropertyValues, _, err := client.Organizations.ListCustomPropertyValues(ctx, "o", &CustomPropertyValuesListOptions{
+		ListOptions: ListOptions{
+			Page:    1,
+			PerPage: 100,
+		},
+		RepositoryQuery: "repo:octocat/Hello-World",
 	})
 	if err != nil {
 		t.Errorf("Organizations.ListCustomPropertyValues returned error: %v", err)
@@ -351,7 +358,7 @@ func TestOrganizationsService_ListCustomPropertyValues(t *testing.T) {
 	const methodName = "ListCustomPropertyValues"
 
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Organizations.ListCustomPropertyValues(ctx, "\n", &ListOptions{})
+		_, _, err = client.Organizations.ListCustomPropertyValues(ctx, "\n", &CustomPropertyValuesListOptions{})
 		return err
 	})
 


### PR DESCRIPTION
## What

SSIA

## Why

I want to use `repository_query` option for `OrganizationService. ListCustomPropertyValues`.

related issue: https://github.com/google/go-github/issues/3596