### PR TITLE
fix: Add `DownloadContent` to support downloads of any size

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -124,33 +124,13 @@ func (s *RepositoriesService) GetReadme(ctx context.Context, owner, repo string,
 }
 
 // DownloadContents returns an io.ReadCloser that reads the contents of the
-// specified file. This function will work with files of any size, as opposed
-// to GetContents which is limited to 1 Mb files. It is the caller's
-// responsibility to close the ReadCloser.
+// specified file, along with the file's metadata. This function will work with
+// files of any size, as opposed to GetContents which is limited to 1 Mb files.
+// It is the caller's responsibility to close the ReadCloser.
 //
-// Note: If you need the file's metadata (name, SHA, URL, etc.) in addition to
-// its content, use DownloadContentsWithMeta instead.
-//
-// It is possible for the download to result in a failed response when the
-// returned error is nil. Callers should check the returned Response status
-// code to verify the content is from a successful response.
-//
-// GitHub API docs: https://docs.github.com/rest/repos/contents#get-repository-content
-//
-//meta:operation GET /repos/{owner}/{repo}/contents/{path}
-func (s *RepositoriesService) DownloadContents(ctx context.Context, owner, repo, filepath string, opts *RepositoryContentGetOptions) (io.ReadCloser, *Response, error) {
-	reader, _, resp, err := s.DownloadContentsWithMeta(ctx, owner, repo, filepath, opts)
-	return reader, resp, err
-}
-
-// DownloadContentsWithMeta returns both an io.ReadCloser for the file content
-// and the RepositoryContent metadata for the requested file. This function will
-// work with files of any size, as opposed to GetContents which is limited to 1 Mb
-// files. It is the caller's responsibility to close the ReadCloser.
-//
-// Use this method when you need access to the file's metadata (SHA, name, path,
-// URL, etc.) in addition to its content. If you only need the content, use
-// DownloadContents for a simpler API.
+// The returned RepositoryContent contains metadata such as the file's SHA, name,
+// path, URL, etc. If you don't need the metadata, you can ignore the second return
+// value.
 //
 // It is possible for the download to result in a failed response when the
 // returned error is nil. Callers should check the returned Response status
@@ -159,7 +139,7 @@ func (s *RepositoriesService) DownloadContents(ctx context.Context, owner, repo,
 // GitHub API docs: https://docs.github.com/rest/repos/contents#get-repository-content
 //
 //meta:operation GET /repos/{owner}/{repo}/contents/{path}
-func (s *RepositoriesService) DownloadContentsWithMeta(ctx context.Context, owner, repo, filepath string, opts *RepositoryContentGetOptions) (io.ReadCloser, *RepositoryContent, *Response, error) {
+func (s *RepositoriesService) DownloadContents(ctx context.Context, owner, repo, filepath string, opts *RepositoryContentGetOptions) (io.ReadCloser, *RepositoryContent, *Response, error) {
 	fileContent, _, resp, err := s.GetContents(ctx, owner, repo, filepath, opts)
 	if err != nil {
 		return nil, nil, resp, err

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -141,7 +141,7 @@ func TestRepositoriesService_DownloadContents_SuccessForFile(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	r, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
+	r, c, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadContents returned error: %v", err)
 	}
@@ -160,14 +160,18 @@ func TestRepositoriesService_DownloadContents_SuccessForFile(t *testing.T) {
 		t.Errorf("Repositories.DownloadContents returned %v, want %v", got, want)
 	}
 
+	if got, want := c.GetName(), "f"; got != want {
+		t.Errorf("Repositories.DownloadContents returned content name %v, want %v", got, want)
+	}
+
 	const methodName = "DownloadContents"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Repositories.DownloadContents(ctx, "\n", "\n", "\n", nil)
+		_, _, _, err = client.Repositories.DownloadContents(ctx, "\n", "\n", "\n", nil)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
+		got, _, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -193,7 +197,7 @@ func TestRepositoriesService_DownloadContents_SuccessForDirectory(t *testing.T) 
 	})
 
 	ctx := t.Context()
-	r, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
+	r, c, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadContents returned error: %v", err)
 	}
@@ -212,14 +216,20 @@ func TestRepositoriesService_DownloadContents_SuccessForDirectory(t *testing.T) 
 		t.Errorf("Repositories.DownloadContents returned %v, want %v", got, want)
 	}
 
