### PR TITLE
fix!: Simplify `Git.ListMatchingRefs` by removing `ReferenceListOptions`

### DIFF
--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -82,31 +82,17 @@ func refURLEscape(ref string) string {
 	return strings.Join(parts, "/")
 }
 
-// ReferenceListOptions specifies optional parameters to the
-// GitService.ListMatchingRefs method.
-type ReferenceListOptions struct {
-	// The ref must be formatted as `heads/<branch name>` for branches and `tags/<tag name>` for tags.
-	Ref string `url:"-"`
-
-	ListOptions
-}
-
 // ListMatchingRefs lists references in a repository that match a supplied ref.
+// The ref in the URL must be formatted as `heads/<branch name>` for branches and `tags/<tag name>` for tags.
+// If the ref doesn't exist in the repository, but existing refs start with ref, they will be returned as an array.
 // Use an empty ref to list all references.
 //
 // GitHub API docs: https://docs.github.com/rest/git/refs#list-matching-references
 //
 //meta:operation GET /repos/{owner}/{repo}/git/matching-refs/{ref}
-func (s *GitService) ListMatchingRefs(ctx context.Context, owner, repo string, opts *ReferenceListOptions) ([]*Reference, *Response, error) {
-	var ref string
-	if opts != nil {
-		ref = strings.TrimPrefix(opts.Ref, "refs/")
-	}
+func (s *GitService) ListMatchingRefs(ctx context.Context, owner, repo, ref string) ([]*Reference, *Response, error) {
+	ref = strings.TrimPrefix(ref, "refs/") // API expects no "refs/" prefix
 	u := fmt.Sprintf("repos/%v/%v/git/matching-refs/%v", owner, repo, refURLEscape(ref))
-	u, err := addOptions(u, opts)
-	if err != nil {
-		return nil, nil, err
-	}
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/github/git_refs_test.go
+++ b/github/git_refs_test.go
@@ -128,9 +128,8 @@ func TestGitService_ListMatchingRefs_singleRef(t *testing.T) {
 		  ]`)
 	})
 
-	opts := &ReferenceListOptions{Ref: "refs/heads/b"}
 	ctx := t.Context()
-	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
+	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", "heads/b")
 	if err != nil {
 		t.Fatalf("Git.ListMatchingRefs returned error: %v", err)
 	}
@@ -149,20 +148,14 @@ func TestGitService_ListMatchingRefs_singleRef(t *testing.T) {
 		t.Errorf("Git.ListMatchingRefs returned %+v, want %+v", ref, want)
 	}
 
-	// without 'refs/' prefix
-	opts = &ReferenceListOptions{Ref: "heads/b"}
-	if _, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts); err != nil {
-		t.Errorf("Git.ListMatchingRefs returned error: %v", err)
-	}
-
 	const methodName = "ListMatchingRefs"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Git.ListMatchingRefs(ctx, "\n", "\n", opts)
+		_, _, err = client.Git.ListMatchingRefs(ctx, "\n", "\n", "")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
+		got, resp, err := client.Git.ListMatchingRefs(ctx, "o", "r", "")
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -200,9 +193,8 @@ func TestGitService_ListMatchingRefs_multipleRefs(t *testing.T) {
 		`)
 	})
 
-	opts := &ReferenceListOptions{Ref: "refs/heads/b"}
 	ctx := t.Context()
-	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
+	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", "heads/b")
 	if err != nil {
 		t.Errorf("Git.ListMatchingRefs returned error: %v", err)
 	}
@@ -222,12 +214,12 @@ func TestGitService_ListMatchingRefs_multipleRefs(t *testing.T) {
 
 	const methodName = "ListMatchingRefs"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Git.ListMatchingRefs(ctx, "\n", "\n", opts)
+		_, _, err = client.Git.ListMatchingRefs(ctx, "\n", "\n", "")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
+		got, resp, err := client.Git.ListMatchingRefs(ctx, "o", "r", "")
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -244,9 +236,8 @@ func TestGitService_ListMatchingRefs_noRefs(t *testing.T) {
 		fmt.Fprint(w, "[]")
 	})
 
-	opts := &ReferenceListOptions{Ref: "refs/heads/b"}
 	ctx := t.Context()
-	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
+	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", "heads/b")
 	if err != nil {
 		t.Errorf("Git.ListMatchingRefs returned error: %v", err)
 	}
