### PR TITLE
chore: Correct typos in comments and tests error messages

### DIFF
--- a/github/issues.go
+++ b/github/issues.go
@@ -136,7 +136,7 @@ type PullRequestLinks struct {
 }
 
 // IssueType represents the type of issue.
-// For now it shows up when receiveing an Issue event.
+// For now it shows up when receiving an Issue event.
 type IssueType struct {
 	ID          *int64     `json:"id,omitempty"`
 	NodeID      *string    `json:"node_id,omitempty"`

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -676,7 +676,7 @@ func TestRepositoriesService_GetAutomatedSecurityFixes(t *testing.T) {
 	ctx := context.Background()
 	fixes, _, err := client.Repositories.GetAutomatedSecurityFixes(ctx, "o", "r")
 	if err != nil {
-		t.Errorf("Repositories.GetAutomatedSecurityFixes returned errpr: #{err}")
+		t.Errorf("Repositories.GetAutomatedSecurityFixes returned error: #{err}")
 	}
 
 	want := &AutomatedSecurityFixes{
@@ -3342,7 +3342,7 @@ func TestRepositoriesService_OptionalSignaturesOnProtectedBranch(t *testing.T) {
 	}
 }
 
-func TestPullRequestReviewsEnforcementRequest_MarshalJSON_nilDismissalRestirctions(t *testing.T) {
+func TestPullRequestReviewsEnforcementRequest_MarshalJSON_nilDismissalRestrictions(t *testing.T) {
 	t.Parallel()
 	req := PullRequestReviewsEnforcementRequest{}
 

--- a/scrape/forms_test.go
+++ b/scrape/forms_test.go
@@ -89,7 +89,7 @@ func Test_ParseForms(t *testing.T) {
 	}
 }
 
-func Test_FetchAndSumbitForm(t *testing.T) {
+func Test_FetchAndSubmitForm(t *testing.T) {
 	t.Parallel()
 	client, mux := setup(t)
 	var submitted bool


### PR DESCRIPTION
The PR fixes typos found with the help of [typos](https://github.com/crate-ci/typos) and [codespell](https://github.com/codespell-project/codespell).