### PR TITLE
refactor: Fix gocritic.paramTypeCombine lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
       enabled-checks:
         - commentedOutCode
         - commentFormatting
+        - paramTypeCombine
     goheader:
       values:
         regexp:

--- a/example/codespaces/newreposecretwithxcrypto/main.go
+++ b/example/codespaces/newreposecretwithxcrypto/main.go
@@ -122,7 +122,7 @@ func getSecretValue(secretName string) (string, error) {
 //
 // Finally, the github.EncodedSecret is passed into the GitHub client.Codespaces.CreateOrUpdateRepoSecret method to
 // populate the secret in the GitHub repo.
-func addRepoSecret(ctx context.Context, client *github.Client, owner string, repo, secretName string, secretValue string) error {
+func addRepoSecret(ctx context.Context, client *github.Client, owner, repo, secretName, secretValue string) error {
 	publicKey, _, err := client.Codespaces.GetRepoPublicKey(ctx, owner, repo)
 	if err != nil {
 		return err
@@ -140,7 +140,7 @@ func addRepoSecret(ctx context.Context, client *github.Client, owner string, rep
 	return nil
 }
 
-func encryptSecretWithPublicKey(publicKey *github.PublicKey, secretName string, secretValue string) (*github.EncryptedSecret, error) {
+func encryptSecretWithPublicKey(publicKey *github.PublicKey, secretName, secretValue string) (*github.EncryptedSecret, error) {
 	decodedPublicKey, err := base64.StdEncoding.DecodeString(publicKey.GetKey())
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode public key: %v", err)

--- a/example/codespaces/newusersecretwithxcrypto/main.go
+++ b/example/codespaces/newusersecretwithxcrypto/main.go
@@ -147,7 +147,7 @@ func addUserSecret(ctx context.Context, client *github.Client, secretName, secre
 	return nil
 }
 
-func encryptSecretWithPublicKey(publicKey *github.PublicKey, secretName string, secretValue string) (*github.EncryptedSecret, error) {
+func encryptSecretWithPublicKey(publicKey *github.PublicKey, secretName, secretValue string) (*github.EncryptedSecret, error) {
 	decodedPublicKey, err := base64.StdEncoding.DecodeString(publicKey.GetKey())
 	if err != nil {
 		return nil, fmt.Errorf("base64.StdEncoding.DecodeString was unable to decode public key: %v", err)

--- a/example/newreposecretwithlibsodium/main.go
+++ b/example/newreposecretwithlibsodium/main.go
@@ -118,7 +118,7 @@ func getSecretValue(secretName string) (string, error) {
 //
 // Finally, the github.EncodedSecret is passed into the GitHub client.Actions.CreateOrUpdateRepoSecret method to
 // populate the secret in the GitHub repo.
-func addRepoSecret(ctx context.Context, client *github.Client, owner string, repo, secretName string, secretValue string) error {
+func addRepoSecret(ctx context.Context, client *github.Client, owner, repo, secretName, secretValue string) error {
 	publicKey, _, err := client.Actions.GetRepoPublicKey(ctx, owner, repo)
 	if err != nil {
 		return err
@@ -136,7 +136,7 @@ func addRepoSecret(ctx context.Context, client *github.Client, owner string, rep
 	return nil
 }
 
-func encryptSecretWithPublicKey(publicKey *github.PublicKey, secretName string, secretValue string) (*github.EncryptedSecret, error) {
+func encryptSecretWithPublicKey(publicKey *github.PublicKey, secretName, secretValue string) (*github.EncryptedSecret, error) {
 	decodedPublicKey, err := base64.StdEncoding.DecodeString(publicKey.GetKey())
 	if err != nil {
 		return nil, fmt.Errorf("base64.StdEncoding.DecodeString was unable to decode public key: %v", err)

--- a/example/newreposecretwithxcrypto/main.go
+++ b/example/newreposecretwithxcrypto/main.go
@@ -122,7 +122,7 @@ func getSecretValue(secretName string) (string, error) {
 //
 // Finally, the github.EncodedSecret is passed into the GitHub client.Actions.CreateOrUpdateRepoSecret method to
 // populate the secret in the GitHub repo.
-func addRepoSecret(ctx context.Context, client *github.Client, owner string, repo, secretName string, secretValue string) error {
+func addRepoSecret(ctx context.Context, client *github.Client, owner, repo, secretName, secretValue string) error {
 	publicKey, _, err := client.Actions.GetRepoPublicKey(ctx, owner, repo)
 	if err != nil {
 		return err
@@ -140,7 +140,7 @@ func addRepoSecret(ctx context.Context, client *github.Client, owner string, rep
 	return nil
 }
 
-func encryptSecretWithPublicKey(publicKey *github.PublicKey, secretName string, secretValue string) (*github.EncryptedSecret, error) {
+func encryptSecretWithPublicKey(publicKey *github.PublicKey, secretName, secretValue string) (*github.EncryptedSecret, error) {
 	decodedPublicKey, err := base64.StdEncoding.DecodeString(publicKey.GetKey())
 	if err != nil {
 		return nil, fmt.Errorf("base64.StdEncoding.DecodeString was unable to decode public key: %v", err)

--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -259,7 +259,7 @@ func (s *ActionsService) GetWorkflowRunAttempt(ctx context.Context, owner, repo 
 // GitHub API docs: https://docs.github.com/rest/actions/workflow-runs#download-workflow-run-attempt-logs
 //
 //meta:operation GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/logs
-func (s *ActionsService) GetWorkflowRunAttemptLogs(ctx context.Context, owner, repo string, runID int64, attemptNumber int, maxRedirects int) (*url.URL, *Response, error) {
+func (s *ActionsService) GetWorkflowRunAttemptLogs(ctx context.Context, owner, repo string, runID int64, attemptNumber, maxRedirects int) (*url.URL, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/attempts/%v/logs", owner, repo, runID, attemptNumber)
 
 	if s.client.RateLimitRedirectionalEndpoints {

--- a/github/git_blobs.go
+++ b/github/git_blobs.go
@@ -26,7 +26,7 @@ type Blob struct {
 // GitHub API docs: https://docs.github.com/rest/git/blobs#get-a-blob
 //
 //meta:operation GET /repos/{owner}/{repo}/git/blobs/{file_sha}
-func (s *GitService) GetBlob(ctx context.Context, owner string, repo string, sha string) (*Blob, *Response, error) {
+func (s *GitService) GetBlob(ctx context.Context, owner, repo, sha string) (*Blob, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/blobs/%v", owner, repo, sha)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -71,7 +71,7 @@ func (s *GitService) GetBlobRaw(ctx context.Context, owner, repo, sha string) ([
 // GitHub API docs: https://docs.github.com/rest/git/blobs#create-a-blob
 //
 //meta:operation POST /repos/{owner}/{repo}/git/blobs
-func (s *GitService) CreateBlob(ctx context.Context, owner string, repo string, blob *Blob) (*Blob, *Response, error) {
+func (s *GitService) CreateBlob(ctx context.Context, owner, repo string, blob *Blob) (*Blob, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/blobs", owner, repo)
 	req, err := s.client.NewRequest("POST", u, blob)
 	if err != nil {

--- a/github/git_commits.go
+++ b/github/git_commits.go
@@ -84,7 +84,7 @@ func (c CommitAuthor) String() string {
 // GitHub API docs: https://docs.github.com/rest/git/commits#get-a-commit-object
 //
 //meta:operation GET /repos/{owner}/{repo}/git/commits/{commit_sha}
-func (s *GitService) GetCommit(ctx context.Context, owner string, repo string, sha string) (*Commit, *Response, error) {
+func (s *GitService) GetCommit(ctx context.Context, owner, repo, sha string) (*Commit, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/commits/%v", owner, repo, sha)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -126,7 +126,7 @@ type CreateCommitOptions struct {
 // GitHub API docs: https://docs.github.com/rest/git/commits#create-a-commit
 //
 //meta:operation POST /repos/{owner}/{repo}/git/commits
-func (s *GitService) CreateCommit(ctx context.Context, owner string, repo string, commit *Commit, opts *CreateCommitOptions) (*Commit, *Response, error) {
+func (s *GitService) CreateCommit(ctx context.Context, owner, repo string, commit *Commit, opts *CreateCommitOptions) (*Commit, *Response, error) {
 	if commit == nil {
 		return nil, nil, errors.New("commit must be provided")
 	}

--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -55,7 +55,7 @@ type updateRefRequest struct {
 // GitHub API docs: https://docs.github.com/rest/git/refs#get-a-reference
 //
 //meta:operation GET /repos/{owner}/{repo}/git/ref/{ref}
-func (s *GitService) GetRef(ctx context.Context, owner string, repo string, ref string) (*Reference, *Response, error) {
+func (s *GitService) GetRef(ctx context.Context, owner, repo, ref string) (*Reference, *Response, error) {
 	ref = strings.TrimPrefix(ref, "refs/")
 	u := fmt.Sprintf("repos/%v/%v/git/ref/%v", owner, repo, refURLEscape(ref))
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -127,7 +127,7 @@ func (s *GitService) ListMatchingRefs(ctx context.Context, owner, repo string, o
 // GitHub API docs: https://docs.github.com/rest/git/refs#create-a-reference
 //
 //meta:operation POST /repos/{owner}/{repo}/git/refs
-func (s *GitService) CreateRef(ctx context.Context, owner string, repo string, ref *Reference) (*Reference, *Response, error) {
+func (s *GitService) CreateRef(ctx context.Context, owner, repo string, ref *Reference) (*Reference, *Response, error) {
 	if ref == nil {
 		return nil, nil, errors.New("reference must be provided")
 	}
@@ -159,7 +159,7 @@ func (s *GitService) CreateRef(ctx context.Context, owner string, repo string, r
 // GitHub API docs: https://docs.github.com/rest/git/refs#update-a-reference
 //
 //meta:operation PATCH /repos/{owner}/{repo}/git/refs/{ref}
-func (s *GitService) UpdateRef(ctx context.Context, owner string, repo string, ref *Reference, force bool) (*Reference, *Response, error) {
+func (s *GitService) UpdateRef(ctx context.Context, owner, repo string, ref *Reference, force bool) (*Reference, *Response, error) {
 	if ref == nil {
 		return nil, nil, errors.New("reference must be provided")
 	}
@@ -191,7 +191,7 @@ func (s *GitService) UpdateRef(ctx context.Context, owner string, repo string, r
 // GitHub API docs: https://docs.github.com/rest/git/refs#delete-a-reference
 //
 //meta:operation DELETE /repos/{owner}/{repo}/git/refs/{ref}
-func (s *GitService) DeleteRef(ctx context.Context, owner string, repo string, ref string) (*Response, error) {
+func (s *GitService) DeleteRef(ctx context.Context, owner, repo, ref string) (*Response, error) {
 	ref = strings.TrimPrefix(ref, "refs/")
 	u := fmt.Sprintf("repos/%v/%v/git/refs/%v", owner, repo, refURLEscape(ref))
 	req, err := s.client.NewRequest("DELETE", u, nil)

--- a/github/git_tags.go
+++ b/github/git_tags.go
@@ -39,7 +39,7 @@ type createTagRequest struct {
 // GitHub API docs: https://docs.github.com/rest/git/tags#get-a-tag
 //
 //meta:operation GET /repos/{owner}/{repo}/git/tags/{tag_sha}
-func (s *GitService) GetTag(ctx context.Context, owner string, repo string, sha string) (*Tag, *Response, error) {
+func (s *GitService) GetTag(ctx context.Context, owner, repo, sha string) (*Tag, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/tags/%v", owner, repo, sha)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -60,7 +60,7 @@ func (s *GitService) GetTag(ctx context.Context, owner string, repo string, sha 
 // GitHub API docs: https://docs.github.com/rest/git/tags#create-a-tag-object
 //
 //meta:operation POST /repos/{owner}/{repo}/git/tags
-func (s *GitService) CreateTag(ctx context.Context, owner string, repo string, tag *Tag) (*Tag, *Response, error) {
+func (s *GitService) CreateTag(ctx context.Context, owner, repo string, tag *Tag) (*Tag, *Response, error) {
 	if tag == nil {
 		return nil, nil, errors.New("tag must be provided")
 	}

--- a/github/git_trees.go
+++ b/github/git_trees.go
@@ -96,7 +96,7 @@ func (t *TreeEntry) MarshalJSON() ([]byte, error) {
 // GitHub API docs: https://docs.github.com/rest/git/trees#get-a-tree
 //
 //meta:operation GET /repos/{owner}/{repo}/git/trees/{tree_sha}
-func (s *GitService) GetTree(ctx context.Context, owner string, repo string, sha string, recursive bool) (*Tree, *Response, error) {
+func (s *GitService) GetTree(ctx context.Context, owner, repo, sha string, recursive bool) (*Tree, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/trees/%v", owner, repo, sha)
 	if recursive {
 		u += "?recursive=1"
@@ -129,7 +129,7 @@ type createTree struct {
 // GitHub API docs: https://docs.github.com/rest/git/trees#create-a-tree
 //
 //meta:operation POST /repos/{owner}/{repo}/git/trees
-func (s *GitService) CreateTree(ctx context.Context, owner string, repo string, baseTree string, entries []*TreeEntry) (*Tree, *Response, error) {
+func (s *GitService) CreateTree(ctx context.Context, owner, repo, baseTree string, entries []*TreeEntry) (*Tree, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/trees", owner, repo)
 
 	newEntries := make([]any, 0, len(entries))

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -132,7 +132,7 @@ func testFormValues(t *testing.T, r *http.Request, values values) {
 	}
 }
 
-func testHeader(t *testing.T, r *http.Request, header string, want string) {
+func testHeader(t *testing.T, r *http.Request, header, want string) {
 	t.Helper()
 	if got := r.Header.Get(header); got != want {
 		t.Errorf("Header.Get(%q) returned %q, want %q", header, got, want)

--- a/github/issues.go
+++ b/github/issues.go
@@ -250,7 +250,7 @@ type IssueListByRepoOptions struct {
 // GitHub API docs: https://docs.github.com/rest/issues/issues#list-repository-issues
 //
 //meta:operation GET /repos/{owner}/{repo}/issues
-func (s *IssuesService) ListByRepo(ctx context.Context, owner string, repo string, opts *IssueListByRepoOptions) ([]*Issue, *Response, error) {
+func (s *IssuesService) ListByRepo(ctx context.Context, owner, repo string, opts *IssueListByRepoOptions) ([]*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues", owner, repo)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -279,7 +279,7 @@ func (s *IssuesService) ListByRepo(ctx context.Context, owner string, repo strin
 // GitHub API docs: https://docs.github.com/rest/issues/issues#get-an-issue
 //
 //meta:operation GET /repos/{owner}/{repo}/issues/{issue_number}
-func (s *IssuesService) Get(ctx context.Context, owner string, repo string, number int) (*Issue, *Response, error) {
+func (s *IssuesService) Get(ctx context.Context, owner, repo string, number int) (*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%d", owner, repo, number)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -303,7 +303,7 @@ func (s *IssuesService) Get(ctx context.Context, owner string, repo string, numb
 // GitHub API docs: https://docs.github.com/rest/issues/issues#create-an-issue
 //
 //meta:operation POST /repos/{owner}/{repo}/issues
-func (s *IssuesService) Create(ctx context.Context, owner string, repo string, issue *IssueRequest) (*Issue, *Response, error) {
+func (s *IssuesService) Create(ctx context.Context, owner, repo string, issue *IssueRequest) (*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues", owner, repo)
 	req, err := s.client.NewRequest("POST", u, issue)
 	if err != nil {
@@ -324,7 +324,7 @@ func (s *IssuesService) Create(ctx context.Context, owner string, repo string, i
 // GitHub API docs: https://docs.github.com/rest/issues/issues#update-an-issue
 //
 //meta:operation PATCH /repos/{owner}/{repo}/issues/{issue_number}
-func (s *IssuesService) Edit(ctx context.Context, owner string, repo string, number int, issue *IssueRequest) (*Issue, *Response, error) {
+func (s *IssuesService) Edit(ctx context.Context, owner, repo string, number int, issue *IssueRequest) (*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%d", owner, repo, number)
 	req, err := s.client.NewRequest("PATCH", u, issue)
 	if err != nil {
@@ -379,7 +379,7 @@ type LockIssueOptions struct {
 // GitHub API docs: https://docs.github.com/rest/issues/issues#lock-an-issue
 //
 //meta:operation PUT /repos/{owner}/{repo}/issues/{issue_number}/lock
-func (s *IssuesService) Lock(ctx context.Context, owner string, repo string, number int, opts *LockIssueOptions) (*Response, error) {
+func (s *IssuesService) Lock(ctx context.Context, owner, repo string, number int, opts *LockIssueOptions) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%d/lock", owner, repo, number)
 	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
@@ -394,7 +394,7 @@ func (s *IssuesService) Lock(ctx context.Context, owner string, repo string, num
 // GitHub API docs: https://docs.github.com/rest/issues/issues#unlock-an-issue
 //
 //meta:operation DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock
-func (s *IssuesService) Unlock(ctx context.Context, owner string, repo string, number int) (*Response, error) {
+func (s *IssuesService) Unlock(ctx context.Context, owner, repo string, number int) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%d/lock", owner, repo, number)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/issues_comments.go
+++ b/github/issues_comments.go
@@ -55,7 +55,7 @@ type IssueListCommentsOptions struct {
 //
 //meta:operation GET /repos/{owner}/{repo}/issues/comments
 //meta:operation GET /repos/{owner}/{repo}/issues/{issue_number}/comments
-func (s *IssuesService) ListComments(ctx context.Context, owner string, repo string, number int, opts *IssueListCommentsOptions) ([]*IssueComment, *Response, error) {
+func (s *IssuesService) ListComments(ctx context.Context, owner, repo string, number int, opts *IssueListCommentsOptions) ([]*IssueComment, *Response, error) {
 	var u string
 	if number == 0 {
 		u = fmt.Sprintf("repos/%v/%v/issues/comments", owner, repo)
@@ -89,7 +89,7 @@ func (s *IssuesService) ListComments(ctx context.Context, owner string, repo str
 // GitHub API docs: https://docs.github.com/rest/issues/comments#get-an-issue-comment
 //
 //meta:operation GET /repos/{owner}/{repo}/issues/comments/{comment_id}
-func (s *IssuesService) GetComment(ctx context.Context, owner string, repo string, commentID int64) (*IssueComment, *Response, error) {
+func (s *IssuesService) GetComment(ctx context.Context, owner, repo string, commentID int64) (*IssueComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/comments/%d", owner, repo, commentID)
 
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -114,7 +114,7 @@ func (s *IssuesService) GetComment(ctx context.Context, owner string, repo strin
 // GitHub API docs: https://docs.github.com/rest/issues/comments#create-an-issue-comment
 //
 //meta:operation POST /repos/{owner}/{repo}/issues/{issue_number}/comments
-func (s *IssuesService) CreateComment(ctx context.Context, owner string, repo string, number int, comment *IssueComment) (*IssueComment, *Response, error) {
+func (s *IssuesService) CreateComment(ctx context.Context, owner, repo string, number int, comment *IssueComment) (*IssueComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%d/comments", owner, repo, number)
 	req, err := s.client.NewRequest("POST", u, comment)
 	if err != nil {
@@ -135,7 +135,7 @@ func (s *IssuesService) CreateComment(ctx context.Context, owner string, repo st
 // GitHub API docs: https://docs.github.com/rest/issues/comments#update-an-issue-comment
 //
 //meta:operation PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}
-func (s *IssuesService) EditComment(ctx context.Context, owner string, repo string, commentID int64, comment *IssueComment) (*IssueComment, *Response, error) {
+func (s *IssuesService) EditComment(ctx context.Context, owner, repo string, commentID int64, comment *IssueComment) (*IssueComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/comments/%d", owner, repo, commentID)
 	req, err := s.client.NewRequest("PATCH", u, comment)
 	if err != nil {
@@ -155,7 +155,7 @@ func (s *IssuesService) EditComment(ctx context.Context, owner string, repo stri
 // GitHub API docs: https://docs.github.com/rest/issues/comments#delete-an-issue-comment
 //
 //meta:operation DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}
-func (s *IssuesService) DeleteComment(ctx context.Context, owner string, repo string, commentID int64) (*Response, error) {
+func (s *IssuesService) DeleteComment(ctx context.Context, owner, repo string, commentID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/comments/%d", owner, repo, commentID)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/issues_labels.go
+++ b/github/issues_labels.go
@@ -30,7 +30,7 @@ func (l Label) String() string {
 // GitHub API docs: https://docs.github.com/rest/issues/labels#list-labels-for-a-repository
 //
 //meta:operation GET /repos/{owner}/{repo}/labels
-func (s *IssuesService) ListLabels(ctx context.Context, owner string, repo string, opts *ListOptions) ([]*Label, *Response, error) {
+func (s *IssuesService) ListLabels(ctx context.Context, owner, repo string, opts *ListOptions) ([]*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/labels", owner, repo)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -56,7 +56,7 @@ func (s *IssuesService) ListLabels(ctx context.Context, owner string, repo strin
 // GitHub API docs: https://docs.github.com/rest/issues/labels#get-a-label
 //
 //meta:operation GET /repos/{owner}/{repo}/labels/{name}
-func (s *IssuesService) GetLabel(ctx context.Context, owner string, repo string, name string) (*Label, *Response, error) {
+func (s *IssuesService) GetLabel(ctx context.Context, owner, repo, name string) (*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/labels/%v", owner, repo, name)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -77,7 +77,7 @@ func (s *IssuesService) GetLabel(ctx context.Context, owner string, repo string,
 // GitHub API docs: https://docs.github.com/rest/issues/labels#create-a-label
 //
 //meta:operation POST /repos/{owner}/{repo}/labels
-func (s *IssuesService) CreateLabel(ctx context.Context, owner string, repo string, label *Label) (*Label, *Response, error) {
+func (s *IssuesService) CreateLabel(ctx context.Context, owner, repo string, label *Label) (*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/labels", owner, repo)
 	req, err := s.client.NewRequest("POST", u, label)
 	if err != nil {
@@ -98,7 +98,7 @@ func (s *IssuesService) CreateLabel(ctx context.Context, owner string, repo stri
 // GitHub API docs: https://docs.github.com/rest/issues/labels#update-a-label
 //
 //meta:operation PATCH /repos/{owner}/{repo}/labels/{name}
-func (s *IssuesService) EditLabel(ctx context.Context, owner string, repo string, name string, label *Label) (*Label, *Response, error) {
+func (s *IssuesService) EditLabel(ctx context.Context, owner, repo, name string, label *Label) (*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/labels/%v", owner, repo, name)
 	req, err := s.client.NewRequest("PATCH", u, label)
 	if err != nil {
@@ -119,7 +119,7 @@ func (s *IssuesService) EditLabel(ctx context.Context, owner string, repo string
 // GitHub API docs: https://docs.github.com/rest/issues/labels#delete-a-label
 //
 //meta:operation DELETE /repos/{owner}/{repo}/labels/{name}
-func (s *IssuesService) DeleteLabel(ctx context.Context, owner string, repo string, name string) (*Response, error) {
+func (s *IssuesService) DeleteLabel(ctx context.Context, owner, repo, name string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/labels/%v", owner, repo, name)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -133,7 +133,7 @@ func (s *IssuesService) DeleteLabel(ctx context.Context, owner string, repo stri
 // GitHub API docs: https://docs.github.com/rest/issues/labels#list-labels-for-an-issue
 //
 //meta:operation GET /repos/{owner}/{repo}/issues/{issue_number}/labels
-func (s *IssuesService) ListLabelsByIssue(ctx context.Context, owner string, repo string, number int, opts *ListOptions) ([]*Label, *Response, error) {
+func (s *IssuesService) ListLabelsByIssue(ctx context.Context, owner, repo string, number int, opts *ListOptions) ([]*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels", owner, repo, number)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -159,7 +159,7 @@ func (s *IssuesService) ListLabelsByIssue(ctx context.Context, owner string, rep
 // GitHub API docs: https://docs.github.com/rest/issues/labels#add-labels-to-an-issue
 //
 //meta:operation POST /repos/{owner}/{repo}/issues/{issue_number}/labels
-func (s *IssuesService) AddLabelsToIssue(ctx context.Context, owner string, repo string, number int, labels []string) ([]*Label, *Response, error) {
+func (s *IssuesService) AddLabelsToIssue(ctx context.Context, owner, repo string, number int, labels []string) ([]*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels", owner, repo, number)
 	req, err := s.client.NewRequest("POST", u, labels)
 	if err != nil {
@@ -180,7 +180,7 @@ func (s *IssuesService) AddLabelsToIssue(ctx context.Context, owner string, repo
 // GitHub API docs: https://docs.github.com/rest/issues/labels#remove-a-label-from-an-issue
 //
 //meta:operation DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}
-func (s *IssuesService) RemoveLabelForIssue(ctx context.Context, owner string, repo string, number int, label string) (*Response, error) {
+func (s *IssuesService) RemoveLabelForIssue(ctx context.Context, owner, repo string, number int, label string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels/%v", owner, repo, number, label)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -195,7 +195,7 @@ func (s *IssuesService) RemoveLabelForIssue(ctx context.Context, owner string, r
 // GitHub API docs: https://docs.github.com/rest/issues/labels#set-labels-for-an-issue
 //
 //meta:operation PUT /repos/{owner}/{repo}/issues/{issue_number}/labels
-func (s *IssuesService) ReplaceLabelsForIssue(ctx context.Context, owner string, repo string, number int, labels []string) ([]*Label, *Response, error) {
+func (s *IssuesService) ReplaceLabelsForIssue(ctx context.Context, owner, repo string, number int, labels []string) ([]*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels", owner, repo, number)
 	req, err := s.client.NewRequest("PUT", u, labels)
 	if err != nil {
@@ -216,7 +216,7 @@ func (s *IssuesService) ReplaceLabelsForIssue(ctx context.Context, owner string,
 // GitHub API docs: https://docs.github.com/rest/issues/labels#remove-all-labels-from-an-issue
 //
 //meta:operation DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels
-func (s *IssuesService) RemoveLabelsForIssue(ctx context.Context, owner string, repo string, number int) (*Response, error) {
+func (s *IssuesService) RemoveLabelsForIssue(ctx context.Context, owner, repo string, number int) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels", owner, repo, number)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -231,7 +231,7 @@ func (s *IssuesService) RemoveLabelsForIssue(ctx context.Context, owner string, 
 // GitHub API docs: https://docs.github.com/rest/issues/labels#list-labels-for-issues-in-a-milestone
 //
 //meta:operation GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels
-func (s *IssuesService) ListLabelsForMilestone(ctx context.Context, owner string, repo string, number int, opts *ListOptions) ([]*Label, *Response, error) {
+func (s *IssuesService) ListLabelsForMilestone(ctx context.Context, owner, repo string, number int, opts *ListOptions) ([]*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/milestones/%d/labels", owner, repo, number)
 	u, err := addOptions(u, opts)
 	if err != nil {

--- a/github/issues_milestones.go
+++ b/github/issues_milestones.go
@@ -57,7 +57,7 @@ type MilestoneListOptions struct {
 // GitHub API docs: https://docs.github.com/rest/issues/milestones#list-milestones
 //
 //meta:operation GET /repos/{owner}/{repo}/milestones
-func (s *IssuesService) ListMilestones(ctx context.Context, owner string, repo string, opts *MilestoneListOptions) ([]*Milestone, *Response, error) {
+func (s *IssuesService) ListMilestones(ctx context.Context, owner, repo string, opts *MilestoneListOptions) ([]*Milestone, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/milestones", owner, repo)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -83,7 +83,7 @@ func (s *IssuesService) ListMilestones(ctx context.Context, owner string, repo s
 // GitHub API docs: https://docs.github.com/rest/issues/milestones#get-a-milestone
 //
 //meta:operation GET /repos/{owner}/{repo}/milestones/{milestone_number}
-func (s *IssuesService) GetMilestone(ctx context.Context, owner string, repo string, number int) (*Milestone, *Response, error) {
+func (s *IssuesService) GetMilestone(ctx context.Context, owner, repo string, number int) (*Milestone, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/milestones/%d", owner, repo, number)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -104,7 +104,7 @@ func (s *IssuesService) GetMilestone(ctx context.Context, owner string, repo str
 // GitHub API docs: https://docs.github.com/rest/issues/milestones#create-a-milestone
 //
 //meta:operation POST /repos/{owner}/{repo}/milestones
-func (s *IssuesService) CreateMilestone(ctx context.Context, owner string, repo string, milestone *Milestone) (*Milestone, *Response, error) {
+func (s *IssuesService) CreateMilestone(ctx context.Context, owner, repo string, milestone *Milestone) (*Milestone, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/milestones", owner, repo)
 	req, err := s.client.NewRequest("POST", u, milestone)
 	if err != nil {
@@ -125,7 +125,7 @@ func (s *IssuesService) CreateMilestone(ctx context.Context, owner string, repo 
 // GitHub API docs: https://docs.github.com/rest/issues/milestones#update-a-milestone
 //
 //meta:operation PATCH /repos/{owner}/{repo}/milestones/{milestone_number}
-func (s *IssuesService) EditMilestone(ctx context.Context, owner string, repo string, number int, milestone *Milestone) (*Milestone, *Response, error) {
+func (s *IssuesService) EditMilestone(ctx context.Context, owner, repo string, number int, milestone *Milestone) (*Milestone, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/milestones/%d", owner, repo, number)
 	req, err := s.client.NewRequest("PATCH", u, milestone)
 	if err != nil {
@@ -146,7 +146,7 @@ func (s *IssuesService) EditMilestone(ctx context.Context, owner string, repo st
 // GitHub API docs: https://docs.github.com/rest/issues/milestones#delete-a-milestone
 //
 //meta:operation DELETE /repos/{owner}/{repo}/milestones/{milestone_number}
-func (s *IssuesService) DeleteMilestone(ctx context.Context, owner string, repo string, number int) (*Response, error) {
+func (s *IssuesService) DeleteMilestone(ctx context.Context, owner, repo string, number int) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/milestones/%d", owner, repo, number)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/github/orgs_outside_collaborators.go
+++ b/github/orgs_outside_collaborators.go
@@ -57,7 +57,7 @@ func (s *OrganizationsService) ListOutsideCollaborators(ctx context.Context, org
 // GitHub API docs: https://docs.github.com/rest/orgs/outside-collaborators#remove-outside-collaborator-from-an-organization
 //
 //meta:operation DELETE /orgs/{org}/outside_collaborators/{username}
-func (s *OrganizationsService) RemoveOutsideCollaborator(ctx context.Context, org string, user string) (*Response, error) {
+func (s *OrganizationsService) RemoveOutsideCollaborator(ctx context.Context, org, user string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/outside_collaborators/%v", org, user)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -76,7 +76,7 @@ func (s *OrganizationsService) RemoveOutsideCollaborator(ctx context.Context, or
 // GitHub API docs: https://docs.github.com/rest/orgs/outside-collaborators#convert-an-organization-member-to-outside-collaborator
 //
 //meta:operation PUT /orgs/{org}/outside_collaborators/{username}
-func (s *OrganizationsService) ConvertMemberToOutsideCollaborator(ctx context.Context, org string, user string) (*Response, error) {
+func (s *OrganizationsService) ConvertMemberToOutsideCollaborator(ctx context.Context, org, user string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/outside_collaborators/%v", org, user)
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {

--- a/github/orgs_users_blocking.go
+++ b/github/orgs_users_blocking.go
@@ -44,7 +44,7 @@ func (s *OrganizationsService) ListBlockedUsers(ctx context.Context, org string,
 // GitHub API docs: https://docs.github.com/rest/orgs/blocking#check-if-a-user-is-blocked-by-an-organization
 //
 //meta:operation GET /orgs/{org}/blocks/{username}
-func (s *OrganizationsService) IsBlocked(ctx context.Context, org string, user string) (bool, *Response, error) {
+func (s *OrganizationsService) IsBlocked(ctx context.Context, org, user string) (bool, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/blocks/%v", org, user)
 
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -65,7 +65,7 @@ func (s *OrganizationsService) IsBlocked(ctx context.Context, org string, user s
 // GitHub API docs: https://docs.github.com/rest/orgs/blocking#block-a-user-from-an-organization
 //
 //meta:operation PUT /orgs/{org}/blocks/{username}
-func (s *OrganizationsService) BlockUser(ctx context.Context, org string, user string) (*Response, error) {
+func (s *OrganizationsService) BlockUser(ctx context.Context, org, user string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/blocks/%v", org, user)
 
 	req, err := s.client.NewRequest("PUT", u, nil)
@@ -84,7 +84,7 @@ func (s *OrganizationsService) BlockUser(ctx context.Context, org string, user s
 // GitHub API docs: https://docs.github.com/rest/orgs/blocking#unblock-a-user-from-an-organization
 //
 //meta:operation DELETE /orgs/{org}/blocks/{username}
-func (s *OrganizationsService) UnblockUser(ctx context.Context, org string, user string) (*Response, error) {
+func (s *OrganizationsService) UnblockUser(ctx context.Context, org, user string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/blocks/%v", org, user)
 
 	req, err := s.client.NewRequest("DELETE", u, nil)

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -148,7 +148,7 @@ type PullRequestListOptions struct {
 // GitHub API docs: https://docs.github.com/rest/pulls/pulls#list-pull-requests
 //
 //meta:operation GET /repos/{owner}/{repo}/pulls
-func (s *PullRequestsService) List(ctx context.Context, owner string, repo string, opts *PullRequestListOptions) ([]*PullRequest, *Response, error) {
+func (s *PullRequestsService) List(ctx context.Context, owner, repo string, opts *PullRequestListOptions) ([]*PullRequest, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls", owner, repo)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -207,7 +207,7 @@ func (s *PullRequestsService) ListPullRequestsWithCommit(ctx context.Context, ow
 // GitHub API docs: https://docs.github.com/rest/pulls/pulls#get-a-pull-request
 //
 //meta:operation GET /repos/{owner}/{repo}/pulls/{pull_number}
-func (s *PullRequestsService) Get(ctx context.Context, owner string, repo string, number int) (*PullRequest, *Response, error) {
+func (s *PullRequestsService) Get(ctx context.Context, owner, repo string, number int) (*PullRequest, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d", owner, repo, number)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -228,7 +228,7 @@ func (s *PullRequestsService) Get(ctx context.Context, owner string, repo string
 // GitHub API docs: https://docs.github.com/rest/pulls/pulls#get-a-pull-request
 //
 //meta:operation GET /repos/{owner}/{repo}/pulls/{pull_number}
-func (s *PullRequestsService) GetRaw(ctx context.Context, owner string, repo string, number int, opts RawOptions) (string, *Response, error) {
+func (s *PullRequestsService) GetRaw(ctx context.Context, owner, repo string, number int, opts RawOptions) (string, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d", owner, repo, number)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -277,7 +277,7 @@ type NewPullRequest struct {
 // GitHub API docs: https://docs.github.com/rest/pulls/pulls#create-a-pull-request
 //
 //meta:operation POST /repos/{owner}/{repo}/pulls
-func (s *PullRequestsService) Create(ctx context.Context, owner string, repo string, pull *NewPullRequest) (*PullRequest, *Response, error) {
+func (s *PullRequestsService) Create(ctx context.Context, owner, repo string, pull *NewPullRequest) (*PullRequest, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls", owner, repo)
 	req, err := s.client.NewRequest("POST", u, pull)
 	if err != nil {
@@ -355,7 +355,7 @@ type pullRequestUpdate struct {
 // GitHub API docs: https://docs.github.com/rest/pulls/pulls#update-a-pull-request
 //
 //meta:operation PATCH /repos/{owner}/{repo}/pulls/{pull_number}
-func (s *PullRequestsService) Edit(ctx context.Context, owner string, repo string, number int, pull *PullRequest) (*PullRequest, *Response, error) {
+func (s *PullRequestsService) Edit(ctx context.Context, owner, repo string, number int, pull *PullRequest) (*PullRequest, *Response, error) {
 	if pull == nil {
 		return nil, nil, errors.New("pull must be provided")
 	}
@@ -394,7 +394,7 @@ func (s *PullRequestsService) Edit(ctx context.Context, owner string, repo strin
 // GitHub API docs: https://docs.github.com/rest/pulls/pulls#list-commits-on-a-pull-request
 //
 //meta:operation GET /repos/{owner}/{repo}/pulls/{pull_number}/commits
-func (s *PullRequestsService) ListCommits(ctx context.Context, owner string, repo string, number int, opts *ListOptions) ([]*RepositoryCommit, *Response, error) {
+func (s *PullRequestsService) ListCommits(ctx context.Context, owner, repo string, number int, opts *ListOptions) ([]*RepositoryCommit, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/commits", owner, repo, number)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -420,7 +420,7 @@ func (s *PullRequestsService) ListCommits(ctx context.Context, owner string, rep
 // GitHub API docs: https://docs.github.com/rest/pulls/pulls#list-pull-requests-files
 //
 //meta:operation GET /repos/{owner}/{repo}/pulls/{pull_number}/files
-func (s *PullRequestsService) ListFiles(ctx context.Context, owner string, repo string, number int, opts *ListOptions) ([]*CommitFile, *Response, error) {
+func (s *PullRequestsService) ListFiles(ctx context.Context, owner, repo string, number int, opts *ListOptions) ([]*CommitFile, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/files", owner, repo, number)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -446,7 +446,7 @@ func (s *PullRequestsService) ListFiles(ctx context.Context, owner string, repo 
 // GitHub API docs: https://docs.github.com/rest/pulls/pulls#check-if-a-pull-request-has-been-merged
 //
 //meta:operation GET /repos/{owner}/{repo}/pulls/{pull_number}/merge
-func (s *PullRequestsService) IsMerged(ctx context.Context, owner string, repo string, number int) (bool, *Response, error) {
+func (s *PullRequestsService) IsMerged(ctx context.Context, owner, repo string, number int) (bool, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/merge", owner, repo, number)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -490,7 +490,7 @@ type pullRequestMergeRequest struct {
 // GitHub API docs: https://docs.github.com/rest/pulls/pulls#merge-a-pull-request
 //
 //meta:operation PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
-func (s *PullRequestsService) Merge(ctx context.Context, owner string, repo string, number int, commitMessage string, options *PullRequestOptions) (*PullRequestMergeResult, *Response, error) {
+func (s *PullRequestsService) Merge(ctx context.Context, owner, repo string, number int, commitMessage string, options *PullRequestOptions) (*PullRequestMergeResult, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d/merge", owner, repo, number)
 
 	pullRequestBody := &pullRequestMergeRequest{}

--- a/github/repos.go
+++ b/github/repos.go
@@ -893,7 +893,7 @@ func (s *RepositoriesService) DisableAutomatedSecurityFixes(ctx context.Context,
 // GitHub API docs: https://docs.github.com/rest/repos/repos#list-repository-contributors
 //
 //meta:operation GET /repos/{owner}/{repo}/contributors
-func (s *RepositoriesService) ListContributors(ctx context.Context, owner string, repository string, opts *ListContributorsOptions) ([]*Contributor, *Response, error) {
+func (s *RepositoriesService) ListContributors(ctx context.Context, owner, repository string, opts *ListContributorsOptions) ([]*Contributor, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/contributors", owner, repository)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -926,7 +926,7 @@ func (s *RepositoriesService) ListContributors(ctx context.Context, owner string
 // GitHub API docs: https://docs.github.com/rest/repos/repos#list-repository-languages
 //
 //meta:operation GET /repos/{owner}/{repo}/languages
-func (s *RepositoriesService) ListLanguages(ctx context.Context, owner string, repo string) (map[string]int, *Response, error) {
+func (s *RepositoriesService) ListLanguages(ctx context.Context, owner, repo string) (map[string]int, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/languages", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -947,7 +947,7 @@ func (s *RepositoriesService) ListLanguages(ctx context.Context, owner string, r
 // GitHub API docs: https://docs.github.com/rest/repos/repos#list-repository-teams
 //
 //meta:operation GET /repos/{owner}/{repo}/teams
-func (s *RepositoriesService) ListTeams(ctx context.Context, owner string, repo string, opts *ListOptions) ([]*Team, *Response, error) {
+func (s *RepositoriesService) ListTeams(ctx context.Context, owner, repo string, opts *ListOptions) ([]*Team, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/teams", owner, repo)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -981,7 +981,7 @@ type RepositoryTag struct {
 // GitHub API docs: https://docs.github.com/rest/repos/repos#list-repository-tags
 //
 //meta:operation GET /repos/{owner}/{repo}/tags
-func (s *RepositoriesService) ListTags(ctx context.Context, owner string, repo string, opts *ListOptions) ([]*RepositoryTag, *Response, error) {
+func (s *RepositoriesService) ListTags(ctx context.Context, owner, repo string, opts *ListOptions) ([]*RepositoryTag, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/tags", owner, repo)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -1415,7 +1415,7 @@ type AutomatedSecurityFixes struct {
 // GitHub API docs: https://docs.github.com/rest/branches/branches#list-branches
 //
 //meta:operation GET /repos/{owner}/{repo}/branches
-func (s *RepositoriesService) ListBranches(ctx context.Context, owner string, repo string, opts *BranchListOptions) ([]*Branch, *Response, error) {
+func (s *RepositoriesService) ListBranches(ctx context.Context, owner, repo string, opts *BranchListOptions) ([]*Branch, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches", owner, repo)
 	u, err := addOptions(u, opts)
 	if err != nil {

--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -179,7 +179,7 @@ func (s *RepositoriesService) GetCommit(ctx context.Context, owner, repo, sha st
 // GitHub API docs: https://docs.github.com/rest/commits/commits#get-a-commit
 //
 //meta:operation GET /repos/{owner}/{repo}/commits/{ref}
-func (s *RepositoriesService) GetCommitRaw(ctx context.Context, owner string, repo string, sha string, opts RawOptions) (string, *Response, error) {
+func (s *RepositoriesService) GetCommitRaw(ctx context.Context, owner, repo, sha string, opts RawOptions) (string, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/commits/%v", owner, repo, sha)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -237,7 +237,7 @@ func (s *RepositoriesService) GetCommitSHA1(ctx context.Context, owner, repo, re
 // GitHub API docs: https://docs.github.com/rest/commits/commits#compare-two-commits
 //
 //meta:operation GET /repos/{owner}/{repo}/compare/{basehead}
-func (s *RepositoriesService) CompareCommits(ctx context.Context, owner, repo string, base, head string, opts *ListOptions) (*CommitsComparison, *Response, error) {
+func (s *RepositoriesService) CompareCommits(ctx context.Context, owner, repo, base, head string, opts *ListOptions) (*CommitsComparison, *Response, error) {
 	escapedBase := url.QueryEscape(base)
 	escapedHead := url.QueryEscape(head)
 

--- a/github/repos_keys.go
+++ b/github/repos_keys.go
@@ -17,7 +17,7 @@ import (
 // GitHub API docs: https://docs.github.com/rest/deploy-keys/deploy-keys#list-deploy-keys
 //
 //meta:operation GET /repos/{owner}/{repo}/keys
-func (s *RepositoriesService) ListKeys(ctx context.Context, owner string, repo string, opts *ListOptions) ([]*Key, *Response, error) {
+func (s *RepositoriesService) ListKeys(ctx context.Context, owner, repo string, opts *ListOptions) ([]*Key, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/keys", owner, repo)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -43,7 +43,7 @@ func (s *RepositoriesService) ListKeys(ctx context.Context, owner string, repo s
 // GitHub API docs: https://docs.github.com/rest/deploy-keys/deploy-keys#get-a-deploy-key
 //
 //meta:operation GET /repos/{owner}/{repo}/keys/{key_id}
-func (s *RepositoriesService) GetKey(ctx context.Context, owner string, repo string, id int64) (*Key, *Response, error) {
+func (s *RepositoriesService) GetKey(ctx context.Context, owner, repo string, id int64) (*Key, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/keys/%v", owner, repo, id)
 
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -65,7 +65,7 @@ func (s *RepositoriesService) GetKey(ctx context.Context, owner string, repo str
 // GitHub API docs: https://docs.github.com/rest/deploy-keys/deploy-keys#create-a-deploy-key
 //
 //meta:operation POST /repos/{owner}/{repo}/keys
-func (s *RepositoriesService) CreateKey(ctx context.Context, owner string, repo string, key *Key) (*Key, *Response, error) {
+func (s *RepositoriesService) CreateKey(ctx context.Context, owner, repo string, key *Key) (*Key, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/keys", owner, repo)
 
 	req, err := s.client.NewRequest("POST", u, key)
@@ -87,7 +87,7 @@ func (s *RepositoriesService) CreateKey(ctx context.Context, owner string, repo 
 // GitHub API docs: https://docs.github.com/rest/deploy-keys/deploy-keys#delete-a-deploy-key
 //
 //meta:operation DELETE /repos/{owner}/{repo}/keys/{key_id}
-func (s *RepositoriesService) DeleteKey(ctx context.Context, owner string, repo string, id int64) (*Response, error) {
+func (s *RepositoriesService) DeleteKey(ctx context.Context, owner, repo string, id int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/keys/%v", owner, repo, id)
 
 	req, err := s.client.NewRequest("DELETE", u, nil)


### PR DESCRIPTION
This PR combines function parameters by type (with the help of [gocritic.paramTypeCombine](https://go-critic.com/overview.html#paramtypecombine)). See https://github.com/google/go-github/pull/3654#discussion_r2236676684