### PR TITLE
Add missing `MergeQueueRuleParameters` config properties

### DIFF
--- a/github/rules.go
+++ b/github/rules.go
@@ -415,7 +415,9 @@ type UpdateRuleParameters struct {
 
 // MergeQueueRuleParameters represents the merge_queue rule parameters.
 type MergeQueueRuleParameters struct {
+	ActorControlledMerging       bool                  `json:"actor_controlled_merging,omitempty"`
 	CheckResponseTimeoutMinutes  int                   `json:"check_response_timeout_minutes"`
+	CheckRunRetriesLimit         int                   `json:"check_run_retries_limit,omitempty"`
 	GroupingStrategy             MergeGroupingStrategy `json:"grouping_strategy"`
 	MaxEntriesToBuild            int                   `json:"max_entries_to_build"`
 	MaxEntriesToMerge            int                   `json:"max_entries_to_merge"`

--- a/github/rules_test.go
+++ b/github/rules_test.go
@@ -691,7 +691,9 @@ func TestRepositoryRule(t *testing.T) {
 			&RepositoryRule{
 				Type: RulesetRuleTypeMergeQueue,
 				Parameters: &MergeQueueRuleParameters{
+					ActorControlledMerging:       true,
 					CheckResponseTimeoutMinutes:  5,
+					CheckRunRetriesLimit:         3,
 					GroupingStrategy:             MergeGroupingStrategyAllGreen,
 					MaxEntriesToBuild:            10,
 					MaxEntriesToMerge:            20,
@@ -700,7 +702,7 @@ func TestRepositoryRule(t *testing.T) {
 					MinEntriesToMergeWaitMinutes: 15,
 				},
 			},
-			`{"type":"merge_queue","parameters":{"check_response_timeout_minutes":5,"grouping_strategy":"ALLGREEN","max_entries_to_build":10,"max_entries_to_merge":20,"merge_method":"SQUASH","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":15}}`,
+			`{"type":"merge_queue","parameters":{"actor_controlled_merging":true,"check_response_timeout_minutes":5,"check_run_retries_limit":3,"grouping_strategy":"ALLGREEN","max_entries_to_build":10,"max_entries_to_merge":20,"merge_method":"SQUASH","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":15}}`,
 		},
 		{
 			"required_deployments",


### PR DESCRIPTION
fixes https://github.com/google/go-github/issues/3822

This adds the missing properties `actor_controlled_merging` and `check_run_retries_limit` to the merge queue rule configuration object. The new properties are added as `omitempty` to avoid behavioral changes for existing logic that may not be setting these values. 

Happy to adjust course and remove `omitempty` and fix tests if that's the desired take.