### PR TITLE
fix: Remove custom Accept headers from search endpoints

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -91,9 +91,6 @@ const (
 	// https://developer.github.com/changes/2016-09-14-projects-api/
 	mediaTypeProjectsPreview = "application/vnd.github.inertia-preview+json"
 
-	// https://developer.github.com/changes/2017-01-05-commit-search-api/
-	mediaTypeCommitSearchPreview = "application/vnd.github.cloak-preview+json"
-
 	// https://developer.github.com/changes/2017-02-28-user-blocking-apis-and-webhook/
 	mediaTypeBlockUsersPreview = "application/vnd.github.giant-sentry-fist-preview+json"
 

--- a/github/search.go
+++ b/github/search.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	qs "github.com/google/go-querystring/query"
 )
@@ -317,32 +316,12 @@ func (s *SearchService) search(ctx context.Context, searchType string, parameter
 	if err != nil {
 		return nil, err
 	}
-	var acceptHeaders []string
-	switch searchType {
-	case "commits":
-		// Accept header for search commits preview endpoint
-		// TODO: remove custom Accept header when this API fully launches.
-		acceptHeaders = append(acceptHeaders, mediaTypeCommitSearchPreview)
-	case "topics":
-		// Accept header for search repositories based on topics preview endpoint
-		// TODO: remove custom Accept header when this API fully launches.
-		acceptHeaders = append(acceptHeaders, mediaTypeTopicsPreview)
-	case "repositories":
-		// Accept header for search repositories based on topics preview endpoint
-		// TODO: remove custom Accept header when this API fully launches.
-		acceptHeaders = append(acceptHeaders, mediaTypeTopicsPreview)
-	case "issues":
-		// Accept header for search issues based on reactions preview endpoint
-		// TODO: remove custom Accept header when this API fully launches.
-		acceptHeaders = append(acceptHeaders, mediaTypeReactionsPreview)
-	}
-	// https://docs.github.com/rest/search#search-repositories
+	// https://docs.github.com/en/rest/search/search#text-match-metadata
 	// Accept header defaults to "application/vnd.github.v3+json"
 	// We change it here to fetch back text-match metadata
 	if opts != nil && opts.TextMatch {
-		acceptHeaders = append(acceptHeaders, "application/vnd.github.v3.text-match+json")
+		req.Header.Set("Accept", "application/vnd.github.v3.text-match+json")
 	}
-	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	return s.client.Do(ctx, req, result)
 }

--- a/github/search_test.go
+++ b/github/search_test.go
@@ -8,7 +8,6 @@ package github
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -78,12 +77,7 @@ func TestSearchService_RepositoriesTextMatch(t *testing.T) {
 				]
 			}
 		`
-		list := strings.Split(r.Header.Get("Accept"), ",")
-		aMap := make(map[string]struct{})
-		for _, s := range list {
-			aMap[strings.TrimSpace(s)] = struct{}{}
-		}
-		if _, ok := aMap["application/vnd.github.v3.text-match+json"]; ok {
+		if r.Header.Get("Accept") == "application/vnd.github.v3.text-match+json" {
 			textMatchResponse = `
 					{
 						"total_count": 1,


### PR DESCRIPTION
The PR removes deprecated preview "Accept" headers from all search endpoints.

The REST API for search was fully launched a long time ago https://docs.github.com/en/rest/search/search