### PR TITLE
chore: Remove duplicated formatters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -421,9 +421,7 @@ issues:
 formatters:
   enable:
     - gci
-    - gofmt
     - gofumpt
-    - goimports
   settings:
     gofumpt:
       extra-rules: true


### PR DESCRIPTION
The formatters `gofmt` and `goimports` can be removed because we have more powerful `gofumpt` and `gci`.

Updates #4070