### PR TITLE
refactor!: Remove pointer from required field of CreateStatus API

### DIFF
--- a/github/repos_statuses.go
+++ b/github/repos_statuses.go
@@ -75,9 +75,9 @@ func (s *RepositoriesService) ListStatuses(ctx context.Context, owner, repo, ref
 // GitHub API docs: https://docs.github.com/rest/commits/statuses#create-a-commit-status
 //
 //meta:operation POST /repos/{owner}/{repo}/statuses/{sha}
-func (s *RepositoriesService) CreateStatus(ctx context.Context, owner, repo, ref string, status *RepoStatus) (*RepoStatus, *Response, error) {
+func (s *RepositoriesService) CreateStatus(ctx context.Context, owner, repo, ref string, status RepoStatus) (*RepoStatus, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/statuses/%v", owner, repo, refURLEscape(ref))
-	req, err := s.client.NewRequest("POST", u, status)
+	req, err := s.client.NewRequest("POST", u, &status)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/repos_statuses_test.go
+++ b/github/repos_statuses_test.go
@@ -64,14 +64,14 @@ func TestRepositoriesService_CreateStatus(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &RepoStatus{State: Ptr("s"), TargetURL: Ptr("t"), Description: Ptr("d")}
+	input := RepoStatus{State: Ptr("s"), TargetURL: Ptr("t"), Description: Ptr("d")}
 
 	mux.HandleFunc("/repos/o/r/statuses/r", func(w http.ResponseWriter, r *http.Request) {
 		v := new(RepoStatus)
 		assertNilError(t, json.NewDecoder(r.Body).Decode(v))
 
 		testMethod(t, r, "POST")
-		if !cmp.Equal(v, input) {
+		if !cmp.Equal(v, &input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 		fmt.Fprint(w, `{"id":1}`)
@@ -108,7 +108,7 @@ func TestRepositoriesService_CreateStatus_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Repositories.CreateStatus(ctx, "%", "r", "r", nil)
+	_, _, err := client.Repositories.CreateStatus(ctx, "%", "r", "r", RepoStatus{})
 	testURLParseError(t, err)
 }
 


### PR DESCRIPTION
BREAKING CHANGE: `RepositoriesService.CreateStatus` now takes value for `status`, not pointer.

Relates to: #3644

Description: fixes part of issue Refactor codebase to use value parameters instead of pointers where appropriate https://github.com/google/go-github/issues/3644

Fix: To improve API design consistency and safety as per issue, removed unnecessary pointer in the file repo_statuses.go

Tested by running go test ./... command.