### PR TITLE
chore: Show correct path when example has lint errors

### DIFF
--- a/script/lint.sh
+++ b/script/lint.sh
@@ -32,7 +32,7 @@ for dir in $MOD_DIRS; do
   echo linting "$dir"
   (
     cd "$dir"
-    "$BIN"/custom-gcl run --path-prefix "$dir"
+    "$BIN"/custom-gcl run
   ) || fail "failed linting $dir"
 done
 


### PR DESCRIPTION
Let's assume `example/simple/main.go` contains a lint issue `fmt.Printf("Enter GitHub username: ")` and we run `./script/lint.sh`.

Before (duplicated `example` in the issued file path):

```console
$ ./script/lint.sh
linting .
0 issues.
linting example
/Users/alexandear/src/github.com/google/go-github/example
example/example/simple/main.go:27:2: unnecessary-format: unnecessary use of formatting function "fmt.Printf", you can replace it with "fmt.Print" or "fmt.Println" (revive)
        fmt.Printf("Enter GitHub username: ")
        ^
1 issues:
* revive: 1
failed linting example
```

After:

```console
$ ./script/lint.sh
linting .
0 issues.
linting example
/Users/alexandear/src/github.com/google/go-github/example
example/simple/main.go:27:2: unnecessary-format: unnecessary use of formatting function "fmt.Printf", you can replace it with "fmt.Print" or "fmt.Println" (revive)
        fmt.Printf("Enter GitHub username: ")
        ^
1 issues:
* revive: 1
failed linting example
```

The fix is simple: remove `--path-prefix` option as not needed in v2. See https://golangci-lint.run/product/migration-guide/#runrelative-path-mode