+	if got, want := c.GetName(), "f"; got != want {
+		if c != nil {
+			t.Errorf("Repositories.DownloadContents returned content name %v, want %v", got, want)
+		}
+	}
+
 	const methodName = "DownloadContents"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Repositories.DownloadContents(ctx, "\n", "\n", "\n", nil)
+		_, _, _, err = client.Repositories.DownloadContents(ctx, "\n", "\n", "\n", nil)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
+		got, _, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -247,7 +257,7 @@ func TestRepositoriesService_DownloadContents_FailedResponse(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	r, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
+	r, _, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err != nil {
 		t.Errorf("Repositories.DownloadContents returned error: %v", err)
 	}
@@ -280,17 +290,21 @@ func TestRepositoriesService_DownloadContents_NoDownloadURL(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	reader, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
+	reader, contents, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err == nil {
 		t.Error("Repositories.DownloadContents did not return expected error")
+	}
+
+	if reader != nil {
+		t.Error("Repositories.DownloadContents did not return expected reader")
 	}
 
 	if resp == nil {
 		t.Error("Repositories.DownloadContents did not return expected response")
 	}
 
-	if reader != nil {
-		t.Error("Repositories.DownloadContents did not return expected reader")
+	if contents == nil {
+		t.Error("Repositories.DownloadContents did not return expected content")
 	}
 }
 
@@ -305,7 +319,7 @@ func TestRepositoriesService_DownloadContents_NoFile(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	reader, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
+	reader, _, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
 	if err == nil {
 		t.Error("Repositories.DownloadContents did not return expected error")
 	}
@@ -316,213 +330,6 @@ func TestRepositoriesService_DownloadContents_NoFile(t *testing.T) {
 
 	if reader != nil {
 		t.Error("Repositories.DownloadContents did not return expected reader")
-	}
-}
-
-func TestRepositoriesService_DownloadContentsWithMeta_SuccessForFile(t *testing.T) {
-	t.Parallel()
-	client, mux, serverURL := setup(t)
-
-	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{
-		  "type": "file",
-		  "name": "f",
-		  "download_url": "`+serverURL+baseURLPath+`/download/f",
-          "content": "foo"
-		}`)
-	})
-
-	ctx := t.Context()
-	r, c, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
-	if err != nil {
-		t.Errorf("Repositories.DownloadContentsWithMeta returned error: %v", err)
-	}
-
-	if got, want := resp.Response.StatusCode, http.StatusOK; got != want {
-		t.Errorf("Repositories.DownloadContentsWithMeta returned status code %v, want %v", got, want)
-	}
-
-	bytes, err := io.ReadAll(r)
-	if err != nil {
-		t.Errorf("Error reading response body: %v", err)
-	}
-	r.Close()
-
-	if got, want := string(bytes), "foo"; got != want {
-		t.Errorf("Repositories.DownloadContentsWithMeta returned %v, want %v", got, want)
-	}
-
-	if c != nil && c.Name != nil {
-		if got, want := *c.Name, "f"; got != want {
-			t.Errorf("Repositories.DownloadContentsWithMeta returned content name %v, want %v", got, want)
-		}
-	} else {
-		t.Error("Returned RepositoryContent is null")
-	}
-
-	const methodName = "DownloadContentsWithMeta"
-	testBadOptions(t, methodName, func() (err error) {
-		_, _, _, err = client.Repositories.DownloadContentsWithMeta(ctx, "\n", "\n", "\n", nil)
-		return err
-	})
-
-	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, cot, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
-		if got != nil {
-			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
-		}
-		if cot != nil {
-			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, cot)
-		}
-		return resp, err
-	})
-}
-
-func TestRepositoriesService_DownloadContentsWithMeta_SuccessForDirectory(t *testing.T) {
-	t.Parallel()
-	client, mux, serverURL := setup(t)
-
-	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{
-		  "type": "file",
-		  "name": "f",
-		  "download_url": "`+serverURL+baseURLPath+`/download/f"
-		}`)
-	})
-	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, "foo")
-	})
-
-	ctx := t.Context()
-	r, c, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
-	if err != nil {
-		t.Errorf("Repositories.DownloadContentsWithMeta returned error: %v", err)
-	}
-
-	if got, want := resp.Response.StatusCode, http.StatusOK; got != want {
-		t.Errorf("Repositories.DownloadContentsWithMeta returned status code %v, want %v", got, want)
-	}
-
-	bytes, err := io.ReadAll(r)
-	if err != nil {
-		t.Errorf("Error reading response body: %v", err)
-	}
-	r.Close()
-
-	if got, want := string(bytes), "foo"; got != want {
-		t.Errorf("Repositories.DownloadContentsWithMeta returned %v, want %v", got, want)
-	}
-
-	if c != nil && c.Name != nil {
-		if got, want := *c.Name, "f"; got != want {
-			t.Errorf("Repositories.DownloadContentsWithMeta returned content name %v, want %v", got, want)
-		}
-	} else {
-		t.Error("Returned RepositoryContent is null")
-	}
-}
-
-func TestRepositoriesService_DownloadContentsWithMeta_FailedResponse(t *testing.T) {
-	t.Parallel()
-	client, mux, serverURL := setup(t)
-
-	downloadURL := fmt.Sprintf("%v%v/download/f", serverURL, baseURLPath)
-
-	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{
-			"type": "file",
-			"name": "f",
-			"download_url": "`+downloadURL+`"
-		  }`)
-	})
-	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprint(w, "foo error")
-	})
-
-	ctx := t.Context()
-	r, c, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
-	if err != nil {
-		t.Errorf("Repositories.DownloadContentsWithMeta returned error: %v", err)
-	}
-
-	if got, want := resp.Response.StatusCode, http.StatusInternalServerError; got != want {
-		t.Errorf("Repositories.DownloadContentsWithMeta returned status code %v, want %v", got, want)
-	}
-
-	bytes, err := io.ReadAll(r)
-	if err != nil {
-		t.Errorf("Error reading response body: %v", err)
-	}
-	r.Close()
-
-	if got, want := string(bytes), "foo error"; got != want {
-		t.Errorf("Repositories.DownloadContentsWithMeta returned %v, want %v", got, want)
-	}
-
-	if c != nil && c.Name != nil {
-		if got, want := *c.Name, "f"; got != want {
-			t.Errorf("Repositories.DownloadContentsWithMeta returned content name %v, want %v", got, want)
-		}
-	} else {
-		t.Error("Returned RepositoryContent is null")
-	}
-}
-
-func TestRepositoriesService_DownloadContentsWithMeta_NoDownloadURL(t *testing.T) {
-	t.Parallel()
-	client, mux, _ := setup(t)
-
-	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{
-		  "type": "file",
-		  "name": "f"
-		}`)
-	})
-
-	ctx := t.Context()
-	reader, contents, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
-	if err == nil {
-		t.Error("Repositories.DownloadContentsWithMeta did not return expected error")
-	}
-
-	if reader != nil {
-		t.Error("Repositories.DownloadContentsWithMeta did not return expected reader")
-	}
-
-	if resp == nil {
-		t.Error("Repositories.DownloadContentsWithMeta did not return expected response")
-	}
-
-	if contents == nil {
-		t.Error("Repositories.DownloadContentsWithMeta did not return expected content")
-	}
-}
-
-func TestRepositoriesService_DownloadContentsWithMeta_NoFile(t *testing.T) {
-	t.Parallel()
-	client, mux, _ := setup(t)
-
-	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprint(w, `{"message":"Not Found"}`)
-	})
-
-	ctx := t.Context()
-	_, _, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
-	if err == nil {
-		t.Error("Repositories.DownloadContentsWithMeta did not return expected error")
-	}
-
-	if resp == nil {
-		t.Error("Repositories.DownloadContentsWithMeta did not return expected response")
 	}
 }
 

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -183,16 +183,9 @@ func TestRepositoriesService_DownloadContents_SuccessForDirectory(t *testing.T) 
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
 		  "type": "file",
