### PR TITLE
fix!: Add ListSCIMProvisionedGroupsForEnterpriseOptions

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -13455,6 +13455,38 @@ func (l *ListRunnersOptions) GetName() string {
 }
 
 // GetCount returns the Count field if it's non-nil, zero value otherwise.
+func (l *ListSCIMProvisionedGroupsForEnterpriseOptions) GetCount() int {
+	if l == nil || l.Count == nil {
+		return 0
+	}
+	return *l.Count
+}
+
+// GetExcludedAttributes returns the ExcludedAttributes field if it's non-nil, zero value otherwise.
+func (l *ListSCIMProvisionedGroupsForEnterpriseOptions) GetExcludedAttributes() string {
+	if l == nil || l.ExcludedAttributes == nil {
+		return ""
+	}
+	return *l.ExcludedAttributes
+}
+
+// GetFilter returns the Filter field if it's non-nil, zero value otherwise.
+func (l *ListSCIMProvisionedGroupsForEnterpriseOptions) GetFilter() string {
+	if l == nil || l.Filter == nil {
+		return ""
+	}
+	return *l.Filter
+}
+
+// GetStartIndex returns the StartIndex field if it's non-nil, zero value otherwise.
+func (l *ListSCIMProvisionedGroupsForEnterpriseOptions) GetStartIndex() int {
+	if l == nil || l.StartIndex == nil {
+		return 0
+	}
+	return *l.StartIndex
+}
+
+// GetCount returns the Count field if it's non-nil, zero value otherwise.
 func (l *ListSCIMProvisionedIdentitiesOptions) GetCount() int {
 	if l == nil || l.Count == nil {
 		return 0

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -17454,6 +17454,50 @@ func TestListRunnersOptions_GetName(tt *testing.T) {
 	l.GetName()
 }
 
+func TestListSCIMProvisionedGroupsForEnterpriseOptions_GetCount(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	l := &ListSCIMProvisionedGroupsForEnterpriseOptions{Count: &zeroValue}
+	l.GetCount()
+	l = &ListSCIMProvisionedGroupsForEnterpriseOptions{}
+	l.GetCount()
+	l = nil
+	l.GetCount()
+}
+
+func TestListSCIMProvisionedGroupsForEnterpriseOptions_GetExcludedAttributes(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	l := &ListSCIMProvisionedGroupsForEnterpriseOptions{ExcludedAttributes: &zeroValue}
+	l.GetExcludedAttributes()
+	l = &ListSCIMProvisionedGroupsForEnterpriseOptions{}
+	l.GetExcludedAttributes()
+	l = nil
+	l.GetExcludedAttributes()
+}
+
+func TestListSCIMProvisionedGroupsForEnterpriseOptions_GetFilter(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	l := &ListSCIMProvisionedGroupsForEnterpriseOptions{Filter: &zeroValue}
+	l.GetFilter()
+	l = &ListSCIMProvisionedGroupsForEnterpriseOptions{}
+	l.GetFilter()
+	l = nil
+	l.GetFilter()
+}
+
+func TestListSCIMProvisionedGroupsForEnterpriseOptions_GetStartIndex(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	l := &ListSCIMProvisionedGroupsForEnterpriseOptions{StartIndex: &zeroValue}
+	l.GetStartIndex()
+	l = &ListSCIMProvisionedGroupsForEnterpriseOptions{}
+	l.GetStartIndex()
+	l = nil
+	l.GetStartIndex()
+}
+
 func TestListSCIMProvisionedIdentitiesOptions_GetCount(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int

--- a/github/scim.go
+++ b/github/scim.go
@@ -108,6 +108,26 @@ type ListSCIMProvisionedIdentitiesOptions struct {
 	Filter *string `url:"filter,omitempty"`
 }
 
+// ListSCIMProvisionedGroupsForEnterpriseOptions represents options for ListSCIMProvisionedGroupsForEnterprise.
+//
+// GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/scim#list-provisioned-scim-groups-for-an-enterprise--parameters
+type ListSCIMProvisionedGroupsForEnterpriseOptions struct {
+	// Filter specifies the matching results to return.
+	// Multiple filters are not supported. Possible filters are externalId, id, and displayName.
+	// For example: ?filter=externalId eq "9138790-10932-109120392-12321".
+	// (Optional.)
+	Filter *string `url:"filter,omitempty"`
+	// ExcludedAttributes excludes the specified attribute from being returned in the results.
+	// Using this parameter can speed up response time. (Optional.)
+	ExcludedAttributes *string `url:"excludedAttributes,omitempty"`
+	// StartIndex used for pagination: the starting index of the first result to return when paginating through values. (Optional.)
+	// Default: 1.
+	StartIndex *int `url:"startIndex,omitempty"`
+	// Count used for pagination: the number of results to return per page. (Optional.)
+	// Default: 30.
+	Count *int `url:"count,omitempty"`
+}
+
 // ListSCIMProvisionedIdentities lists SCIM provisioned identities.
 //
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/scim/scim#list-scim-provisioned-identities
@@ -252,8 +272,12 @@ func (s *SCIMService) DeleteSCIMUserFromOrg(ctx context.Context, org, scimUserID
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/scim#list-provisioned-scim-groups-for-an-enterprise
 //
 //meta:operation GET /scim/v2/enterprises/{enterprise}/Groups
-func (s *SCIMService) ListSCIMProvisionedGroupsForEnterprise(ctx context.Context, enterprise string, _ *ListSCIMProvisionedIdentitiesOptions) (*SCIMProvisionedGroups, *Response, error) {
+func (s *SCIMService) ListSCIMProvisionedGroupsForEnterprise(ctx context.Context, enterprise string, opts *ListSCIMProvisionedGroupsForEnterpriseOptions) (*SCIMProvisionedGroups, *Response, error) {
 	u := fmt.Sprintf("scim/v2/enterprises/%v/Groups", enterprise)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/scim_test.go
+++ b/github/scim_test.go
@@ -127,6 +127,12 @@ func TestSCIMService_ListSCIMProvisionedGroups(t *testing.T) {
 
 	mux.HandleFunc("/scim/v2/enterprises/o/Groups", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"startIndex":         "1",
+			"excludedAttributes": "members,meta",
+			"count":              "3",
+			"filter":             `externalId eq "00u1dhhb1fkIGP7RL1d8"`,
+		})
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{
 			"schemas": [
@@ -162,7 +168,12 @@ func TestSCIMService_ListSCIMProvisionedGroups(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	opts := &ListSCIMProvisionedIdentitiesOptions{}
+	opts := &ListSCIMProvisionedGroupsForEnterpriseOptions{
+		StartIndex:         Ptr(1),
+		ExcludedAttributes: Ptr("members,meta"),
+		Count:              Ptr(3),
+		Filter:             Ptr(`externalId eq "00u1dhhb1fkIGP7RL1d8"`),
+	}
 	groups, _, err := client.SCIM.ListSCIMProvisionedGroupsForEnterprise(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("SCIM.ListSCIMProvisionedIdentities returned error: %v", err)


### PR DESCRIPTION
BREAKING CHANGE: `ListSCIMProvisionedGroupsForEnterprise` now takes `ListSCIMProvisionedGroupsForEnterpriseOptions` instead of `*ListSCIMProvisionedIdentitiesOptions`.

This PR fixes two issues:

1) The options in `ListSCIMProvisionedGroupsForEnterprise` were not beeing handled.
2) `ListSCIMProvisionedIdentitiesOptions` was missing the `excludedAttributes` property.

See https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/scim?apiVersion=2022-11-28#list-provisioned-scim-groups-for-an-enterprise--parameters