### PR TITLE
chore: Bump golangci-lint to v2.9.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ version: "2"
 run:
   build-tags:
     - integration
+  allow-parallel-runners: true
 linters:
   enable:
     - canonicalheader

--- a/script/setup-custom-gcl.sh
+++ b/script/setup-custom-gcl.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-GOLANGCI_LINT_VERSION="2.7.0"
+GOLANGCI_LINT_VERSION="2.9.0"
 
 # should in sync with fmt.sh and lint.sh
 BIN="$(pwd -P)"/bin


### PR DESCRIPTION
This should help to speed up the linting process.

cc: @stevehipwell - @alexandear - @zyfy29 - @Not-Dhananjay-Mishra 