-		  "name": "f"
-		}`)
-	})
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
-		  "type": "file",
 		  "name": "f",
 		  "download_url": "`+serverURL+baseURLPath+`/download/f"
-		}]`)
+		}`)
 	})
 	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -240,18 +233,12 @@ func TestRepositoriesService_DownloadContents_FailedResponse(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{
-			"type": "file",
-			"name": "f"
-		  }`)
-	})
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
+		fmt.Fprint(w,
+			`{
 			"type": "file",
 			"name": "f",
 			"download_url": "`+serverURL+baseURLPath+`/download/f"
-		  }]`)
+		}`)
 	})
 	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -288,17 +275,8 @@ func TestRepositoriesService_DownloadContents_NoDownloadURL(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
 		  "type": "file",
-		  "name": "f",
-		  "content": ""
+		  "name": "f"
 		}`)
-	})
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
-		  "type": "file",
-		  "name": "f",
-		  "content": ""
-		}]`)
 	})
 
 	ctx := t.Context()
@@ -322,16 +300,8 @@ func TestRepositoriesService_DownloadContents_NoFile(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{
-		  "type": "file",
-		  "name": "f",
-		  "content": ""
-		}`)
-	})
-
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[]`)
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"message":"Not Found"}`)
 	})
 
 	ctx := t.Context()
