### PR TITLE
fix: Use `Cursor` pagination for `*.ListHookDeliveriesIter`

### DIFF
--- a/github/gen-iterators.go
+++ b/github/gen-iterators.go
@@ -121,6 +121,7 @@ type method struct {
 	UseListOptions       bool
 	UsePage              bool
 	UseAfter             bool
+	UseCursor            bool
 	WrappedItemsField    string
 	TestJSON1            string
 	TestJSON2            string
@@ -143,6 +144,15 @@ type methodInfo struct {
 	UseListOptions       bool
 	UsePage              bool
 	UseAfter             bool
+	UseCursor            bool
+}
+
+// useCursorPagination identifies method names that require `Cursor` pagination
+// instead of using `After`.
+var useCursorPagination = map[string]bool{
+	"AppsService.ListHookDeliveries":          true,
+	"OrganizationsService.ListHookDeliveries": true,
+	"RepositoriesService.ListHookDeliveries":  true,
 }
 
 // customTestJSON maps method names to the JSON response they expect in tests.
@@ -391,13 +401,18 @@ func (t *templateData) collectMethodInfo(fd *ast.FuncDecl) (*methodInfo, bool) {
 	useListOptions := t.hasListOptions(optsType)
 	usePage := t.hasIntPage(optsType)
 	useAfter := t.hasStringAfter(optsType)
+	recType := strings.TrimPrefix(recvType, "*")
+	var useCursor bool
+	if useCursorPagination[recType+"."+fd.Name.Name] {
+		useCursor = true
+		useAfter = false
+	}
 
-	if !useListCursorOptions && !useListOptions && !usePage && !useAfter {
+	if !useListCursorOptions && !useListOptions && !usePage && !useAfter && !useCursor {
 		logf("Skipping %v.%v: opts %v does not have ListCursorOptions, ListOptions, Page int, or After string", recvType, fd.Name.Name, optsType)
 		return nil, false
 	}
 
-	recType := strings.TrimPrefix(recvType, "*")
 	clientField := strings.TrimSuffix(recType, "Service")
 	if clientField == "Migration" {
 		clientField = "Migrations"
@@ -422,6 +437,7 @@ func (t *templateData) collectMethodInfo(fd *ast.FuncDecl) (*methodInfo, bool) {
 		UseListOptions:       useListOptions,
 		UsePage:              usePage,
 		UseAfter:             useAfter,
+		UseCursor:            useCursor,
 	}, true
 }
 
@@ -457,6 +473,7 @@ func (t *templateData) processReturnArrayType(fd *ast.FuncDecl, sliceRet *ast.Ar
 		UseListOptions:       methodInfo.UseListOptions,
 		UsePage:              methodInfo.UsePage,
 		UseAfter:             methodInfo.UseAfter,
+		UseCursor:            methodInfo.UseCursor,
 		TestJSON1:            testJSON1,
 		TestJSON2:            testJSON2,
 		TestJSON3:            testJSON3,
@@ -514,6 +531,7 @@ func (t *templateData) processReturnStarExpr(fd *ast.FuncDecl, starRet *ast.Star
 		UseListOptions:       methodInfo.UseListOptions,
 		UsePage:              methodInfo.UsePage,
 		UseAfter:             methodInfo.UseAfter,
+		UseCursor:            methodInfo.UseCursor,
 		WrappedItemsField:    itemsField,
 		TestJSON1:            testJSON1,
 		TestJSON2:            testJSON2,
@@ -669,6 +687,11 @@ func ({{.RecvVar}} *{{.RecvType}}) {{.IterMethod}}({{.Args}}) iter.Seq2[{{.Retur
 				break
 			}
 			{{.OptsName}}.After = resp.After
+			{{else if .UseCursor}}
+			if resp.Cursor == "" {
+				break
+			}
+			{{.OptsName}}.Cursor = resp.Cursor
 			{{end -}}
 		}
 	}
@@ -694,7 +717,9 @@ func Test{{.RecvType}}_{{.IterMethod}}(t *testing.T) {
 		callNum++
 		switch callNum {
 		case 1:
-			{{- if or .UseListCursorOptions .UseAfter}}
+			{{- if .UseCursor}}
+			w.Header().Set("Link", ` + "`" + `<https://api.github.com/?cursor=yo>; rel="next"` + "`" + `)
+			{{else if or .UseListCursorOptions .UseAfter}}
 			w.Header().Set("Link", ` + "`" + `<https://api.github.com/?after=yo>; rel="next"` + "`" + `)
 			{{else}}
 			w.Header().Set("Link", ` + "`" + `<https://api.github.com/?page=1>; rel="next"` + "`" + `)

--- a/github/github-iterators.go
+++ b/github/github-iterators.go
@@ -1486,10 +1486,10 @@ func (s *AppsService) ListHookDeliveriesIter(ctx context.Context, opts *ListCurs
 				}
 			}
 
-			if resp.After == "" {
+			if resp.Cursor == "" {
 				break
 			}
-			opts.After = resp.After
+			opts.Cursor = resp.Cursor
 		}
 	}
 }
@@ -4234,10 +4234,10 @@ func (s *OrganizationsService) ListHookDeliveriesIter(ctx context.Context, org s
 				}
 			}
 
-			if resp.After == "" {
+			if resp.Cursor == "" {
 				break
 			}
-			opts.After = resp.After
+			opts.Cursor = resp.Cursor
 		}
 	}
 }
@@ -5878,10 +5878,10 @@ func (s *RepositoriesService) ListHookDeliveriesIter(ctx context.Context, owner 
 				}
 			}
 
-			if resp.After == "" {
+			if resp.Cursor == "" {
 				break
 			}
-			opts.After = resp.After
+			opts.Cursor = resp.Cursor
 		}
 	}
 }

--- a/github/github-iterators_test.go
+++ b/github/github-iterators_test.go
@@ -3119,7 +3119,7 @@ func TestAppsService_ListHookDeliveriesIter(t *testing.T) {
 		callNum++
 		switch callNum {
 		case 1:
-			w.Header().Set("Link", `<https://api.github.com/?after=yo>; rel="next"`)
+			w.Header().Set("Link", `<https://api.github.com/?cursor=yo>; rel="next"`)
 			fmt.Fprint(w, `[{},{},{}]`)
 		case 2:
 			fmt.Fprint(w, `[{},{},{},{}]`)
@@ -9239,7 +9239,7 @@ func TestOrganizationsService_ListHookDeliveriesIter(t *testing.T) {
 		callNum++
 		switch callNum {
 		case 1:
-			w.Header().Set("Link", `<https://api.github.com/?after=yo>; rel="next"`)
+			w.Header().Set("Link", `<https://api.github.com/?cursor=yo>; rel="next"`)
 			fmt.Fprint(w, `[{},{},{}]`)
 		case 2:
 			fmt.Fprint(w, `[{},{},{},{}]`)
@@ -12983,7 +12983,7 @@ func TestRepositoriesService_ListHookDeliveriesIter(t *testing.T) {
 		callNum++
 		switch callNum {
 		case 1:
-			w.Header().Set("Link", `<https://api.github.com/?after=yo>; rel="next"`)
+			w.Header().Set("Link", `<https://api.github.com/?cursor=yo>; rel="next"`)
 			fmt.Fprint(w, `[{},{},{}]`)
 		case 2:
 			fmt.Fprint(w, `[{},{},{},{}]`)


### PR DESCRIPTION
Fixes: #4095.

cc: @stevehipwell - @alexandear - @zyfy29 - @Not-Dhananjay-Mishra - @munlicode 