### PR TITLE
feat: Add the `Digest` field to `ReleaseAsset`

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -21142,6 +21142,14 @@ func (r *ReleaseAsset) GetURL() string {
 	return *r.URL
 }
 
+// GetDigest returns the digest if it's non-nil, zero value otherwise.
+func (r *ReleaseAsset) GetDigest() string {
+	if r == nil || r.Digest == nil {
+		return ""
+	}
+	return *r.Digest
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (r *ReleaseEvent) GetAction() string {
 	if r == nil || r.Action == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -21062,6 +21062,14 @@ func (r *ReleaseAsset) GetCreatedAt() Timestamp {
 	return *r.CreatedAt
 }
 
+// GetDigest returns the Digest field if it's non-nil, zero value otherwise.
+func (r *ReleaseAsset) GetDigest() string {
+	if r == nil || r.Digest == nil {
+		return ""
+	}
+	return *r.Digest
+}
+
 // GetDownloadCount returns the DownloadCount field if it's non-nil, zero value otherwise.
 func (r *ReleaseAsset) GetDownloadCount() int {
 	if r == nil || r.DownloadCount == nil {
@@ -21140,14 +21148,6 @@ func (r *ReleaseAsset) GetURL() string {
 		return ""
 	}
 	return *r.URL
-}
-
-// GetDigest returns the digest if it's non-nil, zero value otherwise.
-func (r *ReleaseAsset) GetDigest() string {
-	if r == nil || r.Digest == nil {
-		return ""
-	}
-	return *r.Digest
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -27245,6 +27245,17 @@ func TestReleaseAsset_GetURL(tt *testing.T) {
 	r.GetURL()
 }
 
+func TestReleaseAsset_GetDigest(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	r := &ReleaseAsset{Digest: &zeroValue}
+	r.GetDigest()
+	r = &ReleaseAsset{}
+	r.GetDigest()
+	r = nil
+	r.GetDigest()
+}
+
 func TestReleaseEvent_GetAction(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -27138,6 +27138,17 @@ func TestReleaseAsset_GetCreatedAt(tt *testing.T) {
 	r.GetCreatedAt()
 }
 
+func TestReleaseAsset_GetDigest(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	r := &ReleaseAsset{Digest: &zeroValue}
+	r.GetDigest()
+	r = &ReleaseAsset{}
+	r.GetDigest()
+	r = nil
+	r.GetDigest()
+}
+
 func TestReleaseAsset_GetDownloadCount(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int
@@ -27243,17 +27254,6 @@ func TestReleaseAsset_GetURL(tt *testing.T) {
 	r.GetURL()
 	r = nil
 	r.GetURL()
-}
-
-func TestReleaseAsset_GetDigest(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	r := &ReleaseAsset{Digest: &zeroValue}
-	r.GetDigest()
-	r = &ReleaseAsset{}
-	r.GetDigest()
-	r = nil
-	r.GetDigest()
 }
 
 func TestReleaseEvent_GetAction(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1661,8 +1661,9 @@ func TestReleaseAsset_String(t *testing.T) {
 		BrowserDownloadURL: Ptr(""),
 		Uploader:           &User{},
 		NodeID:             Ptr(""),
+		Digest:             Ptr(""),
 	}
-	want := `github.ReleaseAsset{ID:0, URL:"", Name:"", Label:"", State:"", ContentType:"", Size:0, DownloadCount:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, BrowserDownloadURL:"", Uploader:github.User{}, NodeID:""}`
+	want := `github.ReleaseAsset{ID:0, URL:"", Name:"", Label:"", State:"", ContentType:"", Size:0, DownloadCount:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, BrowserDownloadURL:"", Uploader:github.User{}, NodeID:"", Digest:""}`
 	if got := v.String(); got != want {
 		t.Errorf("ReleaseAsset.String = %v, want %v", got, want)
 	}

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -79,6 +79,7 @@ type ReleaseAsset struct {
 	BrowserDownloadURL *string    `json:"browser_download_url,omitempty"`
 	Uploader           *User      `json:"uploader,omitempty"`
 	NodeID             *string    `json:"node_id,omitempty"`
+	Digest             *string    `json:"digest,omitempty"`
 }
 
 func (r ReleaseAsset) String() string {


### PR DESCRIPTION
Close #3627

https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/
https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-a-release

The `Get a Release` API returns digests of assets.
To get digests, this commit adds the field `Digest` and the method `GetDigest` to `ReleaseAsset`.
