### PR TITLE
feat: Make `script/lint.sh` output simpler to read

### DIFF
--- a/script/lint.sh
+++ b/script/lint.sh
@@ -41,7 +41,7 @@ trap 'rm -rf "$LOG_DIR"' EXIT
 
 # --- Helper Functions ---
 print_header() {
-    printf "${BOLD}%s${NC}\n\n" "$1"
+  printf "${BOLD}%s${NC}\n\n" "$1"
 }
 
 
@@ -91,26 +91,26 @@ wait_pids
 if [ -n "$CHECK_GITHUB_OPENAPI" ]; then
   print_header "Validating openapi_operations.yaml"
   if script/metadata.sh update-openapi --validate; then
-      printf "${GREEN}✔ openapi_operations.yaml is valid${NC}\n"
+    printf "${GREEN}✔ openapi_operations.yaml is valid${NC}\n"
   else
-      printf "${RED}✘ openapi_operations.yaml validation failed${NC}\n"
-      fail
+    printf "${RED}✘ openapi_operations.yaml validation failed${NC}\n"
+    fail
   fi
 fi
 
 print_header "Validating generated files"
 if script/generate.sh --check; then
-    printf "${GREEN}✔ Generated files are up to date${NC}\n"
+  printf "${GREEN}✔ Generated files are up to date${NC}\n"
 else
-    printf "${RED}✘ Generated files out of sync${NC}\n"
-    fail
+  printf "${RED}✘ Generated files out of sync${NC}\n"
+  fail
 fi
 
 # --- Final Summary ---
 printf -- "----------------------------\n"
 SUMMARY_COLOR="$GREEN"
 if [ "$FAILED_COUNT" -gt 0 ]; then
-    SUMMARY_COLOR="$RED"
+  SUMMARY_COLOR="$RED"
 fi
 
 printf "%bLinting: issues found in %d module directories.%b\n" "$SUMMARY_COLOR" "$FAILED_COUNT" "$NC"


### PR DESCRIPTION
Relates to: #4070.
Updates: #4071.

Turned output into:

# From
<img width="1632" height="605" alt="image" src="https://github.com/user-attachments/assets/998c32a6-d2d9-41c6-b613-8c81c43dddf4" />

# After
## Success
<img width="1211" height="502" alt="image" src="https://github.com/user-attachments/assets/171123ba-d137-4877-a670-76ce1d72f3d0" />

## Error
<img width="1225" height="862" alt="image" src="https://github.com/user-attachments/assets/e92e61b0-4333-4fa7-88f9-04582de24f95" />

# Performance
|  Metric  | Before | After | Delta |
|-------------|-----------|---------|---------|
| Real (Mean) | 33.998s |  30.506s | -3.49s |
| User (CPU) | 54.108s |  52.494 s | -1.61s |
| System (OS) | 13.815s |  13.074s | -0.74s |

## Command
```
 ./bin/custom-gcl cache clean && hyperfine -n 5 --ignore-failure --show-output --warmup 1 './script/lint.sh'
```
 