### PR TITLE
fix!: Change `ListCheckSuiteOptions.AppID` from `int` to `int64`

### DIFF
--- a/github/checks.go
+++ b/github/checks.go
@@ -345,7 +345,7 @@ func (s *ChecksService) ReRequestCheckRun(ctx context.Context, owner, repo strin
 // ListCheckSuiteOptions represents parameters to list check suites.
 type ListCheckSuiteOptions struct {
 	CheckName *string `url:"check_name,omitempty"` // Filters checks suites by the name of the check run.
-	AppID     *int    `url:"app_id,omitempty"`     // Filters check suites by GitHub App id.
+	AppID     *int64  `url:"app_id,omitempty"`     // Filters check suites by GitHub App id.
 
 	ListOptions
 }

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -472,7 +472,7 @@ func TestChecksService_ListCheckSuiteForRef(t *testing.T) {
 
 	opt := &ListCheckSuiteOptions{
 		CheckName:   Ptr("testing"),
-		AppID:       Ptr(2),
+		AppID:       Ptr(int64(2)),
 		ListOptions: ListOptions{Page: 1},
 	}
 	ctx := context.Background()

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -13319,7 +13319,7 @@ func (l *ListCheckRunsResults) GetTotal() int {
 }
 
 // GetAppID returns the AppID field if it's non-nil, zero value otherwise.
-func (l *ListCheckSuiteOptions) GetAppID() int {
+func (l *ListCheckSuiteOptions) GetAppID() int64 {
 	if l == nil || l.AppID == nil {
 		return 0
 	}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -17269,7 +17269,7 @@ func TestListCheckRunsResults_GetTotal(tt *testing.T) {
 
 func TestListCheckSuiteOptions_GetAppID(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue int
+	var zeroValue int64
 	l := &ListCheckSuiteOptions{AppID: &zeroValue}
 	l.GetAppID()
 	l = &ListCheckSuiteOptions{}


### PR DESCRIPTION
BREAKING CHANGE: Change `ListCheckSuiteOptions.AppID` from `int` to `int64`

Fixes: #3631 