### PR TITLE
chore: Update `golangci-lint` and enable some revive rules

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,4 +1,4 @@
-version: v2.7.0
+version: v2.10.1 # should be in sync with script/setup-custom-gcl.sh
 plugins:
   - module: "github.com/google/go-github/v83/tools/fmtpercentv"
     path: ./tools/fmtpercentv

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,6 +71,10 @@ linters:
         - G104
         # int(os.Stdin.Fd())
         - G115
+        # false positive
+        - G704
+        # false positive on valid struct fields "AccessToken", "ClientSecret", "Secret", "Password"
+        - G117
     govet:
       enable-all: true
       disable:
@@ -126,8 +130,16 @@ linters:
         - name: filename-format
           arguments:
             - ^[_a-z][_a-z0-9]*.go$
+        - name: forbidden-call-in-wg-go
+        - name: identical-branches
+        - name: identical-ifelseif-branches
+        - name: identical-ifelseif-conditions
+        - name: identical-switch-branches
+        - name: identical-switch-conditions
+        - name: if-return
         - name: increment-decrement
         - name: indent-error-flow
+        - name: inefficient-map-lookup
         - name: package-comments
         - name: range
         - name: receiver-naming
@@ -138,9 +150,15 @@ linters:
         - name: unexported-naming
         - name: unexported-return
         - name: unnecessary-format
+        - name: unnecessary-if
+        - name: unnecessary-stmt
         - name: unreachable-code
         - name: unused-parameter
         - name: use-any
+        - name: use-errors-new
+        - name: use-fmt-print
+        - name: use-slices-sort
+        - name: use-waitgroup-go
         - name: var-declaration
         - name: var-naming
     staticcheck:
@@ -385,10 +403,10 @@ linters:
       - linters: [errcheck]
         text: Error return value of .(.*Close|fmt\.Fprint.*|fmt\.Scanf|os\.Remove(All)?). is not checked
 
-      # We don't care about file inclusion via variable in examples or internal tools.
+      # We don't care about gosec issues in examples or internal tools.
       - linters: [gosec]
         path: ^(example|tools)\/
-        text: 'G304: Potential file inclusion via variable'
+        text: '(G304|G705|G706)'
 
       # We don't run parallel integration tests
       - linters: [paralleltest, tparallel]

--- a/github/github.go
+++ b/github/github.go
@@ -744,8 +744,7 @@ func (r *Response) populatePageValues() {
 
 			if cursor := q.Get("cursor"); cursor != "" {
 				for _, segment := range segments[1:] {
-					switch strings.TrimSpace(segment) {
-					case `rel="next"`:
+					if strings.TrimSpace(segment) == `rel="next"` {
 						r.Cursor = cursor
 					}
 				}

--- a/github/orgs_network_configurations.go
+++ b/github/orgs_network_configurations.go
@@ -89,10 +89,7 @@ func validateNetworkConfigurationRequest(req NetworkConfigurationRequest) error 
 	}
 
 	networkIDs := req.NetworkSettingsIDs
-	if err := validateNetworkSettingsID(networkIDs); err != nil {
-		return err
-	}
-	return nil
+	return validateNetworkSettingsID(networkIDs)
 }
 
 // NetworkConfigurationRequest represents a request to create or update a network configuration for an organization.

--- a/github/rules.go
+++ b/github/rules.go
@@ -1239,7 +1239,14 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 	r.Type = w.Type
 
 	switch r.Type {
-	case RulesetRuleTypeCreation:
+	case RulesetRuleTypeCreation,
+		RulesetRuleTypeDeletion,
+		RulesetRuleTypeRequiredLinearHistory,
+		RulesetRuleTypeRequiredSignatures,
+		RulesetRuleTypeNonFastForward,
+		RulesetRuleTypeRepositoryCreate,
+		RulesetRuleTypeRepositoryDelete,
+		RulesetRuleTypeRepositoryTransfer:
 		r.Parameters = nil
 	case RulesetRuleTypeUpdate:
 		p := &UpdateRuleParameters{}
@@ -1251,10 +1258,6 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 		}
 
 		r.Parameters = p
-	case RulesetRuleTypeDeletion:
-		r.Parameters = nil
-	case RulesetRuleTypeRequiredLinearHistory:
-		r.Parameters = nil
 	case RulesetRuleTypeMergeQueue:
 		p := &MergeQueueRuleParameters{}
 
@@ -1275,8 +1278,6 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 		}
 
 		r.Parameters = p
-	case RulesetRuleTypeRequiredSignatures:
-		r.Parameters = nil
 	case RulesetRuleTypePullRequest:
 		p := &PullRequestRuleParameters{}
 
