### PR TITLE
fix!: Change `id` from `int64` to `string` in `ActivityService.MarkThreadDone`

### DIFF
--- a/github/activity_notifications.go
+++ b/github/activity_notifications.go
@@ -186,7 +186,7 @@ func (s *ActivityService) MarkThreadRead(ctx context.Context, id string) (*Respo
 // GitHub API docs: https://docs.github.com/rest/activity/notifications#mark-a-thread-as-done
 //
 //meta:operation DELETE /notifications/threads/{thread_id}
-func (s *ActivityService) MarkThreadDone(ctx context.Context, id int64) (*Response, error) {
+func (s *ActivityService) MarkThreadDone(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("notifications/threads/%v", id)
 
 	req, err := s.client.NewRequest("DELETE", u, nil)

--- a/github/activity_notifications_test.go
+++ b/github/activity_notifications_test.go
@@ -255,19 +255,19 @@ func TestActivityService_MarkThreadDone(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	_, err := client.Activity.MarkThreadDone(ctx, 1)
+	_, err := client.Activity.MarkThreadDone(ctx, "1")
 	if err != nil {
 		t.Errorf("Activity.MarkThreadDone returned error: %v", err)
 	}
 
 	const methodName = "MarkThreadDone"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Activity.MarkThreadDone(ctx, 0)
+		_, err = client.Activity.MarkThreadDone(ctx, "\n")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Activity.MarkThreadDone(ctx, 1)
+		return client.Activity.MarkThreadDone(ctx, "1")
 	})
 }
 


### PR DESCRIPTION
BREAKING CHANGE: `ActivityService.MarkThreadDone` accepts `string` `id` instead of `int64`.

---

This is for consistency with `GetThread`, `MarkThreadRead`, `GetThreadSubscription`, which all accept an id as `string` and not `int64`. `ListNotifications` and `ListRepositoryNotifications` return `Notification` with `ID` as `string`.

Fixes #3269