### PR TITLE
docs: Update links to use the latest version of github documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ include the specified OAuth token. Therefore, authenticated clients should
 almost never be shared between different users.
 
 For API methods that require HTTP Basic Authentication, use the
-[`BasicAuthTransport`](https://pkg.go.dev/github.com/google/go-github/github#BasicAuthTransport).
+[`BasicAuthTransport`](https://pkg.go.dev/github.com/google/go-github/v74/github#BasicAuthTransport).
 
 #### As a GitHub App ####
 

--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -13,7 +13,7 @@
 //
 // Note, if you want to push a single file, you probably prefer to use the
 // content API. An example is available here:
-// https://pkg.go.dev/github.com/google/go-github/github#example-RepositoriesService-CreateFile
+// https://pkg.go.dev/github.com/google/go-github/v74/github#example-RepositoriesService-CreateFile
 //
 // Note, for this to work at least 1 commit is needed, so you if you use this
 // after creating a repository you might want to make sure you set `AutoInit` to
@@ -173,7 +173,7 @@ func pushCommit(ref *github.Reference, tree *github.Tree) (err error) {
 	return err
 }
 
-// createPR creates a pull request. Based on: https://pkg.go.dev/github.com/google/go-github/github#example-PullRequestsService-Create
+// createPR creates a pull request. Based on: https://pkg.go.dev/github.com/google/go-github/v74/github#example-PullRequestsService-Create
 func createPR() (err error) {
 	if *prSubject == "" {
 		return errors.New("missing `-pr-title` flag; skipping PR creation")


### PR DESCRIPTION
To avoid seeing the notice "The highest tagged major version is v74":

<img width="840" height="430" alt="image" src="https://github.com/user-attachments/assets/7065cbc5-a3b0-45af-83ac-9a2bb504ee34" />
