### PR TITLE
docs: Use secure URLs in string literals

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ file.
      [REVIEWERS][] takes a look by mentioning them in a PR comment.
 
 [forking]: https://help.github.com/articles/fork-a-repo
-[well-formed commit messages]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[well-formed commit messages]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [pull request]: https://help.github.com/articles/creating-a-pull-request
 [monitored by codecov.io]: https://codecov.io/gh/google/go-github
 [REVIEWERS]: ./REVIEWERS

--- a/github/actions_artifacts_test.go
+++ b/github/actions_artifacts_test.go
@@ -456,7 +456,7 @@ func TestActionsService_DownloadArtifact_StatusMovedPermanently_followRedirects(
 			})
 			mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
-				http.Redirect(w, r, "http://github.com/artifact", http.StatusFound)
+				http.Redirect(w, r, "https://github.com/artifact", http.StatusFound)
 			})
 
 			ctx := context.Background()
@@ -467,7 +467,7 @@ func TestActionsService_DownloadArtifact_StatusMovedPermanently_followRedirects(
 			if resp.StatusCode != http.StatusFound {
 				t.Errorf("Actions.DownloadArtifact return status %d, want %d", resp.StatusCode, http.StatusFound)
 			}
-			want := "http://github.com/artifact"
+			want := "https://github.com/artifact"
 			if url.String() != want {
 				t.Errorf("Actions.DownloadArtifact returned %+v, want %+v", url.String(), want)
 			}

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -207,7 +207,7 @@ func TestActionsService_GetWorkflowJobLogs(t *testing.T) {
 
 			mux.HandleFunc("/repos/o/r/actions/jobs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
-				http.Redirect(w, r, "http://github.com/a", http.StatusFound)
+				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
 
 			ctx := context.Background()
@@ -218,7 +218,7 @@ func TestActionsService_GetWorkflowJobLogs(t *testing.T) {
 			if resp.StatusCode != http.StatusFound {
 				t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusFound)
 			}
-			want := "http://github.com/a"
+			want := "https://github.com/a"
 			if url.String() != want {
 				t.Errorf("Actions.GetWorkflowJobLogs returned %+v, want %+v", url.String(), want)
 			}
@@ -267,7 +267,7 @@ func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_dontFollowRedi
 
 			mux.HandleFunc("/repos/o/r/actions/jobs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
-				http.Redirect(w, r, "http://github.com/a", http.StatusMovedPermanently)
+				http.Redirect(w, r, "https://github.com/a", http.StatusMovedPermanently)
 			})
 
 			ctx := context.Background()
@@ -310,7 +310,7 @@ func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_followRedirect
 
 			mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
-				http.Redirect(w, r, "http://github.com/a", http.StatusFound)
+				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
 
 			ctx := context.Background()
@@ -323,7 +323,7 @@ func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_followRedirect
 				t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusFound)
 			}
 
-			want := "http://github.com/a"
+			want := "https://github.com/a"
 			if url.String() != want {
 				t.Errorf("Actions.GetWorkflowJobLogs returned %+v, want %+v", url.String(), want)
 			}

