### PR TITLE
fix(billing): change PremiumRequestUsageItem quantities to float64

### DIFF
--- a/github/billing.go
+++ b/github/billing.go
@@ -144,11 +144,11 @@ type PremiumRequestUsageItem struct {
 	Model            string  `json:"model"`
 	UnitType         string  `json:"unitType"`
 	PricePerUnit     float64 `json:"pricePerUnit"`
-	GrossQuantity    int     `json:"grossQuantity"`
+	GrossQuantity    float64 `json:"grossQuantity"`
 	GrossAmount      float64 `json:"grossAmount"`
-	DiscountQuantity int     `json:"discountQuantity"`
+	DiscountQuantity float64 `json:"discountQuantity"`
 	DiscountAmount   float64 `json:"discountAmount"`
-	NetQuantity      int     `json:"netQuantity"`
+	NetQuantity      float64 `json:"netQuantity"`
 	NetAmount        float64 `json:"netAmount"`
 }
 


### PR DESCRIPTION
The GitHub API returns float values (e.g. 5054.0) for GrossQuantity, DiscountQuantity, and NetQuantity. Previously these were typed as int, causing JSON unmarshal errors.

Fixes #3996