### PR TITLE
feat: Add ListAcceptedAssignments and GetAssignmentGrades methods to Classroom API

### DIFF
--- a/github/classroom.go
+++ b/github/classroom.go
@@ -16,6 +16,18 @@ import (
 // GitHub API docs: https://docs.github.com/rest/classroom/classroom
 type ClassroomService service
 
+// ClassroomUser represents a GitHub user simplified for Classroom.
+type ClassroomUser struct {
+	ID        *int64  `json:"id,omitempty"`
+	Login     *string `json:"login,omitempty"`
+	AvatarURL *string `json:"avatar_url,omitempty"`
+	HTMLURL   *string `json:"html_url,omitempty"`
+}
+
+func (u ClassroomUser) String() string {
+	return Stringify(u)
+}
+
 // Classroom represents a GitHub Classroom.
 type Classroom struct {
 	ID           *int64        `json:"id,omitempty"`
@@ -63,7 +75,7 @@ type AcceptedAssignment struct {
 	Passing     *bool                `json:"passing,omitempty"`
 	CommitCount *int                 `json:"commit_count,omitempty"`
 	Grade       *string              `json:"grade,omitempty"`
-	Students    []*User              `json:"students,omitempty"`
+	Students    []*ClassroomUser     `json:"students,omitempty"`
 	Repository  *Repository          `json:"repository,omitempty"`
 	Assignment  *ClassroomAssignment `json:"assignment,omitempty"`
 }

--- a/github/classroom_test.go
+++ b/github/classroom_test.go
@@ -125,7 +125,7 @@ func TestAcceptedAssignment_Marshal(t *testing.T) {
 		Passing:     Ptr(true),
 		CommitCount: Ptr(5),
 		Grade:       Ptr("10/10"),
-		Students: []*User{
+		Students: []*ClassroomUser{
 			{
 				ID:        Ptr(int64(1)),
 				Login:     Ptr("octocat"),
@@ -737,7 +737,7 @@ func TestClassroomService_ListAcceptedAssignments(t *testing.T) {
 			Passing:     Ptr(true),
 			CommitCount: Ptr(5),
 			Grade:       Ptr("10/10"),
-			Students: []*User{
+			Students: []*ClassroomUser{
 				{
 					ID:        Ptr(int64(1)),
 					Login:     Ptr("octocat"),
@@ -785,7 +785,7 @@ func TestClassroomService_ListAcceptedAssignments(t *testing.T) {
 			Passing:     Ptr(false),
 			CommitCount: Ptr(2),
 			Grade:       Ptr("5/10"),
-			Students: []*User{
+			Students: []*ClassroomUser{
 				{
 					ID:        Ptr(int64(2)),
 					Login:     Ptr("monalisa"),

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2862,6 +2862,38 @@ func (c *ClassroomAssignment) GetType() string {
 	return *c.Type
 }
 
+// GetAvatarURL returns the AvatarURL field if it's non-nil, zero value otherwise.
+func (c *ClassroomUser) GetAvatarURL() string {
+	if c == nil || c.AvatarURL == nil {
+		return ""
+	}
+	return *c.AvatarURL
+}
+
+// GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
+func (c *ClassroomUser) GetHTMLURL() string {
+	if c == nil || c.HTMLURL == nil {
+		return ""
+	}
+	return *c.HTMLURL
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (c *ClassroomUser) GetID() int64 {
+	if c == nil || c.ID == nil {
+		return 0
+	}
+	return *c.ID
+}
+
+// GetLogin returns the Login field if it's non-nil, zero value otherwise.
+func (c *ClassroomUser) GetLogin() string {
+	if c == nil || c.Login == nil {
+		return ""
+	}
+	return *c.Login
+}
+
 // GetFingerprint returns the Fingerprint field if it's non-nil, zero value otherwise.
 func (c *ClusterSSHKey) GetFingerprint() string {
 	if c == nil || c.Fingerprint == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -3724,6 +3724,50 @@ func TestClassroomAssignment_GetType(tt *testing.T) {
 	c.GetType()
 }
 
+func TestClassroomUser_GetAvatarURL(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &ClassroomUser{AvatarURL: &zeroValue}
+	c.GetAvatarURL()
+	c = &ClassroomUser{}
+	c.GetAvatarURL()
+	c = nil
+	c.GetAvatarURL()
+}
+
+func TestClassroomUser_GetHTMLURL(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &ClassroomUser{HTMLURL: &zeroValue}
+	c.GetHTMLURL()
+	c = &ClassroomUser{}
+	c.GetHTMLURL()
+	c = nil
+	c.GetHTMLURL()
+}
+
+func TestClassroomUser_GetID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int64
+	c := &ClassroomUser{ID: &zeroValue}
+	c.GetID()
+	c = &ClassroomUser{}
+	c.GetID()
+	c = nil
+	c.GetID()
+}
+
+func TestClassroomUser_GetLogin(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &ClassroomUser{Login: &zeroValue}
+	c.GetLogin()
+	c = &ClassroomUser{}
+	c.GetLogin()
+	c = nil
+	c.GetLogin()
+}
+
 func TestClusterSSHKey_GetFingerprint(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -310,6 +310,20 @@ func TestClassroomAssignment_String(t *testing.T) {
 	}
 }
 
+func TestClassroomUser_String(t *testing.T) {
+	t.Parallel()
+	v := ClassroomUser{
+		ID:        Ptr(int64(0)),
+		Login:     Ptr(""),
+		AvatarURL: Ptr(""),
+		HTMLURL:   Ptr(""),
+	}
+	want := `github.ClassroomUser{ID:0, Login:"", AvatarURL:"", HTMLURL:""}`
+	if got := v.String(); got != want {
+		t.Errorf("ClassroomUser.String = %v, want %v", got, want)
+	}
+}
+
 func TestCodeOfConduct_String(t *testing.T) {
 	t.Parallel()
 	v := CodeOfConduct{


### PR DESCRIPTION
Fixes: #3684.

# Summary

This PR adds support for two missing GitHub Classroom API endpoints by implementing the `ListAcceptedAssignments` and `GetAssignmentGrades` methods in the `ClassroomService`.

## Changes

### New Methods
- **`ListAcceptedAssignments`** - Lists accepted assignments for a specific assignment
- **`GetAssignmentGrades`** - Retrieves assignment grades for a specific assignment

### API Coverage
This completes the implementation of all 6 available GitHub Classroom API endpoints:
- ✅ `GET /assignments/{assignment_id}` → `GetAssignment()`
- ✅ `GET /assignments/{assignment_id}/accepted_assignments` → `ListAcceptedAssignments()` **← NEW**
- ✅ `GET /assignments/{assignment_id}/grades` → `GetAssignmentGrades()` **← NEW**
- ✅ `GET /classrooms` → `ListClassrooms()`
- ✅ `GET /classrooms/{classroom_id}` → `GetClassroom()`
- ✅ `GET /classrooms/{classroom_id}/assignments` → `ListClassroomAssignments()`