### PR TITLE
test: Use t.Context() instead of context.Background()

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - tparallel
     - unconvert
     - unparam
+    - usetesting
     - whitespace
   settings:
     errorlint:
@@ -126,6 +127,14 @@ linters:
       checks:
         - "all"
         - "-QF1008" # allow embedded field in selector
+    usetesting:
+      context-background: true
+      context-todo: true
+      os-chdir: true
+      os-mkdir-temp: true
+      os-setenv: true
+      os-create-temp: true
+      os-temp-dir: true
     custom:
       sliceofpointers:
         type: module

--- a/github/actions_artifacts_test.go
+++ b/github/actions_artifacts_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -36,7 +35,7 @@ func TestActionsService_ListArtifacts(t *testing.T) {
 		Name:        Ptr("TheArtifact"),
 		ListOptions: ListOptions{Page: 2},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	artifacts, _, err := client.Actions.ListArtifacts(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Actions.ListArtifacts returned error: %v", err)
@@ -66,7 +65,7 @@ func TestActionsService_ListArtifacts_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Actions.ListArtifacts(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
@@ -75,7 +74,7 @@ func TestActionsService_ListArtifacts_invalidRepo(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Actions.ListArtifacts(ctx, "o", "%", nil)
 	testURLParseError(t, err)
 }
@@ -89,7 +88,7 @@ func TestActionsService_ListArtifacts_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	artifacts, resp, err := client.Actions.ListArtifacts(ctx, "o", "r", nil)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -118,7 +117,7 @@ func TestActionsService_ListWorkflowRunArtifacts(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	artifacts, _, err := client.Actions.ListWorkflowRunArtifacts(ctx, "o", "r", 1, opts)
 	if err != nil {
 		t.Errorf("Actions.ListWorkflowRunArtifacts returned error: %v", err)
@@ -148,7 +147,7 @@ func TestActionsService_ListWorkflowRunArtifacts_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Actions.ListWorkflowRunArtifacts(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
@@ -157,7 +156,7 @@ func TestActionsService_ListWorkflowRunArtifacts_invalidRepo(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Actions.ListWorkflowRunArtifacts(ctx, "o", "%", 1, nil)
 	testURLParseError(t, err)
 }
@@ -171,7 +170,7 @@ func TestActionsService_ListWorkflowRunArtifacts_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	artifacts, resp, err := client.Actions.ListWorkflowRunArtifacts(ctx, "o", "r", 1, nil)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -199,7 +198,7 @@ func TestActionsService_GetArtifact(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	artifact, _, err := client.Actions.GetArtifact(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Actions.GetArtifact returned error: %v", err)
@@ -235,7 +234,7 @@ func TestActionsService_GetArtifact_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Actions.GetArtifact(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
@@ -244,7 +243,7 @@ func TestActionsService_GetArtifact_invalidRepo(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Actions.GetArtifact(ctx, "o", "%", 1)
 	testURLParseError(t, err)
 }
@@ -258,7 +257,7 @@ func TestActionsService_GetArtifact_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	artifact, resp, err := client.Actions.GetArtifact(ctx, "o", "r", 1)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -299,7 +298,7 @@ func TestActionsService_DownloadArtifact(t *testing.T) {
 				http.Redirect(w, r, "https://github.com/artifact", http.StatusFound)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			url, resp, err := client.Actions.DownloadArtifact(ctx, "o", "r", 1, 1)
 			if err != nil {
 				t.Errorf("Actions.DownloadArtifact returned error: %v", err)
@@ -355,7 +354,7 @@ func TestActionsService_DownloadArtifact_invalidOwner(t *testing.T) {
 			client, _, _ := setup(t)
 			client.RateLimitRedirectionalEndpoints = tc.respectRateLimits
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, _, err := client.Actions.DownloadArtifact(ctx, "%", "r", 1, 1)
 			testURLParseError(t, err)
 		})
@@ -384,7 +383,7 @@ func TestActionsService_DownloadArtifact_invalidRepo(t *testing.T) {
 			client, _, _ := setup(t)
 			client.RateLimitRedirectionalEndpoints = tc.respectRateLimits
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, _, err := client.Actions.DownloadArtifact(ctx, "o", "%", 1, 1)
 			testURLParseError(t, err)
 		})
@@ -418,7 +417,7 @@ func TestActionsService_DownloadArtifact_StatusMovedPermanently_dontFollowRedire
 				http.Redirect(w, r, "https://github.com/artifact", http.StatusMovedPermanently)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, resp, _ := client.Actions.DownloadArtifact(ctx, "o", "r", 1, 0)
 			if resp.StatusCode != http.StatusMovedPermanently {
 				t.Errorf("Actions.DownloadArtifact return status %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
@@ -459,7 +458,7 @@ func TestActionsService_DownloadArtifact_StatusMovedPermanently_followRedirects(
 				http.Redirect(w, r, "https://github.com/artifact", http.StatusFound)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			url, resp, err := client.Actions.DownloadArtifact(ctx, "o", "r", 1, 1)
 			if err != nil {
 				t.Errorf("Actions.DownloadArtifact return error: %v", err)
@@ -507,7 +506,7 @@ func TestActionsService_DownloadArtifact_unexpectedCode(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			url, resp, err := client.Actions.DownloadArtifact(ctx, "o", "r", 1, 1)
 			if err == nil {
 				t.Fatal("Actions.DownloadArtifact should return error on unexpected code")
@@ -533,7 +532,7 @@ func TestActionsService_DeleteArtifact(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteArtifact(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Actions.DeleteArtifact return error: %v", err)
@@ -554,7 +553,7 @@ func TestActionsService_DeleteArtifact_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteArtifact(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
@@ -563,7 +562,7 @@ func TestActionsService_DeleteArtifact_invalidRepo(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteArtifact(ctx, "o", "%", 1)
 	testURLParseError(t, err)
 }
@@ -577,7 +576,7 @@ func TestActionsService_DeleteArtifact_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Actions.DeleteArtifact(ctx, "o", "r", 1)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")

--- a/github/actions_cache_test.go
+++ b/github/actions_cache_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -30,7 +29,7 @@ func TestActionsService_ListCaches(t *testing.T) {
 	})
 
 	opts := &ActionsCacheListOptions{ListOptions: ListOptions{Page: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	cacheList, _, err := client.Actions.ListCaches(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Actions.ListCaches returned error: %v", err)
@@ -60,7 +59,7 @@ func TestActionsService_ListCaches_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Actions.ListCaches(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
@@ -69,7 +68,7 @@ func TestActionsService_ListCaches_invalidRepo(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Actions.ListCaches(ctx, "o", "%", nil)
 	testURLParseError(t, err)
 }
@@ -83,7 +82,7 @@ func TestActionsService_ListCaches_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	caches, resp, err := client.Actions.ListCaches(ctx, "o", "r", nil)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -105,7 +104,7 @@ func TestActionsService_DeleteCachesByKey(t *testing.T) {
 		testFormValues(t, r, values{"key": "1", "ref": "main"})
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteCachesByKey(ctx, "o", "r", "1", Ptr("main"))
 	if err != nil {
 		t.Errorf("Actions.DeleteCachesByKey return error: %v", err)
@@ -126,7 +125,7 @@ func TestActionsService_DeleteCachesByKey_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteCachesByKey(ctx, "%", "r", "1", Ptr("main"))
 	testURLParseError(t, err)
 }
@@ -135,7 +134,7 @@ func TestActionsService_DeleteCachesByKey_invalidRepo(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteCachesByKey(ctx, "o", "%", "1", Ptr("main"))
 	testURLParseError(t, err)
 }
@@ -149,7 +148,7 @@ func TestActionsService_DeleteCachesByKey_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Actions.DeleteCachesByKey(ctx, "o", "r", "1", Ptr("main"))
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -167,7 +166,7 @@ func TestActionsService_DeleteCachesByID(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteCachesByID(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Actions.DeleteCachesByID return error: %v", err)
@@ -188,7 +187,7 @@ func TestActionsService_DeleteCachesByID_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteCachesByID(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
@@ -197,7 +196,7 @@ func TestActionsService_DeleteCachesByID_invalidRepo(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteCachesByID(ctx, "o", "%", 1)
 	testURLParseError(t, err)
 }
@@ -211,7 +210,7 @@ func TestActionsService_DeleteCachesByID_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Actions.DeleteCachesByID(ctx, "o", "r", 1)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -236,7 +235,7 @@ func TestActionsService_GetCacheUsageForRepo(t *testing.T) {
 		)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cacheUse, _, err := client.Actions.GetCacheUsageForRepo(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Actions.GetCacheUsageForRepo returned error: %v", err)
@@ -266,7 +265,7 @@ func TestActionsService_GetCacheUsageForRepo_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Actions.GetCacheUsageForRepo(ctx, "%", "r")
 	testURLParseError(t, err)
 }
@@ -275,7 +274,7 @@ func TestActionsService_GetCacheUsageForRepo_invalidRepo(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Actions.GetCacheUsageForRepo(ctx, "o", "%")
 	testURLParseError(t, err)
 }
@@ -289,7 +288,7 @@ func TestActionsService_GetCacheUsageForRepo_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	caches, resp, err := client.Actions.GetCacheUsageForRepo(ctx, "o", "r")
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -318,7 +317,7 @@ func TestActionsService_ListCacheUsageByRepoForOrg(t *testing.T) {
 	})
 
 	opts := &ListOptions{PerPage: 1, Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	cacheList, _, err := client.Actions.ListCacheUsageByRepoForOrg(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Actions.ListCacheUsageByRepoForOrg returned error: %v", err)
@@ -348,7 +347,7 @@ func TestActionsService_ListCacheUsageByRepoForOrg_invalidOrganization(t *testin
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Actions.ListCacheUsageByRepoForOrg(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -362,7 +361,7 @@ func TestActionsService_ListCacheUsageByRepoForOrg_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	caches, resp, err := client.Actions.ListCacheUsageByRepoForOrg(ctx, "o", nil)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -389,7 +388,7 @@ func TestActionsService_GetCacheUsageForOrg(t *testing.T) {
 		)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cache, _, err := client.Actions.GetTotalCacheUsageForOrg(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.GetTotalCacheUsageForOrg returned error: %v", err)
@@ -419,7 +418,7 @@ func TestActionsService_GetCacheUsageForOrg_invalidOrganization(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Actions.GetTotalCacheUsageForOrg(ctx, "%")
 	testURLParseError(t, err)
 }
@@ -433,7 +432,7 @@ func TestActionsService_GetCacheUsageForOrg_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	caches, resp, err := client.Actions.GetTotalCacheUsageForOrg(ctx, "o")
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -460,7 +459,7 @@ func TestActionsService_GetCacheUsageForEnterprise(t *testing.T) {
 		)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cache, _, err := client.Actions.GetTotalCacheUsageForEnterprise(ctx, "e")
 	if err != nil {
 		t.Errorf("Actions.GetTotalCacheUsageForEnterprise returned error: %v", err)
@@ -490,7 +489,7 @@ func TestActionsService_GetCacheUsageForEnterprise_invalidEnterprise(t *testing.
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Actions.GetTotalCacheUsageForEnterprise(ctx, "%")
 	testURLParseError(t, err)
 }
@@ -504,7 +503,7 @@ func TestActionsService_GetCacheUsageForEnterprise_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	caches, resp, err := client.Actions.GetTotalCacheUsageForEnterprise(ctx, "o")
 	if err == nil {
 		t.Error("Expected HTTP 404 response")

--- a/github/actions_hosted_runners_test.go
+++ b/github/actions_hosted_runners_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -76,7 +75,7 @@ func TestActionsService_ListHostedRunners(t *testing.T) {
 		}`)
 	})
 	opts := &ListOptions{Page: 1, PerPage: 1}
-	ctx := context.Background()
+	ctx := t.Context()
 	hostedRunners, _, err := client.Actions.ListHostedRunners(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Actions.ListHostedRunners returned error: %v", err)
@@ -191,7 +190,7 @@ func TestActionsService_CreateHostedRunner(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	validReq := &HostedRunnerRequest{
 		Name: "My Hosted runner",
@@ -363,7 +362,7 @@ func TestActionsService_GetHostedRunnerGitHubOwnedImages(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hostedRunnerImages, _, err := client.Actions.GetHostedRunnerGitHubOwnedImages(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.GetHostedRunnerGitHubOwnedImages returned error: %v", err)
@@ -421,7 +420,7 @@ func TestActionsService_GetHostedRunnerPartnerImages(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hostedRunnerImages, _, err := client.Actions.GetHostedRunnerPartnerImages(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.GetHostedRunnerPartnerImages returned error: %v", err)
@@ -473,7 +472,7 @@ func TestActionsService_GetHostedRunnerLimits(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	publicIPLimits, _, err := client.Actions.GetHostedRunnerLimits(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.GetPartnerImages returned error: %v", err)
@@ -524,7 +523,7 @@ func TestActionsService_GetHostedRunnerMachineSpecs(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	machineSpecs, _, err := client.Actions.GetHostedRunnerMachineSpecs(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.GetHostedRunnerMachineSpecs returned error: %v", err)
@@ -575,7 +574,7 @@ func TestActionsService_GetHostedRunnerPlatforms(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	platforms, _, err := client.Actions.GetHostedRunnerPlatforms(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.GetHostedRunnerPlatforms returned error: %v", err)
@@ -642,7 +641,7 @@ func TestActionsService_GetHostedRunner(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hostedRunner, _, err := client.Actions.GetHostedRunner(ctx, "o", 23)
 	if err != nil {
 		t.Errorf("Actions.GetHostedRunner returned error: %v", err)
@@ -731,7 +730,7 @@ func TestActionsService_UpdateHostedRunner(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	validReq := HostedRunnerRequest{
 		Name:           "My larger runner",
 		RunnerGroupID:  1,
@@ -868,7 +867,7 @@ func TestActionsService_DeleteHostedRunner(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hostedRunner, _, err := client.Actions.DeleteHostedRunner(ctx, "o", 23)
 	if err != nil {
 		t.Errorf("Actions.GetHostedRunner returned error: %v", err)

--- a/github/actions_oidc_test.go
+++ b/github/actions_oidc_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -23,7 +22,7 @@ func TestActionsService_GetOrgOIDCSubjectClaimCustomTemplate(t *testing.T) {
 		fmt.Fprint(w, `{"include_claim_keys":["repo","context"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	template, _, err := client.Actions.GetOrgOIDCSubjectClaimCustomTemplate(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.GetOrgOIDCSubjectClaimCustomTemplate returned error: %v", err)
@@ -58,7 +57,7 @@ func TestActionsService_GetRepoOIDCSubjectClaimCustomTemplate(t *testing.T) {
 		fmt.Fprint(w, `{"use_default":false,"include_claim_keys":["repo","context"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	template, _, err := client.Actions.GetRepoOIDCSubjectClaimCustomTemplate(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Actions.GetRepoOIDCSubjectClaimCustomTemplate returned error: %v", err)
@@ -98,7 +97,7 @@ func TestActionsService_SetOrgOIDCSubjectClaimCustomTemplate(t *testing.T) {
 	input := &OIDCSubjectClaimCustomTemplate{
 		IncludeClaimKeys: []string{"repo", "context"},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.SetOrgOIDCSubjectClaimCustomTemplate(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Actions.SetOrgOIDCSubjectClaimCustomTemplate returned error: %v", err)
@@ -131,7 +130,7 @@ func TestActionsService_SetRepoOIDCSubjectClaimCustomTemplate(t *testing.T) {
 		UseDefault:       Ptr(false),
 		IncludeClaimKeys: []string{"repo", "context"},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.SetRepoOIDCSubjectClaimCustomTemplate(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Actions.SetRepoOIDCSubjectClaimCustomTemplate returned error: %v", err)
@@ -163,7 +162,7 @@ func TestActionService_SetRepoOIDCSubjectClaimCustomTemplateToDefault(t *testing
 	input := &OIDCSubjectClaimCustomTemplate{
 		UseDefault: Ptr(true),
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.SetRepoOIDCSubjectClaimCustomTemplate(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Actions.SetRepoOIDCSubjectClaimCustomTemplate returned error: %v", err)

--- a/github/actions_permissions_enterprise_test.go
+++ b/github/actions_permissions_enterprise_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -24,7 +23,7 @@ func TestActionsService_GetActionsPermissionsInEnterprise(t *testing.T) {
 		fmt.Fprint(w, `{"enabled_organizations": "all", "allowed_actions": "all"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ent, _, err := client.Actions.GetActionsPermissionsInEnterprise(ctx, "e")
 	if err != nil {
 		t.Errorf("Actions.GetActionsPermissionsInEnterprise returned error: %v", err)
@@ -67,7 +66,7 @@ func TestActionsService_UpdateActionsPermissionsInEnterprise(t *testing.T) {
 		fmt.Fprint(w, `{"enabled_organizations": "all", "allowed_actions": "selected"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ent, _, err := client.Actions.UpdateActionsPermissionsInEnterprise(ctx, "e", *input)
 	if err != nil {
 		t.Errorf("Actions.UpdateActionsPermissionsInEnterprise returned error: %v", err)
@@ -105,7 +104,7 @@ func TestActionsService_ListEnabledOrgsInEnterprise(t *testing.T) {
 		fmt.Fprint(w, `{"total_count":2,"organizations":[{"id":2}, {"id":3}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opt := &ListOptions{
 		Page: 1,
 	}
@@ -148,7 +147,7 @@ func TestActionsService_SetEnabledOrgsInEnterprise(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.SetEnabledOrgsInEnterprise(ctx, "e", []int64{123, 1234})
 	if err != nil {
 		t.Errorf("Actions.SetEnabledOrgsInEnterprise returned error: %v", err)
@@ -175,7 +174,7 @@ func TestActionsService_AddEnabledOrgInEnterprise(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.AddEnabledOrgInEnterprise(ctx, "e", 123)
 	if err != nil {
 		t.Errorf("Actions.AddEnabledOrgInEnterprise returned error: %v", err)
@@ -202,7 +201,7 @@ func TestActionsService_RemoveEnabledOrgInEnterprise(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.RemoveEnabledOrgInEnterprise(ctx, "e", 123)
 	if err != nil {
 		t.Errorf("Actions.RemoveEnabledOrgInEnterprise returned error: %v", err)
@@ -229,7 +228,7 @@ func TestActionsService_GetActionsAllowedInEnterprise(t *testing.T) {
 		fmt.Fprint(w, `{"github_owned_allowed":true, "verified_allowed":false, "patterns_allowed":["a/b"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ent, _, err := client.Actions.GetActionsAllowedInEnterprise(ctx, "e")
 	if err != nil {
 		t.Errorf("Actions.GetActionsAllowedInEnterprise returned error: %v", err)
@@ -272,7 +271,7 @@ func TestActionsService_UpdateActionsAllowedInEnterprise(t *testing.T) {
 		fmt.Fprint(w, `{"github_owned_allowed":true, "verified_allowed":false, "patterns_allowed":["a/b"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ent, _, err := client.Actions.UpdateActionsAllowedInEnterprise(ctx, "e", *input)
 	if err != nil {
 		t.Errorf("Actions.UpdateActionsAllowedInEnterprise returned error: %v", err)
@@ -307,7 +306,7 @@ func TestActionsService_GetDefaultWorkflowPermissionsInEnterprise(t *testing.T) 
 		fmt.Fprint(w, `{ "default_workflow_permissions": "read", "can_approve_pull_request_reviews": true }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ent, _, err := client.Actions.GetDefaultWorkflowPermissionsInEnterprise(ctx, "e")
 	if err != nil {
 		t.Errorf("Actions.GetDefaultWorkflowPermissionsInEnterprise returned error: %v", err)
@@ -350,7 +349,7 @@ func TestActionsService_UpdateDefaultWorkflowPermissionsInEnterprise(t *testing.
 		fmt.Fprint(w, `{ "default_workflow_permissions": "read", "can_approve_pull_request_reviews": true }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ent, _, err := client.Actions.UpdateDefaultWorkflowPermissionsInEnterprise(ctx, "e", *input)
 	if err != nil {
 		t.Errorf("Actions.UpdateDefaultWorkflowPermissionsInEnterprise returned error: %v", err)
@@ -385,7 +384,7 @@ func TestActionsService_GetArtifactAndLogRetentionPeriodInEnterprise(t *testing.
 		fmt.Fprint(w, `{"days": 90, "maximum_allowed_days": 365}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	period, _, err := client.Actions.GetArtifactAndLogRetentionPeriodInEnterprise(ctx, "e")
 	if err != nil {
 		t.Errorf("Actions.GetArtifactAndLogRetentionPeriodInEnterprise returned error: %v", err)
@@ -431,7 +430,7 @@ func TestActionsService_UpdateArtifactAndLogRetentionPeriodInEnterprise(t *testi
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Actions.UpdateArtifactAndLogRetentionPeriodInEnterprise(ctx, "e", *input)
 	if err != nil {
 		t.Errorf("Actions.UpdateArtifactAndLogRetentionPeriodInEnterprise returned error: %v", err)
@@ -461,7 +460,7 @@ func TestActionsService_GetSelfHostedRunnerPermissionsInEnterprise(t *testing.T)
 		fmt.Fprint(w, `{"disable_self_hosted_runners_for_all_orgs": true}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	permissions, _, err := client.Actions.GetSelfHostedRunnerPermissionsInEnterprise(ctx, "e")
 	if err != nil {
 		t.Errorf("Actions.GetSelfHostedRunnerPermissionsInEnterprise returned error: %v", err)
@@ -503,7 +502,7 @@ func TestActionsService_UpdateSelfHostedRunnerPermissionsInEnterprise(t *testing
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Actions.UpdateSelfHostedRunnerPermissionsInEnterprise(ctx, "e", *input)
 	if err != nil {
 		t.Errorf("Actions.UpdateSelfHostedRunnerPermissionsInEnterprise returned error: %v", err)
@@ -533,7 +532,7 @@ func TestActionsService_GetPrivateRepoForkPRWorkflowSettingsInEnterprise(t *test
 		fmt.Fprint(w, `{"run_workflows_from_fork_pull_requests": true, "send_write_tokens_to_workflows": false, "send_secrets_and_variables": true, "require_approval_for_fork_pr_workflows": false}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	permissions, _, err := client.Actions.GetPrivateRepoForkPRWorkflowSettingsInEnterprise(ctx, "e")
 	if err != nil {
 		t.Errorf("Actions.GetPrivateRepoForkPRWorkflowSettingsInEnterprise returned error: %v", err)
@@ -584,7 +583,7 @@ func TestActionsService_UpdatePrivateRepoForkPRWorkflowSettingsInEnterprise(t *t
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Actions.UpdatePrivateRepoForkPRWorkflowSettingsInEnterprise(ctx, "e", input)
 	if err != nil {
 		t.Errorf("Actions.UpdatePrivateRepoForkPRWorkflowSettingsInEnterprise returned error: %v", err)

--- a/github/actions_permissions_orgs_test.go
+++ b/github/actions_permissions_orgs_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -24,7 +23,7 @@ func TestActionsService_GetActionsPermissions(t *testing.T) {
 		fmt.Fprint(w, `{"enabled_repositories": "all", "allowed_actions": "all"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Actions.GetActionsPermissions(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.GetActionsPermissions returned error: %v", err)
@@ -67,7 +66,7 @@ func TestActionsService_UpdateActionsPermissions(t *testing.T) {
 		fmt.Fprint(w, `{"enabled_repositories": "all", "allowed_actions": "selected"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Actions.UpdateActionsPermissions(ctx, "o", *input)
 	if err != nil {
 		t.Errorf("Actions.UpdateActionsPermissions returned error: %v", err)
@@ -105,7 +104,7 @@ func TestActionsService_ListEnabledReposInOrg(t *testing.T) {
 		fmt.Fprint(w, `{"total_count":2,"repositories":[{"id":2}, {"id": 3}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opt := &ListOptions{
 		Page: 1,
 	}
@@ -148,7 +147,7 @@ func TestActionsService_SetEnabledReposInOrg(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.SetEnabledReposInOrg(ctx, "o", []int64{123, 1234})
 	if err != nil {
 		t.Errorf("Actions.SetEnabledRepos returned error: %v", err)
@@ -175,7 +174,7 @@ func TestActionsService_AddEnabledReposInOrg(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.AddEnabledReposInOrg(ctx, "o", 123)
 	if err != nil {
 		t.Errorf("Actions.AddEnabledReposInOrg returned error: %v", err)
@@ -202,7 +201,7 @@ func TestActionsService_RemoveEnabledReposInOrg(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.RemoveEnabledReposInOrg(ctx, "o", 123)
 	if err != nil {
 		t.Errorf("Actions.RemoveEnabledReposInOrg returned error: %v", err)
@@ -229,7 +228,7 @@ func TestActionsService_GetActionsAllowed(t *testing.T) {
 		fmt.Fprint(w, `{"github_owned_allowed":true, "verified_allowed":false, "patterns_allowed":["a/b"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Actions.GetActionsAllowed(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.GetActionsAllowed returned error: %v", err)
@@ -272,7 +271,7 @@ func TestActionsService_UpdateActionsAllowed(t *testing.T) {
 		fmt.Fprint(w, `{"github_owned_allowed":true, "verified_allowed":false, "patterns_allowed":["a/b"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Actions.UpdateActionsAllowed(ctx, "o", *input)
 	if err != nil {
 		t.Errorf("Actions.UpdateActionsAllowed returned error: %v", err)
@@ -347,7 +346,7 @@ func TestActionsService_GetDefaultWorkflowPermissionsInOrganization(t *testing.T
 		fmt.Fprint(w, `{ "default_workflow_permissions": "read", "can_approve_pull_request_reviews": true }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Actions.GetDefaultWorkflowPermissionsInOrganization(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.GetDefaultWorkflowPermissionsInOrganization returned error: %v", err)
@@ -390,7 +389,7 @@ func TestActionsService_UpdateDefaultWorkflowPermissionsInOrganization(t *testin
 		fmt.Fprint(w, `{ "default_workflow_permissions": "read", "can_approve_pull_request_reviews": true }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Actions.UpdateDefaultWorkflowPermissionsInOrganization(ctx, "o", *input)
 	if err != nil {
 		t.Errorf("Actions.UpdateDefaultWorkflowPermissionsInOrganization returned error: %v", err)
@@ -425,7 +424,7 @@ func TestActionsService_GetArtifactAndLogRetentionPeriodInOrganization(t *testin
 		fmt.Fprint(w, `{"days": 90, "maximum_allowed_days": 365}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	period, _, err := client.Actions.GetArtifactAndLogRetentionPeriodInOrganization(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.GetArtifactAndLogRetentionPeriodInOrganization returned error: %v", err)
@@ -471,7 +470,7 @@ func TestActionsService_UpdateArtifactAndLogRetentionPeriodInOrganization(t *tes
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Actions.UpdateArtifactAndLogRetentionPeriodInOrganization(ctx, "o", *input)
 	if err != nil {
 		t.Errorf("Actions.UpdateArtifactAndLogRetentionPeriodInOrganization returned error: %v", err)
@@ -501,7 +500,7 @@ func TestActionsService_GetSelfHostedRunnersSettingsInOrganization(t *testing.T)
 		fmt.Fprint(w, `{"enabled_repositories": "all", "selected_repositories_url": "https://api.github.com/orgs/octo-org/actions/permissions/self-hosted-runners/repositories"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	settings, _, err := client.Actions.GetSelfHostedRunnersSettingsInOrganization(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.GetSelfHostedRunnersSettingsInOrganization returned error: %v", err)
@@ -546,7 +545,7 @@ func TestActionsService_UpdateSelfHostedRunnersSettingsInOrganization(t *testing
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Actions.UpdateSelfHostedRunnersSettingsInOrganization(ctx, "o", *input)
 	if err != nil {
 		t.Errorf("Actions.UpdateSelfHostedRunnersSettingsInOrganization returned error: %v", err)
@@ -579,7 +578,7 @@ func TestActionsService_ListRepositoriesSelfHostedRunnersAllowedInOrganization(t
 		fmt.Fprint(w, `{"total_count":2,"repositories":[{"id":2}, {"id": 3}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opt := &ListOptions{
 		Page: 1,
 	}
@@ -622,7 +621,7 @@ func TestActionsService_SetRepositoriesSelfHostedRunnersAllowedInOrganization(t 
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.SetRepositoriesSelfHostedRunnersAllowedInOrganization(ctx, "o", []int64{123, 1234})
 	if err != nil {
 		t.Errorf("Actions.SetRepositoriesSelfHostedRunnersAllowedInOrganization returned error: %v", err)
@@ -649,7 +648,7 @@ func TestActionsService_AddRepositorySelfHostedRunnersAllowedInOrganization(t *t
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.AddRepositorySelfHostedRunnersAllowedInOrganization(ctx, "o", 123)
 	if err != nil {
 		t.Errorf("Actions.AddRepositorySelfHostedRunnersAllowedInOrganization returned error: %v", err)
@@ -676,7 +675,7 @@ func TestActionsService_RemoveRepositorySelfHostedRunnersAllowedInOrganization(t
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.RemoveRepositorySelfHostedRunnersAllowedInOrganization(ctx, "o", 123)
 	if err != nil {
 		t.Errorf("Actions.RemoveRepositorySelfHostedRunnersAllowedInOrganization returned error: %v", err)
@@ -703,7 +702,7 @@ func TestActionsService_GetPrivateRepoForkPRWorkflowSettingsInOrganization(t *te
 		fmt.Fprint(w, `{"run_workflows_from_fork_pull_requests": true, "send_write_tokens_to_workflows": false, "send_secrets_and_variables": true, "require_approval_for_fork_pr_workflows": false}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	permissions, _, err := client.Actions.GetPrivateRepoForkPRWorkflowSettingsInOrganization(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.GetPrivateRepoForkPRWorkflowSettingsInOrganization returned error: %v", err)
@@ -754,7 +753,7 @@ func TestActionsService_UpdatePrivateRepoForkPRWorkflowSettingsInOrganization(t 
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Actions.UpdatePrivateRepoForkPRWorkflowSettingsInOrganization(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Actions.UpdatePrivateRepoForkPRWorkflowSettingsInOrganization returned error: %v", err)

--- a/github/actions_runner_groups_test.go
+++ b/github/actions_runner_groups_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -25,7 +24,7 @@ func TestActionsService_ListOrganizationRunnerGroups(t *testing.T) {
 	})
 
 	opts := &ListOrgRunnerGroupOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	groups, _, err := client.Actions.ListOrganizationRunnerGroups(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Actions.ListOrganizationRunnerGroups returned error: %v", err)
@@ -69,7 +68,7 @@ func TestActionsService_ListOrganizationRunnerGroupsVisibleToRepo(t *testing.T) 
 	})
 
 	opts := &ListOrgRunnerGroupOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}, VisibleToRepository: "github"}
-	ctx := context.Background()
+	ctx := t.Context()
 	groups, _, err := client.Actions.ListOrganizationRunnerGroups(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Actions.ListOrganizationRunnerGroups returned error: %v", err)
@@ -111,7 +110,7 @@ func TestActionsService_GetOrganizationRunnerGroup(t *testing.T) {
 		fmt.Fprint(w, `{"id":2,"name":"octo-runner-group","visibility":"selected","default":false,"selected_repositories_url":"https://api.github.com/orgs/octo-org/actions/runner_groups/2/repositories","runners_url":"https://api.github.com/orgs/octo-org/actions/runner_groups/2/runners","inherited":false,"allows_public_repositories":true,"restricted_to_workflows":false,"selected_workflows":[]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	group, _, err := client.Actions.GetOrganizationRunnerGroup(ctx, "o", 2)
 	if err != nil {
 		t.Errorf("Actions.ListOrganizationRunnerGroups returned error: %v", err)
@@ -157,7 +156,7 @@ func TestActionsService_DeleteOrganizationRunnerGroup(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteOrganizationRunnerGroup(ctx, "o", 2)
 	if err != nil {
 		t.Errorf("Actions.DeleteOrganizationRunnerGroup returned error: %v", err)
@@ -183,7 +182,7 @@ func TestActionsService_CreateOrganizationRunnerGroup(t *testing.T) {
 		fmt.Fprint(w, `{"id":2,"name":"octo-runner-group","visibility":"selected","default":false,"selected_repositories_url":"https://api.github.com/orgs/octo-org/actions/runner_groups/2/repositories","runners_url":"https://api.github.com/orgs/octo-org/actions/runner_groups/2/runners","inherited":false,"allows_public_repositories":true,"restricted_to_workflows":false,"selected_workflows":[]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	req := CreateRunnerGroupRequest{
 		Name:                     Ptr("octo-runner-group"),
 		Visibility:               Ptr("selected"),
@@ -237,7 +236,7 @@ func TestActionsService_UpdateOrganizationRunnerGroup(t *testing.T) {
 		fmt.Fprint(w, `{"id":2,"name":"octo-runner-group","visibility":"selected","default":false,"selected_repositories_url":"https://api.github.com/orgs/octo-org/actions/runner_groups/2/repositories","runners_url":"https://api.github.com/orgs/octo-org/actions/runner_groups/2/runners","inherited":false,"allows_public_repositories":true,"restricted_to_workflows":false,"selected_workflows":[]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	req := UpdateRunnerGroupRequest{
 		Name:                     Ptr("octo-runner-group"),
 		Visibility:               Ptr("selected"),
@@ -292,7 +291,7 @@ func TestActionsService_ListRepositoryAccessRunnerGroup(t *testing.T) {
 		fmt.Fprint(w, `{"total_count": 1, "repositories": [{"id": 43, "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5", "name": "Hello-World", "full_name": "octocat/Hello-World"}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &ListOptions{Page: 1, PerPage: 1}
 	groups, _, err := client.Actions.ListRepositoryAccessRunnerGroup(ctx, "o", 2, opts)
 	if err != nil {
@@ -339,7 +338,7 @@ func TestActionsService_SetRepositoryAccessRunnerGroup(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.SetRepositoryAccessRunnerGroup(ctx, "o", 2, req)
 	if err != nil {
 		t.Errorf("Actions.SetRepositoryAccessRunnerGroup returned error: %v", err)
@@ -364,7 +363,7 @@ func TestActionsService_AddRepositoryAccessRunnerGroup(t *testing.T) {
 		testMethod(t, r, "PUT")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.AddRepositoryAccessRunnerGroup(ctx, "o", 2, 42)
 	if err != nil {
 		t.Errorf("Actions.AddRepositoryAccessRunnerGroup returned error: %v", err)
@@ -389,7 +388,7 @@ func TestActionsService_RemoveRepositoryAccessRunnerGroup(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.RemoveRepositoryAccessRunnerGroup(ctx, "o", 2, 42)
 	if err != nil {
 		t.Errorf("Actions.RemoveRepositoryAccessRunnerGroup returned error: %v", err)
@@ -417,7 +416,7 @@ func TestActionsService_ListRunnerGroupRunners(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	runners, _, err := client.Actions.ListRunnerGroupRunners(ctx, "o", 2, opts)
 	if err != nil {
 		t.Errorf("Actions.ListRunnerGroupRunners returned error: %v", err)
@@ -464,7 +463,7 @@ func TestActionsService_SetRunnerGroupRunners(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.SetRunnerGroupRunners(ctx, "o", 2, req)
 	if err != nil {
 		t.Errorf("Actions.SetRunnerGroupRunners returned error: %v", err)
@@ -489,7 +488,7 @@ func TestActionsService_AddRunnerGroupRunners(t *testing.T) {
 		testMethod(t, r, "PUT")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.AddRunnerGroupRunners(ctx, "o", 2, 42)
 	if err != nil {
 		t.Errorf("Actions.AddRunnerGroupRunners returned error: %v", err)
@@ -514,7 +513,7 @@ func TestActionsService_RemoveRunnerGroupRunners(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.RemoveRunnerGroupRunners(ctx, "o", 2, 42)
 	if err != nil {
 		t.Errorf("Actions.RemoveRunnerGroupRunners returned error: %v", err)

--- a/github/actions_runners_test.go
+++ b/github/actions_runners_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -25,7 +24,7 @@ func TestActionsService_ListRunnerApplicationDownloads(t *testing.T) {
 		fmt.Fprint(w, `[{"os":"osx","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-osx-x64-2.164.0.tar.gz","filename":"actions-runner-osx-x64-2.164.0.tar.gz"},{"os":"linux","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-x64-2.164.0.tar.gz","filename":"actions-runner-linux-x64-2.164.0.tar.gz"},{"os": "linux","architecture":"arm","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm-2.164.0.tar.gz","filename":"actions-runner-linux-arm-2.164.0.tar.gz"},{"os":"win","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-win-x64-2.164.0.zip","filename":"actions-runner-win-x64-2.164.0.zip"},{"os":"linux","architecture":"arm64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm64-2.164.0.tar.gz","filename":"actions-runner-linux-arm64-2.164.0.tar.gz"}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	downloads, _, err := client.Actions.ListRunnerApplicationDownloads(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Actions.ListRunnerApplicationDownloads returned error: %v", err)
@@ -75,7 +74,7 @@ func TestActionsService_GenerateOrgJITConfig(t *testing.T) {
 		fmt.Fprint(w, `{"encoded_jit_config":"foo"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	jitConfig, _, err := client.Actions.GenerateOrgJITConfig(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Actions.GenerateOrgJITConfig returned error: %v", err)
@@ -119,7 +118,7 @@ func TestActionsService_GenerateRepoJITConfig(t *testing.T) {
 		fmt.Fprint(w, `{"encoded_jit_config":"foo"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	jitConfig, _, err := client.Actions.GenerateRepoJITConfig(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Actions.GenerateRepoJITConfig returned error: %v", err)
@@ -154,7 +153,7 @@ func TestActionsService_CreateRegistrationToken(t *testing.T) {
 		fmt.Fprint(w, `{"token":"LLBF3JGZDX3P5PMEXLND6TS6FCWO6","expires_at":"2020-01-22T12:13:35.123Z"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	token, _, err := client.Actions.CreateRegistrationToken(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Actions.CreateRegistrationToken returned error: %v", err)
@@ -198,7 +197,7 @@ func TestActionsService_ListRunners(t *testing.T) {
 		Name:        Ptr("MBP"),
 		ListOptions: ListOptions{Page: 2, PerPage: 2},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	runners, _, err := client.Actions.ListRunners(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Actions.ListRunners returned error: %v", err)
@@ -238,7 +237,7 @@ func TestActionsService_GetRunner(t *testing.T) {
 		fmt.Fprint(w, `{"id":23,"name":"MBP","os":"macos","status":"online"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	runner, _, err := client.Actions.GetRunner(ctx, "o", "r", 23)
 	if err != nil {
 		t.Errorf("Actions.GetRunner returned error: %v", err)
@@ -278,7 +277,7 @@ func TestActionsService_CreateRemoveToken(t *testing.T) {
 		fmt.Fprint(w, `{"token":"AABF3JGZDX3P5PMEXLND6TS6FCWO6","expires_at":"2020-01-29T12:13:35.123Z"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	token, _, err := client.Actions.CreateRemoveToken(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Actions.CreateRemoveToken returned error: %v", err)
@@ -312,7 +311,7 @@ func TestActionsService_RemoveRunner(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.RemoveRunner(ctx, "o", "r", 21)
 	if err != nil {
 		t.Errorf("Actions.RemoveRunner returned error: %v", err)
@@ -338,7 +337,7 @@ func TestActionsService_ListOrganizationRunnerApplicationDownloads(t *testing.T)
 		fmt.Fprint(w, `[{"os":"osx","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-osx-x64-2.164.0.tar.gz","filename":"actions-runner-osx-x64-2.164.0.tar.gz"},{"os":"linux","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-x64-2.164.0.tar.gz","filename":"actions-runner-linux-x64-2.164.0.tar.gz"},{"os": "linux","architecture":"arm","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm-2.164.0.tar.gz","filename":"actions-runner-linux-arm-2.164.0.tar.gz"},{"os":"win","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-win-x64-2.164.0.zip","filename":"actions-runner-win-x64-2.164.0.zip"},{"os":"linux","architecture":"arm64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm64-2.164.0.tar.gz","filename":"actions-runner-linux-arm64-2.164.0.tar.gz"}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	downloads, _, err := client.Actions.ListOrganizationRunnerApplicationDownloads(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.ListRunnerApplicationDownloads returned error: %v", err)
@@ -379,7 +378,7 @@ func TestActionsService_CreateOrganizationRegistrationToken(t *testing.T) {
 		fmt.Fprint(w, `{"token":"LLBF3JGZDX3P5PMEXLND6TS6FCWO6","expires_at":"2020-01-22T12:13:35.123Z"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	token, _, err := client.Actions.CreateOrganizationRegistrationToken(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.CreateRegistrationToken returned error: %v", err)
@@ -422,7 +421,7 @@ func TestActionsService_ListOrganizationRunners(t *testing.T) {
 	opts := &ListRunnersOptions{
 		ListOptions: ListOptions{Page: 2, PerPage: 2},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	runners, _, err := client.Actions.ListOrganizationRunners(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Actions.ListRunners returned error: %v", err)
@@ -463,7 +462,7 @@ func TestActionsService_GetOrganizationRunner(t *testing.T) {
 		fmt.Fprint(w, `{"id":23,"name":"MBP","os":"macos","status":"online"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	runner, _, err := client.Actions.GetOrganizationRunner(ctx, "o", 23)
 	if err != nil {
 		t.Errorf("Actions.GetRunner returned error: %v", err)
@@ -503,7 +502,7 @@ func TestActionsService_CreateOrganizationRemoveToken(t *testing.T) {
 		fmt.Fprint(w, `{"token":"AABF3JGZDX3P5PMEXLND6TS6FCWO6","expires_at":"2020-01-29T12:13:35.123Z"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	token, _, err := client.Actions.CreateOrganizationRemoveToken(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.CreateRemoveToken returned error: %v", err)
@@ -537,7 +536,7 @@ func TestActionsService_RemoveOrganizationRunner(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.RemoveOrganizationRunner(ctx, "o", 21)
 	if err != nil {
 		t.Errorf("Actions.RemoveOrganizationRunner returned error: %v", err)

--- a/github/actions_secrets_test.go
+++ b/github/actions_secrets_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -102,7 +101,7 @@ func TestActionsService_GetRepoPublicKey(t *testing.T) {
 		fmt.Fprint(w, `{"key_id":"1234","key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	key, _, err := client.Actions.GetRepoPublicKey(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Actions.GetRepoPublicKey returned error: %v", err)
@@ -137,7 +136,7 @@ func TestActionsService_GetRepoPublicKeyNumeric(t *testing.T) {
 		fmt.Fprint(w, `{"key_id":1234,"key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	key, _, err := client.Actions.GetRepoPublicKey(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Actions.GetRepoPublicKey returned error: %v", err)
@@ -174,7 +173,7 @@ func TestActionsService_ListRepoSecrets(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	secrets, _, err := client.Actions.ListRepoSecrets(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Actions.ListRepoSecrets returned error: %v", err)
@@ -217,7 +216,7 @@ func TestActionsService_ListRepoOrgSecrets(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	secrets, _, err := client.Actions.ListRepoOrgSecrets(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Actions.ListRepoOrgSecrets returned error: %v", err)
@@ -258,7 +257,7 @@ func TestActionsService_GetRepoSecret(t *testing.T) {
 		fmt.Fprint(w, `{"name":"NAME","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	secret, _, err := client.Actions.GetRepoSecret(ctx, "o", "r", "NAME")
 	if err != nil {
 		t.Errorf("Actions.GetRepoSecret returned error: %v", err)
@@ -304,7 +303,7 @@ func TestActionsService_CreateOrUpdateRepoSecret(t *testing.T) {
 		EncryptedValue: "QIv=",
 		KeyID:          "1234",
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.CreateOrUpdateRepoSecret(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Actions.CreateOrUpdateRepoSecret returned error: %v", err)
@@ -333,7 +332,7 @@ func TestActionsService_DeleteRepoSecret(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteRepoSecret(ctx, "o", "r", "NAME")
 	if err != nil {
 		t.Errorf("Actions.DeleteRepoSecret returned error: %v", err)
@@ -359,7 +358,7 @@ func TestActionsService_GetOrgPublicKey(t *testing.T) {
 		fmt.Fprint(w, `{"key_id":"012345678","key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	key, _, err := client.Actions.GetOrgPublicKey(ctx, "o")
 	if err != nil {
 		t.Errorf("Actions.GetOrgPublicKey returned error: %v", err)
@@ -396,7 +395,7 @@ func TestActionsService_ListOrgSecrets(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	secrets, _, err := client.Actions.ListOrgSecrets(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Actions.ListOrgSecrets returned error: %v", err)
@@ -438,7 +437,7 @@ func TestActionsService_GetOrgSecret(t *testing.T) {
 		fmt.Fprint(w, `{"name":"NAME","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z","visibility":"selected","selected_repositories_url":"https://api.github.com/orgs/octo-org/actions/secrets/SUPER_SECRET/repositories"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	secret, _, err := client.Actions.GetOrgSecret(ctx, "o", "NAME")
 	if err != nil {
 		t.Errorf("Actions.GetOrgSecret returned error: %v", err)
@@ -488,7 +487,7 @@ func TestActionsService_CreateOrUpdateOrgSecret(t *testing.T) {
 		Visibility:            "selected",
 		SelectedRepositoryIDs: SelectedRepoIDs{1296269, 1269280},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.CreateOrUpdateOrgSecret(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Actions.CreateOrUpdateOrgSecret returned error: %v", err)
@@ -519,7 +518,7 @@ func TestActionsService_ListSelectedReposForOrgSecret(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	repos, _, err := client.Actions.ListSelectedReposForOrgSecret(ctx, "o", "NAME", opts)
 	if err != nil {
 		t.Errorf("Actions.ListSelectedReposForOrgSecret returned error: %v", err)
@@ -560,7 +559,7 @@ func TestActionsService_SetSelectedReposForOrgSecret(t *testing.T) {
 		testBody(t, r, `{"selected_repository_ids":[64780797]}`+"\n")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.SetSelectedReposForOrgSecret(ctx, "o", "NAME", SelectedRepoIDs{64780797})
 	if err != nil {
 		t.Errorf("Actions.SetSelectedReposForOrgSecret returned error: %v", err)
@@ -586,7 +585,7 @@ func TestActionsService_AddSelectedRepoToOrgSecret(t *testing.T) {
 	})
 
 	repo := &Repository{ID: Ptr(int64(1234))}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.AddSelectedRepoToOrgSecret(ctx, "o", "NAME", repo)
 	if err != nil {
 		t.Errorf("Actions.AddSelectedRepoToOrgSecret returned error: %v", err)
@@ -616,7 +615,7 @@ func TestActionsService_RemoveSelectedRepoFromOrgSecret(t *testing.T) {
 	})
 
 	repo := &Repository{ID: Ptr(int64(1234))}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.RemoveSelectedRepoFromOrgSecret(ctx, "o", "NAME", repo)
 	if err != nil {
 		t.Errorf("Actions.RemoveSelectedRepoFromOrgSecret returned error: %v", err)
@@ -645,7 +644,7 @@ func TestActionsService_DeleteOrgSecret(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteOrgSecret(ctx, "o", "NAME")
 	if err != nil {
 		t.Errorf("Actions.DeleteOrgSecret returned error: %v", err)
@@ -671,7 +670,7 @@ func TestActionsService_GetEnvPublicKey(t *testing.T) {
 		fmt.Fprint(w, `{"key_id":"1234","key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	key, _, err := client.Actions.GetEnvPublicKey(ctx, 1, "e")
 	if err != nil {
 		t.Errorf("Actions.GetEnvPublicKey returned error: %v", err)
@@ -706,7 +705,7 @@ func TestActionsService_GetEnvPublicKeyNumeric(t *testing.T) {
 		fmt.Fprint(w, `{"key_id":1234,"key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	key, _, err := client.Actions.GetEnvPublicKey(ctx, 1, "e")
 	if err != nil {
 		t.Errorf("Actions.GetEnvPublicKey returned error: %v", err)
@@ -743,7 +742,7 @@ func TestActionsService_ListEnvSecrets(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	secrets, _, err := client.Actions.ListEnvSecrets(ctx, 1, "e", opts)
 	if err != nil {
 		t.Errorf("Actions.ListEnvSecrets returned error: %v", err)
@@ -784,7 +783,7 @@ func TestActionsService_GetEnvSecret(t *testing.T) {
 		fmt.Fprint(w, `{"name":"secret","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	secret, _, err := client.Actions.GetEnvSecret(ctx, 1, "e", "secret")
 	if err != nil {
 		t.Errorf("Actions.GetEnvSecret returned error: %v", err)
@@ -830,7 +829,7 @@ func TestActionsService_CreateOrUpdateEnvSecret(t *testing.T) {
 		EncryptedValue: "QIv=",
 		KeyID:          "1234",
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.CreateOrUpdateEnvSecret(ctx, 1, "e", input)
 	if err != nil {
 		t.Errorf("Actions.CreateOrUpdateEnvSecret returned error: %v", err)
@@ -859,7 +858,7 @@ func TestActionsService_DeleteEnvSecret(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteEnvSecret(ctx, 1, "e", "secret")
 	if err != nil {
 		t.Errorf("Actions.DeleteEnvSecret returned error: %v", err)

--- a/github/actions_variables_test.go
+++ b/github/actions_variables_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -26,7 +25,7 @@ func TestActionsService_ListRepoVariables(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	variables, _, err := client.Actions.ListRepoVariables(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Actions.ListRepoVariables returned error: %v", err)
@@ -69,7 +68,7 @@ func TestActionsService_ListRepoOrgVariables(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	variables, _, err := client.Actions.ListRepoOrgVariables(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Actions.ListRepoOrgVariables returned error: %v", err)
@@ -110,7 +109,7 @@ func TestActionsService_GetRepoVariable(t *testing.T) {
 		fmt.Fprint(w, `{"name":"NAME","value":"VALUE","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	variable, _, err := client.Actions.GetRepoVariable(ctx, "o", "r", "NAME")
 	if err != nil {
 		t.Errorf("Actions.GetRepoVariable returned error: %v", err)
@@ -156,7 +155,7 @@ func TestActionsService_CreateRepoVariable(t *testing.T) {
 		Name:  "NAME",
 		Value: "VALUE",
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.CreateRepoVariable(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Actions.CreateRepoVariable returned error: %v", err)
@@ -188,7 +187,7 @@ func TestActionsService_UpdateRepoVariable(t *testing.T) {
 		Name:  "NAME",
 		Value: "VALUE",
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.UpdateRepoVariable(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Actions.UpdateRepoVariable returned error: %v", err)
@@ -217,7 +216,7 @@ func TestActionsService_DeleteRepoVariable(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteRepoVariable(ctx, "o", "r", "NAME")
 	if err != nil {
 		t.Errorf("Actions.( returned error: %v", err)
@@ -245,7 +244,7 @@ func TestActionsService_ListOrgVariables(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	variables, _, err := client.Actions.ListOrgVariables(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Actions.ListOrgVariables returned error: %v", err)
@@ -287,7 +286,7 @@ func TestActionsService_GetOrgVariable(t *testing.T) {
 		fmt.Fprint(w, `{"name":"NAME","value":"VALUE","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z","visibility":"selected","selected_repositories_url":"https://api.github.com/orgs/octo-org/actions/variables/VAR/repositories"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	variable, _, err := client.Actions.GetOrgVariable(ctx, "o", "NAME")
 	if err != nil {
 		t.Errorf("Actions.GetOrgVariable returned error: %v", err)
@@ -337,7 +336,7 @@ func TestActionsService_CreateOrgVariable(t *testing.T) {
 		Visibility:            Ptr("selected"),
 		SelectedRepositoryIDs: &SelectedRepoIDs{1296269, 1269280},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.CreateOrgVariable(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Actions.CreateOrgVariable returned error: %v", err)
@@ -371,7 +370,7 @@ func TestActionsService_UpdateOrgVariable(t *testing.T) {
 		Visibility:            Ptr("selected"),
 		SelectedRepositoryIDs: &SelectedRepoIDs{1296269, 1269280},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.UpdateOrgVariable(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Actions.UpdateOrgVariable returned error: %v", err)
@@ -402,7 +401,7 @@ func TestActionsService_ListSelectedReposForOrgVariable(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	repos, _, err := client.Actions.ListSelectedReposForOrgVariable(ctx, "o", "NAME", opts)
 	if err != nil {
 		t.Errorf("Actions.( returned error: %v", err)
@@ -443,7 +442,7 @@ func TestActionsService_SetSelectedReposForOrgSVariable(t *testing.T) {
 		testBody(t, r, `{"selected_repository_ids":[64780797]}`+"\n")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.SetSelectedReposForOrgVariable(ctx, "o", "NAME", SelectedRepoIDs{64780797})
 	if err != nil {
 		t.Errorf("Actions.( returned error: %v", err)
@@ -469,7 +468,7 @@ func TestActionsService_AddSelectedRepoToOrgVariable(t *testing.T) {
 	})
 
 	repo := &Repository{ID: Ptr(int64(1234))}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.AddSelectedRepoToOrgVariable(ctx, "o", "NAME", repo)
 	if err != nil {
 		t.Errorf("Actions.AddSelectedRepoToOrgVariable returned error: %v", err)
@@ -503,7 +502,7 @@ func TestActionsService_RemoveSelectedRepoFromOrgVariable(t *testing.T) {
 	})
 
 	repo := &Repository{ID: Ptr(int64(1234))}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.RemoveSelectedRepoFromOrgVariable(ctx, "o", "NAME", repo)
 	if err != nil {
 		t.Errorf("Actions.RemoveSelectedRepoFromOrgVariable returned error: %v", err)
@@ -536,7 +535,7 @@ func TestActionsService_DeleteOrgVariable(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteOrgVariable(ctx, "o", "NAME")
 	if err != nil {
 		t.Errorf("Actions.DeleteOrgVariable returned error: %v", err)
@@ -564,7 +563,7 @@ func TestActionsService_ListEnvVariables(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	variables, _, err := client.Actions.ListEnvVariables(ctx, "usr", "1", "e", opts)
 	if err != nil {
 		t.Errorf("Actions.ListEnvVariables returned error: %v", err)
@@ -605,7 +604,7 @@ func TestActionsService_GetEnvVariable(t *testing.T) {
 		fmt.Fprint(w, `{"name":"variable","value":"VAR","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	variable, _, err := client.Actions.GetEnvVariable(ctx, "usr", "1", "e", "variable")
 	if err != nil {
 		t.Errorf("Actions.GetEnvVariable returned error: %v", err)
@@ -651,7 +650,7 @@ func TestActionsService_CreateEnvVariable(t *testing.T) {
 		Name:  "variable",
 		Value: "VAR",
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.CreateEnvVariable(ctx, "usr", "1", "e", input)
 	if err != nil {
 		t.Errorf("Actions.CreateEnvVariable returned error: %v", err)
@@ -683,7 +682,7 @@ func TestActionsService_UpdateEnvVariable(t *testing.T) {
 		Name:  "variable",
 		Value: "VAR",
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.UpdateEnvVariable(ctx, "usr", "1", "e", input)
 	if err != nil {
 		t.Errorf("Actions.UpdateEnvVariable returned error: %v", err)
@@ -712,7 +711,7 @@ func TestActionsService_DeleteEnvVariable(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DeleteEnvVariable(ctx, "usr", "1", "e", "variable")
 	if err != nil {
 		t.Errorf("Actions.DeleteEnvVariable returned error: %v", err)

--- a/github/actions_workflow_jobs_test.go
+++ b/github/actions_workflow_jobs_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -29,7 +28,7 @@ func TestActionsService_ListWorkflowJobs(t *testing.T) {
 	})
 
 	opts := &ListWorkflowJobsOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	jobs, _, err := client.Actions.ListWorkflowJobs(ctx, "o", "r", 29679449, opts)
 	if err != nil {
 		t.Errorf("Actions.ListWorkflowJobs returned error: %v", err)
@@ -72,7 +71,7 @@ func TestActionsService_ListWorkflowJobs_Filter(t *testing.T) {
 	})
 
 	opts := &ListWorkflowJobsOptions{Filter: "all", ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	jobs, _, err := client.Actions.ListWorkflowJobs(ctx, "o", "r", 29679449, opts)
 	if err != nil {
 		t.Errorf("Actions.ListWorkflowJobs returned error: %v", err)
@@ -100,7 +99,7 @@ func TestActionsService_ListWorkflowJobsAttempt(t *testing.T) {
 		fmt.Fprint(w, `{"total_count":4,"jobs":[{"id":399444496,"run_id":29679449,"started_at":"2019-01-02T15:04:05Z","completed_at":"2020-01-02T15:04:05Z","run_attempt":2},{"id":399444497,"run_id":29679449,"started_at":"2019-01-02T15:04:05Z","completed_at":"2020-01-02T15:04:05Z","run_attempt":2}]}`)
 	})
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	jobs, _, err := client.Actions.ListWorkflowJobsAttempt(ctx, "o", "r", 29679449, 1, opts)
 	if err != nil {
 		t.Errorf("Actions.ListWorkflowJobsAttempt returned error: %v", err)
@@ -153,7 +152,7 @@ func TestActionsService_GetWorkflowJobByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":399444496,"started_at":"2019-01-02T15:04:05Z","completed_at":"2020-01-02T15:04:05Z"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	job, _, err := client.Actions.GetWorkflowJobByID(ctx, "o", "r", 399444496)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowJobByID returned error: %v", err)
@@ -210,7 +209,7 @@ func TestActionsService_GetWorkflowJobLogs(t *testing.T) {
 				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 1)
 			if err != nil {
 				t.Errorf("Actions.GetWorkflowJobLogs returned error: %v", err)
@@ -270,7 +269,7 @@ func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_dontFollowRedi
 				http.Redirect(w, r, "https://github.com/a", http.StatusMovedPermanently)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, resp, _ := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 0)
 			if resp.StatusCode != http.StatusMovedPermanently {
 				t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
@@ -313,7 +312,7 @@ func TestActionsService_GetWorkflowJobLogs_StatusMovedPermanently_followRedirect
 				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 1)
 			if err != nil {
 				t.Errorf("Actions.GetWorkflowJobLogs returned error: %v", err)
@@ -365,7 +364,7 @@ func TestActionsService_GetWorkflowJobLogs_unexpectedCode(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, "o", "r", 399444496, 1)
 			if err == nil {
 				t.Fatal("Actions.GetWorkflowJobLogs should return error on unexpected code")

--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,7 +29,7 @@ func TestActionsService_ListWorkflowRunsByID(t *testing.T) {
 	})
 
 	opts := &ListWorkflowRunsOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	runs, _, err := client.Actions.ListWorkflowRunsByID(ctx, "o", "r", 29679449, opts)
 	if err != nil {
 		t.Errorf("Actions.ListWorkFlowRunsByID returned error: %v", err)
@@ -73,7 +72,7 @@ func TestActionsService_ListWorkflowRunsFileName(t *testing.T) {
 	})
 
 	opts := &ListWorkflowRunsOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	runs, _, err := client.Actions.ListWorkflowRunsByFileName(ctx, "o", "r", "29679449", opts)
 	if err != nil {
 		t.Errorf("Actions.ListWorkFlowRunsByFileName returned error: %v", err)
@@ -114,7 +113,7 @@ func TestActionsService_GetWorkflowRunByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":399444496,"run_number":296,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	runs, _, err := client.Actions.GetWorkflowRunByID(ctx, "o", "r", 29679449)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowRunByID returned error: %v", err)
@@ -157,7 +156,7 @@ func TestActionsService_GetWorkflowRunAttempt(t *testing.T) {
 	})
 
 	opts := &WorkflowRunAttemptOptions{ExcludePullRequests: Ptr(true)}
-	ctx := context.Background()
+	ctx := t.Context()
 	runs, _, err := client.Actions.GetWorkflowRunAttempt(ctx, "o", "r", 29679449, 3, opts)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowRunAttempt returned error: %v", err)
@@ -217,7 +216,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs(t *testing.T) {
 				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			url, resp, err := client.Actions.GetWorkflowRunAttemptLogs(ctx, "o", "r", 399444496, 2, 1)
 			if err != nil {
 				t.Errorf("Actions.GetWorkflowRunAttemptLogs returned error: %v", err)
@@ -266,7 +265,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs_StatusMovedPermanently_dontFol
 				http.Redirect(w, r, "https://github.com/a", http.StatusMovedPermanently)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, resp, _ := client.Actions.GetWorkflowRunAttemptLogs(ctx, "o", "r", 399444496, 2, 0)
 			if resp.StatusCode != http.StatusMovedPermanently {
 				t.Errorf("Actions.GetWorkflowRunAttemptLogs returned status: %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
@@ -309,7 +308,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs_StatusMovedPermanently_followR
 				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			url, resp, err := client.Actions.GetWorkflowRunAttemptLogs(ctx, "o", "r", 399444496, 2, 1)
 			if err != nil {
 				t.Errorf("Actions.GetWorkflowRunAttemptLogs returned error: %v", err)
@@ -367,7 +366,7 @@ func TestActionsService_GetWorkflowRunAttemptLogs_unexpectedCode(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			url, resp, err := client.Actions.GetWorkflowRunAttemptLogs(ctx, "o", "r", 399444496, 2, 1)
 			if err == nil {
 				t.Fatal("Actions.GetWorkflowRunAttemptLogs should return error on unexpected code")
@@ -394,7 +393,7 @@ func TestActionsService_RerunWorkflowRunByID(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Actions.RerunWorkflowByID(ctx, "o", "r", 3434)
 	if err != nil {
 		t.Errorf("Actions.RerunWorkflowByID returned error: %v", err)
@@ -423,7 +422,7 @@ func TestActionsService_RerunFailedJobsByID(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Actions.RerunFailedJobsByID(ctx, "o", "r", 3434)
 	if err != nil {
 		t.Errorf("Actions.RerunFailedJobsByID returned error: %v", err)
@@ -452,7 +451,7 @@ func TestActionsService_RerunJobByID(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Actions.RerunJobByID(ctx, "o", "r", 3434)
 	if err != nil {
 		t.Errorf("Actions.RerunJobByID returned error: %v", err)
@@ -481,7 +480,7 @@ func TestActionsService_CancelWorkflowRunByID(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Actions.CancelWorkflowRunByID(ctx, "o", "r", 3434)
 	if !errors.As(err, new(*AcceptedError)) {
 		t.Errorf("Actions.CancelWorkflowRunByID returned error: %v (want AcceptedError)", err)
@@ -528,7 +527,7 @@ func TestActionsService_GetWorkflowRunLogs(t *testing.T) {
 				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			url, resp, err := client.Actions.GetWorkflowRunLogs(ctx, "o", "r", 399444496, 1)
 			if err != nil {
 				t.Errorf("Actions.GetWorkflowRunLogs returned error: %v", err)
@@ -577,7 +576,7 @@ func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_dontFollowRedi
 				http.Redirect(w, r, "https://github.com/a", http.StatusMovedPermanently)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, resp, _ := client.Actions.GetWorkflowRunLogs(ctx, "o", "r", 399444496, 0)
 			if resp.StatusCode != http.StatusMovedPermanently {
 				t.Errorf("Actions.GetWorkflowJobLogs returned status: %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
@@ -620,7 +619,7 @@ func TestActionsService_GetWorkflowRunLogs_StatusMovedPermanently_followRedirect
 				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			url, resp, err := client.Actions.GetWorkflowRunLogs(ctx, "o", "r", 399444496, 1)
 			if err != nil {
 				t.Errorf("Actions.GetWorkflowJobLogs returned error: %v", err)
@@ -678,7 +677,7 @@ func TestActionsService_GetWorkflowRunLogs_unexpectedCode(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			url, resp, err := client.Actions.GetWorkflowRunLogs(ctx, "o", "r", 399444496, 1)
 			if err == nil {
 				t.Fatal("Actions.GetWorkflowRunLogs should return error on unexpected code")
@@ -710,7 +709,7 @@ func TestActionService_ListRepositoryWorkflowRuns(t *testing.T) {
 	})
 
 	opts := &ListWorkflowRunsOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	runs, _, err := client.Actions.ListRepositoryWorkflowRuns(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Actions.ListRepositoryWorkflowRuns returned error: %v", err)
@@ -755,7 +754,7 @@ func TestActionService_DeleteWorkflowRun(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Actions.DeleteWorkflowRun(ctx, "o", "r", 399444496); err != nil {
 		t.Errorf("DeleteWorkflowRun returned error: %v", err)
 	}
@@ -781,7 +780,7 @@ func TestActionService_DeleteWorkflowRunLogs(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Actions.DeleteWorkflowRunLogs(ctx, "o", "r", 399444496); err != nil {
 		t.Errorf("DeleteWorkflowRunLogs returned error: %v", err)
 	}
@@ -872,7 +871,7 @@ func TestActionsService_ReviewCustomDeploymentProtectionRule(t *testing.T) {
 		Comment:         "Approve deployment",
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Actions.ReviewCustomDeploymentProtectionRule(ctx, "o", "r", 9444496, &request); err != nil {
 		t.Errorf("ReviewCustomDeploymentProtectionRule returned error: %v", err)
 	}
@@ -914,7 +913,7 @@ func TestActionsService_GetWorkflowRunUsageByID(t *testing.T) {
 		fmt.Fprint(w, `{"billable":{"UBUNTU":{"total_ms":180000,"jobs":1,"job_runs":[{"job_id":1,"duration_ms":60000}]},"MACOS":{"total_ms":240000,"jobs":2,"job_runs":[{"job_id":2,"duration_ms":30000},{"job_id":3,"duration_ms":10000}]},"WINDOWS":{"total_ms":300000,"jobs":2}},"run_duration_ms":500000}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	workflowRunUsage, _, err := client.Actions.GetWorkflowRunUsageByID(ctx, "o", "r", 29679449)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowRunUsageByID returned error: %v", err)
@@ -1612,7 +1611,7 @@ func TestActionService_PendingDeployments(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	deployments, _, err := client.Actions.PendingDeployments(ctx, "o", "r", 399444496, input)
 	if err != nil {
 		t.Errorf("Actions.PendingDeployments returned error: %v", err)
@@ -1688,7 +1687,7 @@ func TestActionService_GetPendingDeployments(t *testing.T) {
 		]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	deployments, _, err := client.Actions.GetPendingDeployments(ctx, "o", "r", 399444496)
 	if err != nil {
 		t.Errorf("Actions.GetPendingDeployments returned error: %v", err)

--- a/github/actions_workflows_test.go
+++ b/github/actions_workflows_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -27,7 +26,7 @@ func TestActionsService_ListWorkflows(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	workflows, _, err := client.Actions.ListWorkflows(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Actions.ListWorkflows returned error: %v", err)
@@ -68,7 +67,7 @@ func TestActionsService_GetWorkflowByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":72844,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	workflow, _, err := client.Actions.GetWorkflowByID(ctx, "o", "r", 72844)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowByID returned error: %v", err)
@@ -107,7 +106,7 @@ func TestActionsService_GetWorkflowByFileName(t *testing.T) {
 		fmt.Fprint(w, `{"id":72844,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	workflow, _, err := client.Actions.GetWorkflowByFileName(ctx, "o", "r", "main.yml")
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowByFileName returned error: %v", err)
@@ -146,7 +145,7 @@ func TestActionsService_GetWorkflowUsageByID(t *testing.T) {
 		fmt.Fprint(w, `{"billable":{"UBUNTU":{"total_ms":180000},"MACOS":{"total_ms":240000},"WINDOWS":{"total_ms":300000}}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	workflowUsage, _, err := client.Actions.GetWorkflowUsageByID(ctx, "o", "r", 72844)
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowUsageByID returned error: %v", err)
@@ -193,7 +192,7 @@ func TestActionsService_GetWorkflowUsageByFileName(t *testing.T) {
 		fmt.Fprint(w, `{"billable":{"UBUNTU":{"total_ms":180000},"MACOS":{"total_ms":240000},"WINDOWS":{"total_ms":300000}}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	workflowUsage, _, err := client.Actions.GetWorkflowUsageByFileName(ctx, "o", "r", "main.yml")
 	if err != nil {
 		t.Errorf("Actions.GetWorkflowUsageByFileName returned error: %v", err)
@@ -251,7 +250,7 @@ func TestActionsService_CreateWorkflowDispatchEventByID(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.CreateWorkflowDispatchEventByID(ctx, "o", "r", 72844, event)
 	if err != nil {
 		t.Errorf("Actions.CreateWorkflowDispatchEventByID returned error: %v", err)
@@ -295,7 +294,7 @@ func TestActionsService_CreateWorkflowDispatchEventByFileName(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.CreateWorkflowDispatchEventByFileName(ctx, "o", "r", "main.yml", event)
 	if err != nil {
 		t.Errorf("Actions.CreateWorkflowDispatchEventByFileName returned error: %v", err)
@@ -330,7 +329,7 @@ func TestActionsService_EnableWorkflowByID(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.EnableWorkflowByID(ctx, "o", "r", 72844)
 	if err != nil {
 		t.Errorf("Actions.EnableWorkflowByID returned error: %v", err)
@@ -365,7 +364,7 @@ func TestActionsService_EnableWorkflowByFilename(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.EnableWorkflowByFileName(ctx, "o", "r", "main.yml")
 	if err != nil {
 		t.Errorf("Actions.EnableWorkflowByFilename returned error: %v", err)
@@ -400,7 +399,7 @@ func TestActionsService_DisableWorkflowByID(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DisableWorkflowByID(ctx, "o", "r", 72844)
 	if err != nil {
 		t.Errorf("Actions.DisableWorkflowByID returned error: %v", err)
@@ -435,7 +434,7 @@ func TestActionsService_DisableWorkflowByFileName(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Actions.DisableWorkflowByFileName(ctx, "o", "r", "main.yml")
 	if err != nil {
 		t.Errorf("Actions.DisableWorkflowByFileName returned error: %v", err)

--- a/github/activity_events_test.go
+++ b/github/activity_events_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -28,7 +27,7 @@ func TestActivityService_ListEvents(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	events, _, err := client.Activity.ListEvents(ctx, opt)
 	if err != nil {
 		t.Errorf("Activities.ListEvents returned error: %v", err)
@@ -62,7 +61,7 @@ func TestActivityService_ListRepositoryEvents(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	events, _, err := client.Activity.ListRepositoryEvents(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Activities.ListRepositoryEvents returned error: %v", err)
@@ -92,7 +91,7 @@ func TestActivityService_ListRepositoryEvents_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Activity.ListRepositoryEvents(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
@@ -110,7 +109,7 @@ func TestActivityService_ListIssueEventsForRepository(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	events, _, err := client.Activity.ListIssueEventsForRepository(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Activities.ListIssueEventsForRepository returned error: %v", err)
@@ -140,7 +139,7 @@ func TestActivityService_ListIssueEventsForRepository_invalidOwner(t *testing.T)
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Activity.ListIssueEventsForRepository(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
@@ -158,7 +157,7 @@ func TestActivityService_ListEventsForRepoNetwork(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	events, _, err := client.Activity.ListEventsForRepoNetwork(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Activities.ListEventsForRepoNetwork returned error: %v", err)
@@ -188,7 +187,7 @@ func TestActivityService_ListEventsForRepoNetwork_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Activity.ListEventsForRepoNetwork(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
@@ -206,7 +205,7 @@ func TestActivityService_ListEventsForOrganization(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	events, _, err := client.Activity.ListEventsForOrganization(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Activities.ListEventsForOrganization returned error: %v", err)
@@ -236,7 +235,7 @@ func TestActivityService_ListEventsForOrganization_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Activity.ListEventsForOrganization(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -254,7 +253,7 @@ func TestActivityService_ListEventsPerformedByUser_all(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	events, _, err := client.Activity.ListEventsPerformedByUser(ctx, "u", false, opt)
 	if err != nil {
 		t.Errorf("Events.ListPerformedByUser returned error: %v", err)
@@ -289,7 +288,7 @@ func TestActivityService_ListEventsPerformedByUser_publicOnly(t *testing.T) {
 		fmt.Fprint(w, `[{"id":"1"},{"id":"2"}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	events, _, err := client.Activity.ListEventsPerformedByUser(ctx, "u", true, nil)
 	if err != nil {
 		t.Errorf("Events.ListPerformedByUser returned error: %v", err)
@@ -305,7 +304,7 @@ func TestActivityService_ListEventsPerformedByUser_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Activity.ListEventsPerformedByUser(ctx, "%", false, nil)
 	testURLParseError(t, err)
 }
@@ -323,7 +322,7 @@ func TestActivityService_ListEventsReceivedByUser_all(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	events, _, err := client.Activity.ListEventsReceivedByUser(ctx, "u", false, opt)
 	if err != nil {
 		t.Errorf("Events.ListReceivedByUser returned error: %v", err)
@@ -358,7 +357,7 @@ func TestActivityService_ListEventsReceivedByUser_publicOnly(t *testing.T) {
 		fmt.Fprint(w, `[{"id":"1"},{"id":"2"}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	events, _, err := client.Activity.ListEventsReceivedByUser(ctx, "u", true, nil)
 	if err != nil {
 		t.Errorf("Events.ListReceivedByUser returned error: %v", err)
@@ -374,7 +373,7 @@ func TestActivityService_ListEventsReceivedByUser_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Activity.ListEventsReceivedByUser(ctx, "%", false, nil)
 	testURLParseError(t, err)
 }
@@ -392,7 +391,7 @@ func TestActivityService_ListUserEventsForOrganization(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	events, _, err := client.Activity.ListUserEventsForOrganization(ctx, "o", "u", opt)
 	if err != nil {
 		t.Errorf("Activities.ListUserEventsForOrganization returned error: %v", err)

--- a/github/activity_notifications_test.go
+++ b/github/activity_notifications_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -38,7 +37,7 @@ func TestActivityService_ListNotification(t *testing.T) {
 		Since:         time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC),
 		Before:        time.Date(2007, time.March, 4, 15, 4, 5, 0, time.UTC),
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	notifications, _, err := client.Activity.ListNotifications(ctx, opt)
 	if err != nil {
 		t.Errorf("Activity.ListNotifications returned error: %v", err)
@@ -68,7 +67,7 @@ func TestActivityService_ListRepositoryNotifications(t *testing.T) {
 		fmt.Fprint(w, `[{"id":"1"}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	notifications, _, err := client.Activity.ListRepositoryNotifications(ctx, "o", "r", nil)
 	if err != nil {
 		t.Errorf("Activity.ListRepositoryNotifications returned error: %v", err)
@@ -106,7 +105,7 @@ func TestActivityService_MarkNotificationsRead(t *testing.T) {
 		w.WriteHeader(http.StatusResetContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Activity.MarkNotificationsRead(ctx, Timestamp{time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC)})
 	if err != nil {
 		t.Errorf("Activity.MarkNotificationsRead returned error: %v", err)
@@ -130,7 +129,7 @@ func TestActivityService_MarkRepositoryNotificationsRead(t *testing.T) {
 		w.WriteHeader(http.StatusResetContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Activity.MarkRepositoryNotificationsRead(ctx, "o", "r", Timestamp{time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC)})
 	if err != nil {
 		t.Errorf("Activity.MarkRepositoryNotificationsRead returned error: %v", err)
@@ -156,7 +155,7 @@ func TestActivityService_GetThread(t *testing.T) {
 		fmt.Fprint(w, `{"id":"1"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	notification, _, err := client.Activity.GetThread(ctx, "1")
 	if err != nil {
 		t.Errorf("Activity.GetThread returned error: %v", err)
@@ -191,7 +190,7 @@ func TestActivityService_MarkThreadRead(t *testing.T) {
 		w.WriteHeader(http.StatusResetContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Activity.MarkThreadRead(ctx, "1")
 	if err != nil {
 		t.Errorf("Activity.MarkThreadRead returned error: %v", err)
@@ -217,7 +216,7 @@ func TestActivityService_MarkThreadDone(t *testing.T) {
 		w.WriteHeader(http.StatusResetContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Activity.MarkThreadDone(ctx, 1)
 	if err != nil {
 		t.Errorf("Activity.MarkThreadDone returned error: %v", err)
@@ -243,7 +242,7 @@ func TestActivityService_GetThreadSubscription(t *testing.T) {
 		fmt.Fprint(w, `{"subscribed":true}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	sub, _, err := client.Activity.GetThreadSubscription(ctx, "1")
 	if err != nil {
 		t.Errorf("Activity.GetThreadSubscription returned error: %v", err)
@@ -287,7 +286,7 @@ func TestActivityService_SetThreadSubscription(t *testing.T) {
 		fmt.Fprint(w, `{"ignored":true}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	sub, _, err := client.Activity.SetThreadSubscription(ctx, "1", input)
 	if err != nil {
 		t.Errorf("Activity.SetThreadSubscription returned error: %v", err)
@@ -322,7 +321,7 @@ func TestActivityService_DeleteThreadSubscription(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Activity.DeleteThreadSubscription(ctx, "1")
 	if err != nil {
 		t.Errorf("Activity.DeleteThreadSubscription returned error: %v", err)

--- a/github/activity_star_test.go
+++ b/github/activity_star_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -30,7 +29,7 @@ func TestActivityService_ListStargazers(t *testing.T) {
 		fmt.Fprint(w, `[{"starred_at":"2002-02-10T15:30:00Z","user":{"id":1}}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	stargazers, _, err := client.Activity.ListStargazers(ctx, "o", "r", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Activity.ListStargazers returned error: %v", err)
@@ -66,7 +65,7 @@ func TestActivityService_ListStarred_authenticatedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"starred_at":"2002-02-10T15:30:00Z","repo":{"id":1}}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	repos, _, err := client.Activity.ListStarred(ctx, "", nil)
 	if err != nil {
 		t.Errorf("Activity.ListStarred returned error: %v", err)
@@ -108,7 +107,7 @@ func TestActivityService_ListStarred_specifiedUser(t *testing.T) {
 	})
 
 	opt := &ActivityListStarredOptions{"created", "asc", ListOptions{Page: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	repos, _, err := client.Activity.ListStarred(ctx, "u", opt)
 	if err != nil {
 		t.Errorf("Activity.ListStarred returned error: %v", err)
@@ -138,7 +137,7 @@ func TestActivityService_ListStarred_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Activity.ListStarred(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -152,7 +151,7 @@ func TestActivityService_IsStarred_hasStar(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	star, _, err := client.Activity.IsStarred(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Activity.IsStarred returned error: %v", err)
@@ -185,7 +184,7 @@ func TestActivityService_IsStarred_noStar(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	star, _, err := client.Activity.IsStarred(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Activity.IsStarred returned error: %v", err)
@@ -213,7 +212,7 @@ func TestActivityService_IsStarred_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Activity.IsStarred(ctx, "%", "%")
 	testURLParseError(t, err)
 }
@@ -226,7 +225,7 @@ func TestActivityService_Star(t *testing.T) {
 		testMethod(t, r, "PUT")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Activity.Star(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Activity.Star returned error: %v", err)
@@ -247,7 +246,7 @@ func TestActivityService_Star_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Activity.Star(ctx, "%", "%")
 	testURLParseError(t, err)
 }
@@ -260,7 +259,7 @@ func TestActivityService_Unstar(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Activity.Unstar(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Activity.Unstar returned error: %v", err)
@@ -281,7 +280,7 @@ func TestActivityService_Unstar_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Activity.Unstar(ctx, "%", "%")
 	testURLParseError(t, err)
 }

--- a/github/activity_test.go
+++ b/github/activity_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -24,7 +23,7 @@ func TestActivityService_List(t *testing.T) {
 		assertWrite(t, w, feedsJSON)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Activity.ListFeeds(ctx)
 	if err != nil {
 		t.Errorf("Activity.ListFeeds returned error: %v", err)

--- a/github/activity_watching_test.go
+++ b/github/activity_watching_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -28,7 +27,7 @@ func TestActivityService_ListWatchers(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	watchers, _, err := client.Activity.ListWatchers(ctx, "o", "r", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Activity.ListWatchers returned error: %v", err)
@@ -66,7 +65,7 @@ func TestActivityService_ListWatched_authenticatedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	watched, _, err := client.Activity.ListWatched(ctx, "", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Activity.ListWatched returned error: %v", err)
@@ -104,7 +103,7 @@ func TestActivityService_ListWatched_specifiedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	watched, _, err := client.Activity.ListWatched(ctx, "u", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Activity.ListWatched returned error: %v", err)
@@ -125,7 +124,7 @@ func TestActivityService_GetRepositorySubscription_true(t *testing.T) {
 		fmt.Fprint(w, `{"subscribed":true}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	sub, _, err := client.Activity.GetRepositorySubscription(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Activity.GetRepositorySubscription returned error: %v", err)
@@ -160,7 +159,7 @@ func TestActivityService_GetRepositorySubscription_false(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	sub, _, err := client.Activity.GetRepositorySubscription(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Activity.GetRepositorySubscription returned error: %v", err)
@@ -181,7 +180,7 @@ func TestActivityService_GetRepositorySubscription_error(t *testing.T) {
 		w.WriteHeader(http.StatusBadRequest)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Activity.GetRepositorySubscription(ctx, "o", "r")
 	if err == nil {
 		t.Error("Expected HTTP 400 response")
@@ -206,7 +205,7 @@ func TestActivityService_SetRepositorySubscription(t *testing.T) {
 		fmt.Fprint(w, `{"ignored":true}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	sub, _, err := client.Activity.SetRepositorySubscription(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Activity.SetRepositorySubscription returned error: %v", err)
@@ -241,7 +240,7 @@ func TestActivityService_DeleteRepositorySubscription(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Activity.DeleteRepositorySubscription(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Activity.DeleteRepositorySubscription returned error: %v", err)

--- a/github/admin_orgs_test.go
+++ b/github/admin_orgs_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -36,7 +35,7 @@ func TestAdminOrgs_Create(t *testing.T) {
 		fmt.Fprint(w, `{"login":"github","id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Admin.CreateOrg(ctx, input, "ghAdmin")
 	if err != nil {
 		t.Errorf("Admin.CreateOrg returned error: %v", err)
@@ -78,7 +77,7 @@ func TestAdminOrgs_Rename(t *testing.T) {
 		fmt.Fprint(w, `{"message":"Job queued to rename organization. It may take a few minutes to complete.","url":"https://<hostname>/api/v3/organizations/1"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, _, err := client.Admin.RenameOrg(ctx, input, "the-new-octocats")
 	if err != nil {
 		t.Errorf("Admin.RenameOrg returned error: %v", err)
@@ -125,7 +124,7 @@ func TestAdminOrgs_RenameByName(t *testing.T) {
 		fmt.Fprint(w, `{"message":"Job queued to rename organization. It may take a few minutes to complete.","url":"https://<hostname>/api/v3/organizations/1"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, _, err := client.Admin.RenameOrgByName(ctx, "o", "the-new-octocats")
 	if err != nil {
 		t.Errorf("Admin.RenameOrg returned error: %v", err)

--- a/github/admin_stats_test.go
+++ b/github/admin_stats_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -81,7 +80,7 @@ func TestAdminService_GetAdminStats(t *testing.T) {
 `)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	stats, _, err := client.Admin.GetAdminStats(ctx)
 	if err != nil {
 		t.Errorf("AdminService.GetAdminStats returned error: %v", err)

--- a/github/admin_test.go
+++ b/github/admin_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -34,7 +33,7 @@ func TestAdminService_UpdateUserLDAPMapping(t *testing.T) {
 		fmt.Fprint(w, `{"id":1,"ldap_dn":"uid=asdf,ou=users,dc=github,dc=com"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	mapping, _, err := client.Admin.UpdateUserLDAPMapping(ctx, "u", input)
 	if err != nil {
 		t.Errorf("Admin.UpdateUserLDAPMapping returned error: %v", err)
@@ -82,7 +81,7 @@ func TestAdminService_UpdateTeamLDAPMapping(t *testing.T) {
 		fmt.Fprint(w, `{"id":1,"ldap_dn":"cn=Enterprise Ops,ou=teams,dc=github,dc=com"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	mapping, _, err := client.Admin.UpdateTeamLDAPMapping(ctx, 1, input)
 	if err != nil {
 		t.Errorf("Admin.UpdateTeamLDAPMapping returned error: %v", err)

--- a/github/admin_users_test.go
+++ b/github/admin_users_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -33,7 +32,7 @@ func TestAdminUsers_Create(t *testing.T) {
 		fmt.Fprint(w, `{"login":"github","id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Admin.CreateUser(ctx, CreateUserRequest{
 		Login:     "github",
 		Email:     Ptr("email@domain.com"),
@@ -70,7 +69,7 @@ func TestAdminUsers_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Admin.DeleteUser(ctx, "github")
 	if err != nil {
 		t.Errorf("Admin.DeleteUser returned error: %v", err)
@@ -115,7 +114,7 @@ func TestUserImpersonation_Create(t *testing.T) {
 	})
 
 	opt := &ImpersonateUserOptions{Scopes: []string{"repo"}}
-	ctx := context.Background()
+	ctx := t.Context()
 	auth, _, err := client.Admin.CreateUserImpersonation(ctx, "github", opt)
 	if err != nil {
 		t.Errorf("Admin.CreateUserImpersonation returned error: %v", err)
@@ -167,7 +166,7 @@ func TestUserImpersonation_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Admin.DeleteUserImpersonation(ctx, "github")
 	if err != nil {
 		t.Errorf("Admin.DeleteUserImpersonation returned error: %v", err)

--- a/github/apps_hooks_deliveries_test.go
+++ b/github/apps_hooks_deliveries_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -26,7 +25,7 @@ func TestAppsService_ListHookDeliveries(t *testing.T) {
 
 	opts := &ListCursorOptions{Cursor: "v1_12077215967"}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	deliveries, _, err := client.Apps.ListHookDeliveries(ctx, opts)
 	if err != nil {
@@ -57,7 +56,7 @@ func TestAppsService_GetHookDelivery(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Apps.GetHookDelivery(ctx, 1)
 	if err != nil {
 		t.Errorf("Apps.GetHookDelivery returned error: %v", err)
@@ -92,7 +91,7 @@ func TestAppsService_RedeliverHookDelivery(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Apps.RedeliverHookDelivery(ctx, 1)
 	if err != nil {
 		t.Errorf("Apps.RedeliverHookDelivery returned error: %v", err)

--- a/github/apps_hooks_test.go
+++ b/github/apps_hooks_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -28,7 +27,7 @@ func TestAppsService_GetHookConfig(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	config, _, err := client.Apps.GetHookConfig(ctx)
 	if err != nil {
 		t.Errorf("Apps.GetHookConfig returned error: %v", err)
@@ -76,7 +75,7 @@ func TestAppsService_UpdateHookConfig(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	config, _, err := client.Apps.UpdateHookConfig(ctx, input)
 	if err != nil {
 		t.Errorf("Apps.UpdateHookConfig returned error: %v", err)

--- a/github/apps_installation_test.go
+++ b/github/apps_installation_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -28,7 +27,7 @@ func TestAppsService_ListRepos(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	repositories, _, err := client.Apps.ListRepos(ctx, opt)
 	if err != nil {
 		t.Errorf("Apps.ListRepos returned error: %v", err)
@@ -63,7 +62,7 @@ func TestAppsService_ListUserRepos(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	repositories, _, err := client.Apps.ListUserRepos(ctx, 1, opt)
 	if err != nil {
 		t.Errorf("Apps.ListUserRepos returned error: %v", err)
@@ -98,7 +97,7 @@ func TestAppsService_AddRepository(t *testing.T) {
 		fmt.Fprint(w, `{"id":1,"name":"n","description":"d","owner":{"login":"l"},"license":{"key":"mit"}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	repo, _, err := client.Apps.AddRepository(ctx, 1, 1)
 	if err != nil {
 		t.Errorf("Apps.AddRepository returned error: %v", err)
@@ -128,7 +127,7 @@ func TestAppsService_RemoveRepository(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Apps.RemoveRepository(ctx, 1, 1)
 	if err != nil {
 		t.Errorf("Apps.RemoveRepository returned error: %v", err)
@@ -149,7 +148,7 @@ func TestAppsService_RevokeInstallationToken(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Apps.RevokeInstallationToken(ctx)
 	if err != nil {
 		t.Errorf("Apps.RevokeInstallationToken returned error: %v", err)

--- a/github/apps_manifest_test.go
+++ b/github/apps_manifest_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -34,7 +33,7 @@ func TestGetConfig(t *testing.T) {
 		fmt.Fprint(w, manifestJSON)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg, _, err := client.Apps.CompleteAppManifest(ctx, "code")
 	if err != nil {
 		t.Errorf("AppManifest.GetConfig returned error: %v", err)

--- a/github/apps_marketplace_test.go
+++ b/github/apps_marketplace_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -29,7 +28,7 @@ func TestMarketplaceService_ListPlans(t *testing.T) {
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = false
-	ctx := context.Background()
+	ctx := t.Context()
 	plans, _, err := client.Marketplace.ListPlans(ctx, opt)
 	if err != nil {
 		t.Errorf("Marketplace.ListPlans returned error: %v", err)
@@ -61,7 +60,7 @@ func TestMarketplaceService_Stubbed_ListPlans(t *testing.T) {
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = true
-	ctx := context.Background()
+	ctx := t.Context()
 	plans, _, err := client.Marketplace.ListPlans(ctx, opt)
 	if err != nil {
 		t.Errorf("Marketplace.ListPlans (Stubbed) returned error: %v", err)
@@ -84,7 +83,7 @@ func TestMarketplaceService_ListPlanAccountsForPlan(t *testing.T) {
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = false
-	ctx := context.Background()
+	ctx := t.Context()
 	accounts, _, err := client.Marketplace.ListPlanAccountsForPlan(ctx, 1, opt)
 	if err != nil {
 		t.Errorf("Marketplace.ListPlanAccountsForPlan returned error: %v", err)
@@ -116,7 +115,7 @@ func TestMarketplaceService_Stubbed_ListPlanAccountsForPlan(t *testing.T) {
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = true
-	ctx := context.Background()
+	ctx := t.Context()
 	accounts, _, err := client.Marketplace.ListPlanAccountsForPlan(ctx, 1, opt)
 	if err != nil {
 		t.Errorf("Marketplace.ListPlanAccountsForPlan (Stubbed) returned error: %v", err)
@@ -138,7 +137,7 @@ func TestMarketplaceService_GetPlanAccountForAccount(t *testing.T) {
 	})
 
 	client.Marketplace.Stubbed = false
-	ctx := context.Background()
+	ctx := t.Context()
 	account, _, err := client.Marketplace.GetPlanAccountForAccount(ctx, 1)
 	if err != nil {
 		t.Errorf("Marketplace.GetPlanAccountForAccount returned error: %v", err)
@@ -169,7 +168,7 @@ func TestMarketplaceService_Stubbed_GetPlanAccountForAccount(t *testing.T) {
 	})
 
 	client.Marketplace.Stubbed = true
-	ctx := context.Background()
+	ctx := t.Context()
 	account, _, err := client.Marketplace.GetPlanAccountForAccount(ctx, 1)
 	if err != nil {
 		t.Errorf("Marketplace.GetPlanAccountForAccount (Stubbed) returned error: %v", err)
@@ -192,7 +191,7 @@ func TestMarketplaceService_ListMarketplacePurchasesForUser(t *testing.T) {
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = false
-	ctx := context.Background()
+	ctx := t.Context()
 	purchases, _, err := client.Marketplace.ListMarketplacePurchasesForUser(ctx, opt)
 	if err != nil {
 		t.Errorf("Marketplace.ListMarketplacePurchasesForUser returned error: %v", err)
@@ -224,7 +223,7 @@ func TestMarketplaceService_Stubbed_ListMarketplacePurchasesForUser(t *testing.T
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
 	client.Marketplace.Stubbed = true
-	ctx := context.Background()
+	ctx := t.Context()
 	purchases, _, err := client.Marketplace.ListMarketplacePurchasesForUser(ctx, opt)
 	if err != nil {
 		t.Errorf("Marketplace.ListMarketplacePurchasesForUser returned error: %v", err)

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -25,7 +24,7 @@ func TestAppsService_Get_authenticatedApp(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	app, _, err := client.Apps.Get(ctx, "")
 	if err != nil {
 		t.Errorf("Apps.Get returned error: %v", err)
@@ -60,7 +59,7 @@ func TestAppsService_Get_specifiedApp(t *testing.T) {
 		fmt.Fprint(w, `{"html_url":"https://github.com/apps/a"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	app, _, err := client.Apps.Get(ctx, "a")
 	if err != nil {
 		t.Errorf("Apps.Get returned error: %v", err)
@@ -92,7 +91,7 @@ func TestAppsService_ListInstallationRequests(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	installationRequests, _, err := client.Apps.ListInstallationRequests(ctx, opt)
 	if err != nil {
 		t.Errorf("Apps.ListInstallations returned error: %v", err)
@@ -184,7 +183,7 @@ func TestAppsService_ListInstallations(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	installations, _, err := client.Apps.ListInstallations(ctx, opt)
 	if err != nil {
 		t.Errorf("Apps.ListInstallations returned error: %v", err)
@@ -263,7 +262,7 @@ func TestAppsService_GetInstallation(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "app_id":1, "target_id":1, "target_type": "Organization"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	installation, _, err := client.Apps.GetInstallation(ctx, 1)
 	if err != nil {
 		t.Errorf("Apps.GetInstallation returned error: %v", err)
@@ -303,7 +302,7 @@ func TestAppsService_ListUserInstallations(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	installations, _, err := client.Apps.ListUserInstallations(ctx, opt)
 	if err != nil {
 		t.Errorf("Apps.ListUserInstallations returned error: %v", err)
@@ -334,7 +333,7 @@ func TestAppsService_SuspendInstallation(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Apps.SuspendInstallation(ctx, 1); err != nil {
 		t.Errorf("Apps.SuspendInstallation returned error: %v", err)
 	}
@@ -360,7 +359,7 @@ func TestAppsService_UnsuspendInstallation(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Apps.UnsuspendInstallation(ctx, 1); err != nil {
 		t.Errorf("Apps.UnsuspendInstallation returned error: %v", err)
 	}
@@ -385,7 +384,7 @@ func TestAppsService_DeleteInstallation(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Apps.DeleteInstallation(ctx, 1)
 	if err != nil {
 		t.Errorf("Apps.DeleteInstallation returned error: %v", err)
@@ -411,7 +410,7 @@ func TestAppsService_CreateInstallationToken(t *testing.T) {
 		fmt.Fprint(w, `{"token":"t"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	token, _, err := client.Apps.CreateInstallationToken(ctx, 1, nil)
 	if err != nil {
 		t.Errorf("Apps.CreateInstallationToken returned error: %v", err)
@@ -462,7 +461,7 @@ func TestAppsService_CreateInstallationTokenWithOptions(t *testing.T) {
 		fmt.Fprint(w, `{"token":"t"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	token, _, err := client.Apps.CreateInstallationToken(ctx, 1, installationTokenOptions)
 	if err != nil {
 		t.Errorf("Apps.CreateInstallationToken returned error: %v", err)
@@ -498,7 +497,7 @@ func TestAppsService_CreateInstallationTokenListReposWithOptions(t *testing.T) {
 		fmt.Fprint(w, `{"token":"t"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	token, _, err := client.Apps.CreateInstallationTokenListRepos(ctx, 1, installationTokenListRepoOptions)
 	if err != nil {
 		t.Errorf("Apps.CreateInstallationTokenListRepos returned error: %v", err)
@@ -519,7 +518,7 @@ func TestAppsService_CreateInstallationTokenListReposWithNoOptions(t *testing.T)
 		fmt.Fprint(w, `{"token":"t"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	token, _, err := client.Apps.CreateInstallationTokenListRepos(ctx, 1, nil)
 	if err != nil {
 		t.Errorf("Apps.CreateInstallationTokenListRepos returned error: %v", err)
@@ -557,7 +556,7 @@ func TestAppsService_CreateAttachment(t *testing.T) {
 		assertWrite(t, w, []byte(`{"id":1,"title":"title1","body":"body1"}`))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Apps.CreateAttachment(ctx, 11, "title1", "body1")
 	if err != nil {
 		t.Errorf("CreateAttachment returned error: %v", err)
@@ -592,7 +591,7 @@ func TestAppsService_FindOrganizationInstallation(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "app_id":1, "target_id":1, "target_type": "Organization"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	installation, _, err := client.Apps.FindOrganizationInstallation(ctx, "o")
 	if err != nil {
 		t.Errorf("Apps.FindOrganizationInstallation returned error: %v", err)
@@ -627,7 +626,7 @@ func TestAppsService_FindRepositoryInstallation(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "app_id":1, "target_id":1, "target_type": "Organization"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	installation, _, err := client.Apps.FindRepositoryInstallation(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Apps.FindRepositoryInstallation returned error: %v", err)
@@ -662,7 +661,7 @@ func TestAppsService_FindRepositoryInstallationByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "app_id":1, "target_id":1, "target_type": "Organization"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	installation, _, err := client.Apps.FindRepositoryInstallationByID(ctx, 1)
 	if err != nil {
 		t.Errorf("Apps.FindRepositoryInstallationByID returned error: %v", err)
@@ -697,7 +696,7 @@ func TestAppsService_FindUserInstallation(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "app_id":1, "target_id":1, "target_type": "User"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	installation, _, err := client.Apps.FindUserInstallation(ctx, "u")
 	if err != nil {
 		t.Errorf("Apps.FindUserInstallation returned error: %v", err)

--- a/github/authorizations_test.go
+++ b/github/authorizations_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -25,7 +24,7 @@ func TestAuthorizationsService_Check(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Authorizations.Check(ctx, "id", "a")
 	if err != nil {
 		t.Errorf("Authorizations.Check returned error: %v", err)
@@ -62,7 +61,7 @@ func TestAuthorizationsService_Reset(t *testing.T) {
 		fmt.Fprint(w, `{"ID":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Authorizations.Reset(ctx, "id", "a")
 	if err != nil {
 		t.Errorf("Authorizations.Reset returned error: %v", err)
@@ -99,7 +98,7 @@ func TestAuthorizationsService_Revoke(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Authorizations.Revoke(ctx, "id", "a")
 	if err != nil {
 		t.Errorf("Authorizations.Revoke returned error: %v", err)
@@ -126,7 +125,7 @@ func TestDeleteGrant(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeOAuthAppPreview)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Authorizations.DeleteGrant(ctx, "id", "a")
 	if err != nil {
 		t.Errorf("OAuthAuthorizations.DeleteGrant returned error: %v", err)
@@ -153,7 +152,7 @@ func TestAuthorizationsService_CreateImpersonation(t *testing.T) {
 	})
 
 	req := &AuthorizationRequest{Scopes: []Scope{ScopePublicRepo}}
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Authorizations.CreateImpersonation(ctx, "u", req)
 	if err != nil {
 		t.Errorf("Authorizations.CreateImpersonation returned error: %+v", err)
@@ -187,7 +186,7 @@ func TestAuthorizationsService_DeleteImpersonation(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Authorizations.DeleteImpersonation(ctx, "u")
 	if err != nil {
 		t.Errorf("Authorizations.DeleteImpersonation returned error: %+v", err)

--- a/github/billing_test.go
+++ b/github/billing_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -27,7 +26,7 @@ func TestBillingService_GetPackagesBillingOrg(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Billing.GetPackagesBillingOrg(ctx, "o")
 	if err != nil {
 		t.Errorf("Billing.GetPackagesBillingOrg returned error: %v", err)
@@ -61,7 +60,7 @@ func TestBillingService_GetPackagesBillingOrg_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Billing.GetPackagesBillingOrg(ctx, "%")
 	testURLParseError(t, err)
 }
@@ -79,7 +78,7 @@ func TestBillingService_GetStorageBillingOrg(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Billing.GetStorageBillingOrg(ctx, "o")
 	if err != nil {
 		t.Errorf("Billing.GetStorageBillingOrg returned error: %v", err)
@@ -113,7 +112,7 @@ func TestBillingService_GetStorageBillingOrg_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Billing.GetStorageBillingOrg(ctx, "%")
 	testURLParseError(t, err)
 }
@@ -131,7 +130,7 @@ func TestBillingService_GetPackagesBillingUser(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Billing.GetPackagesBillingUser(ctx, "u")
 	if err != nil {
 		t.Errorf("Billing.GetPackagesBillingUser returned error: %v", err)
@@ -165,7 +164,7 @@ func TestBillingService_GetPackagesBillingUser_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Billing.GetPackagesBillingUser(ctx, "%")
 	testURLParseError(t, err)
 }
@@ -183,7 +182,7 @@ func TestBillingService_GetStorageBillingUser(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Billing.GetStorageBillingUser(ctx, "u")
 	if err != nil {
 		t.Errorf("Billing.GetStorageBillingUser returned error: %v", err)
@@ -217,7 +216,7 @@ func TestBillingService_GetStorageBillingUser_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Billing.GetStorageBillingUser(ctx, "%")
 	testURLParseError(t, err)
 }
@@ -305,7 +304,7 @@ func TestBillingService_GetAdvancedSecurityActiveCommittersOrg(t *testing.T) {
 }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &ListOptions{Page: 2, PerPage: 50}
 	hook, _, err := client.Billing.GetAdvancedSecurityActiveCommittersOrg(ctx, "o", opts)
 	if err != nil {
@@ -353,7 +352,7 @@ func TestBillingService_GetAdvancedSecurityActiveCommittersOrg_invalidOrg(t *tes
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Billing.GetAdvancedSecurityActiveCommittersOrg(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -387,7 +386,7 @@ func TestBillingService_GetUsageReportOrg(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &UsageReportOptions{
 		Year:  Ptr(2023),
 		Month: Ptr(8),
@@ -437,7 +436,7 @@ func TestBillingService_GetUsageReportOrg_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Billing.GetUsageReportOrg(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -469,7 +468,7 @@ func TestBillingService_GetUsageReportUser(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &UsageReportOptions{
 		Day: Ptr(15),
 	}
@@ -517,7 +516,7 @@ func TestBillingService_GetUsageReportUser_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Billing.GetUsageReportUser(ctx, "%", nil)
 	testURLParseError(t, err)
 }

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -30,7 +29,7 @@ func TestChecksService_GetCheckRun(t *testing.T) {
 			"started_at": "2018-05-04T01:14:52Z",
 			"completed_at": "2018-05-04T01:14:52Z"}`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	checkRun, _, err := client.Checks.GetCheckRun(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Checks.GetCheckRun return error: %v", err)
@@ -81,7 +80,7 @@ func TestChecksService_GetCheckSuite(t *testing.T) {
                         "after": "deadbeefa",
 			"status": "completed"}`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	checkSuite, _, err := client.Checks.GetCheckSuite(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Checks.GetCheckSuite return error: %v", err)
@@ -144,7 +143,7 @@ func TestChecksService_CreateCheckRun(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	checkRun, _, err := client.Checks.CreateCheckRun(ctx, "o", "r", checkRunOpt)
 	if err != nil {
 		t.Errorf("Checks.CreateCheckRun return error: %v", err)
@@ -204,7 +203,7 @@ func TestChecksService_ListCheckRunAnnotations(t *testing.T) {
 		)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	checkRunAnnotations, _, err := client.Checks.ListCheckRunAnnotations(ctx, "o", "r", 1, &ListOptions{Page: 1})
 	if err != nil {
 		t.Errorf("Checks.ListCheckRunAnnotations return error: %v", err)
@@ -269,7 +268,7 @@ func TestChecksService_UpdateCheckRun(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	checkRun, _, err := client.Checks.UpdateCheckRun(ctx, "o", "r", 1, updateCheckRunOpt)
 	if err != nil {
 		t.Errorf("Checks.UpdateCheckRun return error: %v", err)
@@ -341,7 +340,7 @@ func TestChecksService_ListCheckRunsForRef(t *testing.T) {
 		AppID:       Ptr(int64(1)),
 		ListOptions: ListOptions{Page: 1},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	checkRuns, _, err := client.Checks.ListCheckRunsForRef(ctx, "o", "r", "master", opt)
 	if err != nil {
 		t.Errorf("Checks.ListCheckRunsForRef return error: %v", err)
@@ -409,7 +408,7 @@ func TestChecksService_ListCheckRunsCheckSuite(t *testing.T) {
 		Filter:      Ptr("all"),
 		ListOptions: ListOptions{Page: 1},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	checkRuns, _, err := client.Checks.ListCheckRunsCheckSuite(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Checks.ListCheckRunsCheckSuite return error: %v", err)
@@ -475,7 +474,7 @@ func TestChecksService_ListCheckSuiteForRef(t *testing.T) {
 		AppID:       Ptr(int64(2)),
 		ListOptions: ListOptions{Page: 1},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	checkSuites, _, err := client.Checks.ListCheckSuitesForRef(ctx, "o", "r", "master", opt)
 	if err != nil {
 		t.Errorf("Checks.ListCheckSuitesForRef return error: %v", err)
@@ -527,7 +526,7 @@ func TestChecksService_SetCheckSuitePreferences(t *testing.T) {
 		Setting: Ptr(false),
 	}}
 	opt := CheckSuitePreferenceOptions{AutoTriggerChecks: a}
-	ctx := context.Background()
+	ctx := t.Context()
 	prefResults, _, err := client.Checks.SetCheckSuitePreferences(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Checks.SetCheckSuitePreferences return error: %v", err)
@@ -581,7 +580,7 @@ func TestChecksService_CreateCheckSuite(t *testing.T) {
 		HeadBranch: Ptr("master"),
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	checkSuite, _, err := client.Checks.CreateCheckSuite(ctx, "o", "r", checkSuiteOpt)
 	if err != nil {
 		t.Errorf("Checks.CreateCheckSuite return error: %v", err)
@@ -624,7 +623,7 @@ func TestChecksService_ReRequestCheckSuite(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
 		w.WriteHeader(http.StatusCreated)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Checks.ReRequestCheckSuite(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Checks.ReRequestCheckSuite return error: %v", err)
@@ -1749,7 +1748,7 @@ func TestChecksService_ReRequestCheckRun(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeCheckRunsPreview)
 		w.WriteHeader(http.StatusCreated)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Checks.ReRequestCheckRun(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Checks.ReRequestCheckRun return error: %v", err)

--- a/github/classroom_test.go
+++ b/github/classroom_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -296,7 +295,7 @@ func TestClassroomService_GetAssignment(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	assignment, _, err := client.Classroom.GetAssignment(ctx, 12)
 	if err != nil {
 		t.Errorf("Classroom.GetAssignment returned error: %v", err)
@@ -377,7 +376,7 @@ func TestClassroomService_GetClassroom(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	classroom, _, err := client.Classroom.GetClassroom(ctx, 1296269)
 	if err != nil {
 		t.Errorf("Classroom.GetClassroom returned error: %v", err)
@@ -441,7 +440,7 @@ func TestClassroomService_ListClassrooms(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	classrooms, _, err := client.Classroom.ListClassrooms(ctx, opt)
 	if err != nil {
 		t.Errorf("Classroom.ListClassrooms returned error: %v", err)
@@ -538,7 +537,7 @@ func TestClassroomService_ListClassroomAssignments(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	assignments, _, err := client.Classroom.ListClassroomAssignments(ctx, 1296269, opt)
 	if err != nil {
 		t.Errorf("Classroom.ListClassroomAssignments returned error: %v", err)
@@ -723,7 +722,7 @@ func TestClassroomService_ListAcceptedAssignments(t *testing.T) {
 		]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opt := &ListOptions{Page: 2, PerPage: 2}
 	acceptedAssignments, _, err := client.Classroom.ListAcceptedAssignments(ctx, 12, opt)
 	if err != nil {
@@ -884,7 +883,7 @@ func TestClassroomService_GetAssignmentGrades(t *testing.T) {
 		]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	grades, _, err := client.Classroom.GetAssignmentGrades(ctx, 12)
 	if err != nil {
 		t.Errorf("Classroom.GetAssignmentGrades returned error: %v", err)

--- a/github/code_scanning_test.go
+++ b/github/code_scanning_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -78,7 +77,7 @@ func TestCodeScanningService_UploadSarif(t *testing.T) {
 		_, _ = w.Write(respBody)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	sarifAnalysis := &SarifAnalysis{CommitSHA: Ptr("abc"), Ref: Ptr("ref/head/main"), Sarif: Ptr("abc"), CheckoutURI: Ptr("uri"), StartedAt: &Timestamp{time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC)}, ToolName: Ptr("codeql-cli")}
 	respSarifID, _, err := client.CodeScanning.UploadSarif(ctx, "o", "r", sarifAnalysis)
 	if err != nil {
@@ -112,7 +111,7 @@ func TestCodeScanningService_GetSARIF(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	sarifUpload, _, err := client.CodeScanning.GetSARIF(ctx, "o", "r", "abc")
 	if err != nil {
 		t.Errorf("CodeScanning.GetSARIF returned error: %v", err)
@@ -240,7 +239,7 @@ func TestCodeScanningService_ListAlertsForOrg(t *testing.T) {
 	})
 
 	opts := &AlertListOptions{State: "open", Ref: "heads/master", Severity: "warning", ToolName: "CodeQL", ToolGUID: "guid", Direction: "asc", Sort: "updated"}
-	ctx := context.Background()
+	ctx := t.Context()
 	alerts, _, err := client.CodeScanning.ListAlertsForOrg(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("CodeScanning.ListAlertsForOrg returned error: %v", err)
@@ -402,7 +401,7 @@ func TestCodeScanningService_ListAlertsForOrgLisCursorOptions(t *testing.T) {
 	})
 
 	opts := &AlertListOptions{State: "open", Ref: "heads/master", Severity: "warning", ToolName: "CodeQL", ListCursorOptions: ListCursorOptions{PerPage: 1, Before: "deadbeefb", After: "deadbeefa"}}
-	ctx := context.Background()
+	ctx := t.Context()
 	alerts, _, err := client.CodeScanning.ListAlertsForOrg(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("CodeScanning.ListAlertsForOrg returned error: %v", err)
@@ -565,7 +564,7 @@ func TestCodeScanningService_ListAlertsForRepo(t *testing.T) {
 	})
 
 	opts := &AlertListOptions{State: "open", Ref: "heads/master", Severity: "warning", ToolName: "CodeQL", ToolGUID: "guid", Direction: "asc", Sort: "updated"}
-	ctx := context.Background()
+	ctx := t.Context()
 	alerts, _, err := client.CodeScanning.ListAlertsForRepo(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("CodeScanning.ListAlertsForRepo returned error: %v", err)
@@ -715,7 +714,7 @@ func TestCodeScanningService_UpdateAlert(t *testing.T) {
 				"html_url":"https://github.com/o/r/security/code-scanning/88"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	dismissedComment := Ptr("This alert is not actually correct as sanitizer is used")
 	dismissedReason := Ptr("false positive")
 	state := Ptr("dismissed")
@@ -816,7 +815,7 @@ func TestCodeScanningService_ListAlertInstances(t *testing.T) {
 	})
 
 	opts := &AlertInstancesListOptions{Ref: "heads/main", ListOptions: ListOptions{Page: 1}}
-	ctx := context.Background()
+	ctx := t.Context()
 	instances, _, err := client.CodeScanning.ListAlertInstances(ctx, "o", "r", 88, opts)
 	if err != nil {
 		t.Errorf("CodeScanning.ListAlertInstances returned error: %v", err)
@@ -912,7 +911,7 @@ func TestCodeScanningService_GetAlert(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	alert, _, err := client.CodeScanning.GetAlert(ctx, "o", "r", 88)
 	if err != nil {
 		t.Errorf("CodeScanning.GetAlert returned error: %v", err)
@@ -1171,7 +1170,7 @@ func TestCodeScanningService_ListAnalysesForRepo(t *testing.T) {
 	})
 
 	opts := &AnalysesListOptions{SarifID: Ptr("8981cd8e-b078-4ac3-a3be-1dad7dbd0b582"), Ref: Ptr("heads/master")}
-	ctx := context.Background()
+	ctx := t.Context()
 	analyses, _, err := client.CodeScanning.ListAnalysesForRepo(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("CodeScanning.ListAnalysesForRepo returned error: %v", err)
@@ -1270,7 +1269,7 @@ func TestCodeScanningService_GetAnalysis(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	analysis, _, err := client.CodeScanning.GetAnalysis(ctx, "o", "r", 3602840)
 	if err != nil {
 		t.Errorf("CodeScanning.GetAnalysis returned error: %v", err)
@@ -1329,7 +1328,7 @@ func TestCodeScanningService_DeleteAnalysis(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	analysis, _, err := client.CodeScanning.DeleteAnalysis(ctx, "o", "r", 40)
 	if err != nil {
 		t.Errorf("CodeScanning.DeleteAnalysis returned error: %v", err)
@@ -1398,7 +1397,7 @@ func TestCodeScanningService_ListCodeQLDatabases(t *testing.T) {
 		]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	databases, _, err := client.CodeScanning.ListCodeQLDatabases(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("CodeScanning.ListCodeQLDatabases returned error: %v", err)
@@ -1495,7 +1494,7 @@ func TestCodeScanningService_GetCodeQLDatabase(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	database, _, err := client.CodeScanning.GetCodeQLDatabase(ctx, "o", "r", "lang")
 	if err != nil {
 		t.Errorf("CodeScanning.GetCodeQLDatabase returned error: %v", err)
@@ -1573,7 +1572,7 @@ func TestCodeScanningService_GetDefaultSetupConfiguration(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg, _, err := client.CodeScanning.GetDefaultSetupConfiguration(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("CodeScanning.GetDefaultSetupConfiguration returned error: %v", err)
@@ -1620,7 +1619,7 @@ func TestCodeScanningService_UpdateDefaultSetupConfiguration(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	options := &UpdateDefaultSetupConfigurationOptions{
 		State:      "configured",
 		Languages:  []string{"go"},

--- a/github/codesofconduct_test.go
+++ b/github/codesofconduct_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -28,7 +27,7 @@ func TestCodesOfConductService_List(t *testing.T) {
 						]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cs, _, err := client.ListCodesOfConduct(ctx)
 	assertNilError(t, err)
 
@@ -68,7 +67,7 @@ func TestCodesOfConductService_Get(t *testing.T) {
 		)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	coc, _, err := client.GetCodeOfConduct(ctx, "k")
 	assertNilError(t, err)
 

--- a/github/codespaces_secrets_test.go
+++ b/github/codespaces_secrets_test.go
@@ -83,7 +83,7 @@ func TestCodespacesService_ListSecrets(t *testing.T) {
 
 			tt.handleFunc(mux)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			secrets, _, err := tt.call(ctx, client)
 			if err != nil {
 				t.Errorf("Codespaces.%v returned error: %v", tt.methodName, err)
@@ -182,7 +182,7 @@ func TestCodespacesService_GetSecret(t *testing.T) {
 
 			tt.handleFunc(mux)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			secret, _, err := tt.call(ctx, client)
 			if err != nil {
 				t.Errorf("Codespaces.%v returned error: %v", tt.methodName, err)
@@ -289,7 +289,7 @@ func TestCodespacesService_CreateOrUpdateSecret(t *testing.T) {
 				EncryptedValue: "QIv=",
 				KeyID:          "1234",
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			_, err := tt.call(ctx, client, input)
 			if err != nil {
 				t.Errorf("Codespaces.%v returned error: %v", tt.methodName, err)
@@ -370,7 +370,7 @@ func TestCodespacesService_DeleteSecret(t *testing.T) {
 
 			tt.handleFunc(mux)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, err := tt.call(ctx, client)
 			if err != nil {
 				t.Errorf("Codespaces.%v returned error: %v", tt.methodName, err)
@@ -455,7 +455,7 @@ func TestCodespacesService_GetPublicKey(t *testing.T) {
 
 			tt.handleFunc(mux)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			key, _, err := tt.call(ctx, client)
 			if err != nil {
 				t.Errorf("Codespaces.%v returned error: %v", tt.methodName, err)
@@ -533,7 +533,7 @@ func TestCodespacesService_ListSelectedReposForSecret(t *testing.T) {
 
 			tt.handleFunc(mux)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			repos, _, err := tt.call(ctx, client)
 			if err != nil {
 				t.Errorf("Codespaces.%v returned error: %v", tt.methodName, err)
@@ -619,7 +619,7 @@ func TestCodespacesService_SetSelectedReposForSecret(t *testing.T) {
 
 			tt.handleFunc(mux)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, err := tt.call(ctx, client)
 			if err != nil {
 				t.Errorf("Codespaces.%v returned error: %v", tt.methodName, err)
@@ -689,7 +689,7 @@ func TestCodespacesService_AddSelectedReposForSecret(t *testing.T) {
 
 			tt.handleFunc(mux)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, err := tt.call(ctx, client)
 			if err != nil {
 				t.Errorf("Codespaces.%v returned error: %v", tt.methodName, err)
@@ -759,7 +759,7 @@ func TestCodespacesService_RemoveSelectedReposFromSecret(t *testing.T) {
 
 			tt.handleFunc(mux)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, err := tt.call(ctx, client)
 			if err != nil {
 				t.Errorf("Codespaces.%v returned error: %v", tt.methodName, err)

--- a/github/codespaces_test.go
+++ b/github/codespaces_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -29,7 +28,7 @@ func TestCodespacesService_ListInRepo(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	codespaces, _, err := client.Codespaces.ListInRepo(ctx, "owner", "repo", opt)
 	if err != nil {
 		t.Errorf("Codespaces.ListInRepo returned error: %v", err)
@@ -115,7 +114,7 @@ func TestCodespacesService_List(t *testing.T) {
 	})
 
 	opt := &ListCodespacesOptions{ListOptions: ListOptions{Page: 1, PerPage: 2}, RepositoryID: 1296269}
-	ctx := context.Background()
+	ctx := t.Context()
 	codespaces, _, err := client.Codespaces.List(ctx, opt)
 	if err != nil {
 		t.Errorf("Codespaces.List returned error: %v", err)
@@ -159,7 +158,7 @@ func TestCodespacesService_CreateInRepo(t *testing.T) {
 		Machine:            Ptr("standardLinux"),
 		IdleTimeoutMinutes: Ptr(60),
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	codespace, _, err := client.Codespaces.CreateInRepo(ctx, "owner", "repo", input)
 	if err != nil {
 		t.Errorf("Codespaces.CreateInRepo returned error: %v", err)
@@ -198,7 +197,7 @@ func TestCodespacesService_Start(t *testing.T) {
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{"id":1, "repository": {"id": 1296269}}`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	codespace, _, err := client.Codespaces.Start(ctx, "codespace_1")
 	if err != nil {
 		t.Errorf("Codespaces.Start returned error: %v", err)
@@ -237,7 +236,7 @@ func TestCodespacesService_Stop(t *testing.T) {
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{"id":1, "repository": {"id": 1296269}}`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	codespace, _, err := client.Codespaces.Stop(ctx, "codespace_1")
 	if err != nil {
 		t.Errorf("Codespaces.Stop returned error: %v", err)
@@ -276,7 +275,7 @@ func TestCodespacesService_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Codespaces.Delete(ctx, "codespace_1")
 	if err != nil {
 		t.Errorf("Codespaces.Delete return error: %v", err)

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -307,7 +306,7 @@ func TestCopilotService_GetCopilotBilling(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Copilot.GetCopilotBilling(ctx, "o")
 	if err != nil {
 		t.Errorf("Copilot.GetCopilotBilling returned error: %v", err)
@@ -492,7 +491,7 @@ func TestCopilotService_ListCopilotSeats(t *testing.T) {
 	}
 	lastActivityAt2 := Timestamp{tmp}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &ListOptions{Page: 1, PerPage: 100}
 	got, _, err := client.Copilot.ListCopilotSeats(ctx, "o", opts)
 	if err != nil {
@@ -743,7 +742,7 @@ func TestCopilotService_ListCopilotEnterpriseSeats(t *testing.T) {
 	}
 	lastActivityAt2 := Timestamp{tmp}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &ListOptions{Page: 1, PerPage: 100}
 	got, _, err := client.Copilot.ListCopilotEnterpriseSeats(ctx, "e", opts)
 	if err != nil {
@@ -860,7 +859,7 @@ func TestCopilotService_AddCopilotTeams(t *testing.T) {
 		fmt.Fprint(w, `{"seats_created": 2}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Copilot.AddCopilotTeams(ctx, "o", []string{"team1", "team2"})
 	if err != nil {
 		t.Errorf("Copilot.AddCopilotTeams returned error: %v", err)
@@ -898,7 +897,7 @@ func TestCopilotService_RemoveCopilotTeams(t *testing.T) {
 		fmt.Fprint(w, `{"seats_cancelled": 2}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Copilot.RemoveCopilotTeams(ctx, "o", []string{"team1", "team2"})
 	if err != nil {
 		t.Errorf("Copilot.RemoveCopilotTeams returned error: %v", err)
@@ -936,7 +935,7 @@ func TestCopilotService_AddCopilotUsers(t *testing.T) {
 		fmt.Fprint(w, `{"seats_created": 2}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Copilot.AddCopilotUsers(ctx, "o", []string{"user1", "user2"})
 	if err != nil {
 		t.Errorf("Copilot.AddCopilotUsers returned error: %v", err)
@@ -974,7 +973,7 @@ func TestCopilotService_RemoveCopilotUsers(t *testing.T) {
 		fmt.Fprint(w, `{"seats_cancelled": 2}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Copilot.RemoveCopilotUsers(ctx, "o", []string{"user1", "user2"})
 	if err != nil {
 		t.Errorf("Copilot.RemoveCopilotUsers returned error: %v", err)
@@ -1070,7 +1069,7 @@ func TestCopilotService_GetSeatDetails(t *testing.T) {
 	}
 	lastActivityAt := Timestamp{tmp}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Copilot.GetSeatDetails(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Copilot.GetSeatDetails returned error: %v", err)
@@ -1300,7 +1299,7 @@ func TestCopilotService_GetEnterpriseMetrics(t *testing.T) {
 		]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Copilot.GetEnterpriseMetrics(ctx, "e", &CopilotMetricsListOptions{})
 	if err != nil {
 		t.Errorf("Copilot.GetEnterpriseMetrics returned error: %v", err)
@@ -1643,7 +1642,7 @@ func TestCopilotService_GetEnterpriseTeamMetrics(t *testing.T) {
 		]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Copilot.GetEnterpriseTeamMetrics(ctx, "e", "t", &CopilotMetricsListOptions{})
 	if err != nil {
 		t.Errorf("Copilot.GetEnterpriseTeamMetrics returned error: %v", err)
@@ -1986,7 +1985,7 @@ func TestCopilotService_GetOrganizationMetrics(t *testing.T) {
 		]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Copilot.GetOrganizationMetrics(ctx, "o", &CopilotMetricsListOptions{})
 	if err != nil {
 		t.Errorf("Copilot.GetOrganizationMetrics returned error: %v", err)
@@ -2329,7 +2328,7 @@ func TestCopilotService_GetOrganizationTeamMetrics(t *testing.T) {
 		]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Copilot.GetOrganizationTeamMetrics(ctx, "o", "t", &CopilotMetricsListOptions{})
 	if err != nil {
 		t.Errorf("Copilot.GetOrganizationTeamMetrics returned error: %v", err)

--- a/github/dependabot_alerts_test.go
+++ b/github/dependabot_alerts_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -26,7 +25,7 @@ func TestDependabotService_ListRepoAlerts(t *testing.T) {
 	})
 
 	opts := &ListAlertsOptions{State: Ptr("open")}
-	ctx := context.Background()
+	ctx := t.Context()
 	alerts, _, err := client.Dependabot.ListRepoAlerts(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Dependabot.ListRepoAlerts returned error: %v", err)
@@ -64,7 +63,7 @@ func TestDependabotService_GetRepoAlert(t *testing.T) {
 		fmt.Fprint(w, `{"number":42,"state":"fixed"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	alert, _, err := client.Dependabot.GetRepoAlert(ctx, "o", "r", 42)
 	if err != nil {
 		t.Errorf("Dependabot.GetRepoAlert returned error: %v", err)
@@ -104,7 +103,7 @@ func TestDependabotService_ListOrgAlerts(t *testing.T) {
 	})
 
 	opts := &ListAlertsOptions{State: Ptr("open")}
-	ctx := context.Background()
+	ctx := t.Context()
 	alerts, _, err := client.Dependabot.ListOrgAlerts(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Dependabot.ListOrgAlerts returned error: %v", err)
@@ -148,7 +147,7 @@ func TestDependabotService_UpdateAlert(t *testing.T) {
 		fmt.Fprint(w, `{"number":42,"state":"dismissed","dismissed_reason":"no_bandwidth","dismissed_comment":"no time to fix this"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	alert, _, err := client.Dependabot.UpdateAlert(ctx, "o", "r", 42, alertState)
 	if err != nil {
 		t.Errorf("Dependabot.UpdateAlert returned error: %v", err)

--- a/github/dependabot_secrets_test.go
+++ b/github/dependabot_secrets_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -24,7 +23,7 @@ func TestDependabotService_GetRepoPublicKey(t *testing.T) {
 		fmt.Fprint(w, `{"key_id":"1234","key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	key, _, err := client.Dependabot.GetRepoPublicKey(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Dependabot.GetRepoPublicKey returned error: %v", err)
@@ -59,7 +58,7 @@ func TestDependabotService_GetRepoPublicKeyNumeric(t *testing.T) {
 		fmt.Fprint(w, `{"key_id":1234,"key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	key, _, err := client.Dependabot.GetRepoPublicKey(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Dependabot.GetRepoPublicKey returned error: %v", err)
@@ -96,7 +95,7 @@ func TestDependabotService_ListRepoSecrets(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	secrets, _, err := client.Dependabot.ListRepoSecrets(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Dependabot.ListRepoSecrets returned error: %v", err)
@@ -137,7 +136,7 @@ func TestDependabotService_GetRepoSecret(t *testing.T) {
 		fmt.Fprint(w, `{"name":"NAME","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	secret, _, err := client.Dependabot.GetRepoSecret(ctx, "o", "r", "NAME")
 	if err != nil {
 		t.Errorf("Dependabot.GetRepoSecret returned error: %v", err)
@@ -183,7 +182,7 @@ func TestDependabotService_CreateOrUpdateRepoSecret(t *testing.T) {
 		EncryptedValue: "QIv=",
 		KeyID:          "1234",
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Dependabot.CreateOrUpdateRepoSecret(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Dependabot.CreateOrUpdateRepoSecret returned error: %v", err)
@@ -212,7 +211,7 @@ func TestDependabotService_DeleteRepoSecret(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Dependabot.DeleteRepoSecret(ctx, "o", "r", "NAME")
 	if err != nil {
 		t.Errorf("Dependabot.DeleteRepoSecret returned error: %v", err)
@@ -238,7 +237,7 @@ func TestDependabotService_GetOrgPublicKey(t *testing.T) {
 		fmt.Fprint(w, `{"key_id":"012345678","key":"2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	key, _, err := client.Dependabot.GetOrgPublicKey(ctx, "o")
 	if err != nil {
 		t.Errorf("Dependabot.GetOrgPublicKey returned error: %v", err)
@@ -275,7 +274,7 @@ func TestDependabotService_ListOrgSecrets(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	secrets, _, err := client.Dependabot.ListOrgSecrets(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Dependabot.ListOrgSecrets returned error: %v", err)
@@ -317,7 +316,7 @@ func TestDependabotService_GetOrgSecret(t *testing.T) {
 		fmt.Fprint(w, `{"name":"NAME","created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z","visibility":"selected","selected_repositories_url":"https://api.github.com/orgs/octo-org/dependabot/secrets/SUPER_SECRET/repositories"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	secret, _, err := client.Dependabot.GetOrgSecret(ctx, "o", "NAME")
 	if err != nil {
 		t.Errorf("Dependabot.GetOrgSecret returned error: %v", err)
@@ -367,7 +366,7 @@ func TestDependabotService_CreateOrUpdateOrgSecret(t *testing.T) {
 		Visibility:            "selected",
 		SelectedRepositoryIDs: DependabotSecretsSelectedRepoIDs{1296269, 1269280},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Dependabot.CreateOrUpdateOrgSecret(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Dependabot.CreateOrUpdateOrgSecret returned error: %v", err)
@@ -398,7 +397,7 @@ func TestDependabotService_ListSelectedReposForOrgSecret(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	repos, _, err := client.Dependabot.ListSelectedReposForOrgSecret(ctx, "o", "NAME", opts)
 	if err != nil {
 		t.Errorf("Dependabot.ListSelectedReposForOrgSecret returned error: %v", err)
@@ -439,7 +438,7 @@ func TestDependabotService_SetSelectedReposForOrgSecret(t *testing.T) {
 		testBody(t, r, `{"selected_repository_ids":[64780797]}`+"\n")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Dependabot.SetSelectedReposForOrgSecret(ctx, "o", "NAME", DependabotSecretsSelectedRepoIDs{64780797})
 	if err != nil {
 		t.Errorf("Dependabot.SetSelectedReposForOrgSecret returned error: %v", err)
@@ -465,7 +464,7 @@ func TestDependabotService_AddSelectedRepoToOrgSecret(t *testing.T) {
 	})
 
 	repo := &Repository{ID: Ptr(int64(1234))}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Dependabot.AddSelectedRepoToOrgSecret(ctx, "o", "NAME", repo)
 	if err != nil {
 		t.Errorf("Dependabot.AddSelectedRepoToOrgSecret returned error: %v", err)
@@ -499,7 +498,7 @@ func TestDependabotService_RemoveSelectedRepoFromOrgSecret(t *testing.T) {
 	})
 
 	repo := &Repository{ID: Ptr(int64(1234))}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Dependabot.RemoveSelectedRepoFromOrgSecret(ctx, "o", "NAME", repo)
 	if err != nil {
 		t.Errorf("Dependabot.RemoveSelectedRepoFromOrgSecret returned error: %v", err)
@@ -532,7 +531,7 @@ func TestDependabotService_DeleteOrgSecret(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Dependabot.DeleteOrgSecret(ctx, "o", "NAME")
 	if err != nil {
 		t.Errorf("Dependabot.DeleteOrgSecret returned error: %v", err)

--- a/github/dependency_graph_snapshots_test.go
+++ b/github/dependency_graph_snapshots_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -25,7 +24,7 @@ func TestDependencyGraphService_CreateSnapshot(t *testing.T) {
 		fmt.Fprint(w, `{"id":12345,"created_at":"2022-06-14T20:25:01Z","message":"Dependency results for the repo have been successfully updated.","result":"SUCCESS"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	snapshot := &DependencyGraphSnapshot{
 		Version: 0,
 		Sha:     Ptr("ce587453ced02b1526dfb4cb910479d431683101"),

--- a/github/dependency_graph_test.go
+++ b/github/dependency_graph_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -37,7 +36,7 @@ func TestDependencyGraphService_GetSBOM(t *testing.T) {
     }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	sbom, _, err := client.DependencyGraph.GetSBOM(ctx, "owner", "repo")
 	if err != nil {
 		t.Errorf("DependencyGraph.GetSBOM returned error: %v", err)

--- a/github/emojis_test.go
+++ b/github/emojis_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -23,7 +22,7 @@ func TestEmojisService_List(t *testing.T) {
 		fmt.Fprint(w, `{"+1": "+1.png"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	emoji, _, err := client.ListEmojis(ctx)
 	if err != nil {
 		t.Errorf("List returned error: %v", err)

--- a/github/enterprise_actions_hosted_runners_test.go
+++ b/github/enterprise_actions_hosted_runners_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -76,7 +75,7 @@ func TestEnterpriseService_ListHostedRunners(t *testing.T) {
 		}`)
 	})
 	opts := &ListOptions{Page: 1, PerPage: 1}
-	ctx := context.Background()
+	ctx := t.Context()
 	hostedRunners, _, err := client.Enterprise.ListHostedRunners(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Enterprise.ListHostedRunners returned error: %v", err)
@@ -191,7 +190,7 @@ func TestEnterpriseService_CreateHostedRunner(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	req := &HostedRunnerRequest{
 		Name: "My Hosted runner",
 		Image: HostedRunnerImage{
@@ -357,7 +356,7 @@ func TestEnterpriseService_GetHostedRunnerGitHubOwnedImages(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hostedRunnerImages, _, err := client.Enterprise.GetHostedRunnerGitHubOwnedImages(ctx, "o")
 	if err != nil {
 		t.Errorf("Enterprise.GetHostedRunnerGitHubOwnedImages returned error: %v", err)
@@ -415,7 +414,7 @@ func TestEnterpriseService_GetHostedRunnerPartnerImages(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hostedRunnerImages, _, err := client.Enterprise.GetHostedRunnerPartnerImages(ctx, "o")
 	if err != nil {
 		t.Errorf("Enterprise.GetHostedRunnerPartnerImages returned error: %v", err)
@@ -466,7 +465,7 @@ func TestEnterpriseService_GetHostedRunnerLimits(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	publicIPLimits, _, err := client.Enterprise.GetHostedRunnerLimits(ctx, "o")
 	if err != nil {
 		t.Errorf("Enterprise.GetPartnerImages returned error: %v", err)
@@ -517,7 +516,7 @@ func TestEnterpriseService_GetHostedRunnerMachineSpecs(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	machineSpecs, _, err := client.Enterprise.GetHostedRunnerMachineSpecs(ctx, "o")
 	if err != nil {
 		t.Errorf("Enterprise.GetHostedRunnerMachineSpecs returned error: %v", err)
@@ -568,7 +567,7 @@ func TestEnterpriseService_GetHostedRunnerPlatforms(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	platforms, _, err := client.Enterprise.GetHostedRunnerPlatforms(ctx, "o")
 	if err != nil {
 		t.Errorf("Enterprise.GetHostedRunnerPlatforms returned error: %v", err)
@@ -635,7 +634,7 @@ func TestEnterpriseService_GetHostedRunner(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hostedRunner, _, err := client.Enterprise.GetHostedRunner(ctx, "o", 23)
 	if err != nil {
 		t.Errorf("Enterprise.GetHostedRunner returned error: %v", err)
@@ -725,7 +724,7 @@ func TestEnterpriseService_UpdateHostedRunner(t *testing.T) {
 	})
 
 	// Test for a valid update without `Size`
-	ctx := context.Background()
+	ctx := t.Context()
 	validReq := HostedRunnerRequest{
 		Name:           "My larger runner",
 		RunnerGroupID:  1,
@@ -862,7 +861,7 @@ func TestEnterpriseService_DeleteHostedRunner(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hostedRunner, _, err := client.Enterprise.DeleteHostedRunner(ctx, "o", 23)
 	if err != nil {
 		t.Errorf("Enterprise.GetHostedRunner returned error: %v", err)

--- a/github/enterprise_actions_runner_groups_test.go
+++ b/github/enterprise_actions_runner_groups_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -25,7 +24,7 @@ func TestEnterpriseService_ListRunnerGroups(t *testing.T) {
 	})
 
 	opts := &ListEnterpriseRunnerGroupOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	groups, _, err := client.Enterprise.ListRunnerGroups(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Enterprise.ListRunnerGroups returned error: %v", err)
@@ -69,7 +68,7 @@ func TestEnterpriseService_ListRunnerGroupsVisibleToOrganization(t *testing.T) {
 	})
 
 	opts := &ListEnterpriseRunnerGroupOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}, VisibleToOrganization: "github"}
-	ctx := context.Background()
+	ctx := t.Context()
 	groups, _, err := client.Enterprise.ListRunnerGroups(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Enterprise.ListRunnerGroups returned error: %v", err)
@@ -111,7 +110,7 @@ func TestEnterpriseService_GetRunnerGroup(t *testing.T) {
 		fmt.Fprint(w, `{"id":2,"name":"octo-runner-group","visibility":"selected","default":false,"selected_organizations_url":"https://api.github.com/enterprises/octo-enterprise/actions/runner_groups/2/organizations","runners_url":"https://api.github.com/enterprises/octo-enterprise/actions/runner_groups/2/runners","inherited":false,"allows_public_repositories":true,"restricted_to_workflows":false,"selected_workflows":[]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	group, _, err := client.Enterprise.GetEnterpriseRunnerGroup(ctx, "o", 2)
 	if err != nil {
 		t.Errorf("Enterprise.GetRunnerGroup returned error: %v", err)
@@ -157,7 +156,7 @@ func TestEnterpriseService_DeleteRunnerGroup(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Enterprise.DeleteEnterpriseRunnerGroup(ctx, "o", 2)
 	if err != nil {
 		t.Errorf("Enterprise.DeleteRunnerGroup returned error: %v", err)
@@ -183,7 +182,7 @@ func TestEnterpriseService_CreateRunnerGroup(t *testing.T) {
 		fmt.Fprint(w, `{"id":2,"name":"octo-runner-group","visibility":"selected","default":false,"selected_organizations_url":"https://api.github.com/enterprises/octo-enterprise/actions/runner_groups/2/organizations","runners_url":"https://api.github.com/enterprises/octo-enterprise/actions/runner_groups/2/runners","inherited":false,"allows_public_repositories":true,"restricted_to_workflows":false,"selected_workflows":[]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	req := CreateEnterpriseRunnerGroupRequest{
 		Name:                     Ptr("octo-runner-group"),
 		Visibility:               Ptr("selected"),
@@ -237,7 +236,7 @@ func TestEnterpriseService_UpdateRunnerGroup(t *testing.T) {
 		fmt.Fprint(w, `{"id":2,"name":"octo-runner-group","visibility":"selected","default":false,"selected_organizations_url":"https://api.github.com/enterprises/octo-enterprise/actions/runner_groups/2/organizations","runners_url":"https://api.github.com/enterprises/octo-enterprise/actions/runner_groups/2/runners","inherited":false,"allows_public_repositories":true,"restricted_to_workflows":false,"selected_workflows":[]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	req := UpdateEnterpriseRunnerGroupRequest{
 		Name:                     Ptr("octo-runner-group"),
 		Visibility:               Ptr("selected"),
@@ -292,7 +291,7 @@ func TestEnterpriseService_ListOrganizationAccessRunnerGroup(t *testing.T) {
 		fmt.Fprint(w, `{"total_count": 1, "organizations": [{"id": 43, "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5", "name": "Hello-World", "login": "octocat"}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &ListOptions{Page: 1, PerPage: 1}
 	groups, _, err := client.Enterprise.ListOrganizationAccessRunnerGroup(ctx, "o", 2, opts)
 	if err != nil {
@@ -339,7 +338,7 @@ func TestEnterpriseService_SetOrganizationAccessRunnerGroup(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Enterprise.SetOrganizationAccessRunnerGroup(ctx, "o", 2, req)
 	if err != nil {
 		t.Errorf("Enterprise.SetOrganizationAccessRunnerGroup returned error: %v", err)
@@ -364,7 +363,7 @@ func TestEnterpriseService_AddOrganizationAccessRunnerGroup(t *testing.T) {
 		testMethod(t, r, "PUT")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Enterprise.AddOrganizationAccessRunnerGroup(ctx, "o", 2, 42)
 	if err != nil {
 		t.Errorf("Enterprise.AddOrganizationAccessRunnerGroup returned error: %v", err)
@@ -389,7 +388,7 @@ func TestEnterpriseService_RemoveOrganizationAccessRunnerGroup(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Enterprise.RemoveOrganizationAccessRunnerGroup(ctx, "o", 2, 42)
 	if err != nil {
 		t.Errorf("Enterprise.RemoveOrganizationAccessRunnerGroup returned error: %v", err)
@@ -417,7 +416,7 @@ func TestEnterpriseService_ListEnterpriseRunnerGroupRunners(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	runners, _, err := client.Enterprise.ListRunnerGroupRunners(ctx, "o", 2, opts)
 	if err != nil {
 		t.Errorf("Enterprise.ListEnterpriseRunnerGroupRunners returned error: %v", err)
@@ -464,7 +463,7 @@ func TestEnterpriseService_SetEnterpriseRunnerGroupRunners(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Enterprise.SetRunnerGroupRunners(ctx, "o", 2, req)
 	if err != nil {
 		t.Errorf("Enterprise.SetEnterpriseRunnerGroupRunners returned error: %v", err)
@@ -489,7 +488,7 @@ func TestEnterpriseService_AddEnterpriseRunnerGroupRunners(t *testing.T) {
 		testMethod(t, r, "PUT")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Enterprise.AddRunnerGroupRunners(ctx, "o", 2, 42)
 	if err != nil {
 		t.Errorf("Enterprise.AddEnterpriseRunnerGroupRunners returned error: %v", err)
@@ -514,7 +513,7 @@ func TestEnterpriseService_RemoveEnterpriseRunnerGroupRunners(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Enterprise.RemoveRunnerGroupRunners(ctx, "o", 2, 42)
 	if err != nil {
 		t.Errorf("Enterprise.RemoveEnterpriseRunnerGroupRunners returned error: %v", err)

--- a/github/enterprise_actions_runners_test.go
+++ b/github/enterprise_actions_runners_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -34,7 +33,7 @@ func TestEnterpriseService_GenerateEnterpriseJITConfig(t *testing.T) {
 		fmt.Fprint(w, `{"encoded_jit_config":"foo"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	jitConfig, _, err := client.Enterprise.GenerateEnterpriseJITConfig(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Enterprise.GenerateEnterpriseJITConfig returned error: %v", err)
@@ -69,7 +68,7 @@ func TestEnterpriseService_CreateRegistrationToken(t *testing.T) {
 		fmt.Fprint(w, `{"token":"LLBF3JGZDX3P5PMEXLND6TS6FCWO6","expires_at":"2020-01-22T12:13:35.123Z"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	token, _, err := client.Enterprise.CreateRegistrationToken(ctx, "e")
 	if err != nil {
 		t.Errorf("Enterprise.CreateRegistrationToken returned error: %v", err)
@@ -113,7 +112,7 @@ func TestEnterpriseService_ListRunners(t *testing.T) {
 		Name:        Ptr("MBP"),
 		ListOptions: ListOptions{Page: 2, PerPage: 2},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	runners, _, err := client.Enterprise.ListRunners(ctx, "e", opts)
 	if err != nil {
 		t.Errorf("Enterprise.ListRunners returned error: %v", err)
@@ -153,7 +152,7 @@ func TestEnterpriseService_GetRunner(t *testing.T) {
 		fmt.Fprint(w, `{"id":23,"name":"MBP","os":"macos","status":"online"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	runner, _, err := client.Enterprise.GetRunner(ctx, "e", 23)
 	if err != nil {
 		t.Errorf("Enterprise.GetRunner returned error: %v", err)
@@ -192,7 +191,7 @@ func TestEnterpriseService_RemoveRunner(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Enterprise.RemoveRunner(ctx, "o", 21)
 	if err != nil {
 		t.Errorf("Actions.RemoveRunner returned error: %v", err)
@@ -218,7 +217,7 @@ func TestEnterpriseService_ListRunnerApplicationDownloads(t *testing.T) {
 		fmt.Fprint(w, `[{"os":"osx","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-osx-x64-2.164.0.tar.gz","filename":"actions-runner-osx-x64-2.164.0.tar.gz"},{"os":"linux","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-x64-2.164.0.tar.gz","filename":"actions-runner-linux-x64-2.164.0.tar.gz"},{"os": "linux","architecture":"arm","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm-2.164.0.tar.gz","filename":"actions-runner-linux-arm-2.164.0.tar.gz"},{"os":"win","architecture":"x64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-win-x64-2.164.0.zip","filename":"actions-runner-win-x64-2.164.0.zip"},{"os":"linux","architecture":"arm64","download_url":"https://github.com/actions/runner/releases/download/v2.164.0/actions-runner-linux-arm64-2.164.0.tar.gz","filename":"actions-runner-linux-arm64-2.164.0.tar.gz"}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	downloads, _, err := client.Enterprise.ListRunnerApplicationDownloads(ctx, "o")
 	if err != nil {
 		t.Errorf("Enterprise.ListRunnerApplicationDownloads returned error: %v", err)

--- a/github/enterprise_audit_log_test.go
+++ b/github/enterprise_audit_log_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -47,7 +46,7 @@ func TestEnterpriseService_GetAuditLog(t *testing.T) {
 		Phrase:  Ptr("action:workflows"),
 		Order:   Ptr("asc"),
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	auditEntries, _, err := client.Enterprise.GetAuditLog(ctx, "e", &getOpts)
 	if err != nil {
 		t.Errorf("Enterprise.GetAuditLog returned error: %v", err)

--- a/github/enterprise_code_security_and_analysis_test.go
+++ b/github/enterprise_code_security_and_analysis_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -32,7 +31,7 @@ func TestEnterpriseService_GetCodeSecurityAndAnalysis(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "GetCodeSecurityAndAnalysis"
 
@@ -88,7 +87,7 @@ func TestEnterpriseService_UpdateCodeSecurityAndAnalysis(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "UpdateCodeSecurityAndAnalysis"
 
@@ -115,7 +114,7 @@ func TestEnterpriseService_EnableAdvancedSecurity(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "EnableDisableSecurityFeature"
 

--- a/github/enterprise_manage_ghes_config_test.go
+++ b/github/enterprise_manage_ghes_config_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -159,7 +158,7 @@ func TestEnterpriseService_Settings(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	configSettings, _, err := client.Enterprise.Settings(ctx)
 	if err != nil {
 		t.Errorf("Enterprise.Settings returned error: %v", err)
@@ -339,7 +338,7 @@ func TestEnterpriseService_NodeMetadata(t *testing.T) {
 	opt := &NodeQueryOptions{
 		UUID: Ptr("1234-1234"), ClusterRoles: Ptr("primary"),
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	configNodes, _, err := client.Enterprise.NodeMetadata(ctx, opt)
 	if err != nil {
 		t.Errorf("Enterprise.NodeMetadata returned error: %v", err)
@@ -380,7 +379,7 @@ func TestEnterpriseService_LicenseStatus(t *testing.T) {
 			}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	licenseCheck, _, err := client.Enterprise.LicenseStatus(ctx)
 	if err != nil {
 		t.Errorf("Enterprise.LicenseStatus returned error: %v", err)
@@ -431,7 +430,7 @@ func TestEnterpriseService_License(t *testing.T) {
 		}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	license, _, err := client.Enterprise.License(ctx)
 	if err != nil {
 		t.Errorf("Enterprise.License returned error: %v", err)
@@ -501,7 +500,7 @@ func TestEnterpriseService_ConfigApplyEvents(t *testing.T) {
 		LastRequestID: Ptr("387cd628c06d606700e79be368e5e574:0cde553750689"),
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	configEvents, _, err := client.Enterprise.ConfigApplyEvents(ctx, input)
 	if err != nil {
 		t.Errorf("Enterprise.ConfigApplyEvents returned error: %v", err)
@@ -557,7 +556,7 @@ func TestEnterpriseService_UpdateSettings(t *testing.T) {
 		PrivateMode: Ptr(false),
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Enterprise.UpdateSettings(ctx, input); err != nil {
 		t.Errorf("Enterprise.UpdateSettings returned error: %v", err)
 	}
@@ -583,7 +582,7 @@ func TestEnterpriseService_UploadLicense(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Enterprise.UploadLicense(ctx, "abc"); err != nil {
 		t.Errorf("Enterprise.UploadLicense returned error: %v", err)
 	}
@@ -613,7 +612,7 @@ func TestEnterpriseService_InitialConfig(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Enterprise.InitialConfig(ctx, "1234-1234", "password"); err != nil {
 		t.Errorf("Enterprise.InitialConfig returned error: %v", err)
 	}
@@ -646,7 +645,7 @@ func TestEnterpriseService_ConfigApply(t *testing.T) {
 		RunID: Ptr("1234"),
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	configApply, _, err := client.Enterprise.ConfigApply(ctx, input)
 	if err != nil {
 		t.Errorf("Enterprise.ConfigApply returned error: %v", err)
@@ -699,7 +698,7 @@ func TestEnterpriseService_ConfigApplyStatus(t *testing.T) {
 	input := &ConfigApplyOptions{
 		RunID: Ptr("1234"),
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	configApplyStatus, _, err := client.Enterprise.ConfigApplyStatus(ctx, input)
 	if err != nil {
 		t.Errorf("Enterprise.ConfigApplyStatus returned error: %v", err)

--- a/github/enterprise_manage_ghes_maintenance_test.go
+++ b/github/enterprise_manage_ghes_maintenance_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -48,7 +47,7 @@ func TestEnterpriseService_GetMaintenanceStatus(t *testing.T) {
 	opt := &NodeQueryOptions{
 		UUID: Ptr("1234-1234"), ClusterRoles: Ptr("primary"),
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	maintenanceStatus, _, err := client.Enterprise.GetMaintenanceStatus(ctx, opt)
 	if err != nil {
 		t.Errorf("Enterprise.GetMaintenanceStatus returned error: %v", err)
@@ -107,7 +106,7 @@ func TestEnterpriseService_CreateMaintenance(t *testing.T) {
 		fmt.Fprint(w, `[ { "hostname": "primary", "uuid": "1b6cf518-f97c-11ed-8544-061d81f7eedb", "message": "Scheduled maintenance for upgrading." } ]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	maintenanceStatus, _, err := client.Enterprise.CreateMaintenance(ctx, true, input)
 	if err != nil {
 		t.Errorf("Enterprise.CreateMaintenance returned error: %v", err)

--- a/github/enterprise_manage_ghes_ssh_test.go
+++ b/github/enterprise_manage_ghes_ssh_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -27,7 +26,7 @@ func TestEnterpriseService_GetSSHKey(t *testing.T) {
 			}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	accessSSH, _, err := client.Enterprise.GetSSHKey(ctx)
 	if err != nil {
 		t.Errorf("Enterprise.GetSSHKey returned error: %v", err)
@@ -71,7 +70,7 @@ func TestEnterpriseService_DeleteSSHKey(t *testing.T) {
 		fmt.Fprint(w, `[ { "hostname": "primary", "uuid": "1b6cf518-f97c-11ed-8544-061d81f7eedb", "message": "SSH key removed successfully" } ]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	sshStatus, _, err := client.Enterprise.DeleteSSHKey(ctx, "ssh-rsa 1234")
 	if err != nil {
 		t.Errorf("Enterprise.DeleteSSHKey returned error: %v", err)
@@ -112,7 +111,7 @@ func TestEnterpriseService_CreateSSHKey(t *testing.T) {
 		fmt.Fprint(w, `[ { "hostname": "primary", "uuid": "1b6cf518-f97c-11ed-8544-061d81f7eedb", "message": "SSH key added successfully", "modified": true } ]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	sshStatus, _, err := client.Enterprise.CreateSSHKey(ctx, "ssh-rsa 1234")
 	if err != nil {
 		t.Errorf("Enterprise.CreateSSHKey returned error: %v", err)

--- a/github/enterprise_manage_ghes_test.go
+++ b/github/enterprise_manage_ghes_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -33,7 +32,7 @@ func TestEnterpriseService_CheckSystemRequirements(t *testing.T) {
 			]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	systemRequirements, _, err := client.Enterprise.CheckSystemRequirements(ctx)
 	if err != nil {
 		t.Errorf("Enterprise.CheckSystemRequirements returned error: %v", err)
@@ -80,7 +79,7 @@ func TestEnterpriseService_ClusterStatus(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	clusterStatus, _, err := client.Enterprise.ClusterStatus(ctx)
 	if err != nil {
 		t.Errorf("Enterprise.ClusterStatus returned error: %v", err)
@@ -131,7 +130,7 @@ func TestEnterpriseService_ReplicationStatus(t *testing.T) {
 	opt := &NodeQueryOptions{
 		UUID: Ptr("1234-1234"), ClusterRoles: Ptr("primary"),
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	replicationStatus, _, err := client.Enterprise.ReplicationStatus(ctx, opt)
 	if err != nil {
 		t.Errorf("Enterprise.ReplicationStatus returned error: %v", err)
@@ -183,7 +182,7 @@ func TestEnterpriseService_Versions(t *testing.T) {
 	opt := &NodeQueryOptions{
 		UUID: Ptr("1234-1234"), ClusterRoles: Ptr("primary"),
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	releaseVersions, _, err := client.Enterprise.GetNodeReleaseVersions(ctx, opt)
 	if err != nil {
 		t.Errorf("Enterprise.GetNodeReleaseVersions returned error: %v", err)

--- a/github/enterprise_network_configurations_test.go
+++ b/github/enterprise_network_configurations_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -49,7 +48,7 @@ func TestEnterpriseService_ListEnterpriseNetworkConfigurations(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	opts := &ListOptions{Page: 3, PerPage: 2}
 	configurations, _, err := client.Enterprise.ListEnterpriseNetworkConfigurations(ctx, "e", opts)
@@ -112,7 +111,7 @@ func TestEnterpriseService_CreateEnterpriseNetworkConfiguration(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	req := NetworkConfigurationRequest{
 		Name:           Ptr("configuration-one"),
@@ -207,7 +206,7 @@ func TestEnterpriseService_GetEnterpriseNetworkConfiguration(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	configuration, _, err := client.Enterprise.GetEnterpriseNetworkConfiguration(ctx, "e", "123456789ABCDEF")
 	if err != nil {
 		t.Errorf("Enterprise.GetEnterpriseNetworkConfiguration returned err: %v", err)
@@ -256,7 +255,7 @@ func TestEnterpriseService_UpdateEnterpriseNetworkConfiguration(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	req := NetworkConfigurationRequest{
 		Name: Ptr("updated-configuration-one"),
 		NetworkSettingsIDs: []string{
@@ -340,7 +339,7 @@ func TestEnterpriseService_DeleteEnterpriseNetworkConfiguration(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Enterprise.DeleteEnterpriseNetworkConfiguration(ctx, "e", "123456789ABCDEF")
 	if err != nil {
 		t.Errorf("Enterprise.DeleteEnterpriseNetworkConfiguration returned error %v", err)
@@ -372,7 +371,7 @@ func TestEnterpriseService_GetEnterpriseNetworkSettingsResource(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resource, _, err := client.Enterprise.GetEnterpriseNetworkSettingsResource(ctx, "e", "123456789ABCDEF")
 	if err != nil {
 		t.Errorf("Enterprise.GetEnterpriseNetworkSettingsResource returned error %v", err)

--- a/github/enterprise_properties_test.go
+++ b/github/enterprise_properties_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -45,7 +44,7 @@ func TestEnterpriseService_GetAllCustomProperties(t *testing.T) {
         ]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	properties, _, err := client.Enterprise.GetAllCustomProperties(ctx, "e")
 	if err != nil {
 		t.Errorf("Enterprise.GetAllCustomProperties returned error: %v", err)
@@ -106,7 +105,7 @@ func TestEnterpriseService_CreateOrUpdateCustomProperties(t *testing.T) {
         ]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	properties, _, err := client.Enterprise.CreateOrUpdateCustomProperties(ctx, "e", []*CustomProperty{
 		{
 			PropertyName: Ptr("name"),
@@ -169,7 +168,7 @@ func TestEnterpriseService_GetCustomProperty(t *testing.T) {
 	  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	property, _, err := client.Enterprise.GetCustomProperty(ctx, "e", "name")
 	if err != nil {
 		t.Errorf("Enterprise.GetCustomProperty returned error: %v", err)
@@ -219,7 +218,7 @@ func TestEnterpriseService_CreateOrUpdateCustomProperty(t *testing.T) {
 	  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	property, _, err := client.Enterprise.CreateOrUpdateCustomProperty(ctx, "e", "name", &CustomProperty{
 		ValueType:        "single_select",
 		Required:         Ptr(true),
@@ -264,7 +263,7 @@ func TestEnterpriseService_RemoveCustomProperty(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Enterprise.RemoveCustomProperty(ctx, "e", "name")
 	if err != nil {
 		t.Errorf("Enterprise.RemoveCustomProperty returned error: %v", err)

--- a/github/enterprise_rules_test.go
+++ b/github/enterprise_rules_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -174,7 +173,7 @@ func TestEnterpriseService_CreateRepositoryRuleset_OrgNameRepoName(t *testing.T)
 		  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ruleset, _, err := client.Enterprise.CreateRepositoryRuleset(ctx, "e", RepositoryRuleset{
 		Name:        "ruleset",
 		Target:      Ptr(RulesetTargetBranch),
@@ -554,7 +553,7 @@ func TestEnterpriseService_CreateRepositoryRuleset_OrgNameRepoProperty(t *testin
 		  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ruleset, _, err := client.Enterprise.CreateRepositoryRuleset(ctx, "e", RepositoryRuleset{
 		Name:        "ruleset",
 		Target:      Ptr(RulesetTargetBranch),
@@ -939,7 +938,7 @@ func TestEnterpriseService_CreateRepositoryRuleset_OrgIdRepoName(t *testing.T) {
 		  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ruleset, _, err := client.Enterprise.CreateRepositoryRuleset(ctx, "e", RepositoryRuleset{
 		Name:        "ruleset",
 		Target:      Ptr(RulesetTargetBranch),
@@ -1311,7 +1310,7 @@ func TestEnterpriseService_CreateRepositoryRuleset_OrgIdRepoProperty(t *testing.
 		  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ruleset, _, err := client.Enterprise.CreateRepositoryRuleset(ctx, "e", RepositoryRuleset{
 		Name:        "ruleset",
 		Target:      Ptr(RulesetTargetBranch),
@@ -1598,7 +1597,7 @@ func TestEnterpriseService_GetRepositoryRuleset(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rulesets, _, err := client.Enterprise.GetRepositoryRuleset(ctx, "e", 84)
 	if err != nil {
 		t.Errorf("Enterprise.GetRepositoryRuleset returned error: %v", err)
@@ -1705,7 +1704,7 @@ func TestEnterpriseService_UpdateRepositoryRuleset(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rulesets, _, err := client.Enterprise.UpdateRepositoryRuleset(ctx, "e", 84, RepositoryRuleset{
 		Name:        "test ruleset",
 		Target:      Ptr(RulesetTargetBranch),
@@ -1822,7 +1821,7 @@ func TestEnterpriseService_UpdateRepositoryRulesetClearBypassActor(t *testing.T)
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := client.Enterprise.UpdateRepositoryRulesetClearBypassActor(ctx, "e", 84)
 	if err != nil {
@@ -1844,7 +1843,7 @@ func TestEnterpriseService_DeleteRepositoryRuleset(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Enterprise.DeleteRepositoryRuleset(ctx, "e", 84)
 	if err != nil {
 		t.Errorf("Enterprise.DeleteRepositoryRuleset returned error: %v", err)

--- a/github/gists_comments_test.go
+++ b/github/gists_comments_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -84,7 +83,7 @@ func TestGistsService_ListComments(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	comments, _, err := client.Gists.ListComments(ctx, "1", opt)
 	if err != nil {
 		t.Errorf("Gists.Comments returned error: %v", err)
@@ -114,7 +113,7 @@ func TestGistsService_ListComments_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Gists.ListComments(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -128,7 +127,7 @@ func TestGistsService_GetComment(t *testing.T) {
 		fmt.Fprint(w, `{"id": 1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.Gists.GetComment(ctx, "1", 2)
 	if err != nil {
 		t.Errorf("Gists.GetComment returned error: %v", err)
@@ -158,7 +157,7 @@ func TestGistsService_GetComment_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Gists.GetComment(ctx, "%", 1)
 	testURLParseError(t, err)
 }
@@ -181,7 +180,7 @@ func TestGistsService_CreateComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.Gists.CreateComment(ctx, "1", input)
 	if err != nil {
 		t.Errorf("Gists.CreateComment returned error: %v", err)
@@ -211,7 +210,7 @@ func TestGistsService_CreateComment_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Gists.CreateComment(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -234,7 +233,7 @@ func TestGistsService_EditComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.Gists.EditComment(ctx, "1", 2, input)
 	if err != nil {
 		t.Errorf("Gists.EditComment returned error: %v", err)
@@ -264,7 +263,7 @@ func TestGistsService_EditComment_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Gists.EditComment(ctx, "%", 1, nil)
 	testURLParseError(t, err)
 }
@@ -277,7 +276,7 @@ func TestGistsService_DeleteComment(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Gists.DeleteComment(ctx, "1", 2)
 	if err != nil {
 		t.Errorf("Gists.Delete returned error: %v", err)
@@ -298,7 +297,7 @@ func TestGistsService_DeleteComment_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Gists.DeleteComment(ctx, "%", 1)
 	testURLParseError(t, err)
 }

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -243,7 +242,7 @@ func TestGistsService_List_specifiedUser(t *testing.T) {
 	})
 
 	opt := &GistListOptions{Since: time.Date(2013, time.January, 1, 0, 0, 0, 0, time.UTC)}
-	ctx := context.Background()
+	ctx := t.Context()
 	gists, _, err := client.Gists.List(ctx, "u", opt)
 	if err != nil {
 		t.Errorf("Gists.List returned error: %v", err)
@@ -278,7 +277,7 @@ func TestGistsService_List_authenticatedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id": "1"}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	gists, _, err := client.Gists.List(ctx, "", nil)
 	if err != nil {
 		t.Errorf("Gists.List returned error: %v", err)
@@ -308,7 +307,7 @@ func TestGistsService_List_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Gists.List(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -328,7 +327,7 @@ func TestGistsService_ListAll(t *testing.T) {
 	})
 
 	opt := &GistListOptions{Since: time.Date(2013, time.January, 1, 0, 0, 0, 0, time.UTC)}
-	ctx := context.Background()
+	ctx := t.Context()
 	gists, _, err := client.Gists.ListAll(ctx, opt)
 	if err != nil {
 		t.Errorf("Gists.ListAll returned error: %v", err)
@@ -364,7 +363,7 @@ func TestGistsService_ListStarred(t *testing.T) {
 	})
 
 	opt := &GistListOptions{Since: time.Date(2013, time.January, 1, 0, 0, 0, 0, time.UTC)}
-	ctx := context.Background()
+	ctx := t.Context()
 	gists, _, err := client.Gists.ListStarred(ctx, opt)
 	if err != nil {
 		t.Errorf("Gists.ListStarred returned error: %v", err)
@@ -394,7 +393,7 @@ func TestGistsService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"id": "1"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	gist, _, err := client.Gists.Get(ctx, "1")
 	if err != nil {
 		t.Errorf("Gists.Get returned error: %v", err)
@@ -424,7 +423,7 @@ func TestGistsService_Get_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Gists.Get(ctx, "%")
 	testURLParseError(t, err)
 }
@@ -438,7 +437,7 @@ func TestGistsService_GetRevision(t *testing.T) {
 		fmt.Fprint(w, `{"id": "1"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	gist, _, err := client.Gists.GetRevision(ctx, "1", "s")
 	if err != nil {
 		t.Errorf("Gists.Get returned error: %v", err)
@@ -468,7 +467,7 @@ func TestGistsService_GetRevision_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Gists.GetRevision(ctx, "%", "%")
 	testURLParseError(t, err)
 }
@@ -508,7 +507,7 @@ func TestGistsService_Create(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	gist, _, err := client.Gists.Create(ctx, input)
 	if err != nil {
 		t.Errorf("Gists.Create returned error: %v", err)
@@ -573,7 +572,7 @@ func TestGistsService_Edit(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	gist, _, err := client.Gists.Edit(ctx, "1", input)
 	if err != nil {
 		t.Errorf("Gists.Edit returned error: %v", err)
@@ -611,7 +610,7 @@ func TestGistsService_Edit_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Gists.Edit(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -642,7 +641,7 @@ func TestGistsService_ListCommits(t *testing.T) {
 		`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	gistCommits, _, err := client.Gists.ListCommits(ctx, "1", nil)
 	if err != nil {
 		t.Errorf("Gists.ListCommits returned error: %v", err)
@@ -691,7 +690,7 @@ func TestGistsService_ListCommits_withOptions(t *testing.T) {
 		fmt.Fprint(w, `[]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Gists.ListCommits(ctx, "1", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Gists.ListCommits returned error: %v", err)
@@ -716,7 +715,7 @@ func TestGistsService_ListCommits_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Gists.ListCommits(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -729,7 +728,7 @@ func TestGistsService_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Gists.Delete(ctx, "1")
 	if err != nil {
 		t.Errorf("Gists.Delete returned error: %v", err)
@@ -750,7 +749,7 @@ func TestGistsService_Delete_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Gists.Delete(ctx, "%")
 	testURLParseError(t, err)
 }
@@ -763,7 +762,7 @@ func TestGistsService_Star(t *testing.T) {
 		testMethod(t, r, "PUT")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Gists.Star(ctx, "1")
 	if err != nil {
 		t.Errorf("Gists.Star returned error: %v", err)
@@ -784,7 +783,7 @@ func TestGistsService_Star_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Gists.Star(ctx, "%")
 	testURLParseError(t, err)
 }
@@ -797,7 +796,7 @@ func TestGistsService_Unstar(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Gists.Unstar(ctx, "1")
 	if err != nil {
 		t.Errorf("Gists.Unstar returned error: %v", err)
@@ -818,7 +817,7 @@ func TestGistsService_Unstar_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Gists.Unstar(ctx, "%")
 	testURLParseError(t, err)
 }
@@ -832,7 +831,7 @@ func TestGistsService_IsStarred_hasStar(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	star, _, err := client.Gists.IsStarred(ctx, "1")
 	if err != nil {
 		t.Errorf("Gists.Starred returned error: %v", err)
@@ -865,7 +864,7 @@ func TestGistsService_IsStarred_noStar(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	star, _, err := client.Gists.IsStarred(ctx, "1")
 	if err != nil {
 		t.Errorf("Gists.Starred returned error: %v", err)
@@ -893,7 +892,7 @@ func TestGistsService_IsStarred_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Gists.IsStarred(ctx, "%")
 	testURLParseError(t, err)
 }
@@ -907,7 +906,7 @@ func TestGistsService_Fork(t *testing.T) {
 		fmt.Fprint(w, `{"id": "2"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	gist, _, err := client.Gists.Fork(ctx, "1")
 	if err != nil {
 		t.Errorf("Gists.Fork returned error: %v", err)
@@ -952,7 +951,7 @@ func TestGistsService_ListForks(t *testing.T) {
 		`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	gistForks, _, err := client.Gists.ListForks(ctx, "1", nil)
 	if err != nil {
 		t.Errorf("Gists.ListForks returned error: %v", err)
@@ -997,7 +996,7 @@ func TestGistsService_ListForks_withOptions(t *testing.T) {
 		fmt.Fprint(w, `[]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	gistForks, _, err := client.Gists.ListForks(ctx, "1", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Gists.ListForks returned error: %v", err)

--- a/github/git_blobs_test.go
+++ b/github/git_blobs_test.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -29,7 +28,7 @@ func TestGitService_GetBlob(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	blob, _, err := client.Git.GetBlob(ctx, "o", "r", "s")
 	if err != nil {
 		t.Errorf("Git.GetBlob returned error: %v", err)
@@ -63,7 +62,7 @@ func TestGitService_GetBlob_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Git.GetBlob(ctx, "%", "%", "%")
 	testURLParseError(t, err)
 }
@@ -79,7 +78,7 @@ func TestGitService_GetBlobRaw(t *testing.T) {
 		fmt.Fprint(w, `raw contents here`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	blob, _, err := client.Git.GetBlobRaw(ctx, "o", "r", "s")
 	if err != nil {
 		t.Errorf("Git.GetBlobRaw returned error: %v", err)
@@ -135,7 +134,7 @@ func TestGitService_CreateBlob(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	blob, _, err := client.Git.CreateBlob(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Git.CreateBlob returned error: %v", err)
@@ -166,7 +165,7 @@ func TestGitService_CreateBlob_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Git.CreateBlob(ctx, "%", "%", Blob{})
 	testURLParseError(t, err)
 }

--- a/github/git_commits_test.go
+++ b/github/git_commits_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -137,7 +136,7 @@ func TestGitService_GetCommit(t *testing.T) {
 		fmt.Fprint(w, `{"sha":"s","message":"Commit Message.","author":{"name":"n"}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	commit, _, err := client.Git.GetCommit(ctx, "o", "r", "s")
 	if err != nil {
 		t.Errorf("Git.GetCommit returned error: %v", err)
@@ -167,7 +166,7 @@ func TestGitService_GetCommit_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Git.GetCommit(ctx, "%", "%", "%")
 	testURLParseError(t, err)
 }
@@ -199,7 +198,7 @@ func TestGitService_CreateCommit(t *testing.T) {
 		fmt.Fprint(w, `{"sha":"s"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	commit, _, err := client.Git.CreateCommit(ctx, "o", "r", input, nil)
 	if err != nil {
 		t.Errorf("Git.CreateCommit returned error: %v", err)
@@ -258,7 +257,7 @@ func TestGitService_CreateSignedCommit(t *testing.T) {
 		fmt.Fprint(w, `{"sha":"commitSha"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	commit, _, err := client.Git.CreateCommit(ctx, "o", "r", input, nil)
 	if err != nil {
 		t.Errorf("Git.CreateCommit returned error: %v", err)
@@ -290,7 +289,7 @@ func TestGitService_CreateSignedCommitWithInvalidParams(t *testing.T) {
 
 	input := Commit{}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := CreateCommitOptions{Signer: uncalledSigner(t)}
 	_, _, err := client.Git.CreateCommit(ctx, "o", "r", input, &opts)
 	if err == nil {
@@ -336,7 +335,7 @@ Commit Message.`
 		testMethod(t, r, "POST")
 		fmt.Fprintf(w, `{"sha":"%s"}`, sha)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	wantCommit := &Commit{SHA: Ptr(sha)}
 	opts := CreateCommitOptions{Signer: mockSigner(t, signature, nil, wantMessage)}
 	commit, _, err := client.Git.CreateCommit(ctx, "o", "r", input, &opts)
@@ -501,7 +500,7 @@ func TestGitService_CreateCommit_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Git.CreateCommit(ctx, "%", "%", Commit{}, nil)
 	testURLParseError(t, err)
 }

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -34,7 +33,7 @@ func TestGitService_GetRef_singleRef(t *testing.T) {
 		  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ref, _, err := client.Git.GetRef(ctx, "o", "r", "refs/heads/b")
 	if err != nil {
 		t.Fatalf("Git.GetRef returned error: %v", err)
@@ -82,7 +81,7 @@ func TestGitService_GetRef_noRefs(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ref, resp, err := client.Git.GetRef(ctx, "o", "r", "refs/heads/b")
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -130,7 +129,7 @@ func TestGitService_ListMatchingRefs_singleRef(t *testing.T) {
 	})
 
 	opts := &ReferenceListOptions{Ref: "refs/heads/b"}
-	ctx := context.Background()
+	ctx := t.Context()
 	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
 	if err != nil {
 		t.Fatalf("Git.ListMatchingRefs returned error: %v", err)
@@ -202,7 +201,7 @@ func TestGitService_ListMatchingRefs_multipleRefs(t *testing.T) {
 	})
 
 	opts := &ReferenceListOptions{Ref: "refs/heads/b"}
-	ctx := context.Background()
+	ctx := t.Context()
 	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Git.ListMatchingRefs returned error: %v", err)
@@ -246,7 +245,7 @@ func TestGitService_ListMatchingRefs_noRefs(t *testing.T) {
 	})
 
 	opts := &ReferenceListOptions{Ref: "refs/heads/b"}
-	ctx := context.Background()
+	ctx := t.Context()
 	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Git.ListMatchingRefs returned error: %v", err)
@@ -300,7 +299,7 @@ func TestGitService_ListMatchingRefs_allRefs(t *testing.T) {
 		  ]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", nil)
 	if err != nil {
 		t.Errorf("Git.ListMatchingRefs returned error: %v", err)
@@ -356,7 +355,7 @@ func TestGitService_ListMatchingRefs_options(t *testing.T) {
 	})
 
 	opts := &ReferenceListOptions{Ref: "t", ListOptions: ListOptions{Page: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Git.ListMatchingRefs returned error: %v", err)
@@ -411,7 +410,7 @@ func TestGitService_CreateRef(t *testing.T) {
 		  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ref, _, err := client.Git.CreateRef(ctx, "o", "r", CreateRef{
 		Ref: "refs/heads/b",
 		SHA: "aa218f56b14c9653891f9e74264a383fa43fefbd",
@@ -496,7 +495,7 @@ func TestGitService_UpdateRef(t *testing.T) {
 		  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ref, _, err := client.Git.UpdateRef(ctx, "o", "r", "refs/heads/b", UpdateRef{
 		SHA:   "aa218f56b14c9653891f9e74264a383fa43fefbd",
 		Force: Ptr(true),
@@ -564,7 +563,7 @@ func TestGitService_DeleteRef(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Git.DeleteRef(ctx, "o", "r", "refs/heads/b")
 	if err != nil {
 		t.Errorf("Git.DeleteRef returned error: %v", err)
@@ -607,7 +606,7 @@ func TestGitService_GetRef_pathEscape(t *testing.T) {
 		  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Git.GetRef(ctx, "o", "r", "refs/heads/b")
 	if err != nil {
 		t.Fatalf("Git.GetRef returned error: %v", err)
@@ -657,7 +656,7 @@ func TestGitService_UpdateRef_pathEscape(t *testing.T) {
 		  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ref, _, err := client.Git.UpdateRef(ctx, "o", "r", "refs/heads/b#1", UpdateRef{
 		SHA:   "aa218f56b14c9653891f9e74264a383fa43fefbd",
 		Force: Ptr(true),

--- a/github/git_tags_test.go
+++ b/github/git_tags_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -24,7 +23,7 @@ func TestGitService_GetTag(t *testing.T) {
 		fmt.Fprint(w, `{"tag": "t"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tag, _, err := client.Git.GetTag(ctx, "o", "r", "s")
 	if err != nil {
 		t.Errorf("Git.GetTag returned error: %v", err)
@@ -73,7 +72,7 @@ func TestGitService_CreateTag(t *testing.T) {
 		fmt.Fprint(w, `{"tag": "t"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tag, _, err := client.Git.CreateTag(ctx, "o", "r", inputTag)
 	if err != nil {
 		t.Errorf("Git.CreateTag returned error: %v", err)

--- a/github/git_trees_test.go
+++ b/github/git_trees_test.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -50,7 +49,7 @@ func TestGitService_GetTree(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tree, _, err := client.Git.GetTree(ctx, "o", "r", "s", true)
 	if err != nil {
 		t.Errorf("Git.GetTree returned error: %v", err)
@@ -88,7 +87,7 @@ func TestGitService_GetTree_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Git.GetTree(ctx, "%", "%", "%", false)
 	testURLParseError(t, err)
 }
@@ -133,7 +132,7 @@ func TestGitService_CreateTree(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tree, _, err := client.Git.CreateTree(ctx, "o", "r", "b", input)
 	if err != nil {
 		t.Errorf("Git.CreateTree returned error: %v", err)
@@ -213,7 +212,7 @@ func TestGitService_CreateTree_Content(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tree, _, err := client.Git.CreateTree(ctx, "o", "r", "b", input)
 	if err != nil {
 		t.Errorf("Git.CreateTree returned error: %v", err)
@@ -293,7 +292,7 @@ func TestGitService_CreateTree_Delete(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tree, _, err := client.Git.CreateTree(ctx, "o", "r", "b", input)
 	if err != nil {
 		t.Errorf("Git.CreateTree returned error: %v", err)
@@ -337,7 +336,7 @@ func TestGitService_CreateTree_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Git.CreateTree(ctx, "%", "%", "", nil)
 	testURLParseError(t, err)
 }

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -280,7 +280,7 @@ func testErrorResponseForStatusCode(t *testing.T, code int) {
 		w.WriteHeader(code)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListHooks(ctx, "o", "r", nil)
 
 	var abuseErr *AbuseRateLimitError
@@ -393,7 +393,7 @@ func TestWithAuthToken(t *testing.T) {
 
 	t.Run("NewTokenClient", func(t *testing.T) {
 		t.Parallel()
-		validate(t, NewTokenClient(context.Background(), token).Client(), token)
+		validate(t, NewTokenClient(t.Context(), token).Client(), token)
 	})
 }
 
@@ -1071,7 +1071,7 @@ func TestDo(t *testing.T) {
 
 	req, _ := client.NewRequest("GET", ".", nil)
 	body := new(foo)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Do(ctx, req, body)
 	assertNilError(t, err)
 
@@ -1102,7 +1102,7 @@ func TestDo_httpError(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Do(ctx, req, nil)
 
 	if err == nil {
@@ -1125,7 +1125,7 @@ func TestDo_redirectLoop(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Do(ctx, req, nil)
 
 	if err == nil {
@@ -1152,7 +1152,7 @@ func TestDo_preservesResponseInHTTPError(t *testing.T) {
 	req, _ := client.NewRequest("GET", ".", nil)
 	var resp *Response
 	var data any
-	resp, err := client.Do(context.Background(), req, &data)
+	resp, err := client.Do(t.Context(), req, &data)
 
 	if err == nil {
 		t.Fatal("Expected error response")
@@ -1195,7 +1195,7 @@ func TestDo_sanitizeURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRequest returned unexpected error: %v", err)
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err = unauthedClient.Do(ctx, req, nil)
 	if err == nil {
 		t.Fatal("Expected error to be returned.")
@@ -1218,7 +1218,7 @@ func TestDo_rateLimit(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Do(ctx, req, nil)
 	if err != nil {
 		t.Errorf("Do returned unexpected error: %v", err)
@@ -1333,7 +1333,7 @@ func TestDo_rateLimit_errorResponse(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Do(ctx, req, nil)
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -1379,7 +1379,7 @@ func TestDo_rateLimit_rateLimitError(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Do(ctx, req, nil)
 
 	if err == nil {
@@ -1435,7 +1435,7 @@ func TestDo_rateLimit_noNetworkCall(t *testing.T) {
 
 	// First request is made, and it makes the client aware of rate reset time being in the future.
 	req, _ := client.NewRequest("GET", "first", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Do(ctx, req, nil)
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -1503,7 +1503,7 @@ func TestDo_rateLimit_ignoredFromCache(t *testing.T) {
 
 	// First request is made so afterwards we can check the returned rate limit headers were ignored.
 	req, _ := client.NewRequest("GET", "first", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Do(ctx, req, nil)
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -1555,7 +1555,7 @@ func TestDo_rateLimit_sleepUntilResponseResetLimit(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Do(context.WithValue(ctx, SleepUntilPrimaryRateLimitResetWhenRateLimited, true), req, nil)
 	if err != nil {
 		t.Errorf("Do returned unexpected error: %v", err)
@@ -1589,7 +1589,7 @@ func TestDo_rateLimit_sleepUntilResponseResetLimitRetryOnce(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Do(context.WithValue(ctx, SleepUntilPrimaryRateLimitResetWhenRateLimited, true), req, nil)
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -1619,7 +1619,7 @@ func TestDo_rateLimit_sleepUntilClientResetLimit(t *testing.T) {
 		fmt.Fprintln(w, `{}`)
 	})
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Do(context.WithValue(ctx, SleepUntilPrimaryRateLimitResetWhenRateLimited, true), req, nil)
 	if err != nil {
 		t.Errorf("Do returned unexpected error: %v", err)
@@ -1656,7 +1656,7 @@ func TestDo_rateLimit_abortSleepContextCancelled(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 	defer cancel()
 	_, err := client.Do(context.WithValue(ctx, SleepUntilPrimaryRateLimitResetWhenRateLimited, true), req, nil)
 	if !errors.Is(err, context.DeadlineExceeded) {
@@ -1687,7 +1687,7 @@ func TestDo_rateLimit_abortSleepContextCancelledClientLimit(t *testing.T) {
 		fmt.Fprintln(w, `{}`)
 	})
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 	defer cancel()
 	_, err := client.Do(context.WithValue(ctx, SleepUntilPrimaryRateLimitResetWhenRateLimited, true), req, nil)
 	var rateLimitError *RateLimitError
@@ -1720,7 +1720,7 @@ func TestDo_rateLimit_abuseRateLimitError(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Do(ctx, req, nil)
 
 	if err == nil {
@@ -1755,7 +1755,7 @@ func TestDo_rateLimit_abuseRateLimitErrorEnterprise(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Do(ctx, req, nil)
 
 	if err == nil {
@@ -1786,7 +1786,7 @@ func TestDo_rateLimit_abuseRateLimitError_retryAfter(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Do(ctx, req, nil)
 
 	if err == nil {
@@ -1842,7 +1842,7 @@ func TestDo_rateLimit_abuseRateLimitError_xRateLimitReset(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Do(ctx, req, nil)
 
 	if err == nil {
@@ -1901,7 +1901,7 @@ func TestDo_rateLimit_abuseRateLimitError_maxDuration(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Do(ctx, req, nil)
 
 	if err == nil {
@@ -1941,7 +1941,7 @@ func TestDo_rateLimit_disableRateLimitCheck(t *testing.T) {
 		fmt.Fprintln(w, `{}`)
 	})
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Do(ctx, req, nil)
 	if err != nil {
 		t.Errorf("Do returned unexpected error: %v", err)
@@ -1977,7 +1977,7 @@ func TestDo_rateLimit_bypassRateLimitCheck(t *testing.T) {
 		fmt.Fprintln(w, `{}`)
 	})
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Do(context.WithValue(ctx, BypassRateLimitCheck, true), req, nil)
 	if err != nil {
 		t.Errorf("Do returned unexpected error: %v", err)
@@ -2004,7 +2004,7 @@ func TestDo_noContent(t *testing.T) {
 	var body json.RawMessage
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Do(ctx, req, &body)
 	if err != nil {
 		t.Fatalf("Do returned unexpected error: %v", err)
@@ -2020,7 +2020,7 @@ func TestBareDoUntilFound_redirectLoop(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.bareDoUntilFound(ctx, req, 1)
 
 	if err == nil {
@@ -2040,7 +2040,7 @@ func TestBareDoUntilFound_UnexpectedRedirection(t *testing.T) {
 	})
 
 	req, _ := client.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.bareDoUntilFound(ctx, req, 1)
 
 	if err == nil {
@@ -2739,7 +2739,7 @@ func TestUnauthenticatedRateLimitedTransport(t *testing.T) {
 	unauthedClient := NewClient(tp.Client())
 	unauthedClient.BaseURL = client.BaseURL
 	req, _ := unauthedClient.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := unauthedClient.Do(ctx, req, nil)
 	assertNilError(t, err)
 }
@@ -2817,7 +2817,7 @@ func TestBasicAuthTransport(t *testing.T) {
 	basicAuthClient := NewClient(tp.Client())
 	basicAuthClient.BaseURL = client.BaseURL
 	req, _ := basicAuthClient.NewRequest("GET", ".", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := basicAuthClient.Do(ctx, req, nil)
 	assertNilError(t, err)
 }
@@ -2970,7 +2970,7 @@ func TestBareDo_returnsOpenBody(t *testing.T) {
 		fmt.Fprint(w, expectedBody)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	req, err := client.NewRequest("GET", "test-url", nil)
 	if err != nil {
 		t.Fatalf("client.NewRequest returned error: %v", err)
@@ -3171,14 +3171,14 @@ func TestClientCopy_leak_transport(t *testing.T) {
 	aliceClient := clientPreconfiguredWithURLs.WithAuthToken("alice")
 	bobClient := clientPreconfiguredWithURLs.WithAuthToken("bob")
 
-	alice, _, err := aliceClient.Users.Get(context.Background(), "")
+	alice, _, err := aliceClient.Users.Get(t.Context(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	assertNoDiff(t, "Bearer alice", alice.GetLogin())
 
-	bob, _, err := bobClient.Users.Get(context.Background(), "")
+	bob, _, err := bobClient.Users.Get(t.Context(), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/github/gitignore_test.go
+++ b/github/gitignore_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -23,7 +22,7 @@ func TestGitignoresService_List(t *testing.T) {
 		fmt.Fprint(w, `["C", "Go"]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	available, _, err := client.Gitignores.List(ctx)
 	if err != nil {
 		t.Errorf("Gitignores.List returned error: %v", err)
@@ -53,7 +52,7 @@ func TestGitignoresService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"name":"Name","source":"template source"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	gitignore, _, err := client.Gitignores.Get(ctx, "name")
 	if err != nil {
 		t.Errorf("Gitignores.List returned error: %v", err)
@@ -83,7 +82,7 @@ func TestGitignoresService_Get_invalidTemplate(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Gitignores.Get(ctx, "%")
 	testURLParseError(t, err)
 }

--- a/github/interactions_orgs_test.go
+++ b/github/interactions_orgs_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -25,7 +24,7 @@ func TestInteractionsService_GetRestrictionsForOrgs(t *testing.T) {
 		fmt.Fprint(w, `{"origin":"organization"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	organizationInteractions, _, err := client.Interactions.GetRestrictionsForOrg(ctx, "o")
 	if err != nil {
 		t.Errorf("Interactions.GetRestrictionsForOrg returned error: %v", err)
@@ -69,7 +68,7 @@ func TestInteractionsService_UpdateRestrictionsForOrg(t *testing.T) {
 		fmt.Fprint(w, `{"origin":"organization"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	organizationInteractions, _, err := client.Interactions.UpdateRestrictionsForOrg(ctx, "o", input.GetLimit())
 	if err != nil {
 		t.Errorf("Interactions.UpdateRestrictionsForOrg returned error: %v", err)
@@ -104,7 +103,7 @@ func TestInteractionsService_RemoveRestrictionsFromOrg(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeInteractionRestrictionsPreview)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Interactions.RemoveRestrictionsFromOrg(ctx, "o")
 	if err != nil {
 		t.Errorf("Interactions.RemoveRestrictionsFromOrg returned error: %v", err)

--- a/github/interactions_repos_test.go
+++ b/github/interactions_repos_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -25,7 +24,7 @@ func TestInteractionsService_GetRestrictionsForRepo(t *testing.T) {
 		fmt.Fprint(w, `{"origin":"repository"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	repoInteractions, _, err := client.Interactions.GetRestrictionsForRepo(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Interactions.GetRestrictionsForRepo returned error: %v", err)
@@ -69,7 +68,7 @@ func TestInteractionsService_UpdateRestrictionsForRepo(t *testing.T) {
 		fmt.Fprint(w, `{"origin":"repository"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	repoInteractions, _, err := client.Interactions.UpdateRestrictionsForRepo(ctx, "o", "r", input.GetLimit())
 	if err != nil {
 		t.Errorf("Interactions.UpdateRestrictionsForRepo returned error: %v", err)
@@ -104,7 +103,7 @@ func TestInteractionsService_RemoveRestrictionsFromRepo(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeInteractionRestrictionsPreview)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Interactions.RemoveRestrictionsFromRepo(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Interactions.RemoveRestrictionsFromRepo returned error: %v", err)

--- a/github/issue_import_test.go
+++ b/github/issue_import_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -49,7 +48,7 @@ func TestIssueImportService_Create(t *testing.T) {
 		assertWrite(t, w, issueImportResponseJSON)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.IssueImport.Create(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Create returned error: %v", err)
@@ -108,7 +107,7 @@ func TestIssueImportService_Create_deferred(t *testing.T) {
 		assertWrite(t, w, issueImportResponseJSON)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.IssueImport.Create(ctx, "o", "r", input)
 
 	if !errors.As(err, new(*AcceptedError)) {
@@ -154,7 +153,7 @@ func TestIssueImportService_Create_badResponse(t *testing.T) {
 		assertWrite(t, w, []byte("{[}"))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.IssueImport.Create(ctx, "o", "r", input)
 
 	if err == nil || err.Error() != "invalid character '[' looking for beginning of object key string" {
@@ -166,7 +165,7 @@ func TestIssueImportService_Create_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.IssueImport.Create(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
@@ -182,7 +181,7 @@ func TestIssueImportService_CheckStatus(t *testing.T) {
 		assertWrite(t, w, issueImportResponseJSON)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.IssueImport.CheckStatus(ctx, "o", "r", 3)
 	if err != nil {
 		t.Errorf("CheckStatus returned error: %v", err)
@@ -212,7 +211,7 @@ func TestIssueImportService_CheckStatus_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.IssueImport.CheckStatus(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
@@ -228,7 +227,7 @@ func TestIssueImportService_CheckStatusSince(t *testing.T) {
 		assertWrite(t, w, []byte(fmt.Sprintf("[%s]", issueImportResponseJSON)))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.IssueImport.CheckStatusSince(ctx, "o", "r", Timestamp{time.Now()})
 	if err != nil {
 		t.Errorf("CheckStatusSince returned error: %v", err)
@@ -265,7 +264,7 @@ func TestIssueImportService_CheckStatusSince_badResponse(t *testing.T) {
 		assertWrite(t, w, []byte("{badly-formed JSON"))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, _, err := client.IssueImport.CheckStatusSince(ctx, "o", "r", Timestamp{time.Now()}); err == nil {
 		t.Error("CheckStatusSince returned no error, want JSON err")
 	}
@@ -275,7 +274,7 @@ func TestIssueImportService_CheckStatusSince_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.IssueImport.CheckStatusSince(ctx, "%", "r", Timestamp{time.Now()})
 	testURLParseError(t, err)
 }

--- a/github/issues_assignees_test.go
+++ b/github/issues_assignees_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,7 +25,7 @@ func TestIssuesService_ListAssignees(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	assignees, _, err := client.Issues.ListAssignees(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Issues.ListAssignees returned error: %v", err)
@@ -56,7 +55,7 @@ func TestIssuesService_ListAssignees_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.ListAssignees(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
@@ -69,7 +68,7 @@ func TestIssuesService_IsAssignee_true(t *testing.T) {
 		testMethod(t, r, "GET")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	assignee, _, err := client.Issues.IsAssignee(ctx, "o", "r", "u")
 	if err != nil {
 		t.Errorf("Issues.IsAssignee returned error: %v", err)
@@ -102,7 +101,7 @@ func TestIssuesService_IsAssignee_false(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	assignee, _, err := client.Issues.IsAssignee(ctx, "o", "r", "u")
 	if err != nil {
 		t.Errorf("Issues.IsAssignee returned error: %v", err)
@@ -135,7 +134,7 @@ func TestIssuesService_IsAssignee_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	assignee, _, err := client.Issues.IsAssignee(ctx, "o", "r", "u")
 	if err == nil {
 		t.Error("Expected HTTP 400 response")
@@ -163,7 +162,7 @@ func TestIssuesService_IsAssignee_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.IsAssignee(ctx, "%", "r", "u")
 	testURLParseError(t, err)
 }
@@ -186,7 +185,7 @@ func TestIssuesService_AddAssignees(t *testing.T) {
 		fmt.Fprint(w, `{"number":1,"assignees":[{"login":"user1"},{"login":"user2"}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Issues.AddAssignees(ctx, "o", "r", 1, []string{"user1", "user2"})
 	if err != nil {
 		t.Errorf("Issues.AddAssignees returned error: %v", err)
@@ -230,7 +229,7 @@ func TestIssuesService_RemoveAssignees(t *testing.T) {
 		fmt.Fprint(w, `{"number":1,"assignees":[]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Issues.RemoveAssignees(ctx, "o", "r", 1, []string{"user1", "user2"})
 	if err != nil {
 		t.Errorf("Issues.RemoveAssignees returned error: %v", err)

--- a/github/issues_comments_test.go
+++ b/github/issues_comments_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -39,7 +38,7 @@ func TestIssuesService_ListComments_allIssues(t *testing.T) {
 		Since:       &since,
 		ListOptions: ListOptions{Page: 2},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	comments, _, err := client.Issues.ListComments(ctx, "o", "r", 0, opt)
 	if err != nil {
 		t.Errorf("Issues.ListComments returned error: %v", err)
@@ -75,7 +74,7 @@ func TestIssuesService_ListComments_specificIssue(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comments, _, err := client.Issues.ListComments(ctx, "o", "r", 1, nil)
 	if err != nil {
 		t.Errorf("Issues.ListComments returned error: %v", err)
@@ -105,7 +104,7 @@ func TestIssuesService_ListComments_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.ListComments(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
@@ -120,7 +119,7 @@ func TestIssuesService_GetComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.Issues.GetComment(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Issues.GetComment returned error: %v", err)
@@ -150,7 +149,7 @@ func TestIssuesService_GetComment_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.GetComment(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
@@ -173,7 +172,7 @@ func TestIssuesService_CreateComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.Issues.CreateComment(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Issues.CreateComment returned error: %v", err)
@@ -203,7 +202,7 @@ func TestIssuesService_CreateComment_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.CreateComment(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
@@ -226,7 +225,7 @@ func TestIssuesService_EditComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.Issues.EditComment(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Issues.EditComment returned error: %v", err)
@@ -256,7 +255,7 @@ func TestIssuesService_EditComment_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.EditComment(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
@@ -269,7 +268,7 @@ func TestIssuesService_DeleteComment(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Issues.DeleteComment(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Issues.DeleteComments returned error: %v", err)
@@ -290,7 +289,7 @@ func TestIssuesService_DeleteComment_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Issues.DeleteComment(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }

--- a/github/issues_events_test.go
+++ b/github/issues_events_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -29,7 +28,7 @@ func TestIssuesService_ListIssueEvents(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	events, _, err := client.Issues.ListIssueEvents(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Issues.ListIssueEvents returned error: %v", err)
@@ -69,7 +68,7 @@ func TestIssuesService_ListRepositoryEvents(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	events, _, err := client.Issues.ListRepositoryEvents(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Issues.ListRepositoryEvents returned error: %v", err)
@@ -104,7 +103,7 @@ func TestIssuesService_GetEvent(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	event, _, err := client.Issues.GetEvent(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Issues.GetEvent returned error: %v", err)

--- a/github/issues_labels_test.go
+++ b/github/issues_labels_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,7 +25,7 @@ func TestIssuesService_ListLabels(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	labels, _, err := client.Issues.ListLabels(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Issues.ListLabels returned error: %v", err)
@@ -56,7 +55,7 @@ func TestIssuesService_ListLabels_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.ListLabels(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
@@ -70,7 +69,7 @@ func TestIssuesService_GetLabel(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u", "name": "n", "color": "c", "description": "d"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	label, _, err := client.Issues.GetLabel(ctx, "o", "r", "n")
 	if err != nil {
 		t.Errorf("Issues.GetLabel returned error: %v", err)
@@ -100,7 +99,7 @@ func TestIssuesService_GetLabel_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.GetLabel(ctx, "%", "%", "%")
 	testURLParseError(t, err)
 }
@@ -123,7 +122,7 @@ func TestIssuesService_CreateLabel(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	label, _, err := client.Issues.CreateLabel(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Issues.CreateLabel returned error: %v", err)
@@ -153,7 +152,7 @@ func TestIssuesService_CreateLabel_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.CreateLabel(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
@@ -176,7 +175,7 @@ func TestIssuesService_EditLabel(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	label, _, err := client.Issues.EditLabel(ctx, "o", "r", "n", input)
 	if err != nil {
 		t.Errorf("Issues.EditLabel returned error: %v", err)
@@ -206,7 +205,7 @@ func TestIssuesService_EditLabel_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.EditLabel(ctx, "%", "%", "%", nil)
 	testURLParseError(t, err)
 }
@@ -219,7 +218,7 @@ func TestIssuesService_DeleteLabel(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Issues.DeleteLabel(ctx, "o", "r", "n")
 	if err != nil {
 		t.Errorf("Issues.DeleteLabel returned error: %v", err)
@@ -240,7 +239,7 @@ func TestIssuesService_DeleteLabel_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Issues.DeleteLabel(ctx, "%", "%", "%")
 	testURLParseError(t, err)
 }
@@ -256,7 +255,7 @@ func TestIssuesService_ListLabelsByIssue(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	labels, _, err := client.Issues.ListLabelsByIssue(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Issues.ListLabelsByIssue returned error: %v", err)
@@ -289,7 +288,7 @@ func TestIssuesService_ListLabelsByIssue_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.ListLabelsByIssue(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }
@@ -312,7 +311,7 @@ func TestIssuesService_AddLabelsToIssue(t *testing.T) {
 		fmt.Fprint(w, `[{"url":"u"}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	labels, _, err := client.Issues.AddLabelsToIssue(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Issues.AddLabelsToIssue returned error: %v", err)
@@ -342,7 +341,7 @@ func TestIssuesService_AddLabelsToIssue_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.AddLabelsToIssue(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }
@@ -355,7 +354,7 @@ func TestIssuesService_RemoveLabelForIssue(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Issues.RemoveLabelForIssue(ctx, "o", "r", 1, "l")
 	if err != nil {
 		t.Errorf("Issues.RemoveLabelForIssue returned error: %v", err)
@@ -376,7 +375,7 @@ func TestIssuesService_RemoveLabelForIssue_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Issues.RemoveLabelForIssue(ctx, "%", "%", 1, "%")
 	testURLParseError(t, err)
 }
@@ -399,7 +398,7 @@ func TestIssuesService_ReplaceLabelsForIssue(t *testing.T) {
 		fmt.Fprint(w, `[{"url":"u"}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	labels, _, err := client.Issues.ReplaceLabelsForIssue(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Issues.ReplaceLabelsForIssue returned error: %v", err)
@@ -429,7 +428,7 @@ func TestIssuesService_ReplaceLabelsForIssue_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.ReplaceLabelsForIssue(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }
@@ -442,7 +441,7 @@ func TestIssuesService_RemoveLabelsForIssue(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Issues.RemoveLabelsForIssue(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Issues.RemoveLabelsForIssue returned error: %v", err)
@@ -463,7 +462,7 @@ func TestIssuesService_RemoveLabelsForIssue_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Issues.RemoveLabelsForIssue(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }
@@ -479,7 +478,7 @@ func TestIssuesService_ListLabelsForMilestone(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	labels, _, err := client.Issues.ListLabelsForMilestone(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Issues.ListLabelsForMilestone returned error: %v", err)
@@ -509,7 +508,7 @@ func TestIssuesService_ListLabelsForMilestone_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.ListLabelsForMilestone(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }

--- a/github/issues_milestones_test.go
+++ b/github/issues_milestones_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -31,7 +30,7 @@ func TestIssuesService_ListMilestones(t *testing.T) {
 	})
 
 	opt := &MilestoneListOptions{"closed", "due_date", "asc", ListOptions{Page: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	milestones, _, err := client.Issues.ListMilestones(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("IssuesService.ListMilestones returned error: %v", err)
@@ -61,7 +60,7 @@ func TestIssuesService_ListMilestones_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.ListMilestones(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
@@ -75,7 +74,7 @@ func TestIssuesService_GetMilestone(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	milestone, _, err := client.Issues.GetMilestone(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("IssuesService.GetMilestone returned error: %v", err)
@@ -105,7 +104,7 @@ func TestIssuesService_GetMilestone_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.GetMilestone(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
@@ -128,7 +127,7 @@ func TestIssuesService_CreateMilestone(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	milestone, _, err := client.Issues.CreateMilestone(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("IssuesService.CreateMilestone returned error: %v", err)
@@ -158,7 +157,7 @@ func TestIssuesService_CreateMilestone_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.CreateMilestone(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
@@ -181,7 +180,7 @@ func TestIssuesService_EditMilestone(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	milestone, _, err := client.Issues.EditMilestone(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("IssuesService.EditMilestone returned error: %v", err)
@@ -211,7 +210,7 @@ func TestIssuesService_EditMilestone_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.EditMilestone(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
@@ -224,7 +223,7 @@ func TestIssuesService_DeleteMilestone(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Issues.DeleteMilestone(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("IssuesService.DeleteMilestone returned error: %v", err)
@@ -245,7 +244,7 @@ func TestIssuesService_DeleteMilestone_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Issues.DeleteMilestone(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -46,7 +45,7 @@ func TestIssuesService_List_all(t *testing.T) {
 		ListCursorOptions{Before: "foo", After: "bar"},
 		ListOptions{Page: 1, PerPage: 2},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	issues, _, err := client.Issues.List(ctx, true, opt)
 	if err != nil {
 		t.Errorf("Issues.List returned error: %v", err)
@@ -77,7 +76,7 @@ func TestIssuesService_List_owned(t *testing.T) {
 		fmt.Fprint(w, `[{"number":1}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	issues, _, err := client.Issues.List(ctx, false, nil)
 	if err != nil {
 		t.Errorf("Issues.List returned error: %v", err)
@@ -99,7 +98,7 @@ func TestIssuesService_ListByOrg(t *testing.T) {
 		fmt.Fprint(w, `[{"number":1}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	issues, _, err := client.Issues.ListByOrg(ctx, "o", nil)
 	if err != nil {
 		t.Errorf("Issues.ListByOrg returned error: %v", err)
@@ -129,7 +128,7 @@ func TestIssuesService_ListByOrg_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.ListByOrg(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -138,7 +137,7 @@ func TestIssuesService_ListByOrg_badOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.ListByOrg(ctx, "\n", nil)
 	testURLParseError(t, err)
 }
@@ -175,7 +174,7 @@ func TestIssuesService_ListByRepo(t *testing.T) {
 		ListCursorOptions{PerPage: 1, Before: "foo", After: "bar"},
 		ListOptions{0, 0},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	issues, _, err := client.Issues.ListByRepo(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Issues.ListByOrg returned error: %v", err)
@@ -205,7 +204,7 @@ func TestIssuesService_ListByRepo_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.ListByRepo(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
@@ -220,7 +219,7 @@ func TestIssuesService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"number":1, "author_association": "MEMBER","labels": [{"url": "u", "name": "n", "color": "c"}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	issue, _, err := client.Issues.Get(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Issues.Get returned error: %v", err)
@@ -258,7 +257,7 @@ func TestIssuesService_Get_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.Get(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
@@ -286,7 +285,7 @@ func TestIssuesService_Create(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	issue, _, err := client.Issues.Create(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Issues.Create returned error: %v", err)
@@ -316,7 +315,7 @@ func TestIssuesService_Create_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.Create(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
@@ -339,7 +338,7 @@ func TestIssuesService_Edit(t *testing.T) {
 		fmt.Fprint(w, `{"number":1, "type": {"name": "bug"}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	issue, _, err := client.Issues.Edit(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Issues.Edit returned error: %v", err)
@@ -374,7 +373,7 @@ func TestIssuesService_RemoveMilestone(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	issue, _, err := client.Issues.RemoveMilestone(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Issues.RemoveMilestone returned error: %v", err)
@@ -404,7 +403,7 @@ func TestIssuesService_Edit_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Issues.Edit(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
@@ -419,7 +418,7 @@ func TestIssuesService_Lock(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Issues.Lock(ctx, "o", "r", 1, nil); err != nil {
 		t.Errorf("Issues.Lock returned error: %v", err)
 	}
@@ -446,7 +445,7 @@ func TestIssuesService_LockWithReason(t *testing.T) {
 
 	opt := &LockIssueOptions{LockReason: "off-topic"}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Issues.Lock(ctx, "o", "r", 1, opt); err != nil {
 		t.Errorf("Issues.Lock returned error: %v", err)
 	}
@@ -462,7 +461,7 @@ func TestIssuesService_Unlock(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Issues.Unlock(ctx, "o", "r", 1); err != nil {
 		t.Errorf("Issues.Unlock returned error: %v", err)
 	}

--- a/github/issues_timeline_test.go
+++ b/github/issues_timeline_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -31,7 +30,7 @@ func TestIssuesService_ListIssueTimeline(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	events, _, err := client.Issues.ListIssueTimeline(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Issues.ListIssueTimeline returned error: %v", err)
@@ -296,7 +295,7 @@ func TestTimeline_ReviewRequests(t *testing.T) {
 		}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	events, _, err := client.Issues.ListIssueTimeline(ctx, "example-org", "example-repo", 3, nil)
 	if err != nil {
 		t.Errorf("Issues.ListIssueTimeline returned error: %v", err)

--- a/github/licenses_test.go
+++ b/github/licenses_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -119,7 +118,7 @@ func TestLicensesService_List(t *testing.T) {
 		fmt.Fprint(w, `[{"key":"mit","name":"MIT","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","featured":true}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	licenses, _, err := client.Licenses.List(ctx)
 	if err != nil {
 		t.Errorf("Licenses.List returned error: %v", err)
@@ -155,7 +154,7 @@ func TestLicensesService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"key":"mit","name":"MIT"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	license, _, err := client.Licenses.Get(ctx, "mit")
 	if err != nil {
 		t.Errorf("Licenses.Get returned error: %v", err)
@@ -185,7 +184,7 @@ func TestLicensesService_Get_invalidTemplate(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Licenses.Get(ctx, "%")
 	testURLParseError(t, err)
 }

--- a/github/markdown_test.go
+++ b/github/markdown_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -35,7 +34,7 @@ func TestMarkdownService_Markdown(t *testing.T) {
 		fmt.Fprint(w, `<h1>text</h1>`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	md, _, err := client.Markdown.Render(ctx, "# text #", &MarkdownOptions{
 		Mode:    "gfm",
 		Context: "google/go-github",

--- a/github/meta_test.go
+++ b/github/meta_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -80,7 +79,7 @@ func TestMetaService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"web":["w"],"api":["a"],"hooks":["h"], "git":["g"], "pages":["p"], "importer":["i"], "github_enterprise_importer": ["gei"], "actions":["a"], "actions_macos": ["192.0.2.1/32", "198.51.100.0/24"], "dependabot":["d"], "verifiable_password_authentication": true, "domains":{"website":["*.github.com","*.github.dev","*.github.io","*.githubassets.com","*.githubusercontent.com"],"artifact_attestations":{"trust_domain":"","services":["*.actions.githubusercontent.com","tuf-repo.github.com","fulcio.githubapp.com","timestamp.githubapp.com"]}}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	meta, _, err := client.Meta.Get(ctx)
 	if err != nil {
 		t.Errorf("Get returned error: %v", err)
@@ -146,7 +145,7 @@ func TestMetaService_Octocat(t *testing.T) {
 		fmt.Fprint(w, output)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Meta.Octocat(ctx, input)
 	if err != nil {
 		t.Errorf("Octocat returned error: %v", err)
@@ -178,7 +177,7 @@ func TestMetaService_Zen(t *testing.T) {
 		fmt.Fprint(w, output)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Meta.Zen(ctx)
 	if err != nil {
 		t.Errorf("Zen returned error: %v", err)

--- a/github/migrations_source_import_test.go
+++ b/github/migrations_source_import_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -39,7 +38,7 @@ func TestMigrationService_StartImport(t *testing.T) {
 		fmt.Fprint(w, `{"status":"importing"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Migrations.StartImport(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("StartImport returned error: %v", err)
@@ -73,7 +72,7 @@ func TestMigrationService_ImportProgress(t *testing.T) {
 		fmt.Fprint(w, `{"status":"complete"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Migrations.ImportProgress(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("ImportProgress returned error: %v", err)
@@ -122,7 +121,7 @@ func TestMigrationService_UpdateImport(t *testing.T) {
 		fmt.Fprint(w, `{"status":"importing"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Migrations.UpdateImport(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("UpdateImport returned error: %v", err)
@@ -156,7 +155,7 @@ func TestMigrationService_CommitAuthors(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1,"name":"a"},{"id":2,"name":"b"}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Migrations.CommitAuthors(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("CommitAuthors returned error: %v", err)
@@ -202,7 +201,7 @@ func TestMigrationService_MapCommitAuthor(t *testing.T) {
 		fmt.Fprint(w, `{"id": 1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Migrations.MapCommitAuthor(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("MapCommitAuthor returned error: %v", err)
@@ -246,7 +245,7 @@ func TestMigrationService_SetLFSPreference(t *testing.T) {
 		fmt.Fprint(w, `{"status":"importing"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Migrations.SetLFSPreference(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("SetLFSPreference returned error: %v", err)
@@ -280,7 +279,7 @@ func TestMigrationService_LargeFiles(t *testing.T) {
 		fmt.Fprint(w, `[{"oid":"a"},{"oid":"b"}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Migrations.LargeFiles(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("LargeFiles returned error: %v", err)
@@ -317,7 +316,7 @@ func TestMigrationService_CancelImport(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Migrations.CancelImport(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("CancelImport returned error: %v", err)

--- a/github/migrations_test.go
+++ b/github/migrations_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -33,7 +32,7 @@ func TestMigrationService_StartMigration(t *testing.T) {
 		ExcludeReleases:    true,
 		Exclude:            []string{"repositories"},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Migrations.StartMigration(ctx, "o", []string{"r"}, opt)
 	if err != nil {
 		t.Errorf("StartMigration returned error: %v", err)
@@ -69,7 +68,7 @@ func TestMigrationService_ListMigrations(t *testing.T) {
 		assertWrite(t, w, []byte(fmt.Sprintf("[%s]", migrationJSON)))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Migrations.ListMigrations(ctx, "o", &ListOptions{Page: 1, PerPage: 2})
 	if err != nil {
 		t.Errorf("ListMigrations returned error: %v", err)
@@ -105,7 +104,7 @@ func TestMigrationService_MigrationStatus(t *testing.T) {
 		assertWrite(t, w, migrationJSON)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Migrations.MigrationStatus(ctx, "o", 1)
 	if err != nil {
 		t.Errorf("MigrationStatus returned error: %v", err)
@@ -146,7 +145,7 @@ func TestMigrationService_MigrationArchiveURL(t *testing.T) {
 		assertWrite(t, w, []byte("0123456789abcdef"))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, err := client.Migrations.MigrationArchiveURL(ctx, "o", 1)
 	if err != nil {
 		t.Errorf("MigrationStatus returned error: %v", err)
@@ -173,7 +172,7 @@ func TestMigrationService_DeleteMigration(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Migrations.DeleteMigration(ctx, "o", 1); err != nil {
 		t.Errorf("DeleteMigration returned error: %v", err)
 	}
@@ -200,7 +199,7 @@ func TestMigrationService_UnlockRepo(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Migrations.UnlockRepo(ctx, "o", 1, "r"); err != nil {
 		t.Errorf("UnlockRepo returned error: %v", err)
 	}

--- a/github/migrations_user_test.go
+++ b/github/migrations_user_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -32,7 +31,7 @@ func TestMigrationService_StartUserMigration(t *testing.T) {
 		ExcludeAttachments: false,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Migrations.StartUserMigration(ctx, []string{"r"}, opt)
 	if err != nil {
 		t.Errorf("StartUserMigration returned error: %v", err)
@@ -65,7 +64,7 @@ func TestMigrationService_ListUserMigrations(t *testing.T) {
 		assertWrite(t, w, []byte(fmt.Sprintf("[%s]", userMigrationJSON)))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Migrations.ListUserMigrations(ctx, &ListOptions{Page: 1, PerPage: 2})
 	if err != nil {
 		t.Errorf("ListUserMigrations returned error %v", err)
@@ -98,7 +97,7 @@ func TestMigrationService_UserMigrationStatus(t *testing.T) {
 		assertWrite(t, w, userMigrationJSON)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Migrations.UserMigrationStatus(ctx, 1)
 	if err != nil {
 		t.Errorf("UserMigrationStatus returned error %v", err)
@@ -136,7 +135,7 @@ func TestMigrationService_UserMigrationArchiveURL(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, err := client.Migrations.UserMigrationArchiveURL(ctx, 1)
 	if err != nil {
 		t.Errorf("UserMigrationArchiveURL returned error %v", err)
@@ -159,7 +158,7 @@ func TestMigrationService_DeleteUserMigration(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, err := client.Migrations.DeleteUserMigration(ctx, 1)
 	if err != nil {
 		t.Errorf("DeleteUserMigration returned error %v", err)
@@ -191,7 +190,7 @@ func TestMigrationService_UnlockUserRepo(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, err := client.Migrations.UnlockUserRepo(ctx, 1, "r")
 	if err != nil {
 		t.Errorf("UnlockUserRepo returned error %v", err)

--- a/github/orgs_actions_allowed_test.go
+++ b/github/orgs_actions_allowed_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -24,7 +23,7 @@ func TestOrganizationsService_GetActionsAllowed(t *testing.T) {
 		fmt.Fprint(w, `{"github_owned_allowed":true, "verified_allowed":false, "patterns_allowed":["a/b"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Organizations.GetActionsAllowed(ctx, "o")
 	if err != nil {
 		t.Errorf("Organizations.GetActionsAllowed returned error: %v", err)
@@ -67,7 +66,7 @@ func TestOrganizationsService_UpdateActionsAllowed(t *testing.T) {
 		fmt.Fprint(w, `{"github_owned_allowed":true, "verified_allowed":false, "patterns_allowed":["a/b"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Organizations.UpdateActionsAllowed(ctx, "o", *input)
 	if err != nil {
 		t.Errorf("Organizations.UpdateActionsAllowed returned error: %v", err)

--- a/github/orgs_actions_permissions_test.go
+++ b/github/orgs_actions_permissions_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -24,7 +23,7 @@ func TestOrganizationsService_GetActionsPermissions(t *testing.T) {
 		fmt.Fprint(w, `{"enabled_repositories": "all", "allowed_actions": "all"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Organizations.GetActionsPermissions(ctx, "o")
 	if err != nil {
 		t.Errorf("Organizations.GetActionsPermissions returned error: %v", err)
@@ -67,7 +66,7 @@ func TestOrganizationsService_UpdateActionsPermissions(t *testing.T) {
 		fmt.Fprint(w, `{"enabled_repositories": "all", "allowed_actions": "selected"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Organizations.UpdateActionsPermissions(ctx, "o", *input)
 	if err != nil {
 		t.Errorf("Organizations.UpdateActionsPermissions returned error: %v", err)

--- a/github/orgs_attestations_test.go
+++ b/github/orgs_attestations_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -33,7 +32,7 @@ func TestOrganizationsService_ListAttestations(t *testing.T) {
 			]
 		}`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	attestations, _, err := client.Organizations.ListAttestations(ctx, "o", "digest", &ListOptions{})
 	if err != nil {
 		t.Errorf("Organizations.ListAttestations returned error: %v", err)

--- a/github/orgs_audit_log_test.go
+++ b/github/orgs_audit_log_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -80,7 +79,7 @@ func TestOrganizationService_GetAuditLog(t *testing.T) {
 		"workflow_run_id": 628312345
 	}]`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	getOpts := GetAuditLogOptions{
 		Include: Ptr("all"),
 		Phrase:  Ptr("action:workflows"),

--- a/github/orgs_codesecurity_configurations_test.go
+++ b/github/orgs_codesecurity_configurations_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -17,7 +16,7 @@ import (
 
 func TestOrganizationsService_GetCodeSecurityConfigurations(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/code-security/configurations", func(w http.ResponseWriter, r *http.Request) {
@@ -64,7 +63,7 @@ func TestOrganizationsService_GetCodeSecurityConfigurations(t *testing.T) {
 func TestOrganizationsService_GetCodeSecurityConfiguration(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mux.HandleFunc("/orgs/o/code-security/configurations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -103,7 +102,7 @@ func TestOrganizationsService_GetCodeSecurityConfiguration(t *testing.T) {
 func TestOrganizationsService_CreateCodeSecurityConfiguration(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	input := &CodeSecurityConfiguration{
 		Name:                     Ptr("config1"),
@@ -153,7 +152,7 @@ func TestOrganizationsService_CreateCodeSecurityConfiguration(t *testing.T) {
 func TestOrganizationsService_GetDefaultCodeSecurityConfigurations(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mux.HandleFunc("/orgs/o/code-security/configurations/defaults", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -208,7 +207,7 @@ func TestOrganizationsService_GetDefaultCodeSecurityConfigurations(t *testing.T)
 func TestOrganizationsService_DetachCodeSecurityConfigurationsFromRepositories(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mux.HandleFunc("/orgs/o/code-security/configurations/detach", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -239,7 +238,7 @@ func TestOrganizationsService_DetachCodeSecurityConfigurationsFromRepositories(t
 
 func TestOrganizationsService_UpdateCodeSecurityConfiguration(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	client, mux, _ := setup(t)
 
 	input := &CodeSecurityConfiguration{
@@ -289,7 +288,7 @@ func TestOrganizationsService_UpdateCodeSecurityConfiguration(t *testing.T) {
 
 func TestOrganizationsService_DeleteCodeSecurityConfiguration(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/code-security/configurations/1", func(w http.ResponseWriter, r *http.Request) {
@@ -321,7 +320,7 @@ func TestOrganizationsService_DeleteCodeSecurityConfiguration(t *testing.T) {
 
 func TestOrganizationsService_AttachCodeSecurityConfigurationsToRepositories(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/code-security/configurations/1/attach", func(w http.ResponseWriter, r *http.Request) {
@@ -365,7 +364,7 @@ func TestOrganizationsService_AttachCodeSecurityConfigurationsToRepositories(t *
 
 func TestOrganizationsService_SetDefaultCodeSecurityConfiguration(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/code-security/configurations/1/defaults", func(w http.ResponseWriter, r *http.Request) {
@@ -416,7 +415,7 @@ func TestOrganizationsService_SetDefaultCodeSecurityConfiguration(t *testing.T) 
 
 func TestOrganizationsService_GetRepositoriesForCodeSecurityConfiguration(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/orgs/o/code-security/configurations/1/repositories", func(w http.ResponseWriter, r *http.Request) {
@@ -468,7 +467,7 @@ func TestOrganizationsService_GetRepositoriesForCodeSecurityConfiguration(t *tes
 
 func TestOrganizationsService_GetCodeSecurityConfigurationForRepository(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/repo8/code-security-configuration", func(w http.ResponseWriter, r *http.Request) {

--- a/github/orgs_credential_authorizations_test.go
+++ b/github/orgs_credential_authorizations_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -39,7 +38,7 @@ func TestOrganizationsService_ListCredentialAuthorizations(t *testing.T) {
 		Login:       "l",
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	creds, _, err := client.Organizations.ListCredentialAuthorizations(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Organizations.ListCredentialAuthorizations returned error: %v", err)
@@ -81,7 +80,7 @@ func TestOrganizationsService_RemoveCredentialAuthorization(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Organizations.RemoveCredentialAuthorization(ctx, "o", 1)
 	if err != nil {
 		t.Errorf("Organizations.RemoveCredentialAuthorization returned error: %v", err)

--- a/github/orgs_custom_repository_roles_test.go
+++ b/github/orgs_custom_repository_roles_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -46,7 +45,7 @@ func TestOrganizationsService_ListCustomRepoRoles(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	apps, _, err := client.Organizations.ListCustomRepoRoles(ctx, "o")
 	if err != nil {
 		t.Errorf("Organizations.ListCustomRepoRoles returned error: %v", err)
@@ -124,7 +123,7 @@ func TestOrganizationsService_GetCustomRepoRole(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	role, _, err := client.Organizations.GetCustomRepoRole(ctx, "o", 1)
 	if err != nil {
 		t.Errorf("Organizations.GetCustomRepoRole returned error: %v", err)
@@ -183,7 +182,7 @@ func TestOrganizationsService_CreateCustomRepoRole(t *testing.T) {
 		fmt.Fprint(w, `{"id":8030,"name":"Labeler","description":"A role for issue and PR labelers","base_role":"read","permissions":["add_label"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	opts := &CreateOrUpdateCustomRepoRoleOptions{
 		Name:        Ptr("Labeler"),
@@ -226,7 +225,7 @@ func TestOrganizationsService_UpdateCustomRepoRole(t *testing.T) {
 		fmt.Fprint(w, `{"id":8030,"name":"Updated Name","description":"Updated Description","base_role":"read","permissions":["add_label"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	opts := &CreateOrUpdateCustomRepoRoleOptions{
 		Name:        Ptr("Updated Name"),
@@ -267,7 +266,7 @@ func TestOrganizationsService_DeleteCustomRepoRole(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	resp, err := client.Organizations.DeleteCustomRepoRole(ctx, "o", 8030)
 	if err != nil {

--- a/github/orgs_hooks_configuration_test.go
+++ b/github/orgs_hooks_configuration_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -24,7 +23,7 @@ func TestOrganizationsService_GetHookConfiguration(t *testing.T) {
 		fmt.Fprint(w, `{"content_type": "json", "insecure_ssl": "0", "secret": "********", "url": "https://example.com/webhook"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	config, _, err := client.Organizations.GetHookConfiguration(ctx, "o", 1)
 	if err != nil {
 		t.Errorf("Organizations.GetHookConfiguration returned error: %v", err)
@@ -59,7 +58,7 @@ func TestOrganizationsService_GetHookConfiguration_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.GetHookConfiguration(ctx, "%", 1)
 	testURLParseError(t, err)
 }
@@ -82,7 +81,7 @@ func TestOrganizationsService_EditHookConfiguration(t *testing.T) {
 		fmt.Fprint(w, `{"content_type": "json", "insecure_ssl": "0", "secret": "********", "url": "https://example.com/webhook"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	config, _, err := client.Organizations.EditHookConfiguration(ctx, "o", 1, input)
 	if err != nil {
 		t.Errorf("Organizations.EditHookConfiguration returned error: %v", err)
@@ -117,7 +116,7 @@ func TestOrganizationsService_EditHookConfiguration_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.EditHookConfiguration(ctx, "%", 1, nil)
 	testURLParseError(t, err)
 }

--- a/github/orgs_hooks_deliveries_test.go
+++ b/github/orgs_hooks_deliveries_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -26,7 +25,7 @@ func TestOrganizationsService_ListHookDeliveries(t *testing.T) {
 
 	opt := &ListCursorOptions{Cursor: "v1_12077215967"}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hooks, _, err := client.Organizations.ListHookDeliveries(ctx, "o", 1, opt)
 	if err != nil {
 		t.Errorf("Organizations.ListHookDeliveries returned error: %v", err)
@@ -56,7 +55,7 @@ func TestOrganizationsService_ListHookDeliveries_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.ListHookDeliveries(ctx, "%", 1, nil)
 	testURLParseError(t, err)
 }
@@ -70,7 +69,7 @@ func TestOrganizationsService_GetHookDelivery(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Organizations.GetHookDelivery(ctx, "o", 1, 1)
 	if err != nil {
 		t.Errorf("Organizations.GetHookDelivery returned error: %v", err)
@@ -100,7 +99,7 @@ func TestOrganizationsService_GetHookDelivery_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.GetHookDelivery(ctx, "%", 1, 1)
 	testURLParseError(t, err)
 }
@@ -114,7 +113,7 @@ func TestOrganizationsService_RedeliverHookDelivery(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Organizations.RedeliverHookDelivery(ctx, "o", 1, 1)
 	if err != nil {
 		t.Errorf("Organizations.RedeliverHookDelivery returned error: %v", err)
@@ -144,7 +143,7 @@ func TestOrganizationsService_RedeliverHookDelivery_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.RedeliverHookDelivery(ctx, "%", 1, 1)
 	testURLParseError(t, err)
 }

--- a/github/orgs_hooks_test.go
+++ b/github/orgs_hooks_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -27,7 +26,7 @@ func TestOrganizationsService_ListHooks(t *testing.T) {
 
 	opt := &ListOptions{Page: 2}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hooks, _, err := client.Organizations.ListHooks(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListHooks returned error: %v", err)
@@ -57,7 +56,7 @@ func TestOrganizationsService_ListHooks_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.ListHooks(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -81,7 +80,7 @@ func TestOrganizationsService_CreateHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Organizations.CreateHook(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Organizations.CreateHook returned error: %v", err)
@@ -120,7 +119,7 @@ func TestOrganizationsService_GetHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Organizations.GetHook(ctx, "o", 1)
 	if err != nil {
 		t.Errorf("Organizations.GetHook returned error: %v", err)
@@ -150,7 +149,7 @@ func TestOrganizationsService_GetHook_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.GetHook(ctx, "%", 1)
 	testURLParseError(t, err)
 }
@@ -173,7 +172,7 @@ func TestOrganizationsService_EditHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Organizations.EditHook(ctx, "o", 1, input)
 	if err != nil {
 		t.Errorf("Organizations.EditHook returned error: %v", err)
@@ -203,7 +202,7 @@ func TestOrganizationsService_EditHook_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.EditHook(ctx, "%", 1, nil)
 	testURLParseError(t, err)
 }
@@ -216,7 +215,7 @@ func TestOrganizationsService_PingHook(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.PingHook(ctx, "o", 1)
 	if err != nil {
 		t.Errorf("Organizations.PingHook returned error: %v", err)
@@ -241,7 +240,7 @@ func TestOrganizationsService_DeleteHook(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.DeleteHook(ctx, "o", 1)
 	if err != nil {
 		t.Errorf("Organizations.DeleteHook returned error: %v", err)
@@ -262,7 +261,7 @@ func TestOrganizationsService_DeleteHook_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.DeleteHook(ctx, "%", 1)
 	testURLParseError(t, err)
 }

--- a/github/orgs_issue_types_test.go
+++ b/github/orgs_issue_types_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -42,7 +41,7 @@ func TestOrganizationsService_ListIssueTypes(t *testing.T) {
 		]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	issueTypes, _, err := client.Organizations.ListIssueTypes(ctx, "o")
 	if err != nil {
 		t.Errorf("Organizations.ListIssueTypes returned error: %v", err)
@@ -116,7 +115,7 @@ func TestOrganizationsService_CreateIssueType(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	issueType, _, err := client.Organizations.CreateIssueType(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Organizations.CreateIssueType returned error: %v", err)
@@ -180,7 +179,7 @@ func TestOrganizationsService_UpdateIssueType(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	issueType, _, err := client.Organizations.UpdateIssueType(ctx, "o", 410, input)
 	if err != nil {
 		t.Errorf("Organizations.UpdateIssueType returned error: %v", err)
@@ -221,7 +220,7 @@ func TestOrganizationsService_DeleteIssueType(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.DeleteIssueType(ctx, "o", 410)
 	if err != nil {
 		t.Errorf("Organizations.DeleteIssueType returned error: %v", err)

--- a/github/orgs_members_test.go
+++ b/github/orgs_members_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -36,7 +35,7 @@ func TestOrganizationsService_ListMembers(t *testing.T) {
 		Role:        "admin",
 		ListOptions: ListOptions{Page: 2},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	members, _, err := client.Organizations.ListMembers(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListMembers returned error: %v", err)
@@ -66,7 +65,7 @@ func TestOrganizationsService_ListMembers_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.ListMembers(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -81,7 +80,7 @@ func TestOrganizationsService_ListMembers_public(t *testing.T) {
 	})
 
 	opt := &ListMembersOptions{PublicOnly: true}
-	ctx := context.Background()
+	ctx := t.Context()
 	members, _, err := client.Organizations.ListMembers(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListMembers returned error: %v", err)
@@ -102,7 +101,7 @@ func TestOrganizationsService_IsMember(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	member, _, err := client.Organizations.IsMember(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.IsMember returned error: %v", err)
@@ -136,7 +135,7 @@ func TestOrganizationsService_IsMember_notMember(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	member, _, err := client.Organizations.IsMember(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.IsMember returned error: %+v", err)
@@ -157,7 +156,7 @@ func TestOrganizationsService_IsMember_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	member, _, err := client.Organizations.IsMember(ctx, "o", "u")
 	if err == nil {
 		t.Error("Expected HTTP 400 response")
@@ -171,7 +170,7 @@ func TestOrganizationsService_IsMember_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.IsMember(ctx, "%", "u")
 	testURLParseError(t, err)
 }
@@ -185,7 +184,7 @@ func TestOrganizationsService_IsPublicMember(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	member, _, err := client.Organizations.IsPublicMember(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.IsPublicMember returned error: %v", err)
@@ -219,7 +218,7 @@ func TestOrganizationsService_IsPublicMember_notMember(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	member, _, err := client.Organizations.IsPublicMember(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.IsPublicMember returned error: %v", err)
@@ -240,7 +239,7 @@ func TestOrganizationsService_IsPublicMember_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	member, _, err := client.Organizations.IsPublicMember(ctx, "o", "u")
 	if err == nil {
 		t.Error("Expected HTTP 400 response")
@@ -254,7 +253,7 @@ func TestOrganizationsService_IsPublicMember_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.IsPublicMember(ctx, "%", "u")
 	testURLParseError(t, err)
 }
@@ -267,7 +266,7 @@ func TestOrganizationsService_RemoveMember(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.RemoveMember(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.RemoveMember returned error: %v", err)
@@ -293,7 +292,7 @@ func TestOrganizationsService_CancelInvite(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.CancelInvite(ctx, "o", 1)
 	if err != nil {
 		t.Errorf("Organizations.CancelInvite returned error: %v", err)
@@ -314,7 +313,7 @@ func TestOrganizationsService_RemoveMember_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.RemoveMember(ctx, "%", "u")
 	testURLParseError(t, err)
 }
@@ -327,7 +326,7 @@ func TestOrganizationsService_PublicizeMembership(t *testing.T) {
 		testMethod(t, r, "PUT")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.PublicizeMembership(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.PublicizeMembership returned error: %v", err)
@@ -352,7 +351,7 @@ func TestOrganizationsService_ConcealMembership(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.ConcealMembership(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.ConcealMembership returned error: %v", err)
@@ -386,7 +385,7 @@ func TestOrganizationsService_ListOrgMemberships(t *testing.T) {
 		State:       "active",
 		ListOptions: ListOptions{Page: 2},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	memberships, _, err := client.Organizations.ListOrgMemberships(ctx, opt)
 	if err != nil {
 		t.Errorf("Organizations.ListOrgMemberships returned error: %v", err)
@@ -416,7 +415,7 @@ func TestOrganizationsService_GetOrgMembership_AuthenticatedUser(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	membership, _, err := client.Organizations.GetOrgMembership(ctx, "", "o")
 	if err != nil {
 		t.Errorf("Organizations.GetOrgMembership returned error: %v", err)
@@ -451,7 +450,7 @@ func TestOrganizationsService_GetOrgMembership_SpecifiedUser(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	membership, _, err := client.Organizations.GetOrgMembership(ctx, "u", "o")
 	if err != nil {
 		t.Errorf("Organizations.GetOrgMembership returned error: %v", err)
@@ -481,7 +480,7 @@ func TestOrganizationsService_EditOrgMembership_AuthenticatedUser(t *testing.T) 
 		fmt.Fprint(w, `{"url":"u"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	membership, _, err := client.Organizations.EditOrgMembership(ctx, "", "o", input)
 	if err != nil {
 		t.Errorf("Organizations.EditOrgMembership returned error: %v", err)
@@ -525,7 +524,7 @@ func TestOrganizationsService_EditOrgMembership_SpecifiedUser(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	membership, _, err := client.Organizations.EditOrgMembership(ctx, "u", "o", input)
 	if err != nil {
 		t.Errorf("Organizations.EditOrgMembership returned error: %v", err)
@@ -546,7 +545,7 @@ func TestOrganizationsService_RemoveOrgMembership(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.RemoveOrgMembership(ctx, "u", "o")
 	if err != nil {
 		t.Errorf("Organizations.RemoveOrgMembership returned error: %v", err)
@@ -603,7 +602,7 @@ func TestOrganizationsService_ListPendingOrgInvitations(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1}
-	ctx := context.Background()
+	ctx := t.Context()
 	invitations, _, err := client.Organizations.ListPendingOrgInvitations(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListPendingOrgInvitations returned error: %v", err)
@@ -685,7 +684,7 @@ func TestOrganizationsService_CreateOrgInvitation(t *testing.T) {
 		fmt.Fprintln(w, `{"email": "octocat@github.com"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	invitations, _, err := client.Organizations.CreateOrgInvitation(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Organizations.CreateOrgInvitation returned error: %v", err)
@@ -734,7 +733,7 @@ func TestOrganizationsService_ListOrgInvitationTeams(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1}
-	ctx := context.Background()
+	ctx := t.Context()
 	invitations, _, err := client.Organizations.ListOrgInvitationTeams(ctx, "o", "22", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListOrgInvitationTeams returned error: %v", err)
@@ -817,7 +816,7 @@ func TestOrganizationsService_ListFailedOrgInvitations(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 1}
-	ctx := context.Background()
+	ctx := t.Context()
 	failedInvitations, _, err := client.Organizations.ListFailedOrgInvitations(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Organizations.ListFailedOrgInvitations returned error: %v", err)

--- a/github/orgs_network_configurations_test.go
+++ b/github/orgs_network_configurations_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -59,7 +58,7 @@ func TestOrganizationsService_ListOrgsNetworkConfigurations(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	opts := &ListOptions{Page: 1, PerPage: 3}
 	configurations, _, err := client.Organizations.ListNetworkConfigurations(ctx, "o", opts)
@@ -137,7 +136,7 @@ func TestOrganizationsService_CreateOrgsNetworkConfiguration(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	req := NetworkConfigurationRequest{
 		Name:           Ptr("network-configuration-two"),
@@ -258,7 +257,7 @@ func TestOrganizationsService_GetOrgsNetworkConfiguration(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	configuration, _, err := client.Organizations.GetNetworkConfiguration(ctx, "o", "789ABDCEF123456")
 	if err != nil {
@@ -311,7 +310,7 @@ func TestOrganizationsService_UpdateOrgsNetworkConfiguration(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	req := NetworkConfigurationRequest{
 		Name:           Ptr("network-configuration-three-update"),
@@ -421,7 +420,7 @@ func TestOrganizationsService_DeleteOrgsNetworkConfiguration(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.DeleteNetworkConfigurations(ctx, "o", "789ABDCEF123456")
 	if err != nil {
 		t.Errorf("Organizations.DeleteNetworkConfigurations returned error %v", err)
@@ -454,7 +453,7 @@ func TestOrganizationsService_GetOrgsNetworkConfigurationResource(t *testing.T) 
 		`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	resource, _, err := client.Organizations.GetNetworkConfigurationResource(ctx, "o", "789ABDCEF123456")
 	if err != nil {

--- a/github/orgs_organization_roles_test.go
+++ b/github/orgs_organization_roles_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -47,7 +46,7 @@ func TestOrganizationsService_ListRoles(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	apps, _, err := client.Organizations.ListRoles(ctx, "o")
 	if err != nil {
 		t.Errorf("Organizations.ListRoles returned error: %v", err)
@@ -117,7 +116,7 @@ func TestOrganizationsService_GetOrgRole(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	gotBuiltInRole, _, err := client.Organizations.GetOrgRole(ctx, "o", 8132)
 	if err != nil {
@@ -206,7 +205,7 @@ func TestOrganizationsService_CreateCustomOrgRole(t *testing.T) {
 		fmt.Fprint(w, `{"id":8030,"name":"Reader","description":"A role for reading custom org roles","permissions":["read_organization_custom_org_role"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	opts := &CreateOrUpdateOrgRoleOptions{
 		Name:        Ptr("Reader"),
@@ -248,7 +247,7 @@ func TestOrganizationsService_UpdateCustomOrgRole(t *testing.T) {
 		fmt.Fprint(w, `{"id":8030,"name":"Updated Name","description":"Updated Description","permissions":["read_organization_custom_org_role"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	opts := &CreateOrUpdateOrgRoleOptions{
 		Name:        Ptr("Updated Name"),
@@ -289,7 +288,7 @@ func TestOrganizationsService_DeleteCustomOrgRole(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	resp, err := client.Organizations.DeleteCustomOrgRole(ctx, "o", 8030)
 	if err != nil {
@@ -320,7 +319,7 @@ func TestOrganizationsService_AssignOrgRoleToTeam(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Organizations.AssignOrgRoleToTeam(ctx, "o", "t", 8030)
 	if err != nil {
 		t.Errorf("Organization.AssignOrgRoleToTeam return error: %v", err)
@@ -349,7 +348,7 @@ func TestOrganizationsService_RemoveOrgRoleFromTeam(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Organizations.RemoveOrgRoleFromTeam(ctx, "o", "t", 8030)
 	if err != nil {
 		t.Errorf("Organization.RemoveOrgRoleFromTeam return error: %v", err)
@@ -378,7 +377,7 @@ func TestOrganizationsService_AssignOrgRoleToUser(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Organizations.AssignOrgRoleToUser(ctx, "o", "t", 8030)
 	if err != nil {
 		t.Errorf("Organization.AssignOrgRoleToUser return error: %v", err)
@@ -407,7 +406,7 @@ func TestOrganizationsService_RemoveOrgRoleFromUser(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Organizations.RemoveOrgRoleFromUser(ctx, "o", "t", 8030)
 	if err != nil {
 		t.Errorf("Organization.RemoveOrgRoleFromUser return error: %v", err)
@@ -436,7 +435,7 @@ func TestOrganizationsService_ListTeamsAssignedToOrgRole(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	apps, _, err := client.Organizations.ListTeamsAssignedToOrgRole(ctx, "o", 1729, opt)
 	if err != nil {
 		t.Errorf("Organizations.ListTeamsAssignedToOrgRole returned error: %v", err)
@@ -471,7 +470,7 @@ func TestOrganizationsService_ListUsersAssignedToOrgRole(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	apps, _, err := client.Organizations.ListUsersAssignedToOrgRole(ctx, "o", 1729, opt)
 	if err != nil {
 		t.Errorf("Organizations.ListUsersAssignedToOrgRole returned error: %v", err)

--- a/github/orgs_outside_collaborators_test.go
+++ b/github/orgs_outside_collaborators_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -32,7 +31,7 @@ func TestOrganizationsService_ListOutsideCollaborators(t *testing.T) {
 		Filter:      "2fa_disabled",
 		ListOptions: ListOptions{Page: 2},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	members, _, err := client.Organizations.ListOutsideCollaborators(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListOutsideCollaborators returned error: %v", err)
@@ -62,7 +61,7 @@ func TestOrganizationsService_ListOutsideCollaborators_invalidOrg(t *testing.T) 
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.ListOutsideCollaborators(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -76,7 +75,7 @@ func TestOrganizationsService_RemoveOutsideCollaborator(t *testing.T) {
 	}
 	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.RemoveOutsideCollaborator(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.RemoveOutsideCollaborator returned error: %v", err)
@@ -103,7 +102,7 @@ func TestOrganizationsService_RemoveOutsideCollaborator_NonMember(t *testing.T) 
 	}
 	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.RemoveOutsideCollaborator(ctx, "o", "u")
 	var rerr *ErrorResponse
 	if !errors.As(err, &rerr) {
@@ -123,7 +122,7 @@ func TestOrganizationsService_RemoveOutsideCollaborator_Member(t *testing.T) {
 	}
 	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.RemoveOutsideCollaborator(ctx, "o", "u")
 	var rerr *ErrorResponse
 	if !errors.As(err, &rerr) {
@@ -142,7 +141,7 @@ func TestOrganizationsService_ConvertMemberToOutsideCollaborator(t *testing.T) {
 	}
 	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.ConvertMemberToOutsideCollaborator(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.ConvertMemberToOutsideCollaborator returned error: %v", err)
@@ -169,7 +168,7 @@ func TestOrganizationsService_ConvertMemberToOutsideCollaborator_NonMemberOrLast
 	}
 	mux.HandleFunc("/orgs/o/outside_collaborators/u", handler)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.ConvertMemberToOutsideCollaborator(ctx, "o", "u")
 	var rerr *ErrorResponse
 	if !errors.As(err, &rerr) {

--- a/github/orgs_packages_test.go
+++ b/github/orgs_packages_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -58,7 +57,7 @@ func TestOrganizationsService_ListPackages(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	packages, _, err := client.Organizations.ListPackages(ctx, "o", &PackageListOptions{})
 	if err != nil {
 		t.Errorf("Organizations.ListPackages returned error: %v", err)
@@ -137,7 +136,7 @@ func TestOrganizationsService_GetPackage(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	packages, _, err := client.Organizations.GetPackage(ctx, "o", "container", "hello/hello_docker")
 	if err != nil {
 		t.Errorf("Organizations.GetPackage returned error: %v", err)
@@ -182,7 +181,7 @@ func TestOrganizationsService_DeletePackage(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.DeletePackage(ctx, "o", "container", "hello/hello_docker")
 	if err != nil {
 		t.Errorf("Organizations.DeletePackage returned error: %v", err)
@@ -212,7 +211,7 @@ func TestOrganizationsService_RestorePackage(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.RestorePackage(ctx, "o", "container", "hello/hello_docker")
 	if err != nil {
 		t.Errorf("Organizations.RestorePackage returned error: %v", err)
@@ -262,7 +261,7 @@ func TestOrganizationsService_ListPackagesVersions(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &PackageListOptions{
 		Ptr("internal"), Ptr("container"), Ptr("deleted"), ListOptions{Page: 1, PerPage: 2},
 	}
@@ -332,7 +331,7 @@ func TestOrganizationsService_PackageGetVersion(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	packages, _, err := client.Organizations.PackageGetVersion(ctx, "o", "container", "hello/hello_docker", 45763)
 	if err != nil {
 		t.Errorf("Organizations.PackageGetVersion returned error: %v", err)
@@ -376,7 +375,7 @@ func TestOrganizationsService_PackageDeleteVersion(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.PackageDeleteVersion(ctx, "o", "container", "hello/hello_docker", 45763)
 	if err != nil {
 		t.Errorf("Organizations.PackageDeleteVersion returned error: %v", err)
@@ -402,7 +401,7 @@ func TestOrganizationsService_PackageRestoreVersion(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.PackageRestoreVersion(ctx, "o", "container", "hello/hello_docker", 45763)
 	if err != nil {
 		t.Errorf("Organizations.PackageRestoreVersion returned error: %v", err)

--- a/github/orgs_personal_access_tokens_test.go
+++ b/github/orgs_personal_access_tokens_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -91,7 +90,7 @@ func TestOrganizationsService_ListFineGrainedPersonalAccessTokens(t *testing.T) 
 		Direction:   "desc",
 		Owner:       []string{"octocat", "octodog", "otherbot"},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	tokens, resp, err := client.Organizations.ListFineGrainedPersonalAccessTokens(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Organizations.ListFineGrainedPersonalAccessTokens returned error: %v", err)
@@ -180,7 +179,7 @@ func TestOrganizationsService_ReviewPersonalAccessTokenRequest(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	res, err := client.Organizations.ReviewPersonalAccessTokenRequest(ctx, "o", 1, input)
 	if err != nil {
 		t.Errorf("Organizations.ReviewPersonalAccessTokenRequest returned error: %v", err)

--- a/github/orgs_properties_test.go
+++ b/github/orgs_properties_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -45,7 +44,7 @@ func TestOrganizationsService_GetAllCustomProperties(t *testing.T) {
         ]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	properties, _, err := client.Organizations.GetAllCustomProperties(ctx, "o")
 	if err != nil {
 		t.Errorf("Organizations.GetAllCustomProperties returned error: %v", err)
@@ -106,7 +105,7 @@ func TestOrganizationsService_CreateOrUpdateCustomProperties(t *testing.T) {
         ]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	properties, _, err := client.Organizations.CreateOrUpdateCustomProperties(ctx, "o", []*CustomProperty{
 		{
 			PropertyName: Ptr("name"),
@@ -169,7 +168,7 @@ func TestOrganizationsService_GetCustomProperty(t *testing.T) {
 	  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	property, _, err := client.Organizations.GetCustomProperty(ctx, "o", "name")
 	if err != nil {
 		t.Errorf("Organizations.GetCustomProperty returned error: %v", err)
@@ -219,7 +218,7 @@ func TestOrganizationsService_CreateOrUpdateCustomProperty(t *testing.T) {
 	  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	property, _, err := client.Organizations.CreateOrUpdateCustomProperty(ctx, "o", "name", &CustomProperty{
 		ValueType:        "single_select",
 		Required:         Ptr(true),
@@ -264,7 +263,7 @@ func TestOrganizationsService_RemoveCustomProperty(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.RemoveCustomProperty(ctx, "o", "name")
 	if err != nil {
 		t.Errorf("Organizations.RemoveCustomProperty returned error: %v", err)
@@ -313,7 +312,7 @@ func TestOrganizationsService_ListCustomPropertyValues(t *testing.T) {
         }]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	repoPropertyValues, _, err := client.Organizations.ListCustomPropertyValues(ctx, "o", &ListCustomPropertyValuesOptions{
 		ListOptions: ListOptions{
 			Page:    1,
@@ -454,7 +453,7 @@ func TestOrganizationsService_CreateOrUpdateRepoCustomPropertyValues(t *testing.
 		testBody(t, r, `{"repository_names":["repo"],"properties":[{"property_name":"service","value":"string"}]}`+"\n")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.CreateOrUpdateRepoCustomPropertyValues(ctx, "o", []string{"repo"}, []*CustomPropertyValue{
 		{
 			PropertyName: "service",

--- a/github/orgs_rules_test.go
+++ b/github/orgs_rules_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -37,7 +36,7 @@ func TestOrganizationsService_GetAllRepositoryRulesets(t *testing.T) {
 		}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rulesets, _, err := client.Organizations.GetAllRepositoryRulesets(ctx, "o", nil)
 	if err != nil {
 		t.Errorf("Organizations.GetAllRepositoryRulesets returned error: %v", err)
@@ -85,7 +84,7 @@ func TestOrganizationsService_GetAllRepositoryRulesets_ListOptions(t *testing.T)
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 35}
-	ctx := context.Background()
+	ctx := t.Context()
 	rulesets, _, err := client.Organizations.GetAllRepositoryRulesets(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Organizations.GetAllRepositoryRulesets returned error: %v", err)
@@ -269,7 +268,7 @@ func TestOrganizationsService_CreateRepositoryRuleset_RepoNames(t *testing.T) {
 		  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ruleset, _, err := client.Organizations.CreateRepositoryRuleset(ctx, "o", RepositoryRuleset{
 		Name:        "ruleset",
 		Target:      Ptr(RulesetTargetBranch),
@@ -633,7 +632,7 @@ func TestOrganizationsService_CreateRepositoryRuleset_RepoProperty(t *testing.T)
 		  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ruleset, _, err := client.Organizations.CreateRepositoryRuleset(ctx, "o", RepositoryRuleset{
 		Name:        "ruleset",
 		Target:      Ptr(RulesetTargetBranch),
@@ -992,7 +991,7 @@ func TestOrganizationsService_CreateRepositoryRuleset_RepoIDs(t *testing.T) {
 		  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ruleset, _, err := client.Organizations.CreateRepositoryRuleset(ctx, "o", RepositoryRuleset{
 		Name:        "ruleset",
 		Target:      Ptr(RulesetTargetBranch),
@@ -1240,7 +1239,7 @@ func TestOrganizationsService_GetRepositoryRuleset(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rulesets, _, err := client.Organizations.GetRepositoryRuleset(ctx, "o", 21)
 	if err != nil {
 		t.Errorf("Organizations.GetOrganizationRepositoryRuleset returned error: %v", err)
@@ -1327,7 +1326,7 @@ func TestOrganizationsService_GetRepositoryRulesetWithRepoPropCondition(t *testi
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rulesets, _, err := client.Organizations.GetRepositoryRuleset(ctx, "o", 21)
 	if err != nil {
 		t.Errorf("Organizations.GetOrganizationRepositoryRuleset returned error: %v", err)
@@ -1422,7 +1421,7 @@ func TestOrganizationsService_UpdateRepositoryRuleset(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rulesets, _, err := client.Organizations.UpdateRepositoryRuleset(ctx, "o", 21, RepositoryRuleset{
 		Name:        "test ruleset",
 		Target:      Ptr(RulesetTargetBranch),
@@ -1525,7 +1524,7 @@ func TestOrganizationsService_UpdateRepositoryRulesetWithRepoProp(t *testing.T) 
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rulesets, _, err := client.Organizations.UpdateRepositoryRuleset(ctx, "o", 21, RepositoryRuleset{
 		Name:        "test ruleset",
 		Target:      Ptr(RulesetTargetBranch),
@@ -1631,7 +1630,7 @@ func TestOrganizationsService_UpdateRepositoryRulesetClearBypassActor(t *testing
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := client.Organizations.UpdateRepositoryRulesetClearBypassActor(ctx, "o", 21)
 	if err != nil {
@@ -1653,7 +1652,7 @@ func TestOrganizationsService_DeleteRepositoryRuleset(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.DeleteRepositoryRuleset(ctx, "o", 21)
 	if err != nil {
 		t.Errorf("Organizations.DeleteRepositoryRuleset returned error: %v", err)

--- a/github/orgs_security_managers_test.go
+++ b/github/orgs_security_managers_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -23,7 +22,7 @@ func TestOrganizationsService_ListSecurityManagerTeams(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	teams, _, err := client.Organizations.ListSecurityManagerTeams(ctx, "o")
 	if err != nil {
 		t.Errorf("Organizations.ListSecurityManagerTeams returned error: %v", err)
@@ -53,7 +52,7 @@ func TestOrganizationsService_ListSecurityManagerTeams_invalidOrg(t *testing.T) 
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.ListSecurityManagerTeams(ctx, "%")
 	testURLParseError(t, err)
 }
@@ -66,7 +65,7 @@ func TestOrganizationsService_AddSecurityManagerTeam(t *testing.T) {
 		testMethod(t, r, "PUT")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.AddSecurityManagerTeam(ctx, "o", "t")
 	if err != nil {
 		t.Errorf("Organizations.AddSecurityManagerTeam returned error: %v", err)
@@ -87,7 +86,7 @@ func TestOrganizationsService_AddSecurityManagerTeam_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.AddSecurityManagerTeam(ctx, "%", "t")
 	testURLParseError(t, err)
 }
@@ -96,7 +95,7 @@ func TestOrganizationsService_AddSecurityManagerTeam_invalidTeam(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.AddSecurityManagerTeam(ctx, "%", "t")
 	testURLParseError(t, err)
 }
@@ -109,7 +108,7 @@ func TestOrganizationsService_RemoveSecurityManagerTeam(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.RemoveSecurityManagerTeam(ctx, "o", "t")
 	if err != nil {
 		t.Errorf("Organizations.RemoveSecurityManagerTeam returned error: %v", err)
@@ -130,7 +129,7 @@ func TestOrganizationsService_RemoveSecurityManagerTeam_invalidOrg(t *testing.T)
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.RemoveSecurityManagerTeam(ctx, "%", "t")
 	testURLParseError(t, err)
 }
@@ -139,7 +138,7 @@ func TestOrganizationsService_RemoveSecurityManagerTeam_invalidTeam(t *testing.T
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.RemoveSecurityManagerTeam(ctx, "%", "t")
 	testURLParseError(t, err)
 }

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -80,7 +79,7 @@ func TestOrganizationsService_ListAll(t *testing.T) {
 	})
 
 	opt := &OrganizationsListOptions{Since: since}
-	ctx := context.Background()
+	ctx := t.Context()
 	orgs, _, err := client.Organizations.ListAll(ctx, opt)
 	if err != nil {
 		t.Errorf("Organizations.ListAll returned error: %v", err)
@@ -110,7 +109,7 @@ func TestOrganizationsService_List_authenticatedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	orgs, _, err := client.Organizations.List(ctx, "", nil)
 	if err != nil {
 		t.Errorf("Organizations.List returned error: %v", err)
@@ -147,7 +146,7 @@ func TestOrganizationsService_List_specifiedUser(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	orgs, _, err := client.Organizations.List(ctx, "u", opt)
 	if err != nil {
 		t.Errorf("Organizations.List returned error: %v", err)
@@ -177,7 +176,7 @@ func TestOrganizationsService_List_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.List(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -192,7 +191,7 @@ func TestOrganizationsService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "login":"l", "url":"u", "avatar_url": "a", "location":"l"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Organizations.Get(ctx, "o")
 	if err != nil {
 		t.Errorf("Organizations.Get returned error: %v", err)
@@ -222,7 +221,7 @@ func TestOrganizationsService_Get_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.Get(ctx, "%")
 	testURLParseError(t, err)
 }
@@ -236,7 +235,7 @@ func TestOrganizationsService_GetByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "login":"l", "url":"u", "avatar_url": "a", "location":"l"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Organizations.GetByID(ctx, 1)
 	if err != nil {
 		t.Fatalf("Organizations.GetByID returned error: %v", err)
@@ -281,7 +280,7 @@ func TestOrganizationsService_Edit(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Organizations.Edit(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Organizations.Edit returned error: %v", err)
@@ -311,7 +310,7 @@ func TestOrganizationsService_Edit_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.Edit(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -324,7 +323,7 @@ func TestOrganizationsService_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.Delete(ctx, "o")
 	if err != nil {
 		t.Errorf("Organizations.Delete returned error: %v", err)
@@ -350,7 +349,7 @@ func TestOrganizationsService_ListInstallations(t *testing.T) {
 		fmt.Fprint(w, `{"total_count": 1, "installations": [{ "id": 1, "app_id": 5}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	apps, _, err := client.Organizations.ListInstallations(ctx, "o", nil)
 	if err != nil {
 		t.Errorf("Organizations.ListInstallations returned error: %v", err)
@@ -380,7 +379,7 @@ func TestOrganizationsService_ListInstallations_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Organizations.ListInstallations(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -395,7 +394,7 @@ func TestOrganizationsService_ListInstallations_withListOptions(t *testing.T) {
 		fmt.Fprint(w, `{"total_count": 2, "installations": [{ "id": 2, "app_id": 10}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	apps, _, err := client.Organizations.ListInstallations(ctx, "o", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Organizations.ListInstallations returned error: %v", err)

--- a/github/orgs_users_blocking_test.go
+++ b/github/orgs_users_blocking_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -28,7 +27,7 @@ func TestOrganizationsService_ListBlockedUsers(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	blockedUsers, _, err := client.Organizations.ListBlockedUsers(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListBlockedUsers returned error: %v", err)
@@ -64,7 +63,7 @@ func TestOrganizationsService_IsBlocked(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isBlocked, _, err := client.Organizations.IsBlocked(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.IsBlocked returned error: %v", err)
@@ -98,7 +97,7 @@ func TestOrganizationsService_BlockUser(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.BlockUser(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.BlockUser returned error: %v", err)
@@ -125,7 +124,7 @@ func TestOrganizationsService_UnblockUser(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Organizations.UnblockUser(ctx, "o", "u")
 	if err != nil {
 		t.Errorf("Organizations.UnblockUser returned error: %v", err)

--- a/github/pulls_comments_test.go
+++ b/github/pulls_comments_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -157,7 +156,7 @@ func TestPullRequestsService_ListComments_allPulls(t *testing.T) {
 		Since:       time.Date(2002, time.February, 10, 15, 30, 0, 0, time.UTC),
 		ListOptions: ListOptions{Page: 2},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	pulls, _, err := client.PullRequests.ListComments(ctx, "o", "r", 0, opt)
 	if err != nil {
 		t.Errorf("PullRequests.ListComments returned error: %v", err)
@@ -194,7 +193,7 @@ func TestPullRequestsService_ListComments_specificPull(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1, "pull_request_review_id":42}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	pulls, _, err := client.PullRequests.ListComments(ctx, "o", "r", 1, nil)
 	if err != nil {
 		t.Errorf("PullRequests.ListComments returned error: %v", err)
@@ -210,7 +209,7 @@ func TestPullRequestsService_ListComments_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.ListComments(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
@@ -226,7 +225,7 @@ func TestPullRequestsService_GetComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.PullRequests.GetComment(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("PullRequests.GetComment returned error: %v", err)
@@ -256,7 +255,7 @@ func TestPullRequestsService_GetComment_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.GetComment(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
@@ -282,7 +281,7 @@ func TestPullRequestsService_CreateComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.PullRequests.CreateComment(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("PullRequests.CreateComment returned error: %v", err)
@@ -312,7 +311,7 @@ func TestPullRequestsService_CreateComment_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.CreateComment(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
@@ -335,7 +334,7 @@ func TestPullRequestsService_CreateCommentInReplyTo(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.PullRequests.CreateCommentInReplyTo(ctx, "o", "r", 1, "b", 2)
 	if err != nil {
 		t.Errorf("PullRequests.CreateCommentInReplyTo returned error: %v", err)
@@ -379,7 +378,7 @@ func TestPullRequestsService_EditComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.PullRequests.EditComment(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("PullRequests.EditComment returned error: %v", err)
@@ -409,7 +408,7 @@ func TestPullRequestsService_EditComment_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.EditComment(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
@@ -422,7 +421,7 @@ func TestPullRequestsService_DeleteComment(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.PullRequests.DeleteComment(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("PullRequests.DeleteComment returned error: %v", err)
@@ -443,7 +442,7 @@ func TestPullRequestsService_DeleteComment_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.PullRequests.DeleteComment(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }

--- a/github/pulls_reviewers_test.go
+++ b/github/pulls_reviewers_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -131,7 +130,7 @@ func TestRequestReviewers(t *testing.T) {
 	})
 
 	// This returns a PR, unmarshaling of which is tested elsewhere
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.PullRequests.RequestReviewers(ctx, "o", "r", 1, ReviewersRequest{Reviewers: []string{"octocat", "googlebot"}, TeamReviewers: []string{"justice-league", "injustice-league"}})
 	if err != nil {
 		t.Errorf("PullRequests.RequestReviewers returned error: %v", err)
@@ -160,7 +159,7 @@ func TestRemoveReviewers(t *testing.T) {
 		testBody(t, r, `{"reviewers":["octocat","googlebot"],"team_reviewers":["justice-league"]}`+"\n")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.PullRequests.RemoveReviewers(ctx, "o", "r", 1, ReviewersRequest{Reviewers: []string{"octocat", "googlebot"}, TeamReviewers: []string{"justice-league"}})
 	if err != nil {
 		t.Errorf("PullRequests.RemoveReviewers returned error: %v", err)
@@ -181,7 +180,7 @@ func TestRemoveReviewers_teamsOnly(t *testing.T) {
 		testBody(t, r, `{"reviewers":[],"team_reviewers":["justice-league"]}`+"\n")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.PullRequests.RemoveReviewers(ctx, "o", "r", 1, ReviewersRequest{TeamReviewers: []string{"justice-league"}})
 	if err != nil {
 		t.Errorf("PullRequests.RemoveReviewers returned error: %v", err)
@@ -202,7 +201,7 @@ func TestListReviewers(t *testing.T) {
 		fmt.Fprint(w, `{"users":[{"login":"octocat","id":1}],"teams":[{"id":1,"name":"Justice League"}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.PullRequests.ListReviewers(ctx, "o", "r", 1, nil)
 	if err != nil {
 		t.Errorf("PullRequests.ListReviewers returned error: %v", err)
@@ -248,7 +247,7 @@ func TestListReviewers_withOptions(t *testing.T) {
 		fmt.Fprint(w, `{}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.ListReviewers(ctx, "o", "r", 1, &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("PullRequests.ListReviewers returned error: %v", err)

--- a/github/pulls_reviews_test.go
+++ b/github/pulls_reviews_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,7 +28,7 @@ func TestPullRequestsService_ListReviews(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	reviews, _, err := client.PullRequests.ListReviews(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("PullRequests.ListReviews returned error: %v", err)
@@ -62,7 +61,7 @@ func TestPullRequestsService_ListReviews_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.ListReviews(ctx, "%", "r", 1, nil)
 	testURLParseError(t, err)
 }
@@ -76,7 +75,7 @@ func TestPullRequestsService_GetReview(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	review, _, err := client.PullRequests.GetReview(ctx, "o", "r", 1, 1)
 	if err != nil {
 		t.Errorf("PullRequests.GetReview returned error: %v", err)
@@ -106,7 +105,7 @@ func TestPullRequestsService_GetReview_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.GetReview(ctx, "%", "r", 1, 1)
 	testURLParseError(t, err)
 }
@@ -120,7 +119,7 @@ func TestPullRequestsService_DeletePendingReview(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	review, _, err := client.PullRequests.DeletePendingReview(ctx, "o", "r", 1, 1)
 	if err != nil {
 		t.Errorf("PullRequests.DeletePendingReview returned error: %v", err)
@@ -150,7 +149,7 @@ func TestPullRequestsService_DeletePendingReview_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.DeletePendingReview(ctx, "%", "r", 1, 1)
 	testURLParseError(t, err)
 }
@@ -164,7 +163,7 @@ func TestPullRequestsService_ListReviewComments(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comments, _, err := client.PullRequests.ListReviewComments(ctx, "o", "r", 1, 1, nil)
 	if err != nil {
 		t.Errorf("PullRequests.ListReviewComments returned error: %v", err)
@@ -205,7 +204,7 @@ func TestPullRequestsService_ListReviewComments_withOptions(t *testing.T) {
 		fmt.Fprint(w, `[]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.ListReviewComments(ctx, "o", "r", 1, 1, &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("PullRequests.ListReviewComments returned error: %v", err)
@@ -351,7 +350,7 @@ func TestPullRequestsService_ListReviewComments_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.ListReviewComments(ctx, "%", "r", 1, 1, nil)
 	testURLParseError(t, err)
 }
@@ -378,7 +377,7 @@ func TestPullRequestsService_CreateReview(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	review, _, err := client.PullRequests.CreateReview(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("PullRequests.CreateReview returned error: %v", err)
@@ -408,7 +407,7 @@ func TestPullRequestsService_CreateReview_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.CreateReview(ctx, "%", "r", 1, &PullRequestReviewRequest{})
 	testURLParseError(t, err)
 }
@@ -417,7 +416,7 @@ func TestPullRequestsService_CreateReview_badReview(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	path := "path/to/file.go"
 	body := "this is a comment body"
@@ -482,7 +481,7 @@ func TestPullRequestsService_CreateReview_addHeader(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, _, err := client.PullRequests.CreateReview(ctx, "o", "r", 1, input)
 	if err != nil {
@@ -499,7 +498,7 @@ func TestPullRequestsService_UpdateReview(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.PullRequests.UpdateReview(ctx, "o", "r", 1, 1, "updated_body")
 	if err != nil {
 		t.Errorf("PullRequests.UpdateReview returned error: %v", err)
@@ -546,7 +545,7 @@ func TestPullRequestsService_SubmitReview(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	review, _, err := client.PullRequests.SubmitReview(ctx, "o", "r", 1, 1, input)
 	if err != nil {
 		t.Errorf("PullRequests.SubmitReview returned error: %v", err)
@@ -576,7 +575,7 @@ func TestPullRequestsService_SubmitReview_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.SubmitReview(ctx, "%", "r", 1, 1, &PullRequestReviewRequest{})
 	testURLParseError(t, err)
 }
@@ -599,7 +598,7 @@ func TestPullRequestsService_DismissReview(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	review, _, err := client.PullRequests.DismissReview(ctx, "o", "r", 1, 1, input)
 	if err != nil {
 		t.Errorf("PullRequests.DismissReview returned error: %v", err)
@@ -629,7 +628,7 @@ func TestPullRequestsService_DismissReview_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.DismissReview(ctx, "%", "r", 1, 1, &PullRequestReviewDismissalRequest{})
 	testURLParseError(t, err)
 }

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -35,7 +34,7 @@ func TestPullRequestsService_List(t *testing.T) {
 	})
 
 	opts := &PullRequestListOptions{"closed", "h", "b", "created", "desc", ListOptions{Page: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	pulls, _, err := client.PullRequests.List(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("PullRequests.List returned error: %v", err)
@@ -75,7 +74,7 @@ func TestPullRequestsService_ListPullRequestsWithCommit(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	pulls, _, err := client.PullRequests.ListPullRequestsWithCommit(ctx, "o", "r", "sha", opts)
 	if err != nil {
 		t.Errorf("PullRequests.ListPullRequestsWithCommit returned error: %v", err)
@@ -105,7 +104,7 @@ func TestPullRequestsService_List_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.List(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
@@ -119,7 +118,7 @@ func TestPullRequestsService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	pull, _, err := client.PullRequests.Get(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("PullRequests.Get returned error: %v", err)
@@ -157,7 +156,7 @@ func TestPullRequestsService_GetRaw_diff(t *testing.T) {
 		fmt.Fprint(w, rawStr)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.PullRequests.GetRaw(ctx, "o", "r", 1, RawOptions{Diff})
 	if err != nil {
 		t.Fatalf("PullRequests.GetRaw returned error: %v", err)
@@ -194,7 +193,7 @@ func TestPullRequestsService_GetRaw_patch(t *testing.T) {
 		fmt.Fprint(w, rawStr)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.PullRequests.GetRaw(ctx, "o", "r", 1, RawOptions{Patch})
 	if err != nil {
 		t.Fatalf("PullRequests.GetRaw returned error: %v", err)
@@ -209,7 +208,7 @@ func TestPullRequestsService_GetRaw_invalid(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.GetRaw(ctx, "o", "r", 1, RawOptions{100})
 	if err == nil {
 		t.Fatal("PullRequests.GetRaw should return error")
@@ -240,7 +239,7 @@ func TestPullRequestsService_Get_links(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	pull, _, err := client.PullRequests.Get(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("PullRequests.Get returned error: %v", err)
@@ -282,7 +281,7 @@ func TestPullRequestsService_Get_headAndBase(t *testing.T) {
 		fmt.Fprint(w, `{"number":1,"head":{"ref":"r2","repo":{"id":2}},"base":{"ref":"r1","repo":{"id":1}}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	pull, _, err := client.PullRequests.Get(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("PullRequests.Get returned error: %v", err)
@@ -321,7 +320,7 @@ func TestPullRequestsService_Get_urlFields(t *testing.T) {
 			"review_comment_url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments{/number}"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	pull, _, err := client.PullRequests.Get(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("PullRequests.Get returned error: %v", err)
@@ -348,7 +347,7 @@ func TestPullRequestsService_Get_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.Get(ctx, "%", "r", 1)
 	testURLParseError(t, err)
 }
@@ -371,7 +370,7 @@ func TestPullRequestsService_Create(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	pull, _, err := client.PullRequests.Create(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("PullRequests.Create returned error: %v", err)
@@ -401,7 +400,7 @@ func TestPullRequestsService_Create_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.Create(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
@@ -424,7 +423,7 @@ func TestPullRequestsService_UpdateBranch(t *testing.T) {
 		ExpectedHeadSHA: Ptr("s"),
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	pull, _, err := client.PullRequests.UpdateBranch(ctx, "o", "r", 1, opts)
 	if err != nil {
 		t.Errorf("PullRequests.UpdateBranch returned error: %v", err)
@@ -493,7 +492,7 @@ func TestPullRequestsService_Edit(t *testing.T) {
 			madeRequest = true
 		})
 
-		ctx := context.Background()
+		ctx := t.Context()
 		pull, _, err := client.PullRequests.Edit(ctx, "o", "r", i, tt.input)
 		if err != nil {
 			t.Errorf("%d: PullRequests.Edit returned error: %v", i, err)
@@ -519,7 +518,7 @@ func TestPullRequestsService_Edit_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.PullRequests.Edit(ctx, "%", "r", 1, &PullRequest{})
 	testURLParseError(t, err)
 }
@@ -553,7 +552,7 @@ func TestPullRequestsService_ListCommits(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	commits, _, err := client.PullRequests.ListCommits(ctx, "o", "r", 1, opts)
 	if err != nil {
 		t.Errorf("PullRequests.ListCommits returned error: %v", err)
@@ -627,7 +626,7 @@ func TestPullRequestsService_ListFiles(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	commitFiles, _, err := client.PullRequests.ListFiles(ctx, "o", "r", 1, opts)
 	if err != nil {
 		t.Errorf("PullRequests.ListFiles returned error: %v", err)
@@ -682,7 +681,7 @@ func TestPullRequestsService_IsMerged(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isMerged, _, err := client.PullRequests.IsMerged(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("PullRequests.IsMerged returned error: %v", err)
@@ -723,7 +722,7 @@ func TestPullRequestsService_Merge(t *testing.T) {
 	})
 
 	options := &PullRequestOptions{MergeMethod: "rebase"}
-	ctx := context.Background()
+	ctx := t.Context()
 	merge, _, err := client.PullRequests.Merge(ctx, "o", "r", 1, "merging pull request", options)
 	if err != nil {
 		t.Errorf("PullRequests.Merge returned error: %v", err)
@@ -801,7 +800,7 @@ func TestPullRequestsService_Merge_options(t *testing.T) {
 			testBody(t, r, test.wantBody+"\n")
 			madeRequest = true
 		})
-		ctx := context.Background()
+		ctx := t.Context()
 		_, _, _ = client.PullRequests.Merge(ctx, "o", "r", i, "merging pull request", test.options)
 		if !madeRequest {
 			t.Errorf("%d: PullRequests.Merge(%#v): expected request was not made", i, test.options)
@@ -821,7 +820,7 @@ func TestPullRequestsService_Merge_Blank_Message(t *testing.T) {
 		madeRequest = true
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	expectedBody = `{}`
 	_, _, _ = client.PullRequests.Merge(ctx, "o", "r", 1, "", nil)
 	if !madeRequest {

--- a/github/rate_limit_test.go
+++ b/github/rate_limit_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -57,7 +56,7 @@ func TestRateLimits(t *testing.T) {
 		}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rate, _, err := client.RateLimit.Get(ctx)
 	if err != nil {
 		t.Errorf("RateLimits returned error: %v", err)
@@ -195,7 +194,7 @@ func TestRateLimits_coverage(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "RateLimits"
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
@@ -230,7 +229,7 @@ func TestRateLimits_overQuota(t *testing.T) {
 		}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rate, _, err := client.RateLimit.Get(ctx)
 	if err != nil {
 		t.Errorf("RateLimits returned error: %v", err)

--- a/github/reactions_test.go
+++ b/github/reactions_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -80,7 +79,7 @@ func TestReactionsService_ListCommentReactions(t *testing.T) {
 	})
 
 	opt := &ListReactionOptions{Content: "+1"}
-	ctx := context.Background()
+	ctx := t.Context()
 	reactions, _, err := client.Reactions.ListCommentReactions(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("ListCommentReactions returned error: %v", err)
@@ -117,7 +116,7 @@ func TestReactionsService_CreateCommentReaction(t *testing.T) {
 		assertWrite(t, w, []byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Reactions.CreateCommentReaction(ctx, "o", "r", 1, "+1")
 	if err != nil {
 		t.Errorf("CreateCommentReaction returned error: %v", err)
@@ -156,7 +155,7 @@ func TestReactionsService_ListIssueReactions(t *testing.T) {
 	})
 
 	opt := &ListReactionOptions{Content: "+1"}
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Reactions.ListIssueReactions(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("ListIssueReactions returned error: %v", err)
@@ -171,7 +170,7 @@ func TestReactionsService_ListIssueReactions_coverage(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "ListIssueReactions"
 	testBadOptions(t, methodName, func() (err error) {
@@ -200,7 +199,7 @@ func TestReactionsService_CreateIssueReaction(t *testing.T) {
 		assertWrite(t, w, []byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Reactions.CreateIssueReaction(ctx, "o", "r", 1, "+1")
 	if err != nil {
 		t.Errorf("CreateIssueReaction returned error: %v", err)
@@ -239,7 +238,7 @@ func TestReactionsService_ListIssueCommentReactions(t *testing.T) {
 	})
 
 	opt := &ListReactionOptions{Content: "+1"}
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Reactions.ListIssueCommentReactions(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("ListIssueCommentReactions returned error: %v", err)
@@ -254,7 +253,7 @@ func TestReactionsService_ListIssueCommentReactions_coverage(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "ListIssueCommentReactions"
 	testBadOptions(t, methodName, func() (err error) {
@@ -283,7 +282,7 @@ func TestReactionsService_CreateIssueCommentReaction(t *testing.T) {
 		assertWrite(t, w, []byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Reactions.CreateIssueCommentReaction(ctx, "o", "r", 1, "+1")
 	if err != nil {
 		t.Errorf("CreateIssueCommentReaction returned error: %v", err)
@@ -322,7 +321,7 @@ func TestReactionsService_ListPullRequestCommentReactions(t *testing.T) {
 	})
 
 	opt := &ListReactionOptions{Content: "+1"}
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Reactions.ListPullRequestCommentReactions(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("ListPullRequestCommentReactions returned error: %v", err)
@@ -337,7 +336,7 @@ func TestReactionsService_ListPullRequestCommentReactions_coverage(t *testing.T)
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "ListPullRequestCommentReactions"
 	testBadOptions(t, methodName, func() (err error) {
@@ -366,7 +365,7 @@ func TestReactionsService_CreatePullRequestCommentReaction(t *testing.T) {
 		assertWrite(t, w, []byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Reactions.CreatePullRequestCommentReaction(ctx, "o", "r", 1, "+1")
 	if err != nil {
 		t.Errorf("CreatePullRequestCommentReaction returned error: %v", err)
@@ -405,7 +404,7 @@ func TestReactionsService_ListTeamDiscussionReactions(t *testing.T) {
 	})
 
 	opt := &ListReactionOptions{Content: "+1"}
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Reactions.ListTeamDiscussionReactions(ctx, 1, 2, opt)
 	if err != nil {
 		t.Errorf("ListTeamDiscussionReactions returned error: %v", err)
@@ -420,7 +419,7 @@ func TestReactionsService_ListTeamDiscussionReactions_coverage(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "ListTeamDiscussionReactions"
 	testBadOptions(t, methodName, func() (err error) {
@@ -449,7 +448,7 @@ func TestReactionsService_CreateTeamDiscussionReaction(t *testing.T) {
 		assertWrite(t, w, []byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Reactions.CreateTeamDiscussionReaction(ctx, 1, 2, "+1")
 	if err != nil {
 		t.Errorf("CreateTeamDiscussionReaction returned error: %v", err)
@@ -488,7 +487,7 @@ func TestReactionService_ListTeamDiscussionCommentReactions(t *testing.T) {
 	})
 
 	opt := &ListReactionOptions{Content: "+1"}
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Reactions.ListTeamDiscussionCommentReactions(ctx, 1, 2, 3, opt)
 	if err != nil {
 		t.Errorf("ListTeamDiscussionCommentReactions returned error: %v", err)
@@ -503,7 +502,7 @@ func TestReactionService_ListTeamDiscussionCommentReactions_coverage(t *testing.
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "ListTeamDiscussionCommentReactions"
 	testBadOptions(t, methodName, func() (err error) {
@@ -532,7 +531,7 @@ func TestReactionService_CreateTeamDiscussionCommentReaction(t *testing.T) {
 		assertWrite(t, w, []byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Reactions.CreateTeamDiscussionCommentReaction(ctx, 1, 2, 3, "+1")
 	if err != nil {
 		t.Errorf("CreateTeamDiscussionCommentReaction returned error: %v", err)
@@ -568,7 +567,7 @@ func TestReactionsService_DeleteCommitCommentReaction(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Reactions.DeleteCommentReaction(ctx, "o", "r", 1, 2); err != nil {
 		t.Errorf("DeleteCommentReaction returned error: %v", err)
 	}
@@ -595,7 +594,7 @@ func TestReactionsService_DeleteCommitCommentReactionByRepoID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Reactions.DeleteCommentReactionByID(ctx, 1, 2, 3); err != nil {
 		t.Errorf("DeleteCommentReactionByRepoID returned error: %v", err)
 	}
@@ -622,7 +621,7 @@ func TestReactionsService_DeleteIssueReaction(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Reactions.DeleteIssueReaction(ctx, "o", "r", 1, 2); err != nil {
 		t.Errorf("DeleteIssueReaction returned error: %v", err)
 	}
@@ -649,7 +648,7 @@ func TestReactionsService_DeleteIssueReactionByRepoID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Reactions.DeleteIssueReactionByID(ctx, 1, 2, 3); err != nil {
 		t.Errorf("DeleteIssueReactionByRepoID returned error: %v", err)
 	}
@@ -676,7 +675,7 @@ func TestReactionsService_DeleteIssueCommentReaction(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Reactions.DeleteIssueCommentReaction(ctx, "o", "r", 1, 2); err != nil {
 		t.Errorf("DeleteIssueCommentReaction returned error: %v", err)
 	}
@@ -703,7 +702,7 @@ func TestReactionsService_DeleteIssueCommentReactionByRepoID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Reactions.DeleteIssueCommentReactionByID(ctx, 1, 2, 3); err != nil {
 		t.Errorf("DeleteIssueCommentReactionByRepoID returned error: %v", err)
 	}
@@ -730,7 +729,7 @@ func TestReactionsService_DeletePullRequestCommentReaction(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Reactions.DeletePullRequestCommentReaction(ctx, "o", "r", 1, 2); err != nil {
 		t.Errorf("DeletePullRequestCommentReaction returned error: %v", err)
 	}
@@ -757,7 +756,7 @@ func TestReactionsService_DeletePullRequestCommentReactionByRepoID(t *testing.T)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Reactions.DeletePullRequestCommentReactionByID(ctx, 1, 2, 3); err != nil {
 		t.Errorf("DeletePullRequestCommentReactionByRepoID returned error: %v", err)
 	}
@@ -784,7 +783,7 @@ func TestReactionsService_DeleteTeamDiscussionReaction(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Reactions.DeleteTeamDiscussionReaction(ctx, "o", "s", 1, 2); err != nil {
 		t.Errorf("DeleteTeamDiscussionReaction returned error: %v", err)
 	}
@@ -811,7 +810,7 @@ func TestReactionsService_DeleteTeamDiscussionReactionByTeamIDAndOrgID(t *testin
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Reactions.DeleteTeamDiscussionReactionByOrgIDAndTeamID(ctx, 1, 2, 3, 4); err != nil {
 		t.Errorf("DeleteTeamDiscussionReactionByTeamIDAndOrgID returned error: %v", err)
 	}
@@ -838,7 +837,7 @@ func TestReactionsService_DeleteTeamDiscussionCommentReaction(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Reactions.DeleteTeamDiscussionCommentReaction(ctx, "o", "s", 1, 2, 3); err != nil {
 		t.Errorf("DeleteTeamDiscussionCommentReaction returned error: %v", err)
 	}
@@ -865,7 +864,7 @@ func TestReactionsService_DeleteTeamDiscussionCommentReactionByTeamIDAndOrgID(t 
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Reactions.DeleteTeamDiscussionCommentReactionByOrgIDAndTeamID(ctx, 1, 2, 3, 4, 5); err != nil {
 		t.Errorf("DeleteTeamDiscussionCommentReactionByTeamIDAndOrgID returned error: %v", err)
 	}
@@ -894,7 +893,7 @@ func TestReactionService_CreateReleaseReaction(t *testing.T) {
 	})
 
 	const methodName = "CreateReleaseReaction"
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Reactions.CreateReleaseReaction(ctx, "o", "r", 1, "rocket")
 	if err != nil {
 		t.Errorf("%v returned error: %v", methodName, err)
@@ -933,7 +932,7 @@ func TestReactionsService_ListReleaseReactions(t *testing.T) {
 	})
 
 	opt := &ListReactionOptions{Content: "+1"}
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Reactions.ListReleaseReactions(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("ListReleaseReactions returned error: %v", err)
@@ -948,7 +947,7 @@ func TestReactionsService_ListReleaseReactions_coverage(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "ListReleaseReactions"
 	testBadOptions(t, methodName, func() (err error) {
@@ -976,7 +975,7 @@ func TestReactionsService_DeleteReleaseReaction(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Reactions.DeleteReleaseReaction(ctx, "o", "r", 1, 2); err != nil {
 		t.Errorf("DeleteReleaseReaction returned error: %v", err)
 	}
@@ -1003,7 +1002,7 @@ func TestReactionsService_DeleteReleaseReactionByRepoID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Reactions.DeleteReleaseReactionByID(ctx, 1, 2, 3); err != nil {
 		t.Errorf("DeleteReleaseReactionByRepoID returned error: %v", err)
 	}

--- a/github/repos_actions_access_test.go
+++ b/github/repos_actions_access_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -24,7 +23,7 @@ func TestRepositoriesService_GetActionsAccessLevel(t *testing.T) {
 		fmt.Fprint(w, `{"access_level": "none"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Repositories.GetActionsAccessLevel(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetActionsAccessLevel returned error: %v", err)
@@ -65,7 +64,7 @@ func TestRepositoriesService_EditActionsAccessLevel(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.EditActionsAccessLevel(ctx, "o", "r", *input)
 	if err != nil {
 		t.Errorf("Repositories.EditActionsAccessLevel returned error: %v", err)

--- a/github/repos_actions_allowed_test.go
+++ b/github/repos_actions_allowed_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -24,7 +23,7 @@ func TestRepositoryService_GetActionsAllowed(t *testing.T) {
 		fmt.Fprint(w, `{"github_owned_allowed":true, "verified_allowed":false, "patterns_allowed":["a/b"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Repositories.GetActionsAllowed(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetActionsAllowed returned error: %v", err)
@@ -67,7 +66,7 @@ func TestRepositoriesService_UpdateActionsAllowed(t *testing.T) {
 		fmt.Fprint(w, `{"github_owned_allowed":true, "verified_allowed":false, "patterns_allowed":["a/b"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Repositories.EditActionsAllowed(ctx, "o", "r", *input)
 	if err != nil {
 		t.Errorf("Repositories.UpdateActionsAllowed returned error: %v", err)

--- a/github/repos_actions_permissions_test.go
+++ b/github/repos_actions_permissions_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -24,7 +23,7 @@ func TestRepositoriesService_GetActionsPermissions(t *testing.T) {
 		fmt.Fprint(w, `{"enabled": true, "allowed_actions": "all"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Repositories.GetActionsPermissions(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetActionsPermissions returned error: %v", err)
@@ -67,7 +66,7 @@ func TestRepositoriesService_UpdateActionsPermissions(t *testing.T) {
 		fmt.Fprint(w, `{"enabled": true, "allowed_actions": "selected"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Repositories.UpdateActionsPermissions(ctx, "o", "r", *input)
 	if err != nil {
 		t.Errorf("Repositories.UpdateActionsPermissions returned error: %v", err)
@@ -121,7 +120,7 @@ func TestRepositoriesService_GetDefaultWorkflowPermissions(t *testing.T) {
 		fmt.Fprint(w, `{ "default_workflow_permissions": "read", "can_approve_pull_request_reviews": true }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Repositories.GetDefaultWorkflowPermissions(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetDefaultWorkflowPermissions returned error: %v", err)
@@ -164,7 +163,7 @@ func TestRepositoriesService_UpdateDefaultWorkflowPermissions(t *testing.T) {
 		fmt.Fprint(w, `{ "default_workflow_permissions": "read", "can_approve_pull_request_reviews": true }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	org, _, err := client.Repositories.UpdateDefaultWorkflowPermissions(ctx, "o", "r", *input)
 	if err != nil {
 		t.Errorf("Repositories.UpdateDefaultWorkflowPermissions returned error: %v", err)
@@ -199,7 +198,7 @@ func TestRepositoriesService_GetArtifactAndLogRetentionPeriod(t *testing.T) {
 		fmt.Fprint(w, `{"days": 90, "maximum_allowed_days": 365}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	period, _, err := client.Repositories.GetArtifactAndLogRetentionPeriod(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetArtifactAndLogRetentionPeriod returned error: %v", err)
@@ -245,7 +244,7 @@ func TestRepositoriesService_UpdateArtifactAndLogRetentionPeriod(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Repositories.UpdateArtifactAndLogRetentionPeriod(ctx, "o", "r", *input)
 	if err != nil {
 		t.Errorf("Repositories.UpdateArtifactAndLogRetentionPeriod returned error: %v", err)
@@ -275,7 +274,7 @@ func TestRepositoriesService_GetPrivateRepoForkPRWorkflowSettings(t *testing.T) 
 		fmt.Fprint(w, `{"run_workflows_from_fork_pull_requests": true, "send_write_tokens_to_workflows": false, "send_secrets_and_variables": true, "require_approval_for_fork_pr_workflows": false}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	permissions, _, err := client.Repositories.GetPrivateRepoForkPRWorkflowSettings(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetPrivateRepoForkPRWorkflowSettings returned error: %v", err)
@@ -326,7 +325,7 @@ func TestRepositoriesService_UpdatePrivateRepoForkPRWorkflowSettings(t *testing.
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Repositories.UpdatePrivateRepoForkPRWorkflowSettings(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.UpdatePrivateRepoForkPRWorkflowSettings returned error: %v", err)

--- a/github/repos_attestations_test.go
+++ b/github/repos_attestations_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -33,7 +32,7 @@ func TestRepositoriesService_ListAttestations(t *testing.T) {
 			]
 		}`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	attestations, _, err := client.Repositories.ListAttestations(ctx, "o", "r", "digest", &ListOptions{})
 	if err != nil {
 		t.Errorf("Repositories.ListAttestations returned error: %v", err)

--- a/github/repos_autolinks_test.go
+++ b/github/repos_autolinks_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -28,7 +27,7 @@ func TestRepositoriesService_ListAutolinks(t *testing.T) {
 	opt := &ListOptions{
 		Page: 2,
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	autolinks, _, err := client.Repositories.ListAutolinks(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListAutolinks returned error: %v", err)
@@ -83,7 +82,7 @@ func TestRepositoriesService_AddAutolink(t *testing.T) {
 			}
 		`))
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	autolink, _, err := client.Repositories.AddAutolink(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.AddAutolink returned error: %v", err)
@@ -122,7 +121,7 @@ func TestRepositoriesService_GetAutolink(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "key_prefix": "TICKET-", "url_template": "https://example.com/TICKET?query=<num>"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	autolink, _, err := client.Repositories.GetAutolink(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetAutolink returned error: %v", err)
@@ -152,7 +151,7 @@ func TestRepositoriesService_DeleteAutolink(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeleteAutolink(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeleteAutolink returned error: %v", err)

--- a/github/repos_codeowners_test.go
+++ b/github/repos_codeowners_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -37,7 +36,7 @@ func TestRepositoriesService_GetCodeownersErrors_noRef(t *testing.T) {
 	`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	codeownersErrors, _, err := client.Repositories.GetCodeownersErrors(ctx, "o", "r", nil)
 	if err != nil {
 		t.Errorf("Repositories.GetCodeownersErrors returned error: %v", err)
@@ -100,7 +99,7 @@ func TestRepositoriesService_GetCodeownersErrors_specificRef(t *testing.T) {
 	})
 
 	opts := &GetCodeownersErrorsOptions{Ref: "mybranch"}
-	ctx := context.Background()
+	ctx := t.Context()
 	codeownersErrors, _, err := client.Repositories.GetCodeownersErrors(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Repositories.GetCodeownersErrors returned error: %v", err)

--- a/github/repos_collaborators_test.go
+++ b/github/repos_collaborators_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -28,7 +27,7 @@ func TestRepositoriesService_ListCollaborators(t *testing.T) {
 	opt := &ListCollaboratorsOptions{
 		ListOptions: ListOptions{Page: 2},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	users, _, err := client.Repositories.ListCollaborators(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListCollaborators returned error: %v", err)
@@ -68,7 +67,7 @@ func TestRepositoriesService_ListCollaborators_withAffiliation(t *testing.T) {
 		ListOptions: ListOptions{Page: 2},
 		Affiliation: "all",
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	users, _, err := client.Repositories.ListCollaborators(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListCollaborators returned error: %v", err)
@@ -108,7 +107,7 @@ func TestRepositoriesService_ListCollaborators_withPermission(t *testing.T) {
 		ListOptions: ListOptions{Page: 2},
 		Permission:  "pull",
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	users, _, err := client.Repositories.ListCollaborators(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListCollaborators returned error: %v", err)
@@ -138,7 +137,7 @@ func TestRepositoriesService_ListCollaborators_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListCollaborators(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
@@ -152,7 +151,7 @@ func TestRepositoriesService_IsCollaborator_True(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isCollab, _, err := client.Repositories.IsCollaborator(ctx, "o", "r", "u")
 	if err != nil {
 		t.Errorf("Repositories.IsCollaborator returned error: %v", err)
@@ -186,7 +185,7 @@ func TestRepositoriesService_IsCollaborator_False(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isCollab, _, err := client.Repositories.IsCollaborator(ctx, "o", "r", "u")
 	if err != nil {
 		t.Errorf("Repositories.IsCollaborator returned error: %v", err)
@@ -215,7 +214,7 @@ func TestRepositoriesService_IsCollaborator_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.IsCollaborator(ctx, "%", "%", "%")
 	testURLParseError(t, err)
 }
@@ -229,7 +228,7 @@ func TestRepositoryService_GetPermissionLevel(t *testing.T) {
 		fmt.Fprint(w, `{"permission":"admin","user":{"login":"u"}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rpl, _, err := client.Repositories.GetPermissionLevel(ctx, "o", "r", "u")
 	if err != nil {
 		t.Errorf("Repositories.GetPermissionLevel returned error: %v", err)
@@ -276,7 +275,7 @@ func TestRepositoriesService_AddCollaborator(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		assertWrite(t, w, []byte(`{"permissions": "write","url": "https://api.github.com/user/repository_invitations/1296269","html_url": "https://github.com/octocat/Hello-World/invitations","id":1,"permissions":"write","repository":{"url":"s","name":"r","id":1},"invitee":{"login":"u"},"inviter":{"login":"o"}}`))
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	collaboratorInvitation, _, err := client.Repositories.AddCollaborator(ctx, "o", "r", "u", opt)
 	if err != nil {
 		t.Errorf("Repositories.AddCollaborator returned error: %v", err)
@@ -322,7 +321,7 @@ func TestRepositoriesService_AddCollaborator_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.AddCollaborator(ctx, "%", "%", "%", nil)
 	testURLParseError(t, err)
 }
@@ -336,7 +335,7 @@ func TestRepositoriesService_RemoveCollaborator(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.RemoveCollaborator(ctx, "o", "r", "u")
 	if err != nil {
 		t.Errorf("Repositories.RemoveCollaborator returned error: %v", err)
@@ -357,7 +356,7 @@ func TestRepositoriesService_RemoveCollaborator_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.RemoveCollaborator(ctx, "%", "%", "%")
 	testURLParseError(t, err)
 }

--- a/github/repos_comments_test.go
+++ b/github/repos_comments_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -27,7 +26,7 @@ func TestRepositoriesService_ListComments(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	comments, _, err := client.Repositories.ListComments(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListComments returned error: %v", err)
@@ -57,7 +56,7 @@ func TestRepositoriesService_ListComments_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListComments(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
@@ -74,7 +73,7 @@ func TestRepositoriesService_ListCommitComments(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	comments, _, err := client.Repositories.ListCommitComments(ctx, "o", "r", "s", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListCommitComments returned error: %v", err)
@@ -104,7 +103,7 @@ func TestRepositoriesService_ListCommitComments_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListCommitComments(ctx, "%", "%", "%", nil)
 	testURLParseError(t, err)
 }
@@ -127,7 +126,7 @@ func TestRepositoriesService_CreateComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.Repositories.CreateComment(ctx, "o", "r", "s", input)
 	if err != nil {
 		t.Errorf("Repositories.CreateComment returned error: %v", err)
@@ -157,7 +156,7 @@ func TestRepositoriesService_CreateComment_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.CreateComment(ctx, "%", "%", "%", nil)
 	testURLParseError(t, err)
 }
@@ -172,7 +171,7 @@ func TestRepositoriesService_GetComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.Repositories.GetComment(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetComment returned error: %v", err)
@@ -202,7 +201,7 @@ func TestRepositoriesService_GetComment_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.GetComment(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }
@@ -225,7 +224,7 @@ func TestRepositoriesService_UpdateComment(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.Repositories.UpdateComment(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Repositories.UpdateComment returned error: %v", err)
@@ -255,7 +254,7 @@ func TestRepositoriesService_UpdateComment_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.UpdateComment(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }
@@ -268,7 +267,7 @@ func TestRepositoriesService_DeleteComment(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeleteComment(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeleteComment returned error: %v", err)
@@ -289,7 +288,7 @@ func TestRepositoriesService_DeleteComment_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeleteComment(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }

--- a/github/repos_commits_test.go
+++ b/github/repos_commits_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -42,7 +41,7 @@ func TestRepositoriesService_ListCommits(t *testing.T) {
 		Since:  time.Date(2013, time.August, 1, 0, 0, 0, 0, time.UTC),
 		Until:  time.Date(2013, time.September, 3, 0, 0, 0, 0, time.UTC),
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	commits, _, err := client.Repositories.ListCommits(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListCommits returned error: %v", err)
@@ -99,7 +98,7 @@ func TestRepositoriesService_GetCommit(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	commit, _, err := client.Repositories.GetCommit(ctx, "o", "r", "s", opts)
 	if err != nil {
 		t.Errorf("Repositories.GetCommit returned error: %v", err)
@@ -171,7 +170,7 @@ func TestRepositoriesService_GetCommitRaw_diff(t *testing.T) {
 		fmt.Fprint(w, rawStr)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.GetCommitRaw(ctx, "o", "r", "s", RawOptions{Type: Diff})
 	if err != nil {
 		t.Fatalf("Repositories.GetCommitRaw returned error: %v", err)
@@ -208,7 +207,7 @@ func TestRepositoriesService_GetCommitRaw_patch(t *testing.T) {
 		fmt.Fprint(w, rawStr)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.GetCommitRaw(ctx, "o", "r", "s", RawOptions{Type: Patch})
 	if err != nil {
 		t.Fatalf("Repositories.GetCommitRaw returned error: %v", err)
@@ -223,7 +222,7 @@ func TestRepositoriesService_GetCommitRaw_invalid(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.GetCommitRaw(ctx, "o", "r", "s", RawOptions{100})
 	if err == nil {
 		t.Fatal("Repositories.GetCommitRaw should return error")
@@ -246,7 +245,7 @@ func TestRepositoriesService_GetCommitSHA1(t *testing.T) {
 		fmt.Fprint(w, sha1)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.GetCommitSHA1(ctx, "o", "r", "master", "")
 	if err != nil {
 		t.Errorf("Repositories.GetCommitSHA1 returned error: %v", err)
@@ -303,7 +302,7 @@ func TestRepositoriesService_NonAlphabetCharacter_GetCommitSHA1(t *testing.T) {
 		fmt.Fprint(w, sha1)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.GetCommitSHA1(ctx, "o", "r", "master%20hash", "")
 	if err != nil {
 		t.Errorf("Repositories.GetCommitSHA1 returned error: %v", err)
@@ -344,7 +343,7 @@ func TestRepositoriesService_TrailingPercent_GetCommitSHA1(t *testing.T) {
 		fmt.Fprint(w, sha1)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.GetCommitSHA1(ctx, "o", "r", "comm%", "")
 	if err != nil {
 		t.Errorf("Repositories.GetCommitSHA1 returned error: %v", err)
@@ -438,7 +437,7 @@ func TestRepositoriesService_CompareCommits(t *testing.T) {
 			})
 
 			opts := &ListOptions{Page: 2, PerPage: 2}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, _, err := client.Repositories.CompareCommits(ctx, "o", "r", base, head, opts)
 			if err != nil {
 				t.Errorf("Repositories.CompareCommits returned error: %v", err)
@@ -544,7 +543,7 @@ func TestRepositoriesService_CompareCommitsRaw_diff(t *testing.T) {
 				fmt.Fprint(w, rawStr)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			got, _, err := client.Repositories.CompareCommitsRaw(ctx, "o", "r", base, head, RawOptions{Type: Diff})
 			if err != nil {
 				t.Fatalf("Repositories.GetCommitRaw returned error: %v", err)
@@ -602,7 +601,7 @@ func TestRepositoriesService_CompareCommitsRaw_patch(t *testing.T) {
 				fmt.Fprint(w, rawStr)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			got, _, err := client.Repositories.CompareCommitsRaw(ctx, "o", "r", base, head, RawOptions{Type: Patch})
 			if err != nil {
 				t.Fatalf("Repositories.GetCommitRaw returned error: %v", err)
@@ -617,7 +616,7 @@ func TestRepositoriesService_CompareCommitsRaw_patch(t *testing.T) {
 
 func TestRepositoriesService_CompareCommitsRaw_invalid(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	testCases := []struct {
 		base string
@@ -652,7 +651,7 @@ func TestRepositoriesService_ListBranchesHeadCommit(t *testing.T) {
 		fmt.Fprint(w, `[{"name": "b","commit":{"sha":"2e90302801c870f17b6152327d9b9a03c8eca0e2","url":"https://api.github.com/repos/google/go-github/commits/2e90302801c870f17b6152327d9b9a03c8eca0e2"},"protected":true}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	branches, _, err := client.Repositories.ListBranchesHeadCommit(ctx, "o", "r", "s")
 	if err != nil {
 		t.Errorf("Repositories.ListBranchesHeadCommit returned error: %v", err)

--- a/github/repos_community_health_test.go
+++ b/github/repos_community_health_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -66,7 +65,7 @@ func TestRepositoriesService_GetCommunityHealthMetrics(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.GetCommunityHealthMetrics(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetCommunityHealthMetrics returned error: %v", err)

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -102,7 +101,7 @@ func TestRepositoriesService_GetReadme(t *testing.T) {
 		  "path": "README.md"
 		}`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	readme, _, err := client.Repositories.GetReadme(ctx, "o", "r", &RepositoryContentGetOptions{})
 	if err != nil {
 		t.Errorf("Repositories.GetReadme returned error: %v", err)
@@ -141,7 +140,7 @@ func TestRepositoriesService_DownloadContents_SuccessForFile(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	r, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadContents returned error: %v", err)
@@ -200,7 +199,7 @@ func TestRepositoriesService_DownloadContents_SuccessForDirectory(t *testing.T) 
 		fmt.Fprint(w, "foo")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	r, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadContents returned error: %v", err)
@@ -260,7 +259,7 @@ func TestRepositoriesService_DownloadContents_FailedResponse(t *testing.T) {
 		fmt.Fprint(w, "foo error")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	r, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadContents returned error: %v", err)
@@ -302,7 +301,7 @@ func TestRepositoriesService_DownloadContents_NoDownloadURL(t *testing.T) {
 		}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	reader, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err == nil {
 		t.Error("Repositories.DownloadContents did not return expected error")
@@ -335,7 +334,7 @@ func TestRepositoriesService_DownloadContents_NoFile(t *testing.T) {
 		fmt.Fprint(w, `[]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	reader, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err == nil {
 		t.Error("Repositories.DownloadContents did not return expected error")
@@ -364,7 +363,7 @@ func TestRepositoriesService_DownloadContentsWithMeta_SuccessForFile(t *testing.
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	r, c, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadContentsWithMeta returned error: %v", err)
@@ -427,7 +426,7 @@ func TestRepositoriesService_DownloadContentsWithMeta_SuccessForDirectory(t *tes
 		fmt.Fprint(w, "foo")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	r, c, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadContentsWithMeta returned error: %v", err)
@@ -484,7 +483,7 @@ func TestRepositoriesService_DownloadContentsWithMeta_FailedResponse(t *testing.
 		  }]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	r, c, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadContentsWithMeta returned error: %v", err)
@@ -533,7 +532,7 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoDownloadURL(t *testing.T
 		}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	reader, contents, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
 	if err == nil {
 		t.Error("Repositories.DownloadContentsWithMeta did not return expected error")
@@ -561,7 +560,7 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoFile(t *testing.T) {
 		fmt.Fprint(w, `[]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
 	if err == nil {
 		t.Error("Repositories.DownloadContentsWithMeta did not return expected error")
@@ -586,7 +585,7 @@ func TestRepositoriesService_GetContents_File(t *testing.T) {
 		  "path": "LICENSE"
 		}`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	fileContents, _, _, err := client.Repositories.GetContents(ctx, "o", "r", "p", &RepositoryContentGetOptions{})
 	if err != nil {
 		t.Errorf("Repositories.GetContents returned error: %v", err)
@@ -619,7 +618,7 @@ func TestRepositoriesService_GetContents_FilenameNeedsEscape(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{}`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, _, err := client.Repositories.GetContents(ctx, "o", "r", "p#?%/中.go", &RepositoryContentGetOptions{})
 	if err != nil {
 		t.Fatalf("Repositories.GetContents returned error: %v", err)
@@ -634,7 +633,7 @@ func TestRepositoriesService_GetContents_DirectoryWithSpaces(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{}`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, _, err := client.Repositories.GetContents(ctx, "o", "r", "some directory/file.go", &RepositoryContentGetOptions{})
 	if err != nil {
 		t.Fatalf("Repositories.GetContents returned error: %v", err)
@@ -649,7 +648,7 @@ func TestRepositoriesService_GetContents_PathWithParent(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{}`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, _, err := client.Repositories.GetContents(ctx, "o", "r", "some/../directory/file.go", &RepositoryContentGetOptions{})
 	if err == nil {
 		t.Fatal("Repositories.GetContents expected error but got none")
@@ -664,7 +663,7 @@ func TestRepositoriesService_GetContents_DirectoryWithPlusChars(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{}`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, _, err := client.Repositories.GetContents(ctx, "o", "r", "some directory+name/file.go", &RepositoryContentGetOptions{})
 	if err != nil {
 		t.Fatalf("Repositories.GetContents returned error: %v", err)
@@ -689,7 +688,7 @@ func TestRepositoriesService_GetContents_Directory(t *testing.T) {
 		  "path": "LICENSE"
 		}]`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	_, directoryContents, _, err := client.Repositories.GetContents(ctx, "o", "r", "p", &RepositoryContentGetOptions{})
 	if err != nil {
 		t.Errorf("Repositories.GetContents returned error: %v", err)
@@ -726,7 +725,7 @@ func TestRepositoriesService_CreateFile(t *testing.T) {
 		Content:   content,
 		Committer: &CommitAuthor{Name: Ptr("n"), Email: Ptr("e")},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	createResponse, _, err := client.Repositories.CreateFile(ctx, "o", "r", "p", repositoryContentsOptions)
 	if err != nil {
 		t.Errorf("Repositories.CreateFile returned error: %v", err)
@@ -782,7 +781,7 @@ func TestRepositoriesService_UpdateFile(t *testing.T) {
 		SHA:       &sha,
 		Committer: &CommitAuthor{Name: Ptr("n"), Email: Ptr("e")},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	updateResponse, _, err := client.Repositories.UpdateFile(ctx, "o", "r", "p", repositoryContentsOptions)
 	if err != nil {
 		t.Errorf("Repositories.UpdateFile returned error: %v", err)
@@ -834,7 +833,7 @@ func TestRepositoriesService_DeleteFile(t *testing.T) {
 		SHA:       &sha,
 		Committer: &CommitAuthor{Name: Ptr("n"), Email: Ptr("e")},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	deleteResponse, _, err := client.Repositories.DeleteFile(ctx, "o", "r", "p", repositoryContentsOptions)
 	if err != nil {
 		t.Errorf("Repositories.DeleteFile returned error: %v", err)
@@ -891,7 +890,7 @@ func TestRepositoriesService_GetArchiveLink(t *testing.T) {
 				testMethod(t, r, "GET")
 				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
-			ctx := context.Background()
+			ctx := t.Context()
 			url, resp, err := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{Ref: "yo"}, 1)
 			if err != nil {
 				t.Errorf("Repositories.GetArchiveLink returned error: %v", err)
@@ -948,7 +947,7 @@ func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_dontFollowRed
 				testMethod(t, r, "GET")
 				http.Redirect(w, r, "https://github.com/a", http.StatusMovedPermanently)
 			})
-			ctx := context.Background()
+			ctx := t.Context()
 			_, resp, _ := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{}, 0)
 			if resp.StatusCode != http.StatusMovedPermanently {
 				t.Errorf("Repositories.GetArchiveLink returned status: %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
@@ -989,7 +988,7 @@ func TestRepositoriesService_GetArchiveLink_StatusMovedPermanently_followRedirec
 				testMethod(t, r, "GET")
 				http.Redirect(w, r, "https://github.com/a", http.StatusFound)
 			})
-			ctx := context.Background()
+			ctx := t.Context()
 			url, resp, err := client.Repositories.GetArchiveLink(ctx, "o", "r", Tarball, &RepositoryContentGetOptions{}, 1)
 			if err != nil {
 				t.Errorf("Repositories.GetArchiveLink returned error: %v", err)
@@ -1017,7 +1016,7 @@ func TestRepositoriesService_GetContents_NoTrailingSlashInDirectoryApiPath(t *te
 		}
 		fmt.Fprint(w, `{}`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, _, err := client.Repositories.GetContents(ctx, "o", "r", ".github/", &RepositoryContentGetOptions{
 		Ref: "mybranch",
 	})

--- a/github/repos_deployment_branch_policies_test.go
+++ b/github/repos_deployment_branch_policies_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -22,7 +21,7 @@ func TestRepositoriesService_ListDeploymentBranchPolicies(t *testing.T) {
 		fmt.Fprint(w, `{"total_count":2, "branch_policies":[{"id":1}, {"id": 2}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.ListDeploymentBranchPolicies(ctx, "o", "r", "e")
 	if err != nil {
 		t.Errorf("Repositories.ListDeploymentBranchPolicies returned error: %v", err)
@@ -57,7 +56,7 @@ func TestRepositoriesService_GetDeploymentBranchPolicy(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.GetDeploymentBranchPolicy(ctx, "o", "r", "e", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetDeploymentBranchPolicy returned error: %v", err)
@@ -87,7 +86,7 @@ func TestRepositoriesService_CreateDeploymentBranchPolicy(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "type":"branch"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.CreateDeploymentBranchPolicy(ctx, "o", "r", "e", &DeploymentBranchPolicyRequest{Name: Ptr("n"), Type: Ptr("branch")})
 	if err != nil {
 		t.Errorf("Repositories.CreateDeploymentBranchPolicy returned error: %v", err)
@@ -117,7 +116,7 @@ func TestRepositoriesService_UpdateDeploymentBranchPolicy(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.UpdateDeploymentBranchPolicy(ctx, "o", "r", "e", 1, &DeploymentBranchPolicyRequest{Name: Ptr("n")})
 	if err != nil {
 		t.Errorf("Repositories.UpdateDeploymentBranchPolicy returned error: %v", err)
@@ -146,7 +145,7 @@ func TestRepositoriesService_DeleteDeploymentBranchPolicy(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeleteDeploymentBranchPolicy(ctx, "o", "r", "e", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeleteDeploymentBranchPolicy returned error: %v", err)

--- a/github/repos_deployment_protection_rules_test.go
+++ b/github/repos_deployment_protection_rules_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -24,7 +23,7 @@ func TestRepositoriesService_GetAllDeploymentProtectionRules(t *testing.T) {
 		fmt.Fprint(w, `{"total_count":2, "custom_deployment_protection_rules":[{ "id": 3, "node_id": "IEH37kRlcGxveW1lbnRTdGF0ddiv", "enabled": true, "app": { "id": 1, "node_id": "GHT58kRlcGxveW1lbnRTdTY!bbcy", "slug": "a-custom-app", "integration_url": "https://api.github.com/apps/a-custom-app"}}, { "id": 4, "node_id": "MDE2OkRlcGxveW1lbnRTdHJ41128", "enabled": true, "app": { "id": 1, "node_id": "UHVE67RlcGxveW1lbnRTdTY!jfeuy", "slug": "another-custom-app", "integration_url": "https://api.github.com/apps/another-custom-app"}}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.GetAllDeploymentProtectionRules(ctx, "o", "r", "e")
 	if err != nil {
 		t.Errorf("Repositories.GetAllDeploymentProtectionRules returned error: %v", err)
@@ -72,7 +71,7 @@ func TestRepositoriesService_CreateCustomDeploymentProtectionRule(t *testing.T) 
 		fmt.Fprint(w, `{"id":3, "node_id": "IEH37kRlcGxveW1lbnRTdGF0ddiv", "enabled": true, "app": {"id": 1, "node_id": "GHT58kRlcGxveW1lbnRTdTY!bbcy", "slug": "a-custom-app", "integration_url": "https://api.github.com/apps/a-custom-app"}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.CreateCustomDeploymentProtectionRule(ctx, "o", "r", "e", input)
 	if err != nil {
 		t.Errorf("Repositories.CreateCustomDeploymentProtectionRule returned error: %v", err)
@@ -117,7 +116,7 @@ func TestRepositoriesService_ListCustomDeploymentRuleIntegrations(t *testing.T) 
 		fmt.Fprint(w, `{"total_count": 2, "available_custom_deployment_protection_rule_integrations": [{"id": 1, "node_id": "GHT58kRlcGxveW1lbnRTdTY!bbcy", "slug": "a-custom-app", "integration_url": "https://api.github.com/apps/a-custom-app"}, {"id": 2, "node_id": "UHVE67RlcGxveW1lbnRTdTY!jfeuy", "slug": "another-custom-app", "integration_url": "https://api.github.com/apps/another-custom-app"}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.ListCustomDeploymentRuleIntegrations(ctx, "o", "r", "e")
 	if err != nil {
 		t.Errorf("Repositories.ListCustomDeploymentRuleIntegrations returned error: %v", err)
@@ -153,7 +152,7 @@ func TestRepositoriesService_GetCustomDeploymentProtectionRule(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "node_id": "IEH37kRlcGxveW1lbnRTdGF0ddiv", "enabled": true, "app": {"id": 1, "node_id": "GHT58kRlcGxveW1lbnRTdTY!bbcy", "slug": "a-custom-app", "integration_url": "https://api.github.com/apps/a-custom-app"}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.GetCustomDeploymentProtectionRule(ctx, "o", "r", "e", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetCustomDeploymentProtectionRule returned error: %v", err)
@@ -194,7 +193,7 @@ func TestRepositoriesService_DisableCustomDeploymentProtectionRule(t *testing.T)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Repositories.DisableCustomDeploymentProtectionRule(ctx, "o", "r", "e", 1)
 	if err != nil {
 		t.Errorf("Repositories.DisableCustomDeploymentProtectionRule returned error: %v", err)

--- a/github/repos_deployments_test.go
+++ b/github/repos_deployments_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -27,7 +26,7 @@ func TestRepositoriesService_ListDeployments(t *testing.T) {
 	})
 
 	opt := &DeploymentsListOptions{Environment: "test"}
-	ctx := context.Background()
+	ctx := t.Context()
 	deployments, _, err := client.Repositories.ListDeployments(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListDeployments returned error: %v", err)
@@ -62,7 +61,7 @@ func TestRepositoriesService_GetDeployment(t *testing.T) {
 		fmt.Fprint(w, `{"id":3}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	deployment, _, err := client.Repositories.GetDeployment(ctx, "o", "r", 3)
 	if err != nil {
 		t.Errorf("Repositories.GetDeployment returned error: %v", err)
@@ -109,7 +108,7 @@ func TestRepositoriesService_CreateDeployment(t *testing.T) {
 		fmt.Fprint(w, `{"ref": "1111", "task": "deploy"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	deployment, _, err := client.Repositories.CreateDeployment(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.CreateDeployment returned error: %v", err)
@@ -144,7 +143,7 @@ func TestRepositoriesService_DeleteDeployment(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Repositories.DeleteDeployment(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeleteDeployment returned error: %v", err)
@@ -185,7 +184,7 @@ func TestRepositoriesService_ListDeploymentStatuses(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	statuses, _, err := client.Repositories.ListDeploymentStatuses(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Repositories.ListDeploymentStatuses returned error: %v", err)
@@ -222,7 +221,7 @@ func TestRepositoriesService_GetDeploymentStatus(t *testing.T) {
 		fmt.Fprint(w, `{"id":4}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	deploymentStatus, _, err := client.Repositories.GetDeploymentStatus(ctx, "o", "r", 3, 4)
 	if err != nil {
 		t.Errorf("Repositories.GetDeploymentStatus returned error: %v", err)
@@ -268,7 +267,7 @@ func TestRepositoriesService_CreateDeploymentStatus(t *testing.T) {
 		fmt.Fprint(w, `{"state": "inactive", "description": "deploy"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	deploymentStatus, _, err := client.Repositories.CreateDeploymentStatus(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Repositories.CreateDeploymentStatus returned error: %v", err)

--- a/github/repos_environments_test.go
+++ b/github/repos_environments_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -117,7 +116,7 @@ func TestRepositoriesService_ListEnvironments(t *testing.T) {
 			PerPage: 2,
 		},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	environments, _, err := client.Repositories.ListEnvironments(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListEnvironments returned error: %v", err)
@@ -151,7 +150,7 @@ func TestRepositoriesService_GetEnvironment(t *testing.T) {
 		fmt.Fprint(w, `{"id": 1,"name": "staging", "deployment_branch_policy": {"protected_branches": true,	"custom_branch_policies": false}, "can_admins_bypass": false}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	release, resp, err := client.Repositories.GetEnvironment(ctx, "o", "r", "e")
 	if err != nil {
 		t.Errorf("Repositories.GetEnvironment returned error: %v\n%v", err, resp.Body)
@@ -197,7 +196,7 @@ func TestRepositoriesService_CreateEnvironment(t *testing.T) {
 		fmt.Fprint(w, `{"id": 1, "name": "staging",	"protection_rules": [{"id": 1, "type": "wait_timer", "wait_timer": 30}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	release, _, err := client.Repositories.CreateUpdateEnvironment(ctx, "o", "r", "e", input)
 	if err != nil {
 		t.Errorf("Repositories.CreateUpdateEnvironment returned error: %v", err)
@@ -247,7 +246,7 @@ func TestRepositoriesService_CreateEnvironment_noEnterprise(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	release, _, err := client.Repositories.CreateUpdateEnvironment(ctx, "o", "r", "e", input)
 	if err != nil {
 		t.Errorf("Repositories.CreateUpdateEnvironment returned error: %v", err)
@@ -287,7 +286,7 @@ func TestRepositoriesService_createNewEnvNoEnterprise(t *testing.T) {
 		fmt.Fprint(w, `{"id": 1, "name": "staging",	"protection_rules": [{"id": 1, "node_id": "id", "type": "branch_policy"}], "deployment_branch_policy": {"protected_branches": true, "custom_branch_policies": false}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	release, _, err := client.Repositories.createNewEnvNoEnterprise(ctx, "repos/o/r/environments/e", input)
 	if err != nil {
 		t.Errorf("Repositories.createNewEnvNoEnterprise returned error: %v", err)
@@ -335,7 +334,7 @@ func TestRepositoriesService_DeleteEnvironment(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeleteEnvironment(ctx, "o", "r", "e")
 	if err != nil {
 		t.Errorf("Repositories.DeleteEnvironment returned error: %v", err)

--- a/github/repos_forks_test.go
+++ b/github/repos_forks_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -33,7 +32,7 @@ func TestRepositoriesService_ListForks(t *testing.T) {
 		Sort:        "newest",
 		ListOptions: ListOptions{Page: 3},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	repos, _, err := client.Repositories.ListForks(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListForks returned error: %v", err)
@@ -63,7 +62,7 @@ func TestRepositoriesService_ListForks_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListForks(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
@@ -79,7 +78,7 @@ func TestRepositoriesService_CreateFork(t *testing.T) {
 	})
 
 	opt := &RepositoryCreateForkOptions{Organization: "o", Name: "n", DefaultBranchOnly: true}
-	ctx := context.Background()
+	ctx := t.Context()
 	repo, _, err := client.Repositories.CreateFork(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.CreateFork returned error: %v", err)
@@ -118,7 +117,7 @@ func TestRepositoriesService_CreateFork_deferred(t *testing.T) {
 	})
 
 	opt := &RepositoryCreateForkOptions{Organization: "o", Name: "n", DefaultBranchOnly: true}
-	ctx := context.Background()
+	ctx := t.Context()
 	repo, _, err := client.Repositories.CreateFork(ctx, "o", "r", opt)
 	if !errors.As(err, new(*AcceptedError)) {
 		t.Errorf("Repositories.CreateFork returned error: %v (want AcceptedError)", err)
@@ -134,7 +133,7 @@ func TestRepositoriesService_CreateFork_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.CreateFork(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }

--- a/github/repos_hooks_configuration_test.go
+++ b/github/repos_hooks_configuration_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -24,7 +23,7 @@ func TestRepositoriesService_GetHookConfiguration(t *testing.T) {
 		fmt.Fprint(w, `{"content_type": "json", "insecure_ssl": "0", "secret": "********", "url": "https://example.com/webhook"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	config, _, err := client.Repositories.GetHookConfiguration(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetHookConfiguration returned error: %v", err)
@@ -59,7 +58,7 @@ func TestRepositoriesService_GetHookConfiguration_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.GetHookConfiguration(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }
@@ -82,7 +81,7 @@ func TestRepositoriesService_EditHookConfiguration(t *testing.T) {
 		fmt.Fprint(w, `{"content_type": "json", "insecure_ssl": "0", "secret": "********", "url": "https://example.com/webhook"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	config, _, err := client.Repositories.EditHookConfiguration(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Repositories.EditHookConfiguration returned error: %v", err)
@@ -117,7 +116,7 @@ func TestRepositoriesService_EditHookConfiguration_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.EditHookConfiguration(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }

--- a/github/repos_hooks_deliveries_test.go
+++ b/github/repos_hooks_deliveries_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -27,7 +26,7 @@ func TestRepositoriesService_ListHookDeliveries(t *testing.T) {
 
 	opt := &ListCursorOptions{Cursor: "v1_12077215967"}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hooks, _, err := client.Repositories.ListHookDeliveries(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Repositories.ListHookDeliveries returned error: %v", err)
@@ -57,7 +56,7 @@ func TestRepositoriesService_ListHookDeliveries_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListHookDeliveries(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }
@@ -71,7 +70,7 @@ func TestRepositoriesService_GetHookDelivery(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Repositories.GetHookDelivery(ctx, "o", "r", 1, 1)
 	if err != nil {
 		t.Errorf("Repositories.GetHookDelivery returned error: %v", err)
@@ -101,7 +100,7 @@ func TestRepositoriesService_GetHookDelivery_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.GetHookDelivery(ctx, "%", "%", 1, 1)
 	testURLParseError(t, err)
 }
@@ -115,7 +114,7 @@ func TestRepositoriesService_RedeliverHookDelivery(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Repositories.RedeliverHookDelivery(ctx, "o", "r", 1, 1)
 	if err != nil {
 		t.Errorf("Repositories.RedeliverHookDelivery returned error: %v", err)

--- a/github/repos_hooks_test.go
+++ b/github/repos_hooks_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -34,7 +33,7 @@ func TestRepositoriesService_CreateHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Repositories.CreateHook(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.CreateHook returned error: %v", err)
@@ -76,7 +75,7 @@ func TestRepositoriesService_ListHooks(t *testing.T) {
 
 	opt := &ListOptions{Page: 2}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hooks, _, err := client.Repositories.ListHooks(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListHooks returned error: %v", err)
@@ -106,7 +105,7 @@ func TestRepositoriesService_ListHooks_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListHooks(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
@@ -130,7 +129,7 @@ func TestRepositoriesService_GetHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Repositories.GetHook(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetHook returned error: %v", err)
@@ -160,7 +159,7 @@ func TestRepositoriesService_GetHook_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.GetHook(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }
@@ -183,7 +182,7 @@ func TestRepositoriesService_EditHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Repositories.EditHook(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Repositories.EditHook returned error: %v", err)
@@ -213,7 +212,7 @@ func TestRepositoriesService_EditHook_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.EditHook(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }
@@ -226,7 +225,7 @@ func TestRepositoriesService_DeleteHook(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeleteHook(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeleteHook returned error: %v", err)
@@ -247,7 +246,7 @@ func TestRepositoriesService_DeleteHook_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeleteHook(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }
@@ -260,7 +259,7 @@ func TestRepositoriesService_PingHook(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.PingHook(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.PingHook returned error: %v", err)
@@ -285,7 +284,7 @@ func TestRepositoriesService_TestHook(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.TestHook(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.TestHook returned error: %v", err)
@@ -306,7 +305,7 @@ func TestRepositoriesService_TestHook_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.TestHook(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }
@@ -585,7 +584,7 @@ func TestRepositoriesService_Subscribe(t *testing.T) {
 		})
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.Subscribe(
 		ctx,
 		"o",
@@ -618,7 +617,7 @@ func TestRepositoriesService_Unsubscribe(t *testing.T) {
 		})
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.Unsubscribe(
 		ctx,
 		"o",

--- a/github/repos_invitations_test.go
+++ b/github/repos_invitations_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -25,7 +24,7 @@ func TestRepositoriesService_ListInvitations(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.ListInvitations(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListInvitations returned error: %v", err)
@@ -60,7 +59,7 @@ func TestRepositoriesService_DeleteInvitation(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeleteInvitation(ctx, "o", "r", 2)
 	if err != nil {
 		t.Errorf("Repositories.DeleteInvitation returned error: %v", err)
@@ -86,7 +85,7 @@ func TestRepositoriesService_UpdateInvitation(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.UpdateInvitation(ctx, "o", "r", 2, "write")
 	if err != nil {
 		t.Errorf("Repositories.UpdateInvitation returned error: %v", err)

--- a/github/repos_keys_test.go
+++ b/github/repos_keys_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,7 +25,7 @@ func TestRepositoriesService_ListKeys(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	keys, _, err := client.Repositories.ListKeys(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListKeys returned error: %v", err)
@@ -56,7 +55,7 @@ func TestRepositoriesService_ListKeys_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListKeys(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
@@ -70,7 +69,7 @@ func TestRepositoriesService_GetKey(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	key, _, err := client.Repositories.GetKey(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetKey returned error: %v", err)
@@ -100,7 +99,7 @@ func TestRepositoriesService_GetKey_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.GetKey(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }
@@ -123,7 +122,7 @@ func TestRepositoriesService_CreateKey(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	key, _, err := client.Repositories.CreateKey(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.GetKey returned error: %v", err)
@@ -153,7 +152,7 @@ func TestRepositoriesService_CreateKey_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.CreateKey(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
@@ -166,7 +165,7 @@ func TestRepositoriesService_DeleteKey(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeleteKey(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeleteKey returned error: %v", err)
@@ -187,7 +186,7 @@ func TestRepositoriesService_DeleteKey_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeleteKey(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }

--- a/github/repos_lfs_test.go
+++ b/github/repos_lfs_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"net/http"
 	"testing"
 )
@@ -21,7 +20,7 @@ func TestRepositoriesService_EnableLFS(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Repositories.EnableLFS(ctx, "o", "r"); err != nil {
 		t.Errorf("Repositories.EnableLFS returned error: %v", err)
 	}
@@ -47,7 +46,7 @@ func TestRepositoriesService_DisableLFS(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Repositories.DisableLFS(ctx, "o", "r"); err != nil {
 		t.Errorf("Repositories.DisableLFS returned error: %v", err)
 	}

--- a/github/repos_merging_test.go
+++ b/github/repos_merging_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -37,7 +36,7 @@ func TestRepositoriesService_Merge(t *testing.T) {
 		fmt.Fprint(w, `{"sha":"s"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	commit, _, err := client.Repositories.Merge(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.Merge returned error: %v", err)
@@ -102,7 +101,7 @@ func TestRepositoriesService_MergeUpstream(t *testing.T) {
 		fmt.Fprint(w, `{"merge_type":"m"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	result, _, err := client.Repositories.MergeUpstream(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.MergeUpstream returned error: %v", err)

--- a/github/repos_pages_test.go
+++ b/github/repos_pages_test.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -44,7 +43,7 @@ func TestRepositoriesService_EnablePagesLegacy(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u","status":"s","cname":"c","custom_404":false,"html_url":"h","build_type": "legacy","source": {"branch":"master", "path":"/"}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	page, _, err := client.Repositories.EnablePages(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.EnablePages returned error: %v", err)
@@ -98,7 +97,7 @@ func TestRepositoriesService_EnablePagesWorkflow(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u","status":"s","cname":"c","custom_404":false,"html_url":"h","build_type": "workflow"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	page, _, err := client.Repositories.EnablePages(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.EnablePages returned error: %v", err)
@@ -148,7 +147,7 @@ func TestRepositoriesService_UpdatePagesLegacy(t *testing.T) {
 		fmt.Fprint(w, `{"cname":"www.my-domain.com","build_type":"legacy","source":{"branch":"gh-pages"}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.UpdatePages(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.UpdatePages returned error: %v", err)
@@ -187,7 +186,7 @@ func TestRepositoriesService_UpdatePagesWorkflow(t *testing.T) {
 		fmt.Fprint(w, `{"cname":"www.my-domain.com","build_type":"workflow"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.UpdatePages(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.UpdatePages returned error: %v", err)
@@ -225,7 +224,7 @@ func TestRepositoriesService_UpdatePagesGHES(t *testing.T) {
 		fmt.Fprint(w, `{"build_type":"workflow"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.UpdatePagesGHES(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.UpdatePagesGHES returned error: %v", err)
@@ -264,7 +263,7 @@ func TestRepositoriesService_UpdatePages_NullCNAME(t *testing.T) {
 		fmt.Fprint(w, `{"cname":null,"source":{"branch":"gh-pages"}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.UpdatePages(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.UpdatePages returned error: %v", err)
@@ -280,7 +279,7 @@ func TestRepositoriesService_DisablePages(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeEnablePagesAPIPreview)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DisablePages(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.DisablePages returned error: %v", err)
@@ -306,7 +305,7 @@ func TestRepositoriesService_GetPagesInfo(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u","status":"s","cname":"c","custom_404":false,"html_url":"h","public":true, "https_certificate": {"state":"approved","description": "Certificate is approved","domains": ["developer.github.com"],"expires_at": "2021-05-22"},"https_enforced": true}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	page, _, err := client.Repositories.GetPagesInfo(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetPagesInfo returned error: %v", err)
@@ -341,7 +340,7 @@ func TestRepositoriesService_ListPagesBuilds(t *testing.T) {
 		fmt.Fprint(w, `[{"url":"u","status":"s","commit":"c"}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	pages, _, err := client.Repositories.ListPagesBuilds(ctx, "o", "r", nil)
 	if err != nil {
 		t.Errorf("Repositories.ListPagesBuilds returned error: %v", err)
@@ -379,7 +378,7 @@ func TestRepositoriesService_ListPagesBuilds_withOptions(t *testing.T) {
 		fmt.Fprint(w, `[]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListPagesBuilds(ctx, "o", "r", &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Repositories.ListPagesBuilds returned error: %v", err)
@@ -395,7 +394,7 @@ func TestRepositoriesService_GetLatestPagesBuild(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u","status":"s","commit":"c"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	build, _, err := client.Repositories.GetLatestPagesBuild(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetLatestPagesBuild returned error: %v", err)
@@ -430,7 +429,7 @@ func TestRepositoriesService_GetPageBuild(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u","status":"s","commit":"c"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	build, _, err := client.Repositories.GetPageBuild(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetPageBuild returned error: %v", err)
@@ -465,7 +464,7 @@ func TestRepositoriesService_RequestPageBuild(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u","status":"s"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	build, _, err := client.Repositories.RequestPageBuild(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.RequestPageBuild returned error: %v", err)
@@ -500,7 +499,7 @@ func TestRepositoriesService_GetPageHealthCheck(t *testing.T) {
 		fmt.Fprint(w, `{"domain":{"host":"example.com","uri":"http://example.com/","nameservers":"default","dns_resolves":true},"alt_domain":{"host":"www.example.com","uri":"http://www.example.com/","nameservers":"default","dns_resolves":true}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	healthCheckResponse, _, err := client.Repositories.GetPageHealthCheck(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetPageHealthCheck returned error: %v", err)

--- a/github/repos_prereceive_hooks_test.go
+++ b/github/repos_prereceive_hooks_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -28,7 +27,7 @@ func TestRepositoriesService_ListPreReceiveHooks(t *testing.T) {
 
 	opt := &ListOptions{Page: 2}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hooks, _, err := client.Repositories.ListPreReceiveHooks(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListHooks returned error: %v", err)
@@ -58,7 +57,7 @@ func TestRepositoriesService_ListPreReceiveHooks_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListPreReceiveHooks(ctx, "%", "%", nil)
 	testURLParseError(t, err)
 }
@@ -73,7 +72,7 @@ func TestRepositoriesService_GetPreReceiveHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Repositories.GetPreReceiveHook(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetPreReceiveHook returned error: %v", err)
@@ -103,7 +102,7 @@ func TestRepositoriesService_GetPreReceiveHook_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.GetPreReceiveHook(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }
@@ -126,7 +125,7 @@ func TestRepositoriesService_UpdatePreReceiveHook(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	hook, _, err := client.Repositories.UpdatePreReceiveHook(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Repositories.UpdatePreReceiveHook returned error: %v", err)
@@ -156,7 +155,7 @@ func TestRepositoriesService_PreReceiveHook_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.UpdatePreReceiveHook(ctx, "%", "%", 1, nil)
 	testURLParseError(t, err)
 }
@@ -169,7 +168,7 @@ func TestRepositoriesService_DeletePreReceiveHook(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeletePreReceiveHook(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeletePreReceiveHook returned error: %v", err)
@@ -190,7 +189,7 @@ func TestRepositoriesService_DeletePreReceiveHook_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeletePreReceiveHook(ctx, "%", "%", 1)
 	testURLParseError(t, err)
 }

--- a/github/repos_properties_test.go
+++ b/github/repos_properties_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -40,7 +39,7 @@ func TestRepositoriesService_GetAllCustomPropertyValues(t *testing.T) {
 		]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	customPropertyValues, _, err := client.Repositories.GetAllCustomPropertyValues(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetAllCustomPropertyValues returned error: %v", err)
@@ -89,7 +88,7 @@ func TestRepositoriesService_CreateOrUpdateCustomProperties(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	repoCustomProperty := []*CustomPropertyValue{
 		{
 			PropertyName: "environment",

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -29,7 +28,7 @@ func TestRepositoriesService_ListReleases(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	releases, _, err := client.Repositories.ListReleases(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListReleases returned error: %v", err)
@@ -67,7 +66,7 @@ func TestRepositoriesService_GenerateReleaseNotes(t *testing.T) {
 	opt := &GenerateNotesOptions{
 		TagName: "v1.0.0",
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	releases, _, err := client.Repositories.GenerateReleaseNotes(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.GenerateReleaseNotes returned error: %v", err)
@@ -104,7 +103,7 @@ func TestRepositoriesService_GetRelease(t *testing.T) {
 		fmt.Fprint(w, `{"id":1,"author":{"login":"l"}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	release, resp, err := client.Repositories.GetRelease(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetRelease returned error: %v\n%v", err, resp.Body)
@@ -139,7 +138,7 @@ func TestRepositoriesService_GetLatestRelease(t *testing.T) {
 		fmt.Fprint(w, `{"id":3}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	release, resp, err := client.Repositories.GetLatestRelease(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetLatestRelease returned error: %v\n%v", err, resp.Body)
@@ -174,7 +173,7 @@ func TestRepositoriesService_GetReleaseByTag(t *testing.T) {
 		fmt.Fprint(w, `{"id":13}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	release, resp, err := client.Repositories.GetReleaseByTag(ctx, "o", "r", "foo")
 	if err != nil {
 		t.Errorf("Repositories.GetReleaseByTag returned error: %v\n%v", err, resp.Body)
@@ -240,7 +239,7 @@ func TestRepositoriesService_CreateRelease(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	release, _, err := client.Repositories.CreateRelease(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.CreateRelease returned error: %v", err)
@@ -309,7 +308,7 @@ func TestRepositoriesService_EditRelease(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	release, _, err := client.Repositories.EditRelease(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Repositories.EditRelease returned error: %v", err)
@@ -346,7 +345,7 @@ func TestRepositoriesService_DeleteRelease(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeleteRelease(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeleteRelease returned error: %v", err)
@@ -374,7 +373,7 @@ func TestRepositoriesService_ListReleaseAssets(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	assets, _, err := client.Repositories.ListReleaseAssets(ctx, "o", "r", 1, opt)
 	if err != nil {
 		t.Errorf("Repositories.ListReleaseAssets returned error: %v", err)
@@ -408,7 +407,7 @@ func TestRepositoriesService_GetReleaseAsset(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	asset, _, err := client.Repositories.GetReleaseAsset(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetReleaseAsset returned error: %v", err)
@@ -445,7 +444,7 @@ func TestRepositoriesService_DownloadReleaseAsset_Stream(t *testing.T) {
 		fmt.Fprint(w, "Hello World")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	reader, _, err := client.Repositories.DownloadReleaseAsset(ctx, "o", "r", 1, nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
@@ -476,7 +475,7 @@ func TestRepositoriesService_DownloadReleaseAsset_Redirect(t *testing.T) {
 		http.Redirect(w, r, "/yo", http.StatusFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, got, err := client.Repositories.DownloadReleaseAsset(ctx, "o", "r", 1, nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
@@ -505,7 +504,7 @@ func TestRepositoriesService_DownloadReleaseAsset_FollowRedirect(t *testing.T) {
 		fmt.Fprint(w, "Hello World")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	reader, _, err := client.Repositories.DownloadReleaseAsset(ctx, "o", "r", 1, http.DefaultClient)
 	if err != nil {
 		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
@@ -547,7 +546,7 @@ func TestRepositoriesService_DownloadReleaseAsset_FollowMultipleRedirects(t *tes
 		fmt.Fprint(w, "Hello World")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	reader, _, err := client.Repositories.DownloadReleaseAsset(ctx, "o", "r", 1, http.DefaultClient)
 	if err != nil {
 		t.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
@@ -579,7 +578,7 @@ func TestRepositoriesService_DownloadReleaseAsset_FollowRedirectToError(t *testi
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, loc, err := client.Repositories.DownloadReleaseAsset(ctx, "o", "r", 1, http.DefaultClient)
 	if err == nil {
 		t.Error("Repositories.DownloadReleaseAsset did not return an error")
@@ -604,7 +603,7 @@ func TestRepositoriesService_DownloadReleaseAsset_APIError(t *testing.T) {
 		fmt.Fprint(w, `{"message":"Not Found","documentation_url":"https://developer.github.com/v3"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, loc, err := client.Repositories.DownloadReleaseAsset(ctx, "o", "r", 1, nil)
 	if err == nil {
 		t.Error("Repositories.DownloadReleaseAsset did not return an error")
@@ -637,7 +636,7 @@ func TestRepositoriesService_EditReleaseAsset(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	asset, _, err := client.Repositories.EditReleaseAsset(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Repositories.EditReleaseAsset returned error: %v", err)
@@ -670,7 +669,7 @@ func TestRepositoriesService_DeleteReleaseAsset(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeleteReleaseAsset(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeleteReleaseAsset returned error: %v", err)
@@ -760,7 +759,7 @@ func TestRepositoriesService_UploadReleaseAsset(t *testing.T) {
 
 		file := openTestFile(t, test.fileName, "Upload me !\n")
 
-		ctx := context.Background()
+		ctx := t.Context()
 		asset, _, err := client.Repositories.UploadReleaseAsset(ctx, "o", "r", int64(key), test.uploadOpts, file)
 		if err != nil {
 			t.Errorf("Repositories.UploadReleaseAssert returned error: %v", err)

--- a/github/repos_rules_test.go
+++ b/github/repos_rules_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -39,7 +38,7 @@ func TestRepositoriesService_GetRulesForBranch(t *testing.T) {
 		]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rules, _, err := client.Repositories.GetRulesForBranch(ctx, "o", "repo", "branch", nil)
 	if err != nil {
 		t.Errorf("Repositories.GetRulesForBranch returned error: %v", err)
@@ -83,7 +82,7 @@ func TestRepositoriesService_GetRulesForBranch_ListOptions(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2, PerPage: 35}
-	ctx := context.Background()
+	ctx := t.Context()
 	rules, _, err := client.Repositories.GetRulesForBranch(ctx, "o", "repo", "branch", opts)
 	if err != nil {
 		t.Errorf("Repositories.GetRulesForBranch returned error: %v", err)
@@ -140,7 +139,7 @@ func TestRepositoriesService_GetAllRulesets(t *testing.T) {
 		]`, referenceTimeStr)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ruleSet, _, err := client.Repositories.GetAllRulesets(ctx, "o", "repo", nil)
 	if err != nil {
 		t.Errorf("Repositories.GetAllRulesets returned error: %v", err)
@@ -205,7 +204,7 @@ func TestRepositoriesService_GetAllRulesets_ListOptions(t *testing.T) {
 			PerPage: 35,
 		},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	ruleSet, _, err := client.Repositories.GetAllRulesets(ctx, "o", "repo", opts)
 	if err != nil {
 		t.Errorf("Repositories.GetAllRulesets returned error: %v", err)
@@ -250,7 +249,7 @@ func TestRepositoriesService_CreateRuleset(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ruleSet, _, err := client.Repositories.CreateRuleset(ctx, "o", "repo", RepositoryRuleset{
 		Name:        "ruleset",
 		Enforcement: RulesetEnforcementActive,
@@ -323,7 +322,7 @@ func TestRepositoriesService_CreateRulesetWithPushRules(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ruleSet, _, err := client.Repositories.CreateRuleset(ctx, "o", "repo", RepositoryRuleset{
 		Name:        "ruleset",
 		Enforcement: RulesetEnforcementActive,
@@ -378,7 +377,7 @@ func TestRepositoriesService_GetRuleset(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ruleSet, _, err := client.Repositories.GetRuleset(ctx, "o", "repo", 42, true)
 	if err != nil {
 		t.Errorf("Repositories.GetRuleset returned error: %v", err)
@@ -423,7 +422,7 @@ func TestRepositoriesService_UpdateRuleset(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ruleSet, _, err := client.Repositories.UpdateRuleset(ctx, "o", "repo", 42, RepositoryRuleset{
 		Name:        "ruleset",
 		Enforcement: RulesetEnforcementActive,
@@ -487,7 +486,7 @@ func TestRepositoriesService_UpdateRulesetClearBypassActor(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := client.Repositories.UpdateRulesetClearBypassActor(ctx, "o", "repo", 42)
 	if err != nil {
@@ -522,7 +521,7 @@ func TestRepositoriesService_UpdateRulesetNoBypassActor(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ruleSet, _, err := client.Repositories.UpdateRulesetNoBypassActor(ctx, "o", "repo", 42, rs)
 	if err != nil {
@@ -560,7 +559,7 @@ func TestRepositoriesService_DeleteRuleset(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeleteRuleset(ctx, "o", "repo", 42)
 	if err != nil {
 		t.Errorf("Repositories.DeleteRuleset returned error: %v", err)

--- a/github/repos_stats_test.go
+++ b/github/repos_stats_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -44,7 +43,7 @@ func TestRepositoriesService_ListContributorsStats(t *testing.T) {
 `)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	stats, _, err := client.Repositories.ListContributorsStats(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("RepositoriesService.ListContributorsStats returned error: %v", err)
@@ -105,7 +104,7 @@ func TestRepositoriesService_ListCommitActivity(t *testing.T) {
 `)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	activity, _, err := client.Repositories.ListCommitActivity(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("RepositoriesService.ListCommitActivity returned error: %v", err)
@@ -148,7 +147,7 @@ func TestRepositoriesService_ListCodeFrequency(t *testing.T) {
 		fmt.Fprint(w, `[[1302998400, 1124, -435]]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	code, _, err := client.Repositories.ListCodeFrequency(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("RepositoriesService.ListCodeFrequency returned error: %v", err)
@@ -204,7 +203,7 @@ func TestRepositoriesService_Participation(t *testing.T) {
 `)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	participation, _, err := client.Repositories.ListParticipation(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("RepositoriesService.ListParticipation returned error: %v", err)
@@ -258,7 +257,7 @@ func TestRepositoriesService_ListPunchCard(t *testing.T) {
 		]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	card, _, err := client.Repositories.ListPunchCard(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("RepositoriesService.ListPunchCard returned error: %v", err)
@@ -300,7 +299,7 @@ func TestRepositoriesService_AcceptedError(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	stats, _, err := client.Repositories.ListContributorsStats(ctx, "o", "r")
 	if err == nil {
 		t.Error("RepositoriesService.AcceptedError should have returned an error")

--- a/github/repos_statuses_test.go
+++ b/github/repos_statuses_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,7 +25,7 @@ func TestRepositoriesService_ListStatuses(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	statuses, _, err := client.Repositories.ListStatuses(ctx, "o", "r", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListStatuses returned error: %v", err)
@@ -56,7 +55,7 @@ func TestRepositoriesService_ListStatuses_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListStatuses(ctx, "%", "r", "r", nil)
 	testURLParseError(t, err)
 }
@@ -78,7 +77,7 @@ func TestRepositoriesService_CreateStatus(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	status, _, err := client.Repositories.CreateStatus(ctx, "o", "r", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.CreateStatus returned error: %v", err)
@@ -108,7 +107,7 @@ func TestRepositoriesService_CreateStatus_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.CreateStatus(ctx, "%", "r", "r", nil)
 	testURLParseError(t, err)
 }
@@ -124,7 +123,7 @@ func TestRepositoriesService_GetCombinedStatus(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	status, _, err := client.Repositories.GetCombinedStatus(ctx, "o", "r", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.GetCombinedStatus returned error: %v", err)

--- a/github/repos_tags_test.go
+++ b/github/repos_tags_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -25,7 +24,7 @@ func TestRepositoriesService_ListTagProtection(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1, "pattern":"tag1"},{"id":2, "pattern":"tag2"}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tagProtections, _, err := client.Repositories.ListTagProtection(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.ListTagProtection returned error: %v", err)
@@ -55,7 +54,7 @@ func TestRepositoriesService_ListTagProtection_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListTagProtection(ctx, "%", "r")
 	testURLParseError(t, err)
 }
@@ -79,7 +78,7 @@ func TestRepositoriesService_CreateTagProtection(t *testing.T) {
 		fmt.Fprint(w, `{"id":1,"pattern":"tag*"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.CreateTagProtection(ctx, "o", "r", pattern)
 	if err != nil {
 		t.Errorf("Repositories.CreateTagProtection returned error: %v", err)
@@ -114,7 +113,7 @@ func TestRepositoriesService_DeleteTagProtection(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DeleteTagProtection(ctx, "o", "r", 1)
 	if err != nil {
 		t.Errorf("Repositories.DeleteTagProtection returned error: %v", err)

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,7 +27,7 @@ func TestRepositoriesService_ListByAuthenticatedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.ListByAuthenticatedUser(ctx, nil)
 	if err != nil {
 		t.Errorf("Repositories.List returned error: %v", err)
@@ -69,7 +68,7 @@ func TestRepositoriesService_ListByUser(t *testing.T) {
 		Direction:   "asc",
 		ListOptions: ListOptions{Page: 2},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	repos, _, err := client.Repositories.ListByUser(ctx, "u", opt)
 	if err != nil {
 		t.Errorf("Repositories.List returned error: %v", err)
@@ -110,7 +109,7 @@ func TestRepositoriesService_ListByUser_type(t *testing.T) {
 	opt := &RepositoryListByUserOptions{
 		Type: "owner",
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	repos, _, err := client.Repositories.ListByUser(ctx, "u", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListByUser returned error: %v", err)
@@ -126,7 +125,7 @@ func TestRepositoriesService_ListByUser_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListByUser(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -146,7 +145,7 @@ func TestRepositoriesService_ListByOrg(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opt := &RepositoryListByOrgOptions{
 		Type:        "forks",
 		ListOptions: ListOptions{Page: 2},
@@ -180,7 +179,7 @@ func TestRepositoriesService_ListByOrg_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListByOrg(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -197,7 +196,7 @@ func TestRepositoriesService_ListAll(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opt := &RepositoryListAllOptions{1}
 	got, _, err := client.Repositories.ListAll(ctx, opt)
 	if err != nil {
@@ -243,7 +242,7 @@ func TestRepositoriesService_Create_user(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.Create(ctx, "", input)
 	if err != nil {
 		t.Errorf("Repositories.Create returned error: %v", err)
@@ -297,7 +296,7 @@ func TestRepositoriesService_Create_org(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	repo, _, err := client.Repositories.Create(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Repositories.Create returned error: %v", err)
@@ -331,7 +330,7 @@ func TestRepositoriesService_CreateFromTemplate(t *testing.T) {
 		fmt.Fprint(w, `{"id":1,"name":"n"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.CreateFromTemplate(ctx, "to", "tr", templateRepoReq)
 	if err != nil {
 		t.Errorf("Repositories.CreateFromTemplate returned error: %v", err)
@@ -368,7 +367,7 @@ func TestRepositoriesService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"id":1,"name":"n","description":"d","owner":{"login":"l"},"license":{"key":"mit"},"security_and_analysis":{"advanced_security":{"status":"enabled"},"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"},"dependabot_security_updates":{"status": "enabled"}, "secret_scanning_validity_checks":{"status":"enabled"}}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.Get(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.Get returned error: %v", err)
@@ -411,7 +410,7 @@ func TestRepositoriesService_GetCodeOfConduct(t *testing.T) {
 		)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.GetCodeOfConduct(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetCodeOfConduct returned error: %v", err)
@@ -452,7 +451,7 @@ func TestRepositoriesService_GetByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":1,"name":"n","description":"d","owner":{"login":"l"},"license":{"key":"mit"}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.GetByID(ctx, 1)
 	if err != nil {
 		t.Fatalf("Repositories.GetByID returned error: %v", err)
@@ -493,7 +492,7 @@ func TestRepositoriesService_Edit(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.Edit(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.Edit returned error: %v", err)
@@ -527,7 +526,7 @@ func TestRepositoriesService_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.Delete(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.Delete returned error: %v", err)
@@ -548,7 +547,7 @@ func TestRepositoriesService_Get_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.Get(ctx, "%", "r")
 	testURLParseError(t, err)
 }
@@ -557,7 +556,7 @@ func TestRepositoriesService_Edit_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.Edit(ctx, "%", "r", nil)
 	testURLParseError(t, err)
 }
@@ -573,7 +572,7 @@ func TestRepositoriesService_GetVulnerabilityAlerts(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	vulnerabilityAlertsEnabled, _, err := client.Repositories.GetVulnerabilityAlerts(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetVulnerabilityAlerts returned error: %v", err)
@@ -609,7 +608,7 @@ func TestRepositoriesService_EnableVulnerabilityAlerts(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Repositories.EnableVulnerabilityAlerts(ctx, "o", "r"); err != nil {
 		t.Errorf("Repositories.EnableVulnerabilityAlerts returned error: %v", err)
 	}
@@ -636,7 +635,7 @@ func TestRepositoriesService_DisableVulnerabilityAlerts(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Repositories.DisableVulnerabilityAlerts(ctx, "o", "r"); err != nil {
 		t.Errorf("Repositories.DisableVulnerabilityAlerts returned error: %v", err)
 	}
@@ -662,7 +661,7 @@ func TestRepositoriesService_EnableAutomatedSecurityFixes(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Repositories.EnableAutomatedSecurityFixes(ctx, "o", "r"); err != nil {
 		t.Errorf("Repositories.EnableAutomatedSecurityFixes returned error: %v", err)
 	}
@@ -677,7 +676,7 @@ func TestRepositoriesService_GetAutomatedSecurityFixes(t *testing.T) {
 		fmt.Fprint(w, `{"enabled": true, "paused": false}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	fixes, _, err := client.Repositories.GetAutomatedSecurityFixes(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.GetAutomatedSecurityFixes returned error: %v", err)
@@ -715,7 +714,7 @@ func TestRepositoriesService_DisableAutomatedSecurityFixes(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Repositories.DisableAutomatedSecurityFixes(ctx, "o", "r"); err != nil {
 		t.Errorf("Repositories.DisableAutomatedSecurityFixes returned error: %v", err)
 	}
@@ -735,7 +734,7 @@ func TestRepositoriesService_ListContributors(t *testing.T) {
 	})
 
 	opts := &ListContributorsOptions{Anon: "true", ListOptions: ListOptions{Page: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	contributors, _, err := client.Repositories.ListContributors(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Repositories.ListContributors returned error: %v", err)
@@ -770,7 +769,7 @@ func TestRepositoriesService_ListLanguages(t *testing.T) {
 		fmt.Fprint(w, `{"go":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	languages, _, err := client.Repositories.ListLanguages(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.ListLanguages returned error: %v", err)
@@ -807,7 +806,7 @@ func TestRepositoriesService_ListTeams(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	teams, _, err := client.Repositories.ListTeams(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListTeams returned error: %v", err)
@@ -844,7 +843,7 @@ func TestRepositoriesService_ListTags(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	tags, _, err := client.Repositories.ListTags(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListTags returned error: %v", err)
@@ -894,7 +893,7 @@ func TestRepositoriesService_ListBranches(t *testing.T) {
 		Protected:   nil,
 		ListOptions: ListOptions{Page: 2},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	branches, _, err := client.Repositories.ListBranches(ctx, "o", "r", opt)
 	if err != nil {
 		t.Errorf("Repositories.ListBranches returned error: %v", err)
@@ -938,7 +937,7 @@ func TestRepositoriesService_GetBranch(t *testing.T) {
 			fmt.Fprint(w, `{"name":"n", "commit":{"sha":"s","commit":{"message":"m"}}, "protected":true, "protection":{"required_status_checks":{"contexts":["c"]}}}`)
 		})
 
-		ctx := context.Background()
+		ctx := t.Context()
 		branch, _, err := client.Repositories.GetBranch(ctx, "o", "r", test.branch, 0)
 		if err != nil {
 			t.Errorf("Repositories.GetBranch returned error: %v", err)
@@ -992,7 +991,7 @@ func TestRepositoriesService_GetBranch_BadJSONResponse(t *testing.T) {
 				fmt.Fprint(w, `{"name":"n", "commit":{"sha":...truncated`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			if _, _, err := client.Repositories.GetBranch(ctx, "o", "r", test.branch, 0); err == nil {
 				t.Error("Repositories.GetBranch returned no error; wanted JSON error")
 			}
@@ -1013,7 +1012,7 @@ func TestRepositoriesService_GetBranch_StatusMovedPermanently_followRedirects(t 
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"name":"n", "commit":{"sha":"s","commit":{"message":"m"}}, "protected":true, "protection":{"required_status_checks":{"contexts":["c"]}}}`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	branch, resp, err := client.Repositories.GetBranch(ctx, "o", "r", "b", 1)
 	if err != nil {
 		t.Errorf("Repositories.GetBranch returned error: %v", err)
@@ -1061,7 +1060,7 @@ func TestRepositoriesService_GetBranch_notFound(t *testing.T) {
 				testMethod(t, r, "GET")
 				http.Error(w, "branch not found", http.StatusNotFound)
 			})
-			ctx := context.Background()
+			ctx := t.Context()
 			_, resp, err := client.Repositories.GetBranch(ctx, "o", "r", test.branch, 1)
 			if err == nil {
 				t.Error("Repositories.GetBranch returned error: nil")
@@ -1114,7 +1113,7 @@ func TestRepositoriesService_RenameBranch(t *testing.T) {
 				fmt.Fprint(w, `{"protected":true,"name":"nn"}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			got, _, err := client.Repositories.RenameBranch(ctx, "o", "r", test.branch, renameBranchReq)
 			if err != nil {
 				t.Errorf("Repositories.RenameBranch returned error: %v", err)
@@ -1217,7 +1216,7 @@ func TestRepositoriesService_GetBranchProtection(t *testing.T) {
 						}`, test.enforceAdminsURLPath)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			protection, _, err := client.Repositories.GetBranchProtection(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.GetBranchProtection returned error: %v", err)
@@ -1344,7 +1343,7 @@ func TestRepositoriesService_GetBranchProtection_noDismissalRestrictions(t *test
 					}`, test.enforceAdminsURLPath)
 		})
 
-		ctx := context.Background()
+		ctx := t.Context()
 		protection, _, err := client.Repositories.GetBranchProtection(ctx, "o", "r", test.branch)
 		if err != nil {
 			t.Errorf("Repositories.GetBranchProtection returned error: %v", err)
@@ -1410,7 +1409,7 @@ func TestRepositoriesService_GetBranchProtection_branchNotProtected(t *testing.T
 					}`, githubBranchNotProtected)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			protection, _, err := client.Repositories.GetBranchProtection(ctx, "o", "r", test.branch)
 
 			if protection != nil {
@@ -1529,7 +1528,7 @@ func TestRepositoriesService_UpdateBranchProtection_Contexts(t *testing.T) {
 				}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			protection, _, err := client.Repositories.UpdateBranchProtection(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.UpdateBranchProtection returned error: %v", err)
@@ -1713,7 +1712,7 @@ func TestRepositoriesService_UpdateBranchProtection_EmptyContexts(t *testing.T) 
 				}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			protection, _, err := client.Repositories.UpdateBranchProtection(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.UpdateBranchProtection returned error: %v", err)
@@ -1889,7 +1888,7 @@ func TestRepositoriesService_UpdateBranchProtection_Checks(t *testing.T) {
 				}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			protection, _, err := client.Repositories.UpdateBranchProtection(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.UpdateBranchProtection returned error: %v", err)
@@ -2038,7 +2037,7 @@ func TestRepositoriesService_UpdateBranchProtection_EmptyChecks(t *testing.T) {
 				}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			protection, _, err := client.Repositories.UpdateBranchProtection(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.UpdateBranchProtection returned error: %v", err)
@@ -2181,7 +2180,7 @@ func TestRepositoriesService_UpdateBranchProtection_StrictNoChecks(t *testing.T)
 				}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			protection, _, err := client.Repositories.UpdateBranchProtection(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.UpdateBranchProtection returned error: %v", err)
@@ -2274,7 +2273,7 @@ func TestRepositoriesService_UpdateBranchProtection_RequireLastPushApproval(t *t
 				}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			protection, _, err := client.Repositories.UpdateBranchProtection(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.UpdateBranchProtection returned error: %v", err)
@@ -2312,7 +2311,7 @@ func TestRepositoriesService_RemoveBranchProtection(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, err := client.Repositories.RemoveBranchProtection(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.RemoveBranchProtection returned error: %v", err)
@@ -2335,7 +2334,7 @@ func TestRepositoriesService_ListLanguages_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListLanguages(ctx, "%", "%")
 	testURLParseError(t, err)
 }
@@ -2349,7 +2348,7 @@ func TestRepositoriesService_License(t *testing.T) {
 		fmt.Fprint(w, `{"name": "LICENSE", "path": "LICENSE", "license":{"key":"mit","name":"MIT License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit","featured":true}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.License(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.License returned error: %v", err)
@@ -2423,7 +2422,7 @@ func TestRepositoriesService_GetRequiredStatusChecks(t *testing.T) {
 				}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			checks, _, err := client.Repositories.GetRequiredStatusChecks(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.GetRequiredStatusChecks returned error: %v", err)
@@ -2490,7 +2489,7 @@ func TestRepositoriesService_GetRequiredStatusChecks_branchNotProtected(t *testi
 			}`, githubBranchNotProtected)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			checks, _, err := client.Repositories.GetRequiredStatusChecks(ctx, "o", "r", test.branch)
 
 			if checks != nil {
@@ -2545,7 +2544,7 @@ func TestRepositoriesService_UpdateRequiredStatusChecks_Contexts(t *testing.T) {
 				}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			statusChecks, _, err := client.Repositories.UpdateRequiredStatusChecks(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.UpdateRequiredStatusChecks returned error: %v", err)
@@ -2644,7 +2643,7 @@ func TestRepositoriesService_UpdateRequiredStatusChecks_Checks(t *testing.T) {
 				}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			statusChecks, _, err := client.Repositories.UpdateRequiredStatusChecks(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.UpdateRequiredStatusChecks returned error: %v", err)
@@ -2694,7 +2693,7 @@ func TestRepositoriesService_RemoveRequiredStatusChecks(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, err := client.Repositories.RemoveRequiredStatusChecks(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.RemoveRequiredStatusChecks returned error: %v", err)
@@ -2733,7 +2732,7 @@ func TestRepositoriesService_ListRequiredStatusChecksContexts(t *testing.T) {
 				fmt.Fprint(w, `["x", "y", "z"]`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			contexts, _, err := client.Repositories.ListRequiredStatusChecksContexts(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.ListRequiredStatusChecksContexts returned error: %v", err)
@@ -2786,7 +2785,7 @@ func TestRepositoriesService_ListRequiredStatusChecksContexts_branchNotProtected
 			}`, githubBranchNotProtected)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			contexts, _, err := client.Repositories.ListRequiredStatusChecksContexts(ctx, "o", "r", test.branch)
 
 			if contexts != nil {
@@ -2831,7 +2830,7 @@ func TestRepositoriesService_GetPullRequestReviewEnforcement(t *testing.T) {
 		}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			enforcement, _, err := client.Repositories.GetPullRequestReviewEnforcement(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.GetPullRequestReviewEnforcement returned error: %v", err)
@@ -2920,7 +2919,7 @@ func TestRepositoriesService_UpdatePullRequestReviewEnforcement(t *testing.T) {
 				}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			enforcement, _, err := client.Repositories.UpdatePullRequestReviewEnforcement(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.UpdatePullRequestReviewEnforcement returned error: %v", err)
@@ -2986,7 +2985,7 @@ func TestRepositoriesService_DisableDismissalRestrictions(t *testing.T) {
 				fmt.Fprint(w, `{"dismiss_stale_reviews":true,"require_code_owner_reviews":true,"required_approving_review_count":1}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			enforcement, _, err := client.Repositories.DisableDismissalRestrictions(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.DisableDismissalRestrictions returned error: %v", err)
@@ -3039,7 +3038,7 @@ func TestRepositoriesService_RemovePullRequestReviewEnforcement(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, err := client.Repositories.RemovePullRequestReviewEnforcement(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.RemovePullRequestReviewEnforcement returned error: %v", err)
@@ -3078,7 +3077,7 @@ func TestRepositoriesService_GetAdminEnforcement(t *testing.T) {
 				fmt.Fprint(w, `{"url":"/repos/o/r/branches/b/protection/enforce_admins","enabled":true}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			enforcement, _, err := client.Repositories.GetAdminEnforcement(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.GetAdminEnforcement returned error: %v", err)
@@ -3130,7 +3129,7 @@ func TestRepositoriesService_AddAdminEnforcement(t *testing.T) {
 				fmt.Fprint(w, `{"url":"/repos/o/r/branches/b/protection/enforce_admins","enabled":true}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			enforcement, _, err := client.Repositories.AddAdminEnforcement(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.AddAdminEnforcement returned error: %v", err)
@@ -3181,7 +3180,7 @@ func TestRepositoriesService_RemoveAdminEnforcement(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, err := client.Repositories.RemoveAdminEnforcement(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.RemoveAdminEnforcement returned error: %v", err)
@@ -3221,7 +3220,7 @@ func TestRepositoriesService_GetSignaturesProtectedBranch(t *testing.T) {
 				fmt.Fprint(w, `{"url":"/repos/o/r/branches/b/protection/required_signatures","enabled":false}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			signature, _, err := client.Repositories.GetSignaturesProtectedBranch(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.GetSignaturesProtectedBranch returned error: %v", err)
@@ -3274,7 +3273,7 @@ func TestRepositoriesService_RequireSignaturesOnProtectedBranch(t *testing.T) {
 				fmt.Fprint(w, `{"url":"/repos/o/r/branches/b/protection/required_signatures","enabled":true}`)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			signature, _, err := client.Repositories.RequireSignaturesOnProtectedBranch(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.RequireSignaturesOnProtectedBranch returned error: %v", err)
@@ -3327,7 +3326,7 @@ func TestRepositoriesService_OptionalSignaturesOnProtectedBranch(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, err := client.Repositories.OptionalSignaturesOnProtectedBranch(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.OptionalSignaturesOnProtectedBranch returned error: %v", err)
@@ -3404,7 +3403,7 @@ func TestRepositoriesService_ListAllTopics(t *testing.T) {
 		fmt.Fprint(w, `{"names":["go", "go-github", "github"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.ListAllTopics(ctx, "o", "r")
 	if err != nil {
 		t.Fatalf("Repositories.ListAllTopics returned error: %v", err)
@@ -3440,7 +3439,7 @@ func TestRepositoriesService_ListAllTopics_emptyTopics(t *testing.T) {
 		fmt.Fprint(w, `{"names":[]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.ListAllTopics(ctx, "o", "r")
 	if err != nil {
 		t.Fatalf("Repositories.ListAllTopics returned error: %v", err)
@@ -3462,7 +3461,7 @@ func TestRepositoriesService_ReplaceAllTopics(t *testing.T) {
 		fmt.Fprint(w, `{"names":["go", "go-github", "github"]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.ReplaceAllTopics(ctx, "o", "r", []string{"go", "go-github", "github"})
 	if err != nil {
 		t.Fatalf("Repositories.ReplaceAllTopics returned error: %v", err)
@@ -3499,7 +3498,7 @@ func TestRepositoriesService_ReplaceAllTopics_nilSlice(t *testing.T) {
 		fmt.Fprint(w, `{"names":[]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.ReplaceAllTopics(ctx, "o", "r", nil)
 	if err != nil {
 		t.Fatalf("Repositories.ReplaceAllTopics returned error: %v", err)
@@ -3522,7 +3521,7 @@ func TestRepositoriesService_ReplaceAllTopics_emptySlice(t *testing.T) {
 		fmt.Fprint(w, `{"names":[]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.ReplaceAllTopics(ctx, "o", "r", []string{})
 	if err != nil {
 		t.Fatalf("Repositories.ReplaceAllTopics returned error: %v", err)
@@ -3553,7 +3552,7 @@ func TestRepositoriesService_ListAppRestrictions(t *testing.T) {
 				testMethod(t, r, "GET")
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, _, err := client.Repositories.ListAppRestrictions(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.ListAppRestrictions returned error: %v", err)
@@ -3598,7 +3597,7 @@ func TestRepositoriesService_ReplaceAppRestrictions(t *testing.T) {
 			}]`)
 			})
 			input := []string{"octocat"}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, _, err := client.Repositories.ReplaceAppRestrictions(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.ReplaceAppRestrictions returned error: %v", err)
@@ -3649,7 +3648,7 @@ func TestRepositoriesService_AddAppRestrictions(t *testing.T) {
 			}]`)
 			})
 			input := []string{"octocat"}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, _, err := client.Repositories.AddAppRestrictions(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.AddAppRestrictions returned error: %v", err)
@@ -3698,7 +3697,7 @@ func TestRepositoriesService_RemoveAppRestrictions(t *testing.T) {
 				fmt.Fprint(w, `[]`)
 			})
 			input := []string{"octocat"}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, _, err := client.Repositories.RemoveAppRestrictions(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.RemoveAppRestrictions returned error: %v", err)
@@ -3744,7 +3743,7 @@ func TestRepositoriesService_ListTeamRestrictions(t *testing.T) {
 				testMethod(t, r, "GET")
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, _, err := client.Repositories.ListTeamRestrictions(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.ListTeamRestrictions returned error: %v", err)
@@ -3789,7 +3788,7 @@ func TestRepositoriesService_ReplaceTeamRestrictions(t *testing.T) {
 			}]`)
 			})
 			input := []string{"octocat"}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, _, err := client.Repositories.ReplaceTeamRestrictions(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.ReplaceTeamRestrictions returned error: %v", err)
@@ -3840,7 +3839,7 @@ func TestRepositoriesService_AddTeamRestrictions(t *testing.T) {
 			}]`)
 			})
 			input := []string{"octocat"}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, _, err := client.Repositories.AddTeamRestrictions(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.AddTeamRestrictions returned error: %v", err)
@@ -3889,7 +3888,7 @@ func TestRepositoriesService_RemoveTeamRestrictions(t *testing.T) {
 				fmt.Fprint(w, `[]`)
 			})
 			input := []string{"octocat"}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, _, err := client.Repositories.RemoveTeamRestrictions(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.RemoveTeamRestrictions returned error: %v", err)
@@ -3935,7 +3934,7 @@ func TestRepositoriesService_ListUserRestrictions(t *testing.T) {
 				testMethod(t, r, "GET")
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, _, err := client.Repositories.ListUserRestrictions(ctx, "o", "r", test.branch)
 			if err != nil {
 				t.Errorf("Repositories.ListUserRestrictions returned error: %v", err)
@@ -3980,7 +3979,7 @@ func TestRepositoriesService_ReplaceUserRestrictions(t *testing.T) {
 			}]`)
 			})
 			input := []string{"octocat"}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, _, err := client.Repositories.ReplaceUserRestrictions(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.ReplaceUserRestrictions returned error: %v", err)
@@ -4031,7 +4030,7 @@ func TestRepositoriesService_AddUserRestrictions(t *testing.T) {
 			}]`)
 			})
 			input := []string{"octocat"}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, _, err := client.Repositories.AddUserRestrictions(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.AddUserRestrictions returned error: %v", err)
@@ -4080,7 +4079,7 @@ func TestRepositoriesService_RemoveUserRestrictions(t *testing.T) {
 				fmt.Fprint(w, `[]`)
 			})
 			input := []string{"octocat"}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, _, err := client.Repositories.RemoveUserRestrictions(ctx, "o", "r", test.branch, input)
 			if err != nil {
 				t.Errorf("Repositories.RemoveUserRestrictions returned error: %v", err)
@@ -4125,7 +4124,7 @@ func TestRepositoriesService_Transfer(t *testing.T) {
 		fmt.Fprint(w, `{"owner":{"login":"a"}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.Transfer(ctx, "o", "r", input)
 	if err != nil {
 		t.Errorf("Repositories.Transfer returned error: %v", err)
@@ -4169,7 +4168,7 @@ func TestRepositoriesService_Dispatch(t *testing.T) {
 		fmt.Fprint(w, `{"owner":{"login":"a"}}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	testCases := []any{
 		nil,
@@ -4445,7 +4444,7 @@ func TestRepositoriesService_EnablePrivateReporting(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.EnablePrivateReporting(ctx, "owner", "repo")
 	if err != nil {
 		t.Errorf("Repositories.EnablePrivateReporting returned error: %v", err)
@@ -4471,7 +4470,7 @@ func TestRepositoriesService_DisablePrivateReporting(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Repositories.DisablePrivateReporting(ctx, "owner", "repo")
 	if err != nil {
 		t.Errorf("Repositories.DisablePrivateReporting returned error: %v", err)
@@ -4497,7 +4496,7 @@ func TestRepositoriesService_IsPrivateReportingEnabled(t *testing.T) {
 		fmt.Fprint(w, `{"enabled": true}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	enabled, _, err := client.Repositories.IsPrivateReportingEnabled(ctx, "owner", "repo")
 	if err != nil {
 		t.Errorf("Repositories.IsPrivateReportingEnabled returned error: %v", err)
@@ -4642,7 +4641,7 @@ func TestRepositoriesService_ListRepositoryActivities(t *testing.T) {
 	})
 
 	opts := &ListRepositoryActivityOptions{PerPage: 100}
-	ctx := context.Background()
+	ctx := t.Context()
 	activities, _, err := client.Repositories.ListRepositoryActivities(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Repositories.ListRepositoryActivities returned error: %v", err)
@@ -4790,7 +4789,7 @@ func TestRepositoriesService_ListRepositoryActivities_withOptions(t *testing.T) 
 		ActivityType: "push",
 		PerPage:      50,
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	activities, _, err := client.Repositories.ListRepositoryActivities(ctx, "o", "r", opts)
 	if err != nil {
 		t.Errorf("Repositories.ListRepositoryActivities returned error: %v", err)
@@ -4843,7 +4842,7 @@ func TestRepositoriesService_ListRepositoryActivities_emptyResponse(t *testing.T
 		fmt.Fprint(w, `[]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	activities, _, err := client.Repositories.ListRepositoryActivities(ctx, "o", "r", nil)
 	if err != nil {
 		t.Errorf("Repositories.ListRepositoryActivities returned error: %v", err)
@@ -4859,7 +4858,7 @@ func TestRepositoriesService_ListRepositoryActivities_invalidOwner(t *testing.T)
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListRepositoryActivities(ctx, "%", "r", nil)
 	if err == nil {
 		t.Error("Expected error to be returned")
@@ -4870,7 +4869,7 @@ func TestRepositoriesService_ListRepositoryActivities_invalidRepo(t *testing.T) 
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Repositories.ListRepositoryActivities(ctx, "o", "%", nil)
 	if err == nil {
 		t.Error("Expected error to be returned")

--- a/github/repos_traffic_test.go
+++ b/github/repos_traffic_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -27,7 +26,7 @@ func TestRepositoriesService_ListTrafficReferrers(t *testing.T) {
 			"uniques": 3
  		}]`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.ListTrafficReferrers(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.ListTrafficReferrers returned error: %+v", err)
@@ -70,7 +69,7 @@ func TestRepositoriesService_ListTrafficPaths(t *testing.T) {
 			"uniques": 2225
  		}]`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.ListTrafficPaths(ctx, "o", "r")
 	if err != nil {
 		t.Errorf("Repositories.ListTrafficPaths returned error: %+v", err)
@@ -116,7 +115,7 @@ func TestRepositoriesService_ListTrafficViews(t *testing.T) {
 		}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.ListTrafficViews(ctx, "o", "r", nil)
 	if err != nil {
 		t.Errorf("Repositories.ListTrafficViews returned error: %+v", err)
@@ -166,7 +165,7 @@ func TestRepositoriesService_ListTrafficClones(t *testing.T) {
 		}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Repositories.ListTrafficClones(ctx, "o", "r", nil)
 	if err != nil {
 		t.Errorf("Repositories.ListTrafficClones returned error: %+v", err)

--- a/github/scim_test.go
+++ b/github/scim_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -61,7 +60,7 @@ func TestSCIMService_ListSCIMProvisionedIdentities(t *testing.T) {
 		  }`))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &ListSCIMProvisionedIdentitiesOptions{}
 	identities, _, err := client.SCIM.ListSCIMProvisionedIdentities(ctx, "o", opts)
 	if err != nil {
@@ -167,7 +166,7 @@ func TestSCIMService_ListSCIMProvisionedGroups(t *testing.T) {
 		  }`))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &ListSCIMProvisionedGroupsForEnterpriseOptions{
 		StartIndex:         Ptr(1),
 		ExcludedAttributes: Ptr("members,meta"),
@@ -236,7 +235,7 @@ func TestSCIMService_ProvisionAndInviteSCIMUser(t *testing.T) {
 		fmt.Fprint(w, `{"id":"1234567890","userName":"userName"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &SCIMUserAttributes{
 		UserName: "userName",
 		Name: SCIMUserName{
@@ -316,7 +315,7 @@ func TestSCIMService_GetSCIMProvisioningInfoForUser(t *testing.T) {
 		  }`))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	user, _, err := client.SCIM.GetSCIMProvisioningInfoForUser(ctx, "o", "123")
 	if err != nil {
 		t.Errorf("SCIM.GetSCIMProvisioningInfoForUser returned error: %v", err)
@@ -379,7 +378,7 @@ func TestSCIMService_UpdateProvisionedOrgMembership(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &SCIMUserAttributes{
 		UserName: "userName",
 		Name: SCIMUserName{
@@ -417,7 +416,7 @@ func TestSCIMService_UpdateAttributeForSCIMUser(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &UpdateAttributeForSCIMUserOptions{}
 	_, err := client.SCIM.UpdateAttributeForSCIMUser(ctx, "o", "123", opts)
 	if err != nil {
@@ -444,7 +443,7 @@ func TestSCIMService_DeleteSCIMUserFromOrg(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.SCIM.DeleteSCIMUserFromOrg(ctx, "o", "123")
 	if err != nil {
 		t.Errorf("SCIM.DeleteSCIMUserFromOrg returned error: %v", err)

--- a/github/search_test.go
+++ b/github/search_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -33,7 +32,7 @@ func TestSearchService_Repositories(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "forks", Order: "desc", ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	result, _, err := client.Search.Repositories(ctx, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Repositories returned error: %v", err)
@@ -53,7 +52,7 @@ func TestSearchService_Repositories_coverage(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "Repositories"
 	testBadOptions(t, methodName, func() (err error) {
@@ -116,7 +115,7 @@ func TestSearchService_RepositoriesTextMatch(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "forks", Order: "desc", ListOptions: ListOptions{Page: 2, PerPage: 2}, TextMatch: true}
-	ctx := context.Background()
+	ctx := t.Context()
 	result, _, err := client.Search.Repositories(ctx, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Code returned error: %v", err)
@@ -158,7 +157,7 @@ func TestSearchService_Topics(t *testing.T) {
 	})
 
 	opts := &SearchOptions{ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	result, _, err := client.Search.Topics(ctx, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Topics returned error: %v", err)
@@ -178,7 +177,7 @@ func TestSearchService_Topics_coverage(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "Topics"
 	testBadOptions(t, methodName, func() (err error) {
@@ -203,7 +202,7 @@ func TestSearchService_Commits(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "author-date", Order: "desc"}
-	ctx := context.Background()
+	ctx := t.Context()
 	result, _, err := client.Search.Commits(ctx, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Commits returned error: %v", err)
@@ -223,7 +222,7 @@ func TestSearchService_Commits_coverage(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "Commits"
 	testBadOptions(t, methodName, func() (err error) {
@@ -250,7 +249,7 @@ func TestSearchService_Issues(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "forks", Order: "desc", ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	result, _, err := client.Search.Issues(ctx, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Issues returned error: %v", err)
@@ -270,7 +269,7 @@ func TestSearchService_Issues_coverage(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "Issues"
 	testBadOptions(t, methodName, func() (err error) {
@@ -297,7 +296,7 @@ func TestSearchService_Issues_withQualifiersNoOpts(t *testing.T) {
 	})
 
 	opts := &SearchOptions{}
-	ctx := context.Background()
+	ctx := t.Context()
 	result, _, err := client.Search.Issues(ctx, q, opts)
 	if err != nil {
 		t.Errorf("Search.Issues returned error: %v", err)
@@ -336,7 +335,7 @@ func TestSearchService_Issues_withQualifiersAndOpts(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "forks"}
-	ctx := context.Background()
+	ctx := t.Context()
 	result, _, err := client.Search.Issues(ctx, q, opts)
 	if err != nil {
 		t.Errorf("Search.Issues returned error: %v", err)
@@ -374,7 +373,7 @@ func TestSearchService_Users(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "forks", Order: "desc", ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	result, _, err := client.Search.Users(ctx, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Issues returned error: %v", err)
@@ -394,7 +393,7 @@ func TestSearchService_Users_coverage(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "Users"
 	testBadOptions(t, methodName, func() (err error) {
@@ -421,7 +420,7 @@ func TestSearchService_Code(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "forks", Order: "desc", ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	result, _, err := client.Search.Code(ctx, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Code returned error: %v", err)
@@ -441,7 +440,7 @@ func TestSearchService_Code_coverage(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "Code"
 	testBadOptions(t, methodName, func() (err error) {
@@ -487,7 +486,7 @@ func TestSearchService_CodeTextMatch(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "forks", Order: "desc", ListOptions: ListOptions{Page: 2, PerPage: 2}, TextMatch: true}
-	ctx := context.Background()
+	ctx := t.Context()
 	result, _, err := client.Search.Code(ctx, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Code returned error: %v", err)
@@ -532,7 +531,7 @@ func TestSearchService_Labels(t *testing.T) {
 	})
 
 	opts := &SearchOptions{Sort: "updated", Order: "desc", ListOptions: ListOptions{Page: 2, PerPage: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	result, _, err := client.Search.Labels(ctx, 1234, "blah", opts)
 	if err != nil {
 		t.Errorf("Search.Code returned error: %v", err)
@@ -555,7 +554,7 @@ func TestSearchService_Labels_coverage(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const methodName = "Labels"
 	testBadOptions(t, methodName, func() (err error) {

--- a/github/secret_scanning_pattern_configs_test.go
+++ b/github/secret_scanning_pattern_configs_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -56,7 +55,7 @@ func TestSecretScanningService_ListPatternConfigsForEnterprise(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	patternConfigs, _, err := client.SecretScanning.ListPatternConfigsForEnterprise(ctx, "e")
 	if err != nil {
@@ -157,7 +156,7 @@ func TestSecretScanningService_ListPatternConfigsForOrg(t *testing.T) {
 			]
 		}`)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		patternConfigs, _, err := client.SecretScanning.ListPatternConfigsForOrg(ctx, "o")
 		if err != nil {
@@ -229,7 +228,7 @@ func TestSecretScanningService_UpdatePatternConfigsForEnterprise(t *testing.T) {
 			"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"
 		}`)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		opts := &SecretScanningPatternConfigsUpdateOptions{
 			PatternConfigVersion: Ptr("0ujsswThIGTUYm2K8FjOOfXtY1K"),
@@ -286,7 +285,7 @@ func TestSecretScanningService_UpdatePatternConfigsForOrg(t *testing.T) {
 			"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"
 		}`)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		opts := &SecretScanningPatternConfigsUpdateOptions{
 			PatternConfigVersion: Ptr("0ujsswThIGTUYm2K8FjOOfXtY1K"),

--- a/github/secret_scanning_test.go
+++ b/github/secret_scanning_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -44,7 +43,7 @@ func TestSecretScanningService_ListAlertsForEnterprise(t *testing.T) {
 		}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &SecretScanningAlertListOptions{State: "open", SecretType: "mailchimp_api_key", Direction: "asc", Sort: "updated"}
 
 	alerts, _, err := client.SecretScanning.ListAlertsForEnterprise(ctx, "e", opts)
@@ -114,7 +113,7 @@ func TestSecretScanningService_ListAlertsForOrg(t *testing.T) {
 		}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &SecretScanningAlertListOptions{State: "open", SecretType: "mailchimp_api_key", Direction: "asc", Sort: "updated"}
 
 	alerts, _, err := client.SecretScanning.ListAlertsForOrg(ctx, "o", opts)
@@ -179,7 +178,7 @@ func TestSecretScanningService_ListAlertsForOrgListOptions(t *testing.T) {
 		}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Testing pagination by index
 	opts := &SecretScanningAlertListOptions{State: "open", SecretType: "mailchimp_api_key", ListOptions: ListOptions{Page: 1, PerPage: 1}, Direction: "asc", Sort: "updated"}
@@ -246,7 +245,7 @@ func TestSecretScanningService_ListAlertsForRepo(t *testing.T) {
 		}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &SecretScanningAlertListOptions{State: "open", SecretType: "mailchimp_api_key", Direction: "asc", Sort: "updated"}
 
 	alerts, _, err := client.SecretScanning.ListAlertsForRepo(ctx, "o", "r", opts)
@@ -310,7 +309,7 @@ func TestSecretScanningService_GetAlert(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	alert, _, err := client.SecretScanning.GetAlert(ctx, "o", "r", 1)
 	if err != nil {
@@ -381,7 +380,7 @@ func TestSecretScanningService_UpdateAlert(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &SecretScanningAlertUpdateOptions{State: "resolved", Resolution: Ptr("used_in_tests")}
 
 	alert, _, err := client.SecretScanning.UpdateAlert(ctx, "o", "r", 1, opts)
@@ -446,7 +445,7 @@ func TestSecretScanningService_ListLocationsForAlert(t *testing.T) {
 		}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &ListOptions{Page: 1, PerPage: 100}
 
 	locations, _, err := client.SecretScanning.ListLocationsForAlert(ctx, "o", "r", 1, opts)

--- a/github/security_advisories_test.go
+++ b/github/security_advisories_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -31,7 +30,7 @@ func TestSecurityAdvisoriesService_RequestCVE(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.SecurityAdvisories.RequestCVE(ctx, "o", "r", "ghsa_id_ok")
 	if err != nil {
 		t.Errorf("SecurityAdvisoriesService.RequestCVE returned error: %v", err)
@@ -166,7 +165,7 @@ func TestSecurityAdvisoriesService_CreateTemporaryPrivateFork(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	fork, _, err := client.SecurityAdvisories.CreateTemporaryPrivateFork(ctx, "o", "r", "ghsa_id")
 	if err != nil {
 		t.Errorf("SecurityAdvisoriesService.CreateTemporaryPrivateFork returned error: %v", err)
@@ -402,7 +401,7 @@ func TestSecurityAdvisoriesService_CreateTemporaryPrivateFork_deferred(t *testin
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	fork, _, err := client.SecurityAdvisories.CreateTemporaryPrivateFork(ctx, "o", "r", "ghsa_id")
 	if !errors.As(err, new(*AcceptedError)) {
 		t.Errorf("SecurityAdvisoriesService.CreateTemporaryPrivateFork returned error: %v (want AcceptedError)", err)
@@ -518,7 +517,7 @@ func TestSecurityAdvisoriesService_CreateTemporaryPrivateFork_invalidOwner(t *te
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.SecurityAdvisories.CreateTemporaryPrivateFork(ctx, "%", "r", "ghsa_id")
 	testURLParseError(t, err)
 }
@@ -533,7 +532,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg_BadReq
 		http.Error(w, "Bad Request", 400)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisoriesForOrg(ctx, "o", nil)
 	if err == nil {
 		t.Error("Expected HTTP 400 response")
@@ -561,7 +560,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg_NotFou
 		http.NotFound(w, r)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisoriesForOrg(ctx, "o", &ListRepositorySecurityAdvisoriesOptions{
 		State: "draft",
 	})
@@ -587,7 +586,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg_Unmars
 		assertWrite(t, w, []byte(`[{"ghsa_id": 12334354}]`))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisoriesForOrg(ctx, "o", nil)
 	if err == nil {
 		t.Error("Expected unmarshal error")
@@ -618,7 +617,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg(t *tes
 		]`))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisoriesForOrg(ctx, "o", nil)
 	if err != nil {
 		t.Errorf("ListRepositorySecurityAdvisoriesForOrg returned error: %v, want nil", err)
@@ -664,7 +663,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories_BadRequest(t
 		http.Error(w, "Bad Request", 400)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisories(ctx, "o", "r", nil)
 	if err == nil {
 		t.Error("Expected HTTP 400 response")
@@ -692,7 +691,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories_NotFound(t *
 		http.NotFound(w, r)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisories(ctx, "o", "r", &ListRepositorySecurityAdvisoriesOptions{
 		State: "draft",
 	})
@@ -718,7 +717,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories_UnmarshalErr
 		assertWrite(t, w, []byte(`[{"ghsa_id": 12334354}]`))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisories(ctx, "o", "r", nil)
 	if err == nil {
 		t.Error("Expected unmarshal error")
@@ -749,7 +748,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories(t *testing.T
 		]`))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisories(ctx, "o", "r", nil)
 	if err != nil {
 		t.Errorf("ListRepositorySecurityAdvisories returned error: %v, want nil", err)
@@ -871,7 +870,7 @@ func TestListGlobalSecurityAdvisories(t *testing.T) {
 		]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &ListGlobalSecurityAdvisoriesOptions{CVEID: Ptr("CVE-xoxo-1234")}
 
 	advisories, _, err := client.SecurityAdvisories.ListGlobalSecurityAdvisories(ctx, opts)
@@ -1055,7 +1054,7 @@ func TestGetGlobalSecurityAdvisories(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	advisory, _, err := client.SecurityAdvisories.GetGlobalSecurityAdvisories(ctx, "GHSA-xoxo-1234-xoxo")
 	if err != nil {
 		t.Errorf("SecurityAdvisories.GetGlobalSecurityAdvisories returned error: %v", err)

--- a/github/sub_issue_test.go
+++ b/github/sub_issue_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -33,7 +32,7 @@ func TestSubIssuesService_Add(t *testing.T) {
 		fmt.Fprint(w, `{"id":42, "number":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.SubIssue.Add(ctx, "o", "r", 1, *input)
 	if err != nil {
 		t.Errorf("SubIssues.Add returned error: %v", err)
@@ -64,7 +63,7 @@ func TestSubIssuesService_ListByIssue(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opt := &IssueListOptions{}
 	issues, _, err := client.SubIssue.ListByIssue(ctx, "o", "r", 1, opt)
 	if err != nil {
@@ -109,7 +108,7 @@ func TestSubIssuesService_Remove(t *testing.T) {
 		fmt.Fprint(w, `{"id":42, "number":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.SubIssue.Remove(ctx, "o", "r", 1, *input)
 	if err != nil {
 		t.Errorf("SubIssues.Remove returned error: %v", err)
@@ -150,7 +149,7 @@ func TestSubIssuesService_Reprioritize(t *testing.T) {
 		fmt.Fprint(w, `{"id":42, "number":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.SubIssue.Reprioritize(ctx, "o", "r", 1, *input)
 	if err != nil {
 		t.Errorf("SubIssues.Reprioritize returned error: %v", err)

--- a/github/teams_discussion_comments_test.go
+++ b/github/teams_discussion_comments_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -118,7 +117,7 @@ func TestTeamsService_ListComments(t *testing.T) {
 	e := tdcEndpointByID("1", "2", "3", "")
 	mux.HandleFunc(e, handleFunc)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	commentsByID, _, err := client.Teams.ListCommentsByID(ctx, 1, 2, 3,
 		&DiscussionCommentListOptions{Direction: "desc"})
 	if err != nil {
@@ -188,7 +187,7 @@ func TestTeamsService_GetComment(t *testing.T) {
 	e := tdcEndpointByID("1", "2", "3", "4")
 	mux.HandleFunc(e, handlerFunc)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	commentByID, _, err := client.Teams.GetCommentByID(ctx, 1, 2, 3, 4)
 	if err != nil {
 		t.Errorf("Teams.GetCommentByID returned error: %v", err)
@@ -261,7 +260,7 @@ func TestTeamsService_CreateComment(t *testing.T) {
 	e := tdcEndpointByID("1", "2", "3", "")
 	mux.HandleFunc(e, handlerFunc)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	commentByID, _, err := client.Teams.CreateCommentByID(ctx, 1, 2, 3, input)
 	if err != nil {
 		t.Errorf("Teams.CreateCommentByID returned error: %v", err)
@@ -333,7 +332,7 @@ func TestTeamsService_EditComment(t *testing.T) {
 	e := tdcEndpointByID("1", "2", "3", "4")
 	mux.HandleFunc(e, handlerFunc)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	commentByID, _, err := client.Teams.EditCommentByID(ctx, 1, 2, 3, 4, input)
 	if err != nil {
 		t.Errorf("Teams.EditCommentByID returned error: %v", err)
@@ -395,7 +394,7 @@ func TestTeamsService_DeleteComment(t *testing.T) {
 	e := tdcEndpointByID("1", "2", "3", "4")
 	mux.HandleFunc(e, handlerFunc)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.DeleteCommentByID(ctx, 1, 2, 3, 4)
 	if err != nil {
 		t.Errorf("Teams.DeleteCommentByID returned error: %v", err)

--- a/github/teams_discussions_test.go
+++ b/github/teams_discussions_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -67,7 +66,7 @@ func TestTeamsService_ListDiscussionsByID(t *testing.T) {
 				}
 			]`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	discussions, _, err := client.Teams.ListDiscussionsByID(ctx, 1, 2, &DiscussionListOptions{"desc", ListOptions{Page: 2}})
 	if err != nil {
 		t.Errorf("Teams.ListDiscussionsByID returned error: %v", err)
@@ -182,7 +181,7 @@ func TestTeamsService_ListDiscussionsBySlug(t *testing.T) {
 				}
 			]`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	discussions, _, err := client.Teams.ListDiscussionsBySlug(ctx, "o", "s", &DiscussionListOptions{"desc", ListOptions{Page: 2}})
 	if err != nil {
 		t.Errorf("Teams.ListDiscussionsBySlug returned error: %v", err)
@@ -255,7 +254,7 @@ func TestTeamsService_GetDiscussionByID(t *testing.T) {
 		fmt.Fprint(w, `{"number":3}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	discussion, _, err := client.Teams.GetDiscussionByID(ctx, 1, 2, 3)
 	if err != nil {
 		t.Errorf("Teams.GetDiscussionByID returned error: %v", err)
@@ -290,7 +289,7 @@ func TestTeamsService_GetDiscussionBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"number":3}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	discussion, _, err := client.Teams.GetDiscussionBySlug(ctx, "o", "s", 3)
 	if err != nil {
 		t.Errorf("Teams.GetDiscussionBySlug returned error: %v", err)
@@ -334,7 +333,7 @@ func TestTeamsService_CreateDiscussionByID(t *testing.T) {
 		fmt.Fprint(w, `{"number":3}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.Teams.CreateDiscussionByID(ctx, 1, 2, input)
 	if err != nil {
 		t.Errorf("Teams.CreateDiscussionByID returned error: %v", err)
@@ -378,7 +377,7 @@ func TestTeamsService_CreateDiscussionBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"number":3}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.Teams.CreateDiscussionBySlug(ctx, "o", "s", input)
 	if err != nil {
 		t.Errorf("Teams.CreateDiscussionBySlug returned error: %v", err)
@@ -422,7 +421,7 @@ func TestTeamsService_EditDiscussionByID(t *testing.T) {
 		fmt.Fprint(w, `{"number":3}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.Teams.EditDiscussionByID(ctx, 1, 2, 3, input)
 	if err != nil {
 		t.Errorf("Teams.EditDiscussionByID returned error: %v", err)
@@ -466,7 +465,7 @@ func TestTeamsService_EditDiscussionBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"number":3}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	comment, _, err := client.Teams.EditDiscussionBySlug(ctx, "o", "s", 3, input)
 	if err != nil {
 		t.Errorf("Teams.EditDiscussionBySlug returned error: %v", err)
@@ -500,7 +499,7 @@ func TestTeamsService_DeleteDiscussionByID(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.DeleteDiscussionByID(ctx, 1, 2, 3)
 	if err != nil {
 		t.Errorf("Teams.DeleteDiscussionByID returned error: %v", err)
@@ -525,7 +524,7 @@ func TestTeamsService_DeleteDiscussionBySlug(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.DeleteDiscussionBySlug(ctx, "o", "s", 3)
 	if err != nil {
 		t.Errorf("Teams.DeleteDiscussionBySlug returned error: %v", err)

--- a/github/teams_members_test.go
+++ b/github/teams_members_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,7 +25,7 @@ func TestTeamsService__ListTeamMembersByID(t *testing.T) {
 	})
 
 	opt := &TeamListTeamMembersOptions{Role: "member", ListOptions: ListOptions{Page: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	members, _, err := client.Teams.ListTeamMembersByID(ctx, 1, 2, opt)
 	if err != nil {
 		t.Errorf("Teams.ListTeamMembersByID returned error: %v", err)
@@ -63,7 +62,7 @@ func TestTeamsService__ListTeamMembersByID_notFound(t *testing.T) {
 	})
 
 	opt := &TeamListTeamMembersOptions{Role: "member", ListOptions: ListOptions{Page: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	members, resp, err := client.Teams.ListTeamMembersByID(ctx, 1, 2, opt)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -101,7 +100,7 @@ func TestTeamsService__ListTeamMembersBySlug(t *testing.T) {
 	})
 
 	opt := &TeamListTeamMembersOptions{Role: "member", ListOptions: ListOptions{Page: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	members, _, err := client.Teams.ListTeamMembersBySlug(ctx, "o", "s", opt)
 	if err != nil {
 		t.Errorf("Teams.ListTeamMembersBySlug returned error: %v", err)
@@ -138,7 +137,7 @@ func TestTeamsService__ListTeamMembersBySlug_notFound(t *testing.T) {
 	})
 
 	opt := &TeamListTeamMembersOptions{Role: "member", ListOptions: ListOptions{Page: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	members, resp, err := client.Teams.ListTeamMembersBySlug(ctx, "o", "s", opt)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -169,7 +168,7 @@ func TestTeamsService__ListTeamMembersBySlug_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Teams.ListTeamMembersBySlug(ctx, "%", "s", nil)
 	testURLParseError(t, err)
 }
@@ -183,7 +182,7 @@ func TestTeamsService__GetTeamMembershipByID(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u", "state":"active"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	membership, _, err := client.Teams.GetTeamMembershipByID(ctx, 1, 2, "u")
 	if err != nil {
 		t.Errorf("Teams.GetTeamMembershipByID returned error: %v", err)
@@ -218,7 +217,7 @@ func TestTeamsService__GetTeamMembershipByID_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	membership, resp, err := client.Teams.GetTeamMembershipByID(ctx, 1, 2, "u")
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -254,7 +253,7 @@ func TestTeamsService__GetTeamMembershipBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u", "state":"active"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	membership, _, err := client.Teams.GetTeamMembershipBySlug(ctx, "o", "s", "u")
 	if err != nil {
 		t.Errorf("Teams.GetTeamMembershipBySlug returned error: %v", err)
@@ -289,7 +288,7 @@ func TestTeamsService__GetTeamMembershipBySlug_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	membership, resp, err := client.Teams.GetTeamMembershipBySlug(ctx, "o", "s", "u")
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -320,7 +319,7 @@ func TestTeamsService__GetTeamMembershipBySlug_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Teams.GetTeamMembershipBySlug(ctx, "%s", "s", "u")
 	testURLParseError(t, err)
 }
@@ -343,7 +342,7 @@ func TestTeamsService__AddTeamMembershipByID(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u", "state":"pending"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	membership, _, err := client.Teams.AddTeamMembershipByID(ctx, 1, 2, "u", opt)
 	if err != nil {
 		t.Errorf("Teams.AddTeamMembershipByID returned error: %v", err)
@@ -387,7 +386,7 @@ func TestTeamsService__AddTeamMembershipByID_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	membership, resp, err := client.Teams.AddTeamMembershipByID(ctx, 1, 2, "u", opt)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -432,7 +431,7 @@ func TestTeamsService__AddTeamMembershipBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"url":"u", "state":"pending"}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	membership, _, err := client.Teams.AddTeamMembershipBySlug(ctx, "o", "s", "u", opt)
 	if err != nil {
 		t.Errorf("Teams.AddTeamMembershipBySlug returned error: %v", err)
@@ -476,7 +475,7 @@ func TestTeamsService__AddTeamMembershipBySlug_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	membership, resp, err := client.Teams.AddTeamMembershipBySlug(ctx, "o", "s", "u", opt)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -507,7 +506,7 @@ func TestTeamsService__AddTeamMembershipBySlug_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Teams.AddTeamMembershipBySlug(ctx, "%", "s", "u", nil)
 	testURLParseError(t, err)
 }
@@ -521,7 +520,7 @@ func TestTeamsService__RemoveTeamMembershipByID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.RemoveTeamMembershipByID(ctx, 1, 2, "u")
 	if err != nil {
 		t.Errorf("Teams.RemoveTeamMembershipByID returned error: %v", err)
@@ -547,7 +546,7 @@ func TestTeamsService__RemoveTeamMembershipByID_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Teams.RemoveTeamMembershipByID(ctx, 1, 2, "u")
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -576,7 +575,7 @@ func TestTeamsService__RemoveTeamMembershipBySlug(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.RemoveTeamMembershipBySlug(ctx, "o", "s", "u")
 	if err != nil {
 		t.Errorf("Teams.RemoveTeamMembershipBySlug returned error: %v", err)
@@ -602,7 +601,7 @@ func TestTeamsService__RemoveTeamMembershipBySlug_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Teams.RemoveTeamMembershipBySlug(ctx, "o", "s", "u")
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -626,7 +625,7 @@ func TestTeamsService__RemoveTeamMembershipBySlug_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.RemoveTeamMembershipBySlug(ctx, "%", "s", "u")
 	testURLParseError(t, err)
 }
@@ -642,7 +641,7 @@ func TestTeamsService__ListPendingTeamInvitationsByID(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	invitations, _, err := client.Teams.ListPendingTeamInvitationsByID(ctx, 1, 2, opt)
 	if err != nil {
 		t.Errorf("Teams.ListPendingTeamInvitationsByID returned error: %v", err)
@@ -679,7 +678,7 @@ func TestTeamsService__ListPendingTeamInvitationsByID_notFound(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	invitations, resp, err := client.Teams.ListPendingTeamInvitationsByID(ctx, 1, 2, opt)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -717,7 +716,7 @@ func TestTeamsService__ListPendingTeamInvitationsBySlug(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	invitations, _, err := client.Teams.ListPendingTeamInvitationsBySlug(ctx, "o", "s", opt)
 	if err != nil {
 		t.Errorf("Teams.ListPendingTeamInvitationsByID returned error: %v", err)
@@ -754,7 +753,7 @@ func TestTeamsService__ListPendingTeamInvitationsBySlug_notFound(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	invitations, resp, err := client.Teams.ListPendingTeamInvitationsBySlug(ctx, "o", "s", opt)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -785,7 +784,7 @@ func TestTeamsService__ListPendingTeamInvitationsBySlug_invalidOrg(t *testing.T)
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Teams.ListPendingTeamInvitationsBySlug(ctx, "%", "s", nil)
 	testURLParseError(t, err)
 }

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -7,7 +7,6 @@ package github
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -28,7 +27,7 @@ func TestTeamsService_ListTeams(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	teams, _, err := client.Teams.ListTeams(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Teams.ListTeams returned error: %v", err)
@@ -58,7 +57,7 @@ func TestTeamsService_ListTeams_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Teams.ListTeams(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -72,7 +71,7 @@ func TestTeamsService_GetTeamByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "name":"n", "description": "d", "url":"u", "slug": "s", "permission":"p", "ldap_dn":"cn=n,ou=groups,dc=example,dc=com", "parent":null}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	team, _, err := client.Teams.GetTeamByID(ctx, 1, 1)
 	if err != nil {
 		t.Errorf("Teams.GetTeamByID returned error: %v", err)
@@ -107,7 +106,7 @@ func TestTeamsService_GetTeamByID_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	team, resp, err := client.Teams.GetTeamByID(ctx, 1, 2)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -129,7 +128,7 @@ func TestTeamsService_GetTeamBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"id":1, "name":"n", "description": "d", "url":"u", "slug": "s", "permission":"p", "ldap_dn":"cn=n,ou=groups,dc=example,dc=com", "parent":null}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	team, _, err := client.Teams.GetTeamBySlug(ctx, "o", "s")
 	if err != nil {
 		t.Errorf("Teams.GetTeamBySlug returned error: %v", err)
@@ -159,7 +158,7 @@ func TestTeamsService_GetTeamBySlug_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Teams.GetTeamBySlug(ctx, "%", "s")
 	testURLParseError(t, err)
 }
@@ -173,7 +172,7 @@ func TestTeamsService_GetTeamBySlug_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	team, resp, err := client.Teams.GetTeamBySlug(ctx, "o", "s")
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -204,7 +203,7 @@ func TestTeamsService_CreateTeam(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	team, _, err := client.Teams.CreateTeam(ctx, "o", input)
 	if err != nil {
 		t.Errorf("Teams.CreateTeam returned error: %v", err)
@@ -234,7 +233,7 @@ func TestTeamsService_CreateTeam_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Teams.CreateTeam(ctx, "%", NewTeam{})
 	testURLParseError(t, err)
 }
@@ -257,7 +256,7 @@ func TestTeamsService_EditTeamByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	team, _, err := client.Teams.EditTeamByID(ctx, 1, 1, input, false)
 	if err != nil {
 		t.Errorf("Teams.EditTeamByID returned error: %v", err)
@@ -307,7 +306,7 @@ func TestTeamsService_EditTeamByID_RemoveParent(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	team, _, err := client.Teams.EditTeamByID(ctx, 1, 1, input, true)
 	if err != nil {
 		t.Errorf("Teams.EditTeamByID returned error: %v", err)
@@ -341,7 +340,7 @@ func TestTeamsService_EditTeamBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	team, _, err := client.Teams.EditTeamBySlug(ctx, "o", "s", input, false)
 	if err != nil {
 		t.Errorf("Teams.EditTeamBySlug returned error: %v", err)
@@ -391,7 +390,7 @@ func TestTeamsService_EditTeamBySlug_RemoveParent(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	team, _, err := client.Teams.EditTeamBySlug(ctx, "o", "s", input, true)
 	if err != nil {
 		t.Errorf("Teams.EditTeam returned error: %v", err)
@@ -415,7 +414,7 @@ func TestTeamsService_DeleteTeamByID(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.DeleteTeamByID(ctx, 1, 1)
 	if err != nil {
 		t.Errorf("Teams.DeleteTeamByID returned error: %v", err)
@@ -440,7 +439,7 @@ func TestTeamsService_DeleteTeamBySlug(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.DeleteTeamBySlug(ctx, "o", "s")
 	if err != nil {
 		t.Errorf("Teams.DeleteTeamBySlug returned error: %v", err)
@@ -468,7 +467,7 @@ func TestTeamsService_ListChildTeamsByParentID(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	teams, _, err := client.Teams.ListChildTeamsByParentID(ctx, 1, 2, opt)
 	if err != nil {
 		t.Errorf("Teams.ListChildTeamsByParentID returned error: %v", err)
@@ -505,7 +504,7 @@ func TestTeamsService_ListChildTeamsByParentSlug(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	teams, _, err := client.Teams.ListChildTeamsByParentSlug(ctx, "o", "s", opt)
 	if err != nil {
 		t.Errorf("Teams.ListChildTeamsByParentSlug returned error: %v", err)
@@ -543,7 +542,7 @@ func TestTeamsService_ListTeamReposByID(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	members, _, err := client.Teams.ListTeamReposByID(ctx, 1, 1, opt)
 	if err != nil {
 		t.Errorf("Teams.ListTeamReposByID returned error: %v", err)
@@ -581,7 +580,7 @@ func TestTeamsService_ListTeamReposBySlug(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	members, _, err := client.Teams.ListTeamReposBySlug(ctx, "o", "s", opt)
 	if err != nil {
 		t.Errorf("Teams.ListTeamReposBySlug returned error: %v", err)
@@ -617,7 +616,7 @@ func TestTeamsService_IsTeamRepoByID_true(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	repo, _, err := client.Teams.IsTeamRepoByID(ctx, 1, 1, "owner", "repo")
 	if err != nil {
 		t.Errorf("Teams.IsTeamRepoByID returned error: %v", err)
@@ -653,7 +652,7 @@ func TestTeamsService_IsTeamRepoBySlug_true(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	repo, _, err := client.Teams.IsTeamRepoBySlug(ctx, "org", "slug", "owner", "repo")
 	if err != nil {
 		t.Errorf("Teams.IsTeamRepoBySlug returned error: %v", err)
@@ -688,7 +687,7 @@ func TestTeamsService_IsTeamRepoByID_false(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	repo, resp, err := client.Teams.IsTeamRepoByID(ctx, 1, 1, "owner", "repo")
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -710,7 +709,7 @@ func TestTeamsService_IsTeamRepoBySlug_false(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	repo, resp, err := client.Teams.IsTeamRepoBySlug(ctx, "org", "slug", "owner", "repo")
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -732,7 +731,7 @@ func TestTeamsService_IsTeamRepoByID_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	repo, resp, err := client.Teams.IsTeamRepoByID(ctx, 1, 1, "owner", "repo")
 	if err == nil {
 		t.Error("Expected HTTP 400 response")
@@ -754,7 +753,7 @@ func TestTeamsService_IsTeamRepoBySlug_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	repo, resp, err := client.Teams.IsTeamRepoBySlug(ctx, "org", "slug", "owner", "repo")
 	if err == nil {
 		t.Error("Expected HTTP 400 response")
@@ -771,7 +770,7 @@ func TestTeamsService_IsTeamRepoByID_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Teams.IsTeamRepoByID(ctx, 1, 1, "%", "r")
 	testURLParseError(t, err)
 }
@@ -780,7 +779,7 @@ func TestTeamsService_IsTeamRepoBySlug_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Teams.IsTeamRepoBySlug(ctx, "o", "s", "%", "r")
 	testURLParseError(t, err)
 }
@@ -803,7 +802,7 @@ func TestTeamsService_AddTeamRepoByID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.AddTeamRepoByID(ctx, 1, 1, "owner", "repo", opt)
 	if err != nil {
 		t.Errorf("Teams.AddTeamRepoByID returned error: %v", err)
@@ -838,7 +837,7 @@ func TestTeamsService_AddTeamRepoBySlug(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.AddTeamRepoBySlug(ctx, "org", "slug", "owner", "repo", opt)
 	if err != nil {
 		t.Errorf("Teams.AddTeamRepoBySlug returned error: %v", err)
@@ -864,7 +863,7 @@ func TestTeamsService_AddTeamRepoByID_noAccess(t *testing.T) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.AddTeamRepoByID(ctx, 1, 1, "owner", "repo", nil)
 	if err == nil {
 		t.Error("Expected error to be returned")
@@ -880,7 +879,7 @@ func TestTeamsService_AddTeamRepoBySlug_noAccess(t *testing.T) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.AddTeamRepoBySlug(ctx, "org", "slug", "owner", "repo", nil)
 	if err == nil {
 		t.Error("Expected error to be returned")
@@ -891,7 +890,7 @@ func TestTeamsService_AddTeamRepoByID_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.AddTeamRepoByID(ctx, 1, 1, "%", "r", nil)
 	testURLParseError(t, err)
 }
@@ -900,7 +899,7 @@ func TestTeamsService_AddTeamRepoBySlug_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.AddTeamRepoBySlug(ctx, "o", "s", "%", "r", nil)
 	testURLParseError(t, err)
 }
@@ -914,7 +913,7 @@ func TestTeamsService_RemoveTeamRepoByID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.RemoveTeamRepoByID(ctx, 1, 1, "owner", "repo")
 	if err != nil {
 		t.Errorf("Teams.RemoveTeamRepoByID returned error: %v", err)
@@ -940,7 +939,7 @@ func TestTeamsService_RemoveTeamRepoBySlug(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.RemoveTeamRepoBySlug(ctx, "org", "slug", "owner", "repo")
 	if err != nil {
 		t.Errorf("Teams.RemoveTeamRepoBySlug returned error: %v", err)
@@ -961,7 +960,7 @@ func TestTeamsService_RemoveTeamRepoByID_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.RemoveTeamRepoByID(ctx, 1, 1, "%", "r")
 	testURLParseError(t, err)
 }
@@ -970,7 +969,7 @@ func TestTeamsService_RemoveTeamRepoBySlug_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.RemoveTeamRepoBySlug(ctx, "o", "s", "%", "r")
 	testURLParseError(t, err)
 }
@@ -986,7 +985,7 @@ func TestTeamsService_ListUserTeams(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1}
-	ctx := context.Background()
+	ctx := t.Context()
 	teams, _, err := client.Teams.ListUserTeams(ctx, opt)
 	if err != nil {
 		t.Errorf("Teams.ListUserTeams returned error: %v", err)
@@ -1017,7 +1016,7 @@ func TestTeamsService_ListProjectsByID(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	projects, _, err := client.Teams.ListTeamProjectsByID(ctx, 1, 1)
 	if err != nil {
 		t.Errorf("Teams.ListTeamProjectsByID returned error: %v", err)
@@ -1053,7 +1052,7 @@ func TestTeamsService_ListProjectsBySlug(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	projects, _, err := client.Teams.ListTeamProjectsBySlug(ctx, "o", "s")
 	if err != nil {
 		t.Errorf("Teams.ListTeamProjectsBySlug returned error: %v", err)
@@ -1089,7 +1088,7 @@ func TestTeamsService_ReviewProjectsByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	project, _, err := client.Teams.ReviewTeamProjectsByID(ctx, 1, 1, 1)
 	if err != nil {
 		t.Errorf("Teams.ReviewTeamProjectsByID returned error: %v", err)
@@ -1125,7 +1124,7 @@ func TestTeamsService_ReviewProjectsBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	project, _, err := client.Teams.ReviewTeamProjectsBySlug(ctx, "o", "s", 1)
 	if err != nil {
 		t.Errorf("Teams.ReviewTeamProjectsBySlug returned error: %v", err)
@@ -1172,7 +1171,7 @@ func TestTeamsService_AddTeamProjectByID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.AddTeamProjectByID(ctx, 1, 1, 1, opt)
 	if err != nil {
 		t.Errorf("Teams.AddTeamProjectByID returned error: %v", err)
@@ -1210,7 +1209,7 @@ func TestTeamsService_AddTeamProjectBySlug(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.AddTeamProjectBySlug(ctx, "o", "s", 1, opt)
 	if err != nil {
 		t.Errorf("Teams.AddTeamProjectBySlug returned error: %v", err)
@@ -1237,7 +1236,7 @@ func TestTeamsService_RemoveTeamProjectByID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.RemoveTeamProjectByID(ctx, 1, 1, 1)
 	if err != nil {
 		t.Errorf("Teams.RemoveTeamProjectByID returned error: %v", err)
@@ -1264,7 +1263,7 @@ func TestTeamsService_RemoveTeamProjectBySlug(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.RemoveTeamProjectBySlug(ctx, "o", "s", 1)
 	if err != nil {
 		t.Errorf("Teams.RemoveTeamProjectBySlug returned error: %v", err)
@@ -1298,7 +1297,7 @@ func TestTeamsService_ListIDPGroupsInOrganization(t *testing.T) {
 		Query:             "n",
 		ListCursorOptions: ListCursorOptions{Page: "url-encoded-next-page-token"},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	groups, _, err := client.Teams.ListIDPGroupsInOrganization(ctx, "o", opt)
 	if err != nil {
 		t.Errorf("Teams.ListIDPGroupsInOrganization returned error: %v", err)
@@ -1341,7 +1340,7 @@ func TestTeamsService_ListIDPGroupsForTeamByID(t *testing.T) {
 		fmt.Fprint(w, `{"groups": [{"group_id": "1",  "group_name": "n", "group_description": "d"}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	groups, _, err := client.Teams.ListIDPGroupsForTeamByID(ctx, 1, 1)
 	if err != nil {
 		t.Errorf("Teams.ListIDPGroupsForTeamByID returned error: %v", err)
@@ -1384,7 +1383,7 @@ func TestTeamsService_ListIDPGroupsForTeamBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"groups": [{"group_id": "1",  "group_name": "n", "group_description": "d"}]}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	groups, _, err := client.Teams.ListIDPGroupsForTeamBySlug(ctx, "o", "slug")
 	if err != nil {
 		t.Errorf("Teams.ListIDPGroupsForTeamBySlug returned error: %v", err)
@@ -1437,7 +1436,7 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnectionsByID(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsByID(ctx, 1, 1, input)
 	if err != nil {
 		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsByID returned error: %v", err)
@@ -1490,7 +1489,7 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnectionsBySlug(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsBySlug(ctx, "o", "slug", input)
 	if err != nil {
 		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsBySlug returned error: %v", err)
@@ -1537,7 +1536,7 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnectionsByID_empty(t *testing.T) 
 		Groups: []*IDPGroup{},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsByID(ctx, 1, 1, input)
 	if err != nil {
 		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsByID returned error: %v", err)
@@ -1564,7 +1563,7 @@ func TestTeamsService_CreateOrUpdateIDPGroupConnectionsBySlug_empty(t *testing.T
 		Groups: []*IDPGroup{},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	groups, _, err := client.Teams.CreateOrUpdateIDPGroupConnectionsBySlug(ctx, "o", "slug", input)
 	if err != nil {
 		t.Errorf("Teams.CreateOrUpdateIDPGroupConnectionsBySlug returned error: %v", err)
@@ -1781,7 +1780,7 @@ func TestTeamsService_GetExternalGroup(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	externalGroup, _, err := client.Teams.GetExternalGroup(ctx, "o", 123)
 	if err != nil {
 		t.Errorf("Teams.GetExternalGroup returned error: %v", err)
@@ -1844,7 +1843,7 @@ func TestTeamsService_GetExternalGroup_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	eg, resp, err := client.Teams.GetExternalGroup(ctx, "o", 123)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -1874,7 +1873,7 @@ func TestTeamsService_ListExternalGroups(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &ListExternalGroupsOptions{
 		DisplayName: Ptr("Octocat"),
 	}
@@ -1920,7 +1919,7 @@ func TestTeamsService_ListExternalGroups_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	eg, resp, err := client.Teams.ListExternalGroups(ctx, "o", nil)
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -1950,7 +1949,7 @@ func TestTeamsService_ListExternalGroupsForTeamBySlug(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	list, _, err := client.Teams.ListExternalGroupsForTeamBySlug(ctx, "o", "t")
 	if err != nil {
 		t.Errorf("Teams.ListExternalGroupsForTeamBySlug returned error: %v", err)
@@ -1993,7 +1992,7 @@ func TestTeamsService_ListExternalGroupsForTeamBySlug_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	eg, resp, err := client.Teams.ListExternalGroupsForTeamBySlug(ctx, "o", "t")
 	if err == nil {
 		t.Error("Expected HTTP 404 response")
@@ -2043,7 +2042,7 @@ func TestTeamsService_UpdateConnectedExternalGroup(t *testing.T) {
 		}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	body := &ExternalGroup{
 		GroupID: Ptr(int64(123)),
 	}
@@ -2109,7 +2108,7 @@ func TestTeamsService_UpdateConnectedExternalGroup_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	body := &ExternalGroup{
 		GroupID: Ptr(int64(123)),
 	}
@@ -2134,7 +2133,7 @@ func TestTeamsService_RemoveConnectedExternalGroup(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Teams.RemoveConnectedExternalGroup(ctx, "o", "t")
 	if err != nil {
 		t.Errorf("Teams.RemoveConnectedExternalGroup returned error: %v", err)
@@ -2160,7 +2159,7 @@ func TestTeamsService_RemoveConnectedExternalGroup_notFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := client.Teams.RemoveConnectedExternalGroup(ctx, "o", "t")
 	if err == nil {
 		t.Error("Expected HTTP 404 response")

--- a/github/users_administration_test.go
+++ b/github/users_administration_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -23,7 +22,7 @@ func TestUsersService_PromoteSiteAdmin(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.PromoteSiteAdmin(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.PromoteSiteAdmin returned error: %v", err)
@@ -49,7 +48,7 @@ func TestUsersService_DemoteSiteAdmin(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.DemoteSiteAdmin(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.DemoteSiteAdmin returned error: %v", err)
@@ -75,7 +74,7 @@ func TestUsersService_Suspend(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.Suspend(ctx, "u", nil)
 	if err != nil {
 		t.Errorf("Users.Suspend returned error: %v", err)
@@ -110,7 +109,7 @@ func TestUsersServiceReason_Suspend(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.Suspend(ctx, "u", input)
 	if err != nil {
 		t.Errorf("Users.Suspend returned error: %v", err)
@@ -126,7 +125,7 @@ func TestUsersService_Unsuspend(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.Unsuspend(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.Unsuspend returned error: %v", err)

--- a/github/users_attestations_test.go
+++ b/github/users_attestations_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -33,7 +32,7 @@ func TestUsersService_ListAttestations(t *testing.T) {
 			]
 		}`)
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 	attestations, _, err := client.Users.ListAttestations(ctx, "u", "digest", &ListOptions{})
 	if err != nil {
 		t.Errorf("Users.ListAttestations returned error: %v", err)

--- a/github/users_blocking_test.go
+++ b/github/users_blocking_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -28,7 +27,7 @@ func TestUsersService_ListBlockedUsers(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	blockedUsers, _, err := client.Users.ListBlockedUsers(ctx, opt)
 	if err != nil {
 		t.Errorf("Users.ListBlockedUsers returned error: %v", err)
@@ -59,7 +58,7 @@ func TestUsersService_IsBlocked(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isBlocked, _, err := client.Users.IsBlocked(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.IsBlocked returned error: %v", err)
@@ -93,7 +92,7 @@ func TestUsersService_BlockUser(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.BlockUser(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.BlockUser returned error: %v", err)
@@ -120,7 +119,7 @@ func TestUsersService_UnblockUser(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.UnblockUser(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.UnblockUser returned error: %v", err)

--- a/github/users_emails_test.go
+++ b/github/users_emails_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -30,7 +29,7 @@ func TestUsersService_ListEmails(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	emails, _, err := client.Users.ListEmails(ctx, opt)
 	if err != nil {
 		t.Errorf("Users.ListEmails returned error: %v", err)
@@ -69,7 +68,7 @@ func TestUsersService_AddEmails(t *testing.T) {
 		fmt.Fprint(w, `[{"email":"old@example.com"}, {"email":"new@example.com"}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	emails, _, err := client.Users.AddEmails(ctx, input)
 	if err != nil {
 		t.Errorf("Users.AddEmails returned error: %v", err)
@@ -109,7 +108,7 @@ func TestUsersService_DeleteEmails(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.DeleteEmails(ctx, input)
 	if err != nil {
 		t.Errorf("Users.DeleteEmails returned error: %v", err)
@@ -165,7 +164,7 @@ func TestUsersService_SetEmailVisibility(t *testing.T) {
 		}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	emails, _, err := client.Users.SetEmailVisibility(ctx, "private")
 	if err != nil {
 		t.Errorf("Users.SetEmailVisibility returned error: %v", err)

--- a/github/users_followers_test.go
+++ b/github/users_followers_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -25,7 +24,7 @@ func TestUsersService_ListFollowers_authenticatedUser(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	users, _, err := client.Users.ListFollowers(ctx, "", opt)
 	if err != nil {
 		t.Errorf("Users.ListFollowers returned error: %v", err)
@@ -60,7 +59,7 @@ func TestUsersService_ListFollowers_specifiedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	users, _, err := client.Users.ListFollowers(ctx, "u", nil)
 	if err != nil {
 		t.Errorf("Users.ListFollowers returned error: %v", err)
@@ -90,7 +89,7 @@ func TestUsersService_ListFollowers_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Users.ListFollowers(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -106,7 +105,7 @@ func TestUsersService_ListFollowing_authenticatedUser(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	users, _, err := client.Users.ListFollowing(ctx, "", opts)
 	if err != nil {
 		t.Errorf("Users.ListFollowing returned error: %v", err)
@@ -141,7 +140,7 @@ func TestUsersService_ListFollowing_specifiedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	users, _, err := client.Users.ListFollowing(ctx, "u", nil)
 	if err != nil {
 		t.Errorf("Users.ListFollowing returned error: %v", err)
@@ -171,7 +170,7 @@ func TestUsersService_ListFollowing_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Users.ListFollowing(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -185,7 +184,7 @@ func TestUsersService_IsFollowing_authenticatedUser(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	following, _, err := client.Users.IsFollowing(ctx, "", "t")
 	if err != nil {
 		t.Errorf("Users.IsFollowing returned error: %v", err)
@@ -218,7 +217,7 @@ func TestUsersService_IsFollowing_specifiedUser(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	following, _, err := client.Users.IsFollowing(ctx, "u", "t")
 	if err != nil {
 		t.Errorf("Users.IsFollowing returned error: %v", err)
@@ -251,7 +250,7 @@ func TestUsersService_IsFollowing_false(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	following, _, err := client.Users.IsFollowing(ctx, "u", "t")
 	if err != nil {
 		t.Errorf("Users.IsFollowing returned error: %v", err)
@@ -284,7 +283,7 @@ func TestUsersService_IsFollowing_error(t *testing.T) {
 		http.Error(w, "BadRequest", http.StatusBadRequest)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	following, _, err := client.Users.IsFollowing(ctx, "u", "t")
 	if err == nil {
 		t.Error("Expected HTTP 400 response")
@@ -312,7 +311,7 @@ func TestUsersService_IsFollowing_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Users.IsFollowing(ctx, "%", "%")
 	testURLParseError(t, err)
 }
@@ -325,7 +324,7 @@ func TestUsersService_Follow(t *testing.T) {
 		testMethod(t, r, "PUT")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.Follow(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.Follow returned error: %v", err)
@@ -346,7 +345,7 @@ func TestUsersService_Follow_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.Follow(ctx, "%")
 	testURLParseError(t, err)
 }
@@ -359,7 +358,7 @@ func TestUsersService_Unfollow(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.Unfollow(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.Follow returned error: %v", err)
@@ -380,7 +379,7 @@ func TestUsersService_Unfollow_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.Unfollow(ctx, "%")
 	testURLParseError(t, err)
 }

--- a/github/users_gpg_keys_test.go
+++ b/github/users_gpg_keys_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,7 +25,7 @@ func TestUsersService_ListGPGKeys_authenticatedUser(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	keys, _, err := client.Users.ListGPGKeys(ctx, "", opt)
 	if err != nil {
 		t.Errorf("Users.ListGPGKeys returned error: %v", err)
@@ -61,7 +60,7 @@ func TestUsersService_ListGPGKeys_specifiedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1,"primary_key_id":2}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	keys, _, err := client.Users.ListGPGKeys(ctx, "u", nil)
 	if err != nil {
 		t.Errorf("Users.ListGPGKeys returned error: %v", err)
@@ -77,7 +76,7 @@ func TestUsersService_ListGPGKeys_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Users.ListGPGKeys(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -91,7 +90,7 @@ func TestUsersService_GetGPGKey(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	key, _, err := client.Users.GetGPGKey(ctx, 1)
 	if err != nil {
 		t.Errorf("Users.GetGPGKey returned error: %v", err)
@@ -144,7 +143,7 @@ mQINBFcEd9kBEACo54TDbGhKlXKWMvJgecEUKPPcv7XdnpKdGb3LRw5MvFwT0V0f
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	gpgKey, _, err := client.Users.CreateGPGKey(ctx, input)
 	if err != nil {
 		t.Errorf("Users.GetGPGKey returned error: %v", err)
@@ -173,7 +172,7 @@ func TestUsersService_DeleteGPGKey(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.DeleteGPGKey(ctx, 1)
 	if err != nil {
 		t.Errorf("Users.DeleteGPGKey returned error: %v", err)

--- a/github/users_keys_test.go
+++ b/github/users_keys_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,7 +25,7 @@ func TestUsersService_ListKeys_authenticatedUser(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	keys, _, err := client.Users.ListKeys(ctx, "", opt)
 	if err != nil {
 		t.Errorf("Users.ListKeys returned error: %v", err)
@@ -61,7 +60,7 @@ func TestUsersService_ListKeys_specifiedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	keys, _, err := client.Users.ListKeys(ctx, "u", nil)
 	if err != nil {
 		t.Errorf("Users.ListKeys returned error: %v", err)
@@ -77,7 +76,7 @@ func TestUsersService_ListKeys_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Users.ListKeys(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -91,7 +90,7 @@ func TestUsersService_GetKey(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	key, _, err := client.Users.GetKey(ctx, 1)
 	if err != nil {
 		t.Errorf("Users.GetKey returned error: %v", err)
@@ -135,7 +134,7 @@ func TestUsersService_CreateKey(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	key, _, err := client.Users.CreateKey(ctx, input)
 	if err != nil {
 		t.Errorf("Users.CreateKey returned error: %v", err)
@@ -164,7 +163,7 @@ func TestUsersService_DeleteKey(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.DeleteKey(ctx, 1)
 	if err != nil {
 		t.Errorf("Users.DeleteKey returned error: %v", err)

--- a/github/users_packages_test.go
+++ b/github/users_packages_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -36,7 +35,7 @@ func TestUsersService_Authenticated_ListPackages(t *testing.T) {
 		  }]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	packages, _, err := client.Users.ListPackages(ctx, "", &PackageListOptions{PackageType: Ptr("container"), Visibility: Ptr("private")})
 	if err != nil {
 		t.Errorf("Users.Authenticated_ListPackages returned error: %v", err)
@@ -92,7 +91,7 @@ func TestUsersService_specifiedUser_ListPackages(t *testing.T) {
 		  }]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	packages, _, err := client.Users.ListPackages(ctx, "u", &PackageListOptions{PackageType: Ptr("container"), Visibility: Ptr("public")})
 	if err != nil {
 		t.Errorf("Users.specifiedUser_ListPackages returned error: %v", err)
@@ -150,7 +149,7 @@ func TestUsersService_specifiedUser_GetPackage(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	packages, _, err := client.Users.GetPackage(ctx, "u", "container", "hello/hello_docker")
 	if err != nil {
 		t.Errorf("Users.GetPackage returned error: %v", err)
@@ -204,7 +203,7 @@ func TestUsersService_Authenticated_GetPackage(t *testing.T) {
 		  }`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	packages, _, err := client.Users.GetPackage(ctx, "", "container", "hello_docker")
 	if err != nil {
 		t.Errorf("Users.Authenticated_GetPackage returned error: %v", err)
@@ -248,7 +247,7 @@ func TestUsersService_Authenticated_DeletePackage(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.DeletePackage(ctx, "", "container", "hello_docker")
 	if err != nil {
 		t.Errorf("Users.Authenticated_DeletePackage returned error: %v", err)
@@ -273,7 +272,7 @@ func TestUsersService_specifiedUser_DeletePackage(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.DeletePackage(ctx, "u", "container", "hello_docker")
 	if err != nil {
 		t.Errorf("Users.specifiedUser_DeletePackage returned error: %v", err)
@@ -298,7 +297,7 @@ func TestUsersService_Authenticated_RestorePackage(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.RestorePackage(ctx, "", "container", "hello_docker")
 	if err != nil {
 		t.Errorf("Users.Authenticated_RestorePackage returned error: %v", err)
@@ -323,7 +322,7 @@ func TestUsersService_specifiedUser_RestorePackage(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.RestorePackage(ctx, "u", "container", "hello_docker")
 	if err != nil {
 		t.Errorf("Users.specifiedUser_RestorePackage returned error: %v", err)
@@ -368,7 +367,7 @@ func TestUsersService_Authenticated_ListPackagesVersions(t *testing.T) {
 			}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &PackageListOptions{
 		Ptr("internal"), Ptr("container"), Ptr("deleted"), ListOptions{Page: 1, PerPage: 2},
 	}
@@ -434,7 +433,7 @@ func TestUsersService_specifiedUser_ListPackagesVersions(t *testing.T) {
 			}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opts := &PackageListOptions{
 		Ptr("internal"), Ptr("container"), Ptr("deleted"), ListOptions{Page: 1, PerPage: 2},
 	}
@@ -500,7 +499,7 @@ func TestUsersService_Authenticated_PackageGetVersion(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	packages, _, err := client.Users.PackageGetVersion(ctx, "", "container", "hello_docker", 45763)
 	if err != nil {
 		t.Errorf("Users.PackageGetVersion returned error: %v", err)
@@ -563,7 +562,7 @@ func TestUsersService_specifiedUser_PackageGetVersion(t *testing.T) {
 			}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	packages, _, err := client.Users.PackageGetVersion(ctx, "u", "container", "hello_docker", 45763)
 	if err != nil {
 		t.Errorf("Users.specifiedUser_PackageGetVersion returned error: %v", err)
@@ -606,7 +605,7 @@ func TestUsersService_Authenticated_PackageDeleteVersion(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.PackageDeleteVersion(ctx, "", "container", "hello_docker", 45763)
 	if err != nil {
 		t.Errorf("Users.Authenticated_PackageDeleteVersion returned error: %v", err)
@@ -631,7 +630,7 @@ func TestUsersService_specifiedUser_PackageDeleteVersion(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.PackageDeleteVersion(ctx, "u", "container", "hello_docker", 45763)
 	if err != nil {
 		t.Errorf("Users.specifiedUser_PackageDeleteVersion returned error: %v", err)
@@ -656,7 +655,7 @@ func TestUsersService_Authenticated_PackageRestoreVersion(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.PackageRestoreVersion(ctx, "", "container", "hello_docker", 45763)
 	if err != nil {
 		t.Errorf("Users.Authenticated_PackageRestoreVersion returned error: %v", err)
@@ -681,7 +680,7 @@ func TestUsersService_specifiedUser_PackageRestoreVersion(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.PackageRestoreVersion(ctx, "u", "container", "hello_docker", 45763)
 	if err != nil {
 		t.Errorf("Users.specifiedUser_PackageRestoreVersion returned error: %v", err)

--- a/github/users_social_accounts_test.go
+++ b/github/users_social_accounts_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -30,7 +29,7 @@ func TestUsersService_ListSocialAccounts(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	accounts, _, err := client.Users.ListSocialAccounts(ctx, opt)
 	if err != nil {
 		t.Errorf("Users.ListSocialAccounts returned error: %v", err)
@@ -70,7 +69,7 @@ func TestUsersService_AddSocialAccounts(t *testing.T) {
 		fmt.Fprint(w, `[{"provider":"twitter","url":"https://twitter.com/github"},{"provider":"facebook","url":"https://facebook.com/github"}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	accounts, _, err := client.Users.AddSocialAccounts(ctx, input)
 	if err != nil {
 		t.Errorf("Users.AddSocialAccounts returned error: %v", err)
@@ -111,7 +110,7 @@ func TestUsersService_DeleteSocialAccounts(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.DeleteSocialAccounts(ctx, input)
 	if err != nil {
 		t.Errorf("Users.DeleteSocialAccounts returned error: %v", err)
@@ -138,7 +137,7 @@ func TestUsersService_ListUserSocialAccounts(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	accounts, _, err := client.Users.ListUserSocialAccounts(ctx, "u", opt)
 	if err != nil {
 		t.Errorf("Users.ListUserSocialAccounts returned error: %v", err)

--- a/github/users_ssh_signing_keys_test.go
+++ b/github/users_ssh_signing_keys_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,7 +25,7 @@ func TestUsersService_ListSSHSigningKeys_authenticatedUser(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	ctx := context.Background()
+	ctx := t.Context()
 	keys, _, err := client.Users.ListSSHSigningKeys(ctx, "", opt)
 	if err != nil {
 		t.Errorf("Users.ListSSHSigningKeys returned error: %v", err)
@@ -61,7 +60,7 @@ func TestUsersService_ListSSHSigningKeys_specifiedUser(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	keys, _, err := client.Users.ListSSHSigningKeys(ctx, "u", nil)
 	if err != nil {
 		t.Errorf("Users.ListSSHSigningKeys returned error: %v", err)
@@ -77,7 +76,7 @@ func TestUsersService_ListSSHSigningKeys_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Users.ListSSHSigningKeys(ctx, "%", nil)
 	testURLParseError(t, err)
 }
@@ -91,7 +90,7 @@ func TestUsersService_GetSSHSigningKey(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	key, _, err := client.Users.GetSSHSigningKey(ctx, 1)
 	if err != nil {
 		t.Errorf("Users.GetSSHSigningKey returned error: %v", err)
@@ -135,7 +134,7 @@ func TestUsersService_CreateSSHSigningKey(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	key, _, err := client.Users.CreateSSHSigningKey(ctx, input)
 	if err != nil {
 		t.Errorf("Users.CreateSSHSigningKey returned error: %v", err)
@@ -164,7 +163,7 @@ func TestUsersService_DeleteSSHSigningKey(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := client.Users.DeleteSSHSigningKey(ctx, 1)
 	if err != nil {
 		t.Errorf("Users.DeleteSSHSigningKey returned error: %v", err)

--- a/github/users_test.go
+++ b/github/users_test.go
@@ -6,7 +6,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -154,7 +153,7 @@ func TestUsersService_Get_authenticatedUser(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	user, _, err := client.Users.Get(ctx, "")
 	if err != nil {
 		t.Errorf("Users.Get returned error: %v", err)
@@ -189,7 +188,7 @@ func TestUsersService_Get_specifiedUser(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	user, _, err := client.Users.Get(ctx, "u")
 	if err != nil {
 		t.Errorf("Users.Get returned error: %v", err)
@@ -205,7 +204,7 @@ func TestUsersService_Get_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Users.Get(ctx, "%")
 	testURLParseError(t, err)
 }
@@ -219,7 +218,7 @@ func TestUsersService_GetByID(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	user, _, err := client.Users.GetByID(ctx, 1)
 	if err != nil {
 		t.Fatalf("Users.GetByID returned error: %v", err)
@@ -263,7 +262,7 @@ func TestUsersService_Edit(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	user, _, err := client.Users.Edit(ctx, input)
 	if err != nil {
 		t.Errorf("Users.Edit returned error: %v", err)
@@ -295,7 +294,7 @@ func TestUsersService_GetHovercard(t *testing.T) {
 	})
 
 	opt := &HovercardOptions{SubjectType: "repository", SubjectID: "20180408"}
-	ctx := context.Background()
+	ctx := t.Context()
 	hovercard, _, err := client.Users.GetHovercard(ctx, "u", opt)
 	if err != nil {
 		t.Errorf("Users.GetHovercard returned error: %v", err)
@@ -332,7 +331,7 @@ func TestUsersService_ListAll(t *testing.T) {
 	})
 
 	opt := &UserListOptions{1, ListOptions{Page: 2}}
-	ctx := context.Background()
+	ctx := t.Context()
 	users, _, err := client.Users.ListAll(ctx, opt)
 	if err != nil {
 		t.Errorf("Users.Get returned error: %v", err)
@@ -362,7 +361,7 @@ func TestUsersService_ListInvitations(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	got, _, err := client.Users.ListInvitations(ctx, nil)
 	if err != nil {
 		t.Errorf("Users.ListInvitations returned error: %v", err)
@@ -395,7 +394,7 @@ func TestUsersService_ListInvitations_withOptions(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := client.Users.ListInvitations(ctx, &ListOptions{Page: 2})
 	if err != nil {
 		t.Errorf("Users.ListInvitations returned error: %v", err)
@@ -411,7 +410,7 @@ func TestUsersService_AcceptInvitation(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Users.AcceptInvitation(ctx, 1); err != nil {
 		t.Errorf("Users.AcceptInvitation returned error: %v", err)
 	}
@@ -436,7 +435,7 @@ func TestUsersService_DeclineInvitation(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := client.Users.DeclineInvitation(ctx, 1); err != nil {
 		t.Errorf("Users.DeclineInvitation returned error: %v", err)
 	}

--- a/test/integration/activity_test.go
+++ b/test/integration/activity_test.go
@@ -8,7 +8,6 @@
 package integration
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-github/v75/github"
@@ -20,7 +19,7 @@ const (
 )
 
 func TestActivity_Starring(t *testing.T) {
-	stargazers, _, err := client.Activity.ListStargazers(context.Background(), owner, repo, nil)
+	stargazers, _, err := client.Activity.ListStargazers(t.Context(), owner, repo, nil)
 	if err != nil {
 		t.Fatalf("Activity.ListStargazers returned error: %v", err)
 	}
@@ -35,7 +34,7 @@ func TestActivity_Starring(t *testing.T) {
 	}
 
 	// first, check if already starred the target repository
-	star, _, err := client.Activity.IsStarred(context.Background(), owner, repo)
+	star, _, err := client.Activity.IsStarred(t.Context(), owner, repo)
 	if err != nil {
 		t.Fatalf("Activity.IsStarred returned error: %v", err)
 	}
@@ -44,13 +43,13 @@ func TestActivity_Starring(t *testing.T) {
 	}
 
 	// star the target repository
-	_, err = client.Activity.Star(context.Background(), owner, repo)
+	_, err = client.Activity.Star(t.Context(), owner, repo)
 	if err != nil {
 		t.Fatalf("Activity.Star returned error: %v", err)
 	}
 
 	// check again and verify starred
-	star, _, err = client.Activity.IsStarred(context.Background(), owner, repo)
+	star, _, err = client.Activity.IsStarred(t.Context(), owner, repo)
 	if err != nil {
 		t.Fatalf("Activity.IsStarred returned error: %v", err)
 	}
@@ -59,13 +58,13 @@ func TestActivity_Starring(t *testing.T) {
 	}
 
 	// unstar
-	_, err = client.Activity.Unstar(context.Background(), owner, repo)
+	_, err = client.Activity.Unstar(t.Context(), owner, repo)
 	if err != nil {
 		t.Fatalf("Activity.Unstar returned error: %v", err)
 	}
 
 	// check again and verify not watching
-	star, _, err = client.Activity.IsStarred(context.Background(), owner, repo)
+	star, _, err = client.Activity.IsStarred(t.Context(), owner, repo)
 	if err != nil {
 		t.Fatalf("Activity.IsStarred returned error: %v", err)
 	}
@@ -76,13 +75,13 @@ func TestActivity_Starring(t *testing.T) {
 
 func deleteSubscription(t *testing.T) {
 	// delete subscription
-	_, err := client.Activity.DeleteRepositorySubscription(context.Background(), owner, repo)
+	_, err := client.Activity.DeleteRepositorySubscription(t.Context(), owner, repo)
 	if err != nil {
 		t.Fatalf("Activity.DeleteRepositorySubscription returned error: %v", err)
 	}
 
 	// check again and verify not watching
-	sub, _, err := client.Activity.GetRepositorySubscription(context.Background(), owner, repo)
+	sub, _, err := client.Activity.GetRepositorySubscription(t.Context(), owner, repo)
 	if err != nil {
 		t.Fatalf("Activity.GetRepositorySubscription returned error: %v", err)
 	}
@@ -94,13 +93,13 @@ func deleteSubscription(t *testing.T) {
 func createSubscription(t *testing.T) {
 	// watch the target repository
 	sub := &github.Subscription{Subscribed: github.Ptr(true)}
-	_, _, err := client.Activity.SetRepositorySubscription(context.Background(), owner, repo, sub)
+	_, _, err := client.Activity.SetRepositorySubscription(t.Context(), owner, repo, sub)
 	if err != nil {
 		t.Fatalf("Activity.SetRepositorySubscription returned error: %v", err)
 	}
 
 	// check again and verify watching
-	sub, _, err = client.Activity.GetRepositorySubscription(context.Background(), owner, repo)
+	sub, _, err = client.Activity.GetRepositorySubscription(t.Context(), owner, repo)
 	if err != nil {
 		t.Fatalf("Activity.GetRepositorySubscription returned error: %v", err)
 	}
@@ -110,7 +109,7 @@ func createSubscription(t *testing.T) {
 }
 
 func TestActivity_Watching(t *testing.T) {
-	watchers, _, err := client.Activity.ListWatchers(context.Background(), owner, repo, nil)
+	watchers, _, err := client.Activity.ListWatchers(t.Context(), owner, repo, nil)
 	if err != nil {
 		t.Fatalf("Activity.ListWatchers returned error: %v", err)
 	}
@@ -125,7 +124,7 @@ func TestActivity_Watching(t *testing.T) {
 	}
 
 	// first, check if already watching the target repository
-	sub, _, err := client.Activity.GetRepositorySubscription(context.Background(), owner, repo)
+	sub, _, err := client.Activity.GetRepositorySubscription(t.Context(), owner, repo)
 	if err != nil {
 		t.Fatalf("Activity.GetRepositorySubscription returned error: %v", err)
 	}

--- a/test/integration/audit_log_test.go
+++ b/test/integration/audit_log_test.go
@@ -8,7 +8,6 @@
 package integration
 
 import (
-	"context"
 	"testing"
 )
 
@@ -17,7 +16,7 @@ import (
 // Test requires auth - set env var GITHUB_AUTH_TOKEN.
 func TestOrganizationAuditLog(t *testing.T) {
 	org := "example_org"
-	entries, _, err := client.Organizations.GetAuditLog(context.Background(), org, nil)
+	entries, _, err := client.Organizations.GetAuditLog(t.Context(), org, nil)
 	if err != nil {
 		t.Fatalf("Organizations.GetAuditLog returned error: %v", err)
 	}

--- a/test/integration/authorizations_test.go
+++ b/test/integration/authorizations_test.go
@@ -8,7 +8,6 @@
 package integration
 
 import (
-	"context"
 	"os"
 	"strings"
 	"testing"
@@ -36,7 +35,7 @@ func TestAuthorizationsAppOperations(t *testing.T) {
 	accessToken := os.Getenv(envKeyAccessToken)
 
 	// Verify the token
-	appAuth, resp, err := appAuthenticatedClient.Authorizations.Check(context.Background(), clientID, accessToken)
+	appAuth, resp, err := appAuthenticatedClient.Authorizations.Check(t.Context(), clientID, accessToken)
 	failOnError(t, err)
 	failIfNotStatusCode(t, resp, 200)
 
@@ -46,19 +45,19 @@ func TestAuthorizationsAppOperations(t *testing.T) {
 	}
 
 	// Let's verify that we get a 404 for a non-existent token
-	_, resp, err = appAuthenticatedClient.Authorizations.Check(context.Background(), clientID, InvalidTokenValue)
+	_, resp, err = appAuthenticatedClient.Authorizations.Check(t.Context(), clientID, InvalidTokenValue)
 	if err == nil {
 		t.Fatal("An error should have been returned because of the invalid token.")
 	}
 	failIfNotStatusCode(t, resp, 404)
 
 	// Let's reset the token
-	resetAuth, resp, err := appAuthenticatedClient.Authorizations.Reset(context.Background(), clientID, accessToken)
+	resetAuth, resp, err := appAuthenticatedClient.Authorizations.Reset(t.Context(), clientID, accessToken)
 	failOnError(t, err)
 	failIfNotStatusCode(t, resp, 200)
 
 	// Let's verify that we get a 404 for a non-existent token
-	_, resp, err = appAuthenticatedClient.Authorizations.Reset(context.Background(), clientID, InvalidTokenValue)
+	_, resp, err = appAuthenticatedClient.Authorizations.Reset(t.Context(), clientID, InvalidTokenValue)
 	if err == nil {
 		t.Fatal("An error should have been returned because of the invalid token.")
 	}
@@ -75,19 +74,19 @@ func TestAuthorizationsAppOperations(t *testing.T) {
 	}
 
 	// Verify that the original token is now invalid
-	_, resp, err = appAuthenticatedClient.Authorizations.Check(context.Background(), clientID, accessToken)
+	_, resp, err = appAuthenticatedClient.Authorizations.Check(t.Context(), clientID, accessToken)
 	if err == nil {
 		t.Fatal("The original token should be invalid.")
 	}
 	failIfNotStatusCode(t, resp, 404)
 
 	// Check that the reset token is valid
-	_, resp, err = appAuthenticatedClient.Authorizations.Check(context.Background(), clientID, *resetAuth.Token)
+	_, resp, err = appAuthenticatedClient.Authorizations.Check(t.Context(), clientID, *resetAuth.Token)
 	failOnError(t, err)
 	failIfNotStatusCode(t, resp, 200)
 
 	// Let's revoke the token
-	resp, err = appAuthenticatedClient.Authorizations.Revoke(context.Background(), clientID, *resetAuth.Token)
+	resp, err = appAuthenticatedClient.Authorizations.Revoke(t.Context(), clientID, *resetAuth.Token)
 	failOnError(t, err)
 	failIfNotStatusCode(t, resp, 204)
 
@@ -96,7 +95,7 @@ func TestAuthorizationsAppOperations(t *testing.T) {
 	time.Sleep(time.Second * 2)
 
 	// Now, the reset token should also be invalid
-	_, resp, err = appAuthenticatedClient.Authorizations.Check(context.Background(), clientID, *resetAuth.Token)
+	_, resp, err = appAuthenticatedClient.Authorizations.Check(t.Context(), clientID, *resetAuth.Token)
 	if err == nil {
 		t.Fatal("The reset token should be invalid.")
 	}

--- a/test/integration/issues_test.go
+++ b/test/integration/issues_test.go
@@ -8,12 +8,11 @@
 package integration
 
 import (
-	"context"
 	"testing"
 )
 
 func TestIssueEvents(t *testing.T) {
-	events, _, err := client.Issues.ListRepositoryEvents(context.Background(), "google", "go-github", nil)
+	events, _, err := client.Issues.ListRepositoryEvents(t.Context(), "google", "go-github", nil)
 	if err != nil {
 		t.Fatalf("Issues.ListRepositoryEvents returned error: %v", err)
 	}
@@ -22,7 +21,7 @@ func TestIssueEvents(t *testing.T) {
 		t.Error("ListRepositoryEvents returned no events")
 	}
 
-	events, _, err = client.Issues.ListIssueEvents(context.Background(), "google", "go-github", 1, nil)
+	events, _, err = client.Issues.ListIssueEvents(t.Context(), "google", "go-github", 1, nil)
 	if err != nil {
 		t.Fatalf("Issues.ListIssueEvents returned error: %v", err)
 	}
@@ -31,7 +30,7 @@ func TestIssueEvents(t *testing.T) {
 		t.Error("ListIssueEvents returned no events")
 	}
 
-	event, _, err := client.Issues.GetEvent(context.Background(), "google", "go-github", *events[0].ID)
+	event, _, err := client.Issues.GetEvent(t.Context(), "google", "go-github", *events[0].ID)
 	if err != nil {
 		t.Fatalf("Issues.GetEvent returned error: %v", err)
 	}

--- a/test/integration/misc_test.go
+++ b/test/integration/misc_test.go
@@ -8,13 +8,12 @@
 package integration
 
 import (
-	"context"
 	"testing"
 	"time"
 )
 
 func TestEmojis(t *testing.T) {
-	emoji, _, err := client.Emojis.List(context.Background())
+	emoji, _, err := client.Emojis.List(t.Context())
 	if err != nil {
 		t.Fatalf("List returned error: %v", err)
 	}
@@ -29,7 +28,7 @@ func TestEmojis(t *testing.T) {
 }
 
 func TestAPIMeta(t *testing.T) {
-	meta, _, err := client.Meta.Get(context.Background())
+	meta, _, err := client.Meta.Get(t.Context())
 	if err != nil {
 		t.Fatalf("Get returned error: %v", err)
 	}
@@ -48,7 +47,7 @@ func TestAPIMeta(t *testing.T) {
 }
 
 func TestRateLimits(t *testing.T) {
-	limits, _, err := client.RateLimit.Get(context.Background())
+	limits, _, err := client.RateLimit.Get(t.Context())
 	if err != nil {
 		t.Fatalf("RateLimits returned error: %v", err)
 	}

--- a/test/integration/pulls_test.go
+++ b/test/integration/pulls_test.go
@@ -8,12 +8,11 @@
 package integration
 
 import (
-	"context"
 	"testing"
 )
 
 func TestPullRequests_ListCommits(t *testing.T) {
-	commits, _, err := client.PullRequests.ListCommits(context.Background(), "google", "go-github", 2, nil)
+	commits, _, err := client.PullRequests.ListCommits(t.Context(), "google", "go-github", 2, nil)
 	if err != nil {
 		t.Fatalf("PullRequests.ListCommits() returned error: %v", err)
 	}

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -8,7 +8,6 @@
 package integration
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"testing"
@@ -22,28 +21,24 @@ func TestRepositories_CRUD(t *testing.T) {
 		return
 	}
 
-	// create a random repository
-	repo, err := createRandomTestRepository("", true)
-	if err != nil {
-		t.Fatalf("createRandomTestRepository returned error: %v", err)
-	}
+	repo := createRandomTestRepository(t, "", true)
 
 	// update the repository description
 	repo.Description = github.Ptr("description")
 	repo.DefaultBranch = nil // FIXME: this shouldn't be necessary
-	_, _, err = client.Repositories.Edit(context.Background(), *repo.Owner.Login, *repo.Name, repo)
+	_, _, err := client.Repositories.Edit(t.Context(), *repo.Owner.Login, *repo.Name, repo)
 	if err != nil {
 		t.Fatalf("Repositories.Edit() returned error: %v", err)
 	}
 
 	// delete the repository
-	_, err = client.Repositories.Delete(context.Background(), *repo.Owner.Login, *repo.Name)
+	_, err = client.Repositories.Delete(t.Context(), *repo.Owner.Login, *repo.Name)
 	if err != nil {
 		t.Fatalf("Repositories.Delete() returned error: %v", err)
 	}
 
 	// verify that the repository was deleted
-	_, resp, err := client.Repositories.Get(context.Background(), *repo.Owner.Login, *repo.Name)
+	_, resp, err := client.Repositories.Get(t.Context(), *repo.Owner.Login, *repo.Name)
 	if err == nil {
 		t.Fatal("Test repository still exists after deleting it.")
 	}
@@ -54,7 +49,7 @@ func TestRepositories_CRUD(t *testing.T) {
 
 func TestRepositories_BranchesTags(t *testing.T) {
 	// branches
-	branches, _, err := client.Repositories.ListBranches(context.Background(), "git", "git", nil)
+	branches, _, err := client.Repositories.ListBranches(t.Context(), "git", "git", nil)
 	if err != nil {
 		t.Fatalf("Repositories.ListBranches() returned error: %v", err)
 	}
@@ -63,13 +58,13 @@ func TestRepositories_BranchesTags(t *testing.T) {
 		t.Fatal("Repositories.ListBranches('git', 'git') returned no branches")
 	}
 
-	_, _, err = client.Repositories.GetBranch(context.Background(), "git", "git", *branches[0].Name, 0)
+	_, _, err = client.Repositories.GetBranch(t.Context(), "git", "git", *branches[0].Name, 0)
 	if err != nil {
 		t.Fatalf("Repositories.GetBranch() returned error: %v", err)
 	}
 
 	// tags
-	tags, _, err := client.Repositories.ListTags(context.Background(), "git", "git", nil)
+	tags, _, err := client.Repositories.ListTags(t.Context(), "git", "git", nil)
 	if err != nil {
 		t.Fatalf("Repositories.ListTags() returned error: %v", err)
 	}
@@ -84,13 +79,9 @@ func TestRepositories_EditBranches(t *testing.T) {
 		return
 	}
 
-	// create a random repository
-	repo, err := createRandomTestRepository("", true)
-	if err != nil {
-		t.Fatalf("createRandomTestRepository returned error: %v", err)
-	}
+	repo := createRandomTestRepository(t, "", true)
 
-	branch, _, err := client.Repositories.GetBranch(context.Background(), *repo.Owner.Login, *repo.Name, "master", 0)
+	branch, _, err := client.Repositories.GetBranch(t.Context(), *repo.Owner.Login, *repo.Name, "master", 0)
 	if err != nil {
 		t.Fatalf("Repositories.GetBranch() returned error: %v", err)
 	}
@@ -117,7 +108,7 @@ func TestRepositories_EditBranches(t *testing.T) {
 		AllowForkSyncing: github.Ptr(false),
 	}
 
-	protection, _, err := client.Repositories.UpdateBranchProtection(context.Background(), *repo.Owner.Login, *repo.Name, "master", protectionRequest)
+	protection, _, err := client.Repositories.UpdateBranchProtection(t.Context(), *repo.Owner.Login, *repo.Name, "master", protectionRequest)
 	if err != nil {
 		t.Fatalf("Repositories.UpdateBranchProtection() returned error: %v", err)
 	}
@@ -150,7 +141,7 @@ func TestRepositories_EditBranches(t *testing.T) {
 		t.Errorf("Repositories.UpdateBranchProtection() returned %+v, want %+v", protection, want)
 	}
 
-	_, err = client.Repositories.Delete(context.Background(), *repo.Owner.Login, *repo.Name)
+	_, err = client.Repositories.Delete(t.Context(), *repo.Owner.Login, *repo.Name)
 	if err != nil {
 		t.Fatalf("Repositories.Delete() returned error: %v", err)
 	}
@@ -161,20 +152,20 @@ func TestRepositories_ListByAuthenticatedUser(t *testing.T) {
 		return
 	}
 
-	_, _, err := client.Repositories.ListByAuthenticatedUser(context.Background(), nil)
+	_, _, err := client.Repositories.ListByAuthenticatedUser(t.Context(), nil)
 	if err != nil {
 		t.Fatalf("Repositories.ListByAuthenticatedUser() returned error: %v", err)
 	}
 }
 
 func TestRepositories_ListByUser(t *testing.T) {
-	_, _, err := client.Repositories.ListByUser(context.Background(), "google", nil)
+	_, _, err := client.Repositories.ListByUser(t.Context(), "google", nil)
 	if err != nil {
 		t.Fatalf("Repositories.ListByUser('google') returned error: %v", err)
 	}
 
 	opt := github.RepositoryListByUserOptions{Sort: "created"}
-	repos, _, err := client.Repositories.ListByUser(context.Background(), "google", &opt)
+	repos, _, err := client.Repositories.ListByUser(t.Context(), "google", &opt)
 	if err != nil {
 		t.Fatalf("Repositories.List('google') with Sort opt returned error: %v", err)
 	}
@@ -190,7 +181,7 @@ func TestRepositories_DownloadReleaseAsset(t *testing.T) {
 		return
 	}
 
-	rc, _, err := client.Repositories.DownloadReleaseAsset(context.Background(), "andersjanmyr", "goose", 484892, http.DefaultClient)
+	rc, _, err := client.Repositories.DownloadReleaseAsset(t.Context(), "andersjanmyr", "goose", 484892, http.DefaultClient)
 	if err != nil {
 		t.Fatalf("Repositories.DownloadReleaseAsset(andersjanmyr, goose, 484892, true) returned error: %v", err)
 	}
@@ -206,11 +197,7 @@ func TestRepositories_Autolinks(t *testing.T) {
 		return
 	}
 
-	// create a random repository
-	repo, err := createRandomTestRepository("", true)
-	if err != nil {
-		t.Fatalf("createRandomTestRepository returned error: %v", err)
-	}
+	repo := createRandomTestRepository(t, "", true)
 
 	opts := &github.AutolinkOptions{
 		KeyPrefix:      github.Ptr("TICKET-"),
@@ -218,7 +205,7 @@ func TestRepositories_Autolinks(t *testing.T) {
 		IsAlphanumeric: github.Ptr(false),
 	}
 
-	actionlink, _, err := client.Repositories.AddAutolink(context.Background(), *repo.Owner.Login, *repo.Name, opts)
+	actionlink, _, err := client.Repositories.AddAutolink(t.Context(), *repo.Owner.Login, *repo.Name, opts)
 	if err != nil {
 		t.Fatalf("Repositories.AddAutolink() returned error: %v", err)
 	}
@@ -229,7 +216,7 @@ func TestRepositories_Autolinks(t *testing.T) {
 		t.Errorf("Repositories.AddAutolink() returned %+v, want %+v", actionlink, opts)
 	}
 
-	_, err = client.Repositories.Delete(context.Background(), *repo.Owner.Login, *repo.Name)
+	_, err = client.Repositories.Delete(t.Context(), *repo.Owner.Login, *repo.Name)
 	if err != nil {
 		t.Fatalf("Repositories.Delete() returned error: %v", err)
 	}

--- a/test/integration/users_test.go
+++ b/test/integration/users_test.go
@@ -8,7 +8,6 @@
 package integration
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -18,7 +17,7 @@ import (
 
 func TestUsers_Get(t *testing.T) {
 	// list all users
-	users, _, err := client.Users.ListAll(context.Background(), nil)
+	users, _, err := client.Users.ListAll(t.Context(), nil)
 	if err != nil {
 		t.Fatalf("Users.ListAll returned error: %v", err)
 	}
@@ -33,7 +32,7 @@ func TestUsers_Get(t *testing.T) {
 	}
 
 	// get individual user
-	u, _, err := client.Users.Get(context.Background(), "octocat")
+	u, _, err := client.Users.Get(t.Context(), "octocat")
 	if err != nil {
 		t.Fatalf("Users.Get('octocat') returned error: %v", err)
 	}
@@ -51,7 +50,7 @@ func TestUsers_Update(t *testing.T) {
 		return
 	}
 
-	u, _, err := client.Users.Get(context.Background(), "")
+	u, _, err := client.Users.Get(t.Context(), "")
 	if err != nil {
 		t.Fatalf("Users.Get('') returned error: %v", err)
 	}
@@ -70,13 +69,13 @@ func TestUsers_Update(t *testing.T) {
 	testLoc := fmt.Sprintf("test-%d", rand.Int())
 	u.Location = &testLoc
 
-	_, _, err = client.Users.Edit(context.Background(), u)
+	_, _, err = client.Users.Edit(t.Context(), u)
 	if err != nil {
 		t.Fatalf("Users.Update returned error: %v", err)
 	}
 
 	// refetch user and check location value
-	u, _, err = client.Users.Get(context.Background(), "")
+	u, _, err = client.Users.Get(t.Context(), "")
 	if err != nil {
 		t.Fatalf("Users.Get('') returned error: %v", err)
 	}
@@ -87,7 +86,7 @@ func TestUsers_Update(t *testing.T) {
 
 	// set location back to the original value
 	u.Location = &location
-	_, _, err = client.Users.Edit(context.Background(), u)
+	_, _, err = client.Users.Edit(t.Context(), u)
 	if err != nil {
 		t.Fatalf("Users.Edit returned error: %v", err)
 	}
@@ -98,7 +97,7 @@ func TestUsers_Emails(t *testing.T) {
 		return
 	}
 
-	emails, _, err := client.Users.ListEmails(context.Background(), nil)
+	emails, _, err := client.Users.ListEmails(t.Context(), nil)
 	if err != nil {
 		t.Fatalf("Users.ListEmails() returned error: %v", err)
 	}
@@ -117,13 +116,13 @@ EmailLoop:
 	}
 
 	// Add new address
-	_, _, err = client.Users.AddEmails(context.Background(), []string{email})
+	_, _, err = client.Users.AddEmails(t.Context(), []string{email})
 	if err != nil {
 		t.Fatalf("Users.AddEmails() returned error: %v", err)
 	}
 
 	// List emails again and verify new email is present
-	emails, _, err = client.Users.ListEmails(context.Background(), nil)
+	emails, _, err = client.Users.ListEmails(t.Context(), nil)
 	if err != nil {
 		t.Fatalf("Users.ListEmails() returned error: %v", err)
 	}
@@ -141,13 +140,13 @@ EmailLoop:
 	}
 
 	// Remove new address
-	_, err = client.Users.DeleteEmails(context.Background(), []string{email})
+	_, err = client.Users.DeleteEmails(t.Context(), []string{email})
 	if err != nil {
 		t.Fatalf("Users.DeleteEmails() returned error: %v", err)
 	}
 
 	// List emails again and verify new email was removed
-	emails, _, err = client.Users.ListEmails(context.Background(), nil)
+	emails, _, err = client.Users.ListEmails(t.Context(), nil)
 	if err != nil {
 		t.Fatalf("Users.ListEmails() returned error: %v", err)
 	}
@@ -160,7 +159,7 @@ EmailLoop:
 }
 
 func TestUsers_Keys(t *testing.T) {
-	keys, _, err := client.Users.ListKeys(context.Background(), "willnorris", nil)
+	keys, _, err := client.Users.ListKeys(t.Context(), "willnorris", nil)
 	if err != nil {
 		t.Fatalf("Users.ListKeys('willnorris') returned error: %v", err)
 	}
@@ -175,7 +174,7 @@ func TestUsers_Keys(t *testing.T) {
 	}
 
 	// TODO: make this integration test work for any authenticated user.
-	keys, _, err = client.Users.ListKeys(context.Background(), "", nil)
+	keys, _, err = client.Users.ListKeys(t.Context(), "", nil)
 	if err != nil {
 		t.Fatalf("Users.ListKeys('') returned error: %v", err)
 	}
@@ -189,7 +188,7 @@ func TestUsers_Keys(t *testing.T) {
 	}
 
 	// Add new key
-	_, _, err = client.Users.CreateKey(context.Background(), &github.Key{
+	_, _, err = client.Users.CreateKey(t.Context(), &github.Key{
 		Title: github.Ptr("go-github test key"),
 		Key:   github.Ptr(key),
 	})
@@ -198,7 +197,7 @@ func TestUsers_Keys(t *testing.T) {
 	}
 
 	// List keys again and verify new key is present
-	keys, _, err = client.Users.ListKeys(context.Background(), "", nil)
+	keys, _, err = client.Users.ListKeys(t.Context(), "", nil)
 	if err != nil {
 		t.Fatalf("Users.ListKeys('') returned error: %v", err)
 	}
@@ -216,7 +215,7 @@ func TestUsers_Keys(t *testing.T) {
 	}
 
 	// Verify that fetching individual key works
-	k, _, err := client.Users.GetKey(context.Background(), id)
+	k, _, err := client.Users.GetKey(t.Context(), id)
 	if err != nil {
 		t.Fatalf("Users.GetKey(%q) returned error: %v", id, err)
 	}
@@ -225,13 +224,13 @@ func TestUsers_Keys(t *testing.T) {
 	}
 
 	// Remove test key
-	_, err = client.Users.DeleteKey(context.Background(), id)
+	_, err = client.Users.DeleteKey(t.Context(), id)
 	if err != nil {
 		t.Fatalf("Users.DeleteKey(%d) returned error: %v", id, err)
 	}
 
 	// List keys again and verify test key was removed
-	keys, _, err = client.Users.ListKeys(context.Background(), "", nil)
+	keys, _, err = client.Users.ListKeys(t.Context(), "", nil)
 	if err != nil {
 		t.Fatalf("Users.ListKeys('') returned error: %v", err)
 	}


### PR DESCRIPTION
This PR replaces `context.Background()` with `t.Context()` in tests. [`T.Context`](https://pkg.go.dev/testing#T.Context) has been available since Go 1.24.

Additionally, it enables the [`usetesting`](https://golangci-lint.run/docs/linters/configuration/#usetesting) linter to automatically suggest using `t.Context()` in future PRs.

The PR also modifies the helper function `createRandomTestRepository` by adding a `*testing.T` parameter. This simplifies integration tests that rely on this function.