### PR TITLE
refactor: Simplify error handling in JSON decoding in tests

### DIFF
--- a/github/enterprise_actions_runners_test.go
+++ b/github/enterprise_actions_runners_test.go
@@ -24,10 +24,7 @@ func TestEnterpriseService_GenerateEnterpriseJITConfig(t *testing.T) {
 
 	mux.HandleFunc("/enterprises/o/actions/runners/generate-jitconfig", func(w http.ResponseWriter, r *http.Request) {
 		v := new(GenerateJITConfigRequest)
-		err := json.NewDecoder(r.Body).Decode(v)
-		if err != nil {
-			t.Errorf("Request body decode failed: %v", err)
-		}
+		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
 
 		testMethod(t, r, "POST")
 		if !cmp.Equal(v, input) {

--- a/github/orgs_codesecurity_configurations_test.go
+++ b/github/orgs_codesecurity_configurations_test.go
@@ -111,10 +111,7 @@ func TestOrganizationsService_CreateCodeSecurityConfiguration(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/code-security/configurations", func(w http.ResponseWriter, r *http.Request) {
 		v := new(CodeSecurityConfiguration)
-		err := json.NewDecoder(r.Body).Decode(v)
-		if err != nil {
-			t.Errorf("Organizations.CreateCodeSecurityConfiguration request body decode failed: %v", err)
-		}
+		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
 
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Organizations.CreateCodeSecurityConfiguration request body = %+v, want %+v", v, input)
@@ -244,10 +241,7 @@ func TestOrganizationsService_UpdateCodeSecurityConfiguration(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/code-security/configurations/1", func(w http.ResponseWriter, r *http.Request) {
 		v := new(CodeSecurityConfiguration)
-		err := json.NewDecoder(r.Body).Decode(v)
-		if err != nil {
-			t.Errorf("Organizations.UpdateCodeSecurityConfiguration request body decode failed: %v", err)
-		}
+		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
 
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Organizations.UpdateCodeSecurityConfiguration request body = %+v, want %+v", v, input)
@@ -329,10 +323,7 @@ func TestOrganizationsService_AttachCodeSecurityConfigurationsToRepositories(t *
 			SelectedRepositoryIDs []int64 `json:"selected_repository_ids,omitempty"`
 		}
 		v := new(request)
-		err := json.NewDecoder(r.Body).Decode(v)
-		if err != nil {
-			t.Errorf("Organizations.AttachCodeSecurityConfigurationsToRepositories request body decode failed: %v", err)
-		}
+		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
 		if v.Scope != "selected" {
 			t.Errorf("Organizations.AttachCodeSecurityConfigurationsToRepositories request body scope = %s, want selected", v.Scope)
 		}


### PR DESCRIPTION
For consistency with other tests https://github.com/search?q=repo%3Agoogle%2Fgo-github%20assertNilError(t%2C%20json.NewDecoder(r.Body).Decode(v))&type=code