### PR TITLE
docs: Fix grammar in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ func main() {
 
 `go-githubauth` implements a set of `oauth2.TokenSource` to be used with `oauth2.Client`. An `oauth2.Client` can be injected into the `github.Client` to authenticate requests.
 
-Other example using `go-githubauth`:
+Another example using `go-githubauth`:
 
 ```go
 package main


### PR DESCRIPTION
Fixed a grammatical inconsistency in README.md.

Changed:
"Other example using go-githubauth :"
to
"Another example using go-githubauth:"

No functional changes were made.