### PR TITLE
chore: Rename 'opt' to 'opts' in multiple methods

### DIFF
--- a/github/enterprise_team.go
+++ b/github/enterprise_team.go
@@ -43,9 +43,9 @@ type EnterpriseTeamCreateOrUpdateRequest struct {
 // GitHub API docs: https://docs.github.com/rest/enterprise-teams/enterprise-teams#list-enterprise-teams
 //
 //meta:operation GET /enterprises/{enterprise}/teams
-func (s *EnterpriseService) ListTeams(ctx context.Context, enterprise string, opt *ListOptions) ([]*EnterpriseTeam, *Response, error) {
+func (s *EnterpriseService) ListTeams(ctx context.Context, enterprise string, opts *ListOptions) ([]*EnterpriseTeam, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams", enterprise)
-	u, err := addOptions(u, opt)
+	u, err := addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -156,9 +156,9 @@ func (s *EnterpriseService) DeleteTeam(ctx context.Context, enterprise, teamSlug
 // GitHub API docs: https://docs.github.com/rest/enterprise-teams/enterprise-team-members#list-members-in-an-enterprise-team
 //
 //meta:operation GET /enterprises/{enterprise}/teams/{enterprise-team}/memberships
-func (s *EnterpriseService) ListTeamMembers(ctx context.Context, enterprise, enterpriseTeam string, opt *ListOptions) ([]*User, *Response, error) {
+func (s *EnterpriseService) ListTeamMembers(ctx context.Context, enterprise, enterpriseTeam string, opts *ListOptions) ([]*User, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams/%v/memberships", enterprise, enterpriseTeam)
-	u, err := addOptions(u, opt)
+	u, err := addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -289,9 +289,9 @@ func (s *EnterpriseService) RemoveTeamMember(ctx context.Context, enterprise, en
 // GitHub API docs: https://docs.github.com/rest/enterprise-teams/enterprise-team-organizations#get-organization-assignments
 //
 //meta:operation GET /enterprises/{enterprise}/teams/{enterprise-team}/organizations
-func (s *EnterpriseService) ListAssignments(ctx context.Context, enterprise, enterpriseTeam string, opt *ListOptions) ([]*Organization, *Response, error) {
+func (s *EnterpriseService) ListAssignments(ctx context.Context, enterprise, enterpriseTeam string, opts *ListOptions) ([]*Organization, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams/%v/organizations", enterprise, enterpriseTeam)
-	u, err := addOptions(u, opt)
+	u, err := addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/orgs_issue_types.go
+++ b/github/orgs_issue_types.go
@@ -46,9 +46,9 @@ func (s *OrganizationsService) ListIssueTypes(ctx context.Context, org string) (
 // GitHub API docs: https://docs.github.com/rest/orgs/issue-types#create-issue-type-for-an-organization
 //
 //meta:operation POST /orgs/{org}/issue-types
-func (s *OrganizationsService) CreateIssueType(ctx context.Context, org string, opt *CreateOrUpdateIssueTypesOptions) (*IssueType, *Response, error) {
+func (s *OrganizationsService) CreateIssueType(ctx context.Context, org string, opts *CreateOrUpdateIssueTypesOptions) (*IssueType, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/issue-types", org)
-	req, err := s.client.NewRequest("POST", u, opt)
+	req, err := s.client.NewRequest("POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -67,9 +67,9 @@ func (s *OrganizationsService) CreateIssueType(ctx context.Context, org string, 
 // GitHub API docs: https://docs.github.com/rest/orgs/issue-types#update-issue-type-for-an-organization
 //
 //meta:operation PUT /orgs/{org}/issue-types/{issue_type_id}
-func (s *OrganizationsService) UpdateIssueType(ctx context.Context, org string, issueTypeID int64, opt *CreateOrUpdateIssueTypesOptions) (*IssueType, *Response, error) {
+func (s *OrganizationsService) UpdateIssueType(ctx context.Context, org string, issueTypeID int64, opts *CreateOrUpdateIssueTypesOptions) (*IssueType, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/issue-types/%v", org, issueTypeID)
-	req, err := s.client.NewRequest("PUT", u, opt)
+	req, err := s.client.NewRequest("PUT", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/security_advisories.go
+++ b/github/security_advisories.go
@@ -190,9 +190,9 @@ func (s *SecurityAdvisoriesService) CreateTemporaryPrivateFork(ctx context.Conte
 // GitHub API docs: https://docs.github.com/rest/security-advisories/repository-advisories#list-repository-security-advisories-for-an-organization
 //
 //meta:operation GET /orgs/{org}/security-advisories
-func (s *SecurityAdvisoriesService) ListRepositorySecurityAdvisoriesForOrg(ctx context.Context, org string, opt *ListRepositorySecurityAdvisoriesOptions) ([]*SecurityAdvisory, *Response, error) {
+func (s *SecurityAdvisoriesService) ListRepositorySecurityAdvisoriesForOrg(ctx context.Context, org string, opts *ListRepositorySecurityAdvisoriesOptions) ([]*SecurityAdvisory, *Response, error) {
 	url := fmt.Sprintf("orgs/%v/security-advisories", org)
-	url, err := addOptions(url, opt)
+	url, err := addOptions(url, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -216,9 +216,9 @@ func (s *SecurityAdvisoriesService) ListRepositorySecurityAdvisoriesForOrg(ctx c
 // GitHub API docs: https://docs.github.com/rest/security-advisories/repository-advisories#list-repository-security-advisories
 //
 //meta:operation GET /repos/{owner}/{repo}/security-advisories
-func (s *SecurityAdvisoriesService) ListRepositorySecurityAdvisories(ctx context.Context, owner, repo string, opt *ListRepositorySecurityAdvisoriesOptions) ([]*SecurityAdvisory, *Response, error) {
+func (s *SecurityAdvisoriesService) ListRepositorySecurityAdvisories(ctx context.Context, owner, repo string, opts *ListRepositorySecurityAdvisoriesOptions) ([]*SecurityAdvisory, *Response, error) {
 	url := fmt.Sprintf("repos/%v/%v/security-advisories", owner, repo)
-	url, err := addOptions(url, opt)
+	url, err := addOptions(url, opts)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This PR standardizes parameter naming from `opt` to `opts` in multiple service methods. Renaming function parameters does not break compatibility, so this change is safe.

`opts` is more commonly used throughout the repository:

```console
❯ grep -r 'opt \*' --include='*.go' --exclude-dir=testdata . | wc -l
       7
❯ grep -r 'opts \*' --include='*.go' --exclude-dir=testdata . | wc -l
     321
```