### PR TITLE
fix: Fix data race on Windows

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -636,7 +636,20 @@ func (c *Client) NewUploadRequest(urlStr string, reader io.Reader, size int64, m
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", u.String(), reader)
+	requestBody := reader
+	if reader != nil {
+		// Wrap the provided reader so transport code does not observe concrete body types
+		// (for example *os.File) and switch to platform-specific sendfile fast paths.
+		//
+		// Why this exists:
+		// race-enabled test runs on Windows have surfaced data races in the sendfile path
+		// while request read/write loops run concurrently. Hiding concrete type information
+		// keeps uploads on the generic io.Reader copy path, which is race-stable and preserves
+		// request semantics (same bytes, same headers, same content length).
+		requestBody = uploadRequestBodyReader{Reader: reader}
+	}
+
+	req, err := http.NewRequest("POST", u.String(), requestBody)
 	if err != nil {
 		return nil, err
 	}
@@ -656,6 +669,12 @@ func (c *Client) NewUploadRequest(urlStr string, reader io.Reader, size int64, m
 	}
 
 	return req, nil
+}
+
+// uploadRequestBodyReader intentionally wraps an io.Reader to hide concrete reader types.
+// See NewUploadRequest for why this prevents race-prone transport optimizations.
+type uploadRequestBodyReader struct {
+	io.Reader
 }
 
 // Response is a GitHub API response. This wraps the standard http.Response

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -30,6 +31,17 @@ const (
 	// to ensure relative URLs are used for all endpoints. See issue #752.
 	baseURLPath = "/api-v3"
 )
+
+// raceSafeTestConn wraps a net.Conn to hide concrete connection types such as *net.TCPConn.
+//
+// Go's HTTP transport may enable OS-level sendfile optimizations when it sees a concrete
+// TCP connection and an *os.File request body. Under the race detector on Windows, that
+// specific optimized path can trigger a known data race in internal polling structures.
+// Returning this wrapper from DialContext keeps behavior identical for tests while forcing
+// the transport onto the generic copy path, which is stable under -race.
+type raceSafeTestConn struct {
+	net.Conn
+}
 
 // setup sets up a test HTTP server along with a github.Client that is
 // configured to talk to that test server. Tests should register handlers on
@@ -57,8 +69,19 @@ func setup(t *testing.T) (client *Client, mux *http.ServeMux, serverURL string) 
 	// server is a test HTTP server used to provide mock API responses.
 	server := httptest.NewServer(apiHandler)
 
+	testDialer := &net.Dialer{Timeout: 30 * time.Second}
+
 	// Create a custom transport with isolated connection pool
 	transport := &http.Transport{
+		// Wrap dialed connections so transport does not take concrete-TCP sendfile fast paths
+		// that can race under Windows + -race in upload tests.
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := testDialer.DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			return &raceSafeTestConn{Conn: conn}, nil
+		},
 		// Controls connection reuse - false allows reuse, true forces new connections for each request
 		DisableKeepAlives: false,
 		// Maximum concurrent connections per host (active + idle)


### PR DESCRIPTION
This is an AI-assisted fix for the data race detected during the GitHub Actions workflows in #4050.
Since this is not an easy data race to understand (at least for me), I asked it to add comments as to why the changes being made are necessary to prevent the data race both in the CI/CD pipeline and potentially when using the library in production.

cc: @stevehipwell - @alexandear - @zyfy29 - @Not-Dhananjay-Mishra - @munlicode 

The original data race is below for posterity:

<details>

From #4050 CI/CD:

```
Run if [ -n "" ]; then
  if [ -n "" ]; then
    script/test.sh -race -covermode atomic -coverprofile coverage.txt ./...
    exit
  fi
  script/test.sh -race -covermode atomic ./...
  shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
  env:
    GO111MODULE: on
    GOTOOLCHAIN: local
testing .
go: downloading github.com/google/go-querystring v1.2.0
go: downloading github.com/google/go-cmp v0.7.0
==================
WARNING: DATA RACE
Read at 0x00c005271b40 by goroutine 8856:
  internal/poll.(*FD).execIO()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/internal/poll/fd_windows.go:269 +0x284
  internal/poll.(*FD).Read()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/internal/poll/fd_windows.go:586 +0x353
  net.(*netFD).Read()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/fd_posix.go:68 +0x4a
  net.(*conn).Read()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/net.go:196 +0xac
  net/http.(*persistConn).Read()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/http/transport.go:2174 +0x232
  bufio.(*Reader).fill()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/bufio/bufio.go:113 +0x2a3
  bufio.(*Reader).Peek()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/bufio/bufio.go:152 +0xaf
  net/http.(*persistConn).readLoop()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/http/transport.go:2330 +0x31a
  net/http.(*Transport).dialConn.gowrap2()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/http/transport.go:1994 +0x2e

Previous write at 0x00c005271b40 by goroutine 8857:
  internal/poll.(*FD).setOffset()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/internal/poll/fd_windows.go:402 +0x6b9
  internal/poll.SendFile()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/internal/poll/sendfile_windows.go:71 +0x697
  net.sendFile.func1()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/sendfile.go:48 +0x64
  internal/poll.(*FD).RawRead()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/internal/poll/fd_windows.go:1275 +0x1ad
  os.(*rawConn).Read()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/os/rawconn.go:31 +0xb2
  net.sendFile()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/sendfile.go:47 +0x3cd
  net.(*TCPConn).readFrom()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/tcpsock_posix.go:51 +0x5b
  net.(*TCPConn).ReadFrom()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/tcpsock.go:165 +0x64
  io.copyBuffer()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/io/io.go:415 +0x20e
  io.Copy()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/io/io.go:388 +0x95
  net/http.persistConnWriter.ReadFrom()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/http/transport.go:2019 +0x12
  bufio.(*Writer).ReadFrom()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/bufio/bufio.go:797 +0x361
  io.copyBuffer()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/io/io.go:415 +0x20e
  io.CopyBuffer()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/io/io.go:402 +0x8f
  net/http.(*transferWriter).doBodyCopy()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/http/transfer.go:417 +0x13a
  net/http.(*transferWriter).writeBody()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/http/transfer.go:372 +0x764
  net/http.(*Request).write()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/http/request.go:762 +0x1376
  net/http.(*persistConn).writeLoop()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/http/transport.go:2655 +0x35d
  net/http.(*Transport).dialConn.gowrap3()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/http/transport.go:1995 +0x2e

Goroutine 8856 (running) created at:
  net/http.(*Transport).dialConn()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/http/transport.go:1994 +0x2fb0
  net/http.(*Transport).dialConnFor()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/http/transport.go:1648 +0x124
  net/http.(*Transport).startDialConnForLocked.func1()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/http/transport.go:1629 +0x3c

Goroutine 8857 (running) created at:
  net/http.(*Transport).dialConn()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/http/transport.go:1995 +0x303c
  net/http.(*Transport).dialConnFor()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/http/transport.go:1648 +0x124
  net/http.(*Transport).startDialConnForLocked.func1()
      C:/hostedtoolcache/windows/go/1.26.0/x64/src/net/http/transport.go:1629 +0x3c
==================
--- FAIL: TestRepositoriesService_DeleteFile (0.02s)
    testing.go:1712: race detected during execution of test
--- FAIL: TestRepositoriesService_TestHook (0.03s)
    testing.go:1712: race detected during execution of test
--- FAIL: TestRepositoriesService_RedeliverHookDelivery (0.03s)
    testing.go:1712: race detected during execution of test
--- FAIL: TestRepositoriesService_UploadReleaseAsset (0.32s)
    testing.go:1712: race detected during execution of test
```

</details>