### PR TITLE
ci: Add `errorlint` configuration to golangci-lint settings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - copyloopvar
     - dogsled
     - dupl
+    - errorlint
     - forbidigo
     - gocritic
     - godot
@@ -25,6 +26,10 @@ linters:
     - unparam
     - whitespace
   settings:
+    errorlint:
+      errorf: false
+      asserts: true
+      comparison: true
     forbidigo:
       forbid:
         - pattern: ^reflect\.DeepEqual$


### PR DESCRIPTION
mentioned https://github.com/google/go-github/pull/3739#issuecomment-3341026988