### PR TITLE
Add type RepositoryAttachment for GetRepositoriesForCodeSecurityConfiguration

### DIFF
--- a/github/orgs_codesecurity_configurations.go
+++ b/github/orgs_codesecurity_configurations.go
@@ -16,6 +16,12 @@ type DependencyGraphAutosubmitActionOptions struct {
 	LabeledRunners *bool `json:"labeled_runners,omitempty"`
 }
 
+// RepositoryAttachment represents a repository attachment to a code security configuration.
+type RepositoryAttachment struct {
+	Status     *string     `json:"status"`
+	Repository *Repository `json:"repository"`
+}
+
 // CodeSecurityConfiguration represents a code security configuration.
 type CodeSecurityConfiguration struct {
 	ID                                     *int64                                  `json:"id,omitempty"`
@@ -247,7 +253,7 @@ func (s *OrganizationsService) SetDefaultCodeSecurityConfiguration(ctx context.C
 // GitHub API docs: https://docs.github.com/rest/code-security/configurations#get-repositories-associated-with-a-code-security-configuration
 //
 //meta:operation GET /orgs/{org}/code-security/configurations/{configuration_id}/repositories
-func (s *OrganizationsService) GetRepositoriesForCodeSecurityConfiguration(ctx context.Context, org string, id int64) ([]*Repository, *Response, error) {
+func (s *OrganizationsService) GetRepositoriesForCodeSecurityConfiguration(ctx context.Context, org string, id int64) ([]*RepositoryAttachment, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/code-security/configurations/%v/repositories", org, id)
 
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -255,12 +261,13 @@ func (s *OrganizationsService) GetRepositoriesForCodeSecurityConfiguration(ctx c
 		return nil, nil, err
 	}
 
-	var repositories []*Repository
-	resp, err := s.client.Do(ctx, req, &repositories)
+	var attachments []*RepositoryAttachment
+	resp, err := s.client.Do(ctx, req, &attachments)
 	if err != nil {
 		return nil, resp, err
 	}
-	return repositories, resp, nil
+
+	return attachments, resp, nil
 }
 
 // GetCodeSecurityConfigurationForRepository gets code security configuration that manages a repository's code security settings.

--- a/github/orgs_codesecurity_configurations_test.go
+++ b/github/orgs_codesecurity_configurations_test.go
@@ -415,26 +415,32 @@ func TestOrganizationsService_GetRepositoriesForCodeSecurityConfiguration(t *tes
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[
 		{
-			"id":8,
-			"name":"repo8"
+			"status": "attached",
+			"repository": {
+				"id":8,
+				"name":"repo8"
+			}
 		},
 		{
-			"id":42,
-			"name":"repo42"
-		}]`)
+			"status": "attached",
+			"repository": {
+				"id":42,
+				"name":"repo42"
+			}
+		}
+	]`)
 	})
 
-	repositories, _, err := client.Organizations.GetRepositoriesForCodeSecurityConfiguration(ctx, "o", 1)
+	attachments, _, err := client.Organizations.GetRepositoriesForCodeSecurityConfiguration(ctx, "o", 1)
 	if err != nil {
 		t.Errorf("Organizations.GetRepositoriesForCodeSecurityConfiguration returned error: %v", err)
 	}
-
-	want := []*Repository{
-		{ID: Ptr(int64(8)), Name: Ptr("repo8")},
-		{ID: Ptr(int64(42)), Name: Ptr("repo42")},
+	want := []*RepositoryAttachment{
+		{Status: Ptr("attached"), Repository: &Repository{ID: Ptr(int64(8)), Name: Ptr("repo8")}},
+		{Status: Ptr("attached"), Repository: &Repository{ID: Ptr(int64(42)), Name: Ptr("repo42")}},
 	}
-	if !reflect.DeepEqual(repositories, want) {
-		t.Errorf("Organizations.GetRepositoriesForCodeSecurityConfiguration returned %+v, want %+v", repositories, want)
+	if !reflect.DeepEqual(attachments, want) {
+		t.Errorf("Organizations.GetRepositoriesForCodeSecurityConfiguration returned %+v, want %+v", attachments, want)
 	}
 
 	const methodName = "GetRepositoriesForCodeSecurityConfiguration"


### PR DESCRIPTION
As mentioned in my comment under #3217 there is a problem with the way GetRepositoriesForCodeSecurityConfiguration unmarshales the API result data. This PR fixes that particular problem.

It does not necessarily fix the original issue as reported.