### PR TITLE
feat: Add support for Codespace Machines APIs

### DIFF
--- a/github/codespaces_machines.go
+++ b/github/codespaces_machines.go
@@ -16,22 +16,22 @@ type CodespacesMachines struct {
 	Machines   []*CodespacesMachine `json:"machines"`
 }
 
-// ListMachinesOptions represent options for ListMachineTypesForRepository.
-type ListMachinesOptions struct {
+// ListRepoMachineTypesOptions represent options for ListMachineTypesForRepository.
+type ListRepoMachineTypesOptions struct {
 	// Ref represent the branch or commit to check for prebuild availability and devcontainer restrictions.
-	Ref *string `json:"ref,omitempty"`
+	Ref *string `url:"ref,omitempty"`
 	// Location represent the location to check for available machines. Assigned by IP if not provided.
-	Location *string `json:"location,omitempty"`
+	Location *string `url:"location,omitempty"`
 	// ClientIP represent the IP for location auto-detection when proxying a request
-	ClientIP *string `json:"client_ip,omitempty"`
+	ClientIP *string `url:"client_ip,omitempty"`
 }
 
-// ListMachineTypesForRepository lists the machine types available for a given repository based on its configuration.
+// ListRepositoryMachineTypes lists the machine types available for a given repository based on its configuration.
 //
 // GitHub API docs: https://docs.github.com/rest/codespaces/machines#list-available-machine-types-for-a-repository
 //
 //meta:operation GET /repos/{owner}/{repo}/codespaces/machines
-func (s *CodespacesService) ListMachineTypesForRepository(ctx context.Context, owner, repo string, opts *ListMachinesOptions) (*CodespacesMachines, *Response, error) {
+func (s *CodespacesService) ListRepositoryMachineTypes(ctx context.Context, owner, repo string, opts *ListRepoMachineTypesOptions) (*CodespacesMachines, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/codespaces/machines", owner, repo)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -52,12 +52,12 @@ func (s *CodespacesService) ListMachineTypesForRepository(ctx context.Context, o
 	return machines, resp, nil
 }
 
-// ListMachineTypesForCodespace lists the machine types a codespace can transition to use.
+// ListCodespaceMachineTypes lists the machine types a codespace can transition to use.
 //
 // GitHub API docs: https://docs.github.com/rest/codespaces/machines#list-machine-types-for-a-codespace
 //
 //meta:operation GET /user/codespaces/{codespace_name}/machines
-func (s *CodespacesService) ListMachineTypesForCodespace(ctx context.Context, codespaceName string) (*CodespacesMachines, *Response, error) {
+func (s *CodespacesService) ListCodespaceMachineTypes(ctx context.Context, codespaceName string) (*CodespacesMachines, *Response, error) {
 	u := fmt.Sprintf("user/codespaces/%v/machines", codespaceName)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/codespaces_machines_test.go
+++ b/github/codespaces_machines_test.go
@@ -13,13 +13,17 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestCodespacesService_ListMachineTypesForRepository(t *testing.T) {
+func TestCodespacesService_ListRepositoryMachineTypes(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/owner/repo/codespaces/machines", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-
+		testFormValues(t, r, values{
+			"ref":       "main",
+			"location":  "WestUs2",
+			"client_ip": "1.2.3.4",
+		})
 		fmt.Fprint(w, `{
 			"total_count": 1,
 			"machines": [
@@ -37,20 +41,20 @@ func TestCodespacesService_ListMachineTypesForRepository(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	opts := &ListMachinesOptions{
+	opts := &ListRepoMachineTypesOptions{
 		Ref:      Ptr("main"),
 		Location: Ptr("WestUs2"),
 		ClientIP: Ptr("1.2.3.4"),
 	}
 
-	got, _, err := client.Codespaces.ListMachineTypesForRepository(
+	got, _, err := client.Codespaces.ListRepositoryMachineTypes(
 		ctx,
 		"owner",
 		"repo",
 		opts,
 	)
 	if err != nil {
-		t.Fatalf("Codespaces.ListMachineTypesForRepository returned error: %v", err)
+		t.Fatalf("Codespaces.ListRepositoryMachineTypes returned error: %v", err)
 	}
 
 	want := &CodespacesMachines{
@@ -69,16 +73,16 @@ func TestCodespacesService_ListMachineTypesForRepository(t *testing.T) {
 	}
 
 	if !cmp.Equal(got, want) {
-		t.Errorf("Codespaces.ListMachineTypesForRepository returned %+v, want %+v", got, want)
+		t.Errorf("Codespaces.ListRepositoryMachineTypes returned %+v, want %+v", got, want)
 	}
 
-	const methodName = "ListMachineTypesForRepository"
+	const methodName = "ListRepositoryMachineTypes"
 	testBadOptions(t, methodName, func() error {
-		_, _, err := client.Codespaces.ListMachineTypesForRepository(ctx, "\n", "/n", opts)
+		_, _, err := client.Codespaces.ListRepositoryMachineTypes(ctx, "\n", "/n", opts)
 		return err
 	})
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Codespaces.ListMachineTypesForRepository(ctx, "/n", "/n", opts)
+		got, resp, err := client.Codespaces.ListRepositoryMachineTypes(ctx, "/n", "/n", opts)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -86,7 +90,7 @@ func TestCodespacesService_ListMachineTypesForRepository(t *testing.T) {
 	})
 }
 
-func TestCodespacesService_ListMachineTypesForCodespace(t *testing.T) {
+func TestCodespacesService_ListCodespaceMachineTypes(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -110,9 +114,9 @@ func TestCodespacesService_ListMachineTypesForCodespace(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	got, _, err := client.Codespaces.ListMachineTypesForCodespace(ctx, "codespace_1")
+	got, _, err := client.Codespaces.ListCodespaceMachineTypes(ctx, "codespace_1")
 	if err != nil {
-		t.Fatalf("Codespaces.ListMachineTypesForCodespace returned error: %v", err)
+		t.Fatalf("Codespaces.ListCodespaceMachineTypes returned error: %v", err)
 	}
 
 	want := &CodespacesMachines{
@@ -131,12 +135,12 @@ func TestCodespacesService_ListMachineTypesForCodespace(t *testing.T) {
 	}
 
 	if !cmp.Equal(got, want) {
-		t.Errorf("Codespaces.ListMachineTypesForCodespace returned %+v, want %+v", got, want)
+		t.Errorf("Codespaces.ListCodespaceMachineTypes returned %+v, want %+v", got, want)
 	}
 
-	const methodName = "ListMachineTypesForCodespace"
+	const methodName = "ListCodespaceMachineTypes"
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Codespaces.ListMachineTypesForCodespace(ctx, "/n")
+		got, resp, err := client.Codespaces.ListCodespaceMachineTypes(ctx, "/n")
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -14550,30 +14550,6 @@ func (l *ListGlobalSecurityAdvisoriesOptions) GetUpdated() string {
 	return *l.Updated
 }
 
-// GetClientIP returns the ClientIP field if it's non-nil, zero value otherwise.
-func (l *ListMachinesOptions) GetClientIP() string {
-	if l == nil || l.ClientIP == nil {
-		return ""
-	}
-	return *l.ClientIP
-}
-
-// GetLocation returns the Location field if it's non-nil, zero value otherwise.
-func (l *ListMachinesOptions) GetLocation() string {
-	if l == nil || l.Location == nil {
-		return ""
-	}
-	return *l.Location
-}
-
-// GetRef returns the Ref field if it's non-nil, zero value otherwise.
-func (l *ListMachinesOptions) GetRef() string {
-	if l == nil || l.Ref == nil {
-		return ""
-	}
-	return *l.Ref
-}
-
 // GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
 func (l *ListOrganizations) GetTotalCount() int {
 	if l == nil || l.TotalCount == nil {
@@ -14700,6 +14676,30 @@ func (l *ListProvisionedSCIMUsersEnterpriseOptions) GetStartIndex() int {
 		return 0
 	}
 	return *l.StartIndex
+}
+
+// GetClientIP returns the ClientIP field if it's non-nil, zero value otherwise.
+func (l *ListRepoMachineTypesOptions) GetClientIP() string {
+	if l == nil || l.ClientIP == nil {
+		return ""
+	}
+	return *l.ClientIP
+}
+
+// GetLocation returns the Location field if it's non-nil, zero value otherwise.
+func (l *ListRepoMachineTypesOptions) GetLocation() string {
+	if l == nil || l.Location == nil {
+		return ""
+	}
+	return *l.Location
+}
+
+// GetRef returns the Ref field if it's non-nil, zero value otherwise.
+func (l *ListRepoMachineTypesOptions) GetRef() string {
+	if l == nil || l.Ref == nil {
+		return ""
+	}
+	return *l.Ref
 }
 
 // GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -18919,39 +18919,6 @@ func TestListGlobalSecurityAdvisoriesOptions_GetUpdated(tt *testing.T) {
 	l.GetUpdated()
 }
 
-func TestListMachinesOptions_GetClientIP(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	l := &ListMachinesOptions{ClientIP: &zeroValue}
-	l.GetClientIP()
-	l = &ListMachinesOptions{}
-	l.GetClientIP()
-	l = nil
-	l.GetClientIP()
-}
-
-func TestListMachinesOptions_GetLocation(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	l := &ListMachinesOptions{Location: &zeroValue}
-	l.GetLocation()
-	l = &ListMachinesOptions{}
-	l.GetLocation()
-	l = nil
-	l.GetLocation()
-}
-
-func TestListMachinesOptions_GetRef(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	l := &ListMachinesOptions{Ref: &zeroValue}
-	l.GetRef()
-	l = &ListMachinesOptions{}
-	l.GetRef()
-	l = nil
-	l.GetRef()
-}
-
 func TestListOrganizations_GetTotalCount(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int
@@ -19126,6 +19093,39 @@ func TestListProvisionedSCIMUsersEnterpriseOptions_GetStartIndex(tt *testing.T) 
 	l.GetStartIndex()
 	l = nil
 	l.GetStartIndex()
+}
+
+func TestListRepoMachineTypesOptions_GetClientIP(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	l := &ListRepoMachineTypesOptions{ClientIP: &zeroValue}
+	l.GetClientIP()
+	l = &ListRepoMachineTypesOptions{}
+	l.GetClientIP()
+	l = nil
+	l.GetClientIP()
+}
+
+func TestListRepoMachineTypesOptions_GetLocation(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	l := &ListRepoMachineTypesOptions{Location: &zeroValue}
+	l.GetLocation()
+	l = &ListRepoMachineTypesOptions{}
+	l.GetLocation()
+	l = nil
+	l.GetLocation()
+}
+
+func TestListRepoMachineTypesOptions_GetRef(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	l := &ListRepoMachineTypesOptions{Ref: &zeroValue}
+	l.GetRef()
+	l = &ListRepoMachineTypesOptions{}
+	l.GetRef()
+	l = nil
+	l.GetRef()
 }
 
 func TestListRepositories_GetTotalCount(tt *testing.T) {


### PR DESCRIPTION
Relates: https://github.com/google/go-github/issues/2362
This PR adds support for endpoint of [Codespace Machines](https://docs.github.com/en/enterprise-cloud@latest/rest/codespaces/machines?apiVersion=2022-11-28)

- GET /repos/{owner}/{repo}/codespaces/machines
- GET /user/codespaces/{codespace_name}/machines