### PR TITLE
chore: Simplify JSON marshaling for RepositoryRulesetRules

### DIFF
--- a/github/rules.go
+++ b/github/rules.go
@@ -791,6 +791,10 @@ func (r *RepositoryRulesetRules) MarshalJSON() ([]byte, error) {
 		rawRules = append(rawRules, json.RawMessage(bytes))
 	}
 
+	if len(rawRules) == 0 {
+		return []byte("[]"), nil
+	}
+
 	return json.Marshal(rawRules)
 }
 


### PR DESCRIPTION
The optimization in the `RepositoryRulesetRules.MarshalJSON` hurts readability and maintainability. I propose removing it because the `append` function is smart enough to allocate memory efficiently.