### PR TITLE
fix: DeleteSocialAccounts and AddSocialAccounts of UsersService

### DIFF
--- a/github/users_social_accounts.go
+++ b/github/users_social_accounts.go
@@ -16,8 +16,8 @@ type SocialAccount struct {
 	URL      *string `json:"url,omitempty"`
 }
 
-// socialAccountRequest represents the request body for adding or deleting social accounts.
-type socialAccountRequest struct {
+// socialAccountsRequest represents the request body for adding or deleting social accounts.
+type socialAccountsRequest struct {
 	AccountURLs []string `json:"account_urls"`
 }
 
@@ -54,7 +54,7 @@ func (s *UsersService) ListSocialAccounts(ctx context.Context, opts *ListOptions
 //meta:operation POST /user/social_accounts
 func (s *UsersService) AddSocialAccounts(ctx context.Context, accountURLs []string) ([]*SocialAccount, *Response, error) {
 	u := "user/social_accounts"
-	req, err := s.client.NewRequest("POST", u, socialAccountRequest{AccountURLs: accountURLs})
+	req, err := s.client.NewRequest("POST", u, &socialAccountsRequest{AccountURLs: accountURLs})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,7 +75,7 @@ func (s *UsersService) AddSocialAccounts(ctx context.Context, accountURLs []stri
 //meta:operation DELETE /user/social_accounts
 func (s *UsersService) DeleteSocialAccounts(ctx context.Context, accountURLs []string) (*Response, error) {
 	u := "user/social_accounts"
-	req, err := s.client.NewRequest("DELETE", u, socialAccountRequest{AccountURLs: accountURLs})
+	req, err := s.client.NewRequest("DELETE", u, &socialAccountsRequest{AccountURLs: accountURLs})
 	if err != nil {
 		return nil, err
 	}

--- a/github/users_social_accounts_test.go
+++ b/github/users_social_accounts_test.go
@@ -22,8 +22,8 @@ func TestUsersService_ListSocialAccounts(t *testing.T) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{
-			"provider": "twitter",
-			"url": "https://twitter.com/github"
+			"provider": "example",
+			"url": "https://example.com"
 		}]`)
 	})
 
@@ -34,7 +34,7 @@ func TestUsersService_ListSocialAccounts(t *testing.T) {
 		t.Errorf("Users.ListSocialAccounts returned error: %v", err)
 	}
 
-	want := []*SocialAccount{{Provider: Ptr("twitter"), URL: Ptr("https://twitter.com/github")}}
+	want := []*SocialAccount{{Provider: Ptr("example"), URL: Ptr("https://example.com")}}
 	if !cmp.Equal(accounts, want) {
 		t.Errorf("Users.ListSocialAccounts returned %#v, want %#v", accounts, want)
 	}
@@ -54,12 +54,12 @@ func TestUsersService_AddSocialAccounts(t *testing.T) {
 
 	client, mux, _ := setup(t)
 
-	input := []string{"https://twitter.com/github"}
+	input := []string{"https://example.com"}
 
 	mux.HandleFunc("/user/social_accounts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testBody(t, r, `{"account_urls":["https://twitter.com/github"]}`+"\n")
-		fmt.Fprint(w, `[{"provider":"twitter","url":"https://twitter.com/github"},{"provider":"facebook","url":"https://facebook.com/github"}]`)
+		testBody(t, r, `{"account_urls":["https://example.com"]}`+"\n")
+		fmt.Fprint(w, `[{"provider":"example","url":"https://example.com"}]`)
 	})
 
 	ctx := t.Context()
@@ -69,8 +69,7 @@ func TestUsersService_AddSocialAccounts(t *testing.T) {
 	}
 
 	want := []*SocialAccount{
-		{Provider: Ptr("twitter"), URL: Ptr("https://twitter.com/github")},
-		{Provider: Ptr("facebook"), URL: Ptr("https://facebook.com/github")},
+		{Provider: Ptr("example"), URL: Ptr("https://example.com")},
 	}
 	if !cmp.Equal(accounts, want) {
 		t.Errorf("Users.AddSocialAccounts returned %#v, want %#v", accounts, want)
@@ -91,11 +90,11 @@ func TestUsersService_DeleteSocialAccounts(t *testing.T) {
 
 	client, mux, _ := setup(t)
 
-	input := []string{"https://twitter.com/github"}
+	input := []string{"https://example.com"}
 
 	mux.HandleFunc("/user/social_accounts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testBody(t, r, `{"account_urls":["https://twitter.com/github"]}`+"\n")
+		testBody(t, r, `{"account_urls":["https://example.com"]}`+"\n")
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -120,8 +119,8 @@ func TestUsersService_ListUserSocialAccounts(t *testing.T) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{
-			"provider": "twitter",
-			"url": "https://twitter.com/github"
+			"provider": "example",
+			"url": "https://example.com"
 		}]`)
 	})
 
@@ -132,7 +131,7 @@ func TestUsersService_ListUserSocialAccounts(t *testing.T) {
 		t.Errorf("Users.ListUserSocialAccounts returned error: %v", err)
 	}
 
-	want := []*SocialAccount{{Provider: Ptr("twitter"), URL: Ptr("https://twitter.com/github")}}
+	want := []*SocialAccount{{Provider: Ptr("example"), URL: Ptr("https://example.com")}}
 	if !cmp.Equal(accounts, want) {
 		t.Errorf("Users.ListUserSocialAccounts returned %#v, want %#v", accounts, want)
 	}


### PR DESCRIPTION
Fixes: #3921 
Added an internal struct `socialAccountsRequest` and use it to send the request body instead of passing `accountURLs` directly, which previously caused an `Invalid input` error.
Since the struct is internal and the public method signature remains unchanged, this change introduces **no** breaking API changes.
