### PR TITLE
feat: Add support for URL custom property value type

### DIFF
--- a/github/enterprise_organization_properties_test.go
+++ b/github/enterprise_organization_properties_test.go
@@ -38,7 +38,7 @@ func TestEnterpriseService_GetOrganizationCustomPropertySchema(t *testing.T) {
 		Properties: []*CustomProperty{
 			{
 				PropertyName: Ptr("team"),
-				ValueType:    "string",
+				ValueType:    PropertyValueTypeString,
 				Description:  Ptr("Team name"),
 			},
 		},
@@ -111,7 +111,7 @@ func TestEnterpriseService_GetOrganizationCustomProperty(t *testing.T) {
 
 	want := &CustomProperty{
 		PropertyName: Ptr("team"),
-		ValueType:    "string",
+		ValueType:    PropertyValueTypeString,
 		Description:  Ptr("Team name"),
 	}
 

--- a/github/enterprise_properties_test.go
+++ b/github/enterprise_properties_test.go
@@ -53,7 +53,7 @@ func TestEnterpriseService_GetAllCustomProperties(t *testing.T) {
 	want := []*CustomProperty{
 		{
 			PropertyName:     Ptr("name"),
-			ValueType:        "single_select",
+			ValueType:        PropertyValueTypeSingleSelect,
 			Required:         Ptr(true),
 			DefaultValue:     Ptr("production"),
 			Description:      Ptr("Prod or dev environment"),
@@ -62,11 +62,11 @@ func TestEnterpriseService_GetAllCustomProperties(t *testing.T) {
 		},
 		{
 			PropertyName: Ptr("service"),
-			ValueType:    "string",
+			ValueType:    PropertyValueTypeString,
 		},
 		{
 			PropertyName: Ptr("team"),
-			ValueType:    "string",
+			ValueType:    PropertyValueTypeString,
 			Description:  Ptr("Team owning the repository"),
 		},
 	}
@@ -109,12 +109,12 @@ func TestEnterpriseService_CreateOrUpdateCustomProperties(t *testing.T) {
 	properties, _, err := client.Enterprise.CreateOrUpdateCustomProperties(ctx, "e", []*CustomProperty{
 		{
 			PropertyName: Ptr("name"),
-			ValueType:    "single_select",
+			ValueType:    PropertyValueTypeSingleSelect,
 			Required:     Ptr(true),
 		},
 		{
 			PropertyName: Ptr("service"),
-			ValueType:    "string",
+			ValueType:    PropertyValueTypeString,
 		},
 	})
 	if err != nil {
@@ -124,12 +124,12 @@ func TestEnterpriseService_CreateOrUpdateCustomProperties(t *testing.T) {
 	want := []*CustomProperty{
 		{
 			PropertyName: Ptr("name"),
-			ValueType:    "single_select",
+			ValueType:    PropertyValueTypeSingleSelect,
 			Required:     Ptr(true),
 		},
 		{
 			PropertyName: Ptr("service"),
-			ValueType:    "string",
+			ValueType:    PropertyValueTypeString,
 		},
 	}
 
@@ -176,7 +176,7 @@ func TestEnterpriseService_GetCustomProperty(t *testing.T) {
 
 	want := &CustomProperty{
 		PropertyName:     Ptr("name"),
-		ValueType:        "single_select",
+		ValueType:        PropertyValueTypeSingleSelect,
 		Required:         Ptr(true),
 		DefaultValue:     Ptr("production"),
 		Description:      Ptr("Prod or dev environment"),
@@ -220,7 +220,7 @@ func TestEnterpriseService_CreateOrUpdateCustomProperty(t *testing.T) {
 
 	ctx := t.Context()
 	property, _, err := client.Enterprise.CreateOrUpdateCustomProperty(ctx, "e", "name", &CustomProperty{
-		ValueType:        "single_select",
+		ValueType:        PropertyValueTypeSingleSelect,
 		Required:         Ptr(true),
 		DefaultValue:     Ptr("production"),
 		Description:      Ptr("Prod or dev environment"),
@@ -233,7 +233,7 @@ func TestEnterpriseService_CreateOrUpdateCustomProperty(t *testing.T) {
 
 	want := &CustomProperty{
 		PropertyName:     Ptr("name"),
-		ValueType:        "single_select",
+		ValueType:        PropertyValueTypeSingleSelect,
 		Required:         Ptr(true),
 		DefaultValue:     Ptr("production"),
 		Description:      Ptr("Prod or dev environment"),

--- a/github/event_types_test.go
+++ b/github/event_types_test.go
@@ -13729,7 +13729,7 @@ func TestCustomPropertyEvent_Marshal(t *testing.T) {
 		Action: Ptr("created"),
 		Definition: &CustomProperty{
 			PropertyName:     Ptr("name"),
-			ValueType:        "single_select",
+			ValueType:        PropertyValueTypeSingleSelect,
 			SourceType:       Ptr("enterprise"),
 			Required:         Ptr(true),
 			DefaultValue:     Ptr("production"),

--- a/github/orgs_properties.go
+++ b/github/orgs_properties.go
@@ -12,6 +12,15 @@ import (
 	"fmt"
 )
 
+// Valid values for CustomProperty.ValueType.
+const (
+	PropertyValueTypeString       = "string"
+	PropertyValueTypeSingleSelect = "single_select"
+	PropertyValueTypeMultiSelect  = "multi_select"
+	PropertyValueTypeTrueFalse    = "true_false"
+	PropertyValueTypeURL          = "url"
+)
+
 // CustomProperty represents an organization custom property object.
 type CustomProperty struct {
 	// PropertyName is required for most endpoints except when calling CreateOrUpdateCustomProperty;

--- a/github/orgs_properties_test.go
+++ b/github/orgs_properties_test.go
@@ -60,7 +60,7 @@ func TestOrganizationsService_GetAllCustomProperties(t *testing.T) {
 	want := []*CustomProperty{
 		{
 			PropertyName:     Ptr("name"),
-			ValueType:        "single_select",
+			ValueType:        PropertyValueTypeSingleSelect,
 			Required:         Ptr(true),
 			DefaultValue:     Ptr("production"),
 			Description:      Ptr("Prod or dev environment"),
@@ -69,16 +69,16 @@ func TestOrganizationsService_GetAllCustomProperties(t *testing.T) {
 		},
 		{
 			PropertyName: Ptr("service"),
-			ValueType:    "string",
+			ValueType:    PropertyValueTypeString,
 		},
 		{
 			PropertyName: Ptr("team"),
-			ValueType:    "string",
+			ValueType:    PropertyValueTypeString,
 			Description:  Ptr("Team owning the repository"),
 		},
 		{
 			PropertyName: Ptr("documentation"),
-			ValueType:    "url",
+			ValueType:    PropertyValueTypeURL,
 			Required:     Ptr(true),
 			Description:  Ptr("Link to the documentation"),
 			DefaultValue: Ptr("https://example.com/docs"),
@@ -123,12 +123,12 @@ func TestOrganizationsService_CreateOrUpdateCustomProperties(t *testing.T) {
 	properties, _, err := client.Organizations.CreateOrUpdateCustomProperties(ctx, "o", []*CustomProperty{
 		{
 			PropertyName: Ptr("name"),
-			ValueType:    "single_select",
+			ValueType:    PropertyValueTypeSingleSelect,
 			Required:     Ptr(true),
 		},
 		{
 			PropertyName: Ptr("service"),
-			ValueType:    "string",
+			ValueType:    PropertyValueTypeString,
 		},
 	})
 	if err != nil {
@@ -138,12 +138,12 @@ func TestOrganizationsService_CreateOrUpdateCustomProperties(t *testing.T) {
 	want := []*CustomProperty{
 		{
 			PropertyName: Ptr("name"),
-			ValueType:    "single_select",
+			ValueType:    PropertyValueTypeSingleSelect,
 			Required:     Ptr(true),
 		},
 		{
 			PropertyName: Ptr("service"),
-			ValueType:    "string",
+			ValueType:    PropertyValueTypeString,
 		},
 	}
 
@@ -190,7 +190,7 @@ func TestOrganizationsService_GetCustomProperty(t *testing.T) {
 
 	want := &CustomProperty{
 		PropertyName:     Ptr("name"),
-		ValueType:        "single_select",
+		ValueType:        PropertyValueTypeSingleSelect,
 		Required:         Ptr(true),
 		DefaultValue:     Ptr("production"),
 		Description:      Ptr("Prod or dev environment"),
@@ -234,7 +234,7 @@ func TestOrganizationsService_CreateOrUpdateCustomProperty(t *testing.T) {
 
 	ctx := t.Context()
 	property, _, err := client.Organizations.CreateOrUpdateCustomProperty(ctx, "o", "name", &CustomProperty{
-		ValueType:        "single_select",
+		ValueType:        PropertyValueTypeSingleSelect,
 		Required:         Ptr(true),
 		DefaultValue:     Ptr("production"),
 		Description:      Ptr("Prod or dev environment"),
@@ -247,7 +247,7 @@ func TestOrganizationsService_CreateOrUpdateCustomProperty(t *testing.T) {
 
 	want := &CustomProperty{
 		PropertyName:     Ptr("name"),
-		ValueType:        "single_select",
+		ValueType:        PropertyValueTypeSingleSelect,
 		Required:         Ptr(true),
 		DefaultValue:     Ptr("production"),
 		Description:      Ptr("Prod or dev environment"),


### PR DESCRIPTION
Since `ValueType` is just a string field with no validation, I only updated the documentation comment and added a test. Let me know if I'm missing something.

Fixes #3878 