### PR TITLE
test: Simplify the function that skips integration tests

### DIFF
--- a/test/integration/activity_test.go
+++ b/test/integration/activity_test.go
@@ -29,9 +29,7 @@ func TestActivity_Starring(t *testing.T) {
 	}
 
 	// the rest of the tests requires auth
-	if !checkAuth("TestActivity_Starring") {
-		return
-	}
+	skipIfMissingAuth(t)
 
 	// first, check if already starred the target repository
 	star, _, err := client.Activity.IsStarred(t.Context(), owner, repo)
@@ -119,9 +117,7 @@ func TestActivity_Watching(t *testing.T) {
 	}
 
 	// the rest of the tests requires auth
-	if !checkAuth("TestActivity_Watching") {
-		return
-	}
+	skipIfMissingAuth(t)
 
 	// first, check if already watching the target repository
 	sub, _, err := client.Activity.GetRepositorySubscription(t.Context(), owner, repo)

--- a/test/integration/audit_log_test.go
+++ b/test/integration/audit_log_test.go
@@ -15,6 +15,8 @@ import (
 // Note: Org must be part of an enterprise.
 // Test requires auth - set env var GITHUB_AUTH_TOKEN.
 func TestOrganizationAuditLog(t *testing.T) {
+	skipIfMissingAuth(t)
+
 	org := "example_org"
 	entries, _, err := client.Organizations.GetAuditLog(t.Context(), org, nil)
 	if err != nil {

--- a/test/integration/misc_test.go
+++ b/test/integration/misc_test.go
@@ -41,8 +41,8 @@ func TestAPIMeta(t *testing.T) {
 		t.Error("Get returned no git addresses")
 	}
 
-	if !*meta.VerifiablePasswordAuthentication {
-		t.Error("APIMeta VerifiablePasswordAuthentication is false")
+	if *meta.VerifiablePasswordAuthentication {
+		t.Error("APIMeta VerifiablePasswordAuthentication is true")
 	}
 }
 

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -17,9 +17,7 @@ import (
 )
 
 func TestRepositories_CRUD(t *testing.T) {
-	if !checkAuth("TestRepositories_CRUD") {
-		return
-	}
+	skipIfMissingAuth(t)
 
 	repo := createRandomTestRepository(t, "", true)
 
@@ -75,9 +73,7 @@ func TestRepositories_BranchesTags(t *testing.T) {
 }
 
 func TestRepositories_EditBranches(t *testing.T) {
-	if !checkAuth("TestRepositories_EditBranches") {
-		return
-	}
+	skipIfMissingAuth(t)
 
 	repo := createRandomTestRepository(t, "", true)
 
@@ -148,9 +144,7 @@ func TestRepositories_EditBranches(t *testing.T) {
 }
 
 func TestRepositories_ListByAuthenticatedUser(t *testing.T) {
-	if !checkAuth("TestRepositories_ListByAuthenticatedUser") {
-		return
-	}
+	skipIfMissingAuth(t)
 
 	_, _, err := client.Repositories.ListByAuthenticatedUser(t.Context(), nil)
 	if err != nil {
@@ -177,9 +171,7 @@ func TestRepositories_ListByUser(t *testing.T) {
 }
 
 func TestRepositories_DownloadReleaseAsset(t *testing.T) {
-	if !checkAuth("TestRepositories_DownloadReleaseAsset") {
-		return
-	}
+	skipIfMissingAuth(t)
 
 	rc, _, err := client.Repositories.DownloadReleaseAsset(t.Context(), "andersjanmyr", "goose", 484892, http.DefaultClient)
 	if err != nil {
@@ -193,9 +185,7 @@ func TestRepositories_DownloadReleaseAsset(t *testing.T) {
 }
 
 func TestRepositories_Autolinks(t *testing.T) {
-	if !checkAuth("TestRepositories_Autolinks") {
-		return
-	}
+	skipIfMissingAuth(t)
 
 	repo := createRandomTestRepository(t, "", true)
 

--- a/test/integration/users_test.go
+++ b/test/integration/users_test.go
@@ -46,9 +46,7 @@ func TestUsers_Get(t *testing.T) {
 }
 
 func TestUsers_Update(t *testing.T) {
-	if !checkAuth("TestUsers_Get") {
-		return
-	}
+	skipIfMissingAuth(t)
 
 	u, _, err := client.Users.Get(t.Context(), "")
 	if err != nil {
@@ -93,9 +91,7 @@ func TestUsers_Update(t *testing.T) {
 }
 
 func TestUsers_Emails(t *testing.T) {
-	if !checkAuth("TestUsers_Emails") {
-		return
-	}
+	skipIfMissingAuth(t)
 
 	emails, _, err := client.Users.ListEmails(t.Context(), nil)
 	if err != nil {
@@ -169,9 +165,7 @@ func TestUsers_Keys(t *testing.T) {
 	}
 
 	// the rest of the tests requires auth
-	if !checkAuth("TestUsers_Keys") {
-		return
-	}
+	skipIfMissingAuth(t)
 
 	// TODO: make this integration test work for any authenticated user.
 	keys, _, err = client.Users.ListKeys(t.Context(), "", nil)


### PR DESCRIPTION
This PR refactors integration tests:

- Refactor `checkAuth` function in by passing `*testing.T` parameter and renaming for clarity.
- Simplifying `client` and `auth` initialization by using [`sync.OnceValues`](https://pkg.go.dev/sync#OnceValues).
- Fix `TestAPIMeta` which fails if run without OAuth token.

<details><summary>Running integration tests locally</summary>
<p>

`TestAPIMeta` without token:

```console
❯ go test -tags=integration -count=1 -v -run=TestAPIMeta ./test/integration/...
=== RUN   TestAPIMeta
--- PASS: TestAPIMeta (0.28s)
PASS
ok      github.com/google/go-github/v75/test/integration        0.860s
```

`TestAPIMeta` with token:

```console
❯ GITHUB_AUTH_TOKEN=ghp_... go test -tags=integration -count=1 -v -run=TestAPIMeta ./test/integration/...
=== RUN   TestAPIMeta
--- PASS: TestAPIMeta (0.28s)
PASS
ok      github.com/google/go-github/v75/test/integration        0.860s
```

All tests without token:

```console
❯ go test -tags=integration -count=1 -v ./test/integration/...
=== RUN   TestActivity_Starring
    github_test.go:34: No OAuth token - skipping portions of TestActivity_Starring
--- SKIP: TestActivity_Starring (0.30s)
=== RUN   TestActivity_Watching
    github_test.go:34: No OAuth token - skipping portions of TestActivity_Watching
--- SKIP: TestActivity_Watching (0.20s)
=== RUN   TestOrganizationAuditLog
    github_test.go:34: No OAuth token - skipping portions of TestOrganizationAuditLog
--- SKIP: TestOrganizationAuditLog (0.00s)
=== RUN   TestAuthorizationsAppOperations
    authorizations_test.go:130: Skipping test because the required environment variable (GITHUB_CLIENT_ID) is not present.
--- SKIP: TestAuthorizationsAppOperations (0.00s)
=== RUN   TestIssueEvents
--- PASS: TestIssueEvents (1.06s)
=== RUN   TestEmojis
--- PASS: TestEmojis (0.17s)
=== RUN   TestAPIMeta
--- PASS: TestAPIMeta (0.16s)
=== RUN   TestRateLimits
--- PASS: TestRateLimits (0.04s)
=== RUN   TestPullRequests_ListCommits
--- PASS: TestPullRequests_ListCommits (0.26s)
=== RUN   TestRepositories_CRUD
    github_test.go:34: No OAuth token - skipping portions of TestRepositories_CRUD
--- SKIP: TestRepositories_CRUD (0.00s)
=== RUN   TestRepositories_BranchesTags
--- PASS: TestRepositories_BranchesTags (0.65s)
=== RUN   TestRepositories_EditBranches
    github_test.go:34: No OAuth token - skipping portions of TestRepositories_EditBranches
--- SKIP: TestRepositories_EditBranches (0.00s)
=== RUN   TestRepositories_ListByAuthenticatedUser
    github_test.go:34: No OAuth token - skipping portions of TestRepositories_ListByAuthenticatedUser
--- SKIP: TestRepositories_ListByAuthenticatedUser (0.00s)
=== RUN   TestRepositories_ListByUser
--- PASS: TestRepositories_ListByUser (0.65s)
=== RUN   TestRepositories_DownloadReleaseAsset
    github_test.go:34: No OAuth token - skipping portions of TestRepositories_DownloadReleaseAsset
--- SKIP: TestRepositories_DownloadReleaseAsset (0.00s)
=== RUN   TestRepositories_Autolinks
    github_test.go:34: No OAuth token - skipping portions of TestRepositories_Autolinks
--- SKIP: TestRepositories_Autolinks (0.00s)
=== RUN   TestUsers_Get
--- PASS: TestUsers_Get (0.34s)
=== RUN   TestUsers_Update
    github_test.go:34: No OAuth token - skipping portions of TestUsers_Update
--- SKIP: TestUsers_Update (0.00s)
=== RUN   TestUsers_Emails
    github_test.go:34: No OAuth token - skipping portions of TestUsers_Emails
--- SKIP: TestUsers_Emails (0.00s)
=== RUN   TestUsers_Keys
    github_test.go:34: No OAuth token - skipping portions of TestUsers_Keys
--- SKIP: TestUsers_Keys (0.16s)
PASS
ok      github.com/google/go-github/v75/test/integration        4.347s
```

</p>
</details> 