--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -213,7 +213,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs(t *testing.T) {
 
 			mux.HandleFunc("/repos/o/r/actions/runs/399444496/attempts/2/logs", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
-				http.Redirect(w, r, "http://github.com/a", http.StatusFound)
+				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
 
 			ctx := context.Background()
@@ -224,7 +224,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs(t *testing.T) {
 			if resp.StatusCode != http.StatusFound {
 				t.Errorf("Actions.GetWorkflowRunAttemptLogs returned status: %d, want %d", resp.StatusCode, http.StatusFound)
 			}
-			want := "http://github.com/a"
+			want := "https://github.com/a"
 			if url.String() != want {
 				t.Errorf("Actions.GetWorkflowRunAttemptLogs returned %+v, want %+v", url.String(), want)
 			}
@@ -262,7 +262,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs_StatusMovedPermanently_dontFol
 
 			mux.HandleFunc("/repos/o/r/actions/runs/399444496/attempts/2/logs", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
-				http.Redirect(w, r, "http://github.com/a", http.StatusMovedPermanently)
+				http.Redirect(w, r, "https://github.com/a", http.StatusMovedPermanently)
 			})
 
 			ctx := context.Background()
@@ -305,7 +305,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs_StatusMovedPermanently_followR
 
 			mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
-				http.Redirect(w, r, "http://github.com/a", http.StatusFound)
+				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
 
 			ctx := context.Background()
@@ -318,7 +318,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs_StatusMovedPermanently_followR
 				t.Errorf("Actions.GetWorkflowRunAttemptLogs returned status: %d, want %d", resp.StatusCode, http.StatusFound)
 			}
 
-			want := "http://github.com/a"
+			want := "https://github.com/a"
 			if url.String() != want {
 				t.Errorf("Actions.GetWorkflowRunAttemptLogs returned %+v, want %+v", url.String(), want)
 			}
@@ -524,7 +524,7 @@ func TestActionsService_GetWorkflowRunLogs(t *testing.T) {
 
 			mux.HandleFunc("/repos/o/r/actions/runs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
-				http.Redirect(w, r, "http://github.com/a", http.StatusFound)
+				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
 
 			ctx := context.Background()
@@ -535,7 +535,7 @@ func TestActionsService_GetWorkflowRunLogs(t *testing.T) {
 			if resp.StatusCode != http.StatusFound {
 				t.Errorf("Actions.GetWorkflowRunLogs returned status: %d, want %d", resp.StatusCode, http.StatusFound)
 			}
-			want := "http://github.com/a"
+			want := "https://github.com/a"
 			if url.String() != want {
 				t.Errorf("Actions.GetWorkflowRunLogs returned %+v, want %+v", url.String(), want)
 			}
@@ -573,7 +573,7 @@ func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_dontFollowRedi
 
 			mux.HandleFunc("/repos/o/r/actions/runs/399444496/logs", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
-				http.Redirect(w, r, "http://github.com/a", http.StatusMovedPermanently)
+				http.Redirect(w, r, "https://github.com/a", http.StatusMovedPermanently)
 			})
 
 			ctx := context.Background()
@@ -616,7 +616,7 @@ func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_followRedirect
 
 			mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
-				http.Redirect(w, r, "http://github.com/a", http.StatusFound)
+				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
 
 			ctx := context.Background()
@@ -629,7 +629,7 @@ func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_followRedirect
 				t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusFound)
 			}
 
-			want := "http://github.com/a"
+			want := "https://github.com/a"
 			if url.String() != want {
 				t.Errorf("Actions.GetWorkflowJobLogs returned %+v, want %+v", url.String(), want)
 			}

--- a/github/dependabot_alerts_test.go
+++ b/github/dependabot_alerts_test.go
@@ -309,7 +309,7 @@ func TestDependabotSecurityAdvisory_Marshal(t *testing.T) {
 				URL: Ptr("https://www.djangoproject.com/weblog/2018/feb/01/security-releases/"),
 			},
 			{
-				URL: Ptr("http://www.securitytracker.com/id/1040422"),
+				URL: Ptr("https://www.securitytracker.com/id/1040422"),
 			},
 		},
 		PublishedAt: &Timestamp{publishedAt},
@@ -385,7 +385,7 @@ func TestDependabotSecurityAdvisory_Marshal(t *testing.T) {
           "url": "https://www.djangoproject.com/weblog/2018/feb/01/security-releases/"
         },
         {
-          "url": "http://www.securitytracker.com/id/1040422"
+          "url": "https://www.securitytracker.com/id/1040422"
         }
       ],
       "published_at": "2018-10-03T21:13:54Z",

