### PR TITLE
refactor!: Replace `Edit` with `Update` in permissions method names

### DIFF
--- a/example/actionpermissions/main.go
+++ b/example/actionpermissions/main.go
@@ -45,7 +45,7 @@ func main() {
 	fmt.Printf("Current ActionsPermissions %s\n", actionsPermissionsRepository.String())
 
 	actionsPermissionsRepository = &github.ActionsPermissionsRepository{Enabled: github.Ptr(true), AllowedActions: github.Ptr("selected")}
-	_, _, err = client.Repositories.EditActionsPermissions(ctx, *owner, *name, *actionsPermissionsRepository)
+	_, _, err = client.Repositories.UpdateActionsPermissions(ctx, *owner, *name, *actionsPermissionsRepository)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func main() {
 	fmt.Printf("Current ActionsAllowed %s\n", actionsAllowed.String())
 
 	actionsPermissionsRepository = &github.ActionsPermissionsRepository{Enabled: github.Ptr(true), AllowedActions: github.Ptr("all")}
-	_, _, err = client.Repositories.EditActionsPermissions(ctx, *owner, *name, *actionsPermissionsRepository)
+	_, _, err = client.Repositories.UpdateActionsPermissions(ctx, *owner, *name, *actionsPermissionsRepository)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/github/actions_permissions_enterprise.go
+++ b/github/actions_permissions_enterprise.go
@@ -68,12 +68,12 @@ func (s *ActionsService) GetActionsPermissionsInEnterprise(ctx context.Context, 
 	return permissions, resp, nil
 }
 
-// EditActionsPermissionsInEnterprise sets the permissions policy in an enterprise.
+// UpdateActionsPermissionsInEnterprise sets the permissions policy in an enterprise.
 //
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/actions/permissions#set-github-actions-permissions-for-an-enterprise
 //
 //meta:operation PUT /enterprises/{enterprise}/actions/permissions
-func (s *ActionsService) EditActionsPermissionsInEnterprise(ctx context.Context, enterprise string, actionsPermissionsEnterprise ActionsPermissionsEnterprise) (*ActionsPermissionsEnterprise, *Response, error) {
+func (s *ActionsService) UpdateActionsPermissionsInEnterprise(ctx context.Context, enterprise string, actionsPermissionsEnterprise ActionsPermissionsEnterprise) (*ActionsPermissionsEnterprise, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions", enterprise)
 	req, err := s.client.NewRequest("PUT", u, actionsPermissionsEnterprise)
 	if err != nil {
@@ -202,12 +202,12 @@ func (s *ActionsService) GetActionsAllowedInEnterprise(ctx context.Context, ente
 	return actionsAllowed, resp, nil
 }
 
-// EditActionsAllowedInEnterprise sets the actions that are allowed in an enterprise.
+// UpdateActionsAllowedInEnterprise sets the actions that are allowed in an enterprise.
 //
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/actions/permissions#set-allowed-actions-and-reusable-workflows-for-an-enterprise
 //
 //meta:operation PUT /enterprises/{enterprise}/actions/permissions/selected-actions
-func (s *ActionsService) EditActionsAllowedInEnterprise(ctx context.Context, enterprise string, actionsAllowed ActionsAllowed) (*ActionsAllowed, *Response, error) {
+func (s *ActionsService) UpdateActionsAllowedInEnterprise(ctx context.Context, enterprise string, actionsAllowed ActionsAllowed) (*ActionsAllowed, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/selected-actions", enterprise)
 	req, err := s.client.NewRequest("PUT", u, actionsAllowed)
 	if err != nil {
@@ -245,12 +245,12 @@ func (s *ActionsService) GetDefaultWorkflowPermissionsInEnterprise(ctx context.C
 	return permissions, resp, nil
 }
 
-// EditDefaultWorkflowPermissionsInEnterprise sets the GitHub Actions default workflow permissions for an enterprise.
+// UpdateDefaultWorkflowPermissionsInEnterprise sets the GitHub Actions default workflow permissions for an enterprise.
 //
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/actions/permissions#set-default-workflow-permissions-for-an-enterprise
 //
 //meta:operation PUT /enterprises/{enterprise}/actions/permissions/workflow
-func (s *ActionsService) EditDefaultWorkflowPermissionsInEnterprise(ctx context.Context, enterprise string, permissions DefaultWorkflowPermissionEnterprise) (*DefaultWorkflowPermissionEnterprise, *Response, error) {
+func (s *ActionsService) UpdateDefaultWorkflowPermissionsInEnterprise(ctx context.Context, enterprise string, permissions DefaultWorkflowPermissionEnterprise) (*DefaultWorkflowPermissionEnterprise, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/workflow", enterprise)
 	req, err := s.client.NewRequest("PUT", u, permissions)
 	if err != nil {
@@ -288,12 +288,12 @@ func (s *ActionsService) GetArtifactAndLogRetentionPeriodInEnterprise(ctx contex
 	return arp, resp, nil
 }
 
-// EditArtifactAndLogRetentionPeriodInEnterprise sets the artifact and log retention period for an enterprise.
+// UpdateArtifactAndLogRetentionPeriodInEnterprise sets the artifact and log retention period for an enterprise.
 //
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/actions/permissions#set-artifact-and-log-retention-settings-for-an-enterprise
 //
 //meta:operation PUT /enterprises/{enterprise}/actions/permissions/artifact-and-log-retention
-func (s *ActionsService) EditArtifactAndLogRetentionPeriodInEnterprise(ctx context.Context, enterprise string, period ArtifactPeriodOpt) (*Response, error) {
+func (s *ActionsService) UpdateArtifactAndLogRetentionPeriodInEnterprise(ctx context.Context, enterprise string, period ArtifactPeriodOpt) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/artifact-and-log-retention", enterprise)
 	req, err := s.client.NewRequest("PUT", u, period)
 	if err != nil {
@@ -324,12 +324,12 @@ func (s *ActionsService) GetSelfHostedRunnerPermissionsInEnterprise(ctx context.
 	return permissions, resp, nil
 }
 
-// EditSelfHostedRunnerPermissionsInEnterprise sets the self-hosted runner permissions for an enterprise.
+// UpdateSelfHostedRunnerPermissionsInEnterprise sets the self-hosted runner permissions for an enterprise.
 //
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/actions/permissions#set-self-hosted-runners-permissions-for-an-enterprise
 //
 //meta:operation PUT /enterprises/{enterprise}/actions/permissions/self-hosted-runners
-func (s *ActionsService) EditSelfHostedRunnerPermissionsInEnterprise(ctx context.Context, enterprise string, permissions SelfHostRunnerPermissionsEnterprise) (*Response, error) {
+func (s *ActionsService) UpdateSelfHostedRunnerPermissionsInEnterprise(ctx context.Context, enterprise string, permissions SelfHostRunnerPermissionsEnterprise) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/self-hosted-runners", enterprise)
 	req, err := s.client.NewRequest("PUT", u, permissions)
 	if err != nil {

--- a/github/actions_permissions_enterprise_test.go
+++ b/github/actions_permissions_enterprise_test.go
@@ -49,7 +49,7 @@ func TestActionsService_GetActionsPermissionsInEnterprise(t *testing.T) {
 	})
 }
 
-func TestActionsService_EditActionsPermissionsInEnterprise(t *testing.T) {
+func TestActionsService_UpdateActionsPermissionsInEnterprise(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -68,24 +68,24 @@ func TestActionsService_EditActionsPermissionsInEnterprise(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	ent, _, err := client.Actions.EditActionsPermissionsInEnterprise(ctx, "e", *input)
+	ent, _, err := client.Actions.UpdateActionsPermissionsInEnterprise(ctx, "e", *input)
 	if err != nil {
-		t.Errorf("Actions.EditActionsPermissionsInEnterprise returned error: %v", err)
+		t.Errorf("Actions.UpdateActionsPermissionsInEnterprise returned error: %v", err)
 	}
 
 	want := &ActionsPermissionsEnterprise{EnabledOrganizations: Ptr("all"), AllowedActions: Ptr("selected")}
 	if !cmp.Equal(ent, want) {
-		t.Errorf("Actions.EditActionsPermissionsInEnterprise returned %+v, want %+v", ent, want)
+		t.Errorf("Actions.UpdateActionsPermissionsInEnterprise returned %+v, want %+v", ent, want)
 	}
 
-	const methodName = "EditActionsPermissionsInEnterprise"
+	const methodName = "UpdateActionsPermissionsInEnterprise"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.EditActionsPermissionsInEnterprise(ctx, "\n", *input)
+		_, _, err = client.Actions.UpdateActionsPermissionsInEnterprise(ctx, "\n", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.EditActionsPermissionsInEnterprise(ctx, "e", *input)
+		got, resp, err := client.Actions.UpdateActionsPermissionsInEnterprise(ctx, "e", *input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -254,7 +254,7 @@ func TestActionsService_GetActionsAllowedInEnterprise(t *testing.T) {
 	})
 }
 
-func TestActionsService_EditActionsAllowedInEnterprise(t *testing.T) {
+func TestActionsService_UpdateActionsAllowedInEnterprise(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -273,24 +273,24 @@ func TestActionsService_EditActionsAllowedInEnterprise(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	ent, _, err := client.Actions.EditActionsAllowedInEnterprise(ctx, "e", *input)
+	ent, _, err := client.Actions.UpdateActionsAllowedInEnterprise(ctx, "e", *input)
 	if err != nil {
-		t.Errorf("Actions.EditActionsAllowedInEnterprise returned error: %v", err)
+		t.Errorf("Actions.UpdateActionsAllowedInEnterprise returned error: %v", err)
 	}
 
 	want := &ActionsAllowed{GithubOwnedAllowed: Ptr(true), VerifiedAllowed: Ptr(false), PatternsAllowed: []string{"a/b"}}
 	if !cmp.Equal(ent, want) {
-		t.Errorf("Actions.EditActionsAllowedInEnterprise returned %+v, want %+v", ent, want)
+		t.Errorf("Actions.UpdateActionsAllowedInEnterprise returned %+v, want %+v", ent, want)
 	}
 
-	const methodName = "EditActionsAllowedInEnterprise"
+	const methodName = "UpdateActionsAllowedInEnterprise"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.EditActionsAllowedInEnterprise(ctx, "\n", *input)
+		_, _, err = client.Actions.UpdateActionsAllowedInEnterprise(ctx, "\n", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.EditActionsAllowedInEnterprise(ctx, "e", *input)
+		got, resp, err := client.Actions.UpdateActionsAllowedInEnterprise(ctx, "e", *input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -332,7 +332,7 @@ func TestActionsService_GetDefaultWorkflowPermissionsInEnterprise(t *testing.T) 
 	})
 }
 
-func TestActionsService_EditDefaultWorkflowPermissionsInEnterprise(t *testing.T) {
+func TestActionsService_UpdateDefaultWorkflowPermissionsInEnterprise(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -351,24 +351,24 @@ func TestActionsService_EditDefaultWorkflowPermissionsInEnterprise(t *testing.T)
 	})
 
 	ctx := context.Background()
-	ent, _, err := client.Actions.EditDefaultWorkflowPermissionsInEnterprise(ctx, "e", *input)
+	ent, _, err := client.Actions.UpdateDefaultWorkflowPermissionsInEnterprise(ctx, "e", *input)
 	if err != nil {
-		t.Errorf("Actions.EditDefaultWorkflowPermissionsInEnterprise returned error: %v", err)
+		t.Errorf("Actions.UpdateDefaultWorkflowPermissionsInEnterprise returned error: %v", err)
 	}
 
 	want := &DefaultWorkflowPermissionEnterprise{DefaultWorkflowPermissions: Ptr("read"), CanApprovePullRequestReviews: Ptr(true)}
 	if !cmp.Equal(ent, want) {
-		t.Errorf("Actions.EditDefaultWorkflowPermissionsInEnterprise returned %+v, want %+v", ent, want)
+		t.Errorf("Actions.UpdateDefaultWorkflowPermissionsInEnterprise returned %+v, want %+v", ent, want)
 	}
 
-	const methodName = "EditDefaultWorkflowPermissionsInEnterprise"
+	const methodName = "UpdateDefaultWorkflowPermissionsInEnterprise"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.EditDefaultWorkflowPermissionsInEnterprise(ctx, "\n", *input)
+		_, _, err = client.Actions.UpdateDefaultWorkflowPermissionsInEnterprise(ctx, "\n", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.EditDefaultWorkflowPermissionsInEnterprise(ctx, "e", *input)
+		got, resp, err := client.Actions.UpdateDefaultWorkflowPermissionsInEnterprise(ctx, "e", *input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -414,7 +414,7 @@ func TestActionsService_GetArtifactAndLogRetentionPeriodInEnterprise(t *testing.
 	})
 }
 
-func TestActionsService_EditArtifactAndLogRetentionPeriodInEnterprise(t *testing.T) {
+func TestActionsService_UpdateArtifactAndLogRetentionPeriodInEnterprise(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -432,23 +432,23 @@ func TestActionsService_EditArtifactAndLogRetentionPeriodInEnterprise(t *testing
 	})
 
 	ctx := context.Background()
-	resp, err := client.Actions.EditArtifactAndLogRetentionPeriodInEnterprise(ctx, "e", *input)
+	resp, err := client.Actions.UpdateArtifactAndLogRetentionPeriodInEnterprise(ctx, "e", *input)
 	if err != nil {
-		t.Errorf("Actions.EditArtifactAndLogRetentionPeriodInEnterprise returned error: %v", err)
+		t.Errorf("Actions.UpdateArtifactAndLogRetentionPeriodInEnterprise returned error: %v", err)
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		t.Errorf("Actions.EditArtifactAndLogRetentionPeriodInEnterprise = %d, want %d", resp.StatusCode, http.StatusNoContent)
+		t.Errorf("Actions.UpdateArtifactAndLogRetentionPeriodInEnterprise = %d, want %d", resp.StatusCode, http.StatusNoContent)
 	}
 
-	const methodName = "EditArtifactAndLogRetentionPeriodInEnterprise"
+	const methodName = "UpdateArtifactAndLogRetentionPeriodInEnterprise"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.EditArtifactAndLogRetentionPeriodInEnterprise(ctx, "\n", *input)
+		_, err = client.Actions.UpdateArtifactAndLogRetentionPeriodInEnterprise(ctx, "\n", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.EditArtifactAndLogRetentionPeriodInEnterprise(ctx, "e", *input)
+		return client.Actions.UpdateArtifactAndLogRetentionPeriodInEnterprise(ctx, "e", *input)
 	})
 }
 
@@ -486,7 +486,7 @@ func TestActionsService_GetSelfHostedRunnerPermissionsInEnterprise(t *testing.T)
 	})
 }
 
-func TestActionsService_EditSelfHostedRunnerPermissionsInEnterprise(t *testing.T) {
+func TestActionsService_UpdateSelfHostedRunnerPermissionsInEnterprise(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -504,23 +504,23 @@ func TestActionsService_EditSelfHostedRunnerPermissionsInEnterprise(t *testing.T
 	})
 
 	ctx := context.Background()
-	resp, err := client.Actions.EditSelfHostedRunnerPermissionsInEnterprise(ctx, "e", *input)
+	resp, err := client.Actions.UpdateSelfHostedRunnerPermissionsInEnterprise(ctx, "e", *input)
 	if err != nil {
-		t.Errorf("Actions.EditSelfHostedRunnerPermissionsInEnterprise returned error: %v", err)
+		t.Errorf("Actions.UpdateSelfHostedRunnerPermissionsInEnterprise returned error: %v", err)
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		t.Errorf("Actions.EditSelfHostedRunnerPermissionsInEnterprise = %d, want %d", resp.StatusCode, http.StatusNoContent)
+		t.Errorf("Actions.UpdateSelfHostedRunnerPermissionsInEnterprise = %d, want %d", resp.StatusCode, http.StatusNoContent)
 	}
 
-	const methodName = "EditSelfHostedRunnerPermissionsInEnterprise"
+	const methodName = "UpdateSelfHostedRunnerPermissionsInEnterprise"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.EditSelfHostedRunnerPermissionsInEnterprise(ctx, "\n", *input)
+		_, err = client.Actions.UpdateSelfHostedRunnerPermissionsInEnterprise(ctx, "\n", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.EditSelfHostedRunnerPermissionsInEnterprise(ctx, "e", *input)
+		return client.Actions.UpdateSelfHostedRunnerPermissionsInEnterprise(ctx, "e", *input)
 	})
 }
 

--- a/github/actions_permissions_orgs.go
+++ b/github/actions_permissions_orgs.go
@@ -87,12 +87,12 @@ func (s *ActionsService) GetActionsPermissions(ctx context.Context, org string) 
 	return permissions, resp, nil
 }
 
-// EditActionsPermissions sets the permissions policy for repositories and allowed actions in an organization.
+// UpdateActionsPermissions sets the permissions policy for repositories and allowed actions in an organization.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/permissions#set-github-actions-permissions-for-an-organization
 //
 //meta:operation PUT /orgs/{org}/actions/permissions
-func (s *ActionsService) EditActionsPermissions(ctx context.Context, org string, actionsPermissions ActionsPermissions) (*ActionsPermissions, *Response, error) {
+func (s *ActionsService) UpdateActionsPermissions(ctx context.Context, org string, actionsPermissions ActionsPermissions) (*ActionsPermissions, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions", org)
 	req, err := s.client.NewRequest("PUT", u, actionsPermissions)
 	if err != nil {
@@ -221,12 +221,12 @@ func (s *ActionsService) GetActionsAllowed(ctx context.Context, org string) (*Ac
 	return actionsAllowed, resp, nil
 }
 
-// EditActionsAllowed sets the actions that are allowed in an organization.
+// UpdateActionsAllowed sets the actions that are allowed in an organization.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/permissions#set-allowed-actions-and-reusable-workflows-for-an-organization
 //
 //meta:operation PUT /orgs/{org}/actions/permissions/selected-actions
-func (s *ActionsService) EditActionsAllowed(ctx context.Context, org string, actionsAllowed ActionsAllowed) (*ActionsAllowed, *Response, error) {
+func (s *ActionsService) UpdateActionsAllowed(ctx context.Context, org string, actionsAllowed ActionsAllowed) (*ActionsAllowed, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/selected-actions", org)
 	req, err := s.client.NewRequest("PUT", u, actionsAllowed)
 	if err != nil {
@@ -264,12 +264,12 @@ func (s *ActionsService) GetDefaultWorkflowPermissionsInOrganization(ctx context
 	return permissions, resp, nil
 }
 
-// EditDefaultWorkflowPermissionsInOrganization sets the GitHub Actions default workflow permissions for an organization.
+// UpdateDefaultWorkflowPermissionsInOrganization sets the GitHub Actions default workflow permissions for an organization.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/permissions#set-default-workflow-permissions-for-an-organization
 //
 //meta:operation PUT /orgs/{org}/actions/permissions/workflow
-func (s *ActionsService) EditDefaultWorkflowPermissionsInOrganization(ctx context.Context, org string, permissions DefaultWorkflowPermissionOrganization) (*DefaultWorkflowPermissionOrganization, *Response, error) {
+func (s *ActionsService) UpdateDefaultWorkflowPermissionsInOrganization(ctx context.Context, org string, permissions DefaultWorkflowPermissionOrganization) (*DefaultWorkflowPermissionOrganization, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/workflow", org)
 	req, err := s.client.NewRequest("PUT", u, permissions)
 	if err != nil {
@@ -307,12 +307,12 @@ func (s *ActionsService) GetArtifactAndLogRetentionPeriodInOrganization(ctx cont
 	return arp, resp, nil
 }
 
-// EditArtifactAndLogRetentionPeriodInOrganization sets the artifact and log retention period for an organization.
+// UpdateArtifactAndLogRetentionPeriodInOrganization sets the artifact and log retention period for an organization.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/permissions#set-artifact-and-log-retention-settings-for-an-organization
 //
 //meta:operation PUT /orgs/{org}/actions/permissions/artifact-and-log-retention
-func (s *ActionsService) EditArtifactAndLogRetentionPeriodInOrganization(ctx context.Context, org string, period ArtifactPeriodOpt) (*Response, error) {
+func (s *ActionsService) UpdateArtifactAndLogRetentionPeriodInOrganization(ctx context.Context, org string, period ArtifactPeriodOpt) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/artifact-and-log-retention", org)
 	req, err := s.client.NewRequest("PUT", u, period)
 	if err != nil {
@@ -344,12 +344,12 @@ func (s *ActionsService) GetSelfHostedRunnersSettingsInOrganization(ctx context.
 	return settings, resp, nil
 }
 
-// EditSelfHostedRunnersSettingsInOrganization sets the self-hosted runners permissions settings for repositories in an organization.
+// UpdateSelfHostedRunnersSettingsInOrganization sets the self-hosted runners permissions settings for repositories in an organization.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/permissions#set-self-hosted-runners-settings-for-an-organization
 //
 //meta:operation PUT /orgs/{org}/actions/permissions/self-hosted-runners
-func (s *ActionsService) EditSelfHostedRunnersSettingsInOrganization(ctx context.Context, org string, opt SelfHostedRunnersSettingsOrganizationOpt) (*Response, error) {
+func (s *ActionsService) UpdateSelfHostedRunnersSettingsInOrganization(ctx context.Context, org string, opt SelfHostedRunnersSettingsOrganizationOpt) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/self-hosted-runners", org)
 
 	req, err := s.client.NewRequest("PUT", u, opt)

--- a/github/actions_permissions_orgs_test.go
+++ b/github/actions_permissions_orgs_test.go
@@ -49,7 +49,7 @@ func TestActionsService_GetActionsPermissions(t *testing.T) {
 	})
 }
 
-func TestActionsService_EditActionsPermissions(t *testing.T) {
+func TestActionsService_UpdateActionsPermissions(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -68,24 +68,24 @@ func TestActionsService_EditActionsPermissions(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	org, _, err := client.Actions.EditActionsPermissions(ctx, "o", *input)
+	org, _, err := client.Actions.UpdateActionsPermissions(ctx, "o", *input)
 	if err != nil {
-		t.Errorf("Actions.EditActionsPermissions returned error: %v", err)
+		t.Errorf("Actions.UpdateActionsPermissions returned error: %v", err)
 	}
 
 	want := &ActionsPermissions{EnabledRepositories: Ptr("all"), AllowedActions: Ptr("selected")}
 	if !cmp.Equal(org, want) {
-		t.Errorf("Actions.EditActionsPermissions returned %+v, want %+v", org, want)
+		t.Errorf("Actions.UpdateActionsPermissions returned %+v, want %+v", org, want)
 	}
 
-	const methodName = "EditActionsPermissions"
+	const methodName = "UpdateActionsPermissions"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.EditActionsPermissions(ctx, "\n", *input)
+		_, _, err = client.Actions.UpdateActionsPermissions(ctx, "\n", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.EditActionsPermissions(ctx, "o", *input)
+		got, resp, err := client.Actions.UpdateActionsPermissions(ctx, "o", *input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -254,7 +254,7 @@ func TestActionsService_GetActionsAllowed(t *testing.T) {
 	})
 }
 
-func TestActionsService_EditActionsAllowed(t *testing.T) {
+func TestActionsService_UpdateActionsAllowed(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -273,24 +273,24 @@ func TestActionsService_EditActionsAllowed(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	org, _, err := client.Actions.EditActionsAllowed(ctx, "o", *input)
+	org, _, err := client.Actions.UpdateActionsAllowed(ctx, "o", *input)
 	if err != nil {
-		t.Errorf("Actions.EditActionsAllowed returned error: %v", err)
+		t.Errorf("Actions.UpdateActionsAllowed returned error: %v", err)
 	}
 
 	want := &ActionsAllowed{GithubOwnedAllowed: Ptr(true), VerifiedAllowed: Ptr(false), PatternsAllowed: []string{"a/b"}}
 	if !cmp.Equal(org, want) {
-		t.Errorf("Actions.EditActionsAllowed returned %+v, want %+v", org, want)
+		t.Errorf("Actions.UpdateActionsAllowed returned %+v, want %+v", org, want)
 	}
 
-	const methodName = "EditActionsAllowed"
+	const methodName = "UpdateActionsAllowed"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.EditActionsAllowed(ctx, "\n", *input)
+		_, _, err = client.Actions.UpdateActionsAllowed(ctx, "\n", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.EditActionsAllowed(ctx, "o", *input)
+		got, resp, err := client.Actions.UpdateActionsAllowed(ctx, "o", *input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -372,7 +372,7 @@ func TestActionsService_GetDefaultWorkflowPermissionsInOrganization(t *testing.T
 	})
 }
 
-func TestActionsService_EditDefaultWorkflowPermissionsInOrganization(t *testing.T) {
+func TestActionsService_UpdateDefaultWorkflowPermissionsInOrganization(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -391,24 +391,24 @@ func TestActionsService_EditDefaultWorkflowPermissionsInOrganization(t *testing.
 	})
 
 	ctx := context.Background()
-	org, _, err := client.Actions.EditDefaultWorkflowPermissionsInOrganization(ctx, "o", *input)
+	org, _, err := client.Actions.UpdateDefaultWorkflowPermissionsInOrganization(ctx, "o", *input)
 	if err != nil {
-		t.Errorf("Actions.EditDefaultWorkflowPermissionsInOrganization returned error: %v", err)
+		t.Errorf("Actions.UpdateDefaultWorkflowPermissionsInOrganization returned error: %v", err)
 	}
 
 	want := &DefaultWorkflowPermissionOrganization{DefaultWorkflowPermissions: Ptr("read"), CanApprovePullRequestReviews: Ptr(true)}
 	if !cmp.Equal(org, want) {
-		t.Errorf("Actions.EditDefaultWorkflowPermissionsInOrganization returned %+v, want %+v", org, want)
+		t.Errorf("Actions.UpdateDefaultWorkflowPermissionsInOrganization returned %+v, want %+v", org, want)
 	}
 
-	const methodName = "EditDefaultWorkflowPermissionsInOrganization"
+	const methodName = "UpdateDefaultWorkflowPermissionsInOrganization"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.EditDefaultWorkflowPermissionsInOrganization(ctx, "\n", *input)
+		_, _, err = client.Actions.UpdateDefaultWorkflowPermissionsInOrganization(ctx, "\n", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.EditDefaultWorkflowPermissionsInOrganization(ctx, "o", *input)
+		got, resp, err := client.Actions.UpdateDefaultWorkflowPermissionsInOrganization(ctx, "o", *input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -454,7 +454,7 @@ func TestActionsService_GetArtifactAndLogRetentionPeriodInOrganization(t *testin
 	})
 }
 
-func TestActionsService_EditArtifactAndLogRetentionPeriodInOrganization(t *testing.T) {
+func TestActionsService_UpdateArtifactAndLogRetentionPeriodInOrganization(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -472,23 +472,23 @@ func TestActionsService_EditArtifactAndLogRetentionPeriodInOrganization(t *testi
 	})
 
 	ctx := context.Background()
-	resp, err := client.Actions.EditArtifactAndLogRetentionPeriodInOrganization(ctx, "o", *input)
+	resp, err := client.Actions.UpdateArtifactAndLogRetentionPeriodInOrganization(ctx, "o", *input)
 	if err != nil {
-		t.Errorf("Actions.EditArtifactAndLogRetentionPeriodInOrganization returned error: %v", err)
+		t.Errorf("Actions.UpdateArtifactAndLogRetentionPeriodInOrganization returned error: %v", err)
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		t.Errorf("Actions.EditArtifactAndLogRetentionPeriodInOrganization = %d, want %d", resp.StatusCode, http.StatusNoContent)
+		t.Errorf("Actions.UpdateArtifactAndLogRetentionPeriodInOrganization = %d, want %d", resp.StatusCode, http.StatusNoContent)
 	}
 
-	const methodName = "EditArtifactAndLogRetentionPeriodInOrganization"
+	const methodName = "UpdateArtifactAndLogRetentionPeriodInOrganization"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.EditArtifactAndLogRetentionPeriodInOrganization(ctx, "\n", *input)
+		_, err = client.Actions.UpdateArtifactAndLogRetentionPeriodInOrganization(ctx, "\n", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.EditArtifactAndLogRetentionPeriodInOrganization(ctx, "o", *input)
+		return client.Actions.UpdateArtifactAndLogRetentionPeriodInOrganization(ctx, "o", *input)
 	})
 }
 
@@ -529,7 +529,7 @@ func TestActionsService_GetSelfHostedRunnersSettingsInOrganization(t *testing.T)
 	})
 }
 
-func TestActionsService_EditSelfHostedRunnersSettingsInOrganization(t *testing.T) {
+func TestActionsService_UpdateSelfHostedRunnersSettingsInOrganization(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -547,23 +547,23 @@ func TestActionsService_EditSelfHostedRunnersSettingsInOrganization(t *testing.T
 	})
 
 	ctx := context.Background()
-	resp, err := client.Actions.EditSelfHostedRunnersSettingsInOrganization(ctx, "o", *input)
+	resp, err := client.Actions.UpdateSelfHostedRunnersSettingsInOrganization(ctx, "o", *input)
 	if err != nil {
-		t.Errorf("Actions.EditSelfHostedRunnersSettingsInOrganization returned error: %v", err)
+		t.Errorf("Actions.UpdateSelfHostedRunnersSettingsInOrganization returned error: %v", err)
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		t.Errorf("Actions.EditSelfHostedRunnersSettingsInOrganization = %d, want %d", resp.StatusCode, http.StatusNoContent)
+		t.Errorf("Actions.UpdateSelfHostedRunnersSettingsInOrganization = %d, want %d", resp.StatusCode, http.StatusNoContent)
 	}
 
-	const methodName = "EditSelfHostedRunnersSettingsInOrganization"
+	const methodName = "UpdateSelfHostedRunnersSettingsInOrganization"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.EditSelfHostedRunnersSettingsInOrganization(ctx, "\n", *input)
+		_, err = client.Actions.UpdateSelfHostedRunnersSettingsInOrganization(ctx, "\n", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.EditSelfHostedRunnersSettingsInOrganization(ctx, "o", *input)
+		return client.Actions.UpdateSelfHostedRunnersSettingsInOrganization(ctx, "o", *input)
 	})
 }
 

--- a/github/orgs_actions_allowed.go
+++ b/github/orgs_actions_allowed.go
@@ -21,14 +21,14 @@ func (s *OrganizationsService) GetActionsAllowed(ctx context.Context, org string
 	return s2.GetActionsAllowed(ctx, org)
 }
 
-// EditActionsAllowed sets the actions that are allowed in an organization.
+// UpdateActionsAllowed sets the actions that are allowed in an organization.
 //
-// Deprecated: please use `client.Actions.EditActionsAllowed` instead.
+// Deprecated: please use `client.Actions.UpdateActionsAllowed` instead.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/permissions#set-allowed-actions-and-reusable-workflows-for-an-organization
 //
 //meta:operation PUT /orgs/{org}/actions/permissions/selected-actions
-func (s *OrganizationsService) EditActionsAllowed(ctx context.Context, org string, actionsAllowed ActionsAllowed) (*ActionsAllowed, *Response, error) {
+func (s *OrganizationsService) UpdateActionsAllowed(ctx context.Context, org string, actionsAllowed ActionsAllowed) (*ActionsAllowed, *Response, error) {
 	s2 := (*ActionsService)(s)
-	return s2.EditActionsAllowed(ctx, org, actionsAllowed)
+	return s2.UpdateActionsAllowed(ctx, org, actionsAllowed)
 }

--- a/github/orgs_actions_allowed_test.go
+++ b/github/orgs_actions_allowed_test.go
@@ -49,7 +49,7 @@ func TestOrganizationsService_GetActionsAllowed(t *testing.T) {
 	})
 }
 
-func TestOrganizationsService_EditActionsAllowed(t *testing.T) {
+func TestOrganizationsService_UpdateActionsAllowed(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -68,24 +68,24 @@ func TestOrganizationsService_EditActionsAllowed(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	org, _, err := client.Organizations.EditActionsAllowed(ctx, "o", *input)
+	org, _, err := client.Organizations.UpdateActionsAllowed(ctx, "o", *input)
 	if err != nil {
-		t.Errorf("Organizations.EditActionsAllowed returned error: %v", err)
+		t.Errorf("Organizations.UpdateActionsAllowed returned error: %v", err)
 	}
 
 	want := &ActionsAllowed{GithubOwnedAllowed: Ptr(true), VerifiedAllowed: Ptr(false), PatternsAllowed: []string{"a/b"}}
 	if !cmp.Equal(org, want) {
-		t.Errorf("Organizations.EditActionsAllowed returned %+v, want %+v", org, want)
+		t.Errorf("Organizations.UpdateActionsAllowed returned %+v, want %+v", org, want)
 	}
 
-	const methodName = "EditActionsAllowed"
+	const methodName = "UpdateActionsAllowed"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Organizations.EditActionsAllowed(ctx, "\n", *input)
+		_, _, err = client.Organizations.UpdateActionsAllowed(ctx, "\n", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Organizations.EditActionsAllowed(ctx, "o", *input)
+		got, resp, err := client.Organizations.UpdateActionsAllowed(ctx, "o", *input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/github/orgs_actions_permissions.go
+++ b/github/orgs_actions_permissions.go
@@ -21,14 +21,14 @@ func (s *OrganizationsService) GetActionsPermissions(ctx context.Context, org st
 	return s2.GetActionsPermissions(ctx, org)
 }
 
-// EditActionsPermissions sets the permissions policy for repositories and allowed actions in an organization.
+// UpdateActionsPermissions sets the permissions policy for repositories and allowed actions in an organization.
 //
-// Deprecated: please use `client.Actions.EditActionsPermissions` instead.
+// Deprecated: please use `client.Actions.UpdateActionsPermissions` instead.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/permissions#set-github-actions-permissions-for-an-organization
 //
 //meta:operation PUT /orgs/{org}/actions/permissions
-func (s *OrganizationsService) EditActionsPermissions(ctx context.Context, org string, actionsPermissions ActionsPermissions) (*ActionsPermissions, *Response, error) {
+func (s *OrganizationsService) UpdateActionsPermissions(ctx context.Context, org string, actionsPermissions ActionsPermissions) (*ActionsPermissions, *Response, error) {
 	s2 := (*ActionsService)(s)
-	return s2.EditActionsPermissions(ctx, org, actionsPermissions)
+	return s2.UpdateActionsPermissions(ctx, org, actionsPermissions)
 }

--- a/github/orgs_actions_permissions_test.go
+++ b/github/orgs_actions_permissions_test.go
@@ -49,7 +49,7 @@ func TestOrganizationsService_GetActionsPermissions(t *testing.T) {
 	})
 }
 
-func TestOrganizationsService_EditActionsPermissions(t *testing.T) {
+func TestOrganizationsService_UpdateActionsPermissions(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -68,24 +68,24 @@ func TestOrganizationsService_EditActionsPermissions(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	org, _, err := client.Organizations.EditActionsPermissions(ctx, "o", *input)
+	org, _, err := client.Organizations.UpdateActionsPermissions(ctx, "o", *input)
 	if err != nil {
-		t.Errorf("Organizations.EditActionsPermissions returned error: %v", err)
+		t.Errorf("Organizations.UpdateActionsPermissions returned error: %v", err)
 	}
 
 	want := &ActionsPermissions{EnabledRepositories: Ptr("all"), AllowedActions: Ptr("selected")}
 	if !cmp.Equal(org, want) {
-		t.Errorf("Organizations.EditActionsPermissions returned %+v, want %+v", org, want)
+		t.Errorf("Organizations.UpdateActionsPermissions returned %+v, want %+v", org, want)
 	}
 
-	const methodName = "EditActionsPermissions"
+	const methodName = "UpdateActionsPermissions"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Organizations.EditActionsPermissions(ctx, "\n", *input)
+		_, _, err = client.Organizations.UpdateActionsPermissions(ctx, "\n", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Organizations.EditActionsPermissions(ctx, "o", *input)
+		got, resp, err := client.Organizations.UpdateActionsPermissions(ctx, "o", *input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/github/repos_actions_allowed_test.go
+++ b/github/repos_actions_allowed_test.go
@@ -49,7 +49,7 @@ func TestRepositoryService_GetActionsAllowed(t *testing.T) {
 	})
 }
 
-func TestRepositoriesService_EditActionsAllowed(t *testing.T) {
+func TestRepositoriesService_UpdateActionsAllowed(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -70,15 +70,15 @@ func TestRepositoriesService_EditActionsAllowed(t *testing.T) {
 	ctx := context.Background()
 	org, _, err := client.Repositories.EditActionsAllowed(ctx, "o", "r", *input)
 	if err != nil {
-		t.Errorf("Repositories.EditActionsAllowed returned error: %v", err)
+		t.Errorf("Repositories.UpdateActionsAllowed returned error: %v", err)
 	}
 
 	want := &ActionsAllowed{GithubOwnedAllowed: Ptr(true), VerifiedAllowed: Ptr(false), PatternsAllowed: []string{"a/b"}}
 	if !cmp.Equal(org, want) {
-		t.Errorf("Repositories.EditActionsAllowed returned %+v, want %+v", org, want)
+		t.Errorf("Repositories.UpdateActionsAllowed returned %+v, want %+v", org, want)
 	}
 
-	const methodName = "EditActionsAllowed"
+	const methodName = "UpdateActionsAllowed"
 	testBadOptions(t, methodName, func() (err error) {
 		_, _, err = client.Repositories.EditActionsAllowed(ctx, "\n", "\n", *input)
 		return err

--- a/github/repos_actions_permissions.go
+++ b/github/repos_actions_permissions.go
@@ -53,12 +53,12 @@ func (s *RepositoriesService) GetActionsPermissions(ctx context.Context, owner, 
 	return permissions, resp, nil
 }
 
-// EditActionsPermissions sets the permissions policy for repositories and allowed actions in a repository.
+// UpdateActionsPermissions sets the permissions policy for repositories and allowed actions in a repository.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/permissions#set-github-actions-permissions-for-a-repository
 //
 //meta:operation PUT /repos/{owner}/{repo}/actions/permissions
-func (s *RepositoriesService) EditActionsPermissions(ctx context.Context, owner, repo string, actionsPermissionsRepository ActionsPermissionsRepository) (*ActionsPermissionsRepository, *Response, error) {
+func (s *RepositoriesService) UpdateActionsPermissions(ctx context.Context, owner, repo string, actionsPermissionsRepository ActionsPermissionsRepository) (*ActionsPermissionsRepository, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions", owner, repo)
 	req, err := s.client.NewRequest("PUT", u, actionsPermissionsRepository)
 	if err != nil {
@@ -96,12 +96,12 @@ func (s *RepositoriesService) GetDefaultWorkflowPermissions(ctx context.Context,
 	return permissions, resp, nil
 }
 
-// EditDefaultWorkflowPermissions sets the GitHub Actions default workflow permissions in a repository.
+// UpdateDefaultWorkflowPermissions sets the GitHub Actions default workflow permissions in a repository.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/permissions#set-default-workflow-permissions-for-a-repository
 //
 //meta:operation PUT /repos/{owner}/{repo}/actions/permissions/workflow
-func (s *RepositoriesService) EditDefaultWorkflowPermissions(ctx context.Context, owner, repo string, permissions DefaultWorkflowPermissionRepository) (*DefaultWorkflowPermissionRepository, *Response, error) {
+func (s *RepositoriesService) UpdateDefaultWorkflowPermissions(ctx context.Context, owner, repo string, permissions DefaultWorkflowPermissionRepository) (*DefaultWorkflowPermissionRepository, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions/workflow", owner, repo)
 	req, err := s.client.NewRequest("PUT", u, permissions)
 	if err != nil {
@@ -139,12 +139,12 @@ func (s *RepositoriesService) GetArtifactAndLogRetentionPeriod(ctx context.Conte
 	return arp, resp, nil
 }
 
-// EditArtifactAndLogRetentionPeriod sets the artifact and log retention period for a repository.
+// UpdateArtifactAndLogRetentionPeriod sets the artifact and log retention period for a repository.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/permissions#set-artifact-and-log-retention-settings-for-a-repository
 //
 //meta:operation PUT /repos/{owner}/{repo}/actions/permissions/artifact-and-log-retention
-func (s *RepositoriesService) EditArtifactAndLogRetentionPeriod(ctx context.Context, owner, repo string, period ArtifactPeriodOpt) (*Response, error) {
+func (s *RepositoriesService) UpdateArtifactAndLogRetentionPeriod(ctx context.Context, owner, repo string, period ArtifactPeriodOpt) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions/artifact-and-log-retention", owner, repo)
 	req, err := s.client.NewRequest("PUT", u, period)
 	if err != nil {

--- a/github/repos_actions_permissions_test.go
+++ b/github/repos_actions_permissions_test.go
@@ -49,7 +49,7 @@ func TestRepositoriesService_GetActionsPermissions(t *testing.T) {
 	})
 }
 
-func TestRepositoriesService_EditActionsPermissions(t *testing.T) {
+func TestRepositoriesService_UpdateActionsPermissions(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -68,24 +68,24 @@ func TestRepositoriesService_EditActionsPermissions(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	org, _, err := client.Repositories.EditActionsPermissions(ctx, "o", "r", *input)
+	org, _, err := client.Repositories.UpdateActionsPermissions(ctx, "o", "r", *input)
 	if err != nil {
-		t.Errorf("Repositories.EditActionsPermissions returned error: %v", err)
+		t.Errorf("Repositories.UpdateActionsPermissions returned error: %v", err)
 	}
 
 	want := &ActionsPermissionsRepository{Enabled: Ptr(true), AllowedActions: Ptr("selected")}
 	if !cmp.Equal(org, want) {
-		t.Errorf("Repositories.EditActionsPermissions returned %+v, want %+v", org, want)
+		t.Errorf("Repositories.UpdateActionsPermissions returned %+v, want %+v", org, want)
 	}
 
-	const methodName = "EditActionsPermissions"
+	const methodName = "UpdateActionsPermissions"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Repositories.EditActionsPermissions(ctx, "\n", "\n", *input)
+		_, _, err = client.Repositories.UpdateActionsPermissions(ctx, "\n", "\n", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.EditActionsPermissions(ctx, "o", "r", *input)
+		got, resp, err := client.Repositories.UpdateActionsPermissions(ctx, "o", "r", *input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -146,7 +146,7 @@ func TestRepositoriesService_GetDefaultWorkflowPermissions(t *testing.T) {
 	})
 }
 
-func TestRepositoriesService_EditDefaultWorkflowPermissions(t *testing.T) {
+func TestRepositoriesService_UpdateDefaultWorkflowPermissions(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -165,24 +165,24 @@ func TestRepositoriesService_EditDefaultWorkflowPermissions(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	org, _, err := client.Repositories.EditDefaultWorkflowPermissions(ctx, "o", "r", *input)
+	org, _, err := client.Repositories.UpdateDefaultWorkflowPermissions(ctx, "o", "r", *input)
 	if err != nil {
-		t.Errorf("Repositories.EditDefaultWorkflowPermissions returned error: %v", err)
+		t.Errorf("Repositories.UpdateDefaultWorkflowPermissions returned error: %v", err)
 	}
 
 	want := &DefaultWorkflowPermissionRepository{DefaultWorkflowPermissions: Ptr("read"), CanApprovePullRequestReviews: Ptr(true)}
 	if !cmp.Equal(org, want) {
-		t.Errorf("Repositories.EditDefaultWorkflowPermissions returned %+v, want %+v", org, want)
+		t.Errorf("Repositories.UpdateDefaultWorkflowPermissions returned %+v, want %+v", org, want)
 	}
 
-	const methodName = "EditDefaultWorkflowPermissions"
+	const methodName = "UpdateDefaultWorkflowPermissions"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Repositories.EditDefaultWorkflowPermissions(ctx, "\n", "\n", *input)
+		_, _, err = client.Repositories.UpdateDefaultWorkflowPermissions(ctx, "\n", "\n", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.EditDefaultWorkflowPermissions(ctx, "o", "r", *input)
+		got, resp, err := client.Repositories.UpdateDefaultWorkflowPermissions(ctx, "o", "r", *input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -228,7 +228,7 @@ func TestRepositoriesService_GetArtifactAndLogRetentionPeriod(t *testing.T) {
 	})
 }
 
-func TestRepositoriesService_EditArtifactAndLogRetentionPeriod(t *testing.T) {
+func TestRepositoriesService_UpdateArtifactAndLogRetentionPeriod(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -246,23 +246,23 @@ func TestRepositoriesService_EditArtifactAndLogRetentionPeriod(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	resp, err := client.Repositories.EditArtifactAndLogRetentionPeriod(ctx, "o", "r", *input)
+	resp, err := client.Repositories.UpdateArtifactAndLogRetentionPeriod(ctx, "o", "r", *input)
 	if err != nil {
-		t.Errorf("Repositories.EditArtifactAndLogRetentionPeriod returned error: %v", err)
+		t.Errorf("Repositories.UpdateArtifactAndLogRetentionPeriod returned error: %v", err)
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		t.Errorf("Repositories.EditArtifactAndLogRetentionPeriod = %d, want %d", resp.StatusCode, http.StatusNoContent)
+		t.Errorf("Repositories.UpdateArtifactAndLogRetentionPeriod = %d, want %d", resp.StatusCode, http.StatusNoContent)
 	}
 
-	const methodName = "EditArtifactAndLogRetentionPeriod"
+	const methodName = "UpdateArtifactAndLogRetentionPeriod"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Repositories.EditArtifactAndLogRetentionPeriod(ctx, "\n", "\n", *input)
+		_, err = client.Repositories.UpdateArtifactAndLogRetentionPeriod(ctx, "\n", "\n", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Repositories.EditArtifactAndLogRetentionPeriod(ctx, "o", "r", *input)
+		return client.Repositories.UpdateArtifactAndLogRetentionPeriod(ctx, "o", "r", *input)
 	})
 }
 


### PR DESCRIPTION
BREAKING CHANGE: Permissions-related methods are renamed from `Edit*` to `Update*`.

Rename the methods `EditXXX` to `UpdateXXX` for the permissions related apis

accomplish https://github.com/google/go-github/pull/3679#discussion_r2281878877 