@@ -1297,49 +1298,11 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 		}
 
 		r.Parameters = p
-	case RulesetRuleTypeNonFastForward:
-		r.Parameters = nil
-	case RulesetRuleTypeCommitMessagePattern:
-		p := &PatternRuleParameters{}
-
-		if w.Parameters != nil {
-			if err := json.Unmarshal(w.Parameters, p); err != nil {
-				return err
-			}
-		}
-
-		r.Parameters = p
-	case RulesetRuleTypeCommitAuthorEmailPattern:
-		p := &PatternRuleParameters{}
-
-		if w.Parameters != nil {
-			if err := json.Unmarshal(w.Parameters, p); err != nil {
-				return err
-			}
-		}
-
-		r.Parameters = p
-	case RulesetRuleTypeCommitterEmailPattern:
-		p := &PatternRuleParameters{}
-
-		if w.Parameters != nil {
-			if err := json.Unmarshal(w.Parameters, p); err != nil {
-				return err
-			}
-		}
-
-		r.Parameters = p
-	case RulesetRuleTypeBranchNamePattern:
-		p := &PatternRuleParameters{}
-
-		if w.Parameters != nil {
-			if err := json.Unmarshal(w.Parameters, p); err != nil {
-				return err
-			}
-		}
-
-		r.Parameters = p
-	case RulesetRuleTypeTagNamePattern:
+	case RulesetRuleTypeCommitMessagePattern,
+		RulesetRuleTypeCommitAuthorEmailPattern,
+		RulesetRuleTypeCommitterEmailPattern,
+		RulesetRuleTypeBranchNamePattern,
+		RulesetRuleTypeTagNamePattern:
 		p := &PatternRuleParameters{}
 
 		if w.Parameters != nil {
@@ -1419,10 +1382,6 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 		}
 
 		r.Parameters = p
-	case RulesetRuleTypeRepositoryCreate:
-		r.Parameters = nil
-	case RulesetRuleTypeRepositoryDelete:
-		r.Parameters = nil
 	case RulesetRuleTypeRepositoryName:
 		p := &SimplePatternRuleParameters{}
 
@@ -1433,8 +1392,6 @@ func (r *RepositoryRule) UnmarshalJSON(data []byte) error {
 		}
 
 		r.Parameters = p
-	case RulesetRuleTypeRepositoryTransfer:
-		r.Parameters = nil
 	case RulesetRuleTypeRepositoryVisibility:
 		p := &RepositoryVisibilityRuleParameters{}
 

--- a/github/search.go
+++ b/github/search.go
@@ -325,10 +325,7 @@ func (s *SearchService) search(ctx context.Context, searchType string, parameter
 	case "commits":
 		// Accept header for search commits preview endpoint
 		acceptHeaders = append(acceptHeaders, mediaTypeCommitSearchPreview)
-	case "topics":
-		// Accept header for search repositories based on topics preview endpoint
-		acceptHeaders = append(acceptHeaders, mediaTypeTopicsPreview)
-	case "repositories":
+	case "topics", "repositories":
 		// Accept header for search repositories based on topics preview endpoint
 		acceptHeaders = append(acceptHeaders, mediaTypeTopicsPreview)
 	case "issues":

--- a/script/setup-custom-gcl.sh
+++ b/script/setup-custom-gcl.sh
@@ -4,7 +4,8 @@
 
 set -e
 
-GOLANGCI_LINT_VERSION="2.9.0"
+# should be in sync with .custom-gcl.yml
+GOLANGCI_LINT_VERSION="2.10.1"
 
 # should in sync with fmt.sh and lint.sh
 BIN="$(pwd -P)"/bin

--- a/tools/fmtpercentv/fmtpercentv.go
+++ b/tools/fmtpercentv/fmtpercentv.go
@@ -52,8 +52,7 @@ func run(pass *analysis.Pass) (any, error) {
 				return false
 			}
 
-			switch t := n.(type) {
-			case *ast.CallExpr:
+			if t, ok := n.(*ast.CallExpr); ok {
 				checkCallExpr(t, t.Pos(), pass)
 			}
 

--- a/tools/sliceofpointers/sliceofpointers.go
+++ b/tools/sliceofpointers/sliceofpointers.go
@@ -52,8 +52,7 @@ func run(pass *analysis.Pass) (any, error) {
 				return false
 			}
 
-			switch t := n.(type) {
-			case *ast.ArrayType:
+			if t, ok := n.(*ast.ArrayType); ok {
 				checkArrayType(t, t.Pos(), pass)
 			}
 


### PR DESCRIPTION
Update golangci-lint to [v2.10.1](https://golangci-lint.run/docs/product/changelog/#v2101) and add some new [revive](https://revive.run/) rules.