### PR TITLE
chore: Enable gocritic.deprecatedComment check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
       enabled-checks:
         - commentedOutCode
         - commentFormatting
+        - deprecatedComment
         - paramTypeCombine
     goheader:
       values:


### PR DESCRIPTION
This PR enables https://go-critic.com/overview.html#deprecatedcomment to automatically detect cases like https://github.com/google/go-github/pull/3682#discussion_r2282118446