### PR TITLE
Bump version of go-github to v83.0.0

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,8 +1,8 @@
 version: v2.7.0
 plugins:
-  - module: "github.com/google/go-github/v82/tools/fmtpercentv"
+  - module: "github.com/google/go-github/v83/tools/fmtpercentv"
     path: ./tools/fmtpercentv
-  - module: "github.com/google/go-github/v82/tools/sliceofpointers"
+  - module: "github.com/google/go-github/v83/tools/sliceofpointers"
     path: ./tools/sliceofpointers
-  - module: "github.com/google/go-github/v82/tools/structfield"
+  - module: "github.com/google/go-github/v83/tools/structfield"
     path: ./tools/structfield

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -159,15 +159,15 @@ linters:
       fmtpercentv:
         type: module
         description: Reports usage of %d or %s in format strings.
-        original-url: github.com/google/go-github/v82/tools/fmtpercentv
+        original-url: github.com/google/go-github/v83/tools/fmtpercentv
       sliceofpointers:
         type: module
         description: Reports usage of []*string and slices of structs without pointers.
-        original-url: github.com/google/go-github/v82/tools/sliceofpointers
+        original-url: github.com/google/go-github/v83/tools/sliceofpointers
       structfield:
         type: module
         description: Reports mismatches between Go field and JSON, URL tag names and types.
-        original-url: github.com/google/go-github/v82/tools/structfield
+        original-url: github.com/google/go-github/v83/tools/structfield
         settings:
           allowed-tag-names:
             - ActionsCacheUsageList.RepoCacheUsage # TODO: RepoCacheUsages ?

--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@
 2BFL <imqksl@gmail.com>
 413x <dedifferentiator@gmail.com>
 6543 <6543@obermui.de>
+Aaron LaBrie <bigdadbear@github.com>
 Abed Kibbe <abed.kibbe@gmail.com>
 Abhijit Hota <abhihota025@gmail.com>
 Abhinav Gupta <mail@abhinavg.net>
@@ -77,6 +78,7 @@ Arda Kuyumcu <kuyumcuarda@gmail.com>
 Ary <arylmoraesn@hotmail.com>
 Arıl Bozoluk <arilbozoluk@hotmail.com>
 Asier Marruedo <asiermarruedo@gmail.com>
+Austen Stone <austenstone@github.com>
 Austin Burdine <acburdine@gmail.com>
 Austin Dizzy <dizzy@wow.com>
 Azuka Okuleye <azuka@zatechcorp.com>
@@ -101,6 +103,7 @@ Bradley Falzon <brad@teambrad.net>
 Bradley McAllister <brad.mcallister@hotmail.com>
 Brandon Butler <b.butler@chia.net>
 Brandon Cook <phylake@gmail.com>
+Brandon Everett <bme2010@gmail.com>
 Brandon Stubbs <brstubbs1@gmail.com>
 Brett Kuhlman <kuhlman-labs@github.com>
 Brett Logan <lindluni@github.com>
@@ -130,7 +133,9 @@ Christian Muehlhaeuser <muesli@gmail.com>
 Christoph Jerolimov <jerolimov@gmail.com>
 Christoph Sassenberg <defsprite@gmail.com>
 CI Monk <ci-monk@protonmail.com>
+Claus Näveke <github@naeveke.de>
 Clemens W <Clemens.wijnekus@nordnet.se>
+cointem <jsyin1@163.com>
 Colby Williams <ColbyLWilliams@gmail.com>
 Colin Misare <github.com/cmisare>
 Craig Gumbley <craiggumbley@gmail.com>
@@ -157,6 +162,7 @@ Davide Zipeto <dawez1@gmail.com>
 Dennis Webb <dennis@bluesentryit.com>
 Derek Jobst <derekjobst@gmail.com>
 DeviousLab <deviouslab@gmail.com>
+Dhananjay Mishra <technicaldmcontact@gmail.com>
 Dhi Aurrahman <diorahman@rockybars.com>
 Diego Lapiduz <diego.lapiduz@cfpb.gov>
 Diogo Vilela <be0x74a@gmail.com>
