### PR TITLE
refactor!: Use `RepositoryPermissions` struct for `User.Permissions`

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -30622,10 +30622,10 @@ func (u *User) GetOwnedPrivateRepos() int64 {
 	return *u.OwnedPrivateRepos
 }
 
-// GetPermissions returns the Permissions map if it's non-nil, an empty map otherwise.
-func (u *User) GetPermissions() map[string]bool {
-	if u == nil || u.Permissions == nil {
-		return map[string]bool{}
+// GetPermissions returns the Permissions field.
+func (u *User) GetPermissions() *RepositoryPermissions {
+	if u == nil {
+		return nil
 	}
 	return u.Permissions
 }

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -39496,10 +39496,7 @@ func TestUser_GetOwnedPrivateRepos(tt *testing.T) {
 
 func TestUser_GetPermissions(tt *testing.T) {
 	tt.Parallel()
-	zeroValue := map[string]bool{}
-	u := &User{Permissions: zeroValue}
-	u.GetPermissions()
-	u = &User{}
+	u := &User{}
 	u.GetPermissions()
 	u = nil
 	u.GetPermissions()

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -2393,10 +2393,11 @@ func TestUser_String(t *testing.T) {
 		ReposURL:                Ptr(""),
 		StarredURL:              Ptr(""),
 		SubscriptionsURL:        Ptr(""),
+		Permissions:             &RepositoryPermissions{},
 		RoleName:                Ptr(""),
 		Assignment:              Ptr(""),
 	}
-	want := `github.User{Login:"", ID:0, NodeID:"", AvatarURL:"", HTMLURL:"", GravatarID:"", Name:"", Company:"", Blog:"", Location:"", Email:"", Hireable:false, Bio:"", TwitterUsername:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, SuspendedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Type:"", SiteAdmin:false, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, TwoFactorAuthentication:false, Plan:github.Plan{}, LdapDn:"", URL:"", EventsURL:"", FollowingURL:"", FollowersURL:"", GistsURL:"", OrganizationsURL:"", ReceivedEventsURL:"", ReposURL:"", StarredURL:"", SubscriptionsURL:"", RoleName:"", Assignment:""}`
+	want := `github.User{Login:"", ID:0, NodeID:"", AvatarURL:"", HTMLURL:"", GravatarID:"", Name:"", Company:"", Blog:"", Location:"", Email:"", Hireable:false, Bio:"", TwitterUsername:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, SuspendedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Type:"", SiteAdmin:false, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, TwoFactorAuthentication:false, Plan:github.Plan{}, LdapDn:"", URL:"", EventsURL:"", FollowingURL:"", FollowersURL:"", GistsURL:"", OrganizationsURL:"", ReceivedEventsURL:"", ReposURL:"", StarredURL:"", SubscriptionsURL:"", Permissions:github.RepositoryPermissions{}, RoleName:"", Assignment:""}`
 	if got := v.String(); got != want {
 		t.Errorf("User.String = %v, want %v", got, want)
 	}

--- a/github/security_advisories_test.go
+++ b/github/security_advisories_test.go
@@ -1257,7 +1257,7 @@ func TestRepoAdvisoryCreditDetailed_Marshal(t *testing.T) {
 					},
 				},
 			},
-			Permissions: map[string]bool{"p1": true},
+			Permissions: &RepositoryPermissions{Pull: Ptr(true)},
 			RoleName:    Ptr("r"),
 		},
 	}
@@ -1323,7 +1323,7 @@ func TestRepoAdvisoryCreditDetailed_Marshal(t *testing.T) {
 			}
 		  ],
 		  "permissions": {
-			"p1": true
+			"pull": true
 		  },
 		  "role_name": "r"
 		}
@@ -1396,7 +1396,7 @@ func TestCredit_Marshal(t *testing.T) {
 					},
 				},
 			},
-			Permissions: map[string]bool{"p1": true},
+			Permissions: &RepositoryPermissions{Pull: Ptr(true)},
 			RoleName:    Ptr("r"),
 		},
 	}
@@ -1461,7 +1461,7 @@ func TestCredit_Marshal(t *testing.T) {
 			}
 			],
 			"permissions": {
-			"p1": true
+			"pull": true
 			},
 			"role_name": "r"
 		}
@@ -1554,7 +1554,7 @@ func TestGlobalSecurityAdvisory_Marshal(t *testing.T) {
 							},
 						},
 					},
-					Permissions: map[string]bool{"p1": true},
+					Permissions: &RepositoryPermissions{Pull: Ptr(true)},
 					RoleName:    Ptr("r"),
 				},
 			},
@@ -1708,7 +1708,7 @@ func TestGlobalSecurityAdvisory_Marshal(t *testing.T) {
 				}
 			  ],
 			  "permissions": {
-				"p1": true
+				"pull": true
 			  },
 			  "role_name": "r"
 			},

--- a/github/users.go
+++ b/github/users.go
@@ -68,8 +68,8 @@ type User struct {
 
 	// Permissions and RoleName identify the permissions and role that a user has on a given
 	// repository. These are only populated when calling Repositories.ListCollaborators.
-	Permissions map[string]bool `json:"permissions,omitempty"`
-	RoleName    *string         `json:"role_name,omitempty"`
+	Permissions *RepositoryPermissions `json:"permissions,omitempty"`
+	RoleName    *string                `json:"role_name,omitempty"`
 
 	// Assignment identifies how a user was assigned to an organization role. Its
 	// possible values are: "direct", "indirect", "mixed". This is only populated when


### PR DESCRIPTION
BREAKING CHANGE: `User.Permissions` is now `*RepositoryPermissions` instead of `map[string]bool`.

## Summary

Replace `map[string]bool` with `*RepositoryPermissions` struct for the `User.Permissions` field.

Fixes #3947

## Changes

- Changed `User.Permissions` from `map[string]bool` to `*RepositoryPermissions`
- Updated related tests to use the struct format
- Regenerated accessor functions

## Rationale

According to the [List Collaborators API docs](https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#list-repository-collaborators), the permissions object has a fixed, well-defined structure with `pull`, `triage`, `push`, `maintain`, and `admin` boolean fields.

Using the existing `RepositoryPermissions` struct provides:
- Better type safety
- Consistency with `Repository.Permissions`
- IDE autocompletion for permission fields

## Breaking Change

This is a breaking API change as noted in the issue labels. Users who access `User.Permissions` will need to update their code from map access (`u.Permissions["pull"]`) to struct access (`u.GetPermissions().GetPull()`).

## Testing

All existing tests pass with the updated types.