### PR TITLE
feat: add ListTeamsOptions with type filter for ListTeams

### DIFF
--- a/github/github-iterators.go
+++ b/github/github-iterators.go
@@ -6921,11 +6921,11 @@ func (s *TeamsService) ListTeamReposBySlugIter(ctx context.Context, org string, 
 }
 
 // ListTeamsIter returns an iterator that paginates through all results of ListTeams.
-func (s *TeamsService) ListTeamsIter(ctx context.Context, org string, opts *ListOptions) iter.Seq2[*Team, error] {
+func (s *TeamsService) ListTeamsIter(ctx context.Context, org string, opts *ListTeamsOptions) iter.Seq2[*Team, error] {
 	return func(yield func(*Team, error) bool) {
 		// Create a copy of opts to avoid mutating the caller's struct
 		if opts == nil {
-			opts = &ListOptions{}
+			opts = &ListTeamsOptions{}
 		} else {
 			opts = Ptr(*opts)
 		}

--- a/github/github-iterators_test.go
+++ b/github/github-iterators_test.go
@@ -15456,7 +15456,7 @@ func TestTeamsService_ListTeamsIter(t *testing.T) {
 		t.Errorf("client.Teams.ListTeamsIter call 1 got %v items; want %v", gotItems, want)
 	}
 
-	opts := &ListOptions{}
+	opts := &ListTeamsOptions{}
 	iter = client.Teams.ListTeamsIter(t.Context(), "", opts)
 	gotItems = 0
 	for _, err := range iter {

--- a/github/teams.go
+++ b/github/teams.go
@@ -90,12 +90,23 @@ func (i Invitation) String() string {
 	return Stringify(i)
 }
 
+// ListTeamsOptions specifies the optional parameters to the TeamsService.ListTeams method.
+type ListTeamsOptions struct {
+	// Type filters the list of teams by ownership type. Possible values are:
+	//   "all" - returns all teams (default)
+	//   "organization" - returns only organization-level teams
+	//   "enterprise" - returns only enterprise-level teams
+	Type string `url:"type,omitempty"`
+
+	ListOptions
+}
+
 // ListTeams lists all of the teams for an organization.
 //
 // GitHub API docs: https://docs.github.com/rest/teams/teams#list-teams
 //
 //meta:operation GET /orgs/{org}/teams
-func (s *TeamsService) ListTeams(ctx context.Context, org string, opts *ListOptions) ([]*Team, *Response, error) {
+func (s *TeamsService) ListTeams(ctx context.Context, org string, opts *ListTeamsOptions) ([]*Team, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams", org)
 	u, err := addOptions(u, opts)
 	if err != nil {

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -26,7 +26,7 @@ func TestTeamsService_ListTeams(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	opt := &ListOptions{Page: 2}
+	opt := &ListTeamsOptions{ListOptions: ListOptions{Page: 2}}
 	ctx := t.Context()
 	teams, _, err := client.Teams.ListTeams(ctx, "o", opt)
 	if err != nil {
@@ -51,6 +51,29 @@ func TestTeamsService_ListTeams(t *testing.T) {
 		}
 		return resp, err
 	})
+}
+
+func TestTeamsService_ListTeams_withTypeFilter(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/teams", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"type": "enterprise"})
+		fmt.Fprint(w, `[{"id":1,"type":"enterprise"}]`)
+	})
+
+	opt := &ListTeamsOptions{Type: "enterprise"}
+	ctx := t.Context()
+	teams, _, err := client.Teams.ListTeams(ctx, "o", opt)
+	if err != nil {
+		t.Errorf("Teams.ListTeams returned error: %v", err)
+	}
+
+	want := []*Team{{ID: Ptr(int64(1)), Type: Ptr("enterprise")}}
+	if !cmp.Equal(teams, want) {
+		t.Errorf("Teams.ListTeams returned %+v, want %+v", teams, want)
+	}
 }
 
 func TestTeamsService_ListTeams_invalidOrg(t *testing.T) {


### PR DESCRIPTION
## Summary

The GitHub Teams API now returns a `type` field and supports filtering teams by ownership type to distinguish between organization-level and enterprise-level teams (see [changelog announcement](https://github.blog/changelog/2026-02-23-enterprise-team-support-in-organization-apis/)).

The `type` field was already added to the `Team` struct. This PR adds the ability to **filter by team type** when listing teams:

### Changes

- **`ListTeamsOptions`** — new struct embedding `ListOptions` with a `Type` field accepting:
  - `"all"` — returns all teams (default)
  - `"organization"` — returns only organization-level teams
  - `"enterprise"` — returns only enterprise-level teams
- **`ListTeams`** updated to accept `*ListTeamsOptions` instead of `*ListOptions`
- **`ListTeamsIter`** updated to match
- Tests added for the new type filter behavior

### Usage

```go
// List only enterprise teams
teams, _, err := client.Teams.ListTeams(ctx, "my-org", &github.ListTeamsOptions{
    Type: "enterprise",
})
```

Closes #4033

Made with [Cursor](https://cursor.com)