### PR TITLE
feat: Add organization migration options

### DIFF
--- a/github/migrations.go
+++ b/github/migrations.go
@@ -56,11 +56,11 @@ type MigrationOptions struct {
 	// the migration (to reduce migration archive file size).
 	ExcludeAttachments bool
 
-	// ExcludeReleases Indicates whether releases should be excluded from
+	// ExcludeReleases indicates whether releases should be excluded from
 	// the migration (to reduce migration archive file size).
 	ExcludeReleases bool
 
-	// Exclude related items from being returned in the response in order
+	// Exclude is a slice of related items to exclude from the response in order
 	// to improve performance of the request. Supported values are: "repositories"
 	Exclude []string
 }
@@ -78,7 +78,7 @@ type startMigration struct {
 	// the migration (to reduce migration archive file size).
 	ExcludeAttachments *bool `json:"exclude_attachments,omitempty"`
 
-	// ExcludeReleases Indicates whether releases should be excluded from
+	// ExcludeReleases indicates whether releases should be excluded from
 	// the migration (to reduce migration archive file size).
 	ExcludeReleases *bool `json:"exclude_releases,omitempty"`
 

--- a/github/migrations.go
+++ b/github/migrations.go
@@ -82,7 +82,7 @@ type startMigration struct {
 	// the migration (to reduce migration archive file size).
 	ExcludeReleases *bool `json:"exclude_releases,omitempty"`
 
-	// Exclude related items from being returned in the response in order
+	// Exclude is a slice of related items to exclude from the response in order
 	// to improve performance of the request. Supported values are: "repositories"
 	Exclude []string `json:"exclude,omitempty"`
 }

--- a/github/migrations.go
+++ b/github/migrations.go
@@ -55,6 +55,14 @@ type MigrationOptions struct {
 	// ExcludeAttachments indicates whether attachments should be excluded from
 	// the migration (to reduce migration archive file size).
 	ExcludeAttachments bool
+
+	// ExcludeReleases Indicates whether releases should be excluded from
+	// the migration (to reduce migration archive file size).
+	ExcludeReleases bool
+
+	// Exclude related items from being returned in the response in order
+	// to improve performance of the request. Supported values are: "repositories"
+	Exclude []string
 }
 
 // startMigration represents the body of a StartMigration request.
@@ -69,6 +77,14 @@ type startMigration struct {
 	// ExcludeAttachments indicates whether attachments should be excluded from
 	// the migration (to reduce migration archive file size).
 	ExcludeAttachments *bool `json:"exclude_attachments,omitempty"`
+
+	// ExcludeReleases Indicates whether releases should be excluded from
+	// the migration (to reduce migration archive file size).
+	ExcludeReleases *bool `json:"exclude_releases,omitempty"`
+
+	// Exclude related items from being returned in the response in order
+	// to improve performance of the request. Supported values are: "repositories"
+	Exclude []string `json:"exclude,omitempty"`
 }
 
 // StartMigration starts the generation of a migration archive.
@@ -84,6 +100,8 @@ func (s *MigrationService) StartMigration(ctx context.Context, org string, repos
 	if opts != nil {
 		body.LockRepositories = Ptr(opts.LockRepositories)
 		body.ExcludeAttachments = Ptr(opts.ExcludeAttachments)
+		body.ExcludeReleases = Ptr(opts.ExcludeReleases)
+		body.Exclude = append(body.Exclude, opts.Exclude...)
 	}
 
 	req, err := s.client.NewRequest("POST", u, body)

--- a/github/migrations_test.go
+++ b/github/migrations_test.go
@@ -30,6 +30,8 @@ func TestMigrationService_StartMigration(t *testing.T) {
 	opt := &MigrationOptions{
 		LockRepositories:   true,
 		ExcludeAttachments: false,
+		ExcludeReleases:    true,
+		Exclude:            []string{"repositories"},
 	}
 	ctx := context.Background()
 	got, _, err := client.Migrations.StartMigration(ctx, "o", []string{"r"}, opt)


### PR DESCRIPTION
Implements https://github.com/google/go-github/issues/3597

Add support for two options of the migrate organization endpoint:

- `ExcludeReleases`
- `Exclude`

### Here are a couple of manual test scenarios

#### Exclude `repositories` from response

```
func Test_ExcludeRepositories(t *testing.T) {
	client := github.NewClient(nil).WithAuthToken("GITHUB_AUTH_TOKEN")

	m, _, err := client.Migrations.StartMigration(context.Background(), "GITHUB_ORG", []string{"GITHUB_ORG_REPO"}, &github.MigrationOptions{
		Exclude: []string{"repositories"},
	})

	assert.NoError(t, err)
	assert.Empty(t, m.Repositories)
}
```

#### Exclude releases from response

```
func Test_ExcludeReleases(t *testing.T) {
	client := github.NewClient(nil).WithAuthToken("GITHUB_AUTH_TOKEN")

	m, _, err := client.Migrations.StartMigration(context.Background(), "GITHUB_ORG", []string{"GITHUB_ORG_REPO"}, &github.MigrationOptions{
		ExcludeReleases: true,
	})
	assert.NoError(t, err)

	url, err := client.Migrations.MigrationArchiveURL(context.Background(), "GITHUB_ORG", m.GetID())
	assert.NoError(t, err)

	fmt.Println(url)

	// Then download the tarball and confirm that the releases were not migrated
	// There sould be no `releases_*.json` file
}
```

#### Without new options (regression testing)

```
func Test_Regression(t *testing.T) {
	client := github.NewClient(nil).WithAuthToken("GITHUB_AUTH_TOKEN")

	_, _, err := client.Migrations.StartMigration(context.Background(), "GITHUB_ORG", []string{"GITHUB_ORG_REPO"}, &github.MigrationOptions{})
	assert.NoError(t, err)
}   
```