### PR TITLE
fix: Org/Enterprise UpdateRepositoryRulesetClearBypassActor sends empty array

### DIFF
--- a/github/enterprise_rules.go
+++ b/github/enterprise_rules.go
@@ -86,7 +86,9 @@ func (s *EnterpriseService) UpdateRepositoryRuleset(ctx context.Context, enterpr
 func (s *EnterpriseService) UpdateRepositoryRulesetClearBypassActor(ctx context.Context, enterprise string, rulesetID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/rulesets/%v", enterprise, rulesetID)
 
-	rsClearBypassActor := rulesetClearBypassActors{}
+	rsClearBypassActor := rulesetClearBypassActors{
+		BypassActors: []*BypassActor{},
+	}
 
 	req, err := s.client.NewRequest("PUT", u, rsClearBypassActor)
 	if err != nil {

--- a/github/enterprise_rules_test.go
+++ b/github/enterprise_rules_test.go
@@ -1775,6 +1775,7 @@ func TestEnterpriseService_UpdateRepositoryRulesetClearBypassActor(t *testing.T)
 
 	mux.HandleFunc("/enterprises/e/rulesets/84", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
+		testBody(t, r, `{"bypass_actors":[]}`+"\n")
 		fmt.Fprint(w, `{
 			"id": 84,
 			"name": "test ruleset",

--- a/github/orgs_rules.go
+++ b/github/orgs_rules.go
@@ -113,7 +113,9 @@ func (s *OrganizationsService) UpdateRepositoryRuleset(ctx context.Context, org 
 func (s *OrganizationsService) UpdateRepositoryRulesetClearBypassActor(ctx context.Context, org string, rulesetID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/rulesets/%v", org, rulesetID)
 
-	rsClearBypassActor := rulesetClearBypassActors{}
+	rsClearBypassActor := rulesetClearBypassActors{
+		BypassActors: []*BypassActor{},
+	}
 
 	req, err := s.client.NewRequest("PUT", u, rsClearBypassActor)
 	if err != nil {

--- a/github/orgs_rules_test.go
+++ b/github/orgs_rules_test.go
@@ -1593,6 +1593,7 @@ func TestOrganizationsService_UpdateRepositoryRulesetClearBypassActor(t *testing
 
 	mux.HandleFunc("/orgs/o/rulesets/21", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
+		testBody(t, r, `{"bypass_actors":[]}`+"\n")
 		fmt.Fprint(w, `{
 			"id": 21,
 			"name": "test ruleset",


### PR DESCRIPTION
This PR Fixes the same bug in organization and enterprise rulesets that was fixed for repository rulesets in PR #3727 (issue #3726).

### Changes
- Initialize `BypassActors` with empty slice instead of nil 
- Add test validation to verify correct JSON payload is sent

Closes #3795.