### PR TITLE
chore(deps): Switch from `gopkg.in/yaml.v3` to `go.yaml.in/yaml/v3` in /tools

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v82 v82.0.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.19.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -23,6 +23,7 @@ require (
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/woodsbury/decimal128 v1.3.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 // Use version at HEAD, not the latest published.

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -47,6 +47,8 @@ github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIjVWss0=
 github.com/woodsbury/decimal128 v1.3.0/go.mod h1:C5UTmyTjW3JftjUFzOVhC20BEQa2a4ZKOB5I6Zjb+ds=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/tools/metadata/metadata.go
+++ b/tools/metadata/metadata.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 
 	"github.com/google/go-github/v82/github"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type operation struct {


### PR DESCRIPTION
The latter is a maintained fork of the former, https://github.com/yaml/go-yaml#project-status

While at it, upgrade from 3.0.1 to 3.0.4.

3.0.1 are identical, 3.0.1..3.0.2 diff between upstreams: https://gist.github.com/scop/57f94f2bf97fb6a2d01349fa59d88530
