### PR TITLE
feat: Add `NetworkConfigurationID` and `HostedRunnersURL` to enterprise runner group types

### DIFF
--- a/github/enterprise_actions_runner_groups.go
+++ b/github/enterprise_actions_runner_groups.go
@@ -24,6 +24,8 @@ type EnterpriseRunnerGroup struct {
 	Default                      *bool    `json:"default,omitempty"`
 	SelectedOrganizationsURL     *string  `json:"selected_organizations_url,omitempty"`
 	RunnersURL                   *string  `json:"runners_url,omitempty"`
+	HostedRunnersURL             *string  `json:"hosted_runners_url,omitempty"`
+	NetworkConfigurationID       *string  `json:"network_configuration_id,omitempty"`
 	Inherited                    *bool    `json:"inherited,omitempty"`
 	AllowsPublicRepositories     *bool    `json:"allows_public_repositories,omitempty"`
 	RestrictedToWorkflows        *bool    `json:"restricted_to_workflows,omitempty"`
@@ -51,6 +53,8 @@ type CreateEnterpriseRunnerGroupRequest struct {
 	RestrictedToWorkflows *bool `json:"restricted_to_workflows,omitempty"`
 	// List of workflows the runner group should be allowed to run. This setting will be ignored unless RestrictedToWorkflows is set to true.
 	SelectedWorkflows []string `json:"selected_workflows,omitempty"`
+	// The identifier of a hosted compute network configuration.
+	NetworkConfigurationID *string `json:"network_configuration_id,omitempty"`
 }
 
 // UpdateEnterpriseRunnerGroupRequest represents a request to update a Runner group for an enterprise.
@@ -60,6 +64,7 @@ type UpdateEnterpriseRunnerGroupRequest struct {
 	AllowsPublicRepositories *bool    `json:"allows_public_repositories,omitempty"`
 	RestrictedToWorkflows    *bool    `json:"restricted_to_workflows,omitempty"`
 	SelectedWorkflows        []string `json:"selected_workflows,omitempty"`
+	NetworkConfigurationID   *string  `json:"network_configuration_id,omitempty"`
 }
 
 // SetOrgAccessRunnerGroupRequest represents a request to replace the list of organizations

--- a/github/enterprise_actions_runner_groups_test.go
+++ b/github/enterprise_actions_runner_groups_test.go
@@ -541,6 +541,8 @@ func TestEnterpriseRunnerGroup_Marshal(t *testing.T) {
 		Default:                  Ptr(true),
 		SelectedOrganizationsURL: Ptr("s"),
 		RunnersURL:               Ptr("r"),
+		HostedRunnersURL:         Ptr("h"),
+		NetworkConfigurationID:   Ptr("nc"),
 		Inherited:                Ptr(true),
 		AllowsPublicRepositories: Ptr(true),
 		RestrictedToWorkflows:    Ptr(false),
@@ -553,6 +555,8 @@ func TestEnterpriseRunnerGroup_Marshal(t *testing.T) {
 		"default": true,
 		"selected_organizations_url": "s",
 		"runners_url": "r",
+		"hosted_runners_url": "h",
+		"network_configuration_id": "nc",
 		"inherited": true,
 		"allows_public_repositories": true,
 		"restricted_to_workflows": false
@@ -575,6 +579,8 @@ func TestEnterpriseRunnerGroups_Marshal(t *testing.T) {
 				Default:                  Ptr(true),
 				SelectedOrganizationsURL: Ptr("s"),
 				RunnersURL:               Ptr("r"),
+				HostedRunnersURL:         Ptr("h"),
+				NetworkConfigurationID:   Ptr("nc"),
 				Inherited:                Ptr(true),
 				AllowsPublicRepositories: Ptr(true),
 				RestrictedToWorkflows:    Ptr(false),
@@ -591,6 +597,8 @@ func TestEnterpriseRunnerGroups_Marshal(t *testing.T) {
 			"default": true,
 			"selected_organizations_url": "s",
 			"runners_url": "r",
+			"hosted_runners_url": "h",
+			"network_configuration_id": "nc",
 			"inherited": true,
 			"allows_public_repositories": true,
 			"restricted_to_workflows": false
@@ -612,6 +620,7 @@ func TestCreateEnterpriseRunnerGroupRequest_Marshal(t *testing.T) {
 		AllowsPublicRepositories: Ptr(true),
 		RestrictedToWorkflows:    Ptr(true),
 		SelectedWorkflows:        []string{"a", "b"},
+		NetworkConfigurationID:   Ptr("nc-123"),
 	}
 
 	want := `{
@@ -621,7 +630,8 @@ func TestCreateEnterpriseRunnerGroupRequest_Marshal(t *testing.T) {
 		"runners": [1],
 		"allows_public_repositories": true,
 		"restricted_to_workflows": true,
-		"selected_workflows": ["a","b"]
+		"selected_workflows": ["a","b"],
+		"network_configuration_id": "nc-123"
 	}`
 
 	testJSONMarshal(t, u, want)
@@ -636,13 +646,15 @@ func TestUpdateEnterpriseRunnerGroupRequest_Marshal(t *testing.T) {
 		Visibility:               Ptr("v"),
 		AllowsPublicRepositories: Ptr(true),
 		RestrictedToWorkflows:    Ptr(false),
+		NetworkConfigurationID:   Ptr("nc-456"),
 	}
 
 	want := `{
 		"name": "n",
 		"visibility": "v",
 		"allows_public_repositories": true,
-		"restricted_to_workflows": false
+		"restricted_to_workflows": false,
+		"network_configuration_id": "nc-456"
 	}`
 
 	testJSONMarshal(t, u, want)

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6886,6 +6886,14 @@ func (c *CreateEnterpriseRunnerGroupRequest) GetName() string {
 	return *c.Name
 }
 
+// GetNetworkConfigurationID returns the NetworkConfigurationID field if it's non-nil, zero value otherwise.
+func (c *CreateEnterpriseRunnerGroupRequest) GetNetworkConfigurationID() string {
+	if c == nil || c.NetworkConfigurationID == nil {
+		return ""
+	}
+	return *c.NetworkConfigurationID
+}
+
 // GetRestrictedToWorkflows returns the RestrictedToWorkflows field if it's non-nil, zero value otherwise.
 func (c *CreateEnterpriseRunnerGroupRequest) GetRestrictedToWorkflows() bool {
 	if c == nil || c.RestrictedToWorkflows == nil {
@@ -10038,6 +10046,14 @@ func (e *EnterpriseRunnerGroup) GetDefault() bool {
 	return *e.Default
 }
 
+// GetHostedRunnersURL returns the HostedRunnersURL field if it's non-nil, zero value otherwise.
+func (e *EnterpriseRunnerGroup) GetHostedRunnersURL() string {
+	if e == nil || e.HostedRunnersURL == nil {
+		return ""
+	}
+	return *e.HostedRunnersURL
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (e *EnterpriseRunnerGroup) GetID() int64 {
 	if e == nil || e.ID == nil {
@@ -10060,6 +10076,14 @@ func (e *EnterpriseRunnerGroup) GetName() string {
 		return ""
 	}
 	return *e.Name
+}
+
+// GetNetworkConfigurationID returns the NetworkConfigurationID field if it's non-nil, zero value otherwise.
+func (e *EnterpriseRunnerGroup) GetNetworkConfigurationID() string {
+	if e == nil || e.NetworkConfigurationID == nil {
+		return ""
+	}
+	return *e.NetworkConfigurationID
 }
 
 // GetRestrictedToWorkflows returns the RestrictedToWorkflows field if it's non-nil, zero value otherwise.
@@ -30716,6 +30740,14 @@ func (u *UpdateEnterpriseRunnerGroupRequest) GetName() string {
 		return ""
 	}
 	return *u.Name
+}
+
+// GetNetworkConfigurationID returns the NetworkConfigurationID field if it's non-nil, zero value otherwise.
+func (u *UpdateEnterpriseRunnerGroupRequest) GetNetworkConfigurationID() string {
+	if u == nil || u.NetworkConfigurationID == nil {
+		return ""
+	}
+	return *u.NetworkConfigurationID
 }
 
 // GetRestrictedToWorkflows returns the RestrictedToWorkflows field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -9014,6 +9014,17 @@ func TestCreateEnterpriseRunnerGroupRequest_GetName(tt *testing.T) {
 	c.GetName()
 }
 
+func TestCreateEnterpriseRunnerGroupRequest_GetNetworkConfigurationID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateEnterpriseRunnerGroupRequest{NetworkConfigurationID: &zeroValue}
+	c.GetNetworkConfigurationID()
+	c = &CreateEnterpriseRunnerGroupRequest{}
+	c.GetNetworkConfigurationID()
+	c = nil
+	c.GetNetworkConfigurationID()
+}
+
 func TestCreateEnterpriseRunnerGroupRequest_GetRestrictedToWorkflows(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
@@ -13033,6 +13044,17 @@ func TestEnterpriseRunnerGroup_GetDefault(tt *testing.T) {
 	e.GetDefault()
 }
 
+func TestEnterpriseRunnerGroup_GetHostedRunnersURL(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	e := &EnterpriseRunnerGroup{HostedRunnersURL: &zeroValue}
+	e.GetHostedRunnersURL()
+	e = &EnterpriseRunnerGroup{}
+	e.GetHostedRunnersURL()
+	e = nil
+	e.GetHostedRunnersURL()
+}
+
 func TestEnterpriseRunnerGroup_GetID(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int64
@@ -13064,6 +13086,17 @@ func TestEnterpriseRunnerGroup_GetName(tt *testing.T) {
 	e.GetName()
 	e = nil
 	e.GetName()
+}
+
+func TestEnterpriseRunnerGroup_GetNetworkConfigurationID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	e := &EnterpriseRunnerGroup{NetworkConfigurationID: &zeroValue}
+	e.GetNetworkConfigurationID()
+	e = &EnterpriseRunnerGroup{}
+	e.GetNetworkConfigurationID()
+	e = nil
+	e.GetNetworkConfigurationID()
 }
 
 func TestEnterpriseRunnerGroup_GetRestrictedToWorkflows(tt *testing.T) {
@@ -39612,6 +39645,17 @@ func TestUpdateEnterpriseRunnerGroupRequest_GetName(tt *testing.T) {
 	u.GetName()
 	u = nil
 	u.GetName()
+}
+
+func TestUpdateEnterpriseRunnerGroupRequest_GetNetworkConfigurationID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateEnterpriseRunnerGroupRequest{NetworkConfigurationID: &zeroValue}
+	u.GetNetworkConfigurationID()
+	u = &UpdateEnterpriseRunnerGroupRequest{}
+	u.GetNetworkConfigurationID()
+	u = nil
+	u.GetNetworkConfigurationID()
 }
 
 func TestUpdateEnterpriseRunnerGroupRequest_GetRestrictedToWorkflows(tt *testing.T) {


### PR DESCRIPTION
## Summary

Add `NetworkConfigurationID` and `HostedRunnersURL` fields to enterprise runner group types to match the GitHub API response schema.

## Changes

- **`EnterpriseRunnerGroup`** — added `HostedRunnersURL` and `NetworkConfigurationID` fields
- **`CreateEnterpriseRunnerGroupRequest`** — added `NetworkConfigurationID` field
- **`UpdateEnterpriseRunnerGroupRequest`** — added `NetworkConfigurationID` field
- Generated accessors via `go generate`
- Updated marshal tests to cover the new fields

## Context

These fields already exist on the organization-scoped `RunnerGroup` type ([`actions_runner_groups.go`](https://github.com/google/go-github/blob/master/github/actions_runner_groups.go#L21-L22)) but were missing from the enterprise equivalents.

The GitHub API returns both fields on all enterprise runner group endpoints:
- `GET /enterprises/{enterprise}/actions/runner-groups`
- `POST /enterprises/{enterprise}/actions/runner-groups`
- `GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}`
- `PATCH /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}`

API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/actions/self-hosted-runner-groups?apiVersion=2026-03-10

The `network_configuration_id` field is used for associating hosted compute network configurations (GitHub-hosted private networking / VNET injection) with enterprise runner groups. The `hosted_runners_url` field provides the URL for listing GitHub-hosted runners in a group.

## Motivation

This is needed by the Terraform provider for GitHub ([PR #3274](https://github.com/integrations/terraform-provider-github/pull/3274)) which currently has to make raw HTTP calls to work around the missing fields.

## Testing

- All existing enterprise runner group tests pass
- Marshal tests updated for `EnterpriseRunnerGroup`, `EnterpriseRunnerGroups`, `CreateEnterpriseRunnerGroupRequest`, and `UpdateEnterpriseRunnerGroupRequest`
- Generated accessor tests pass
- Verified against live API (`octodemo` enterprise) — both fields deserialize correctly