### PR TITLE
fix: Remove custom Accept in Apps.ListRepos and Apps.ListUserRepos

### DIFF
--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"strings"
 )
 
 // ListRepositories represents the response from the list repos endpoints.
@@ -32,14 +31,6 @@ func (s *AppsService) ListRepos(ctx context.Context, opts *ListOptions) (*ListRe
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{
-		mediaTypeTopicsPreview,
-		mediaTypeRepositoryVisibilityPreview,
-		mediaTypeRepositoryTemplatePreview,
-	}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var r *ListRepositories
 
@@ -68,14 +59,6 @@ func (s *AppsService) ListUserRepos(ctx context.Context, id int64, opts *ListOpt
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{
-		mediaTypeTopicsPreview,
-		mediaTypeRepositoryVisibilityPreview,
-		mediaTypeRepositoryTemplatePreview,
-	}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var r *ListRepositories
 	resp, err := s.client.Do(ctx, req, &r)

--- a/github/apps_installation_test.go
+++ b/github/apps_installation_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -19,14 +18,8 @@ func TestAppsService_ListRepos(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	wantAcceptHeaders := []string{
-		mediaTypeTopicsPreview,
-		mediaTypeRepositoryVisibilityPreview,
-		mediaTypeRepositoryTemplatePreview,
-	}
 	mux.HandleFunc("/installation/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"page":     "1",
 			"per_page": "2",
@@ -60,14 +53,8 @@ func TestAppsService_ListUserRepos(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	wantAcceptHeaders := []string{
-		mediaTypeTopicsPreview,
-		mediaTypeRepositoryVisibilityPreview,
-		mediaTypeRepositoryTemplatePreview,
-	}
 	mux.HandleFunc("/user/installations/1/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
 		testFormValues(t, r, values{
 			"page":     "1",
 			"per_page": "2",


### PR DESCRIPTION
The PR removes no longer needed preview "Accept" headers in `AppsService.ListRepos` and `AppsService.ListUserRepos`.

https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28#list-repositories-accessible-to-the-app-installation--parameters
https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28#list-app-installations-accessible-to-the-user-access-token--parameters
