### PR TITLE
Add the metadata field to create `DependencyGraphSnapshot`

### DIFF
--- a/github/dependency_graph_snapshots.go
+++ b/github/dependency_graph_snapshots.go
@@ -72,6 +72,7 @@ type DependencyGraphSnapshot struct {
 	Job       *DependencyGraphSnapshotJob                 `json:"job,omitempty"`
 	Detector  *DependencyGraphSnapshotDetector            `json:"detector,omitempty"`
 	Scanned   *Timestamp                                  `json:"scanned,omitempty"`
+	Metadata  map[string]any                              `json:"metadata,omitempty"`
 	Manifests map[string]*DependencyGraphSnapshotManifest `json:"manifests,omitempty"`
 }
 

--- a/github/dependency_graph_snapshots_test.go
+++ b/github/dependency_graph_snapshots_test.go
@@ -21,7 +21,7 @@ func TestDependencyGraphService_CreateSnapshot(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/dependency-graph/snapshots", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testBody(t, r, `{"version":0,"sha":"ce587453ced02b1526dfb4cb910479d431683101","ref":"refs/heads/main","job":{"correlator":"yourworkflowname_youractionname","id":"yourrunid","html_url":"https://example.com"},"detector":{"name":"octo-detector","version":"0.0.1","url":"https://github.com/octo-org/octo-repo"},"scanned":"2022-06-14T20:25:00Z","manifests":{"package-lock.json":{"name":"package-lock.json","file":{"source_location":"src/package-lock.json"},"resolved":{"@actions/core":{"package_url":"pkg:/npm/%40actions/core@1.1.9","relationship":"direct","scope":"runtime","dependencies":["@actions/http-client"]},"@actions/http-client":{"package_url":"pkg:/npm/%40actions/http-client@1.0.7","relationship":"indirect","scope":"runtime","dependencies":["tunnel"]},"tunnel":{"package_url":"pkg:/npm/tunnel@0.0.6","relationship":"indirect","scope":"runtime"}}}}}`+"\n")
+		testBody(t, r, `{"version":0,"sha":"ce587453ced02b1526dfb4cb910479d431683101","ref":"refs/heads/main","job":{"correlator":"yourworkflowname_youractionname","id":"yourrunid","html_url":"https://example.com"},"detector":{"name":"octo-detector","version":"0.0.1","url":"https://github.com/octo-org/octo-repo"},"scanned":"2022-06-14T20:25:00Z","metadata":{"key1":"value1","key2":"value2"},"manifests":{"package-lock.json":{"name":"package-lock.json","file":{"source_location":"src/package-lock.json"},"resolved":{"@actions/core":{"package_url":"pkg:/npm/%40actions/core@1.1.9","relationship":"direct","scope":"runtime","dependencies":["@actions/http-client"]},"@actions/http-client":{"package_url":"pkg:/npm/%40actions/http-client@1.0.7","relationship":"indirect","scope":"runtime","dependencies":["tunnel"]},"tunnel":{"package_url":"pkg:/npm/tunnel@0.0.6","relationship":"indirect","scope":"runtime"}}}}}`+"\n")
 		fmt.Fprint(w, `{"id":12345,"created_at":"2022-06-14T20:25:01Z","message":"Dependency results for the repo have been successfully updated.","result":"SUCCESS"}`)
 	})
 
@@ -41,6 +41,10 @@ func TestDependencyGraphService_CreateSnapshot(t *testing.T) {
 			URL:     Ptr("https://github.com/octo-org/octo-repo"),
 		},
 		Scanned: &Timestamp{time.Date(2022, time.June, 14, 20, 25, 00, 0, time.UTC)},
+		Metadata: map[string]any{
+			"key1": "value1",
+			"key2": "value2",
+		},
 		Manifests: map[string]*DependencyGraphSnapshotManifest{
 			"package-lock.json": {
 				Name: Ptr("package-lock.json"),

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -7014,6 +7014,14 @@ func (d *DependencyGraphSnapshot) GetJob() *DependencyGraphSnapshotJob {
 	return d.Job
 }
 
+// GetMetadata returns the Metadata map if it's non-nil, an empty map otherwise.
+func (d *DependencyGraphSnapshot) GetMetadata() map[string]any {
+	if d == nil || d.Metadata == nil {
+		return map[string]any{}
+	}
+	return d.Metadata
+}
+
 // GetRef returns the Ref field if it's non-nil, zero value otherwise.
 func (d *DependencyGraphSnapshot) GetRef() string {
 	if d == nil || d.Ref == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -9112,6 +9112,17 @@ func TestDependencyGraphSnapshot_GetJob(tt *testing.T) {
 	d.GetJob()
 }
 
+func TestDependencyGraphSnapshot_GetMetadata(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := map[string]any{}
+	d := &DependencyGraphSnapshot{Metadata: zeroValue}
+	d.GetMetadata()
+	d = &DependencyGraphSnapshot{}
+	d.GetMetadata()
+	d = nil
+	d.GetMetadata()
+}
+
 func TestDependencyGraphSnapshot_GetRef(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string


### PR DESCRIPTION
Fixes: #3635.

This PR adds support for the metadata field in the `DependencyGraphSnapshot` struct, enabling users to include custom information when submitting dependency snapshots to GitHub's dependency graph API.

I have added comprehensive test coverage including JSON serialization validation.

This implementation follows the official GitHub API specification. The field type is `map[string]any` matching the API's object type. It has constraints of being limited to 8 keys with scalar values as documented.