### PR TITLE
refactor: Use sorting functions from `slices` instead of `sort`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,8 @@ linters:
           msg: "Use cmp.Equal instead of reflect.DeepEqual"
         - pattern: "^http\\.Method[A-Z][a-z]*$"
           msg: "Use string literals instead of http.Method constants (https://pkg.go.dev/net/http#pkg-constants)"
+        - pattern: ^sort\..*$
+          msg: "Use sorting functions from the slices package instead."
     gocritic:
       disable-all: true
       enabled-checks:

--- a/github/messages.go
+++ b/github/messages.go
@@ -19,11 +19,12 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"maps"
 	"mime"
 	"net/http"
 	"net/url"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -334,12 +335,7 @@ func ParseWebHook(messageType string, payload []byte) (any, error) {
 // MessageTypes returns a sorted list of all the known GitHub event type strings
 // supported by go-github.
 func MessageTypes() []string {
-	types := make([]string, 0, len(eventTypeMapping))
-	for t := range eventTypeMapping {
-		types = append(types, t)
-	}
-	sort.Strings(types)
-	return types
+	return slices.Sorted(maps.Keys(eventTypeMapping))
 }
 
 // EventForType returns an empty struct matching the specified GitHub event type.

--- a/tools/check-structfield-settings/main.go
+++ b/tools/check-structfield-settings/main.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"cmp"
 	"errors"
 	"flag"
 	"fmt"
@@ -21,7 +22,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/golangci/plugin-module-register/register"
@@ -278,8 +278,7 @@ func diffKeys(all, used map[string]bool) []string {
 			obsolete = append(obsolete, key)
 		}
 	}
-	slices.Sort(obsolete)
-	return obsolete
+	return slices.Sorted(slices.Values(obsolete))
 }
 
 func findDuplicates(values []string) map[string]int {
@@ -401,8 +400,8 @@ type listItem struct {
 }
 
 func appendSortedItems(lines []string, items []*listItem) []string {
-	sort.Slice(items, func(i, j int) bool {
-		return items[i].value < items[j].value
+	slices.SortFunc(items, func(a, b *listItem) int {
+		return cmp.Compare(a.value, b.value)
 	})
 	for _, item := range items {
 		lines = append(lines, item.line)


### PR DESCRIPTION
Because sorting functions from the `slices` package are easier to use than those in `sort`.