@@ -208,6 +214,7 @@ Glen Mailer <glenjamin@gmail.com>
 Gnahz <p@oath.pl>
 Google Inc.
 Grachev Mikhail <work@mgrachev.com>
+Gregor Jasny <gjasny@googlemail.com>
 Gregory Oschwald <oschwald@gmail.com>
 griffin_stewie <panterathefamilyguy@gmail.com>
 guangwu <guoguangwu@magic-shield.com>
@@ -227,6 +234,7 @@ Huy Tr <kingbazoka@gmail.com>
 huydx <doxuanhuy@gmail.com>
 i2bskn <i2bskn@gmail.com>
 Iain Steers <iainsteers@gmail.com>
+Iehana Fu <wasuremono127@gmail.com>
 Ikko Ashimine <eltociear@gmail.com>
 Ilia Choly <ilia.choly@gmail.com>
 Ioannis Georgoulas <igeorgoulas21@gmail.com>
@@ -239,6 +247,7 @@ Jake Krammer <jake.krammer1@gmail.com>
 Jake Scaltreto <jake.scaltreto@circle.com>
 Jake White <jake@jwhite.network>
 Jameel Haffejee <RC1140@republiccommandos.co.za>
+James Alseth <james@jalseth.me>
 James Bowes <jbowes@repl.ca>
 James Cockbain <james.cockbain@ibm.com>
 James Loh <github@jloh.co>
@@ -261,6 +270,7 @@ Jesse Newland <jesse@jnewland.com>
 Jihoon Chung <j.c@navercorp.com>
 Jille Timmermans <jille@quis.cx>
 Jimmi Dyson <jimmidyson@gmail.com>
+Jiří Žižkovský <jirizizkovsky@post.cz>
 Joan Saum <joan.saum@epitech.eu>
 JoannaaKL <joannaakl@github.com>
 Joe Tsai <joetsai@digital-static.net>
@@ -312,6 +322,7 @@ kyokomi <kyoko1220adword@gmail.com>
 Lachlan Cooper <lachlancooper@gmail.com>
 Lars Lehtonen <lars.lehtonen@gmail.com>
 Laurent Verdoïa <verdoialaurent@gmail.com>
+Leonard Sheng Sheng Lee <leonard.sheng.sheng.lee@gmail.com>
 leopoldwang <leopold.wang@gmail.com>
 Liam Galvin <liam@liam-galvin.co.uk>
 Liam Stanley <liam@liam.sh>
@@ -332,6 +343,8 @@ Léo Salé <leo.sale@datadoghq.com>
 M. Ryan Rigdon <mr.rigdon@gmail.com>
 Magnus Kulke <mkulke@gmail.com>
 Maksim Zhylinski <uzzable@gmail.com>
+Manas Sivakumar <manas23601@gmail.com>
+Manav Sharma <manav.acno1@gmail.com>
 Manuel Bergler <manue1@github.com>
 Marc Binder <marcandrebinder@gmail.com>
 Marcelo Carlos <marcelo@permutive.com>
@@ -343,6 +356,8 @@ Marwan Sulaiman <marwan.sameer@gmail.com>
 Masayuki Izumi <m@izum.in>
 Mat Geist <matgeist@gmail.com>
 Matheus Santos Araújo <wenked.matheus@yahoo.com.br>
+MathewClegg <mathew.clegg@live.se>
+Mathieu Sévégny <mathieu.sevegny@goto.com>
 Matija Horvat <horvat2112@gmail.com>
 Matin Rahmanian <itsmatinx@gmail.com>
 Matt <alpmatthew@gmail.com>
@@ -356,6 +371,7 @@ Matt Simons <mattsimons@ntlworld.com>
 Matthew Reidy <matthewreidy5@gmail.com>
 Maxime Bury <maxime.bury@gmail.com>
 Michael Meng <mmeng@lyft.com>
+Michael Recachinas <mrecachinas@github.com>
 Michael Spiegel <michael.m.spiegel@gmail.com>
 Michael Tiller <michael.tiller@gmail.com>
 Michał Glapa <michal.glapa@gmail.com>
