### PR TITLE
Add `reason` field to `PullRequestEvent`

### DIFF
--- a/github/event_types.go
+++ b/github/event_types.go
@@ -1237,7 +1237,8 @@ type PullRequestEvent struct {
 	Repo          *Repository   `json:"repository,omitempty"`
 	Sender        *User         `json:"sender,omitempty"`
 	Installation  *Installation `json:"installation,omitempty"`
-	Label         *Label        `json:"label,omitempty"` // Populated in "labeled" event deliveries.
+	Label         *Label        `json:"label,omitempty"`  // Populated in "labeled" event deliveries.
+	Reason        *string       `json:"reason,omitempty"` // Populated in "dequeued" event deliveries.
 
 	// The following field is only present when the webhook is triggered on
 	// a repository belonging to an organization.

--- a/github/event_types_test.go
+++ b/github/event_types_test.go
@@ -16079,6 +16079,7 @@ func TestPullRequestEvent_Marshal(t *testing.T) {
 		},
 		RequestedTeam: &Team{ID: Ptr(int64(1))},
 		Label:         &Label{ID: Ptr(int64(1))},
+		Reason:        Ptr("CI_FAILURE"),
 		Before:        Ptr("before"),
 		After:         Ptr("after"),
 		Repo: &Repository{
@@ -16268,6 +16269,7 @@ func TestPullRequestEvent_Marshal(t *testing.T) {
 		"label": {
 			"id": 1
 		},
+		"reason": "CI_FAILURE",
 		"before": "before",
 		"after": "after",
 		"repository": {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -19918,6 +19918,14 @@ func (p *PullRequestEvent) GetPullRequest() *PullRequest {
 	return p.PullRequest
 }
 
+// GetReason returns the Reason field if it's non-nil, zero value otherwise.
+func (p *PullRequestEvent) GetReason() string {
+	if p == nil || p.Reason == nil {
+		return ""
+	}
+	return *p.Reason
+}
+
 // GetRepo returns the Repo field.
 func (p *PullRequestEvent) GetRepo() *Repository {
 	if p == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -25751,6 +25751,17 @@ func TestPullRequestEvent_GetPullRequest(tt *testing.T) {
 	p.GetPullRequest()
 }
 
+func TestPullRequestEvent_GetReason(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PullRequestEvent{Reason: &zeroValue}
+	p.GetReason()
+	p = &PullRequestEvent{}
+	p.GetReason()
+	p = nil
+	p.GetReason()
+}
+
 func TestPullRequestEvent_GetRepo(tt *testing.T) {
 	tt.Parallel()
 	p := &PullRequestEvent{}


### PR DESCRIPTION
## WHAT

- Add Reason *string field to PullRequestEvent struct
- Update tests to include new field in JSON marshaling
- Generate accessor method GetReason() with corresponding tests

## WHY

- Field is populated in 'dequeued' event deliveries
- Fixes: https://github.com/google/go-github/issues/3729