### PR TITLE
Add `FieldValue` field to `ProjectV2ItemChange` event.

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -1146,12 +1146,23 @@ type ProjectV2ItemEvent struct {
 // ProjectV2ItemChange represents a project v2 item change.
 type ProjectV2ItemChange struct {
 	ArchivedAt *ArchivedAt `json:"archived_at,omitempty"`
+	FieldValue *FieldValue `json:"field_value,omitempty"`
 }
 
 // ArchivedAt represents an archiving date change.
 type ArchivedAt struct {
 	From *Timestamp `json:"from,omitempty"`
 	To   *Timestamp `json:"to,omitempty"`
+}
+
+// FieldValue represents an editing field value change.
+type FieldValue struct {
+	FieldNodeID   *string         `json:"field_node_id,omitempty"`
+	FieldType     *string         `json:"field_type,omitempty"`
+	FieldName     *string         `json:"field_name,omitempty"`
+	ProjectNumber *int64          `json:"project_number,omitempty"`
+	From          json.RawMessage `json:"from,omitempty"`
+	To            json.RawMessage `json:"to,omitempty"`
 }
 
 // ProjectV2Item represents an item belonging to a project.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9190,6 +9190,38 @@ func (f *Feeds) GetUserURL() string {
 	return *f.UserURL
 }
 
+// GetFieldName returns the FieldName field if it's non-nil, zero value otherwise.
+func (f *FieldValue) GetFieldName() string {
+	if f == nil || f.FieldName == nil {
+		return ""
+	}
+	return *f.FieldName
+}
+
+// GetFieldNodeID returns the FieldNodeID field if it's non-nil, zero value otherwise.
+func (f *FieldValue) GetFieldNodeID() string {
+	if f == nil || f.FieldNodeID == nil {
+		return ""
+	}
+	return *f.FieldNodeID
+}
+
+// GetFieldType returns the FieldType field if it's non-nil, zero value otherwise.
+func (f *FieldValue) GetFieldType() string {
+	if f == nil || f.FieldType == nil {
+		return ""
+	}
+	return *f.FieldType
+}
+
+// GetProjectNumber returns the ProjectNumber field if it's non-nil, zero value otherwise.
+func (f *FieldValue) GetProjectNumber() int64 {
+	if f == nil || f.ProjectNumber == nil {
+		return 0
+	}
+	return *f.ProjectNumber
+}
+
 // GetIdentifier returns the Identifier field if it's non-nil, zero value otherwise.
 func (f *FirstPatchedVersion) GetIdentifier() string {
 	if f == nil || f.Identifier == nil {
@@ -18436,6 +18468,14 @@ func (p *ProjectV2ItemChange) GetArchivedAt() *ArchivedAt {
 		return nil
 	}
 	return p.ArchivedAt
+}
+
+// GetFieldValue returns the FieldValue field.
+func (p *ProjectV2ItemChange) GetFieldValue() *FieldValue {
+	if p == nil {
+		return nil
+	}
+	return p.FieldValue
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11885,6 +11885,50 @@ func TestFeeds_GetUserURL(tt *testing.T) {
 	f.GetUserURL()
 }
 
+func TestFieldValue_GetFieldName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	f := &FieldValue{FieldName: &zeroValue}
+	f.GetFieldName()
+	f = &FieldValue{}
+	f.GetFieldName()
+	f = nil
+	f.GetFieldName()
+}
+
+func TestFieldValue_GetFieldNodeID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	f := &FieldValue{FieldNodeID: &zeroValue}
+	f.GetFieldNodeID()
+	f = &FieldValue{}
+	f.GetFieldNodeID()
+	f = nil
+	f.GetFieldNodeID()
+}
+
+func TestFieldValue_GetFieldType(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	f := &FieldValue{FieldType: &zeroValue}
+	f.GetFieldType()
+	f = &FieldValue{}
+	f.GetFieldType()
+	f = nil
+	f.GetFieldType()
+}
+
+func TestFieldValue_GetProjectNumber(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int64
+	f := &FieldValue{ProjectNumber: &zeroValue}
+	f.GetProjectNumber()
+	f = &FieldValue{}
+	f.GetProjectNumber()
+	f = nil
+	f.GetProjectNumber()
+}
+
 func TestFirstPatchedVersion_GetIdentifier(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -23909,6 +23953,14 @@ func TestProjectV2ItemChange_GetArchivedAt(tt *testing.T) {
 	p.GetArchivedAt()
 	p = nil
 	p.GetArchivedAt()
+}
+
+func TestProjectV2ItemChange_GetFieldValue(tt *testing.T) {
+	tt.Parallel()
+	p := &ProjectV2ItemChange{}
+	p.GetFieldValue()
+	p = nil
+	p.GetFieldValue()
 }
 
 func TestProjectV2ItemEvent_GetAction(tt *testing.T) {


### PR DESCRIPTION
Just adding a few fields for edited project v2 item changes that we use for project automation.

Here is a link to the docs: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#projects_v2_item

Hope this is fine. :)