### PR TITLE
fix: Add support for GitHub Enterprise cloud upload URLs

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -412,7 +412,8 @@ func (c *Client) WithEnterpriseURLs(baseURL, uploadURL string) (*Client, error) 
 	}
 	if !strings.HasSuffix(c2.UploadURL.Path, "/api/uploads/") &&
 		!strings.HasPrefix(c2.UploadURL.Host, "api.") &&
-		!strings.Contains(c2.UploadURL.Host, ".api.") {
+		!strings.Contains(c2.UploadURL.Host, ".api.") &&
+		!strings.HasPrefix(c2.UploadURL.Host, "uploads.") {
 		c2.UploadURL.Path += "api/uploads/"
 	}
 	return c2, nil

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -509,6 +509,13 @@ func TestWithEnterpriseURLs(t *testing.T) {
 			uploadURL:     "https://cloud-api.custom-upload-url/",
 			wantUploadURL: "https://cloud-api.custom-upload-url/api/uploads/",
 		},
+		{
+			name:          "URL has uploads subdomain, does not modify",
+			baseURL:       "https://api.custom-url/",
+			wantBaseURL:   "https://api.custom-url/",
+			uploadURL:     "https://uploads.custom-upload-url/",
+			wantUploadURL: "https://uploads.custom-upload-url/",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Fixes: #3985 by not adding API suffixes to upload.* enterprise URLs.