@@ -365,6 +381,7 @@ Mike Ball <mikedball@gmail.com>
 Mike Chen <mchen300@gmail.com>
 Miles Crabill <miles@milescrabill.com>
 Mishin Nikolai <sanduku.default@gmail.com>
+Mohamad Al-Zawahreh <merchantmoh@gmail.com>
 mohammad ali <2018cs92@student.uet.edu.pk>
 Mohammed AlDujaili <avainer11@gmail.com>
 Mohammed Nafees <hello@mnafees.me>
@@ -449,6 +466,7 @@ Riaje <francois@mbfr.fr>
 Ricco Førgaard <ricco@fiskeben.dk>
 Richard de Vries <richard.de.vries@topicus.nl>
 Rob Figueiredo <robfig@yext.com>
+Roger Peppe <rogpeppe@gmail.com>
 Rohit Upadhyay <urohit011@gmail.com>
 Rojan Dinc <rojand94@gmail.com>
 Roman Wu <me@romanwu.com>
@@ -478,6 +496,7 @@ Sanket Payghan <sanket.payghan8@gmail.com>
 Sarah Funkhouser <sarah.k.funkhouser@gmail.com>
 Sarasa Kisaragi <lingsamuelgrace@gmail.com>
 Sasha Melentyev <sasha@melentyev.io>
+Scott Dawson <scott@daw.sn>
 Sean Wang <sean@decrypted.org>
 Sebastian Mandrean <sebastian.mandrean@gmail.com>
 Sebastian Mæland Pedersen <sem.pedersen@stud.uis.no>
@@ -542,6 +561,7 @@ Victor Castell <victor@victorcastell.com>
 Victor Vrantchan <vrancean+github@gmail.com>
 Victory Osikwemhe <osikwemhev@gmail.com>
 vikkyomkar <vikky.omkar@samsung.com>
+Ville Skyttä <ville.skytta@iki.fi>
 Vivek <y.vivekanand@gmail.com>
 Vivek Kumar Sahu <vivekkumarsahu650@gmail.com>
 Vlad Ungureanu <vladu@palantir.com>
@@ -564,6 +584,7 @@ Yumikiyo Osanai <yumios.art@gmail.com>
 Yurii Soldak <ysoldak@gmail.com>
 Yusef Mohamadi <yuseferi@gmail.com>
 Yusuke Kuoka <ykuoka@gmail.com>
