### PR TITLE
test: Ensure bypass_actors serializes as an empty array when clearing ruleset bypass actors

### DIFF
--- a/github/repos_rules_test.go
+++ b/github/repos_rules_test.go
@@ -461,6 +461,7 @@ func TestRepositoriesService_UpdateRulesetClearBypassActor(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/repo/rulesets/42", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
+		testBody(t, r, `{"bypass_actors":[]}`+"\n")
 		fmt.Fprint(w, `{
 			"id": 42,
 			"name": "ruleset",


### PR DESCRIPTION
As asked in #3727, here's a test to ensure bypass_actors is never serialized as null when clearing bypass actors.

Test is failing prior to the fix and passes with the current implementation.

Validates #3726 
