### PR TITLE
feat: Add `sha_pinning_required` to `ActionsPermissions` structs

### DIFF
--- a/github/actions_permissions_orgs.go
+++ b/github/actions_permissions_orgs.go
@@ -17,7 +17,7 @@ type ActionsPermissions struct {
 	EnabledRepositories *string `json:"enabled_repositories,omitempty"`
 	AllowedActions      *string `json:"allowed_actions,omitempty"`
 	SelectedActionsURL  *string `json:"selected_actions_url,omitempty"`
-	ShaPinningRequired  *bool   `json:"sha_pinning_required,omitempty"`
+	SHAPinningRequired  *bool   `json:"sha_pinning_required,omitempty"`
 }
 
 func (a ActionsPermissions) String() string {

--- a/github/actions_permissions_orgs_test.go
+++ b/github/actions_permissions_orgs_test.go
@@ -28,7 +28,7 @@ func TestActionsService_GetActionsPermissions(t *testing.T) {
 	if err != nil {
 		t.Errorf("Actions.GetActionsPermissions returned error: %v", err)
 	}
-	want := &ActionsPermissions{EnabledRepositories: Ptr("all"), AllowedActions: Ptr("all"), ShaPinningRequired: Ptr(true)}
+	want := &ActionsPermissions{EnabledRepositories: Ptr("all"), AllowedActions: Ptr("all"), SHAPinningRequired: Ptr(true)}
 	if !cmp.Equal(org, want) {
 		t.Errorf("Actions.GetActionsPermissions returned %+v, want %+v", org, want)
 	}
@@ -52,7 +52,7 @@ func TestActionsService_UpdateActionsPermissions(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &ActionsPermissions{EnabledRepositories: Ptr("all"), AllowedActions: Ptr("selected"), ShaPinningRequired: Ptr(true)}
+	input := &ActionsPermissions{EnabledRepositories: Ptr("all"), AllowedActions: Ptr("selected"), SHAPinningRequired: Ptr(true)}
 
 	mux.HandleFunc("/orgs/o/actions/permissions", func(w http.ResponseWriter, r *http.Request) {
 		v := new(ActionsPermissions)
@@ -72,7 +72,7 @@ func TestActionsService_UpdateActionsPermissions(t *testing.T) {
 		t.Errorf("Actions.UpdateActionsPermissions returned error: %v", err)
 	}
 
-	want := &ActionsPermissions{EnabledRepositories: Ptr("all"), AllowedActions: Ptr("selected"), ShaPinningRequired: Ptr(true)}
+	want := &ActionsPermissions{EnabledRepositories: Ptr("all"), AllowedActions: Ptr("selected"), SHAPinningRequired: Ptr(true)}
 	if !cmp.Equal(org, want) {
 		t.Errorf("Actions.UpdateActionsPermissions returned %+v, want %+v", org, want)
 	}
@@ -326,7 +326,7 @@ func TestActionsPermissions_Marshal(t *testing.T) {
 		EnabledRepositories: Ptr("e"),
 		AllowedActions:      Ptr("a"),
 		SelectedActionsURL:  Ptr("sau"),
-		ShaPinningRequired:  Ptr(true),
+		SHAPinningRequired:  Ptr(true),
 	}
 
 	want := `{

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -206,6 +206,14 @@ func (a *ActionsPermissions) GetSelectedActionsURL() string {
 	return *a.SelectedActionsURL
 }
 
+// GetSHAPinningRequired returns the SHAPinningRequired field if it's non-nil, zero value otherwise.
+func (a *ActionsPermissions) GetSHAPinningRequired() bool {
+	if a == nil || a.SHAPinningRequired == nil {
+		return false
+	}
+	return *a.SHAPinningRequired
+}
+
 // GetAllowedActions returns the AllowedActions field if it's non-nil, zero value otherwise.
 func (a *ActionsPermissionsEnterprise) GetAllowedActions() string {
 	if a == nil || a.AllowedActions == nil {
@@ -252,6 +260,14 @@ func (a *ActionsPermissionsRepository) GetSelectedActionsURL() string {
 		return ""
 	}
 	return *a.SelectedActionsURL
+}
+
+// GetSHAPinningRequired returns the SHAPinningRequired field if it's non-nil, zero value otherwise.
+func (a *ActionsPermissionsRepository) GetSHAPinningRequired() bool {
+	if a == nil || a.SHAPinningRequired == nil {
+		return false
+	}
+	return *a.SHAPinningRequired
 }
 
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -273,6 +273,17 @@ func TestActionsPermissions_GetSelectedActionsURL(tt *testing.T) {
 	a.GetSelectedActionsURL()
 }
 
+func TestActionsPermissions_GetSHAPinningRequired(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	a := &ActionsPermissions{SHAPinningRequired: &zeroValue}
+	a.GetSHAPinningRequired()
+	a = &ActionsPermissions{}
+	a.GetSHAPinningRequired()
+	a = nil
+	a.GetSHAPinningRequired()
+}
+
 func TestActionsPermissionsEnterprise_GetAllowedActions(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -337,6 +348,17 @@ func TestActionsPermissionsRepository_GetSelectedActionsURL(tt *testing.T) {
 	a.GetSelectedActionsURL()
 	a = nil
 	a.GetSelectedActionsURL()
+}
+
+func TestActionsPermissionsRepository_GetSHAPinningRequired(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	a := &ActionsPermissionsRepository{SHAPinningRequired: &zeroValue}
+	a.GetSHAPinningRequired()
+	a = &ActionsPermissionsRepository{}
+	a.GetSHAPinningRequired()
+	a = nil
+	a.GetSHAPinningRequired()
 }
 
 func TestActionsVariable_GetCreatedAt(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -49,8 +49,9 @@ func TestActionsPermissions_String(t *testing.T) {
 		EnabledRepositories: Ptr(""),
 		AllowedActions:      Ptr(""),
 		SelectedActionsURL:  Ptr(""),
+		SHAPinningRequired:  Ptr(false),
 	}
-	want := `github.ActionsPermissions{EnabledRepositories:"", AllowedActions:"", SelectedActionsURL:""}`
+	want := `github.ActionsPermissions{EnabledRepositories:"", AllowedActions:"", SelectedActionsURL:"", SHAPinningRequired:false}`
 	if got := v.String(); got != want {
 		t.Errorf("ActionsPermissions.String = %v, want %v", got, want)
 	}
@@ -75,8 +76,9 @@ func TestActionsPermissionsRepository_String(t *testing.T) {
 		Enabled:            Ptr(false),
 		AllowedActions:     Ptr(""),
 		SelectedActionsURL: Ptr(""),
+		SHAPinningRequired: Ptr(false),
 	}
-	want := `github.ActionsPermissionsRepository{Enabled:false, AllowedActions:"", SelectedActionsURL:""}`
+	want := `github.ActionsPermissionsRepository{Enabled:false, AllowedActions:"", SelectedActionsURL:"", SHAPinningRequired:false}`
 	if got := v.String(); got != want {
 		t.Errorf("ActionsPermissionsRepository.String = %v, want %v", got, want)
 	}

--- a/github/repos_actions_permissions.go
+++ b/github/repos_actions_permissions.go
@@ -17,7 +17,7 @@ type ActionsPermissionsRepository struct {
 	Enabled            *bool   `json:"enabled,omitempty"`
 	AllowedActions     *string `json:"allowed_actions,omitempty"`
 	SelectedActionsURL *string `json:"selected_actions_url,omitempty"`
-	ShaPinningRequired *bool   `json:"sha_pinning_required,omitempty"`
+	SHAPinningRequired *bool   `json:"sha_pinning_required,omitempty"`
 }
 
 func (a ActionsPermissionsRepository) String() string {

--- a/github/repos_actions_permissions_test.go
+++ b/github/repos_actions_permissions_test.go
@@ -28,7 +28,7 @@ func TestRepositoriesService_GetActionsPermissions(t *testing.T) {
 	if err != nil {
 		t.Errorf("Repositories.GetActionsPermissions returned error: %v", err)
 	}
-	want := &ActionsPermissionsRepository{Enabled: Ptr(true), AllowedActions: Ptr("all"), ShaPinningRequired: Ptr(true)}
+	want := &ActionsPermissionsRepository{Enabled: Ptr(true), AllowedActions: Ptr("all"), SHAPinningRequired: Ptr(true)}
 	if !cmp.Equal(org, want) {
 		t.Errorf("Repositories.GetActionsPermissions returned %+v, want %+v", org, want)
 	}
@@ -52,7 +52,7 @@ func TestRepositoriesService_UpdateActionsPermissions(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &ActionsPermissionsRepository{Enabled: Ptr(true), AllowedActions: Ptr("selected"), ShaPinningRequired: Ptr(true)}
+	input := &ActionsPermissionsRepository{Enabled: Ptr(true), AllowedActions: Ptr("selected"), SHAPinningRequired: Ptr(true)}
 
 	mux.HandleFunc("/repos/o/r/actions/permissions", func(w http.ResponseWriter, r *http.Request) {
 		v := new(ActionsPermissionsRepository)
@@ -72,7 +72,7 @@ func TestRepositoriesService_UpdateActionsPermissions(t *testing.T) {
 		t.Errorf("Repositories.UpdateActionsPermissions returned error: %v", err)
 	}
 
-	want := &ActionsPermissionsRepository{Enabled: Ptr(true), AllowedActions: Ptr("selected"), ShaPinningRequired: Ptr(true)}
+	want := &ActionsPermissionsRepository{Enabled: Ptr(true), AllowedActions: Ptr("selected"), SHAPinningRequired: Ptr(true)}
 	if !cmp.Equal(org, want) {
 		t.Errorf("Repositories.UpdateActionsPermissions returned %+v, want %+v", org, want)
 	}
@@ -100,7 +100,7 @@ func TestActionsPermissionsRepository_Marshal(t *testing.T) {
 		Enabled:            Ptr(true),
 		AllowedActions:     Ptr("all"),
 		SelectedActionsURL: Ptr("someURL"),
-		ShaPinningRequired: Ptr(true),
+		SHAPinningRequired: Ptr(true),
 	}
 
 	want := `{


### PR DESCRIPTION
Support https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/#enforce-sha-pinning.

Fix https://github.com/google/go-github/issues/3808.