### PR TITLE
feat!: Refactor request context

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ Every exported method and type needs to have code comments that follow
 //meta:operation GET /repos/{owner}/{repo}
 func (s *RepositoriesService) Get(ctx context.Context, owner, repo string) (*Repository, *Response, error) {
     u := fmt.Sprintf("repos/%v/%v", owner, repo)
-    req, err := s.client.NewRequest("GET", u, nil)
+    req, err := s.client.NewRequest(ctx, "GET", u, nil)
     ...
 }
 ```

--- a/github/actions_artifacts.go
+++ b/github/actions_artifacts.go
@@ -91,13 +91,13 @@ func (s *ActionsService) ListArtifacts(ctx context.Context, owner, repo string, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var artifactList *ArtifactList
-	resp, err := s.client.Do(ctx, req, &artifactList)
+	resp, err := s.client.Do(req, &artifactList)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -117,13 +117,13 @@ func (s *ActionsService) ListWorkflowRunArtifacts(ctx context.Context, owner, re
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var artifactList *ArtifactList
-	resp, err := s.client.Do(ctx, req, &artifactList)
+	resp, err := s.client.Do(req, &artifactList)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -139,13 +139,13 @@ func (s *ActionsService) ListWorkflowRunArtifacts(ctx context.Context, owner, re
 func (s *ActionsService) GetArtifact(ctx context.Context, owner, repo string, artifactID int64) (*Artifact, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/artifacts/%v", owner, repo, artifactID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var artifact *Artifact
-	resp, err := s.client.Do(ctx, req, &artifact)
+	resp, err := s.client.Do(req, &artifact)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -188,12 +188,12 @@ func (s *ActionsService) downloadArtifactWithoutRateLimit(ctx context.Context, u
 }
 
 func (s *ActionsService) downloadArtifactWithRateLimit(ctx context.Context, u string, maxRedirects int) (*url.URL, *Response, error) {
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	url, resp, err := s.client.bareDoUntilFound(ctx, req, maxRedirects)
+	url, resp, err := s.client.bareDoUntilFound(req, maxRedirects)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -215,10 +215,10 @@ func (s *ActionsService) downloadArtifactWithRateLimit(ctx context.Context, u st
 func (s *ActionsService) DeleteArtifact(ctx context.Context, owner, repo string, artifactID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/artifacts/%v", owner, repo, artifactID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/actions_cache.go
+++ b/github/actions_cache.go
@@ -87,13 +87,13 @@ func (s *ActionsService) ListCaches(ctx context.Context, owner, repo string, opt
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var actionCacheList *ActionsCacheList
-	resp, err := s.client.Do(ctx, req, &actionCacheList)
+	resp, err := s.client.Do(req, &actionCacheList)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -119,12 +119,12 @@ func (s *ActionsService) DeleteCachesByKey(ctx context.Context, owner, repo, key
 		return nil, err
 	}
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DeleteCachesByID deletes a GitHub Actions cache for a repository, using a cache ID.
@@ -136,12 +136,12 @@ func (s *ActionsService) DeleteCachesByKey(ctx context.Context, owner, repo, key
 //meta:operation DELETE /repos/{owner}/{repo}/actions/caches/{cache_id}
 func (s *ActionsService) DeleteCachesByID(ctx context.Context, owner, repo string, cacheID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/caches/%v", owner, repo, cacheID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetCacheUsageForRepo gets GitHub Actions cache usage for a repository. The data fetched using this API is refreshed approximately every 5 minutes,
@@ -155,13 +155,13 @@ func (s *ActionsService) DeleteCachesByID(ctx context.Context, owner, repo strin
 //meta:operation GET /repos/{owner}/{repo}/actions/cache/usage
 func (s *ActionsService) GetCacheUsageForRepo(ctx context.Context, owner, repo string) (*ActionsCacheUsage, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/cache/usage", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var cacheUsage *ActionsCacheUsage
-	res, err := s.client.Do(ctx, req, &cacheUsage)
+	res, err := s.client.Do(req, &cacheUsage)
 	if err != nil {
 		return nil, res, err
 	}
@@ -185,13 +185,13 @@ func (s *ActionsService) ListCacheUsageByRepoForOrg(ctx context.Context, org str
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var cacheUsage *ActionsCacheUsageList
-	res, err := s.client.Do(ctx, req, &cacheUsage)
+	res, err := s.client.Do(req, &cacheUsage)
 	if err != nil {
 		return nil, res, err
 	}
@@ -210,13 +210,13 @@ func (s *ActionsService) ListCacheUsageByRepoForOrg(ctx context.Context, org str
 //meta:operation GET /orgs/{org}/actions/cache/usage
 func (s *ActionsService) GetTotalCacheUsageForOrg(ctx context.Context, org string) (*TotalCacheUsage, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/cache/usage", org)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var cacheUsage *TotalCacheUsage
-	res, err := s.client.Do(ctx, req, &cacheUsage)
+	res, err := s.client.Do(req, &cacheUsage)
 	if err != nil {
 		return nil, res, err
 	}
@@ -234,13 +234,13 @@ func (s *ActionsService) GetTotalCacheUsageForOrg(ctx context.Context, org strin
 //meta:operation GET /enterprises/{enterprise}/actions/cache/usage
 func (s *ActionsService) GetTotalCacheUsageForEnterprise(ctx context.Context, enterprise string) (*TotalCacheUsage, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/cache/usage", enterprise)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var cacheUsage *TotalCacheUsage
-	res, err := s.client.Do(ctx, req, &cacheUsage)
+	res, err := s.client.Do(req, &cacheUsage)
 	if err != nil {
 		return nil, res, err
 	}

--- a/github/actions_hosted_runners.go
+++ b/github/actions_hosted_runners.go
@@ -68,13 +68,13 @@ func (s *ActionsService) ListHostedRunners(ctx context.Context, org string, opts
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runners *HostedRunners
-	resp, err := s.client.Do(ctx, req, &runners)
+	resp, err := s.client.Do(req, &runners)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -146,13 +146,13 @@ func (s *ActionsService) CreateHostedRunner(ctx context.Context, org string, req
 	}
 
 	u := fmt.Sprintf("orgs/%v/actions/hosted-runners", org)
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hostedRunner *HostedRunner
-	resp, err := s.client.Do(ctx, req, &hostedRunner)
+	resp, err := s.client.Do(req, &hostedRunner)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -215,13 +215,13 @@ type HostedRunnerImages struct {
 //meta:operation GET /orgs/{org}/actions/hosted-runners/images/github-owned
 func (s *ActionsService) GetHostedRunnerGitHubOwnedImages(ctx context.Context, org string) (*HostedRunnerImages, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/images/github-owned", org)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hostedRunnerImages *HostedRunnerImages
-	resp, err := s.client.Do(ctx, req, &hostedRunnerImages)
+	resp, err := s.client.Do(req, &hostedRunnerImages)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -236,13 +236,13 @@ func (s *ActionsService) GetHostedRunnerGitHubOwnedImages(ctx context.Context, o
 //meta:operation GET /orgs/{org}/actions/hosted-runners/images/partner
 func (s *ActionsService) GetHostedRunnerPartnerImages(ctx context.Context, org string) (*HostedRunnerImages, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/images/partner", org)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hostedRunnerImages *HostedRunnerImages
-	resp, err := s.client.Do(ctx, req, &hostedRunnerImages)
+	resp, err := s.client.Do(req, &hostedRunnerImages)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -268,13 +268,13 @@ type PublicIPUsage struct {
 //meta:operation GET /orgs/{org}/actions/hosted-runners/limits
 func (s *ActionsService) GetHostedRunnerLimits(ctx context.Context, org string) (*HostedRunnerPublicIPLimits, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/limits", org)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var publicIPLimits *HostedRunnerPublicIPLimits
-	resp, err := s.client.Do(ctx, req, &publicIPLimits)
+	resp, err := s.client.Do(req, &publicIPLimits)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -295,13 +295,13 @@ type HostedRunnerMachineSpecs struct {
 //meta:operation GET /orgs/{org}/actions/hosted-runners/machine-sizes
 func (s *ActionsService) GetHostedRunnerMachineSpecs(ctx context.Context, org string) (*HostedRunnerMachineSpecs, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/machine-sizes", org)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var machineSpecs *HostedRunnerMachineSpecs
-	resp, err := s.client.Do(ctx, req, &machineSpecs)
+	resp, err := s.client.Do(req, &machineSpecs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -322,13 +322,13 @@ type HostedRunnerPlatforms struct {
 //meta:operation GET /orgs/{org}/actions/hosted-runners/platforms
 func (s *ActionsService) GetHostedRunnerPlatforms(ctx context.Context, org string) (*HostedRunnerPlatforms, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/platforms", org)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var platforms *HostedRunnerPlatforms
-	resp, err := s.client.Do(ctx, req, &platforms)
+	resp, err := s.client.Do(req, &platforms)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -343,13 +343,13 @@ func (s *ActionsService) GetHostedRunnerPlatforms(ctx context.Context, org strin
 //meta:operation GET /orgs/{org}/actions/hosted-runners/{hosted_runner_id}
 func (s *ActionsService) GetHostedRunner(ctx context.Context, org string, runnerID int64) (*HostedRunner, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/%v", org, runnerID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hostedRunner *HostedRunner
-	resp, err := s.client.Do(ctx, req, &hostedRunner)
+	resp, err := s.client.Do(req, &hostedRunner)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -364,13 +364,13 @@ func (s *ActionsService) GetHostedRunner(ctx context.Context, org string, runner
 //meta:operation PATCH /orgs/{org}/actions/hosted-runners/{hosted_runner_id}
 func (s *ActionsService) UpdateHostedRunner(ctx context.Context, org string, runnerID int64, request UpdateHostedRunnerRequest) (*HostedRunner, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/%v", org, runnerID)
-	req, err := s.client.NewRequest("PATCH", u, request)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hostedRunner *HostedRunner
-	resp, err := s.client.Do(ctx, req, &hostedRunner)
+	resp, err := s.client.Do(req, &hostedRunner)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -385,13 +385,13 @@ func (s *ActionsService) UpdateHostedRunner(ctx context.Context, org string, run
 //meta:operation DELETE /orgs/{org}/actions/hosted-runners/{hosted_runner_id}
 func (s *ActionsService) DeleteHostedRunner(ctx context.Context, org string, runnerID int64) (*HostedRunner, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/%v", org, runnerID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hostedRunner *HostedRunner
-	resp, err := s.client.Do(ctx, req, &hostedRunner)
+	resp, err := s.client.Do(req, &hostedRunner)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -406,13 +406,13 @@ func (s *ActionsService) DeleteHostedRunner(ctx context.Context, org string, run
 //meta:operation GET /orgs/{org}/actions/hosted-runners/images/custom
 func (s *ActionsService) ListHostedRunnerCustomImages(ctx context.Context, org string) (*HostedRunnerCustomImages, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/images/custom", org)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var images *HostedRunnerCustomImages
-	resp, err := s.client.Do(ctx, req, &images)
+	resp, err := s.client.Do(req, &images)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -427,13 +427,13 @@ func (s *ActionsService) ListHostedRunnerCustomImages(ctx context.Context, org s
 //meta:operation GET /orgs/{org}/actions/hosted-runners/images/custom/{image_definition_id}
 func (s *ActionsService) GetHostedRunnerCustomImage(ctx context.Context, org string, imageDefinitionID int64) (*HostedRunnerCustomImage, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/images/custom/%v", org, imageDefinitionID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var image *HostedRunnerCustomImage
-	resp, err := s.client.Do(ctx, req, &image)
+	resp, err := s.client.Do(req, &image)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -448,12 +448,12 @@ func (s *ActionsService) GetHostedRunnerCustomImage(ctx context.Context, org str
 //meta:operation DELETE /orgs/{org}/actions/hosted-runners/images/custom/{image_definition_id}
 func (s *ActionsService) DeleteHostedRunnerCustomImage(ctx context.Context, org string, imageDefinitionID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/images/custom/%v", org, imageDefinitionID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListHostedRunnerCustomImageVersions lists image versions of a custom image for an organization.
@@ -463,13 +463,13 @@ func (s *ActionsService) DeleteHostedRunnerCustomImage(ctx context.Context, org 
 //meta:operation GET /orgs/{org}/actions/hosted-runners/images/custom/{image_definition_id}/versions
 func (s *ActionsService) ListHostedRunnerCustomImageVersions(ctx context.Context, org string, imageDefinitionID int64) (*HostedRunnerCustomImageVersions, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/images/custom/%v/versions", org, imageDefinitionID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var versions *HostedRunnerCustomImageVersions
-	resp, err := s.client.Do(ctx, req, &versions)
+	resp, err := s.client.Do(req, &versions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -484,13 +484,13 @@ func (s *ActionsService) ListHostedRunnerCustomImageVersions(ctx context.Context
 //meta:operation GET /orgs/{org}/actions/hosted-runners/images/custom/{image_definition_id}/versions/{version}
 func (s *ActionsService) GetHostedRunnerCustomImageVersion(ctx context.Context, org string, imageDefinitionID int64, version string) (*HostedRunnerCustomImageVersion, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/images/custom/%v/versions/%v", org, imageDefinitionID, version)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var imageVersion *HostedRunnerCustomImageVersion
-	resp, err := s.client.Do(ctx, req, &imageVersion)
+	resp, err := s.client.Do(req, &imageVersion)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -505,10 +505,10 @@ func (s *ActionsService) GetHostedRunnerCustomImageVersion(ctx context.Context, 
 //meta:operation DELETE /orgs/{org}/actions/hosted-runners/images/custom/{image_definition_id}/versions/{version}
 func (s *ActionsService) DeleteHostedRunnerCustomImageVersion(ctx context.Context, org string, imageDefinitionID int64, version string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/hosted-runners/images/custom/%v/versions/%v", org, imageDefinitionID, version)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/actions_oidc.go
+++ b/github/actions_oidc.go
@@ -37,13 +37,13 @@ func (s *ActionsService) GetRepoOIDCSubjectClaimCustomTemplate(ctx context.Conte
 }
 
 func (s *ActionsService) getOIDCSubjectClaimCustomTemplate(ctx context.Context, url string) (*OIDCSubjectClaimCustomTemplate, *Response, error) {
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var tmpl *OIDCSubjectClaimCustomTemplate
-	resp, err := s.client.Do(ctx, req, &tmpl)
+	resp, err := s.client.Do(req, &tmpl)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -72,10 +72,10 @@ func (s *ActionsService) SetRepoOIDCSubjectClaimCustomTemplate(ctx context.Conte
 }
 
 func (s *ActionsService) setOIDCSubjectClaimCustomTemplate(ctx context.Context, url string, template *OIDCSubjectClaimCustomTemplate) (*Response, error) {
-	req, err := s.client.NewRequest("PUT", url, template)
+	req, err := s.client.NewRequest(ctx, "PUT", url, template)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/actions_permissions_enterprise.go
+++ b/github/actions_permissions_enterprise.go
@@ -54,13 +54,13 @@ func (a SelfHostRunnerPermissionsEnterprise) String() string {
 func (s *ActionsService) GetActionsPermissionsInEnterprise(ctx context.Context, enterprise string) (*ActionsPermissionsEnterprise, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var permissions *ActionsPermissionsEnterprise
-	resp, err := s.client.Do(ctx, req, &permissions)
+	resp, err := s.client.Do(req, &permissions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -75,13 +75,13 @@ func (s *ActionsService) GetActionsPermissionsInEnterprise(ctx context.Context, 
 //meta:operation PUT /enterprises/{enterprise}/actions/permissions
 func (s *ActionsService) UpdateActionsPermissionsInEnterprise(ctx context.Context, enterprise string, actionsPermissionsEnterprise ActionsPermissionsEnterprise) (*ActionsPermissionsEnterprise, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions", enterprise)
-	req, err := s.client.NewRequest("PUT", u, actionsPermissionsEnterprise)
+	req, err := s.client.NewRequest(ctx, "PUT", u, actionsPermissionsEnterprise)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var p *ActionsPermissionsEnterprise
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -101,13 +101,13 @@ func (s *ActionsService) ListEnabledOrgsInEnterprise(ctx context.Context, owner 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var orgs *ActionsEnabledOnEnterpriseRepos
-	resp, err := s.client.Do(ctx, req, &orgs)
+	resp, err := s.client.Do(req, &orgs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -123,14 +123,14 @@ func (s *ActionsService) ListEnabledOrgsInEnterprise(ctx context.Context, owner 
 func (s *ActionsService) SetEnabledOrgsInEnterprise(ctx context.Context, owner string, organizationIDs []int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/organizations", owner)
 
-	req, err := s.client.NewRequest("PUT", u, struct {
+	req, err := s.client.NewRequest(ctx, "PUT", u, struct {
 		IDs []int64 `json:"selected_organization_ids"`
 	}{IDs: organizationIDs})
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -146,12 +146,12 @@ func (s *ActionsService) SetEnabledOrgsInEnterprise(ctx context.Context, owner s
 func (s *ActionsService) AddEnabledOrgInEnterprise(ctx context.Context, owner string, organizationID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/organizations/%v", owner, organizationID)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -167,12 +167,12 @@ func (s *ActionsService) AddEnabledOrgInEnterprise(ctx context.Context, owner st
 func (s *ActionsService) RemoveEnabledOrgInEnterprise(ctx context.Context, owner string, organizationID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/organizations/%v", owner, organizationID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -188,13 +188,13 @@ func (s *ActionsService) RemoveEnabledOrgInEnterprise(ctx context.Context, owner
 func (s *ActionsService) GetActionsAllowedInEnterprise(ctx context.Context, enterprise string) (*ActionsAllowed, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/selected-actions", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var actionsAllowed *ActionsAllowed
-	resp, err := s.client.Do(ctx, req, &actionsAllowed)
+	resp, err := s.client.Do(req, &actionsAllowed)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -209,13 +209,13 @@ func (s *ActionsService) GetActionsAllowedInEnterprise(ctx context.Context, ente
 //meta:operation PUT /enterprises/{enterprise}/actions/permissions/selected-actions
 func (s *ActionsService) UpdateActionsAllowedInEnterprise(ctx context.Context, enterprise string, actionsAllowed ActionsAllowed) (*ActionsAllowed, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/selected-actions", enterprise)
-	req, err := s.client.NewRequest("PUT", u, actionsAllowed)
+	req, err := s.client.NewRequest(ctx, "PUT", u, actionsAllowed)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var p *ActionsAllowed
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -231,13 +231,13 @@ func (s *ActionsService) UpdateActionsAllowedInEnterprise(ctx context.Context, e
 func (s *ActionsService) GetDefaultWorkflowPermissionsInEnterprise(ctx context.Context, enterprise string) (*DefaultWorkflowPermissionEnterprise, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/workflow", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var permissions *DefaultWorkflowPermissionEnterprise
-	resp, err := s.client.Do(ctx, req, &permissions)
+	resp, err := s.client.Do(req, &permissions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -252,13 +252,13 @@ func (s *ActionsService) GetDefaultWorkflowPermissionsInEnterprise(ctx context.C
 //meta:operation PUT /enterprises/{enterprise}/actions/permissions/workflow
 func (s *ActionsService) UpdateDefaultWorkflowPermissionsInEnterprise(ctx context.Context, enterprise string, permissions DefaultWorkflowPermissionEnterprise) (*DefaultWorkflowPermissionEnterprise, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/workflow", enterprise)
-	req, err := s.client.NewRequest("PUT", u, permissions)
+	req, err := s.client.NewRequest(ctx, "PUT", u, permissions)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var p *DefaultWorkflowPermissionEnterprise
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -274,13 +274,13 @@ func (s *ActionsService) UpdateDefaultWorkflowPermissionsInEnterprise(ctx contex
 func (s *ActionsService) GetArtifactAndLogRetentionPeriodInEnterprise(ctx context.Context, enterprise string) (*ArtifactPeriod, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/artifact-and-log-retention", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var arp *ArtifactPeriod
-	resp, err := s.client.Do(ctx, req, &arp)
+	resp, err := s.client.Do(req, &arp)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -295,12 +295,12 @@ func (s *ActionsService) GetArtifactAndLogRetentionPeriodInEnterprise(ctx contex
 //meta:operation PUT /enterprises/{enterprise}/actions/permissions/artifact-and-log-retention
 func (s *ActionsService) UpdateArtifactAndLogRetentionPeriodInEnterprise(ctx context.Context, enterprise string, period ArtifactPeriodOpt) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/artifact-and-log-retention", enterprise)
-	req, err := s.client.NewRequest("PUT", u, period)
+	req, err := s.client.NewRequest(ctx, "PUT", u, period)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetSelfHostedRunnerPermissionsInEnterprise gets the self-hosted runner permissions for an enterprise.
@@ -310,13 +310,13 @@ func (s *ActionsService) UpdateArtifactAndLogRetentionPeriodInEnterprise(ctx con
 //meta:operation GET /enterprises/{enterprise}/actions/permissions/self-hosted-runners
 func (s *ActionsService) GetSelfHostedRunnerPermissionsInEnterprise(ctx context.Context, enterprise string) (*SelfHostRunnerPermissionsEnterprise, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/self-hosted-runners", enterprise)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var permissions *SelfHostRunnerPermissionsEnterprise
-	resp, err := s.client.Do(ctx, req, &permissions)
+	resp, err := s.client.Do(req, &permissions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -331,12 +331,12 @@ func (s *ActionsService) GetSelfHostedRunnerPermissionsInEnterprise(ctx context.
 //meta:operation PUT /enterprises/{enterprise}/actions/permissions/self-hosted-runners
 func (s *ActionsService) UpdateSelfHostedRunnerPermissionsInEnterprise(ctx context.Context, enterprise string, permissions SelfHostRunnerPermissionsEnterprise) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/self-hosted-runners", enterprise)
-	req, err := s.client.NewRequest("PUT", u, permissions)
+	req, err := s.client.NewRequest(ctx, "PUT", u, permissions)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetPrivateRepoForkPRWorkflowSettingsInEnterprise gets the settings for whether workflows from fork pull requests can run on private repositories in an enterprise.
@@ -347,13 +347,13 @@ func (s *ActionsService) UpdateSelfHostedRunnerPermissionsInEnterprise(ctx conte
 func (s *ActionsService) GetPrivateRepoForkPRWorkflowSettingsInEnterprise(ctx context.Context, enterprise string) (*WorkflowsPermissions, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/fork-pr-workflows-private-repos", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var permissions *WorkflowsPermissions
-	resp, err := s.client.Do(ctx, req, &permissions)
+	resp, err := s.client.Do(req, &permissions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -368,12 +368,12 @@ func (s *ActionsService) GetPrivateRepoForkPRWorkflowSettingsInEnterprise(ctx co
 //meta:operation PUT /enterprises/{enterprise}/actions/permissions/fork-pr-workflows-private-repos
 func (s *ActionsService) UpdatePrivateRepoForkPRWorkflowSettingsInEnterprise(ctx context.Context, enterprise string, permissions *WorkflowsPermissionsOpt) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/fork-pr-workflows-private-repos", enterprise)
-	req, err := s.client.NewRequest("PUT", u, permissions)
+	req, err := s.client.NewRequest(ctx, "PUT", u, permissions)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetEnterpriseForkPRContributorApprovalPermissions gets the fork PR contributor approval policy for an enterprise.
@@ -384,13 +384,13 @@ func (s *ActionsService) UpdatePrivateRepoForkPRWorkflowSettingsInEnterprise(ctx
 func (s *ActionsService) GetEnterpriseForkPRContributorApprovalPermissions(ctx context.Context, enterprise string) (*ContributorApprovalPermissions, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/fork-pr-contributor-approval", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var policy *ContributorApprovalPermissions
-	resp, err := s.client.Do(ctx, req, &policy)
+	resp, err := s.client.Do(req, &policy)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -405,10 +405,10 @@ func (s *ActionsService) GetEnterpriseForkPRContributorApprovalPermissions(ctx c
 //meta:operation PUT /enterprises/{enterprise}/actions/permissions/fork-pr-contributor-approval
 func (s *ActionsService) UpdateEnterpriseForkPRContributorApprovalPermissions(ctx context.Context, enterprise string, policy ContributorApprovalPermissions) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/permissions/fork-pr-contributor-approval", enterprise)
-	req, err := s.client.NewRequest("PUT", u, policy)
+	req, err := s.client.NewRequest(ctx, "PUT", u, policy)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/actions_permissions_orgs.go
+++ b/github/actions_permissions_orgs.go
@@ -74,13 +74,13 @@ type SelfHostedRunnersSettingsOrganizationOpt struct {
 func (s *ActionsService) GetActionsPermissions(ctx context.Context, org string) (*ActionsPermissions, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var permissions *ActionsPermissions
-	resp, err := s.client.Do(ctx, req, &permissions)
+	resp, err := s.client.Do(req, &permissions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -95,13 +95,13 @@ func (s *ActionsService) GetActionsPermissions(ctx context.Context, org string) 
 //meta:operation PUT /orgs/{org}/actions/permissions
 func (s *ActionsService) UpdateActionsPermissions(ctx context.Context, org string, actionsPermissions ActionsPermissions) (*ActionsPermissions, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions", org)
-	req, err := s.client.NewRequest("PUT", u, actionsPermissions)
+	req, err := s.client.NewRequest(ctx, "PUT", u, actionsPermissions)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var p *ActionsPermissions
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -121,13 +121,13 @@ func (s *ActionsService) ListEnabledReposInOrg(ctx context.Context, owner string
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var repos *ActionsEnabledOnOrgRepos
-	resp, err := s.client.Do(ctx, req, &repos)
+	resp, err := s.client.Do(req, &repos)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -143,14 +143,14 @@ func (s *ActionsService) ListEnabledReposInOrg(ctx context.Context, owner string
 func (s *ActionsService) SetEnabledReposInOrg(ctx context.Context, owner string, repositoryIDs []int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/repositories", owner)
 
-	req, err := s.client.NewRequest("PUT", u, struct {
+	req, err := s.client.NewRequest(ctx, "PUT", u, struct {
 		IDs []int64 `json:"selected_repository_ids"`
 	}{IDs: repositoryIDs})
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -166,12 +166,12 @@ func (s *ActionsService) SetEnabledReposInOrg(ctx context.Context, owner string,
 func (s *ActionsService) AddEnabledReposInOrg(ctx context.Context, owner string, repositoryID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/repositories/%v", owner, repositoryID)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -187,12 +187,12 @@ func (s *ActionsService) AddEnabledReposInOrg(ctx context.Context, owner string,
 func (s *ActionsService) RemoveEnabledReposInOrg(ctx context.Context, owner string, repositoryID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/repositories/%v", owner, repositoryID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -208,13 +208,13 @@ func (s *ActionsService) RemoveEnabledReposInOrg(ctx context.Context, owner stri
 func (s *ActionsService) GetActionsAllowed(ctx context.Context, org string) (*ActionsAllowed, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/selected-actions", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var actionsAllowed *ActionsAllowed
-	resp, err := s.client.Do(ctx, req, &actionsAllowed)
+	resp, err := s.client.Do(req, &actionsAllowed)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -229,13 +229,13 @@ func (s *ActionsService) GetActionsAllowed(ctx context.Context, org string) (*Ac
 //meta:operation PUT /orgs/{org}/actions/permissions/selected-actions
 func (s *ActionsService) UpdateActionsAllowed(ctx context.Context, org string, actionsAllowed ActionsAllowed) (*ActionsAllowed, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/selected-actions", org)
-	req, err := s.client.NewRequest("PUT", u, actionsAllowed)
+	req, err := s.client.NewRequest(ctx, "PUT", u, actionsAllowed)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var p *ActionsAllowed
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -251,13 +251,13 @@ func (s *ActionsService) UpdateActionsAllowed(ctx context.Context, org string, a
 func (s *ActionsService) GetDefaultWorkflowPermissionsInOrganization(ctx context.Context, org string) (*DefaultWorkflowPermissionOrganization, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/workflow", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var permissions *DefaultWorkflowPermissionOrganization
-	resp, err := s.client.Do(ctx, req, &permissions)
+	resp, err := s.client.Do(req, &permissions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -272,13 +272,13 @@ func (s *ActionsService) GetDefaultWorkflowPermissionsInOrganization(ctx context
 //meta:operation PUT /orgs/{org}/actions/permissions/workflow
 func (s *ActionsService) UpdateDefaultWorkflowPermissionsInOrganization(ctx context.Context, org string, permissions DefaultWorkflowPermissionOrganization) (*DefaultWorkflowPermissionOrganization, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/workflow", org)
-	req, err := s.client.NewRequest("PUT", u, permissions)
+	req, err := s.client.NewRequest(ctx, "PUT", u, permissions)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var p *DefaultWorkflowPermissionOrganization
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -294,13 +294,13 @@ func (s *ActionsService) UpdateDefaultWorkflowPermissionsInOrganization(ctx cont
 func (s *ActionsService) GetArtifactAndLogRetentionPeriodInOrganization(ctx context.Context, org string) (*ArtifactPeriod, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/artifact-and-log-retention", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var arp *ArtifactPeriod
-	resp, err := s.client.Do(ctx, req, &arp)
+	resp, err := s.client.Do(req, &arp)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -315,12 +315,12 @@ func (s *ActionsService) GetArtifactAndLogRetentionPeriodInOrganization(ctx cont
 //meta:operation PUT /orgs/{org}/actions/permissions/artifact-and-log-retention
 func (s *ActionsService) UpdateArtifactAndLogRetentionPeriodInOrganization(ctx context.Context, org string, period ArtifactPeriodOpt) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/artifact-and-log-retention", org)
-	req, err := s.client.NewRequest("PUT", u, period)
+	req, err := s.client.NewRequest(ctx, "PUT", u, period)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetSelfHostedRunnersSettingsInOrganization gets the self-hosted runners permissions settings for repositories in an organization.
@@ -331,13 +331,13 @@ func (s *ActionsService) UpdateArtifactAndLogRetentionPeriodInOrganization(ctx c
 func (s *ActionsService) GetSelfHostedRunnersSettingsInOrganization(ctx context.Context, org string) (*SelfHostedRunnersSettingsOrganization, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/self-hosted-runners", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var settings *SelfHostedRunnersSettingsOrganization
-	resp, err := s.client.Do(ctx, req, &settings)
+	resp, err := s.client.Do(req, &settings)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -353,12 +353,12 @@ func (s *ActionsService) GetSelfHostedRunnersSettingsInOrganization(ctx context.
 func (s *ActionsService) UpdateSelfHostedRunnersSettingsInOrganization(ctx context.Context, org string, opt SelfHostedRunnersSettingsOrganizationOpt) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/self-hosted-runners", org)
 
-	req, err := s.client.NewRequest("PUT", u, opt)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opt)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // SelfHostedRunnersAllowedRepos represents the repositories that are allowed to use self-hosted runners in an organization.
@@ -379,13 +379,13 @@ func (s *ActionsService) ListRepositoriesSelfHostedRunnersAllowedInOrganization(
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var settings *SelfHostedRunnersAllowedRepos
-	resp, err := s.client.Do(ctx, req, &settings)
+	resp, err := s.client.Do(req, &settings)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -401,14 +401,14 @@ func (s *ActionsService) ListRepositoriesSelfHostedRunnersAllowedInOrganization(
 func (s *ActionsService) SetRepositoriesSelfHostedRunnersAllowedInOrganization(ctx context.Context, org string, repositoryIDs []int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/self-hosted-runners/repositories", org)
 
-	req, err := s.client.NewRequest("PUT", u, struct {
+	req, err := s.client.NewRequest(ctx, "PUT", u, struct {
 		IDs []int64 `json:"selected_repository_ids"`
 	}{IDs: repositoryIDs})
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // AddRepositorySelfHostedRunnersAllowedInOrganization adds a repository to the list of repositories that are allowed to use self-hosted runners in an organization.
@@ -419,12 +419,12 @@ func (s *ActionsService) SetRepositoriesSelfHostedRunnersAllowedInOrganization(c
 func (s *ActionsService) AddRepositorySelfHostedRunnersAllowedInOrganization(ctx context.Context, org string, repositoryID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/self-hosted-runners/repositories/%v", org, repositoryID)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RemoveRepositorySelfHostedRunnersAllowedInOrganization removes a repository from the list of repositories that are allowed to use self-hosted runners in an organization.
@@ -435,12 +435,12 @@ func (s *ActionsService) AddRepositorySelfHostedRunnersAllowedInOrganization(ctx
 func (s *ActionsService) RemoveRepositorySelfHostedRunnersAllowedInOrganization(ctx context.Context, org string, repositoryID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/self-hosted-runners/repositories/%v", org, repositoryID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -456,13 +456,13 @@ func (s *ActionsService) RemoveRepositorySelfHostedRunnersAllowedInOrganization(
 func (s *ActionsService) GetPrivateRepoForkPRWorkflowSettingsInOrganization(ctx context.Context, org string) (*WorkflowsPermissions, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/fork-pr-workflows-private-repos", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var permissions *WorkflowsPermissions
-	resp, err := s.client.Do(ctx, req, &permissions)
+	resp, err := s.client.Do(req, &permissions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -477,12 +477,12 @@ func (s *ActionsService) GetPrivateRepoForkPRWorkflowSettingsInOrganization(ctx 
 //meta:operation PUT /orgs/{org}/actions/permissions/fork-pr-workflows-private-repos
 func (s *ActionsService) UpdatePrivateRepoForkPRWorkflowSettingsInOrganization(ctx context.Context, org string, permissions *WorkflowsPermissionsOpt) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/fork-pr-workflows-private-repos", org)
-	req, err := s.client.NewRequest("PUT", u, permissions)
+	req, err := s.client.NewRequest(ctx, "PUT", u, permissions)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetOrganizationForkPRContributorApprovalPermissions gets the fork PR contributor approval policy for an organization.
@@ -493,13 +493,13 @@ func (s *ActionsService) UpdatePrivateRepoForkPRWorkflowSettingsInOrganization(c
 func (s *ActionsService) GetOrganizationForkPRContributorApprovalPermissions(ctx context.Context, org string) (*ContributorApprovalPermissions, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/fork-pr-contributor-approval", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var policy *ContributorApprovalPermissions
-	resp, err := s.client.Do(ctx, req, &policy)
+	resp, err := s.client.Do(req, &policy)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -514,10 +514,10 @@ func (s *ActionsService) GetOrganizationForkPRContributorApprovalPermissions(ctx
 //meta:operation PUT /orgs/{org}/actions/permissions/fork-pr-contributor-approval
 func (s *ActionsService) UpdateOrganizationForkPRContributorApprovalPermissions(ctx context.Context, org string, policy ContributorApprovalPermissions) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/permissions/fork-pr-contributor-approval", org)
-	req, err := s.client.NewRequest("PUT", u, policy)
+	req, err := s.client.NewRequest(ctx, "PUT", u, policy)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/actions_runner_groups.go
+++ b/github/actions_runner_groups.go
@@ -95,13 +95,13 @@ func (s *ActionsService) ListOrganizationRunnerGroups(ctx context.Context, org s
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var groups *RunnerGroups
-	resp, err := s.client.Do(ctx, req, &groups)
+	resp, err := s.client.Do(req, &groups)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -116,13 +116,13 @@ func (s *ActionsService) ListOrganizationRunnerGroups(ctx context.Context, org s
 //meta:operation GET /orgs/{org}/actions/runner-groups/{runner_group_id}
 func (s *ActionsService) GetOrganizationRunnerGroup(ctx context.Context, org string, groupID int64) (*RunnerGroup, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v", org, groupID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runnerGroup *RunnerGroup
-	resp, err := s.client.Do(ctx, req, &runnerGroup)
+	resp, err := s.client.Do(req, &runnerGroup)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -138,12 +138,12 @@ func (s *ActionsService) GetOrganizationRunnerGroup(ctx context.Context, org str
 func (s *ActionsService) DeleteOrganizationRunnerGroup(ctx context.Context, org string, groupID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v", org, groupID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // CreateOrganizationRunnerGroup creates a new self-hosted runner group for an organization.
@@ -153,13 +153,13 @@ func (s *ActionsService) DeleteOrganizationRunnerGroup(ctx context.Context, org 
 //meta:operation POST /orgs/{org}/actions/runner-groups
 func (s *ActionsService) CreateOrganizationRunnerGroup(ctx context.Context, org string, createReq CreateRunnerGroupRequest) (*RunnerGroup, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runner-groups", org)
-	req, err := s.client.NewRequest("POST", u, createReq)
+	req, err := s.client.NewRequest(ctx, "POST", u, createReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runnerGroup *RunnerGroup
-	resp, err := s.client.Do(ctx, req, &runnerGroup)
+	resp, err := s.client.Do(req, &runnerGroup)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -174,13 +174,13 @@ func (s *ActionsService) CreateOrganizationRunnerGroup(ctx context.Context, org 
 //meta:operation PATCH /orgs/{org}/actions/runner-groups/{runner_group_id}
 func (s *ActionsService) UpdateOrganizationRunnerGroup(ctx context.Context, org string, groupID int64, updateReq UpdateRunnerGroupRequest) (*RunnerGroup, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v", org, groupID)
-	req, err := s.client.NewRequest("PATCH", u, updateReq)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, updateReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runnerGroup *RunnerGroup
-	resp, err := s.client.Do(ctx, req, &runnerGroup)
+	resp, err := s.client.Do(req, &runnerGroup)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -200,13 +200,13 @@ func (s *ActionsService) ListRepositoryAccessRunnerGroup(ctx context.Context, or
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var repos *ListRepositories
-	resp, err := s.client.Do(ctx, req, &repos)
+	resp, err := s.client.Do(req, &repos)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -223,12 +223,12 @@ func (s *ActionsService) ListRepositoryAccessRunnerGroup(ctx context.Context, or
 func (s *ActionsService) SetRepositoryAccessRunnerGroup(ctx context.Context, org string, groupID int64, ids SetRepoAccessRunnerGroupRequest) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v/repositories", org, groupID)
 
-	req, err := s.client.NewRequest("PUT", u, ids)
+	req, err := s.client.NewRequest(ctx, "PUT", u, ids)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // AddRepositoryAccessRunnerGroup adds a repository to the list of selected repositories that can access a self-hosted runner group.
@@ -240,12 +240,12 @@ func (s *ActionsService) SetRepositoryAccessRunnerGroup(ctx context.Context, org
 func (s *ActionsService) AddRepositoryAccessRunnerGroup(ctx context.Context, org string, groupID, repoID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v/repositories/%v", org, groupID, repoID)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RemoveRepositoryAccessRunnerGroup removes a repository from the list of selected repositories that can access a self-hosted runner group.
@@ -257,12 +257,12 @@ func (s *ActionsService) AddRepositoryAccessRunnerGroup(ctx context.Context, org
 func (s *ActionsService) RemoveRepositoryAccessRunnerGroup(ctx context.Context, org string, groupID, repoID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v/repositories/%v", org, groupID, repoID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListRunnerGroupHostedRunners lists the GitHub-hosted runners in an organization runner group.
@@ -277,13 +277,13 @@ func (s *ActionsService) ListRunnerGroupHostedRunners(ctx context.Context, org s
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runners *HostedRunners
-	resp, err := s.client.Do(ctx, req, &runners)
+	resp, err := s.client.Do(req, &runners)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -303,13 +303,13 @@ func (s *ActionsService) ListRunnerGroupRunners(ctx context.Context, org string,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runners *Runners
-	resp, err := s.client.Do(ctx, req, &runners)
+	resp, err := s.client.Do(req, &runners)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -326,12 +326,12 @@ func (s *ActionsService) ListRunnerGroupRunners(ctx context.Context, org string,
 func (s *ActionsService) SetRunnerGroupRunners(ctx context.Context, org string, groupID int64, ids SetRunnerGroupRunnersRequest) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v/runners", org, groupID)
 
-	req, err := s.client.NewRequest("PUT", u, ids)
+	req, err := s.client.NewRequest(ctx, "PUT", u, ids)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // AddRunnerGroupRunners adds a self-hosted runner to a runner group configured in an organization.
@@ -342,12 +342,12 @@ func (s *ActionsService) SetRunnerGroupRunners(ctx context.Context, org string, 
 func (s *ActionsService) AddRunnerGroupRunners(ctx context.Context, org string, groupID, runnerID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v/runners/%v", org, groupID, runnerID)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RemoveRunnerGroupRunners removes a self-hosted runner from a group configured in an organization.
@@ -359,10 +359,10 @@ func (s *ActionsService) AddRunnerGroupRunners(ctx context.Context, org string, 
 func (s *ActionsService) RemoveRunnerGroupRunners(ctx context.Context, org string, groupID, runnerID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runner-groups/%v/runners/%v", org, groupID, runnerID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -27,13 +27,13 @@ type RunnerApplicationDownload struct {
 //meta:operation GET /repos/{owner}/{repo}/actions/runners/downloads
 func (s *ActionsService) ListRunnerApplicationDownloads(ctx context.Context, owner, repo string) ([]*RunnerApplicationDownload, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners/downloads", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var rads []*RunnerApplicationDownload
-	resp, err := s.client.Do(ctx, req, &rads)
+	resp, err := s.client.Do(req, &rads)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -65,13 +65,13 @@ type JITRunnerConfig struct {
 //meta:operation POST /orgs/{org}/actions/runners/generate-jitconfig
 func (s *ActionsService) GenerateOrgJITConfig(ctx context.Context, org string, request *GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runners/generate-jitconfig", org)
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var jitConfig *JITRunnerConfig
-	resp, err := s.client.Do(ctx, req, &jitConfig)
+	resp, err := s.client.Do(req, &jitConfig)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -86,13 +86,13 @@ func (s *ActionsService) GenerateOrgJITConfig(ctx context.Context, org string, r
 //meta:operation POST /repos/{owner}/{repo}/actions/runners/generate-jitconfig
 func (s *ActionsService) GenerateRepoJITConfig(ctx context.Context, owner, repo string, request *GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners/generate-jitconfig", owner, repo)
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var jitConfig *JITRunnerConfig
-	resp, err := s.client.Do(ctx, req, &jitConfig)
+	resp, err := s.client.Do(req, &jitConfig)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -114,13 +114,13 @@ type RegistrationToken struct {
 func (s *ActionsService) CreateRegistrationToken(ctx context.Context, owner, repo string) (*RegistrationToken, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners/registration-token", owner, repo)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var registrationToken *RegistrationToken
-	resp, err := s.client.Do(ctx, req, &registrationToken)
+	resp, err := s.client.Do(req, &registrationToken)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -169,13 +169,13 @@ func (s *ActionsService) ListRunners(ctx context.Context, owner, repo string, op
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runners *Runners
-	resp, err := s.client.Do(ctx, req, &runners)
+	resp, err := s.client.Do(req, &runners)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -190,13 +190,13 @@ func (s *ActionsService) ListRunners(ctx context.Context, owner, repo string, op
 //meta:operation GET /repos/{owner}/{repo}/actions/runners/{runner_id}
 func (s *ActionsService) GetRunner(ctx context.Context, owner, repo string, runnerID int64) (*Runner, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners/%v", owner, repo, runnerID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runner *Runner
-	resp, err := s.client.Do(ctx, req, &runner)
+	resp, err := s.client.Do(req, &runner)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -218,13 +218,13 @@ type RemoveToken struct {
 func (s *ActionsService) CreateRemoveToken(ctx context.Context, owner, repo string) (*RemoveToken, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners/remove-token", owner, repo)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var removeToken *RemoveToken
-	resp, err := s.client.Do(ctx, req, &removeToken)
+	resp, err := s.client.Do(req, &removeToken)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -240,12 +240,12 @@ func (s *ActionsService) CreateRemoveToken(ctx context.Context, owner, repo stri
 func (s *ActionsService) RemoveRunner(ctx context.Context, owner, repo string, runnerID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners/%v", owner, repo, runnerID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListOrganizationRunnerApplicationDownloads lists self-hosted runner application binaries that can be downloaded and run.
@@ -255,13 +255,13 @@ func (s *ActionsService) RemoveRunner(ctx context.Context, owner, repo string, r
 //meta:operation GET /orgs/{org}/actions/runners/downloads
 func (s *ActionsService) ListOrganizationRunnerApplicationDownloads(ctx context.Context, org string) ([]*RunnerApplicationDownload, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runners/downloads", org)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var rads []*RunnerApplicationDownload
-	resp, err := s.client.Do(ctx, req, &rads)
+	resp, err := s.client.Do(req, &rads)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -277,13 +277,13 @@ func (s *ActionsService) ListOrganizationRunnerApplicationDownloads(ctx context.
 func (s *ActionsService) CreateOrganizationRegistrationToken(ctx context.Context, org string) (*RegistrationToken, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runners/registration-token", org)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var registrationToken *RegistrationToken
-	resp, err := s.client.Do(ctx, req, &registrationToken)
+	resp, err := s.client.Do(req, &registrationToken)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -303,13 +303,13 @@ func (s *ActionsService) ListOrganizationRunners(ctx context.Context, org string
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runners *Runners
-	resp, err := s.client.Do(ctx, req, &runners)
+	resp, err := s.client.Do(req, &runners)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -324,13 +324,13 @@ func (s *ActionsService) ListOrganizationRunners(ctx context.Context, org string
 //meta:operation GET /orgs/{org}/actions/runners/{runner_id}
 func (s *ActionsService) GetOrganizationRunner(ctx context.Context, org string, runnerID int64) (*Runner, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runners/%v", org, runnerID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runner *Runner
-	resp, err := s.client.Do(ctx, req, &runner)
+	resp, err := s.client.Do(req, &runner)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -346,13 +346,13 @@ func (s *ActionsService) GetOrganizationRunner(ctx context.Context, org string, 
 func (s *ActionsService) CreateOrganizationRemoveToken(ctx context.Context, org string) (*RemoveToken, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runners/remove-token", org)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var removeToken *RemoveToken
-	resp, err := s.client.Do(ctx, req, &removeToken)
+	resp, err := s.client.Do(req, &removeToken)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -368,10 +368,10 @@ func (s *ActionsService) CreateOrganizationRemoveToken(ctx context.Context, org 
 func (s *ActionsService) RemoveOrganizationRunner(ctx context.Context, org string, runnerID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runners/%v", org, runnerID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -49,13 +49,13 @@ func (p *PublicKey) UnmarshalJSON(data []byte) error {
 }
 
 func (s *ActionsService) getPublicKey(ctx context.Context, url string) (*PublicKey, *Response, error) {
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var pubKey *PublicKey
-	resp, err := s.client.Do(ctx, req, &pubKey)
+	resp, err := s.client.Do(req, &pubKey)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -114,13 +114,13 @@ func (s *ActionsService) listSecrets(ctx context.Context, url string, opts *List
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var secrets *Secrets
-	resp, err := s.client.Do(ctx, req, &secrets)
+	resp, err := s.client.Do(req, &secrets)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -172,13 +172,13 @@ func (s *ActionsService) ListEnvSecrets(ctx context.Context, repoID int, env str
 }
 
 func (s *ActionsService) getSecret(ctx context.Context, url string) (*Secret, *Response, error) {
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var secret *Secret
-	resp, err := s.client.Do(ctx, req, &secret)
+	resp, err := s.client.Do(req, &secret)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -233,12 +233,12 @@ type EncryptedSecret struct {
 }
 
 func (s *ActionsService) putSecret(ctx context.Context, url string, eSecret *EncryptedSecret) (*Response, error) {
-	req, err := s.client.NewRequest("PUT", url, eSecret)
+	req, err := s.client.NewRequest(ctx, "PUT", url, eSecret)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // CreateOrUpdateRepoSecret creates or updates a repository secret with an encrypted value.
@@ -284,12 +284,12 @@ func (s *ActionsService) CreateOrUpdateEnvSecret(ctx context.Context, repoID int
 }
 
 func (s *ActionsService) deleteSecret(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest("DELETE", url, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DeleteRepoSecret deletes a secret in a repository using the secret name.
@@ -334,13 +334,13 @@ func (s *ActionsService) listSelectedReposForSecret(ctx context.Context, url str
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var result *SelectedReposList
-	resp, err := s.client.Do(ctx, req, &result)
+	resp, err := s.client.Do(req, &result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -363,12 +363,12 @@ func (s *ActionsService) setSelectedReposForSecret(ctx context.Context, url stri
 		SelectedIDs SelectedRepoIDs `json:"selected_repository_ids"`
 	}
 
-	req, err := s.client.NewRequest("PUT", url, repoIDs{SelectedIDs: ids})
+	req, err := s.client.NewRequest(ctx, "PUT", url, repoIDs{SelectedIDs: ids})
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // SetSelectedReposForOrgSecret sets the repositories that have access to a secret.
@@ -382,12 +382,12 @@ func (s *ActionsService) SetSelectedReposForOrgSecret(ctx context.Context, org, 
 }
 
 func (s *ActionsService) addSelectedRepoToSecret(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest("PUT", url, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // AddSelectedRepoToOrgSecret adds a repository to an organization secret.
@@ -405,12 +405,12 @@ func (s *ActionsService) AddSelectedRepoToOrgSecret(ctx context.Context, org, na
 }
 
 func (s *ActionsService) removeSelectedRepoFromSecret(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest("DELETE", url, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RemoveSelectedRepoFromOrgSecret removes a repository from an organization secret.

--- a/github/actions_variables.go
+++ b/github/actions_variables.go
@@ -36,13 +36,13 @@ func (s *ActionsService) listVariables(ctx context.Context, url string, opts *Li
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var variables *ActionsVariables
-	resp, err := s.client.Do(ctx, req, &variables)
+	resp, err := s.client.Do(req, &variables)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -91,13 +91,13 @@ func (s *ActionsService) ListEnvVariables(ctx context.Context, owner, repo, env 
 }
 
 func (s *ActionsService) getVariable(ctx context.Context, url string) (*ActionsVariable, *Response, error) {
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var variable *ActionsVariable
-	resp, err := s.client.Do(ctx, req, &variable)
+	resp, err := s.client.Do(req, &variable)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -136,11 +136,11 @@ func (s *ActionsService) GetEnvVariable(ctx context.Context, owner, repo, env, v
 }
 
 func (s *ActionsService) postVariable(ctx context.Context, url string, variable *ActionsVariable) (*Response, error) {
-	req, err := s.client.NewRequest("POST", url, variable)
+	req, err := s.client.NewRequest(ctx, "POST", url, variable)
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // CreateRepoVariable creates a repository variable.
@@ -174,11 +174,11 @@ func (s *ActionsService) CreateEnvVariable(ctx context.Context, owner, repo, env
 }
 
 func (s *ActionsService) patchVariable(ctx context.Context, url string, variable *ActionsVariable) (*Response, error) {
-	req, err := s.client.NewRequest("PATCH", url, variable)
+	req, err := s.client.NewRequest(ctx, "PATCH", url, variable)
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // UpdateRepoVariable updates a repository variable.
@@ -224,12 +224,12 @@ func (s *ActionsService) UpdateEnvVariable(ctx context.Context, owner, repo, env
 }
 
 func (s *ActionsService) deleteVariable(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest("DELETE", url, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DeleteRepoVariable deletes a variable in a repository.
@@ -268,13 +268,13 @@ func (s *ActionsService) listSelectedReposForVariable(ctx context.Context, url s
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var result *SelectedReposList
-	resp, err := s.client.Do(ctx, req, &result)
+	resp, err := s.client.Do(req, &result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -297,12 +297,12 @@ func (s *ActionsService) setSelectedReposForVariable(ctx context.Context, url st
 		SelectedIDs SelectedRepoIDs `json:"selected_repository_ids"`
 	}
 
-	req, err := s.client.NewRequest("PUT", url, repoIDs{SelectedIDs: ids})
+	req, err := s.client.NewRequest(ctx, "PUT", url, repoIDs{SelectedIDs: ids})
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // SetSelectedReposForOrgVariable sets the repositories that have access to a variable.
@@ -316,12 +316,12 @@ func (s *ActionsService) SetSelectedReposForOrgVariable(ctx context.Context, org
 }
 
 func (s *ActionsService) addSelectedRepoToVariable(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest("PUT", url, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // AddSelectedRepoToOrgVariable adds a repository to an organization variable.
@@ -342,12 +342,12 @@ func (s *ActionsService) AddSelectedRepoToOrgVariable(ctx context.Context, org, 
 }
 
 func (s *ActionsService) removeSelectedRepoFromVariable(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest("DELETE", url, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RemoveSelectedRepoFromOrgVariable removes a repository from an organization variable.

--- a/github/actions_workflow_jobs.go
+++ b/github/actions_workflow_jobs.go
@@ -80,13 +80,13 @@ func (s *ActionsService) ListWorkflowJobs(ctx context.Context, owner, repo strin
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var jobs *Jobs
-	resp, err := s.client.Do(ctx, req, &jobs)
+	resp, err := s.client.Do(req, &jobs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -106,13 +106,13 @@ func (s *ActionsService) ListWorkflowJobsAttempt(ctx context.Context, owner, rep
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var jobs *Jobs
-	resp, err := s.client.Do(ctx, req, &jobs)
+	resp, err := s.client.Do(req, &jobs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -128,13 +128,13 @@ func (s *ActionsService) ListWorkflowJobsAttempt(ctx context.Context, owner, rep
 func (s *ActionsService) GetWorkflowJobByID(ctx context.Context, owner, repo string, jobID int64) (*WorkflowJob, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/jobs/%v", owner, repo, jobID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var job *WorkflowJob
-	resp, err := s.client.Do(ctx, req, &job)
+	resp, err := s.client.Do(req, &job)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -173,12 +173,12 @@ func (s *ActionsService) getWorkflowJobLogsWithoutRateLimit(ctx context.Context,
 }
 
 func (s *ActionsService) getWorkflowJobLogsWithRateLimit(ctx context.Context, u string, maxRedirects int) (*url.URL, *Response, error) {
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	url, resp, err := s.client.bareDoUntilFound(ctx, req, maxRedirects)
+	url, resp, err := s.client.bareDoUntilFound(req, maxRedirects)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -144,13 +144,13 @@ func (s *ActionsService) listWorkflowRuns(ctx context.Context, endpoint string, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runs *WorkflowRuns
-	resp, err := s.client.Do(ctx, req, &runs)
+	resp, err := s.client.Do(req, &runs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -190,13 +190,13 @@ func (s *ActionsService) ListRepositoryWorkflowRuns(ctx context.Context, owner, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runs *WorkflowRuns
-	resp, err := s.client.Do(ctx, req, &runs)
+	resp, err := s.client.Do(req, &runs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -213,13 +213,13 @@ func (s *ActionsService) ListRepositoryWorkflowRuns(ctx context.Context, owner, 
 func (s *ActionsService) GetWorkflowRunByID(ctx context.Context, owner, repo string, runID int64) (*WorkflowRun, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v", owner, repo, runID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var run *WorkflowRun
-	resp, err := s.client.Do(ctx, req, &run)
+	resp, err := s.client.Do(req, &run)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -240,13 +240,13 @@ func (s *ActionsService) GetWorkflowRunAttempt(ctx context.Context, owner, repo 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var run *WorkflowRun
-	resp, err := s.client.Do(ctx, req, &run)
+	resp, err := s.client.Do(req, &run)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -286,12 +286,12 @@ func (s *ActionsService) getWorkflowRunAttemptLogsWithoutRateLimit(ctx context.C
 }
 
 func (s *ActionsService) getWorkflowRunAttemptLogsWithRateLimit(ctx context.Context, u string, maxRedirects int) (*url.URL, *Response, error) {
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	url, resp, err := s.client.bareDoUntilFound(ctx, req, maxRedirects)
+	url, resp, err := s.client.bareDoUntilFound(req, maxRedirects)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -314,12 +314,12 @@ func (s *ActionsService) getWorkflowRunAttemptLogsWithRateLimit(ctx context.Cont
 func (s *ActionsService) RerunWorkflowByID(ctx context.Context, owner, repo string, runID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/rerun", owner, repo, runID)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RerunFailedJobsByID re-runs all of the failed jobs and their dependent jobs in a workflow run by ID.
@@ -331,12 +331,12 @@ func (s *ActionsService) RerunWorkflowByID(ctx context.Context, owner, repo stri
 func (s *ActionsService) RerunFailedJobsByID(ctx context.Context, owner, repo string, runID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/rerun-failed-jobs", owner, repo, runID)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RerunJobByID re-runs a job and its dependent jobs in a workflow run by ID.
@@ -349,12 +349,12 @@ func (s *ActionsService) RerunFailedJobsByID(ctx context.Context, owner, repo st
 func (s *ActionsService) RerunJobByID(ctx context.Context, owner, repo string, jobID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/jobs/%v/rerun", owner, repo, jobID)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // CancelWorkflowRunByID cancels a workflow run by ID.
@@ -366,12 +366,12 @@ func (s *ActionsService) RerunJobByID(ctx context.Context, owner, repo string, j
 func (s *ActionsService) CancelWorkflowRunByID(ctx context.Context, owner, repo string, runID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/cancel", owner, repo, runID)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetWorkflowRunLogs gets a redirect URL to download a plain text file of logs for a workflow run.
@@ -406,12 +406,12 @@ func (s *ActionsService) getWorkflowRunLogsWithoutRateLimit(ctx context.Context,
 }
 
 func (s *ActionsService) getWorkflowRunLogsWithRateLimit(ctx context.Context, u string, maxRedirects int) (*url.URL, *Response, error) {
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	url, resp, err := s.client.bareDoUntilFound(ctx, req, maxRedirects)
+	url, resp, err := s.client.bareDoUntilFound(req, maxRedirects)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -434,12 +434,12 @@ func (s *ActionsService) getWorkflowRunLogsWithRateLimit(ctx context.Context, u 
 func (s *ActionsService) DeleteWorkflowRun(ctx context.Context, owner, repo string, runID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v", owner, repo, runID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DeleteWorkflowRunLogs deletes all logs for a workflow run.
@@ -451,12 +451,12 @@ func (s *ActionsService) DeleteWorkflowRun(ctx context.Context, owner, repo stri
 func (s *ActionsService) DeleteWorkflowRunLogs(ctx context.Context, owner, repo string, runID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/logs", owner, repo, runID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetWorkflowRunUsageByID gets a specific workflow usage run by run ID in the unit of billable milliseconds.
@@ -468,13 +468,13 @@ func (s *ActionsService) DeleteWorkflowRunLogs(ctx context.Context, owner, repo 
 func (s *ActionsService) GetWorkflowRunUsageByID(ctx context.Context, owner, repo string, runID int64) (*WorkflowRunUsage, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/timing", owner, repo, runID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var workflowRunUsage *WorkflowRunUsage
-	resp, err := s.client.Do(ctx, req, &workflowRunUsage)
+	resp, err := s.client.Do(req, &workflowRunUsage)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -491,13 +491,13 @@ func (s *ActionsService) GetWorkflowRunUsageByID(ctx context.Context, owner, rep
 func (s *ActionsService) GetPendingDeployments(ctx context.Context, owner, repo string, runID int64) ([]*PendingDeployment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/pending_deployments", owner, repo, runID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var deployments []*PendingDeployment
-	resp, err := s.client.Do(ctx, req, &deployments)
+	resp, err := s.client.Do(req, &deployments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -514,13 +514,13 @@ func (s *ActionsService) GetPendingDeployments(ctx context.Context, owner, repo 
 func (s *ActionsService) PendingDeployments(ctx context.Context, owner, repo string, runID int64, request *PendingDeploymentsRequest) ([]*Deployment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/pending_deployments", owner, repo, runID)
 
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var deployments []*Deployment
-	resp, err := s.client.Do(ctx, req, &deployments)
+	resp, err := s.client.Do(req, &deployments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -537,11 +537,11 @@ func (s *ActionsService) PendingDeployments(ctx context.Context, owner, repo str
 func (s *ActionsService) ReviewCustomDeploymentProtectionRule(ctx context.Context, owner, repo string, runID int64, request *ReviewCustomDeploymentProtectionRuleRequest) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/deployment_protection_rule", owner, repo, runID)
 
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	return resp, err
 }

--- a/github/actions_workflows.go
+++ b/github/actions_workflows.go
@@ -109,13 +109,13 @@ func (s *ActionsService) ListWorkflows(ctx context.Context, owner, repo string, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var workflows *Workflows
-	resp, err := s.client.Do(ctx, req, &workflows)
+	resp, err := s.client.Do(req, &workflows)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -146,13 +146,13 @@ func (s *ActionsService) GetWorkflowByFileName(ctx context.Context, owner, repo,
 }
 
 func (s *ActionsService) getWorkflow(ctx context.Context, url string) (*Workflow, *Response, error) {
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var workflow *Workflow
-	resp, err := s.client.Do(ctx, req, &workflow)
+	resp, err := s.client.Do(req, &workflow)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -183,13 +183,13 @@ func (s *ActionsService) GetWorkflowUsageByFileName(ctx context.Context, owner, 
 }
 
 func (s *ActionsService) getWorkflowUsage(ctx context.Context, url string) (*WorkflowUsage, *Response, error) {
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var workflowUsage *WorkflowUsage
-	resp, err := s.client.Do(ctx, req, &workflowUsage)
+	resp, err := s.client.Do(req, &workflowUsage)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -220,13 +220,13 @@ func (s *ActionsService) CreateWorkflowDispatchEventByFileName(ctx context.Conte
 }
 
 func (s *ActionsService) createWorkflowDispatchEvent(ctx context.Context, url string, event *CreateWorkflowDispatchEventRequest) (*WorkflowDispatchRunDetails, *Response, error) {
-	req, err := s.client.NewRequest("POST", url, event)
+	req, err := s.client.NewRequest(ctx, "POST", url, event)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var dispatchRunDetails *WorkflowDispatchRunDetails
-	resp, err := s.client.Do(ctx, req, &dispatchRunDetails)
+	resp, err := s.client.Do(req, &dispatchRunDetails)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -275,10 +275,10 @@ func (s *ActionsService) DisableWorkflowByFileName(ctx context.Context, owner, r
 }
 
 func (s *ActionsService) doNewPutRequest(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest("PUT", url, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/activity.go
+++ b/github/activity.go
@@ -62,13 +62,13 @@ type FeedLinks struct {
 //
 //meta:operation GET /feeds
 func (s *ActivityService) ListFeeds(ctx context.Context) (*Feeds, *Response, error) {
-	req, err := s.client.NewRequest("GET", "feeds", nil)
+	req, err := s.client.NewRequest(ctx, "GET", "feeds", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var f *Feeds
-	resp, err := s.client.Do(ctx, req, &f)
+	resp, err := s.client.Do(req, &f)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -21,13 +21,13 @@ func (s *ActivityService) ListEvents(ctx context.Context, opts *ListOptions) ([]
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var events []*Event
-	resp, err := s.client.Do(ctx, req, &events)
+	resp, err := s.client.Do(req, &events)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -47,13 +47,13 @@ func (s *ActivityService) ListRepositoryEvents(ctx context.Context, owner, repo 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var events []*Event
-	resp, err := s.client.Do(ctx, req, &events)
+	resp, err := s.client.Do(req, &events)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -73,13 +73,13 @@ func (s *ActivityService) ListIssueEventsForRepository(ctx context.Context, owne
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var events []*IssueEvent
-	resp, err := s.client.Do(ctx, req, &events)
+	resp, err := s.client.Do(req, &events)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -99,13 +99,13 @@ func (s *ActivityService) ListEventsForRepoNetwork(ctx context.Context, owner, r
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var events []*Event
-	resp, err := s.client.Do(ctx, req, &events)
+	resp, err := s.client.Do(req, &events)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -125,13 +125,13 @@ func (s *ActivityService) ListEventsForOrganization(ctx context.Context, org str
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var events []*Event
-	resp, err := s.client.Do(ctx, req, &events)
+	resp, err := s.client.Do(req, &events)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -160,13 +160,13 @@ func (s *ActivityService) ListEventsPerformedByUser(ctx context.Context, user st
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var events []*Event
-	resp, err := s.client.Do(ctx, req, &events)
+	resp, err := s.client.Do(req, &events)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -195,13 +195,13 @@ func (s *ActivityService) ListEventsReceivedByUser(ctx context.Context, user str
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var events []*Event
-	resp, err := s.client.Do(ctx, req, &events)
+	resp, err := s.client.Do(req, &events)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -222,13 +222,13 @@ func (s *ActivityService) ListUserEventsForOrganization(ctx context.Context, org
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var events []*Event
-	resp, err := s.client.Do(ctx, req, &events)
+	resp, err := s.client.Do(req, &events)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/activity_notifications.go
+++ b/github/activity_notifications.go
@@ -59,13 +59,13 @@ func (s *ActivityService) ListNotifications(ctx context.Context, opts *Notificat
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var notifications []*Notification
-	resp, err := s.client.Do(ctx, req, &notifications)
+	resp, err := s.client.Do(req, &notifications)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -86,13 +86,13 @@ func (s *ActivityService) ListRepositoryNotifications(ctx context.Context, owner
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var notifications []*Notification
-	resp, err := s.client.Do(ctx, req, &notifications)
+	resp, err := s.client.Do(req, &notifications)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -114,12 +114,12 @@ func (s *ActivityService) MarkNotificationsRead(ctx context.Context, lastRead Ti
 	opts := &markReadOptions{
 		LastReadAt: lastRead,
 	}
-	req, err := s.client.NewRequest("PUT", "notifications", opts)
+	req, err := s.client.NewRequest(ctx, "PUT", "notifications", opts)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // MarkRepositoryNotificationsRead marks all notifications up to lastRead in
@@ -134,12 +134,12 @@ func (s *ActivityService) MarkRepositoryNotificationsRead(ctx context.Context, o
 		LastReadAt: lastRead,
 	}
 	u := fmt.Sprintf("repos/%v/%v/notifications", owner, repo)
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetThread gets the specified notification thread.
@@ -150,13 +150,13 @@ func (s *ActivityService) MarkRepositoryNotificationsRead(ctx context.Context, o
 func (s *ActivityService) GetThread(ctx context.Context, id string) (*Notification, *Response, error) {
 	u := fmt.Sprintf("notifications/threads/%v", id)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var notification *Notification
-	resp, err := s.client.Do(ctx, req, &notification)
+	resp, err := s.client.Do(req, &notification)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -172,12 +172,12 @@ func (s *ActivityService) GetThread(ctx context.Context, id string) (*Notificati
 func (s *ActivityService) MarkThreadRead(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("notifications/threads/%v", id)
 
-	req, err := s.client.NewRequest("PATCH", u, nil)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // MarkThreadDone marks the specified thread as done.
@@ -189,12 +189,12 @@ func (s *ActivityService) MarkThreadRead(ctx context.Context, id string) (*Respo
 func (s *ActivityService) MarkThreadDone(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("notifications/threads/%v", id)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetThreadSubscription checks to see if the authenticated user is subscribed
@@ -206,13 +206,13 @@ func (s *ActivityService) MarkThreadDone(ctx context.Context, id string) (*Respo
 func (s *ActivityService) GetThreadSubscription(ctx context.Context, id string) (*Subscription, *Response, error) {
 	u := fmt.Sprintf("notifications/threads/%v/subscription", id)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var sub *Subscription
-	resp, err := s.client.Do(ctx, req, &sub)
+	resp, err := s.client.Do(req, &sub)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -229,13 +229,13 @@ func (s *ActivityService) GetThreadSubscription(ctx context.Context, id string) 
 func (s *ActivityService) SetThreadSubscription(ctx context.Context, id string, subscription *Subscription) (*Subscription, *Response, error) {
 	u := fmt.Sprintf("notifications/threads/%v/subscription", id)
 
-	req, err := s.client.NewRequest("PUT", u, subscription)
+	req, err := s.client.NewRequest(ctx, "PUT", u, subscription)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var sub *Subscription
-	resp, err := s.client.Do(ctx, req, &sub)
+	resp, err := s.client.Do(req, &sub)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -251,10 +251,10 @@ func (s *ActivityService) SetThreadSubscription(ctx context.Context, id string, 
 //meta:operation DELETE /notifications/threads/{thread_id}/subscription
 func (s *ActivityService) DeleteThreadSubscription(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("notifications/threads/%v/subscription", id)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/activity_star.go
+++ b/github/activity_star.go
@@ -35,7 +35,7 @@ func (s *ActivityService) ListStargazers(ctx context.Context, owner, repo string
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -43,7 +43,7 @@ func (s *ActivityService) ListStargazers(ctx context.Context, owner, repo string
 	req.Header.Set("Accept", mediaTypeStarring)
 
 	var stargazers []*Stargazer
-	resp, err := s.client.Do(ctx, req, &stargazers)
+	resp, err := s.client.Do(req, &stargazers)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -86,7 +86,7 @@ func (s *ActivityService) ListStarred(ctx context.Context, user string, opts *Ac
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -95,7 +95,7 @@ func (s *ActivityService) ListStarred(ctx context.Context, user string, opts *Ac
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var repos []*StarredRepository
-	resp, err := s.client.Do(ctx, req, &repos)
+	resp, err := s.client.Do(req, &repos)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -110,12 +110,12 @@ func (s *ActivityService) ListStarred(ctx context.Context, user string, opts *Ac
 //meta:operation GET /user/starred/{owner}/{repo}
 func (s *ActivityService) IsStarred(ctx context.Context, owner, repo string) (bool, *Response, error) {
 	u := fmt.Sprintf("user/starred/%v/%v", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return false, nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	starred, err := parseBoolResponse(err)
 	return starred, resp, err
 }
@@ -127,12 +127,12 @@ func (s *ActivityService) IsStarred(ctx context.Context, owner, repo string) (bo
 //meta:operation PUT /user/starred/{owner}/{repo}
 func (s *ActivityService) Star(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("user/starred/%v/%v", owner, repo)
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // Unstar a repository as the authenticated user.
@@ -142,10 +142,10 @@ func (s *ActivityService) Star(ctx context.Context, owner, repo string) (*Respon
 //meta:operation DELETE /user/starred/{owner}/{repo}
 func (s *ActivityService) Unstar(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("user/starred/%v/%v", owner, repo)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/activity_watching.go
+++ b/github/activity_watching.go
@@ -37,13 +37,13 @@ func (s *ActivityService) ListWatchers(ctx context.Context, owner, repo string, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var watchers []*User
-	resp, err := s.client.Do(ctx, req, &watchers)
+	resp, err := s.client.Do(req, &watchers)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -72,13 +72,13 @@ func (s *ActivityService) ListWatched(ctx context.Context, user string, opts *Li
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var watched []*Repository
-	resp, err := s.client.Do(ctx, req, &watched)
+	resp, err := s.client.Do(req, &watched)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -96,13 +96,13 @@ func (s *ActivityService) ListWatched(ctx context.Context, user string, opts *Li
 func (s *ActivityService) GetRepositorySubscription(ctx context.Context, owner, repo string) (*Subscription, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/subscription", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var sub *Subscription
-	resp, err := s.client.Do(ctx, req, &sub)
+	resp, err := s.client.Do(req, &sub)
 	if err != nil {
 		// if it's just a 404, don't return that as an error
 		_, err = parseBoolResponse(err)
@@ -125,13 +125,13 @@ func (s *ActivityService) GetRepositorySubscription(ctx context.Context, owner, 
 func (s *ActivityService) SetRepositorySubscription(ctx context.Context, owner, repo string, subscription *Subscription) (*Subscription, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/subscription", owner, repo)
 
-	req, err := s.client.NewRequest("PUT", u, subscription)
+	req, err := s.client.NewRequest(ctx, "PUT", u, subscription)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var sub *Subscription
-	resp, err := s.client.Do(ctx, req, &sub)
+	resp, err := s.client.Do(req, &sub)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -150,10 +150,10 @@ func (s *ActivityService) SetRepositorySubscription(ctx context.Context, owner, 
 //meta:operation DELETE /repos/{owner}/{repo}/subscription
 func (s *ActivityService) DeleteRepositorySubscription(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/subscription", owner, repo)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/admin.go
+++ b/github/admin.go
@@ -87,13 +87,13 @@ func (m Enterprise) String() string {
 //meta:operation PATCH /admin/ldap/users/{username}/mapping
 func (s *AdminService) UpdateUserLDAPMapping(ctx context.Context, user string, mapping *UserLDAPMapping) (*UserLDAPMapping, *Response, error) {
 	u := fmt.Sprintf("admin/ldap/users/%v/mapping", user)
-	req, err := s.client.NewRequest("PATCH", u, mapping)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, mapping)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var m *UserLDAPMapping
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -108,13 +108,13 @@ func (s *AdminService) UpdateUserLDAPMapping(ctx context.Context, user string, m
 //meta:operation PATCH /admin/ldap/teams/{team_id}/mapping
 func (s *AdminService) UpdateTeamLDAPMapping(ctx context.Context, team int64, mapping *TeamLDAPMapping) (*TeamLDAPMapping, *Response, error) {
 	u := fmt.Sprintf("admin/ldap/teams/%v/mapping", team)
-	req, err := s.client.NewRequest("PATCH", u, mapping)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, mapping)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var m *TeamLDAPMapping
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/admin_orgs.go
+++ b/github/admin_orgs.go
@@ -34,13 +34,13 @@ func (s *AdminService) CreateOrg(ctx context.Context, org *Organization, admin s
 		Admin: &admin,
 	}
 
-	req, err := s.client.NewRequest("POST", u, orgReq)
+	req, err := s.client.NewRequest(ctx, "POST", u, orgReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var o *Organization
-	resp, err := s.client.Do(ctx, req, &o)
+	resp, err := s.client.Do(req, &o)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -88,13 +88,13 @@ func (s *AdminService) RenameOrgByName(ctx context.Context, org, newName string)
 		Login: &newName,
 	}
 
-	req, err := s.client.NewRequest("PATCH", u, orgReq)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, orgReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var o *RenameOrgResponse
-	resp, err := s.client.Do(ctx, req, &o)
+	resp, err := s.client.Do(req, &o)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/admin_stats.go
+++ b/github/admin_stats.go
@@ -157,13 +157,13 @@ func (s RepoStats) String() string {
 //meta:operation GET /enterprise/stats/all
 func (s *AdminService) GetAdminStats(ctx context.Context) (*AdminStats, *Response, error) {
 	u := "enterprise/stats/all"
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var m *AdminStats
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/admin_users.go
+++ b/github/admin_users.go
@@ -26,13 +26,13 @@ type CreateUserRequest struct {
 func (s *AdminService) CreateUser(ctx context.Context, userReq CreateUserRequest) (*User, *Response, error) {
 	u := "admin/users"
 
-	req, err := s.client.NewRequest("POST", u, userReq)
+	req, err := s.client.NewRequest(ctx, "POST", u, userReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var user User
-	resp, err := s.client.Do(ctx, req, &user)
+	resp, err := s.client.Do(req, &user)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -48,12 +48,12 @@ func (s *AdminService) CreateUser(ctx context.Context, userReq CreateUserRequest
 func (s *AdminService) DeleteUser(ctx context.Context, username string) (*Response, error) {
 	u := "admin/users/" + username
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -101,13 +101,13 @@ type UserAuthorization struct {
 func (s *AdminService) CreateUserImpersonation(ctx context.Context, username string, opts *ImpersonateUserOptions) (*UserAuthorization, *Response, error) {
 	u := fmt.Sprintf("admin/users/%v/authorizations", username)
 
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var a *UserAuthorization
-	resp, err := s.client.Do(ctx, req, &a)
+	resp, err := s.client.Do(req, &a)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -123,12 +123,12 @@ func (s *AdminService) CreateUserImpersonation(ctx context.Context, username str
 func (s *AdminService) DeleteUserImpersonation(ctx context.Context, username string) (*Response, error) {
 	u := fmt.Sprintf("admin/users/%v/authorizations", username)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/github/apps.go
+++ b/github/apps.go
@@ -230,13 +230,13 @@ func (s *AppsService) Get(ctx context.Context, appSlug string) (*App, *Response,
 		u = "app"
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var app *App
-	resp, err := s.client.Do(ctx, req, &app)
+	resp, err := s.client.Do(req, &app)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -255,13 +255,13 @@ func (s *AppsService) ListInstallationRequests(ctx context.Context, opts *ListOp
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var i []*InstallationRequest
-	resp, err := s.client.Do(ctx, req, &i)
+	resp, err := s.client.Do(req, &i)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -280,13 +280,13 @@ func (s *AppsService) ListInstallations(ctx context.Context, opts *ListOptions) 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var i []*Installation
-	resp, err := s.client.Do(ctx, req, &i)
+	resp, err := s.client.Do(req, &i)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -314,7 +314,7 @@ func (s *AppsService) ListUserInstallations(ctx context.Context, opts *ListOptio
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -322,7 +322,7 @@ func (s *AppsService) ListUserInstallations(ctx context.Context, opts *ListOptio
 	var i struct {
 		Installations []*Installation `json:"installations"`
 	}
-	resp, err := s.client.Do(ctx, req, &i)
+	resp, err := s.client.Do(req, &i)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -338,12 +338,12 @@ func (s *AppsService) ListUserInstallations(ctx context.Context, opts *ListOptio
 func (s *AppsService) SuspendInstallation(ctx context.Context, id int64) (*Response, error) {
 	u := fmt.Sprintf("app/installations/%v/suspended", id)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // UnsuspendInstallation unsuspends the specified installation.
@@ -354,12 +354,12 @@ func (s *AppsService) SuspendInstallation(ctx context.Context, id int64) (*Respo
 func (s *AppsService) UnsuspendInstallation(ctx context.Context, id int64) (*Response, error) {
 	u := fmt.Sprintf("app/installations/%v/suspended", id)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DeleteInstallation deletes the specified installation.
@@ -370,12 +370,12 @@ func (s *AppsService) UnsuspendInstallation(ctx context.Context, id int64) (*Res
 func (s *AppsService) DeleteInstallation(ctx context.Context, id int64) (*Response, error) {
 	u := fmt.Sprintf("app/installations/%v", id)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // CreateInstallationToken creates a new installation token.
@@ -386,13 +386,13 @@ func (s *AppsService) DeleteInstallation(ctx context.Context, id int64) (*Respon
 func (s *AppsService) CreateInstallationToken(ctx context.Context, id int64, opts *InstallationTokenOptions) (*InstallationToken, *Response, error) {
 	u := fmt.Sprintf("app/installations/%v/access_tokens", id)
 
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var t *InstallationToken
-	resp, err := s.client.Do(ctx, req, &t)
+	resp, err := s.client.Do(req, &t)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -410,13 +410,13 @@ func (s *AppsService) CreateInstallationToken(ctx context.Context, id int64, opt
 func (s *AppsService) CreateInstallationTokenListRepos(ctx context.Context, id int64, opts *InstallationTokenListRepoOptions) (*InstallationToken, *Response, error) {
 	u := fmt.Sprintf("app/installations/%v/access_tokens", id)
 
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var t *InstallationToken
-	resp, err := s.client.Do(ctx, req, &t)
+	resp, err := s.client.Do(req, &t)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -432,7 +432,7 @@ func (s *AppsService) CreateInstallationTokenListRepos(ctx context.Context, id i
 func (s *AppsService) CreateAttachment(ctx context.Context, contentReferenceID int64, title, body string) (*Attachment, *Response, error) {
 	u := fmt.Sprintf("content_references/%v/attachments", contentReferenceID)
 	payload := &Attachment{Title: &title, Body: &body}
-	req, err := s.client.NewRequest("POST", u, payload)
+	req, err := s.client.NewRequest(ctx, "POST", u, payload)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -440,7 +440,7 @@ func (s *AppsService) CreateAttachment(ctx context.Context, contentReferenceID i
 	req.Header.Set("Accept", mediaTypeContentAttachmentsPreview)
 
 	var m *Attachment
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -485,13 +485,13 @@ func (s *AppsService) FindUserInstallation(ctx context.Context, user string) (*I
 }
 
 func (s *AppsService) getInstallation(ctx context.Context, url string) (*Installation, *Response, error) {
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var i *Installation
-	resp, err := s.client.Do(ctx, req, &i)
+	resp, err := s.client.Do(req, &i)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/apps_hooks.go
+++ b/github/apps_hooks.go
@@ -16,13 +16,13 @@ import (
 //
 //meta:operation GET /app/hook/config
 func (s *AppsService) GetHookConfig(ctx context.Context) (*HookConfig, *Response, error) {
-	req, err := s.client.NewRequest("GET", "app/hook/config", nil)
+	req, err := s.client.NewRequest(ctx, "GET", "app/hook/config", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var config *HookConfig
-	resp, err := s.client.Do(ctx, req, &config)
+	resp, err := s.client.Do(req, &config)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -37,13 +37,13 @@ func (s *AppsService) GetHookConfig(ctx context.Context) (*HookConfig, *Response
 //
 //meta:operation PATCH /app/hook/config
 func (s *AppsService) UpdateHookConfig(ctx context.Context, config *HookConfig) (*HookConfig, *Response, error) {
-	req, err := s.client.NewRequest("PATCH", "app/hook/config", config)
+	req, err := s.client.NewRequest(ctx, "PATCH", "app/hook/config", config)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var c *HookConfig
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/apps_hooks_deliveries.go
+++ b/github/apps_hooks_deliveries.go
@@ -21,13 +21,13 @@ func (s *AppsService) ListHookDeliveries(ctx context.Context, opts *ListCursorOp
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	deliveries := []*HookDelivery{}
-	resp, err := s.client.Do(ctx, req, &deliveries)
+	resp, err := s.client.Do(req, &deliveries)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -42,13 +42,13 @@ func (s *AppsService) ListHookDeliveries(ctx context.Context, opts *ListCursorOp
 //meta:operation GET /app/hook/deliveries/{delivery_id}
 func (s *AppsService) GetHookDelivery(ctx context.Context, deliveryID int64) (*HookDelivery, *Response, error) {
 	u := fmt.Sprintf("app/hook/deliveries/%v", deliveryID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var h *HookDelivery
-	resp, err := s.client.Do(ctx, req, &h)
+	resp, err := s.client.Do(req, &h)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -63,13 +63,13 @@ func (s *AppsService) GetHookDelivery(ctx context.Context, deliveryID int64) (*H
 //meta:operation POST /app/hook/deliveries/{delivery_id}/attempts
 func (s *AppsService) RedeliverHookDelivery(ctx context.Context, deliveryID int64) (*HookDelivery, *Response, error) {
 	u := fmt.Sprintf("app/hook/deliveries/%v/attempts", deliveryID)
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var h *HookDelivery
-	resp, err := s.client.Do(ctx, req, &h)
+	resp, err := s.client.Do(req, &h)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -27,13 +27,13 @@ func (s *AppsService) ListRepos(ctx context.Context, opts *ListOptions) (*ListRe
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *ListRepositories
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -54,13 +54,13 @@ func (s *AppsService) ListUserRepos(ctx context.Context, id int64, opts *ListOpt
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *ListRepositories
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -75,13 +75,13 @@ func (s *AppsService) ListUserRepos(ctx context.Context, id int64, opts *ListOpt
 //meta:operation PUT /user/installations/{installation_id}/repositories/{repository_id}
 func (s *AppsService) AddRepository(ctx context.Context, instID, repoID int64) (*Repository, *Response, error) {
 	u := fmt.Sprintf("user/installations/%v/repositories/%v", instID, repoID)
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *Repository
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -96,12 +96,12 @@ func (s *AppsService) AddRepository(ctx context.Context, instID, repoID int64) (
 //meta:operation DELETE /user/installations/{installation_id}/repositories/{repository_id}
 func (s *AppsService) RemoveRepository(ctx context.Context, instID, repoID int64) (*Response, error) {
 	u := fmt.Sprintf("user/installations/%v/repositories/%v", instID, repoID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RevokeInstallationToken revokes an installation token.
@@ -111,10 +111,10 @@ func (s *AppsService) RemoveRepository(ctx context.Context, instID, repoID int64
 //meta:operation DELETE /installation/token
 func (s *AppsService) RevokeInstallationToken(ctx context.Context) (*Response, error) {
 	u := "installation/token"
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/apps_manifest.go
+++ b/github/apps_manifest.go
@@ -36,13 +36,13 @@ type AppConfig struct {
 //meta:operation POST /app-manifests/{code}/conversions
 func (s *AppsService) CompleteAppManifest(ctx context.Context, code string) (*AppConfig, *Response, error) {
 	u := fmt.Sprintf("app-manifests/%v/conversions", code)
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var cfg *AppConfig
-	resp, err := s.client.Do(ctx, req, &cfg)
+	resp, err := s.client.Do(req, &cfg)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/apps_marketplace.go
+++ b/github/apps_marketplace.go
@@ -102,13 +102,13 @@ func (s *MarketplaceService) ListPlans(ctx context.Context, opts *ListOptions) (
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var plans []*MarketplacePlan
-	resp, err := s.client.Do(ctx, req, &plans)
+	resp, err := s.client.Do(req, &plans)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -131,13 +131,13 @@ func (s *MarketplaceService) ListPlanAccountsForPlan(ctx context.Context, planID
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var accounts []*MarketplacePlanAccount
-	resp, err := s.client.Do(ctx, req, &accounts)
+	resp, err := s.client.Do(req, &accounts)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -156,13 +156,13 @@ func (s *MarketplaceService) ListPlanAccountsForPlan(ctx context.Context, planID
 func (s *MarketplaceService) GetPlanAccountForAccount(ctx context.Context, accountID int64) (*MarketplacePlanAccount, *Response, error) {
 	uri := s.marketplaceURI(fmt.Sprintf("accounts/%v", accountID))
 
-	req, err := s.client.NewRequest("GET", uri, nil)
+	req, err := s.client.NewRequest(ctx, "GET", uri, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var account *MarketplacePlanAccount
-	resp, err := s.client.Do(ctx, req, &account)
+	resp, err := s.client.Do(req, &account)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -189,13 +189,13 @@ func (s *MarketplaceService) ListMarketplacePurchasesForUser(ctx context.Context
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var purchases []*MarketplacePurchase
-	resp, err := s.client.Do(ctx, req, &purchases)
+	resp, err := s.client.Do(req, &purchases)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/authorizations.go
+++ b/github/authorizations.go
@@ -153,14 +153,14 @@ func (s *AuthorizationsService) Check(ctx context.Context, clientID, accessToken
 		AccessToken string `json:"access_token"`
 	}{AccessToken: accessToken}
 
-	req, err := s.client.NewRequest("POST", u, reqBody)
+	req, err := s.client.NewRequest(ctx, "POST", u, reqBody)
 	if err != nil {
 		return nil, nil, err
 	}
 	req.Header.Set("Accept", mediaTypeOAuthAppPreview)
 
 	var a *Authorization
-	resp, err := s.client.Do(ctx, req, &a)
+	resp, err := s.client.Do(req, &a)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -188,14 +188,14 @@ func (s *AuthorizationsService) Reset(ctx context.Context, clientID, accessToken
 		AccessToken string `json:"access_token"`
 	}{AccessToken: accessToken}
 
-	req, err := s.client.NewRequest("PATCH", u, reqBody)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, reqBody)
 	if err != nil {
 		return nil, nil, err
 	}
 	req.Header.Set("Accept", mediaTypeOAuthAppPreview)
 
 	var a *Authorization
-	resp, err := s.client.Do(ctx, req, &a)
+	resp, err := s.client.Do(req, &a)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -219,13 +219,13 @@ func (s *AuthorizationsService) Revoke(ctx context.Context, clientID, accessToke
 		AccessToken string `json:"access_token"`
 	}{AccessToken: accessToken}
 
-	req, err := s.client.NewRequest("DELETE", u, reqBody)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, reqBody)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", mediaTypeOAuthAppPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DeleteGrant deletes an OAuth application grant. Deleting an application's
@@ -242,13 +242,13 @@ func (s *AuthorizationsService) DeleteGrant(ctx context.Context, clientID, acces
 		AccessToken string `json:"access_token"`
 	}{AccessToken: accessToken}
 
-	req, err := s.client.NewRequest("DELETE", u, reqBody)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, reqBody)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", mediaTypeOAuthAppPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // CreateImpersonation creates an impersonation OAuth token.
@@ -262,13 +262,13 @@ func (s *AuthorizationsService) DeleteGrant(ctx context.Context, clientID, acces
 //meta:operation POST /admin/users/{username}/authorizations
 func (s *AuthorizationsService) CreateImpersonation(ctx context.Context, username string, authReq *AuthorizationRequest) (*Authorization, *Response, error) {
 	u := fmt.Sprintf("admin/users/%v/authorizations", username)
-	req, err := s.client.NewRequest("POST", u, authReq)
+	req, err := s.client.NewRequest(ctx, "POST", u, authReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var a *Authorization
-	resp, err := s.client.Do(ctx, req, &a)
+	resp, err := s.client.Do(req, &a)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -284,10 +284,10 @@ func (s *AuthorizationsService) CreateImpersonation(ctx context.Context, usernam
 //meta:operation DELETE /admin/users/{username}/authorizations
 func (s *AuthorizationsService) DeleteImpersonation(ctx context.Context, username string) (*Response, error) {
 	u := fmt.Sprintf("admin/users/%v/authorizations", username)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/billing.go
+++ b/github/billing.go
@@ -177,13 +177,13 @@ type PremiumRequestUsageReport struct {
 // See https://github.com/google/go-github/issues/3894 for details.
 func (s *BillingService) GetOrganizationPackagesBilling(ctx context.Context, org string) (*PackagesBilling, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/settings/billing/packages", org)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var result *PackagesBilling
-	resp, err := s.client.Do(ctx, req, &result)
+	resp, err := s.client.Do(req, &result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -198,13 +198,13 @@ func (s *BillingService) GetOrganizationPackagesBilling(ctx context.Context, org
 // See https://github.com/google/go-github/issues/3894 for details.
 func (s *BillingService) GetOrganizationStorageBilling(ctx context.Context, org string) (*StorageBilling, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/settings/billing/shared-storage", org)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var result *StorageBilling
-	resp, err := s.client.Do(ctx, req, &result)
+	resp, err := s.client.Do(req, &result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -224,13 +224,13 @@ func (s *BillingService) GetOrganizationAdvancedSecurityActiveCommitters(ctx con
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var result *ActiveCommitters
-	resp, err := s.client.Do(ctx, req, &result)
+	resp, err := s.client.Do(req, &result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -244,13 +244,13 @@ func (s *BillingService) GetOrganizationAdvancedSecurityActiveCommitters(ctx con
 // See https://github.com/google/go-github/issues/3894 for details.
 func (s *BillingService) GetPackagesBilling(ctx context.Context, user string) (*PackagesBilling, *Response, error) {
 	u := fmt.Sprintf("users/%v/settings/billing/packages", user)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var packagesUserBilling *PackagesBilling
-	resp, err := s.client.Do(ctx, req, &packagesUserBilling)
+	resp, err := s.client.Do(req, &packagesUserBilling)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -265,13 +265,13 @@ func (s *BillingService) GetPackagesBilling(ctx context.Context, user string) (*
 // See https://github.com/google/go-github/issues/3894 for details.
 func (s *BillingService) GetStorageBilling(ctx context.Context, user string) (*StorageBilling, *Response, error) {
 	u := fmt.Sprintf("users/%v/settings/billing/shared-storage", user)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var storageUserBilling *StorageBilling
-	resp, err := s.client.Do(ctx, req, &storageUserBilling)
+	resp, err := s.client.Do(req, &storageUserBilling)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -293,13 +293,13 @@ func (s *BillingService) GetOrganizationUsageReport(ctx context.Context, org str
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var usageReport *UsageReport
-	resp, err := s.client.Do(ctx, req, &usageReport)
+	resp, err := s.client.Do(req, &usageReport)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -321,13 +321,13 @@ func (s *BillingService) GetUsageReport(ctx context.Context, user string, opts *
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var usageReport *UsageReport
-	resp, err := s.client.Do(ctx, req, &usageReport)
+	resp, err := s.client.Do(req, &usageReport)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -350,13 +350,13 @@ func (s *BillingService) GetOrganizationPremiumRequestUsageReport(ctx context.Co
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var premiumRequestUsageReport *PremiumRequestUsageReport
-	resp, err := s.client.Do(ctx, req, &premiumRequestUsageReport)
+	resp, err := s.client.Do(req, &premiumRequestUsageReport)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -379,13 +379,13 @@ func (s *BillingService) GetPremiumRequestUsageReport(ctx context.Context, user 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var premiumRequestUsageReport *PremiumRequestUsageReport
-	resp, err := s.client.Do(ctx, req, &premiumRequestUsageReport)
+	resp, err := s.client.Do(req, &premiumRequestUsageReport)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/checks.go
+++ b/github/checks.go
@@ -106,7 +106,7 @@ func (c CheckSuite) String() string {
 //meta:operation GET /repos/{owner}/{repo}/check-runs/{check_run_id}
 func (s *ChecksService) GetCheckRun(ctx context.Context, owner, repo string, checkRunID int64) (*CheckRun, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/check-runs/%v", owner, repo, checkRunID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -114,7 +114,7 @@ func (s *ChecksService) GetCheckRun(ctx context.Context, owner, repo string, che
 	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
 	var checkRun *CheckRun
-	resp, err := s.client.Do(ctx, req, &checkRun)
+	resp, err := s.client.Do(req, &checkRun)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -129,7 +129,7 @@ func (s *ChecksService) GetCheckRun(ctx context.Context, owner, repo string, che
 //meta:operation GET /repos/{owner}/{repo}/check-suites/{check_suite_id}
 func (s *ChecksService) GetCheckSuite(ctx context.Context, owner, repo string, checkSuiteID int64) (*CheckSuite, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/check-suites/%v", owner, repo, checkSuiteID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -137,7 +137,7 @@ func (s *ChecksService) GetCheckSuite(ctx context.Context, owner, repo string, c
 	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
 	var checkSuite *CheckSuite
-	resp, err := s.client.Do(ctx, req, &checkSuite)
+	resp, err := s.client.Do(req, &checkSuite)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -173,7 +173,7 @@ type CheckRunAction struct {
 //meta:operation POST /repos/{owner}/{repo}/check-runs
 func (s *ChecksService) CreateCheckRun(ctx context.Context, owner, repo string, opts CreateCheckRunOptions) (*CheckRun, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/check-runs", owner, repo)
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -181,7 +181,7 @@ func (s *ChecksService) CreateCheckRun(ctx context.Context, owner, repo string, 
 	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
 	var checkRun *CheckRun
-	resp, err := s.client.Do(ctx, req, &checkRun)
+	resp, err := s.client.Do(req, &checkRun)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -208,7 +208,7 @@ type UpdateCheckRunOptions struct {
 //meta:operation PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}
 func (s *ChecksService) UpdateCheckRun(ctx context.Context, owner, repo string, checkRunID int64, opts UpdateCheckRunOptions) (*CheckRun, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/check-runs/%v", owner, repo, checkRunID)
-	req, err := s.client.NewRequest("PATCH", u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -216,7 +216,7 @@ func (s *ChecksService) UpdateCheckRun(ctx context.Context, owner, repo string, 
 	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
 	var checkRun *CheckRun
-	resp, err := s.client.Do(ctx, req, &checkRun)
+	resp, err := s.client.Do(req, &checkRun)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -236,7 +236,7 @@ func (s *ChecksService) ListCheckRunAnnotations(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -244,7 +244,7 @@ func (s *ChecksService) ListCheckRunAnnotations(ctx context.Context, owner, repo
 	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
 	var checkRunAnnotations []*CheckRunAnnotation
-	resp, err := s.client.Do(ctx, req, &checkRunAnnotations)
+	resp, err := s.client.Do(req, &checkRunAnnotations)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -282,7 +282,7 @@ func (s *ChecksService) ListCheckRunsForRef(ctx context.Context, owner, repo, re
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -290,7 +290,7 @@ func (s *ChecksService) ListCheckRunsForRef(ctx context.Context, owner, repo, re
 	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
 	var checkRunResults *ListCheckRunsResults
-	resp, err := s.client.Do(ctx, req, &checkRunResults)
+	resp, err := s.client.Do(req, &checkRunResults)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -310,7 +310,7 @@ func (s *ChecksService) ListCheckRunsCheckSuite(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -318,7 +318,7 @@ func (s *ChecksService) ListCheckRunsCheckSuite(ctx context.Context, owner, repo
 	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
 	var checkRunResults *ListCheckRunsResults
-	resp, err := s.client.Do(ctx, req, &checkRunResults)
+	resp, err := s.client.Do(req, &checkRunResults)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -334,14 +334,14 @@ func (s *ChecksService) ListCheckRunsCheckSuite(ctx context.Context, owner, repo
 func (s *ChecksService) ReRequestCheckRun(ctx context.Context, owner, repo string, checkRunID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/check-runs/%v/rerequest", owner, repo, checkRunID)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListCheckSuiteOptions represents parameters to list check suites.
@@ -372,7 +372,7 @@ func (s *ChecksService) ListCheckSuitesForRef(ctx context.Context, owner, repo, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -380,7 +380,7 @@ func (s *ChecksService) ListCheckSuitesForRef(ctx context.Context, owner, repo, 
 	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
 	var checkSuiteResults *ListCheckSuiteResults
-	resp, err := s.client.Do(ctx, req, &checkSuiteResults)
+	resp, err := s.client.Do(req, &checkSuiteResults)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -417,7 +417,7 @@ type PreferenceList struct {
 //meta:operation PATCH /repos/{owner}/{repo}/check-suites/preferences
 func (s *ChecksService) SetCheckSuitePreferences(ctx context.Context, owner, repo string, opts CheckSuitePreferenceOptions) (*CheckSuitePreferenceResults, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/check-suites/preferences", owner, repo)
-	req, err := s.client.NewRequest("PATCH", u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -425,7 +425,7 @@ func (s *ChecksService) SetCheckSuitePreferences(ctx context.Context, owner, rep
 	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
 	var checkSuitePrefResults *CheckSuitePreferenceResults
-	resp, err := s.client.Do(ctx, req, &checkSuitePrefResults)
+	resp, err := s.client.Do(req, &checkSuitePrefResults)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -446,7 +446,7 @@ type CreateCheckSuiteOptions struct {
 //meta:operation POST /repos/{owner}/{repo}/check-suites
 func (s *ChecksService) CreateCheckSuite(ctx context.Context, owner, repo string, opts CreateCheckSuiteOptions) (*CheckSuite, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/check-suites", owner, repo)
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -454,7 +454,7 @@ func (s *ChecksService) CreateCheckSuite(ctx context.Context, owner, repo string
 	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
 	var checkSuite *CheckSuite
-	resp, err := s.client.Do(ctx, req, &checkSuite)
+	resp, err := s.client.Do(req, &checkSuite)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -470,13 +470,13 @@ func (s *ChecksService) CreateCheckSuite(ctx context.Context, owner, repo string
 func (s *ChecksService) ReRequestCheckSuite(ctx context.Context, owner, repo string, checkSuiteID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/check-suites/%v/rerequest", owner, repo, checkSuiteID)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeCheckRunsPreview)
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	return resp, err
 }

--- a/github/classroom.go
+++ b/github/classroom.go
@@ -113,13 +113,13 @@ func (g AssignmentGrade) String() string {
 func (s *ClassroomService) GetAssignment(ctx context.Context, assignmentID int64) (*ClassroomAssignment, *Response, error) {
 	u := fmt.Sprintf("assignments/%v", assignmentID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var assignment *ClassroomAssignment
-	resp, err := s.client.Do(ctx, req, &assignment)
+	resp, err := s.client.Do(req, &assignment)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -136,13 +136,13 @@ func (s *ClassroomService) GetAssignment(ctx context.Context, assignmentID int64
 func (s *ClassroomService) GetClassroom(ctx context.Context, classroomID int64) (*Classroom, *Response, error) {
 	u := fmt.Sprintf("classrooms/%v", classroomID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var classroom *Classroom
-	resp, err := s.client.Do(ctx, req, &classroom)
+	resp, err := s.client.Do(req, &classroom)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -162,13 +162,13 @@ func (s *ClassroomService) ListClassrooms(ctx context.Context, opts *ListOptions
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var classrooms []*Classroom
-	resp, err := s.client.Do(ctx, req, &classrooms)
+	resp, err := s.client.Do(req, &classrooms)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -189,13 +189,13 @@ func (s *ClassroomService) ListClassroomAssignments(ctx context.Context, classro
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var assignments []*ClassroomAssignment
-	resp, err := s.client.Do(ctx, req, &assignments)
+	resp, err := s.client.Do(req, &assignments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -217,13 +217,13 @@ func (s *ClassroomService) ListAcceptedAssignments(ctx context.Context, assignme
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var acceptedAssignments []*AcceptedAssignment
-	resp, err := s.client.Do(ctx, req, &acceptedAssignments)
+	resp, err := s.client.Do(req, &acceptedAssignments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -241,13 +241,13 @@ func (s *ClassroomService) ListAcceptedAssignments(ctx context.Context, assignme
 func (s *ClassroomService) GetAssignmentGrades(ctx context.Context, assignmentID int64) ([]*AssignmentGrade, *Response, error) {
 	u := fmt.Sprintf("assignments/%v/grades", assignmentID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var grades []*AssignmentGrade
-	resp, err := s.client.Do(ctx, req, &grades)
+	resp, err := s.client.Do(req, &grades)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/code_scanning.go
+++ b/github/code_scanning.go
@@ -256,13 +256,13 @@ func (s *CodeScanningService) ListAlertsForOrg(ctx context.Context, org string, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var alerts []*Alert
-	resp, err := s.client.Do(ctx, req, &alerts)
+	resp, err := s.client.Do(req, &alerts)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -286,13 +286,13 @@ func (s *CodeScanningService) ListAlertsForRepo(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var alerts []*Alert
-	resp, err := s.client.Do(ctx, req, &alerts)
+	resp, err := s.client.Do(req, &alerts)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -313,13 +313,13 @@ func (s *CodeScanningService) ListAlertsForRepo(ctx context.Context, owner, repo
 func (s *CodeScanningService) GetAlert(ctx context.Context, owner, repo string, id int64) (*Alert, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/code-scanning/alerts/%v", owner, repo, id)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var a *Alert
-	resp, err := s.client.Do(ctx, req, &a)
+	resp, err := s.client.Do(req, &a)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -340,13 +340,13 @@ func (s *CodeScanningService) GetAlert(ctx context.Context, owner, repo string, 
 func (s *CodeScanningService) UpdateAlert(ctx context.Context, owner, repo string, id int64, stateInfo *CodeScanningAlertState) (*Alert, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/code-scanning/alerts/%v", owner, repo, id)
 
-	req, err := s.client.NewRequest("PATCH", u, stateInfo)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, stateInfo)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var a *Alert
-	resp, err := s.client.Do(ctx, req, &a)
+	resp, err := s.client.Do(req, &a)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -369,13 +369,13 @@ func (s *CodeScanningService) ListAlertInstances(ctx context.Context, owner, rep
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var alertInstances []*MostRecentInstance
-	resp, err := s.client.Do(ctx, req, &alertInstances)
+	resp, err := s.client.Do(req, &alertInstances)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -395,13 +395,13 @@ func (s *CodeScanningService) ListAlertInstances(ctx context.Context, owner, rep
 func (s *CodeScanningService) UploadSarif(ctx context.Context, owner, repo string, sarif *SarifAnalysis) (*SarifID, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/code-scanning/sarifs", owner, repo)
 
-	req, err := s.client.NewRequest("POST", u, sarif)
+	req, err := s.client.NewRequest(ctx, "POST", u, sarif)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// This will always return an error without unmarshaling the data
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	// Even though there was an error, we still return the response
 	// in case the caller wants to inspect it further.
 	// However, if the error is AcceptedError, decode it below before
@@ -439,13 +439,13 @@ type SARIFUpload struct {
 func (s *CodeScanningService) GetSARIF(ctx context.Context, owner, repo, sarifID string) (*SARIFUpload, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/code-scanning/sarifs/%v", owner, repo, sarifID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var sarifUpload *SARIFUpload
-	resp, err := s.client.Do(ctx, req, &sarifUpload)
+	resp, err := s.client.Do(req, &sarifUpload)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -469,13 +469,13 @@ func (s *CodeScanningService) ListAnalysesForRepo(ctx context.Context, owner, re
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var analyses []*ScanningAnalysis
-	resp, err := s.client.Do(ctx, req, &analyses)
+	resp, err := s.client.Do(req, &analyses)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -496,13 +496,13 @@ func (s *CodeScanningService) ListAnalysesForRepo(ctx context.Context, owner, re
 func (s *CodeScanningService) GetAnalysis(ctx context.Context, owner, repo string, id int64) (*ScanningAnalysis, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/code-scanning/analyses/%v", owner, repo, id)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var analysis *ScanningAnalysis
-	resp, err := s.client.Do(ctx, req, &analysis)
+	resp, err := s.client.Do(req, &analysis)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -531,13 +531,13 @@ type DeleteAnalysis struct {
 func (s *CodeScanningService) DeleteAnalysis(ctx context.Context, owner, repo string, id int64) (*DeleteAnalysis, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/code-scanning/analyses/%v", owner, repo, id)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var deleteAnalysis *DeleteAnalysis
-	resp, err := s.client.Do(ctx, req, &deleteAnalysis)
+	resp, err := s.client.Do(req, &deleteAnalysis)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -556,13 +556,13 @@ func (s *CodeScanningService) DeleteAnalysis(ctx context.Context, owner, repo st
 func (s *CodeScanningService) ListCodeQLDatabases(ctx context.Context, owner, repo string) ([]*CodeQLDatabase, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/code-scanning/codeql/databases", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codeqlDatabases []*CodeQLDatabase
-	resp, err := s.client.Do(ctx, req, &codeqlDatabases)
+	resp, err := s.client.Do(req, &codeqlDatabases)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -581,13 +581,13 @@ func (s *CodeScanningService) ListCodeQLDatabases(ctx context.Context, owner, re
 func (s *CodeScanningService) GetCodeQLDatabase(ctx context.Context, owner, repo, language string) (*CodeQLDatabase, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/code-scanning/codeql/databases/%v", owner, repo, language)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codeqlDatabase *CodeQLDatabase
-	resp, err := s.client.Do(ctx, req, &codeqlDatabase)
+	resp, err := s.client.Do(req, &codeqlDatabase)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -615,13 +615,13 @@ type DefaultSetupConfiguration struct {
 func (s *CodeScanningService) GetDefaultSetupConfiguration(ctx context.Context, owner, repo string) (*DefaultSetupConfiguration, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/code-scanning/default-setup", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var cfg *DefaultSetupConfiguration
-	resp, err := s.client.Do(ctx, req, &cfg)
+	resp, err := s.client.Do(req, &cfg)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -658,13 +658,13 @@ type UpdateDefaultSetupConfigurationResponse struct {
 func (s *CodeScanningService) UpdateDefaultSetupConfiguration(ctx context.Context, owner, repo string, options *UpdateDefaultSetupConfigurationOptions) (*UpdateDefaultSetupConfigurationResponse, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/code-scanning/default-setup", owner, repo)
 
-	req, err := s.client.NewRequest("PATCH", u, options)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var a *UpdateDefaultSetupConfigurationResponse
-	resp, err := s.client.Do(ctx, req, &a)
+	resp, err := s.client.Do(req, &a)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/codesofconduct.go
+++ b/github/codesofconduct.go
@@ -31,7 +31,7 @@ func (c *CodeOfConduct) String() string {
 //
 //meta:operation GET /codes_of_conduct
 func (s *CodesOfConductService) List(ctx context.Context) ([]*CodeOfConduct, *Response, error) {
-	req, err := s.client.NewRequest("GET", "codes_of_conduct", nil)
+	req, err := s.client.NewRequest(ctx, "GET", "codes_of_conduct", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -39,7 +39,7 @@ func (s *CodesOfConductService) List(ctx context.Context) ([]*CodeOfConduct, *Re
 	req.Header.Set("Accept", mediaTypeCodesOfConductPreview)
 
 	var cs []*CodeOfConduct
-	resp, err := s.client.Do(ctx, req, &cs)
+	resp, err := s.client.Do(req, &cs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -61,7 +61,7 @@ func (c *Client) ListCodesOfConduct(ctx context.Context) ([]*CodeOfConduct, *Res
 //meta:operation GET /codes_of_conduct/{key}
 func (s *CodesOfConductService) Get(ctx context.Context, key string) (*CodeOfConduct, *Response, error) {
 	u := fmt.Sprintf("codes_of_conduct/%v", key)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -69,7 +69,7 @@ func (s *CodesOfConductService) Get(ctx context.Context, key string) (*CodeOfCon
 	req.Header.Set("Accept", mediaTypeCodesOfConductPreview)
 
 	var coc *CodeOfConduct
-	resp, err := s.client.Do(ctx, req, &coc)
+	resp, err := s.client.Do(req, &coc)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/codespaces.go
+++ b/github/codespaces.go
@@ -100,13 +100,13 @@ func (s *CodespacesService) ListInRepo(ctx context.Context, owner, repo string, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codespaces *ListCodespaces
-	resp, err := s.client.Do(ctx, req, &codespaces)
+	resp, err := s.client.Do(req, &codespaces)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -136,13 +136,13 @@ func (s *CodespacesService) List(ctx context.Context, opts *ListCodespacesOption
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codespaces *ListCodespaces
-	resp, err := s.client.Do(ctx, req, &codespaces)
+	resp, err := s.client.Do(req, &codespaces)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -275,13 +275,13 @@ type CodespacePermissions struct {
 //meta:operation POST /repos/{owner}/{repo}/codespaces
 func (s *CodespacesService) CreateInRepo(ctx context.Context, owner, repo string, request *CreateCodespaceOptions) (*Codespace, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/codespaces", owner, repo)
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codespace *Codespace
-	resp, err := s.client.Do(ctx, req, &codespace)
+	resp, err := s.client.Do(req, &codespace)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -299,13 +299,13 @@ func (s *CodespacesService) CreateInRepo(ctx context.Context, owner, repo string
 //meta:operation POST /user/codespaces/{codespace_name}/start
 func (s *CodespacesService) Start(ctx context.Context, codespaceName string) (*Codespace, *Response, error) {
 	u := fmt.Sprintf("user/codespaces/%v/start", codespaceName)
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codespace *Codespace
-	resp, err := s.client.Do(ctx, req, &codespace)
+	resp, err := s.client.Do(req, &codespace)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -323,13 +323,13 @@ func (s *CodespacesService) Start(ctx context.Context, codespaceName string) (*C
 //meta:operation POST /user/codespaces/{codespace_name}/stop
 func (s *CodespacesService) Stop(ctx context.Context, codespaceName string) (*Codespace, *Response, error) {
 	u := fmt.Sprintf("user/codespaces/%v/stop", codespaceName)
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codespace *Codespace
-	resp, err := s.client.Do(ctx, req, &codespace)
+	resp, err := s.client.Do(req, &codespace)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -347,12 +347,12 @@ func (s *CodespacesService) Stop(ctx context.Context, codespaceName string) (*Co
 //meta:operation DELETE /user/codespaces/{codespace_name}
 func (s *CodespacesService) Delete(ctx context.Context, codespaceName string) (*Response, error) {
 	u := fmt.Sprintf("user/codespaces/%v", codespaceName)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListDevContainerConfigurations lists devcontainer configurations in a repository for the authenticated user.
@@ -367,13 +367,13 @@ func (s *CodespacesService) ListDevContainerConfigurations(ctx context.Context, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var devcontainers *DevContainerConfigurations
-	resp, err := s.client.Do(ctx, req, &devcontainers)
+	resp, err := s.client.Do(req, &devcontainers)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -393,13 +393,13 @@ func (s *CodespacesService) GetDefaultAttributes(ctx context.Context, owner, rep
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var attributes *CodespaceDefaultAttributes
-	resp, err := s.client.Do(ctx, req, &attributes)
+	resp, err := s.client.Do(req, &attributes)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -425,13 +425,13 @@ func (s *CodespacesService) CheckPermissions(ctx context.Context, owner, repo, r
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var permissions *CodespacePermissions
-	resp, err := s.client.Do(ctx, req, &permissions)
+	resp, err := s.client.Do(req, &permissions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -446,13 +446,13 @@ func (s *CodespacesService) CheckPermissions(ctx context.Context, owner, repo, r
 //meta:operation POST /repos/{owner}/{repo}/pulls/{pull_number}/codespaces
 func (s *CodespacesService) CreateFromPullRequest(ctx context.Context, owner, repo string, pullNumber int, request *CreateCodespaceOptions) (*Codespace, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/codespaces", owner, repo, pullNumber)
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codespace *Codespace
-	resp, err := s.client.Do(ctx, req, &codespace)
+	resp, err := s.client.Do(req, &codespace)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -469,13 +469,13 @@ func (s *CodespacesService) CreateFromPullRequest(ctx context.Context, owner, re
 //meta:operation POST /user/codespaces
 func (s *CodespacesService) Create(ctx context.Context, opts *CodespaceCreateForUserOptions) (*Codespace, *Response, error) {
 	u := "user/codespaces"
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codespace *Codespace
-	resp, err := s.client.Do(ctx, req, &codespace)
+	resp, err := s.client.Do(req, &codespace)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -490,13 +490,13 @@ func (s *CodespacesService) Create(ctx context.Context, opts *CodespaceCreateFor
 //meta:operation GET /user/codespaces/{codespace_name}
 func (s *CodespacesService) Get(ctx context.Context, codespaceName string) (*Codespace, *Response, error) {
 	u := fmt.Sprintf("user/codespaces/%v", codespaceName)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codespace *Codespace
-	resp, err := s.client.Do(ctx, req, &codespace)
+	resp, err := s.client.Do(req, &codespace)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -513,13 +513,13 @@ func (s *CodespacesService) Get(ctx context.Context, codespaceName string) (*Cod
 //meta:operation PATCH /user/codespaces/{codespace_name}
 func (s *CodespacesService) Update(ctx context.Context, codespaceName string, opts *UpdateCodespaceOptions) (*Codespace, *Response, error) {
 	u := fmt.Sprintf("user/codespaces/%v", codespaceName)
-	req, err := s.client.NewRequest("PATCH", u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codespace *Codespace
-	resp, err := s.client.Do(ctx, req, &codespace)
+	resp, err := s.client.Do(req, &codespace)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -534,13 +534,13 @@ func (s *CodespacesService) Update(ctx context.Context, codespaceName string, op
 //meta:operation POST /user/codespaces/{codespace_name}/exports
 func (s *CodespacesService) ExportCodespace(ctx context.Context, codespaceName string) (*CodespaceExport, *Response, error) {
 	u := fmt.Sprintf("user/codespaces/%v/exports", codespaceName)
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codespace *CodespaceExport
-	resp, err := s.client.Do(ctx, req, &codespace)
+	resp, err := s.client.Do(req, &codespace)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -555,13 +555,13 @@ func (s *CodespacesService) ExportCodespace(ctx context.Context, codespaceName s
 //meta:operation GET /user/codespaces/{codespace_name}/exports/{export_id}
 func (s *CodespacesService) GetLatestCodespaceExport(ctx context.Context, codespaceName string) (*CodespaceExport, *Response, error) {
 	u := fmt.Sprintf("user/codespaces/%v/exports/latest", codespaceName)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codespace *CodespaceExport
-	resp, err := s.client.Do(ctx, req, &codespace)
+	resp, err := s.client.Do(req, &codespace)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -576,13 +576,13 @@ func (s *CodespacesService) GetLatestCodespaceExport(ctx context.Context, codesp
 //meta:operation POST /user/codespaces/{codespace_name}/publish
 func (s *CodespacesService) Publish(ctx context.Context, codespaceName string, opts *PublishCodespaceOptions) (*Codespace, *Response, error) {
 	u := fmt.Sprintf("user/codespaces/%v/publish", codespaceName)
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codespace *Codespace
-	resp, err := s.client.Do(ctx, req, &codespace)
+	resp, err := s.client.Do(req, &codespace)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/codespaces_machines.go
+++ b/github/codespaces_machines.go
@@ -38,13 +38,13 @@ func (s *CodespacesService) ListRepositoryMachineTypes(ctx context.Context, owne
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var machines *CodespacesMachines
-	resp, err := s.client.Do(ctx, req, &machines)
+	resp, err := s.client.Do(req, &machines)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -59,13 +59,13 @@ func (s *CodespacesService) ListRepositoryMachineTypes(ctx context.Context, owne
 //meta:operation GET /user/codespaces/{codespace_name}/machines
 func (s *CodespacesService) ListCodespaceMachineTypes(ctx context.Context, codespaceName string) (*CodespacesMachines, *Response, error) {
 	u := fmt.Sprintf("user/codespaces/%v/machines", codespaceName)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var machines *CodespacesMachines
-	resp, err := s.client.Do(ctx, req, &machines)
+	resp, err := s.client.Do(req, &machines)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/codespaces_orgs.go
+++ b/github/codespaces_orgs.go
@@ -32,13 +32,13 @@ func (s *CodespacesService) ListInOrg(ctx context.Context, org string, opts *Lis
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codespaces *ListCodespaces
-	resp, err := s.client.Do(ctx, req, &codespaces)
+	resp, err := s.client.Do(req, &codespaces)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -53,12 +53,12 @@ func (s *CodespacesService) ListInOrg(ctx context.Context, org string, opts *Lis
 //meta:operation PUT /orgs/{org}/codespaces/access
 func (s *CodespacesService) SetOrgAccessControl(ctx context.Context, org string, request CodespacesOrgAccessControlRequest) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/codespaces/access", org)
-	req, err := s.client.NewRequest("PUT", u, request)
+	req, err := s.client.NewRequest(ctx, "PUT", u, request)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -73,12 +73,12 @@ func (s *CodespacesService) SetOrgAccessControl(ctx context.Context, org string,
 //meta:operation POST /orgs/{org}/codespaces/access/selected_users
 func (s *CodespacesService) AddUsersToOrgAccess(ctx context.Context, org string, usernames []string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/codespaces/access/selected_users", org)
-	req, err := s.client.NewRequest("POST", u, map[string][]string{"selected_usernames": usernames})
+	req, err := s.client.NewRequest(ctx, "POST", u, map[string][]string{"selected_usernames": usernames})
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -93,12 +93,12 @@ func (s *CodespacesService) AddUsersToOrgAccess(ctx context.Context, org string,
 //meta:operation DELETE /orgs/{org}/codespaces/access/selected_users
 func (s *CodespacesService) RemoveUsersFromOrgAccess(ctx context.Context, org string, usernames []string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/codespaces/access/selected_users", org)
-	req, err := s.client.NewRequest("DELETE", u, map[string][]string{"selected_usernames": usernames})
+	req, err := s.client.NewRequest(ctx, "DELETE", u, map[string][]string{"selected_usernames": usernames})
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -118,13 +118,13 @@ func (s *CodespacesService) ListUserCodespacesInOrg(ctx context.Context, org, us
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codespaces *ListCodespaces
-	resp, err := s.client.Do(ctx, req, &codespaces)
+	resp, err := s.client.Do(req, &codespaces)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -139,12 +139,12 @@ func (s *CodespacesService) ListUserCodespacesInOrg(ctx context.Context, org, us
 //meta:operation DELETE /orgs/{org}/members/{username}/codespaces/{codespace_name}
 func (s *CodespacesService) DeleteUserCodespaceInOrg(ctx context.Context, org, username, codespaceName string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/members/%v/codespaces/%v", org, username, codespaceName)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -159,12 +159,12 @@ func (s *CodespacesService) DeleteUserCodespaceInOrg(ctx context.Context, org, u
 //meta:operation POST /orgs/{org}/members/{username}/codespaces/{codespace_name}/stop
 func (s *CodespacesService) StopUserCodespaceInOrg(ctx context.Context, org, username, codespaceName string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/members/%v/codespaces/%v/stop", org, username, codespaceName)
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/github/codespaces_secrets.go
+++ b/github/codespaces_secrets.go
@@ -61,13 +61,13 @@ func (s *CodespacesService) ListRepoSecrets(ctx context.Context, owner, repo str
 }
 
 func (s *CodespacesService) listSecrets(ctx context.Context, url string) (*Secrets, *Response, error) {
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var secrets *Secrets
-	resp, err := s.client.Do(ctx, req, &secrets)
+	resp, err := s.client.Do(req, &secrets)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -111,13 +111,13 @@ func (s *CodespacesService) GetRepoPublicKey(ctx context.Context, owner, repo st
 }
 
 func (s *CodespacesService) getPublicKey(ctx context.Context, url string) (*PublicKey, *Response, error) {
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var publicKey *PublicKey
-	resp, err := s.client.Do(ctx, req, &publicKey)
+	resp, err := s.client.Do(req, &publicKey)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -164,13 +164,13 @@ func (s *CodespacesService) GetRepoSecret(ctx context.Context, owner, repo, name
 }
 
 func (s *CodespacesService) getSecret(ctx context.Context, url string) (*Secret, *Response, error) {
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var secret *Secret
-	resp, err := s.client.Do(ctx, req, &secret)
+	resp, err := s.client.Do(req, &secret)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -229,12 +229,12 @@ func (s *CodespacesService) CreateOrUpdateRepoSecret(ctx context.Context, owner,
 }
 
 func (s *CodespacesService) createOrUpdateSecret(ctx context.Context, url string, eSecret *EncryptedSecret) (*Response, error) {
-	req, err := s.client.NewRequest("PUT", url, eSecret)
+	req, err := s.client.NewRequest(ctx, "PUT", url, eSecret)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -281,12 +281,12 @@ func (s *CodespacesService) DeleteRepoSecret(ctx context.Context, owner, repo, n
 }
 
 func (s *CodespacesService) deleteSecret(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest("DELETE", url, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -330,13 +330,13 @@ func (s *CodespacesService) ListSelectedReposForOrgSecret(ctx context.Context, o
 }
 
 func (s *CodespacesService) listSelectedReposForSecret(ctx context.Context, url string) (*SelectedReposList, *Response, error) {
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var repositories *SelectedReposList
-	resp, err := s.client.Do(ctx, req, &repositories)
+	resp, err := s.client.Do(req, &repositories)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -374,12 +374,12 @@ func (s *CodespacesService) setSelectedRepoForSecret(ctx context.Context, url st
 		SelectedIDs SelectedRepoIDs `json:"selected_repository_ids"`
 	}
 
-	req, err := s.client.NewRequest("PUT", url, repoIDs{SelectedIDs: ids})
+	req, err := s.client.NewRequest(ctx, "PUT", url, repoIDs{SelectedIDs: ids})
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -426,12 +426,12 @@ func (s *CodespacesService) AddSelectedRepoToOrgSecret(ctx context.Context, org,
 }
 
 func (s *CodespacesService) addSelectedRepoToSecret(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest("PUT", url, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -478,12 +478,12 @@ func (s *CodespacesService) RemoveSelectedRepoFromOrgSecret(ctx context.Context,
 }
 
 func (s *CodespacesService) removeSelectedRepoFromSecret(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest("DELETE", url, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/github/copilot.go
+++ b/github/copilot.go
@@ -375,13 +375,13 @@ func (s *CopilotService) ListOrganizationCodingAgentRepositories(ctx context.Con
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var result *ListOrganizationCopilotCodingAgentRepositoriesResponse
-	resp, err := s.client.Do(ctx, req, &result)
+	resp, err := s.client.Do(req, &result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -402,13 +402,13 @@ type CopilotOrganizationContentExclusionDetails map[string][]string
 func (s *CopilotService) GetOrganizationContentExclusionDetails(ctx context.Context, org string) (CopilotOrganizationContentExclusionDetails, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/copilot/content_exclusion", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	details := CopilotOrganizationContentExclusionDetails{}
-	resp, err := s.client.Do(ctx, req, &details)
+	resp, err := s.client.Do(req, &details)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/copilot.go
+++ b/github/copilot.go
@@ -286,13 +286,13 @@ func (cp *CopilotSeatDetails) GetOrganization() (*Organization, bool) {
 func (s *CopilotService) GetCopilotBilling(ctx context.Context, org string) (*CopilotOrganizationDetails, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/copilot/billing", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var copilotDetails *CopilotOrganizationDetails
-	resp, err := s.client.Do(ctx, req, &copilotDetails)
+	resp, err := s.client.Do(req, &copilotDetails)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -314,13 +314,13 @@ func (s *CopilotService) ListCopilotSeats(ctx context.Context, org string, opts 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var copilotSeats *ListCopilotSeatsResponse
-	resp, err := s.client.Do(ctx, req, &copilotSeats)
+	resp, err := s.client.Do(req, &copilotSeats)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -342,13 +342,13 @@ func (s *CopilotService) ListCopilotEnterpriseSeats(ctx context.Context, enterpr
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var copilotSeats *ListCopilotSeatsResponse
-	resp, err := s.client.Do(ctx, req, &copilotSeats)
+	resp, err := s.client.Do(req, &copilotSeats)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -370,13 +370,13 @@ func (s *CopilotService) AddCopilotTeams(ctx context.Context, org string, teamNa
 		SelectedTeams: teamNames,
 	}
 
-	req, err := s.client.NewRequest("POST", u, body)
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var seatAssignments *SeatAssignments
-	resp, err := s.client.Do(ctx, req, &seatAssignments)
+	resp, err := s.client.Do(req, &seatAssignments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -398,13 +398,13 @@ func (s *CopilotService) RemoveCopilotTeams(ctx context.Context, org string, tea
 		SelectedTeams: teamNames,
 	}
 
-	req, err := s.client.NewRequest("DELETE", u, body)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var seatCancellations *SeatCancellations
-	resp, err := s.client.Do(ctx, req, &seatCancellations)
+	resp, err := s.client.Do(req, &seatCancellations)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -426,13 +426,13 @@ func (s *CopilotService) AddCopilotUsers(ctx context.Context, org string, users 
 		SelectedUsernames: users,
 	}
 
-	req, err := s.client.NewRequest("POST", u, body)
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var seatAssignments *SeatAssignments
-	resp, err := s.client.Do(ctx, req, &seatAssignments)
+	resp, err := s.client.Do(req, &seatAssignments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -454,13 +454,13 @@ func (s *CopilotService) RemoveCopilotUsers(ctx context.Context, org string, use
 		SelectedUsernames: users,
 	}
 
-	req, err := s.client.NewRequest("DELETE", u, body)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var seatCancellations *SeatCancellations
-	resp, err := s.client.Do(ctx, req, &seatCancellations)
+	resp, err := s.client.Do(req, &seatCancellations)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -476,13 +476,13 @@ func (s *CopilotService) RemoveCopilotUsers(ctx context.Context, org string, use
 func (s *CopilotService) GetSeatDetails(ctx context.Context, org, user string) (*CopilotSeatDetails, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/members/%v/copilot", org, user)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var seatDetails *CopilotSeatDetails
-	resp, err := s.client.Do(ctx, req, &seatDetails)
+	resp, err := s.client.Do(req, &seatDetails)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -506,13 +506,13 @@ func (s *CopilotService) GetEnterpriseMetrics(ctx context.Context, enterprise st
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var metrics []*CopilotMetrics
-	resp, err := s.client.Do(ctx, req, &metrics)
+	resp, err := s.client.Do(req, &metrics)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -536,13 +536,13 @@ func (s *CopilotService) GetEnterpriseTeamMetrics(ctx context.Context, enterpris
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var metrics []*CopilotMetrics
-	resp, err := s.client.Do(ctx, req, &metrics)
+	resp, err := s.client.Do(req, &metrics)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -566,13 +566,13 @@ func (s *CopilotService) GetOrganizationMetrics(ctx context.Context, org string,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var metrics []*CopilotMetrics
-	resp, err := s.client.Do(ctx, req, &metrics)
+	resp, err := s.client.Do(req, &metrics)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -596,13 +596,13 @@ func (s *CopilotService) GetOrganizationTeamMetrics(ctx context.Context, org, te
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var metrics []*CopilotMetrics
-	resp, err := s.client.Do(ctx, req, &metrics)
+	resp, err := s.client.Do(req, &metrics)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -622,13 +622,13 @@ func (s *CopilotService) GetEnterpriseDailyMetricsReport(ctx context.Context, en
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var report *CopilotDailyMetricsReport
-	resp, err := s.client.Do(ctx, req, &report)
+	resp, err := s.client.Do(req, &report)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -644,13 +644,13 @@ func (s *CopilotService) GetEnterpriseDailyMetricsReport(ctx context.Context, en
 func (s *CopilotService) GetEnterpriseMetricsReport(ctx context.Context, enterprise string) (*CopilotMetricsReport, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/copilot/metrics/reports/enterprise-28-day/latest", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var report *CopilotMetricsReport
-	resp, err := s.client.Do(ctx, req, &report)
+	resp, err := s.client.Do(req, &report)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -670,13 +670,13 @@ func (s *CopilotService) GetEnterpriseUsersDailyMetricsReport(ctx context.Contex
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var report *CopilotDailyMetricsReport
-	resp, err := s.client.Do(ctx, req, &report)
+	resp, err := s.client.Do(req, &report)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -692,13 +692,13 @@ func (s *CopilotService) GetEnterpriseUsersDailyMetricsReport(ctx context.Contex
 func (s *CopilotService) GetEnterpriseUsersMetricsReport(ctx context.Context, enterprise string) (*CopilotMetricsReport, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/copilot/metrics/reports/users-28-day/latest", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var report *CopilotMetricsReport
-	resp, err := s.client.Do(ctx, req, &report)
+	resp, err := s.client.Do(req, &report)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -718,13 +718,13 @@ func (s *CopilotService) GetOrganizationDailyMetricsReport(ctx context.Context, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var report *CopilotDailyMetricsReport
-	resp, err := s.client.Do(ctx, req, &report)
+	resp, err := s.client.Do(req, &report)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -740,13 +740,13 @@ func (s *CopilotService) GetOrganizationDailyMetricsReport(ctx context.Context, 
 func (s *CopilotService) GetOrganizationMetricsReport(ctx context.Context, org string) (*CopilotMetricsReport, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/copilot/metrics/reports/organization-28-day/latest", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var report *CopilotMetricsReport
-	resp, err := s.client.Do(ctx, req, &report)
+	resp, err := s.client.Do(req, &report)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -766,13 +766,13 @@ func (s *CopilotService) GetOrganizationUsersDailyMetricsReport(ctx context.Cont
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var report *CopilotDailyMetricsReport
-	resp, err := s.client.Do(ctx, req, &report)
+	resp, err := s.client.Do(req, &report)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -788,13 +788,13 @@ func (s *CopilotService) GetOrganizationUsersDailyMetricsReport(ctx context.Cont
 func (s *CopilotService) GetOrganizationUsersMetricsReport(ctx context.Context, org string) (*CopilotMetricsReport, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/copilot/metrics/reports/users-28-day/latest", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var report *CopilotMetricsReport
-	resp, err := s.client.Do(ctx, req, &report)
+	resp, err := s.client.Do(req, &report)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -813,20 +813,16 @@ func (s *CopilotService) DownloadCopilotMetrics(ctx context.Context, url string)
 		return nil, nil, err
 	}
 
-	resp, err := s.client.client.Do(req)
+	resp, err := s.client.BareDo(req)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer resp.Body.Close()
 
-	if err := CheckResponse(resp); err != nil {
-		return nil, newResponse(resp), err
-	}
-
 	var metrics []*CopilotMetrics
 	if err := json.NewDecoder(resp.Body).Decode(&metrics); err != nil {
-		return nil, newResponse(resp), err
+		return nil, resp, err
 	}
 
-	return metrics, newResponse(resp), nil
+	return metrics, resp, nil
 }

--- a/github/credentials.go
+++ b/github/credentials.go
@@ -28,10 +28,10 @@ func (s *CredentialsService) Revoke(ctx context.Context, credentials []string) (
 
 	reqBody := &revokeCredentialsRequest{Credentials: credentials}
 
-	req, err := s.client.NewRequest("POST", u, reqBody)
+	req, err := s.client.NewRequest(ctx, "POST", u, reqBody)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/dependabot_alerts.go
+++ b/github/dependabot_alerts.go
@@ -109,13 +109,13 @@ func (s *DependabotService) listAlerts(ctx context.Context, url string, opts *Li
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var alerts []*DependabotAlert
-	resp, err := s.client.Do(ctx, req, &alerts)
+	resp, err := s.client.Do(req, &alerts)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -150,13 +150,13 @@ func (s *DependabotService) ListOrgAlerts(ctx context.Context, org string, opts 
 //meta:operation GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number}
 func (s *DependabotService) GetRepoAlert(ctx context.Context, owner, repo string, number int) (*DependabotAlert, *Response, error) {
 	url := fmt.Sprintf("repos/%v/%v/dependabot/alerts/%v", owner, repo, number)
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var alert *DependabotAlert
-	resp, err := s.client.Do(ctx, req, &alert)
+	resp, err := s.client.Do(req, &alert)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -171,13 +171,13 @@ func (s *DependabotService) GetRepoAlert(ctx context.Context, owner, repo string
 //meta:operation PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number}
 func (s *DependabotService) UpdateAlert(ctx context.Context, owner, repo string, number int, stateInfo *DependabotAlertState) (*DependabotAlert, *Response, error) {
 	url := fmt.Sprintf("repos/%v/%v/dependabot/alerts/%v", owner, repo, number)
-	req, err := s.client.NewRequest("PATCH", url, stateInfo)
+	req, err := s.client.NewRequest(ctx, "PATCH", url, stateInfo)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var alert *DependabotAlert
-	resp, err := s.client.Do(ctx, req, &alert)
+	resp, err := s.client.Do(req, &alert)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/dependabot_secrets.go
+++ b/github/dependabot_secrets.go
@@ -12,13 +12,13 @@ import (
 )
 
 func (s *DependabotService) getPublicKey(ctx context.Context, url string) (*PublicKey, *Response, error) {
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var pubKey *PublicKey
-	resp, err := s.client.Do(ctx, req, &pubKey)
+	resp, err := s.client.Do(req, &pubKey)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -52,13 +52,13 @@ func (s *DependabotService) listSecrets(ctx context.Context, url string, opts *L
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var secrets *Secrets
-	resp, err := s.client.Do(ctx, req, &secrets)
+	resp, err := s.client.Do(req, &secrets)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -89,13 +89,13 @@ func (s *DependabotService) ListOrgSecrets(ctx context.Context, org string, opts
 }
 
 func (s *DependabotService) getSecret(ctx context.Context, url string) (*Secret, *Response, error) {
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var secret *Secret
-	resp, err := s.client.Do(ctx, req, &secret)
+	resp, err := s.client.Do(req, &secret)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -137,12 +137,12 @@ type DependabotEncryptedSecret struct {
 }
 
 func (s *DependabotService) putSecret(ctx context.Context, url string, eSecret *DependabotEncryptedSecret) (*Response, error) {
-	req, err := s.client.NewRequest("PUT", url, eSecret)
+	req, err := s.client.NewRequest(ctx, "PUT", url, eSecret)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // CreateOrUpdateRepoSecret creates or updates a repository Dependabot secret with an encrypted value.
@@ -182,21 +182,21 @@ func (s *DependabotService) CreateOrUpdateOrgSecret(ctx context.Context, org str
 	}
 
 	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v", org, eSecret.Name)
-	req, err := s.client.NewRequest("PUT", url, params)
+	req, err := s.client.NewRequest(ctx, "PUT", url, params)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 func (s *DependabotService) deleteSecret(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest("DELETE", url, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DeleteRepoSecret deletes a Dependabot secret in a repository using the secret name.
@@ -231,13 +231,13 @@ func (s *DependabotService) ListSelectedReposForOrgSecret(ctx context.Context, o
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var result *SelectedReposList
-	resp, err := s.client.Do(ctx, req, &result)
+	resp, err := s.client.Do(req, &result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -259,12 +259,12 @@ func (s *DependabotService) SetSelectedReposForOrgSecret(ctx context.Context, or
 		SelectedIDs DependabotSecretsSelectedRepoIDs `json:"selected_repository_ids"`
 	}
 
-	req, err := s.client.NewRequest("PUT", url, repoIDs{SelectedIDs: ids})
+	req, err := s.client.NewRequest(ctx, "PUT", url, repoIDs{SelectedIDs: ids})
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // AddSelectedRepoToOrgSecret adds a repository to an organization Dependabot secret.
@@ -281,12 +281,12 @@ func (s *DependabotService) AddSelectedRepoToOrgSecret(ctx context.Context, org,
 	}
 
 	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v/repositories/%v", org, name, *repo.ID)
-	req, err := s.client.NewRequest("PUT", url, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RemoveSelectedRepoFromOrgSecret removes a repository from an organization Dependabot secret.
@@ -303,10 +303,10 @@ func (s *DependabotService) RemoveSelectedRepoFromOrgSecret(ctx context.Context,
 	}
 
 	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v/repositories/%v", org, name, *repo.ID)
-	req, err := s.client.NewRequest("DELETE", url, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/dependency_graph.go
+++ b/github/dependency_graph.go
@@ -114,13 +114,13 @@ func (s SBOM) String() string {
 func (s *DependencyGraphService) GetSBOM(ctx context.Context, owner, repo string) (*SBOM, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/dependency-graph/sbom", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var sbom *SBOM
-	resp, err := s.client.Do(ctx, req, &sbom)
+	resp, err := s.client.Do(req, &sbom)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/dependency_graph_snapshots.go
+++ b/github/dependency_graph_snapshots.go
@@ -109,13 +109,13 @@ type DependencyGraphSnapshotCreationData struct {
 func (s *DependencyGraphService) CreateSnapshot(ctx context.Context, owner, repo string, dependencyGraphSnapshot *DependencyGraphSnapshot) (*DependencyGraphSnapshotCreationData, *Response, error) {
 	url := fmt.Sprintf("repos/%v/%v/dependency-graph/snapshots", owner, repo)
 
-	req, err := s.client.NewRequest("POST", url, dependencyGraphSnapshot)
+	req, err := s.client.NewRequest(ctx, "POST", url, dependencyGraphSnapshot)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var snapshotCreationData *DependencyGraphSnapshotCreationData
-	resp, err := s.client.Do(ctx, req, &snapshotCreationData)
+	resp, err := s.client.Do(req, &snapshotCreationData)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/emojis.go
+++ b/github/emojis.go
@@ -18,13 +18,13 @@ type EmojisService service
 //
 //meta:operation GET /emojis
 func (s *EmojisService) List(ctx context.Context) (map[string]string, *Response, error) {
-	req, err := s.client.NewRequest("GET", "emojis", nil)
+	req, err := s.client.NewRequest(ctx, "GET", "emojis", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var emoji map[string]string
-	resp, err := s.client.Do(ctx, req, &emoji)
+	resp, err := s.client.Do(req, &emoji)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/enterprise_actions_hosted_runners.go
+++ b/github/enterprise_actions_hosted_runners.go
@@ -22,13 +22,13 @@ func (s *EnterpriseService) ListHostedRunners(ctx context.Context, enterprise st
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runners *HostedRunners
-	resp, err := s.client.Do(ctx, req, &runners)
+	resp, err := s.client.Do(req, &runners)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -47,13 +47,13 @@ func (s *EnterpriseService) CreateHostedRunner(ctx context.Context, enterprise s
 	}
 
 	u := fmt.Sprintf("enterprises/%v/actions/hosted-runners", enterprise)
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hostedRunner *HostedRunner
-	resp, err := s.client.Do(ctx, req, &hostedRunner)
+	resp, err := s.client.Do(req, &hostedRunner)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -68,13 +68,13 @@ func (s *EnterpriseService) CreateHostedRunner(ctx context.Context, enterprise s
 //meta:operation GET /enterprises/{enterprise}/actions/hosted-runners/images/github-owned
 func (s *EnterpriseService) GetHostedRunnerGitHubOwnedImages(ctx context.Context, enterprise string) (*HostedRunnerImages, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/hosted-runners/images/github-owned", enterprise)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hostedRunnerImages *HostedRunnerImages
-	resp, err := s.client.Do(ctx, req, &hostedRunnerImages)
+	resp, err := s.client.Do(req, &hostedRunnerImages)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -89,13 +89,13 @@ func (s *EnterpriseService) GetHostedRunnerGitHubOwnedImages(ctx context.Context
 //meta:operation GET /enterprises/{enterprise}/actions/hosted-runners/images/partner
 func (s *EnterpriseService) GetHostedRunnerPartnerImages(ctx context.Context, enterprise string) (*HostedRunnerImages, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/hosted-runners/images/partner", enterprise)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hostedRunnerImages *HostedRunnerImages
-	resp, err := s.client.Do(ctx, req, &hostedRunnerImages)
+	resp, err := s.client.Do(req, &hostedRunnerImages)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -110,13 +110,13 @@ func (s *EnterpriseService) GetHostedRunnerPartnerImages(ctx context.Context, en
 //meta:operation GET /enterprises/{enterprise}/actions/hosted-runners/limits
 func (s *EnterpriseService) GetHostedRunnerLimits(ctx context.Context, enterprise string) (*HostedRunnerPublicIPLimits, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/hosted-runners/limits", enterprise)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var publicIPLimits *HostedRunnerPublicIPLimits
-	resp, err := s.client.Do(ctx, req, &publicIPLimits)
+	resp, err := s.client.Do(req, &publicIPLimits)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -131,13 +131,13 @@ func (s *EnterpriseService) GetHostedRunnerLimits(ctx context.Context, enterpris
 //meta:operation GET /enterprises/{enterprise}/actions/hosted-runners/machine-sizes
 func (s *EnterpriseService) GetHostedRunnerMachineSpecs(ctx context.Context, enterprise string) (*HostedRunnerMachineSpecs, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/hosted-runners/machine-sizes", enterprise)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var machineSpecs *HostedRunnerMachineSpecs
-	resp, err := s.client.Do(ctx, req, &machineSpecs)
+	resp, err := s.client.Do(req, &machineSpecs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -152,13 +152,13 @@ func (s *EnterpriseService) GetHostedRunnerMachineSpecs(ctx context.Context, ent
 //meta:operation GET /enterprises/{enterprise}/actions/hosted-runners/platforms
 func (s *EnterpriseService) GetHostedRunnerPlatforms(ctx context.Context, enterprise string) (*HostedRunnerPlatforms, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/hosted-runners/platforms", enterprise)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var platforms *HostedRunnerPlatforms
-	resp, err := s.client.Do(ctx, req, &platforms)
+	resp, err := s.client.Do(req, &platforms)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -173,13 +173,13 @@ func (s *EnterpriseService) GetHostedRunnerPlatforms(ctx context.Context, enterp
 //meta:operation GET /enterprises/{enterprise}/actions/hosted-runners/{hosted_runner_id}
 func (s *EnterpriseService) GetHostedRunner(ctx context.Context, enterprise string, runnerID int64) (*HostedRunner, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/hosted-runners/%v", enterprise, runnerID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hostedRunner *HostedRunner
-	resp, err := s.client.Do(ctx, req, &hostedRunner)
+	resp, err := s.client.Do(req, &hostedRunner)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -194,13 +194,13 @@ func (s *EnterpriseService) GetHostedRunner(ctx context.Context, enterprise stri
 //meta:operation PATCH /enterprises/{enterprise}/actions/hosted-runners/{hosted_runner_id}
 func (s *EnterpriseService) UpdateHostedRunner(ctx context.Context, enterprise string, runnerID int64, request UpdateHostedRunnerRequest) (*HostedRunner, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/hosted-runners/%v", enterprise, runnerID)
-	req, err := s.client.NewRequest("PATCH", u, request)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hostedRunner *HostedRunner
-	resp, err := s.client.Do(ctx, req, &hostedRunner)
+	resp, err := s.client.Do(req, &hostedRunner)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -215,13 +215,13 @@ func (s *EnterpriseService) UpdateHostedRunner(ctx context.Context, enterprise s
 //meta:operation DELETE /enterprises/{enterprise}/actions/hosted-runners/{hosted_runner_id}
 func (s *EnterpriseService) DeleteHostedRunner(ctx context.Context, enterprise string, runnerID int64) (*HostedRunner, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/hosted-runners/%v", enterprise, runnerID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hostedRunner *HostedRunner
-	resp, err := s.client.Do(ctx, req, &hostedRunner)
+	resp, err := s.client.Do(req, &hostedRunner)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -236,13 +236,13 @@ func (s *EnterpriseService) DeleteHostedRunner(ctx context.Context, enterprise s
 //meta:operation GET /enterprises/{enterprise}/actions/hosted-runners/images/custom
 func (s *EnterpriseService) ListHostedRunnerCustomImages(ctx context.Context, enterprise string) (*HostedRunnerCustomImages, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/hosted-runners/images/custom", enterprise)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var images *HostedRunnerCustomImages
-	resp, err := s.client.Do(ctx, req, &images)
+	resp, err := s.client.Do(req, &images)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -257,13 +257,13 @@ func (s *EnterpriseService) ListHostedRunnerCustomImages(ctx context.Context, en
 //meta:operation GET /enterprises/{enterprise}/actions/hosted-runners/images/custom/{image_definition_id}
 func (s *EnterpriseService) GetHostedRunnerCustomImage(ctx context.Context, enterprise string, imageDefinitionID int64) (*HostedRunnerCustomImage, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/hosted-runners/images/custom/%v", enterprise, imageDefinitionID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var image *HostedRunnerCustomImage
-	resp, err := s.client.Do(ctx, req, &image)
+	resp, err := s.client.Do(req, &image)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -278,12 +278,12 @@ func (s *EnterpriseService) GetHostedRunnerCustomImage(ctx context.Context, ente
 //meta:operation DELETE /enterprises/{enterprise}/actions/hosted-runners/images/custom/{image_definition_id}
 func (s *EnterpriseService) DeleteHostedRunnerCustomImage(ctx context.Context, enterprise string, imageDefinitionID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/hosted-runners/images/custom/%v", enterprise, imageDefinitionID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListHostedRunnerCustomImageVersions lists image versions of a custom image for an enterprise.
@@ -293,13 +293,13 @@ func (s *EnterpriseService) DeleteHostedRunnerCustomImage(ctx context.Context, e
 //meta:operation GET /enterprises/{enterprise}/actions/hosted-runners/images/custom/{image_definition_id}/versions
 func (s *EnterpriseService) ListHostedRunnerCustomImageVersions(ctx context.Context, enterprise string, imageDefinitionID int64) (*HostedRunnerCustomImageVersions, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/hosted-runners/images/custom/%v/versions", enterprise, imageDefinitionID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var versions *HostedRunnerCustomImageVersions
-	resp, err := s.client.Do(ctx, req, &versions)
+	resp, err := s.client.Do(req, &versions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -314,13 +314,13 @@ func (s *EnterpriseService) ListHostedRunnerCustomImageVersions(ctx context.Cont
 //meta:operation GET /enterprises/{enterprise}/actions/hosted-runners/images/custom/{image_definition_id}/versions/{version}
 func (s *EnterpriseService) GetHostedRunnerCustomImageVersion(ctx context.Context, enterprise string, imageDefinitionID int64, version string) (*HostedRunnerCustomImageVersion, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/hosted-runners/images/custom/%v/versions/%v", enterprise, imageDefinitionID, version)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var imageVersion *HostedRunnerCustomImageVersion
-	resp, err := s.client.Do(ctx, req, &imageVersion)
+	resp, err := s.client.Do(req, &imageVersion)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -335,10 +335,10 @@ func (s *EnterpriseService) GetHostedRunnerCustomImageVersion(ctx context.Contex
 //meta:operation DELETE /enterprises/{enterprise}/actions/hosted-runners/images/custom/{image_definition_id}/versions/{version}
 func (s *EnterpriseService) DeleteHostedRunnerCustomImageVersion(ctx context.Context, enterprise string, imageDefinitionID int64, version string) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/hosted-runners/images/custom/%v/versions/%v", enterprise, imageDefinitionID, version)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/enterprise_actions_runner_groups.go
+++ b/github/enterprise_actions_runner_groups.go
@@ -94,13 +94,13 @@ func (s *EnterpriseService) ListRunnerGroups(ctx context.Context, enterprise str
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var groups *EnterpriseRunnerGroups
-	resp, err := s.client.Do(ctx, req, &groups)
+	resp, err := s.client.Do(req, &groups)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -115,13 +115,13 @@ func (s *EnterpriseService) ListRunnerGroups(ctx context.Context, enterprise str
 //meta:operation GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}
 func (s *EnterpriseService) GetEnterpriseRunnerGroup(ctx context.Context, enterprise string, groupID int64) (*EnterpriseRunnerGroup, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runner-groups/%v", enterprise, groupID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runnerGroup *EnterpriseRunnerGroup
-	resp, err := s.client.Do(ctx, req, &runnerGroup)
+	resp, err := s.client.Do(req, &runnerGroup)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -137,12 +137,12 @@ func (s *EnterpriseService) GetEnterpriseRunnerGroup(ctx context.Context, enterp
 func (s *EnterpriseService) DeleteEnterpriseRunnerGroup(ctx context.Context, enterprise string, groupID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runner-groups/%v", enterprise, groupID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // CreateEnterpriseRunnerGroup creates a new self-hosted runner group for an enterprise.
@@ -152,13 +152,13 @@ func (s *EnterpriseService) DeleteEnterpriseRunnerGroup(ctx context.Context, ent
 //meta:operation POST /enterprises/{enterprise}/actions/runner-groups
 func (s *EnterpriseService) CreateEnterpriseRunnerGroup(ctx context.Context, enterprise string, createReq CreateEnterpriseRunnerGroupRequest) (*EnterpriseRunnerGroup, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runner-groups", enterprise)
-	req, err := s.client.NewRequest("POST", u, createReq)
+	req, err := s.client.NewRequest(ctx, "POST", u, createReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runnerGroup *EnterpriseRunnerGroup
-	resp, err := s.client.Do(ctx, req, &runnerGroup)
+	resp, err := s.client.Do(req, &runnerGroup)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -173,13 +173,13 @@ func (s *EnterpriseService) CreateEnterpriseRunnerGroup(ctx context.Context, ent
 //meta:operation PATCH /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}
 func (s *EnterpriseService) UpdateEnterpriseRunnerGroup(ctx context.Context, enterprise string, groupID int64, updateReq UpdateEnterpriseRunnerGroupRequest) (*EnterpriseRunnerGroup, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runner-groups/%v", enterprise, groupID)
-	req, err := s.client.NewRequest("PATCH", u, updateReq)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, updateReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runnerGroup *EnterpriseRunnerGroup
-	resp, err := s.client.Do(ctx, req, &runnerGroup)
+	resp, err := s.client.Do(req, &runnerGroup)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -199,13 +199,13 @@ func (s *EnterpriseService) ListOrganizationAccessRunnerGroup(ctx context.Contex
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var orgs *ListOrganizations
-	resp, err := s.client.Do(ctx, req, &orgs)
+	resp, err := s.client.Do(req, &orgs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -222,12 +222,12 @@ func (s *EnterpriseService) ListOrganizationAccessRunnerGroup(ctx context.Contex
 func (s *EnterpriseService) SetOrganizationAccessRunnerGroup(ctx context.Context, enterprise string, groupID int64, ids SetOrgAccessRunnerGroupRequest) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runner-groups/%v/organizations", enterprise, groupID)
 
-	req, err := s.client.NewRequest("PUT", u, ids)
+	req, err := s.client.NewRequest(ctx, "PUT", u, ids)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // AddOrganizationAccessRunnerGroup adds an organization to the list of selected organizations that can access a self-hosted runner group.
@@ -239,12 +239,12 @@ func (s *EnterpriseService) SetOrganizationAccessRunnerGroup(ctx context.Context
 func (s *EnterpriseService) AddOrganizationAccessRunnerGroup(ctx context.Context, enterprise string, groupID, orgID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runner-groups/%v/organizations/%v", enterprise, groupID, orgID)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RemoveOrganizationAccessRunnerGroup removes an organization from the list of selected organizations that can access a self-hosted runner group.
@@ -256,12 +256,12 @@ func (s *EnterpriseService) AddOrganizationAccessRunnerGroup(ctx context.Context
 func (s *EnterpriseService) RemoveOrganizationAccessRunnerGroup(ctx context.Context, enterprise string, groupID, orgID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runner-groups/%v/organizations/%v", enterprise, groupID, orgID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListRunnerGroupRunners lists self-hosted runners that are in a specific enterprise group.
@@ -276,13 +276,13 @@ func (s *EnterpriseService) ListRunnerGroupRunners(ctx context.Context, enterpri
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runners *Runners
-	resp, err := s.client.Do(ctx, req, &runners)
+	resp, err := s.client.Do(req, &runners)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -299,12 +299,12 @@ func (s *EnterpriseService) ListRunnerGroupRunners(ctx context.Context, enterpri
 func (s *EnterpriseService) SetRunnerGroupRunners(ctx context.Context, enterprise string, groupID int64, ids SetRunnerGroupRunnersRequest) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runner-groups/%v/runners", enterprise, groupID)
 
-	req, err := s.client.NewRequest("PUT", u, ids)
+	req, err := s.client.NewRequest(ctx, "PUT", u, ids)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // AddRunnerGroupRunners adds a self-hosted runner to a runner group configured in an enterprise.
@@ -315,12 +315,12 @@ func (s *EnterpriseService) SetRunnerGroupRunners(ctx context.Context, enterpris
 func (s *EnterpriseService) AddRunnerGroupRunners(ctx context.Context, enterprise string, groupID, runnerID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runner-groups/%v/runners/%v", enterprise, groupID, runnerID)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RemoveRunnerGroupRunners removes a self-hosted runner from a group configured in an enterprise.
@@ -332,10 +332,10 @@ func (s *EnterpriseService) AddRunnerGroupRunners(ctx context.Context, enterpris
 func (s *EnterpriseService) RemoveRunnerGroupRunners(ctx context.Context, enterprise string, groupID, runnerID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runner-groups/%v/runners/%v", enterprise, groupID, runnerID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/enterprise_actions_runners.go
+++ b/github/enterprise_actions_runners.go
@@ -17,13 +17,13 @@ import (
 //meta:operation GET /enterprises/{enterprise}/actions/runners/downloads
 func (s *EnterpriseService) ListRunnerApplicationDownloads(ctx context.Context, enterprise string) ([]*RunnerApplicationDownload, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runners/downloads", enterprise)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var rads []*RunnerApplicationDownload
-	resp, err := s.client.Do(ctx, req, &rads)
+	resp, err := s.client.Do(req, &rads)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -39,13 +39,13 @@ func (s *EnterpriseService) ListRunnerApplicationDownloads(ctx context.Context, 
 func (s *EnterpriseService) GenerateEnterpriseJITConfig(ctx context.Context, enterprise string, request *GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runners/generate-jitconfig", enterprise)
 
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var jitConfig *JITRunnerConfig
-	resp, err := s.client.Do(ctx, req, &jitConfig)
+	resp, err := s.client.Do(req, &jitConfig)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -61,13 +61,13 @@ func (s *EnterpriseService) GenerateEnterpriseJITConfig(ctx context.Context, ent
 func (s *EnterpriseService) CreateRegistrationToken(ctx context.Context, enterprise string) (*RegistrationToken, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runners/registration-token", enterprise)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var registrationToken *RegistrationToken
-	resp, err := s.client.Do(ctx, req, &registrationToken)
+	resp, err := s.client.Do(req, &registrationToken)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -87,13 +87,13 @@ func (s *EnterpriseService) ListRunners(ctx context.Context, enterprise string, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runners *Runners
-	resp, err := s.client.Do(ctx, req, &runners)
+	resp, err := s.client.Do(req, &runners)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -108,13 +108,13 @@ func (s *EnterpriseService) ListRunners(ctx context.Context, enterprise string, 
 //meta:operation GET /enterprises/{enterprise}/actions/runners/{runner_id}
 func (s *EnterpriseService) GetRunner(ctx context.Context, enterprise string, runnerID int64) (*Runner, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runners/%v", enterprise, runnerID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var runner *Runner
-	resp, err := s.client.Do(ctx, req, &runner)
+	resp, err := s.client.Do(req, &runner)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -130,10 +130,10 @@ func (s *EnterpriseService) GetRunner(ctx context.Context, enterprise string, ru
 func (s *EnterpriseService) RemoveRunner(ctx context.Context, enterprise string, runnerID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runners/%v", enterprise, runnerID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/enterprise_app_installation.go
+++ b/github/enterprise_app_installation.go
@@ -48,13 +48,13 @@ func (s *EnterpriseService) ListAppInstallableOrganizations(ctx context.Context,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var orgs []*InstallableOrganization
-	resp, err := s.client.Do(ctx, req, &orgs)
+	resp, err := s.client.Do(req, &orgs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -75,13 +75,13 @@ func (s *EnterpriseService) ListAppAccessibleOrganizationRepositories(ctx contex
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var repos []*AccessibleRepository
-	resp, err := s.client.Do(ctx, req, &repos)
+	resp, err := s.client.Do(req, &repos)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -102,13 +102,13 @@ func (s *EnterpriseService) ListAppInstallations(ctx context.Context, enterprise
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var installation []*Installation
-	resp, err := s.client.Do(ctx, req, &installation)
+	resp, err := s.client.Do(req, &installation)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -124,13 +124,13 @@ func (s *EnterpriseService) ListAppInstallations(ctx context.Context, enterprise
 //meta:operation POST /enterprises/{enterprise}/apps/organizations/{org}/installations
 func (s *EnterpriseService) InstallApp(ctx context.Context, enterprise, org string, request InstallAppRequest) (*Installation, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/apps/organizations/%v/installations", enterprise, org)
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var installation *Installation
-	resp, err := s.client.Do(ctx, req, &installation)
+	resp, err := s.client.Do(req, &installation)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -145,12 +145,12 @@ func (s *EnterpriseService) InstallApp(ctx context.Context, enterprise, org stri
 //meta:operation DELETE /enterprises/{enterprise}/apps/organizations/{org}/installations/{installation_id}
 func (s *EnterpriseService) UninstallApp(ctx context.Context, enterprise, org string, installationID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/apps/organizations/%v/installations/%v", enterprise, org, installationID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/github/enterprise_apps.go
+++ b/github/enterprise_apps.go
@@ -37,13 +37,13 @@ func (s *EnterpriseService) ListRepositoriesForOrgAppInstallation(ctx context.Co
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r []*AccessibleRepository
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -59,13 +59,13 @@ func (s *EnterpriseService) ListRepositoriesForOrgAppInstallation(ctx context.Co
 //meta:operation PATCH /enterprises/{enterprise}/apps/organizations/{org}/installations/{installation_id}/repositories
 func (s *EnterpriseService) UpdateAppInstallationRepositories(ctx context.Context, enterprise, org string, installationID int64, opts UpdateAppInstallationRepositoriesOptions) (*Installation, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/apps/organizations/%v/installations/%v/repositories", enterprise, org, installationID)
-	req, err := s.client.NewRequest("PATCH", u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *Installation
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -80,13 +80,13 @@ func (s *EnterpriseService) UpdateAppInstallationRepositories(ctx context.Contex
 //meta:operation PATCH /enterprises/{enterprise}/apps/organizations/{org}/installations/{installation_id}/repositories/add
 func (s *EnterpriseService) AddRepositoriesToAppInstallation(ctx context.Context, enterprise, org string, installationID int64, opts AppInstallationRepositoriesOptions) ([]*AccessibleRepository, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/apps/organizations/%v/installations/%v/repositories/add", enterprise, org, installationID)
-	req, err := s.client.NewRequest("PATCH", u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r []*AccessibleRepository
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -101,13 +101,13 @@ func (s *EnterpriseService) AddRepositoriesToAppInstallation(ctx context.Context
 //meta:operation PATCH /enterprises/{enterprise}/apps/organizations/{org}/installations/{installation_id}/repositories/remove
 func (s *EnterpriseService) RemoveRepositoriesFromAppInstallation(ctx context.Context, enterprise, org string, installationID int64, opts AppInstallationRepositoriesOptions) ([]*AccessibleRepository, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/apps/organizations/%v/installations/%v/repositories/remove", enterprise, org, installationID)
-	req, err := s.client.NewRequest("PATCH", u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r []*AccessibleRepository
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/enterprise_audit_log.go
+++ b/github/enterprise_audit_log.go
@@ -22,13 +22,13 @@ func (s *EnterpriseService) GetAuditLog(ctx context.Context, enterprise string, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var auditEntries []*AuditEntry
-	resp, err := s.client.Do(ctx, req, &auditEntries)
+	resp, err := s.client.Do(req, &auditEntries)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/enterprise_audit_log_stream.go
+++ b/github/enterprise_audit_log_stream.go
@@ -166,13 +166,13 @@ func NewDatadogStreamConfig(enabled bool, cfg *DatadogConfig) *AuditLogStreamCon
 func (s *EnterpriseService) GetAuditLogStreamKey(ctx context.Context, enterprise string) (*AuditLogStreamKey, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/audit-log/stream-key", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var key *AuditLogStreamKey
-	resp, err := s.client.Do(ctx, req, &key)
+	resp, err := s.client.Do(req, &key)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -188,13 +188,13 @@ func (s *EnterpriseService) GetAuditLogStreamKey(ctx context.Context, enterprise
 func (s *EnterpriseService) ListAuditLogStreams(ctx context.Context, enterprise string) ([]*AuditLogStream, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/audit-log/streams", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var streams []*AuditLogStream
-	resp, err := s.client.Do(ctx, req, &streams)
+	resp, err := s.client.Do(req, &streams)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -210,13 +210,13 @@ func (s *EnterpriseService) ListAuditLogStreams(ctx context.Context, enterprise 
 func (s *EnterpriseService) GetAuditLogStream(ctx context.Context, enterprise string, streamID int64) (*AuditLogStream, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/audit-log/streams/%v", enterprise, streamID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var stream *AuditLogStream
-	resp, err := s.client.Do(ctx, req, &stream)
+	resp, err := s.client.Do(req, &stream)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -233,13 +233,13 @@ func (s *EnterpriseService) GetAuditLogStream(ctx context.Context, enterprise st
 func (s *EnterpriseService) CreateAuditLogStream(ctx context.Context, enterprise string, config AuditLogStreamConfig) (*AuditLogStream, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/audit-log/streams", enterprise)
 
-	req, err := s.client.NewRequest("POST", u, config)
+	req, err := s.client.NewRequest(ctx, "POST", u, config)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var stream *AuditLogStream
-	resp, err := s.client.Do(ctx, req, &stream)
+	resp, err := s.client.Do(req, &stream)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -256,13 +256,13 @@ func (s *EnterpriseService) CreateAuditLogStream(ctx context.Context, enterprise
 func (s *EnterpriseService) UpdateAuditLogStream(ctx context.Context, enterprise string, streamID int64, config AuditLogStreamConfig) (*AuditLogStream, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/audit-log/streams/%v", enterprise, streamID)
 
-	req, err := s.client.NewRequest("PUT", u, config)
+	req, err := s.client.NewRequest(ctx, "PUT", u, config)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var stream *AuditLogStream
-	resp, err := s.client.Do(ctx, req, &stream)
+	resp, err := s.client.Do(req, &stream)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -278,10 +278,10 @@ func (s *EnterpriseService) UpdateAuditLogStream(ctx context.Context, enterprise
 func (s *EnterpriseService) DeleteAuditLogStream(ctx context.Context, enterprise string, streamID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/audit-log/streams/%v", enterprise, streamID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/enterprise_billing_cost_centers.go
+++ b/github/enterprise_billing_cost_centers.go
@@ -86,13 +86,13 @@ func (s *EnterpriseService) ListCostCenters(ctx context.Context, enterprise stri
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var costCenters *CostCenters
-	resp, err := s.client.Do(ctx, req, &costCenters)
+	resp, err := s.client.Do(req, &costCenters)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -108,13 +108,13 @@ func (s *EnterpriseService) ListCostCenters(ctx context.Context, enterprise stri
 func (s *EnterpriseService) CreateCostCenter(ctx context.Context, enterprise string, costCenter CostCenterRequest) (*CostCenter, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/settings/billing/cost-centers", enterprise)
 
-	req, err := s.client.NewRequest("POST", u, costCenter)
+	req, err := s.client.NewRequest(ctx, "POST", u, costCenter)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var result *CostCenter
-	resp, err := s.client.Do(ctx, req, &result)
+	resp, err := s.client.Do(req, &result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -130,13 +130,13 @@ func (s *EnterpriseService) CreateCostCenter(ctx context.Context, enterprise str
 func (s *EnterpriseService) GetCostCenter(ctx context.Context, enterprise, costCenterID string) (*CostCenter, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/settings/billing/cost-centers/%v", enterprise, costCenterID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var costCenter *CostCenter
-	resp, err := s.client.Do(ctx, req, &costCenter)
+	resp, err := s.client.Do(req, &costCenter)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -152,13 +152,13 @@ func (s *EnterpriseService) GetCostCenter(ctx context.Context, enterprise, costC
 func (s *EnterpriseService) UpdateCostCenter(ctx context.Context, enterprise, costCenterID string, costCenter CostCenterRequest) (*CostCenter, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/settings/billing/cost-centers/%v", enterprise, costCenterID)
 
-	req, err := s.client.NewRequest("PATCH", u, costCenter)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, costCenter)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var result *CostCenter
-	resp, err := s.client.Do(ctx, req, &result)
+	resp, err := s.client.Do(req, &result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -174,13 +174,13 @@ func (s *EnterpriseService) UpdateCostCenter(ctx context.Context, enterprise, co
 func (s *EnterpriseService) DeleteCostCenter(ctx context.Context, enterprise, costCenterID string) (*DeleteCostCenterResponse, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/settings/billing/cost-centers/%v", enterprise, costCenterID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var result *DeleteCostCenterResponse
-	resp, err := s.client.Do(ctx, req, &result)
+	resp, err := s.client.Do(req, &result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -196,13 +196,13 @@ func (s *EnterpriseService) DeleteCostCenter(ctx context.Context, enterprise, co
 func (s *EnterpriseService) AddResourcesToCostCenter(ctx context.Context, enterprise, costCenterID string, resources CostCenterResourceRequest) (*AddResourcesToCostCenterResponse, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/settings/billing/cost-centers/%v/resource", enterprise, costCenterID)
 
-	req, err := s.client.NewRequest("POST", u, resources)
+	req, err := s.client.NewRequest(ctx, "POST", u, resources)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var result *AddResourcesToCostCenterResponse
-	resp, err := s.client.Do(ctx, req, &result)
+	resp, err := s.client.Do(req, &result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -218,13 +218,13 @@ func (s *EnterpriseService) AddResourcesToCostCenter(ctx context.Context, enterp
 func (s *EnterpriseService) RemoveResourcesFromCostCenter(ctx context.Context, enterprise, costCenterID string, resources CostCenterResourceRequest) (*RemoveResourcesFromCostCenterResponse, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/settings/billing/cost-centers/%v/resource", enterprise, costCenterID)
 
-	req, err := s.client.NewRequest("DELETE", u, resources)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, resources)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var result *RemoveResourcesFromCostCenterResponse
-	resp, err := s.client.Do(ctx, req, &result)
+	resp, err := s.client.Do(req, &result)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/enterprise_budgets.go
+++ b/github/enterprise_budgets.go
@@ -95,13 +95,13 @@ type EnterpriseDeleteBudgetResponse struct {
 func (s *EnterpriseService) ListBudgets(ctx context.Context, enterprise string) (*EnterpriseListBudgets, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/settings/billing/budgets", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var budgets *EnterpriseListBudgets
-	resp, err := s.client.Do(ctx, req, &budgets)
+	resp, err := s.client.Do(req, &budgets)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -117,13 +117,13 @@ func (s *EnterpriseService) ListBudgets(ctx context.Context, enterprise string) 
 func (s *EnterpriseService) CreateBudget(ctx context.Context, enterprise string, budget EnterpriseCreateBudget) (*EnterpriseCreateOrUpdateBudgetResponse, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/settings/billing/budgets", enterprise)
 
-	req, err := s.client.NewRequest("POST", u, budget)
+	req, err := s.client.NewRequest(ctx, "POST", u, budget)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var createBudgetResponse *EnterpriseCreateOrUpdateBudgetResponse
-	resp, err := s.client.Do(ctx, req, &createBudgetResponse)
+	resp, err := s.client.Do(req, &createBudgetResponse)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -139,13 +139,13 @@ func (s *EnterpriseService) CreateBudget(ctx context.Context, enterprise string,
 func (s *EnterpriseService) GetBudget(ctx context.Context, enterprise, budgetID string) (*EnterpriseBudget, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/settings/billing/budgets/%v", enterprise, budgetID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var budget *EnterpriseBudget
-	resp, err := s.client.Do(ctx, req, &budget)
+	resp, err := s.client.Do(req, &budget)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -161,13 +161,13 @@ func (s *EnterpriseService) GetBudget(ctx context.Context, enterprise, budgetID 
 func (s *EnterpriseService) UpdateBudget(ctx context.Context, enterprise, budgetID string, budget EnterpriseUpdateBudget) (*EnterpriseCreateOrUpdateBudgetResponse, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/settings/billing/budgets/%v", enterprise, budgetID)
 
-	req, err := s.client.NewRequest("PATCH", u, budget)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, budget)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var updateBudgetResponse *EnterpriseCreateOrUpdateBudgetResponse
-	resp, err := s.client.Do(ctx, req, &updateBudgetResponse)
+	resp, err := s.client.Do(req, &updateBudgetResponse)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -183,13 +183,13 @@ func (s *EnterpriseService) UpdateBudget(ctx context.Context, enterprise, budget
 func (s *EnterpriseService) DeleteBudget(ctx context.Context, enterprise, budgetID string) (*EnterpriseDeleteBudgetResponse, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/settings/billing/budgets/%v", enterprise, budgetID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var deleteBudgetResponse *EnterpriseDeleteBudgetResponse
-	resp, err := s.client.Do(ctx, req, &deleteBudgetResponse)
+	resp, err := s.client.Do(req, &deleteBudgetResponse)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/enterprise_code_security_and_analysis.go
+++ b/github/enterprise_code_security_and_analysis.go
@@ -27,13 +27,13 @@ type EnterpriseSecurityAnalysisSettings struct {
 func (s *EnterpriseService) GetCodeSecurityAndAnalysis(ctx context.Context, enterprise string) (*EnterpriseSecurityAnalysisSettings, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/code_security_and_analysis", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var settings *EnterpriseSecurityAnalysisSettings
-	resp, err := s.client.Do(ctx, req, &settings)
+	resp, err := s.client.Do(req, &settings)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -48,12 +48,12 @@ func (s *EnterpriseService) GetCodeSecurityAndAnalysis(ctx context.Context, ente
 //meta:operation PATCH /enterprises/{enterprise}/code_security_and_analysis
 func (s *EnterpriseService) UpdateCodeSecurityAndAnalysis(ctx context.Context, enterprise string, settings *EnterpriseSecurityAnalysisSettings) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/code_security_and_analysis", enterprise)
-	req, err := s.client.NewRequest("PATCH", u, settings)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, settings)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -71,12 +71,12 @@ func (s *EnterpriseService) UpdateCodeSecurityAndAnalysis(ctx context.Context, e
 //meta:operation POST /enterprises/{enterprise}/{security_product}/{enablement}
 func (s *EnterpriseService) EnableDisableSecurityFeature(ctx context.Context, enterprise, securityProduct, enablement string) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/%v/%v", enterprise, securityProduct, enablement)
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/github/enterprise_codesecurity_configurations.go
+++ b/github/enterprise_codesecurity_configurations.go
@@ -42,13 +42,13 @@ func (s *EnterpriseService) ListCodeSecurityConfigurations(ctx context.Context, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configurations []*CodeSecurityConfiguration
-	resp, err := s.client.Do(ctx, req, &configurations)
+	resp, err := s.client.Do(req, &configurations)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -63,13 +63,13 @@ func (s *EnterpriseService) ListCodeSecurityConfigurations(ctx context.Context, 
 func (s *EnterpriseService) CreateCodeSecurityConfiguration(ctx context.Context, enterprise string, config CodeSecurityConfiguration) (*CodeSecurityConfiguration, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/code-security/configurations", enterprise)
 
-	req, err := s.client.NewRequest("POST", u, config)
+	req, err := s.client.NewRequest(ctx, "POST", u, config)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configuration *CodeSecurityConfiguration
-	resp, err := s.client.Do(ctx, req, &configuration)
+	resp, err := s.client.Do(req, &configuration)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -84,13 +84,13 @@ func (s *EnterpriseService) CreateCodeSecurityConfiguration(ctx context.Context,
 func (s *EnterpriseService) ListDefaultCodeSecurityConfigurations(ctx context.Context, enterprise string) ([]*CodeSecurityConfigurationWithDefaultForNewRepos, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/code-security/configurations/defaults", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configurations []*CodeSecurityConfigurationWithDefaultForNewRepos
-	resp, err := s.client.Do(ctx, req, &configurations)
+	resp, err := s.client.Do(req, &configurations)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -105,13 +105,13 @@ func (s *EnterpriseService) ListDefaultCodeSecurityConfigurations(ctx context.Co
 func (s *EnterpriseService) GetCodeSecurityConfiguration(ctx context.Context, enterprise string, configurationID int64) (*CodeSecurityConfiguration, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/code-security/configurations/%v", enterprise, configurationID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configuration *CodeSecurityConfiguration
-	resp, err := s.client.Do(ctx, req, &configuration)
+	resp, err := s.client.Do(req, &configuration)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -126,13 +126,13 @@ func (s *EnterpriseService) GetCodeSecurityConfiguration(ctx context.Context, en
 func (s *EnterpriseService) UpdateCodeSecurityConfiguration(ctx context.Context, enterprise string, configurationID int64, config CodeSecurityConfiguration) (*CodeSecurityConfiguration, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/code-security/configurations/%v", enterprise, configurationID)
 
-	req, err := s.client.NewRequest("PATCH", u, config)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, config)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configuration *CodeSecurityConfiguration
-	resp, err := s.client.Do(ctx, req, &configuration)
+	resp, err := s.client.Do(req, &configuration)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -147,11 +147,11 @@ func (s *EnterpriseService) UpdateCodeSecurityConfiguration(ctx context.Context,
 func (s *EnterpriseService) DeleteCodeSecurityConfiguration(ctx context.Context, enterprise string, configurationID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/code-security/configurations/%v", enterprise, configurationID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -171,11 +171,11 @@ func (s *EnterpriseService) AttachCodeSecurityConfigurationToRepositories(ctx co
 		Scope string `json:"scope"`
 	}
 
-	req, err := s.client.NewRequest("POST", u, scopeType{Scope: scope})
+	req, err := s.client.NewRequest(ctx, "POST", u, scopeType{Scope: scope})
 	if err != nil {
 		return nil, err
 	}
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil && resp.StatusCode != http.StatusAccepted { // StatusAccepted(202) is the expected status code as job is queued for processing
 		return resp, err
 	}
@@ -195,12 +195,12 @@ func (s *EnterpriseService) SetDefaultCodeSecurityConfiguration(ctx context.Cont
 		DefaultForNewRepos string `json:"default_for_new_repos"`
 	}
 
-	req, err := s.client.NewRequest("PUT", u, configParam{DefaultForNewRepos: defaultForNewRepos})
+	req, err := s.client.NewRequest(ctx, "PUT", u, configParam{DefaultForNewRepos: defaultForNewRepos})
 	if err != nil {
 		return nil, nil, err
 	}
 	var config *CodeSecurityConfigurationWithDefaultForNewRepos
-	resp, err := s.client.Do(ctx, req, &config)
+	resp, err := s.client.Do(req, &config)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -219,12 +219,12 @@ func (s *EnterpriseService) ListCodeSecurityConfigurationRepositories(ctx contex
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 	var attachments []*RepositoryAttachment
-	resp, err := s.client.Do(ctx, req, &attachments)
+	resp, err := s.client.Do(req, &attachments)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/enterprise_licenses.go
+++ b/github/enterprise_licenses.go
@@ -101,13 +101,13 @@ func (s *EnterpriseService) GetConsumedLicenses(ctx context.Context, enterprise 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var consumedLicenses *EnterpriseConsumedLicenses
-	resp, err := s.client.Do(ctx, req, &consumedLicenses)
+	resp, err := s.client.Do(req, &consumedLicenses)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -123,13 +123,13 @@ func (s *EnterpriseService) GetConsumedLicenses(ctx context.Context, enterprise 
 func (s *EnterpriseService) GetLicenseSyncStatus(ctx context.Context, enterprise string) (*EnterpriseLicenseSyncStatus, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/license-sync-status", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var syncStatus *EnterpriseLicenseSyncStatus
-	resp, err := s.client.Do(ctx, req, &syncStatus)
+	resp, err := s.client.Do(req, &syncStatus)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/enterprise_manage_ghes.go
+++ b/github/enterprise_manage_ghes.go
@@ -79,13 +79,13 @@ type ReleaseVersion struct {
 //meta:operation GET /manage/v1/checks/system-requirements
 func (s *EnterpriseService) CheckSystemRequirements(ctx context.Context) (*SystemRequirements, *Response, error) {
 	u := "manage/v1/checks/system-requirements"
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var systemRequirements *SystemRequirements
-	resp, err := s.client.Do(ctx, req, &systemRequirements)
+	resp, err := s.client.Do(req, &systemRequirements)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -100,13 +100,13 @@ func (s *EnterpriseService) CheckSystemRequirements(ctx context.Context) (*Syste
 //meta:operation GET /manage/v1/cluster/status
 func (s *EnterpriseService) ClusterStatus(ctx context.Context) (*ClusterStatus, *Response, error) {
 	u := "manage/v1/cluster/status"
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var clusterStatus *ClusterStatus
-	resp, err := s.client.Do(ctx, req, &clusterStatus)
+	resp, err := s.client.Do(req, &clusterStatus)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -124,13 +124,13 @@ func (s *EnterpriseService) ReplicationStatus(ctx context.Context, opts *NodeQue
 	if err != nil {
 		return nil, nil, err
 	}
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var status *ClusterStatus
-	resp, err := s.client.Do(ctx, req, &status)
+	resp, err := s.client.Do(req, &status)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -148,13 +148,13 @@ func (s *EnterpriseService) GetNodeReleaseVersions(ctx context.Context, opts *No
 	if err != nil {
 		return nil, nil, err
 	}
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var releaseVersions []*NodeReleaseVersion
-	resp, err := s.client.Do(ctx, req, &releaseVersions)
+	resp, err := s.client.Do(req, &releaseVersions)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/enterprise_manage_ghes_config.go
+++ b/github/enterprise_manage_ghes_config.go
@@ -313,13 +313,13 @@ func (s *EnterpriseService) ConfigApplyEvents(ctx context.Context, opts *ConfigA
 	if err != nil {
 		return nil, nil, err
 	}
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configApplyEvents *ConfigApplyEvents
-	resp, err := s.client.Do(ctx, req, &configApplyEvents)
+	resp, err := s.client.Do(req, &configApplyEvents)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -341,12 +341,12 @@ func (s *EnterpriseService) InitialConfig(ctx context.Context, license, password
 		Password: password,
 	}
 
-	req, err := s.client.NewRequest("POST", u, payload)
+	req, err := s.client.NewRequest(ctx, "POST", u, payload)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // License gets the current license information for the GitHub Enterprise instance.
@@ -356,13 +356,13 @@ func (s *EnterpriseService) InitialConfig(ctx context.Context, license, password
 //meta:operation GET /manage/v1/config/license
 func (s *EnterpriseService) License(ctx context.Context) ([]*LicenseStatus, *Response, error) {
 	u := "manage/v1/config/license"
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var licenseStatus []*LicenseStatus
-	resp, err := s.client.Do(ctx, req, &licenseStatus)
+	resp, err := s.client.Do(req, &licenseStatus)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -380,12 +380,12 @@ func (s *EnterpriseService) UploadLicense(ctx context.Context, license string) (
 	opts := &UploadLicenseOptions{
 		License: license,
 	}
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // LicenseStatus gets the current license status for the GitHub Enterprise instance.
@@ -395,13 +395,13 @@ func (s *EnterpriseService) UploadLicense(ctx context.Context, license string) (
 //meta:operation GET /manage/v1/config/license/check
 func (s *EnterpriseService) LicenseStatus(ctx context.Context) ([]*LicenseCheck, *Response, error) {
 	u := "manage/v1/config/license/check"
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var checks []*LicenseCheck
-	resp, err := s.client.Do(ctx, req, &checks)
+	resp, err := s.client.Do(req, &checks)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -420,13 +420,13 @@ func (s *EnterpriseService) NodeMetadata(ctx context.Context, opts *NodeQueryOpt
 	if err != nil {
 		return nil, nil, err
 	}
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var status *NodeMetadataStatus
-	resp, err := s.client.Do(ctx, req, &status)
+	resp, err := s.client.Do(req, &status)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -441,13 +441,13 @@ func (s *EnterpriseService) NodeMetadata(ctx context.Context, opts *NodeQueryOpt
 //meta:operation GET /manage/v1/config/settings
 func (s *EnterpriseService) Settings(ctx context.Context) (*ConfigSettings, *Response, error) {
 	u := "manage/v1/config/settings"
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configSettings *ConfigSettings
-	resp, err := s.client.Do(ctx, req, &configSettings)
+	resp, err := s.client.Do(req, &configSettings)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -466,12 +466,12 @@ func (s *EnterpriseService) UpdateSettings(ctx context.Context, opts *ConfigSett
 	if opts == nil {
 		return nil, errors.New("opts should not be nil")
 	}
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ConfigApply triggers a configuration apply run on the GitHub Enterprise instance.
@@ -481,13 +481,13 @@ func (s *EnterpriseService) UpdateSettings(ctx context.Context, opts *ConfigSett
 //meta:operation POST /manage/v1/config/apply
 func (s *EnterpriseService) ConfigApply(ctx context.Context, opts *ConfigApplyOptions) (*ConfigApplyOptions, *Response, error) {
 	u := "manage/v1/config/apply"
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configApplyOptions *ConfigApplyOptions
-	resp, err := s.client.Do(ctx, req, &configApplyOptions)
+	resp, err := s.client.Do(req, &configApplyOptions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -502,13 +502,13 @@ func (s *EnterpriseService) ConfigApply(ctx context.Context, opts *ConfigApplyOp
 //meta:operation GET /manage/v1/config/apply
 func (s *EnterpriseService) ConfigApplyStatus(ctx context.Context, opts *ConfigApplyOptions) (*ConfigApplyStatus, *Response, error) {
 	u := "manage/v1/config/apply"
-	req, err := s.client.NewRequest("GET", u, opts)
+	req, err := s.client.NewRequest(ctx, "GET", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var status *ConfigApplyStatus
-	resp, err := s.client.Do(ctx, req, &status)
+	resp, err := s.client.Do(req, &status)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/enterprise_manage_ghes_maintenance.go
+++ b/github/enterprise_manage_ghes_maintenance.go
@@ -54,13 +54,13 @@ func (s *EnterpriseService) GetMaintenanceStatus(ctx context.Context, opts *Node
 	if err != nil {
 		return nil, nil, err
 	}
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var status []*MaintenanceStatus
-	resp, err := s.client.Do(ctx, req, &status)
+	resp, err := s.client.Do(req, &status)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -79,13 +79,13 @@ func (s *EnterpriseService) CreateMaintenance(ctx context.Context, enable bool, 
 
 	opts.Enabled = enable
 
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var i []*MaintenanceOperationStatus
-	resp, err := s.client.Do(ctx, req, &i)
+	resp, err := s.client.Do(req, &i)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/enterprise_manage_ghes_ssh.go
+++ b/github/enterprise_manage_ghes_ssh.go
@@ -39,13 +39,13 @@ func (s *EnterpriseService) DeleteSSHKey(ctx context.Context, key string) ([]*SS
 	opts := &SSHKeyOptions{
 		Key: key,
 	}
-	req, err := s.client.NewRequest("DELETE", u, opts)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var sshStatus []*SSHKeyStatus
-	resp, err := s.client.Do(ctx, req, &sshStatus)
+	resp, err := s.client.Do(req, &sshStatus)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -60,13 +60,13 @@ func (s *EnterpriseService) DeleteSSHKey(ctx context.Context, key string) ([]*SS
 //meta:operation GET /manage/v1/access/ssh
 func (s *EnterpriseService) GetSSHKey(ctx context.Context) ([]*ClusterSSHKey, *Response, error) {
 	u := "manage/v1/access/ssh"
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var sshKeys []*ClusterSSHKey
-	resp, err := s.client.Do(ctx, req, &sshKeys)
+	resp, err := s.client.Do(req, &sshKeys)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -84,13 +84,13 @@ func (s *EnterpriseService) CreateSSHKey(ctx context.Context, key string) ([]*SS
 	opts := &SSHKeyOptions{
 		Key: key,
 	}
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var sshKeyResponse []*SSHKeyStatus
-	resp, err := s.client.Do(ctx, req, &sshKeyResponse)
+	resp, err := s.client.Do(req, &sshKeyResponse)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/enterprise_network_configurations.go
+++ b/github/enterprise_network_configurations.go
@@ -22,13 +22,13 @@ func (s *EnterpriseService) ListEnterpriseNetworkConfigurations(ctx context.Cont
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var networks *NetworkConfigurations
-	resp, err := s.client.Do(ctx, req, &networks)
+	resp, err := s.client.Do(req, &networks)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -47,13 +47,13 @@ func (s *EnterpriseService) CreateEnterpriseNetworkConfiguration(ctx context.Con
 	}
 
 	u := fmt.Sprintf("enterprises/%v/network-configurations", enterprise)
-	req, err := s.client.NewRequest("POST", u, createReq)
+	req, err := s.client.NewRequest(ctx, "POST", u, createReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var network *NetworkConfiguration
-	resp, err := s.client.Do(ctx, req, &network)
+	resp, err := s.client.Do(req, &network)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -68,13 +68,13 @@ func (s *EnterpriseService) CreateEnterpriseNetworkConfiguration(ctx context.Con
 //meta:operation GET /enterprises/{enterprise}/network-configurations/{network_configuration_id}
 func (s *EnterpriseService) GetEnterpriseNetworkConfiguration(ctx context.Context, enterprise, networkID string) (*NetworkConfiguration, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/network-configurations/%v", enterprise, networkID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var network *NetworkConfiguration
-	resp, err := s.client.Do(ctx, req, &network)
+	resp, err := s.client.Do(req, &network)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -93,13 +93,13 @@ func (s *EnterpriseService) UpdateEnterpriseNetworkConfiguration(ctx context.Con
 	}
 
 	u := fmt.Sprintf("enterprises/%v/network-configurations/%v", enterprise, networkID)
-	req, err := s.client.NewRequest("PATCH", u, updateReq)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, updateReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var network *NetworkConfiguration
-	resp, err := s.client.Do(ctx, req, &network)
+	resp, err := s.client.Do(req, &network)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -114,12 +114,12 @@ func (s *EnterpriseService) UpdateEnterpriseNetworkConfiguration(ctx context.Con
 //meta:operation DELETE /enterprises/{enterprise}/network-configurations/{network_configuration_id}
 func (s *EnterpriseService) DeleteEnterpriseNetworkConfiguration(ctx context.Context, enterprise, networkID string) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/network-configurations/%v", enterprise, networkID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetEnterpriseNetworkSettingsResource gets a hosted compute network settings resource configured for an enterprise.
@@ -129,13 +129,13 @@ func (s *EnterpriseService) DeleteEnterpriseNetworkConfiguration(ctx context.Con
 //meta:operation GET /enterprises/{enterprise}/network-settings/{network_settings_id}
 func (s *EnterpriseService) GetEnterpriseNetworkSettingsResource(ctx context.Context, enterprise, networkID string) (*NetworkSettingsResource, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/network-settings/%v", enterprise, networkID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var resource *NetworkSettingsResource
-	resp, err := s.client.Do(ctx, req, &resource)
+	resp, err := s.client.Do(req, &resource)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/enterprise_organization_properties.go
+++ b/github/enterprise_organization_properties.go
@@ -43,13 +43,13 @@ type EnterpriseCustomPropertyValuesRequest struct {
 func (s *EnterpriseService) GetOrganizationCustomPropertySchema(ctx context.Context, enterprise string) (*EnterpriseCustomPropertySchema, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/org-properties/schema", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var schema *EnterpriseCustomPropertySchema
-	resp, err := s.client.Do(ctx, req, &schema)
+	resp, err := s.client.Do(req, &schema)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -64,12 +64,12 @@ func (s *EnterpriseService) GetOrganizationCustomPropertySchema(ctx context.Cont
 //meta:operation PATCH /enterprises/{enterprise}/org-properties/schema
 func (s *EnterpriseService) CreateOrUpdateOrganizationCustomPropertySchema(ctx context.Context, enterprise string, schema EnterpriseCustomPropertySchema) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/org-properties/schema", enterprise)
-	req, err := s.client.NewRequest("PATCH", u, schema)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, schema)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -85,13 +85,13 @@ func (s *EnterpriseService) CreateOrUpdateOrganizationCustomPropertySchema(ctx c
 func (s *EnterpriseService) GetOrganizationCustomProperty(ctx context.Context, enterprise, customPropertyName string) (*CustomProperty, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/org-properties/schema/%v", enterprise, customPropertyName)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var property *CustomProperty
-	resp, err := s.client.Do(ctx, req, &property)
+	resp, err := s.client.Do(req, &property)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -106,12 +106,12 @@ func (s *EnterpriseService) GetOrganizationCustomProperty(ctx context.Context, e
 //meta:operation PUT /enterprises/{enterprise}/org-properties/schema/{custom_property_name}
 func (s *EnterpriseService) CreateOrUpdateOrganizationCustomProperty(ctx context.Context, enterprise, customPropertyName string, property CustomProperty) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/org-properties/schema/%v", enterprise, customPropertyName)
-	req, err := s.client.NewRequest("PUT", u, property)
+	req, err := s.client.NewRequest(ctx, "PUT", u, property)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -126,12 +126,12 @@ func (s *EnterpriseService) CreateOrUpdateOrganizationCustomProperty(ctx context
 //meta:operation DELETE /enterprises/{enterprise}/org-properties/schema/{custom_property_name}
 func (s *EnterpriseService) DeleteOrganizationCustomProperty(ctx context.Context, enterprise, customPropertyName string) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/org-properties/schema/%v", enterprise, customPropertyName)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -153,13 +153,13 @@ func (s *EnterpriseService) ListOrganizationCustomPropertyValues(ctx context.Con
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var values []*EnterpriseCustomPropertiesValues
-	resp, err := s.client.Do(ctx, req, &values)
+	resp, err := s.client.Do(req, &values)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -175,12 +175,12 @@ func (s *EnterpriseService) ListOrganizationCustomPropertyValues(ctx context.Con
 //meta:operation PATCH /enterprises/{enterprise}/org-properties/values
 func (s *EnterpriseService) CreateOrUpdateOrganizationCustomPropertyValues(ctx context.Context, enterprise string, values EnterpriseCustomPropertyValuesRequest) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/org-properties/values", enterprise)
-	req, err := s.client.NewRequest("PATCH", u, values)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, values)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/github/enterprise_properties.go
+++ b/github/enterprise_properties.go
@@ -18,13 +18,13 @@ import (
 func (s *EnterpriseService) GetAllCustomProperties(ctx context.Context, enterprise string) ([]*CustomProperty, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/properties/schema", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var customProperties []*CustomProperty
-	resp, err := s.client.Do(ctx, req, &customProperties)
+	resp, err := s.client.Do(req, &customProperties)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -46,13 +46,13 @@ func (s *EnterpriseService) CreateOrUpdateCustomProperties(ctx context.Context, 
 		Properties: properties,
 	}
 
-	req, err := s.client.NewRequest("PATCH", u, params)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, params)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var customProperties []*CustomProperty
-	resp, err := s.client.Do(ctx, req, &customProperties)
+	resp, err := s.client.Do(req, &customProperties)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -68,13 +68,13 @@ func (s *EnterpriseService) CreateOrUpdateCustomProperties(ctx context.Context, 
 func (s *EnterpriseService) GetCustomProperty(ctx context.Context, enterprise, customPropertyName string) (*CustomProperty, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/properties/schema/%v", enterprise, customPropertyName)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var customProperty *CustomProperty
-	resp, err := s.client.Do(ctx, req, &customProperty)
+	resp, err := s.client.Do(req, &customProperty)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -90,13 +90,13 @@ func (s *EnterpriseService) GetCustomProperty(ctx context.Context, enterprise, c
 func (s *EnterpriseService) CreateOrUpdateCustomProperty(ctx context.Context, enterprise, customPropertyName string, property *CustomProperty) (*CustomProperty, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/properties/schema/%v", enterprise, customPropertyName)
 
-	req, err := s.client.NewRequest("PUT", u, property)
+	req, err := s.client.NewRequest(ctx, "PUT", u, property)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var customProperty *CustomProperty
-	resp, err := s.client.Do(ctx, req, &customProperty)
+	resp, err := s.client.Do(req, &customProperty)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -112,10 +112,10 @@ func (s *EnterpriseService) CreateOrUpdateCustomProperty(ctx context.Context, en
 func (s *EnterpriseService) RemoveCustomProperty(ctx context.Context, enterprise, customPropertyName string) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/properties/schema/%v", enterprise, customPropertyName)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/enterprise_rules.go
+++ b/github/enterprise_rules.go
@@ -18,13 +18,13 @@ import (
 func (s *EnterpriseService) CreateRepositoryRuleset(ctx context.Context, enterprise string, ruleset RepositoryRuleset) (*RepositoryRuleset, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/rulesets", enterprise)
 
-	req, err := s.client.NewRequest("POST", u, ruleset)
+	req, err := s.client.NewRequest(ctx, "POST", u, ruleset)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var rs *RepositoryRuleset
-	resp, err := s.client.Do(ctx, req, &rs)
+	resp, err := s.client.Do(req, &rs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -40,13 +40,13 @@ func (s *EnterpriseService) CreateRepositoryRuleset(ctx context.Context, enterpr
 func (s *EnterpriseService) GetRepositoryRuleset(ctx context.Context, enterprise string, rulesetID int64) (*RepositoryRuleset, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/rulesets/%v", enterprise, rulesetID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var ruleset *RepositoryRuleset
-	resp, err := s.client.Do(ctx, req, &ruleset)
+	resp, err := s.client.Do(req, &ruleset)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -62,13 +62,13 @@ func (s *EnterpriseService) GetRepositoryRuleset(ctx context.Context, enterprise
 func (s *EnterpriseService) UpdateRepositoryRuleset(ctx context.Context, enterprise string, rulesetID int64, ruleset RepositoryRuleset) (*RepositoryRuleset, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/rulesets/%v", enterprise, rulesetID)
 
-	req, err := s.client.NewRequest("PUT", u, ruleset)
+	req, err := s.client.NewRequest(ctx, "PUT", u, ruleset)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var rs *RepositoryRuleset
-	resp, err := s.client.Do(ctx, req, &rs)
+	resp, err := s.client.Do(req, &rs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -84,10 +84,10 @@ func (s *EnterpriseService) UpdateRepositoryRuleset(ctx context.Context, enterpr
 func (s *EnterpriseService) DeleteRepositoryRuleset(ctx context.Context, enterprise string, rulesetID int64) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/rulesets/%v", enterprise, rulesetID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/enterprise_scim.go
+++ b/github/enterprise_scim.go
@@ -184,14 +184,14 @@ func (s *EnterpriseService) ListProvisionedSCIMGroups(ctx context.Context, enter
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 	req.Header.Set("Accept", mediaTypeSCIM)
 
 	var groups *SCIMEnterpriseGroups
-	resp, err := s.client.Do(ctx, req, &groups)
+	resp, err := s.client.Do(req, &groups)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -215,14 +215,14 @@ func (s *EnterpriseService) ListProvisionedSCIMUsers(ctx context.Context, enterp
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 	req.Header.Set("Accept", mediaTypeSCIM)
 
 	var users *SCIMEnterpriseUsers
-	resp, err := s.client.Do(ctx, req, &users)
+	resp, err := s.client.Do(req, &users)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -241,14 +241,14 @@ func (s *EnterpriseService) ListProvisionedSCIMUsers(ctx context.Context, enterp
 //meta:operation PUT /scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}
 func (s *EnterpriseService) SetProvisionedSCIMGroup(ctx context.Context, enterprise, scimGroupID string, group SCIMEnterpriseGroupAttributes) (*SCIMEnterpriseGroupAttributes, *Response, error) {
 	u := fmt.Sprintf("scim/v2/enterprises/%v/Groups/%v", enterprise, scimGroupID)
-	req, err := s.client.NewRequest("PUT", u, group)
+	req, err := s.client.NewRequest(ctx, "PUT", u, group)
 	if err != nil {
 		return nil, nil, err
 	}
 	req.Header.Set("Accept", mediaTypeSCIM)
 
 	var groupNew *SCIMEnterpriseGroupAttributes
-	resp, err := s.client.Do(ctx, req, &groupNew)
+	resp, err := s.client.Do(req, &groupNew)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -269,14 +269,14 @@ func (s *EnterpriseService) SetProvisionedSCIMGroup(ctx context.Context, enterpr
 //meta:operation PUT /scim/v2/enterprises/{enterprise}/Users/{scim_user_id}
 func (s *EnterpriseService) SetProvisionedSCIMUser(ctx context.Context, enterprise, scimUserID string, user SCIMEnterpriseUserAttributes) (*SCIMEnterpriseUserAttributes, *Response, error) {
 	u := fmt.Sprintf("scim/v2/enterprises/%v/Users/%v", enterprise, scimUserID)
-	req, err := s.client.NewRequest("PUT", u, user)
+	req, err := s.client.NewRequest(ctx, "PUT", u, user)
 	if err != nil {
 		return nil, nil, err
 	}
 	req.Header.Set("Accept", mediaTypeSCIM)
 
 	var userNew *SCIMEnterpriseUserAttributes
-	resp, err := s.client.Do(ctx, req, &userNew)
+	resp, err := s.client.Do(req, &userNew)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -299,14 +299,14 @@ func (s *EnterpriseService) SetProvisionedSCIMUser(ctx context.Context, enterpri
 //meta:operation PATCH /scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}
 func (s *EnterpriseService) UpdateSCIMGroupAttribute(ctx context.Context, enterprise, scimGroupID string, attribute SCIMEnterpriseAttribute) (*SCIMEnterpriseGroupAttributes, *Response, error) {
 	u := fmt.Sprintf("scim/v2/enterprises/%v/Groups/%v", enterprise, scimGroupID)
-	req, err := s.client.NewRequest("PATCH", u, attribute)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, attribute)
 	if err != nil {
 		return nil, nil, err
 	}
 	req.Header.Set("Accept", mediaTypeSCIM)
 
 	var group *SCIMEnterpriseGroupAttributes
-	resp, err := s.client.Do(ctx, req, &group)
+	resp, err := s.client.Do(req, &group)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -331,14 +331,14 @@ func (s *EnterpriseService) UpdateSCIMGroupAttribute(ctx context.Context, enterp
 //meta:operation PATCH /scim/v2/enterprises/{enterprise}/Users/{scim_user_id}
 func (s *EnterpriseService) UpdateSCIMUserAttribute(ctx context.Context, enterprise, scimUserID string, attribute SCIMEnterpriseAttribute) (*SCIMEnterpriseUserAttributes, *Response, error) {
 	u := fmt.Sprintf("scim/v2/enterprises/%v/Users/%v", enterprise, scimUserID)
-	req, err := s.client.NewRequest("PATCH", u, attribute)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, attribute)
 	if err != nil {
 		return nil, nil, err
 	}
 	req.Header.Set("Accept", mediaTypeSCIM)
 
 	var user *SCIMEnterpriseUserAttributes
-	resp, err := s.client.Do(ctx, req, &user)
+	resp, err := s.client.Do(req, &user)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -353,14 +353,14 @@ func (s *EnterpriseService) UpdateSCIMUserAttribute(ctx context.Context, enterpr
 //meta:operation POST /scim/v2/enterprises/{enterprise}/Groups
 func (s *EnterpriseService) ProvisionSCIMGroup(ctx context.Context, enterprise string, group SCIMEnterpriseGroupAttributes) (*SCIMEnterpriseGroupAttributes, *Response, error) {
 	u := fmt.Sprintf("scim/v2/enterprises/%v/Groups", enterprise)
-	req, err := s.client.NewRequest("POST", u, group)
+	req, err := s.client.NewRequest(ctx, "POST", u, group)
 	if err != nil {
 		return nil, nil, err
 	}
 	req.Header.Set("Accept", mediaTypeSCIM)
 
 	var groupProvisioned *SCIMEnterpriseGroupAttributes
-	resp, err := s.client.Do(ctx, req, &groupProvisioned)
+	resp, err := s.client.Do(req, &groupProvisioned)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -375,14 +375,14 @@ func (s *EnterpriseService) ProvisionSCIMGroup(ctx context.Context, enterprise s
 //meta:operation POST /scim/v2/enterprises/{enterprise}/Users
 func (s *EnterpriseService) ProvisionSCIMUser(ctx context.Context, enterprise string, user SCIMEnterpriseUserAttributes) (*SCIMEnterpriseUserAttributes, *Response, error) {
 	u := fmt.Sprintf("scim/v2/enterprises/%v/Users", enterprise)
-	req, err := s.client.NewRequest("POST", u, user)
+	req, err := s.client.NewRequest(ctx, "POST", u, user)
 	if err != nil {
 		return nil, nil, err
 	}
 	req.Header.Set("Accept", mediaTypeSCIM)
 
 	var userProvisioned *SCIMEnterpriseUserAttributes
-	resp, err := s.client.Do(ctx, req, &userProvisioned)
+	resp, err := s.client.Do(req, &userProvisioned)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -406,14 +406,14 @@ func (s *EnterpriseService) GetProvisionedSCIMGroup(ctx context.Context, enterpr
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 	req.Header.Set("Accept", mediaTypeSCIM)
 
 	var group *SCIMEnterpriseGroupAttributes
-	resp, err := s.client.Do(ctx, req, &group)
+	resp, err := s.client.Do(req, &group)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -429,14 +429,14 @@ func (s *EnterpriseService) GetProvisionedSCIMGroup(ctx context.Context, enterpr
 func (s *EnterpriseService) GetProvisionedSCIMUser(ctx context.Context, enterprise, scimUserID string) (*SCIMEnterpriseUserAttributes, *Response, error) {
 	u := fmt.Sprintf("scim/v2/enterprises/%v/Users/%v", enterprise, scimUserID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 	req.Header.Set("Accept", mediaTypeSCIM)
 
 	var user *SCIMEnterpriseUserAttributes
-	resp, err := s.client.Do(ctx, req, &user)
+	resp, err := s.client.Do(req, &user)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -451,12 +451,12 @@ func (s *EnterpriseService) GetProvisionedSCIMUser(ctx context.Context, enterpri
 //meta:operation DELETE /scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}
 func (s *EnterpriseService) DeleteSCIMGroup(ctx context.Context, enterprise, scimGroupID string) (*Response, error) {
 	u := fmt.Sprintf("scim/v2/enterprises/%v/Groups/%v", enterprise, scimGroupID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DeleteSCIMUser deletes a SCIM user from an enterprise.
@@ -472,10 +472,10 @@ func (s *EnterpriseService) DeleteSCIMGroup(ctx context.Context, enterprise, sci
 //meta:operation DELETE /scim/v2/enterprises/{enterprise}/Users/{scim_user_id}
 func (s *EnterpriseService) DeleteSCIMUser(ctx context.Context, enterprise, scimUserID string) (*Response, error) {
 	u := fmt.Sprintf("scim/v2/enterprises/%v/Users/%v", enterprise, scimUserID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/enterprise_team.go
+++ b/github/enterprise_team.go
@@ -50,13 +50,13 @@ func (s *EnterpriseService) ListTeams(ctx context.Context, enterprise string, op
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teams []*EnterpriseTeam
-	resp, err := s.client.Do(ctx, req, &teams)
+	resp, err := s.client.Do(req, &teams)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -72,13 +72,13 @@ func (s *EnterpriseService) ListTeams(ctx context.Context, enterprise string, op
 func (s *EnterpriseService) CreateTeam(ctx context.Context, enterprise string, team EnterpriseTeamCreateOrUpdateRequest) (*EnterpriseTeam, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams", enterprise)
 
-	req, err := s.client.NewRequest("POST", u, team)
+	req, err := s.client.NewRequest(ctx, "POST", u, team)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var createdTeam *EnterpriseTeam
-	resp, err := s.client.Do(ctx, req, &createdTeam)
+	resp, err := s.client.Do(req, &createdTeam)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -94,13 +94,13 @@ func (s *EnterpriseService) CreateTeam(ctx context.Context, enterprise string, t
 func (s *EnterpriseService) GetTeam(ctx context.Context, enterprise, teamSlug string) (*EnterpriseTeam, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams/%v", enterprise, teamSlug)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var team *EnterpriseTeam
-	resp, err := s.client.Do(ctx, req, &team)
+	resp, err := s.client.Do(req, &team)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -116,13 +116,13 @@ func (s *EnterpriseService) GetTeam(ctx context.Context, enterprise, teamSlug st
 func (s *EnterpriseService) UpdateTeam(ctx context.Context, enterprise, teamSlug string, team EnterpriseTeamCreateOrUpdateRequest) (*EnterpriseTeam, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams/%v", enterprise, teamSlug)
 
-	req, err := s.client.NewRequest("PATCH", u, team)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, team)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var updatedTeam *EnterpriseTeam
-	resp, err := s.client.Do(ctx, req, &updatedTeam)
+	resp, err := s.client.Do(req, &updatedTeam)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -138,12 +138,12 @@ func (s *EnterpriseService) UpdateTeam(ctx context.Context, enterprise, teamSlug
 func (s *EnterpriseService) DeleteTeam(ctx context.Context, enterprise, teamSlug string) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams/%v", enterprise, teamSlug)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -163,13 +163,13 @@ func (s *EnterpriseService) ListTeamMembers(ctx context.Context, enterprise, ent
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var members []*User
-	resp, err := s.client.Do(ctx, req, &members)
+	resp, err := s.client.Do(req, &members)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -184,13 +184,13 @@ func (s *EnterpriseService) ListTeamMembers(ctx context.Context, enterprise, ent
 //meta:operation POST /enterprises/{enterprise}/teams/{enterprise-team}/memberships/add
 func (s *EnterpriseService) BulkAddTeamMembers(ctx context.Context, enterprise, enterpriseTeam string, username []string) ([]*User, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams/%v/memberships/add", enterprise, enterpriseTeam)
-	req, err := s.client.NewRequest("POST", u, map[string][]string{"usernames": username})
+	req, err := s.client.NewRequest(ctx, "POST", u, map[string][]string{"usernames": username})
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var members []*User
-	resp, err := s.client.Do(ctx, req, &members)
+	resp, err := s.client.Do(req, &members)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -205,13 +205,13 @@ func (s *EnterpriseService) BulkAddTeamMembers(ctx context.Context, enterprise, 
 //meta:operation POST /enterprises/{enterprise}/teams/{enterprise-team}/memberships/remove
 func (s *EnterpriseService) BulkRemoveTeamMembers(ctx context.Context, enterprise, enterpriseTeam string, username []string) ([]*User, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams/%v/memberships/remove", enterprise, enterpriseTeam)
-	req, err := s.client.NewRequest("POST", u, map[string][]string{"usernames": username})
+	req, err := s.client.NewRequest(ctx, "POST", u, map[string][]string{"usernames": username})
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var members []*User
-	resp, err := s.client.Do(ctx, req, &members)
+	resp, err := s.client.Do(req, &members)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -227,13 +227,13 @@ func (s *EnterpriseService) BulkRemoveTeamMembers(ctx context.Context, enterpris
 func (s *EnterpriseService) GetTeamMembership(ctx context.Context, enterprise, enterpriseTeam, username string) (*User, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams/%v/memberships/%v", enterprise, enterpriseTeam, username)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var membership *User
-	resp, err := s.client.Do(ctx, req, &membership)
+	resp, err := s.client.Do(req, &membership)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -249,13 +249,13 @@ func (s *EnterpriseService) GetTeamMembership(ctx context.Context, enterprise, e
 func (s *EnterpriseService) AddTeamMember(ctx context.Context, enterprise, enterpriseTeam, username string) (*User, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams/%v/memberships/%v", enterprise, enterpriseTeam, username)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var member *User
-	resp, err := s.client.Do(ctx, req, &member)
+	resp, err := s.client.Do(req, &member)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -271,12 +271,12 @@ func (s *EnterpriseService) AddTeamMember(ctx context.Context, enterprise, enter
 func (s *EnterpriseService) RemoveTeamMember(ctx context.Context, enterprise, enterpriseTeam, username string) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams/%v/memberships/%v", enterprise, enterpriseTeam, username)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -296,13 +296,13 @@ func (s *EnterpriseService) ListAssignments(ctx context.Context, enterprise, ent
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var orgs []*Organization
-	resp, err := s.client.Do(ctx, req, &orgs)
+	resp, err := s.client.Do(req, &orgs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -318,13 +318,13 @@ func (s *EnterpriseService) ListAssignments(ctx context.Context, enterprise, ent
 func (s *EnterpriseService) AddMultipleAssignments(ctx context.Context, enterprise, enterpriseTeam string, organizationSlugs []string) ([]*Organization, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams/%v/organizations/add", enterprise, enterpriseTeam)
 
-	req, err := s.client.NewRequest("POST", u, map[string][]string{"organization_slugs": organizationSlugs})
+	req, err := s.client.NewRequest(ctx, "POST", u, map[string][]string{"organization_slugs": organizationSlugs})
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var orgs []*Organization
-	resp, err := s.client.Do(ctx, req, &orgs)
+	resp, err := s.client.Do(req, &orgs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -340,13 +340,13 @@ func (s *EnterpriseService) AddMultipleAssignments(ctx context.Context, enterpri
 func (s *EnterpriseService) RemoveMultipleAssignments(ctx context.Context, enterprise, enterpriseTeam string, organizationSlugs []string) ([]*Organization, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams/%v/organizations/remove", enterprise, enterpriseTeam)
 
-	req, err := s.client.NewRequest("POST", u, map[string][]string{"organization_slugs": organizationSlugs})
+	req, err := s.client.NewRequest(ctx, "POST", u, map[string][]string{"organization_slugs": organizationSlugs})
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var orgs []*Organization
-	resp, err := s.client.Do(ctx, req, &orgs)
+	resp, err := s.client.Do(req, &orgs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -362,13 +362,13 @@ func (s *EnterpriseService) RemoveMultipleAssignments(ctx context.Context, enter
 func (s *EnterpriseService) GetAssignment(ctx context.Context, enterprise, enterpriseTeam, org string) (*Organization, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams/%v/organizations/%v", enterprise, enterpriseTeam, org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var organization *Organization
-	resp, err := s.client.Do(ctx, req, &organization)
+	resp, err := s.client.Do(req, &organization)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -384,13 +384,13 @@ func (s *EnterpriseService) GetAssignment(ctx context.Context, enterprise, enter
 func (s *EnterpriseService) AddAssignment(ctx context.Context, enterprise, enterpriseTeam, org string) (*Organization, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams/%v/organizations/%v", enterprise, enterpriseTeam, org)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var organization *Organization
-	resp, err := s.client.Do(ctx, req, &organization)
+	resp, err := s.client.Do(req, &organization)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -406,12 +406,12 @@ func (s *EnterpriseService) AddAssignment(ctx context.Context, enterprise, enter
 func (s *EnterpriseService) RemoveAssignment(ctx context.Context, enterprise, enterpriseTeam, org string) (*Response, error) {
 	u := fmt.Sprintf("enterprises/%v/teams/%v/organizations/%v", enterprise, enterpriseTeam, org)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/github/gists.go
+++ b/github/gists.go
@@ -114,13 +114,13 @@ func (s *GistsService) List(ctx context.Context, user string, opts *GistListOpti
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var gists []*Gist
-	resp, err := s.client.Do(ctx, req, &gists)
+	resp, err := s.client.Do(req, &gists)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -139,13 +139,13 @@ func (s *GistsService) ListAll(ctx context.Context, opts *GistListOptions) ([]*G
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var gists []*Gist
-	resp, err := s.client.Do(ctx, req, &gists)
+	resp, err := s.client.Do(req, &gists)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -164,13 +164,13 @@ func (s *GistsService) ListStarred(ctx context.Context, opts *GistListOptions) (
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var gists []*Gist
-	resp, err := s.client.Do(ctx, req, &gists)
+	resp, err := s.client.Do(req, &gists)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -185,13 +185,13 @@ func (s *GistsService) ListStarred(ctx context.Context, opts *GistListOptions) (
 //meta:operation GET /gists/{gist_id}
 func (s *GistsService) Get(ctx context.Context, id string) (*Gist, *Response, error) {
 	u := fmt.Sprintf("gists/%v", id)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var gist *Gist
-	resp, err := s.client.Do(ctx, req, &gist)
+	resp, err := s.client.Do(req, &gist)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -206,13 +206,13 @@ func (s *GistsService) Get(ctx context.Context, id string) (*Gist, *Response, er
 //meta:operation GET /gists/{gist_id}/{sha}
 func (s *GistsService) GetRevision(ctx context.Context, id, sha string) (*Gist, *Response, error) {
 	u := fmt.Sprintf("gists/%v/%v", id, sha)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var gist *Gist
-	resp, err := s.client.Do(ctx, req, &gist)
+	resp, err := s.client.Do(req, &gist)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -227,13 +227,13 @@ func (s *GistsService) GetRevision(ctx context.Context, id, sha string) (*Gist, 
 //meta:operation POST /gists
 func (s *GistsService) Create(ctx context.Context, gist *Gist) (*Gist, *Response, error) {
 	u := "gists"
-	req, err := s.client.NewRequest("POST", u, gist)
+	req, err := s.client.NewRequest(ctx, "POST", u, gist)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var g *Gist
-	resp, err := s.client.Do(ctx, req, &g)
+	resp, err := s.client.Do(req, &g)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -248,13 +248,13 @@ func (s *GistsService) Create(ctx context.Context, gist *Gist) (*Gist, *Response
 //meta:operation PATCH /gists/{gist_id}
 func (s *GistsService) Edit(ctx context.Context, id string, gist *Gist) (*Gist, *Response, error) {
 	u := fmt.Sprintf("gists/%v", id)
-	req, err := s.client.NewRequest("PATCH", u, gist)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, gist)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var g *Gist
-	resp, err := s.client.Do(ctx, req, &g)
+	resp, err := s.client.Do(req, &g)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -274,13 +274,13 @@ func (s *GistsService) ListCommits(ctx context.Context, id string, opts *ListOpt
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var gistCommits []*GistCommit
-	resp, err := s.client.Do(ctx, req, &gistCommits)
+	resp, err := s.client.Do(req, &gistCommits)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -295,12 +295,12 @@ func (s *GistsService) ListCommits(ctx context.Context, id string, opts *ListOpt
 //meta:operation DELETE /gists/{gist_id}
 func (s *GistsService) Delete(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("gists/%v", id)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // Star a gist on behalf of authenticated user.
@@ -310,12 +310,12 @@ func (s *GistsService) Delete(ctx context.Context, id string) (*Response, error)
 //meta:operation PUT /gists/{gist_id}/star
 func (s *GistsService) Star(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("gists/%v/star", id)
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // Unstar a gist on a behalf of authenticated user.
@@ -325,12 +325,12 @@ func (s *GistsService) Star(ctx context.Context, id string) (*Response, error) {
 //meta:operation DELETE /gists/{gist_id}/star
 func (s *GistsService) Unstar(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("gists/%v/star", id)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // IsStarred checks if a gist is starred by authenticated user.
@@ -340,12 +340,12 @@ func (s *GistsService) Unstar(ctx context.Context, id string) (*Response, error)
 //meta:operation GET /gists/{gist_id}/star
 func (s *GistsService) IsStarred(ctx context.Context, id string) (bool, *Response, error) {
 	u := fmt.Sprintf("gists/%v/star", id)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return false, nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	starred, err := parseBoolResponse(err)
 	return starred, resp, err
 }
@@ -357,13 +357,13 @@ func (s *GistsService) IsStarred(ctx context.Context, id string) (bool, *Respons
 //meta:operation POST /gists/{gist_id}/forks
 func (s *GistsService) Fork(ctx context.Context, id string) (*Gist, *Response, error) {
 	u := fmt.Sprintf("gists/%v/forks", id)
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var g *Gist
-	resp, err := s.client.Do(ctx, req, &g)
+	resp, err := s.client.Do(req, &g)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -383,13 +383,13 @@ func (s *GistsService) ListForks(ctx context.Context, id string, opts *ListOptio
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var gistForks []*GistFork
-	resp, err := s.client.Do(ctx, req, &gistForks)
+	resp, err := s.client.Do(req, &gistForks)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/gists_comments.go
+++ b/github/gists_comments.go
@@ -35,13 +35,13 @@ func (s *GistsService) ListComments(ctx context.Context, gistID string, opts *Li
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var comments []*GistComment
-	resp, err := s.client.Do(ctx, req, &comments)
+	resp, err := s.client.Do(req, &comments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -56,13 +56,13 @@ func (s *GistsService) ListComments(ctx context.Context, gistID string, opts *Li
 //meta:operation GET /gists/{gist_id}/comments/{comment_id}
 func (s *GistsService) GetComment(ctx context.Context, gistID string, commentID int64) (*GistComment, *Response, error) {
 	u := fmt.Sprintf("gists/%v/comments/%v", gistID, commentID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var c *GistComment
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -77,13 +77,13 @@ func (s *GistsService) GetComment(ctx context.Context, gistID string, commentID 
 //meta:operation POST /gists/{gist_id}/comments
 func (s *GistsService) CreateComment(ctx context.Context, gistID string, comment *GistComment) (*GistComment, *Response, error) {
 	u := fmt.Sprintf("gists/%v/comments", gistID)
-	req, err := s.client.NewRequest("POST", u, comment)
+	req, err := s.client.NewRequest(ctx, "POST", u, comment)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var c *GistComment
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -98,13 +98,13 @@ func (s *GistsService) CreateComment(ctx context.Context, gistID string, comment
 //meta:operation PATCH /gists/{gist_id}/comments/{comment_id}
 func (s *GistsService) EditComment(ctx context.Context, gistID string, commentID int64, comment *GistComment) (*GistComment, *Response, error) {
 	u := fmt.Sprintf("gists/%v/comments/%v", gistID, commentID)
-	req, err := s.client.NewRequest("PATCH", u, comment)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var c *GistComment
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -119,10 +119,10 @@ func (s *GistsService) EditComment(ctx context.Context, gistID string, commentID
 //meta:operation DELETE /gists/{gist_id}/comments/{comment_id}
 func (s *GistsService) DeleteComment(ctx context.Context, gistID string, commentID int64) (*Response, error) {
 	u := fmt.Sprintf("gists/%v/comments/%v", gistID, commentID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/git_blobs.go
+++ b/github/git_blobs.go
@@ -28,13 +28,13 @@ type Blob struct {
 //meta:operation GET /repos/{owner}/{repo}/git/blobs/{file_sha}
 func (s *GitService) GetBlob(ctx context.Context, owner, repo, sha string) (*Blob, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/blobs/%v", owner, repo, sha)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var blob *Blob
-	resp, err := s.client.Do(ctx, req, &blob)
+	resp, err := s.client.Do(req, &blob)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -50,7 +50,7 @@ func (s *GitService) GetBlob(ctx context.Context, owner, repo, sha string) (*Blo
 //meta:operation GET /repos/{owner}/{repo}/git/blobs/{file_sha}
 func (s *GitService) GetBlobRaw(ctx context.Context, owner, repo, sha string) ([]byte, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/blobs/%v", owner, repo, sha)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -58,7 +58,7 @@ func (s *GitService) GetBlobRaw(ctx context.Context, owner, repo, sha string) ([
 	req.Header.Set("Accept", "application/vnd.github.v3.raw")
 
 	var buf bytes.Buffer
-	resp, err := s.client.Do(ctx, req, &buf)
+	resp, err := s.client.Do(req, &buf)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -73,13 +73,13 @@ func (s *GitService) GetBlobRaw(ctx context.Context, owner, repo, sha string) ([
 //meta:operation POST /repos/{owner}/{repo}/git/blobs
 func (s *GitService) CreateBlob(ctx context.Context, owner, repo string, blob Blob) (*Blob, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/blobs", owner, repo)
-	req, err := s.client.NewRequest("POST", u, blob)
+	req, err := s.client.NewRequest(ctx, "POST", u, blob)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var v *Blob
-	resp, err := s.client.Do(ctx, req, &v)
+	resp, err := s.client.Do(req, &v)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/git_commits.go
+++ b/github/git_commits.go
@@ -87,13 +87,13 @@ func (c CommitAuthor) String() string {
 //meta:operation GET /repos/{owner}/{repo}/git/commits/{commit_sha}
 func (s *GitService) GetCommit(ctx context.Context, owner, repo, sha string) (*Commit, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/commits/%v", owner, repo, sha)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var c *Commit
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -161,13 +161,13 @@ func (s *GitService) CreateCommit(ctx context.Context, owner, repo string, commi
 		body.Signature = &signature
 	}
 
-	req, err := s.client.NewRequest("POST", u, body)
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var c *Commit
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/git_refs.go
+++ b/github/git_refs.go
@@ -58,13 +58,13 @@ type UpdateRef struct {
 func (s *GitService) GetRef(ctx context.Context, owner, repo, ref string) (*Reference, *Response, error) {
 	ref = strings.TrimPrefix(ref, "refs/")
 	u := fmt.Sprintf("repos/%v/%v/git/ref/%v", owner, repo, refURLEscape(ref))
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *Reference
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -94,13 +94,13 @@ func (s *GitService) ListMatchingRefs(ctx context.Context, owner, repo, ref stri
 	ref = strings.TrimPrefix(ref, "refs/") // API expects no "refs/" prefix
 	u := fmt.Sprintf("repos/%v/%v/git/matching-refs/%v", owner, repo, refURLEscape(ref))
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var rs []*Reference
-	resp, err := s.client.Do(ctx, req, &rs)
+	resp, err := s.client.Do(req, &rs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -126,13 +126,13 @@ func (s *GitService) CreateRef(ctx context.Context, owner, repo string, ref Crea
 	ref.Ref = "refs/" + strings.TrimPrefix(ref.Ref, "refs/")
 
 	u := fmt.Sprintf("repos/%v/%v/git/refs", owner, repo)
-	req, err := s.client.NewRequest("POST", u, ref)
+	req, err := s.client.NewRequest(ctx, "POST", u, ref)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *Reference
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -156,13 +156,13 @@ func (s *GitService) UpdateRef(ctx context.Context, owner, repo, ref string, upd
 
 	refPath := strings.TrimPrefix(ref, "refs/")
 	u := fmt.Sprintf("repos/%v/%v/git/refs/%v", owner, repo, refURLEscape(refPath))
-	req, err := s.client.NewRequest("PATCH", u, updateRef)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, updateRef)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *Reference
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -178,10 +178,10 @@ func (s *GitService) UpdateRef(ctx context.Context, owner, repo, ref string, upd
 func (s *GitService) DeleteRef(ctx context.Context, owner, repo, ref string) (*Response, error) {
 	ref = strings.TrimPrefix(ref, "refs/")
 	u := fmt.Sprintf("repos/%v/%v/git/refs/%v", owner, repo, refURLEscape(ref))
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/git_tags.go
+++ b/github/git_tags.go
@@ -38,13 +38,13 @@ type CreateTag struct {
 //meta:operation GET /repos/{owner}/{repo}/git/tags/{tag_sha}
 func (s *GitService) GetTag(ctx context.Context, owner, repo, sha string) (*Tag, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/tags/%v", owner, repo, sha)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var tag *Tag
-	resp, err := s.client.Do(ctx, req, &tag)
+	resp, err := s.client.Do(req, &tag)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -60,13 +60,13 @@ func (s *GitService) GetTag(ctx context.Context, owner, repo, sha string) (*Tag,
 func (s *GitService) CreateTag(ctx context.Context, owner, repo string, tag CreateTag) (*Tag, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/tags", owner, repo)
 
-	req, err := s.client.NewRequest("POST", u, tag)
+	req, err := s.client.NewRequest(ctx, "POST", u, tag)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var t *Tag
-	resp, err := s.client.Do(ctx, req, &t)
+	resp, err := s.client.Do(req, &t)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/git_trees.go
+++ b/github/git_trees.go
@@ -110,13 +110,13 @@ func (s *GitService) GetTree(ctx context.Context, owner, repo, sha string, recur
 		u += "?recursive=1"
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var t *Tree
-	resp, err := s.client.Do(ctx, req, &t)
+	resp, err := s.client.Do(req, &t)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -165,13 +165,13 @@ func (s *GitService) CreateTree(ctx context.Context, owner, repo, baseTree strin
 		BaseTree: baseTree,
 		Entries:  newEntries,
 	}
-	req, err := s.client.NewRequest("POST", u, body)
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var t *Tree
-	resp, err := s.client.Do(ctx, req, &t)
+	resp, err := s.client.Do(req, &t)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/github.go
+++ b/github/github.go
@@ -1037,9 +1037,6 @@ func (c *Client) bareDo(caller *http.Client, req *http.Request) (*Response, erro
 // are supposed to read and close the response's Body. If rate limit is exceeded
 // and reset time is in the future, BareDo returns *RateLimitError immediately
 // without making a network API call.
-//
-// The provided ctx must be non-nil, if it is nil an error is returned. If it is
-// canceled or times out, ctx.Err() will be returned.
 func (c *Client) BareDo(req *http.Request) (*Response, error) {
 	return c.bareDo(c.client, req)
 }
@@ -1047,9 +1044,6 @@ func (c *Client) BareDo(req *http.Request) (*Response, error) {
 // bareDoIgnoreRedirects has the exact same behavior as BareDo but stops at the first
 // redirection code returned by the API. If a redirection is returned by the api, bareDoIgnoreRedirects
 // returns a *RedirectionError.
-//
-// The provided ctx must be non-nil, if it is nil an error is returned. If it is
-// canceled or times out, ctx.Err() will be returned.
 func (c *Client) bareDoIgnoreRedirects(req *http.Request) (*Response, error) {
 	return c.bareDo(c.clientIgnoreRedirects, req)
 }
@@ -1060,9 +1054,6 @@ var errInvalidLocation = errors.New("invalid or empty Location header in redirec
 // a 302, it will parse the Location header into a *url.URL and return that.
 // This is useful for endpoints that return a 302 in successful cases but still might return 301s for
 // permanent redirections.
-//
-// The provided ctx must be non-nil, if it is nil an error is returned. If it is
-// canceled or times out, ctx.Err() will be returned.
 func (c *Client) bareDoUntilFound(req *http.Request, maxRedirects int) (*url.URL, *Response, error) {
 	response, err := c.bareDoIgnoreRedirects(req)
 	if err != nil {
@@ -1111,9 +1102,6 @@ func (c *Client) bareDoUntilFound(req *http.Request, maxRedirects int) (*url.URL
 // decode it. If v is nil, and no error happens, the response is returned as is.
 // If rate limit is exceeded and reset time is in the future, Do returns
 // *RateLimitError immediately without making a network API call.
-//
-// The provided ctx must be non-nil, if it is nil an error is returned. If it
-// is canceled or times out, ctx.Err() will be returned.
 func (c *Client) Do(req *http.Request, v any) (*Response, error) {
 	resp, err := c.BareDo(req)
 	if err != nil {

--- a/github/github.go
+++ b/github/github.go
@@ -156,8 +156,6 @@ const (
 	mediaTypeContentAttachmentsPreview = "application/vnd.github.corsair-preview+json"
 )
 
-var errNonNilContext = errors.New("context must be non-nil")
-
 // ErrPathForbidden is returned when a URL path contains ".." as a path
 // segment, which could allow path traversal attacks.
 var ErrPathForbidden = errors.New("path must not contain '..' due to auth vulnerability issue")
@@ -561,7 +559,7 @@ func WithVersion(version string) RequestOption {
 // Relative URLs should always be specified without a preceding slash. If
 // specified, the value pointed to by body is JSON encoded and included as the
 // request body.
-func (c *Client) NewRequest(method, urlStr string, body any, opts ...RequestOption) (*http.Request, error) {
+func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body any, opts ...RequestOption) (*http.Request, error) {
 	if !strings.HasSuffix(c.BaseURL.Path, "/") {
 		return nil, fmt.Errorf("baseURL must have a trailing slash, but %q does not", c.BaseURL)
 	}
@@ -586,7 +584,7 @@ func (c *Client) NewRequest(method, urlStr string, body any, opts ...RequestOpti
 		}
 	}
 
-	req, err := http.NewRequest(method, u.String(), buf)
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), buf)
 	if err != nil {
 		return nil, err
 	}
@@ -611,7 +609,7 @@ func (c *Client) NewRequest(method, urlStr string, body any, opts ...RequestOpti
 // in which case it is resolved relative to the BaseURL of the Client.
 // Relative URLs should always be specified without a preceding slash.
 // Body is sent with Content-Type: application/x-www-form-urlencoded.
-func (c *Client) NewFormRequest(urlStr string, body io.Reader, opts ...RequestOption) (*http.Request, error) {
+func (c *Client) NewFormRequest(ctx context.Context, urlStr string, body io.Reader, opts ...RequestOption) (*http.Request, error) {
 	if !strings.HasSuffix(c.BaseURL.Path, "/") {
 		return nil, fmt.Errorf("baseURL must have a trailing slash, but %q does not", c.BaseURL)
 	}
@@ -625,7 +623,7 @@ func (c *Client) NewFormRequest(urlStr string, body io.Reader, opts ...RequestOp
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", u.String(), body)
+	req, err := http.NewRequestWithContext(ctx, "POST", u.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -666,7 +664,7 @@ func checkURLPathTraversal(urlStr string) error {
 // NewUploadRequest creates an upload request. A relative URL can be provided in
 // urlStr, in which case it is resolved relative to the UploadURL of the Client.
 // Relative URLs should always be specified without a preceding slash.
-func (c *Client) NewUploadRequest(urlStr string, reader io.Reader, size int64, mediaType string, opts ...RequestOption) (*http.Request, error) {
+func (c *Client) NewUploadRequest(ctx context.Context, urlStr string, reader io.Reader, size int64, mediaType string, opts ...RequestOption) (*http.Request, error) {
 	if !strings.HasSuffix(c.UploadURL.Path, "/") {
 		return nil, fmt.Errorf("uploadURL must have a trailing slash, but %q does not", c.UploadURL)
 	}
@@ -693,7 +691,7 @@ func (c *Client) NewUploadRequest(urlStr string, reader io.Reader, size int64, m
 		requestBody = uploadRequestBodyReader{Reader: reader}
 	}
 
-	req, err := http.NewRequest("POST", u.String(), requestBody)
+	req, err := http.NewRequestWithContext(ctx, "POST", u.String(), requestBody)
 	if err != nil {
 		return nil, err
 	}
@@ -927,15 +925,8 @@ const (
 // will contain more information. Otherwise, you are supposed to read and close the
 // response's Body. If rate limit is exceeded and reset time is in the future,
 // bareDo returns *RateLimitError immediately without making a network API call.
-//
-// The provided ctx must be non-nil, if it is nil an error is returned. If it is
-// canceled or times out, ctx.Err() will be returned.
-func (c *Client) bareDo(ctx context.Context, caller *http.Client, req *http.Request) (*Response, error) {
-	if ctx == nil {
-		return nil, errNonNilContext
-	}
-
-	req = withContext(ctx, req)
+func (c *Client) bareDo(caller *http.Client, req *http.Request) (*Response, error) {
+	ctx := req.Context()
 
 	rateLimitCategory := CoreCategory
 
@@ -1017,12 +1008,13 @@ func (c *Client) bareDo(ctx context.Context, caller *http.Client, req *http.Requ
 
 		var rateLimitError *RateLimitError
 		if errors.As(err, &rateLimitError) &&
-			req.Context().Value(SleepUntilPrimaryRateLimitResetWhenRateLimited) != nil {
-			if err := sleepUntilResetWithBuffer(req.Context(), rateLimitError.Rate.Reset.Time); err != nil {
+			ctx.Value(SleepUntilPrimaryRateLimitResetWhenRateLimited) != nil {
+			if err := sleepUntilResetWithBuffer(ctx, rateLimitError.Rate.Reset.Time); err != nil {
 				return response, err
 			}
-			// retry the request once when the rate limit has reset
-			return c.bareDo(context.WithValue(req.Context(), SleepUntilPrimaryRateLimitResetWhenRateLimited, nil), caller, req)
+			// retry the request now the rate limit should have been reset
+			newReq := req.Clone(context.WithValue(ctx, SleepUntilPrimaryRateLimitResetWhenRateLimited, nil))
+			return c.bareDo(caller, newReq)
 		}
 
 		// Update the secondary rate limit if we hit it.
@@ -1048,8 +1040,8 @@ func (c *Client) bareDo(ctx context.Context, caller *http.Client, req *http.Requ
 //
 // The provided ctx must be non-nil, if it is nil an error is returned. If it is
 // canceled or times out, ctx.Err() will be returned.
-func (c *Client) BareDo(ctx context.Context, req *http.Request) (*Response, error) {
-	return c.bareDo(ctx, c.client, req)
+func (c *Client) BareDo(req *http.Request) (*Response, error) {
+	return c.bareDo(c.client, req)
 }
 
 // bareDoIgnoreRedirects has the exact same behavior as BareDo but stops at the first
@@ -1058,8 +1050,8 @@ func (c *Client) BareDo(ctx context.Context, req *http.Request) (*Response, erro
 //
 // The provided ctx must be non-nil, if it is nil an error is returned. If it is
 // canceled or times out, ctx.Err() will be returned.
-func (c *Client) bareDoIgnoreRedirects(ctx context.Context, req *http.Request) (*Response, error) {
-	return c.bareDo(ctx, c.clientIgnoreRedirects, req)
+func (c *Client) bareDoIgnoreRedirects(req *http.Request) (*Response, error) {
+	return c.bareDo(c.clientIgnoreRedirects, req)
 }
 
 var errInvalidLocation = errors.New("invalid or empty Location header in redirection response")
@@ -1071,8 +1063,8 @@ var errInvalidLocation = errors.New("invalid or empty Location header in redirec
 //
 // The provided ctx must be non-nil, if it is nil an error is returned. If it is
 // canceled or times out, ctx.Err() will be returned.
-func (c *Client) bareDoUntilFound(ctx context.Context, req *http.Request, maxRedirects int) (*url.URL, *Response, error) {
-	response, err := c.bareDoIgnoreRedirects(ctx, req)
+func (c *Client) bareDoUntilFound(req *http.Request, maxRedirects int) (*url.URL, *Response, error) {
+	response, err := c.bareDoIgnoreRedirects(req)
 	if err != nil {
 		var rerr *RedirectionError
 		if errors.As(err, &rerr) {
@@ -1096,9 +1088,9 @@ func (c *Client) bareDoUntilFound(ctx context.Context, req *http.Request, maxRed
 				if newURL.Host != c.BaseURL.Host {
 					return nil, response, fmt.Errorf("refusing to follow cross-host redirect from %q to %q", c.BaseURL.Host, newURL.Host)
 				}
-				newRequest := req.Clone(ctx)
+				newRequest := req.Clone(req.Context())
 				newRequest.URL = newURL
-				return c.bareDoUntilFound(ctx, newRequest, maxRedirects-1)
+				return c.bareDoUntilFound(newRequest, maxRedirects-1)
 			}
 			// If we reached the maximum amount of redirections, return an error
 			if maxRedirects <= 0 && rerr.StatusCode == http.StatusMovedPermanently {
@@ -1122,8 +1114,8 @@ func (c *Client) bareDoUntilFound(ctx context.Context, req *http.Request, maxRed
 //
 // The provided ctx must be non-nil, if it is nil an error is returned. If it
 // is canceled or times out, ctx.Err() will be returned.
-func (c *Client) Do(ctx context.Context, req *http.Request, v any) (*Response, error) {
-	resp, err := c.BareDo(ctx, req)
+func (c *Client) Do(req *http.Request, v any) (*Response, error) {
+	resp, err := c.BareDo(req)
 	if err != nil {
 		return resp, err
 	}
@@ -1150,6 +1142,8 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v any) (*Response, e
 // from Client.Do, and if so, returns it so that Client.Do can skip making a network API call unnecessarily.
 // Otherwise it returns nil, and Client.Do should proceed normally.
 func (c *Client) checkRateLimitBeforeDo(req *http.Request, rateLimitCategory RateLimitCategory) *RateLimitError {
+	ctx := req.Context()
+
 	c.rateMu.Lock()
 	rate := c.rateLimits[rateLimitCategory]
 	c.rateMu.Unlock()
@@ -1163,8 +1157,8 @@ func (c *Client) checkRateLimitBeforeDo(req *http.Request, rateLimitCategory Rat
 			Body:       io.NopCloser(strings.NewReader("")),
 		}
 
-		if req.Context().Value(SleepUntilPrimaryRateLimitResetWhenRateLimited) != nil {
-			if err := sleepUntilResetWithBuffer(req.Context(), rate.Reset.Time); err == nil {
+		if ctx.Value(SleepUntilPrimaryRateLimitResetWhenRateLimited) != nil {
+			if err := sleepUntilResetWithBuffer(ctx, rate.Reset.Time); err == nil {
 				return nil
 			}
 			return &RateLimitError{
@@ -1831,14 +1825,13 @@ func sleepUntilResetWithBuffer(ctx context.Context, reset time.Time) error {
 // When using roundTripWithOptionalFollowRedirect, note that it
 // is the responsibility of the caller to close the response body.
 func (c *Client) roundTripWithOptionalFollowRedirect(ctx context.Context, u string, maxRedirects int, opts ...RequestOption) (*http.Response, error) {
-	req, err := c.NewRequest("GET", u, nil, opts...)
+	req, err := c.NewRequest(ctx, "GET", u, nil, opts...)
 	if err != nil {
 		return nil, err
 	}
 
 	var resp *http.Response
 	// Use http.DefaultTransport if no custom Transport is configured
-	req = withContext(ctx, req)
 	if c.client.Transport == nil {
 		resp, err = http.DefaultTransport.RoundTrip(req)
 	} else {
@@ -1939,9 +1932,4 @@ func (e *DeploymentProtectionRuleEvent) GetRunID() (int64, error) {
 		return -1, err
 	}
 	return runID, nil
-}
-
-// withContext returns a shallow copy of req with its context changed to ctx.
-func withContext(ctx context.Context, req *http.Request) *http.Request {
-	return req.WithContext(ctx)
 }

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -664,7 +664,7 @@ func TestNewRequest(t *testing.T) {
 
 	inURL, outURL := "/foo", defaultBaseURL+"foo"
 	inBody, outBody := &User{Login: Ptr("l")}, `{"login":"l"}`+"\n"
-	req, _ := c.NewRequest("GET", inURL, inBody)
+	req, _ := c.NewRequest(t.Context(), "GET", inURL, inBody)
 
 	// test that relative URL was expanded
 	if got, want := req.URL.String(), outURL; got != want {
@@ -693,7 +693,7 @@ func TestNewRequest(t *testing.T) {
 		t.Errorf("NewRequest() %v header is %v, want %v", headerAPIVersion, got, want)
 	}
 
-	req, _ = c.NewRequest("GET", inURL, inBody, WithVersion("2022-11-29"))
+	req, _ = c.NewRequest(t.Context(), "GET", inURL, inBody, WithVersion("2022-11-29"))
 	apiVersion = req.Header.Get(headerAPIVersion)
 	if got, want := apiVersion, "2022-11-29"; got != want {
 		t.Errorf("NewRequest() %v header is %v, want %v", headerAPIVersion, got, want)
@@ -707,7 +707,7 @@ func TestNewRequest_invalidJSON(t *testing.T) {
 	type T struct {
 		F func()
 	}
-	_, err := c.NewRequest("GET", ".", &T{})
+	_, err := c.NewRequest(t.Context(), "GET", ".", &T{})
 
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -717,14 +717,14 @@ func TestNewRequest_invalidJSON(t *testing.T) {
 func TestNewRequest_badURL(t *testing.T) {
 	t.Parallel()
 	c := NewClient(nil)
-	_, err := c.NewRequest("GET", ":", nil)
+	_, err := c.NewRequest(t.Context(), "GET", ":", nil)
 	testURLParseError(t, err)
 }
 
 func TestNewRequest_badMethod(t *testing.T) {
 	t.Parallel()
 	c := NewClient(nil)
-	if _, err := c.NewRequest("BOGUS\nMETHOD", ".", nil); err == nil {
+	if _, err := c.NewRequest(t.Context(), "BOGUS\nMETHOD", ".", nil); err == nil {
 		t.Fatal("NewRequest returned nil; expected error")
 	}
 }
@@ -735,7 +735,7 @@ func TestNewRequest_emptyUserAgent(t *testing.T) {
 	t.Parallel()
 	c := NewClient(nil)
 	c.UserAgent = ""
-	req, err := c.NewRequest("GET", ".", nil)
+	req, err := c.NewRequest(t.Context(), "GET", ".", nil)
 	if err != nil {
 		t.Fatalf("NewRequest returned unexpected error: %v", err)
 	}
@@ -753,7 +753,7 @@ func TestNewRequest_emptyUserAgent(t *testing.T) {
 func TestNewRequest_emptyBody(t *testing.T) {
 	t.Parallel()
 	c := NewClient(nil)
-	req, err := c.NewRequest("GET", ".", nil)
+	req, err := c.NewRequest(t.Context(), "GET", ".", nil)
 	if err != nil {
 		t.Fatalf("NewRequest returned unexpected error: %v", err)
 	}
@@ -778,7 +778,7 @@ func TestNewRequest_errorForNoTrailingSlash(t *testing.T) {
 			t.Fatalf("url.Parse returned unexpected error: %v.", err)
 		}
 		c.BaseURL = u
-		if _, err := c.NewRequest("GET", "test", nil); test.wantError && err == nil {
+		if _, err := c.NewRequest(t.Context(), "GET", "test", nil); test.wantError && err == nil {
 			t.Fatal("Expected error to be returned.")
 		} else if !test.wantError && err != nil {
 			t.Fatalf("NewRequest returned unexpected error: %v.", err)
@@ -834,7 +834,7 @@ func TestNewRequest_pathTraversal(t *testing.T) {
 		{"repos/../admin", true},
 	}
 	for _, tt := range tests {
-		_, err := c.NewRequest("GET", tt.urlStr, nil)
+		_, err := c.NewRequest(t.Context(), "GET", tt.urlStr, nil)
 		if tt.wantError && !errors.Is(err, ErrPathForbidden) {
 			t.Errorf("NewRequest(%q): want ErrPathForbidden, got %v", tt.urlStr, err)
 		} else if !tt.wantError && err != nil {
@@ -847,7 +847,7 @@ func TestNewFormRequest_pathTraversal(t *testing.T) {
 	t.Parallel()
 	c := NewClient(nil)
 
-	_, err := c.NewFormRequest("repos/x/../../../admin", nil)
+	_, err := c.NewFormRequest(t.Context(), "repos/x/../../../admin", nil)
 	if !errors.Is(err, ErrPathForbidden) {
 		t.Fatalf("NewFormRequest with path traversal: want ErrPathForbidden, got %v", err)
 	}
@@ -857,7 +857,7 @@ func TestNewUploadRequest_pathTraversal(t *testing.T) {
 	t.Parallel()
 	c := NewClient(nil)
 
-	_, err := c.NewUploadRequest("repos/x/../../../admin", nil, 0, "")
+	_, err := c.NewUploadRequest(t.Context(), "repos/x/../../../admin", nil, 0, "")
 	if !errors.Is(err, ErrPathForbidden) {
 		t.Fatalf("NewUploadRequest with path traversal: want ErrPathForbidden, got %v", err)
 	}
@@ -871,7 +871,7 @@ func TestNewFormRequest(t *testing.T) {
 	form := url.Values{}
 	form.Add("login", "l")
 	inBody, outBody := strings.NewReader(form.Encode()), "login=l"
-	req, err := c.NewFormRequest(inURL, inBody)
+	req, err := c.NewFormRequest(t.Context(), inURL, inBody)
 	if err != nil {
 		t.Fatalf("NewFormRequest returned unexpected error: %v", err)
 	}
@@ -900,7 +900,7 @@ func TestNewFormRequest(t *testing.T) {
 		t.Errorf("NewFormRequest() %v header is %v, want %v", headerAPIVersion, got, want)
 	}
 
-	req, err = c.NewFormRequest(inURL, inBody, WithVersion("2022-11-29"))
+	req, err = c.NewFormRequest(t.Context(), inURL, inBody, WithVersion("2022-11-29"))
 	if err != nil {
 		t.Fatalf("NewFormRequest with WithVersion returned unexpected error: %v", err)
 	}
@@ -913,7 +913,7 @@ func TestNewFormRequest(t *testing.T) {
 func TestNewFormRequest_badURL(t *testing.T) {
 	t.Parallel()
 	c := NewClient(nil)
-	_, err := c.NewFormRequest(":", nil)
+	_, err := c.NewFormRequest(t.Context(), ":", nil)
 	testURLParseError(t, err)
 }
 
@@ -921,7 +921,7 @@ func TestNewFormRequest_emptyUserAgent(t *testing.T) {
 	t.Parallel()
 	c := NewClient(nil)
 	c.UserAgent = ""
-	req, err := c.NewFormRequest(".", nil)
+	req, err := c.NewFormRequest(t.Context(), ".", nil)
 	if err != nil {
 		t.Fatalf("NewFormRequest returned unexpected error: %v", err)
 	}
@@ -933,7 +933,7 @@ func TestNewFormRequest_emptyUserAgent(t *testing.T) {
 func TestNewFormRequest_emptyBody(t *testing.T) {
 	t.Parallel()
 	c := NewClient(nil)
-	req, err := c.NewFormRequest(".", nil)
+	req, err := c.NewFormRequest(t.Context(), ".", nil)
 	if err != nil {
 		t.Fatalf("NewFormRequest returned unexpected error: %v", err)
 	}
@@ -958,7 +958,7 @@ func TestNewFormRequest_errorForNoTrailingSlash(t *testing.T) {
 			t.Fatalf("url.Parse returned unexpected error: %v.", err)
 		}
 		c.BaseURL = u
-		if _, err := c.NewFormRequest("test", nil); test.wantError && err == nil {
+		if _, err := c.NewFormRequest(t.Context(), "test", nil); test.wantError && err == nil {
 			t.Fatal("Expected error to be returned.")
 		} else if !test.wantError && err != nil {
 			t.Fatalf("NewFormRequest returned unexpected error: %v.", err)
@@ -969,14 +969,14 @@ func TestNewFormRequest_errorForNoTrailingSlash(t *testing.T) {
 func TestNewUploadRequest_WithVersion(t *testing.T) {
 	t.Parallel()
 	c := NewClient(nil)
-	req, _ := c.NewUploadRequest("https://example.com/", nil, 0, "")
+	req, _ := c.NewUploadRequest(t.Context(), "https://example.com/", nil, 0, "")
 
 	apiVersion := req.Header.Get(headerAPIVersion)
 	if got, want := apiVersion, defaultAPIVersion; got != want {
 		t.Errorf("NewRequest() %v header is %v, want %v", headerAPIVersion, got, want)
 	}
 
-	req, _ = c.NewUploadRequest("https://example.com/", nil, 0, "", WithVersion("2022-11-29"))
+	req, _ = c.NewUploadRequest(t.Context(), "https://example.com/", nil, 0, "", WithVersion("2022-11-29"))
 	apiVersion = req.Header.Get(headerAPIVersion)
 	if got, want := apiVersion, "2022-11-29"; got != want {
 		t.Errorf("NewRequest() %v header is %v, want %v", headerAPIVersion, got, want)
@@ -986,12 +986,12 @@ func TestNewUploadRequest_WithVersion(t *testing.T) {
 func TestNewUploadRequest_badURL(t *testing.T) {
 	t.Parallel()
 	c := NewClient(nil)
-	_, err := c.NewUploadRequest(":", nil, 0, "")
+	_, err := c.NewUploadRequest(t.Context(), ":", nil, 0, "")
 	testURLParseError(t, err)
 
 	const methodName = "NewUploadRequest"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = c.NewUploadRequest("\n", nil, -1, "\n")
+		_, err = c.NewUploadRequest(t.Context(), "\n", nil, -1, "\n")
 		return err
 	})
 }
@@ -1012,7 +1012,7 @@ func TestNewUploadRequest_errorForNoTrailingSlash(t *testing.T) {
 			t.Fatalf("url.Parse returned unexpected error: %v.", err)
 		}
 		c.UploadURL = u
-		if _, err = c.NewUploadRequest("test", nil, 0, ""); test.wantError && err == nil {
+		if _, err = c.NewUploadRequest(t.Context(), "test", nil, 0, ""); test.wantError && err == nil {
 			t.Fatal("Expected error to be returned.")
 		} else if !test.wantError && err != nil {
 			t.Fatalf("NewUploadRequest returned unexpected error: %v.", err)
@@ -1285,26 +1285,14 @@ func TestDo(t *testing.T) {
 		fmt.Fprint(w, `{"A":"a"}`)
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
+	req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
 	var body *foo
-	_, err := client.Do(t.Context(), req, &body)
+	_, err := client.Do(req, &body)
 	assertNilError(t, err)
 
 	want := &foo{"a"}
 	if !cmp.Equal(body, want) {
 		t.Errorf("Response body = %v, want %v", body, want)
-	}
-}
-
-func TestDo_nilContext(t *testing.T) {
-	t.Parallel()
-	client, _, _ := setup(t)
-
-	req, _ := client.NewRequest("GET", ".", nil)
-	_, err := client.Do(nil, req, nil)
-
-	if !errors.Is(err, errNonNilContext) {
-		t.Error("Expected context must be non-nil error")
 	}
 }
 
@@ -1316,8 +1304,8 @@ func TestDo_httpError(t *testing.T) {
 		http.Error(w, "Bad Request", 400)
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
-	resp, err := client.Do(t.Context(), req, nil)
+	req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
+	resp, err := client.Do(req, nil)
 
 	if err == nil {
 		t.Fatal("Expected HTTP 400 error, got no error.")
@@ -1338,8 +1326,8 @@ func TestDo_redirectLoop(t *testing.T) {
 		http.Redirect(w, r, baseURLPath, http.StatusFound)
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
-	_, err := client.Do(t.Context(), req, nil)
+	req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
+	_, err := client.Do(req, nil)
 
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -1362,10 +1350,10 @@ func TestDo_preservesResponseInHTTPError(t *testing.T) {
 		}`)
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
+	req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
 	var resp *Response
 	var data any
-	resp, err := client.Do(t.Context(), req, &data)
+	resp, err := client.Do(req, &data)
 
 	if err == nil {
 		t.Fatal("Expected error response")
@@ -1404,11 +1392,11 @@ func TestDo_sanitizeURL(t *testing.T) {
 	}
 	unauthedClient := NewClient(tp.Client())
 	unauthedClient.BaseURL = &url.URL{Scheme: "http", Host: "127.0.0.1:0", Path: "/"} // Use port 0 on purpose to trigger a dial TCP error, expect to get "dial tcp 127.0.0.1:0: connect: can't assign requested address".
-	req, err := unauthedClient.NewRequest("GET", ".", nil)
+	req, err := unauthedClient.NewRequest(t.Context(), "GET", ".", nil)
 	if err != nil {
 		t.Fatalf("NewRequest returned unexpected error: %v", err)
 	}
-	_, err = unauthedClient.Do(t.Context(), req, nil)
+	_, err = unauthedClient.Do(req, nil)
 	if err == nil {
 		t.Fatal("Expected error to be returned.")
 	}
@@ -1429,8 +1417,8 @@ func TestDo_rateLimit(t *testing.T) {
 		w.Header().Set(HeaderRateResource, "core")
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
-	resp, err := client.Do(t.Context(), req, nil)
+	req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
+	resp, err := client.Do(req, nil)
 	if err != nil {
 		t.Errorf("Do returned unexpected error: %v", err)
 	}
@@ -1548,8 +1536,8 @@ func TestDo_rateLimit_errorResponse(t *testing.T) {
 		http.Error(w, "Bad Request", 400)
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
-	resp, err := client.Do(t.Context(), req, nil)
+	req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
+	resp, err := client.Do(req, nil)
 	if err == nil {
 		t.Error("Expected error to be returned.")
 	}
@@ -1593,8 +1581,8 @@ func TestDo_rateLimit_rateLimitError(t *testing.T) {
 }`)
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
-	_, err := client.Do(t.Context(), req, nil)
+	req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
+	_, err := client.Do(req, nil)
 
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -1648,16 +1636,16 @@ func TestDo_rateLimit_noNetworkCall(t *testing.T) {
 	})
 
 	// First request is made, and it makes the client aware of rate reset time being in the future.
-	req, _ := client.NewRequest("GET", "first", nil)
-	ctx := t.Context()
-	_, err := client.Do(ctx, req, nil)
+	req, _ := client.NewRequest(t.Context(), "GET", "first", nil)
+
+	_, err := client.Do(req, nil)
 	if err == nil {
 		t.Error("Expected error to be returned.")
 	}
 
 	// Second request should not cause a network call to be made, since client can predict a rate limit error.
-	req, _ = client.NewRequest("GET", "second", nil)
-	_, err = client.Do(ctx, req, nil)
+	req, _ = client.NewRequest(t.Context(), "GET", "second", nil)
+	_, err = client.Do(req, nil)
 
 	if madeNetworkCall {
 		t.Fatal("Network call was made, even though rate limit is known to still be exceeded.")
@@ -1716,16 +1704,15 @@ func TestDo_rateLimit_ignoredFromCache(t *testing.T) {
 	})
 
 	// First request is made so afterwards we can check the returned rate limit headers were ignored.
-	req, _ := client.NewRequest("GET", "first", nil)
-	ctx := t.Context()
-	_, err := client.Do(ctx, req, nil)
+	req, _ := client.NewRequest(t.Context(), "GET", "first", nil)
+	_, err := client.Do(req, nil)
 	if err == nil {
 		t.Error("Expected error to be returned.")
 	}
 
 	// Second request should not be hindered by rate limits.
-	req, _ = client.NewRequest("GET", "second", nil)
-	_, err = client.Do(ctx, req, nil)
+	req, _ = client.NewRequest(t.Context(), "GET", "second", nil)
+	_, err = client.Do(req, nil)
 	if err != nil {
 		t.Fatalf("Second request failed, even though the rate limits from the cache should've been ignored: %v", err)
 	}
@@ -1768,8 +1755,8 @@ func TestDo_rateLimit_sleepUntilResponseResetLimit(t *testing.T) {
 		fmt.Fprintln(w, `{}`)
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
-	resp, err := client.Do(context.WithValue(t.Context(), SleepUntilPrimaryRateLimitResetWhenRateLimited, true), req, nil)
+	req, _ := client.NewRequest(context.WithValue(t.Context(), SleepUntilPrimaryRateLimitResetWhenRateLimited, true), "GET", ".", nil)
+	resp, err := client.Do(req, nil)
 	if err != nil {
 		t.Errorf("Do returned unexpected error: %v", err)
 	}
@@ -1801,8 +1788,8 @@ func TestDo_rateLimit_sleepUntilResponseResetLimitRetryOnce(t *testing.T) {
 }`)
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
-	_, err := client.Do(context.WithValue(t.Context(), SleepUntilPrimaryRateLimitResetWhenRateLimited, true), req, nil)
+	req, _ := client.NewRequest(context.WithValue(t.Context(), SleepUntilPrimaryRateLimitResetWhenRateLimited, true), "GET", ".", nil)
+	_, err := client.Do(req, nil)
 	if err == nil {
 		t.Error("Expected error to be returned.")
 	}
@@ -1830,8 +1817,8 @@ func TestDo_rateLimit_sleepUntilClientResetLimit(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, `{}`)
 	})
-	req, _ := client.NewRequest("GET", ".", nil)
-	resp, err := client.Do(context.WithValue(t.Context(), SleepUntilPrimaryRateLimitResetWhenRateLimited, true), req, nil)
+	req, _ := client.NewRequest(context.WithValue(t.Context(), SleepUntilPrimaryRateLimitResetWhenRateLimited, true), "GET", ".", nil)
+	resp, err := client.Do(req, nil)
 	if err != nil {
 		t.Errorf("Do returned unexpected error: %v", err)
 	}
@@ -1866,10 +1853,11 @@ func TestDo_rateLimit_abortSleepContextCancelled(t *testing.T) {
 }`)
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 	defer cancel()
-	_, err := client.Do(context.WithValue(ctx, SleepUntilPrimaryRateLimitResetWhenRateLimited, true), req, nil)
+
+	req, _ := client.NewRequest(context.WithValue(ctx, SleepUntilPrimaryRateLimitResetWhenRateLimited, true), "GET", ".", nil)
+	_, err := client.Do(req, nil)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Error("Expected context deadline exceeded error.")
 	}
@@ -1897,10 +1885,10 @@ func TestDo_rateLimit_abortSleepContextCancelledClientLimit(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, `{}`)
 	})
-	req, _ := client.NewRequest("GET", ".", nil)
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 	defer cancel()
-	_, err := client.Do(context.WithValue(ctx, SleepUntilPrimaryRateLimitResetWhenRateLimited, true), req, nil)
+	req, _ := client.NewRequest(context.WithValue(ctx, SleepUntilPrimaryRateLimitResetWhenRateLimited, true), "GET", ".", nil)
+	_, err := client.Do(req, nil)
 	var rateLimitError *RateLimitError
 	if !errors.As(err, &rateLimitError) {
 		t.Fatalf("Expected a *rateLimitError error; got %#v.", err)
@@ -1930,8 +1918,8 @@ func TestDo_rateLimit_abuseRateLimitError(t *testing.T) {
 }`)
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
-	_, err := client.Do(t.Context(), req, nil)
+	req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
+	_, err := client.Do(req, nil)
 
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -1964,8 +1952,8 @@ func TestDo_rateLimit_abuseRateLimitErrorEnterprise(t *testing.T) {
 }`)
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
-	_, err := client.Do(t.Context(), req, nil)
+	req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
+	_, err := client.Do(req, nil)
 
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -1995,9 +1983,8 @@ func TestDo_rateLimit_abuseRateLimitError_retryAfter(t *testing.T) {
 }`)
 		})
 
-		req, _ := client.NewRequest("GET", ".", nil)
-		ctx := t.Context()
-		_, err := client.Do(ctx, req, nil)
+		req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
+		_, err := client.Do(req, nil)
 
 		if err == nil {
 			t.Error("Expected error to be returned.")
@@ -2014,7 +2001,7 @@ func TestDo_rateLimit_abuseRateLimitError_retryAfter(t *testing.T) {
 		}
 
 		// expect prevention of a following request
-		if _, err = client.Do(ctx, req, nil); err == nil {
+		if _, err = client.Do(req, nil); err == nil {
 			t.Error("Expected error to be returned.")
 		}
 		if !errors.As(err, &abuseRateLimitErr) {
@@ -2052,9 +2039,8 @@ func TestDo_rateLimit_abuseRateLimitError_xRateLimitReset(t *testing.T) {
 }`)
 		})
 
-		req, _ := client.NewRequest("GET", ".", nil)
-		ctx := t.Context()
-		_, err := client.Do(ctx, req, nil)
+		req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
+		_, err := client.Do(req, nil)
 
 		if err == nil {
 			t.Error("Expected error to be returned.")
@@ -2072,7 +2058,7 @@ func TestDo_rateLimit_abuseRateLimitError_xRateLimitReset(t *testing.T) {
 		}
 
 		// expect prevention of a following request
-		if _, err = client.Do(ctx, req, nil); err == nil {
+		if _, err = client.Do(req, nil); err == nil {
 			t.Error("Expected error to be returned.")
 		}
 		if !errors.As(err, &abuseRateLimitErr) {
@@ -2111,8 +2097,8 @@ func TestDo_rateLimit_abuseRateLimitError_maxDuration(t *testing.T) {
 }`)
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
-	_, err := client.Do(t.Context(), req, nil)
+	req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
+	_, err := client.Do(req, nil)
 
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -2150,8 +2136,8 @@ func TestDo_rateLimit_disableRateLimitCheck(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, `{}`)
 	})
-	req, _ := client.NewRequest("GET", ".", nil)
-	resp, err := client.Do(t.Context(), req, nil)
+	req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
+	resp, err := client.Do(req, nil)
 	if err != nil {
 		t.Errorf("Do returned unexpected error: %v", err)
 	}
@@ -2185,8 +2171,8 @@ func TestDo_rateLimit_bypassRateLimitCheck(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, `{}`)
 	})
-	req, _ := client.NewRequest("GET", ".", nil)
-	resp, err := client.Do(context.WithValue(t.Context(), BypassRateLimitCheck, true), req, nil)
+	req, _ := client.NewRequest(context.WithValue(t.Context(), BypassRateLimitCheck, true), "GET", ".", nil)
+	resp, err := client.Do(req, nil)
 	if err != nil {
 		t.Errorf("Do returned unexpected error: %v", err)
 	}
@@ -2211,8 +2197,8 @@ func TestDo_noContent(t *testing.T) {
 
 	var body json.RawMessage
 
-	req, _ := client.NewRequest("GET", ".", nil)
-	_, err := client.Do(t.Context(), req, &body)
+	req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
+	_, err := client.Do(req, &body)
 	if err != nil {
 		t.Fatalf("Do returned unexpected error: %v", err)
 	}
@@ -2226,8 +2212,8 @@ func TestBareDoUntilFound_redirectLoop(t *testing.T) {
 		http.Redirect(w, r, baseURLPath, http.StatusMovedPermanently)
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
-	_, _, err := client.bareDoUntilFound(t.Context(), req, 1)
+	req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
+	_, _, err := client.bareDoUntilFound(req, 1)
 
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -2245,8 +2231,8 @@ func TestBareDoUntilFound_UnexpectedRedirection(t *testing.T) {
 		http.Redirect(w, r, baseURLPath, http.StatusSeeOther)
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
-	_, _, err := client.bareDoUntilFound(t.Context(), req, 1)
+	req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
+	_, _, err := client.bareDoUntilFound(req, 1)
 
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -2269,8 +2255,8 @@ func TestBareDoUntilFound_RejectsCrossHostRedirect(t *testing.T) {
 		w.WriteHeader(http.StatusMovedPermanently)
 	})
 
-	req, _ := client.NewRequest("GET", ".", nil)
-	_, _, err := client.bareDoUntilFound(t.Context(), req, 1)
+	req, _ := client.NewRequest(t.Context(), "GET", ".", nil)
+	_, _, err := client.bareDoUntilFound(req, 1)
 	if err == nil {
 		t.Fatal("Expected cross-host redirect to be rejected, got nil error.")
 	}
@@ -3091,8 +3077,8 @@ func TestUnauthenticatedRateLimitedTransport(t *testing.T) {
 	}
 	unauthedClient := NewClient(tp.Client())
 	unauthedClient.BaseURL = client.BaseURL
-	req, _ := unauthedClient.NewRequest("GET", ".", nil)
-	_, err := unauthedClient.Do(t.Context(), req, nil)
+	req, _ := unauthedClient.NewRequest(t.Context(), "GET", ".", nil)
+	_, err := unauthedClient.Do(req, nil)
 	assertNilError(t, err)
 }
 
@@ -3168,8 +3154,8 @@ func TestBasicAuthTransport(t *testing.T) {
 	}
 	basicAuthClient := NewClient(tp.Client())
 	basicAuthClient.BaseURL = client.BaseURL
-	req, _ := basicAuthClient.NewRequest("GET", ".", nil)
-	_, err := basicAuthClient.Do(t.Context(), req, nil)
+	req, _ := basicAuthClient.NewRequest(t.Context(), "GET", ".", nil)
+	_, err := basicAuthClient.Do(req, nil)
 	assertNilError(t, err)
 }
 
@@ -3314,12 +3300,12 @@ func TestBareDo_returnsOpenBody(t *testing.T) {
 		fmt.Fprint(w, expectedBody)
 	})
 
-	req, err := client.NewRequest("GET", "test-url", nil)
+	req, err := client.NewRequest(t.Context(), "GET", "test-url", nil)
 	if err != nil {
 		t.Fatalf("client.NewRequest returned error: %v", err)
 	}
 
-	resp, err := client.BareDo(t.Context(), req)
+	resp, err := client.BareDo(req)
 	if err != nil {
 		t.Fatalf("client.BareDo returned error: %v", err)
 	}

--- a/github/gitignore.go
+++ b/github/gitignore.go
@@ -32,13 +32,13 @@ func (g Gitignore) String() string {
 //
 //meta:operation GET /gitignore/templates
 func (s *GitignoresService) List(ctx context.Context) ([]string, *Response, error) {
-	req, err := s.client.NewRequest("GET", "gitignore/templates", nil)
+	req, err := s.client.NewRequest(ctx, "GET", "gitignore/templates", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var availableTemplates []string
-	resp, err := s.client.Do(ctx, req, &availableTemplates)
+	resp, err := s.client.Do(req, &availableTemplates)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -53,13 +53,13 @@ func (s *GitignoresService) List(ctx context.Context) ([]string, *Response, erro
 //meta:operation GET /gitignore/templates/{name}
 func (s *GitignoresService) Get(ctx context.Context, name string) (*Gitignore, *Response, error) {
 	u := fmt.Sprintf("gitignore/templates/%v", name)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var gitignore *Gitignore
-	resp, err := s.client.Do(ctx, req, &gitignore)
+	resp, err := s.client.Do(req, &gitignore)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/interactions_orgs.go
+++ b/github/interactions_orgs.go
@@ -17,7 +17,7 @@ import (
 //meta:operation GET /orgs/{org}/interaction-limits
 func (s *InteractionsService) GetRestrictionsForOrg(ctx context.Context, organization string) (*InteractionRestriction, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/interaction-limits", organization)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -25,7 +25,7 @@ func (s *InteractionsService) GetRestrictionsForOrg(ctx context.Context, organiz
 	req.Header.Set("Accept", mediaTypeInteractionRestrictionsPreview)
 
 	var organizationInteractions *InteractionRestriction
-	resp, err := s.client.Do(ctx, req, &organizationInteractions)
+	resp, err := s.client.Do(req, &organizationInteractions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -47,7 +47,7 @@ func (s *InteractionsService) UpdateRestrictionsForOrg(ctx context.Context, orga
 
 	interaction := &InteractionRestriction{Limit: &limit}
 
-	req, err := s.client.NewRequest("PUT", u, interaction)
+	req, err := s.client.NewRequest(ctx, "PUT", u, interaction)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -55,7 +55,7 @@ func (s *InteractionsService) UpdateRestrictionsForOrg(ctx context.Context, orga
 	req.Header.Set("Accept", mediaTypeInteractionRestrictionsPreview)
 
 	var organizationInteractions *InteractionRestriction
-	resp, err := s.client.Do(ctx, req, &organizationInteractions)
+	resp, err := s.client.Do(req, &organizationInteractions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -70,12 +70,12 @@ func (s *InteractionsService) UpdateRestrictionsForOrg(ctx context.Context, orga
 //meta:operation DELETE /orgs/{org}/interaction-limits
 func (s *InteractionsService) RemoveRestrictionsFromOrg(ctx context.Context, organization string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/interaction-limits", organization)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeInteractionRestrictionsPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/interactions_repos.go
+++ b/github/interactions_repos.go
@@ -17,7 +17,7 @@ import (
 //meta:operation GET /repos/{owner}/{repo}/interaction-limits
 func (s *InteractionsService) GetRestrictionsForRepo(ctx context.Context, owner, repo string) (*InteractionRestriction, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/interaction-limits", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -25,7 +25,7 @@ func (s *InteractionsService) GetRestrictionsForRepo(ctx context.Context, owner,
 	req.Header.Set("Accept", mediaTypeInteractionRestrictionsPreview)
 
 	var repositoryInteractions *InteractionRestriction
-	resp, err := s.client.Do(ctx, req, &repositoryInteractions)
+	resp, err := s.client.Do(req, &repositoryInteractions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -47,7 +47,7 @@ func (s *InteractionsService) UpdateRestrictionsForRepo(ctx context.Context, own
 
 	interaction := &InteractionRestriction{Limit: &limit}
 
-	req, err := s.client.NewRequest("PUT", u, interaction)
+	req, err := s.client.NewRequest(ctx, "PUT", u, interaction)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -55,7 +55,7 @@ func (s *InteractionsService) UpdateRestrictionsForRepo(ctx context.Context, own
 	req.Header.Set("Accept", mediaTypeInteractionRestrictionsPreview)
 
 	var repositoryInteractions *InteractionRestriction
-	resp, err := s.client.Do(ctx, req, &repositoryInteractions)
+	resp, err := s.client.Do(req, &repositoryInteractions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -70,12 +70,12 @@ func (s *InteractionsService) UpdateRestrictionsForRepo(ctx context.Context, own
 //meta:operation DELETE /repos/{owner}/{repo}/interaction-limits
 func (s *InteractionsService) RemoveRestrictionsFromRepo(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/interaction-limits", owner, repo)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeInteractionRestrictionsPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/issue_import.go
+++ b/github/issue_import.go
@@ -76,7 +76,7 @@ type IssueImportError struct {
 //meta:operation POST /repos/{owner}/{repo}/import/issues
 func (s *IssueImportService) Create(ctx context.Context, owner, repo string, issue *IssueImportRequest) (*IssueImportResponse, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/import/issues", owner, repo)
-	req, err := s.client.NewRequest("POST", u, issue)
+	req, err := s.client.NewRequest(ctx, "POST", u, issue)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -84,7 +84,7 @@ func (s *IssueImportService) Create(ctx context.Context, owner, repo string, iss
 	req.Header.Set("Accept", mediaTypeIssueImportAPI)
 
 	var i IssueImportResponse
-	resp, err := s.client.Do(ctx, req, &i)
+	resp, err := s.client.Do(req, &i)
 	if err != nil {
 		var aerr *AcceptedError
 		if errors.As(err, &aerr) {
@@ -106,7 +106,7 @@ func (s *IssueImportService) Create(ctx context.Context, owner, repo string, iss
 //meta:operation GET /repos/{owner}/{repo}/import/issues/{issue_number}
 func (s *IssueImportService) CheckStatus(ctx context.Context, owner, repo string, issueID int64) (*IssueImportResponse, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/import/issues/%v", owner, repo, issueID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -114,7 +114,7 @@ func (s *IssueImportService) CheckStatus(ctx context.Context, owner, repo string
 	req.Header.Set("Accept", mediaTypeIssueImportAPI)
 
 	var i *IssueImportResponse
-	resp, err := s.client.Do(ctx, req, &i)
+	resp, err := s.client.Do(req, &i)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -129,7 +129,7 @@ func (s *IssueImportService) CheckStatus(ctx context.Context, owner, repo string
 //meta:operation GET /repos/{owner}/{repo}/import/issues
 func (s *IssueImportService) CheckStatusSince(ctx context.Context, owner, repo string, since Timestamp) ([]*IssueImportResponse, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/import/issues?since=%v", owner, repo, since.Format("2006-01-02"))
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -137,7 +137,7 @@ func (s *IssueImportService) CheckStatusSince(ctx context.Context, owner, repo s
 	req.Header.Set("Accept", mediaTypeIssueImportAPI)
 
 	var b bytes.Buffer
-	resp, err := s.client.Do(ctx, req, &b)
+	resp, err := s.client.Do(req, &b)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/issues.go
+++ b/github/issues.go
@@ -169,7 +169,7 @@ func (s *IssuesService) ListAllIssues(ctx context.Context, opts *ListAllIssuesOp
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -177,7 +177,7 @@ func (s *IssuesService) ListAllIssues(ctx context.Context, opts *ListAllIssuesOp
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var issues []*Issue
-	resp, err := s.client.Do(ctx, req, &issues)
+	resp, err := s.client.Do(req, &issues)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -225,7 +225,7 @@ func (s *IssuesService) ListUserIssues(ctx context.Context, opts *ListUserIssues
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -233,7 +233,7 @@ func (s *IssuesService) ListUserIssues(ctx context.Context, opts *ListUserIssues
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var issues []*Issue
-	resp, err := s.client.Do(ctx, req, &issues)
+	resp, err := s.client.Do(req, &issues)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -285,7 +285,7 @@ func (s *IssuesService) ListByOrg(ctx context.Context, org string, opts *IssueLi
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -293,7 +293,7 @@ func (s *IssuesService) ListByOrg(ctx context.Context, org string, opts *IssueLi
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var issues []*Issue
-	resp, err := s.client.Do(ctx, req, &issues)
+	resp, err := s.client.Do(req, &issues)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -363,7 +363,7 @@ func (s *IssuesService) ListByRepo(ctx context.Context, owner, repo string, opts
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -371,7 +371,7 @@ func (s *IssuesService) ListByRepo(ctx context.Context, owner, repo string, opts
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var issues []*Issue
-	resp, err := s.client.Do(ctx, req, &issues)
+	resp, err := s.client.Do(req, &issues)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -386,7 +386,7 @@ func (s *IssuesService) ListByRepo(ctx context.Context, owner, repo string, opts
 //meta:operation GET /repos/{owner}/{repo}/issues/{issue_number}
 func (s *IssuesService) Get(ctx context.Context, owner, repo string, number int) (*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v", owner, repo, number)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -394,7 +394,7 @@ func (s *IssuesService) Get(ctx context.Context, owner, repo string, number int)
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var issue *Issue
-	resp, err := s.client.Do(ctx, req, &issue)
+	resp, err := s.client.Do(req, &issue)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -409,13 +409,13 @@ func (s *IssuesService) Get(ctx context.Context, owner, repo string, number int)
 //meta:operation POST /repos/{owner}/{repo}/issues
 func (s *IssuesService) Create(ctx context.Context, owner, repo string, issue *IssueRequest) (*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues", owner, repo)
-	req, err := s.client.NewRequest("POST", u, issue)
+	req, err := s.client.NewRequest(ctx, "POST", u, issue)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var i *Issue
-	resp, err := s.client.Do(ctx, req, &i)
+	resp, err := s.client.Do(req, &i)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -430,13 +430,13 @@ func (s *IssuesService) Create(ctx context.Context, owner, repo string, issue *I
 //meta:operation PATCH /repos/{owner}/{repo}/issues/{issue_number}
 func (s *IssuesService) Edit(ctx context.Context, owner, repo string, number int, issue *IssueRequest) (*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v", owner, repo, number)
-	req, err := s.client.NewRequest("PATCH", u, issue)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, issue)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var i *Issue
-	resp, err := s.client.Do(ctx, req, &i)
+	resp, err := s.client.Do(req, &i)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -453,7 +453,7 @@ func (s *IssuesService) Edit(ctx context.Context, owner, repo string, number int
 //meta:operation PATCH /repos/{owner}/{repo}/issues/{issue_number}
 func (s *IssuesService) RemoveMilestone(ctx context.Context, owner, repo string, issueNumber int) (*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v", owner, repo, issueNumber)
-	req, err := s.client.NewRequest("PATCH", u, &struct {
+	req, err := s.client.NewRequest(ctx, "PATCH", u, &struct {
 		Milestone *Milestone `json:"milestone"`
 	}{})
 	if err != nil {
@@ -461,7 +461,7 @@ func (s *IssuesService) RemoveMilestone(ctx context.Context, owner, repo string,
 	}
 
 	var i *Issue
-	resp, err := s.client.Do(ctx, req, &i)
+	resp, err := s.client.Do(req, &i)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -485,12 +485,12 @@ type LockIssueOptions struct {
 //meta:operation PUT /repos/{owner}/{repo}/issues/{issue_number}/lock
 func (s *IssuesService) Lock(ctx context.Context, owner, repo string, number int, opts *LockIssueOptions) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v/lock", owner, repo, number)
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // Unlock an issue's conversation.
@@ -500,10 +500,10 @@ func (s *IssuesService) Lock(ctx context.Context, owner, repo string, number int
 //meta:operation DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock
 func (s *IssuesService) Unlock(ctx context.Context, owner, repo string, number int) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v/lock", owner, repo, number)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/issues_assignees.go
+++ b/github/issues_assignees.go
@@ -23,13 +23,13 @@ func (s *IssuesService) ListAssignees(ctx context.Context, owner, repo string, o
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var assignees []*User
-	resp, err := s.client.Do(ctx, req, &assignees)
+	resp, err := s.client.Do(req, &assignees)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -44,12 +44,12 @@ func (s *IssuesService) ListAssignees(ctx context.Context, owner, repo string, o
 //meta:operation GET /repos/{owner}/{repo}/assignees/{assignee}
 func (s *IssuesService) IsAssignee(ctx context.Context, owner, repo, user string) (bool, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/assignees/%v", owner, repo, user)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return false, nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	assignee, err := parseBoolResponse(err)
 	return assignee, resp, err
 }
@@ -64,13 +64,13 @@ func (s *IssuesService) AddAssignees(ctx context.Context, owner, repo string, nu
 		Assignees []string `json:"assignees,omitempty"`
 	}{Assignees: assignees}
 	u := fmt.Sprintf("repos/%v/%v/issues/%v/assignees", owner, repo, number)
-	req, err := s.client.NewRequest("POST", u, users)
+	req, err := s.client.NewRequest(ctx, "POST", u, users)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var issue *Issue
-	resp, err := s.client.Do(ctx, req, &issue)
+	resp, err := s.client.Do(req, &issue)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -88,13 +88,13 @@ func (s *IssuesService) RemoveAssignees(ctx context.Context, owner, repo string,
 		Assignees []string `json:"assignees,omitempty"`
 	}{Assignees: assignees}
 	u := fmt.Sprintf("repos/%v/%v/issues/%v/assignees", owner, repo, number)
-	req, err := s.client.NewRequest("DELETE", u, users)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, users)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var issue *Issue
-	resp, err := s.client.Do(ctx, req, &issue)
+	resp, err := s.client.Do(req, &issue)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/issues_comments.go
+++ b/github/issues_comments.go
@@ -72,7 +72,7 @@ func (s *IssuesService) ListComments(ctx context.Context, owner, repo string, nu
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -80,7 +80,7 @@ func (s *IssuesService) ListComments(ctx context.Context, owner, repo string, nu
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var comments []*IssueComment
-	resp, err := s.client.Do(ctx, req, &comments)
+	resp, err := s.client.Do(req, &comments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -96,7 +96,7 @@ func (s *IssuesService) ListComments(ctx context.Context, owner, repo string, nu
 func (s *IssuesService) GetComment(ctx context.Context, owner, repo string, commentID int64) (*IssueComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/comments/%v", owner, repo, commentID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -104,7 +104,7 @@ func (s *IssuesService) GetComment(ctx context.Context, owner, repo string, comm
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var comment *IssueComment
-	resp, err := s.client.Do(ctx, req, &comment)
+	resp, err := s.client.Do(req, &comment)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -119,12 +119,12 @@ func (s *IssuesService) GetComment(ctx context.Context, owner, repo string, comm
 //meta:operation POST /repos/{owner}/{repo}/issues/{issue_number}/comments
 func (s *IssuesService) CreateComment(ctx context.Context, owner, repo string, number int, comment *IssueComment) (*IssueComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v/comments", owner, repo, number)
-	req, err := s.client.NewRequest("POST", u, comment)
+	req, err := s.client.NewRequest(ctx, "POST", u, comment)
 	if err != nil {
 		return nil, nil, err
 	}
 	var c *IssueComment
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -140,12 +140,12 @@ func (s *IssuesService) CreateComment(ctx context.Context, owner, repo string, n
 //meta:operation PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}
 func (s *IssuesService) EditComment(ctx context.Context, owner, repo string, commentID int64, comment *IssueComment) (*IssueComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/comments/%v", owner, repo, commentID)
-	req, err := s.client.NewRequest("PATCH", u, comment)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
 	}
 	var c *IssueComment
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -160,9 +160,9 @@ func (s *IssuesService) EditComment(ctx context.Context, owner, repo string, com
 //meta:operation DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}
 func (s *IssuesService) DeleteComment(ctx context.Context, owner, repo string, commentID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/comments/%v", owner, repo, commentID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/issues_events.go
+++ b/github/issues_events.go
@@ -114,7 +114,7 @@ func (s *IssuesService) ListIssueEvents(ctx context.Context, owner, repo string,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -122,7 +122,7 @@ func (s *IssuesService) ListIssueEvents(ctx context.Context, owner, repo string,
 	req.Header.Set("Accept", mediaTypeProjectCardDetailsPreview)
 
 	var events []*IssueEvent
-	resp, err := s.client.Do(ctx, req, &events)
+	resp, err := s.client.Do(req, &events)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -142,13 +142,13 @@ func (s *IssuesService) ListRepositoryEvents(ctx context.Context, owner, repo st
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var events []*IssueEvent
-	resp, err := s.client.Do(ctx, req, &events)
+	resp, err := s.client.Do(req, &events)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -164,13 +164,13 @@ func (s *IssuesService) ListRepositoryEvents(ctx context.Context, owner, repo st
 func (s *IssuesService) GetEvent(ctx context.Context, owner, repo string, id int64) (*IssueEvent, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/events/%v", owner, repo, id)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var event *IssueEvent
-	resp, err := s.client.Do(ctx, req, &event)
+	resp, err := s.client.Do(req, &event)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/issues_labels.go
+++ b/github/issues_labels.go
@@ -37,13 +37,13 @@ func (s *IssuesService) ListLabels(ctx context.Context, owner, repo string, opts
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var labels []*Label
-	resp, err := s.client.Do(ctx, req, &labels)
+	resp, err := s.client.Do(req, &labels)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -58,13 +58,13 @@ func (s *IssuesService) ListLabels(ctx context.Context, owner, repo string, opts
 //meta:operation GET /repos/{owner}/{repo}/labels/{name}
 func (s *IssuesService) GetLabel(ctx context.Context, owner, repo, name string) (*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/labels/%v", owner, repo, name)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var label *Label
-	resp, err := s.client.Do(ctx, req, &label)
+	resp, err := s.client.Do(req, &label)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -79,13 +79,13 @@ func (s *IssuesService) GetLabel(ctx context.Context, owner, repo, name string) 
 //meta:operation POST /repos/{owner}/{repo}/labels
 func (s *IssuesService) CreateLabel(ctx context.Context, owner, repo string, label *Label) (*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/labels", owner, repo)
-	req, err := s.client.NewRequest("POST", u, label)
+	req, err := s.client.NewRequest(ctx, "POST", u, label)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var l *Label
-	resp, err := s.client.Do(ctx, req, &l)
+	resp, err := s.client.Do(req, &l)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -100,13 +100,13 @@ func (s *IssuesService) CreateLabel(ctx context.Context, owner, repo string, lab
 //meta:operation PATCH /repos/{owner}/{repo}/labels/{name}
 func (s *IssuesService) EditLabel(ctx context.Context, owner, repo, name string, label *Label) (*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/labels/%v", owner, repo, name)
-	req, err := s.client.NewRequest("PATCH", u, label)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, label)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var l *Label
-	resp, err := s.client.Do(ctx, req, &l)
+	resp, err := s.client.Do(req, &l)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -121,11 +121,11 @@ func (s *IssuesService) EditLabel(ctx context.Context, owner, repo, name string,
 //meta:operation DELETE /repos/{owner}/{repo}/labels/{name}
 func (s *IssuesService) DeleteLabel(ctx context.Context, owner, repo, name string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/labels/%v", owner, repo, name)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListLabelsByIssue lists all labels for an issue.
@@ -140,13 +140,13 @@ func (s *IssuesService) ListLabelsByIssue(ctx context.Context, owner, repo strin
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var labels []*Label
-	resp, err := s.client.Do(ctx, req, &labels)
+	resp, err := s.client.Do(req, &labels)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -161,13 +161,13 @@ func (s *IssuesService) ListLabelsByIssue(ctx context.Context, owner, repo strin
 //meta:operation POST /repos/{owner}/{repo}/issues/{issue_number}/labels
 func (s *IssuesService) AddLabelsToIssue(ctx context.Context, owner, repo string, number int, labels []string) ([]*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v/labels", owner, repo, number)
-	req, err := s.client.NewRequest("POST", u, labels)
+	req, err := s.client.NewRequest(ctx, "POST", u, labels)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var l []*Label
-	resp, err := s.client.Do(ctx, req, &l)
+	resp, err := s.client.Do(req, &l)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -182,12 +182,12 @@ func (s *IssuesService) AddLabelsToIssue(ctx context.Context, owner, repo string
 //meta:operation DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}
 func (s *IssuesService) RemoveLabelForIssue(ctx context.Context, owner, repo string, number int, label string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v/labels/%v", owner, repo, number, label)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ReplaceLabelsForIssue replaces all labels for an issue.
@@ -197,13 +197,13 @@ func (s *IssuesService) RemoveLabelForIssue(ctx context.Context, owner, repo str
 //meta:operation PUT /repos/{owner}/{repo}/issues/{issue_number}/labels
 func (s *IssuesService) ReplaceLabelsForIssue(ctx context.Context, owner, repo string, number int, labels []string) ([]*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v/labels", owner, repo, number)
-	req, err := s.client.NewRequest("PUT", u, labels)
+	req, err := s.client.NewRequest(ctx, "PUT", u, labels)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var l []*Label
-	resp, err := s.client.Do(ctx, req, &l)
+	resp, err := s.client.Do(req, &l)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -218,12 +218,12 @@ func (s *IssuesService) ReplaceLabelsForIssue(ctx context.Context, owner, repo s
 //meta:operation DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels
 func (s *IssuesService) RemoveLabelsForIssue(ctx context.Context, owner, repo string, number int) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v/labels", owner, repo, number)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListLabelsForMilestone lists labels for every issue in a milestone.
@@ -238,13 +238,13 @@ func (s *IssuesService) ListLabelsForMilestone(ctx context.Context, owner, repo 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var labels []*Label
-	resp, err := s.client.Do(ctx, req, &labels)
+	resp, err := s.client.Do(req, &labels)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/issues_milestones.go
+++ b/github/issues_milestones.go
@@ -64,13 +64,13 @@ func (s *IssuesService) ListMilestones(ctx context.Context, owner, repo string, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var milestones []*Milestone
-	resp, err := s.client.Do(ctx, req, &milestones)
+	resp, err := s.client.Do(req, &milestones)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -85,13 +85,13 @@ func (s *IssuesService) ListMilestones(ctx context.Context, owner, repo string, 
 //meta:operation GET /repos/{owner}/{repo}/milestones/{milestone_number}
 func (s *IssuesService) GetMilestone(ctx context.Context, owner, repo string, number int) (*Milestone, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/milestones/%v", owner, repo, number)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var milestone *Milestone
-	resp, err := s.client.Do(ctx, req, &milestone)
+	resp, err := s.client.Do(req, &milestone)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -106,13 +106,13 @@ func (s *IssuesService) GetMilestone(ctx context.Context, owner, repo string, nu
 //meta:operation POST /repos/{owner}/{repo}/milestones
 func (s *IssuesService) CreateMilestone(ctx context.Context, owner, repo string, milestone *Milestone) (*Milestone, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/milestones", owner, repo)
-	req, err := s.client.NewRequest("POST", u, milestone)
+	req, err := s.client.NewRequest(ctx, "POST", u, milestone)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var m *Milestone
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -127,13 +127,13 @@ func (s *IssuesService) CreateMilestone(ctx context.Context, owner, repo string,
 //meta:operation PATCH /repos/{owner}/{repo}/milestones/{milestone_number}
 func (s *IssuesService) EditMilestone(ctx context.Context, owner, repo string, number int, milestone *Milestone) (*Milestone, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/milestones/%v", owner, repo, number)
-	req, err := s.client.NewRequest("PATCH", u, milestone)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, milestone)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var m *Milestone
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -148,10 +148,10 @@ func (s *IssuesService) EditMilestone(ctx context.Context, owner, repo string, n
 //meta:operation DELETE /repos/{owner}/{repo}/milestones/{milestone_number}
 func (s *IssuesService) DeleteMilestone(ctx context.Context, owner, repo string, number int) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/milestones/%v", owner, repo, number)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/issues_timeline.go
+++ b/github/issues_timeline.go
@@ -183,7 +183,7 @@ func (s *IssuesService) ListIssueTimeline(ctx context.Context, owner, repo strin
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -192,7 +192,7 @@ func (s *IssuesService) ListIssueTimeline(ctx context.Context, owner, repo strin
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var events []*Timeline
-	resp, err := s.client.Do(ctx, req, &events)
+	resp, err := s.client.Do(req, &events)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/licenses.go
+++ b/github/licenses.go
@@ -77,13 +77,13 @@ func (s *LicensesService) List(ctx context.Context, opts *ListLicensesOptions) (
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var licenses []*License
-	resp, err := s.client.Do(ctx, req, &licenses)
+	resp, err := s.client.Do(req, &licenses)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -99,13 +99,13 @@ func (s *LicensesService) List(ctx context.Context, opts *ListLicensesOptions) (
 func (s *LicensesService) Get(ctx context.Context, licenseName string) (*License, *Response, error) {
 	u := fmt.Sprintf("licenses/%v", licenseName)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var license *License
-	resp, err := s.client.Do(ctx, req, &license)
+	resp, err := s.client.Do(req, &license)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/markdown.go
+++ b/github/markdown.go
@@ -54,13 +54,13 @@ func (s *MarkdownService) Render(ctx context.Context, text string, opts *Markdow
 		}
 	}
 
-	req, err := s.client.NewRequest("POST", "markdown", request)
+	req, err := s.client.NewRequest(ctx, "POST", "markdown", request)
 	if err != nil {
 		return "", nil, err
 	}
 
 	var buf bytes.Buffer
-	resp, err := s.client.Do(ctx, req, &buf)
+	resp, err := s.client.Do(req, &buf)
 	if err != nil {
 		return "", resp, err
 	}

--- a/github/meta.go
+++ b/github/meta.go
@@ -118,13 +118,13 @@ type APIMetaArtifactAttestations struct {
 //
 //meta:operation GET /meta
 func (s *MetaService) Get(ctx context.Context) (*APIMeta, *Response, error) {
-	req, err := s.client.NewRequest("GET", "meta", nil)
+	req, err := s.client.NewRequest(ctx, "GET", "meta", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var meta *APIMeta
-	resp, err := s.client.Do(ctx, req, &meta)
+	resp, err := s.client.Do(req, &meta)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -151,13 +151,13 @@ func (s *MetaService) Octocat(ctx context.Context, message string) (string, *Res
 		u = fmt.Sprintf("%v?s=%v", u, url.QueryEscape(message))
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return "", nil, err
 	}
 
 	var buf bytes.Buffer
-	resp, err := s.client.Do(ctx, req, &buf)
+	resp, err := s.client.Do(req, &buf)
 	if err != nil {
 		return "", resp, err
 	}
@@ -181,13 +181,13 @@ func (c *Client) Octocat(ctx context.Context, message string) (string, *Response
 //
 //meta:operation GET /zen
 func (s *MetaService) Zen(ctx context.Context) (string, *Response, error) {
-	req, err := s.client.NewRequest("GET", "zen", nil)
+	req, err := s.client.NewRequest(ctx, "GET", "zen", nil)
 	if err != nil {
 		return "", nil, err
 	}
 
 	var buf bytes.Buffer
-	resp, err := s.client.Do(ctx, req, &buf)
+	resp, err := s.client.Do(req, &buf)
 	if err != nil {
 		return "", resp, err
 	}

--- a/github/migrations.go
+++ b/github/migrations.go
@@ -102,7 +102,7 @@ func (s *MigrationService) StartMigration(ctx context.Context, org string, repos
 		body.Exclude = append(body.Exclude, opts.Exclude...)
 	}
 
-	req, err := s.client.NewRequest("POST", u, body)
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -110,7 +110,7 @@ func (s *MigrationService) StartMigration(ctx context.Context, org string, repos
 	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
 	var m *Migration
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -130,7 +130,7 @@ func (s *MigrationService) ListMigrations(ctx context.Context, org string, opts 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -138,7 +138,7 @@ func (s *MigrationService) ListMigrations(ctx context.Context, org string, opts 
 	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
 	var m []*Migration
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -155,7 +155,7 @@ func (s *MigrationService) ListMigrations(ctx context.Context, org string, opts 
 func (s *MigrationService) MigrationStatus(ctx context.Context, org string, id int64) (*Migration, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/migrations/%v", org, id)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -163,7 +163,7 @@ func (s *MigrationService) MigrationStatus(ctx context.Context, org string, id i
 	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
 	var m *Migration
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -180,13 +180,13 @@ func (s *MigrationService) MigrationStatus(ctx context.Context, org string, id i
 func (s *MigrationService) MigrationArchiveURL(ctx context.Context, org string, id int64) (url string, err error) {
 	u := fmt.Sprintf("orgs/%v/migrations/%v/archive", org, id)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return "", err
 	}
 	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
-	loc, _, err := s.client.bareDoUntilFound(ctx, req, 10)
+	loc, _, err := s.client.bareDoUntilFound(req, 10)
 	if err != nil {
 		return "", err
 	}
@@ -207,14 +207,14 @@ func (s *MigrationService) MigrationArchiveURL(ctx context.Context, org string, 
 func (s *MigrationService) DeleteMigration(ctx context.Context, org string, id int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/migrations/%v/archive", org, id)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // UnlockRepo unlocks a repository that was locked for migration.
@@ -228,12 +228,12 @@ func (s *MigrationService) DeleteMigration(ctx context.Context, org string, id i
 func (s *MigrationService) UnlockRepo(ctx context.Context, org string, id int64, repo string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/migrations/%v/repos/%v/lock", org, id, repo)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/migrations_source_import.go
+++ b/github/migrations_source_import.go
@@ -151,13 +151,13 @@ func (f LargeFile) String() string {
 //meta:operation PUT /repos/{owner}/{repo}/import
 func (s *MigrationService) StartImport(ctx context.Context, owner, repo string, in *Import) (*Import, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
-	req, err := s.client.NewRequest("PUT", u, in)
+	req, err := s.client.NewRequest(ctx, "PUT", u, in)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var out *Import
-	resp, err := s.client.Do(ctx, req, &out)
+	resp, err := s.client.Do(req, &out)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -172,13 +172,13 @@ func (s *MigrationService) StartImport(ctx context.Context, owner, repo string, 
 //meta:operation GET /repos/{owner}/{repo}/import
 func (s *MigrationService) ImportProgress(ctx context.Context, owner, repo string) (*Import, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var out *Import
-	resp, err := s.client.Do(ctx, req, &out)
+	resp, err := s.client.Do(req, &out)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -193,13 +193,13 @@ func (s *MigrationService) ImportProgress(ctx context.Context, owner, repo strin
 //meta:operation PATCH /repos/{owner}/{repo}/import
 func (s *MigrationService) UpdateImport(ctx context.Context, owner, repo string, in *Import) (*Import, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
-	req, err := s.client.NewRequest("PATCH", u, in)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, in)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var out *Import
-	resp, err := s.client.Do(ctx, req, &out)
+	resp, err := s.client.Do(req, &out)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -224,13 +224,13 @@ func (s *MigrationService) UpdateImport(ctx context.Context, owner, repo string,
 //meta:operation GET /repos/{owner}/{repo}/import/authors
 func (s *MigrationService) CommitAuthors(ctx context.Context, owner, repo string) ([]*SourceImportAuthor, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/import/authors", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var authors []*SourceImportAuthor
-	resp, err := s.client.Do(ctx, req, &authors)
+	resp, err := s.client.Do(req, &authors)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -247,13 +247,13 @@ func (s *MigrationService) CommitAuthors(ctx context.Context, owner, repo string
 //meta:operation PATCH /repos/{owner}/{repo}/import/authors/{author_id}
 func (s *MigrationService) MapCommitAuthor(ctx context.Context, owner, repo string, id int64, author *SourceImportAuthor) (*SourceImportAuthor, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/import/authors/%v", owner, repo, id)
-	req, err := s.client.NewRequest("PATCH", u, author)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, author)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var out *SourceImportAuthor
-	resp, err := s.client.Do(ctx, req, &out)
+	resp, err := s.client.Do(req, &out)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -270,13 +270,13 @@ func (s *MigrationService) MapCommitAuthor(ctx context.Context, owner, repo stri
 //meta:operation PATCH /repos/{owner}/{repo}/import/lfs
 func (s *MigrationService) SetLFSPreference(ctx context.Context, owner, repo string, in *Import) (*Import, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/import/lfs", owner, repo)
-	req, err := s.client.NewRequest("PATCH", u, in)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, in)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var out *Import
-	resp, err := s.client.Do(ctx, req, &out)
+	resp, err := s.client.Do(req, &out)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -291,13 +291,13 @@ func (s *MigrationService) SetLFSPreference(ctx context.Context, owner, repo str
 //meta:operation GET /repos/{owner}/{repo}/import/large_files
 func (s *MigrationService) LargeFiles(ctx context.Context, owner, repo string) ([]*LargeFile, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/import/large_files", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var files []*LargeFile
-	resp, err := s.client.Do(ctx, req, &files)
+	resp, err := s.client.Do(req, &files)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -312,10 +312,10 @@ func (s *MigrationService) LargeFiles(ctx context.Context, owner, repo string) (
 //meta:operation DELETE /repos/{owner}/{repo}/import
 func (s *MigrationService) CancelImport(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/migrations_user.go
+++ b/github/migrations_user.go
@@ -79,7 +79,7 @@ func (s *MigrationService) StartUserMigration(ctx context.Context, repos []strin
 		body.ExcludeAttachments = &opts.ExcludeAttachments
 	}
 
-	req, err := s.client.NewRequest("POST", u, body)
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -87,7 +87,7 @@ func (s *MigrationService) StartUserMigration(ctx context.Context, repos []strin
 	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
 	var m *UserMigration
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -107,7 +107,7 @@ func (s *MigrationService) ListUserMigrations(ctx context.Context, opts *ListOpt
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -115,7 +115,7 @@ func (s *MigrationService) ListUserMigrations(ctx context.Context, opts *ListOpt
 	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
 	var m []*UserMigration
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -132,7 +132,7 @@ func (s *MigrationService) ListUserMigrations(ctx context.Context, opts *ListOpt
 func (s *MigrationService) UserMigrationStatus(ctx context.Context, id int64) (*UserMigration, *Response, error) {
 	u := fmt.Sprintf("user/migrations/%v", id)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -140,7 +140,7 @@ func (s *MigrationService) UserMigrationStatus(ctx context.Context, id int64) (*
 	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
 	var m *UserMigration
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -157,7 +157,7 @@ func (s *MigrationService) UserMigrationStatus(ctx context.Context, id int64) (*
 func (s *MigrationService) UserMigrationArchiveURL(ctx context.Context, id int64) (string, error) {
 	url := fmt.Sprintf("user/migrations/%v/archive", id)
 
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return "", err
 	}
@@ -175,7 +175,7 @@ func (s *MigrationService) UserMigrationArchiveURL(ctx context.Context, id int64
 	}()
 
 	var m *UserMigration
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err == nil {
 		return "", errors.New("expected redirect, none provided")
 	}
@@ -193,14 +193,14 @@ func (s *MigrationService) UserMigrationArchiveURL(ctx context.Context, id int64
 func (s *MigrationService) DeleteUserMigration(ctx context.Context, id int64) (*Response, error) {
 	url := fmt.Sprintf("user/migrations/%v/archive", id)
 
-	req, err := s.client.NewRequest("DELETE", url, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // UnlockUserRepo will unlock a repo that was locked for migration.
@@ -214,12 +214,12 @@ func (s *MigrationService) DeleteUserMigration(ctx context.Context, id int64) (*
 func (s *MigrationService) UnlockUserRepo(ctx context.Context, id int64, repo string) (*Response, error) {
 	url := fmt.Sprintf("user/migrations/%v/repos/%v/lock", id, repo)
 
-	req, err := s.client.NewRequest("DELETE", url, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeMigrationsPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -175,13 +175,13 @@ func (s *OrganizationsService) ListAll(ctx context.Context, opts *OrganizationsL
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	orgs := []*Organization{}
-	resp, err := s.client.Do(ctx, req, &orgs)
+	resp, err := s.client.Do(req, &orgs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -209,13 +209,13 @@ func (s *OrganizationsService) List(ctx context.Context, user string, opts *List
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var orgs []*Organization
-	resp, err := s.client.Do(ctx, req, &orgs)
+	resp, err := s.client.Do(req, &orgs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -230,7 +230,7 @@ func (s *OrganizationsService) List(ctx context.Context, user string, opts *List
 //meta:operation GET /orgs/{org}
 func (s *OrganizationsService) Get(ctx context.Context, org string) (*Organization, *Response, error) {
 	u := fmt.Sprintf("orgs/%v", org)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -238,7 +238,7 @@ func (s *OrganizationsService) Get(ctx context.Context, org string) (*Organizati
 	req.Header.Set("Accept", mediaTypeMemberAllowedRepoCreationTypePreview)
 
 	var o *Organization
-	resp, err := s.client.Do(ctx, req, &o)
+	resp, err := s.client.Do(req, &o)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -253,13 +253,13 @@ func (s *OrganizationsService) Get(ctx context.Context, org string) (*Organizati
 //meta:operation GET /organizations/{organization_id}
 func (s *OrganizationsService) GetByID(ctx context.Context, id int64) (*Organization, *Response, error) {
 	u := fmt.Sprintf("organizations/%v", id)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var org *Organization
-	resp, err := s.client.Do(ctx, req, &org)
+	resp, err := s.client.Do(req, &org)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -274,7 +274,7 @@ func (s *OrganizationsService) GetByID(ctx context.Context, id int64) (*Organiza
 //meta:operation PATCH /orgs/{org}
 func (s *OrganizationsService) Edit(ctx context.Context, name string, org *Organization) (*Organization, *Response, error) {
 	u := fmt.Sprintf("orgs/%v", name)
-	req, err := s.client.NewRequest("PATCH", u, org)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, org)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -282,7 +282,7 @@ func (s *OrganizationsService) Edit(ctx context.Context, name string, org *Organ
 	req.Header.Set("Accept", mediaTypeMemberAllowedRepoCreationTypePreview)
 
 	var o *Organization
-	resp, err := s.client.Do(ctx, req, &o)
+	resp, err := s.client.Do(req, &o)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -297,12 +297,12 @@ func (s *OrganizationsService) Edit(ctx context.Context, name string, org *Organ
 //meta:operation DELETE /orgs/{org}
 func (s *OrganizationsService) Delete(ctx context.Context, org string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v", org)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListInstallations lists installations for an organization.
@@ -318,13 +318,13 @@ func (s *OrganizationsService) ListInstallations(ctx context.Context, org string
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var result *OrganizationInstallations
-	resp, err := s.client.Do(ctx, req, &result)
+	resp, err := s.client.Do(req, &result)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/orgs_artifacts.go
+++ b/github/orgs_artifacts.go
@@ -114,13 +114,13 @@ type ArtifactStorageResponse struct {
 //meta:operation POST /orgs/{org}/artifacts/metadata/deployment-record
 func (s *OrganizationsService) CreateArtifactDeploymentRecord(ctx context.Context, org string, record CreateArtifactDeploymentRequest) (*ArtifactDeploymentResponse, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/artifacts/metadata/deployment-record", org)
-	req, err := s.client.NewRequest("POST", u, record)
+	req, err := s.client.NewRequest(ctx, "POST", u, record)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var v *ArtifactDeploymentResponse
-	resp, err := s.client.Do(ctx, req, &v)
+	resp, err := s.client.Do(req, &v)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -135,13 +135,13 @@ func (s *OrganizationsService) CreateArtifactDeploymentRecord(ctx context.Contex
 //meta:operation POST /orgs/{org}/artifacts/metadata/deployment-record/cluster/{cluster}
 func (s *OrganizationsService) SetClusterDeploymentRecords(ctx context.Context, org, cluster string, request ClusterDeploymentRecordsRequest) (*ArtifactDeploymentResponse, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/artifacts/metadata/deployment-record/cluster/%v", org, cluster)
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var v *ArtifactDeploymentResponse
-	resp, err := s.client.Do(ctx, req, &v)
+	resp, err := s.client.Do(req, &v)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -156,13 +156,13 @@ func (s *OrganizationsService) SetClusterDeploymentRecords(ctx context.Context, 
 //meta:operation POST /orgs/{org}/artifacts/metadata/storage-record
 func (s *OrganizationsService) CreateArtifactStorageRecord(ctx context.Context, org string, record CreateArtifactStorageRequest) (*ArtifactStorageResponse, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/artifacts/metadata/storage-record", org)
-	req, err := s.client.NewRequest("POST", u, record)
+	req, err := s.client.NewRequest(ctx, "POST", u, record)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var v *ArtifactStorageResponse
-	resp, err := s.client.Do(ctx, req, &v)
+	resp, err := s.client.Do(req, &v)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -180,13 +180,13 @@ func (s *OrganizationsService) CreateArtifactStorageRecord(ctx context.Context, 
 func (s *OrganizationsService) ListArtifactDeploymentRecords(ctx context.Context, org, subjectDigest string) (*ArtifactDeploymentResponse, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/artifacts/%v/metadata/deployment-records", org, subjectDigest)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var v *ArtifactDeploymentResponse
-	resp, err := s.client.Do(ctx, req, &v)
+	resp, err := s.client.Do(req, &v)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -204,13 +204,13 @@ func (s *OrganizationsService) ListArtifactDeploymentRecords(ctx context.Context
 func (s *OrganizationsService) ListArtifactStorageRecords(ctx context.Context, org, subjectDigest string) (*ArtifactStorageResponse, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/artifacts/%v/metadata/storage-records", org, subjectDigest)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var v *ArtifactStorageResponse
-	resp, err := s.client.Do(ctx, req, &v)
+	resp, err := s.client.Do(req, &v)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/orgs_attestations.go
+++ b/github/orgs_attestations.go
@@ -25,13 +25,13 @@ func (s *OrganizationsService) ListAttestations(ctx context.Context, org, subjec
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var attestations *AttestationsResponse
-	resp, err := s.client.Do(ctx, req, &attestations)
+	resp, err := s.client.Do(req, &attestations)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/orgs_audit_log.go
+++ b/github/orgs_audit_log.go
@@ -129,13 +129,13 @@ func (s *OrganizationsService) GetAuditLog(ctx context.Context, org string, opts
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var auditEntries []*AuditEntry
-	resp, err := s.client.Do(ctx, req, &auditEntries)
+	resp, err := s.client.Do(req, &auditEntries)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/orgs_codesecurity_configurations.go
+++ b/github/orgs_codesecurity_configurations.go
@@ -152,13 +152,13 @@ func (s *OrganizationsService) ListCodeSecurityConfigurations(ctx context.Contex
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configurations []*CodeSecurityConfiguration
-	resp, err := s.client.Do(ctx, req, &configurations)
+	resp, err := s.client.Do(req, &configurations)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -173,13 +173,13 @@ func (s *OrganizationsService) ListCodeSecurityConfigurations(ctx context.Contex
 func (s *OrganizationsService) CreateCodeSecurityConfiguration(ctx context.Context, org string, config CodeSecurityConfiguration) (*CodeSecurityConfiguration, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/code-security/configurations", org)
 
-	req, err := s.client.NewRequest("POST", u, config)
+	req, err := s.client.NewRequest(ctx, "POST", u, config)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configuration *CodeSecurityConfiguration
-	resp, err := s.client.Do(ctx, req, &configuration)
+	resp, err := s.client.Do(req, &configuration)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -194,13 +194,13 @@ func (s *OrganizationsService) CreateCodeSecurityConfiguration(ctx context.Conte
 func (s *OrganizationsService) ListDefaultCodeSecurityConfigurations(ctx context.Context, org string) ([]*CodeSecurityConfigurationWithDefaultForNewRepos, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/code-security/configurations/defaults", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configurations []*CodeSecurityConfigurationWithDefaultForNewRepos
-	resp, err := s.client.Do(ctx, req, &configurations)
+	resp, err := s.client.Do(req, &configurations)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -217,11 +217,11 @@ func (s *OrganizationsService) DetachCodeSecurityConfigurationsFromRepositories(
 	type selectedRepoIDs struct {
 		SelectedIDs []int64 `json:"selected_repository_ids"`
 	}
-	req, err := s.client.NewRequest("DELETE", u, selectedRepoIDs{SelectedIDs: repoIDs})
+	req, err := s.client.NewRequest(ctx, "DELETE", u, selectedRepoIDs{SelectedIDs: repoIDs})
 	if err != nil {
 		return nil, err
 	}
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -236,13 +236,13 @@ func (s *OrganizationsService) DetachCodeSecurityConfigurationsFromRepositories(
 func (s *OrganizationsService) GetCodeSecurityConfiguration(ctx context.Context, org string, configurationID int64) (*CodeSecurityConfiguration, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/code-security/configurations/%v", org, configurationID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configuration *CodeSecurityConfiguration
-	resp, err := s.client.Do(ctx, req, &configuration)
+	resp, err := s.client.Do(req, &configuration)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -257,13 +257,13 @@ func (s *OrganizationsService) GetCodeSecurityConfiguration(ctx context.Context,
 func (s *OrganizationsService) UpdateCodeSecurityConfiguration(ctx context.Context, org string, configurationID int64, config CodeSecurityConfiguration) (*CodeSecurityConfiguration, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/code-security/configurations/%v", org, configurationID)
 
-	req, err := s.client.NewRequest("PATCH", u, config)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, config)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configuration *CodeSecurityConfiguration
-	resp, err := s.client.Do(ctx, req, &configuration)
+	resp, err := s.client.Do(req, &configuration)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -278,11 +278,11 @@ func (s *OrganizationsService) UpdateCodeSecurityConfiguration(ctx context.Conte
 func (s *OrganizationsService) DeleteCodeSecurityConfiguration(ctx context.Context, org string, configurationID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/code-security/configurations/%v", org, configurationID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -300,11 +300,11 @@ func (s *OrganizationsService) AttachCodeSecurityConfigurationToRepositories(ctx
 		Scope       string  `json:"scope"`
 		SelectedIDs []int64 `json:"selected_repository_ids,omitempty"`
 	}
-	req, err := s.client.NewRequest("POST", u, selectedRepoIDs{Scope: scope, SelectedIDs: repoIDs})
+	req, err := s.client.NewRequest(ctx, "POST", u, selectedRepoIDs{Scope: scope, SelectedIDs: repoIDs})
 	if err != nil {
 		return nil, err
 	}
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil && resp.StatusCode != http.StatusAccepted { // StatusAccepted(202) is the expected status code as job is queued for processing
 		return resp, err
 	}
@@ -321,12 +321,12 @@ func (s *OrganizationsService) SetDefaultCodeSecurityConfiguration(ctx context.C
 	type configParam struct {
 		DefaultForNewRepos string `json:"default_for_new_repos"`
 	}
-	req, err := s.client.NewRequest("PUT", u, configParam{DefaultForNewRepos: newReposParam})
+	req, err := s.client.NewRequest(ctx, "PUT", u, configParam{DefaultForNewRepos: newReposParam})
 	if err != nil {
 		return nil, nil, err
 	}
 	var config *CodeSecurityConfigurationWithDefaultForNewRepos
-	resp, err := s.client.Do(ctx, req, &config)
+	resp, err := s.client.Do(req, &config)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -345,13 +345,13 @@ func (s *OrganizationsService) ListCodeSecurityConfigurationRepositories(ctx con
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var attachments []*RepositoryAttachment
-	resp, err := s.client.Do(ctx, req, &attachments)
+	resp, err := s.client.Do(req, &attachments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -367,12 +367,12 @@ func (s *OrganizationsService) ListCodeSecurityConfigurationRepositories(ctx con
 func (s *OrganizationsService) GetCodeSecurityConfigurationForRepository(ctx context.Context, org, repo string) (*RepositoryCodeSecurityConfiguration, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/code-security-configuration", org, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 	var repoConfig *RepositoryCodeSecurityConfiguration
-	resp, err := s.client.Do(ctx, req, &repoConfig)
+	resp, err := s.client.Do(req, &repoConfig)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/orgs_credential_authorizations.go
+++ b/github/orgs_credential_authorizations.go
@@ -77,13 +77,13 @@ func (s *OrganizationsService) ListCredentialAuthorizations(ctx context.Context,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var creds []*CredentialAuthorization
-	resp, err := s.client.Do(ctx, req, &creds)
+	resp, err := s.client.Do(req, &creds)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -99,10 +99,10 @@ func (s *OrganizationsService) ListCredentialAuthorizations(ctx context.Context,
 //meta:operation DELETE /orgs/{org}/credential-authorizations/{credential_id}
 func (s *OrganizationsService) RemoveCredentialAuthorization(ctx context.Context, org string, credentialID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/credential-authorizations/%v", org, credentialID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/orgs_custom_repository_roles.go
+++ b/github/orgs_custom_repository_roles.go
@@ -53,13 +53,13 @@ type RepoFineGrainedPermission struct {
 func (s *OrganizationsService) ListCustomRepoRoles(ctx context.Context, org string) (*OrganizationCustomRepoRoles, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/custom-repository-roles", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var customRepoRoles *OrganizationCustomRepoRoles
-	resp, err := s.client.Do(ctx, req, &customRepoRoles)
+	resp, err := s.client.Do(req, &customRepoRoles)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -76,13 +76,13 @@ func (s *OrganizationsService) ListCustomRepoRoles(ctx context.Context, org stri
 func (s *OrganizationsService) GetCustomRepoRole(ctx context.Context, org string, roleID int64) (*CustomRepoRoles, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/custom-repository-roles/%v", org, roleID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var resultingRole *CustomRepoRoles
-	resp, err := s.client.Do(ctx, req, &resultingRole)
+	resp, err := s.client.Do(req, &resultingRole)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -99,13 +99,13 @@ func (s *OrganizationsService) GetCustomRepoRole(ctx context.Context, org string
 func (s *OrganizationsService) CreateCustomRepoRole(ctx context.Context, org string, opts *CreateOrUpdateCustomRepoRoleOptions) (*CustomRepoRoles, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/custom-repository-roles", org)
 
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var resultingRole *CustomRepoRoles
-	resp, err := s.client.Do(ctx, req, &resultingRole)
+	resp, err := s.client.Do(req, &resultingRole)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -122,13 +122,13 @@ func (s *OrganizationsService) CreateCustomRepoRole(ctx context.Context, org str
 func (s *OrganizationsService) UpdateCustomRepoRole(ctx context.Context, org string, roleID int64, opts *CreateOrUpdateCustomRepoRoleOptions) (*CustomRepoRoles, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/custom-repository-roles/%v", org, roleID)
 
-	req, err := s.client.NewRequest("PATCH", u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var resultingRole *CustomRepoRoles
-	resp, err := s.client.Do(ctx, req, &resultingRole)
+	resp, err := s.client.Do(req, &resultingRole)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -145,13 +145,13 @@ func (s *OrganizationsService) UpdateCustomRepoRole(ctx context.Context, org str
 func (s *OrganizationsService) DeleteCustomRepoRole(ctx context.Context, org string, roleID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/custom-repository-roles/%v", org, roleID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	var resultingRole *CustomRepoRoles
-	resp, err := s.client.Do(ctx, req, &resultingRole)
+	resp, err := s.client.Do(req, &resultingRole)
 	if err != nil {
 		return resp, err
 	}
@@ -168,13 +168,13 @@ func (s *OrganizationsService) DeleteCustomRepoRole(ctx context.Context, org str
 func (s *OrganizationsService) ListRepositoryFineGrainedPermissions(ctx context.Context, org string) ([]*RepoFineGrainedPermission, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/repository-fine-grained-permissions", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var perms []*RepoFineGrainedPermission
-	resp, err := s.client.Do(ctx, req, &perms)
+	resp, err := s.client.Do(req, &perms)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/orgs_hooks.go
+++ b/github/orgs_hooks.go
@@ -23,13 +23,13 @@ func (s *OrganizationsService) ListHooks(ctx context.Context, org string, opts *
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hooks []*Hook
-	resp, err := s.client.Do(ctx, req, &hooks)
+	resp, err := s.client.Do(req, &hooks)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -44,13 +44,13 @@ func (s *OrganizationsService) ListHooks(ctx context.Context, org string, opts *
 //meta:operation GET /orgs/{org}/hooks/{hook_id}
 func (s *OrganizationsService) GetHook(ctx context.Context, org string, id int64) (*Hook, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/hooks/%v", org, id)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hook *Hook
-	resp, err := s.client.Do(ctx, req, &hook)
+	resp, err := s.client.Do(req, &hook)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -81,13 +81,13 @@ func (s *OrganizationsService) CreateHook(ctx context.Context, org string, hook 
 		Config: hook.Config,
 	}
 
-	req, err := s.client.NewRequest("POST", u, hookReq)
+	req, err := s.client.NewRequest(ctx, "POST", u, hookReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var h *Hook
-	resp, err := s.client.Do(ctx, req, &h)
+	resp, err := s.client.Do(req, &h)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -102,13 +102,13 @@ func (s *OrganizationsService) CreateHook(ctx context.Context, org string, hook 
 //meta:operation PATCH /orgs/{org}/hooks/{hook_id}
 func (s *OrganizationsService) EditHook(ctx context.Context, org string, id int64, hook *Hook) (*Hook, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/hooks/%v", org, id)
-	req, err := s.client.NewRequest("PATCH", u, hook)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, hook)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var h *Hook
-	resp, err := s.client.Do(ctx, req, &h)
+	resp, err := s.client.Do(req, &h)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -123,12 +123,12 @@ func (s *OrganizationsService) EditHook(ctx context.Context, org string, id int6
 //meta:operation POST /orgs/{org}/hooks/{hook_id}/pings
 func (s *OrganizationsService) PingHook(ctx context.Context, org string, id int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/hooks/%v/pings", org, id)
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DeleteHook deletes a specified Hook.
@@ -138,10 +138,10 @@ func (s *OrganizationsService) PingHook(ctx context.Context, org string, id int6
 //meta:operation DELETE /orgs/{org}/hooks/{hook_id}
 func (s *OrganizationsService) DeleteHook(ctx context.Context, org string, id int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/hooks/%v", org, id)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/orgs_hooks_configuration.go
+++ b/github/orgs_hooks_configuration.go
@@ -17,13 +17,13 @@ import (
 //meta:operation GET /orgs/{org}/hooks/{hook_id}/config
 func (s *OrganizationsService) GetHookConfiguration(ctx context.Context, org string, id int64) (*HookConfig, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/hooks/%v/config", org, id)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var config *HookConfig
-	resp, err := s.client.Do(ctx, req, &config)
+	resp, err := s.client.Do(req, &config)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -38,13 +38,13 @@ func (s *OrganizationsService) GetHookConfiguration(ctx context.Context, org str
 //meta:operation PATCH /orgs/{org}/hooks/{hook_id}/config
 func (s *OrganizationsService) EditHookConfiguration(ctx context.Context, org string, id int64, config *HookConfig) (*HookConfig, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/hooks/%v/config", org, id)
-	req, err := s.client.NewRequest("PATCH", u, config)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, config)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var c *HookConfig
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/orgs_hooks_deliveries.go
+++ b/github/orgs_hooks_deliveries.go
@@ -22,13 +22,13 @@ func (s *OrganizationsService) ListHookDeliveries(ctx context.Context, org strin
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	deliveries := []*HookDelivery{}
-	resp, err := s.client.Do(ctx, req, &deliveries)
+	resp, err := s.client.Do(req, &deliveries)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -43,13 +43,13 @@ func (s *OrganizationsService) ListHookDeliveries(ctx context.Context, org strin
 //meta:operation GET /orgs/{org}/hooks/{hook_id}/deliveries/{delivery_id}
 func (s *OrganizationsService) GetHookDelivery(ctx context.Context, owner string, hookID, deliveryID int64) (*HookDelivery, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/hooks/%v/deliveries/%v", owner, hookID, deliveryID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var h *HookDelivery
-	resp, err := s.client.Do(ctx, req, &h)
+	resp, err := s.client.Do(req, &h)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -64,13 +64,13 @@ func (s *OrganizationsService) GetHookDelivery(ctx context.Context, owner string
 //meta:operation POST /orgs/{org}/hooks/{hook_id}/deliveries/{delivery_id}/attempts
 func (s *OrganizationsService) RedeliverHookDelivery(ctx context.Context, owner string, hookID, deliveryID int64) (*HookDelivery, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/hooks/%v/deliveries/%v/attempts", owner, hookID, deliveryID)
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var h *HookDelivery
-	resp, err := s.client.Do(ctx, req, &h)
+	resp, err := s.client.Do(req, &h)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/orgs_immutable_releases.go
+++ b/github/orgs_immutable_releases.go
@@ -41,13 +41,13 @@ type setImmutableReleasesRepositoriesOptions struct {
 func (s *OrganizationsService) GetImmutableReleasesSettings(ctx context.Context, org string) (*ImmutableReleaseSettings, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/settings/immutable-releases", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var settings *ImmutableReleaseSettings
-	resp, err := s.client.Do(ctx, req, &settings)
+	resp, err := s.client.Do(req, &settings)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -63,12 +63,12 @@ func (s *OrganizationsService) GetImmutableReleasesSettings(ctx context.Context,
 func (s *OrganizationsService) UpdateImmutableReleasesSettings(ctx context.Context, org string, opts ImmutableReleasePolicy) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/settings/immutable-releases", org)
 
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -89,13 +89,13 @@ func (s *OrganizationsService) ListImmutableReleaseRepositories(ctx context.Cont
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var repositories *ListRepositories
-	resp, err := s.client.Do(ctx, req, &repositories)
+	resp, err := s.client.Do(req, &repositories)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -116,12 +116,12 @@ func (s *OrganizationsService) SetImmutableReleaseRepositories(ctx context.Conte
 		SelectedRepositoryIDs: repositoryIDs,
 	}
 
-	req, err := s.client.NewRequest("PUT", u, body)
+	req, err := s.client.NewRequest(ctx, "PUT", u, body)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -138,12 +138,12 @@ func (s *OrganizationsService) SetImmutableReleaseRepositories(ctx context.Conte
 func (s *OrganizationsService) EnableRepositoryForImmutableRelease(ctx context.Context, org string, repoID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/settings/immutable-releases/repositories/%v", org, repoID)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -160,12 +160,12 @@ func (s *OrganizationsService) EnableRepositoryForImmutableRelease(ctx context.C
 func (s *OrganizationsService) DisableRepositoryForImmutableRelease(ctx context.Context, org string, repoID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/settings/immutable-releases/repositories/%v", org, repoID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/github/orgs_issue_types.go
+++ b/github/orgs_issue_types.go
@@ -27,13 +27,13 @@ type CreateOrUpdateIssueTypesOptions struct {
 func (s *OrganizationsService) ListIssueTypes(ctx context.Context, org string) ([]*IssueType, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/issue-types", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var issueTypes []*IssueType
-	resp, err := s.client.Do(ctx, req, &issueTypes)
+	resp, err := s.client.Do(req, &issueTypes)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -48,13 +48,13 @@ func (s *OrganizationsService) ListIssueTypes(ctx context.Context, org string) (
 //meta:operation POST /orgs/{org}/issue-types
 func (s *OrganizationsService) CreateIssueType(ctx context.Context, org string, opts *CreateOrUpdateIssueTypesOptions) (*IssueType, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/issue-types", org)
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var issueType *IssueType
-	resp, err := s.client.Do(ctx, req, &issueType)
+	resp, err := s.client.Do(req, &issueType)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -69,13 +69,13 @@ func (s *OrganizationsService) CreateIssueType(ctx context.Context, org string, 
 //meta:operation PUT /orgs/{org}/issue-types/{issue_type_id}
 func (s *OrganizationsService) UpdateIssueType(ctx context.Context, org string, issueTypeID int64, opts *CreateOrUpdateIssueTypesOptions) (*IssueType, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/issue-types/%v", org, issueTypeID)
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var issueType *IssueType
-	resp, err := s.client.Do(ctx, req, &issueType)
+	resp, err := s.client.Do(req, &issueType)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -90,10 +90,10 @@ func (s *OrganizationsService) UpdateIssueType(ctx context.Context, org string, 
 //meta:operation DELETE /orgs/{org}/issue-types/{issue_type_id}
 func (s *OrganizationsService) DeleteIssueType(ctx context.Context, org string, issueTypeID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/issue-types/%v", org, issueTypeID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/orgs_members.go
+++ b/github/orgs_members.go
@@ -89,13 +89,13 @@ func (s *OrganizationsService) ListMembers(ctx context.Context, org string, opts
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var members []*User
-	resp, err := s.client.Do(ctx, req, &members)
+	resp, err := s.client.Do(req, &members)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -110,12 +110,12 @@ func (s *OrganizationsService) ListMembers(ctx context.Context, org string, opts
 //meta:operation GET /orgs/{org}/members/{username}
 func (s *OrganizationsService) IsMember(ctx context.Context, org, user string) (bool, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/members/%v", org, user)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return false, nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	member, err := parseBoolResponse(err)
 	return member, resp, err
 }
@@ -127,12 +127,12 @@ func (s *OrganizationsService) IsMember(ctx context.Context, org, user string) (
 //meta:operation GET /orgs/{org}/public_members/{username}
 func (s *OrganizationsService) IsPublicMember(ctx context.Context, org, user string) (bool, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/public_members/%v", org, user)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return false, nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	member, err := parseBoolResponse(err)
 	return member, resp, err
 }
@@ -144,12 +144,12 @@ func (s *OrganizationsService) IsPublicMember(ctx context.Context, org, user str
 //meta:operation DELETE /orgs/{org}/members/{username}
 func (s *OrganizationsService) RemoveMember(ctx context.Context, org, user string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/members/%v", org, user)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // CancelInvite cancels an organization invitation.
@@ -159,11 +159,11 @@ func (s *OrganizationsService) RemoveMember(ctx context.Context, org, user strin
 //meta:operation DELETE /orgs/{org}/invitations/{invitation_id}
 func (s *OrganizationsService) CancelInvite(ctx context.Context, org string, invitationID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/invitations/%v", org, invitationID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // PublicizeMembership publicizes a user's membership in an organization. (A
@@ -174,12 +174,12 @@ func (s *OrganizationsService) CancelInvite(ctx context.Context, org string, inv
 //meta:operation PUT /orgs/{org}/public_members/{username}
 func (s *OrganizationsService) PublicizeMembership(ctx context.Context, org, user string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/public_members/%v", org, user)
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ConcealMembership conceals a user's membership in an organization.
@@ -189,12 +189,12 @@ func (s *OrganizationsService) PublicizeMembership(ctx context.Context, org, use
 //meta:operation DELETE /orgs/{org}/public_members/{username}
 func (s *OrganizationsService) ConcealMembership(ctx context.Context, org, user string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/public_members/%v", org, user)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListOrgMembershipsOptions specifies optional parameters to the
@@ -219,13 +219,13 @@ func (s *OrganizationsService) ListOrgMemberships(ctx context.Context, opts *Lis
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var memberships []*Membership
-	resp, err := s.client.Do(ctx, req, &memberships)
+	resp, err := s.client.Do(req, &memberships)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -251,13 +251,13 @@ func (s *OrganizationsService) GetOrgMembership(ctx context.Context, user, org s
 		u = fmt.Sprintf("user/memberships/orgs/%v", org)
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var membership *Membership
-	resp, err := s.client.Do(ctx, req, &membership)
+	resp, err := s.client.Do(req, &membership)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -285,13 +285,13 @@ func (s *OrganizationsService) EditOrgMembership(ctx context.Context, user, org 
 		method = "PATCH"
 	}
 
-	req, err := s.client.NewRequest(method, u, membership)
+	req, err := s.client.NewRequest(ctx, method, u, membership)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var m *Membership
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -307,12 +307,12 @@ func (s *OrganizationsService) EditOrgMembership(ctx context.Context, user, org 
 //meta:operation DELETE /orgs/{org}/memberships/{username}
 func (s *OrganizationsService) RemoveOrgMembership(ctx context.Context, user, org string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/memberships/%v", org, user)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListPendingOrgInvitations returns a list of pending invitations.
@@ -327,13 +327,13 @@ func (s *OrganizationsService) ListPendingOrgInvitations(ctx context.Context, or
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var pendingInvitations []*Invitation
-	resp, err := s.client.Do(ctx, req, &pendingInvitations)
+	resp, err := s.client.Do(req, &pendingInvitations)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -371,13 +371,13 @@ type CreateOrgInvitationOptions struct {
 func (s *OrganizationsService) CreateOrgInvitation(ctx context.Context, org string, opts *CreateOrgInvitationOptions) (*Invitation, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/invitations", org)
 
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var invitation *Invitation
-	resp, err := s.client.Do(ctx, req, &invitation)
+	resp, err := s.client.Do(req, &invitation)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -398,13 +398,13 @@ func (s *OrganizationsService) ListOrgInvitationTeams(ctx context.Context, org, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var orgInvitationTeams []*Team
-	resp, err := s.client.Do(ctx, req, &orgInvitationTeams)
+	resp, err := s.client.Do(req, &orgInvitationTeams)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -424,13 +424,13 @@ func (s *OrganizationsService) ListFailedOrgInvitations(ctx context.Context, org
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var failedInvitations []*Invitation
-	resp, err := s.client.Do(ctx, req, &failedInvitations)
+	resp, err := s.client.Do(req, &failedInvitations)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/orgs_network_configurations.go
+++ b/github/orgs_network_configurations.go
@@ -111,13 +111,13 @@ func (s *OrganizationsService) ListNetworkConfigurations(ctx context.Context, or
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configurations *NetworkConfigurations
-	resp, err := s.client.Do(ctx, req, &configurations)
+	resp, err := s.client.Do(req, &configurations)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -136,13 +136,13 @@ func (s *OrganizationsService) CreateNetworkConfiguration(ctx context.Context, o
 	}
 
 	u := fmt.Sprintf("orgs/%v/settings/network-configurations", org)
-	req, err := s.client.NewRequest("POST", u, createReq)
+	req, err := s.client.NewRequest(ctx, "POST", u, createReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configuration *NetworkConfiguration
-	resp, err := s.client.Do(ctx, req, &configuration)
+	resp, err := s.client.Do(req, &configuration)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -157,13 +157,13 @@ func (s *OrganizationsService) CreateNetworkConfiguration(ctx context.Context, o
 //meta:operation GET /orgs/{org}/settings/network-configurations/{network_configuration_id}
 func (s *OrganizationsService) GetNetworkConfiguration(ctx context.Context, org, networkID string) (*NetworkConfiguration, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/settings/network-configurations/%v", org, networkID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configuration *NetworkConfiguration
-	resp, err := s.client.Do(ctx, req, &configuration)
+	resp, err := s.client.Do(req, &configuration)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -182,13 +182,13 @@ func (s *OrganizationsService) UpdateNetworkConfiguration(ctx context.Context, o
 	}
 
 	u := fmt.Sprintf("orgs/%v/settings/network-configurations/%v", org, networkID)
-	req, err := s.client.NewRequest("PATCH", u, updateReq)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, updateReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var configuration *NetworkConfiguration
-	resp, err := s.client.Do(ctx, req, &configuration)
+	resp, err := s.client.Do(req, &configuration)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -203,13 +203,13 @@ func (s *OrganizationsService) UpdateNetworkConfiguration(ctx context.Context, o
 //meta:operation DELETE /orgs/{org}/settings/network-configurations/{network_configuration_id}
 func (s *OrganizationsService) DeleteNetworkConfigurations(ctx context.Context, org, networkID string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/settings/network-configurations/%v", org, networkID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	var configuration *NetworkConfiguration
-	resp, err := s.client.Do(ctx, req, &configuration)
+	resp, err := s.client.Do(req, &configuration)
 	if err != nil {
 		return resp, err
 	}
@@ -224,13 +224,13 @@ func (s *OrganizationsService) DeleteNetworkConfigurations(ctx context.Context, 
 //meta:operation GET /orgs/{org}/settings/network-settings/{network_settings_id}
 func (s *OrganizationsService) GetNetworkConfigurationResource(ctx context.Context, org, networkID string) (*NetworkSettingsResource, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/settings/network-settings/%v", org, networkID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var resource *NetworkSettingsResource
-	resp, err := s.client.Do(ctx, req, &resource)
+	resp, err := s.client.Do(req, &resource)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/orgs_organization_properties.go
+++ b/github/orgs_organization_properties.go
@@ -24,13 +24,13 @@ type OrganizationCustomPropertyValues struct {
 func (s *OrganizationsService) GetOrganizationCustomPropertyValues(ctx context.Context, org string) ([]*CustomPropertyValue, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/org-properties/values", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var values []*CustomPropertyValue
-	resp, err := s.client.Do(ctx, req, &values)
+	resp, err := s.client.Do(req, &values)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -46,12 +46,12 @@ func (s *OrganizationsService) GetOrganizationCustomPropertyValues(ctx context.C
 //meta:operation PATCH /organizations/{org}/org-properties/values
 func (s *OrganizationsService) CreateOrUpdateOrganizationCustomPropertyValues(ctx context.Context, org string, values OrganizationCustomPropertyValues) (*Response, error) {
 	u := fmt.Sprintf("organizations/%v/org-properties/values", org)
-	req, err := s.client.NewRequest("PATCH", u, values)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, values)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/github/orgs_organization_roles.go
+++ b/github/orgs_organization_roles.go
@@ -60,13 +60,13 @@ type OrganizationFineGrainedPermission struct {
 func (s *OrganizationsService) ListRoles(ctx context.Context, org string) (*OrganizationCustomRoles, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/organization-roles", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var customRepoRoles *OrganizationCustomRoles
-	resp, err := s.client.Do(ctx, req, &customRepoRoles)
+	resp, err := s.client.Do(req, &customRepoRoles)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -83,13 +83,13 @@ func (s *OrganizationsService) ListRoles(ctx context.Context, org string) (*Orga
 func (s *OrganizationsService) GetOrgRole(ctx context.Context, org string, roleID int64) (*CustomOrgRole, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/organization-roles/%v", org, roleID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var resultingRole *CustomOrgRole
-	resp, err := s.client.Do(ctx, req, &resultingRole)
+	resp, err := s.client.Do(req, &resultingRole)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -106,13 +106,13 @@ func (s *OrganizationsService) GetOrgRole(ctx context.Context, org string, roleI
 func (s *OrganizationsService) CreateCustomOrgRole(ctx context.Context, org string, request CreateCustomOrgRoleRequest) (*CustomOrgRole, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/organization-roles", org)
 
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var resultingRole *CustomOrgRole
-	resp, err := s.client.Do(ctx, req, &resultingRole)
+	resp, err := s.client.Do(req, &resultingRole)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -129,13 +129,13 @@ func (s *OrganizationsService) CreateCustomOrgRole(ctx context.Context, org stri
 func (s *OrganizationsService) UpdateCustomOrgRole(ctx context.Context, org string, roleID int64, request UpdateCustomOrgRoleRequest) (*CustomOrgRole, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/organization-roles/%v", org, roleID)
 
-	req, err := s.client.NewRequest("PATCH", u, request)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var resultingRole *CustomOrgRole
-	resp, err := s.client.Do(ctx, req, &resultingRole)
+	resp, err := s.client.Do(req, &resultingRole)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -152,13 +152,13 @@ func (s *OrganizationsService) UpdateCustomOrgRole(ctx context.Context, org stri
 func (s *OrganizationsService) DeleteCustomOrgRole(ctx context.Context, org string, roleID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/organization-roles/%v", org, roleID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	var resultingRole *CustomOrgRole
-	resp, err := s.client.Do(ctx, req, &resultingRole)
+	resp, err := s.client.Do(req, &resultingRole)
 	if err != nil {
 		return resp, err
 	}
@@ -175,12 +175,12 @@ func (s *OrganizationsService) DeleteCustomOrgRole(ctx context.Context, org stri
 func (s *OrganizationsService) AssignOrgRoleToTeam(ctx context.Context, org, teamSlug string, roleID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/organization-roles/teams/%v/%v", org, teamSlug, roleID)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -197,12 +197,12 @@ func (s *OrganizationsService) AssignOrgRoleToTeam(ctx context.Context, org, tea
 func (s *OrganizationsService) RemoveOrgRoleFromTeam(ctx context.Context, org, teamSlug string, roleID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/organization-roles/teams/%v/%v", org, teamSlug, roleID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -219,12 +219,12 @@ func (s *OrganizationsService) RemoveOrgRoleFromTeam(ctx context.Context, org, t
 func (s *OrganizationsService) AssignOrgRoleToUser(ctx context.Context, org, username string, roleID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/organization-roles/users/%v/%v", org, username, roleID)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -241,12 +241,12 @@ func (s *OrganizationsService) AssignOrgRoleToUser(ctx context.Context, org, use
 func (s *OrganizationsService) RemoveOrgRoleFromUser(ctx context.Context, org, username string, roleID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/organization-roles/users/%v/%v", org, username, roleID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -267,13 +267,13 @@ func (s *OrganizationsService) ListTeamsAssignedToOrgRole(ctx context.Context, o
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teams []*Team
-	resp, err := s.client.Do(ctx, req, &teams)
+	resp, err := s.client.Do(req, &teams)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -294,13 +294,13 @@ func (s *OrganizationsService) ListUsersAssignedToOrgRole(ctx context.Context, o
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var users []*User
-	resp, err := s.client.Do(ctx, req, &users)
+	resp, err := s.client.Do(req, &users)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -322,13 +322,13 @@ func (s *OrganizationsService) ListUsersAssignedToOrgRole(ctx context.Context, o
 func (s *OrganizationsService) ListFineGrainedPermissions(ctx context.Context, org string) ([]*OrganizationFineGrainedPermission, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/organization-fine-grained-permissions", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var permissions []*OrganizationFineGrainedPermission
-	resp, err := s.client.Do(ctx, req, &permissions)
+	resp, err := s.client.Do(req, &permissions)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/orgs_outside_collaborators.go
+++ b/github/orgs_outside_collaborators.go
@@ -37,13 +37,13 @@ func (s *OrganizationsService) ListOutsideCollaborators(ctx context.Context, org
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var members []*User
-	resp, err := s.client.Do(ctx, req, &members)
+	resp, err := s.client.Do(req, &members)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -59,12 +59,12 @@ func (s *OrganizationsService) ListOutsideCollaborators(ctx context.Context, org
 //meta:operation DELETE /orgs/{org}/outside_collaborators/{username}
 func (s *OrganizationsService) RemoveOutsideCollaborator(ctx context.Context, org, user string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/outside_collaborators/%v", org, user)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ConvertMemberToOutsideCollaborator reduces the permission level of a member of the
@@ -78,10 +78,10 @@ func (s *OrganizationsService) RemoveOutsideCollaborator(ctx context.Context, or
 //meta:operation PUT /orgs/{org}/outside_collaborators/{username}
 func (s *OrganizationsService) ConvertMemberToOutsideCollaborator(ctx context.Context, org, user string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/outside_collaborators/%v", org, user)
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/orgs_packages.go
+++ b/github/orgs_packages.go
@@ -23,13 +23,13 @@ func (s *OrganizationsService) ListPackages(ctx context.Context, org string, opt
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var packages []*Package
-	resp, err := s.client.Do(ctx, req, &packages)
+	resp, err := s.client.Do(req, &packages)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -46,13 +46,13 @@ func (s *OrganizationsService) ListPackages(ctx context.Context, org string, opt
 //meta:operation GET /orgs/{org}/packages/{package_type}/{package_name}
 func (s *OrganizationsService) GetPackage(ctx context.Context, org, packageType, packageName string) (*Package, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages/%v/%v", org, packageType, url.PathEscape(packageName))
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var pack *Package
-	resp, err := s.client.Do(ctx, req, &pack)
+	resp, err := s.client.Do(req, &pack)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -69,12 +69,12 @@ func (s *OrganizationsService) GetPackage(ctx context.Context, org, packageType,
 //meta:operation DELETE /orgs/{org}/packages/{package_type}/{package_name}
 func (s *OrganizationsService) DeletePackage(ctx context.Context, org, packageType, packageName string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages/%v/%v", org, packageType, url.PathEscape(packageName))
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RestorePackage restores a package to an organization.
@@ -86,12 +86,12 @@ func (s *OrganizationsService) DeletePackage(ctx context.Context, org, packageTy
 //meta:operation POST /orgs/{org}/packages/{package_type}/{package_name}/restore
 func (s *OrganizationsService) RestorePackage(ctx context.Context, org, packageType, packageName string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages/%v/%v/restore", org, packageType, url.PathEscape(packageName))
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // PackageGetAllVersions gets all versions of a package in an organization.
@@ -108,13 +108,13 @@ func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, p
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var versions []*PackageVersion
-	resp, err := s.client.Do(ctx, req, &versions)
+	resp, err := s.client.Do(req, &versions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -131,13 +131,13 @@ func (s *OrganizationsService) PackageGetAllVersions(ctx context.Context, org, p
 //meta:operation GET /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}
 func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*PackageVersion, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v", org, packageType, url.PathEscape(packageName), packageVersionID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var version *PackageVersion
-	resp, err := s.client.Do(ctx, req, &version)
+	resp, err := s.client.Do(req, &version)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -154,12 +154,12 @@ func (s *OrganizationsService) PackageGetVersion(ctx context.Context, org, packa
 //meta:operation DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}
 func (s *OrganizationsService) PackageDeleteVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v", org, packageType, url.PathEscape(packageName), packageVersionID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // PackageRestoreVersion restores a package version to an organization.
@@ -171,10 +171,10 @@ func (s *OrganizationsService) PackageDeleteVersion(ctx context.Context, org, pa
 //meta:operation POST /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore
 func (s *OrganizationsService) PackageRestoreVersion(ctx context.Context, org, packageType, packageName string, packageVersionID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/packages/%v/%v/versions/%v/restore", org, packageType, url.PathEscape(packageName), packageVersionID)
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/orgs_personal_access_tokens.go
+++ b/github/orgs_personal_access_tokens.go
@@ -104,14 +104,14 @@ func (s *OrganizationsService) ListFineGrainedPersonalAccessTokens(ctx context.C
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, opts)
+	req, err := s.client.NewRequest(ctx, "GET", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var pats []*PersonalAccessToken
 
-	resp, err := s.client.Do(ctx, req, &pats)
+	resp, err := s.client.Do(req, &pats)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -174,13 +174,13 @@ func (s *OrganizationsService) ListFineGrainedPersonalAccessTokenRequests(ctx co
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, opts)
+	req, err := s.client.NewRequest(ctx, "GET", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var pats []*FineGrainedPersonalAccessTokenRequest
-	resp, err := s.client.Do(ctx, req, &pats)
+	resp, err := s.client.Do(req, &pats)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -204,12 +204,12 @@ type ReviewPersonalAccessTokenRequestOptions struct {
 func (s *OrganizationsService) ReviewPersonalAccessTokenRequest(ctx context.Context, org string, requestID int64, opts ReviewPersonalAccessTokenRequestOptions) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/personal-access-token-requests/%v", org, requestID)
 
-	req, err := s.client.NewRequest("POST", u, &opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, &opts)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // addListFineGrainedPATOptions adds the owner and token_id parameters to the URL query string with the correct format if they are set.

--- a/github/orgs_properties.go
+++ b/github/orgs_properties.go
@@ -162,13 +162,13 @@ func (cpv *CustomPropertyValue) UnmarshalJSON(data []byte) error {
 func (s *OrganizationsService) GetAllCustomProperties(ctx context.Context, org string) ([]*CustomProperty, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/properties/schema", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var customProperties []*CustomProperty
-	resp, err := s.client.Do(ctx, req, &customProperties)
+	resp, err := s.client.Do(req, &customProperties)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -190,13 +190,13 @@ func (s *OrganizationsService) CreateOrUpdateCustomProperties(ctx context.Contex
 		Properties: properties,
 	}
 
-	req, err := s.client.NewRequest("PATCH", u, params)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, params)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var customProperties []*CustomProperty
-	resp, err := s.client.Do(ctx, req, &customProperties)
+	resp, err := s.client.Do(req, &customProperties)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -212,13 +212,13 @@ func (s *OrganizationsService) CreateOrUpdateCustomProperties(ctx context.Contex
 func (s *OrganizationsService) GetCustomProperty(ctx context.Context, org, name string) (*CustomProperty, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/properties/schema/%v", org, name)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var customProperty *CustomProperty
-	resp, err := s.client.Do(ctx, req, &customProperty)
+	resp, err := s.client.Do(req, &customProperty)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -234,13 +234,13 @@ func (s *OrganizationsService) GetCustomProperty(ctx context.Context, org, name 
 func (s *OrganizationsService) CreateOrUpdateCustomProperty(ctx context.Context, org, customPropertyName string, property *CustomProperty) (*CustomProperty, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/properties/schema/%v", org, customPropertyName)
 
-	req, err := s.client.NewRequest("PUT", u, property)
+	req, err := s.client.NewRequest(ctx, "PUT", u, property)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var customProperty *CustomProperty
-	resp, err := s.client.Do(ctx, req, &customProperty)
+	resp, err := s.client.Do(req, &customProperty)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -256,12 +256,12 @@ func (s *OrganizationsService) CreateOrUpdateCustomProperty(ctx context.Context,
 func (s *OrganizationsService) RemoveCustomProperty(ctx context.Context, org, customPropertyName string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/properties/schema/%v", org, customPropertyName)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListCustomPropertyValues lists all custom property values for repositories in the specified organization.
@@ -276,13 +276,13 @@ func (s *OrganizationsService) ListCustomPropertyValues(ctx context.Context, org
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var repoCustomPropertyValues []*RepoCustomPropertyValue
-	resp, err := s.client.Do(ctx, req, &repoCustomPropertyValues)
+	resp, err := s.client.Do(req, &repoCustomPropertyValues)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -306,10 +306,10 @@ func (s *OrganizationsService) CreateOrUpdateRepoCustomPropertyValues(ctx contex
 		Properties:      properties,
 	}
 
-	req, err := s.client.NewRequest("PATCH", u, params)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, params)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/orgs_rules.go
+++ b/github/orgs_rules.go
@@ -23,13 +23,13 @@ func (s *OrganizationsService) GetAllRepositoryRulesets(ctx context.Context, org
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var rulesets []*RepositoryRuleset
-	resp, err := s.client.Do(ctx, req, &rulesets)
+	resp, err := s.client.Do(req, &rulesets)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -45,13 +45,13 @@ func (s *OrganizationsService) GetAllRepositoryRulesets(ctx context.Context, org
 func (s *OrganizationsService) CreateRepositoryRuleset(ctx context.Context, org string, ruleset RepositoryRuleset) (*RepositoryRuleset, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/rulesets", org)
 
-	req, err := s.client.NewRequest("POST", u, ruleset)
+	req, err := s.client.NewRequest(ctx, "POST", u, ruleset)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var rs *RepositoryRuleset
-	resp, err := s.client.Do(ctx, req, &rs)
+	resp, err := s.client.Do(req, &rs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -67,13 +67,13 @@ func (s *OrganizationsService) CreateRepositoryRuleset(ctx context.Context, org 
 func (s *OrganizationsService) GetRepositoryRuleset(ctx context.Context, org string, rulesetID int64) (*RepositoryRuleset, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/rulesets/%v", org, rulesetID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var ruleset *RepositoryRuleset
-	resp, err := s.client.Do(ctx, req, &ruleset)
+	resp, err := s.client.Do(req, &ruleset)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -89,13 +89,13 @@ func (s *OrganizationsService) GetRepositoryRuleset(ctx context.Context, org str
 func (s *OrganizationsService) UpdateRepositoryRuleset(ctx context.Context, org string, rulesetID int64, ruleset RepositoryRuleset) (*RepositoryRuleset, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/rulesets/%v", org, rulesetID)
 
-	req, err := s.client.NewRequest("PUT", u, ruleset)
+	req, err := s.client.NewRequest(ctx, "PUT", u, ruleset)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var rs *RepositoryRuleset
-	resp, err := s.client.Do(ctx, req, &rs)
+	resp, err := s.client.Do(req, &rs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -111,10 +111,10 @@ func (s *OrganizationsService) UpdateRepositoryRuleset(ctx context.Context, org 
 func (s *OrganizationsService) DeleteRepositoryRuleset(ctx context.Context, org string, rulesetID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/rulesets/%v", org, rulesetID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/orgs_security_managers.go
+++ b/github/orgs_security_managers.go
@@ -20,13 +20,13 @@ import (
 func (s *OrganizationsService) ListSecurityManagerTeams(ctx context.Context, org string) ([]*Team, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/security-managers", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teams []*Team
-	resp, err := s.client.Do(ctx, req, &teams)
+	resp, err := s.client.Do(req, &teams)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -43,12 +43,12 @@ func (s *OrganizationsService) ListSecurityManagerTeams(ctx context.Context, org
 //meta:operation PUT /orgs/{org}/security-managers/teams/{team_slug}
 func (s *OrganizationsService) AddSecurityManagerTeam(ctx context.Context, org, team string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/security-managers/teams/%v", org, team)
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RemoveSecurityManagerTeam removes a team from the list of security managers for an organization.
@@ -60,10 +60,10 @@ func (s *OrganizationsService) AddSecurityManagerTeam(ctx context.Context, org, 
 //meta:operation DELETE /orgs/{org}/security-managers/teams/{team_slug}
 func (s *OrganizationsService) RemoveSecurityManagerTeam(ctx context.Context, org, team string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/security-managers/teams/%v", org, team)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/orgs_users_blocking.go
+++ b/github/orgs_users_blocking.go
@@ -22,7 +22,7 @@ func (s *OrganizationsService) ListBlockedUsers(ctx context.Context, org string,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -30,7 +30,7 @@ func (s *OrganizationsService) ListBlockedUsers(ctx context.Context, org string,
 	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
 
 	var blockedUsers []*User
-	resp, err := s.client.Do(ctx, req, &blockedUsers)
+	resp, err := s.client.Do(req, &blockedUsers)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -46,14 +46,14 @@ func (s *OrganizationsService) ListBlockedUsers(ctx context.Context, org string,
 func (s *OrganizationsService) IsBlocked(ctx context.Context, org, user string) (bool, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/blocks/%v", org, user)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return false, nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	isBlocked, err := parseBoolResponse(err)
 	return isBlocked, resp, err
 }
@@ -66,14 +66,14 @@ func (s *OrganizationsService) IsBlocked(ctx context.Context, org, user string) 
 func (s *OrganizationsService) BlockUser(ctx context.Context, org, user string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/blocks/%v", org, user)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // UnblockUser unblocks specified user from an organization.
@@ -84,12 +84,12 @@ func (s *OrganizationsService) BlockUser(ctx context.Context, org, user string) 
 func (s *OrganizationsService) UnblockUser(ctx context.Context, org, user string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/blocks/%v", org, user)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/private_registries.go
+++ b/github/private_registries.go
@@ -139,13 +139,13 @@ func (s *PrivateRegistriesService) ListOrganizationPrivateRegistries(ctx context
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var privateRegistries PrivateRegistries
-	resp, err := s.client.Do(ctx, req, &privateRegistries)
+	resp, err := s.client.Do(req, &privateRegistries)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -160,13 +160,13 @@ func (s *PrivateRegistriesService) ListOrganizationPrivateRegistries(ctx context
 func (s *PrivateRegistriesService) CreateOrganizationPrivateRegistry(ctx context.Context, org string, privateRegistry CreateOrganizationPrivateRegistry) (*PrivateRegistry, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries", org)
 
-	req, err := s.client.NewRequest("POST", u, privateRegistry)
+	req, err := s.client.NewRequest(ctx, "POST", u, privateRegistry)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var result PrivateRegistry
-	resp, err := s.client.Do(ctx, req, &result)
+	resp, err := s.client.Do(req, &result)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -181,13 +181,13 @@ func (s *PrivateRegistriesService) CreateOrganizationPrivateRegistry(ctx context
 func (s *PrivateRegistriesService) GetOrganizationPrivateRegistriesPublicKey(ctx context.Context, org string) (*PublicKey, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/public-key", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var publicKey PublicKey
-	resp, err := s.client.Do(ctx, req, &publicKey)
+	resp, err := s.client.Do(req, &publicKey)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -203,13 +203,13 @@ func (s *PrivateRegistriesService) GetOrganizationPrivateRegistriesPublicKey(ctx
 func (s *PrivateRegistriesService) GetOrganizationPrivateRegistry(ctx context.Context, org, secretName string) (*PrivateRegistry, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/%v", org, secretName)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var privateRegistry PrivateRegistry
-	resp, err := s.client.Do(ctx, req, &privateRegistry)
+	resp, err := s.client.Do(req, &privateRegistry)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -226,13 +226,13 @@ func (s *PrivateRegistriesService) GetOrganizationPrivateRegistry(ctx context.Co
 func (s *PrivateRegistriesService) UpdateOrganizationPrivateRegistry(ctx context.Context, org, secretName string, privateRegistry UpdateOrganizationPrivateRegistry) (*PrivateRegistry, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/%v", org, secretName)
 
-	req, err := s.client.NewRequest("PATCH", u, privateRegistry)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, privateRegistry)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var updatedRegistry PrivateRegistry
-	resp, err := s.client.Do(ctx, req, &updatedRegistry)
+	resp, err := s.client.Do(req, &updatedRegistry)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -249,12 +249,12 @@ func (s *PrivateRegistriesService) UpdateOrganizationPrivateRegistry(ctx context
 func (s *PrivateRegistriesService) DeleteOrganizationPrivateRegistry(ctx context.Context, org, secretName string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/%v", org, secretName)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/github/projects.go
+++ b/github/projects.go
@@ -285,13 +285,13 @@ func (s *ProjectsService) ListOrganizationProjects(ctx context.Context, org stri
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var projects []*ProjectV2
-	resp, err := s.client.Do(ctx, req, &projects)
+	resp, err := s.client.Do(req, &projects)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -306,13 +306,13 @@ func (s *ProjectsService) ListOrganizationProjects(ctx context.Context, org stri
 //meta:operation GET /orgs/{org}/projectsV2/{project_number}
 func (s *ProjectsService) GetOrganizationProject(ctx context.Context, org string, projectNumber int) (*ProjectV2, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/projectsV2/%v", org, projectNumber)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var project *ProjectV2
-	resp, err := s.client.Do(ctx, req, &project)
+	resp, err := s.client.Do(req, &project)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -331,13 +331,13 @@ func (s *ProjectsService) ListUserProjects(ctx context.Context, username string,
 	if err != nil {
 		return nil, nil, err
 	}
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var projects []*ProjectV2
-	resp, err := s.client.Do(ctx, req, &projects)
+	resp, err := s.client.Do(req, &projects)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -352,13 +352,13 @@ func (s *ProjectsService) ListUserProjects(ctx context.Context, username string,
 //meta:operation GET /users/{username}/projectsV2/{project_number}
 func (s *ProjectsService) GetUserProject(ctx context.Context, username string, projectNumber int) (*ProjectV2, *Response, error) {
 	u := fmt.Sprintf("users/%v/projectsV2/%v", username, projectNumber)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var project *ProjectV2
-	resp, err := s.client.Do(ctx, req, &project)
+	resp, err := s.client.Do(req, &project)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -378,13 +378,13 @@ func (s *ProjectsService) ListOrganizationProjectFields(ctx context.Context, org
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var fields []*ProjectV2Field
-	resp, err := s.client.Do(ctx, req, &fields)
+	resp, err := s.client.Do(req, &fields)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -404,13 +404,13 @@ func (s *ProjectsService) ListUserProjectFields(ctx context.Context, user string
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var fields []*ProjectV2Field
-	resp, err := s.client.Do(ctx, req, &fields)
+	resp, err := s.client.Do(req, &fields)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -425,13 +425,13 @@ func (s *ProjectsService) ListUserProjectFields(ctx context.Context, user string
 //meta:operation GET /orgs/{org}/projectsV2/{project_number}/fields/{field_id}
 func (s *ProjectsService) GetOrganizationProjectField(ctx context.Context, org string, projectNumber int, fieldID int64) (*ProjectV2Field, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/projectsV2/%v/fields/%v", org, projectNumber, fieldID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var field *ProjectV2Field
-	resp, err := s.client.Do(ctx, req, &field)
+	resp, err := s.client.Do(req, &field)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -446,13 +446,13 @@ func (s *ProjectsService) GetOrganizationProjectField(ctx context.Context, org s
 //meta:operation GET /users/{username}/projectsV2/{project_number}/fields/{field_id}
 func (s *ProjectsService) GetUserProjectField(ctx context.Context, user string, projectNumber int, fieldID int64) (*ProjectV2Field, *Response, error) {
 	u := fmt.Sprintf("users/%v/projectsV2/%v/fields/%v", user, projectNumber, fieldID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var field *ProjectV2Field
-	resp, err := s.client.Do(ctx, req, &field)
+	resp, err := s.client.Do(req, &field)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -523,13 +523,13 @@ func (s *ProjectsService) ListOrganizationProjectItems(ctx context.Context, org 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var items []*ProjectV2Item
-	resp, err := s.client.Do(ctx, req, &items)
+	resp, err := s.client.Do(req, &items)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -544,13 +544,13 @@ func (s *ProjectsService) ListOrganizationProjectItems(ctx context.Context, org 
 //meta:operation POST /orgs/{org}/projectsV2/{project_number}/items
 func (s *ProjectsService) AddOrganizationProjectItem(ctx context.Context, org string, projectNumber int, opts *AddProjectItemOptions) (*ProjectV2Item, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/projectsV2/%v/items", org, projectNumber)
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var item *ProjectV2Item
-	resp, err := s.client.Do(ctx, req, &item)
+	resp, err := s.client.Do(req, &item)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -570,13 +570,13 @@ func (s *ProjectsService) GetOrganizationProjectItem(ctx context.Context, org st
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var item *ProjectV2Item
-	resp, err := s.client.Do(ctx, req, &item)
+	resp, err := s.client.Do(req, &item)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -591,13 +591,13 @@ func (s *ProjectsService) GetOrganizationProjectItem(ctx context.Context, org st
 //meta:operation PATCH /orgs/{org}/projectsV2/{project_number}/items/{item_id}
 func (s *ProjectsService) UpdateOrganizationProjectItem(ctx context.Context, org string, projectNumber int, itemID int64, opts *UpdateProjectItemOptions) (*ProjectV2Item, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/projectsV2/%v/items/%v", org, projectNumber, itemID)
-	req, err := s.client.NewRequest("PATCH", u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var item *ProjectV2Item
-	resp, err := s.client.Do(ctx, req, &item)
+	resp, err := s.client.Do(req, &item)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -612,12 +612,12 @@ func (s *ProjectsService) UpdateOrganizationProjectItem(ctx context.Context, org
 //meta:operation DELETE /orgs/{org}/projectsV2/{project_number}/items/{item_id}
 func (s *ProjectsService) DeleteOrganizationProjectItem(ctx context.Context, org string, projectNumber int, itemID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/projectsV2/%v/items/%v", org, projectNumber, itemID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListUserProjectItems lists items for a user owned project.
@@ -632,13 +632,13 @@ func (s *ProjectsService) ListUserProjectItems(ctx context.Context, username str
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var items []*ProjectV2Item
-	resp, err := s.client.Do(ctx, req, &items)
+	resp, err := s.client.Do(req, &items)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -653,13 +653,13 @@ func (s *ProjectsService) ListUserProjectItems(ctx context.Context, username str
 //meta:operation POST /users/{username}/projectsV2/{project_number}/items
 func (s *ProjectsService) AddUserProjectItem(ctx context.Context, username string, projectNumber int, opts *AddProjectItemOptions) (*ProjectV2Item, *Response, error) {
 	u := fmt.Sprintf("users/%v/projectsV2/%v/items", username, projectNumber)
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var item *ProjectV2Item
-	resp, err := s.client.Do(ctx, req, &item)
+	resp, err := s.client.Do(req, &item)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -679,13 +679,13 @@ func (s *ProjectsService) GetUserProjectItem(ctx context.Context, username strin
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var item *ProjectV2Item
-	resp, err := s.client.Do(ctx, req, &item)
+	resp, err := s.client.Do(req, &item)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -700,13 +700,13 @@ func (s *ProjectsService) GetUserProjectItem(ctx context.Context, username strin
 //meta:operation PATCH /users/{username}/projectsV2/{project_number}/items/{item_id}
 func (s *ProjectsService) UpdateUserProjectItem(ctx context.Context, username string, projectNumber int, itemID int64, opts *UpdateProjectItemOptions) (*ProjectV2Item, *Response, error) {
 	u := fmt.Sprintf("users/%v/projectsV2/%v/items/%v", username, projectNumber, itemID)
-	req, err := s.client.NewRequest("PATCH", u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var item *ProjectV2Item
-	resp, err := s.client.Do(ctx, req, &item)
+	resp, err := s.client.Do(req, &item)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -721,10 +721,10 @@ func (s *ProjectsService) UpdateUserProjectItem(ctx context.Context, username st
 //meta:operation DELETE /users/{username}/projectsV2/{project_number}/items/{item_id}
 func (s *ProjectsService) DeleteUserProjectItem(ctx context.Context, username string, projectNumber int, itemID int64) (*Response, error) {
 	u := fmt.Sprintf("users/%v/projectsV2/%v/items/%v", username, projectNumber, itemID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -161,13 +161,13 @@ func (s *PullRequestsService) List(ctx context.Context, owner, repo string, opts
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var pulls []*PullRequest
-	resp, err := s.client.Do(ctx, req, &pulls)
+	resp, err := s.client.Do(req, &pulls)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -192,14 +192,14 @@ func (s *PullRequestsService) ListPullRequestsWithCommit(ctx context.Context, ow
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeListPullsOrBranchesForCommitPreview)
 	var pulls []*PullRequest
-	resp, err := s.client.Do(ctx, req, &pulls)
+	resp, err := s.client.Do(req, &pulls)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -214,13 +214,13 @@ func (s *PullRequestsService) ListPullRequestsWithCommit(ctx context.Context, ow
 //meta:operation GET /repos/{owner}/{repo}/pulls/{pull_number}
 func (s *PullRequestsService) Get(ctx context.Context, owner, repo string, number int) (*PullRequest, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v", owner, repo, number)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var pull *PullRequest
-	resp, err := s.client.Do(ctx, req, &pull)
+	resp, err := s.client.Do(req, &pull)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -235,7 +235,7 @@ func (s *PullRequestsService) Get(ctx context.Context, owner, repo string, numbe
 //meta:operation GET /repos/{owner}/{repo}/pulls/{pull_number}
 func (s *PullRequestsService) GetRaw(ctx context.Context, owner, repo string, number int, opts RawOptions) (string, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v", owner, repo, number)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return "", nil, err
 	}
@@ -250,7 +250,7 @@ func (s *PullRequestsService) GetRaw(ctx context.Context, owner, repo string, nu
 	}
 
 	var buf bytes.Buffer
-	resp, err := s.client.Do(ctx, req, &buf)
+	resp, err := s.client.Do(req, &buf)
 	if err != nil {
 		return "", resp, err
 	}
@@ -284,13 +284,13 @@ type NewPullRequest struct {
 //meta:operation POST /repos/{owner}/{repo}/pulls
 func (s *PullRequestsService) Create(ctx context.Context, owner, repo string, pull *NewPullRequest) (*PullRequest, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls", owner, repo)
-	req, err := s.client.NewRequest("POST", u, pull)
+	req, err := s.client.NewRequest(ctx, "POST", u, pull)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var p *PullRequest
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -326,7 +326,7 @@ type PullRequestBranchUpdateResponse struct {
 func (s *PullRequestsService) UpdateBranch(ctx context.Context, owner, repo string, number int, opts *PullRequestBranchUpdateOptions) (*PullRequestBranchUpdateResponse, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/update-branch", owner, repo, number)
 
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -334,7 +334,7 @@ func (s *PullRequestsService) UpdateBranch(ctx context.Context, owner, repo stri
 	req.Header.Set("Accept", mediaTypeUpdatePullRequestBranchPreview)
 
 	var p *PullRequestBranchUpdateResponse
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -379,13 +379,13 @@ func (s *PullRequestsService) Edit(ctx context.Context, owner, repo string, numb
 		update.Base = pull.Base.Ref
 	}
 
-	req, err := s.client.NewRequest("PATCH", u, update)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, update)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var p *PullRequest
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -405,13 +405,13 @@ func (s *PullRequestsService) ListCommits(ctx context.Context, owner, repo strin
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var commits []*RepositoryCommit
-	resp, err := s.client.Do(ctx, req, &commits)
+	resp, err := s.client.Do(req, &commits)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -431,13 +431,13 @@ func (s *PullRequestsService) ListFiles(ctx context.Context, owner, repo string,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var commitFiles []*CommitFile
-	resp, err := s.client.Do(ctx, req, &commitFiles)
+	resp, err := s.client.Do(req, &commitFiles)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -452,12 +452,12 @@ func (s *PullRequestsService) ListFiles(ctx context.Context, owner, repo string,
 //meta:operation GET /repos/{owner}/{repo}/pulls/{pull_number}/merge
 func (s *PullRequestsService) IsMerged(ctx context.Context, owner, repo string, number int) (bool, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/merge", owner, repo, number)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return false, nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	merged, err := parseBoolResponse(err)
 	return merged, resp, err
 }
@@ -509,13 +509,13 @@ func (s *PullRequestsService) Merge(ctx context.Context, owner, repo string, num
 			pullRequestBody.CommitMessage = &commitMessage
 		}
 	}
-	req, err := s.client.NewRequest("PUT", u, &pullRequestBody)
+	req, err := s.client.NewRequest(ctx, "PUT", u, &pullRequestBody)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var mergeResult *PullRequestMergeResult
-	resp, err := s.client.Do(ctx, req, &mergeResult)
+	resp, err := s.client.Do(req, &mergeResult)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -90,7 +90,7 @@ func (s *PullRequestsService) ListComments(ctx context.Context, owner, repo stri
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -99,7 +99,7 @@ func (s *PullRequestsService) ListComments(ctx context.Context, owner, repo stri
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var comments []*PullRequestComment
-	resp, err := s.client.Do(ctx, req, &comments)
+	resp, err := s.client.Do(req, &comments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -114,7 +114,7 @@ func (s *PullRequestsService) ListComments(ctx context.Context, owner, repo stri
 //meta:operation GET /repos/{owner}/{repo}/pulls/comments/{comment_id}
 func (s *PullRequestsService) GetComment(ctx context.Context, owner, repo string, commentID int64) (*PullRequestComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%v", owner, repo, commentID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -123,7 +123,7 @@ func (s *PullRequestsService) GetComment(ctx context.Context, owner, repo string
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var comment *PullRequestComment
-	resp, err := s.client.Do(ctx, req, &comment)
+	resp, err := s.client.Do(req, &comment)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -138,7 +138,7 @@ func (s *PullRequestsService) GetComment(ctx context.Context, owner, repo string
 //meta:operation POST /repos/{owner}/{repo}/pulls/{pull_number}/comments
 func (s *PullRequestsService) CreateComment(ctx context.Context, owner, repo string, number int, comment *PullRequestComment) (*PullRequestComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/comments", owner, repo, number)
-	req, err := s.client.NewRequest("POST", u, comment)
+	req, err := s.client.NewRequest(ctx, "POST", u, comment)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -146,7 +146,7 @@ func (s *PullRequestsService) CreateComment(ctx context.Context, owner, repo str
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var c *PullRequestComment
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -168,13 +168,13 @@ func (s *PullRequestsService) CreateCommentInReplyTo(ctx context.Context, owner,
 		InReplyTo: commentID,
 	}
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/comments", owner, repo, number)
-	req, err := s.client.NewRequest("POST", u, comment)
+	req, err := s.client.NewRequest(ctx, "POST", u, comment)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var c *PullRequestComment
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -190,13 +190,13 @@ func (s *PullRequestsService) CreateCommentInReplyTo(ctx context.Context, owner,
 //meta:operation PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}
 func (s *PullRequestsService) EditComment(ctx context.Context, owner, repo string, commentID int64, comment *PullRequestComment) (*PullRequestComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%v", owner, repo, commentID)
-	req, err := s.client.NewRequest("PATCH", u, comment)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var c *PullRequestComment
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -211,10 +211,10 @@ func (s *PullRequestsService) EditComment(ctx context.Context, owner, repo strin
 //meta:operation DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}
 func (s *PullRequestsService) DeleteComment(ctx context.Context, owner, repo string, commentID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%v", owner, repo, commentID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/pulls_reviewers.go
+++ b/github/pulls_reviewers.go
@@ -37,13 +37,13 @@ type removeReviewersRequest struct {
 //meta:operation POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
 func (s *PullRequestsService) RequestReviewers(ctx context.Context, owner, repo string, number int, reviewers ReviewersRequest) (*PullRequest, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/requested_reviewers", owner, repo, number)
-	req, err := s.client.NewRequest("POST", u, &reviewers)
+	req, err := s.client.NewRequest(ctx, "POST", u, &reviewers)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *PullRequest
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -59,13 +59,13 @@ func (s *PullRequestsService) RequestReviewers(ctx context.Context, owner, repo 
 func (s *PullRequestsService) ListReviewers(ctx context.Context, owner, repo string, number int) (*Reviewers, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/requested_reviewers", owner, repo, number)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var reviewers *Reviewers
-	resp, err := s.client.Do(ctx, req, &reviewers)
+	resp, err := s.client.Do(req, &reviewers)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -90,10 +90,10 @@ func (s *PullRequestsService) RemoveReviewers(ctx context.Context, owner, repo s
 	}
 
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/requested_reviewers", owner, repo, number)
-	req, err := s.client.NewRequest("DELETE", u, &removeRequest)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, &removeRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/pulls_reviews.go
+++ b/github/pulls_reviews.go
@@ -114,13 +114,13 @@ func (s *PullRequestsService) ListReviews(ctx context.Context, owner, repo strin
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var reviews []*PullRequestReview
-	resp, err := s.client.Do(ctx, req, &reviews)
+	resp, err := s.client.Do(req, &reviews)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -136,13 +136,13 @@ func (s *PullRequestsService) ListReviews(ctx context.Context, owner, repo strin
 func (s *PullRequestsService) GetReview(ctx context.Context, owner, repo string, number int, reviewID int64) (*PullRequestReview, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/reviews/%v", owner, repo, number, reviewID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var review *PullRequestReview
-	resp, err := s.client.Do(ctx, req, &review)
+	resp, err := s.client.Do(req, &review)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -158,13 +158,13 @@ func (s *PullRequestsService) GetReview(ctx context.Context, owner, repo string,
 func (s *PullRequestsService) DeletePendingReview(ctx context.Context, owner, repo string, number int, reviewID int64) (*PullRequestReview, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/reviews/%v", owner, repo, number, reviewID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var review *PullRequestReview
-	resp, err := s.client.Do(ctx, req, &review)
+	resp, err := s.client.Do(req, &review)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -184,13 +184,13 @@ func (s *PullRequestsService) ListReviewComments(ctx context.Context, owner, rep
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var comments []*PullRequestComment
-	resp, err := s.client.Do(ctx, req, &comments)
+	resp, err := s.client.Do(req, &comments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -240,7 +240,7 @@ func (s *PullRequestsService) ListReviewComments(ctx context.Context, owner, rep
 func (s *PullRequestsService) CreateReview(ctx context.Context, owner, repo string, number int, review *PullRequestReviewRequest) (*PullRequestReview, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/reviews", owner, repo, number)
 
-	req, err := s.client.NewRequest("POST", u, review)
+	req, err := s.client.NewRequest(ctx, "POST", u, review)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -255,7 +255,7 @@ func (s *PullRequestsService) CreateReview(ctx context.Context, owner, repo stri
 	}
 
 	var r *PullRequestReview
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -274,13 +274,13 @@ func (s *PullRequestsService) UpdateReview(ctx context.Context, owner, repo stri
 	}{Body: body}
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/reviews/%v", owner, repo, number, reviewID)
 
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var review *PullRequestReview
-	resp, err := s.client.Do(ctx, req, &review)
+	resp, err := s.client.Do(req, &review)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -296,13 +296,13 @@ func (s *PullRequestsService) UpdateReview(ctx context.Context, owner, repo stri
 func (s *PullRequestsService) SubmitReview(ctx context.Context, owner, repo string, number int, reviewID int64, review *PullRequestReviewRequest) (*PullRequestReview, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/reviews/%v/events", owner, repo, number, reviewID)
 
-	req, err := s.client.NewRequest("POST", u, review)
+	req, err := s.client.NewRequest(ctx, "POST", u, review)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *PullRequestReview
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -318,13 +318,13 @@ func (s *PullRequestsService) SubmitReview(ctx context.Context, owner, repo stri
 func (s *PullRequestsService) DismissReview(ctx context.Context, owner, repo string, number int, reviewID int64, review *PullRequestReviewDismissalRequest) (*PullRequestReview, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/reviews/%v/dismissals", owner, repo, number, reviewID)
 
-	req, err := s.client.NewRequest("PUT", u, review)
+	req, err := s.client.NewRequest(ctx, "PUT", u, review)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *PullRequestReview
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/rate_limit.go
+++ b/github/rate_limit.go
@@ -76,7 +76,12 @@ func (r RateLimits) String() string {
 //
 //meta:operation GET /rate_limit
 func (s *RateLimitService) Get(ctx context.Context) (*RateLimits, *Response, error) {
-	req, err := s.client.NewRequest("GET", "rate_limit", nil)
+	// This resource is not subject to rate limits.
+	if !s.client.DisableRateLimitCheck {
+		ctx = context.WithValue(ctx, BypassRateLimitCheck, true)
+	}
+
+	req, err := s.client.NewRequest(ctx, "GET", "rate_limit", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -85,9 +90,7 @@ func (s *RateLimitService) Get(ctx context.Context) (*RateLimits, *Response, err
 		Resources *RateLimits `json:"resources"`
 	})
 
-	// This resource is not subject to rate limits.
-	ctx = context.WithValue(ctx, BypassRateLimitCheck, true)
-	resp, err := s.client.Do(ctx, req, response)
+	resp, err := s.client.Do(req, response)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/rate_limit_test.go
+++ b/github/rate_limit_test.go
@@ -386,6 +386,48 @@ func TestRateLimits_overQuota(t *testing.T) {
 	}
 }
 
+func TestRateLimits_bypassRateLimitCheckContext(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                  string
+		disableRateLimitCheck bool
+		wantBypassValue       any
+	}{
+		{
+			name:                  "DisableRateLimitCheck disabled",
+			disableRateLimitCheck: false,
+			wantBypassValue:       true,
+		},
+		{
+			name:                  "DisableRateLimitCheck enabled",
+			disableRateLimitCheck: true,
+			wantBypassValue:       nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client, mux, _ := setup(t)
+			client.DisableRateLimitCheck = tt.disableRateLimitCheck
+
+			mux.HandleFunc("/rate_limit", func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "GET")
+				fmt.Fprint(w, `{"resources":{}}`)
+			})
+
+			_, resp, err := client.RateLimit.Get(t.Context())
+			if err != nil {
+				t.Errorf("RateLimits returned error: %v", err)
+			}
+
+			if got, want := resp.Request.Context().Value(BypassRateLimitCheck), tt.wantBypassValue; got != want {
+				t.Errorf("Request context bypass value = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
 func TestRateLimits_Marshal(t *testing.T) {
 	t.Parallel()
 	testJSONMarshal(t, &RateLimits{}, `{

--- a/github/reactions.go
+++ b/github/reactions.go
@@ -69,7 +69,7 @@ func (s *ReactionsService) ListCommentReactions(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -77,7 +77,7 @@ func (s *ReactionsService) ListCommentReactions(ctx context.Context, owner, repo
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var m []*Reaction
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -97,7 +97,7 @@ func (s *ReactionsService) CreateCommentReaction(ctx context.Context, owner, rep
 	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions", owner, repo, id)
 
 	body := &Reaction{Content: &content}
-	req, err := s.client.NewRequest("POST", u, body)
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -105,7 +105,7 @@ func (s *ReactionsService) CreateCommentReaction(ctx context.Context, owner, rep
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var m *Reaction
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -147,7 +147,7 @@ func (s *ReactionsService) ListIssueReactions(ctx context.Context, owner, repo s
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -155,7 +155,7 @@ func (s *ReactionsService) ListIssueReactions(ctx context.Context, owner, repo s
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var m []*Reaction
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -175,7 +175,7 @@ func (s *ReactionsService) CreateIssueReaction(ctx context.Context, owner, repo 
 	u := fmt.Sprintf("repos/%v/%v/issues/%v/reactions", owner, repo, number)
 
 	body := &Reaction{Content: &content}
-	req, err := s.client.NewRequest("POST", u, body)
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -183,7 +183,7 @@ func (s *ReactionsService) CreateIssueReaction(ctx context.Context, owner, repo 
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var m *Reaction
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -225,7 +225,7 @@ func (s *ReactionsService) ListIssueCommentReactions(ctx context.Context, owner,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -233,7 +233,7 @@ func (s *ReactionsService) ListIssueCommentReactions(ctx context.Context, owner,
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var m []*Reaction
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -253,7 +253,7 @@ func (s *ReactionsService) CreateIssueCommentReaction(ctx context.Context, owner
 	u := fmt.Sprintf("repos/%v/%v/issues/comments/%v/reactions", owner, repo, id)
 
 	body := &Reaction{Content: &content}
-	req, err := s.client.NewRequest("POST", u, body)
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -261,7 +261,7 @@ func (s *ReactionsService) CreateIssueCommentReaction(ctx context.Context, owner
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var m *Reaction
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -303,7 +303,7 @@ func (s *ReactionsService) ListPullRequestCommentReactions(ctx context.Context, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -311,7 +311,7 @@ func (s *ReactionsService) ListPullRequestCommentReactions(ctx context.Context, 
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var m []*Reaction
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -331,7 +331,7 @@ func (s *ReactionsService) CreatePullRequestCommentReaction(ctx context.Context,
 	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%v/reactions", owner, repo, id)
 
 	body := &Reaction{Content: &content}
-	req, err := s.client.NewRequest("POST", u, body)
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -339,7 +339,7 @@ func (s *ReactionsService) CreatePullRequestCommentReaction(ctx context.Context,
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var m *Reaction
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -381,7 +381,7 @@ func (s *ReactionsService) ListTeamDiscussionReactions(ctx context.Context, team
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -389,7 +389,7 @@ func (s *ReactionsService) ListTeamDiscussionReactions(ctx context.Context, team
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var m []*Reaction
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -407,7 +407,7 @@ func (s *ReactionsService) CreateTeamDiscussionReaction(ctx context.Context, tea
 	u := fmt.Sprintf("teams/%v/discussions/%v/reactions", teamID, discussionNumber)
 
 	body := &Reaction{Content: &content}
-	req, err := s.client.NewRequest("POST", u, body)
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -415,7 +415,7 @@ func (s *ReactionsService) CreateTeamDiscussionReaction(ctx context.Context, tea
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var m *Reaction
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -457,7 +457,7 @@ func (s *ReactionsService) ListTeamDiscussionCommentReactions(ctx context.Contex
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -465,7 +465,7 @@ func (s *ReactionsService) ListTeamDiscussionCommentReactions(ctx context.Contex
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var m []*Reaction
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -482,7 +482,7 @@ func (s *ReactionsService) CreateTeamDiscussionCommentReaction(ctx context.Conte
 	u := fmt.Sprintf("teams/%v/discussions/%v/comments/%v/reactions", teamID, discussionNumber, commentNumber)
 
 	body := &Reaction{Content: &content}
-	req, err := s.client.NewRequest("POST", u, body)
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -490,7 +490,7 @@ func (s *ReactionsService) CreateTeamDiscussionCommentReaction(ctx context.Conte
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var m *Reaction
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -521,14 +521,14 @@ func (s *ReactionsService) DeleteTeamDiscussionCommentReactionByOrgIDAndTeamID(c
 }
 
 func (s *ReactionsService) deleteReaction(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest("DELETE", url, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // CreateReleaseReaction creates a reaction to a release.
@@ -543,7 +543,7 @@ func (s *ReactionsService) CreateReleaseReaction(ctx context.Context, owner, rep
 	u := fmt.Sprintf("repos/%v/%v/releases/%v/reactions", owner, repo, releaseID)
 
 	body := &Reaction{Content: &content}
-	req, err := s.client.NewRequest("POST", u, body)
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -551,7 +551,7 @@ func (s *ReactionsService) CreateReleaseReaction(ctx context.Context, owner, rep
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var m *Reaction
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -571,7 +571,7 @@ func (s *ReactionsService) ListReleaseReactions(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -579,7 +579,7 @@ func (s *ReactionsService) ListReleaseReactions(ctx context.Context, owner, repo
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var m []*Reaction
-	resp, err := s.client.Do(ctx, req, &m)
+	resp, err := s.client.Do(req, &m)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos.go
+++ b/github/repos.go
@@ -344,13 +344,13 @@ func (s *RepositoriesService) ListByUser(ctx context.Context, user string, opts 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var repos []*Repository
-	resp, err := s.client.Do(ctx, req, &repos)
+	resp, err := s.client.Do(req, &repos)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -407,13 +407,13 @@ func (s *RepositoriesService) ListByAuthenticatedUser(ctx context.Context, opts 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var repos []*Repository
-	resp, err := s.client.Do(ctx, req, &repos)
+	resp, err := s.client.Do(req, &repos)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -451,7 +451,7 @@ func (s *RepositoriesService) ListByOrg(ctx context.Context, org string, opts *R
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -460,7 +460,7 @@ func (s *RepositoriesService) ListByOrg(ctx context.Context, org string, opts *R
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var repos []*Repository
-	resp, err := s.client.Do(ctx, req, &repos)
+	resp, err := s.client.Do(req, &repos)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -486,13 +486,13 @@ func (s *RepositoriesService) ListAll(ctx context.Context, opts *RepositoryListA
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var repos []*Repository
-	resp, err := s.client.Do(ctx, req, &repos)
+	resp, err := s.client.Do(req, &repos)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -600,7 +600,7 @@ func (s *RepositoriesService) Create(ctx context.Context, org string, repo *Repo
 		CustomProperties:          repo.CustomProperties,
 	}
 
-	req, err := s.client.NewRequest("POST", u, repoReq)
+	req, err := s.client.NewRequest(ctx, "POST", u, repoReq)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -608,7 +608,7 @@ func (s *RepositoriesService) Create(ctx context.Context, org string, repo *Repo
 	acceptHeaders := []string{mediaTypeRepositoryTemplatePreview, mediaTypeRepositoryVisibilityPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 	var r *Repository
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -635,14 +635,14 @@ type TemplateRepoRequest struct {
 func (s *RepositoriesService) CreateFromTemplate(ctx context.Context, templateOwner, templateRepo string, templateRepoReq *TemplateRepoRequest) (*Repository, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/generate", templateOwner, templateRepo)
 
-	req, err := s.client.NewRequest("POST", u, templateRepoReq)
+	req, err := s.client.NewRequest(ctx, "POST", u, templateRepoReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeRepositoryTemplatePreview)
 	var r *Repository
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -657,7 +657,7 @@ func (s *RepositoriesService) CreateFromTemplate(ctx context.Context, templateOw
 //meta:operation GET /repos/{owner}/{repo}
 func (s *RepositoriesService) Get(ctx context.Context, owner, repo string) (*Repository, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -672,7 +672,7 @@ func (s *RepositoriesService) Get(ctx context.Context, owner, repo string) (*Rep
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var repository *Repository
-	resp, err := s.client.Do(ctx, req, &repository)
+	resp, err := s.client.Do(req, &repository)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -689,7 +689,7 @@ func (s *RepositoriesService) Get(ctx context.Context, owner, repo string) (*Rep
 //meta:operation GET /repos/{owner}/{repo}
 func (s *RepositoriesService) GetCodeOfConduct(ctx context.Context, owner, repo string) (*CodeOfConduct, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -697,7 +697,7 @@ func (s *RepositoriesService) GetCodeOfConduct(ctx context.Context, owner, repo 
 	req.Header.Set("Accept", mediaTypeCodesOfConductPreview)
 
 	var r *Repository
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -712,13 +712,13 @@ func (s *RepositoriesService) GetCodeOfConduct(ctx context.Context, owner, repo 
 //meta:operation GET /repositories/{repository_id}
 func (s *RepositoriesService) GetByID(ctx context.Context, id int64) (*Repository, *Response, error) {
 	u := fmt.Sprintf("repositories/%v", id)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var repository *Repository
-	resp, err := s.client.Do(ctx, req, &repository)
+	resp, err := s.client.Do(req, &repository)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -733,7 +733,7 @@ func (s *RepositoriesService) GetByID(ctx context.Context, id int64) (*Repositor
 //meta:operation PATCH /repos/{owner}/{repo}
 func (s *RepositoriesService) Edit(ctx context.Context, owner, repo string, repository *Repository) (*Repository, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v", owner, repo)
-	req, err := s.client.NewRequest("PATCH", u, repository)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, repository)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -741,7 +741,7 @@ func (s *RepositoriesService) Edit(ctx context.Context, owner, repo string, repo
 	acceptHeaders := []string{mediaTypeRepositoryTemplatePreview, mediaTypeRepositoryVisibilityPreview}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 	var r *Repository
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -756,12 +756,12 @@ func (s *RepositoriesService) Edit(ctx context.Context, owner, repo string, repo
 //meta:operation DELETE /repos/{owner}/{repo}
 func (s *RepositoriesService) Delete(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v", owner, repo)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // Contributor represents a repository contributor.
@@ -806,14 +806,14 @@ type ListContributorsOptions struct {
 func (s *RepositoriesService) GetVulnerabilityAlerts(ctx context.Context, owner, repository string) (bool, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/vulnerability-alerts", owner, repository)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return false, nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeRequiredVulnerabilityAlertsPreview)
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	vulnerabilityAlertsEnabled, err := parseBoolResponse(err)
 	return vulnerabilityAlertsEnabled, resp, err
 }
@@ -826,14 +826,14 @@ func (s *RepositoriesService) GetVulnerabilityAlerts(ctx context.Context, owner,
 func (s *RepositoriesService) EnableVulnerabilityAlerts(ctx context.Context, owner, repository string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/vulnerability-alerts", owner, repository)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeRequiredVulnerabilityAlertsPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DisableVulnerabilityAlerts disables vulnerability alerts and the dependency graph for a repository.
@@ -844,14 +844,14 @@ func (s *RepositoriesService) EnableVulnerabilityAlerts(ctx context.Context, own
 func (s *RepositoriesService) DisableVulnerabilityAlerts(ctx context.Context, owner, repository string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/vulnerability-alerts", owner, repository)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeRequiredVulnerabilityAlertsPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetAutomatedSecurityFixes checks if the automated security fixes for a repository are enabled.
@@ -862,13 +862,13 @@ func (s *RepositoriesService) DisableVulnerabilityAlerts(ctx context.Context, ow
 func (s *RepositoriesService) GetAutomatedSecurityFixes(ctx context.Context, owner, repository string) (*AutomatedSecurityFixes, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/automated-security-fixes", owner, repository)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var p *AutomatedSecurityFixes
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -883,12 +883,12 @@ func (s *RepositoriesService) GetAutomatedSecurityFixes(ctx context.Context, own
 func (s *RepositoriesService) EnableAutomatedSecurityFixes(ctx context.Context, owner, repository string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/automated-security-fixes", owner, repository)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DisableAutomatedSecurityFixes disables vulnerability alerts and the dependency graph for a repository.
@@ -899,12 +899,12 @@ func (s *RepositoriesService) EnableAutomatedSecurityFixes(ctx context.Context, 
 func (s *RepositoriesService) DisableAutomatedSecurityFixes(ctx context.Context, owner, repository string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/automated-security-fixes", owner, repository)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListContributors lists contributors for a repository.
@@ -919,13 +919,13 @@ func (s *RepositoriesService) ListContributors(ctx context.Context, owner, repos
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var contributor []*Contributor
-	resp, err := s.client.Do(ctx, req, &contributor)
+	resp, err := s.client.Do(req, &contributor)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -947,13 +947,13 @@ func (s *RepositoriesService) ListContributors(ctx context.Context, owner, repos
 //meta:operation GET /repos/{owner}/{repo}/languages
 func (s *RepositoriesService) ListLanguages(ctx context.Context, owner, repo string) (map[string]int, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/languages", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	languages := make(map[string]int)
-	resp, err := s.client.Do(ctx, req, &languages)
+	resp, err := s.client.Do(req, &languages)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -973,13 +973,13 @@ func (s *RepositoriesService) ListTeams(ctx context.Context, owner, repo string,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teams []*Team
-	resp, err := s.client.Do(ctx, req, &teams)
+	resp, err := s.client.Do(req, &teams)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1007,13 +1007,13 @@ func (s *RepositoriesService) ListTags(ctx context.Context, owner, repo string, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var tags []*RepositoryTag
-	resp, err := s.client.Do(ctx, req, &tags)
+	resp, err := s.client.Do(req, &tags)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1441,13 +1441,13 @@ func (s *RepositoriesService) ListBranches(ctx context.Context, owner, repo stri
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var branches []*Branch
-	resp, err := s.client.Do(ctx, req, &branches)
+	resp, err := s.client.Do(req, &branches)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1498,13 +1498,13 @@ type renameBranchRequest struct {
 func (s *RepositoriesService) RenameBranch(ctx context.Context, owner, repo, branch, newName string) (*Branch, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/rename", owner, repo, url.PathEscape(branch))
 	r := &renameBranchRequest{NewName: newName}
-	req, err := s.client.NewRequest("POST", u, r)
+	req, err := s.client.NewRequest(ctx, "POST", u, r)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var b *Branch
-	resp, err := s.client.Do(ctx, req, &b)
+	resp, err := s.client.Do(req, &b)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1521,7 +1521,7 @@ func (s *RepositoriesService) RenameBranch(ctx context.Context, owner, repo, bra
 //meta:operation GET /repos/{owner}/{repo}/branches/{branch}/protection
 func (s *RepositoriesService) GetBranchProtection(ctx context.Context, owner, repo, branch string) (*Protection, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1529,7 +1529,7 @@ func (s *RepositoriesService) GetBranchProtection(ctx context.Context, owner, re
 	req.Header.Set("Accept", mediaTypeRequiredApprovingReviewsPreview)
 
 	var p *Protection
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		if isBranchNotProtected(err) {
 			err = ErrBranchNotProtected
@@ -1549,13 +1549,13 @@ func (s *RepositoriesService) GetBranchProtection(ctx context.Context, owner, re
 //meta:operation GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks
 func (s *RepositoriesService) GetRequiredStatusChecks(ctx context.Context, owner, repo, branch string) (*RequiredStatusChecks, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_status_checks", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var p *RequiredStatusChecks
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		if isBranchNotProtected(err) {
 			err = ErrBranchNotProtected
@@ -1575,12 +1575,12 @@ func (s *RepositoriesService) GetRequiredStatusChecks(ctx context.Context, owner
 //meta:operation GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts
 func (s *RepositoriesService) ListRequiredStatusChecksContexts(ctx context.Context, owner, repo, branch string) (contexts []string, resp *Response, err error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_status_checks/contexts", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	resp, err = s.client.Do(ctx, req, &contexts)
+	resp, err = s.client.Do(req, &contexts)
 	if err != nil {
 		if isBranchNotProtected(err) {
 			err = ErrBranchNotProtected
@@ -1600,7 +1600,7 @@ func (s *RepositoriesService) ListRequiredStatusChecksContexts(ctx context.Conte
 //meta:operation PUT /repos/{owner}/{repo}/branches/{branch}/protection
 func (s *RepositoriesService) UpdateBranchProtection(ctx context.Context, owner, repo, branch string, preq *ProtectionRequest) (*Protection, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("PUT", u, preq)
+	req, err := s.client.NewRequest(ctx, "PUT", u, preq)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1608,7 +1608,7 @@ func (s *RepositoriesService) UpdateBranchProtection(ctx context.Context, owner,
 	req.Header.Set("Accept", mediaTypeRequiredApprovingReviewsPreview)
 
 	var p *Protection
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1625,12 +1625,12 @@ func (s *RepositoriesService) UpdateBranchProtection(ctx context.Context, owner,
 //meta:operation DELETE /repos/{owner}/{repo}/branches/{branch}/protection
 func (s *RepositoriesService) RemoveBranchProtection(ctx context.Context, owner, repo, branch string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetSignaturesProtectedBranch gets required signatures of protected branch.
@@ -1642,7 +1642,7 @@ func (s *RepositoriesService) RemoveBranchProtection(ctx context.Context, owner,
 //meta:operation GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures
 func (s *RepositoriesService) GetSignaturesProtectedBranch(ctx context.Context, owner, repo, branch string) (*SignaturesProtectedBranch, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_signatures", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1650,7 +1650,7 @@ func (s *RepositoriesService) GetSignaturesProtectedBranch(ctx context.Context, 
 	req.Header.Set("Accept", mediaTypeSignaturePreview)
 
 	var p *SignaturesProtectedBranch
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		if isBranchNotProtected(err) {
 			err = ErrBranchNotProtected
@@ -1671,7 +1671,7 @@ func (s *RepositoriesService) GetSignaturesProtectedBranch(ctx context.Context, 
 //meta:operation POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures
 func (s *RepositoriesService) RequireSignaturesOnProtectedBranch(ctx context.Context, owner, repo, branch string) (*SignaturesProtectedBranch, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_signatures", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1679,7 +1679,7 @@ func (s *RepositoriesService) RequireSignaturesOnProtectedBranch(ctx context.Con
 	req.Header.Set("Accept", mediaTypeSignaturePreview)
 
 	var r *SignaturesProtectedBranch
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1696,14 +1696,14 @@ func (s *RepositoriesService) RequireSignaturesOnProtectedBranch(ctx context.Con
 //meta:operation DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures
 func (s *RepositoriesService) OptionalSignaturesOnProtectedBranch(ctx context.Context, owner, repo, branch string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_signatures", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeSignaturePreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // UpdateRequiredStatusChecks updates the required status checks for a given protected branch.
@@ -1715,13 +1715,13 @@ func (s *RepositoriesService) OptionalSignaturesOnProtectedBranch(ctx context.Co
 //meta:operation PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks
 func (s *RepositoriesService) UpdateRequiredStatusChecks(ctx context.Context, owner, repo, branch string, sreq *RequiredStatusChecksRequest) (*RequiredStatusChecks, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_status_checks", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("PATCH", u, sreq)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, sreq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var sc *RequiredStatusChecks
-	resp, err := s.client.Do(ctx, req, &sc)
+	resp, err := s.client.Do(req, &sc)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1738,12 +1738,12 @@ func (s *RepositoriesService) UpdateRequiredStatusChecks(ctx context.Context, ow
 //meta:operation DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks
 func (s *RepositoriesService) RemoveRequiredStatusChecks(ctx context.Context, owner, repo, branch string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_status_checks", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // License gets the contents of a repository's license if one is detected.
@@ -1753,13 +1753,13 @@ func (s *RepositoriesService) RemoveRequiredStatusChecks(ctx context.Context, ow
 //meta:operation GET /repos/{owner}/{repo}/license
 func (s *RepositoriesService) License(ctx context.Context, owner, repo string) (*RepositoryLicense, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/license", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *RepositoryLicense
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1776,7 +1776,7 @@ func (s *RepositoriesService) License(ctx context.Context, owner, repo string) (
 //meta:operation GET /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews
 func (s *RepositoriesService) GetPullRequestReviewEnforcement(ctx context.Context, owner, repo, branch string) (*PullRequestReviewsEnforcement, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_pull_request_reviews", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1784,7 +1784,7 @@ func (s *RepositoriesService) GetPullRequestReviewEnforcement(ctx context.Contex
 	req.Header.Set("Accept", mediaTypeRequiredApprovingReviewsPreview)
 
 	var r *PullRequestReviewsEnforcement
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1802,7 +1802,7 @@ func (s *RepositoriesService) GetPullRequestReviewEnforcement(ctx context.Contex
 //meta:operation PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews
 func (s *RepositoriesService) UpdatePullRequestReviewEnforcement(ctx context.Context, owner, repo, branch string, patch *PullRequestReviewsEnforcementUpdate) (*PullRequestReviewsEnforcement, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_pull_request_reviews", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("PATCH", u, patch)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, patch)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1810,7 +1810,7 @@ func (s *RepositoriesService) UpdatePullRequestReviewEnforcement(ctx context.Con
 	req.Header.Set("Accept", mediaTypeRequiredApprovingReviewsPreview)
 
 	var r *PullRequestReviewsEnforcement
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1833,7 +1833,7 @@ func (s *RepositoriesService) DisableDismissalRestrictions(ctx context.Context, 
 		DismissalRestrictionsRequest `json:"dismissal_restrictions"`
 	})
 
-	req, err := s.client.NewRequest("PATCH", u, data)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, data)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1841,7 +1841,7 @@ func (s *RepositoriesService) DisableDismissalRestrictions(ctx context.Context, 
 	req.Header.Set("Accept", mediaTypeRequiredApprovingReviewsPreview)
 
 	var r *PullRequestReviewsEnforcement
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1858,12 +1858,12 @@ func (s *RepositoriesService) DisableDismissalRestrictions(ctx context.Context, 
 //meta:operation DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews
 func (s *RepositoriesService) RemovePullRequestReviewEnforcement(ctx context.Context, owner, repo, branch string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/required_pull_request_reviews", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetAdminEnforcement gets admin enforcement information of a protected branch.
@@ -1875,13 +1875,13 @@ func (s *RepositoriesService) RemovePullRequestReviewEnforcement(ctx context.Con
 //meta:operation GET /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
 func (s *RepositoriesService) GetAdminEnforcement(ctx context.Context, owner, repo, branch string) (*AdminEnforcement, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/enforce_admins", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *AdminEnforcement
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1899,13 +1899,13 @@ func (s *RepositoriesService) GetAdminEnforcement(ctx context.Context, owner, re
 //meta:operation POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
 func (s *RepositoriesService) AddAdminEnforcement(ctx context.Context, owner, repo, branch string) (*AdminEnforcement, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/enforce_admins", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *AdminEnforcement
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1922,12 +1922,12 @@ func (s *RepositoriesService) AddAdminEnforcement(ctx context.Context, owner, re
 //meta:operation DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
 func (s *RepositoriesService) RemoveAdminEnforcement(ctx context.Context, owner, repo, branch string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/enforce_admins", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // repositoryTopics represents a collection of repository topics.
@@ -1947,7 +1947,7 @@ func (s *RepositoriesService) ListAllTopics(ctx context.Context, owner, repo str
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1955,7 +1955,7 @@ func (s *RepositoriesService) ListAllTopics(ctx context.Context, owner, repo str
 	req.Header.Set("Accept", mediaTypeTopicsPreview)
 
 	var topics *repositoryTopics
-	resp, err := s.client.Do(ctx, req, &topics)
+	resp, err := s.client.Do(req, &topics)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1976,7 +1976,7 @@ func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo 
 	if t.Names == nil {
 		t.Names = []string{}
 	}
-	req, err := s.client.NewRequest("PUT", u, t)
+	req, err := s.client.NewRequest(ctx, "PUT", u, t)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1984,7 +1984,7 @@ func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo 
 	req.Header.Set("Accept", mediaTypeTopicsPreview)
 
 	t = new(repositoryTopics)
-	resp, err := s.client.Do(ctx, req, t)
+	resp, err := s.client.Do(req, t)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -2004,13 +2004,13 @@ func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo 
 //meta:operation GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps
 func (s *RepositoriesService) ListApps(ctx context.Context, owner, repo, branch string) ([]*App, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/apps", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var apps []*App
-	resp, err := s.client.Do(ctx, req, &apps)
+	resp, err := s.client.Do(req, &apps)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -2043,13 +2043,13 @@ func (s *RepositoriesService) ListAppRestrictions(ctx context.Context, owner, re
 //meta:operation PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps
 func (s *RepositoriesService) ReplaceAppRestrictions(ctx context.Context, owner, repo, branch string, apps []string) ([]*App, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/apps", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("PUT", u, apps)
+	req, err := s.client.NewRequest(ctx, "PUT", u, apps)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var newApps []*App
-	resp, err := s.client.Do(ctx, req, &newApps)
+	resp, err := s.client.Do(req, &newApps)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -2069,13 +2069,13 @@ func (s *RepositoriesService) ReplaceAppRestrictions(ctx context.Context, owner,
 //meta:operation POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps
 func (s *RepositoriesService) AddAppRestrictions(ctx context.Context, owner, repo, branch string, apps []string) ([]*App, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/apps", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("POST", u, apps)
+	req, err := s.client.NewRequest(ctx, "POST", u, apps)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var newApps []*App
-	resp, err := s.client.Do(ctx, req, &newApps)
+	resp, err := s.client.Do(req, &newApps)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -2095,13 +2095,13 @@ func (s *RepositoriesService) AddAppRestrictions(ctx context.Context, owner, rep
 //meta:operation DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps
 func (s *RepositoriesService) RemoveAppRestrictions(ctx context.Context, owner, repo, branch string, apps []string) ([]*App, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/apps", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("DELETE", u, apps)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, apps)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var newApps []*App
-	resp, err := s.client.Do(ctx, req, &newApps)
+	resp, err := s.client.Do(req, &newApps)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -2119,13 +2119,13 @@ func (s *RepositoriesService) RemoveAppRestrictions(ctx context.Context, owner, 
 //meta:operation GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams
 func (s *RepositoriesService) ListTeamRestrictions(ctx context.Context, owner, repo, branch string) ([]*Team, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/teams", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teams []*Team
-	resp, err := s.client.Do(ctx, req, &teams)
+	resp, err := s.client.Do(req, &teams)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -2146,13 +2146,13 @@ func (s *RepositoriesService) ListTeamRestrictions(ctx context.Context, owner, r
 //meta:operation PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams
 func (s *RepositoriesService) ReplaceTeamRestrictions(ctx context.Context, owner, repo, branch string, teams []string) ([]*Team, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/teams", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("PUT", u, teams)
+	req, err := s.client.NewRequest(ctx, "PUT", u, teams)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var newTeams []*Team
-	resp, err := s.client.Do(ctx, req, &newTeams)
+	resp, err := s.client.Do(req, &newTeams)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -2172,13 +2172,13 @@ func (s *RepositoriesService) ReplaceTeamRestrictions(ctx context.Context, owner
 //meta:operation POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams
 func (s *RepositoriesService) AddTeamRestrictions(ctx context.Context, owner, repo, branch string, teams []string) ([]*Team, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/teams", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("POST", u, teams)
+	req, err := s.client.NewRequest(ctx, "POST", u, teams)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var newTeams []*Team
-	resp, err := s.client.Do(ctx, req, &newTeams)
+	resp, err := s.client.Do(req, &newTeams)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -2198,13 +2198,13 @@ func (s *RepositoriesService) AddTeamRestrictions(ctx context.Context, owner, re
 //meta:operation DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams
 func (s *RepositoriesService) RemoveTeamRestrictions(ctx context.Context, owner, repo, branch string, teams []string) ([]*Team, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/teams", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("DELETE", u, teams)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, teams)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var newTeams []*Team
-	resp, err := s.client.Do(ctx, req, &newTeams)
+	resp, err := s.client.Do(req, &newTeams)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -2222,13 +2222,13 @@ func (s *RepositoriesService) RemoveTeamRestrictions(ctx context.Context, owner,
 //meta:operation GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users
 func (s *RepositoriesService) ListUserRestrictions(ctx context.Context, owner, repo, branch string) ([]*User, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/users", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var users []*User
-	resp, err := s.client.Do(ctx, req, &users)
+	resp, err := s.client.Do(req, &users)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -2249,13 +2249,13 @@ func (s *RepositoriesService) ListUserRestrictions(ctx context.Context, owner, r
 //meta:operation PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users
 func (s *RepositoriesService) ReplaceUserRestrictions(ctx context.Context, owner, repo, branch string, users []string) ([]*User, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/users", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("PUT", u, users)
+	req, err := s.client.NewRequest(ctx, "PUT", u, users)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var newUsers []*User
-	resp, err := s.client.Do(ctx, req, &newUsers)
+	resp, err := s.client.Do(req, &newUsers)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -2275,13 +2275,13 @@ func (s *RepositoriesService) ReplaceUserRestrictions(ctx context.Context, owner
 //meta:operation POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users
 func (s *RepositoriesService) AddUserRestrictions(ctx context.Context, owner, repo, branch string, users []string) ([]*User, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/users", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("POST", u, users)
+	req, err := s.client.NewRequest(ctx, "POST", u, users)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var newUsers []*User
-	resp, err := s.client.Do(ctx, req, &newUsers)
+	resp, err := s.client.Do(req, &newUsers)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -2301,13 +2301,13 @@ func (s *RepositoriesService) AddUserRestrictions(ctx context.Context, owner, re
 //meta:operation DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users
 func (s *RepositoriesService) RemoveUserRestrictions(ctx context.Context, owner, repo, branch string, users []string) ([]*User, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/branches/%v/protection/restrictions/users", owner, repo, url.PathEscape(branch))
-	req, err := s.client.NewRequest("DELETE", u, users)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, users)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var newUsers []*User
-	resp, err := s.client.Do(ctx, req, &newUsers)
+	resp, err := s.client.Do(req, &newUsers)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -2336,13 +2336,13 @@ type TransferRequest struct {
 func (s *RepositoriesService) Transfer(ctx context.Context, owner, repo string, transfer TransferRequest) (*Repository, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/transfer", owner, repo)
 
-	req, err := s.client.NewRequest("POST", u, &transfer)
+	req, err := s.client.NewRequest(ctx, "POST", u, &transfer)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *Repository
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -2367,13 +2367,13 @@ type DispatchRequestOptions struct {
 func (s *RepositoriesService) Dispatch(ctx context.Context, owner, repo string, opts DispatchRequestOptions) (*Repository, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/dispatches", owner, repo)
 
-	req, err := s.client.NewRequest("POST", u, &opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, &opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *Repository
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -2397,12 +2397,12 @@ func isBranchNotProtected(err error) bool {
 func (s *RepositoriesService) EnablePrivateReporting(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/private-vulnerability-reporting", owner, repo)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -2419,12 +2419,12 @@ func (s *RepositoriesService) EnablePrivateReporting(ctx context.Context, owner,
 func (s *RepositoriesService) DisablePrivateReporting(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/private-vulnerability-reporting", owner, repo)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -2446,13 +2446,13 @@ type checkPrivateReporting struct {
 func (s *RepositoriesService) IsPrivateReportingEnabled(ctx context.Context, owner, repo string) (bool, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/private-vulnerability-reporting", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return false, nil, err
 	}
 
 	var privateReporting checkPrivateReporting
-	resp, err := s.client.Do(ctx, req, &privateReporting)
+	resp, err := s.client.Do(req, &privateReporting)
 	return privateReporting.Enabled, resp, err
 }
 
@@ -2538,13 +2538,13 @@ func (s *RepositoriesService) ListRepositoryActivities(ctx context.Context, owne
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var activities []*RepositoryActivity
-	resp, err := s.client.Do(ctx, req, &activities)
+	resp, err := s.client.Do(req, &activities)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_actions_access.go
+++ b/github/repos_actions_access.go
@@ -28,13 +28,13 @@ type RepositoryActionsAccessLevel struct {
 //meta:operation GET /repos/{owner}/{repo}/actions/permissions/access
 func (s *RepositoriesService) GetActionsAccessLevel(ctx context.Context, owner, repo string) (*RepositoryActionsAccessLevel, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions/access", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var raal *RepositoryActionsAccessLevel
-	resp, err := s.client.Do(ctx, req, &raal)
+	resp, err := s.client.Do(req, &raal)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -50,10 +50,10 @@ func (s *RepositoriesService) GetActionsAccessLevel(ctx context.Context, owner, 
 //meta:operation PUT /repos/{owner}/{repo}/actions/permissions/access
 func (s *RepositoriesService) EditActionsAccessLevel(ctx context.Context, owner, repo string, repositoryActionsAccessLevel RepositoryActionsAccessLevel) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions/access", owner, repo)
-	req, err := s.client.NewRequest("PUT", u, repositoryActionsAccessLevel)
+	req, err := s.client.NewRequest(ctx, "PUT", u, repositoryActionsAccessLevel)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/repos_actions_allowed.go
+++ b/github/repos_actions_allowed.go
@@ -17,13 +17,13 @@ import (
 //meta:operation GET /repos/{owner}/{repo}/actions/permissions/selected-actions
 func (s *RepositoriesService) GetActionsAllowed(ctx context.Context, org, repo string) (*ActionsAllowed, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions/selected-actions", org, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var actionsAllowed *ActionsAllowed
-	resp, err := s.client.Do(ctx, req, &actionsAllowed)
+	resp, err := s.client.Do(req, &actionsAllowed)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -38,13 +38,13 @@ func (s *RepositoriesService) GetActionsAllowed(ctx context.Context, org, repo s
 //meta:operation PUT /repos/{owner}/{repo}/actions/permissions/selected-actions
 func (s *RepositoriesService) EditActionsAllowed(ctx context.Context, org, repo string, actionsAllowed ActionsAllowed) (*ActionsAllowed, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions/selected-actions", org, repo)
-	req, err := s.client.NewRequest("PUT", u, actionsAllowed)
+	req, err := s.client.NewRequest(ctx, "PUT", u, actionsAllowed)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var p *ActionsAllowed
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_actions_permissions.go
+++ b/github/repos_actions_permissions.go
@@ -40,13 +40,13 @@ type DefaultWorkflowPermissionRepository struct {
 func (s *RepositoriesService) GetActionsPermissions(ctx context.Context, owner, repo string) (*ActionsPermissionsRepository, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var permissions *ActionsPermissionsRepository
-	resp, err := s.client.Do(ctx, req, &permissions)
+	resp, err := s.client.Do(req, &permissions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -61,13 +61,13 @@ func (s *RepositoriesService) GetActionsPermissions(ctx context.Context, owner, 
 //meta:operation PUT /repos/{owner}/{repo}/actions/permissions
 func (s *RepositoriesService) UpdateActionsPermissions(ctx context.Context, owner, repo string, actionsPermissionsRepository ActionsPermissionsRepository) (*ActionsPermissionsRepository, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions", owner, repo)
-	req, err := s.client.NewRequest("PUT", u, actionsPermissionsRepository)
+	req, err := s.client.NewRequest(ctx, "PUT", u, actionsPermissionsRepository)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var permissions *ActionsPermissionsRepository
-	resp, err := s.client.Do(ctx, req, &permissions)
+	resp, err := s.client.Do(req, &permissions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -83,13 +83,13 @@ func (s *RepositoriesService) UpdateActionsPermissions(ctx context.Context, owne
 func (s *RepositoriesService) GetDefaultWorkflowPermissions(ctx context.Context, owner, repo string) (*DefaultWorkflowPermissionRepository, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions/workflow", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var permissions *DefaultWorkflowPermissionRepository
-	resp, err := s.client.Do(ctx, req, &permissions)
+	resp, err := s.client.Do(req, &permissions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -104,13 +104,13 @@ func (s *RepositoriesService) GetDefaultWorkflowPermissions(ctx context.Context,
 //meta:operation PUT /repos/{owner}/{repo}/actions/permissions/workflow
 func (s *RepositoriesService) UpdateDefaultWorkflowPermissions(ctx context.Context, owner, repo string, permissions DefaultWorkflowPermissionRepository) (*DefaultWorkflowPermissionRepository, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions/workflow", owner, repo)
-	req, err := s.client.NewRequest("PUT", u, permissions)
+	req, err := s.client.NewRequest(ctx, "PUT", u, permissions)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var p *DefaultWorkflowPermissionRepository
-	resp, err := s.client.Do(ctx, req, &p)
+	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -126,13 +126,13 @@ func (s *RepositoriesService) UpdateDefaultWorkflowPermissions(ctx context.Conte
 func (s *RepositoriesService) GetArtifactAndLogRetentionPeriod(ctx context.Context, owner, repo string) (*ArtifactPeriod, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions/artifact-and-log-retention", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var arp *ArtifactPeriod
-	resp, err := s.client.Do(ctx, req, &arp)
+	resp, err := s.client.Do(req, &arp)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -147,12 +147,12 @@ func (s *RepositoriesService) GetArtifactAndLogRetentionPeriod(ctx context.Conte
 //meta:operation PUT /repos/{owner}/{repo}/actions/permissions/artifact-and-log-retention
 func (s *RepositoriesService) UpdateArtifactAndLogRetentionPeriod(ctx context.Context, owner, repo string, period ArtifactPeriodOpt) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions/artifact-and-log-retention", owner, repo)
-	req, err := s.client.NewRequest("PUT", u, period)
+	req, err := s.client.NewRequest(ctx, "PUT", u, period)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetPrivateRepoForkPRWorkflowSettings gets the settings for whether workflows from fork pull requests can run on a private repository.
@@ -163,13 +163,13 @@ func (s *RepositoriesService) UpdateArtifactAndLogRetentionPeriod(ctx context.Co
 func (s *RepositoriesService) GetPrivateRepoForkPRWorkflowSettings(ctx context.Context, owner, repo string) (*WorkflowsPermissions, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions/fork-pr-workflows-private-repos", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var permissions *WorkflowsPermissions
-	resp, err := s.client.Do(ctx, req, &permissions)
+	resp, err := s.client.Do(req, &permissions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -184,12 +184,12 @@ func (s *RepositoriesService) GetPrivateRepoForkPRWorkflowSettings(ctx context.C
 //meta:operation PUT /repos/{owner}/{repo}/actions/permissions/fork-pr-workflows-private-repos
 func (s *RepositoriesService) UpdatePrivateRepoForkPRWorkflowSettings(ctx context.Context, owner, repo string, permissions *WorkflowsPermissionsOpt) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions/fork-pr-workflows-private-repos", owner, repo)
-	req, err := s.client.NewRequest("PUT", u, permissions)
+	req, err := s.client.NewRequest(ctx, "PUT", u, permissions)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetForkPRContributorApprovalPermissions gets the fork PR contributor approval policy for a repository.
@@ -200,13 +200,13 @@ func (s *RepositoriesService) UpdatePrivateRepoForkPRWorkflowSettings(ctx contex
 func (s *ActionsService) GetForkPRContributorApprovalPermissions(ctx context.Context, owner, repo string) (*ContributorApprovalPermissions, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions/fork-pr-contributor-approval", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var policy *ContributorApprovalPermissions
-	resp, err := s.client.Do(ctx, req, &policy)
+	resp, err := s.client.Do(req, &policy)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -221,10 +221,10 @@ func (s *ActionsService) GetForkPRContributorApprovalPermissions(ctx context.Con
 //meta:operation PUT /repos/{owner}/{repo}/actions/permissions/fork-pr-contributor-approval
 func (s *ActionsService) UpdateForkPRContributorApprovalPermissions(ctx context.Context, owner, repo string, policy ContributorApprovalPermissions) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/permissions/fork-pr-contributor-approval", owner, repo)
-	req, err := s.client.NewRequest("PUT", u, policy)
+	req, err := s.client.NewRequest(ctx, "PUT", u, policy)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/repos_attestations.go
+++ b/github/repos_attestations.go
@@ -24,13 +24,13 @@ func (s *RepositoriesService) ListAttestations(ctx context.Context, owner, repo,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var attestations *AttestationsResponse
-	resp, err := s.client.Do(ctx, req, &attestations)
+	resp, err := s.client.Do(req, &attestations)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_autolinks.go
+++ b/github/repos_autolinks.go
@@ -34,13 +34,13 @@ type Autolink struct {
 func (s *RepositoriesService) ListAutolinks(ctx context.Context, owner, repo string) ([]*Autolink, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/autolinks", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var autolinks []*Autolink
-	resp, err := s.client.Do(ctx, req, &autolinks)
+	resp, err := s.client.Do(req, &autolinks)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -56,13 +56,13 @@ func (s *RepositoriesService) ListAutolinks(ctx context.Context, owner, repo str
 //meta:operation POST /repos/{owner}/{repo}/autolinks
 func (s *RepositoriesService) AddAutolink(ctx context.Context, owner, repo string, opts *AutolinkOptions) (*Autolink, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/autolinks", owner, repo)
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var al *Autolink
-	resp, err := s.client.Do(ctx, req, &al)
+	resp, err := s.client.Do(req, &al)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -78,13 +78,13 @@ func (s *RepositoriesService) AddAutolink(ctx context.Context, owner, repo strin
 func (s *RepositoriesService) GetAutolink(ctx context.Context, owner, repo string, id int64) (*Autolink, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/autolinks/%v", owner, repo, id)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var autolink *Autolink
-	resp, err := s.client.Do(ctx, req, &autolink)
+	resp, err := s.client.Do(req, &autolink)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -100,9 +100,9 @@ func (s *RepositoriesService) GetAutolink(ctx context.Context, owner, repo strin
 //meta:operation DELETE /repos/{owner}/{repo}/autolinks/{autolink_id}
 func (s *RepositoriesService) DeleteAutolink(ctx context.Context, owner, repo string, id int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/autolinks/%v", owner, repo, id)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/repos_codeowners.go
+++ b/github/repos_codeowners.go
@@ -46,13 +46,13 @@ func (s *RepositoriesService) GetCodeownersErrors(ctx context.Context, owner, re
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var codeownersErrors *CodeownersErrors
-	resp, err := s.client.Do(ctx, req, &codeownersErrors)
+	resp, err := s.client.Do(req, &codeownersErrors)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_collaborators.go
+++ b/github/repos_collaborators.go
@@ -58,13 +58,13 @@ func (s *RepositoriesService) ListCollaborators(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var users []*User
-	resp, err := s.client.Do(ctx, req, &users)
+	resp, err := s.client.Do(req, &users)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -82,12 +82,12 @@ func (s *RepositoriesService) ListCollaborators(ctx context.Context, owner, repo
 //meta:operation GET /repos/{owner}/{repo}/collaborators/{username}
 func (s *RepositoriesService) IsCollaborator(ctx context.Context, owner, repo, user string) (bool, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/collaborators/%v", owner, repo, user)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return false, nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	isCollab, err := parseBoolResponse(err)
 	return isCollab, resp, err
 }
@@ -110,13 +110,13 @@ type RepositoryPermissionLevel struct {
 //meta:operation GET /repos/{owner}/{repo}/collaborators/{username}/permission
 func (s *RepositoriesService) GetPermissionLevel(ctx context.Context, owner, repo, user string) (*RepositoryPermissionLevel, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/collaborators/%v/permission", owner, repo, user)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var rpl *RepositoryPermissionLevel
-	resp, err := s.client.Do(ctx, req, &rpl)
+	resp, err := s.client.Do(req, &rpl)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -147,13 +147,13 @@ type RepositoryAddCollaboratorOptions struct {
 //meta:operation PUT /repos/{owner}/{repo}/collaborators/{username}
 func (s *RepositoriesService) AddCollaborator(ctx context.Context, owner, repo, user string, opts *RepositoryAddCollaboratorOptions) (*CollaboratorInvitation, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/collaborators/%v", owner, repo, user)
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var acr *CollaboratorInvitation
-	resp, err := s.client.Do(ctx, req, &acr)
+	resp, err := s.client.Do(req, &acr)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -169,10 +169,10 @@ func (s *RepositoriesService) AddCollaborator(ctx context.Context, owner, repo, 
 //meta:operation DELETE /repos/{owner}/{repo}/collaborators/{username}
 func (s *RepositoriesService) RemoveCollaborator(ctx context.Context, owner, repo, user string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/collaborators/%v", owner, repo, user)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/repos_comments.go
+++ b/github/repos_comments.go
@@ -45,7 +45,7 @@ func (s *RepositoriesService) ListComments(ctx context.Context, owner, repo stri
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -53,7 +53,7 @@ func (s *RepositoriesService) ListComments(ctx context.Context, owner, repo stri
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var comments []*RepositoryComment
-	resp, err := s.client.Do(ctx, req, &comments)
+	resp, err := s.client.Do(req, &comments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -73,7 +73,7 @@ func (s *RepositoriesService) ListCommitComments(ctx context.Context, owner, rep
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -81,7 +81,7 @@ func (s *RepositoriesService) ListCommitComments(ctx context.Context, owner, rep
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var comments []*RepositoryComment
-	resp, err := s.client.Do(ctx, req, &comments)
+	resp, err := s.client.Do(req, &comments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -97,13 +97,13 @@ func (s *RepositoriesService) ListCommitComments(ctx context.Context, owner, rep
 //meta:operation POST /repos/{owner}/{repo}/commits/{commit_sha}/comments
 func (s *RepositoriesService) CreateComment(ctx context.Context, owner, repo, sha string, comment *RepositoryComment) (*RepositoryComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/commits/%v/comments", owner, repo, sha)
-	req, err := s.client.NewRequest("POST", u, comment)
+	req, err := s.client.NewRequest(ctx, "POST", u, comment)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var c *RepositoryComment
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -118,7 +118,7 @@ func (s *RepositoriesService) CreateComment(ctx context.Context, owner, repo, sh
 //meta:operation GET /repos/{owner}/{repo}/comments/{comment_id}
 func (s *RepositoriesService) GetComment(ctx context.Context, owner, repo string, id int64) (*RepositoryComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, id)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -126,7 +126,7 @@ func (s *RepositoriesService) GetComment(ctx context.Context, owner, repo string
 	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	var c *RepositoryComment
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -141,13 +141,13 @@ func (s *RepositoriesService) GetComment(ctx context.Context, owner, repo string
 //meta:operation PATCH /repos/{owner}/{repo}/comments/{comment_id}
 func (s *RepositoriesService) UpdateComment(ctx context.Context, owner, repo string, id int64, comment *RepositoryComment) (*RepositoryComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, id)
-	req, err := s.client.NewRequest("PATCH", u, comment)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var c *RepositoryComment
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -162,10 +162,10 @@ func (s *RepositoriesService) UpdateComment(ctx context.Context, owner, repo str
 //meta:operation DELETE /repos/{owner}/{repo}/comments/{comment_id}
 func (s *RepositoriesService) DeleteComment(ctx context.Context, owner, repo string, id int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, id)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/repos_commits.go
+++ b/github/repos_commits.go
@@ -134,13 +134,13 @@ func (s *RepositoriesService) ListCommits(ctx context.Context, owner, repo strin
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var commits []*RepositoryCommit
-	resp, err := s.client.Do(ctx, req, &commits)
+	resp, err := s.client.Do(req, &commits)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -160,13 +160,13 @@ func (s *RepositoriesService) GetCommit(ctx context.Context, owner, repo, sha st
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var commit *RepositoryCommit
-	resp, err := s.client.Do(ctx, req, &commit)
+	resp, err := s.client.Do(req, &commit)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -181,7 +181,7 @@ func (s *RepositoriesService) GetCommit(ctx context.Context, owner, repo, sha st
 //meta:operation GET /repos/{owner}/{repo}/commits/{ref}
 func (s *RepositoriesService) GetCommitRaw(ctx context.Context, owner, repo, sha string, opts RawOptions) (string, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/commits/%v", owner, repo, sha)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return "", nil, err
 	}
@@ -196,7 +196,7 @@ func (s *RepositoriesService) GetCommitRaw(ctx context.Context, owner, repo, sha
 	}
 
 	var buf bytes.Buffer
-	resp, err := s.client.Do(ctx, req, &buf)
+	resp, err := s.client.Do(req, &buf)
 	if err != nil {
 		return "", resp, err
 	}
@@ -213,7 +213,7 @@ func (s *RepositoriesService) GetCommitRaw(ctx context.Context, owner, repo, sha
 func (s *RepositoriesService) GetCommitSHA1(ctx context.Context, owner, repo, ref, lastSHA string) (string, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/commits/%v", owner, repo, refURLEscape(ref))
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return "", nil, err
 	}
@@ -224,7 +224,7 @@ func (s *RepositoriesService) GetCommitSHA1(ctx context.Context, owner, repo, re
 	req.Header.Set("Accept", mediaTypeV3SHA)
 
 	var buf bytes.Buffer
-	resp, err := s.client.Do(ctx, req, &buf)
+	resp, err := s.client.Do(req, &buf)
 	if err != nil {
 		return "", resp, err
 	}
@@ -247,13 +247,13 @@ func (s *RepositoriesService) CompareCommits(ctx context.Context, owner, repo, b
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var comp *CommitsComparison
-	resp, err := s.client.Do(ctx, req, &comp)
+	resp, err := s.client.Do(req, &comp)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -276,7 +276,7 @@ func (s *RepositoriesService) CompareCommitsRaw(ctx context.Context, owner, repo
 
 	u := fmt.Sprintf("repos/%v/%v/compare/%v...%v", owner, repo, escapedBase, escapedHead)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return "", nil, err
 	}
@@ -291,7 +291,7 @@ func (s *RepositoriesService) CompareCommitsRaw(ctx context.Context, owner, repo
 	}
 
 	var buf bytes.Buffer
-	resp, err := s.client.Do(ctx, req, &buf)
+	resp, err := s.client.Do(req, &buf)
 	if err != nil {
 		return "", resp, err
 	}
@@ -308,14 +308,14 @@ func (s *RepositoriesService) CompareCommitsRaw(ctx context.Context, owner, repo
 func (s *RepositoriesService) ListBranchesHeadCommit(ctx context.Context, owner, repo, sha string) ([]*BranchCommit, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/commits/%v/branches-where-head", owner, repo, sha)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeListPullsOrBranchesForCommitPreview)
 	var branchCommits []*BranchCommit
-	resp, err := s.client.Do(ctx, req, &branchCommits)
+	resp, err := s.client.Do(req, &branchCommits)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_community_health.go
+++ b/github/repos_community_health.go
@@ -48,13 +48,13 @@ type CommunityHealthMetrics struct {
 //meta:operation GET /repos/{owner}/{repo}/community/profile
 func (s *RepositoriesService) GetCommunityHealthMetrics(ctx context.Context, owner, repo string) (*CommunityHealthMetrics, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/community/profile", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var metrics *CommunityHealthMetrics
-	resp, err := s.client.Do(ctx, req, &metrics)
+	resp, err := s.client.Do(req, &metrics)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -107,13 +107,13 @@ func (s *RepositoriesService) GetReadme(ctx context.Context, owner, repo string,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var readme *RepositoryContent
-	resp, err := s.client.Do(ctx, req, &readme)
+	resp, err := s.client.Do(req, &readme)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -201,13 +201,13 @@ func (s *RepositoriesService) GetContents(ctx context.Context, owner, repo, path
 		return nil, nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
 	var rawJSON json.RawMessage
-	resp, err = s.client.Do(ctx, req, &rawJSON)
+	resp, err = s.client.Do(req, &rawJSON)
 	if err != nil {
 		return nil, nil, resp, err
 	}
@@ -233,13 +233,13 @@ func (s *RepositoriesService) GetContents(ctx context.Context, owner, repo, path
 //meta:operation PUT /repos/{owner}/{repo}/contents/{path}
 func (s *RepositoriesService) CreateFile(ctx context.Context, owner, repo, path string, opts *RepositoryContentFileOptions) (*RepositoryContentResponse, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/contents/%v", owner, repo, path)
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var createResponse *RepositoryContentResponse
-	resp, err := s.client.Do(ctx, req, &createResponse)
+	resp, err := s.client.Do(req, &createResponse)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -255,13 +255,13 @@ func (s *RepositoriesService) CreateFile(ctx context.Context, owner, repo, path 
 //meta:operation PUT /repos/{owner}/{repo}/contents/{path}
 func (s *RepositoriesService) UpdateFile(ctx context.Context, owner, repo, path string, opts *RepositoryContentFileOptions) (*RepositoryContentResponse, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/contents/%v", owner, repo, path)
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var updateResponse *RepositoryContentResponse
-	resp, err := s.client.Do(ctx, req, &updateResponse)
+	resp, err := s.client.Do(req, &updateResponse)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -277,13 +277,13 @@ func (s *RepositoriesService) UpdateFile(ctx context.Context, owner, repo, path 
 //meta:operation DELETE /repos/{owner}/{repo}/contents/{path}
 func (s *RepositoriesService) DeleteFile(ctx context.Context, owner, repo, path string, opts *RepositoryContentFileOptions) (*RepositoryContentResponse, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/contents/%v", owner, repo, path)
-	req, err := s.client.NewRequest("DELETE", u, opts)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var deleteResponse *RepositoryContentResponse
-	resp, err := s.client.Do(ctx, req, &deleteResponse)
+	resp, err := s.client.Do(req, &deleteResponse)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -345,12 +345,12 @@ func (s *RepositoriesService) getArchiveLinkWithoutRateLimit(ctx context.Context
 }
 
 func (s *RepositoriesService) getArchiveLinkWithRateLimit(ctx context.Context, u string, maxRedirects int) (*url.URL, *Response, error) {
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	url, resp, err := s.client.bareDoUntilFound(ctx, req, maxRedirects)
+	url, resp, err := s.client.bareDoUntilFound(req, maxRedirects)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_deployment_branch_policies.go
+++ b/github/repos_deployment_branch_policies.go
@@ -42,13 +42,13 @@ func (s *RepositoriesService) ListDeploymentBranchPolicies(ctx context.Context, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var list *DeploymentBranchPolicyResponse
-	resp, err := s.client.Do(ctx, req, &list)
+	resp, err := s.client.Do(req, &list)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -64,13 +64,13 @@ func (s *RepositoriesService) ListDeploymentBranchPolicies(ctx context.Context, 
 func (s *RepositoriesService) GetDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, branchPolicyID int64) (*DeploymentBranchPolicy, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment-branch-policies/%v", owner, repo, environment, branchPolicyID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var policy *DeploymentBranchPolicy
-	resp, err := s.client.Do(ctx, req, &policy)
+	resp, err := s.client.Do(req, &policy)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -86,13 +86,13 @@ func (s *RepositoriesService) GetDeploymentBranchPolicy(ctx context.Context, own
 func (s *RepositoriesService) CreateDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, request *DeploymentBranchPolicyRequest) (*DeploymentBranchPolicy, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment-branch-policies", owner, repo, environment)
 
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var policy *DeploymentBranchPolicy
-	resp, err := s.client.Do(ctx, req, &policy)
+	resp, err := s.client.Do(req, &policy)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -108,13 +108,13 @@ func (s *RepositoriesService) CreateDeploymentBranchPolicy(ctx context.Context, 
 func (s *RepositoriesService) UpdateDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, branchPolicyID int64, request *DeploymentBranchPolicyRequest) (*DeploymentBranchPolicy, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment-branch-policies/%v", owner, repo, environment, branchPolicyID)
 
-	req, err := s.client.NewRequest("PUT", u, request)
+	req, err := s.client.NewRequest(ctx, "PUT", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var policy *DeploymentBranchPolicy
-	resp, err := s.client.Do(ctx, req, &policy)
+	resp, err := s.client.Do(req, &policy)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -130,10 +130,10 @@ func (s *RepositoriesService) UpdateDeploymentBranchPolicy(ctx context.Context, 
 func (s *RepositoriesService) DeleteDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, branchPolicyID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment-branch-policies/%v", owner, repo, environment, branchPolicyID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/repos_deployment_protection_rules.go
+++ b/github/repos_deployment_protection_rules.go
@@ -51,13 +51,13 @@ type CustomDeploymentProtectionRuleRequest struct {
 func (s *RepositoriesService) GetAllDeploymentProtectionRules(ctx context.Context, owner, repo, environment string) (*ListDeploymentProtectionRuleResponse, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment_protection_rules", owner, repo, environment)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var list *ListDeploymentProtectionRuleResponse
-	resp, err := s.client.Do(ctx, req, &list)
+	resp, err := s.client.Do(req, &list)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -73,13 +73,13 @@ func (s *RepositoriesService) GetAllDeploymentProtectionRules(ctx context.Contex
 func (s *RepositoriesService) CreateCustomDeploymentProtectionRule(ctx context.Context, owner, repo, environment string, request *CustomDeploymentProtectionRuleRequest) (*CustomDeploymentProtectionRule, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment_protection_rules", owner, repo, environment)
 
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var protectionRule *CustomDeploymentProtectionRule
-	resp, err := s.client.Do(ctx, req, &protectionRule)
+	resp, err := s.client.Do(req, &protectionRule)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -99,13 +99,13 @@ func (s *RepositoriesService) ListCustomDeploymentRuleIntegrations(ctx context.C
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var list *ListCustomDeploymentRuleIntegrationsResponse
-	resp, err := s.client.Do(ctx, req, &list)
+	resp, err := s.client.Do(req, &list)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -121,13 +121,13 @@ func (s *RepositoriesService) ListCustomDeploymentRuleIntegrations(ctx context.C
 func (s *RepositoriesService) GetCustomDeploymentProtectionRule(ctx context.Context, owner, repo, environment string, protectionRuleID int64) (*CustomDeploymentProtectionRule, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment_protection_rules/%v", owner, repo, environment, protectionRuleID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var protectionRule *CustomDeploymentProtectionRule
-	resp, err := s.client.Do(ctx, req, &protectionRule)
+	resp, err := s.client.Do(req, &protectionRule)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -143,10 +143,10 @@ func (s *RepositoriesService) GetCustomDeploymentProtectionRule(ctx context.Cont
 func (s *RepositoriesService) DisableCustomDeploymentProtectionRule(ctx context.Context, owner, repo, environment string, protectionRuleID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment_protection_rules/%v", owner, repo, environment, protectionRuleID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -73,13 +73,13 @@ func (s *RepositoriesService) ListDeployments(ctx context.Context, owner, repo s
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var deployments []*Deployment
-	resp, err := s.client.Do(ctx, req, &deployments)
+	resp, err := s.client.Do(req, &deployments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -95,13 +95,13 @@ func (s *RepositoriesService) ListDeployments(ctx context.Context, owner, repo s
 func (s *RepositoriesService) GetDeployment(ctx context.Context, owner, repo string, deploymentID int64) (*Deployment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/deployments/%v", owner, repo, deploymentID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var deployment *Deployment
-	resp, err := s.client.Do(ctx, req, &deployment)
+	resp, err := s.client.Do(req, &deployment)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -117,7 +117,7 @@ func (s *RepositoriesService) GetDeployment(ctx context.Context, owner, repo str
 func (s *RepositoriesService) CreateDeployment(ctx context.Context, owner, repo string, request *DeploymentRequest) (*Deployment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/deployments", owner, repo)
 
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -126,7 +126,7 @@ func (s *RepositoriesService) CreateDeployment(ctx context.Context, owner, repo 
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var d *Deployment
-	resp, err := s.client.Do(ctx, req, &d)
+	resp, err := s.client.Do(req, &d)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -141,11 +141,11 @@ func (s *RepositoriesService) CreateDeployment(ctx context.Context, owner, repo 
 //meta:operation DELETE /repos/{owner}/{repo}/deployments/{deployment_id}
 func (s *RepositoriesService) DeleteDeployment(ctx context.Context, owner, repo string, deploymentID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/deployments/%v", owner, repo, deploymentID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DeploymentStatus represents the status of a
@@ -192,7 +192,7 @@ func (s *RepositoriesService) ListDeploymentStatuses(ctx context.Context, owner,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -201,7 +201,7 @@ func (s *RepositoriesService) ListDeploymentStatuses(ctx context.Context, owner,
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var statuses []*DeploymentStatus
-	resp, err := s.client.Do(ctx, req, &statuses)
+	resp, err := s.client.Do(req, &statuses)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -217,7 +217,7 @@ func (s *RepositoriesService) ListDeploymentStatuses(ctx context.Context, owner,
 func (s *RepositoriesService) GetDeploymentStatus(ctx context.Context, owner, repo string, deploymentID, deploymentStatusID int64) (*DeploymentStatus, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/deployments/%v/statuses/%v", owner, repo, deploymentID, deploymentStatusID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -226,7 +226,7 @@ func (s *RepositoriesService) GetDeploymentStatus(ctx context.Context, owner, re
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var d *DeploymentStatus
-	resp, err := s.client.Do(ctx, req, &d)
+	resp, err := s.client.Do(req, &d)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -242,7 +242,7 @@ func (s *RepositoriesService) GetDeploymentStatus(ctx context.Context, owner, re
 func (s *RepositoriesService) CreateDeploymentStatus(ctx context.Context, owner, repo string, deployment int64, request *DeploymentStatusRequest) (*DeploymentStatus, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/deployments/%v/statuses", owner, repo, deployment)
 
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -251,7 +251,7 @@ func (s *RepositoriesService) CreateDeploymentStatus(ctx context.Context, owner,
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var d *DeploymentStatus
-	resp, err := s.client.Do(ctx, req, &d)
+	resp, err := s.client.Do(req, &d)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_environments.go
+++ b/github/repos_environments.go
@@ -117,13 +117,13 @@ func (s *RepositoriesService) ListEnvironments(ctx context.Context, owner, repo 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var list *EnvResponse
-	resp, err := s.client.Do(ctx, req, &list)
+	resp, err := s.client.Do(req, &list)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -137,13 +137,13 @@ func (s *RepositoriesService) ListEnvironments(ctx context.Context, owner, repo 
 //meta:operation GET /repos/{owner}/{repo}/environments/{environment_name}
 func (s *RepositoriesService) GetEnvironment(ctx context.Context, owner, repo, name string) (*Environment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v", owner, repo, name)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var env *Environment
-	resp, err := s.client.Do(ctx, req, &env)
+	resp, err := s.client.Do(req, &env)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -194,13 +194,13 @@ type createUpdateEnvironmentNoEnterprise struct {
 //meta:operation PUT /repos/{owner}/{repo}/environments/{environment_name}
 func (s *RepositoriesService) CreateUpdateEnvironment(ctx context.Context, owner, repo, name string, environment *CreateUpdateEnvironment) (*Environment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v", owner, repo, name)
-	req, err := s.client.NewRequest("PUT", u, environment)
+	req, err := s.client.NewRequest(ctx, "PUT", u, environment)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var e *Environment
-	resp, err := s.client.Do(ctx, req, &e)
+	resp, err := s.client.Do(req, &e)
 	if err != nil {
 		// The API returns 422 when the pricing plan doesn't support all the fields sent.
 		// This path will be executed for Pro/Teams private repos.
@@ -220,7 +220,7 @@ func (s *RepositoriesService) CreateUpdateEnvironment(ctx context.Context, owner
 // createNewEnvNoEnterprise is an internal function for cases where the original call returned 422.
 // Currently only the `deployment_branch_policy` parameter is supported for Pro/Team private repos.
 func (s *RepositoriesService) createNewEnvNoEnterprise(ctx context.Context, u string, environment *CreateUpdateEnvironment) (*Environment, *Response, error) {
-	req, err := s.client.NewRequest("PUT", u, &createUpdateEnvironmentNoEnterprise{
+	req, err := s.client.NewRequest(ctx, "PUT", u, &createUpdateEnvironmentNoEnterprise{
 		DeploymentBranchPolicy: environment.DeploymentBranchPolicy,
 	})
 	if err != nil {
@@ -228,7 +228,7 @@ func (s *RepositoriesService) createNewEnvNoEnterprise(ctx context.Context, u st
 	}
 
 	var e *Environment
-	resp, err := s.client.Do(ctx, req, &e)
+	resp, err := s.client.Do(req, &e)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -243,10 +243,10 @@ func (s *RepositoriesService) createNewEnvNoEnterprise(ctx context.Context, u st
 //meta:operation DELETE /repos/{owner}/{repo}/environments/{environment_name}
 func (s *RepositoriesService) DeleteEnvironment(ctx context.Context, owner, repo, name string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v", owner, repo, name)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/repos_forks.go
+++ b/github/repos_forks.go
@@ -34,7 +34,7 @@ func (s *RepositoriesService) ListForks(ctx context.Context, owner, repo string,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -42,7 +42,7 @@ func (s *RepositoriesService) ListForks(ctx context.Context, owner, repo string,
 	req.Header.Set("Accept", mediaTypeTopicsPreview)
 
 	var repos []*Repository
-	resp, err := s.client.Do(ctx, req, &repos)
+	resp, err := s.client.Do(req, &repos)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -74,13 +74,13 @@ type RepositoryCreateForkOptions struct {
 func (s *RepositoriesService) CreateFork(ctx context.Context, owner, repo string, opts *RepositoryCreateForkOptions) (*Repository, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/forks", owner, repo)
 
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var fork Repository
-	resp, err := s.client.Do(ctx, req, &fork)
+	resp, err := s.client.Do(req, &fork)
 	if err != nil {
 		// Persist AcceptedError's metadata to the Repository object.
 		var aerr *AcceptedError

--- a/github/repos_hooks.go
+++ b/github/repos_hooks.go
@@ -97,13 +97,13 @@ func (s *RepositoriesService) CreateHook(ctx context.Context, owner, repo string
 		Config: hook.Config,
 	}
 
-	req, err := s.client.NewRequest("POST", u, hookReq)
+	req, err := s.client.NewRequest(ctx, "POST", u, hookReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var h *Hook
-	resp, err := s.client.Do(ctx, req, &h)
+	resp, err := s.client.Do(req, &h)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -123,13 +123,13 @@ func (s *RepositoriesService) ListHooks(ctx context.Context, owner, repo string,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hooks []*Hook
-	resp, err := s.client.Do(ctx, req, &hooks)
+	resp, err := s.client.Do(req, &hooks)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -144,13 +144,13 @@ func (s *RepositoriesService) ListHooks(ctx context.Context, owner, repo string,
 //meta:operation GET /repos/{owner}/{repo}/hooks/{hook_id}
 func (s *RepositoriesService) GetHook(ctx context.Context, owner, repo string, id int64) (*Hook, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/hooks/%v", owner, repo, id)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var h *Hook
-	resp, err := s.client.Do(ctx, req, &h)
+	resp, err := s.client.Do(req, &h)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -165,13 +165,13 @@ func (s *RepositoriesService) GetHook(ctx context.Context, owner, repo string, i
 //meta:operation PATCH /repos/{owner}/{repo}/hooks/{hook_id}
 func (s *RepositoriesService) EditHook(ctx context.Context, owner, repo string, id int64, hook *Hook) (*Hook, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/hooks/%v", owner, repo, id)
-	req, err := s.client.NewRequest("PATCH", u, hook)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, hook)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var h *Hook
-	resp, err := s.client.Do(ctx, req, &h)
+	resp, err := s.client.Do(req, &h)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -186,12 +186,12 @@ func (s *RepositoriesService) EditHook(ctx context.Context, owner, repo string, 
 //meta:operation DELETE /repos/{owner}/{repo}/hooks/{hook_id}
 func (s *RepositoriesService) DeleteHook(ctx context.Context, owner, repo string, id int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/hooks/%v", owner, repo, id)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // PingHook triggers a 'ping' event to be sent to the Hook.
@@ -201,11 +201,11 @@ func (s *RepositoriesService) DeleteHook(ctx context.Context, owner, repo string
 //meta:operation POST /repos/{owner}/{repo}/hooks/{hook_id}/pings
 func (s *RepositoriesService) PingHook(ctx context.Context, owner, repo string, id int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/hooks/%v/pings", owner, repo, id)
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // TestHook triggers a test Hook by github.
@@ -215,11 +215,11 @@ func (s *RepositoriesService) PingHook(ctx context.Context, owner, repo string, 
 //meta:operation POST /repos/{owner}/{repo}/hooks/{hook_id}/tests
 func (s *RepositoriesService) TestHook(ctx context.Context, owner, repo string, id int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/hooks/%v/tests", owner, repo, id)
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // Subscribe lets servers register to receive updates when a topic is updated.
@@ -228,12 +228,12 @@ func (s *RepositoriesService) TestHook(ctx context.Context, owner, repo string, 
 //
 //meta:operation POST /hub
 func (s *RepositoriesService) Subscribe(ctx context.Context, owner, repo, event, callback string, secret []byte) (*Response, error) {
-	req, err := s.createWebSubRequest("subscribe", owner, repo, event, callback, secret)
+	req, err := s.createWebSubRequest(ctx, "subscribe", owner, repo, event, callback, secret)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // Unsubscribe lets servers unregister to no longer receive updates when a topic is updated.
@@ -242,19 +242,19 @@ func (s *RepositoriesService) Subscribe(ctx context.Context, owner, repo, event,
 //
 //meta:operation POST /hub
 func (s *RepositoriesService) Unsubscribe(ctx context.Context, owner, repo, event, callback string, secret []byte) (*Response, error) {
-	req, err := s.createWebSubRequest("unsubscribe", owner, repo, event, callback, secret)
+	req, err := s.createWebSubRequest(ctx, "unsubscribe", owner, repo, event, callback, secret)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // createWebSubRequest returns a subscribe/unsubscribe request that implements
 // the WebSub (formerly PubSubHubbub) protocol.
 //
 // See: https://www.w3.org/TR/websub/#subscriber-sends-subscription-request
-func (s *RepositoriesService) createWebSubRequest(hubMode, owner, repo, event, callback string, secret []byte) (*http.Request, error) {
+func (s *RepositoriesService) createWebSubRequest(ctx context.Context, hubMode, owner, repo, event, callback string, secret []byte) (*http.Request, error) {
 	topic := fmt.Sprintf(
 		"https://github.com/%v/%v/events/%v",
 		owner,
@@ -270,7 +270,7 @@ func (s *RepositoriesService) createWebSubRequest(hubMode, owner, repo, event, c
 	}
 	body := strings.NewReader(form.Encode())
 
-	req, err := s.client.NewFormRequest("hub", body)
+	req, err := s.client.NewFormRequest(ctx, "hub", body)
 	if err != nil {
 		return nil, err
 	}

--- a/github/repos_hooks_configuration.go
+++ b/github/repos_hooks_configuration.go
@@ -32,13 +32,13 @@ type HookConfig struct {
 //meta:operation GET /repos/{owner}/{repo}/hooks/{hook_id}/config
 func (s *RepositoriesService) GetHookConfiguration(ctx context.Context, owner, repo string, id int64) (*HookConfig, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/hooks/%v/config", owner, repo, id)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var config *HookConfig
-	resp, err := s.client.Do(ctx, req, &config)
+	resp, err := s.client.Do(req, &config)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -53,13 +53,13 @@ func (s *RepositoriesService) GetHookConfiguration(ctx context.Context, owner, r
 //meta:operation PATCH /repos/{owner}/{repo}/hooks/{hook_id}/config
 func (s *RepositoriesService) EditHookConfiguration(ctx context.Context, owner, repo string, id int64, config *HookConfig) (*HookConfig, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/hooks/%v/config", owner, repo, id)
-	req, err := s.client.NewRequest("PATCH", u, config)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, config)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var c *HookConfig
-	resp, err := s.client.Do(ctx, req, &c)
+	resp, err := s.client.Do(req, &c)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_hooks_deliveries.go
+++ b/github/repos_hooks_deliveries.go
@@ -94,13 +94,13 @@ func (s *RepositoriesService) ListHookDeliveries(ctx context.Context, owner, rep
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	deliveries := []*HookDelivery{}
-	resp, err := s.client.Do(ctx, req, &deliveries)
+	resp, err := s.client.Do(req, &deliveries)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -115,13 +115,13 @@ func (s *RepositoriesService) ListHookDeliveries(ctx context.Context, owner, rep
 //meta:operation GET /repos/{owner}/{repo}/hooks/{hook_id}/deliveries/{delivery_id}
 func (s *RepositoriesService) GetHookDelivery(ctx context.Context, owner, repo string, hookID, deliveryID int64) (*HookDelivery, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/hooks/%v/deliveries/%v", owner, repo, hookID, deliveryID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var h *HookDelivery
-	resp, err := s.client.Do(ctx, req, &h)
+	resp, err := s.client.Do(req, &h)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -136,13 +136,13 @@ func (s *RepositoriesService) GetHookDelivery(ctx context.Context, owner, repo s
 //meta:operation POST /repos/{owner}/{repo}/hooks/{hook_id}/deliveries/{delivery_id}/attempts
 func (s *RepositoriesService) RedeliverHookDelivery(ctx context.Context, owner, repo string, hookID, deliveryID int64) (*HookDelivery, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/hooks/%v/deliveries/%v/attempts", owner, repo, hookID, deliveryID)
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var h *HookDelivery
-	resp, err := s.client.Do(ctx, req, &h)
+	resp, err := s.client.Do(req, &h)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_immutable_releases.go
+++ b/github/repos_immutable_releases.go
@@ -24,12 +24,12 @@ type RepoImmutableReleasesStatus struct {
 func (s *RepositoriesService) EnableImmutableReleases(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/immutable-releases", owner, repo)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -45,12 +45,12 @@ func (s *RepositoriesService) EnableImmutableReleases(ctx context.Context, owner
 func (s *RepositoriesService) DisableImmutableReleases(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/immutable-releases", owner, repo)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -67,13 +67,13 @@ func (s *RepositoriesService) DisableImmutableReleases(ctx context.Context, owne
 func (s *RepositoriesService) AreImmutableReleasesEnabled(ctx context.Context, owner, repo string) (*RepoImmutableReleasesStatus, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/immutable-releases", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var status *RepoImmutableReleasesStatus
-	resp, err := s.client.Do(ctx, req, &status)
+	resp, err := s.client.Do(req, &status)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_invitations.go
+++ b/github/repos_invitations.go
@@ -38,13 +38,13 @@ func (s *RepositoriesService) ListInvitations(ctx context.Context, owner, repo s
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	invites := []*RepositoryInvitation{}
-	resp, err := s.client.Do(ctx, req, &invites)
+	resp, err := s.client.Do(req, &invites)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -59,12 +59,12 @@ func (s *RepositoriesService) ListInvitations(ctx context.Context, owner, repo s
 //meta:operation DELETE /repos/{owner}/{repo}/invitations/{invitation_id}
 func (s *RepositoriesService) DeleteInvitation(ctx context.Context, owner, repo string, invitationID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/invitations/%v", owner, repo, invitationID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // UpdateInvitation updates the permissions associated with a repository
@@ -81,13 +81,13 @@ func (s *RepositoriesService) UpdateInvitation(ctx context.Context, owner, repo 
 		Permissions string `json:"permissions"`
 	}{Permissions: permissions}
 	u := fmt.Sprintf("repos/%v/%v/invitations/%v", owner, repo, invitationID)
-	req, err := s.client.NewRequest("PATCH", u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var invite *RepositoryInvitation
-	resp, err := s.client.Do(ctx, req, &invite)
+	resp, err := s.client.Do(req, &invite)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_keys.go
+++ b/github/repos_keys.go
@@ -24,13 +24,13 @@ func (s *RepositoriesService) ListKeys(ctx context.Context, owner, repo string, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var keys []*Key
-	resp, err := s.client.Do(ctx, req, &keys)
+	resp, err := s.client.Do(req, &keys)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -46,13 +46,13 @@ func (s *RepositoriesService) ListKeys(ctx context.Context, owner, repo string, 
 func (s *RepositoriesService) GetKey(ctx context.Context, owner, repo string, id int64) (*Key, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/keys/%v", owner, repo, id)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var key *Key
-	resp, err := s.client.Do(ctx, req, &key)
+	resp, err := s.client.Do(req, &key)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -68,13 +68,13 @@ func (s *RepositoriesService) GetKey(ctx context.Context, owner, repo string, id
 func (s *RepositoriesService) CreateKey(ctx context.Context, owner, repo string, key *Key) (*Key, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/keys", owner, repo)
 
-	req, err := s.client.NewRequest("POST", u, key)
+	req, err := s.client.NewRequest(ctx, "POST", u, key)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var k *Key
-	resp, err := s.client.Do(ctx, req, &k)
+	resp, err := s.client.Do(req, &k)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -90,10 +90,10 @@ func (s *RepositoriesService) CreateKey(ctx context.Context, owner, repo string,
 func (s *RepositoriesService) DeleteKey(ctx context.Context, owner, repo string, id int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/keys/%v", owner, repo, id)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/repos_lfs.go
+++ b/github/repos_lfs.go
@@ -18,12 +18,12 @@ import (
 func (s *RepositoriesService) EnableLFS(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/lfs", owner, repo)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -39,12 +39,12 @@ func (s *RepositoriesService) EnableLFS(ctx context.Context, owner, repo string)
 func (s *RepositoriesService) DisableLFS(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/lfs", owner, repo)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/github/repos_merging.go
+++ b/github/repos_merging.go
@@ -39,13 +39,13 @@ type RepoMergeUpstreamResult struct {
 //meta:operation POST /repos/{owner}/{repo}/merges
 func (s *RepositoriesService) Merge(ctx context.Context, owner, repo string, request *RepositoryMergeRequest) (*RepositoryCommit, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/merges", owner, repo)
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var commit *RepositoryCommit
-	resp, err := s.client.Do(ctx, req, &commit)
+	resp, err := s.client.Do(req, &commit)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -61,13 +61,13 @@ func (s *RepositoriesService) Merge(ctx context.Context, owner, repo string, req
 //meta:operation POST /repos/{owner}/{repo}/merge-upstream
 func (s *RepositoriesService) MergeUpstream(ctx context.Context, owner, repo string, request *RepoMergeUpstreamRequest) (*RepoMergeUpstreamResult, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/merge-upstream", owner, repo)
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var result *RepoMergeUpstreamResult
-	resp, err := s.client.Do(ctx, req, &result)
+	resp, err := s.client.Do(req, &result)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_pages.go
+++ b/github/repos_pages.go
@@ -119,7 +119,7 @@ func (s *RepositoriesService) EnablePages(ctx context.Context, owner, repo strin
 		Source:    pages.Source,
 	}
 
-	req, err := s.client.NewRequest("POST", u, pagesReq)
+	req, err := s.client.NewRequest(ctx, "POST", u, pagesReq)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -127,7 +127,7 @@ func (s *RepositoriesService) EnablePages(ctx context.Context, owner, repo strin
 	req.Header.Set("Accept", mediaTypeEnablePagesAPIPreview)
 
 	var enable *Pages
-	resp, err := s.client.Do(ctx, req, &enable)
+	resp, err := s.client.Do(req, &enable)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -166,12 +166,12 @@ type PagesUpdate struct {
 func (s *RepositoriesService) UpdatePages(ctx context.Context, owner, repo string, opts *PagesUpdate) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
 
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -195,12 +195,12 @@ type PagesUpdateWithoutCNAME struct {
 func (s *RepositoriesService) UpdatePagesGHES(ctx context.Context, owner, repo string, opts *PagesUpdateWithoutCNAME) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
 
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -214,14 +214,14 @@ func (s *RepositoriesService) UpdatePagesGHES(ctx context.Context, owner, repo s
 //meta:operation DELETE /repos/{owner}/{repo}/pages
 func (s *RepositoriesService) DisablePages(ctx context.Context, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeEnablePagesAPIPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // GetPagesInfo fetches information about a GitHub Pages site.
@@ -231,13 +231,13 @@ func (s *RepositoriesService) DisablePages(ctx context.Context, owner, repo stri
 //meta:operation GET /repos/{owner}/{repo}/pages
 func (s *RepositoriesService) GetPagesInfo(ctx context.Context, owner, repo string) (*Pages, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var site *Pages
-	resp, err := s.client.Do(ctx, req, &site)
+	resp, err := s.client.Do(req, &site)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -257,13 +257,13 @@ func (s *RepositoriesService) ListPagesBuilds(ctx context.Context, owner, repo s
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var pages []*PagesBuild
-	resp, err := s.client.Do(ctx, req, &pages)
+	resp, err := s.client.Do(req, &pages)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -278,13 +278,13 @@ func (s *RepositoriesService) ListPagesBuilds(ctx context.Context, owner, repo s
 //meta:operation GET /repos/{owner}/{repo}/pages/builds/latest
 func (s *RepositoriesService) GetLatestPagesBuild(ctx context.Context, owner, repo string) (*PagesBuild, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pages/builds/latest", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var build *PagesBuild
-	resp, err := s.client.Do(ctx, req, &build)
+	resp, err := s.client.Do(req, &build)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -299,13 +299,13 @@ func (s *RepositoriesService) GetLatestPagesBuild(ctx context.Context, owner, re
 //meta:operation GET /repos/{owner}/{repo}/pages/builds/{build_id}
 func (s *RepositoriesService) GetPageBuild(ctx context.Context, owner, repo string, id int64) (*PagesBuild, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pages/builds/%v", owner, repo, id)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var build *PagesBuild
-	resp, err := s.client.Do(ctx, req, &build)
+	resp, err := s.client.Do(req, &build)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -320,13 +320,13 @@ func (s *RepositoriesService) GetPageBuild(ctx context.Context, owner, repo stri
 //meta:operation POST /repos/{owner}/{repo}/pages/builds
 func (s *RepositoriesService) RequestPageBuild(ctx context.Context, owner, repo string) (*PagesBuild, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pages/builds", owner, repo)
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var build *PagesBuild
-	resp, err := s.client.Do(ctx, req, &build)
+	resp, err := s.client.Do(req, &build)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -341,13 +341,13 @@ func (s *RepositoriesService) RequestPageBuild(ctx context.Context, owner, repo 
 //meta:operation GET /repos/{owner}/{repo}/pages/health
 func (s *RepositoriesService) GetPageHealthCheck(ctx context.Context, owner, repo string) (*PagesHealthCheckResponse, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pages/health", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var healthCheckResponse *PagesHealthCheckResponse
-	resp, err := s.client.Do(ctx, req, &healthCheckResponse)
+	resp, err := s.client.Do(req, &healthCheckResponse)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_prereceive_hooks.go
+++ b/github/repos_prereceive_hooks.go
@@ -34,7 +34,7 @@ func (s *RepositoriesService) ListPreReceiveHooks(ctx context.Context, owner, re
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -42,7 +42,7 @@ func (s *RepositoriesService) ListPreReceiveHooks(ctx context.Context, owner, re
 	req.Header.Set("Accept", mediaTypePreReceiveHooksPreview)
 
 	var hooks []*PreReceiveHook
-	resp, err := s.client.Do(ctx, req, &hooks)
+	resp, err := s.client.Do(req, &hooks)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -57,7 +57,7 @@ func (s *RepositoriesService) ListPreReceiveHooks(ctx context.Context, owner, re
 //meta:operation GET /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}
 func (s *RepositoriesService) GetPreReceiveHook(ctx context.Context, owner, repo string, id int64) (*PreReceiveHook, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pre-receive-hooks/%v", owner, repo, id)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -65,7 +65,7 @@ func (s *RepositoriesService) GetPreReceiveHook(ctx context.Context, owner, repo
 	req.Header.Set("Accept", mediaTypePreReceiveHooksPreview)
 
 	var h *PreReceiveHook
-	resp, err := s.client.Do(ctx, req, &h)
+	resp, err := s.client.Do(req, &h)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -80,7 +80,7 @@ func (s *RepositoriesService) GetPreReceiveHook(ctx context.Context, owner, repo
 //meta:operation PATCH /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}
 func (s *RepositoriesService) UpdatePreReceiveHook(ctx context.Context, owner, repo string, id int64, hook *PreReceiveHook) (*PreReceiveHook, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pre-receive-hooks/%v", owner, repo, id)
-	req, err := s.client.NewRequest("PATCH", u, hook)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, hook)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -88,7 +88,7 @@ func (s *RepositoriesService) UpdatePreReceiveHook(ctx context.Context, owner, r
 	req.Header.Set("Accept", mediaTypePreReceiveHooksPreview)
 
 	var h *PreReceiveHook
-	resp, err := s.client.Do(ctx, req, &h)
+	resp, err := s.client.Do(req, &h)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -103,12 +103,12 @@ func (s *RepositoriesService) UpdatePreReceiveHook(ctx context.Context, owner, r
 //meta:operation DELETE /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}
 func (s *RepositoriesService) DeletePreReceiveHook(ctx context.Context, owner, repo string, id int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pre-receive-hooks/%v", owner, repo, id)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypePreReceiveHooksPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/repos_properties.go
+++ b/github/repos_properties.go
@@ -18,13 +18,13 @@ import (
 func (s *RepositoriesService) GetAllCustomPropertyValues(ctx context.Context, org, repo string) ([]*CustomPropertyValue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/properties/values", org, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var customPropertyValues []*CustomPropertyValue
-	resp, err := s.client.Do(ctx, req, &customPropertyValues)
+	resp, err := s.client.Do(req, &customPropertyValues)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -46,12 +46,12 @@ func (s *RepositoriesService) CreateOrUpdateCustomProperties(ctx context.Context
 		Properties: customPropertyValues,
 	}
 
-	req, err := s.client.NewRequest("PATCH", u, params)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, params)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -100,13 +100,13 @@ func (s *RepositoriesService) ListReleases(ctx context.Context, owner, repo stri
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var releases []*RepositoryRelease
-	resp, err := s.client.Do(ctx, req, &releases)
+	resp, err := s.client.Do(req, &releases)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -150,13 +150,13 @@ func (s *RepositoriesService) GetReleaseByTag(ctx context.Context, owner, repo, 
 //meta:operation POST /repos/{owner}/{repo}/releases/generate-notes
 func (s *RepositoriesService) GenerateReleaseNotes(ctx context.Context, owner, repo string, opts *GenerateNotesOptions) (*RepositoryReleaseNotes, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/releases/generate-notes", owner, repo)
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *RepositoryReleaseNotes
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -165,13 +165,13 @@ func (s *RepositoriesService) GenerateReleaseNotes(ctx context.Context, owner, r
 }
 
 func (s *RepositoriesService) getSingleRelease(ctx context.Context, url string) (*RepositoryRelease, *Response, error) {
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var release *RepositoryRelease
-	resp, err := s.client.Do(ctx, req, &release)
+	resp, err := s.client.Do(req, &release)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -224,13 +224,13 @@ func (s *RepositoriesService) CreateRelease(ctx context.Context, owner, repo str
 		GenerateReleaseNotes:   release.GenerateReleaseNotes,
 	}
 
-	req, err := s.client.NewRequest("POST", u, releaseReq)
+	req, err := s.client.NewRequest(ctx, "POST", u, releaseReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *RepositoryRelease
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -264,13 +264,13 @@ func (s *RepositoriesService) EditRelease(ctx context.Context, owner, repo strin
 		DiscussionCategoryName: release.DiscussionCategoryName,
 	}
 
-	req, err := s.client.NewRequest("PATCH", u, releaseReq)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, releaseReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var r *RepositoryRelease
-	resp, err := s.client.Do(ctx, req, &r)
+	resp, err := s.client.Do(req, &r)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -286,11 +286,11 @@ func (s *RepositoriesService) EditRelease(ctx context.Context, owner, repo strin
 func (s *RepositoriesService) DeleteRelease(ctx context.Context, owner, repo string, id int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/releases/%v", owner, repo, id)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListReleaseAssets lists the release's assets.
@@ -305,13 +305,13 @@ func (s *RepositoriesService) ListReleaseAssets(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var assets []*ReleaseAsset
-	resp, err := s.client.Do(ctx, req, &assets)
+	resp, err := s.client.Do(req, &assets)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -326,13 +326,13 @@ func (s *RepositoriesService) ListReleaseAssets(ctx context.Context, owner, repo
 func (s *RepositoriesService) GetReleaseAsset(ctx context.Context, owner, repo string, id int64) (*ReleaseAsset, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/releases/assets/%v", owner, repo, id)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var asset *ReleaseAsset
-	resp, err := s.client.Do(ctx, req, &asset)
+	resp, err := s.client.Do(req, &asset)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -359,13 +359,13 @@ func (s *RepositoriesService) GetReleaseAsset(ctx context.Context, owner, repo s
 func (s *RepositoriesService) DownloadReleaseAsset(ctx context.Context, owner, repo string, id int64, followRedirectsClient *http.Client) (rc io.ReadCloser, redirectURL string, err error) {
 	u := fmt.Sprintf("repos/%v/%v/releases/assets/%v", owner, repo, id)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, "", err
 	}
 	req.Header.Set("Accept", defaultMediaType)
 
-	loc, resp, err := s.client.bareDoUntilFound(ctx, req, 10)
+	loc, resp, err := s.client.bareDoUntilFound(req, 10)
 	if err != nil {
 		return nil, "", err
 	}
@@ -389,11 +389,10 @@ func (s *RepositoriesService) DownloadReleaseAsset(ctx context.Context, owner, r
 }
 
 func (s *RepositoriesService) downloadReleaseAssetFromURL(ctx context.Context, followRedirectsClient *http.Client, url string) (rc io.ReadCloser, err error) {
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
-	req = withContext(ctx, req)
 	req.Header.Set("Accept", defaultMediaType)
 	resp, err := followRedirectsClient.Do(req)
 	if err != nil {
@@ -414,13 +413,13 @@ func (s *RepositoriesService) downloadReleaseAssetFromURL(ctx context.Context, f
 func (s *RepositoriesService) EditReleaseAsset(ctx context.Context, owner, repo string, id int64, release *ReleaseAsset) (*ReleaseAsset, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/releases/assets/%v", owner, repo, id)
 
-	req, err := s.client.NewRequest("PATCH", u, release)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, release)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var asset *ReleaseAsset
-	resp, err := s.client.Do(ctx, req, &asset)
+	resp, err := s.client.Do(req, &asset)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -436,11 +435,11 @@ func (s *RepositoriesService) EditReleaseAsset(ctx context.Context, owner, repo 
 func (s *RepositoriesService) DeleteReleaseAsset(ctx context.Context, owner, repo string, id int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/releases/assets/%v", owner, repo, id)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // UploadReleaseAsset creates an asset by uploading a file into a release repository.
@@ -473,13 +472,13 @@ func (s *RepositoriesService) UploadReleaseAsset(ctx context.Context, owner, rep
 		mediaType = opts.MediaType
 	}
 
-	req, err := s.client.NewUploadRequest(u, file, stat.Size(), mediaType)
+	req, err := s.client.NewUploadRequest(ctx, u, file, stat.Size(), mediaType)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var asset *ReleaseAsset
-	resp, err := s.client.Do(ctx, req, &asset)
+	resp, err := s.client.Do(req, &asset)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -547,13 +546,13 @@ func (s *RepositoriesService) UploadReleaseAssetFromRelease(
 		}
 	}
 
-	req, err := s.client.NewUploadRequest(u, reader, size, mediaType)
+	req, err := s.client.NewUploadRequest(ctx, u, reader, size, mediaType)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var asset *ReleaseAsset
-	resp, err := s.client.Do(ctx, req, &asset)
+	resp, err := s.client.Do(req, &asset)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -23,13 +23,13 @@ func (s *RepositoriesService) GetRulesForBranch(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var rules *BranchRules
-	resp, err := s.client.Do(ctx, req, &rules)
+	resp, err := s.client.Do(req, &rules)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -60,13 +60,13 @@ func (s *RepositoriesService) GetAllRulesets(ctx context.Context, owner, repo st
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var ruleset []*RepositoryRuleset
-	resp, err := s.client.Do(ctx, req, &ruleset)
+	resp, err := s.client.Do(req, &ruleset)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -82,13 +82,13 @@ func (s *RepositoriesService) GetAllRulesets(ctx context.Context, owner, repo st
 func (s *RepositoriesService) CreateRuleset(ctx context.Context, owner, repo string, ruleset RepositoryRuleset) (*RepositoryRuleset, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/rulesets", owner, repo)
 
-	req, err := s.client.NewRequest("POST", u, ruleset)
+	req, err := s.client.NewRequest(ctx, "POST", u, ruleset)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var rs *RepositoryRuleset
-	resp, err := s.client.Do(ctx, req, &rs)
+	resp, err := s.client.Do(req, &rs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -105,13 +105,13 @@ func (s *RepositoriesService) CreateRuleset(ctx context.Context, owner, repo str
 func (s *RepositoriesService) GetRuleset(ctx context.Context, owner, repo string, rulesetID int64, includesParents bool) (*RepositoryRuleset, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/rulesets/%v?includes_parents=%v", owner, repo, rulesetID, includesParents)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var ruleset *RepositoryRuleset
-	resp, err := s.client.Do(ctx, req, &ruleset)
+	resp, err := s.client.Do(req, &ruleset)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -127,13 +127,13 @@ func (s *RepositoriesService) GetRuleset(ctx context.Context, owner, repo string
 func (s *RepositoriesService) UpdateRuleset(ctx context.Context, owner, repo string, rulesetID int64, ruleset RepositoryRuleset) (*RepositoryRuleset, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/rulesets/%v", owner, repo, rulesetID)
 
-	req, err := s.client.NewRequest("PUT", u, ruleset)
+	req, err := s.client.NewRequest(ctx, "PUT", u, ruleset)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var rs *RepositoryRuleset
-	resp, err := s.client.Do(ctx, req, &rs)
+	resp, err := s.client.Do(req, &rs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -149,10 +149,10 @@ func (s *RepositoriesService) UpdateRuleset(ctx context.Context, owner, repo str
 func (s *RepositoriesService) DeleteRuleset(ctx context.Context, owner, repo string, rulesetID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/rulesets/%v", owner, repo, rulesetID)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/repos_stats.go
+++ b/github/repos_stats.go
@@ -50,13 +50,13 @@ func (w WeeklyStats) String() string {
 //meta:operation GET /repos/{owner}/{repo}/stats/contributors
 func (s *RepositoriesService) ListContributorsStats(ctx context.Context, owner, repo string) ([]*ContributorStats, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/stats/contributors", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var contributorStats []*ContributorStats
-	resp, err := s.client.Do(ctx, req, &contributorStats)
+	resp, err := s.client.Do(req, &contributorStats)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -91,13 +91,13 @@ func (w WeeklyCommitActivity) String() string {
 //meta:operation GET /repos/{owner}/{repo}/stats/commit_activity
 func (s *RepositoriesService) ListCommitActivity(ctx context.Context, owner, repo string) ([]*WeeklyCommitActivity, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/stats/commit_activity", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var weeklyCommitActivity []*WeeklyCommitActivity
-	resp, err := s.client.Do(ctx, req, &weeklyCommitActivity)
+	resp, err := s.client.Do(req, &weeklyCommitActivity)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -120,13 +120,13 @@ func (s *RepositoriesService) ListCommitActivity(ctx context.Context, owner, rep
 //meta:operation GET /repos/{owner}/{repo}/stats/code_frequency
 func (s *RepositoriesService) ListCodeFrequency(ctx context.Context, owner, repo string) ([]*WeeklyStats, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/stats/code_frequency", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var weeks [][]int
-	resp, err := s.client.Do(ctx, req, &weeks)
+	resp, err := s.client.Do(req, &weeks)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -178,13 +178,13 @@ func (r RepositoryParticipation) String() string {
 //meta:operation GET /repos/{owner}/{repo}/stats/participation
 func (s *RepositoriesService) ListParticipation(ctx context.Context, owner, repo string) (*RepositoryParticipation, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/stats/participation", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var participation *RepositoryParticipation
-	resp, err := s.client.Do(ctx, req, &participation)
+	resp, err := s.client.Do(req, &participation)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -213,13 +213,13 @@ type PunchCard struct {
 //meta:operation GET /repos/{owner}/{repo}/stats/punch_card
 func (s *RepositoriesService) ListPunchCard(ctx context.Context, owner, repo string) ([]*PunchCard, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/stats/punch_card", owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var results [][]int
-	resp, err := s.client.Do(ctx, req, &results)
+	resp, err := s.client.Do(req, &results)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_statuses.go
+++ b/github/repos_statuses.go
@@ -55,13 +55,13 @@ func (s *RepositoriesService) ListStatuses(ctx context.Context, owner, repo, ref
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var statuses []*RepoStatus
-	resp, err := s.client.Do(ctx, req, &statuses)
+	resp, err := s.client.Do(req, &statuses)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -77,13 +77,13 @@ func (s *RepositoriesService) ListStatuses(ctx context.Context, owner, repo, ref
 //meta:operation POST /repos/{owner}/{repo}/statuses/{sha}
 func (s *RepositoriesService) CreateStatus(ctx context.Context, owner, repo, ref string, status RepoStatus) (*RepoStatus, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/statuses/%v", owner, repo, refURLEscape(ref))
-	req, err := s.client.NewRequest("POST", u, &status)
+	req, err := s.client.NewRequest(ctx, "POST", u, &status)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var repoStatus *RepoStatus
-	resp, err := s.client.Do(ctx, req, &repoStatus)
+	resp, err := s.client.Do(req, &repoStatus)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -123,13 +123,13 @@ func (s *RepositoriesService) GetCombinedStatus(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var status *CombinedStatus
-	resp, err := s.client.Do(ctx, req, &status)
+	resp, err := s.client.Do(req, &status)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/repos_tags.go
+++ b/github/repos_tags.go
@@ -32,13 +32,13 @@ type tagProtectionRequest struct {
 func (s *RepositoriesService) ListTagProtection(ctx context.Context, owner, repo string) ([]*TagProtection, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/tags/protection", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var tagProtections []*TagProtection
-	resp, err := s.client.Do(ctx, req, &tagProtections)
+	resp, err := s.client.Do(req, &tagProtections)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -56,13 +56,13 @@ func (s *RepositoriesService) ListTagProtection(ctx context.Context, owner, repo
 func (s *RepositoriesService) CreateTagProtection(ctx context.Context, owner, repo, pattern string) (*TagProtection, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/tags/protection", owner, repo)
 	r := &tagProtectionRequest{Pattern: pattern}
-	req, err := s.client.NewRequest("POST", u, r)
+	req, err := s.client.NewRequest(ctx, "POST", u, r)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var tagProtection *TagProtection
-	resp, err := s.client.Do(ctx, req, &tagProtection)
+	resp, err := s.client.Do(req, &tagProtection)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -79,10 +79,10 @@ func (s *RepositoriesService) CreateTagProtection(ctx context.Context, owner, re
 //meta:operation DELETE /repos/{owner}/{repo}/tags/protection/{tag_protection_id}
 func (s *RepositoriesService) DeleteTagProtection(ctx context.Context, owner, repo string, tagProtectionID int64) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/tags/protection/%v", owner, repo, tagProtectionID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/repos_traffic.go
+++ b/github/repos_traffic.go
@@ -60,13 +60,13 @@ type TrafficBreakdownOptions struct {
 func (s *RepositoriesService) ListTrafficReferrers(ctx context.Context, owner, repo string) ([]*TrafficReferrer, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/traffic/popular/referrers", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var trafficReferrers []*TrafficReferrer
-	resp, err := s.client.Do(ctx, req, &trafficReferrers)
+	resp, err := s.client.Do(req, &trafficReferrers)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -82,13 +82,13 @@ func (s *RepositoriesService) ListTrafficReferrers(ctx context.Context, owner, r
 func (s *RepositoriesService) ListTrafficPaths(ctx context.Context, owner, repo string) ([]*TrafficPath, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/traffic/popular/paths", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var paths []*TrafficPath
-	resp, err := s.client.Do(ctx, req, &paths)
+	resp, err := s.client.Do(req, &paths)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -108,13 +108,13 @@ func (s *RepositoriesService) ListTrafficViews(ctx context.Context, owner, repo 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var trafficViews *TrafficViews
-	resp, err := s.client.Do(ctx, req, &trafficViews)
+	resp, err := s.client.Do(req, &trafficViews)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -134,13 +134,13 @@ func (s *RepositoriesService) ListTrafficClones(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var trafficClones *TrafficClones
-	resp, err := s.client.Do(ctx, req, &trafficClones)
+	resp, err := s.client.Do(req, &trafficClones)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/scim.go
+++ b/github/scim.go
@@ -105,13 +105,13 @@ func (s *SCIMService) ListSCIMProvisionedIdentities(ctx context.Context, org str
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var identities *SCIMProvisionedIdentities
-	resp, err := s.client.Do(ctx, req, &identities)
+	resp, err := s.client.Do(req, &identities)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -127,13 +127,13 @@ func (s *SCIMService) ListSCIMProvisionedIdentities(ctx context.Context, org str
 func (s *SCIMService) ProvisionAndInviteSCIMUser(ctx context.Context, org string, opts *SCIMUserAttributes) (*SCIMUserAttributes, *Response, error) {
 	u := fmt.Sprintf("scim/v2/organizations/%v/Users", org)
 
-	req, err := s.client.NewRequest("POST", u, opts)
+	req, err := s.client.NewRequest(ctx, "POST", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var user *SCIMUserAttributes
-	resp, err := s.client.Do(ctx, req, &user)
+	resp, err := s.client.Do(req, &user)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -148,13 +148,13 @@ func (s *SCIMService) ProvisionAndInviteSCIMUser(ctx context.Context, org string
 //meta:operation GET /scim/v2/organizations/{org}/Users/{scim_user_id}
 func (s *SCIMService) GetSCIMProvisioningInfoForUser(ctx context.Context, org, scimUserID string) (*SCIMUserAttributes, *Response, error) {
 	u := fmt.Sprintf("scim/v2/organizations/%v/Users/%v", org, scimUserID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var user *SCIMUserAttributes
-	resp, err := s.client.Do(ctx, req, &user)
+	resp, err := s.client.Do(req, &user)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -174,12 +174,12 @@ func (s *SCIMService) UpdateProvisionedOrgMembership(ctx context.Context, org, s
 		return nil, err
 	}
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // UpdateAttributeForSCIMUserOptions represents options for UpdateAttributeForSCIMUser.
@@ -209,12 +209,12 @@ func (s *SCIMService) UpdateAttributeForSCIMUser(ctx context.Context, org, scimU
 		return nil, err
 	}
 
-	req, err := s.client.NewRequest("PATCH", u, nil)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DeleteSCIMUserFromOrg deletes SCIM user from an organization.
@@ -224,10 +224,10 @@ func (s *SCIMService) UpdateAttributeForSCIMUser(ctx context.Context, org, scimU
 //meta:operation DELETE /scim/v2/organizations/{org}/Users/{scim_user_id}
 func (s *SCIMService) DeleteSCIMUserFromOrg(ctx context.Context, org, scimUserID string) (*Response, error) {
 	u := fmt.Sprintf("scim/v2/organizations/%v/Users/%v", org, scimUserID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/search.go
+++ b/github/search.go
@@ -316,7 +316,7 @@ func (s *SearchService) search(ctx context.Context, searchType string, parameter
 	params.Set("q", parameters.Query)
 	u := fmt.Sprintf("search/%v?%v", searchType, params.Encode())
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -340,5 +340,5 @@ func (s *SearchService) search(ctx context.Context, searchType string, parameter
 	}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
-	return s.client.Do(ctx, req, result)
+	return s.client.Do(req, result)
 }

--- a/github/secret_scanning.go
+++ b/github/secret_scanning.go
@@ -182,13 +182,13 @@ func (s *SecretScanningService) ListAlertsForEnterprise(ctx context.Context, ent
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var alerts []*SecretScanningAlert
-	resp, err := s.client.Do(ctx, req, &alerts)
+	resp, err := s.client.Do(req, &alerts)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -211,13 +211,13 @@ func (s *SecretScanningService) ListAlertsForOrg(ctx context.Context, org string
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var alerts []*SecretScanningAlert
-	resp, err := s.client.Do(ctx, req, &alerts)
+	resp, err := s.client.Do(req, &alerts)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -240,13 +240,13 @@ func (s *SecretScanningService) ListAlertsForRepo(ctx context.Context, owner, re
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var alerts []*SecretScanningAlert
-	resp, err := s.client.Do(ctx, req, &alerts)
+	resp, err := s.client.Do(req, &alerts)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -265,13 +265,13 @@ func (s *SecretScanningService) ListAlertsForRepo(ctx context.Context, owner, re
 func (s *SecretScanningService) GetAlert(ctx context.Context, owner, repo string, number int64) (*SecretScanningAlert, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/secret-scanning/alerts/%v", owner, repo, number)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var alert *SecretScanningAlert
-	resp, err := s.client.Do(ctx, req, &alert)
+	resp, err := s.client.Do(req, &alert)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -290,13 +290,13 @@ func (s *SecretScanningService) GetAlert(ctx context.Context, owner, repo string
 func (s *SecretScanningService) UpdateAlert(ctx context.Context, owner, repo string, number int64, opts *SecretScanningAlertUpdateOptions) (*SecretScanningAlert, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/secret-scanning/alerts/%v", owner, repo, number)
 
-	req, err := s.client.NewRequest("PATCH", u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var alert *SecretScanningAlert
-	resp, err := s.client.Do(ctx, req, &alert)
+	resp, err := s.client.Do(req, &alert)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -319,13 +319,13 @@ func (s *SecretScanningService) ListLocationsForAlert(ctx context.Context, owner
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var locations []*SecretScanningAlertLocation
-	resp, err := s.client.Do(ctx, req, &locations)
+	resp, err := s.client.Do(req, &locations)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -344,13 +344,13 @@ func (s *SecretScanningService) ListLocationsForAlert(ctx context.Context, owner
 func (s *SecretScanningService) CreatePushProtectionBypass(ctx context.Context, owner, repo string, request PushProtectionBypassRequest) (*PushProtectionBypass, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/secret-scanning/push-protection-bypasses", owner, repo)
 
-	req, err := s.client.NewRequest("POST", u, request)
+	req, err := s.client.NewRequest(ctx, "POST", u, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var pushProtectionBypass *PushProtectionBypass
-	resp, err := s.client.Do(ctx, req, &pushProtectionBypass)
+	resp, err := s.client.Do(req, &pushProtectionBypass)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -368,13 +368,13 @@ func (s *SecretScanningService) CreatePushProtectionBypass(ctx context.Context, 
 func (s *SecretScanningService) GetScanHistory(ctx context.Context, owner, repo string) (*SecretScanningScanHistory, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/secret-scanning/scan-history", owner, repo)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var secretScanningHistory *SecretScanningScanHistory
-	resp, err := s.client.Do(ctx, req, &secretScanningHistory)
+	resp, err := s.client.Do(req, &secretScanningHistory)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/secret_scanning_pattern_configs.go
+++ b/github/secret_scanning_pattern_configs.go
@@ -84,13 +84,13 @@ type SecretScanningCustomPatternSetting struct {
 func (s *SecretScanningService) ListPatternConfigsForEnterprise(ctx context.Context, enterprise string) (*SecretScanningPatternConfigs, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/secret-scanning/pattern-configurations", enterprise)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var patternConfigs *SecretScanningPatternConfigs
-	resp, err := s.client.Do(ctx, req, &patternConfigs)
+	resp, err := s.client.Do(req, &patternConfigs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -106,13 +106,13 @@ func (s *SecretScanningService) ListPatternConfigsForEnterprise(ctx context.Cont
 func (s *SecretScanningService) ListPatternConfigsForOrg(ctx context.Context, org string) (*SecretScanningPatternConfigs, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/secret-scanning/pattern-configurations", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var patternConfigs *SecretScanningPatternConfigs
-	resp, err := s.client.Do(ctx, req, &patternConfigs)
+	resp, err := s.client.Do(req, &patternConfigs)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -128,13 +128,13 @@ func (s *SecretScanningService) ListPatternConfigsForOrg(ctx context.Context, or
 func (s *SecretScanningService) UpdatePatternConfigsForEnterprise(ctx context.Context, enterprise string, opts *SecretScanningPatternConfigsUpdateOptions) (*SecretScanningPatternConfigsUpdate, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/secret-scanning/pattern-configurations", enterprise)
 
-	req, err := s.client.NewRequest("PATCH", u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var patternConfigsUpdate *SecretScanningPatternConfigsUpdate
-	resp, err := s.client.Do(ctx, req, &patternConfigsUpdate)
+	resp, err := s.client.Do(req, &patternConfigsUpdate)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -150,13 +150,13 @@ func (s *SecretScanningService) UpdatePatternConfigsForEnterprise(ctx context.Co
 func (s *SecretScanningService) UpdatePatternConfigsForOrg(ctx context.Context, org string, opts *SecretScanningPatternConfigsUpdateOptions) (*SecretScanningPatternConfigsUpdate, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/secret-scanning/pattern-configurations", org)
 
-	req, err := s.client.NewRequest("PATCH", u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var patternConfigsUpdate *SecretScanningPatternConfigsUpdate
-	resp, err := s.client.Do(ctx, req, &patternConfigsUpdate)
+	resp, err := s.client.Do(req, &patternConfigsUpdate)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/security_advisories.go
+++ b/github/security_advisories.go
@@ -137,12 +137,12 @@ type Credit struct {
 func (s *SecurityAdvisoriesService) RequestCVE(ctx context.Context, owner, repo, ghsaID string) (*Response, error) {
 	url := fmt.Sprintf("repos/%v/%v/security-advisories/%v/cve", owner, repo, ghsaID)
 
-	req, err := s.client.NewRequest("POST", url, nil)
+	req, err := s.client.NewRequest(ctx, "POST", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		if errors.As(err, new(*AcceptedError)) {
 			return resp, nil
@@ -163,13 +163,13 @@ func (s *SecurityAdvisoriesService) RequestCVE(ctx context.Context, owner, repo,
 func (s *SecurityAdvisoriesService) CreateTemporaryPrivateFork(ctx context.Context, owner, repo, ghsaID string) (*Repository, *Response, error) {
 	url := fmt.Sprintf("repos/%v/%v/security-advisories/%v/forks", owner, repo, ghsaID)
 
-	req, err := s.client.NewRequest("POST", url, nil)
+	req, err := s.client.NewRequest(ctx, "POST", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var fork Repository
-	resp, err := s.client.Do(ctx, req, &fork)
+	resp, err := s.client.Do(req, &fork)
 	if err != nil {
 		var aerr *AcceptedError
 		if errors.As(err, &aerr) {
@@ -197,13 +197,13 @@ func (s *SecurityAdvisoriesService) ListRepositorySecurityAdvisoriesForOrg(ctx c
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var advisories []*SecurityAdvisory
-	resp, err := s.client.Do(ctx, req, &advisories)
+	resp, err := s.client.Do(req, &advisories)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -223,13 +223,13 @@ func (s *SecurityAdvisoriesService) ListRepositorySecurityAdvisories(ctx context
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var advisories []*SecurityAdvisory
-	resp, err := s.client.Do(ctx, req, &advisories)
+	resp, err := s.client.Do(req, &advisories)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -249,13 +249,13 @@ func (s *SecurityAdvisoriesService) ListGlobalSecurityAdvisories(ctx context.Con
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var advisories []*GlobalSecurityAdvisory
-	resp, err := s.client.Do(ctx, req, &advisories)
+	resp, err := s.client.Do(req, &advisories)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -270,13 +270,13 @@ func (s *SecurityAdvisoriesService) ListGlobalSecurityAdvisories(ctx context.Con
 //meta:operation GET /advisories/{ghsa_id}
 func (s *SecurityAdvisoriesService) GetGlobalSecurityAdvisories(ctx context.Context, ghsaID string) (*GlobalSecurityAdvisory, *Response, error) {
 	url := fmt.Sprintf("advisories/%v", ghsaID)
-	req, err := s.client.NewRequest("GET", url, nil)
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var advisory *GlobalSecurityAdvisory
-	resp, err := s.client.Do(ctx, req, &advisory)
+	resp, err := s.client.Do(req, &advisory)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/sub_issue.go
+++ b/github/sub_issue.go
@@ -52,13 +52,13 @@ type SubIssueRequest struct {
 func (s *SubIssueService) Remove(ctx context.Context, owner, repo string, issueNumber int64, subIssue SubIssueRequest) (*SubIssue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v/sub_issue", owner, repo, issueNumber)
 
-	req, err := s.client.NewRequest("DELETE", u, subIssue)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, subIssue)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var si *SubIssue
-	resp, err := s.client.Do(ctx, req, &si)
+	resp, err := s.client.Do(req, &si)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -78,13 +78,13 @@ func (s *SubIssueService) ListByIssue(ctx context.Context, owner, repo string, i
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var subIssues []*SubIssue
-	resp, err := s.client.Do(ctx, req, &subIssues)
+	resp, err := s.client.Do(req, &subIssues)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -102,13 +102,13 @@ func (s *SubIssueService) ListByIssue(ctx context.Context, owner, repo string, i
 //meta:operation POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues
 func (s *SubIssueService) Add(ctx context.Context, owner, repo string, issueNumber int64, subIssue SubIssueRequest) (*SubIssue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v/sub_issues", owner, repo, issueNumber)
-	req, err := s.client.NewRequest("POST", u, subIssue)
+	req, err := s.client.NewRequest(ctx, "POST", u, subIssue)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var si *SubIssue
-	resp, err := s.client.Do(ctx, req, &si)
+	resp, err := s.client.Do(req, &si)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -125,13 +125,13 @@ func (s *SubIssueService) Add(ctx context.Context, owner, repo string, issueNumb
 //meta:operation PATCH /repos/{owner}/{repo}/issues/{issue_number}/sub_issues/priority
 func (s *SubIssueService) Reprioritize(ctx context.Context, owner, repo string, issueNumber int64, subIssue SubIssueRequest) (*SubIssue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v/sub_issues/priority", owner, repo, issueNumber)
-	req, err := s.client.NewRequest("PATCH", u, subIssue)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, subIssue)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var si *SubIssue
-	resp, err := s.client.Do(ctx, req, &si)
+	resp, err := s.client.Do(req, &si)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/teams.go
+++ b/github/teams.go
@@ -102,13 +102,13 @@ func (s *TeamsService) ListTeams(ctx context.Context, org string, opts *ListOpti
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teams []*Team
-	resp, err := s.client.Do(ctx, req, &teams)
+	resp, err := s.client.Do(req, &teams)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -125,13 +125,13 @@ func (s *TeamsService) ListTeams(ctx context.Context, org string, opts *ListOpti
 //meta:operation GET /orgs/{org}/teams/{team_slug}
 func (s *TeamsService) GetTeamByID(ctx context.Context, orgID, teamID int64) (*Team, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v", orgID, teamID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var t *Team
-	resp, err := s.client.Do(ctx, req, &t)
+	resp, err := s.client.Do(req, &t)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -146,13 +146,13 @@ func (s *TeamsService) GetTeamByID(ctx context.Context, orgID, teamID int64) (*T
 //meta:operation GET /orgs/{org}/teams/{team_slug}
 func (s *TeamsService) GetTeamBySlug(ctx context.Context, org, slug string) (*Team, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v", org, slug)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var t *Team
-	resp, err := s.client.Do(ctx, req, &t)
+	resp, err := s.client.Do(req, &t)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -201,13 +201,13 @@ func (s NewTeam) String() string {
 //meta:operation POST /orgs/{org}/teams
 func (s *TeamsService) CreateTeam(ctx context.Context, org string, team NewTeam) (*Team, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams", org)
-	req, err := s.client.NewRequest("POST", u, team)
+	req, err := s.client.NewRequest(ctx, "POST", u, team)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var t *Team
-	resp, err := s.client.Do(ctx, req, &t)
+	resp, err := s.client.Do(req, &t)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -258,16 +258,16 @@ func (s *TeamsService) EditTeamByID(ctx context.Context, orgID, teamID int64, te
 	var err error
 	if removeParent {
 		teamRemoveParent := copyNewTeamWithoutParent(&team)
-		req, err = s.client.NewRequest("PATCH", u, teamRemoveParent)
+		req, err = s.client.NewRequest(ctx, "PATCH", u, teamRemoveParent)
 	} else {
-		req, err = s.client.NewRequest("PATCH", u, team)
+		req, err = s.client.NewRequest(ctx, "PATCH", u, team)
 	}
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var t *Team
-	resp, err := s.client.Do(ctx, req, &t)
+	resp, err := s.client.Do(req, &t)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -287,16 +287,16 @@ func (s *TeamsService) EditTeamBySlug(ctx context.Context, org, slug string, tea
 	var err error
 	if removeParent {
 		teamRemoveParent := copyNewTeamWithoutParent(&team)
-		req, err = s.client.NewRequest("PATCH", u, teamRemoveParent)
+		req, err = s.client.NewRequest(ctx, "PATCH", u, teamRemoveParent)
 	} else {
-		req, err = s.client.NewRequest("PATCH", u, team)
+		req, err = s.client.NewRequest(ctx, "PATCH", u, team)
 	}
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var t *Team
-	resp, err := s.client.Do(ctx, req, &t)
+	resp, err := s.client.Do(req, &t)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -313,12 +313,12 @@ func (s *TeamsService) EditTeamBySlug(ctx context.Context, org, slug string, tea
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}
 func (s *TeamsService) DeleteTeamByID(ctx context.Context, orgID, teamID int64) (*Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v", orgID, teamID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DeleteTeamBySlug deletes a team reference by slug.
@@ -328,12 +328,12 @@ func (s *TeamsService) DeleteTeamByID(ctx context.Context, orgID, teamID int64) 
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}
 func (s *TeamsService) DeleteTeamBySlug(ctx context.Context, org, slug string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v", org, slug)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListChildTeamsByParentID lists child teams for a parent team given parent ID.
@@ -350,13 +350,13 @@ func (s *TeamsService) ListChildTeamsByParentID(ctx context.Context, orgID, team
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teams []*Team
-	resp, err := s.client.Do(ctx, req, &teams)
+	resp, err := s.client.Do(req, &teams)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -376,13 +376,13 @@ func (s *TeamsService) ListChildTeamsByParentSlug(ctx context.Context, org, slug
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teams []*Team
-	resp, err := s.client.Do(ctx, req, &teams)
+	resp, err := s.client.Do(req, &teams)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -404,7 +404,7 @@ func (s *TeamsService) ListTeamReposByID(ctx context.Context, orgID, teamID int6
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -412,7 +412,7 @@ func (s *TeamsService) ListTeamReposByID(ctx context.Context, orgID, teamID int6
 	req.Header.Set("Accept", mediaTypeTopicsPreview)
 
 	var repos []*Repository
-	resp, err := s.client.Do(ctx, req, &repos)
+	resp, err := s.client.Do(req, &repos)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -432,7 +432,7 @@ func (s *TeamsService) ListTeamReposBySlug(ctx context.Context, org, slug string
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -440,7 +440,7 @@ func (s *TeamsService) ListTeamReposBySlug(ctx context.Context, org, slug string
 	req.Header.Set("Accept", mediaTypeTopicsPreview)
 
 	var repos []*Repository
-	resp, err := s.client.Do(ctx, req, &repos)
+	resp, err := s.client.Do(req, &repos)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -459,7 +459,7 @@ func (s *TeamsService) ListTeamReposBySlug(ctx context.Context, org, slug string
 //meta:operation GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
 func (s *TeamsService) IsTeamRepoByID(ctx context.Context, orgID, teamID int64, owner, repo string) (*Repository, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/repos/%v/%v", orgID, teamID, owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -467,7 +467,7 @@ func (s *TeamsService) IsTeamRepoByID(ctx context.Context, orgID, teamID int64, 
 	req.Header.Set("Accept", mediaTypeOrgPermissionRepo)
 
 	var repository *Repository
-	resp, err := s.client.Do(ctx, req, &repository)
+	resp, err := s.client.Do(req, &repository)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -484,7 +484,7 @@ func (s *TeamsService) IsTeamRepoByID(ctx context.Context, orgID, teamID int64, 
 //meta:operation GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
 func (s *TeamsService) IsTeamRepoBySlug(ctx context.Context, org, slug, owner, repo string) (*Repository, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/repos/%v/%v", org, slug, owner, repo)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -492,7 +492,7 @@ func (s *TeamsService) IsTeamRepoBySlug(ctx context.Context, org, slug, owner, r
 	req.Header.Set("Accept", mediaTypeOrgPermissionRepo)
 
 	var repository *Repository
-	resp, err := s.client.Do(ctx, req, &repository)
+	resp, err := s.client.Do(req, &repository)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -526,12 +526,12 @@ type TeamAddTeamRepoOptions struct {
 //meta:operation PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
 func (s *TeamsService) AddTeamRepoByID(ctx context.Context, orgID, teamID int64, owner, repo string, opts *TeamAddTeamRepoOptions) (*Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/repos/%v/%v", orgID, teamID, owner, repo)
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // AddTeamRepoBySlug adds a repository to be managed by the specified team given the team slug.
@@ -543,12 +543,12 @@ func (s *TeamsService) AddTeamRepoByID(ctx context.Context, orgID, teamID int64,
 //meta:operation PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
 func (s *TeamsService) AddTeamRepoBySlug(ctx context.Context, org, slug, owner, repo string, opts *TeamAddTeamRepoOptions) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/repos/%v/%v", org, slug, owner, repo)
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RemoveTeamRepoByID removes a repository from being managed by the specified
@@ -562,12 +562,12 @@ func (s *TeamsService) AddTeamRepoBySlug(ctx context.Context, org, slug, owner, 
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
 func (s *TeamsService) RemoveTeamRepoByID(ctx context.Context, orgID, teamID int64, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/repos/%v/%v", orgID, teamID, owner, repo)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RemoveTeamRepoBySlug removes a repository from being managed by the specified
@@ -579,12 +579,12 @@ func (s *TeamsService) RemoveTeamRepoByID(ctx context.Context, orgID, teamID int
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
 func (s *TeamsService) RemoveTeamRepoBySlug(ctx context.Context, org, slug, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/repos/%v/%v", org, slug, owner, repo)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListUserTeams lists a user's teams
@@ -599,13 +599,13 @@ func (s *TeamsService) ListUserTeams(ctx context.Context, opts *ListOptions) ([]
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teams []*Team
-	resp, err := s.client.Do(ctx, req, &teams)
+	resp, err := s.client.Do(req, &teams)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -623,7 +623,7 @@ func (s *TeamsService) ListUserTeams(ctx context.Context, opts *ListOptions) ([]
 func (s *TeamsService) ListTeamProjectsByID(ctx context.Context, orgID, teamID int64) ([]*ProjectV2, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/projects", orgID, teamID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -631,7 +631,7 @@ func (s *TeamsService) ListTeamProjectsByID(ctx context.Context, orgID, teamID i
 	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	var projects []*ProjectV2
-	resp, err := s.client.Do(ctx, req, &projects)
+	resp, err := s.client.Do(req, &projects)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -647,7 +647,7 @@ func (s *TeamsService) ListTeamProjectsByID(ctx context.Context, orgID, teamID i
 func (s *TeamsService) ListTeamProjectsBySlug(ctx context.Context, org, slug string) ([]*ProjectV2, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/projects", org, slug)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -655,7 +655,7 @@ func (s *TeamsService) ListTeamProjectsBySlug(ctx context.Context, org, slug str
 	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	var projects []*ProjectV2
-	resp, err := s.client.Do(ctx, req, &projects)
+	resp, err := s.client.Do(req, &projects)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -673,7 +673,7 @@ func (s *TeamsService) ListTeamProjectsBySlug(ctx context.Context, org, slug str
 //meta:operation GET /orgs/{org}/teams/{team_slug}/projects/{project_id}
 func (s *TeamsService) ReviewTeamProjectsByID(ctx context.Context, orgID, teamID, projectID int64) (*ProjectV2, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/projects/%v", orgID, teamID, projectID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -681,7 +681,7 @@ func (s *TeamsService) ReviewTeamProjectsByID(ctx context.Context, orgID, teamID
 	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	var projects *ProjectV2
-	resp, err := s.client.Do(ctx, req, &projects)
+	resp, err := s.client.Do(req, &projects)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -697,7 +697,7 @@ func (s *TeamsService) ReviewTeamProjectsByID(ctx context.Context, orgID, teamID
 //meta:operation GET /orgs/{org}/teams/{team_slug}/projects/{project_id}
 func (s *TeamsService) ReviewTeamProjectsBySlug(ctx context.Context, org, slug string, projectID int64) (*ProjectV2, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/projects/%v", org, slug, projectID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -705,7 +705,7 @@ func (s *TeamsService) ReviewTeamProjectsBySlug(ctx context.Context, org, slug s
 	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
 	var projects *ProjectV2
-	resp, err := s.client.Do(ctx, req, &projects)
+	resp, err := s.client.Do(req, &projects)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -736,14 +736,14 @@ type TeamProjectOptions struct {
 //meta:operation PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}
 func (s *TeamsService) AddTeamProjectByID(ctx context.Context, orgID, teamID, projectID int64, opts *TeamProjectOptions) (*Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/projects/%v", orgID, teamID, projectID)
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // AddTeamProjectBySlug adds an organization project to a team given the team slug.
@@ -755,14 +755,14 @@ func (s *TeamsService) AddTeamProjectByID(ctx context.Context, orgID, teamID, pr
 //meta:operation PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}
 func (s *TeamsService) AddTeamProjectBySlug(ctx context.Context, org, slug string, projectID int64, opts *TeamProjectOptions) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/projects/%v", org, slug, projectID)
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RemoveTeamProjectByID removes an organization project from a team given team ID.
@@ -779,14 +779,14 @@ func (s *TeamsService) AddTeamProjectBySlug(ctx context.Context, org, slug strin
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}/projects/{project_id}
 func (s *TeamsService) RemoveTeamProjectByID(ctx context.Context, orgID, teamID, projectID int64) (*Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/projects/%v", orgID, teamID, projectID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RemoveTeamProjectBySlug removes an organization project from a team given team slug.
@@ -801,14 +801,14 @@ func (s *TeamsService) RemoveTeamProjectByID(ctx context.Context, orgID, teamID,
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}/projects/{project_id}
 func (s *TeamsService) RemoveTeamProjectBySlug(ctx context.Context, org, slug string, projectID int64) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/projects/%v", org, slug, projectID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeProjectsPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListIDPGroupsOptions specifies the optional parameters to the ListIDPGroupsInOrganization method.
@@ -843,13 +843,13 @@ func (s *TeamsService) ListIDPGroupsInOrganization(ctx context.Context, org stri
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var groups *IDPGroupList
-	resp, err := s.client.Do(ctx, req, &groups)
+	resp, err := s.client.Do(req, &groups)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -868,13 +868,13 @@ func (s *TeamsService) ListIDPGroupsInOrganization(ctx context.Context, org stri
 func (s *TeamsService) ListIDPGroupsForTeamByID(ctx context.Context, orgID, teamID int64) (*IDPGroupList, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/team-sync/group-mappings", orgID, teamID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var groups *IDPGroupList
-	resp, err := s.client.Do(ctx, req, &groups)
+	resp, err := s.client.Do(req, &groups)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -891,13 +891,13 @@ func (s *TeamsService) ListIDPGroupsForTeamByID(ctx context.Context, orgID, team
 func (s *TeamsService) ListIDPGroupsForTeamBySlug(ctx context.Context, org, slug string) (*IDPGroupList, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/team-sync/group-mappings", org, slug)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var groups *IDPGroupList
-	resp, err := s.client.Do(ctx, req, &groups)
+	resp, err := s.client.Do(req, &groups)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -916,13 +916,13 @@ func (s *TeamsService) ListIDPGroupsForTeamBySlug(ctx context.Context, org, slug
 func (s *TeamsService) CreateOrUpdateIDPGroupConnectionsByID(ctx context.Context, orgID, teamID int64, opts IDPGroupList) (*IDPGroupList, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/team-sync/group-mappings", orgID, teamID)
 
-	req, err := s.client.NewRequest("PATCH", u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var groups *IDPGroupList
-	resp, err := s.client.Do(ctx, req, &groups)
+	resp, err := s.client.Do(req, &groups)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -939,13 +939,13 @@ func (s *TeamsService) CreateOrUpdateIDPGroupConnectionsByID(ctx context.Context
 func (s *TeamsService) CreateOrUpdateIDPGroupConnectionsBySlug(ctx context.Context, org, slug string, opts IDPGroupList) (*IDPGroupList, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/team-sync/group-mappings", org, slug)
 
-	req, err := s.client.NewRequest("PATCH", u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var groups *IDPGroupList
-	resp, err := s.client.Do(ctx, req, &groups)
+	resp, err := s.client.Do(req, &groups)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -988,13 +988,13 @@ type ExternalGroupList struct {
 //meta:operation GET /orgs/{org}/external-group/{group_id}
 func (s *TeamsService) GetExternalGroup(ctx context.Context, org string, groupID int64) (*ExternalGroup, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/external-group/%v", org, groupID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var externalGroup *ExternalGroup
-	resp, err := s.client.Do(ctx, req, &externalGroup)
+	resp, err := s.client.Do(req, &externalGroup)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1022,13 +1022,13 @@ func (s *TeamsService) ListExternalGroups(ctx context.Context, org string, opts 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var externalGroups *ExternalGroupList
-	resp, err := s.client.Do(ctx, req, &externalGroups)
+	resp, err := s.client.Do(req, &externalGroups)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1044,13 +1044,13 @@ func (s *TeamsService) ListExternalGroups(ctx context.Context, org string, opts 
 func (s *TeamsService) ListExternalGroupsForTeamBySlug(ctx context.Context, org, slug string) (*ExternalGroupList, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/external-groups", org, slug)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var externalGroups *ExternalGroupList
-	resp, err := s.client.Do(ctx, req, &externalGroups)
+	resp, err := s.client.Do(req, &externalGroups)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1066,13 +1066,13 @@ func (s *TeamsService) ListExternalGroupsForTeamBySlug(ctx context.Context, org,
 func (s *TeamsService) UpdateConnectedExternalGroup(ctx context.Context, org, slug string, eg *ExternalGroup) (*ExternalGroup, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/external-groups", org, slug)
 
-	req, err := s.client.NewRequest("PATCH", u, eg)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, eg)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var externalGroup *ExternalGroup
-	resp, err := s.client.Do(ctx, req, &externalGroup)
+	resp, err := s.client.Do(req, &externalGroup)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -1088,10 +1088,10 @@ func (s *TeamsService) UpdateConnectedExternalGroup(ctx context.Context, org, sl
 func (s *TeamsService) RemoveConnectedExternalGroup(ctx context.Context, org, slug string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/external-groups", org, slug)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/teams_discussion_comments.go
+++ b/github/teams_discussion_comments.go
@@ -53,13 +53,13 @@ func (s *TeamsService) ListCommentsByID(ctx context.Context, orgID, teamID int64
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var comments []*DiscussionComment
-	resp, err := s.client.Do(ctx, req, &comments)
+	resp, err := s.client.Do(req, &comments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -80,13 +80,13 @@ func (s *TeamsService) ListCommentsBySlug(ctx context.Context, org, slug string,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var comments []*DiscussionComment
-	resp, err := s.client.Do(ctx, req, &comments)
+	resp, err := s.client.Do(req, &comments)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -102,13 +102,13 @@ func (s *TeamsService) ListCommentsBySlug(ctx context.Context, org, slug string,
 //meta:operation GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
 func (s *TeamsService) GetCommentByID(ctx context.Context, orgID, teamID int64, discussionNumber, commentNumber int) (*DiscussionComment, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/comments/%v", orgID, teamID, discussionNumber, commentNumber)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var discussionComment *DiscussionComment
-	resp, err := s.client.Do(ctx, req, &discussionComment)
+	resp, err := s.client.Do(req, &discussionComment)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -125,13 +125,13 @@ func (s *TeamsService) GetCommentByID(ctx context.Context, orgID, teamID int64, 
 func (s *TeamsService) GetCommentBySlug(ctx context.Context, org, slug string, discussionNumber, commentNumber int) (*DiscussionComment, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments/%v", org, slug, discussionNumber, commentNumber)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var discussionComment *DiscussionComment
-	resp, err := s.client.Do(ctx, req, &discussionComment)
+	resp, err := s.client.Do(req, &discussionComment)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -147,13 +147,13 @@ func (s *TeamsService) GetCommentBySlug(ctx context.Context, org, slug string, d
 //meta:operation POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments
 func (s *TeamsService) CreateCommentByID(ctx context.Context, orgID, teamID int64, discussionNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/comments", orgID, teamID, discussionNumber)
-	req, err := s.client.NewRequest("POST", u, comment)
+	req, err := s.client.NewRequest(ctx, "POST", u, comment)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var discussionComment *DiscussionComment
-	resp, err := s.client.Do(ctx, req, &discussionComment)
+	resp, err := s.client.Do(req, &discussionComment)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -169,13 +169,13 @@ func (s *TeamsService) CreateCommentByID(ctx context.Context, orgID, teamID int6
 //meta:operation POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments
 func (s *TeamsService) CreateCommentBySlug(ctx context.Context, org, slug string, discussionNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments", org, slug, discussionNumber)
-	req, err := s.client.NewRequest("POST", u, comment)
+	req, err := s.client.NewRequest(ctx, "POST", u, comment)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var discussionComment *DiscussionComment
-	resp, err := s.client.Do(ctx, req, &discussionComment)
+	resp, err := s.client.Do(req, &discussionComment)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -192,13 +192,13 @@ func (s *TeamsService) CreateCommentBySlug(ctx context.Context, org, slug string
 //meta:operation PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
 func (s *TeamsService) EditCommentByID(ctx context.Context, orgID, teamID int64, discussionNumber, commentNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/comments/%v", orgID, teamID, discussionNumber, commentNumber)
-	req, err := s.client.NewRequest("PATCH", u, comment)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var discussionComment *DiscussionComment
-	resp, err := s.client.Do(ctx, req, &discussionComment)
+	resp, err := s.client.Do(req, &discussionComment)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -215,13 +215,13 @@ func (s *TeamsService) EditCommentByID(ctx context.Context, orgID, teamID int64,
 //meta:operation PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
 func (s *TeamsService) EditCommentBySlug(ctx context.Context, org, slug string, discussionNumber, commentNumber int, comment DiscussionComment) (*DiscussionComment, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments/%v", org, slug, discussionNumber, commentNumber)
-	req, err := s.client.NewRequest("PATCH", u, comment)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, comment)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var discussionComment *DiscussionComment
-	resp, err := s.client.Do(ctx, req, &discussionComment)
+	resp, err := s.client.Do(req, &discussionComment)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -237,12 +237,12 @@ func (s *TeamsService) EditCommentBySlug(ctx context.Context, org, slug string, 
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
 func (s *TeamsService) DeleteCommentByID(ctx context.Context, orgID, teamID int64, discussionNumber, commentNumber int) (*Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v/comments/%v", orgID, teamID, discussionNumber, commentNumber)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DeleteCommentBySlug deletes a comment on a team discussion by team slug.
@@ -253,10 +253,10 @@ func (s *TeamsService) DeleteCommentByID(ctx context.Context, orgID, teamID int6
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
 func (s *TeamsService) DeleteCommentBySlug(ctx context.Context, org, slug string, discussionNumber, commentNumber int) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v/comments/%v", org, slug, discussionNumber, commentNumber)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/teams_discussions.go
+++ b/github/teams_discussions.go
@@ -59,13 +59,13 @@ func (s *TeamsService) ListDiscussionsByID(ctx context.Context, orgID, teamID in
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teamDiscussions []*TeamDiscussion
-	resp, err := s.client.Do(ctx, req, &teamDiscussions)
+	resp, err := s.client.Do(req, &teamDiscussions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -86,13 +86,13 @@ func (s *TeamsService) ListDiscussionsBySlug(ctx context.Context, org, slug stri
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teamDiscussions []*TeamDiscussion
-	resp, err := s.client.Do(ctx, req, &teamDiscussions)
+	resp, err := s.client.Do(req, &teamDiscussions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -108,13 +108,13 @@ func (s *TeamsService) ListDiscussionsBySlug(ctx context.Context, org, slug stri
 //meta:operation GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
 func (s *TeamsService) GetDiscussionByID(ctx context.Context, orgID, teamID int64, discussionNumber int) (*TeamDiscussion, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v", orgID, teamID, discussionNumber)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teamDiscussion *TeamDiscussion
-	resp, err := s.client.Do(ctx, req, &teamDiscussion)
+	resp, err := s.client.Do(req, &teamDiscussion)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -130,13 +130,13 @@ func (s *TeamsService) GetDiscussionByID(ctx context.Context, orgID, teamID int6
 //meta:operation GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
 func (s *TeamsService) GetDiscussionBySlug(ctx context.Context, org, slug string, discussionNumber int) (*TeamDiscussion, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v", org, slug, discussionNumber)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teamDiscussion *TeamDiscussion
-	resp, err := s.client.Do(ctx, req, &teamDiscussion)
+	resp, err := s.client.Do(req, &teamDiscussion)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -152,13 +152,13 @@ func (s *TeamsService) GetDiscussionBySlug(ctx context.Context, org, slug string
 //meta:operation POST /orgs/{org}/teams/{team_slug}/discussions
 func (s *TeamsService) CreateDiscussionByID(ctx context.Context, orgID, teamID int64, discussion TeamDiscussion) (*TeamDiscussion, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/discussions", orgID, teamID)
-	req, err := s.client.NewRequest("POST", u, discussion)
+	req, err := s.client.NewRequest(ctx, "POST", u, discussion)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teamDiscussion *TeamDiscussion
-	resp, err := s.client.Do(ctx, req, &teamDiscussion)
+	resp, err := s.client.Do(req, &teamDiscussion)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -174,13 +174,13 @@ func (s *TeamsService) CreateDiscussionByID(ctx context.Context, orgID, teamID i
 //meta:operation POST /orgs/{org}/teams/{team_slug}/discussions
 func (s *TeamsService) CreateDiscussionBySlug(ctx context.Context, org, slug string, discussion TeamDiscussion) (*TeamDiscussion, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/discussions", org, slug)
-	req, err := s.client.NewRequest("POST", u, discussion)
+	req, err := s.client.NewRequest(ctx, "POST", u, discussion)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teamDiscussion *TeamDiscussion
-	resp, err := s.client.Do(ctx, req, &teamDiscussion)
+	resp, err := s.client.Do(req, &teamDiscussion)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -197,13 +197,13 @@ func (s *TeamsService) CreateDiscussionBySlug(ctx context.Context, org, slug str
 //meta:operation PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
 func (s *TeamsService) EditDiscussionByID(ctx context.Context, orgID, teamID int64, discussionNumber int, discussion TeamDiscussion) (*TeamDiscussion, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v", orgID, teamID, discussionNumber)
-	req, err := s.client.NewRequest("PATCH", u, discussion)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, discussion)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teamDiscussion *TeamDiscussion
-	resp, err := s.client.Do(ctx, req, &teamDiscussion)
+	resp, err := s.client.Do(req, &teamDiscussion)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -220,13 +220,13 @@ func (s *TeamsService) EditDiscussionByID(ctx context.Context, orgID, teamID int
 //meta:operation PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
 func (s *TeamsService) EditDiscussionBySlug(ctx context.Context, org, slug string, discussionNumber int, discussion TeamDiscussion) (*TeamDiscussion, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v", org, slug, discussionNumber)
-	req, err := s.client.NewRequest("PATCH", u, discussion)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, discussion)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var teamDiscussion *TeamDiscussion
-	resp, err := s.client.Do(ctx, req, &teamDiscussion)
+	resp, err := s.client.Do(req, &teamDiscussion)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -242,12 +242,12 @@ func (s *TeamsService) EditDiscussionBySlug(ctx context.Context, org, slug strin
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
 func (s *TeamsService) DeleteDiscussionByID(ctx context.Context, orgID, teamID int64, discussionNumber int) (*Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/discussions/%v", orgID, teamID, discussionNumber)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DeleteDiscussionBySlug deletes a discussion from team's page given Organization name and Team's slug.
@@ -258,10 +258,10 @@ func (s *TeamsService) DeleteDiscussionByID(ctx context.Context, orgID, teamID i
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
 func (s *TeamsService) DeleteDiscussionBySlug(ctx context.Context, org, slug string, discussionNumber int) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/discussions/%v", org, slug, discussionNumber)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/teams_members.go
+++ b/github/teams_members.go
@@ -33,13 +33,13 @@ func (s *TeamsService) ListTeamMembersByID(ctx context.Context, orgID, teamID in
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var members []*User
-	resp, err := s.client.Do(ctx, req, &members)
+	resp, err := s.client.Do(req, &members)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -60,13 +60,13 @@ func (s *TeamsService) ListTeamMembersBySlug(ctx context.Context, org, slug stri
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var members []*User
-	resp, err := s.client.Do(ctx, req, &members)
+	resp, err := s.client.Do(req, &members)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -82,13 +82,13 @@ func (s *TeamsService) ListTeamMembersBySlug(ctx context.Context, org, slug stri
 //meta:operation GET /orgs/{org}/teams/{team_slug}/members
 func (s *TeamsService) GetTeamMembershipByID(ctx context.Context, orgID, teamID int64, user string) (*Membership, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/memberships/%v", orgID, teamID, user)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var t *Membership
-	resp, err := s.client.Do(ctx, req, &t)
+	resp, err := s.client.Do(req, &t)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -104,13 +104,13 @@ func (s *TeamsService) GetTeamMembershipByID(ctx context.Context, orgID, teamID 
 //meta:operation GET /orgs/{org}/teams/{team_slug}/memberships/{username}
 func (s *TeamsService) GetTeamMembershipBySlug(ctx context.Context, org, slug, user string) (*Membership, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/memberships/%v", org, slug, user)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var t *Membership
-	resp, err := s.client.Do(ctx, req, &t)
+	resp, err := s.client.Do(req, &t)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -140,13 +140,13 @@ type TeamAddTeamMembershipOptions struct {
 //meta:operation PUT /orgs/{org}/teams/{team_slug}/memberships/{username}
 func (s *TeamsService) AddTeamMembershipByID(ctx context.Context, orgID, teamID int64, user string, opts *TeamAddTeamMembershipOptions) (*Membership, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/memberships/%v", orgID, teamID, user)
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var t *Membership
-	resp, err := s.client.Do(ctx, req, &t)
+	resp, err := s.client.Do(req, &t)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -162,13 +162,13 @@ func (s *TeamsService) AddTeamMembershipByID(ctx context.Context, orgID, teamID 
 //meta:operation PUT /orgs/{org}/teams/{team_slug}/memberships/{username}
 func (s *TeamsService) AddTeamMembershipBySlug(ctx context.Context, org, slug, user string, opts *TeamAddTeamMembershipOptions) (*Membership, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/memberships/%v", org, slug, user)
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var t *Membership
-	resp, err := s.client.Do(ctx, req, &t)
+	resp, err := s.client.Do(req, &t)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -184,12 +184,12 @@ func (s *TeamsService) AddTeamMembershipBySlug(ctx context.Context, org, slug, u
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}
 func (s *TeamsService) RemoveTeamMembershipByID(ctx context.Context, orgID, teamID int64, user string) (*Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/memberships/%v", orgID, teamID, user)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RemoveTeamMembershipBySlug removes a user from a team, given a specified
@@ -200,12 +200,12 @@ func (s *TeamsService) RemoveTeamMembershipByID(ctx context.Context, orgID, team
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}
 func (s *TeamsService) RemoveTeamMembershipBySlug(ctx context.Context, org, slug, user string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/memberships/%v", org, slug, user)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListPendingTeamInvitationsByID gets pending invitation list of a team, given a specified
@@ -221,13 +221,13 @@ func (s *TeamsService) ListPendingTeamInvitationsByID(ctx context.Context, orgID
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var pendingInvitations []*Invitation
-	resp, err := s.client.Do(ctx, req, &pendingInvitations)
+	resp, err := s.client.Do(req, &pendingInvitations)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -248,13 +248,13 @@ func (s *TeamsService) ListPendingTeamInvitationsBySlug(ctx context.Context, org
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var pendingInvitations []*Invitation
-	resp, err := s.client.Do(ctx, req, &pendingInvitations)
+	resp, err := s.client.Do(req, &pendingInvitations)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/users.go
+++ b/github/users.go
@@ -103,13 +103,13 @@ func (s *UsersService) Get(ctx context.Context, user string) (*User, *Response, 
 	} else {
 		u = "user"
 	}
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var uResp *User
-	resp, err := s.client.Do(ctx, req, &uResp)
+	resp, err := s.client.Do(req, &uResp)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -124,13 +124,13 @@ func (s *UsersService) Get(ctx context.Context, user string) (*User, *Response, 
 //meta:operation GET /user/{account_id}
 func (s *UsersService) GetByID(ctx context.Context, id int64) (*User, *Response, error) {
 	u := fmt.Sprintf("user/%v", id)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var user *User
-	resp, err := s.client.Do(ctx, req, &user)
+	resp, err := s.client.Do(req, &user)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -145,13 +145,13 @@ func (s *UsersService) GetByID(ctx context.Context, id int64) (*User, *Response,
 //meta:operation PATCH /user
 func (s *UsersService) Edit(ctx context.Context, user *User) (*User, *Response, error) {
 	u := "user"
-	req, err := s.client.NewRequest("PATCH", u, user)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, user)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var uResp *User
-	resp, err := s.client.Do(ctx, req, &uResp)
+	resp, err := s.client.Do(req, &uResp)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -194,13 +194,13 @@ func (s *UsersService) GetHovercard(ctx context.Context, user string, opts *Hove
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var hc *Hovercard
-	resp, err := s.client.Do(ctx, req, &hc)
+	resp, err := s.client.Do(req, &hc)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -229,13 +229,13 @@ func (s *UsersService) ListAll(ctx context.Context, opts *UserListOptions) ([]*U
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var users []*User
-	resp, err := s.client.Do(ctx, req, &users)
+	resp, err := s.client.Do(req, &users)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -255,13 +255,13 @@ func (s *UsersService) ListInvitations(ctx context.Context, opts *ListOptions) (
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	invites := []*RepositoryInvitation{}
-	resp, err := s.client.Do(ctx, req, &invites)
+	resp, err := s.client.Do(req, &invites)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -277,12 +277,12 @@ func (s *UsersService) ListInvitations(ctx context.Context, opts *ListOptions) (
 //meta:operation PATCH /user/repository_invitations/{invitation_id}
 func (s *UsersService) AcceptInvitation(ctx context.Context, invitationID int64) (*Response, error) {
 	u := fmt.Sprintf("user/repository_invitations/%v", invitationID)
-	req, err := s.client.NewRequest("PATCH", u, nil)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DeclineInvitation declines the currently-open repository invitation for the
@@ -293,10 +293,10 @@ func (s *UsersService) AcceptInvitation(ctx context.Context, invitationID int64)
 //meta:operation DELETE /user/repository_invitations/{invitation_id}
 func (s *UsersService) DeclineInvitation(ctx context.Context, invitationID int64) (*Response, error) {
 	u := fmt.Sprintf("user/repository_invitations/%v", invitationID)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/users_administration.go
+++ b/github/users_administration.go
@@ -18,12 +18,12 @@ import (
 func (s *UsersService) PromoteSiteAdmin(ctx context.Context, user string) (*Response, error) {
 	u := fmt.Sprintf("users/%v/site_admin", user)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // DemoteSiteAdmin demotes a user from site administrator of a GitHub Enterprise instance.
@@ -34,12 +34,12 @@ func (s *UsersService) PromoteSiteAdmin(ctx context.Context, user string) (*Resp
 func (s *UsersService) DemoteSiteAdmin(ctx context.Context, user string) (*Response, error) {
 	u := fmt.Sprintf("users/%v/site_admin", user)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // UserSuspendOptions represents the reason to suspend a user.
@@ -55,12 +55,12 @@ type UserSuspendOptions struct {
 func (s *UsersService) Suspend(ctx context.Context, user string, opts *UserSuspendOptions) (*Response, error) {
 	u := fmt.Sprintf("users/%v/suspended", user)
 
-	req, err := s.client.NewRequest("PUT", u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // Unsuspend a user on a GitHub Enterprise instance.
@@ -71,10 +71,10 @@ func (s *UsersService) Suspend(ctx context.Context, user string, opts *UserSuspe
 func (s *UsersService) Unsuspend(ctx context.Context, user string) (*Response, error) {
 	u := fmt.Sprintf("users/%v/suspended", user)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/users_attestations.go
+++ b/github/users_attestations.go
@@ -25,13 +25,13 @@ func (s *UsersService) ListAttestations(ctx context.Context, user, subjectDigest
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var attestations *AttestationsResponse
-	res, err := s.client.Do(ctx, req, &attestations)
+	res, err := s.client.Do(req, &attestations)
 	if err != nil {
 		return nil, res, err
 	}

--- a/github/users_blocking.go
+++ b/github/users_blocking.go
@@ -22,7 +22,7 @@ func (s *UsersService) ListBlockedUsers(ctx context.Context, opts *ListOptions) 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -30,7 +30,7 @@ func (s *UsersService) ListBlockedUsers(ctx context.Context, opts *ListOptions) 
 	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
 
 	var blockedUsers []*User
-	resp, err := s.client.Do(ctx, req, &blockedUsers)
+	resp, err := s.client.Do(req, &blockedUsers)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -46,14 +46,14 @@ func (s *UsersService) ListBlockedUsers(ctx context.Context, opts *ListOptions) 
 func (s *UsersService) IsBlocked(ctx context.Context, user string) (bool, *Response, error) {
 	u := fmt.Sprintf("user/blocks/%v", user)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return false, nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	isBlocked, err := parseBoolResponse(err)
 	return isBlocked, resp, err
 }
@@ -66,14 +66,14 @@ func (s *UsersService) IsBlocked(ctx context.Context, user string) (bool, *Respo
 func (s *UsersService) BlockUser(ctx context.Context, user string) (*Response, error) {
 	u := fmt.Sprintf("user/blocks/%v", user)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // UnblockUser unblocks specified user for the authenticated user.
@@ -84,12 +84,12 @@ func (s *UsersService) BlockUser(ctx context.Context, user string) (*Response, e
 func (s *UsersService) UnblockUser(ctx context.Context, user string) (*Response, error) {
 	u := fmt.Sprintf("user/blocks/%v", user)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Accept", mediaTypeBlockUsersPreview)
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/users_emails.go
+++ b/github/users_emails.go
@@ -27,13 +27,13 @@ func (s *UsersService) ListEmails(ctx context.Context, opts *ListOptions) ([]*Us
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var emails []*UserEmail
-	resp, err := s.client.Do(ctx, req, &emails)
+	resp, err := s.client.Do(req, &emails)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -48,13 +48,13 @@ func (s *UsersService) ListEmails(ctx context.Context, opts *ListOptions) ([]*Us
 //meta:operation POST /user/emails
 func (s *UsersService) AddEmails(ctx context.Context, emails []string) ([]*UserEmail, *Response, error) {
 	u := "user/emails"
-	req, err := s.client.NewRequest("POST", u, emails)
+	req, err := s.client.NewRequest(ctx, "POST", u, emails)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var e []*UserEmail
-	resp, err := s.client.Do(ctx, req, &e)
+	resp, err := s.client.Do(req, &e)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -69,12 +69,12 @@ func (s *UsersService) AddEmails(ctx context.Context, emails []string) ([]*UserE
 //meta:operation DELETE /user/emails
 func (s *UsersService) DeleteEmails(ctx context.Context, emails []string) (*Response, error) {
 	u := "user/emails"
-	req, err := s.client.NewRequest("DELETE", u, emails)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, emails)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // SetEmailVisibility sets the visibility for the primary email address of the authenticated user.
@@ -90,13 +90,13 @@ func (s *UsersService) SetEmailVisibility(ctx context.Context, visibility string
 		Visibility: &visibility,
 	}
 
-	req, err := s.client.NewRequest("PATCH", u, updateVisibilityReq)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, updateVisibilityReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var e []*UserEmail
-	resp, err := s.client.Do(ctx, req, &e)
+	resp, err := s.client.Do(req, &e)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/users_followers.go
+++ b/github/users_followers.go
@@ -31,13 +31,13 @@ func (s *UsersService) ListFollowers(ctx context.Context, user string, opts *Lis
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var users []*User
-	resp, err := s.client.Do(ctx, req, &users)
+	resp, err := s.client.Do(req, &users)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -66,13 +66,13 @@ func (s *UsersService) ListFollowing(ctx context.Context, user string, opts *Lis
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var users []*User
-	resp, err := s.client.Do(ctx, req, &users)
+	resp, err := s.client.Do(req, &users)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -97,12 +97,12 @@ func (s *UsersService) IsFollowing(ctx context.Context, user, target string) (bo
 		u = fmt.Sprintf("user/following/%v", target)
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return false, nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.client.Do(req, nil)
 	following, err := parseBoolResponse(err)
 	return following, resp, err
 }
@@ -114,12 +114,12 @@ func (s *UsersService) IsFollowing(ctx context.Context, user, target string) (bo
 //meta:operation PUT /user/following/{username}
 func (s *UsersService) Follow(ctx context.Context, user string) (*Response, error) {
 	u := fmt.Sprintf("user/following/%v", user)
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // Unfollow will cause the authenticated user to unfollow the specified user.
@@ -129,10 +129,10 @@ func (s *UsersService) Follow(ctx context.Context, user string) (*Response, erro
 //meta:operation DELETE /user/following/{username}
 func (s *UsersService) Unfollow(ctx context.Context, user string) (*Response, error) {
 	u := fmt.Sprintf("user/following/%v", user)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/users_gpg_keys.go
+++ b/github/users_gpg_keys.go
@@ -62,13 +62,13 @@ func (s *UsersService) ListGPGKeys(ctx context.Context, user string, opts *ListO
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var keys []*GPGKey
-	resp, err := s.client.Do(ctx, req, &keys)
+	resp, err := s.client.Do(req, &keys)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -84,13 +84,13 @@ func (s *UsersService) ListGPGKeys(ctx context.Context, user string, opts *ListO
 //meta:operation GET /user/gpg_keys/{gpg_key_id}
 func (s *UsersService) GetGPGKey(ctx context.Context, id int64) (*GPGKey, *Response, error) {
 	u := fmt.Sprintf("user/gpg_keys/%v", id)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var key *GPGKey
-	resp, err := s.client.Do(ctx, req, &key)
+	resp, err := s.client.Do(req, &key)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -108,13 +108,13 @@ func (s *UsersService) CreateGPGKey(ctx context.Context, armoredPublicKey string
 	gpgKey := &struct {
 		ArmoredPublicKey string `json:"armored_public_key"`
 	}{ArmoredPublicKey: armoredPublicKey}
-	req, err := s.client.NewRequest("POST", "user/gpg_keys", gpgKey)
+	req, err := s.client.NewRequest(ctx, "POST", "user/gpg_keys", gpgKey)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var key *GPGKey
-	resp, err := s.client.Do(ctx, req, &key)
+	resp, err := s.client.Do(req, &key)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -130,10 +130,10 @@ func (s *UsersService) CreateGPGKey(ctx context.Context, armoredPublicKey string
 //meta:operation DELETE /user/gpg_keys/{gpg_key_id}
 func (s *UsersService) DeleteGPGKey(ctx context.Context, id int64) (*Response, error) {
 	u := fmt.Sprintf("user/gpg_keys/%v", id)
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/users_keys.go
+++ b/github/users_keys.go
@@ -48,13 +48,13 @@ func (s *UsersService) ListKeys(ctx context.Context, user string, opts *ListOpti
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var keys []*Key
-	resp, err := s.client.Do(ctx, req, &keys)
+	resp, err := s.client.Do(req, &keys)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -70,13 +70,13 @@ func (s *UsersService) ListKeys(ctx context.Context, user string, opts *ListOpti
 func (s *UsersService) GetKey(ctx context.Context, id int64) (*Key, *Response, error) {
 	u := fmt.Sprintf("user/keys/%v", id)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var key *Key
-	resp, err := s.client.Do(ctx, req, &key)
+	resp, err := s.client.Do(req, &key)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -92,13 +92,13 @@ func (s *UsersService) GetKey(ctx context.Context, id int64) (*Key, *Response, e
 func (s *UsersService) CreateKey(ctx context.Context, key *Key) (*Key, *Response, error) {
 	u := "user/keys"
 
-	req, err := s.client.NewRequest("POST", u, key)
+	req, err := s.client.NewRequest(ctx, "POST", u, key)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var k *Key
-	resp, err := s.client.Do(ctx, req, &k)
+	resp, err := s.client.Do(req, &k)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -114,10 +114,10 @@ func (s *UsersService) CreateKey(ctx context.Context, key *Key) (*Key, *Response
 func (s *UsersService) DeleteKey(ctx context.Context, id int64) (*Response, error) {
 	u := fmt.Sprintf("user/keys/%v", id)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/users_packages.go
+++ b/github/users_packages.go
@@ -32,13 +32,13 @@ func (s *UsersService) ListPackages(ctx context.Context, user string, opts *Pack
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var packages []*Package
-	resp, err := s.client.Do(ctx, req, &packages)
+	resp, err := s.client.Do(req, &packages)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -63,13 +63,13 @@ func (s *UsersService) GetPackage(ctx context.Context, user, packageType, packag
 		u = fmt.Sprintf("user/packages/%v/%v", packageType, url.PathEscape(packageName))
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var pack *Package
-	resp, err := s.client.Do(ctx, req, &pack)
+	resp, err := s.client.Do(req, &pack)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -94,12 +94,12 @@ func (s *UsersService) DeletePackage(ctx context.Context, user, packageType, pac
 		u = fmt.Sprintf("user/packages/%v/%v", packageType, packageName)
 	}
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // RestorePackage restores a package to a user. Passing the empty string for "user" will
@@ -119,12 +119,12 @@ func (s *UsersService) RestorePackage(ctx context.Context, user, packageType, pa
 		u = fmt.Sprintf("user/packages/%v/%v/restore", packageType, packageName)
 	}
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListPackageVersionsOptions specifies the optional parameters to the UsersService.ListPackageVersions.
@@ -147,13 +147,13 @@ func (s *UsersService) ListPackageVersions(ctx context.Context, packageType, pac
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var versions []*PackageVersion
-	resp, err := s.client.Do(ctx, req, &versions)
+	resp, err := s.client.Do(req, &versions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -169,13 +169,13 @@ func (s *UsersService) ListPackageVersions(ctx context.Context, packageType, pac
 func (s *UsersService) ListUserPackageVersions(ctx context.Context, user, packageType, packageName string) ([]*PackageVersion, *Response, error) {
 	u := fmt.Sprintf("users/%v/packages/%v/%v/versions", user, packageType, packageName)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var versions []*PackageVersion
-	resp, err := s.client.Do(ctx, req, &versions)
+	resp, err := s.client.Do(req, &versions)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -200,13 +200,13 @@ func (s *UsersService) PackageGetVersion(ctx context.Context, user, packageType,
 		u = fmt.Sprintf("user/packages/%v/%v/versions/%v", packageType, packageName, packageVersionID)
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var version *PackageVersion
-	resp, err := s.client.Do(ctx, req, &version)
+	resp, err := s.client.Do(req, &version)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -231,12 +231,12 @@ func (s *UsersService) PackageDeleteVersion(ctx context.Context, user, packageTy
 		u = fmt.Sprintf("user/packages/%v/%v/versions/%v", packageType, packageName, packageVersionID)
 	}
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // PackageRestoreVersion restores a package version to a user. Passing the empty string for "user" will
@@ -256,10 +256,10 @@ func (s *UsersService) PackageRestoreVersion(ctx context.Context, user, packageT
 		u = fmt.Sprintf("user/packages/%v/%v/versions/%v/restore", packageType, packageName, packageVersionID)
 	}
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/github/users_social_accounts.go
+++ b/github/users_social_accounts.go
@@ -33,13 +33,13 @@ func (s *UsersService) ListSocialAccounts(ctx context.Context, opts *ListOptions
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var socialAccounts []*SocialAccount
-	resp, err := s.client.Do(ctx, req, &socialAccounts)
+	resp, err := s.client.Do(req, &socialAccounts)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -54,13 +54,13 @@ func (s *UsersService) ListSocialAccounts(ctx context.Context, opts *ListOptions
 //meta:operation POST /user/social_accounts
 func (s *UsersService) AddSocialAccounts(ctx context.Context, accountURLs []string) ([]*SocialAccount, *Response, error) {
 	u := "user/social_accounts"
-	req, err := s.client.NewRequest("POST", u, &socialAccountsRequest{AccountURLs: accountURLs})
+	req, err := s.client.NewRequest(ctx, "POST", u, &socialAccountsRequest{AccountURLs: accountURLs})
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var accounts []*SocialAccount
-	resp, err := s.client.Do(ctx, req, &accounts)
+	resp, err := s.client.Do(req, &accounts)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -75,12 +75,12 @@ func (s *UsersService) AddSocialAccounts(ctx context.Context, accountURLs []stri
 //meta:operation DELETE /user/social_accounts
 func (s *UsersService) DeleteSocialAccounts(ctx context.Context, accountURLs []string) (*Response, error) {
 	u := "user/social_accounts"
-	req, err := s.client.NewRequest("DELETE", u, &socialAccountsRequest{AccountURLs: accountURLs})
+	req, err := s.client.NewRequest(ctx, "DELETE", u, &socialAccountsRequest{AccountURLs: accountURLs})
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }
 
 // ListUserSocialAccounts lists all social accounts for a user.
@@ -95,13 +95,13 @@ func (s *UsersService) ListUserSocialAccounts(ctx context.Context, username stri
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var addedAccounts []*SocialAccount
-	resp, err := s.client.Do(ctx, req, &addedAccounts)
+	resp, err := s.client.Do(req, &addedAccounts)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/github/users_ssh_signing_keys.go
+++ b/github/users_ssh_signing_keys.go
@@ -43,13 +43,13 @@ func (s *UsersService) ListSSHSigningKeys(ctx context.Context, user string, opts
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var keys []*SSHSigningKey
-	resp, err := s.client.Do(ctx, req, &keys)
+	resp, err := s.client.Do(req, &keys)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -65,13 +65,13 @@ func (s *UsersService) ListSSHSigningKeys(ctx context.Context, user string, opts
 func (s *UsersService) GetSSHSigningKey(ctx context.Context, id int64) (*SSHSigningKey, *Response, error) {
 	u := fmt.Sprintf("user/ssh_signing_keys/%v", id)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var key *SSHSigningKey
-	resp, err := s.client.Do(ctx, req, &key)
+	resp, err := s.client.Do(req, &key)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -87,13 +87,13 @@ func (s *UsersService) GetSSHSigningKey(ctx context.Context, id int64) (*SSHSign
 func (s *UsersService) CreateSSHSigningKey(ctx context.Context, key *Key) (*SSHSigningKey, *Response, error) {
 	u := "user/ssh_signing_keys"
 
-	req, err := s.client.NewRequest("POST", u, key)
+	req, err := s.client.NewRequest(ctx, "POST", u, key)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var k *SSHSigningKey
-	resp, err := s.client.Do(ctx, req, &k)
+	resp, err := s.client.Do(req, &k)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -109,10 +109,10 @@ func (s *UsersService) CreateSSHSigningKey(ctx context.Context, key *Key) (*SSHS
 func (s *UsersService) DeleteSSHSigningKey(ctx context.Context, id int64) (*Response, error) {
 	u := fmt.Sprintf("user/ssh_signing_keys/%v", id)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.client.Do(req, nil)
 }

--- a/test/fields/fields.go
+++ b/test/fields/fields.go
@@ -67,16 +67,17 @@ func main() {
 // testType fetches the JSON resource at urlStr and compares its keys to the
 // struct fields of typ.
 func testType(urlStr string, typ any) error {
+	ctx := context.Background()
 	slice := reflect.Indirect(reflect.ValueOf(typ)).Kind() == reflect.Slice
 
-	req, err := client.NewRequest("GET", urlStr, nil)
+	req, err := client.NewRequest(ctx, "GET", urlStr, nil)
 	if err != nil {
 		return err
 	}
 
 	// start with a json.RawMessage so we can decode multiple ways below
 	raw := new(json.RawMessage)
-	_, err = client.Do(context.Background(), req, raw)
+	_, err = client.Do(req, raw)
 	if err != nil {
 		return err
 	}

--- a/tools/extraneousnew/extraneousnew.go
+++ b/tools/extraneousnew/extraneousnew.go
@@ -196,8 +196,8 @@ func inspectBlock(pass *analysis.Pass, block *ast.BlockStmt) {
 			}
 
 			var targetArg ast.Expr
-			if fnName == "Do" && len(call.Args) == 3 {
-				targetArg = call.Args[2]
+			if fnName == "Do" && len(call.Args) == 2 {
+				targetArg = call.Args[1]
 			} else if fnName == "Decode" && len(call.Args) == 1 {
 				targetArg = call.Args[0]
 			}
@@ -251,8 +251,8 @@ func lookAhead(pass *analysis.Pass, block *ast.BlockStmt, startIndex int, lhsIde
 
 				fnName := getFunctionName(call.Fun)
 				var targetArg ast.Expr
-				if fnName == "Do" && len(call.Args) == 3 {
-					targetArg = call.Args[2]
+				if fnName == "Do" && len(call.Args) == 2 {
+					targetArg = call.Args[1]
 				} else if fnName == "Decode" && len(call.Args) == 1 {
 					targetArg = call.Args[0]
 				}

--- a/tools/extraneousnew/testdata/src/has-warnings/main.go
+++ b/tools/extraneousnew/testdata/src/has-warnings/main.go
@@ -30,10 +30,10 @@ func assertNilError(t *testing.T, err error) {}
 
 func (s *Service) TestMethod(ctx context.Context, req any, r *http.Request, t *testing.T) {
 	v1 := new(T)
-	s.client.Do(ctx, req, v1) // want "use 'var v1 [*]T' and pass '&v1' instead"
+	s.client.Do(req, v1) // want "use 'var v1 [*]T' and pass '&v1' instead"
 
 	v2 := &T{}
-	s.client.Do(ctx, req, v2) // want "use 'var v2 [*]T' and pass '&v2' instead"
+	s.client.Do(req, v2) // want "use 'var v2 [*]T' and pass '&v2' instead"
 
 	v3 := new(T)
 	json.NewDecoder(r.Body).Decode(v3) // want "use 'var v3 [*]T' and pass '&v3' instead"
@@ -42,36 +42,36 @@ func (s *Service) TestMethod(ctx context.Context, req any, r *http.Request, t *t
 	json.NewDecoder(r.Body).Decode(v4) // want "use 'var v4 [*]T' and pass '&v4' instead"
 
 	v5 := &T{}
-	s.client.Do(ctx, req, &v5) // want "use 'var v5 [*]T' and pass '&v5' instead"
+	s.client.Do(req, &v5) // want "use 'var v5 [*]T' and pass '&v5' instead"
 
 	v6 := new(T)
 	assertNilError(t, json.NewDecoder(r.Body).Decode(v6)) // want "use 'var v6 [*]T' and pass '&v6' instead"
 
 	v7 := &T{Field: "something"}
-	s.client.Do(ctx, req, v7) // No warning
+	s.client.Do(req, v7) // No warning
 
 	var v8 *T
 	v8 = new(T)
-	s.client.Do(ctx, req, v8) // want "use 'var v8 [*]T' and pass '&v8' instead"
+	s.client.Do(req, v8) // want "use 'var v8 [*]T' and pass '&v8' instead"
 
 	// Multiple assignments in same block
 	v9 := new(T)
 	v10 := new(T)
-	s.client.Do(ctx, req, v9)  // want "use 'var v9 [*]T' and pass '&v9' instead"
-	s.client.Do(ctx, req, v10) // want "use 'var v10 [*]T' and pass '&v10' instead"
+	s.client.Do(req, v9)  // want "use 'var v9 [*]T' and pass '&v9' instead"
+	s.client.Do(req, v10) // want "use 'var v10 [*]T' and pass '&v10' instead"
 
 	// Anonymous struct
 	v11 := new(struct {
 		F string
 	})
-	s.client.Do(ctx, req, v11) // want "use 'var v11 [*]T' and pass '&v11' instead"
+	s.client.Do(req, v11) // want "use 'var v11 [*]T' and pass '&v11' instead"
 
 	// Anonymous struct
 	var v12 *struct {
 		F string
 	}
-	s.client.Do(ctx, req, v12) // want "pass '&v12' instead"
+	s.client.Do(req, v12) // want "pass '&v12' instead"
 
 	var v13 *T
-	s.client.Do(ctx, req, v13) // want "pass '&v13' instead"
+	s.client.Do(req, v13) // want "pass '&v13' instead"
 }

--- a/tools/extraneousnew/testdata/src/has-warnings/main.go
+++ b/tools/extraneousnew/testdata/src/has-warnings/main.go
@@ -6,7 +6,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -18,7 +17,7 @@ type T struct {
 
 type Client struct{}
 
-func (c *Client) Do(ctx context.Context, req any, v any) (any, error) {
+func (c *Client) Do(req any, v any) (any, error) {
 	return nil, nil
 }
 
@@ -28,7 +27,7 @@ type Service struct {
 
 func assertNilError(t *testing.T, err error) {}
 
-func (s *Service) TestMethod(ctx context.Context, req any, r *http.Request, t *testing.T) {
+func (s *Service) TestMethod(req any, r *http.Request, t *testing.T) {
 	v1 := new(T)
 	s.client.Do(req, v1) // want "use 'var v1 [*]T' and pass '&v1' instead"
 

--- a/tools/extraneousnew/testdata/src/no-warnings/main.go
+++ b/tools/extraneousnew/testdata/src/no-warnings/main.go
@@ -5,17 +5,13 @@
 
 package main
 
-import (
-	"context"
-)
-
 type T struct {
 	Field string
 }
 
 type Client struct{}
 
-func (c *Client) Do(ctx context.Context, req any, v any) (any, error) {
+func (c *Client) Do(req any, v any) (any, error) {
 	return nil, nil
 }
 
@@ -23,7 +19,7 @@ type Receiver struct {
 	client *Client
 }
 
-func (s *Receiver) TestMethod(ctx context.Context, req any) {
+func (s *Receiver) TestMethod(req any) {
 	// Proper usage: var pointer and pass &v
 	var v1 *T
 	s.client.Do(req, &v1)
@@ -44,12 +40,12 @@ func (s *Receiver) TestMethod(ctx context.Context, req any) {
 	s.client.Do(req, &v11)
 }
 
-func (s *Receiver) MethodNameToIgnore(ctx context.Context, req any) {
+func (s *Receiver) MethodNameToIgnore(req any) {
 	v := new(T)
 	s.client.Do(req, v)
 }
 
-func (s *Receiver) unexportedMethod(ctx context.Context, req any) {
+func (s *Receiver) unexportedMethod(req any) {
 	v := new(T)
 	s.client.Do(req, v) // Should be ignored because unexported.
 }

--- a/tools/extraneousnew/testdata/src/no-warnings/main.go
+++ b/tools/extraneousnew/testdata/src/no-warnings/main.go
@@ -26,30 +26,30 @@ type Receiver struct {
 func (s *Receiver) TestMethod(ctx context.Context, req any) {
 	// Proper usage: var pointer and pass &v
 	var v1 *T
-	s.client.Do(ctx, req, &v1)
+	s.client.Do(req, &v1)
 
 	// Literal with fields
 	v2 := &T{Field: "something"}
-	s.client.Do(ctx, req, v2)
+	s.client.Do(req, v2)
 
 	// new(T) but used for something else first
 	v3 := new(T)
 	v3.Field = "set"
-	s.client.Do(ctx, req, v3)
+	s.client.Do(req, v3)
 
 	// Anonymous struct
 	var v11 *struct {
 		F string
 	}
-	s.client.Do(ctx, req, &v11)
+	s.client.Do(req, &v11)
 }
 
 func (s *Receiver) MethodNameToIgnore(ctx context.Context, req any) {
 	v := new(T)
-	s.client.Do(ctx, req, v)
+	s.client.Do(req, v)
 }
 
 func (s *Receiver) unexportedMethod(ctx context.Context, req any) {
 	v := new(T)
-	s.client.Do(ctx, req, v) // Should be ignored because unexported.
+	s.client.Do(req, v) // Should be ignored because unexported.
 }


### PR DESCRIPTION
BREAKING CHANGE: All internal calls now provide `Context` via the `Request` itself.

Closes #4127

This PR makes the following changes:

- Switch to using `http.NewRequestWithContext` so we no longer need the `withContext` helper
- Refactor all HTTP calls to use `client.BareDo` to get benefits such as rate limit support