+Yuto Kimura <biosugar0@gmail.com>
 Zach Latta <zach@zachlatta.com>
 Ze Peng <zehui.peng@circle.com>
 zhouhaibing089 <zhouhaibing089@gmail.com>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-github #
 
 [![go-github release (latest SemVer)](https://img.shields.io/github/v/release/google/go-github?sort=semver)](https://github.com/google/go-github/releases)
-[![Go Reference](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/google/go-github/v82/github)
+[![Go Reference](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/google/go-github/v83/github)
 [![Test Status](https://github.com/google/go-github/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/google/go-github/actions/workflows/tests.yml)
 [![Test Coverage](https://codecov.io/gh/google/go-github/branch/master/graph/badge.svg)](https://codecov.io/gh/google/go-github)
 [![Discuss at go-github@googlegroups.com](https://img.shields.io/badge/discuss-go--github%40googlegroups.com-blue.svg)](https://groups.google.com/group/go-github)
@@ -30,7 +30,7 @@ If you're interested in using the [GraphQL API v4][], the recommended library is
 go-github is compatible with modern Go releases in module mode, with Go installed:
 
 ```bash
-go get github.com/google/go-github/v82
+go get github.com/google/go-github/v83
 ```
 
 will resolve and add the package to the current development module, along with its dependencies.
@@ -38,7 +38,7 @@ will resolve and add the package to the current development module, along with i
 Alternatively the same can be achieved if you use import in a package:
 
 ```go
-import "github.com/google/go-github/v82/github"
+import "github.com/google/go-github/v83/github"
 ```
 
 and run `go get` without parameters.
@@ -46,20 +46,20 @@ and run `go get` without parameters.
 Finally, to use the top-of-trunk version of this repo, use the following command:
 
 ```bash
-go get github.com/google/go-github/v82@master
+go get github.com/google/go-github/v83@master
 ```
 
 To discover all the changes that have occurred since a prior release, you can
 first clone the repo, then run (for example):
 
 ```bash
-go run tools/gen-release-notes/main.go --tag v82.0.0
+go run tools/gen-release-notes/main.go --tag v83.0.0
 ```
 
 ## Usage ##
 
 ```go
-import "github.com/google/go-github/v82/github"
+import "github.com/google/go-github/v83/github"
 ```
 
 Construct a new GitHub client, then use the various services on the client to
@@ -108,7 +108,7 @@ include the specified OAuth token. Therefore, authenticated clients should
 almost never be shared between different users.
 
 For API methods that require HTTP Basic Authentication, use the
-[`BasicAuthTransport`](https://pkg.go.dev/github.com/google/go-github/v82/github#BasicAuthTransport).
+[`BasicAuthTransport`](https://pkg.go.dev/github.com/google/go-github/v83/github#BasicAuthTransport).
 
 #### As a GitHub App ####
 
@@ -131,7 +131,7 @@ import (
 	"net/http"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 func main() {
@@ -165,7 +165,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 	"github.com/jferrl/go-githubauth"
 	"golang.org/x/oauth2"
 )
@@ -434,7 +434,7 @@ For complete usage of go-github, see the full [package docs][].
 
 [GitHub API v3]: https://docs.github.com/en/rest
 [personal access token]: https://github.com/blog/1509-personal-api-tokens
-[package docs]: https://pkg.go.dev/github.com/google/go-github/v82/github
+[package docs]: https://pkg.go.dev/github.com/google/go-github/v83/github
 [GraphQL API v4]: https://developer.github.com/v4/
 [shurcooL/githubv4]: https://github.com/shurcooL/githubv4
 [GitHub webhook events]: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads
@@ -508,7 +508,7 @@ Versions prior to 48.2.0 are not listed.
 
 | go-github Version | GitHub v3 API Version |
 | ----------------- | --------------------- |
-| 82.0.0            | 2022-11-28            |
+| 83.0.0            | 2022-11-28            |
 | ...               | 2022-11-28            |
 | 48.2.0            | 2022-11-28            |
 

--- a/example/actionpermissions/main.go
+++ b/example/actionpermissions/main.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 var (

--- a/example/appengine/app.go
+++ b/example/appengine/app.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/log"
 )

--- a/example/basicauth/main.go
+++ b/example/basicauth/main.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 	"golang.org/x/term"
 )
 

--- a/example/codespaces/newreposecretwithxcrypto/main.go
+++ b/example/codespaces/newreposecretwithxcrypto/main.go
@@ -37,7 +37,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/codespaces/newusersecretwithxcrypto/main.go
+++ b/example/codespaces/newusersecretwithxcrypto/main.go
@@ -38,7 +38,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -13,7 +13,7 @@
 //
 // Note, if you want to push a single file, you probably prefer to use the
 // content API. An example is available here:
-// https://pkg.go.dev/github.com/google/go-github/v82/github#example-RepositoriesService-CreateFile
+// https://pkg.go.dev/github.com/google/go-github/v83/github#example-RepositoriesService-CreateFile
 //
 // Note, for this to work at least 1 commit is needed, so you if you use this
 // after creating a repository you might want to make sure you set `AutoInit` to
@@ -33,7 +33,7 @@ import (
 	"time"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 var (
@@ -178,7 +178,7 @@ func pushCommit(ref *github.Reference, tree *github.Tree) (err error) {
 	return err
 }
 
-// createPR creates a pull request. Based on: https://pkg.go.dev/github.com/google/go-github/v82/github#example-PullRequestsService-Create
+// createPR creates a pull request. Based on: https://pkg.go.dev/github.com/google/go-github/v83/github#example-PullRequestsService-Create
 func createPR() (err error) {
 	if *prSubject == "" {
 		return errors.New("missing `-pr-title` flag; skipping PR creation")

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v82/example
+module github.com/google/go-github/v83/example
 
 go 1.24.0
 
@@ -7,8 +7,8 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.17.0
 	github.com/gofri/go-github-pagination v1.0.1
 	github.com/gofri/go-github-ratelimit/v2 v2.0.2
-	github.com/google/go-github/v82 v82.0.0
-	github.com/google/go-github/v82/otel v0.0.0-00010101000000-000000000000
+	github.com/google/go-github/v83 v83.0.0
+	github.com/google/go-github/v83/otel v0.0.0-00010101000000-000000000000
 	github.com/sigstore/sigstore-go v0.6.1
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.40.0
 	go.opentelemetry.io/otel/sdk v1.40.0
@@ -105,6 +105,6 @@ require (
 )
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v82 => ../
+replace github.com/google/go-github/v83 => ../
 
-replace github.com/google/go-github/v82/otel => ../otel
+replace github.com/google/go-github/v83/otel => ../otel

--- a/example/listenvironments/main.go
+++ b/example/listenvironments/main.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 func main() {

--- a/example/migrations/main.go
+++ b/example/migrations/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 func fetchAllUserMigrations() ([]*github.UserMigration, error) {

--- a/example/newfilewithappauth/main.go
+++ b/example/newfilewithappauth/main.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 func main() {

--- a/example/newrepo/main.go
+++ b/example/newrepo/main.go
@@ -16,7 +16,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 var (

--- a/example/newreposecretwithlibsodium/go.mod
+++ b/example/newreposecretwithlibsodium/go.mod
@@ -4,10 +4,10 @@ go 1.24.0
 
 require (
 	github.com/GoKillers/libsodium-go v0.0.0-20171022220152-dd733721c3cb
-	github.com/google/go-github/v82 v82.0.0
+	github.com/google/go-github/v83 v83.0.0
 )
 
 require github.com/google/go-querystring v1.2.0 // indirect
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v82 => ../..
+replace github.com/google/go-github/v83 => ../..

--- a/example/newreposecretwithlibsodium/main.go
+++ b/example/newreposecretwithlibsodium/main.go
@@ -36,7 +36,7 @@ import (
 	"os"
 
 	sodium "github.com/GoKillers/libsodium-go/cryptobox"
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 var (

--- a/example/newreposecretwithxcrypto/main.go
+++ b/example/newreposecretwithxcrypto/main.go
@@ -37,7 +37,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/otel/main.go
+++ b/example/otel/main.go
@@ -13,8 +13,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v82/github"
-	"github.com/google/go-github/v82/otel"
+	"github.com/google/go-github/v83/github"
+	"github.com/google/go-github/v83/otel"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/trace"
 )

--- a/example/ratelimit/main.go
+++ b/example/ratelimit/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit"
 	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit/github_primary_ratelimit"
 	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit/github_secondary_ratelimit"
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 func main() {

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 // Fetch all the public organizations' membership of a user.

--- a/example/tokenauth/main.go
+++ b/example/tokenauth/main.go
@@ -15,7 +15,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 	"golang.org/x/term"
 )
 

--- a/example/topics/main.go
+++ b/example/topics/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 // Fetch and lists all the public topics associated with the specified GitHub topic.

--- a/example/uploadreleaseassetfromrelease/main.go
+++ b/example/uploadreleaseassetfromrelease/main.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 func main() {

--- a/example/verifyartifact/main.go
+++ b/example/verifyartifact/main.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/verify"

--- a/github/doc.go
+++ b/github/doc.go
@@ -8,7 +8,7 @@ Package github provides a client for using the GitHub API.
 
 Usage:
 
-	import "github.com/google/go-github/v82/github"
+	import "github.com/google/go-github/v83/github"
 
 Construct a new GitHub client, then use the various services on the client to
 access different parts of the GitHub API. For example:

--- a/github/example_iterators_test.go
+++ b/github/example_iterators_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 func ExampleRepositoriesService_ListByUserIter() {

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 func ExampleMarkdownService_Render() {

--- a/github/github.go
+++ b/github/github.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	Version = "v82.0.0"
+	Version = "v83.0.0"
 
 	HeaderRateLimit     = "X-Ratelimit-Limit"
 	HeaderRateRemaining = "X-Ratelimit-Remaining"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v82
+module github.com/google/go-github/v83
 
 go 1.24.0
 

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -1,9 +1,9 @@
-module github.com/google/go-github/v82/otel
+module github.com/google/go-github/v83/otel
 
 go 1.24.0
 
 require (
-	github.com/google/go-github/v82 v82.0.0
+	github.com/google/go-github/v83 v83.0.0
 	go.opentelemetry.io/otel v1.40.0
 	go.opentelemetry.io/otel/metric v1.40.0
 	go.opentelemetry.io/otel/sdk v1.40.0
@@ -20,4 +20,4 @@ require (
 	golang.org/x/sys v0.40.0 // indirect
 )
 
-replace github.com/google/go-github/v82 => ../
+replace github.com/google/go-github/v83 => ../

--- a/otel/transport.go
+++ b/otel/transport.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -22,7 +22,7 @@ import (
 
 const (
 	// instrumentationName is the name of this instrumentation package.
-	instrumentationName = "github.com/google/go-github/v82/otel"
+	instrumentationName = "github.com/google/go-github/v83/otel"
 )
 
 // Transport is an http.RoundTripper that instrument requests with OpenTelemetry.

--- a/test/fields/fields.go
+++ b/test/fields/fields.go
@@ -25,7 +25,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 var (

--- a/test/integration/activity_test.go
+++ b/test/integration/activity_test.go
@@ -10,7 +10,7 @@ package integration
 import (
 	"testing"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 const (

--- a/test/integration/authorizations_test.go
+++ b/test/integration/authorizations_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 const (

--- a/test/integration/github_test.go
+++ b/test/integration/github_test.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 // client is a github.Client with the default http.Client. It is authorized if auth is true.

--- a/test/integration/licences_test.go
+++ b/test/integration/licences_test.go
@@ -10,7 +10,7 @@ package integration
 import (
 	"testing"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 func TestLicenses_ListIter(t *testing.T) {

--- a/test/integration/pagination_test.go
+++ b/test/integration/pagination_test.go
@@ -10,7 +10,7 @@ package integration
 import (
 	"testing"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 func TestSecurityAdvisories_ListGlobalSecurityAdvisories(t *testing.T) {

--- a/test/integration/projects_test.go
+++ b/test/integration/projects_test.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 // Integration tests for Projects V2 endpoints defined in github/projects.go.

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 func TestRepositories_CRUD(t *testing.T) {

--- a/test/integration/users_test.go
+++ b/test/integration/users_test.go
@@ -12,7 +12,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 func TestUsers_Get(t *testing.T) {

--- a/tools/check-structfield-settings/go.mod
+++ b/tools/check-structfield-settings/go.mod
@@ -1,10 +1,10 @@
-module github.com/google/go-github/v82/tools/check-structfield-settings
+module github.com/google/go-github/v83/tools/check-structfield-settings
 
 go 1.24.0
 
 require (
 	github.com/golangci/plugin-module-register v0.1.1
-	github.com/google/go-github/v82/tools/structfield v0.0.0
+	github.com/google/go-github/v83/tools/structfield v0.0.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/tools v0.29.0
 )
@@ -15,4 +15,4 @@ require (
 )
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v82/tools/structfield v0.0.0 => ../structfield
+replace github.com/google/go-github/v83/tools/structfield v0.0.0 => ../structfield

--- a/tools/check-structfield-settings/main.go
+++ b/tools/check-structfield-settings/main.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/golangci/plugin-module-register/register"
-	"github.com/google/go-github/v82/tools/structfield"
+	"github.com/google/go-github/v83/tools/structfield"
 	"go.yaml.in/yaml/v3"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/checker"

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v1.14.0
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/google/go-cmp v0.7.0
-	github.com/google/go-github/v82 v82.0.0
+	github.com/google/go-github/v83 v83.0.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.19.0
 )
@@ -27,4 +27,4 @@ require (
 )
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v82 => ../
+replace github.com/google/go-github/v83 => ../

--- a/tools/metadata/main.go
+++ b/tools/metadata/main.go
@@ -16,7 +16,7 @@ import (
 	"path/filepath"
 
 	"github.com/alecthomas/kong"
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 var helpVars = kong.Vars{

--- a/tools/metadata/main_test.go
+++ b/tools/metadata/main_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 )
 
 func TestUpdateGo(t *testing.T) {

--- a/tools/metadata/metadata.go
+++ b/tools/metadata/metadata.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 	"go.yaml.in/yaml/v3"
 )
 

--- a/tools/metadata/openapi.go
+++ b/tools/metadata/openapi.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v83/github"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/tools/structfield/go.mod
+++ b/tools/structfield/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v82/tools/structfield
+module github.com/google/go-github/v83/tools/structfield
 
 go 1.24.0
 


### PR DESCRIPTION
I don't recall ever having this many breaking API changes in a single release, and the last release was only 3 weeks ago!

A special heart-felt thanks goes to @merchantmoh-debug, @Not-Dhananjay-Mishra, and @alexandear for the addition of a long-requested feature to this repo:
* native auto-generated iterators for all `List*` methods that support pagination (change your call from `List*` to `List*Iter` and make sure to use a rate-limiting transport or you will quickly exhaust your quotas!)

A second set of heart-felt thanks go to @stevehipwell for setting up our REVIEWERS file and to our amazing volunteer reviewers:
* @stevehipwell 
* @alexandear 
* @zyfy29 
* @Not-Dhananjay-Mishra 

who have reduced our code-review wait times from days (_sometimes weeks_) down to literally _**hours**_ and thereby enable rapid responses to bug fixes and attempts to stay up-to-date with the ever-evolving GitHub v3 API.

This release contains the following breaking API changes:

* #4014
  BREAKING CHANGE: `PackageGetAllVersions` is now divided into `ListPackageVersions` and `ListUserPackageVersions`.
* #4012
  BREAKING CHANGE: `opts *ListOptions` is removed from `RepositoriesService.ListAutoLinks`.
* #4009
  BREAKING CHANGE: `PullRequestsService.ListReviewers` no longer has `opts *ListOptions`.
* #4002
  BREAKING CHANGE: `PremiumRequestUsageItem` numeric fields are now `float64`.
* #3988
  BREAKING CHANGE: `RepositoriesService.ListDeploymentBranchPolicies` and `RepositoriesService.ListCustomDeploymentRuleIntegrations` now accept `ListOptions`.
* #3991
  BREAKING CHANGE: Many `*Options` structs now pass `omitempty` URL struct fields by value instead of by reference.
* #3984
  BREAKING CHANGE: `ListCursorOptions` is removed from `IssueListOptions`.
* #3986
  BREAKING CHANGE: `OrganizationsListOptions` now contains only `PerPage` instead of `ListOptions`.
* #3981
  BREAKING CHANGE: `LicensesService.List` now accepts `ListLicensesOptions` for pagination.
* #3971
  BREAKING CHANGE: `SCIMEnterpriseAttributeOperation.Value` is changed from `*string` to `any`.
* #3978
  BREAKING CHANGE: `RepositoriesService.ListAllTopics` now accepts `ListOptions` for pagination.
* #3977
  BREAKING CHANGE: Replaces `UserListOptions.ListOptions` with `UserListOptions.PerPage` which also removes `UsersService.ListAllIter`.
* #3973
  BREAKING CHANGE: `ActionsService.CreateHostedRunner` and `EnterpriseService.CreateHostedRunner` now accept `CreateHostedRunnerRequest`; `ActionsService.UpdateHostedRunner` and `EnterpriseService.UpdateHostedRunner` now accept `UpdateHostedRunnerRequest`.
* #3963
  BREAKING CHANGE: `User.Permissions` is now `*RepositoryPermissions` instead of `map[string]bool`.

...and the following additional changes:

* #4011
* #4013
* #4008
* #4007
* #3998
* #4001
* #4003
* #3999
* #4004
* #4006
* #3994
* #3993
* #3982
* #3980
* #3972
* #3944
* #3969
* #3938
* #3965
* #3962
* #3916
* #3961
* #3960
* #3955
* #3958
* #3948
* #3957
* #3907
* #3952
* #3949
* #3951
* #3950
* #3946