### PR TITLE
feat: Support roles field in SCIM

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -25342,6 +25342,30 @@ func (s *SCIMUserName) GetFormatted() string {
 	return *s.Formatted
 }
 
+// GetDisplay returns the Display field if it's non-nil, zero value otherwise.
+func (s *SCIMUserRole) GetDisplay() string {
+	if s == nil || s.Display == nil {
+		return ""
+	}
+	return *s.Display
+}
+
+// GetPrimary returns the Primary field if it's non-nil, zero value otherwise.
+func (s *SCIMUserRole) GetPrimary() bool {
+	if s == nil || s.Primary == nil {
+		return false
+	}
+	return *s.Primary
+}
+
+// GetType returns the Type field if it's non-nil, zero value otherwise.
+func (s *SCIMUserRole) GetType() string {
+	if s == nil || s.Type == nil {
+		return ""
+	}
+	return *s.Type
+}
+
 // GetStatus returns the Status field if it's non-nil, zero value otherwise.
 func (s *SecretScanning) GetStatus() string {
 	if s == nil || s.Status == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -32666,6 +32666,39 @@ func TestSCIMUserName_GetFormatted(tt *testing.T) {
 	s.GetFormatted()
 }
 
+func TestSCIMUserRole_GetDisplay(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	s := &SCIMUserRole{Display: &zeroValue}
+	s.GetDisplay()
+	s = &SCIMUserRole{}
+	s.GetDisplay()
+	s = nil
+	s.GetDisplay()
+}
+
+func TestSCIMUserRole_GetPrimary(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	s := &SCIMUserRole{Primary: &zeroValue}
+	s.GetPrimary()
+	s = &SCIMUserRole{}
+	s.GetPrimary()
+	s = nil
+	s.GetPrimary()
+}
+
+func TestSCIMUserRole_GetType(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	s := &SCIMUserRole{Type: &zeroValue}
+	s.GetType()
+	s = &SCIMUserRole{}
+	s.GetType()
+	s = nil
+	s.GetType()
+}
+
 func TestSecretScanning_GetStatus(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/scim.go
+++ b/github/scim.go
@@ -39,7 +39,8 @@ type SCIMDisplayReference struct {
 
 // SCIMUserAttributes represents supported SCIM User attributes.
 //
-// GitHub API docs: https://docs.github.com/rest/scim#supported-scim-user-attributes
+// GitHub Enterprise Cloud API docs: https://docs.github.com/rest/scim#supported-scim-user-attributes
+// GitHub Enterprise Server API docs: https://docs.github.com/en/enterprise-server@latest/rest/enterprise-admin/scim?apiVersion=2022-11-28#supported-scim-user-attributes
 type SCIMUserAttributes struct {
 	UserName    string           `json:"userName"`              // Configured by the admin. Could be an email, login, or username. (Required.)
 	Name        SCIMUserName     `json:"name"`                  // (Required.)
@@ -48,6 +49,7 @@ type SCIMUserAttributes struct {
 	Schemas     []string         `json:"schemas,omitempty"`     // (Optional.)
 	ExternalID  *string          `json:"externalId,omitempty"`  // (Optional.)
 	Groups      []string         `json:"groups,omitempty"`      // (Optional.)
+	Roles       []*SCIMUserRole  `json:"roles,omitempty"`       // (Optional, GHES only.)
 	Active      *bool            `json:"active,omitempty"`      // (Optional.)
 	// Only populated as a result of calling ListSCIMProvisionedIdentitiesOptions or GetSCIMProvisioningInfoForUser:
 	ID   *string   `json:"id,omitempty"`
@@ -66,6 +68,18 @@ type SCIMUserEmail struct {
 	Value   string  `json:"value"`             // (Required.)
 	Primary *bool   `json:"primary,omitempty"` // (Optional.)
 	Type    *string `json:"type,omitempty"`    // (Optional.)
+}
+
+// SCIMUserRole is an enterprise-wide role granted to the user. This is only
+// supported in GitHub Enterprise Server, and not GitHub Enterprise Cloud.
+// See the docs for allowed role names.
+//
+// https://docs.github.com/en/enterprise-server@latest/rest/enterprise-admin/scim?apiVersion=2022-11-28#provision-a-scim-enterprise-user
+type SCIMUserRole struct {
+	Value   string  `json:"value"`             // (Required.)
+	Display *string `json:"display,omitempty"` // (Optional.)
+	Type    *string `json:"type,omitempty"`    // (Optional.)
+	Primary *bool   `json:"primary,omitempty"` // (Optional.)
 }
 
 // SCIMMeta represents metadata about the SCIM resource.

--- a/github/scim_test.go
+++ b/github/scim_test.go
@@ -621,6 +621,24 @@ func TestSCIMMeta_Marshal(t *testing.T) {
 	testJSONMarshal(t, u, want)
 }
 
+func TestSCIMUserRole_Marshal(t *testing.T) {
+	t.Parallel()
+
+	testJSONMarshal(t, &SCIMUserRole{
+		Value:   "enterprise_owner",
+		Primary: Bool(true),
+	}, `{
+		"value": "enterprise_owner",
+		"primary": true
+	}`)
+
+	r := &SCIMUserRole{
+		Value: "billing_manager",
+	}
+	want := `{"value": "billing_manager"}`
+	testJSONMarshal(t, r, want)
+}
+
 func TestSCIMProvisionedIdentities_Marshal(t *testing.T) {
 	t.Parallel()
 	testJSONMarshal(t, &SCIMProvisionedIdentities{}, `{}`)


### PR DESCRIPTION
GHES supports setting enterprise-wide role grants via the SCIM API. This can be used to grant enterprise owner, billing manager, etc.