### PR TITLE
chore: Update golangci-lint to v2.7.0

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,4 +1,4 @@
-version: v2.6.1
+version: v2.7.0
 plugins:
   - module: "github.com/google/go-github/v79/tools/fmtpercentv"
     path: ./tools/fmtpercentv

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ vendor/
 
 # golangci-lint -v custom generates the following local file:
 custom-gcl
+custom-gcl.exe

--- a/script/lint.sh
+++ b/script/lint.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-GOLANGCI_LINT_VERSION="2.6.1"
+GOLANGCI_LINT_VERSION="2.7.0"
 
 CDPATH="" cd -- "$(dirname -- "$0")/.."
 BIN="$(pwd -P)"/bin
@@ -22,7 +22,7 @@ fail() {
 # install golangci-lint and custom-gcl in ./bin if they don't exist with the correct version
 if ! "$BIN"/custom-gcl --version 2> /dev/null | grep -q "$GOLANGCI_LINT_VERSION"; then
   GOBIN="$BIN" go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$GOLANGCI_LINT_VERSION"
-  "$BIN"/golangci-lint custom && mv ./custom-gcl "$BIN"
+  "$BIN"/golangci-lint custom --name custom-gcl --destination "$BIN"
 fi
 
 MOD_DIRS="$(git ls-files '*go.mod' | xargs dirname | sort)"

--- a/tools/gen-release-notes/main.go
+++ b/tools/gen-release-notes/main.go
@@ -96,8 +96,8 @@ func splitIntoPRs(text string) []string {
 
 func stripPRHTML(text string) string {
 	_, innerText := getTagSequence(text)
-	if i := strings.Index(text, "</a>"); i > 0 {
-		newText := text[:i] + strings.Join(innerText, "")
+	if before, _, ok := strings.Cut(text, "</a>"); ok {
+		newText := before + strings.Join(innerText, "")
 		newText = strings.ReplaceAll(newText, "…", "")
 		newText = newlinesRE.ReplaceAllString(newText, "\n  ")
 		return newText
@@ -138,8 +138,8 @@ func getTagSequence(text string) (tagSeq, innerText []string) {
 			tagSeq = append(tagSeq, s)
 			continue
 		}
-		if i := strings.Index(s, " "); i > 0 {
-			tagSeq = append(tagSeq, s[0:i])
+		if before, _, ok := strings.Cut(s, " "); ok {
+			tagSeq = append(tagSeq, before)
 		} else {
 			tagSeq = append(tagSeq, s)
 		}


### PR DESCRIPTION
This PR fixes the currently broken `golangci-lint` custom plugin implementation (broken due to the GitHub Actions Git version). It also makes an auto-fix change that otherwise fails the linter.