### PR TITLE
feat: Add support for Enterprise Team APIs

### DIFF
--- a/github/enterprise_team.go
+++ b/github/enterprise_team.go
@@ -21,7 +21,7 @@ type EnterpriseTeam struct {
 	Slug                      string    `json:"slug"`
 	CreatedAt                 Timestamp `json:"created_at"`
 	UpdatedAt                 Timestamp `json:"updated_at"`
-	GroupID                   int64     `json:"group_id"`
+	GroupID                   string    `json:"group_id"`
 	OrganizationSelectionType *string   `json:"organization_selection_type,omitempty"`
 }
 
@@ -35,7 +35,7 @@ type EnterpriseTeamCreateOrUpdateRequest struct {
 	// Possible values are "disabled" , "all" and "selected". If not specified, the default is "disabled".
 	OrganizationSelectionType *string `json:"organization_selection_type,omitempty"`
 	// The ID of the IdP group to assign team membership with.
-	GroupID *int64 `json:"group_id,omitempty"`
+	GroupID *string `json:"group_id,omitempty"`
 }
 
 // ListTeams lists all teams in an enterprise.

--- a/github/enterprise_team_test.go
+++ b/github/enterprise_team_test.go
@@ -29,7 +29,7 @@ func TestEnterpriseService_ListTeams(t *testing.T) {
 			"slug": "team-one",
 			"created_at": "2020-01-01T00:00:00Z",
 			"updated_at": "2020-01-02T00:00:00Z",
-			"group_id": 99
+			"group_id": "99"
 		}]`)
 	})
 
@@ -48,7 +48,7 @@ func TestEnterpriseService_ListTeams(t *testing.T) {
 			Name:      "Team One",
 			HTMLURL:   "https://example.com/html",
 			Slug:      "team-one",
-			GroupID:   99,
+			GroupID:   "99",
 			CreatedAt: Timestamp{Time: time.Date(2020, time.January, 1, 0, 0, 0, 0, time.UTC)},
 			UpdatedAt: Timestamp{Time: time.Date(2020, time.January, 2, 0, 0, 0, 0, time.UTC)},
 		},

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9471,9 +9471,9 @@ func (e *EnterpriseTeamCreateOrUpdateRequest) GetDescription() string {
 }
 
 // GetGroupID returns the GroupID field if it's non-nil, zero value otherwise.
-func (e *EnterpriseTeamCreateOrUpdateRequest) GetGroupID() int64 {
+func (e *EnterpriseTeamCreateOrUpdateRequest) GetGroupID() string {
 	if e == nil || e.GroupID == nil {
-		return 0
+		return ""
 	}
 	return *e.GroupID
 }

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -12281,7 +12281,7 @@ func TestEnterpriseTeamCreateOrUpdateRequest_GetDescription(tt *testing.T) {
 
 func TestEnterpriseTeamCreateOrUpdateRequest_GetGroupID(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue int64
+	var zeroValue string
 	e := &EnterpriseTeamCreateOrUpdateRequest{GroupID: &zeroValue}
 	e.GetGroupID()
 	e = &EnterpriseTeamCreateOrUpdateRequest{}


### PR DESCRIPTION
Related: [#3860](https://github.com/google/go-github/issues/3860)

This PR adds support for [Enterprise Teams](https://docs.github.com/en/rest/enterprise-teams/enterprise-teams)

- GET /enterprises/{enterprise}/teams
- POST /enterprises/{enterprise}/teams
- GET /enterprises/{enterprise}/teams/{team_slug}
- PATCH /enterprises/{enterprise}/teams/{team_slug}
- DELETE /enterprises/{enterprise}/teams/{team_slug}