--- a/github/meta.go
+++ b/github/meta.go
@@ -160,7 +160,7 @@ func (c *Client) Octocat(ctx context.Context, message string) (string, *Response
 
 // Zen returns a random line from The Zen of GitHub.
 //
-// See also: http://warpspire.com/posts/taste/
+// See also: https://warpspire.com/posts/taste/
 //
 // GitHub API docs: https://docs.github.com/rest/meta/meta#get-the-zen-of-github
 //

--- a/github/orgs_audit_log.go
+++ b/github/orgs_audit_log.go
@@ -43,7 +43,7 @@ type AuditEntry struct {
 	HashedToken              *string        `json:"hashed_token,omitempty"`
 	Org                      *string        `json:"org,omitempty"`
 	OrgID                    *int64         `json:"org_id,omitempty"`
-	Timestamp                *Timestamp     `json:"@timestamp,omitempty"` // The time the audit log event occurred, given as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time).
+	Timestamp                *Timestamp     `json:"@timestamp,omitempty"` // The time the audit log event occurred, given as a [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time).
 	TokenID                  *int64         `json:"token_id,omitempty"`
 	TokenScopes              *string        `json:"token_scopes,omitempty"`
 	User                     *string        `json:"user,omitempty"` // The user that was affected by the action performed (if available).

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -887,7 +887,7 @@ func TestRepositoriesService_GetArchiveLink(t *testing.T) {
 
 			mux.HandleFunc("/repos/o/r/tarball/yo", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
-				http.Redirect(w, r, "http://github.com/a", http.StatusFound)
+				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
 			ctx := context.Background()
 			url, resp, err := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{Ref: "yo"}, 1)
@@ -897,7 +897,7 @@ func TestRepositoriesService_GetArchiveLink(t *testing.T) {
 			if resp.StatusCode != http.StatusFound {
 				t.Errorf("Repositories.GetArchiveLink returned status: %d, want %d", resp.StatusCode, http.StatusFound)
 			}
-			want := "http://github.com/a"
+			want := "https://github.com/a"
 			if url.String() != want {
 				t.Errorf("Repositories.GetArchiveLink returned %+v, want %+v", url.String(), want)
 			}
@@ -944,7 +944,7 @@ func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_dontFollowRed
 
 			mux.HandleFunc("/repos/o/r/tarball", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
-				http.Redirect(w, r, "http://github.com/a", http.StatusMovedPermanently)
+				http.Redirect(w, r, "https://github.com/a", http.StatusMovedPermanently)
 			})
 			ctx := context.Background()
 			_, resp, _ := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{}, 0)
@@ -985,7 +985,7 @@ func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_followRedirec
 			})
 			mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
-				http.Redirect(w, r, "http://github.com/a", http.StatusFound)
+				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
 			ctx := context.Background()
 			url, resp, err := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{}, 1)
@@ -995,7 +995,7 @@ func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_followRedirec
 			if resp.StatusCode != http.StatusFound {
 				t.Errorf("Repositories.GetArchiveLink returned status: %d, want %d", resp.StatusCode, http.StatusFound)
 			}
-			want := "http://github.com/a"
+			want := "https://github.com/a"
 			if url.String() != want {
 				t.Errorf("Repositories.GetArchiveLink returned %+v, want %+v", url.String(), want)
 			}

--- a/github/repos_hooks_test.go
+++ b/github/repos_hooks_test.go
@@ -580,7 +580,7 @@ func TestRepositoriesService_Subscribe(t *testing.T) {
 		testFormValues(t, r, values{
 			"hub.mode":     "subscribe",
 			"hub.topic":    "https://github.com/o/r/events/push",
-			"hub.callback": "http://postbin.org/123",
+			"hub.callback": "https://postbin.org/123",
 			"hub.secret":   "test secret",
 		})
 	})
@@ -591,7 +591,7 @@ func TestRepositoriesService_Subscribe(t *testing.T) {
 		"o",
 		"r",
 		"push",
-		"http://postbin.org/123",
+		"https://postbin.org/123",
 		[]byte("test secret"),
 	)
 	if err != nil {
@@ -599,7 +599,7 @@ func TestRepositoriesService_Subscribe(t *testing.T) {
 	}
 
 	testNewRequestAndDoFailure(t, "Subscribe", client, func() (*Response, error) {
-		return client.Repositories.Subscribe(ctx, "o", "r", "push", "http://postbin.org/123", nil)
+		return client.Repositories.Subscribe(ctx, "o", "r", "push", "https://postbin.org/123", nil)
 	})
 }
 
