### PR TITLE
chore: Enable 'modernize'; bump golangci-lint to v2.6.1

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,4 +1,4 @@
-version: v2.2.2
+version: v2.6.1
 plugins:
   - module: "github.com/google/go-github/v78/tools/fmtpercentv"
     path: ./tools/fmtpercentv

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - intrange
     - jsonfieldname
     - misspell
+    - modernize
     - musttag
     - nakedret
     - paralleltest
@@ -84,6 +85,9 @@ linters:
       ignore-rules:
         - analyses # returned by the GitHub API
         - cancelled # returned by the GitHub API
+    modernize:
+      disable:
+        - omitzero # TODO: fix
     perfsprint:
       errorf: true
       strconcat: false

--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -100,7 +100,7 @@ func getTree(ref *github.Reference) (tree *github.Tree, err error) {
 	entries := []*github.TreeEntry{}
 
 	// Load each file into the tree.
-	for _, fileArg := range strings.Split(*sourceFiles, ",") {
+	for fileArg := range strings.SplitSeq(*sourceFiles, ",") {
 		file, content, err := getFileContent(fileArg)
 		if err != nil {
 			return nil, err

--- a/github/github.go
+++ b/github/github.go
@@ -506,6 +506,7 @@ func NewClientWithEnvProxy() *Client {
 }
 
 // NewTokenClient returns a new GitHub API client authenticated with the provided token.
+//
 // Deprecated: Use NewClient(nil).WithAuthToken(token) instead.
 func NewTokenClient(_ context.Context, token string) *Client {
 	// This always returns a nil error.
@@ -709,7 +710,7 @@ func newResponse(r *http.Response) *Response {
 // various pagination link values in the Response.
 func (r *Response) populatePageValues() {
 	if links, ok := r.Response.Header["Link"]; ok && len(links) > 0 {
-		for _, link := range strings.Split(links[0], ",") {
+		for link := range strings.SplitSeq(links[0], ",") {
 			segments := strings.Split(strings.TrimSpace(link), ";")
 
 			// link must at least have href and rel

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -540,7 +540,7 @@ func TestWithEnterpriseURLs(t *testing.T) {
 // Ensure that length of Client.rateLimits is the same as number of fields in RateLimits struct.
 func TestClient_rateLimits(t *testing.T) {
 	t.Parallel()
-	if got, want := len(Client{}.rateLimits), reflect.TypeOf(RateLimits{}).NumField(); got != want {
+	if got, want := len(Client{}.rateLimits), reflect.TypeFor[RateLimits]().NumField(); got != want {
 		t.Errorf("len(Client{}.rateLimits) is %v, want %v", got, want)
 	}
 }

--- a/github/issue_import_test.go
+++ b/github/issue_import_test.go
@@ -225,7 +225,7 @@ func TestIssueImportService_CheckStatusSince(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeIssueImportAPI)
 		w.WriteHeader(http.StatusOK)
 		//nolint:fmtpercentv
-		assertWrite(t, w, []byte(fmt.Sprintf("[%s]", issueImportResponseJSON)))
+		assertWrite(t, w, fmt.Appendf(nil, "[%s]", issueImportResponseJSON))
 	})
 
 	ctx := t.Context()

--- a/github/migrations_test.go
+++ b/github/migrations_test.go
@@ -66,7 +66,7 @@ func TestMigrationService_ListMigrations(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		//nolint:fmtpercentv
-		assertWrite(t, w, []byte(fmt.Sprintf("[%s]", migrationJSON)))
+		assertWrite(t, w, fmt.Appendf(nil, "[%s]", migrationJSON))
 	})
 
 	ctx := t.Context()

--- a/github/migrations_user_test.go
+++ b/github/migrations_user_test.go
@@ -62,7 +62,7 @@ func TestMigrationService_ListUserMigrations(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		//nolint:fmtpercentv
-		assertWrite(t, w, []byte(fmt.Sprintf("[%s]", userMigrationJSON)))
+		assertWrite(t, w, fmt.Appendf(nil, "[%s]", userMigrationJSON))
 	})
 
 	ctx := t.Context()

--- a/github/strings.go
+++ b/github/strings.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 )
 
-var timestampType = reflect.TypeOf(Timestamp{})
+var timestampType = reflect.TypeFor[Timestamp]()
 
 // Stringify attempts to create a reasonable string representation of types in
 // the GitHub library. It does things like resolve pointers to their values

--- a/script/lint.sh
+++ b/script/lint.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-GOLANGCI_LINT_VERSION="2.3.0"
+GOLANGCI_LINT_VERSION="2.6.1"
 
 CDPATH="" cd -- "$(dirname -- "$0")/.."
 BIN="$(pwd -P)"/bin


### PR DESCRIPTION
This PR bumps golangci-lint to [v2.6.1](https://golangci-lint.run/docs/product/changelog/#v261) and fixes [modernize](https://golangci-lint.run/docs/linters/configuration/#modernize) lint issues.

The `omitzero` check is not easy to fix, so I disabled it with the `TODO` comment.