### PR TITLE
fix: Add missing `require_last_push_approval` field to branch protection rule event structs

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1878,6 +1878,14 @@ func (b *BranchProtectionRule) GetRequiredStatusChecksEnforcementLevel() string 
 	return *b.RequiredStatusChecksEnforcementLevel
 }
 
+// GetRequireLastPushApproval returns the RequireLastPushApproval field if it's non-nil, zero value otherwise.
+func (b *BranchProtectionRule) GetRequireLastPushApproval() bool {
+	if b == nil || b.RequireLastPushApproval == nil {
+		return false
+	}
+	return *b.RequireLastPushApproval
+}
+
 // GetSignatureRequirementEnforcementLevel returns the SignatureRequirementEnforcementLevel field if it's non-nil, zero value otherwise.
 func (b *BranchProtectionRule) GetSignatureRequirementEnforcementLevel() string {
 	if b == nil || b.SignatureRequirementEnforcementLevel == nil {
@@ -18614,6 +18622,14 @@ func (p *ProtectionChanges) GetRequiredStatusChecksEnforcementLevel() *RequiredS
 	return p.RequiredStatusChecksEnforcementLevel
 }
 
+// GetRequireLastPushApproval returns the RequireLastPushApproval field.
+func (p *ProtectionChanges) GetRequireLastPushApproval() *RequireLastPushApprovalChanges {
+	if p == nil {
+		return nil
+	}
+	return p.RequireLastPushApproval
+}
+
 // GetSignatureRequirementEnforcementLevel returns the SignatureRequirementEnforcementLevel field.
 func (p *ProtectionChanges) GetSignatureRequirementEnforcementLevel() *SignatureRequirementEnforcementLevelChanges {
 	if p == nil {
@@ -24036,6 +24052,14 @@ func (r *RequiredStatusChecksRuleParameters) GetDoNotEnforceOnCreate() bool {
 		return false
 	}
 	return *r.DoNotEnforceOnCreate
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (r *RequireLastPushApprovalChanges) GetFrom() bool {
+	if r == nil || r.From == nil {
+		return false
+	}
+	return *r.From
 }
 
 // GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -2467,6 +2467,17 @@ func TestBranchProtectionRule_GetRequiredStatusChecksEnforcementLevel(tt *testin
 	b.GetRequiredStatusChecksEnforcementLevel()
 }
 
+func TestBranchProtectionRule_GetRequireLastPushApproval(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	b := &BranchProtectionRule{RequireLastPushApproval: &zeroValue}
+	b.GetRequireLastPushApproval()
+	b = &BranchProtectionRule{}
+	b.GetRequireLastPushApproval()
+	b = nil
+	b.GetRequireLastPushApproval()
+}
+
 func TestBranchProtectionRule_GetSignatureRequirementEnforcementLevel(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -24060,6 +24071,14 @@ func TestProtectionChanges_GetRequiredStatusChecksEnforcementLevel(tt *testing.T
 	p.GetRequiredStatusChecksEnforcementLevel()
 }
 
+func TestProtectionChanges_GetRequireLastPushApproval(tt *testing.T) {
+	tt.Parallel()
+	p := &ProtectionChanges{}
+	p.GetRequireLastPushApproval()
+	p = nil
+	p.GetRequireLastPushApproval()
+}
+
 func TestProtectionChanges_GetSignatureRequirementEnforcementLevel(tt *testing.T) {
 	tt.Parallel()
 	p := &ProtectionChanges{}
@@ -30907,6 +30926,17 @@ func TestRequiredStatusChecksRuleParameters_GetDoNotEnforceOnCreate(tt *testing.
 	r.GetDoNotEnforceOnCreate()
 	r = nil
 	r.GetDoNotEnforceOnCreate()
+}
+
+func TestRequireLastPushApprovalChanges_GetFrom(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	r := &RequireLastPushApprovalChanges{From: &zeroValue}
+	r.GetFrom()
+	r = &RequireLastPushApprovalChanges{}
+	r.GetFrom()
+	r = nil
+	r.GetFrom()
 }
 
 func TestReviewersRequest_GetNodeID(tt *testing.T) {

--- a/github/repos.go
+++ b/github/repos.go
@@ -1074,6 +1074,7 @@ type BranchProtectionRule struct {
 	RequiredConversationResolutionLevel      *string    `json:"required_conversation_resolution_level,omitempty"`
 	AuthorizedActorsOnly                     *bool      `json:"authorized_actors_only,omitempty"`
 	AuthorizedActorNames                     []string   `json:"authorized_actor_names,omitempty"`
+	RequireLastPushApproval                  *bool      `json:"require_last_push_approval,omitempty"`
 }
 
 // ProtectionChanges represents the changes to the rule if the BranchProtection was edited.
@@ -1093,6 +1094,7 @@ type ProtectionChanges struct {
 	RequiredStatusChecks                     *RequiredStatusChecksChanges                     `json:"required_status_checks,omitempty"`
 	RequiredStatusChecksEnforcementLevel     *RequiredStatusChecksEnforcementLevelChanges     `json:"required_status_checks_enforcement_level,omitempty"`
 	SignatureRequirementEnforcementLevel     *SignatureRequirementEnforcementLevelChanges     `json:"signature_requirement_enforcement_level,omitempty"`
+	RequireLastPushApproval                  *RequireLastPushApprovalChanges                  `json:"require_last_push_approval,omitempty"`
 }
 
 // AdminEnforcedChanges represents the changes made to the AdminEnforced policy.
@@ -1168,6 +1170,11 @@ type RequiredStatusChecksEnforcementLevelChanges struct {
 // SignatureRequirementEnforcementLevelChanges represents the changes made to the SignatureRequirementEnforcementLevel policy.
 type SignatureRequirementEnforcementLevelChanges struct {
 	From *string `json:"from,omitempty"`
+}
+
+// RequireLastPushApprovalChanges represents the changes made to the RequireLastPushApproval policy.
+type RequireLastPushApprovalChanges struct {
+	From *bool `json:"from,omitempty"`
 }
 
 // ProtectionRequest represents a request to create/edit a branch's protection.


### PR DESCRIPTION
Adds the `require_last_push_approval` field in order to be returned as part of the webhook payload object for `branch_protection_rule` as documented [here](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=created#branch_protection_rule).

It's being added to both the `ProtectionChanges` and `BranchProtectionRule` to account for the `created` and `edited` action types of the webhook.

_For context_:
- in https://github.com/google/go-github/pull/2567 the `require_last_push_approval` field was added originally
- request for addition of ☝🏼 field: https://github.com/google/go-github/issues/2574