### PR TITLE
chore: Enable `govet` linter with all checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - godot
     - goheader
     - gosec
+    - govet
     - intrange
     - misspell
     - modernize
@@ -65,6 +66,11 @@ linters:
         - G104
         # int(os.Stdin.Fd())
         - G115
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+        - shadow
     misspell:
       locale: US
       # extra words from https://go.dev//wiki/Spelling

--- a/test/integration/activity_test.go
+++ b/test/integration/activity_test.go
@@ -125,11 +125,10 @@ func TestActivity_Watching(t *testing.T) {
 		t.Fatalf("Activity.GetRepositorySubscription returned error: %v", err)
 	}
 
-	switch {
-	case sub != nil: // If already subscribing, delete then recreate subscription.
+	if sub != nil { // If already subscribing, delete then recreate subscription.
 		deleteSubscription(t)
 		createSubscription(t)
-	case sub == nil: // Otherwise, create subscription and then delete it.
+	} else { // Otherwise, create subscription and then delete it.
 		createSubscription(t)
 		deleteSubscription(t)
 	}

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -40,7 +40,7 @@ func TestRepositories_CRUD(t *testing.T) {
 	if err == nil {
 		t.Fatal("Test repository still exists after deleting it.")
 	}
-	if err != nil && resp.StatusCode != http.StatusNotFound {
+	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("Repositories.Get() returned error: %v", err)
 	}
 }


### PR DESCRIPTION
This PR enables all `govet` checks except `fieldalignment` and `shadow`.

`fieldalignment` suggests rearranging fields to reduce struct size in memory, while `shadow` generates many warnings about shadowing local `err` variables.