### PR TITLE
feat: Implement Enterprise SCIM - Get a Group or User 

### DIFF
--- a/github/enterprise_scim.go
+++ b/github/enterprise_scim.go
@@ -70,7 +70,7 @@ type ListProvisionedSCIMGroupsEnterpriseOptions struct {
 	// If specified, only results that match the specified filter will be returned.
 	// Possible filters are `externalId`, `id`, and `displayName`. For example, `externalId eq "a123"`.
 	Filter *string `url:"filter,omitempty"`
-	// Excludes the specified attribute from being returned in the results.
+	// Excludes the specified attributes from being returned in the results.
 	ExcludedAttributes *string `url:"excludedAttributes,omitempty"`
 	// Used for pagination: the starting index of the first result to return when paginating through values.
 	// Default: 1.
@@ -78,6 +78,14 @@ type ListProvisionedSCIMGroupsEnterpriseOptions struct {
 	// Used for pagination: the number of results to return per page.
 	// Default: 30.
 	Count *int `url:"count,omitempty"`
+}
+
+// GetProvisionedSCIMGroupEnterpriseOptions represents query parameters for GetProvisionedSCIMGroup.
+//
+// GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-group
+type GetProvisionedSCIMGroupEnterpriseOptions struct {
+	// Excludes the specified attributes from being returned in the results.
+	ExcludedAttributes *string `url:"excludedAttributes,omitempty"`
 }
 
 // SCIMEnterpriseUserAttributes represents supported SCIM enterprise user attributes, and represents the result of calling UpdateSCIMUserAttribute.
@@ -162,8 +170,9 @@ type SCIMEnterpriseAttributeOperation struct {
 
 // ListProvisionedSCIMGroups lists provisioned SCIM groups in an enterprise.
 //
-// You can improve query search time by using the `excludedAttributes` query
-// parameter with a value of `members` to exclude members from the response.
+// You can improve query search time by using the `excludedAttributes` and
+// exclude the specified attributes, e.g. `members` to exclude members from the
+// response.
 //
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/scim#list-provisioned-scim-groups-for-an-enterprise
 //
@@ -383,19 +392,18 @@ func (s *EnterpriseService) ProvisionSCIMUser(ctx context.Context, enterprise st
 
 // GetProvisionedSCIMGroup gets information about a SCIM group.
 //
+// You can use the `excludedAttributes` from `opts` and exclude the specified
+// attributes from being returned in the results. Using this parameter can
+// speed up response time.
+//
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-group
 //
 //meta:operation GET /scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}
-func (s *EnterpriseService) GetProvisionedSCIMGroup(ctx context.Context, enterprise, scimGroupID, excludedAttributes string) (*SCIMEnterpriseGroupAttributes, *Response, error) {
-	var err error
+func (s *EnterpriseService) GetProvisionedSCIMGroup(ctx context.Context, enterprise, scimGroupID string, opts *GetProvisionedSCIMGroupEnterpriseOptions) (*SCIMEnterpriseGroupAttributes, *Response, error) {
 	u := fmt.Sprintf("scim/v2/enterprises/%v/Groups/%v", enterprise, scimGroupID)
-	if excludedAttributes != "" {
-		u, err = addOptions(u, &ListProvisionedSCIMGroupsEnterpriseOptions{
-			ExcludedAttributes: &excludedAttributes,
-		})
-		if err != nil {
-			return nil, nil, err
-		}
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -419,7 +427,6 @@ func (s *EnterpriseService) GetProvisionedSCIMGroup(ctx context.Context, enterpr
 //
 //meta:operation GET /scim/v2/enterprises/{enterprise}/Users/{scim_user_id}
 func (s *EnterpriseService) GetProvisionedSCIMUser(ctx context.Context, enterprise, scimUserID string) (*SCIMEnterpriseUserAttributes, *Response, error) {
-	var err error
 	u := fmt.Sprintf("scim/v2/enterprises/%v/Users/%v", enterprise, scimUserID)
 
 	req, err := s.client.NewRequest("GET", u, nil)

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -10006,6 +10006,14 @@ func (g *GetAuditLogOptions) GetPhrase() string {
 	return *g.Phrase
 }
 
+// GetExcludedAttributes returns the ExcludedAttributes field if it's non-nil, zero value otherwise.
+func (g *GetProvisionedSCIMGroupEnterpriseOptions) GetExcludedAttributes() string {
+	if g == nil || g.ExcludedAttributes == nil {
+		return ""
+	}
+	return *g.ExcludedAttributes
+}
+
 // GetComments returns the Comments field if it's non-nil, zero value otherwise.
 func (g *Gist) GetComments() int {
 	if g == nil || g.Comments == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -12968,6 +12968,17 @@ func TestGetAuditLogOptions_GetPhrase(tt *testing.T) {
 	g.GetPhrase()
 }
 
+func TestGetProvisionedSCIMGroupEnterpriseOptions_GetExcludedAttributes(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	g := &GetProvisionedSCIMGroupEnterpriseOptions{ExcludedAttributes: &zeroValue}
+	g.GetExcludedAttributes()
+	g = &GetProvisionedSCIMGroupEnterpriseOptions{}
+	g.GetExcludedAttributes()
+	g = nil
+	g.GetExcludedAttributes()
+}
+
 func TestGist_GetComments(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int


### PR DESCRIPTION
Related with #3813

From REST API endpoints for Enterprise SCIM docs, implements:
- [Get SCIM provisioning information for an enterprise group](https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-group), GET /scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}

- [Get SCIM provisioning information for an enterprise user](https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-user), GET /scim/v2/enterprises/{enterprise}/Users/{scim_user_id}