### PR TITLE
docs: Fix documentation links

### DIFF
--- a/github/doc.go
+++ b/github/doc.go
@@ -150,7 +150,7 @@ recommended when making requests using short-lived credentials such as a
 GitHub App installation token.
 
 Learn more about GitHub conditional requests at
-https://docs.github.com/rest/overview/resources-in-the-rest-api#conditional-requests.
+https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#use-conditional-requests-if-appropriate.
 
 # Creating and Updating Resources
 

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -72,7 +72,7 @@ func ExampleRepositoriesService_CreateFile() {
 	// so you will need to modify the example to provide an oauth client to
 	// github.NewClient() instead of nil. See the following documentation for more
 	// information on how to authenticate with the client:
-	// https://pkg.go.dev/github.com/google/go-github/github#hdr-Authentication
+	// https://pkg.go.dev/github.com/google/go-github/v83/github#hdr-Authentication
 	client := github.NewClient(nil)
 
 	ctx := context.Background()
@@ -117,7 +117,7 @@ func ExamplePullRequestsService_Create() {
 	// so you will need to modify the example to provide an oauth client to
 	// github.NewClient() instead of nil. See the following documentation for more
 	// information on how to authenticate with the client:
-	// https://pkg.go.dev/github.com/google/go-github/github#hdr-Authentication
+	// https://pkg.go.dev/github.com/google/go-github/v83/github#hdr-Authentication
 	client := github.NewClient(nil)
 
 	newPR := &github.NewPullRequest{
@@ -146,7 +146,7 @@ func ExampleTeamsService_ListTeams() {
 	// the example to provide an oauth client to github.NewClient() instead of nil.
 	// See the following documentation for more information on how to authenticate
 	// with the client:
-	// https://pkg.go.dev/github.com/google/go-github/github#hdr-Authentication
+	// https://pkg.go.dev/github.com/google/go-github/v83/github#hdr-Authentication
 	client := github.NewClient(nil)
 
 	teamName := "Developers team"


### PR DESCRIPTION
Change links to the latest in `examples_test.go` and fix the link to GitHub conditional requests.