### PR TITLE
fix: Handle null assignee in Copilot Seat Billing API response

### DIFF
--- a/github/copilot.go
+++ b/github/copilot.go
@@ -203,6 +203,9 @@ func (cp *CopilotSeatDetails) UnmarshalJSON(data []byte) error {
 	cp.PlanType = seatDetail.PlanType
 
 	switch v := seatDetail.Assignee.(type) {
+	case nil:
+		// Assignee can be null according to GitHub API specification
+		cp.Assignee = nil
 	case map[string]any:
 		jsonData, err := json.Marshal(seatDetail.Assignee)
 		if err != nil {

--- a/github/copilot.go
+++ b/github/copilot.go
@@ -204,7 +204,9 @@ func (cp *CopilotSeatDetails) UnmarshalJSON(data []byte) error {
 
 	switch v := seatDetail.Assignee.(type) {
 	case nil:
-		// Assignee can be null according to GitHub API specification
+		// Assignee can be null according to GitHub API specification.
+		// See: https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#list-all-copilot-seat-assignments-for-an-organization
+		// Note: Copilot API is in public preview and subject to change.
 		cp.Assignee = nil
 	case map[string]any:
 		jsonData, err := json.Marshal(seatDetail.Assignee)

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -59,6 +59,16 @@ func TestCopilotSeatDetails_UnmarshalJSON(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "Null Assignee",
+			data: `{
+					"assignee": null
+				}`,
+			want: &CopilotSeatDetails{
+				Assignee: nil,
+			},
+			wantErr: false,
+		},
+		{
 			name: "Invalid Assignee Field Type",
 			data: `{
 					"assignee": "test"


### PR DESCRIPTION
### Fix: Handle `null` assignee in Copilot API response
Resolves #3616  
#### 🔧 Changes Made
- **Fixed `UnmarshalJSON` method** in `copilot.go`:
  - Added a `case nil:` branch to handle `null` `assignee` values.
  - Sets `cp.Assignee = nil` when `assignee` is `null`, instead of returning an error.
- **Updated `copilot_test.go`**:
  - Added a unit test case `"Null Assignee"` to ensure the `assignee: null` scenario is handled correctly and no error is thrown.

#### 🐛 Problem
The current implementation of `UnmarshalJSON` for `CopilotSeatDetails` throws an error when the `assignee` field is `null`, even though the [GitHub API documentation](https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#list-all-copilot-seat-assignments-for-an-organization) explicitly states that `assignee` can be `null`.


