### PR TITLE
chore: Remove unnecessary `fmt.Print` in tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,8 @@ linters:
       comparison: true
     forbidigo:
       forbid:
+        - pattern: ^fmt\.Print.*$
+          msg: "Do not use fmt.Print statements."
         - pattern: ^reflect\.DeepEqual$
           msg: "Use cmp.Equal instead of reflect.DeepEqual"
         - pattern: "^http\\.Method[A-Z][a-z]*$"
@@ -358,6 +360,11 @@ linters:
           - gosec
           - unparam
         path: _test\.go
+
+      # Allow fmt.Print in examples, internal tools, and tests.
+      - linters: [forbidigo]
+        path: ^(example|tools|test|scrape)\/
+        text: 'fmt\.Print'
 
       # We need to pass nil Context in order to test DoBare erroring on nil ctx.
       - linters: [staticcheck]

--- a/github/actions_variables_test.go
+++ b/github/actions_variables_test.go
@@ -752,7 +752,5 @@ func TestActionVariable_Marshal(t *testing.T) {
 		"selected_repository_ids": [1,2,3]
 	}`, referenceTimeStr, referenceTimeStr)
 
-	fmt.Println(want)
-
 	testJSONMarshal(t, av, want)
 }

--- a/github/enterprise_licenses_test.go
+++ b/github/enterprise_licenses_test.go
@@ -171,8 +171,6 @@ func TestEnterpriseService_GetLicenseSyncStatus(t *testing.T) {
 		},
 	}
 
-	fmt.Printf("%v\n", cmp.Diff(want, syncStatus))
-
 	if !cmp.Equal(syncStatus, want) {
 		t.Errorf("Enterprise.GetLicenseSyncStatus returned %+v, want %+v", syncStatus, want)
 	}


### PR DESCRIPTION
1. Remove `fmt.Printf` and `fmt.Println` from unit tests. Looks like they were used for debugging.
2. Configure the `forbidigo` linter to forbid `fmt.Print` statements.