### PR TITLE
feat: Add support for Enterprise GitHub App Installation APIs

### DIFF
--- a/github/enterprise_app_installation.go
+++ b/github/enterprise_app_installation.go
@@ -14,14 +14,14 @@ import (
 type InstallableOrganization struct {
 	ID                        int64   `json:"id"`
 	Login                     string  `json:"login"`
-	AccessibleRepositoriesURL *string `json:"accessible_repositories_url"`
+	AccessibleRepositoriesURL *string `json:"accessible_repositories_url,omitempty"`
 }
 
 // AccessibleRepository represents a repository that can be made accessible to a GitHub app.
 type AccessibleRepository struct {
-	ID       int64   `json:"id"`
-	Name     string  `json:"name"`
-	FullName *string `json:"full_name,omitempty"`
+	ID       int64  `json:"id"`
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
 }
 
 // InstallAppRequest represents the request to install a GitHub app on an enterprise-owned organization.

--- a/github/enterprise_app_installation_test.go
+++ b/github/enterprise_app_installation_test.go
@@ -68,7 +68,7 @@ func TestEnterpriseService_ListAppAccessibleOrganizationRepositories(t *testing.
 	}
 
 	want := []*AccessibleRepository{
-		{ID: int64(10), Name: "repo1", FullName: Ptr("org1/repo1")},
+		{ID: int64(10), Name: "repo1", FullName: "org1/repo1"},
 	}
 
 	if !cmp.Equal(repos, want) {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -78,14 +78,6 @@ func (a *AcceptedAssignment) GetSubmitted() bool {
 	return *a.Submitted
 }
 
-// GetFullName returns the FullName field if it's non-nil, zero value otherwise.
-func (a *AccessibleRepository) GetFullName() string {
-	if a == nil || a.FullName == nil {
-		return ""
-	}
-	return *a.FullName
-}
-
 // GetGithubOwnedAllowed returns the GithubOwnedAllowed field if it's non-nil, zero value otherwise.
 func (a *ActionsAllowed) GetGithubOwnedAllowed() bool {
 	if a == nil || a.GithubOwnedAllowed == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -97,17 +97,6 @@ func TestAcceptedAssignment_GetSubmitted(tt *testing.T) {
 	a.GetSubmitted()
 }
 
-func TestAccessibleRepository_GetFullName(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	a := &AccessibleRepository{FullName: &zeroValue}
-	a.GetFullName()
-	a = &AccessibleRepository{}
-	a.GetFullName()
-	a = nil
-	a.GetFullName()
-}
-
 func TestActionsAllowed_GetGithubOwnedAllowed(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool


### PR DESCRIPTION
Relates-to: #3829

This PR add support for the following API endpoints -

- GET /enterprises/{enterprise}/apps/installable_organizations
- GET /enterprises/{enterprise}/apps/installable_organizations/{org}/accessible_repositories
- GET /enterprises/{enterprise}/apps/organizations/{org}/installations
- POST /enterprises/{enterprise}/apps/organizations/{org}/installations
- DELETE /enterprises/{enterprise}/apps/organizations/{org}/installations/{installation_id}

[REST API endpoints for Github App Installation](https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/organization-installations?apiVersion=2022-11-28)