### PR TITLE
docs: Update usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ go run tools/gen-release-notes/main.go --tag v82.0.0
 ## Usage ##
 
 ```go
-import "github.com/google/go-github/v82/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
-import "github.com/google/go-github/github" // with go modules disabled
+import "github.com/google/go-github/v82/github"
 ```
 
 Construct a new GitHub client, then use the various services on the client to

--- a/github/doc.go
+++ b/github/doc.go
@@ -8,8 +8,7 @@ Package github provides a client for using the GitHub API.
 
 Usage:
 
-	import "github.com/google/go-github/v82/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
-	import "github.com/google/go-github/github"     // with go modules disabled
+	import "github.com/google/go-github/v82/github"
 
 Construct a new GitHub client, then use the various services on the client to
 access different parts of the GitHub API. For example:


### PR DESCRIPTION
This PR removes the usage note explaining how to import this library when Go modules are disabled.

Go modules were introduced in Go 1.11 ([released in 2018](https://go.dev/blog/go1.11)) and are now the de facto standard. Developers who use this library with Go modules disabled are typically experts and don't need guidance on how to import `go-github` into their projects.