@@ -257,12 +248,12 @@ func TestGitService_ListMatchingRefs_noRefs(t *testing.T) {
 
 	const methodName = "ListMatchingRefs"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Git.ListMatchingRefs(ctx, "\n", "\n", opts)
+		_, _, err = client.Git.ListMatchingRefs(ctx, "\n", "\n", "")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
+		got, resp, err := client.Git.ListMatchingRefs(ctx, "o", "r", "")
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -300,7 +291,7 @@ func TestGitService_ListMatchingRefs_allRefs(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", nil)
+	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", "")
 	if err != nil {
 		t.Errorf("Git.ListMatchingRefs returned error: %v", err)
 	}
@@ -331,49 +322,12 @@ func TestGitService_ListMatchingRefs_allRefs(t *testing.T) {
 
 	const methodName = "ListMatchingRefs"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Git.ListMatchingRefs(ctx, "\n", "\n", nil)
+		_, _, err = client.Git.ListMatchingRefs(ctx, "\n", "\n", "")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Git.ListMatchingRefs(ctx, "o", "r", nil)
-		if got != nil {
-			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
-		}
-		return resp, err
-	})
-}
-
-func TestGitService_ListMatchingRefs_options(t *testing.T) {
-	t.Parallel()
-	client, mux, _ := setup(t)
-
-	mux.HandleFunc("/repos/o/r/git/matching-refs/t", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		testFormValues(t, r, values{"page": "2"})
-		fmt.Fprint(w, `[{"ref": "r"}]`)
-	})
-
-	opts := &ReferenceListOptions{Ref: "t", ListOptions: ListOptions{Page: 2}}
-	ctx := t.Context()
-	refs, _, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
-	if err != nil {
-		t.Errorf("Git.ListMatchingRefs returned error: %v", err)
-	}
-
-	want := []*Reference{{Ref: Ptr("r")}}
-	if !cmp.Equal(refs, want) {
-		t.Errorf("Git.ListMatchingRefs returned %+v, want %+v", refs, want)
-	}
-
-	const methodName = "ListMatchingRefs"
-	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Git.ListMatchingRefs(ctx, "\n", "\n", opts)
-		return err
-	})
-
-	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Git.ListMatchingRefs(ctx, "o", "r", opts)
+		got, resp, err := client.Git.ListMatchingRefs(ctx, "o", "r", "")
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}


### PR DESCRIPTION
BREAKING CHANGE: `Git.ListMatchingRefs` accepts `ref` instead of the `ReferenceListOptions`.

