### PR TITLE
chore(ci): Add example dir to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
   directory: tools
   schedule:
     interval: weekly
+- package-ecosystem: gomod
+  directory: example
+  schedule:
+    interval: weekly
 - package-ecosystem: github-actions
   directory: /
   schedule:


### PR DESCRIPTION
I think, @dependabot should handle packages in the `example`: https://github.com/google/go-github/blob/68b82b5bb174a85d6ed23108ee0cde4cf6ead589/example/go.mod#L5-L15.