### PR TITLE
docs: Clarify `CreateTree` semantics and `TreeEntry` usage

### DIFF
--- a/github/git_trees.go
+++ b/github/git_trees.go
@@ -30,6 +30,13 @@ func (t Tree) String() string {
 // TreeEntry represents the contents of a tree structure. TreeEntry can
 // represent either a blob, a commit (in the case of a submodule), or another
 // tree.
+//
+// When used with [GitService.CreateTree], set Content for small text files,
+// or set SHA to reference an existing blob (use [GitService.CreateBlob] for
+// binary files or large content). To delete an entry, set both Content and SHA
+// to nil; the entry will be serialized with `"sha": null` which the API interprets
+// as a deletion. When deleting, the Type and Mode fields are ignored; only Path
+// is required.
 type TreeEntry struct {
 	SHA     *string `json:"sha,omitempty"`
 	Path    *string `json:"path,omitempty"`
@@ -126,6 +133,12 @@ type createTree struct {
 // CreateTree creates a new tree in a repository. If both a tree and a nested
 // path modifying that tree are specified, it will overwrite the contents of
 // that tree with the new path contents and write a new tree out.
+//
+// When baseTree is provided, entries are merged with that tree: paths not
+// mentioned in entries are preserved from the base tree. If the same path
+// appears multiple times in entries, the last entry wins. To delete an entry,
+// include a [TreeEntry] with the path and both SHA and Content set to nil.
+// Entire directories can be deleted this way.
 //
 // GitHub API docs: https://docs.github.com/rest/git/trees#create-a-tree
 //


### PR DESCRIPTION
## Summary

This PR improves the documentation for `CreateTree` and `TreeEntry` to clarify several behaviors that are not obvious from the existing docs:

- **Merge semantics**: When `baseTree` is provided, entries are merged with that tree - paths not mentioned in `entries` are preserved from the base tree
- **Duplicate entries**: If the same path appears multiple times in entries, the last entry wins
- **File/directory deletion**: To delete an entry, set both `SHA` and `Content` to nil; this works for both files and entire directories
- **Type/Mode ignored on delete**: When deleting, the `Type` and `Mode` fields are ignored by the API; only `Path` is required
- **Content vs SHA**: Clarifies when to use `Content` (small text files) vs `SHA` (reference to existing blob), with a reference to `CreateBlob` for binary files

These behaviors were verified experimentally against the GitHub API.

## Test plan

- [x] Documentation-only change, no code changes
- [x] Existing tests pass (`go test ./github/... -run TestGitService_.*Tree`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)