### PR TITLE
Bump Go toolchain to 1.24

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        go-version: [1.x, 1.23.0] # test with N and the .0 release of N-1
+        go-version: [1.x, 1.24.0] # test with N and the .0 release of N-1
         platform: [ubuntu-latest]
         include:
           # include windows, but only with the latest Go version, since there

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/go-github/v74/example
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371

--- a/example/newreposecretwithlibsodium/go.mod
+++ b/example/newreposecretwithlibsodium/go.mod
@@ -1,6 +1,6 @@
 module newreposecretwithlibsodium
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoKillers/libsodium-go v0.0.0-20171022220152-dd733721c3cb

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/go-github/v74
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/alecthomas/kong v1.12.1

--- a/tools/sliceofpointers/go.mod
+++ b/tools/sliceofpointers/go.mod
@@ -1,6 +1,6 @@
 module tools/sliceofpointers
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/golangci/plugin-module-register v0.1.1


### PR DESCRIPTION
This bumps the minimum version of the Go toolchain to 1.24 and should solve this issue:
https://github.com/google/go-github/actions/runs/17930082094/job/50985713799

```
testing scrape
go: go.mod requires go >= 1.24.0 (running go 1.23.0; GOTOOLCHAIN=local)
```