### PR TITLE
refactor!: Change `GitService` methods to pass required params by-value instead of by-ref

### DIFF
--- a/github/git_blobs.go
+++ b/github/git_blobs.go
@@ -71,7 +71,7 @@ func (s *GitService) GetBlobRaw(ctx context.Context, owner, repo, sha string) ([
 // GitHub API docs: https://docs.github.com/rest/git/blobs#create-a-blob
 //
 //meta:operation POST /repos/{owner}/{repo}/git/blobs
-func (s *GitService) CreateBlob(ctx context.Context, owner, repo string, blob *Blob) (*Blob, *Response, error) {
+func (s *GitService) CreateBlob(ctx context.Context, owner, repo string, blob Blob) (*Blob, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/blobs", owner, repo)
 	req, err := s.client.NewRequest("POST", u, blob)
 	if err != nil {

--- a/github/git_blobs_test.go
+++ b/github/git_blobs_test.go
@@ -109,7 +109,7 @@ func TestGitService_CreateBlob(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &Blob{
+	input := Blob{
 		SHA:      Ptr("s"),
 		Content:  Ptr("blob content"),
 		Encoding: Ptr("utf-8"),
@@ -123,8 +123,8 @@ func TestGitService_CreateBlob(t *testing.T) {
 		testMethod(t, r, "POST")
 
 		want := input
-		if !cmp.Equal(v, want) {
-			t.Errorf("Git.CreateBlob request body: %+v, want %+v", v, want)
+		if !cmp.Equal(*v, want) {
+			t.Errorf("Git.CreateBlob request body: %+v, want %+v", *v, want)
 		}
 
 		fmt.Fprint(w, `{
@@ -143,8 +143,8 @@ func TestGitService_CreateBlob(t *testing.T) {
 
 	want := input
 
-	if !cmp.Equal(*blob, *want) {
-		t.Errorf("Git.CreateBlob returned %+v, want %+v", *blob, *want)
+	if !cmp.Equal(*blob, want) {
+		t.Errorf("Git.CreateBlob returned %+v, want %+v", *blob, want)
 	}
 
 	const methodName = "CreateBlob"
@@ -167,7 +167,7 @@ func TestGitService_CreateBlob_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := context.Background()
-	_, _, err := client.Git.CreateBlob(ctx, "%", "%", &Blob{})
+	_, _, err := client.Git.CreateBlob(ctx, "%", "%", Blob{})
 	testURLParseError(t, err)
 }
 

--- a/github/git_commits.go
+++ b/github/git_commits.go
@@ -126,10 +126,7 @@ type CreateCommitOptions struct {
 // GitHub API docs: https://docs.github.com/rest/git/commits#create-a-commit
 //
 //meta:operation POST /repos/{owner}/{repo}/git/commits
-func (s *GitService) CreateCommit(ctx context.Context, owner, repo string, commit *Commit, opts *CreateCommitOptions) (*Commit, *Response, error) {
-	if commit == nil {
-		return nil, nil, errors.New("commit must be provided")
-	}
+func (s *GitService) CreateCommit(ctx context.Context, owner, repo string, commit Commit, opts *CreateCommitOptions) (*Commit, *Response, error) {
 	if opts == nil {
 		opts = &CreateCommitOptions{}
 	}

--- a/github/git_commits_test.go
+++ b/github/git_commits_test.go
@@ -176,7 +176,7 @@ func TestGitService_CreateCommit(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &Commit{
+	input := Commit{
 		Message: Ptr("Commit Message."),
 		Tree:    &Tree{SHA: Ptr("t")},
 		Parents: []*Commit{{SHA: Ptr("p")}},
@@ -231,7 +231,7 @@ func TestGitService_CreateSignedCommit(t *testing.T) {
 
 	signature := "----- BEGIN PGP SIGNATURE -----\n\naaaa\naaaa\n----- END PGP SIGNATURE -----"
 
-	input := &Commit{
+	input := Commit{
 		Message: Ptr("Commit Message."),
 		Tree:    &Tree{SHA: Ptr("t")},
 		Parents: []*Commit{{SHA: Ptr("p")}},
@@ -288,24 +288,13 @@ func TestGitService_CreateSignedCommitWithInvalidParams(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	input := &Commit{}
+	input := Commit{}
 
 	ctx := context.Background()
 	opts := CreateCommitOptions{Signer: uncalledSigner(t)}
 	_, _, err := client.Git.CreateCommit(ctx, "o", "r", input, &opts)
 	if err == nil {
 		t.Error("Expected error to be returned because invalid params were passed")
-	}
-}
-
-func TestGitService_CreateCommitWithNilCommit(t *testing.T) {
-	t.Parallel()
-	client, _, _ := setup(t)
-
-	ctx := context.Background()
-	_, _, err := client.Git.CreateCommit(ctx, "o", "r", nil, nil)
-	if err == nil {
-		t.Error("Expected error to be returned because commit=nil")
 	}
 }
 
@@ -327,7 +316,7 @@ committer go-github <go-github@github.com> 1493849023 +0200
 
 Commit Message.`
 	sha := "commitSha"
-	input := &Commit{
+	input := Commit{
 		SHA:     &sha,
 		Message: Ptr("Commit Message."),
 		Tree:    &Tree{SHA: Ptr("t")},
@@ -513,7 +502,7 @@ func TestGitService_CreateCommit_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := context.Background()
-	_, _, err := client.Git.CreateCommit(ctx, "%", "%", &Commit{}, nil)
+	_, _, err := client.Git.CreateCommit(ctx, "%", "%", Commit{}, nil)
 	testURLParseError(t, err)
 }
 

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -386,18 +386,18 @@ func TestGitService_CreateRef(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	args := &createRefRequest{
-		Ref: Ptr("refs/heads/b"),
-		SHA: Ptr("aa218f56b14c9653891f9e74264a383fa43fefbd"),
+	args := CreateRef{
+		Ref: "refs/heads/b",
+		SHA: "aa218f56b14c9653891f9e74264a383fa43fefbd",
 	}
 
 	mux.HandleFunc("/repos/o/r/git/refs", func(w http.ResponseWriter, r *http.Request) {
-		v := new(createRefRequest)
+		v := new(CreateRef)
 		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
 
 		testMethod(t, r, "POST")
-		if !cmp.Equal(v, args) {
-			t.Errorf("Request body = %+v, want %+v", v, args)
+		if !cmp.Equal(*v, args) {
+			t.Errorf("Request body = %+v, want %+v", *v, args)
 		}
 		fmt.Fprint(w, `
 		  {
@@ -412,11 +412,9 @@ func TestGitService_CreateRef(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	ref, _, err := client.Git.CreateRef(ctx, "o", "r", &Reference{
-		Ref: Ptr("refs/heads/b"),
-		Object: &GitObject{
-			SHA: Ptr("aa218f56b14c9653891f9e74264a383fa43fefbd"),
-		},
+	ref, _, err := client.Git.CreateRef(ctx, "o", "r", CreateRef{
+		Ref: "refs/heads/b",
+		SHA: "aa218f56b14c9653891f9e74264a383fa43fefbd",
 	})
 	if err != nil {
 		t.Errorf("Git.CreateRef returned error: %v", err)
@@ -436,11 +434,9 @@ func TestGitService_CreateRef(t *testing.T) {
 	}
 
 	// without 'refs/' prefix
-	_, _, err = client.Git.CreateRef(ctx, "o", "r", &Reference{
-		Ref: Ptr("heads/b"),
-		Object: &GitObject{
-			SHA: Ptr("aa218f56b14c9653891f9e74264a383fa43fefbd"),
-		},
+	_, _, err = client.Git.CreateRef(ctx, "o", "r", CreateRef{
+		Ref: "heads/b",
+		SHA: "aa218f56b14c9653891f9e74264a383fa43fefbd",
 	})
 	if err != nil {
 		t.Errorf("Git.CreateRef returned error: %v", err)
@@ -448,29 +444,21 @@ func TestGitService_CreateRef(t *testing.T) {
 
 	const methodName = "CreateRef"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Git.CreateRef(ctx, "o", "r", nil)
+		_, _, err = client.Git.CreateRef(ctx, "o", "r", CreateRef{Ref: ""})
 		return err
 	})
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Git.CreateRef(ctx, "o", "r", &Reference{Ref: nil})
-		return err
-	})
-	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Git.CreateRef(ctx, "\n", "\n", &Reference{
-			Ref: Ptr("refs/heads/b"),
-			Object: &GitObject{
-				SHA: Ptr("aa218f56b14c9653891f9e74264a383fa43fefbd"),
-			},
+		_, _, err = client.Git.CreateRef(ctx, "\n", "\n", CreateRef{
+			Ref: "refs/heads/b",
+			SHA: "aa218f56b14c9653891f9e74264a383fa43fefbd",
 		})
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Git.CreateRef(ctx, "o", "r", &Reference{
-			Ref: Ptr("refs/heads/b"),
-			Object: &GitObject{
-				SHA: Ptr("aa218f56b14c9653891f9e74264a383fa43fefbd"),
-			},
+		got, resp, err := client.Git.CreateRef(ctx, "o", "r", CreateRef{
+			Ref: "refs/heads/b",
+			SHA: "aa218f56b14c9653891f9e74264a383fa43fefbd",
 		})
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
@@ -483,18 +471,18 @@ func TestGitService_UpdateRef(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	args := &updateRefRequest{
-		SHA:   Ptr("aa218f56b14c9653891f9e74264a383fa43fefbd"),
+	args := UpdateRef{
+		SHA:   "aa218f56b14c9653891f9e74264a383fa43fefbd",
 		Force: Ptr(true),
 	}
 
 	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
-		v := new(updateRefRequest)
+		v := new(UpdateRef)
 		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
 
 		testMethod(t, r, "PATCH")
-		if !cmp.Equal(v, args) {
-			t.Errorf("Request body = %+v, want %+v", v, args)
+		if !cmp.Equal(*v, args) {
+			t.Errorf("Request body = %+v, want %+v", *v, args)
 		}
 		fmt.Fprint(w, `
 		  {
@@ -509,10 +497,10 @@ func TestGitService_UpdateRef(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	ref, _, err := client.Git.UpdateRef(ctx, "o", "r", &Reference{
-		Ref:    Ptr("refs/heads/b"),
-		Object: &GitObject{SHA: Ptr("aa218f56b14c9653891f9e74264a383fa43fefbd")},
-	}, true)
+	ref, _, err := client.Git.UpdateRef(ctx, "o", "r", "refs/heads/b", UpdateRef{
+		SHA:   "aa218f56b14c9653891f9e74264a383fa43fefbd",
+		Force: Ptr(true),
+	})
 	if err != nil {
 		t.Errorf("Git.UpdateRef returned error: %v", err)
 	}
@@ -531,36 +519,36 @@ func TestGitService_UpdateRef(t *testing.T) {
 	}
 
 	// without 'refs/' prefix
-	_, _, err = client.Git.UpdateRef(ctx, "o", "r", &Reference{
-		Ref:    Ptr("heads/b"),
-		Object: &GitObject{SHA: Ptr("aa218f56b14c9653891f9e74264a383fa43fefbd")},
-	}, true)
+	_, _, err = client.Git.UpdateRef(ctx, "o", "r", "heads/b", UpdateRef{
+		SHA:   "aa218f56b14c9653891f9e74264a383fa43fefbd",
+		Force: Ptr(true),
+	})
 	if err != nil {
 		t.Errorf("Git.UpdateRef returned error: %v", err)
 	}
 
 	const methodName = "UpdateRef"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Git.UpdateRef(ctx, "o", "r", nil, true)
+		_, _, err = client.Git.UpdateRef(ctx, "o", "r", "", UpdateRef{SHA: "aa218f56b14c9653891f9e74264a383fa43fefbd"})
 		return err
 	})
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Git.UpdateRef(ctx, "o", "r", &Reference{Ref: nil}, true)
+		_, _, err = client.Git.UpdateRef(ctx, "o", "r", "refs/heads/b", UpdateRef{SHA: ""})
 		return err
 	})
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Git.UpdateRef(ctx, "\n", "\n", &Reference{
-			Ref:    Ptr("refs/heads/b"),
-			Object: &GitObject{SHA: Ptr("aa218f56b14c9653891f9e74264a383fa43fefbd")},
-		}, true)
+		_, _, err = client.Git.UpdateRef(ctx, "\n", "\n", "refs/heads/b", UpdateRef{
+			SHA:   "aa218f56b14c9653891f9e74264a383fa43fefbd",
+			Force: Ptr(true),
+		})
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Git.UpdateRef(ctx, "o", "r", &Reference{
-			Ref:    Ptr("refs/heads/b"),
-			Object: &GitObject{SHA: Ptr("aa218f56b14c9653891f9e74264a383fa43fefbd")},
-		}, true)
+		got, resp, err := client.Git.UpdateRef(ctx, "o", "r", "refs/heads/b", UpdateRef{
+			SHA:   "aa218f56b14c9653891f9e74264a383fa43fefbd",
+			Force: Ptr(true),
+		})
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -644,18 +632,18 @@ func TestGitService_UpdateRef_pathEscape(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	args := &updateRefRequest{
-		SHA:   Ptr("aa218f56b14c9653891f9e74264a383fa43fefbd"),
+	args := UpdateRef{
+		SHA:   "aa218f56b14c9653891f9e74264a383fa43fefbd",
 		Force: Ptr(true),
 	}
 
 	mux.HandleFunc("/repos/o/r/git/refs/heads/b#1", func(w http.ResponseWriter, r *http.Request) {
-		v := new(updateRefRequest)
+		v := new(UpdateRef)
 		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
 
 		testMethod(t, r, "PATCH")
-		if !cmp.Equal(v, args) {
-			t.Errorf("Request body = %+v, want %+v", v, args)
+		if !cmp.Equal(*v, args) {
+			t.Errorf("Request body = %+v, want %+v", *v, args)
 		}
 		fmt.Fprint(w, `
 		  {
@@ -670,10 +658,10 @@ func TestGitService_UpdateRef_pathEscape(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	ref, _, err := client.Git.UpdateRef(ctx, "o", "r", &Reference{
-		Ref:    Ptr("refs/heads/b#1"),
-		Object: &GitObject{SHA: Ptr("aa218f56b14c9653891f9e74264a383fa43fefbd")},
-	}, true)
+	ref, _, err := client.Git.UpdateRef(ctx, "o", "r", "refs/heads/b#1", UpdateRef{
+		SHA:   "aa218f56b14c9653891f9e74264a383fa43fefbd",
+		Force: Ptr(true),
+	})
 	if err != nil {
 		t.Errorf("Git.UpdateRef returned error: %v", err)
 	}
@@ -740,13 +728,13 @@ func TestGitObject_Marshal(t *testing.T) {
 	testJSONMarshal(t, u, want)
 }
 
-func TestCreateRefRequest_Marshal(t *testing.T) {
+func TestCreateRef_Marshal(t *testing.T) {
 	t.Parallel()
-	testJSONMarshal(t, &createRefRequest{}, "{}")
+	testJSONMarshal(t, CreateRef{}, `{"ref":"","sha":""}`)
 
-	u := &createRefRequest{
-		Ref: Ptr("ref"),
-		SHA: Ptr("sha"),
+	u := CreateRef{
+		Ref: "ref",
+		SHA: "sha",
 	}
 
 	want := `{
@@ -757,12 +745,12 @@ func TestCreateRefRequest_Marshal(t *testing.T) {
 	testJSONMarshal(t, u, want)
 }
 
-func TestUpdateRefRequest_Marshal(t *testing.T) {
+func TestUpdateRef_Marshal(t *testing.T) {
 	t.Parallel()
-	testJSONMarshal(t, &updateRefRequest{}, "{}")
+	testJSONMarshal(t, UpdateRef{}, `{"sha":""}`)
 
-	u := &updateRefRequest{
-		SHA:   Ptr("sha"),
+	u := UpdateRef{
+		SHA:   "sha",
 		Force: Ptr(true),
 	}
 

--- a/github/git_tags.go
+++ b/github/git_tags.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"context"
-	"errors"
 	"fmt"
 )
 
@@ -23,14 +22,12 @@ type Tag struct {
 	NodeID       *string                `json:"node_id,omitempty"`
 }
 
-// createTagRequest represents the body of a CreateTag request. This is mostly
-// identical to Tag with the exception that the object SHA and Type are
-// top-level fields, rather than being nested inside a JSON object.
-type createTagRequest struct {
-	Tag     *string       `json:"tag,omitempty"`
-	Message *string       `json:"message,omitempty"`
-	Object  *string       `json:"object,omitempty"`
-	Type    *string       `json:"type,omitempty"`
+// CreateTag represents the payload for creating a tag.
+type CreateTag struct {
+	Tag     string        `json:"tag,omitempty"`
+	Message string        `json:"message,omitempty"`
+	Object  string        `json:"object,omitempty"`
+	Type    string        `json:"type,omitempty"`
 	Tagger  *CommitAuthor `json:"tagger,omitempty"`
 }
 
@@ -60,25 +57,10 @@ func (s *GitService) GetTag(ctx context.Context, owner, repo, sha string) (*Tag,
 // GitHub API docs: https://docs.github.com/rest/git/tags#create-a-tag-object
 //
 //meta:operation POST /repos/{owner}/{repo}/git/tags
-func (s *GitService) CreateTag(ctx context.Context, owner, repo string, tag *Tag) (*Tag, *Response, error) {
-	if tag == nil {
-		return nil, nil, errors.New("tag must be provided")
-	}
-
+func (s *GitService) CreateTag(ctx context.Context, owner, repo string, tag CreateTag) (*Tag, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/tags", owner, repo)
 
-	// convert Tag into a createTagRequest
-	tagRequest := &createTagRequest{
-		Tag:     tag.Tag,
-		Message: tag.Message,
-		Tagger:  tag.Tagger,
-	}
-	if tag.Object != nil {
-		tagRequest.Object = tag.Object.SHA
-		tagRequest.Type = tag.Object.Type
-	}
-
-	req, err := s.client.NewRequest("POST", u, tagRequest)
+	req, err := s.client.NewRequest("POST", u, tag)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6030,6 +6030,14 @@ func (c *CreateRunnerGroupRequest) GetVisibility() string {
 	return *c.Visibility
 }
 
+// GetTagger returns the Tagger field.
+func (c *CreateTag) GetTagger() *CommitAuthor {
+	if c == nil {
+		return nil
+	}
+	return c.Tagger
+}
+
 // GetCanAdminsBypass returns the CanAdminsBypass field if it's non-nil, zero value otherwise.
 func (c *CreateUpdateEnvironment) GetCanAdminsBypass() bool {
 	if c == nil || c.CanAdminsBypass == nil {
@@ -27924,6 +27932,14 @@ func (u *UpdateEnterpriseRunnerGroupRequest) GetVisibility() string {
 		return ""
 	}
 	return *u.Visibility
+}
+
+// GetForce returns the Force field if it's non-nil, zero value otherwise.
+func (u *UpdateRef) GetForce() bool {
+	if u == nil || u.Force == nil {
+		return false
+	}
+	return *u.Force
 }
 
 // GetAllowsPublicRepositories returns the AllowsPublicRepositories field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -7864,6 +7864,14 @@ func TestCreateRunnerGroupRequest_GetVisibility(tt *testing.T) {
 	c.GetVisibility()
 }
 
+func TestCreateTag_GetTagger(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateTag{}
+	c.GetTagger()
+	c = nil
+	c.GetTagger()
+}
+
 func TestCreateUpdateEnvironment_GetCanAdminsBypass(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
@@ -35926,6 +35934,17 @@ func TestUpdateEnterpriseRunnerGroupRequest_GetVisibility(tt *testing.T) {
 	u.GetVisibility()
 	u = nil
 	u.GetVisibility()
+}
+
+func TestUpdateRef_GetForce(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	u := &UpdateRef{Force: &zeroValue}
+	u.GetForce()
+	u = &UpdateRef{}
+	u.GetForce()
+	u = nil
+	u.GetForce()
 }
 
 func TestUpdateRunnerGroupRequest_GetAllowsPublicRepositories(tt *testing.T) {


### PR DESCRIPTION
BREAKING CHANGE: `GitService` methods now pass required params by-value instead of by-ref.

### What problem are you solving?

- Related to #3644
- Convert parameters to values instead of pointers wherever appropriate. This eliminates nil pointer errors for required inputs and improves API clarity by using value semantics for immutable, required data.
 
### Notes

This is most likely going to be a multi PR issue, since this is my first time working on this codebase. I started by picking a "service" area ( Git ) and converted each function that I thought met the criteria set in the issue mentioned, which are:
 
1. The input is required (not optional)
2. The function does not modify the input

