### PR TITLE
fix: Correct body in `EnterpriseService.InitialConfig`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - gosec
     - intrange
     - misspell
+    - musttag
     - nakedret
     - paralleltest
     - perfsprint

--- a/github/enterprise_manage_ghes_config.go
+++ b/github/enterprise_manage_ghes_config.go
@@ -63,10 +63,10 @@ type ConfigApplyEventsNodeEvent struct {
 	SpanDepth    *int       `json:"span_depth,omitempty"`
 }
 
-// InitialConfigOptions is a struct to hold the options for the InitialConfig API.
+// InitialConfigOptions represents the payload for initializing instance configuration.
 type InitialConfigOptions struct {
-	License  string `url:"license"`
-	Password string `url:"password"`
+	License  string `json:"license"`
+	Password string `json:"password"`
 }
 
 // LicenseStatus is a struct to hold the response from the License API.
@@ -336,12 +336,12 @@ func (s *EnterpriseService) ConfigApplyEvents(ctx context.Context, opts *ConfigA
 func (s *EnterpriseService) InitialConfig(ctx context.Context, license, password string) (*Response, error) {
 	u := "manage/v1/config/init"
 
-	opts := &InitialConfigOptions{
+	payload := &InitialConfigOptions{
 		License:  license,
 		Password: password,
 	}
 
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest("POST", u, payload)
 	if err != nil {
 		return nil, err
 	}

--- a/github/timestamp_test.go
+++ b/github/timestamp_test.go
@@ -111,8 +111,8 @@ func TestTimestamp_MarshalReflexivity(t *testing.T) {
 }
 
 type WrappedTimestamp struct {
-	A    int
-	Time Timestamp
+	A    int       `json:"A"`
+	Time Timestamp `json:"Time"`
 }
 
 func TestWrappedTimestamp_Marshal(t *testing.T) {


### PR DESCRIPTION
This PR fixes the body in the `EnterpriseService.InitialConfig` endpoint. From the [documentation](https://docs.github.com/en/enterprise-server@3.17/rest/enterprise-admin/manage-ghes?apiVersion=2022-11-28#initialize-instance-configuration-with-license-and-password):

<img width="578" height="291" alt="image" src="https://github.com/user-attachments/assets/d11ae87b-b675-453a-96ef-f259452cfa7f" />

Before the PR, the request body is:

```json
{"License":"1234-1234","Password":"password"}
```

After:
```json
{"license":"1234-1234","password":"password"}
```

The bug was found with the help of [`musttag`](https://golangci-lint.run/docs/linters/configuration/#musttag) linter:

```console
$ ./script/lint.sh
linting .
github/enterprise_manage_ghes_config_test.go:607:52: the given struct should be annotated with the `json` tag (musttag)
                assertNilError(t, json.NewDecoder(r.Body).Decode(v))
                                                                 ^
github/timestamp_test.go:132:28: the given struct should be annotated with the `json` tag (musttag)
                out, err := json.Marshal(tc.data)
                                         ^
github/timestamp_test.go:199:30: the given struct should be annotated with the `json` tag (musttag)
                bytes, err := json.Marshal(tc.data)
                                           ^
3 issues:
* musttag: 3
```

So, the PR enables it as well.