### PR TITLE
chore: Do not print any output when `check-structfield-settings` is OK

### DIFF
--- a/tools/check-structfield-settings/main.go
+++ b/tools/check-structfield-settings/main.go
@@ -74,7 +74,6 @@ func main() {
 	obsoleteTypes := diffKeys(allowedTypes, usedTypes)
 
 	if len(obsoleteNames) == 0 && len(obsoleteTypes) == 0 && len(duplicateNames) == 0 && len(duplicateTypes) == 0 {
-		fmt.Println("No obsolete structfield exceptions found.")
 		return
 	}
 


### PR DESCRIPTION
This PR changes `check-structcheck-settings` to output nothing when `structcheck` settings are OK.

Before:
```console
❯ ./script/generate.sh
/Users/alexandear/src/github.com/google/go-github/tools/metadata
/Users/alexandear/src/github.com/google/go-github/example
/Users/alexandear/src/github.com/google/go-github/example/newreposecretwithlibsodium
/Users/alexandear/src/github.com/google/go-github/otel
/Users/alexandear/src/github.com/google/go-github/scrape
/Users/alexandear/src/github.com/google/go-github/tools
/Users/alexandear/src/github.com/google/go-github/tools/check-structfield-settings
/Users/alexandear/src/github.com/google/go-github/tools/fmtpercentv
/Users/alexandear/src/github.com/google/go-github/tools/sliceofpointers
/Users/alexandear/src/github.com/google/go-github/tools/structfield
No obsolete structfield exceptions found.
```

After
```console
❯ ./script/generate.sh
/Users/alexandear/src/github.com/google/go-github/tools/metadata
/Users/alexandear/src/github.com/google/go-github/example
/Users/alexandear/src/github.com/google/go-github/example/newreposecretwithlibsodium
/Users/alexandear/src/github.com/google/go-github/otel
/Users/alexandear/src/github.com/google/go-github/scrape
/Users/alexandear/src/github.com/google/go-github/tools
/Users/alexandear/src/github.com/google/go-github/tools/check-structfield-settings
/Users/alexandear/src/github.com/google/go-github/tools/fmtpercentv
/Users/alexandear/src/github.com/google/go-github/tools/sliceofpointers
/Users/alexandear/src/github.com/google/go-github/tools/structfield
```