### PR TITLE
test: Add fuzz test for `ParseWebHook`

### DIFF
--- a/github/fuzz_messages_test.go
+++ b/github/fuzz_messages_test.go
@@ -12,7 +12,14 @@ import (
 )
 
 // FuzzParseWebHook tests ParseWebHook against arbitrary event types and payloads.
-// It verifies that no input causes a panic or nil pointer dereference.
+// It verifies that no input triggers a panic or nil pointer dereference.
+//
+// This fuzz test is intended for integration with OSS-Fuzz (https://google.github.io/oss-fuzz/)
+// for continuous fuzzing in the cloud.
+//
+// To run:
+//
+//	go test -fuzz=^FuzzParseWebHook$ -fuzztime=30s .
 func FuzzParseWebHook(f *testing.F) {
 	seeds := []struct {
 		eventType string


### PR DESCRIPTION
Add a native Go fuzz target for ParseWebHook to improve robustness
and support future OSS-Fuzz integration.

Seeds all known event types via MessageTypes() and EventForType()
to maximize coverage of valid JSON decoding paths.
The fuzzer verifies that no input triggers a panic or nil pointer dereference.

To run:

    go test -fuzz=^FuzzParseWebHook$ -fuzztime=30s .