### PR TITLE
fix!: Divide `PackageGetAllVersions` into two separate methods `ListPackageVersions` and `ListUserPackageVersions`

### DIFF
--- a/github/github-iterators.go
+++ b/github/github-iterators.go
@@ -7173,11 +7173,11 @@ func (s *UsersService) ListKeysIter(ctx context.Context, user string, opts *List
 }
 
 // ListPackageVersionsIter returns an iterator that paginates through all results of ListPackageVersions.
-func (s *UsersService) ListPackageVersionsIter(ctx context.Context, packageType string, packageName string, opts *ListPackageVersionOptions) iter.Seq2[*PackageVersion, error] {
+func (s *UsersService) ListPackageVersionsIter(ctx context.Context, packageType string, packageName string, opts *ListPackageVersionsOptions) iter.Seq2[*PackageVersion, error] {
 	return func(yield func(*PackageVersion, error) bool) {
 		// Create a copy of opts to avoid mutating the caller's struct
 		if opts == nil {
-			opts = &ListPackageVersionOptions{}
+			opts = &ListPackageVersionsOptions{}
 		} else {
 			opts = Ptr(*opts)
 		}

--- a/github/github-iterators_test.go
+++ b/github/github-iterators_test.go
@@ -16032,7 +16032,7 @@ func TestUsersService_ListPackageVersionsIter(t *testing.T) {
 		t.Errorf("client.Users.ListPackageVersionsIter call 1 got %v items; want %v", gotItems, want)
 	}
 
-	opts := &ListPackageVersionOptions{}
+	opts := &ListPackageVersionsOptions{}
 	iter = client.Users.ListPackageVersionsIter(t.Context(), "", "", opts)
 	gotItems = 0
 	for _, err := range iter {

--- a/github/users_packages.go
+++ b/github/users_packages.go
@@ -127,8 +127,8 @@ func (s *UsersService) RestorePackage(ctx context.Context, user, packageType, pa
 	return s.client.Do(ctx, req, nil)
 }
 
-// ListPackageVersionOptions specifies the optional parameters to the UsersService.ListPackageVersions.
-type ListPackageVersionOptions struct {
+// ListPackageVersionsOptions specifies the optional parameters to the UsersService.ListPackageVersions.
+type ListPackageVersionsOptions struct {
 	// State of package either "active" or "deleted".
 	State string `url:"state,omitempty"`
 
@@ -140,7 +140,7 @@ type ListPackageVersionOptions struct {
 // GitHub API docs: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-the-authenticated-user
 //
 //meta:operation GET /user/packages/{package_type}/{package_name}/versions
-func (s *UsersService) ListPackageVersions(ctx context.Context, packageType, packageName string, opts *ListPackageVersionOptions) ([]*PackageVersion, *Response, error) {
+func (s *UsersService) ListPackageVersions(ctx context.Context, packageType, packageName string, opts *ListPackageVersionsOptions) ([]*PackageVersion, *Response, error) {
 	u := fmt.Sprintf("user/packages/%v/%v/versions", packageType, packageName)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -161,12 +161,12 @@ func (s *UsersService) ListPackageVersions(ctx context.Context, packageType, pac
 	return versions, resp, nil
 }
 
-// ListPackageVersionsForUser gets all versions of a package for a user.
+// ListUserPackageVersions returns package versions for a public package owned by a specified user.
 //
 // GitHub API docs: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-a-user
 //
 //meta:operation GET /users/{username}/packages/{package_type}/{package_name}/versions
-func (s *UsersService) ListPackageVersionsForUser(ctx context.Context, user, packageType, packageName string) ([]*PackageVersion, *Response, error) {
+func (s *UsersService) ListUserPackageVersions(ctx context.Context, user, packageType, packageName string) ([]*PackageVersion, *Response, error) {
 	u := fmt.Sprintf("users/%v/packages/%v/%v/versions", user, packageType, packageName)
 
 	req, err := s.client.NewRequest("GET", u, nil)

--- a/github/users_packages_test.go
+++ b/github/users_packages_test.go
@@ -368,7 +368,7 @@ func TestUsersService_ListPackageVersions(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	opts := &ListPackageVersionOptions{
+	opts := &ListPackageVersionsOptions{
 		ListOptions: ListOptions{Page: 1, PerPage: 2},
 	}
 	packages, _, err := client.Users.ListPackageVersions(ctx, "container", "hello_docker", opts)
@@ -392,12 +392,12 @@ func TestUsersService_ListPackageVersions(t *testing.T) {
 
 	const methodName = "ListPackageVersions"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Users.ListPackageVersions(ctx, "\n", "\n", &ListPackageVersionOptions{})
+		_, _, err = client.Users.ListPackageVersions(ctx, "\n", "\n", &ListPackageVersionsOptions{})
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Users.ListPackageVersions(ctx, "", "", &ListPackageVersionOptions{})
+		got, resp, err := client.Users.ListPackageVersions(ctx, "", "", &ListPackageVersionsOptions{})
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -405,7 +405,7 @@ func TestUsersService_ListPackageVersions(t *testing.T) {
 	})
 }
 
-func TestUsersService_ListPackageVersionsForUser(t *testing.T) {
+func TestUsersService_ListUserPackageVersions(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -434,9 +434,9 @@ func TestUsersService_ListPackageVersionsForUser(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	packages, _, err := client.Users.ListPackageVersionsForUser(ctx, "u", "container", "hello_docker")
+	packages, _, err := client.Users.ListUserPackageVersions(ctx, "u", "container", "hello_docker")
 	if err != nil {
-		t.Errorf("Users.ListPackageVersionsForUser returned error: %v", err)
+		t.Errorf("Users.ListUserPackageVersions returned error: %v", err)
 	}
 
 	want := []*PackageVersion{{
@@ -450,17 +450,17 @@ func TestUsersService_ListPackageVersionsForUser(t *testing.T) {
 		Metadata:       json.RawMessage(m),
 	}}
 	if !cmp.Equal(packages, want) {
-		t.Errorf("Users.ListPackageVersionsForUser returned %+v, want %+v", packages, want)
+		t.Errorf("Users.ListUserPackageVersions returned %+v, want %+v", packages, want)
 	}
 
-	const methodName = "ListPackageVersionsForUser"
+	const methodName = "ListUserPackageVersions"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Users.ListPackageVersionsForUser(ctx, "\n", "\n", "\n")
+		_, _, err = client.Users.ListUserPackageVersions(ctx, "\n", "\n", "\n")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Users.ListPackageVersionsForUser(ctx, "", "", "")
+		got, resp, err := client.Users.ListUserPackageVersions(ctx, "", "", "")
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}


### PR DESCRIPTION
BREAKING CHANGE: `PackageGetAllVersions` is now divided into `ListPackageVersions` and `ListUserPackageVersions`.

`PackageGetAllVersions` handles two endpoints one of them doesn't support pagination acc to docs also its Iterator doesn't get generated because its method name does not contain `List` as prefix. 

- `ListPackageVersions` [docs](https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-the-authenticated-user)
- `ListUserPackageVersions` [docs](https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-a-user)

Updates : #3976