### PR TITLE
Add support for organization Immutable Releases API

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -10887,7 +10887,7 @@ func (i *IDPGroup) GetGroupName() string {
 }
 
 // GetEnforcedRepositories returns the EnforcedRepositories field if it's non-nil, zero value otherwise.
-func (i *ImmutableReleaseRepository) GetEnforcedRepositories() string {
+func (i *ImmutableReleasePolicy) GetEnforcedRepositories() string {
 	if i == nil || i.EnforcedRepositories == nil {
 		return ""
 	}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -14121,12 +14121,12 @@ func TestIDPGroup_GetGroupName(tt *testing.T) {
 	i.GetGroupName()
 }
 
-func TestImmutableReleaseRepository_GetEnforcedRepositories(tt *testing.T) {
+func TestImmutableReleasePolicy_GetEnforcedRepositories(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
-	i := &ImmutableReleaseRepository{EnforcedRepositories: &zeroValue}
+	i := &ImmutableReleasePolicy{EnforcedRepositories: &zeroValue}
 	i.GetEnforcedRepositories()
-	i = &ImmutableReleaseRepository{}
+	i = &ImmutableReleasePolicy{}
 	i.GetEnforcedRepositories()
 	i = nil
 	i.GetEnforcedRepositories()

--- a/github/orgs_immutable_releases.go
+++ b/github/orgs_immutable_releases.go
@@ -19,8 +19,8 @@ type ImmutableReleaseSettings struct {
 	SelectedRepositoriesURL *string `json:"selected_repositories_url,omitempty"`
 }
 
-// ImmutableReleaseRepository is for setting the immutable releases policy for repositories in an organization.
-type ImmutableReleaseRepository struct {
+// ImmutableReleasePolicy is for setting the immutable releases policy for repositories in an organization.
+type ImmutableReleasePolicy struct {
 	// EnforcedRepositories specifies how immutable releases are enforced in the organization. Possible values include "all", "none", or "selected".
 	EnforcedRepositories *string `json:"enforced_repositories,omitempty"`
 	// An array of repository ids for which immutable releases enforcement should be applied.
@@ -60,7 +60,7 @@ func (s *OrganizationsService) GetImmutableReleasesSettings(ctx context.Context,
 // GitHub API docs: https://docs.github.com/rest/orgs/orgs#set-immutable-releases-settings-for-an-organization
 //
 //meta:operation PUT /orgs/{org}/settings/immutable-releases
-func (s *OrganizationsService) UpdateImmutableReleasesSettings(ctx context.Context, org string, opts ImmutableReleaseRepository) (*Response, error) {
+func (s *OrganizationsService) UpdateImmutableReleasesSettings(ctx context.Context, org string, opts ImmutableReleasePolicy) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/settings/immutable-releases", org)
 
 	req, err := s.client.NewRequest("PUT", u, opts)

--- a/github/orgs_immutable_releases_test.go
+++ b/github/orgs_immutable_releases_test.go
@@ -62,7 +62,7 @@ func TestOrganizationsService_UpdateImmutableReleasesSettings(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := ImmutableReleaseRepository{
+	input := ImmutableReleasePolicy{
 		EnforcedRepositories: Ptr("selected"),
 	}
 


### PR DESCRIPTION
Fixes: #3771.

This PR adds support for [Organization Immutable Releases API](https://docs.github.com/en/rest/orgs/orgs#get-immutable-releases-settings-for-an-organization) 

**Implement**

- GET `/orgs/{org}/settings/immutable-releases`
- PUT `/orgs/{org}/settings/immutable-releases`
- GET `/orgs/{org}/settings/immutable-releases/repositories`
- PUT `/orgs/{org}/settings/immutable-releases/repositories`
- PUT `/orgs/{org}/settings/immutable-releases/repositories/{repository_id}`
- DELETE `/orgs/{org}/settings/immutable-releases/repositories/{repository_id}`

issue - [#3771](https://github.com/google/go-github/issues/3771)
