### PR TITLE
feat: Add artifact and log retension period api support

### DIFF
--- a/github/actions_artifacts.go
+++ b/github/actions_artifacts.go
@@ -69,6 +69,8 @@ type ArtifactPeriod struct {
 	MaximumAllowedDays *int `json:"maximum_allowed_days,omitempty"`
 }
 
+func (a ArtifactPeriod) String() string { return Stringify(a) }
+
 type ArtifactPeriodOpt struct {
 	Days *int `json:"days,omitempty"`
 }

--- a/github/actions_artifacts.go
+++ b/github/actions_artifacts.go
@@ -64,6 +64,15 @@ type ListArtifactsOptions struct {
 	ListOptions
 }
 
+type ArtifactPeriod struct {
+	Days               *int `json:"days,omitempty"`
+	MaximumAllowedDays *int `json:"maximum_allowed_days,omitempty"`
+}
+
+type ArtifactPeriodOpt struct {
+	Days *int `json:"days,omitempty"`
+}
+
 // ListArtifacts lists all artifacts that belong to a repository.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/artifacts#list-artifacts-for-a-repository

--- a/github/actions_permissions_enterprise.go
+++ b/github/actions_permissions_enterprise.go
@@ -256,3 +256,40 @@ func (s *ActionsService) EditDefaultWorkflowPermissionsInEnterprise(ctx context.
 
 	return p, resp, nil
 }
+
+// GetArtifactAndLogRetentionPeriodInEnterprise gets the artifact and log retention period for an enterprise.
+//
+// GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/actions/permissions#get-artifact-and-log-retention-settings-for-an-enterprise
+//
+//meta:operation GET /enterprises/{enterprise}/actions/permissions/artifact-and-log-retention
+func (s *ActionsService) GetArtifactAndLogRetentionPeriodInEnterprise(ctx context.Context, enterprise string) (*ArtifactPeriod, *Response, error) {
+	u := fmt.Sprintf("enterprises/%v/actions/permissions/artifact-and-log-retention", enterprise)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	arp := new(ArtifactPeriod)
+	resp, err := s.client.Do(ctx, req, arp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return arp, resp, nil
+}
+
+// EditArtifactAndLogRetentionPeriodInEnterprise sets the artifact and log retention period for an enterprise.
+//
+// GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/actions/permissions#set-artifact-and-log-retention-settings-for-an-enterprise
+//
+//meta:operation PUT /enterprises/{enterprise}/actions/permissions/artifact-and-log-retention
+func (s *ActionsService) EditArtifactAndLogRetentionPeriodInEnterprise(ctx context.Context, enterprise string, period ArtifactPeriodOpt) (*Response, error) {
+	u := fmt.Sprintf("enterprises/%v/actions/permissions/artifact-and-log-retention", enterprise)
+	req, err := s.client.NewRequest("PUT", u, period)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/actions_permissions_enterprise_test.go
+++ b/github/actions_permissions_enterprise_test.go
@@ -375,3 +375,79 @@ func TestActionsService_EditDefaultWorkflowPermissionsInEnterprise(t *testing.T)
 		return resp, err
 	})
 }
