### PR TITLE
chore: Turn off commit with `gpgsign` in script/generate.sh

### DIFF
--- a/script/generate.sh
+++ b/script/generate.sh
@@ -24,7 +24,7 @@ if [ "$1" = "--check" ]; then
   (
     cd "$GENTEMP"
     git add .
-    git -c user.name='bot' -c user.email='bot@localhost' commit -m "generate" -q --allow-empty
+    git -c user.name='bot' -c user.email='bot@localhost' -c commit.gpgsign=false commit -m "generate" -q --allow-empty
     script/generate.sh
     [ -z "$(git status --porcelain)" ] || {
       msg="Generated files are out of date. Please run script/generate.sh and commit the results"


### PR DESCRIPTION
This PR resolves the following problem. I'm using [gpgsign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for signing my commits. When I run `./script/lint.sh` and get the error:

```console
❯ ./script/lint.sh
linting .
0 issues.
linting example
...
linting tools/structfield
/Users/alexandear/src/github.com/google/go-github/tools/structfield
0 issues.
validating generated files
error: gpg failed to sign the data:
gpg: skipped "bot <bot@localhost>": No secret key
[GNUPG:] INV_SGNR 9 bot <bot@localhost>
[GNUPG:] FAILURE sign 17
gpg: signing failed: No secret key

fatal: failed to write commit object
failed validating generated files
```

This happens when `./script/lint.sh` calls `./script/generate.sh` with the `--check` argument. Therefore, I decided to explicitly disable `commit.gpgsign` to resolve the issue for all users of `gpgsign`.

---

P.S. I think `./script/generate.sh` is overcomplicated and can be simplified. But this is another story and can be discussed in issue #3983.