### PR TITLE
Remove unnecessary pointer from SearchService

### DIFF
--- a/github/repos_statuses.go
+++ b/github/repos_statuses.go
@@ -75,9 +75,9 @@ func (s *RepositoriesService) ListStatuses(ctx context.Context, owner, repo, ref
 // GitHub API docs: https://docs.github.com/rest/commits/statuses#create-a-commit-status
 //
 //meta:operation POST /repos/{owner}/{repo}/statuses/{sha}
-func (s *RepositoriesService) CreateStatus(ctx context.Context, owner, repo, ref string, status *RepoStatus) (*RepoStatus, *Response, error) {
+func (s *RepositoriesService) CreateStatus(ctx context.Context, owner, repo, ref string, status RepoStatus) (*RepoStatus, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/statuses/%v", owner, repo, refURLEscape(ref))
-	req, err := s.client.NewRequest("POST", u, status)
+	req, err := s.client.NewRequest("POST", u, &status)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/repos_statuses_test.go
+++ b/github/repos_statuses_test.go
@@ -64,14 +64,14 @@ func TestRepositoriesService_CreateStatus(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &RepoStatus{State: Ptr("s"), TargetURL: Ptr("t"), Description: Ptr("d")}
+	input := RepoStatus{State: Ptr("s"), TargetURL: Ptr("t"), Description: Ptr("d")}
 
 	mux.HandleFunc("/repos/o/r/statuses/r", func(w http.ResponseWriter, r *http.Request) {
 		v := new(RepoStatus)
 		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
 
 		testMethod(t, r, "POST")
-		if !cmp.Equal(v, input) {
+		if !cmp.Equal(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 		fmt.Fprint(w, `{"id":1}`)
@@ -108,7 +108,7 @@ func TestRepositoriesService_CreateStatus_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Repositories.CreateStatus(ctx, "%", "r", "r", nil)
+	_, _, err := client.Repositories.CreateStatus(ctx, "%", "r", "r", RepoStatus{})
 	testURLParseError(t, err)
 }
 

--- a/github/search.go
+++ b/github/search.go
@@ -77,7 +77,7 @@ type RepositoriesSearchResult struct {
 //meta:operation GET /search/repositories
 func (s *SearchService) Repositories(ctx context.Context, query string, opts *SearchOptions) (*RepositoriesSearchResult, *Response, error) {
 	result := new(RepositoriesSearchResult)
-	resp, err := s.search(ctx, "repositories", searchParameters{Query: query}, opts, result)
+	resp, err := s.search(ctx, "repositories", &searchParameters{Query: query}, opts, result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -115,7 +115,7 @@ type TopicResult struct {
 //meta:operation GET /search/topics
 func (s *SearchService) Topics(ctx context.Context, query string, opts *SearchOptions) (*TopicsSearchResult, *Response, error) {
 	result := new(TopicsSearchResult)
-	resp, err := s.search(ctx, "topics", searchParameters{Query: query}, opts, result)
+	resp, err := s.search(ctx, "topics", &searchParameters{Query: query}, opts, result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -152,7 +152,7 @@ type CommitResult struct {
 //meta:operation GET /search/commits
 func (s *SearchService) Commits(ctx context.Context, query string, opts *SearchOptions) (*CommitsSearchResult, *Response, error) {
 	result := new(CommitsSearchResult)
-	resp, err := s.search(ctx, "commits", searchParameters{Query: query}, opts, result)
+	resp, err := s.search(ctx, "commits", &searchParameters{Query: query}, opts, result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -174,7 +174,7 @@ type IssuesSearchResult struct {
 //meta:operation GET /search/issues
 func (s *SearchService) Issues(ctx context.Context, query string, opts *SearchOptions) (*IssuesSearchResult, *Response, error) {
 	result := new(IssuesSearchResult)
-	resp, err := s.search(ctx, "issues", searchParameters{Query: query}, opts, result)
+	resp, err := s.search(ctx, "issues", &searchParameters{Query: query}, opts, result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -196,7 +196,7 @@ type UsersSearchResult struct {
 //meta:operation GET /search/users
 func (s *SearchService) Users(ctx context.Context, query string, opts *SearchOptions) (*UsersSearchResult, *Response, error) {
 	result := new(UsersSearchResult)
-	resp, err := s.search(ctx, "users", searchParameters{Query: query}, opts, result)
+	resp, err := s.search(ctx, "users", &searchParameters{Query: query}, opts, result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -251,7 +251,7 @@ func (c CodeResult) String() string {
 //meta:operation GET /search/code
 func (s *SearchService) Code(ctx context.Context, query string, opts *SearchOptions) (*CodeSearchResult, *Response, error) {
 	result := new(CodeSearchResult)
-	resp, err := s.search(ctx, "code", searchParameters{Query: query}, opts, result)
+	resp, err := s.search(ctx, "code", &searchParameters{Query: query}, opts, result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -288,7 +288,7 @@ func (l LabelResult) String() string {
 //meta:operation GET /search/labels
 func (s *SearchService) Labels(ctx context.Context, repoID int64, query string, opts *SearchOptions) (*LabelsSearchResult, *Response, error) {
 	result := new(LabelsSearchResult)
-	resp, err := s.search(ctx, "labels", searchParameters{RepositoryID: &repoID, Query: query}, opts, result)
+	resp, err := s.search(ctx, "labels", &searchParameters{RepositoryID: &repoID, Query: query}, opts, result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -301,7 +301,7 @@ func (s *SearchService) Labels(ctx context.Context, repoID int64, query string, 
 //
 // If searchParameters.Query includes multiple condition, it MUST NOT include "+" as condition separator.
 // For example, querying with "language:c++" and "leveldb", then searchParameters.Query should be "language:c++ leveldb" but not "language:c+++leveldb".
-func (s *SearchService) search(ctx context.Context, searchType string, parameters searchParameters, opts *SearchOptions, result any) (*Response, error) {
+func (s *SearchService) search(ctx context.Context, searchType string, parameters *searchParameters, opts *SearchOptions, result any) (*Response, error) {
 	params, err := qs.Values(opts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Description:  fixes part of issue Refactor codebase to use value parameters instead of pointers where appropriate #3644

Fix:  To improve API design consistency and safety as per issue, removed unnecessary pointer in the file repo_statuses.go

Tested by running go test ./... command.
 