### PR TITLE
fix: Repositories.UpdateRulesetClearBypassActor sets BypassActors to empty slice

### DIFF
--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -174,7 +174,9 @@ func (s *RepositoriesService) UpdateRuleset(ctx context.Context, owner, repo str
 func (s *RepositoriesService) UpdateRulesetClearBypassActor(ctx context.Context, owner, repo string, rulesetID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/rulesets/%v", owner, repo, rulesetID)
 
-	rsClearBypassActor := rulesetClearBypassActors{}
+	rsClearBypassActor := rulesetClearBypassActors{
+		BypassActors: []*BypassActor{},
+	}
 
 	req, err := s.client.NewRequest("PUT", u, rsClearBypassActor)
 	if err != nil {


### PR DESCRIPTION
# Summary
Ensure bypass_actors is serialized as an empty array rather than null when clearing bypass actors in repository rulesets.
# Problem
As noted in #3726, the method Repositories.UpdateRulesetClearBypassActor constructs a rulesetClearBypassActors with BypassActors left at its zero value. In Go, the zero value for a slice (e.g., []*BypassActor) is nil, which serializes to null in JSON. The GitHub API requires bypass_actors to be an array, not null, and returns a 422 error
# Result
* Payload now includes bypass_actors: [] instead of null.
* Clearing bypass actors succeeds without a 422 error.
# References
#3726 
