### PR TITLE
docs: Clarify `nil` `http.Client` usage has no timeout

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -336,6 +336,10 @@ func addOptions(s string, opts any) (string, error) {
 // authentication, either use Client.WithAuthToken or provide NewClient with
 // an http.Client that will perform the authentication for you (such as that
 // provided by the golang.org/x/oauth2 library).
+//
+// Note: When using a nil httpClient, the default client has no timeout set.
+// This may not be suitable for production environments. It is recommended to
+// provide a custom http.Client with an appropriate timeout.
 func NewClient(httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = &http.Client{}


### PR DESCRIPTION
This PR adds a documentation comment to the `NewClient` function in `github/github.go`. 

The comment warns users that passing a `nil` `httpClient` results in the use of a default `http.Client` which has no timeout. This can lead to resource exhaustion or "slowloris" style issues in production environments. It recommends providing a custom `http.Client` with an appropriate timeout.

This change aligns with security best practices (Sentinel) by making the default behavior's risks explicit without introducing breaking changes