### PR TITLE
chore: Adapt `lint.sh` to Windows Git Bash

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,28 @@ file.
 [monitored by codecov.io]: https://codecov.io/gh/google/go-github
 [REVIEWERS]: ./REVIEWERS
 
+### Windows users
+
+Use Git Bash as a terminal or WSL instead of PowerShell.
+
+To avoid [issues][] with a few linters and formatters within golangci-lint,
+make sure you check out files only with LF endings:
+
+```sh
+git config core.autocrlf false
+git config core.eol lf
+```
+
+To convert an existing cloned repo from CRLF to LF, use the following commands:
+
+```sh
+git config core.autocrlf false
+git rm --cached -r .
+git reset --hard HEAD
+```
+
+[issues]: https://github.com/golangci/golangci-lint/discussions/5840
+
 ## Tips
 
 Although we have not (yet) banned AI-driven contributions to this repo (as many

--- a/github/github.go
+++ b/github/github.go
@@ -5,7 +5,7 @@
 
 //go:generate go run gen-accessors.go
 //go:generate go run gen-stringify-test.go
-//go:generate ../script/metadata.sh update-go
+//go:generate sh ../script/metadata.sh update-go
 
 package github
 


### PR DESCRIPTION
`./script/lint.sh` now works in Git Bash on Windows. Tested on a virtual machine with Windows 11 installed. This should improve the developer experience for contributors who don't use Windows Subsystem for Linux.

<img width="1000" alt="VS Code on Windows" src="https://github.com/user-attachments/assets/dc43a971-1e4e-41b1-bf66-96c2a55b1cdd" />

Before we have an issue:

```
$ ./script/lint.sh 
linting .
0 issues.
linting example
linting example
0 issues.
linting scrape
0 issues.
linting tools
0 issues.
linting tools/fmtpercentv
0 issues.
linting tools/sliceofpointers
0 issues.
linting tools/structfield
0 issues.
validating generated files
github\github.go:8: running "../script/metadata.sh": fork/exec ../script/metadata.sh: %1 is not a valid Win32 application.
failed validating generated files
```

Inspired by discussion comments in #3938.