### PR TITLE
Add additional settings fields to org API

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -15286,6 +15286,14 @@ func (o *Organization) GetDefaultRepoSettings() string {
 	return *o.DefaultRepoSettings
 }
 
+// GetDefaultRepositoryBranch returns the DefaultRepositoryBranch field if it's non-nil, zero value otherwise.
+func (o *Organization) GetDefaultRepositoryBranch() string {
+	if o == nil || o.DefaultRepositoryBranch == nil {
+		return ""
+	}
+	return *o.DefaultRepositoryBranch
+}
+
 // GetDependabotAlertsEnabledForNewRepos returns the DependabotAlertsEnabledForNewRepos field if it's non-nil, zero value otherwise.
 func (o *Organization) GetDependabotAlertsEnabledForNewRepos() bool {
 	if o == nil || o.DependabotAlertsEnabledForNewRepos == nil {
@@ -15324,6 +15332,14 @@ func (o *Organization) GetDiskUsage() int {
 		return 0
 	}
 	return *o.DiskUsage
+}
+
+// GetDisplayCommenterFullNameSettingEnabled returns the DisplayCommenterFullNameSettingEnabled field if it's non-nil, zero value otherwise.
+func (o *Organization) GetDisplayCommenterFullNameSettingEnabled() bool {
+	if o == nil || o.DisplayCommenterFullNameSettingEnabled == nil {
+		return false
+	}
+	return *o.DisplayCommenterFullNameSettingEnabled
 }
 
 // GetEmail returns the Email field if it's non-nil, zero value otherwise.
@@ -15438,6 +15454,14 @@ func (o *Organization) GetMembersAllowedRepositoryCreationType() string {
 	return *o.MembersAllowedRepositoryCreationType
 }
 
+// GetMembersCanChangeRepoVisibility returns the MembersCanChangeRepoVisibility field if it's non-nil, zero value otherwise.
+func (o *Organization) GetMembersCanChangeRepoVisibility() bool {
+	if o == nil || o.MembersCanChangeRepoVisibility == nil {
+		return false
+	}
+	return *o.MembersCanChangeRepoVisibility
+}
+
 // GetMembersCanCreateInternalRepos returns the MembersCanCreateInternalRepos field if it's non-nil, zero value otherwise.
 func (o *Organization) GetMembersCanCreateInternalRepos() bool {
 	if o == nil || o.MembersCanCreateInternalRepos == nil {
@@ -15494,12 +15518,52 @@ func (o *Organization) GetMembersCanCreateRepos() bool {
 	return *o.MembersCanCreateRepos
 }
 
+// GetMembersCanCreateTeams returns the MembersCanCreateTeams field if it's non-nil, zero value otherwise.
+func (o *Organization) GetMembersCanCreateTeams() bool {
+	if o == nil || o.MembersCanCreateTeams == nil {
+		return false
+	}
+	return *o.MembersCanCreateTeams
+}
+
+// GetMembersCanDeleteIssues returns the MembersCanDeleteIssues field if it's non-nil, zero value otherwise.
+func (o *Organization) GetMembersCanDeleteIssues() bool {
+	if o == nil || o.MembersCanDeleteIssues == nil {
+		return false
+	}
+	return *o.MembersCanDeleteIssues
+}
+
+// GetMembersCanDeleteRepositories returns the MembersCanDeleteRepositories field if it's non-nil, zero value otherwise.
+func (o *Organization) GetMembersCanDeleteRepositories() bool {
+	if o == nil || o.MembersCanDeleteRepositories == nil {
+		return false
+	}
+	return *o.MembersCanDeleteRepositories
+}
+
 // GetMembersCanForkPrivateRepos returns the MembersCanForkPrivateRepos field if it's non-nil, zero value otherwise.
 func (o *Organization) GetMembersCanForkPrivateRepos() bool {
 	if o == nil || o.MembersCanForkPrivateRepos == nil {
 		return false
 	}
 	return *o.MembersCanForkPrivateRepos
+}
+
+// GetMembersCanInviteOutsideCollaborators returns the MembersCanInviteOutsideCollaborators field if it's non-nil, zero value otherwise.
+func (o *Organization) GetMembersCanInviteOutsideCollaborators() bool {
+	if o == nil || o.MembersCanInviteOutsideCollaborators == nil {
+		return false
+	}
+	return *o.MembersCanInviteOutsideCollaborators
+}
+
+// GetMembersCanViewDependencyInsights returns the MembersCanViewDependencyInsights field if it's non-nil, zero value otherwise.
+func (o *Organization) GetMembersCanViewDependencyInsights() bool {
+	if o == nil || o.MembersCanViewDependencyInsights == nil {
+		return false
+	}
+	return *o.MembersCanViewDependencyInsights
 }
 
 // GetMembersURL returns the MembersURL field if it's non-nil, zero value otherwise.
@@ -15572,6 +15636,14 @@ func (o *Organization) GetPublicRepos() int {
 		return 0
 	}
 	return *o.PublicRepos
+}
+
+// GetReadersCanCreateDiscussions returns the ReadersCanCreateDiscussions field if it's non-nil, zero value otherwise.
+func (o *Organization) GetReadersCanCreateDiscussions() bool {
+	if o == nil || o.ReadersCanCreateDiscussions == nil {
+		return false
+	}
+	return *o.ReadersCanCreateDiscussions
 }
 
 // GetReposURL returns the ReposURL field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -19823,6 +19823,17 @@ func TestOrganization_GetDefaultRepoSettings(tt *testing.T) {
 	o.GetDefaultRepoSettings()
 }
 
+func TestOrganization_GetDefaultRepositoryBranch(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	o := &Organization{DefaultRepositoryBranch: &zeroValue}
+	o.GetDefaultRepositoryBranch()
+	o = &Organization{}
+	o.GetDefaultRepositoryBranch()
+	o = nil
+	o.GetDefaultRepositoryBranch()
+}
+
 func TestOrganization_GetDependabotAlertsEnabledForNewRepos(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
@@ -19876,6 +19887,17 @@ func TestOrganization_GetDiskUsage(tt *testing.T) {
 	o.GetDiskUsage()
 	o = nil
 	o.GetDiskUsage()
+}
+
+func TestOrganization_GetDisplayCommenterFullNameSettingEnabled(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	o := &Organization{DisplayCommenterFullNameSettingEnabled: &zeroValue}
+	o.GetDisplayCommenterFullNameSettingEnabled()
+	o = &Organization{}
+	o.GetDisplayCommenterFullNameSettingEnabled()
+	o = nil
+	o.GetDisplayCommenterFullNameSettingEnabled()
 }
 
 func TestOrganization_GetEmail(tt *testing.T) {
@@ -20032,6 +20054,17 @@ func TestOrganization_GetMembersAllowedRepositoryCreationType(tt *testing.T) {
 	o.GetMembersAllowedRepositoryCreationType()
 }
 
+func TestOrganization_GetMembersCanChangeRepoVisibility(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	o := &Organization{MembersCanChangeRepoVisibility: &zeroValue}
+	o.GetMembersCanChangeRepoVisibility()
+	o = &Organization{}
+	o.GetMembersCanChangeRepoVisibility()
+	o = nil
+	o.GetMembersCanChangeRepoVisibility()
+}
+
 func TestOrganization_GetMembersCanCreateInternalRepos(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
@@ -20109,6 +20142,39 @@ func TestOrganization_GetMembersCanCreateRepos(tt *testing.T) {
 	o.GetMembersCanCreateRepos()
 }
 
+func TestOrganization_GetMembersCanCreateTeams(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	o := &Organization{MembersCanCreateTeams: &zeroValue}
+	o.GetMembersCanCreateTeams()
+	o = &Organization{}
+	o.GetMembersCanCreateTeams()
+	o = nil
+	o.GetMembersCanCreateTeams()
+}
+
+func TestOrganization_GetMembersCanDeleteIssues(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	o := &Organization{MembersCanDeleteIssues: &zeroValue}
+	o.GetMembersCanDeleteIssues()
+	o = &Organization{}
+	o.GetMembersCanDeleteIssues()
+	o = nil
+	o.GetMembersCanDeleteIssues()
+}
+
+func TestOrganization_GetMembersCanDeleteRepositories(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	o := &Organization{MembersCanDeleteRepositories: &zeroValue}
+	o.GetMembersCanDeleteRepositories()
+	o = &Organization{}
+	o.GetMembersCanDeleteRepositories()
+	o = nil
+	o.GetMembersCanDeleteRepositories()
+}
+
 func TestOrganization_GetMembersCanForkPrivateRepos(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
@@ -20118,6 +20184,28 @@ func TestOrganization_GetMembersCanForkPrivateRepos(tt *testing.T) {
 	o.GetMembersCanForkPrivateRepos()
 	o = nil
 	o.GetMembersCanForkPrivateRepos()
+}
+
+func TestOrganization_GetMembersCanInviteOutsideCollaborators(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	o := &Organization{MembersCanInviteOutsideCollaborators: &zeroValue}
+	o.GetMembersCanInviteOutsideCollaborators()
+	o = &Organization{}
+	o.GetMembersCanInviteOutsideCollaborators()
+	o = nil
+	o.GetMembersCanInviteOutsideCollaborators()
+}
+
+func TestOrganization_GetMembersCanViewDependencyInsights(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	o := &Organization{MembersCanViewDependencyInsights: &zeroValue}
+	o.GetMembersCanViewDependencyInsights()
+	o = &Organization{}
+	o.GetMembersCanViewDependencyInsights()
+	o = nil
+	o.GetMembersCanViewDependencyInsights()
 }
 
 func TestOrganization_GetMembersURL(tt *testing.T) {
@@ -20214,6 +20302,17 @@ func TestOrganization_GetPublicRepos(tt *testing.T) {
 	o.GetPublicRepos()
 	o = nil
 	o.GetPublicRepos()
+}
+
+func TestOrganization_GetReadersCanCreateDiscussions(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	o := &Organization{ReadersCanCreateDiscussions: &zeroValue}
+	o.GetReadersCanCreateDiscussions()
+	o = &Organization{}
+	o.GetReadersCanCreateDiscussions()
+	o = nil
+	o.GetReadersCanCreateDiscussions()
 }
 
 func TestOrganization_GetReposURL(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1115,6 +1115,15 @@ func TestOrganization_String(t *testing.T) {
 		SecretScanningEnabledForNewRepos:               Ptr(false),
 		SecretScanningPushProtectionEnabledForNewRepos: Ptr(false),
 		SecretScanningValidityChecksEnabled:            Ptr(false),
+		MembersCanDeleteRepositories:                   Ptr(false),
+		MembersCanChangeRepoVisibility:                 Ptr(false),
+		MembersCanInviteOutsideCollaborators:           Ptr(false),
+		MembersCanDeleteIssues:                         Ptr(false),
+		DisplayCommenterFullNameSettingEnabled:         Ptr(false),
+		ReadersCanCreateDiscussions:                    Ptr(false),
+		MembersCanCreateTeams:                          Ptr(false),
+		MembersCanViewDependencyInsights:               Ptr(false),
+		DefaultRepositoryBranch:                        Ptr(""),
 		URL:                                            Ptr(""),
 		EventsURL:                                      Ptr(""),
 		HooksURL:                                       Ptr(""),
@@ -1123,7 +1132,7 @@ func TestOrganization_String(t *testing.T) {
 		PublicMembersURL:                               Ptr(""),
 		ReposURL:                                       Ptr(""),
 	}
-	want := `github.Organization{Login:"", ID:0, NodeID:"", AvatarURL:"", HTMLURL:"", Name:"", Company:"", Blog:"", Location:"", Email:"", TwitterUsername:"", Description:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, BillingEmail:"", Type:"", Plan:github.Plan{}, TwoFactorRequirementEnabled:false, IsVerified:false, HasOrganizationProjects:false, HasRepositoryProjects:false, DefaultRepoPermission:"", DefaultRepoSettings:"", MembersCanCreateRepos:false, MembersCanCreatePublicRepos:false, MembersCanCreatePrivateRepos:false, MembersCanCreateInternalRepos:false, MembersCanForkPrivateRepos:false, MembersAllowedRepositoryCreationType:"", MembersCanCreatePages:false, MembersCanCreatePublicPages:false, MembersCanCreatePrivatePages:false, WebCommitSignoffRequired:false, AdvancedSecurityEnabledForNewRepos:false, DependabotAlertsEnabledForNewRepos:false, DependabotSecurityUpdatesEnabledForNewRepos:false, DependencyGraphEnabledForNewRepos:false, SecretScanningEnabledForNewRepos:false, SecretScanningPushProtectionEnabledForNewRepos:false, SecretScanningValidityChecksEnabled:false, URL:"", EventsURL:"", HooksURL:"", IssuesURL:"", MembersURL:"", PublicMembersURL:"", ReposURL:""}`
+	want := `github.Organization{Login:"", ID:0, NodeID:"", AvatarURL:"", HTMLURL:"", Name:"", Company:"", Blog:"", Location:"", Email:"", TwitterUsername:"", Description:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, BillingEmail:"", Type:"", Plan:github.Plan{}, TwoFactorRequirementEnabled:false, IsVerified:false, HasOrganizationProjects:false, HasRepositoryProjects:false, DefaultRepoPermission:"", DefaultRepoSettings:"", MembersCanCreateRepos:false, MembersCanCreatePublicRepos:false, MembersCanCreatePrivateRepos:false, MembersCanCreateInternalRepos:false, MembersCanForkPrivateRepos:false, MembersAllowedRepositoryCreationType:"", MembersCanCreatePages:false, MembersCanCreatePublicPages:false, MembersCanCreatePrivatePages:false, WebCommitSignoffRequired:false, AdvancedSecurityEnabledForNewRepos:false, DependabotAlertsEnabledForNewRepos:false, DependabotSecurityUpdatesEnabledForNewRepos:false, DependencyGraphEnabledForNewRepos:false, SecretScanningEnabledForNewRepos:false, SecretScanningPushProtectionEnabledForNewRepos:false, SecretScanningValidityChecksEnabled:false, MembersCanDeleteRepositories:false, MembersCanChangeRepoVisibility:false, MembersCanInviteOutsideCollaborators:false, MembersCanDeleteIssues:false, DisplayCommenterFullNameSettingEnabled:false, ReadersCanCreateDiscussions:false, MembersCanCreateTeams:false, MembersCanViewDependencyInsights:false, DefaultRepositoryBranch:"", URL:"", EventsURL:"", HooksURL:"", IssuesURL:"", MembersURL:"", PublicMembersURL:"", ReposURL:""}`
 	if got := v.String(); got != want {
 		t.Errorf("Organization.String = %v, want %v", got, want)
 	}

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -115,7 +115,7 @@ type Organization struct {
 	MembersCanViewDependencyInsights *bool `json:"members_can_view_dependency_insights,omitempty"`
 	// DefaultRepositoryBranch is the default branch for new repositories in the organization.
 	DefaultRepositoryBranch *string `json:"default_repository_branch,omitempty"`
-	
+
 	// API URLs
 	URL              *string `json:"url,omitempty"`
 	EventsURL        *string `json:"events_url,omitempty"`

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -97,7 +97,25 @@ type Organization struct {
 	SecretScanningPushProtectionEnabledForNewRepos *bool `json:"secret_scanning_push_protection_enabled_for_new_repositories,omitempty"`
 	// SecretScanningValidityChecksEnabled toggles whether secret scanning validity check is enabled.
 	SecretScanningValidityChecksEnabled *bool `json:"secret_scanning_validity_checks_enabled,omitempty"`
-
+	// MembersCanDeleteRepositories toggles whether members with admin permissions can delete a repository.
+	MembersCanDeleteRepositories *bool `json:"members_can_delete_repositories,omitempty"`
+	// MembersCanChangeRepoVisibility toggles whether members with admin permissions can change the visibility for a repository.
+	MembersCanChangeRepoVisibility *bool `json:"members_can_change_repo_visiblilty,omitempty"`
+	// MembersCanInviteOutsideCollaborators toggles whether members with admin permissions can invite outside collaborators.
+	MembersCanInviteOutsideCollaborators *bool `json:"members_can_invite_outside_collaborators,omitempty"`
+	// MembersCanDeleteIssues toggles whether members with admin permissions can delete issues.
+	MembersCanDeleteIssues *bool `json:"members_can_delete_issues,omitempty"`
+	// DisplayCommenterFullNameSettingEnabled toggles whether members can see the comment author's profile name in private repositories.
+	DisplayCommenterFullNameSettingEnabled *bool `json:"display_commenter_full_name_setting_enabled,omitempty"`
+	// ReadersCanCreateDiscussions toggles whether users with read access can create and comment on discussions.
+	ReadersCanCreateDiscussions *bool `json:"readers_can_create_discussions,omitempty"`
+	// MembersCanCreateTeams toggles whether members of an organization can create new teams.
+	MembersCanCreateTeams *bool `json:"members_can_create_teams,omitempty"`
+	// MembersCanViewDependencyInsights toggles whether members may view dependency insights.
+	MembersCanViewDependencyInsights *bool `json:"members_can_view_dependency_insights,omitempty"`
+	// DefaultRepositoryBranch is the default branch for new repositories in the organization.
+	DefaultRepositoryBranch *string `json:"default_repository_branch,omitempty"`
+	
 	// API URLs
 	URL              *string `json:"url,omitempty"`
 	EventsURL        *string `json:"events_url,omitempty"`


### PR DESCRIPTION
This PR adds a number of new fields to the Organization struct that are available when getting an org via the REST API. They can be seen in the [sample response](https://docs.github.com/en/rest/orgs/orgs?apiVersion=2022-11-28#get-an-organization) in the GitHub documentation.

```
  "default_repository_branch": "main",
```

```
  "members_can_delete_repositories": true,
  "members_can_change_repo_visibility": true,
  "members_can_invite_outside_collaborators": true,
  "members_can_delete_issues": false,
  "display_commenter_full_name_setting_enabled": false,
  "readers_can_create_discussions": true,
  "members_can_create_teams": true,
  "members_can_view_dependency_insights": true,
```