### PR TITLE
fix return type of GetDefaultCodeSecurityConfigurations

### DIFF
--- a/github/orgs_codesecurity_configurations.go
+++ b/github/orgs_codesecurity_configurations.go
@@ -106,7 +106,7 @@ func (s *OrganizationsService) CreateCodeSecurityConfiguration(ctx context.Conte
 // GitHub API docs: https://docs.github.com/rest/code-security/configurations#get-default-code-security-configurations
 //
 //meta:operation GET /orgs/{org}/code-security/configurations/defaults
-func (s *OrganizationsService) GetDefaultCodeSecurityConfigurations(ctx context.Context, org string) ([]*CodeSecurityConfiguration, *Response, error) {
+func (s *OrganizationsService) GetDefaultCodeSecurityConfigurations(ctx context.Context, org string) ([]*CodeSecurityConfigurationWithDefaultForNewRepos, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/code-security/configurations/defaults", org)
 
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -114,7 +114,7 @@ func (s *OrganizationsService) GetDefaultCodeSecurityConfigurations(ctx context.
 		return nil, nil, err
 	}
 
-	var configurations []*CodeSecurityConfiguration
+	var configurations []*CodeSecurityConfigurationWithDefaultForNewRepos
 	resp, err := s.client.Do(ctx, req, &configurations)
 	if err != nil {
 		return nil, resp, err

--- a/github/orgs_codesecurity_configurations_test.go
+++ b/github/orgs_codesecurity_configurations_test.go
@@ -159,15 +159,22 @@ func TestOrganizationsService_GetDefaultCodeSecurityConfigurations(t *testing.T)
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[
 		{
-			"id":1,
-			"name":"config1",
-			"code_scanning_default_setup": "enabled"
+			"default_for_new_repos": "public",
+			"configuration": {
+				"id":1,
+				"name":"config1",
+				"code_scanning_default_setup": "enabled"
+			}
 		},
 		{
-			"id":2,
-			"name":"config2",
-			"private_vulnerability_reporting": "enabled"
-		}]`)
+			"default_for_new_repos": "private",
+			"configuration": {
+				"id":2,
+				"name":"config2",
+				"private_vulnerability_reporting": "enabled"
+			}
+		}
+	]`)
 	})
 
 	configurations, _, err := client.Organizations.GetDefaultCodeSecurityConfigurations(ctx, "o")
@@ -175,9 +182,9 @@ func TestOrganizationsService_GetDefaultCodeSecurityConfigurations(t *testing.T)
 		t.Errorf("Organizations.GetDefaultCodeSecurityConfigurations returned error: %v", err)
 	}
 
-	want := []*CodeSecurityConfiguration{
-		{ID: Ptr(int64(1)), Name: Ptr("config1"), CodeScanningDefaultSetup: Ptr("enabled")},
-		{ID: Ptr(int64(2)), Name: Ptr("config2"), PrivateVulnerabilityReporting: Ptr("enabled")},
+	want := []*CodeSecurityConfigurationWithDefaultForNewRepos{
+		{DefaultForNewRepos: Ptr("public"), Configuration: &CodeSecurityConfiguration{ID: Ptr(int64(1)), Name: Ptr("config1"), CodeScanningDefaultSetup: Ptr("enabled")}},
+		{DefaultForNewRepos: Ptr("private"), Configuration: &CodeSecurityConfiguration{ID: Ptr(int64(2)), Name: Ptr("config2"), PrivateVulnerabilityReporting: Ptr("enabled")}},
 	}
 	if !cmp.Equal(configurations, want) {
 		t.Errorf("Organizations.GetDefaultCodeSecurityConfigurations returned %+v, want %+v", configurations, want)


### PR DESCRIPTION
Modifies the return type of `GetDefaultCodeSecurityConfigurations` to match the response schema of the API.

Fixes #3744 
