### PR TITLE
chore: Use `structfield.Settings` in `check-structfield-settings`

### DIFF
--- a/tools/check-structfield-settings/main.go
+++ b/tools/check-structfield-settings/main.go
@@ -125,8 +125,7 @@ type golangciConfig struct {
 			Custom struct {
 				Structfield struct {
 					Settings struct {
-						AllowedTagNames []string `yaml:"allowed-tag-names"`
-						AllowedTagTypes []string `yaml:"allowed-tag-types"`
+						structfield.Settings `yaml:",inline"`
 					} `yaml:"settings"`
 				} `yaml:"structfield"`
 			} `yaml:"custom"`


### PR DESCRIPTION
`structfield.Settings` is unused, and we can remove it.
But I think that it is better to use it in the `check-struct-field-settings` to avoid duplication