+
+func TestActionsService_GetArtifactAndLogRetentionPeriodInEnterprise(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/enterprises/e/actions/permissions/artifact-and-log-retention", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"days": 90, "maximum_allowed_days": 365}`)
+	})
+
+	ctx := context.Background()
+	period, _, err := client.Actions.GetArtifactAndLogRetentionPeriodInEnterprise(ctx, "e")
+	if err != nil {
+		t.Errorf("Actions.GetArtifactAndLogRetentionPeriodInEnterprise returned error: %v", err)
+	}
+
+	want := &ArtifactPeriod{
+		Days:               Ptr(90),
+		MaximumAllowedDays: Ptr(365),
+	}
+	if !cmp.Equal(period, want) {
+		t.Errorf("Actions.GetArtifactAndLogRetentionPeriodInEnterprise = %+v, want %+v", period, want)
+	}
+
+	const methodName = "GetArtifactAndLogRetentionPeriodInEnterprise"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.GetArtifactAndLogRetentionPeriodInEnterprise(ctx, "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.GetArtifactAndLogRetentionPeriodInEnterprise(ctx, "e")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestActionsService_EditArtifactAndLogRetentionPeriodInEnterprise(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	input := &ArtifactPeriodOpt{Days: Ptr(90)}
+
+	mux.HandleFunc("/enterprises/e/actions/permissions/artifact-and-log-retention", func(w http.ResponseWriter, r *http.Request) {
+		v := new(ArtifactPeriodOpt)
+		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
+
+		testMethod(t, r, "PUT")
+		if !cmp.Equal(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Actions.EditArtifactAndLogRetentionPeriodInEnterprise(ctx, "e", *input)
+	if err != nil {
+		t.Errorf("Actions.EditArtifactAndLogRetentionPeriodInEnterprise returned error: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("Actions.EditArtifactAndLogRetentionPeriodInEnterprise = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+
+	const methodName = "EditArtifactAndLogRetentionPeriodInEnterprise"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.EditArtifactAndLogRetentionPeriodInEnterprise(ctx, "\n", *input)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.EditArtifactAndLogRetentionPeriodInEnterprise(ctx, "e", *input)
+	})
+}

--- a/github/actions_permissions_orgs.go
+++ b/github/actions_permissions_orgs.go
@@ -269,3 +269,40 @@ func (s *ActionsService) EditDefaultWorkflowPermissionsInOrganization(ctx contex
 
 	return p, resp, nil
 }
+
+// GetArtifactAndLogRetentionPeriodInOrganization gets the artifact and log retention period for an organization.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/permissions#get-artifact-and-log-retention-settings-for-an-organization
+//
+//meta:operation GET /organizations/{org}/actions/permissions/artifact-and-log-retention
+func (s *ActionsService) GetArtifactAndLogRetentionPeriodInOrganization(ctx context.Context, org string) (*ArtifactPeriod, *Response, error) {
+	u := fmt.Sprintf("organizations/%v/actions/permissions/artifact-and-log-retention", org)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	arp := new(ArtifactPeriod)
+	resp, err := s.client.Do(ctx, req, arp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return arp, resp, nil
+}
+
+// EditArtifactAndLogRetentionPeriodInOrganization sets the artifact and log retention period for an organization.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/permissions#set-artifact-and-log-retention-settings-for-an-organization
+//
+//meta:operation PUT /organizations/{org}/actions/permissions/artifact-and-log-retention
+func (s *ActionsService) EditArtifactAndLogRetentionPeriodInOrganization(ctx context.Context, org string, period ArtifactPeriodOpt) (*Response, error) {
+	u := fmt.Sprintf("organizations/%v/actions/permissions/artifact-and-log-retention", org)
+	req, err := s.client.NewRequest("PUT", u, period)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -1022,6 +1022,30 @@ func (a *ArtifactList) GetTotalCount() int64 {
 	return *a.TotalCount
 }
 
+// GetDays returns the Days field if it's non-nil, zero value otherwise.
+func (a *ArtifactPeriod) GetDays() int {
+	if a == nil || a.Days == nil {
+		return 0
+	}
+	return *a.Days
+}
+
+// GetMaximumAllowedDays returns the MaximumAllowedDays field if it's non-nil, zero value otherwise.
+func (a *ArtifactPeriod) GetMaximumAllowedDays() int {
+	if a == nil || a.MaximumAllowedDays == nil {
+		return 0
+	}
+	return *a.MaximumAllowedDays
+}
+
+// GetDays returns the Days field if it's non-nil, zero value otherwise.
+func (a *ArtifactPeriodOpt) GetDays() int {
+	if a == nil || a.Days == nil {
+		return 0
+	}
+	return *a.Days
+}
+
 // GetHeadBranch returns the HeadBranch field if it's non-nil, zero value otherwise.
 func (a *ArtifactWorkflowRun) GetHeadBranch() string {
 	if a == nil || a.HeadBranch == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -1323,6 +1323,39 @@ func TestArtifactList_GetTotalCount(tt *testing.T) {
 	a.GetTotalCount()
 }
 
+func TestArtifactPeriod_GetDays(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	a := &ArtifactPeriod{Days: &zeroValue}
+	a.GetDays()
+	a = &ArtifactPeriod{}
+	a.GetDays()
+	a = nil
+	a.GetDays()
+}
+
+func TestArtifactPeriod_GetMaximumAllowedDays(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	a := &ArtifactPeriod{MaximumAllowedDays: &zeroValue}
+	a.GetMaximumAllowedDays()
+	a = &ArtifactPeriod{}
+	a.GetMaximumAllowedDays()
+	a = nil
+	a.GetMaximumAllowedDays()
+}
+
+func TestArtifactPeriodOpt_GetDays(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	a := &ArtifactPeriodOpt{Days: &zeroValue}
+	a.GetDays()
+	a = &ArtifactPeriodOpt{}
+	a.GetDays()
+	a = nil
+	a.GetDays()
+}
+
 func TestArtifactWorkflowRun_GetHeadBranch(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -96,6 +96,18 @@ func TestAdvancedSecurity_String(t *testing.T) {
 	}
 }
 
+func TestArtifactPeriod_String(t *testing.T) {
+	t.Parallel()
+	v := ArtifactPeriod{
+		Days:               Ptr(0),
+		MaximumAllowedDays: Ptr(0),
+	}
+	want := `github.ArtifactPeriod{Days:0, MaximumAllowedDays:0}`
+	if got := v.String(); got != want {
+		t.Errorf("ArtifactPeriod.String = %v, want %v", got, want)
+	}
+}
+
 func TestAuthorization_String(t *testing.T) {
 	t.Parallel()
 	v := Authorization{

--- a/github/repos_actions_permissions.go
+++ b/github/repos_actions_permissions.go
@@ -116,3 +116,40 @@ func (s *RepositoriesService) EditDefaultWorkflowPermissions(ctx context.Context
 
 	return p, resp, nil
 }
+
+// GetArtifactAndLogRetentionPeriod gets the artifact and log retention period for a repository.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/permissions#get-artifact-and-log-retention-settings-for-a-repository
+//
+//meta:operation GET /repos/{owner}/{repo}/actions/permissions/artifact-and-log-retention
+func (s *RepositoriesService) GetArtifactAndLogRetentionPeriod(ctx context.Context, owner, repo string) (*ArtifactPeriod, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/permissions/artifact-and-log-retention", owner, repo)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	arp := new(ArtifactPeriod)
+	resp, err := s.client.Do(ctx, req, arp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return arp, resp, nil
+}
+
+// EditArtifactAndLogRetentionPeriod sets the artifact and log retention period for a repository.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/permissions#set-artifact-and-log-retention-settings-for-a-repository
+//
+//meta:operation PUT /repos/{owner}/{repo}/actions/permissions/artifact-and-log-retention
+func (s *RepositoriesService) EditArtifactAndLogRetentionPeriod(ctx context.Context, owner, repo string, period ArtifactPeriodOpt) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/permissions/artifact-and-log-retention", owner, repo)
+	req, err := s.client.NewRequest("PUT", u, period)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/github/repos_actions_permissions_test.go
+++ b/github/repos_actions_permissions_test.go
@@ -189,3 +189,79 @@ func TestRepositoriesService_EditDefaultWorkflowPermissions(t *testing.T) {
 		return resp, err
 	})
 }
+
+func TestRepositoriesService_GetArtifactAndLogRetentionPeriod(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/repos/o/r/actions/permissions/artifact-and-log-retention", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"days": 90, "maximum_allowed_days": 365}`)
+	})
+
+	ctx := context.Background()
+	period, _, err := client.Repositories.GetArtifactAndLogRetentionPeriod(ctx, "o", "r")
+	if err != nil {
+		t.Errorf("Repositories.GetArtifactAndLogRetentionPeriod returned error: %v", err)
+	}
+
+	want := &ArtifactPeriod{
+		Days:               Ptr(90),
+		MaximumAllowedDays: Ptr(365),
+	}
+	if !cmp.Equal(period, want) {
+		t.Errorf("Repositories.GetArtifactAndLogRetentionPeriod = %+v, want %+v", period, want)
+	}
+
+	const methodName = "GetArtifactAndLogRetentionPeriod"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Repositories.GetArtifactAndLogRetentionPeriod(ctx, "\n", "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Repositories.GetArtifactAndLogRetentionPeriod(ctx, "o", "r")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestRepositoriesService_EditArtifactAndLogRetentionPeriod(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	input := &ArtifactPeriodOpt{Days: Ptr(90)}
+
+	mux.HandleFunc("/repos/o/r/actions/permissions/artifact-and-log-retention", func(w http.ResponseWriter, r *http.Request) {
+		v := new(ArtifactPeriodOpt)
+		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
+
+		testMethod(t, r, "PUT")
+		if !cmp.Equal(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Repositories.EditArtifactAndLogRetentionPeriod(ctx, "o", "r", *input)
+	if err != nil {
+		t.Errorf("Repositories.EditArtifactAndLogRetentionPeriod returned error: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("Repositories.EditArtifactAndLogRetentionPeriod = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+
+	const methodName = "EditArtifactAndLogRetentionPeriod"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Repositories.EditArtifactAndLogRetentionPeriod(ctx, "\n", "\n", *input)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Repositories.EditArtifactAndLogRetentionPeriod(ctx, "o", "r", *input)
+	})
+}


### PR DESCRIPTION
1 of 4 apis in #3660

The "Setting artifact and log retention periods" api for each of repos, organizations and enterprises.