@@ -613,7 +613,7 @@ func TestRepositoriesService_Unsubscribe(t *testing.T) {
 		testFormValues(t, r, values{
 			"hub.mode":     "unsubscribe",
 			"hub.topic":    "https://github.com/o/r/events/push",
-			"hub.callback": "http://postbin.org/123",
+			"hub.callback": "https://postbin.org/123",
 			"hub.secret":   "test secret",
 		})
 	})
@@ -624,7 +624,7 @@ func TestRepositoriesService_Unsubscribe(t *testing.T) {
 		"o",
 		"r",
 		"push",
-		"http://postbin.org/123",
+		"https://postbin.org/123",
 		[]byte("test secret"),
 	)
 	if err != nil {
@@ -632,6 +632,6 @@ func TestRepositoriesService_Unsubscribe(t *testing.T) {
 	}
 
 	testNewRequestAndDoFailure(t, "Unsubscribe", client, func() (*Response, error) {
-		return client.Repositories.Unsubscribe(ctx, "o", "r", "push", "http://postbin.org/123", nil)
+		return client.Repositories.Unsubscribe(ctx, "o", "r", "push", "https://postbin.org/123", nil)
 	})
 }

--- a/github/repos_hooks_test.go
+++ b/github/repos_hooks_test.go
@@ -580,7 +580,7 @@ func TestRepositoriesService_Subscribe(t *testing.T) {
 		testFormValues(t, r, values{
 			"hub.mode":     "subscribe",
 			"hub.topic":    "https://github.com/o/r/events/push",
-			"hub.callback": "https://postbin.org/123",
+			"hub.callback": "http://localhost:8080/callback",
 			"hub.secret":   "test secret",
 		})
 	})
@@ -591,7 +591,7 @@ func TestRepositoriesService_Subscribe(t *testing.T) {
 		"o",
 		"r",
 		"push",
-		"https://postbin.org/123",
+		"http://localhost:8080/callback",
 		[]byte("test secret"),
 	)
 	if err != nil {
@@ -599,7 +599,7 @@ func TestRepositoriesService_Subscribe(t *testing.T) {
 	}
 
 	testNewRequestAndDoFailure(t, "Subscribe", client, func() (*Response, error) {
-		return client.Repositories.Subscribe(ctx, "o", "r", "push", "https://postbin.org/123", nil)
+		return client.Repositories.Subscribe(ctx, "o", "r", "push", "http://localhost:8080", nil)
 	})
 }
 
@@ -613,7 +613,7 @@ func TestRepositoriesService_Unsubscribe(t *testing.T) {
 		testFormValues(t, r, values{
 			"hub.mode":     "unsubscribe",
 			"hub.topic":    "https://github.com/o/r/events/push",
-			"hub.callback": "https://postbin.org/123",
+			"hub.callback": "http://localhost:8080/callback",
 			"hub.secret":   "test secret",
 		})
 	})
@@ -624,7 +624,7 @@ func TestRepositoriesService_Unsubscribe(t *testing.T) {
 		"o",
 		"r",
 		"push",
-		"https://postbin.org/123",
+		"http://localhost:8080/callback",
 		[]byte("test secret"),
 	)
 	if err != nil {
@@ -632,6 +632,6 @@ func TestRepositoriesService_Unsubscribe(t *testing.T) {
 	}
 
 	testNewRequestAndDoFailure(t, "Unsubscribe", client, func() (*Response, error) {
-		return client.Repositories.Unsubscribe(ctx, "o", "r", "push", "https://postbin.org/123", nil)
+		return client.Repositories.Unsubscribe(ctx, "o", "r", "push", "http://localhost:8080/callback", nil)
 	})
 }


### PR DESCRIPTION
This PR replaces `http://` with `https://` where possible.