### PR TITLE
refactor: fix revive.unnecessary-format lint issues

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,4 +1,4 @@
-version: v2.1.6
+version: v2.2.2
 plugins:
   - module: "github.com/google/go-github/v68/tools/sliceofpointers"
     path: ./tools/sliceofpointers

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,6 +97,7 @@ linters:
         - name: time-naming
         - name: unexported-naming
         - name: unexported-return
+        - name: unnecessary-format
         - name: unreachable-code
         - name: unused-parameter
         - name: use-any

--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -218,7 +218,7 @@ func main() {
 		log.Fatalf("Unable to get/create the commit reference: %s\n", err)
 	}
 	if ref == nil {
-		log.Fatalf("No error where returned but the reference is nil")
+		log.Fatal("No error where returned but the reference is nil")
 	}
 
 	tree, err := getTree(ref)

--- a/example/verifyartifact/main.go
+++ b/example/verifyartifact/main.go
@@ -186,7 +186,7 @@ func runVerification(sev *verify.SignedEntityVerifier, pb *verify.PolicyBuilder,
 		return err
 	}
 
-	fmt.Fprintf(os.Stderr, "Verification successful!\n")
+	fmt.Fprint(os.Stderr, "Verification successful!\n")
 
 	marshaled, err := json.MarshalIndent(res, "", "  ")
 	if err != nil {

--- a/github/actions_artifacts_test.go
+++ b/github/actions_artifacts_test.go
@@ -92,7 +92,7 @@ func TestActionsService_ListArtifacts_notFound(t *testing.T) {
 	ctx := context.Background()
 	artifacts, resp, err := client.Actions.ListArtifacts(ctx, "o", "r", nil)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Actions.ListArtifacts return status %d, want %d", got, want)
@@ -174,7 +174,7 @@ func TestActionsService_ListWorkflowRunArtifacts_notFound(t *testing.T) {
 	ctx := context.Background()
 	artifacts, resp, err := client.Actions.ListWorkflowRunArtifacts(ctx, "o", "r", 1, nil)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Actions.ListWorkflowRunArtifacts return status %d, want %d", got, want)
@@ -261,7 +261,7 @@ func TestActionsService_GetArtifact_notFound(t *testing.T) {
 	ctx := context.Background()
 	artifact, resp, err := client.Actions.GetArtifact(ctx, "o", "r", 1)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Actions.GetArtifact return status %d, want %d", got, want)
@@ -510,7 +510,7 @@ func TestActionsService_DownloadArtifact_unexpectedCode(t *testing.T) {
 			ctx := context.Background()
 			url, resp, err := client.Actions.DownloadArtifact(ctx, "o", "r", 1, 1)
 			if err == nil {
-				t.Fatalf("Actions.DownloadArtifact should return error on unexpected code")
+				t.Fatal("Actions.DownloadArtifact should return error on unexpected code")
 			}
 			if !strings.Contains(err.Error(), "unexpected status code") {
 				t.Error("Actions.DownloadArtifact should return unexpected status code")
@@ -580,7 +580,7 @@ func TestActionsService_DeleteArtifact_notFound(t *testing.T) {
 	ctx := context.Background()
 	resp, err := client.Actions.DeleteArtifact(ctx, "o", "r", 1)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Actions.DeleteArtifact return status %d, want %d", got, want)

--- a/github/actions_cache_test.go
+++ b/github/actions_cache_test.go
@@ -86,7 +86,7 @@ func TestActionsService_ListCaches_notFound(t *testing.T) {
 	ctx := context.Background()
 	caches, resp, err := client.Actions.ListCaches(ctx, "o", "r", nil)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Actions.ListCaches return status %d, want %d", got, want)
@@ -151,7 +151,7 @@ func TestActionsService_DeleteCachesByKey_notFound(t *testing.T) {
 	ctx := context.Background()
 	resp, err := client.Actions.DeleteCachesByKey(ctx, "o", "r", "1", Ptr("main"))
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Actions.DeleteCachesByKey return status %d, want %d", got, want)
@@ -213,7 +213,7 @@ func TestActionsService_DeleteCachesByID_notFound(t *testing.T) {
 	ctx := context.Background()
 	resp, err := client.Actions.DeleteCachesByID(ctx, "o", "r", 1)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Actions.DeleteCachesByID return status %d, want %d", got, want)
@@ -291,7 +291,7 @@ func TestActionsService_GetCacheUsageForRepo_notFound(t *testing.T) {
 	ctx := context.Background()
 	caches, resp, err := client.Actions.GetCacheUsageForRepo(ctx, "o", "r")
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Actions.GetCacheUsageForRepo return status %d, want %d", got, want)
@@ -364,7 +364,7 @@ func TestActionsService_ListCacheUsageByRepoForOrg_notFound(t *testing.T) {
 	ctx := context.Background()
 	caches, resp, err := client.Actions.ListCacheUsageByRepoForOrg(ctx, "o", nil)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Actions.ListCacheUsageByRepoForOrg return status %d, want %d", got, want)
@@ -435,7 +435,7 @@ func TestActionsService_GetCacheUsageForOrg_notFound(t *testing.T) {
 	ctx := context.Background()
 	caches, resp, err := client.Actions.GetTotalCacheUsageForOrg(ctx, "o")
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Actions.GetTotalCacheUsageForOrg return status %d, want %d", got, want)
@@ -506,7 +506,7 @@ func TestActionsService_GetCacheUsageForEnterprise_notFound(t *testing.T) {
 	ctx := context.Background()
 	caches, resp, err := client.Actions.GetTotalCacheUsageForEnterprise(ctx, "o")
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Actions.GetTotalCacheUsageForEnterprise return status %d, want %d", got, want)

--- a/github/actions_secrets_test.go
+++ b/github/actions_secrets_test.go
@@ -81,7 +81,7 @@ func TestPublicKey_UnmarshalJSON(t *testing.T) {
 			pk := PublicKey{}
 			err := json.Unmarshal(tt.data, &pk)
 			if err == nil && tt.wantErr {
-				t.Errorf("PublicKey.UnmarshalJSON returned nil instead of an error")
+				t.Error("PublicKey.UnmarshalJSON returned nil instead of an error")
 			}
 			if err != nil && !tt.wantErr {
 				t.Errorf("PublicKey.UnmarshalJSON returned an unexpected error: %+v", err)
@@ -507,7 +507,7 @@ func TestActionsService_ListSelectedReposForOrgSecret(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/actions/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `{"total_count":1,"repositories":[{"id":1}]}`)
+		fmt.Fprint(w, `{"total_count":1,"repositories":[{"id":1}]}`)
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}

--- a/github/actions_variables_test.go
+++ b/github/actions_variables_test.go
@@ -390,7 +390,7 @@ func TestActionsService_ListSelectedReposForOrgVariable(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/actions/variables/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `{"total_count":1,"repositories":[{"id":1}]}`)
+		fmt.Fprint(w, `{"total_count":1,"repositories":[{"id":1}]}`)
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -368,7 +368,7 @@ func TestActionsService_GetWorkflowJobLogs_unexpectedCode(t *testing.T) {
 			ctx := context.Background()
 			url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 1)
 			if err == nil {
-				t.Fatalf("Actions.GetWorkflowJobLogs should return error on unexpected code")
+				t.Fatal("Actions.GetWorkflowJobLogs should return error on unexpected code")
 			}
 			if !strings.Contains(err.Error(), "unexpected status code") {
 				t.Error("Actions.GetWorkflowJobLogs should return unexpected status code")

--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -369,7 +369,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs_unexpectedCode(t *testing.T) {
 			ctx := context.Background()
 			url, resp, err := client.Actions.GetWorkflowRunAttemptLogs(ctx, "o", "r", 399444496, 2, 1)
 			if err == nil {
-				t.Fatalf("Actions.GetWorkflowRunAttemptLogs should return error on unexpected code")
+				t.Fatal("Actions.GetWorkflowRunAttemptLogs should return error on unexpected code")
 			}
 			if !strings.Contains(err.Error(), "unexpected status code") {
 				t.Error("Actions.GetWorkflowRunAttemptLogs should return unexpected status code")
@@ -680,7 +680,7 @@ func TestActionsService_GetWorkflowRunLogs_unexpectedCode(t *testing.T) {
 			ctx := context.Background()
 			url, resp, err := client.Actions.GetWorkflowRunLogs(ctx, "o", "r", 399444496, 1)
 			if err == nil {
-				t.Fatalf("Actions.GetWorkflowRunLogs should return error on unexpected code")
+				t.Fatal("Actions.GetWorkflowRunLogs should return error on unexpected code")
 			}
 			if !strings.Contains(err.Error(), "unexpected status code") {
 				t.Error("Actions.GetWorkflowRunLogs should return unexpected status code")

--- a/github/activity_watching_test.go
+++ b/github/activity_watching_test.go
@@ -184,7 +184,7 @@ func TestActivityService_GetRepositorySubscription_error(t *testing.T) {
 	ctx := context.Background()
 	_, _, err := client.Activity.GetRepositorySubscription(ctx, "o", "r")
 	if err == nil {
-		t.Errorf("Expected HTTP 400 response")
+		t.Error("Expected HTTP 400 response")
 	}
 }
 

--- a/github/codespaces_secrets_test.go
+++ b/github/codespaces_secrets_test.go
@@ -497,7 +497,7 @@ func TestCodespacesService_ListSelectedReposForSecret(t *testing.T) {
 			handleFunc: func(mux *http.ServeMux) {
 				mux.HandleFunc("/user/codespaces/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
 					testMethod(t, r, "GET")
-					fmt.Fprintf(w, `{"total_count":1,"repositories":[{"id":1}]}`)
+					fmt.Fprint(w, `{"total_count":1,"repositories":[{"id":1}]}`)
 				})
 			},
 			call: func(ctx context.Context, client *Client) (*SelectedReposList, *Response, error) {
@@ -510,7 +510,7 @@ func TestCodespacesService_ListSelectedReposForSecret(t *testing.T) {
 			handleFunc: func(mux *http.ServeMux) {
 				mux.HandleFunc("/orgs/o/codespaces/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
 					testMethod(t, r, "GET")
-					fmt.Fprintf(w, `{"total_count":1,"repositories":[{"id":1}]}`)
+					fmt.Fprint(w, `{"total_count":1,"repositories":[{"id":1}]}`)
 				})
 			},
 			call: func(ctx context.Context, client *Client) (*SelectedReposList, *Response, error) {

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -130,7 +130,7 @@ func TestCopilotSeatDetails_UnmarshalJSON(t *testing.T) {
 			t.Parallel()
 			err := json.Unmarshal([]byte(tc.data), seatDetails)
 			if err == nil && tc.wantErr {
-				t.Errorf("CopilotSeatDetails.UnmarshalJSON returned nil instead of an error")
+				t.Error("CopilotSeatDetails.UnmarshalJSON returned nil instead of an error")
 			}
 			if err != nil && !tc.wantErr {
 				t.Errorf("CopilotSeatDetails.UnmarshalJSON returned an unexpected error: %v", err)
@@ -166,7 +166,7 @@ func TestCopilotService_GetSeatDetailsUser(t *testing.T) {
 	if got, ok := seatDetails.GetUser(); ok && !cmp.Equal(got, want) {
 		t.Errorf("CopilotSeatDetails.GetTeam returned %+v, want %+v", got, want)
 	} else if !ok {
-		t.Errorf("CopilotSeatDetails.GetUser returned false, expected true")
+		t.Error("CopilotSeatDetails.GetUser returned false, expected true")
 	}
 
 	data = `{
@@ -214,7 +214,7 @@ func TestCopilotService_GetSeatDetailsTeam(t *testing.T) {
 	if got, ok := seatDetails.GetTeam(); ok && !cmp.Equal(got, want) {
 		t.Errorf("CopilotSeatDetails.GetTeam returned %+v, want %+v", got, want)
 	} else if !ok {
-		t.Errorf("CopilotSeatDetails.GetTeam returned false, expected true")
+		t.Error("CopilotSeatDetails.GetTeam returned false, expected true")
 	}
 
 	data = `{
@@ -263,7 +263,7 @@ func TestCopilotService_GetSeatDetailsOrganization(t *testing.T) {
 	if got, ok := seatDetails.GetOrganization(); ok && !cmp.Equal(got, want) {
 		t.Errorf("CopilotSeatDetails.GetOrganization returned %+v, want %+v", got, want)
 	} else if !ok {
-		t.Errorf("CopilotSeatDetails.GetOrganization returned false, expected true")
+		t.Error("CopilotSeatDetails.GetOrganization returned false, expected true")
 	}
 
 	data = `{

--- a/github/dependabot_secrets_test.go
+++ b/github/dependabot_secrets_test.go
@@ -386,7 +386,7 @@ func TestDependabotService_ListSelectedReposForOrgSecret(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `{"total_count":1,"repositories":[{"id":1}]}`)
+		fmt.Fprint(w, `{"total_count":1,"repositories":[{"id":1}]}`)
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}

--- a/github/enterprise_network_configurations_test.go
+++ b/github/enterprise_network_configurations_test.go
@@ -22,7 +22,7 @@ func TestEnterpriseService_ListEnterpriseNetworkConfigurations(t *testing.T) {
 	mux.HandleFunc(" /enterprises/e/network-configurations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"page": "3", "per_page": "2"})
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 		  "total_count": 2,
 		  "network_configurations": [
 			{
@@ -101,7 +101,7 @@ func TestEnterpriseService_CreateEnterpriseNetworkConfiguration(t *testing.T) {
 
 	mux.HandleFunc("/enterprises/e/network-configurations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 		  "id": "123456789ABCDEF",
 		  "name": "configuration one",
 		  "compute_service": "actions",
@@ -195,7 +195,7 @@ func TestEnterpriseService_GetEnterpriseNetworkConfiguration(t *testing.T) {
 
 	mux.HandleFunc("/enterprises/e/network-configurations/123456789ABCDEF", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 		  "id": "123456789ABCDEF",
 		  "name": "configuration one",
 		  "compute_service": "actions",
@@ -245,7 +245,7 @@ func TestEnterpriseService_UpdateEnterpriseNetworkConfiguration(t *testing.T) {
 
 	mux.HandleFunc("/enterprises/e/network-configurations/123456789ABCDEF", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 		  "id": "123456789ABCDEF",
 		  "name": "updated configuration one",
 		  "compute_service": "none",
@@ -363,7 +363,7 @@ func TestEnterpriseService_GetEnterpriseNetworkSettingsResource(t *testing.T) {
 
 	mux.HandleFunc("/enterprises/e/network-settings/123456789ABCDEF", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"id": "220F78DACB92BBFBC5E6F22DE1CCF52309D",
 			"network_configuration_id": "934E208B3EE0BD60CF5F752C426BFB53562",
 			"name": "my_network_settings",

--- a/github/event_test.go
+++ b/github/event_test.go
@@ -14,7 +14,7 @@ func TestPayload_Panic(t *testing.T) {
 	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
-			t.Errorf("Payload did not panic but should have")
+			t.Error("Payload did not panic but should have")
 		}
 	}()
 

--- a/github/git_commits_test.go
+++ b/github/git_commits_test.go
@@ -294,7 +294,7 @@ func TestGitService_CreateSignedCommitWithInvalidParams(t *testing.T) {
 	opts := CreateCommitOptions{Signer: uncalledSigner(t)}
 	_, _, err := client.Git.CreateCommit(ctx, "o", "r", input, &opts)
 	if err == nil {
-		t.Errorf("Expected error to be returned because invalid params were passed")
+		t.Error("Expected error to be returned because invalid params were passed")
 	}
 }
 
@@ -305,7 +305,7 @@ func TestGitService_CreateCommitWithNilCommit(t *testing.T) {
 	ctx := context.Background()
 	_, _, err := client.Git.CreateCommit(ctx, "o", "r", nil, nil)
 	if err == nil {
-		t.Errorf("Expected error to be returned because commit=nil")
+		t.Error("Expected error to be returned because commit=nil")
 	}
 }
 
@@ -371,7 +371,7 @@ func TestGitService_createSignature_nilSigner(t *testing.T) {
 	_, err := createSignature(nil, a)
 
 	if err == nil {
-		t.Errorf("Expected error to be returned because no author was passed")
+		t.Error("Expected error to be returned because no author was passed")
 	}
 }
 
@@ -380,7 +380,7 @@ func TestGitService_createSignature_nilCommit(t *testing.T) {
 	_, err := createSignature(uncalledSigner(t), nil)
 
 	if err == nil {
-		t.Errorf("Expected error to be returned because no author was passed")
+		t.Error("Expected error to be returned because no author was passed")
 	}
 }
 
@@ -397,7 +397,7 @@ func TestGitService_createSignature_signerError(t *testing.T) {
 	_, err := createSignature(signer, a)
 
 	if err == nil {
-		t.Errorf("Expected error to be returned because signer returned an error")
+		t.Error("Expected error to be returned because signer returned an error")
 	}
 }
 
@@ -405,7 +405,7 @@ func TestGitService_createSignatureMessage_nilCommit(t *testing.T) {
 	t.Parallel()
 	_, err := createSignatureMessage(nil)
 	if err == nil {
-		t.Errorf("Expected error to be returned due to nil key")
+		t.Error("Expected error to be returned due to nil key")
 	}
 }
 
@@ -423,7 +423,7 @@ func TestGitService_createSignatureMessage_nilMessage(t *testing.T) {
 		},
 	})
 	if err == nil {
-		t.Errorf("Expected error to be returned due to nil key")
+		t.Error("Expected error to be returned due to nil key")
 	}
 }
 
@@ -441,7 +441,7 @@ func TestGitService_createSignatureMessage_emptyMessage(t *testing.T) {
 		},
 	})
 	if err == nil {
-		t.Errorf("Expected error to be returned due to nil key")
+		t.Error("Expected error to be returned due to nil key")
 	}
 }
 
@@ -453,7 +453,7 @@ func TestGitService_createSignatureMessage_nilAuthor(t *testing.T) {
 		Author:  nil,
 	})
 	if err == nil {
-		t.Errorf("Expected error to be returned due to nil key")
+		t.Error("Expected error to be returned due to nil key")
 	}
 }
 

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -85,7 +85,7 @@ func TestGitService_GetRef_noRefs(t *testing.T) {
 	ctx := context.Background()
 	ref, resp, err := client.Git.GetRef(ctx, "o", "r", "refs/heads/b")
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Git.GetRef returned status %d, want %d", got, want)

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -142,7 +142,7 @@ func testHeader(t *testing.T, r *http.Request, header string, want string) {
 func testURLParseError(t *testing.T, err error) {
 	t.Helper()
 	if err == nil {
-		t.Errorf("Expected error to be returned")
+		t.Error("Expected error to be returned")
 	}
 	if err, ok := err.(*url.Error); !ok || err.Op != "parse" {
 		t.Errorf("Expected URL parse error, got %+v", err)
@@ -626,7 +626,7 @@ func TestNewRequest_emptyBody(t *testing.T) {
 		t.Fatalf("NewRequest returned unexpected error: %v", err)
 	}
 	if req.Body != nil {
-		t.Fatalf("constructed request contains a non-nil Body")
+		t.Fatal("constructed request contains a non-nil Body")
 	}
 }
 
@@ -647,7 +647,7 @@ func TestNewRequest_errorForNoTrailingSlash(t *testing.T) {
 		}
 		c.BaseURL = u
 		if _, err := c.NewRequest(http.MethodGet, "test", nil); test.wantError && err == nil {
-			t.Fatalf("Expected error to be returned.")
+			t.Fatal("Expected error to be returned.")
 		} else if !test.wantError && err != nil {
 			t.Fatalf("NewRequest returned unexpected error: %v.", err)
 		}
@@ -720,7 +720,7 @@ func TestNewFormRequest_emptyBody(t *testing.T) {
 		t.Fatalf("NewFormRequest returned unexpected error: %v", err)
 	}
 	if req.Body != nil {
-		t.Fatalf("constructed request contains a non-nil Body")
+		t.Fatal("constructed request contains a non-nil Body")
 	}
 }
 
@@ -741,7 +741,7 @@ func TestNewFormRequest_errorForNoTrailingSlash(t *testing.T) {
 		}
 		c.BaseURL = u
 		if _, err := c.NewFormRequest("test", nil); test.wantError && err == nil {
-			t.Fatalf("Expected error to be returned.")
+			t.Fatal("Expected error to be returned.")
 		} else if !test.wantError && err != nil {
 			t.Fatalf("NewFormRequest returned unexpected error: %v.", err)
 		}
@@ -795,7 +795,7 @@ func TestNewUploadRequest_errorForNoTrailingSlash(t *testing.T) {
 		}
 		c.UploadURL = u
 		if _, err = c.NewUploadRequest("test", nil, 0, ""); test.wantError && err == nil {
-			t.Fatalf("Expected error to be returned.")
+			t.Fatal("Expected error to be returned.")
 		} else if !test.wantError && err != nil {
 			t.Fatalf("NewUploadRequest returned unexpected error: %v.", err)
 		}
@@ -1081,7 +1081,7 @@ func TestDo_nilContext(t *testing.T) {
 	_, err := client.Do(nil, req, nil)
 
 	if !errors.Is(err, errNonNilContext) {
-		t.Errorf("Expected context must be non-nil error")
+		t.Error("Expected context must be non-nil error")
 	}
 }
 
@@ -1135,7 +1135,7 @@ func TestDo_preservesResponseInHTTPError(t *testing.T) {
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			"message": "Resource not found",
 			"documentation_url": "https://docs.github.com/rest/reference/repos#get-a-repository"
 		}`)
@@ -1790,7 +1790,7 @@ func TestDo_rateLimit_abuseRateLimitError_retryAfter(t *testing.T) {
 		t.Fatalf("Expected a *AbuseRateLimitError error; got %#v.", err)
 	}
 	if abuseRateLimitErr.RetryAfter == nil {
-		t.Fatalf("abuseRateLimitErr RetryAfter is nil, expected not-nil")
+		t.Fatal("abuseRateLimitErr RetryAfter is nil, expected not-nil")
 	}
 	if got, want := *abuseRateLimitErr.RetryAfter, 123*time.Second; got != want {
 		t.Errorf("abuseRateLimitErr RetryAfter = %v, want %v", got, want)
@@ -1805,7 +1805,7 @@ func TestDo_rateLimit_abuseRateLimitError_retryAfter(t *testing.T) {
 		t.Fatalf("Expected a *AbuseRateLimitError error; got %#v.", err)
 	}
 	if abuseRateLimitErr.RetryAfter == nil {
-		t.Fatalf("abuseRateLimitErr RetryAfter is nil, expected not-nil")
+		t.Fatal("abuseRateLimitErr RetryAfter is nil, expected not-nil")
 	}
 	// the saved duration might be a bit smaller than Retry-After because the duration is calculated from the expected end-of-cooldown time
 	if got, want := *abuseRateLimitErr.RetryAfter, 123*time.Second; want-got > 1*time.Second {
@@ -1847,7 +1847,7 @@ func TestDo_rateLimit_abuseRateLimitError_xRateLimitReset(t *testing.T) {
 		t.Fatalf("Expected a *AbuseRateLimitError error; got %#v.", err)
 	}
 	if abuseRateLimitErr.RetryAfter == nil {
-		t.Fatalf("abuseRateLimitErr RetryAfter is nil, expected not-nil")
+		t.Fatal("abuseRateLimitErr RetryAfter is nil, expected not-nil")
 	}
 	// the retry after value might be a bit smaller than the original duration because the duration is calculated from the expected end-of-cooldown time
 	if got, want := *abuseRateLimitErr.RetryAfter, 123*time.Second; want-got > 1*time.Second {
@@ -1863,7 +1863,7 @@ func TestDo_rateLimit_abuseRateLimitError_xRateLimitReset(t *testing.T) {
 		t.Fatalf("Expected a *AbuseRateLimitError error; got %#v.", err)
 	}
 	if abuseRateLimitErr.RetryAfter == nil {
-		t.Fatalf("abuseRateLimitErr RetryAfter is nil, expected not-nil")
+		t.Fatal("abuseRateLimitErr RetryAfter is nil, expected not-nil")
 	}
 	// the saved duration might be a bit smaller than Retry-After because the duration is calculated from the expected end-of-cooldown time
 	if got, want := *abuseRateLimitErr.RetryAfter, 123*time.Second; want-got > 1*time.Second {
@@ -1907,7 +1907,7 @@ func TestDo_rateLimit_abuseRateLimitError_maxDuration(t *testing.T) {
 		t.Fatalf("Expected a *AbuseRateLimitError error; got %#v.", err)
 	}
 	if abuseRateLimitErr.RetryAfter == nil {
-		t.Fatalf("abuseRateLimitErr RetryAfter is nil, expected not-nil")
+		t.Fatal("abuseRateLimitErr RetryAfter is nil, expected not-nil")
 	}
 	// check that the retry after is set to be the max allowed duration
 	if got, want := *abuseRateLimitErr.RetryAfter, client.MaxSecondaryRateLimitRetryAfterDuration; got != want {
@@ -2080,7 +2080,7 @@ func TestCheckResponse(t *testing.T) {
 	err := CheckResponse(res).(*ErrorResponse)
 
 	if err == nil {
-		t.Errorf("Expected error response.")
+		t.Error("Expected error response.")
 	}
 
 	want := &ErrorResponse{
@@ -2115,7 +2115,7 @@ func TestCheckResponse_RateLimit(t *testing.T) {
 	err := CheckResponse(res).(*RateLimitError)
 
 	if err == nil {
-		t.Errorf("Expected error response.")
+		t.Error("Expected error response.")
 	}
 
 	want := &RateLimitError{
@@ -2139,7 +2139,7 @@ func TestCheckResponse_AbuseRateLimit(t *testing.T) {
 	err := CheckResponse(res).(*AbuseRateLimitError)
 
 	if err == nil {
-		t.Errorf("Expected error response.")
+		t.Error("Expected error response.")
 	}
 
 	want := &AbuseRateLimitError{
@@ -2165,7 +2165,7 @@ func TestCheckResponse_RedirectionError(t *testing.T) {
 	err := CheckResponse(res).(*RedirectionError)
 
 	if err == nil {
-		t.Errorf("Expected error response.")
+		t.Error("Expected error response.")
 	}
 
 	wantedURL, parseErr := url.Parse(urlStr)
@@ -2574,7 +2574,7 @@ func TestCheckResponse_noBody(t *testing.T) {
 	err := CheckResponse(res).(*ErrorResponse)
 
 	if err == nil {
-		t.Errorf("Expected error response.")
+		t.Error("Expected error response.")
 	}
 
 	want := &ErrorResponse{
@@ -2596,7 +2596,7 @@ func TestCheckResponse_unexpectedErrorStructure(t *testing.T) {
 	err := CheckResponse(res).(*ErrorResponse)
 
 	if err == nil {
-		t.Errorf("Expected error response.")
+		t.Error("Expected error response.")
 	}
 
 	want := &ErrorResponse{
@@ -2647,7 +2647,7 @@ func TestParseBooleanResponse_error(t *testing.T) {
 	result, err := parseBoolResponse(v)
 
 	if err == nil {
-		t.Errorf("Expected error to be returned.")
+		t.Error("Expected error to be returned.")
 	}
 
 	if want := false; result != want {
@@ -2660,20 +2660,20 @@ func TestErrorResponse_Error(t *testing.T) {
 	res := &http.Response{Request: &http.Request{}}
 	err := ErrorResponse{Message: "m", Response: res}
 	if err.Error() == "" {
-		t.Errorf("Expected non-empty ErrorResponse.Error()")
+		t.Error("Expected non-empty ErrorResponse.Error()")
 	}
 
 	// dont panic if request is nil
 	res = &http.Response{}
 	err = ErrorResponse{Message: "m", Response: res}
 	if err.Error() == "" {
-		t.Errorf("Expected non-empty ErrorResponse.Error()")
+		t.Error("Expected non-empty ErrorResponse.Error()")
 	}
 
 	// dont panic if response is nil
 	err = ErrorResponse{Message: "m"}
 	if err.Error() == "" {
-		t.Errorf("Expected non-empty ErrorResponse.Error()")
+		t.Error("Expected non-empty ErrorResponse.Error()")
 	}
 }
 
@@ -2681,7 +2681,7 @@ func TestError_Error(t *testing.T) {
 	t.Parallel()
 	err := Error{}
 	if err.Error() == "" {
-		t.Errorf("Expected non-empty Error.Error()")
+		t.Error("Expected non-empty Error.Error()")
 	}
 }
 
@@ -2693,7 +2693,7 @@ func TestSetCredentialsAsHeaders(t *testing.T) {
 
 	actualID, actualSecret, ok := modifiedRequest.BasicAuth()
 	if !ok {
-		t.Errorf("request does not contain basic credentials")
+		t.Error("request does not contain basic credentials")
 	}
 
 	if actualID != id {
@@ -2713,7 +2713,7 @@ func TestUnauthenticatedRateLimitedTransport(t *testing.T) {
 	mux.HandleFunc("/", func(_ http.ResponseWriter, r *http.Request) {
 		id, secret, ok := r.BasicAuth()
 		if !ok {
-			t.Errorf("request does not contain basic auth credentials")
+			t.Error("request does not contain basic auth credentials")
 		}
 		if id != clientID {
 			t.Errorf("request contained basic auth username %q, want %q", id, clientID)
@@ -2743,7 +2743,7 @@ func TestUnauthenticatedRateLimitedTransport_missingFields(t *testing.T) {
 	}
 	_, err := tp.RoundTrip(nil)
 	if err == nil {
-		t.Errorf("Expected error to be returned")
+		t.Error("Expected error to be returned")
 	}
 
 	// missing ClientSecret
@@ -2752,7 +2752,7 @@ func TestUnauthenticatedRateLimitedTransport_missingFields(t *testing.T) {
 	}
 	_, err = tp.RoundTrip(nil)
 	if err == nil {
-		t.Errorf("Expected error to be returned")
+		t.Error("Expected error to be returned")
 	}
 }
 
@@ -2764,7 +2764,7 @@ func TestUnauthenticatedRateLimitedTransport_transport(t *testing.T) {
 		ClientSecret: "secret",
 	}
 	if tp.transport() != http.DefaultTransport {
-		t.Errorf("Expected http.DefaultTransport to be used.")
+		t.Error("Expected http.DefaultTransport to be used.")
 	}
 
 	// custom transport
@@ -2774,7 +2774,7 @@ func TestUnauthenticatedRateLimitedTransport_transport(t *testing.T) {
 		Transport:    &http.Transport{},
 	}
 	if tp.transport() == http.DefaultTransport {
-		t.Errorf("Expected custom transport to be used.")
+		t.Error("Expected custom transport to be used.")
 	}
 }
 
@@ -2787,7 +2787,7 @@ func TestBasicAuthTransport(t *testing.T) {
 	mux.HandleFunc("/", func(_ http.ResponseWriter, r *http.Request) {
 		u, p, ok := r.BasicAuth()
 		if !ok {
-			t.Errorf("request does not contain basic auth credentials")
+			t.Error("request does not contain basic auth credentials")
 		}
 		if u != username {
 			t.Errorf("request contained basic auth username %q, want %q", u, username)
@@ -2818,7 +2818,7 @@ func TestBasicAuthTransport_transport(t *testing.T) {
 	// default transport
 	tp := &BasicAuthTransport{}
 	if tp.transport() != http.DefaultTransport {
-		t.Errorf("Expected http.DefaultTransport to be used.")
+		t.Error("Expected http.DefaultTransport to be used.")
 	}
 
 	// custom transport
@@ -2826,7 +2826,7 @@ func TestBasicAuthTransport_transport(t *testing.T) {
 		Transport: &http.Transport{},
 	}
 	if tp.transport() == http.DefaultTransport {
-		t.Errorf("Expected custom transport to be used.")
+		t.Error("Expected custom transport to be used.")
 	}
 }
 
@@ -3223,7 +3223,7 @@ func TestDeploymentProtectionRuleEvent_GetRunID(t *testing.T) {
 	url = "https://api.github.com/repos/dummy-org/dummy-repo/actions/runs/abc123/deployment_protection_rule"
 	got, err := e.GetRunID()
 	if err == nil {
-		t.Errorf("Expected error to be returned")
+		t.Error("Expected error to be returned")
 	}
 
 	if got != want {

--- a/github/issue_import_test.go
+++ b/github/issue_import_test.go
@@ -266,7 +266,7 @@ func TestIssueImportService_CheckStatusSince_badResponse(t *testing.T) {
 
 	ctx := context.Background()
 	if _, _, err := client.IssueImport.CheckStatusSince(ctx, "o", "r", Timestamp{time.Now()}); err == nil {
-		t.Errorf("CheckStatusSince returned no error, want JSON err")
+		t.Error("CheckStatusSince returned no error, want JSON err")
 	}
 }
 

--- a/github/issues_assignees_test.go
+++ b/github/issues_assignees_test.go
@@ -138,7 +138,7 @@ func TestIssuesService_IsAssignee_error(t *testing.T) {
 	ctx := context.Background()
 	assignee, _, err := client.Issues.IsAssignee(ctx, "o", "r", "u")
 	if err == nil {
-		t.Errorf("Expected HTTP 400 response")
+		t.Error("Expected HTTP 400 response")
 	}
 	if want := false; assignee != want {
 		t.Errorf("Issues.IsAssignee returned %+v, want %+v", assignee, want)

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -589,14 +589,14 @@ func TestParseWebHook_BadMessageType(t *testing.T) {
 func TestValidatePayloadFromBody_UnableToParseBody(t *testing.T) {
 	t.Parallel()
 	if _, err := ValidatePayloadFromBody("application/x-www-form-urlencoded", bytes.NewReader([]byte(`%`)), "sha1=", []byte{}); err == nil {
-		t.Errorf("ValidatePayloadFromBody returned nil; wanted error")
+		t.Error("ValidatePayloadFromBody returned nil; wanted error")
 	}
 }
 
 func TestValidatePayloadFromBody_UnsupportedContentType(t *testing.T) {
 	t.Parallel()
 	if _, err := ValidatePayloadFromBody("invalid", bytes.NewReader([]byte(`{}`)), "sha1=", []byte{}); err == nil {
-		t.Errorf("ValidatePayloadFromBody returned nil; wanted error")
+		t.Error("ValidatePayloadFromBody returned nil; wanted error")
 	}
 }
 

--- a/github/orgs_codesecurity_configurations_test.go
+++ b/github/orgs_codesecurity_configurations_test.go
@@ -362,7 +362,7 @@ func TestOrganizationsService_SetDefaultCodeSecurityConfiguration(t *testing.T) 
 
 	mux.HandleFunc("/orgs/o/code-security/configurations/1/defaults", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		fmt.Fprintf(w, `
+		fmt.Fprint(w, `
 		{
 			"default_for_new_repos": "all",
 			"configuration":

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -160,7 +160,7 @@ func TestOrganizationsService_IsMember_error(t *testing.T) {
 	ctx := context.Background()
 	member, _, err := client.Organizations.IsMember(ctx, "o", "u")
 	if err == nil {
-		t.Errorf("Expected HTTP 400 response")
+		t.Error("Expected HTTP 400 response")
 	}
 	if want := false; member != want {
 		t.Errorf("Organizations.IsMember returned %+v, want %+v", member, want)
@@ -243,7 +243,7 @@ func TestOrganizationsService_IsPublicMember_error(t *testing.T) {
 	ctx := context.Background()
 	member, _, err := client.Organizations.IsPublicMember(ctx, "o", "u")
 	if err == nil {
-		t.Errorf("Expected HTTP 400 response")
+		t.Error("Expected HTTP 400 response")
 	}
 	if want := false; member != want {
 		t.Errorf("Organizations.IsPublicMember returned %+v, want %+v", member, want)

--- a/github/orgs_network_configurations_test.go
+++ b/github/orgs_network_configurations_test.go
@@ -22,7 +22,7 @@ func TestOrganizationsService_ListOrgsNetworkConfigurations(t *testing.T) {
 	mux.HandleFunc("/orgs/o/settings/network-configurations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"page": "1", "per_page": "3"})
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 		  "total_count": 3,
 		  "network_configurations": [
 			{
@@ -126,7 +126,7 @@ func TestOrganizationsService_CreateOrgsNetworkConfiguration(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/settings/network-configurations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 		  "id": "456789ABDCEF123",
 		  "name": "network-configuration-two",
 		  "compute_service": "none",
@@ -246,7 +246,7 @@ func TestOrganizationsService_GetOrgsNetworkConfiguration(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/settings/network-configurations/789ABDCEF123456", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 			 "id": "789ABDCEF123456",
 			  "name": "Network Configuration Three",
 			  "compute_service": "codespaces",
@@ -299,7 +299,7 @@ func TestOrganizationsService_UpdateOrgsNetworkConfiguration(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/settings/network-configurations/789ABDCEF123456", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 		  "id": "789ABDCEF123456",
 		  "name": "Network Configuration Three Update",
 		  "compute_service": "actions",
@@ -444,7 +444,7 @@ func TestOrganizationsService_GetOrgsNetworkConfigurationResource(t *testing.T) 
 
 	mux.HandleFunc("/orgs/o/settings/network-settings/789ABDCEF123456", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 		  "id": "220F78DACB92BBFBC5E6F22DE1CCF52309D",
 		  "network_configuration_id": "934E208B3EE0BD60CF5F752C426BFB53562",
 		  "name": "my_network_settings",

--- a/github/orgs_outside_collaborators_test.go
+++ b/github/orgs_outside_collaborators_test.go
@@ -105,9 +105,9 @@ func TestOrganizationsService_RemoveOutsideCollaborator_NonMember(t *testing.T) 
 	ctx := context.Background()
 	_, err := client.Organizations.RemoveOutsideCollaborator(ctx, "o", "u")
 	if err, ok := err.(*ErrorResponse); !ok {
-		t.Errorf("Organizations.RemoveOutsideCollaborator did not return an error")
+		t.Error("Organizations.RemoveOutsideCollaborator did not return an error")
 	} else if err.Response.StatusCode != http.StatusNotFound {
-		t.Errorf("Organizations.RemoveOutsideCollaborator did not return 404 status code")
+		t.Error("Organizations.RemoveOutsideCollaborator did not return 404 status code")
 	}
 }
 
@@ -124,9 +124,9 @@ func TestOrganizationsService_RemoveOutsideCollaborator_Member(t *testing.T) {
 	ctx := context.Background()
 	_, err := client.Organizations.RemoveOutsideCollaborator(ctx, "o", "u")
 	if err, ok := err.(*ErrorResponse); !ok {
-		t.Errorf("Organizations.RemoveOutsideCollaborator did not return an error")
+		t.Error("Organizations.RemoveOutsideCollaborator did not return an error")
 	} else if err.Response.StatusCode != http.StatusUnprocessableEntity {
-		t.Errorf("Organizations.RemoveOutsideCollaborator did not return 422 status code")
+		t.Error("Organizations.RemoveOutsideCollaborator did not return 422 status code")
 	}
 }
 
@@ -169,8 +169,8 @@ func TestOrganizationsService_ConvertMemberToOutsideCollaborator_NonMemberOrLast
 	ctx := context.Background()
 	_, err := client.Organizations.ConvertMemberToOutsideCollaborator(ctx, "o", "u")
 	if err, ok := err.(*ErrorResponse); !ok {
-		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator did not return an error")
+		t.Error("Organizations.ConvertMemberToOutsideCollaborator did not return an error")
 	} else if err.Response.StatusCode != http.StatusForbidden {
-		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator did not return 403 status code")
+		t.Error("Organizations.ConvertMemberToOutsideCollaborator did not return 403 status code")
 	}
 }

--- a/github/pulls_reviews_test.go
+++ b/github/pulls_reviews_test.go
@@ -437,7 +437,7 @@ func TestPullRequestsService_CreateReview_badReview(t *testing.T) {
 
 	_, _, err := client.PullRequests.CreateReview(ctx, "o", "r", 1, badReview)
 	if err == nil {
-		t.Errorf("CreateReview badReview err = nil, want err")
+		t.Error("CreateReview badReview err = nil, want err")
 	}
 }
 
@@ -494,7 +494,7 @@ func TestPullRequestsService_UpdateReview(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pulls/1/reviews/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		fmt.Fprintf(w, `{"id":1}`)
+		fmt.Fprint(w, `{"id":1}`)
 	})
 
 	ctx := context.Background()

--- a/github/repos_actions_access_test.go
+++ b/github/repos_actions_access_test.go
@@ -21,7 +21,7 @@ func TestRepositoriesService_GetActionsAccessLevel(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/actions/permissions/access", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `{"access_level": "none"}`)
+		fmt.Fprint(w, `{"access_level": "none"}`)
 	})
 
 	ctx := context.Background()

--- a/github/repos_autolinks_test.go
+++ b/github/repos_autolinks_test.go
@@ -22,7 +22,7 @@ func TestRepositoriesService_ListAutolinks(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/autolinks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"page": "2"})
-		fmt.Fprintf(w, `[{"id":1, "key_prefix": "TICKET-", "url_template": "https://example.com/TICKET?query=<num>"}, {"id":2, "key_prefix": "STORY-", "url_template": "https://example.com/STORY?query=<num>"}]`)
+		fmt.Fprint(w, `[{"id":1, "key_prefix": "TICKET-", "url_template": "https://example.com/TICKET?query=<num>"}, {"id":2, "key_prefix": "STORY-", "url_template": "https://example.com/STORY?query=<num>"}]`)
 	})
 
 	opt := &ListOptions{
@@ -119,7 +119,7 @@ func TestRepositoriesService_GetAutolink(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/autolinks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `{"id":1, "key_prefix": "TICKET-", "url_template": "https://example.com/TICKET?query=<num>"}`)
+		fmt.Fprint(w, `{"id":1, "key_prefix": "TICKET-", "url_template": "https://example.com/TICKET?query=<num>"}`)
 	})
 
 	ctx := context.Background()

--- a/github/repos_collaborators_test.go
+++ b/github/repos_collaborators_test.go
@@ -22,7 +22,7 @@ func TestRepositoriesService_ListCollaborators(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/collaborators", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"page": "2"})
-		fmt.Fprintf(w, `[{"id":1}, {"id":2}]`)
+		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
 
 	opt := &ListCollaboratorsOptions{
@@ -61,7 +61,7 @@ func TestRepositoriesService_ListCollaborators_withAffiliation(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/collaborators", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"affiliation": "all", "page": "2"})
-		fmt.Fprintf(w, `[{"id":1}, {"id":2}]`)
+		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
 
 	opt := &ListCollaboratorsOptions{
@@ -101,7 +101,7 @@ func TestRepositoriesService_ListCollaborators_withPermission(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/collaborators", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"permission": "pull", "page": "2"})
-		fmt.Fprintf(w, `[{"id":1}, {"id":2}]`)
+		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
 
 	opt := &ListCollaboratorsOptions{
@@ -159,7 +159,7 @@ func TestRepositoriesService_IsCollaborator_True(t *testing.T) {
 	}
 
 	if !isCollab {
-		t.Errorf("Repositories.IsCollaborator returned false, want true")
+		t.Error("Repositories.IsCollaborator returned false, want true")
 	}
 
 	const methodName = "IsCollaborator"
@@ -193,7 +193,7 @@ func TestRepositoriesService_IsCollaborator_False(t *testing.T) {
 	}
 
 	if isCollab {
-		t.Errorf("Repositories.IsCollaborator returned true, want false")
+		t.Error("Repositories.IsCollaborator returned true, want false")
 	}
 
 	const methodName = "IsCollaborator"
@@ -226,7 +226,7 @@ func TestRepositoryService_GetPermissionLevel(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/collaborators/u/permission", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `{"permission":"admin","user":{"login":"u"}}`)
+		fmt.Fprint(w, `{"permission":"admin","user":{"login":"u"}}`)
 	})
 
 	ctx := context.Background()

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -32,7 +32,7 @@ func TestRepositoriesService_ListCommits(t *testing.T) {
 				"since":  "2013-08-01T00:00:00Z",
 				"until":  "2013-09-03T00:00:00Z",
 			})
-		fmt.Fprintf(w, `[{"sha": "s"}]`)
+		fmt.Fprint(w, `[{"sha": "s"}]`)
 	})
 
 	opt := &CommitsListOptions{
@@ -75,7 +75,7 @@ func TestRepositoriesService_GetCommit(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/commits/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"per_page": "2", "page": "2"})
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 		  "sha": "s",
 		  "commit": { "message": "m" },
 		  "author": { "login": "l" },
@@ -267,7 +267,7 @@ func TestRepositoriesService_GetCommitSHA1(t *testing.T) {
 
 	got, _, err = client.Repositories.GetCommitSHA1(ctx, "o", "r", "tag", sha1)
 	if err == nil {
-		t.Errorf("Expected HTTP 304 response")
+		t.Error("Expected HTTP 304 response")
 	}
 
 	want = ""
@@ -323,7 +323,7 @@ func TestRepositoriesService_NonAlphabetCharacter_GetCommitSHA1(t *testing.T) {
 
 	got, _, err = client.Repositories.GetCommitSHA1(ctx, "o", "r", "tag", sha1)
 	if err == nil {
-		t.Errorf("Expected HTTP 304 response")
+		t.Error("Expected HTTP 304 response")
 	}
 
 	if want := ""; got != want {
@@ -364,7 +364,7 @@ func TestRepositoriesService_TrailingPercent_GetCommitSHA1(t *testing.T) {
 
 	got, _, err = client.Repositories.GetCommitSHA1(ctx, "o", "r", "tag", sha1)
 	if err == nil {
-		t.Errorf("Expected HTTP 304 response")
+		t.Error("Expected HTTP 304 response")
 	}
 
 	if want := ""; got != want {
@@ -649,7 +649,7 @@ func TestRepositoriesService_ListBranchesHeadCommit(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/commits/s/branches-where-head", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `[{"name": "b","commit":{"sha":"2e90302801c870f17b6152327d9b9a03c8eca0e2","url":"https://api.github.com/repos/google/go-github/commits/2e90302801c870f17b6152327d9b9a03c8eca0e2"},"protected":true}]`)
+		fmt.Fprint(w, `[{"name": "b","commit":{"sha":"2e90302801c870f17b6152327d9b9a03c8eca0e2","url":"https://api.github.com/repos/google/go-github/commits/2e90302801c870f17b6152327d9b9a03c8eca0e2"},"protected":true}]`)
 	})
 
 	ctx := context.Background()

--- a/github/repos_community_health_test.go
+++ b/github/repos_community_health_test.go
@@ -21,7 +21,7 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/community/profile", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `{
+		fmt.Fprint(w, `{
 				"health_percentage": 100,
 				"description": "My first repository on GitHub!",
 				"documentation": null,

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -305,15 +305,15 @@ func TestRepositoriesService_DownloadContents_NoDownloadURL(t *testing.T) {
 	ctx := context.Background()
 	reader, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err == nil {
-		t.Errorf("Repositories.DownloadContents did not return expected error")
+		t.Error("Repositories.DownloadContents did not return expected error")
 	}
 
 	if resp == nil {
-		t.Errorf("Repositories.DownloadContents did not return expected response")
+		t.Error("Repositories.DownloadContents did not return expected response")
 	}
 
 	if reader != nil {
-		t.Errorf("Repositories.DownloadContents did not return expected reader")
+		t.Error("Repositories.DownloadContents did not return expected reader")
 	}
 }
 
@@ -338,15 +338,15 @@ func TestRepositoriesService_DownloadContents_NoFile(t *testing.T) {
 	ctx := context.Background()
 	reader, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err == nil {
-		t.Errorf("Repositories.DownloadContents did not return expected error")
+		t.Error("Repositories.DownloadContents did not return expected error")
 	}
 
 	if resp == nil {
-		t.Errorf("Repositories.DownloadContents did not return expected response")
+		t.Error("Repositories.DownloadContents did not return expected response")
 	}
 
 	if reader != nil {
-		t.Errorf("Repositories.DownloadContents did not return expected reader")
+		t.Error("Repositories.DownloadContents did not return expected reader")
 	}
 }
 
@@ -389,7 +389,7 @@ func TestRepositoriesService_DownloadContentsWithMeta_SuccessForFile(t *testing.
 			t.Errorf("Repositories.DownloadContentsWithMeta returned content name %v, want %v", got, want)
 		}
 	} else {
-		t.Errorf("Returned RepositoryContent is null")
+		t.Error("Returned RepositoryContent is null")
 	}
 
 	const methodName = "DownloadContentsWithMeta"
@@ -452,7 +452,7 @@ func TestRepositoriesService_DownloadContentsWithMeta_SuccessForDirectory(t *tes
 			t.Errorf("Repositories.DownloadContentsWithMeta returned content name %v, want %v", got, want)
 		}
 	} else {
-		t.Errorf("Returned RepositoryContent is null")
+		t.Error("Returned RepositoryContent is null")
 	}
 }
 
@@ -509,7 +509,7 @@ func TestRepositoriesService_DownloadContentsWithMeta_FailedResponse(t *testing.
 			t.Errorf("Repositories.DownloadContentsWithMeta returned content name %v, want %v", got, want)
 		}
 	} else {
-		t.Errorf("Returned RepositoryContent is null")
+		t.Error("Returned RepositoryContent is null")
 	}
 }
 
@@ -536,19 +536,19 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoDownloadURL(t *testing.T
 	ctx := context.Background()
 	reader, contents, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
 	if err == nil {
-		t.Errorf("Repositories.DownloadContentsWithMeta did not return expected error")
+		t.Error("Repositories.DownloadContentsWithMeta did not return expected error")
 	}
 
 	if reader != nil {
-		t.Errorf("Repositories.DownloadContentsWithMeta did not return expected reader")
+		t.Error("Repositories.DownloadContentsWithMeta did not return expected reader")
 	}
 
 	if resp == nil {
-		t.Errorf("Repositories.DownloadContentsWithMeta did not return expected response")
+		t.Error("Repositories.DownloadContentsWithMeta did not return expected response")
 	}
 
 	if contents == nil {
-		t.Errorf("Repositories.DownloadContentsWithMeta did not return expected content")
+		t.Error("Repositories.DownloadContentsWithMeta did not return expected content")
 	}
 }
 
@@ -564,11 +564,11 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoFile(t *testing.T) {
 	ctx := context.Background()
 	_, _, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
 	if err == nil {
-		t.Errorf("Repositories.DownloadContentsWithMeta did not return expected error")
+		t.Error("Repositories.DownloadContentsWithMeta did not return expected error")
 	}
 
 	if resp == nil {
-		t.Errorf("Repositories.DownloadContentsWithMeta did not return expected response")
+		t.Error("Repositories.DownloadContentsWithMeta did not return expected response")
 	}
 }
 

--- a/github/repos_environments_test.go
+++ b/github/repos_environments_test.go
@@ -75,10 +75,10 @@ func TestRequiredReviewer_UnmarshalJSON(t *testing.T) {
 			rule := []*RequiredReviewer{}
 			err := json.Unmarshal(test.data, &rule)
 			if err != nil && !test.wantError {
-				t.Errorf("RequiredReviewer.UnmarshalJSON returned an error when we expected nil")
+				t.Error("RequiredReviewer.UnmarshalJSON returned an error when we expected nil")
 			}
 			if err == nil && test.wantError {
-				t.Errorf("RequiredReviewer.UnmarshalJSON returned no error when we expected one")
+				t.Error("RequiredReviewer.UnmarshalJSON returned no error when we expected one")
 			}
 			if !cmp.Equal(test.wantRule, rule) {
 				t.Errorf("RequiredReviewer.UnmarshalJSON expected rule %+v, got %+v", test.wantRule, rule)

--- a/github/repos_invitations_test.go
+++ b/github/repos_invitations_test.go
@@ -21,7 +21,7 @@ func TestRepositoriesService_ListInvitations(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"page": "2"})
-		fmt.Fprintf(w, `[{"id":1}, {"id":2}]`)
+		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
 
 	opt := &ListOptions{Page: 2}
@@ -83,7 +83,7 @@ func TestRepositoriesService_UpdateInvitation(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/invitations/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		fmt.Fprintf(w, `{"id":1}`)
+		fmt.Fprint(w, `{"id":1}`)
 	})
 
 	ctx := context.Background()

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -745,7 +745,7 @@ func TestRepositoriesService_UploadReleaseAsset(t *testing.T) {
 			testFormValues(t, r, test.expectedFormValues)
 			testBody(t, r, "Upload me !\n")
 
-			fmt.Fprintf(w, `{"id":1}`)
+			fmt.Fprint(w, `{"id":1}`)
 		})
 
 		file := openTestFile(t, test.fileName, "Upload me !\n")

--- a/github/repos_stats_test.go
+++ b/github/repos_stats_test.go
@@ -302,7 +302,7 @@ func TestRepositoriesService_AcceptedError(t *testing.T) {
 	ctx := context.Background()
 	stats, _, err := client.Repositories.ListContributorsStats(ctx, "o", "r")
 	if err == nil {
-		t.Errorf("RepositoriesService.AcceptedError should have returned an error")
+		t.Error("RepositoriesService.AcceptedError should have returned an error")
 	}
 
 	if _, ok := err.(*AcceptedError); !ok {

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -676,7 +676,7 @@ func TestRepositoriesService_GetAutomatedSecurityFixes(t *testing.T) {
 	ctx := context.Background()
 	fixes, _, err := client.Repositories.GetAutomatedSecurityFixes(ctx, "o", "r")
 	if err != nil {
-		t.Errorf("Repositories.GetAutomatedSecurityFixes returned error: #{err}")
+		t.Errorf("Repositories.GetAutomatedSecurityFixes returned error: %v", err)
 	}
 
 	want := &AutomatedSecurityFixes{
@@ -684,7 +684,7 @@ func TestRepositoriesService_GetAutomatedSecurityFixes(t *testing.T) {
 		Paused:  Ptr(false),
 	}
 	if !cmp.Equal(fixes, want) {
-		t.Errorf("Repositories.GetAutomatedSecurityFixes returned #{fixes}, want #{want}")
+		t.Errorf("Repositories.GetAutomatedSecurityFixes returned %#v, want %#v", fixes, want)
 	}
 
 	const methodName = "GetAutomatedSecurityFixes"
@@ -1410,7 +1410,7 @@ func TestRepositoriesService_GetBranchProtection_branchNotProtected(t *testing.T
 			protection, _, err := client.Repositories.GetBranchProtection(ctx, "o", "r", test.branch)
 
 			if protection != nil {
-				t.Errorf("Repositories.GetBranchProtection returned non-nil protection data")
+				t.Error("Repositories.GetBranchProtection returned non-nil protection data")
 			}
 
 			if err != ErrBranchNotProtected {
@@ -1474,7 +1474,7 @@ func TestRepositoriesService_UpdateBranchProtection_Contexts(t *testing.T) {
 
 				// TODO: remove custom Accept header when this API fully launches
 				testHeader(t, r, "Accept", mediaTypeRequiredApprovingReviewsPreview)
-				fmt.Fprintf(w, `{
+				fmt.Fprint(w, `{
 					"required_status_checks":{
 						"strict":true,
 						"contexts":["continuous-integration"],
@@ -1663,7 +1663,7 @@ func TestRepositoriesService_UpdateBranchProtection_EmptyContexts(t *testing.T) 
 
 				// TODO: remove custom Accept header when this API fully launches
 				testHeader(t, r, "Accept", mediaTypeRequiredApprovingReviewsPreview)
-				fmt.Fprintf(w, `{
+				fmt.Fprint(w, `{
 					"required_status_checks":{
 						"strict":true,
 						"contexts":[],
@@ -1843,7 +1843,7 @@ func TestRepositoriesService_UpdateBranchProtection_Checks(t *testing.T) {
 
 				// TODO: remove custom Accept header when this API fully launches
 				testHeader(t, r, "Accept", mediaTypeRequiredApprovingReviewsPreview)
-				fmt.Fprintf(w, `{
+				fmt.Fprint(w, `{
 					"required_status_checks":{
 						"strict":true,
 						"contexts":["continuous-integration"],
@@ -1997,7 +1997,7 @@ func TestRepositoriesService_UpdateBranchProtection_EmptyChecks(t *testing.T) {
 
 				// TODO: remove custom Accept header when this API fully launches
 				testHeader(t, r, "Accept", mediaTypeRequiredApprovingReviewsPreview)
-				fmt.Fprintf(w, `{
+				fmt.Fprint(w, `{
 					"required_status_checks":{
 						"strict":true,
 						"contexts":null,
@@ -2140,7 +2140,7 @@ func TestRepositoriesService_UpdateBranchProtection_StrictNoChecks(t *testing.T)
 
 				// TODO: remove custom Accept header when this API fully launches
 				testHeader(t, r, "Accept", mediaTypeRequiredApprovingReviewsPreview)
-				fmt.Fprintf(w, `{
+				fmt.Fprint(w, `{
 					"required_status_checks":{
 						"strict":true,
 						"contexts":[]
@@ -2263,7 +2263,7 @@ func TestRepositoriesService_UpdateBranchProtection_RequireLastPushApproval(t *t
 					t.Errorf("Request body = %+v, want %+v", v, input)
 				}
 
-				fmt.Fprintf(w, `{
+				fmt.Fprint(w, `{
 					"required_pull_request_reviews":{
 						"require_last_push_approval":true
 					}
@@ -2490,7 +2490,7 @@ func TestRepositoriesService_GetRequiredStatusChecks_branchNotProtected(t *testi
 			checks, _, err := client.Repositories.GetRequiredStatusChecks(ctx, "o", "r", test.branch)
 
 			if checks != nil {
-				t.Errorf("Repositories.GetRequiredStatusChecks returned non-nil status-checks data")
+				t.Error("Repositories.GetRequiredStatusChecks returned non-nil status-checks data")
 			}
 
 			if err != ErrBranchNotProtected {
@@ -2529,7 +2529,7 @@ func TestRepositoriesService_UpdateRequiredStatusChecks_Contexts(t *testing.T) {
 					t.Errorf("Request body = %+v, want %+v", v, input)
 				}
 				testHeader(t, r, "Accept", mediaTypeV3)
-				fmt.Fprintf(w, `{
+				fmt.Fprint(w, `{
 					"strict":true,
 					"contexts":["continuous-integration"],
 					"checks": [
@@ -2620,7 +2620,7 @@ func TestRepositoriesService_UpdateRequiredStatusChecks_Checks(t *testing.T) {
 					t.Errorf("Request body = %+v, want %+v", v, input)
 				}
 				testHeader(t, r, "Accept", mediaTypeV3)
-				fmt.Fprintf(w, `{
+				fmt.Fprint(w, `{
 					"strict":true,
 					"contexts":["continuous-integration"],
 					"checks": [
@@ -2786,7 +2786,7 @@ func TestRepositoriesService_ListRequiredStatusChecksContexts_branchNotProtected
 			contexts, _, err := client.Repositories.ListRequiredStatusChecksContexts(ctx, "o", "r", test.branch)
 
 			if contexts != nil {
-				t.Errorf("Repositories.ListRequiredStatusChecksContexts returned non-nil contexts data")
+				t.Error("Repositories.ListRequiredStatusChecksContexts returned non-nil contexts data")
 			}
 
 			if err != ErrBranchNotProtected {
@@ -2815,7 +2815,7 @@ func TestRepositoriesService_GetPullRequestReviewEnforcement(t *testing.T) {
 				testMethod(t, r, "GET")
 				// TODO: remove custom Accept header when this API fully launches
 				testHeader(t, r, "Accept", mediaTypeRequiredApprovingReviewsPreview)
-				fmt.Fprintf(w, `{
+				fmt.Fprint(w, `{
 			"dismissal_restrictions":{
 				"users":[{"id":1,"login":"u"}],
 				"teams":[{"id":2,"slug":"t"}],
@@ -2904,7 +2904,7 @@ func TestRepositoriesService_UpdatePullRequestReviewEnforcement(t *testing.T) {
 				}
 				// TODO: remove custom Accept header when this API fully launches
 				testHeader(t, r, "Accept", mediaTypeRequiredApprovingReviewsPreview)
-				fmt.Fprintf(w, `{
+				fmt.Fprint(w, `{
 					"dismissal_restrictions":{
 						"users":[{"id":1,"login":"u"}],
 						"teams":[{"id":2,"slug":"t"}],
@@ -2979,7 +2979,7 @@ func TestRepositoriesService_DisableDismissalRestrictions(t *testing.T) {
 				// TODO: remove custom Accept header when this API fully launches
 				testHeader(t, r, "Accept", mediaTypeRequiredApprovingReviewsPreview)
 				testBody(t, r, `{"dismissal_restrictions":{}}`+"\n")
-				fmt.Fprintf(w, `{"dismiss_stale_reviews":true,"require_code_owner_reviews":true,"required_approving_review_count":1}`)
+				fmt.Fprint(w, `{"dismiss_stale_reviews":true,"require_code_owner_reviews":true,"required_approving_review_count":1}`)
 			})
 
 			ctx := context.Background()
@@ -3071,7 +3071,7 @@ func TestRepositoriesService_GetAdminEnforcement(t *testing.T) {
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
-				fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/enforce_admins","enabled":true}`)
+				fmt.Fprint(w, `{"url":"/repos/o/r/branches/b/protection/enforce_admins","enabled":true}`)
 			})
 
 			ctx := context.Background()
@@ -3123,7 +3123,7 @@ func TestRepositoriesService_AddAdminEnforcement(t *testing.T) {
 
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "POST")
-				fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/enforce_admins","enabled":true}`)
+				fmt.Fprint(w, `{"url":"/repos/o/r/branches/b/protection/enforce_admins","enabled":true}`)
 			})
 
 			ctx := context.Background()
@@ -3214,7 +3214,7 @@ func TestRepositoriesService_GetSignaturesProtectedBranch(t *testing.T) {
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
 				testHeader(t, r, "Accept", mediaTypeSignaturePreview)
-				fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/required_signatures","enabled":false}`)
+				fmt.Fprint(w, `{"url":"/repos/o/r/branches/b/protection/required_signatures","enabled":false}`)
 			})
 
 			ctx := context.Background()
@@ -3267,7 +3267,7 @@ func TestRepositoriesService_RequireSignaturesOnProtectedBranch(t *testing.T) {
 			mux.HandleFunc(test.urlPath, func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "POST")
 				testHeader(t, r, "Accept", mediaTypeSignaturePreview)
-				fmt.Fprintf(w, `{"url":"/repos/o/r/branches/b/protection/required_signatures","enabled":true}`)
+				fmt.Fprint(w, `{"url":"/repos/o/r/branches/b/protection/required_signatures","enabled":true}`)
 			})
 
 			ctx := context.Background()
@@ -4552,7 +4552,7 @@ func TestRepository_UnmarshalJSON(t *testing.T) {
 			pk := Repository{}
 			err := json.Unmarshal(tt.data, &pk)
 			if err == nil && tt.wantErr {
-				t.Errorf("Repository.UnmarshalJSON returned nil instead of an error")
+				t.Error("Repository.UnmarshalJSON returned nil instead of an error")
 			}
 			if err != nil && !tt.wantErr {
 				t.Errorf("Repository.UnmarshalJSON returned an unexpected error: %+v", err)

--- a/github/repos_traffic_test.go
+++ b/github/repos_traffic_test.go
@@ -21,7 +21,7 @@ func TestRepositoriesService_ListTrafficReferrers(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/traffic/popular/referrers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `[{
+		fmt.Fprint(w, `[{
 			"referrer": "Google",
 			"count": 4,
 			"uniques": 3
@@ -63,7 +63,7 @@ func TestRepositoriesService_ListTrafficPaths(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/traffic/popular/paths", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `[{
+		fmt.Fprint(w, `[{
 			"path": "/github/hubot",
 			"title": "github/hubot: A customizable life embetterment robot.",
 			"count": 3542,
@@ -107,7 +107,7 @@ func TestRepositoriesService_ListTrafficViews(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/traffic/views", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `{"count": 7,
+		fmt.Fprint(w, `{"count": 7,
 			"uniques": 6,
 			"views": [{
 				"timestamp": "2016-05-31T16:00:00.000Z",
@@ -157,7 +157,7 @@ func TestRepositoriesService_ListTrafficClones(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/traffic/clones", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `{"count": 7,
+		fmt.Fprint(w, `{"count": 7,
 			"uniques": 6,
 			"clones": [{
 				"timestamp": "2016-05-31T16:00:00.00Z",

--- a/github/security_advisories_test.go
+++ b/github/security_advisories_test.go
@@ -535,7 +535,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg_BadReq
 	ctx := context.Background()
 	advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisoriesForOrg(ctx, "o", nil)
 	if err == nil {
-		t.Errorf("Expected HTTP 400 response")
+		t.Error("Expected HTTP 400 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusBadRequest; got != want {
 		t.Errorf("ListRepositorySecurityAdvisoriesForOrg return status %d, want %d", got, want)
@@ -565,7 +565,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg_NotFou
 		State: "draft",
 	})
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("ListRepositorySecurityAdvisoriesForOrg return status %d, want %d", got, want)
@@ -589,7 +589,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg_Unmars
 	ctx := context.Background()
 	advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisoriesForOrg(ctx, "o", nil)
 	if err == nil {
-		t.Errorf("Expected unmarshal error")
+		t.Error("Expected unmarshal error")
 	} else if !strings.Contains(err.Error(), "json: cannot unmarshal number into Go struct field SecurityAdvisory.ghsa_id of type string") {
 		t.Errorf("ListRepositorySecurityAdvisoriesForOrg returned unexpected error: %v", err)
 	}
@@ -666,7 +666,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories_BadRequest(t
 	ctx := context.Background()
 	advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisories(ctx, "o", "r", nil)
 	if err == nil {
-		t.Errorf("Expected HTTP 400 response")
+		t.Error("Expected HTTP 400 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusBadRequest; got != want {
 		t.Errorf("ListRepositorySecurityAdvisories return status %d, want %d", got, want)
@@ -696,7 +696,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories_NotFound(t *
 		State: "draft",
 	})
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("ListRepositorySecurityAdvisories return status %d, want %d", got, want)
@@ -720,7 +720,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories_UnmarshalErr
 	ctx := context.Background()
 	advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisories(ctx, "o", "r", nil)
 	if err == nil {
-		t.Errorf("Expected unmarshal error")
+		t.Error("Expected unmarshal error")
 	} else if !strings.Contains(err.Error(), "json: cannot unmarshal number into Go struct field SecurityAdvisory.ghsa_id of type string") {
 		t.Errorf("ListRepositorySecurityAdvisories returned unexpected error: %v", err)
 	}

--- a/github/teams_discussion_comments_test.go
+++ b/github/teams_discussion_comments_test.go
@@ -43,7 +43,7 @@ func TestTeamsService_ListComments(t *testing.T) {
 		testFormValues(t, r, values{
 			"direction": "desc",
 		})
-		fmt.Fprintf(w,
+		fmt.Fprint(w,
 			`[
 				{
 					"author": {

--- a/github/teams_discussions_test.go
+++ b/github/teams_discussions_test.go
@@ -26,7 +26,7 @@ func TestTeamsService_ListDiscussionsByID(t *testing.T) {
 			"direction": "desc",
 			"page":      "2",
 		})
-		fmt.Fprintf(w,
+		fmt.Fprint(w,
 			`[
 				{
 					"author": {
@@ -141,7 +141,7 @@ func TestTeamsService_ListDiscussionsBySlug(t *testing.T) {
 			"direction": "desc",
 			"page":      "2",
 		})
-		fmt.Fprintf(w,
+		fmt.Fprint(w,
 			`[
 				{
 					"author": {

--- a/github/teams_members_test.go
+++ b/github/teams_members_test.go
@@ -66,7 +66,7 @@ func TestTeamsService__ListTeamMembersByID_notFound(t *testing.T) {
 	ctx := context.Background()
 	members, resp, err := client.Teams.ListTeamMembersByID(ctx, 1, 2, opt)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.ListTeamMembersByID returned status %d, want %d", got, want)
@@ -141,7 +141,7 @@ func TestTeamsService__ListTeamMembersBySlug_notFound(t *testing.T) {
 	ctx := context.Background()
 	members, resp, err := client.Teams.ListTeamMembersBySlug(ctx, "o", "s", opt)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.ListTeamMembersBySlug returned status %d, want %d", got, want)
@@ -221,7 +221,7 @@ func TestTeamsService__GetTeamMembershipByID_notFound(t *testing.T) {
 	ctx := context.Background()
 	membership, resp, err := client.Teams.GetTeamMembershipByID(ctx, 1, 2, "u")
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.GetTeamMembershipByID returned status %d, want %d", got, want)
@@ -292,7 +292,7 @@ func TestTeamsService__GetTeamMembershipBySlug_notFound(t *testing.T) {
 	ctx := context.Background()
 	membership, resp, err := client.Teams.GetTeamMembershipBySlug(ctx, "o", "s", "u")
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.GetTeamMembershipBySlug returned status %d, want %d", got, want)
@@ -390,7 +390,7 @@ func TestTeamsService__AddTeamMembershipByID_notFound(t *testing.T) {
 	ctx := context.Background()
 	membership, resp, err := client.Teams.AddTeamMembershipByID(ctx, 1, 2, "u", opt)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.AddTeamMembershipByID returned status %d, want %d", got, want)
@@ -479,7 +479,7 @@ func TestTeamsService__AddTeamMembershipBySlug_notFound(t *testing.T) {
 	ctx := context.Background()
 	membership, resp, err := client.Teams.AddTeamMembershipBySlug(ctx, "o", "s", "u", opt)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.AddTeamMembershipBySlug returned status %d, want %d", got, want)
@@ -550,7 +550,7 @@ func TestTeamsService__RemoveTeamMembershipByID_notFound(t *testing.T) {
 	ctx := context.Background()
 	resp, err := client.Teams.RemoveTeamMembershipByID(ctx, 1, 2, "u")
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.RemoveTeamMembershipByID returned status %d, want %d", got, want)
@@ -605,7 +605,7 @@ func TestTeamsService__RemoveTeamMembershipBySlug_notFound(t *testing.T) {
 	ctx := context.Background()
 	resp, err := client.Teams.RemoveTeamMembershipBySlug(ctx, "o", "s", "u")
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.RemoveTeamMembershipBySlug returned status %d, want %d", got, want)
@@ -682,7 +682,7 @@ func TestTeamsService__ListPendingTeamInvitationsByID_notFound(t *testing.T) {
 	ctx := context.Background()
 	invitations, resp, err := client.Teams.ListPendingTeamInvitationsByID(ctx, 1, 2, opt)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.RemoveTeamMembershipByID returned status %d, want %d", got, want)
@@ -757,7 +757,7 @@ func TestTeamsService__ListPendingTeamInvitationsBySlug_notFound(t *testing.T) {
 	ctx := context.Background()
 	invitations, resp, err := client.Teams.ListPendingTeamInvitationsBySlug(ctx, "o", "s", opt)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.RemoveTeamMembershipByID returned status %d, want %d", got, want)

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -110,7 +110,7 @@ func TestTeamsService_GetTeamByID_notFound(t *testing.T) {
 	ctx := context.Background()
 	team, resp, err := client.Teams.GetTeamByID(ctx, 1, 2)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.GetTeamByID returned status %d, want %d", got, want)
@@ -176,7 +176,7 @@ func TestTeamsService_GetTeamBySlug_notFound(t *testing.T) {
 	ctx := context.Background()
 	team, resp, err := client.Teams.GetTeamBySlug(ctx, "o", "s")
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.GetTeamBySlug returned status %d, want %d", got, want)
@@ -691,7 +691,7 @@ func TestTeamsService_IsTeamRepoByID_false(t *testing.T) {
 	ctx := context.Background()
 	repo, resp, err := client.Teams.IsTeamRepoByID(ctx, 1, 1, "owner", "repo")
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.IsTeamRepoByID returned status %d, want %d", got, want)
@@ -713,7 +713,7 @@ func TestTeamsService_IsTeamRepoBySlug_false(t *testing.T) {
 	ctx := context.Background()
 	repo, resp, err := client.Teams.IsTeamRepoBySlug(ctx, "org", "slug", "owner", "repo")
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.IsTeamRepoByID returned status %d, want %d", got, want)
@@ -735,7 +735,7 @@ func TestTeamsService_IsTeamRepoByID_error(t *testing.T) {
 	ctx := context.Background()
 	repo, resp, err := client.Teams.IsTeamRepoByID(ctx, 1, 1, "owner", "repo")
 	if err == nil {
-		t.Errorf("Expected HTTP 400 response")
+		t.Error("Expected HTTP 400 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusBadRequest; got != want {
 		t.Errorf("Teams.IsTeamRepoByID returned status %d, want %d", got, want)
@@ -757,7 +757,7 @@ func TestTeamsService_IsTeamRepoBySlug_error(t *testing.T) {
 	ctx := context.Background()
 	repo, resp, err := client.Teams.IsTeamRepoBySlug(ctx, "org", "slug", "owner", "repo")
 	if err == nil {
-		t.Errorf("Expected HTTP 400 response")
+		t.Error("Expected HTTP 400 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusBadRequest; got != want {
 		t.Errorf("Teams.IsTeamRepoBySlug returned status %d, want %d", got, want)
@@ -867,7 +867,7 @@ func TestTeamsService_AddTeamRepoByID_noAccess(t *testing.T) {
 	ctx := context.Background()
 	_, err := client.Teams.AddTeamRepoByID(ctx, 1, 1, "owner", "repo", nil)
 	if err == nil {
-		t.Errorf("Expected error to be returned")
+		t.Error("Expected error to be returned")
 	}
 }
 
@@ -883,7 +883,7 @@ func TestTeamsService_AddTeamRepoBySlug_noAccess(t *testing.T) {
 	ctx := context.Background()
 	_, err := client.Teams.AddTeamRepoBySlug(ctx, "org", "slug", "owner", "repo", nil)
 	if err == nil {
-		t.Errorf("Expected error to be returned")
+		t.Error("Expected error to be returned")
 	}
 }
 
@@ -1846,7 +1846,7 @@ func TestTeamsService_GetExternalGroup_notFound(t *testing.T) {
 	ctx := context.Background()
 	eg, resp, err := client.Teams.GetExternalGroup(ctx, "o", 123)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.GetExternalGroup returned status %d, want %d", got, want)
@@ -1922,7 +1922,7 @@ func TestTeamsService_ListExternalGroups_notFound(t *testing.T) {
 	ctx := context.Background()
 	eg, resp, err := client.Teams.ListExternalGroups(ctx, "o", nil)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.ListExternalGroups returned status %d, want %d", got, want)
@@ -1995,7 +1995,7 @@ func TestTeamsService_ListExternalGroupsForTeamBySlug_notFound(t *testing.T) {
 	ctx := context.Background()
 	eg, resp, err := client.Teams.ListExternalGroupsForTeamBySlug(ctx, "o", "t")
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.ListExternalGroupsForTeamBySlug returned status %d, want %d", got, want)
@@ -2114,7 +2114,7 @@ func TestTeamsService_UpdateConnectedExternalGroup_notFound(t *testing.T) {
 	}
 	eg, resp, err := client.Teams.UpdateConnectedExternalGroup(ctx, "o", "t", body)
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.UpdateConnectedExternalGroup returned status %d, want %d", got, want)
@@ -2162,7 +2162,7 @@ func TestTeamsService_RemoveConnectedExternalGroup_notFound(t *testing.T) {
 	ctx := context.Background()
 	resp, err := client.Teams.RemoveConnectedExternalGroup(ctx, "o", "t")
 	if err == nil {
-		t.Errorf("Expected HTTP 404 response")
+		t.Error("Expected HTTP 404 response")
 	}
 	if got, want := resp.Response.StatusCode, http.StatusNotFound; got != want {
 		t.Errorf("Teams.GetExternalGroup returned status %d, want %d", got, want)

--- a/github/users_followers_test.go
+++ b/github/users_followers_test.go
@@ -287,7 +287,7 @@ func TestUsersService_IsFollowing_error(t *testing.T) {
 	ctx := context.Background()
 	following, _, err := client.Users.IsFollowing(ctx, "u", "t")
 	if err == nil {
-		t.Errorf("Expected HTTP 400 response")
+		t.Error("Expected HTTP 400 response")
 	}
 	if want := false; following != want {
 		t.Errorf("Users.IsFollowing returned %+v, want %+v", following, want)

--- a/github/users_test.go
+++ b/github/users_test.go
@@ -359,7 +359,7 @@ func TestUsersService_ListInvitations(t *testing.T) {
 
 	mux.HandleFunc("/user/repository_invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `[{"id":1}, {"id":2}]`)
+		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
 
 	ctx := context.Background()
@@ -392,7 +392,7 @@ func TestUsersService_ListInvitations_withOptions(t *testing.T) {
 		testFormValues(t, r, values{
 			"page": "2",
 		})
-		fmt.Fprintf(w, `[{"id":1}, {"id":2}]`)
+		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
 
 	ctx := context.Background()

--- a/script/lint.sh
+++ b/script/lint.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-GOLANGCI_LINT_VERSION="2.1.6"
+GOLANGCI_LINT_VERSION="2.2.2"
 
 CDPATH="" cd -- "$(dirname -- "$0")/.."
 BIN="$(pwd -P)"/bin

--- a/test/integration/audit_log_test.go
+++ b/test/integration/audit_log_test.go
@@ -23,7 +23,7 @@ func TestOrganizationAuditLog(t *testing.T) {
 	}
 
 	if len(entries) == 0 {
-		t.Errorf("No AuditLog events returned for org")
+		t.Error("No AuditLog events returned for org")
 	}
 
 	for _, e := range entries {

--- a/test/integration/issues_test.go
+++ b/test/integration/issues_test.go
@@ -19,7 +19,7 @@ func TestIssueEvents(t *testing.T) {
 	}
 
 	if len(events) == 0 {
-		t.Errorf("ListRepositoryEvents returned no events")
+		t.Error("ListRepositoryEvents returned no events")
 	}
 
 	events, _, err = client.Issues.ListIssueEvents(context.Background(), "google", "go-github", 1, nil)
@@ -28,7 +28,7 @@ func TestIssueEvents(t *testing.T) {
 	}
 
 	if len(events) == 0 {
-		t.Errorf("ListIssueEvents returned no events")
+		t.Error("ListIssueEvents returned no events")
 	}
 
 	event, _, err := client.Issues.GetEvent(context.Background(), "google", "go-github", *events[0].ID)

--- a/test/integration/misc_test.go
+++ b/test/integration/misc_test.go
@@ -20,11 +20,11 @@ func TestEmojis(t *testing.T) {
 	}
 
 	if len(emoji) == 0 {
-		t.Errorf("List returned no emojis")
+		t.Error("List returned no emojis")
 	}
 
 	if _, ok := emoji["+1"]; !ok {
-		t.Errorf("List missing '+1' emoji")
+		t.Error("List missing '+1' emoji")
 	}
 }
 
@@ -35,15 +35,15 @@ func TestAPIMeta(t *testing.T) {
 	}
 
 	if len(meta.Hooks) == 0 {
-		t.Errorf("Get returned no hook addresses")
+		t.Error("Get returned no hook addresses")
 	}
 
 	if len(meta.Git) == 0 {
-		t.Errorf("Get returned no git addresses")
+		t.Error("Get returned no git addresses")
 	}
 
 	if !*meta.VerifiablePasswordAuthentication {
-		t.Errorf("APIMeta VerifiablePasswordAuthentication is false")
+		t.Error("APIMeta VerifiablePasswordAuthentication is false")
 	}
 }
 
@@ -55,14 +55,14 @@ func TestRateLimits(t *testing.T) {
 
 	// do some sanity checks
 	if limits.Core.Limit == 0 {
-		t.Errorf("RateLimits returned 0 core limit")
+		t.Error("RateLimits returned 0 core limit")
 	}
 
 	if limits.Core.Limit < limits.Core.Remaining {
-		t.Errorf("Core.Limits is less than Core.Remaining.")
+		t.Error("Core.Limits is less than Core.Remaining.")
 	}
 
 	if limits.Core.Reset.Time.Before(time.Now().Add(-1 * time.Minute)) {
-		t.Errorf("Core.Reset is more than 1 minute in the past; that doesn't seem right.")
+		t.Error("Core.Reset is more than 1 minute in the past; that doesn't seem right.")
 	}
 }

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -45,7 +45,7 @@ func TestRepositories_CRUD(t *testing.T) {
 	// verify that the repository was deleted
 	_, resp, err := client.Repositories.Get(context.Background(), *repo.Owner.Login, *repo.Name)
 	if err == nil {
-		t.Fatalf("Test repository still exists after deleting it.")
+		t.Fatal("Test repository still exists after deleting it.")
 	}
 	if err != nil && resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("Repositories.Get() returned error: %v", err)
@@ -60,7 +60,7 @@ func TestRepositories_BranchesTags(t *testing.T) {
 	}
 
 	if len(branches) == 0 {
-		t.Fatalf("Repositories.ListBranches('git', 'git') returned no branches")
+		t.Fatal("Repositories.ListBranches('git', 'git') returned no branches")
 	}
 
 	_, _, err = client.Repositories.GetBranch(context.Background(), "git", "git", *branches[0].Name, 0)
@@ -75,7 +75,7 @@ func TestRepositories_BranchesTags(t *testing.T) {
 	}
 
 	if len(tags) == 0 {
-		t.Fatalf("Repositories.ListTags('git', 'git') returned no tags")
+		t.Fatal("Repositories.ListTags('git', 'git') returned no tags")
 	}
 }
 
@@ -180,7 +180,7 @@ func TestRepositories_ListByUser(t *testing.T) {
 	}
 	for i, repo := range repos {
 		if i > 0 && (*repos[i-1].CreatedAt).Time.Before((*repo.CreatedAt).Time) {
-			t.Fatalf("Repositories.ListByUser('google') with default descending Sort returned incorrect order")
+			t.Fatal("Repositories.ListByUser('google') with default descending Sort returned incorrect order")
 		}
 	}
 }

--- a/test/integration/users_test.go
+++ b/test/integration/users_test.go
@@ -24,7 +24,7 @@ func TestUsers_Get(t *testing.T) {
 	}
 
 	if len(users) == 0 {
-		t.Errorf("Users.ListAll returned no users")
+		t.Error("Users.ListAll returned no users")
 	}
 
 	// mojombo is user #1
@@ -57,7 +57,7 @@ func TestUsers_Update(t *testing.T) {
 	}
 
 	if *u.Login == "" {
-		t.Errorf("wanted non-empty values for user.Login")
+		t.Error("wanted non-empty values for user.Login")
 	}
 
 	// save original location
@@ -166,7 +166,7 @@ func TestUsers_Keys(t *testing.T) {
 	}
 
 	if len(keys) == 0 {
-		t.Errorf("Users.ListKeys('willnorris') returned no keys")
+		t.Error("Users.ListKeys('willnorris') returned no keys")
 	}
 
 	// the rest of the tests requires auth
@@ -184,7 +184,7 @@ func TestUsers_Keys(t *testing.T) {
 	key := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCy/RIqaMFj2wjkOEjx9EAU0ReLAIhodga82/feo5nnT9UUkHLbL9xrIavfdLHx28lD3xYgPfAoSicUMaAeNwuQhmuerr2c2LFGxzrdXP8pVsQ+Ol7y7OdmFPfe0KrzoZaLJs9aSiZ4VKyY4z5Se/k2UgcJTdgQVlLfw/P96aqCx8yUu94BiWqkDqYEvgWKRNHrTiIo1EXeVBCCcfgNZe1suFfNJUJSUU2T3EG2bpwBbSOCjE3FyH8+Lz3K3BOGzm3df8E7Regj9j4YIcD8cWJYO86jLJoGgQ0L5MSOq+ishNaHQXech22Ix03D1lVMjCvDT7S/C94Z1LzhI2lhvyff"
 	for _, k := range keys {
 		if k.Key != nil && *k.Key == key {
-			t.Fatalf("Test key already exists for user. Please manually remove it first.")
+			t.Fatal("Test key already exists for user. Please manually remove it first.")
 		}
 	}
 
@@ -212,7 +212,7 @@ func TestUsers_Keys(t *testing.T) {
 	}
 
 	if id == 0 {
-		t.Fatalf("Users.ListKeys('') does not contain added test key")
+		t.Fatal("Users.ListKeys('') does not contain added test key")
 	}
 
 	// Verify that fetching individual key works
@@ -238,7 +238,7 @@ func TestUsers_Keys(t *testing.T) {
 
 	for _, k := range keys {
 		if k.Key != nil && *k.Key == key {
-			t.Fatalf("Users.ListKeys('') still contains test key after removing it")
+			t.Fatal("Users.ListKeys('') still contains test key after removing it")
 		}
 	}
 }


### PR DESCRIPTION
Changes:

- Enabled the [`revive.unnecessary`](https://revive.run/r#unnecessary-format) rule in golangci-lint config. This requires upgrading golangci-lint to version [2.2.2](https://golangci-lint.run/product/changelog/#v222).
- Fixes assert messages in `TestRepositoriesService_GetAutomatedSecurityFixes`.
- Replaced `t.Errorf` with `t.Error`.
- Replaced `t.Fatalf` with `t.Fatal`.
- Replaced `fmt.Fprintf` with `fmt.Fprint`.
- Replaced `log.Fatalf` with `log.Fatal`.