While working on iterator pagination, I found that `Git.ListMatchingRefs` no longer accepts `ListOptions`, according to the [documentation](https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#list-matching-references):

<img width="400" alt="image" src="https://github.com/user-attachments/assets/726bc766-033e-46e3-b146-9915f9c84c64" />

I wrote a simple example that calls `ListMatchingRefs` with `heads/master` and with `tags` ref for the `google/go-github` repo. And it lists one `master` reference and all ref tags.

<details><summary>Example</summary>
<p>

```go
package main

import (
	"context"
	"flag"
	"fmt"
	"log"
	"os"

	"github.com/google/go-github/v81/github"
)

func main() {
	flag.Parse()
	token := os.Getenv("GITHUB_AUTH_TOKEN")
	if token == "" {
		log.Fatal("Unauthorized: No token present")
	}

	ctx := context.Background()
	client := github.NewClient(nil).WithAuthToken(token)

	owner := "google"
	repo := "go-github"

	refs, _, err := client.Git.ListMatchingRefs(ctx, owner, repo, "heads/master")
	if err != nil {
		log.Fatalf("ListMatchingRefs for master failed: %v", err)
	}
	fmt.Printf("Ref for `master` (%d):\n", len(refs))
	for _, r := range refs {
		fmt.Println(r.GetRef())
	}

	pageRefs, _, err := client.Git.ListMatchingRefs(ctx, owner, repo, "tags")
	if err != nil {
		log.Fatalf("ListMatchingRefs for tags failed: %v", err)
	}
	fmt.Printf("Tag refs (%d):\n", len(pageRefs))
	for _, r := range pageRefs {
		fmt.Println(r.GetRef())
	}
}
```

Output
```
Ref for `master` (1):
refs/heads/master
Tag refs (142):
refs/tags/v10.0.0
refs/tags/v11.0.0
refs/tags/v12.0.0
refs/tags/v13.0.0
refs/tags/v14.0.0
refs/tags/v15.0.0
refs/tags/v16.0.0
refs/tags/v17.0.0
refs/tags/v18.0.0
refs/tags/v18.1.0
refs/tags/v18.2.0
refs/tags/v19.0.0
refs/tags/v19.1.0
refs/tags/v2.0.0
refs/tags/v20.0.0
refs/tags/v21.0.0
refs/tags/v21.0.1
refs/tags/v22.0.0
refs/tags/v23.0.0
refs/tags/v24.0.0
refs/tags/v24.0.1
refs/tags/v25.0.0
refs/tags/v25.0.1
refs/tags/v25.0.2
refs/tags/v25.0.3
refs/tags/v25.0.4
refs/tags/v25.0.5
refs/tags/v25.1.0
refs/tags/v25.1.1
refs/tags/v25.1.2
refs/tags/v25.1.3
refs/tags/v26.0.0
refs/tags/v26.0.1
refs/tags/v26.0.10
refs/tags/v26.0.2
refs/tags/v26.0.3
refs/tags/v26.0.4
refs/tags/v26.0.5
refs/tags/v26.0.6
refs/tags/v26.0.7
refs/tags/v26.0.8
refs/tags/v26.0.9
refs/tags/v26.1.0
refs/tags/v26.1.1
refs/tags/v26.1.2
refs/tags/v26.1.3
refs/tags/v27.0.0
refs/tags/v27.0.1
refs/tags/v27.0.2
refs/tags/v27.0.3
refs/tags/v27.0.4
refs/tags/v27.0.5
refs/tags/v27.0.6
refs/tags/v28.0.0
refs/tags/v28.0.1
refs/tags/v28.0.2
refs/tags/v28.1.0
refs/tags/v28.1.1
refs/tags/v29.0.0
refs/tags/v29.0.1
refs/tags/v29.0.2
refs/tags/v29.0.3
refs/tags/v3.0.0
refs/tags/v30.0.0
refs/tags/v30.1.0
refs/tags/v31.0.0
refs/tags/v32.0.0
refs/tags/v32.1.0
refs/tags/v33.0.0
refs/tags/v34.0.0
refs/tags/v35.0.0
refs/tags/v35.1.0
refs/tags/v35.2.0
refs/tags/v35.3.0
refs/tags/v36.0.0
refs/tags/v37.0.0
refs/tags/v38.0.0
refs/tags/v38.1.0
refs/tags/v39.0.0
refs/tags/v39.1.0
refs/tags/v39.2.0
refs/tags/v4.0.0
refs/tags/v40.0.0
refs/tags/v41.0.0
refs/tags/v42.0.0
refs/tags/v43.0.0
refs/tags/v44.0.0
refs/tags/v44.1.0
refs/tags/v45.0.0
refs/tags/v45.1.0
refs/tags/v45.2.0
refs/tags/v46.0.0
refs/tags/v47.0.0
refs/tags/v47.1.0
refs/tags/v48.0.0
refs/tags/v48.1.0
refs/tags/v48.2.0
refs/tags/v49.0.0
refs/tags/v49.1.0
refs/tags/v5.0.0
refs/tags/v50.0.0
refs/tags/v50.1.0
refs/tags/v50.2.0
refs/tags/v51.0.0
refs/tags/v52.0.0
refs/tags/v53.0.0
refs/tags/v53.1.0
refs/tags/v53.2.0
refs/tags/v54.0.0
refs/tags/v55.0.0
refs/tags/v56.0.0
refs/tags/v57.0.0
refs/tags/v58.0.0
refs/tags/v59.0.0
refs/tags/v6.0.0
refs/tags/v60.0.0
refs/tags/v61.0.0
refs/tags/v62.0.0
refs/tags/v63.0.0
refs/tags/v64.0.0
refs/tags/v65.0.0
refs/tags/v66.0.0
refs/tags/v67.0.0
refs/tags/v68.0.0
refs/tags/v69.0.0
refs/tags/v69.1.0
refs/tags/v69.2.0
refs/tags/v7.0.0
refs/tags/v70.0.0
refs/tags/v71.0.0
refs/tags/v72.0.0
refs/tags/v73.0.0
refs/tags/v74.0.0
refs/tags/v75.0.0
refs/tags/v76.0.0
refs/tags/v77.0.0
refs/tags/v78.0.0
refs/tags/v79.0.0
refs/tags/v8.0.0
refs/tags/v80.0.0
refs/tags/v81.0.0
refs/tags/v9.0.0
```

</p>
</details> 