### PR TITLE
chore: Speed up linting

### DIFF
--- a/script/lint.sh
+++ b/script/lint.sh
@@ -8,7 +8,6 @@ set -e
 CUSTOM_GCL="$(script/setup-custom-gcl.sh)"
 
 CDPATH="" cd -- "$(dirname -- "$0")/.."
-BIN="$(pwd -P)"/bin
 
 EXIT_CODE=0
 
@@ -17,16 +16,48 @@ fail() {
   EXIT_CODE=1
 }
 
-MOD_DIRS="$(git ls-files '*go.mod' | xargs dirname | sort)"
+MOD_DIRS="$(git ls-files '*go.mod' | xargs dirname | sort -u)"
 
-for dir in $MOD_DIRS; do
-  [ "$dir" = "example/newreposecretwithlibsodium" ] && continue
-  echo linting "$dir"
+# Number of module lint jobs to run concurrently.
+# Override with LINT_JOBS, otherwise use detected CPU count.
+: "${LINT_JOBS:=$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)}"
+
+LINT_DIRS="$(printf '%s\n' "$MOD_DIRS" | grep -v '^example/newreposecretwithlibsodium$')"
+
+LINT_FAILED=0
+RUNNING=0
+PIDS=""
+
+wait_pids() {
+  for pid in $PIDS; do
+    if ! wait "$pid"; then
+      LINT_FAILED=1
+    fi
+  done
+  PIDS=""
+  RUNNING=0
+}
+
+for dir in $LINT_DIRS; do
   (
+    echo linting "$dir"
     cd "$dir"
     "$CUSTOM_GCL" run
-  ) || fail "failed linting $dir"
+  ) &
+
+  PIDS="$PIDS $!"
+  RUNNING=$((RUNNING + 1))
+
+  if [ "$RUNNING" -ge "$LINT_JOBS" ]; then
+    wait_pids
+  fi
 done
+
+wait_pids
+
+if [ "$LINT_FAILED" -ne 0 ]; then
+  fail "failed linting one or more module directories"
+fi
 
 if [ -n "$CHECK_GITHUB_OPENAPI" ]; then
   echo validating openapi_operations.yaml
@@ -35,7 +66,5 @@ fi
 
 echo validating generated files
 script/generate.sh --check || fail "failed validating generated files"
-
-[ -z "$FAILED" ] || exit 1
 
 exit "$EXIT_CODE"

--- a/script/setup-custom-gcl.sh
+++ b/script/setup-custom-gcl.sh
@@ -5,7 +5,7 @@
 set -e
 
 # should be in sync with .custom-gcl.yml
-GOLANGCI_LINT_VERSION="2.10.1"
+GOLANGCI_LINT_VERSION="v2.10.1"
 
 # should in sync with fmt.sh and lint.sh
 BIN="$(pwd -P)"/bin
@@ -13,8 +13,8 @@ BIN="$(pwd -P)"/bin
 mkdir -p "$BIN"
 
 # install golangci-lint and custom-gcl in ./bin if they don't exist with the correct version
-if ! "$BIN"/custom-gcl --version 2> /dev/null | grep -q "$GOLANGCI_LINT_VERSION"; then
-  GOBIN="$BIN" go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$GOLANGCI_LINT_VERSION"
+if ! "$BIN"/custom-gcl version --short 2> /dev/null | grep -q "$GOLANGCI_LINT_VERSION"; then
+  curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b "$BIN" "$GOLANGCI_LINT_VERSION"
   "$BIN"/golangci-lint custom --name custom-gcl --destination "$BIN"
 fi
 


### PR DESCRIPTION
I propose parallelizing golangci-lint runs on modules. This can slightly speed up the lint step.

Lint step on my machine (without cache): before 60s, after 46s.


|  | Before | After | Change |
| -- | -- | -- | -- |
|Wall clock | 59.8s | 45.7s | -24% |
|CPU utilization | 375% | 522% | +147% |
|User CPU | 114.5s | 118.3s | ~same |
|System CPU | 110.0s | 120.5s | ~same |

Updates #4070

Before:

```console
./bin/custom-gcl cache clean
❯ time ./script/lint.sh
linting .
0 issues.
linting example
/Users/alexandear/src/github.com/google/go-github/example
0 issues.
linting otel
/Users/alexandear/src/github.com/google/go-github/otel
0 issues.
linting scrape
/Users/alexandear/src/github.com/google/go-github/scrape
0 issues.
linting tools
/Users/alexandear/src/github.com/google/go-github/tools
0 issues.
linting tools/check-structfield-settings
/Users/alexandear/src/github.com/google/go-github/tools/check-structfield-settings
0 issues.
linting tools/fmtpercentv
/Users/alexandear/src/github.com/google/go-github/tools/fmtpercentv
0 issues.
linting tools/sliceofpointers
/Users/alexandear/src/github.com/google/go-github/tools/sliceofpointers
0 issues.
linting tools/structfield
/Users/alexandear/src/github.com/google/go-github/tools/structfield
0 issues.
validating generated files
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.A7dIZ4R7N4/tools/metadata
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.A7dIZ4R7N4/example
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.A7dIZ4R7N4/example/newreposecretwithlibsodium
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.A7dIZ4R7N4/otel
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.A7dIZ4R7N4/scrape
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.A7dIZ4R7N4/tools
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.A7dIZ4R7N4/tools/check-structfield-settings
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.A7dIZ4R7N4/tools/fmtpercentv
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.A7dIZ4R7N4/tools/sliceofpointers
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.A7dIZ4R7N4/tools/structfield
./script/lint.sh  114.55s user 109.97s system 375% cpu 59.842 total
```

After:
```console
❯ git switch chore/improve-setup-custom-gcl
Switched to branch 'chore/improve-setup-custom-gcl'
Your branch is up to date with 'origin/chore/improve-setup-custom-gcl'.
❯ ./bin/custom-gcl cache clean
❯ time ./script/lint.sh
linting .
linting example
/Users/alexandear/src/github.com/google/go-github/example
linting otel
/Users/alexandear/src/github.com/google/go-github/otel
linting scrape
/Users/alexandear/src/github.com/google/go-github/scrape
linting tools
/Users/alexandear/src/github.com/google/go-github/tools
linting tools/check-structfield-settings
/Users/alexandear/src/github.com/google/go-github/tools/check-structfield-settings
linting tools/fmtpercentv
/Users/alexandear/src/github.com/google/go-github/tools/fmtpercentv
linting tools/sliceofpointers
/Users/alexandear/src/github.com/google/go-github/tools/sliceofpointers
linting tools/structfield
/Users/alexandear/src/github.com/google/go-github/tools/structfield
0 issues.
0 issues.
0 issues.
0 issues.
0 issues.
0 issues.
0 issues.
0 issues.
0 issues.
validating generated files
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.LTjN6a1alw/tools/metadata
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.LTjN6a1alw/example
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.LTjN6a1alw/example/newreposecretwithlibsodium
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.LTjN6a1alw/otel
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.LTjN6a1alw/scrape
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.LTjN6a1alw/tools
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.LTjN6a1alw/tools/check-structfield-settings
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.LTjN6a1alw/tools/fmtpercentv
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.LTjN6a1alw/tools/sliceofpointers
/var/folders/q0/5_z6pvw574z1c0zcrr2xvk0r0000gn/T/tmp.LTjN6a1alw/tools/structfield
./script/lint.sh  118.34s user 120.52s system 522% cpu 45.716 total
```