### PR TITLE
docs: Update CONTRIBUTING.md to clarify documentation requirements for exported types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ file.
 
 ## Code Comments
 
-Every exported method needs to have code comments that follow
+Every exported method and type needs to have code comments that follow
 [Go Doc Comments][]. A typical method's comments will look like this:
 
 ```go
@@ -102,9 +102,20 @@ Every exported method needs to have code comments that follow
 //
 //meta:operation GET /repos/{owner}/{repo}
 func (s *RepositoriesService) Get(ctx context.Context, owner, repo string) (*Repository, *Response, error) {
-u := fmt.Sprintf("repos/%v/%v", owner, repo)
-req, err := s.client.NewRequest("GET", u, nil)
-...
+    u := fmt.Sprintf("repos/%v/%v", owner, repo)
+    req, err := s.client.NewRequest("GET", u, nil)
+    ...
+}
+```
+And the returned type `Repository` will have comments like this:
+
+```go
+// Repository represents a GitHub repository.
+type Repository struct {
+    ID     *int64  `json:"id,omitempty"`
+    NodeID *string `json:"node_id,omitempty"`
+    Owner  *User   `json:"owner,omitempty"`
+    ...
 }
 ```
 


### PR DESCRIPTION
I noticed it in the #3666 but forgot to do in the former pr. I think it's better to notify the rule here as well.