### PR TITLE
fix!: Add field `PerPage` to `OrganizationsListOptions`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -361,6 +361,8 @@ linters:
             - NotificationListOptions.Before # TODO: Activities
             - NotificationListOptions.Participating # TODO: Activities
             - NotificationListOptions.Since # TODO: Activities
+            - OrganizationsListOptions.Since # TODO: Organizations
+            - OrganizationsListOptions.PerPage # TODO: Organizations
             - ProjectV2ItemFieldValue.DataType # TODO: Projects
             - ProjectV2ItemFieldValue.Name # TODO: Projects
             - PullRequestListCommentsOptions.Direction # TODO: PullRequests

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -17374,22 +17374,6 @@ func (o *OrganizationInstallations) GetTotalCount() int {
 	return *o.TotalCount
 }
 
-// GetPerPage returns the PerPage field if it's non-nil, zero value otherwise.
-func (o *OrganizationsListOptions) GetPerPage() int {
-	if o == nil || o.PerPage == nil {
-		return 0
-	}
-	return *o.PerPage
-}
-
-// GetSince returns the Since field if it's non-nil, zero value otherwise.
-func (o *OrganizationsListOptions) GetSince() int64 {
-	if o == nil || o.Since == nil {
-		return 0
-	}
-	return *o.Since
-}
-
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (o *OrgBlockEvent) GetAction() string {
 	if o == nil || o.Action == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -22631,28 +22631,6 @@ func TestOrganizationInstallations_GetTotalCount(tt *testing.T) {
 	o.GetTotalCount()
 }
 
-func TestOrganizationsListOptions_GetPerPage(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue int
-	o := &OrganizationsListOptions{PerPage: &zeroValue}
-	o.GetPerPage()
-	o = &OrganizationsListOptions{}
-	o.GetPerPage()
-	o = nil
-	o.GetPerPage()
-}
-
-func TestOrganizationsListOptions_GetSince(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue int64
-	o := &OrganizationsListOptions{Since: &zeroValue}
-	o.GetSince()
-	o = &OrganizationsListOptions{}
-	o.GetSince()
-	o = nil
-	o.GetSince()
-}
-
 func TestOrgBlockEvent_GetAction(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -154,10 +154,10 @@ func (p Plan) String() string {
 // OrganizationsService.ListAll method.
 type OrganizationsListOptions struct {
 	// An organization ID. Only return organizations with an ID greater than this ID.
-	Since *int64 `url:"since,omitempty"`
+	Since int64 `url:"since,omitempty"`
 
 	// The number of results per page (max 100).
-	PerPage *int `url:"per_page,omitempty"`
+	PerPage int `url:"per_page,omitempty"`
 }
 
 // ListAll lists all organizations, in the order that they were created on GitHub.

--- a/github/orgs_test.go
+++ b/github/orgs_test.go
@@ -77,7 +77,7 @@ func TestOrganizationsService_ListAll(t *testing.T) {
 		fmt.Fprint(w, `[{"id":4314092}]`)
 	})
 
-	opt := &OrganizationsListOptions{Since: Ptr(int64(1342004)), PerPage: Ptr(30)}
+	opt := &OrganizationsListOptions{Since: int64(1342004), PerPage: 30}
 	ctx := t.Context()
 	orgs, _, err := client.Organizations.ListAll(ctx, opt)
 	if err != nil {


### PR DESCRIPTION
BREAKING CHANGE: `OrganizationsListOptions` now contains only `PerPage` instead of `ListOptions`.

Updates #3976

We could build an iterator for `ListAll` using the `Since` field, but it is not very useful. `ListAllIter` would return all organizations across GitHub, which is a large result set.