### PR TITLE
refactor: fix revive.unused-parameter lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,6 +98,7 @@ linters:
         - name: unexported-naming
         - name: unexported-return
         - name: unreachable-code
+        - name: unused-parameter
         - name: use-any
         - name: var-declaration
         - name: var-naming

--- a/github/actions_artifacts_test.go
+++ b/github/actions_artifacts_test.go
@@ -320,7 +320,7 @@ func TestActionsService_DownloadArtifact(t *testing.T) {
 			})
 
 			// Add custom round tripper
-			client.client.Transport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			client.client.Transport = roundTripperFunc(func(*http.Request) (*http.Response, error) {
 				return nil, errors.New("failed to download artifact")
 			})
 			// propagate custom round tripper to client without CheckRedirect
@@ -529,7 +529,7 @@ func TestActionsService_DeleteArtifact(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/actions/artifacts/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/artifacts/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/actions_cache_test.go
+++ b/github/actions_cache_test.go
@@ -100,7 +100,7 @@ func TestActionsService_DeleteCachesByKey(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/actions/caches", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/caches", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		testFormValues(t, r, values{"key": "1", "ref": "main"})
 	})
@@ -162,7 +162,7 @@ func TestActionsService_DeleteCachesByID(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/actions/caches/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/caches/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/actions_runner_groups_test.go
+++ b/github/actions_runner_groups_test.go
@@ -153,7 +153,7 @@ func TestActionsService_DeleteOrganizationRunnerGroup(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/runner-groups/2", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/runner-groups/2", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -328,7 +328,7 @@ func TestActionsService_SetRepositoryAccessRunnerGroup(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/runner-groups/2/repositories", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/runner-groups/2/repositories", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -360,7 +360,7 @@ func TestActionsService_AddRepositoryAccessRunnerGroup(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/runner-groups/2/repositories/42", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/runner-groups/2/repositories/42", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -385,7 +385,7 @@ func TestActionsService_RemoveRepositoryAccessRunnerGroup(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/runner-groups/2/repositories/42", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/runner-groups/2/repositories/42", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -453,7 +453,7 @@ func TestActionsService_SetRunnerGroupRunners(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/runner-groups/2/runners", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/runner-groups/2/runners", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -485,7 +485,7 @@ func TestActionsService_AddRunnerGroupRunners(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/runner-groups/2/runners/42", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/runner-groups/2/runners/42", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -510,7 +510,7 @@ func TestActionsService_RemoveRunnerGroupRunners(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/runner-groups/2/runners/42", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/runner-groups/2/runners/42", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/actions_runners_test.go
+++ b/github/actions_runners_test.go
@@ -306,7 +306,7 @@ func TestActionsService_RemoveRunner(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/actions/runners/21", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/runners/21", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -529,7 +529,7 @@ func TestActionsService_RemoveOrganizationRunner(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/runners/21", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/runners/21", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/actions_secrets_test.go
+++ b/github/actions_secrets_test.go
@@ -325,7 +325,7 @@ func TestActionsService_DeleteRepoSecret(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/secrets/NAME", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -546,7 +546,7 @@ func TestActionsService_SetSelectedReposForOrgSecret(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
 		testBody(t, r, `{"selected_repository_ids":[64780797]}`+"\n")
@@ -573,7 +573,7 @@ func TestActionsService_AddSelectedRepoToOrgSecret(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories/1234", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -599,7 +599,7 @@ func TestActionsService_RemoveSelectedRepoFromOrgSecret(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories/1234", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -625,7 +625,7 @@ func TestActionsService_DeleteOrgSecret(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/secrets/NAME", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -835,7 +835,7 @@ func TestActionsService_DeleteEnvSecret(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repositories/1/environments/e/secrets/secret", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repositories/1/environments/e/secrets/secret", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/actions_variables_test.go
+++ b/github/actions_variables_test.go
@@ -209,7 +209,7 @@ func TestActionsService_DeleteRepoVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/actions/variables/NAME", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/variables/NAME", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -429,7 +429,7 @@ func TestActionsService_SetSelectedReposForOrgSVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/variables/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/variables/NAME/repositories", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
 		testBody(t, r, `{"selected_repository_ids":[64780797]}`+"\n")
@@ -456,7 +456,7 @@ func TestActionsService_AddSelectedRepoToOrgVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/variables/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/variables/NAME/repositories/1234", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -482,7 +482,7 @@ func TestActionsService_RemoveSelectedRepoFromOrgVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/variables/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/variables/NAME/repositories/1234", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -508,7 +508,7 @@ func TestActionsService_DeleteOrgVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/variables/NAME", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/actions/variables/NAME", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -680,7 +680,7 @@ func TestActionsService_DeleteEnvVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/usr/1/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/usr/1/environments/e/variables/variable", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -230,7 +230,7 @@ func TestActionsService_GetWorkflowJobLogs(t *testing.T) {
 			})
 
 			// Add custom round tripper
-			client.client.Transport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			client.client.Transport = roundTripperFunc(func(*http.Request) (*http.Response, error) {
 				return nil, errors.New("failed to get workflow logs")
 			})
 			// propagate custom round tripper to client without CheckRedirect

--- a/github/actions_workflows_test.go
+++ b/github/actions_workflows_test.go
@@ -241,7 +241,7 @@ func TestActionsService_CreateWorkflowDispatchEventByID(t *testing.T) {
 			"key": "value",
 		},
 	}
-	mux.HandleFunc("/repos/o/r/actions/workflows/72844/dispatches", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/workflows/72844/dispatches", func(_ http.ResponseWriter, r *http.Request) {
 		var v CreateWorkflowDispatchEventRequest
 		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
 
@@ -285,7 +285,7 @@ func TestActionsService_CreateWorkflowDispatchEventByFileName(t *testing.T) {
 			"key": "value",
 		},
 	}
-	mux.HandleFunc("/repos/o/r/actions/workflows/main.yml/dispatches", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/workflows/main.yml/dispatches", func(_ http.ResponseWriter, r *http.Request) {
 		var v CreateWorkflowDispatchEventRequest
 		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
 
@@ -323,7 +323,7 @@ func TestActionsService_EnableWorkflowByID(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/actions/workflows/72844/enable", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/workflows/72844/enable", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		if r.Body != http.NoBody {
 			t.Errorf("Request body = %+v, want %+v", r.Body, http.NoBody)
@@ -358,7 +358,7 @@ func TestActionsService_EnableWorkflowByFilename(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/actions/workflows/main.yml/enable", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/workflows/main.yml/enable", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		if r.Body != http.NoBody {
 			t.Errorf("Request body = %+v, want %+v", r.Body, http.NoBody)
@@ -393,7 +393,7 @@ func TestActionsService_DisableWorkflowByID(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/actions/workflows/72844/disable", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/workflows/72844/disable", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		if r.Body != http.NoBody {
 			t.Errorf("Request body = %+v, want %+v", r.Body, http.NoBody)
@@ -428,7 +428,7 @@ func TestActionsService_DisableWorkflowByFileName(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/actions/workflows/main.yml/disable", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/workflows/main.yml/disable", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		if r.Body != http.NoBody {
 			t.Errorf("Request body = %+v, want %+v", r.Body, http.NoBody)

--- a/github/activity_star_test.go
+++ b/github/activity_star_test.go
@@ -222,7 +222,7 @@ func TestActivityService_Star(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/user/starred/o/r", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/starred/o/r", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -256,7 +256,7 @@ func TestActivityService_Unstar(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/user/starred/o/r", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/starred/o/r", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/admin_users_test.go
+++ b/github/admin_users_test.go
@@ -66,7 +66,7 @@ func TestAdminUsers_Delete(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/admin/users/github", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/admin/users/github", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -163,7 +163,7 @@ func TestUserImpersonation_Delete(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/admin/users/github/authorizations", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/admin/users/github/authorizations", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/authorizations_test.go
+++ b/github/authorizations_test.go
@@ -120,7 +120,7 @@ func TestDeleteGrant(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/applications/id/grant", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/applications/id/grant", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		testBody(t, r, `{"access_token":"a"}`+"\n")
 		testHeader(t, r, "Accept", mediaTypeOAuthAppPreview)
@@ -183,7 +183,7 @@ func TestAuthorizationsService_DeleteImpersonation(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/admin/users/u/authorizations", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/admin/users/u/authorizations", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/codespaces_secrets_test.go
+++ b/github/codespaces_secrets_test.go
@@ -319,7 +319,7 @@ func TestCodespacesService_DeleteSecret(t *testing.T) {
 		{
 			name: "User",
 			handleFunc: func(mux *http.ServeMux) {
-				mux.HandleFunc("/user/codespaces/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
+				mux.HandleFunc("/user/codespaces/secrets/NAME", func(_ http.ResponseWriter, r *http.Request) {
 					testMethod(t, r, "DELETE")
 				})
 			},
@@ -331,7 +331,7 @@ func TestCodespacesService_DeleteSecret(t *testing.T) {
 		{
 			name: "Org",
 			handleFunc: func(mux *http.ServeMux) {
-				mux.HandleFunc("/orgs/o/codespaces/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
+				mux.HandleFunc("/orgs/o/codespaces/secrets/NAME", func(_ http.ResponseWriter, r *http.Request) {
 					testMethod(t, r, "DELETE")
 				})
 			},
@@ -346,7 +346,7 @@ func TestCodespacesService_DeleteSecret(t *testing.T) {
 		{
 			name: "Repo",
 			handleFunc: func(mux *http.ServeMux) {
-				mux.HandleFunc("/repos/o/r/codespaces/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
+				mux.HandleFunc("/repos/o/r/codespaces/secrets/NAME", func(_ http.ResponseWriter, r *http.Request) {
 					testMethod(t, r, "DELETE")
 				})
 			},
@@ -579,7 +579,7 @@ func TestCodespacesService_SetSelectedReposForSecret(t *testing.T) {
 		{
 			name: "User",
 			handleFunc: func(mux *http.ServeMux) {
-				mux.HandleFunc("/user/codespaces/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
+				mux.HandleFunc("/user/codespaces/secrets/NAME/repositories", func(_ http.ResponseWriter, r *http.Request) {
 					testMethod(t, r, "PUT")
 					testHeader(t, r, "Content-Type", "application/json")
 					testBody(t, r, `{"selected_repository_ids":[64780797]}`+"\n")
@@ -593,7 +593,7 @@ func TestCodespacesService_SetSelectedReposForSecret(t *testing.T) {
 		{
 			name: "Org",
 			handleFunc: func(mux *http.ServeMux) {
-				mux.HandleFunc("/orgs/o/codespaces/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
+				mux.HandleFunc("/orgs/o/codespaces/secrets/NAME/repositories", func(_ http.ResponseWriter, r *http.Request) {
 					testMethod(t, r, "PUT")
 					testHeader(t, r, "Content-Type", "application/json")
 					testBody(t, r, `{"selected_repository_ids":[64780797]}`+"\n")
@@ -650,7 +650,7 @@ func TestCodespacesService_AddSelectedReposForSecret(t *testing.T) {
 		{
 			name: "User",
 			handleFunc: func(mux *http.ServeMux) {
-				mux.HandleFunc("/user/codespaces/secrets/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
+				mux.HandleFunc("/user/codespaces/secrets/NAME/repositories/1234", func(_ http.ResponseWriter, r *http.Request) {
 					testMethod(t, r, "PUT")
 				})
 			},
@@ -662,7 +662,7 @@ func TestCodespacesService_AddSelectedReposForSecret(t *testing.T) {
 		{
 			name: "Org",
 			handleFunc: func(mux *http.ServeMux) {
-				mux.HandleFunc("/orgs/o/codespaces/secrets/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
+				mux.HandleFunc("/orgs/o/codespaces/secrets/NAME/repositories/1234", func(_ http.ResponseWriter, r *http.Request) {
 					testMethod(t, r, "PUT")
 				})
 			},
@@ -717,7 +717,7 @@ func TestCodespacesService_RemoveSelectedReposFromSecret(t *testing.T) {
 		{
 			name: "User",
 			handleFunc: func(mux *http.ServeMux) {
-				mux.HandleFunc("/user/codespaces/secrets/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
+				mux.HandleFunc("/user/codespaces/secrets/NAME/repositories/1234", func(_ http.ResponseWriter, r *http.Request) {
 					testMethod(t, r, "DELETE")
 				})
 			},
@@ -729,7 +729,7 @@ func TestCodespacesService_RemoveSelectedReposFromSecret(t *testing.T) {
 		{
 			name: "Org",
 			handleFunc: func(mux *http.ServeMux) {
-				mux.HandleFunc("/orgs/o/codespaces/secrets/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
+				mux.HandleFunc("/orgs/o/codespaces/secrets/NAME/repositories/1234", func(_ http.ResponseWriter, r *http.Request) {
 					testMethod(t, r, "DELETE")
 				})
 			},

--- a/github/codespaces_test.go
+++ b/github/codespaces_test.go
@@ -272,7 +272,7 @@ func TestCodespacesService_Delete(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/user/codespaces/codespace_1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/codespaces/codespace_1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/dependabot_secrets_test.go
+++ b/github/dependabot_secrets_test.go
@@ -204,7 +204,7 @@ func TestDependabotService_DeleteRepoSecret(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/dependabot/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/dependabot/secrets/NAME", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -425,7 +425,7 @@ func TestDependabotService_SetSelectedReposForOrgSecret(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME/repositories", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
 		testBody(t, r, `{"selected_repository_ids":[64780797]}`+"\n")
@@ -452,7 +452,7 @@ func TestDependabotService_AddSelectedRepoToOrgSecret(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME/repositories/1234", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -478,7 +478,7 @@ func TestDependabotService_RemoveSelectedRepoFromOrgSecret(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME/repositories/1234", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME/repositories/1234", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -504,7 +504,7 @@ func TestDependabotService_DeleteOrgSecret(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/enterprise_actions_runner_groups_test.go
+++ b/github/enterprise_actions_runner_groups_test.go
@@ -153,7 +153,7 @@ func TestEnterpriseService_DeleteRunnerGroup(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/enterprises/o/actions/runner-groups/2", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/enterprises/o/actions/runner-groups/2", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -328,7 +328,7 @@ func TestEnterpriseService_SetOrganizationAccessRunnerGroup(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/organizations", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/organizations", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -360,7 +360,7 @@ func TestEnterpriseService_AddOrganizationAccessRunnerGroup(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/organizations/42", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/organizations/42", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -385,7 +385,7 @@ func TestEnterpriseService_RemoveOrganizationAccessRunnerGroup(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/organizations/42", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/organizations/42", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -453,7 +453,7 @@ func TestEnterpriseService_SetEnterpriseRunnerGroupRunners(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/runners", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/runners", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -485,7 +485,7 @@ func TestEnterpriseService_AddEnterpriseRunnerGroupRunners(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/runners/42", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/runners/42", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -510,7 +510,7 @@ func TestEnterpriseService_RemoveEnterpriseRunnerGroupRunners(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/runners/42", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/enterprises/o/actions/runner-groups/2/runners/42", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/enterprise_actions_runners_test.go
+++ b/github/enterprise_actions_runners_test.go
@@ -189,7 +189,7 @@ func TestEnterpriseService_RemoveRunner(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/enterprises/o/actions/runners/21", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/enterprises/o/actions/runners/21", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/enterprise_code_security_and_analysis_test.go
+++ b/github/enterprise_code_security_and_analysis_test.go
@@ -78,7 +78,7 @@ func TestEnterpriseService_UpdateCodeSecurityAndAnalysis(t *testing.T) {
 		SecretScanningValidityChecksEnabled:                   Ptr(true),
 	}
 
-	mux.HandleFunc("/enterprises/e/code_security_and_analysis", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/enterprises/e/code_security_and_analysis", func(_ http.ResponseWriter, r *http.Request) {
 		v := new(EnterpriseSecurityAnalysisSettings)
 		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
 
@@ -111,7 +111,7 @@ func TestEnterpriseService_EnableAdvancedSecurity(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/enterprises/e/advanced_security/enable_all", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/enterprises/e/advanced_security/enable_all", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 

--- a/github/enterprise_manage_ghes_config_test.go
+++ b/github/enterprise_manage_ghes_config_test.go
@@ -603,7 +603,7 @@ func TestEnterpriseService_InitialConfig(t *testing.T) {
 		Password: "password",
 	}
 
-	mux.HandleFunc("/manage/v1/config/init", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/manage/v1/config/init", func(_ http.ResponseWriter, r *http.Request) {
 		v := new(InitialConfigOptions)
 		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
 

--- a/github/enterprise_network_configurations_test.go
+++ b/github/enterprise_network_configurations_test.go
@@ -336,7 +336,7 @@ func TestEnterpriseService_DeleteEnterpriseNetworkConfiguration(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/enterprises/e/network-configurations/123456789ABCDEF", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/enterprises/e/network-configurations/123456789ABCDEF", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/enterprise_properties_test.go
+++ b/github/enterprise_properties_test.go
@@ -260,7 +260,7 @@ func TestEnterpriseService_RemoveCustomProperty(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/enterprises/e/properties/schema/name", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/enterprises/e/properties/schema/name", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/enterprise_rules_test.go
+++ b/github/enterprise_rules_test.go
@@ -1840,7 +1840,7 @@ func TestEnterpriseService_DeleteRepositoryRuleset(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/enterprises/e/rulesets/84", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/enterprises/e/rulesets/84", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/gists_comments_test.go
+++ b/github/gists_comments_test.go
@@ -272,7 +272,7 @@ func TestGistsService_DeleteComment(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/gists/1/comments/2", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/gists/1/comments/2", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -724,7 +724,7 @@ func TestGistsService_Delete(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/gists/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/gists/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -758,7 +758,7 @@ func TestGistsService_Star(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/gists/1/star", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/gists/1/star", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -792,7 +792,7 @@ func TestGistsService_Unstar(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/gists/1/star", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/gists/1/star", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/git_commits_test.go
+++ b/github/git_commits_test.go
@@ -32,7 +32,7 @@ func mockSigner(t *testing.T, signature string, emitErr error, wantMessage strin
 }
 
 func uncalledSigner(t *testing.T) MessageSignerFunc {
-	return func(w io.Writer, r io.Reader) error {
+	return func(io.Writer, io.Reader) error {
 		t.Error("MessageSignerFunc should not be called")
 		return nil
 	}

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -556,7 +556,7 @@ func TestGitService_DeleteRef(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/github.go
+++ b/github/github.go
@@ -409,7 +409,7 @@ func (c *Client) initialize() {
 	c.clientIgnoreRedirects.Transport = c.client.Transport
 	c.clientIgnoreRedirects.Timeout = c.client.Timeout
 	c.clientIgnoreRedirects.Jar = c.client.Jar
-	c.clientIgnoreRedirects.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+	c.clientIgnoreRedirects.CheckRedirect = func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
 	if c.BaseURL == nil {

--- a/github/interactions_orgs_test.go
+++ b/github/interactions_orgs_test.go
@@ -99,7 +99,7 @@ func TestInteractionsService_RemoveRestrictionsFromOrg(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/interaction-limits", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/interaction-limits", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		testHeader(t, r, "Accept", mediaTypeInteractionRestrictionsPreview)
 	})

--- a/github/interactions_repos_test.go
+++ b/github/interactions_repos_test.go
@@ -99,7 +99,7 @@ func TestInteractionsService_RemoveRestrictionsFromRepo(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/interaction-limits", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/interaction-limits", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		testHeader(t, r, "Accept", mediaTypeInteractionRestrictionsPreview)
 	})

--- a/github/issues_assignees_test.go
+++ b/github/issues_assignees_test.go
@@ -65,7 +65,7 @@ func TestIssuesService_IsAssignee_true(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/assignees/u", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/assignees/u", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 	})
 

--- a/github/issues_comments_test.go
+++ b/github/issues_comments_test.go
@@ -265,7 +265,7 @@ func TestIssuesService_DeleteComment(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/issues/comments/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/issues/comments/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/issues_labels_test.go
+++ b/github/issues_labels_test.go
@@ -215,7 +215,7 @@ func TestIssuesService_DeleteLabel(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/labels/n", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/labels/n", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -351,7 +351,7 @@ func TestIssuesService_RemoveLabelForIssue(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/issues/1/labels/l", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/issues/1/labels/l", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -438,7 +438,7 @@ func TestIssuesService_RemoveLabelsForIssue(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/issues/1/labels", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/issues/1/labels", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/issues_milestones_test.go
+++ b/github/issues_milestones_test.go
@@ -220,7 +220,7 @@ func TestIssuesService_DeleteMilestone(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/milestones/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/milestones/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -199,7 +199,7 @@ func TestValidatePayload_NoSecretKey(t *testing.T) {
 // badReader satisfies io.Reader but always returns an error.
 type badReader struct{}
 
-func (b *badReader) Read(p []byte) (int, error) {
+func (b *badReader) Read([]byte) (int, error) {
 	return 0, errors.New("bad reader")
 }
 

--- a/github/migrations.go
+++ b/github/migrations.go
@@ -181,7 +181,7 @@ func (s *MigrationService) MigrationArchiveURL(ctx context.Context, org string, 
 	// Disable the redirect mechanism because AWS fails if the GitHub auth token is provided.
 	var loc string
 	saveRedirect := s.client.client.CheckRedirect
-	s.client.client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+	s.client.client.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
 		loc = req.URL.String()
 		return errors.New("disable redirect")
 	}

--- a/github/migrations_user.go
+++ b/github/migrations_user.go
@@ -172,7 +172,7 @@ func (s *MigrationService) UserMigrationArchiveURL(ctx context.Context, id int64
 
 	var loc string
 	originalRedirect := s.client.client.CheckRedirect
-	s.client.client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+	s.client.client.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
 		loc = req.URL.String()
 		return http.ErrUseLastResponse
 	}

--- a/github/orgs_hooks_test.go
+++ b/github/orgs_hooks_test.go
@@ -208,7 +208,7 @@ func TestOrganizationsService_PingHook(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/hooks/1/pings", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/hooks/1/pings", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 
@@ -233,7 +233,7 @@ func TestOrganizationsService_DeleteHook(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/hooks/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/hooks/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/orgs_issue_types_test.go
+++ b/github/orgs_issue_types_test.go
@@ -216,7 +216,7 @@ func TestOrganizationsService_DeleteIssueType(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/issue-types/410", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/issue-types/410", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -263,7 +263,7 @@ func TestOrganizationsService_RemoveMember(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/members/u", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/members/u", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -323,7 +323,7 @@ func TestOrganizationsService_PublicizeMembership(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/public_members/u", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/public_members/u", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -348,7 +348,7 @@ func TestOrganizationsService_ConcealMembership(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/public_members/u", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/public_members/u", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/orgs_network_configurations_test.go
+++ b/github/orgs_network_configurations_test.go
@@ -417,7 +417,7 @@ func TestOrganizationsService_DeleteOrgsNetworkConfiguration(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/settings/network-configurations/789ABDCEF123456", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/settings/network-configurations/789ABDCEF123456", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/orgs_outside_collaborators_test.go
+++ b/github/orgs_outside_collaborators_test.go
@@ -70,7 +70,7 @@ func TestOrganizationsService_RemoveOutsideCollaborator(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	handler := func(w http.ResponseWriter, r *http.Request) {
+	handler := func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	}
 	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
@@ -134,7 +134,7 @@ func TestOrganizationsService_ConvertMemberToOutsideCollaborator(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	handler := func(w http.ResponseWriter, r *http.Request) {
+	handler := func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	}
 	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)

--- a/github/orgs_packages_test.go
+++ b/github/orgs_packages_test.go
@@ -178,7 +178,7 @@ func TestOrganizationsService_DeletePackage(t *testing.T) {
 	client, mux, _ := setup(t)
 
 	// don't url escape the package name here since mux will convert it to a slash automatically
-	mux.HandleFunc("/orgs/o/packages/container/hello%2fhello_docker", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/packages/container/hello%2fhello_docker", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -208,7 +208,7 @@ func TestOrganizationsService_RestorePackage(t *testing.T) {
 	client, mux, _ := setup(t)
 
 	// don't url escape the package name here since mux will convert it to a slash automatically
-	mux.HandleFunc("/orgs/o/packages/container/hello%2Fhello_docker/restore", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/packages/container/hello%2Fhello_docker/restore", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 
@@ -372,7 +372,7 @@ func TestOrganizationsService_PackageDeleteVersion(t *testing.T) {
 	client, mux, _ := setup(t)
 
 	// don't url escape the package name here since mux will convert it to a slash automatically
-	mux.HandleFunc("/orgs/o/packages/container/hello%2Fhello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/packages/container/hello%2Fhello_docker/versions/45763", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -398,7 +398,7 @@ func TestOrganizationsService_PackageRestoreVersion(t *testing.T) {
 	client, mux, _ := setup(t)
 
 	// don't url escape the package name here since mux will convert it to a slash automatically
-	mux.HandleFunc("/orgs/o/packages/container/hello%2Fhello_docker/versions/45763/restore", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/packages/container/hello%2Fhello_docker/versions/45763/restore", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 

--- a/github/orgs_properties_test.go
+++ b/github/orgs_properties_test.go
@@ -260,7 +260,7 @@ func TestOrganizationsService_RemoveCustomProperty(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/properties/schema/name", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/properties/schema/name", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -449,7 +449,7 @@ func TestOrganizationsService_CreateOrUpdateRepoCustomPropertyValues(t *testing.
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/properties/values", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/properties/values", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
 		testBody(t, r, `{"repository_names":["repo"],"properties":[{"property_name":"service","value":"string"}]}`+"\n")
 	})

--- a/github/orgs_rules_test.go
+++ b/github/orgs_rules_test.go
@@ -1634,7 +1634,7 @@ func TestOrganizationsService_DeleteRepositoryRuleset(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/rulesets/21", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/rulesets/21", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/orgs_security_managers_test.go
+++ b/github/orgs_security_managers_test.go
@@ -62,7 +62,7 @@ func TestOrganizationsService_AddSecurityManagerTeam(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/security-managers/teams/t", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/security-managers/teams/t", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -105,7 +105,7 @@ func TestOrganizationsService_RemoveSecurityManagerTeam(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/security-managers/teams/t", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/security-managers/teams/t", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -320,7 +320,7 @@ func TestOrganizationsService_Delete(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/pulls_comments_test.go
+++ b/github/pulls_comments_test.go
@@ -418,7 +418,7 @@ func TestPullRequestsService_DeleteComment(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/pulls/comments/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/pulls/comments/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/pulls_reviewers_test.go
+++ b/github/pulls_reviewers_test.go
@@ -155,7 +155,7 @@ func TestRemoveReviewers(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/pulls/1/requested_reviewers", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/pulls/1/requested_reviewers", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		testBody(t, r, `{"reviewers":["octocat","googlebot"],"team_reviewers":["justice-league"]}`+"\n")
 	})
@@ -176,7 +176,7 @@ func TestRemoveReviewers_teamsOnly(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/pulls/1/requested_reviewers", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/pulls/1/requested_reviewers", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		testBody(t, r, `{"reviewers":[],"team_reviewers":["justice-league"]}`+"\n")
 	})

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -796,7 +796,7 @@ func TestPullRequestsService_Merge_options(t *testing.T) {
 
 	for i, test := range tests {
 		madeRequest := false
-		mux.HandleFunc(fmt.Sprintf("/repos/o/r/pulls/%d/merge", i), func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc(fmt.Sprintf("/repos/o/r/pulls/%d/merge", i), func(_ http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, "PUT")
 			testBody(t, r, test.wantBody+"\n")
 			madeRequest = true
@@ -815,7 +815,7 @@ func TestPullRequestsService_Merge_Blank_Message(t *testing.T) {
 
 	madeRequest := false
 	expectedBody := ""
-	mux.HandleFunc("/repos/o/r/pulls/1/merge", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/pulls/1/merge", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testBody(t, r, expectedBody+"\n")
 		madeRequest = true

--- a/github/rate_limit_test.go
+++ b/github/rate_limit_test.go
@@ -214,7 +214,7 @@ func TestRateLimits_overQuota(t *testing.T) {
 		Used:      1,
 		Reset:     Timestamp{time.Now().Add(time.Hour).Local()},
 	}
-	mux.HandleFunc("/rate_limit", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/rate_limit", func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, `{"resources":{
 			"core": {"limit":2,"remaining":1,"used":1,"reset":1372700873},
 			"search": {"limit":3,"remaining":2,"used":1,"reset":1372700874},

--- a/github/repos_actions_access_test.go
+++ b/github/repos_actions_access_test.go
@@ -55,7 +55,7 @@ func TestRepositoriesService_EditActionsAccessLevel(t *testing.T) {
 
 	input := &RepositoryActionsAccessLevel{AccessLevel: Ptr("organization")}
 
-	mux.HandleFunc("/repos/o/r/actions/permissions/access", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/actions/permissions/access", func(_ http.ResponseWriter, r *http.Request) {
 		v := new(RepositoryActionsAccessLevel)
 		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
 

--- a/github/repos_comments_test.go
+++ b/github/repos_comments_test.go
@@ -264,7 +264,7 @@ func TestRepositoriesService_DeleteComment(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/comments/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/comments/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -298,7 +298,7 @@ func TestRepositoriesService_DownloadContents_NoDownloadURL(t *testing.T) {
 		fmt.Fprint(w, `[{
 		  "type": "file",
 		  "name": "f",
-		  "content": ""	
+		  "content": ""
 		}]`)
 	})
 
@@ -909,7 +909,7 @@ func TestRepositoriesService_GetArchiveLink(t *testing.T) {
 			})
 
 			// Add custom round tripper
-			client.client.Transport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			client.client.Transport = roundTripperFunc(func(*http.Request) (*http.Response, error) {
 				return nil, errors.New("failed to get archive link")
 			})
 			testBadOptions(t, methodName, func() (err error) {

--- a/github/repos_deployment_branch_policies_test.go
+++ b/github/repos_deployment_branch_policies_test.go
@@ -17,7 +17,7 @@ func TestRepositoriesService_ListDeploymentBranchPolicies(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/environments/e/deployment-branch-policies", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/environments/e/deployment-branch-policies", func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, `{"total_count":2, "branch_policies":[{"id":1}, {"id": 2}]}`)
 	})
 
@@ -52,7 +52,7 @@ func TestRepositoriesService_GetDeploymentBranchPolicy(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/environments/e/deployment-branch-policies/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/environments/e/deployment-branch-policies/1", func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -141,7 +141,7 @@ func TestRepositoriesService_DeleteDeploymentBranchPolicy(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/environments/e/deployment-branch-policies/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/environments/e/deployment-branch-policies/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/repos_environments_test.go
+++ b/github/repos_environments_test.go
@@ -331,7 +331,7 @@ func TestRepositoriesService_DeleteEnvironment(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/environments/e", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/environments/e", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/repos_hooks_test.go
+++ b/github/repos_hooks_test.go
@@ -218,7 +218,7 @@ func TestRepositoriesService_DeleteHook(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/hooks/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/hooks/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -252,7 +252,7 @@ func TestRepositoriesService_PingHook(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/hooks/1/pings", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/hooks/1/pings", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 
@@ -277,7 +277,7 @@ func TestRepositoriesService_TestHook(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/hooks/1/tests", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/hooks/1/tests", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 
@@ -570,7 +570,7 @@ func TestRepositoriesService_Subscribe(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/hub", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/hub", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		testHeader(t, r, "Content-Type", "application/x-www-form-urlencoded")
 		testFormValues(t, r, values{
@@ -603,7 +603,7 @@ func TestRepositoriesService_Unsubscribe(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/hub", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/hub", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		testHeader(t, r, "Content-Type", "application/x-www-form-urlencoded")
 		testFormValues(t, r, values{

--- a/github/repos_keys_test.go
+++ b/github/repos_keys_test.go
@@ -162,7 +162,7 @@ func TestRepositoriesService_DeleteKey(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/keys/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/keys/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -271,7 +271,7 @@ func TestRepositoriesService_DisablePages(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/pages", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/pages", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		testHeader(t, r, "Accept", mediaTypeEnablePagesAPIPreview)
 	})

--- a/github/repos_prereceive_hooks_test.go
+++ b/github/repos_prereceive_hooks_test.go
@@ -165,7 +165,7 @@ func TestRepositoriesService_DeletePreReceiveHook(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/pre-receive-hooks/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/pre-receive-hooks/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -355,7 +355,7 @@ func (s *RepositoriesService) DownloadReleaseAsset(ctx context.Context, owner, r
 
 	var loc string
 	saveRedirect := s.client.client.CheckRedirect
-	s.client.client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+	s.client.client.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
 		loc = req.URL.String()
 		return errors.New("disable redirect")
 	}

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -332,7 +332,7 @@ func TestRepositoriesService_DeleteRelease(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/releases/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/releases/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -656,7 +656,7 @@ func TestRepositoriesService_DeleteReleaseAsset(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/releases/assets/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/repos_rules_test.go
+++ b/github/repos_rules_test.go
@@ -555,7 +555,7 @@ func TestRepositoriesService_DeleteRuleset(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/repo/rulesets/42", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/repo/rulesets/42", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -519,7 +519,7 @@ func TestRepositoriesService_Delete(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -1067,7 +1067,7 @@ func TestRepositoriesService_GetBranch_notFound(t *testing.T) {
 			}
 
 			// Add custom round tripper
-			client.client.Transport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			client.client.Transport = roundTripperFunc(func(*http.Request) (*http.Response, error) {
 				return nil, errors.New("failed to get branch")
 			})
 
@@ -3545,7 +3545,7 @@ func TestRepositoriesService_ListAppRestrictions(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
 
-			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc(test.urlPath, func(_ http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
 			})
 
@@ -3736,7 +3736,7 @@ func TestRepositoriesService_ListTeamRestrictions(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
 
-			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc(test.urlPath, func(_ http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
 			})
 
@@ -3927,7 +3927,7 @@ func TestRepositoriesService_ListUserRestrictions(t *testing.T) {
 			t.Parallel()
 			client, mux, _ := setup(t)
 
-			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc(test.urlPath, func(_ http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
 			})
 

--- a/github/scim.go
+++ b/github/scim.go
@@ -252,7 +252,7 @@ func (s *SCIMService) DeleteSCIMUserFromOrg(ctx context.Context, org, scimUserID
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/scim#list-provisioned-scim-groups-for-an-enterprise
 //
 //meta:operation GET /scim/v2/enterprises/{enterprise}/Groups
-func (s *SCIMService) ListSCIMProvisionedGroupsForEnterprise(ctx context.Context, enterprise string, opts *ListSCIMProvisionedIdentitiesOptions) (*SCIMProvisionedGroups, *Response, error) {
+func (s *SCIMService) ListSCIMProvisionedGroupsForEnterprise(ctx context.Context, enterprise string, _ *ListSCIMProvisionedIdentitiesOptions) (*SCIMProvisionedGroups, *Response, error) {
 	u := fmt.Sprintf("scim/v2/enterprises/%v/Groups", enterprise)
 
 	req, err := s.client.NewRequest("GET", u, nil)

--- a/github/teams_discussion_comments_test.go
+++ b/github/teams_discussion_comments_test.go
@@ -388,7 +388,7 @@ func TestTeamsService_DeleteComment(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	handlerFunc := func(w http.ResponseWriter, r *http.Request) {
+	handlerFunc := func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	}
 

--- a/github/teams_discussions_test.go
+++ b/github/teams_discussions_test.go
@@ -496,7 +496,7 @@ func TestTeamsService_DeleteDiscussionByID(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/organizations/1/team/2/discussions/3", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/organizations/1/team/2/discussions/3", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -521,7 +521,7 @@ func TestTeamsService_DeleteDiscussionBySlug(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/teams/s/discussions/3", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/teams/s/discussions/3", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -411,7 +411,7 @@ func TestTeamsService_DeleteTeamByID(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/organizations/1/team/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/organizations/1/team/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -436,7 +436,7 @@ func TestTeamsService_DeleteTeamBySlug(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/teams/s", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/teams/s", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/users_emails_test.go
+++ b/github/users_emails_test.go
@@ -99,7 +99,7 @@ func TestUsersService_DeleteEmails(t *testing.T) {
 
 	input := []string{"user@example.com"}
 
-	mux.HandleFunc("/user/emails", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/emails", func(_ http.ResponseWriter, r *http.Request) {
 		var v []string
 		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
 

--- a/github/users_followers_test.go
+++ b/github/users_followers_test.go
@@ -321,7 +321,7 @@ func TestUsersService_Follow(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/user/following/u", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/following/u", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 	})
 
@@ -355,7 +355,7 @@ func TestUsersService_Unfollow(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/user/following/u", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/following/u", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/users_gpg_keys_test.go
+++ b/github/users_gpg_keys_test.go
@@ -169,7 +169,7 @@ func TestUsersService_DeleteGPGKey(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/user/gpg_keys/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/gpg_keys/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/users_keys_test.go
+++ b/github/users_keys_test.go
@@ -160,7 +160,7 @@ func TestUsersService_DeleteKey(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/user/keys/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/keys/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/github/users_packages_test.go
+++ b/github/users_packages_test.go
@@ -244,7 +244,7 @@ func TestUsersService_Authenticated_DeletePackage(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/user/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/packages/container/hello_docker", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -269,7 +269,7 @@ func TestUsersService_specifiedUser_DeletePackage(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/users/u/packages/container/hello_docker", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/users/u/packages/container/hello_docker", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -294,7 +294,7 @@ func TestUsersService_Authenticated_RestorePackage(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/user/packages/container/hello_docker/restore", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/packages/container/hello_docker/restore", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 
@@ -319,7 +319,7 @@ func TestUsersService_specifiedUser_RestorePackage(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/users/u/packages/container/hello_docker/restore", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/users/u/packages/container/hello_docker/restore", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 
@@ -602,7 +602,7 @@ func TestUsersService_Authenticated_PackageDeleteVersion(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/user/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/packages/container/hello_docker/versions/45763", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -627,7 +627,7 @@ func TestUsersService_specifiedUser_PackageDeleteVersion(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/users/u/packages/container/hello_docker/versions/45763", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/users/u/packages/container/hello_docker/versions/45763", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -652,7 +652,7 @@ func TestUsersService_Authenticated_PackageRestoreVersion(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/user/packages/container/hello_docker/versions/45763/restore", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/packages/container/hello_docker/versions/45763/restore", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 
@@ -677,7 +677,7 @@ func TestUsersService_specifiedUser_PackageRestoreVersion(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/users/u/packages/container/hello_docker/versions/45763/restore", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/users/u/packages/container/hello_docker/versions/45763/restore", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 

--- a/github/users_ssh_signing_keys_test.go
+++ b/github/users_ssh_signing_keys_test.go
@@ -160,7 +160,7 @@ func TestUsersService_DeleteSSHSigningKey(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/user/ssh_signing_keys/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user/ssh_signing_keys/1", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/scrape/apps.go
+++ b/scrape/apps.go
@@ -53,7 +53,7 @@ func (c *Client) ListOAuthApps(org string) ([]*OAuthApp, error) {
 	}
 
 	var apps []*OAuthApp
-	doc.Find(".oauth-application-allowlist ul > li").Each(func(i int, s *goquery.Selection) {
+	doc.Find(".oauth-application-allowlist ul > li").Each(func(_ int, s *goquery.Selection) {
 		var app OAuthApp
 		app.Name = s.Find(".request-info strong").First().Text()
 		app.Description = s.Find(".request-info .application-description").Text()

--- a/scrape/apps_test.go
+++ b/scrape/apps_test.go
@@ -38,7 +38,7 @@ func Test_AppRestrictionsEnabled(t *testing.T) {
 			t.Parallel()
 			client, mux := setup(t)
 
-			mux.HandleFunc("/organizations/o/settings/oauth_application_policy", func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/organizations/o/settings/oauth_application_policy", func(w http.ResponseWriter, _ *http.Request) {
 				copyTestFile(t, w, tt.testFile)
 			})
 
@@ -57,7 +57,7 @@ func Test_ListOAuthApps(t *testing.T) {
 	t.Parallel()
 	client, mux := setup(t)
 
-	mux.HandleFunc("/organizations/e/settings/oauth_application_policy", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/organizations/e/settings/oauth_application_policy", func(w http.ResponseWriter, _ *http.Request) {
 		copyTestFile(t, w, "access-restrictions-enabled.html")
 	})
 
@@ -94,7 +94,7 @@ func Test_CreateApp(t *testing.T) {
 	t.Parallel()
 	client, mux := setup(t)
 
-	mux.HandleFunc("/apps/settings/new", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/apps/settings/new", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 	})
 
@@ -112,7 +112,7 @@ func Test_CreateAppWithOrg(t *testing.T) {
 	t.Parallel()
 	client, mux := setup(t)
 
-	mux.HandleFunc("/organizations/example/apps/settings/new", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/organizations/example/apps/settings/new", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 	})
 

--- a/scrape/forms_test.go
+++ b/scrape/forms_test.go
@@ -94,13 +94,13 @@ func Test_FetchAndSumbitForm(t *testing.T) {
 	client, mux := setup(t)
 	var submitted bool
 
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, `<html><form action="/submit">
 		  <input type="hidden" name="hidden" value="h">
 		  <input type="text" name="name">
 		</form></html>`)
 	})
-	mux.HandleFunc("/submit", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/submit", func(_ http.ResponseWriter, r *http.Request) {
 		err := r.ParseForm()
 		if err != nil {
 			t.Fatalf("error parsing form: %v", err)

--- a/scrape/payment.go
+++ b/scrape/payment.go
@@ -23,7 +23,7 @@ func (c *Client) OrgPaymentInformation(org string) (PaymentInformation, error) {
 		return info, err
 	}
 
-	doc.Find("main h4.mb-1").Each(func(i int, s *goquery.Selection) {
+	doc.Find("main h4.mb-1").Each(func(_ int, s *goquery.Selection) {
 		name := strings.TrimSpace(strings.ToLower(s.Text()))
 		value := strings.Join(strings.Fields(strings.TrimSpace(s.NextFiltered("p").Text())), " ")
 

--- a/tools/sliceofpointers/sliceofpointers.go
+++ b/tools/sliceofpointers/sliceofpointers.go
@@ -24,7 +24,7 @@ func init() {
 type SliceOfPointersPlugin struct{}
 
 // New returns an analysis.Analyzer to use with golangci-lint.
-func New(settings any) (register.LinterPlugin, error) {
+func New(_ any) (register.LinterPlugin, error) {
 	return &SliceOfPointersPlugin{}, nil
 }
 


### PR DESCRIPTION
This PR enables the [`revive.unused-parameter`](https://revive.run/r#unused-parameter) rule and fixes the resulting lint issues, mostly in tests.

Bug #3601 was discovered with the help of `revive.unused-parameter`, so I propose enabling the rule to prevent these bugs in the future.