@@ -413,13 +383,13 @@ func TestRepositoriesService_DownloadContentsWithMeta_SuccessForDirectory(t *tes
 	t.Parallel()
 	client, mux, serverURL := setup(t)
 
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
+		fmt.Fprint(w, `{
 		  "type": "file",
 		  "name": "f",
 		  "download_url": "`+serverURL+baseURLPath+`/download/f"
-		}]`)
+		}`)
 	})
 	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -474,14 +444,6 @@ func TestRepositoriesService_DownloadContentsWithMeta_FailedResponse(t *testing.
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(w, "foo error")
 	})
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
-			"type": "file",
-			"name": "f",
-			"download_url": "`+downloadURL+`"
-		  }]`)
-	})
 
 	ctx := t.Context()
 	r, c, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
@@ -520,16 +482,8 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoDownloadURL(t *testing.T
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
 		  "type": "file",
-		  "name": "f",
+		  "name": "f"
 		}`)
-	})
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
-		  "type": "file",
-		  "name": "f",
-		  "content": ""
-		}]`)
 	})
 
 	ctx := t.Context()
@@ -555,9 +509,10 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoFile(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[]`)
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"message":"Not Found"}`)
 	})
 
 	ctx := t.Context()

--- a/tools/metadata/openapi.go
+++ b/tools/metadata/openapi.go
@@ -55,7 +55,7 @@ func getOpsFromGithub(ctx context.Context, client *github.Client, gitRef string)
 }
 
 func (o *openapiFile) loadDescription(ctx context.Context, client *github.Client, gitRef string) error {
-	contents, resp, err := client.Repositories.DownloadContents(
+	contents, _, resp, err := client.Repositories.DownloadContents(
 		ctx,
 		descriptionsOwnerName,
 		descriptionsRepoName,


### PR DESCRIPTION
Fix https://github.com/google/go-github/issues/3810.
Fix https://github.com/google/go-github/issues/2480.