### PR TITLE
add type to IssueListByRepoOptions and update ListByOrg to support type filter as well

### DIFF
--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -151,6 +151,7 @@ func TestIssuesService_ListByRepo(t *testing.T) {
 			"milestone": "*",
 			"state":     "closed",
 			"assignee":  "a",
+			"type":      "bug",
 			"creator":   "c",
 			"mentioned": "m",
 			"labels":    "a,b",
@@ -165,14 +166,14 @@ func TestIssuesService_ListByRepo(t *testing.T) {
 	})
 
 	opt := &IssueListByRepoOptions{
-		"*", "closed", "a", "c", "m", []string{"a", "b"}, "updated", "asc",
+		"*", "closed", "a", "bug", "c", "m", []string{"a", "b"}, "updated", "asc",
 		time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC),
 		ListCursorOptions{PerPage: 1, Before: "foo", After: "bar"}, ListOptions{0, 0},
 	}
 	ctx := context.Background()
 	issues, _, err := client.Issues.ListByRepo(ctx, "o", "r", opt)
 	if err != nil {
-		t.Errorf("Issues.ListByOrg returned error: %v", err)
+		t.Errorf("Issues.ListByRepo returned error: %v", err)
 	}
 
 	want := []*Issue{{Number: Ptr(1)}}


### PR DESCRIPTION
we now can pass the `Type` of an issue to list issues for repo and orgs, so we can have a better filtering

https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues

