### PR TITLE
refactor!: Adjust function names and field types for billing API

### DIFF
--- a/github/billing.go
+++ b/github/billing.go
@@ -21,25 +21,38 @@ type MinutesUsedBreakdown = map[string]int
 
 // PackageBilling represents a GitHub Package billing.
 type PackageBilling struct {
-	TotalGigabytesBandwidthUsed     int     `json:"total_gigabytes_bandwidth_used"`
-	TotalPaidGigabytesBandwidthUsed int     `json:"total_paid_gigabytes_bandwidth_used"`
-	IncludedGigabytesBandwidth      float64 `json:"included_gigabytes_bandwidth"`
+	TotalGigabytesBandwidthUsed     int `json:"total_gigabytes_bandwidth_used"`
+	TotalPaidGigabytesBandwidthUsed int `json:"total_paid_gigabytes_bandwidth_used"`
+	IncludedGigabytesBandwidth      int `json:"included_gigabytes_bandwidth"`
 }
 
 // StorageBilling represents a GitHub Storage billing.
 type StorageBilling struct {
-	DaysLeftInBillingCycle       int     `json:"days_left_in_billing_cycle"`
-	EstimatedPaidStorageForMonth float64 `json:"estimated_paid_storage_for_month"`
-	EstimatedStorageForMonth     float64 `json:"estimated_storage_for_month"`
+	DaysLeftInBillingCycle       int `json:"days_left_in_billing_cycle"`
+	EstimatedPaidStorageForMonth int `json:"estimated_paid_storage_for_month"`
+	EstimatedStorageForMonth     int `json:"estimated_storage_for_month"`
+}
+
+// ActiveCommittersListOptions specifies optional parameters to the
+// BillingService.GetAdvancedSecurityActiveCommittersOrg method.
+type ActiveCommittersListOptions struct {
+	// The security product to get GitHub Advanced Security active committers for. For standalone
+	// Code Scanning or Secret Protection products, this parameter is required to specify which
+	// product you want committer information for. For other plans this parameter cannot be used.
+	//
+	// Can be one of: "code_security", "secret_protection".
+	AdvancedSecurityProduct *string `url:"advanced_security_product,omitempty"`
+
+	ListOptions
 }
 
 // ActiveCommitters represents the total active committers across all repositories in an Organization.
 type ActiveCommitters struct {
-	TotalAdvancedSecurityCommitters     int                           `json:"total_advanced_security_committers"`
-	TotalCount                          int                           `json:"total_count"`
-	MaximumAdvancedSecurityCommitters   int                           `json:"maximum_advanced_security_committers"`
-	PurchasedAdvancedSecurityCommitters int                           `json:"purchased_advanced_security_committers"`
-	Repositories                        []*RepositoryActiveCommitters `json:"repositories,omitempty"`
+	TotalAdvancedSecurityCommitters     *int                          `json:"total_advanced_security_committers,omitempty"`
+	TotalCount                          *int                          `json:"total_count,omitempty"`
+	MaximumAdvancedSecurityCommitters   *int                          `json:"maximum_advanced_security_committers,omitempty"`
+	PurchasedAdvancedSecurityCommitters *int                          `json:"purchased_advanced_security_committers,omitempty"`
+	Repositories                        []*RepositoryActiveCommitters `json:"repositories"`
 }
 
 // RepositoryActiveCommitters represents active committers on each repository.
@@ -104,16 +117,16 @@ type PremiumRequestUsageReportOptions struct {
 
 // UsageItem represents a single usage item in the enhanced billing platform report.
 type UsageItem struct {
-	Date           *string  `json:"date"`
-	Product        *string  `json:"product"`
-	SKU            *string  `json:"sku"`
-	Quantity       *float64 `json:"quantity"`
-	UnitType       *string  `json:"unitType"`
-	PricePerUnit   *float64 `json:"pricePerUnit"`
-	GrossAmount    *float64 `json:"grossAmount"`
-	DiscountAmount *float64 `json:"discountAmount"`
-	NetAmount      *float64 `json:"netAmount"`
-	RepositoryName *string  `json:"repositoryName,omitempty"`
+	Date           string  `json:"date"`
+	Product        string  `json:"product"`
+	SKU            string  `json:"sku"`
+	Quantity       int     `json:"quantity"`
+	UnitType       string  `json:"unitType"`
+	PricePerUnit   float64 `json:"pricePerUnit"`
+	GrossAmount    float64 `json:"grossAmount"`
+	DiscountAmount float64 `json:"discountAmount"`
+	NetAmount      float64 `json:"netAmount"`
+	RepositoryName *string `json:"repositoryName,omitempty"`
 	// Organization name is only used for organization-level reports.
 	OrganizationName *string `json:"organizationName,omitempty"`
 }
@@ -155,55 +168,55 @@ type PremiumRequestUsageReport struct {
 	UsageItems   []*PremiumRequestUsageItem    `json:"usageItems"`
 }
 
-// GetPackagesBillingOrg returns the free and paid storage used for GitHub Packages in gigabytes for an Org.
+// GetOrganizationPackagesBilling returns the free and paid storage used for GitHub Packages in gigabytes for an Org.
 //
 // GitHub API docs: https://docs.github.com/rest/billing/billing#get-github-packages-billing-for-an-organization
 //
 //meta:operation GET /orgs/{org}/settings/billing/packages
-func (s *BillingService) GetPackagesBillingOrg(ctx context.Context, org string) (*PackageBilling, *Response, error) {
+func (s *BillingService) GetOrganizationPackagesBilling(ctx context.Context, org string) (*PackageBilling, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/settings/billing/packages", org)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	packagesOrgBilling := new(PackageBilling)
-	resp, err := s.client.Do(ctx, req, packagesOrgBilling)
+	result := new(PackageBilling)
+	resp, err := s.client.Do(ctx, req, result)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return packagesOrgBilling, resp, nil
+	return result, resp, nil
 }
 
-// GetStorageBillingOrg returns the estimated paid and estimated total storage used for GitHub Actions
+// GetOrganizationStorageBilling returns the estimated paid and estimated total storage used for GitHub Actions
 // and GitHub Packages in gigabytes for an Org.
 //
 // GitHub API docs: https://docs.github.com/rest/billing/billing#get-shared-storage-billing-for-an-organization
 //
 //meta:operation GET /orgs/{org}/settings/billing/shared-storage
-func (s *BillingService) GetStorageBillingOrg(ctx context.Context, org string) (*StorageBilling, *Response, error) {
+func (s *BillingService) GetOrganizationStorageBilling(ctx context.Context, org string) (*StorageBilling, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/settings/billing/shared-storage", org)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	storageOrgBilling := new(StorageBilling)
-	resp, err := s.client.Do(ctx, req, storageOrgBilling)
+	result := new(StorageBilling)
+	resp, err := s.client.Do(ctx, req, result)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return storageOrgBilling, resp, nil
+	return result, resp, nil
 }
 
-// GetAdvancedSecurityActiveCommittersOrg returns the GitHub Advanced Security active committers for an organization per repository.
+// GetOrganizationAdvancedSecurityActiveCommitters returns the GitHub Advanced Security active committers for an organization per repository.
 //
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/billing/billing#get-github-advanced-security-active-committers-for-an-organization
 //
 //meta:operation GET /orgs/{org}/settings/billing/advanced-security
-func (s *BillingService) GetAdvancedSecurityActiveCommittersOrg(ctx context.Context, org string, opts *ListOptions) (*ActiveCommitters, *Response, error) {
+func (s *BillingService) GetOrganizationAdvancedSecurityActiveCommitters(ctx context.Context, org string, opts *ActiveCommittersListOptions) (*ActiveCommitters, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/settings/billing/advanced-security", org)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -215,21 +228,21 @@ func (s *BillingService) GetAdvancedSecurityActiveCommittersOrg(ctx context.Cont
 		return nil, nil, err
 	}
 
-	activeOrgCommitters := new(ActiveCommitters)
-	resp, err := s.client.Do(ctx, req, activeOrgCommitters)
+	result := new(ActiveCommitters)
+	resp, err := s.client.Do(ctx, req, result)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return activeOrgCommitters, resp, nil
+	return result, resp, nil
 }
 
-// GetPackagesBillingUser returns the free and paid storage used for GitHub Packages in gigabytes for a user.
+// GetPackagesBilling returns the free and paid storage used for GitHub Packages in gigabytes for a user.
 //
 // GitHub API docs: https://docs.github.com/rest/billing/billing#get-github-packages-billing-for-a-user
 //
 //meta:operation GET /users/{username}/settings/billing/packages
-func (s *BillingService) GetPackagesBillingUser(ctx context.Context, user string) (*PackageBilling, *Response, error) {
+func (s *BillingService) GetPackagesBilling(ctx context.Context, user string) (*PackageBilling, *Response, error) {
 	u := fmt.Sprintf("users/%v/settings/billing/packages", user)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -245,13 +258,13 @@ func (s *BillingService) GetPackagesBillingUser(ctx context.Context, user string
 	return packagesUserBilling, resp, nil
 }
 
-// GetStorageBillingUser returns the estimated paid and estimated total storage used for GitHub Actions
+// GetStorageBilling returns the estimated paid and estimated total storage used for GitHub Actions
 // and GitHub Packages in gigabytes for a user.
 //
 // GitHub API docs: https://docs.github.com/rest/billing/billing#get-shared-storage-billing-for-a-user
 //
 //meta:operation GET /users/{username}/settings/billing/shared-storage
-func (s *BillingService) GetStorageBillingUser(ctx context.Context, user string) (*StorageBilling, *Response, error) {
+func (s *BillingService) GetStorageBilling(ctx context.Context, user string) (*StorageBilling, *Response, error) {
 	u := fmt.Sprintf("users/%v/settings/billing/shared-storage", user)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -267,14 +280,14 @@ func (s *BillingService) GetStorageBillingUser(ctx context.Context, user string)
 	return storageUserBilling, resp, nil
 }
 
-// GetUsageReportOrg returns a report of the total usage for an organization using the enhanced billing platform.
+// GetOrganizationUsageReport returns a report of the total usage for an organization using the enhanced billing platform.
 //
 // Note: This endpoint is only available to organizations with access to the enhanced billing platform.
 //
 // GitHub API docs: https://docs.github.com/rest/billing/enhanced-billing#get-billing-usage-report-for-an-organization
 //
 //meta:operation GET /organizations/{org}/settings/billing/usage
-func (s *BillingService) GetUsageReportOrg(ctx context.Context, org string, opts *UsageReportOptions) (*UsageReport, *Response, error) {
+func (s *BillingService) GetOrganizationUsageReport(ctx context.Context, org string, opts *UsageReportOptions) (*UsageReport, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/settings/billing/usage", org)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -295,14 +308,14 @@ func (s *BillingService) GetUsageReportOrg(ctx context.Context, org string, opts
 	return usageReport, resp, nil
 }
 
-// GetUsageReportUser returns a report of the total usage for a user using the enhanced billing platform.
+// GetUsageReport returns a report of the total usage for a user using the enhanced billing platform.
 //
 // Note: This endpoint is only available to users with access to the enhanced billing platform.
 //
 // GitHub API docs: https://docs.github.com/rest/billing/enhanced-billing#get-billing-usage-report-for-a-user
 //
 //meta:operation GET /users/{username}/settings/billing/usage
-func (s *BillingService) GetUsageReportUser(ctx context.Context, user string, opts *UsageReportOptions) (*UsageReport, *Response, error) {
+func (s *BillingService) GetUsageReport(ctx context.Context, user string, opts *UsageReportOptions) (*UsageReport, *Response, error) {
 	u := fmt.Sprintf("users/%v/settings/billing/usage", user)
 	u, err := addOptions(u, opts)
 	if err != nil {

--- a/github/billing_test.go
+++ b/github/billing_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestBillingService_GetPackagesBillingOrg(t *testing.T) {
+func TestBillingService_GetOrganizationPackagesBilling(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -27,9 +27,9 @@ func TestBillingService_GetPackagesBillingOrg(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	hook, _, err := client.Billing.GetPackagesBillingOrg(ctx, "o")
+	hook, _, err := client.Billing.GetOrganizationPackagesBilling(ctx, "o")
 	if err != nil {
-		t.Errorf("Billing.GetPackagesBillingOrg returned error: %v", err)
+		t.Errorf("Billing.GetOrganizationPackagesBilling returned error: %v", err)
 	}
 
 	want := &PackageBilling{
@@ -38,17 +38,17 @@ func TestBillingService_GetPackagesBillingOrg(t *testing.T) {
 		IncludedGigabytesBandwidth:      10,
 	}
 	if !cmp.Equal(hook, want) {
-		t.Errorf("Billing.GetPackagesBillingOrg returned %+v, want %+v", hook, want)
+		t.Errorf("Billing.GetOrganizationPackagesBilling returned %+v, want %+v", hook, want)
 	}
 
-	const methodName = "GetPackagesBillingOrg"
+	const methodName = "GetOrganizationPackagesBilling"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Billing.GetPackagesBillingOrg(ctx, "\n")
+		_, _, err = client.Billing.GetOrganizationPackagesBilling(ctx, "\n")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Billing.GetPackagesBillingOrg(ctx, "o")
+		got, resp, err := client.Billing.GetOrganizationPackagesBilling(ctx, "o")
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -56,16 +56,16 @@ func TestBillingService_GetPackagesBillingOrg(t *testing.T) {
 	})
 }
 
-func TestBillingService_GetPackagesBillingOrg_invalidOrg(t *testing.T) {
+func TestBillingService_GetOrganizationPackagesBilling_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Billing.GetPackagesBillingOrg(ctx, "%")
+	_, _, err := client.Billing.GetOrganizationPackagesBilling(ctx, "%")
 	testURLParseError(t, err)
 }
 
-func TestBillingService_GetStorageBillingOrg(t *testing.T) {
+func TestBillingService_GetOrganizationStorageBilling(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -73,34 +73,34 @@ func TestBillingService_GetStorageBillingOrg(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
 				"days_left_in_billing_cycle": 20,
-				"estimated_paid_storage_for_month": 15.25,
+				"estimated_paid_storage_for_month": 15,
 				"estimated_storage_for_month": 40
 			}`)
 	})
 
 	ctx := t.Context()
-	hook, _, err := client.Billing.GetStorageBillingOrg(ctx, "o")
+	hook, _, err := client.Billing.GetOrganizationStorageBilling(ctx, "o")
 	if err != nil {
-		t.Errorf("Billing.GetStorageBillingOrg returned error: %v", err)
+		t.Errorf("Billing.GetOrganizationStorageBilling returned error: %v", err)
 	}
 
 	want := &StorageBilling{
 		DaysLeftInBillingCycle:       20,
-		EstimatedPaidStorageForMonth: 15.25,
+		EstimatedPaidStorageForMonth: 15,
 		EstimatedStorageForMonth:     40,
 	}
 	if !cmp.Equal(hook, want) {
-		t.Errorf("Billing.GetStorageBillingOrg returned %+v, want %+v", hook, want)
+		t.Errorf("Billing.GetOrganizationStorageBilling returned %+v, want %+v", hook, want)
 	}
 
-	const methodName = "GetStorageBillingOrg"
+	const methodName = "GetOrganizationStorageBilling"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Billing.GetStorageBillingOrg(ctx, "\n")
+		_, _, err = client.Billing.GetOrganizationStorageBilling(ctx, "\n")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Billing.GetStorageBillingOrg(ctx, "o")
+		got, resp, err := client.Billing.GetOrganizationStorageBilling(ctx, "o")
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -108,16 +108,16 @@ func TestBillingService_GetStorageBillingOrg(t *testing.T) {
 	})
 }
 
-func TestBillingService_GetStorageBillingOrg_invalidOrg(t *testing.T) {
+func TestBillingService_GetOrganizationStorageBilling_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Billing.GetStorageBillingOrg(ctx, "%")
+	_, _, err := client.Billing.GetOrganizationStorageBilling(ctx, "%")
 	testURLParseError(t, err)
 }
 
-func TestBillingService_GetPackagesBillingUser(t *testing.T) {
+func TestBillingService_GetPackagesBilling(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -131,9 +131,9 @@ func TestBillingService_GetPackagesBillingUser(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	hook, _, err := client.Billing.GetPackagesBillingUser(ctx, "u")
+	hook, _, err := client.Billing.GetPackagesBilling(ctx, "u")
 	if err != nil {
-		t.Errorf("Billing.GetPackagesBillingUser returned error: %v", err)
+		t.Errorf("Billing.GetPackagesBilling returned error: %v", err)
 	}
 
 	want := &PackageBilling{
@@ -142,17 +142,17 @@ func TestBillingService_GetPackagesBillingUser(t *testing.T) {
 		IncludedGigabytesBandwidth:      10,
 	}
 	if !cmp.Equal(hook, want) {
-		t.Errorf("Billing.GetPackagesBillingUser returned %+v, want %+v", hook, want)
+		t.Errorf("Billing.GetPackagesBilling returned %+v, want %+v", hook, want)
 	}
 
-	const methodName = "GetPackagesBillingUser"
+	const methodName = "GetPackagesBilling"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Billing.GetPackagesBillingUser(ctx, "\n")
+		_, _, err = client.Billing.GetPackagesBilling(ctx, "\n")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Billing.GetPackagesBillingUser(ctx, "o")
+		got, resp, err := client.Billing.GetPackagesBilling(ctx, "o")
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -160,16 +160,16 @@ func TestBillingService_GetPackagesBillingUser(t *testing.T) {
 	})
 }
 
-func TestBillingService_GetPackagesBillingUser_invalidUser(t *testing.T) {
+func TestBillingService_GetPackagesBilling_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Billing.GetPackagesBillingUser(ctx, "%")
+	_, _, err := client.Billing.GetPackagesBilling(ctx, "%")
 	testURLParseError(t, err)
 }
 
-func TestBillingService_GetStorageBillingUser(t *testing.T) {
+func TestBillingService_GetStorageBilling(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -177,34 +177,34 @@ func TestBillingService_GetStorageBillingUser(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
 				"days_left_in_billing_cycle": 20,
-				"estimated_paid_storage_for_month": 15.25,
+				"estimated_paid_storage_for_month": 15,
 				"estimated_storage_for_month": 40
 			}`)
 	})
 
 	ctx := t.Context()
-	hook, _, err := client.Billing.GetStorageBillingUser(ctx, "u")
+	hook, _, err := client.Billing.GetStorageBilling(ctx, "u")
 	if err != nil {
-		t.Errorf("Billing.GetStorageBillingUser returned error: %v", err)
+		t.Errorf("Billing.GetStorageBilling returned error: %v", err)
 	}
 
 	want := &StorageBilling{
 		DaysLeftInBillingCycle:       20,
-		EstimatedPaidStorageForMonth: 15.25,
+		EstimatedPaidStorageForMonth: 15,
 		EstimatedStorageForMonth:     40,
 	}
 	if !cmp.Equal(hook, want) {
-		t.Errorf("Billing.GetStorageBillingUser returned %+v, want %+v", hook, want)
+		t.Errorf("Billing.GetStorageBilling returned %+v, want %+v", hook, want)
 	}
 
-	const methodName = "GetStorageBillingUser"
+	const methodName = "GetStorageBilling"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Billing.GetStorageBillingUser(ctx, "\n")
+		_, _, err = client.Billing.GetStorageBilling(ctx, "\n")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Billing.GetStorageBillingUser(ctx, "o")
+		got, resp, err := client.Billing.GetStorageBilling(ctx, "o")
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -212,12 +212,12 @@ func TestBillingService_GetStorageBillingUser(t *testing.T) {
 	})
 }
 
-func TestBillingService_GetStorageBillingUser_invalidUser(t *testing.T) {
+func TestBillingService_GetStorageBilling_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Billing.GetStorageBillingUser(ctx, "%")
+	_, _, err := client.Billing.GetStorageBilling(ctx, "%")
 	testURLParseError(t, err)
 }
 
@@ -278,7 +278,7 @@ func TestStorageBilling_Marshal(t *testing.T) {
 	testJSONMarshal(t, u, want)
 }
 
-func TestBillingService_GetAdvancedSecurityActiveCommittersOrg(t *testing.T) {
+func TestBillingService_GetOrganizationAdvancedSecurityActiveCommitters(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -305,17 +305,20 @@ func TestBillingService_GetAdvancedSecurityActiveCommittersOrg(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	opts := &ListOptions{Page: 2, PerPage: 50}
-	hook, _, err := client.Billing.GetAdvancedSecurityActiveCommittersOrg(ctx, "o", opts)
+	opts := &ActiveCommittersListOptions{
+		nil,
+		ListOptions{Page: 2, PerPage: 50},
+	}
+	hook, _, err := client.Billing.GetOrganizationAdvancedSecurityActiveCommitters(ctx, "o", opts)
 	if err != nil {
-		t.Errorf("Billing.GetAdvancedSecurityActiveCommittersOrg	 returned error: %v", err)
+		t.Errorf("Billing.GetOrganizationAdvancedSecurityActiveCommitters returned error: %v", err)
 	}
 
 	want := &ActiveCommitters{
-		TotalAdvancedSecurityCommitters:     2,
-		TotalCount:                          2,
-		MaximumAdvancedSecurityCommitters:   3,
-		PurchasedAdvancedSecurityCommitters: 4,
+		TotalAdvancedSecurityCommitters:     Ptr(2),
+		TotalCount:                          Ptr(2),
+		MaximumAdvancedSecurityCommitters:   Ptr(3),
+		PurchasedAdvancedSecurityCommitters: Ptr(4),
 		Repositories: []*RepositoryActiveCommitters{
 			{
 				Name:                       Ptr("octocat-org/Hello-World"),
@@ -330,17 +333,17 @@ func TestBillingService_GetAdvancedSecurityActiveCommittersOrg(t *testing.T) {
 		},
 	}
 	if !cmp.Equal(hook, want) {
-		t.Errorf("Billing.GetAdvancedSecurityActiveCommittersOrg returned %+v, want %+v", hook, want)
+		t.Errorf("Billing.GetOrganizationAdvancedSecurityActiveCommitters returned %+v, want %+v", hook, want)
 	}
 
-	const methodName = "GetAdvancedSecurityActiveCommittersOrg"
+	const methodName = "GetOrganizationAdvancedSecurityActiveCommitters"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Billing.GetAdvancedSecurityActiveCommittersOrg(ctx, "\n", nil)
+		_, _, err = client.Billing.GetOrganizationAdvancedSecurityActiveCommitters(ctx, "\n", nil)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Billing.GetAdvancedSecurityActiveCommittersOrg(ctx, "o", nil)
+		got, resp, err := client.Billing.GetOrganizationAdvancedSecurityActiveCommitters(ctx, "o", nil)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -348,16 +351,16 @@ func TestBillingService_GetAdvancedSecurityActiveCommittersOrg(t *testing.T) {
 	})
 }
 
-func TestBillingService_GetAdvancedSecurityActiveCommittersOrg_invalidOrg(t *testing.T) {
+func TestBillingService_GetOrganizationAdvancedSecurityActiveCommitters_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Billing.GetAdvancedSecurityActiveCommittersOrg(ctx, "%", nil)
+	_, _, err := client.Billing.GetOrganizationAdvancedSecurityActiveCommitters(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
-func TestBillingService_GetUsageReportOrg(t *testing.T) {
+func TestBillingService_GetOrganizationUsageReport(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -391,40 +394,40 @@ func TestBillingService_GetUsageReportOrg(t *testing.T) {
 		Year:  Ptr(2023),
 		Month: Ptr(8),
 	}
-	report, _, err := client.Billing.GetUsageReportOrg(ctx, "o", opts)
+	report, _, err := client.Billing.GetOrganizationUsageReport(ctx, "o", opts)
 	if err != nil {
-		t.Errorf("Billing.GetUsageReportOrg returned error: %v", err)
+		t.Errorf("Billing.GetOrganizationUsageReport returned error: %v", err)
 	}
 
 	want := &UsageReport{
 		UsageItems: []*UsageItem{
 			{
-				Date:             Ptr("2023-08-01"),
-				Product:          Ptr("Actions"),
-				SKU:              Ptr("Actions Linux"),
-				Quantity:         Ptr(100.0),
-				UnitType:         Ptr("minutes"),
-				PricePerUnit:     Ptr(0.008),
-				GrossAmount:      Ptr(0.8),
-				DiscountAmount:   Ptr(0.0),
-				NetAmount:        Ptr(0.8),
+				Date:             "2023-08-01",
+				Product:          "Actions",
+				SKU:              "Actions Linux",
+				Quantity:         100,
+				UnitType:         "minutes",
+				PricePerUnit:     0.008,
+				GrossAmount:      0.8,
+				DiscountAmount:   0.0,
+				NetAmount:        0.8,
 				OrganizationName: Ptr("GitHub"),
 				RepositoryName:   Ptr("github/example"),
 			},
 		},
 	}
 	if !cmp.Equal(report, want) {
-		t.Errorf("Billing.GetUsageReportOrg returned %+v, want %+v", report, want)
+		t.Errorf("Billing.GetOrganizationUsageReport returned %+v, want %+v", report, want)
 	}
 
-	const methodName = "GetUsageReportOrg"
+	const methodName = "GetOrganizationUsageReport"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Billing.GetUsageReportOrg(ctx, "\n", opts)
+		_, _, err = client.Billing.GetOrganizationUsageReport(ctx, "\n", opts)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Billing.GetUsageReportOrg(ctx, "o", nil)
+		got, resp, err := client.Billing.GetOrganizationUsageReport(ctx, "o", nil)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -432,16 +435,16 @@ func TestBillingService_GetUsageReportOrg(t *testing.T) {
 	})
 }
 
-func TestBillingService_GetUsageReportOrg_invalidOrg(t *testing.T) {
+func TestBillingService_GetOrganizationUsageReport_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Billing.GetUsageReportOrg(ctx, "%", nil)
+	_, _, err := client.Billing.GetOrganizationUsageReport(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 
-func TestBillingService_GetUsageReportUser(t *testing.T) {
+func TestBillingService_GetUsageReport(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -472,39 +475,39 @@ func TestBillingService_GetUsageReportUser(t *testing.T) {
 	opts := &UsageReportOptions{
 		Day: Ptr(15),
 	}
-	report, _, err := client.Billing.GetUsageReportUser(ctx, "u", opts)
+	report, _, err := client.Billing.GetUsageReport(ctx, "u", opts)
 	if err != nil {
-		t.Errorf("Billing.GetUsageReportUser returned error: %v", err)
+		t.Errorf("Billing.GetUsageReport returned error: %v", err)
 	}
 
 	want := &UsageReport{
 		UsageItems: []*UsageItem{
 			{
-				Date:           Ptr("2023-08-15"),
-				Product:        Ptr("Codespaces"),
-				SKU:            Ptr("Codespaces Linux"),
-				Quantity:       Ptr(50.0),
-				UnitType:       Ptr("hours"),
-				PricePerUnit:   Ptr(0.18),
-				GrossAmount:    Ptr(9.0),
-				DiscountAmount: Ptr(1.0),
-				NetAmount:      Ptr(8.0),
+				Date:           "2023-08-15",
+				Product:        "Codespaces",
+				SKU:            "Codespaces Linux",
+				Quantity:       50,
+				UnitType:       "hours",
+				PricePerUnit:   0.18,
+				GrossAmount:    9.0,
+				DiscountAmount: 1.0,
+				NetAmount:      8.0,
 				RepositoryName: Ptr("user/example"),
 			},
 		},
 	}
 	if !cmp.Equal(report, want) {
-		t.Errorf("Billing.GetUsageReportUser returned %+v, want %+v", report, want)
+		t.Errorf("Billing.GetUsageReport returned %+v, want %+v", report, want)
 	}
 
-	const methodName = "GetUsageReportUser"
+	const methodName = "GetUsageReport"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Billing.GetUsageReportUser(ctx, "\n", opts)
+		_, _, err = client.Billing.GetUsageReport(ctx, "\n", opts)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Billing.GetUsageReportUser(ctx, "u", nil)
+		got, resp, err := client.Billing.GetUsageReport(ctx, "u", nil)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -512,12 +515,12 @@ func TestBillingService_GetUsageReportUser(t *testing.T) {
 	})
 }
 
-func TestBillingService_GetUsageReportUser_invalidUser(t *testing.T) {
+func TestBillingService_GetUsageReport_invalidUser(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Billing.GetUsageReportUser(ctx, "%", nil)
+	_, _, err := client.Billing.GetUsageReport(ctx, "%", nil)
 	testURLParseError(t, err)
 }
 

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -294,6 +294,46 @@ func (a *ActionsVariable) GetVisibility() string {
 	return *a.Visibility
 }
 
+// GetMaximumAdvancedSecurityCommitters returns the MaximumAdvancedSecurityCommitters field if it's non-nil, zero value otherwise.
+func (a *ActiveCommitters) GetMaximumAdvancedSecurityCommitters() int {
+	if a == nil || a.MaximumAdvancedSecurityCommitters == nil {
+		return 0
+	}
+	return *a.MaximumAdvancedSecurityCommitters
+}
+
+// GetPurchasedAdvancedSecurityCommitters returns the PurchasedAdvancedSecurityCommitters field if it's non-nil, zero value otherwise.
+func (a *ActiveCommitters) GetPurchasedAdvancedSecurityCommitters() int {
+	if a == nil || a.PurchasedAdvancedSecurityCommitters == nil {
+		return 0
+	}
+	return *a.PurchasedAdvancedSecurityCommitters
+}
+
+// GetTotalAdvancedSecurityCommitters returns the TotalAdvancedSecurityCommitters field if it's non-nil, zero value otherwise.
+func (a *ActiveCommitters) GetTotalAdvancedSecurityCommitters() int {
+	if a == nil || a.TotalAdvancedSecurityCommitters == nil {
+		return 0
+	}
+	return *a.TotalAdvancedSecurityCommitters
+}
+
+// GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
+func (a *ActiveCommitters) GetTotalCount() int {
+	if a == nil || a.TotalCount == nil {
+		return 0
+	}
+	return *a.TotalCount
+}
+
+// GetAdvancedSecurityProduct returns the AdvancedSecurityProduct field if it's non-nil, zero value otherwise.
+func (a *ActiveCommittersListOptions) GetAdvancedSecurityProduct() string {
+	if a == nil || a.AdvancedSecurityProduct == nil {
+		return ""
+	}
+	return *a.AdvancedSecurityProduct
+}
+
 // GetCountryCode returns the CountryCode field if it's non-nil, zero value otherwise.
 func (a *ActorLocation) GetCountryCode() string {
 	if a == nil || a.CountryCode == nil {
@@ -28678,38 +28718,6 @@ func (u *UpdateRunnerGroupRequest) GetVisibility() string {
 	return *u.Visibility
 }
 
-// GetDate returns the Date field if it's non-nil, zero value otherwise.
-func (u *UsageItem) GetDate() string {
-	if u == nil || u.Date == nil {
-		return ""
-	}
-	return *u.Date
-}
-
-// GetDiscountAmount returns the DiscountAmount field.
-func (u *UsageItem) GetDiscountAmount() *float64 {
-	if u == nil {
-		return nil
-	}
-	return u.DiscountAmount
-}
-
-// GetGrossAmount returns the GrossAmount field.
-func (u *UsageItem) GetGrossAmount() *float64 {
-	if u == nil {
-		return nil
-	}
-	return u.GrossAmount
-}
-
-// GetNetAmount returns the NetAmount field.
-func (u *UsageItem) GetNetAmount() *float64 {
-	if u == nil {
-		return nil
-	}
-	return u.NetAmount
-}
-
 // GetOrganizationName returns the OrganizationName field if it's non-nil, zero value otherwise.
 func (u *UsageItem) GetOrganizationName() string {
 	if u == nil || u.OrganizationName == nil {
@@ -28718,52 +28726,12 @@ func (u *UsageItem) GetOrganizationName() string {
 	return *u.OrganizationName
 }
 
-// GetPricePerUnit returns the PricePerUnit field.
-func (u *UsageItem) GetPricePerUnit() *float64 {
-	if u == nil {
-		return nil
-	}
-	return u.PricePerUnit
-}
-
-// GetProduct returns the Product field if it's non-nil, zero value otherwise.
-func (u *UsageItem) GetProduct() string {
-	if u == nil || u.Product == nil {
-		return ""
-	}
-	return *u.Product
-}
-
-// GetQuantity returns the Quantity field.
-func (u *UsageItem) GetQuantity() *float64 {
-	if u == nil {
-		return nil
-	}
-	return u.Quantity
-}
-
 // GetRepositoryName returns the RepositoryName field if it's non-nil, zero value otherwise.
 func (u *UsageItem) GetRepositoryName() string {
 	if u == nil || u.RepositoryName == nil {
 		return ""
 	}
 	return *u.RepositoryName
-}
-
-// GetSKU returns the SKU field if it's non-nil, zero value otherwise.
-func (u *UsageItem) GetSKU() string {
-	if u == nil || u.SKU == nil {
-		return ""
-	}
-	return *u.SKU
-}
-
-// GetUnitType returns the UnitType field if it's non-nil, zero value otherwise.
-func (u *UsageItem) GetUnitType() string {
-	if u == nil || u.UnitType == nil {
-		return ""
-	}
-	return *u.UnitType
 }
 
 // GetDay returns the Day field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -391,6 +391,61 @@ func TestActionsVariable_GetVisibility(tt *testing.T) {
 	a.GetVisibility()
 }
 
+func TestActiveCommitters_GetMaximumAdvancedSecurityCommitters(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	a := &ActiveCommitters{MaximumAdvancedSecurityCommitters: &zeroValue}
+	a.GetMaximumAdvancedSecurityCommitters()
+	a = &ActiveCommitters{}
+	a.GetMaximumAdvancedSecurityCommitters()
+	a = nil
+	a.GetMaximumAdvancedSecurityCommitters()
+}
+
+func TestActiveCommitters_GetPurchasedAdvancedSecurityCommitters(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	a := &ActiveCommitters{PurchasedAdvancedSecurityCommitters: &zeroValue}
+	a.GetPurchasedAdvancedSecurityCommitters()
+	a = &ActiveCommitters{}
+	a.GetPurchasedAdvancedSecurityCommitters()
+	a = nil
+	a.GetPurchasedAdvancedSecurityCommitters()
+}
+
+func TestActiveCommitters_GetTotalAdvancedSecurityCommitters(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	a := &ActiveCommitters{TotalAdvancedSecurityCommitters: &zeroValue}
+	a.GetTotalAdvancedSecurityCommitters()
+	a = &ActiveCommitters{}
+	a.GetTotalAdvancedSecurityCommitters()
+	a = nil
+	a.GetTotalAdvancedSecurityCommitters()
+}
+
+func TestActiveCommitters_GetTotalCount(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	a := &ActiveCommitters{TotalCount: &zeroValue}
+	a.GetTotalCount()
+	a = &ActiveCommitters{}
+	a.GetTotalCount()
+	a = nil
+	a.GetTotalCount()
+}
+
+func TestActiveCommittersListOptions_GetAdvancedSecurityProduct(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	a := &ActiveCommittersListOptions{AdvancedSecurityProduct: &zeroValue}
+	a.GetAdvancedSecurityProduct()
+	a = &ActiveCommittersListOptions{}
+	a.GetAdvancedSecurityProduct()
+	a = nil
+	a.GetAdvancedSecurityProduct()
+}
+
 func TestActorLocation_GetCountryCode(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -36941,41 +36996,6 @@ func TestUpdateRunnerGroupRequest_GetVisibility(tt *testing.T) {
 	u.GetVisibility()
 }
 
-func TestUsageItem_GetDate(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	u := &UsageItem{Date: &zeroValue}
-	u.GetDate()
-	u = &UsageItem{}
-	u.GetDate()
-	u = nil
-	u.GetDate()
-}
-
-func TestUsageItem_GetDiscountAmount(tt *testing.T) {
-	tt.Parallel()
-	u := &UsageItem{}
-	u.GetDiscountAmount()
-	u = nil
-	u.GetDiscountAmount()
-}
-
-func TestUsageItem_GetGrossAmount(tt *testing.T) {
-	tt.Parallel()
-	u := &UsageItem{}
-	u.GetGrossAmount()
-	u = nil
-	u.GetGrossAmount()
-}
-
-func TestUsageItem_GetNetAmount(tt *testing.T) {
-	tt.Parallel()
-	u := &UsageItem{}
-	u.GetNetAmount()
-	u = nil
-	u.GetNetAmount()
-}
-
 func TestUsageItem_GetOrganizationName(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -36987,33 +37007,6 @@ func TestUsageItem_GetOrganizationName(tt *testing.T) {
 	u.GetOrganizationName()
 }
 
-func TestUsageItem_GetPricePerUnit(tt *testing.T) {
-	tt.Parallel()
-	u := &UsageItem{}
-	u.GetPricePerUnit()
-	u = nil
-	u.GetPricePerUnit()
-}
-
-func TestUsageItem_GetProduct(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	u := &UsageItem{Product: &zeroValue}
-	u.GetProduct()
-	u = &UsageItem{}
-	u.GetProduct()
-	u = nil
-	u.GetProduct()
-}
-
-func TestUsageItem_GetQuantity(tt *testing.T) {
-	tt.Parallel()
-	u := &UsageItem{}
-	u.GetQuantity()
-	u = nil
-	u.GetQuantity()
-}
-
 func TestUsageItem_GetRepositoryName(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -37023,28 +37016,6 @@ func TestUsageItem_GetRepositoryName(tt *testing.T) {
 	u.GetRepositoryName()
 	u = nil
 	u.GetRepositoryName()
-}
-
-func TestUsageItem_GetSKU(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	u := &UsageItem{SKU: &zeroValue}
-	u.GetSKU()
-	u = &UsageItem{}
-	u.GetSKU()
-	u = nil
-	u.GetSKU()
-}
-
-func TestUsageItem_GetUnitType(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	u := &UsageItem{UnitType: &zeroValue}
-	u.GetUnitType()
-	u = &UsageItem{}
-	u.GetUnitType()
-	u = nil
-	u.GetUnitType()
 }
 
 func TestUsageReportOptions_GetDay(tt *testing.T) {


### PR DESCRIPTION
BREAKING CHANGE: Billing-related methods are renamed to `<verb><scope><subject>` pattern, and required fields are changed to value types