### PR TITLE
chore: Ignore hidden `.claude` settings folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage.out
 vendor/
 .DS_Store
 .vscode
+.claude/
 # vim temp files
 *.swp
 


### PR DESCRIPTION
ignore settings files like `.claude/settings.local.json` for claude code usage