### PR TITLE
refactor: Simplify for range loops

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - godot
     - goheader
     - gosec
+    - intrange
     - misspell
     - nakedret
     - paralleltest

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -193,7 +193,7 @@ func testAddURLOptions(t *testing.T, url string, v any, want string) {
 	t.Helper()
 
 	vt := reflect.Indirect(reflect.ValueOf(v)).Type()
-	for i := 0; i < vt.NumField(); i++ {
+	for i := range vt.NumField() {
 		field := vt.Field(i)
 		if alias, ok := field.Tag.Lookup("url"); ok {
 			if alias == "" {

--- a/github/strings.go
+++ b/github/strings.go
@@ -38,7 +38,7 @@ func stringifyValue(w *bytes.Buffer, val reflect.Value) {
 		fmt.Fprintf(w, `"%v"`, v)
 	case reflect.Slice:
 		w.WriteByte('[')
-		for i := 0; i < v.Len(); i++ {
+		for i := range v.Len() {
 			if i > 0 {
 				w.WriteByte(' ')
 			}
@@ -62,7 +62,7 @@ func stringifyValue(w *bytes.Buffer, val reflect.Value) {
 		w.WriteByte('{')
 
 		var sep bool
-		for i := 0; i < v.NumField(); i++ {
+		for i := range v.NumField() {
 			fv := v.Field(i)
 			if fv.Kind() == reflect.Pointer && fv.IsNil() {
 				continue


### PR DESCRIPTION
This PR enables the [`intrange`](https://golangci-lint.run/docs/linters/configuration/#intrange) linter to detect for range loops that can be simplified.