### PR TITLE
chore: Enable nolintlint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - modernize
     - musttag
     - nakedret
+    - nolintlint
     - paralleltest
     - perfsprint
     - revive
@@ -88,6 +89,9 @@ linters:
     modernize:
       disable:
         - omitzero # TODO: fix
+    nolintlint:
+      allow-unused: true
+      require-specific: true
     perfsprint:
       errorf: true
       strconcat: false

--- a/github/issue_import_test.go
+++ b/github/issue_import_test.go
@@ -224,7 +224,6 @@ func TestIssueImportService_CheckStatusSince(t *testing.T) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", mediaTypeIssueImportAPI)
 		w.WriteHeader(http.StatusOK)
-		//nolint:fmtpercentv
 		assertWrite(t, w, fmt.Appendf(nil, "[%s]", issueImportResponseJSON))
 	})
 

--- a/github/migrations_test.go
+++ b/github/migrations_test.go
@@ -65,7 +65,6 @@ func TestMigrationService_ListMigrations(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeMigrationsPreview)
 
 		w.WriteHeader(http.StatusOK)
-		//nolint:fmtpercentv
 		assertWrite(t, w, fmt.Appendf(nil, "[%s]", migrationJSON))
 	})
 

--- a/github/migrations_user_test.go
+++ b/github/migrations_user_test.go
@@ -61,7 +61,6 @@ func TestMigrationService_ListUserMigrations(t *testing.T) {
 		testHeader(t, r, "Accept", mediaTypeMigrationsPreview)
 
 		w.WriteHeader(http.StatusOK)
-		//nolint:fmtpercentv
 		assertWrite(t, w, fmt.Appendf(nil, "[%s]", userMigrationJSON))
 	})
 

--- a/tools/gen-release-notes/main.go
+++ b/tools/gen-release-notes/main.go
@@ -207,7 +207,7 @@ func genRefLines(breaking, nonBreaking []string) (ref, refNon []string) {
 
 func newChangesSinceRelease(priorRelease string) string {
 	url := fmt.Sprintf("%v/compare/%v...master", baseWebURL, priorRelease)
-	resp, err := http.Get(url) //nolint: gosec
+	resp, err := http.Get(url) //nolint:gosec
 	must(err)
 	defer resp.Body.Close()
 

--- a/tools/metadata/main_test.go
+++ b/tools/metadata/main_test.go
@@ -67,7 +67,7 @@ GET /undocumented/{undocumented_id}
 `, "")
 }
 
-//nolint:tparallel,paralleltest // cannot use t.Parallel() when helper calls t.Setenv
+//nolint:paralleltest // cannot use t.Parallel() when helper calls t.Setenv
 func TestUpdateOpenAPI(t *testing.T) {
 	testServer := newTestServer(t, "main", map[string]any{
 		"api.github.com/api.github.com.json": openapi3.T{


### PR DESCRIPTION
The PR enables the [`nolintlint`](https://golangci-lint.run/docs/linters/configuration/#nolintlint) linter and fixes appeared lint issues.

This tiny linter detects unused `//nolint` comments.