### PR TITLE
feat: Refactor repositories download contents

### DIFF
--- a/example/contents/main.go
+++ b/example/contents/main.go
@@ -3,67 +3,72 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// The commitpr command utilizes go-github as a CLI tool for
-// pushing files to a branch and creating a pull request from it.
-// It takes an auth token as an environment variable and creates
-// the commit and the PR under the account affiliated with that token.
-//
-// The purpose of this example is to show how to use refs, trees and commits to
-// create commits and pull requests.
-//
-// Note, if you want to push a single file, you probably prefer to use the
-// content API. An example is available here:
-// https://pkg.go.dev/github.com/google/go-github/v84/github#example-RepositoriesService-CreateFile
-//
-// Note, for this to work at least 1 commit is needed, so you if you use this
-// after creating a repository you might want to make sure you set `AutoInit` to
-// `true`.
+// The contents command utilizes go-github as a CLI tool for
+// downloading the contents of a file in a repository.
+// It takes an inputs of the repository owner, repository name, path to the
+// file in the repository, reference (branch, tag or commit SHA), and output
+// path for the downloaded file. It then uses the Repositories.DownloadContents
+// method to download the file and saves it to the specified output path.
 package main
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/google/go-github/v84/github"
 )
 
-// downloadContents downloads the contents of a file in a repository and returns it as a byte slice.
-func downloadContents(ctx context.Context, client *github.Client, owner, repo, path, ref string) ([]byte, error) {
-	rc, _, err := client.Repositories.DownloadContents(ctx, owner, repo, path, &github.RepositoryContentGetOptions{Ref: ref})
+func main() {
+	fmt.Println("This example will download the contents of a file from a GitHub repository.")
+
+	r := bufio.NewReader(os.Stdin)
+
+	fmt.Print("Repository Owner: ")
+	owner, _ := r.ReadString('\n')
+	owner = strings.TrimSpace(owner)
+
+	fmt.Print("Repository Name: ")
+	repo, _ := r.ReadString('\n')
+	repo = strings.TrimSpace(repo)
+
+	fmt.Print("Repository Path: ")
+	repoPath, _ := r.ReadString('\n')
+	repoPath = strings.TrimSpace(repoPath)
+
+	fmt.Print("Reference (branch, tag or commit SHA): ")
+	ref, _ := r.ReadString('\n')
+	ref = strings.TrimSpace(ref)
+
+	fmt.Print("Output Path: ")
+	outputPath, _ := r.ReadString('\n')
+	outputPath = strings.TrimSpace(outputPath)
+
+	fmt.Printf("\nDownloading %v/%v/%v at ref %v to %v...\n", owner, repo, repoPath, ref, outputPath)
+
+	client := github.NewClient(nil)
+
+	rc, _, err := client.Repositories.DownloadContents(context.Background(), owner, repo, repoPath, &github.RepositoryContentGetOptions{Ref: ref})
 	if err != nil {
-		return nil, err
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
 	}
 	defer rc.Close()
 
-	by, err := io.ReadAll(rc)
+	f, err := os.Create(outputPath)
 	if err != nil {
-		return nil, err
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, rc); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
 	}
 
-	fmt.Printf("Downloaded %v/%v/%v as %d bytes\n", owner, repo, path, len(by))
-	return by, nil
-}
-
-func main() {
-	client := github.NewClient(nil)
-
-	t := []struct {
-		owner string
-		repo  string
-		path  string
-		ref   string
-	}{
-		{"google", "go-github", "README.md", "master"},
-		{"github", "rest-api-description", "descriptions/api.github.com/api.github.com.2026-03-10.yaml", "main"},
-		{"ScoopInstaller", "Main", "bucket/yq.json", "master"},
-	}
-
-	for _, v := range t {
-		if _, err := downloadContents(context.Background(), client, v.owner, v.repo, v.path, v.ref); err != nil {
-			fmt.Printf("Error: %v\n", err)
-			os.Exit(1)
-		}
-	}
+	fmt.Println("Download completed.")
 }

--- a/example/contents/main.go
+++ b/example/contents/main.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/google/go-github/v84/github"
@@ -45,7 +46,7 @@ func main() {
 
 	fmt.Print("Output Path: ")
 	outputPath, _ := r.ReadString('\n')
-	outputPath = strings.TrimSpace(outputPath)
+	outputPath = filepath.Clean(strings.TrimSpace(outputPath))
 
 	fmt.Printf("\nDownloading %v/%v/%v at ref %v to %v...\n", owner, repo, repoPath, ref, outputPath)
 
@@ -58,7 +59,7 @@ func main() {
 	}
 	defer rc.Close()
 
-	f, err := os.Create(outputPath)
+	f, err := os.Create(outputPath) //#nosec G703 -- path is validated above
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)

--- a/example/contents/main.go
+++ b/example/contents/main.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// The commitpr command utilizes go-github as a CLI tool for
+// pushing files to a branch and creating a pull request from it.
+// It takes an auth token as an environment variable and creates
+// the commit and the PR under the account affiliated with that token.
+//
+// The purpose of this example is to show how to use refs, trees and commits to
+// create commits and pull requests.
+//
+// Note, if you want to push a single file, you probably prefer to use the
+// content API. An example is available here:
+// https://pkg.go.dev/github.com/google/go-github/v84/github#example-RepositoriesService-CreateFile
+//
+// Note, for this to work at least 1 commit is needed, so you if you use this
+// after creating a repository you might want to make sure you set `AutoInit` to
+// `true`.
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/google/go-github/v84/github"
+)
+
+// downloadContents downloads the contents of a file in a repository and returns it as a byte slice.
+func downloadContents(ctx context.Context, client *github.Client, owner, repo, path, ref string) ([]byte, error) {
+	rc, _, err := client.Repositories.DownloadContents(ctx, owner, repo, path, &github.RepositoryContentGetOptions{Ref: ref})
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	by, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("Downloaded %v/%v/%v as %d bytes\n", owner, repo, path, len(by))
+	return by, nil
+}
+
+func main() {
+	client := github.NewClient(nil)
+
+	t := []struct {
+		owner string
+		repo  string
+		path  string
+		ref   string
+	}{
+		{"google", "go-github", "README.md", "master"},
+		{"github", "rest-api-description", "descriptions/api.github.com/api.github.com.2026-03-10.yaml", "main"},
+		{"ScoopInstaller", "Main", "bucket/yq.json", "master"},
+	}
+
+	for _, v := range t {
+		if _, err := downloadContents(context.Background(), client, v.owner, v.repo, v.path, v.ref); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
+	}
+}

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -159,7 +159,7 @@ func (s *RepositoriesService) DownloadContentsWithMeta(ctx context.Context, owne
 	}
 
 	if fileContent == nil {
-		return nil, nil, resp, fmt.Errorf("no file content found")
+		return nil, nil, resp, errors.New("no file content found")
 	}
 
 	content, err := fileContent.GetContent()
@@ -169,7 +169,7 @@ func (s *RepositoriesService) DownloadContentsWithMeta(ctx context.Context, owne
 
 	downloadURL := fileContent.GetDownloadURL()
 	if downloadURL == "" {
-		return nil, fileContent, resp, fmt.Errorf("download url is empty")
+		return nil, fileContent, resp, errors.New("download url is empty")
 	}
 
 	dlReq, err := http.NewRequestWithContext(ctx, "GET", downloadURL, nil)

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -17,7 +17,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -137,40 +136,8 @@ func (s *RepositoriesService) GetReadme(ctx context.Context, owner, repo string,
 //
 //meta:operation GET /repos/{owner}/{repo}/contents/{path}
 func (s *RepositoriesService) DownloadContents(ctx context.Context, owner, repo, filepath string, opts *RepositoryContentGetOptions) (io.ReadCloser, *Response, error) {
-	dir := path.Dir(filepath)
-	filename := path.Base(filepath)
-	fileContent, _, resp, err := s.GetContents(ctx, owner, repo, filepath, opts)
-	if err == nil && fileContent != nil {
-		content, err := fileContent.GetContent()
-		if err == nil && content != "" {
-			return io.NopCloser(strings.NewReader(content)), resp, nil
-		}
-	}
-
-	_, dirContents, resp, err := s.GetContents(ctx, owner, repo, dir, opts)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	for _, contents := range dirContents {
-		if contents.GetName() == filename {
-			if contents.GetDownloadURL() == "" {
-				return nil, resp, fmt.Errorf("no download link found for %v", filepath)
-			}
-			dlReq, err := http.NewRequestWithContext(ctx, "GET", *contents.DownloadURL, nil)
-			if err != nil {
-				return nil, resp, err
-			}
-			dlResp, err := s.client.client.Do(dlReq)
-			if err != nil {
-				return nil, &Response{Response: dlResp}, err
-			}
-
-			return dlResp.Body, &Response{Response: dlResp}, nil
-		}
-	}
-
-	return nil, resp, fmt.Errorf("no file named %v found in %v", filename, dir)
+	rc, _, resp, err := s.DownloadContentsWithMeta(ctx, owner, repo, filepath, opts)
+	return rc, resp, err
 }
 
 // DownloadContentsWithMeta is identical to DownloadContents but additionally
@@ -186,40 +153,36 @@ func (s *RepositoriesService) DownloadContents(ctx context.Context, owner, repo,
 //
 //meta:operation GET /repos/{owner}/{repo}/contents/{path}
 func (s *RepositoriesService) DownloadContentsWithMeta(ctx context.Context, owner, repo, filepath string, opts *RepositoryContentGetOptions) (io.ReadCloser, *RepositoryContent, *Response, error) {
-	dir := path.Dir(filepath)
-	filename := path.Base(filepath)
 	fileContent, _, resp, err := s.GetContents(ctx, owner, repo, filepath, opts)
-	if err == nil && fileContent != nil {
-		content, err := fileContent.GetContent()
-		if err == nil && content != "" {
-			return io.NopCloser(strings.NewReader(content)), fileContent, resp, nil
-		}
-	}
-
-	_, dirContents, resp, err := s.GetContents(ctx, owner, repo, dir, opts)
 	if err != nil {
 		return nil, nil, resp, err
 	}
 
-	for _, contents := range dirContents {
-		if contents.GetName() == filename {
-			if contents.GetDownloadURL() == "" {
-				return nil, contents, resp, fmt.Errorf("no download link found for %v", filepath)
-			}
-			dlReq, err := http.NewRequestWithContext(ctx, "GET", *contents.DownloadURL, nil)
-			if err != nil {
-				return nil, contents, resp, err
-			}
-			dlResp, err := s.client.client.Do(dlReq)
-			if err != nil {
-				return nil, contents, &Response{Response: dlResp}, err
-			}
-
-			return dlResp.Body, contents, &Response{Response: dlResp}, nil
-		}
+	if fileContent == nil {
+		return nil, nil, resp, fmt.Errorf("no file content found at path %v in %v/%v", filepath, owner, repo)
 	}
 
-	return nil, nil, resp, fmt.Errorf("no file named %v found in %v", filename, dir)
+	content, err := fileContent.GetContent()
+	if err == nil && content != "" {
+		return io.NopCloser(strings.NewReader(content)), fileContent, resp, nil
+	}
+
+	downloadURL := fileContent.GetDownloadURL()
+	if downloadURL == "" {
+		return nil, fileContent, resp, fmt.Errorf("could not get download url for path %v in %v/%v", filepath, owner, repo)
+	}
+
+	dlReq, err := http.NewRequestWithContext(ctx, "GET", downloadURL, nil)
+	if err != nil {
+		return nil, fileContent, resp, err
+	}
+
+	dlResp, err := s.client.client.Do(dlReq)
+	if err != nil {
+		return nil, fileContent, &Response{Response: dlResp}, err
+	}
+
+	return dlResp.Body, fileContent, &Response{Response: dlResp}, nil
 }
 
 // GetContents can return either the metadata and content of a single file

--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -159,7 +159,7 @@ func (s *RepositoriesService) DownloadContentsWithMeta(ctx context.Context, owne
 	}
 
 	if fileContent == nil {
-		return nil, nil, resp, fmt.Errorf("no file content found at path %v in %v/%v", filepath, owner, repo)
+		return nil, nil, resp, fmt.Errorf("no file content found")
 	}
 
 	content, err := fileContent.GetContent()
@@ -169,7 +169,7 @@ func (s *RepositoriesService) DownloadContentsWithMeta(ctx context.Context, owne
 
 	downloadURL := fileContent.GetDownloadURL()
 	if downloadURL == "" {
-		return nil, fileContent, resp, fmt.Errorf("could not get download url for path %v in %v/%v", filepath, owner, repo)
+		return nil, fileContent, resp, fmt.Errorf("download url is empty")
 	}
 
 	dlReq, err := http.NewRequestWithContext(ctx, "GET", downloadURL, nil)

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -126,18 +126,17 @@ func TestRepositoriesService_GetReadme(t *testing.T) {
 	})
 }
 
-func TestRepositoriesService_DownloadContents_SuccessForFile(t *testing.T) {
+func TestRepositoriesService_DownloadContents_Success(t *testing.T) {
 	t.Parallel()
-	client, mux, serverURL := setup(t)
+	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
-		  "type": "file",
-		  "name": "f",
-          "content": "foo",
-		  "download_url": "`+serverURL+baseURLPath+`/download/f"
-		}`)
+  "type": "file",
+  "name": "f",
+  "content": "foo"
+}`)
 	})
 
 	ctx := t.Context()
@@ -173,111 +172,6 @@ func TestRepositoriesService_DownloadContents_SuccessForFile(t *testing.T) {
 		}
 		return resp, err
 	})
-}
-
-func TestRepositoriesService_DownloadContents_SuccessForDirectory(t *testing.T) {
-	t.Parallel()
-	client, mux, serverURL := setup(t)
-
-	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{
-		  "type": "file",
-		  "name": "f"
-		}`)
-	})
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
-		  "type": "file",
-		  "name": "f",
-		  "download_url": "`+serverURL+baseURLPath+`/download/f"
-		}]`)
-	})
-	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, "foo")
-	})
-
-	ctx := t.Context()
-	r, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
-	if err != nil {
-		t.Errorf("Repositories.DownloadContents returned error: %v", err)
-	}
-
-	if got, want := resp.Response.StatusCode, http.StatusOK; got != want {
-		t.Errorf("Repositories.DownloadContents returned status code %v, want %v", got, want)
-	}
-
-	bytes, err := io.ReadAll(r)
-	if err != nil {
-		t.Errorf("Error reading response body: %v", err)
-	}
-	r.Close()
-
-	if got, want := string(bytes), "foo"; got != want {
-		t.Errorf("Repositories.DownloadContents returned %v, want %v", got, want)
-	}
-
-	const methodName = "DownloadContents"
-	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Repositories.DownloadContents(ctx, "\n", "\n", "\n", nil)
-		return err
-	})
-
-	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
-		if got != nil {
-			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
-		}
-		return resp, err
-	})
-}
-
-func TestRepositoriesService_DownloadContents_FailedResponse(t *testing.T) {
-	t.Parallel()
-	client, mux, serverURL := setup(t)
-
-	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{
-			"type": "file",
-			"name": "f"
-		  }`)
-	})
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
-			"type": "file",
-			"name": "f",
-			"download_url": "`+serverURL+baseURLPath+`/download/f"
-		  }]`)
-	})
-	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprint(w, "foo error")
-	})
-
-	ctx := t.Context()
-	r, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
-	if err != nil {
-		t.Errorf("Repositories.DownloadContents returned error: %v", err)
-	}
-
-	if got, want := resp.Response.StatusCode, http.StatusInternalServerError; got != want {
-		t.Errorf("Repositories.DownloadContents returned status code %v, want %v", got, want)
-	}
-
-	bytes, err := io.ReadAll(r)
-	if err != nil {
-		t.Errorf("Error reading response body: %v", err)
-	}
-	r.Close()
-
-	if got, want := string(bytes), "foo error"; got != want {
-		t.Errorf("Repositories.DownloadContents returned %v, want %v", got, want)
-	}
 }
 
 func TestRepositoriesService_DownloadContents_NoDownloadURL(t *testing.T) {
@@ -287,18 +181,9 @@ func TestRepositoriesService_DownloadContents_NoDownloadURL(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
-		  "type": "file",
-		  "name": "f",
-		  "content": ""
-		}`)
-	})
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
-		  "type": "file",
-		  "name": "f",
-		  "content": ""
-		}]`)
+  "type": "file",
+  "name": "f"
+}`)
 	})
 
 	ctx := t.Context()
@@ -312,55 +197,45 @@ func TestRepositoriesService_DownloadContents_NoDownloadURL(t *testing.T) {
 	}
 
 	if reader != nil {
-		t.Error("Repositories.DownloadContents did not return expected reader")
+		t.Error("Repositories.DownloadContents returned unexpected reader")
 	}
 }
 
-func TestRepositoriesService_DownloadContents_NoFile(t *testing.T) {
+func TestRepositoriesService_DownloadContents_GetContentsError(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	ctx := t.Context()
+	reader, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
+	if err == nil {
+		t.Error("Repositories.DownloadContents did not return expected error")
+	}
+
+	if resp == nil {
+		t.Error("Repositories.DownloadContents did not return expected response")
+	}
+
+	if reader != nil {
+		t.Error("Repositories.DownloadContents returned unexpected reader")
+	}
+}
+
+func TestRepositoriesService_DownloadContentsWithMeta_SuccessWithContent(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
-		  "type": "file",
-		  "name": "f",
-		  "content": ""
-		}`)
-	})
-
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[]`)
-	})
-
-	ctx := t.Context()
-	reader, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
-	if err == nil {
-		t.Error("Repositories.DownloadContents did not return expected error")
-	}
-
-	if resp == nil {
-		t.Error("Repositories.DownloadContents did not return expected response")
-	}
-
-	if reader != nil {
-		t.Error("Repositories.DownloadContents did not return expected reader")
-	}
-}
-
-func TestRepositoriesService_DownloadContentsWithMeta_SuccessForFile(t *testing.T) {
-	t.Parallel()
-	client, mux, serverURL := setup(t)
-
-	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{
-		  "type": "file",
-		  "name": "f",
-		  "download_url": "`+serverURL+baseURLPath+`/download/f",
-          "content": "foo"
-		}`)
+  "type": "file",
+  "name": "f",
+  "content": "foo"
+}`)
 	})
 
 	ctx := t.Context()
@@ -409,17 +284,17 @@ func TestRepositoriesService_DownloadContentsWithMeta_SuccessForFile(t *testing.
 	})
 }
 
-func TestRepositoriesService_DownloadContentsWithMeta_SuccessForDirectory(t *testing.T) {
+func TestRepositoriesService_DownloadContentsWithMeta_SuccessViaDownloadURL(t *testing.T) {
 	t.Parallel()
 	client, mux, serverURL := setup(t)
 
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
-		  "type": "file",
-		  "name": "f",
-		  "download_url": "`+serverURL+baseURLPath+`/download/f"
-		}]`)
+		fmt.Fprintf(w, `{
+  "type": "file",
+  "name": "f",
+  "download_url": "%v/download/f"
+}`, serverURL+baseURLPath)
 	})
 	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -459,28 +334,18 @@ func TestRepositoriesService_DownloadContentsWithMeta_FailedResponse(t *testing.
 	t.Parallel()
 	client, mux, serverURL := setup(t)
 
-	downloadURL := fmt.Sprintf("%v%v/download/f", serverURL, baseURLPath)
-
 	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{
-			"type": "file",
-			"name": "f",
-			"download_url": "`+downloadURL+`"
-		  }`)
+		fmt.Fprintf(w, `{
+  "type": "file",
+  "name": "f",
+  "download_url": "%v/download/f"
+}`, serverURL+baseURLPath)
 	})
 	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(w, "foo error")
-	})
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
-			"type": "file",
-			"name": "f",
-			"download_url": "`+downloadURL+`"
-		  }]`)
 	})
 
 	ctx := t.Context()
@@ -519,17 +384,9 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoDownloadURL(t *testing.T
 	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
-		  "type": "file",
-		  "name": "f",
-		}`)
-	})
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
-		  "type": "file",
-		  "name": "f",
-		  "content": ""
-		}]`)
+  "type": "file",
+  "name": "f"
+}`)
 	})
 
 	ctx := t.Context()
@@ -539,7 +396,7 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoDownloadURL(t *testing.T
 	}
 
 	if reader != nil {
-		t.Error("Repositories.DownloadContentsWithMeta did not return expected reader")
+		t.Error("Repositories.DownloadContentsWithMeta returned unexpected reader")
 	}
 
 	if resp == nil {
@@ -551,23 +408,62 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoDownloadURL(t *testing.T
 	}
 }
 
-func TestRepositoriesService_DownloadContentsWithMeta_NoFile(t *testing.T) {
+func TestRepositoriesService_DownloadContentsWithMeta_GetContentsError(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	ctx := t.Context()
+	reader, contents, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
+	if err == nil {
+		t.Error("Repositories.DownloadContentsWithMeta did not return expected error")
+	}
+
+	if reader != nil {
+		t.Error("Repositories.DownloadContentsWithMeta returned unexpected reader")
+	}
+
+	if resp == nil {
+		t.Error("Repositories.DownloadContentsWithMeta did not return expected response")
+	}
+
+	if contents != nil {
+		t.Error("Repositories.DownloadContentsWithMeta returned unexpected content")
+	}
+}
+
+func TestRepositoriesService_DownloadContentsWithMeta_NilFileContent(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
 	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[]`)
+		fmt.Fprint(w, `[{
+  "type": "file",
+  "name": "f"
+}]`)
 	})
 
 	ctx := t.Context()
-	_, _, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
+	reader, contents, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d", nil)
 	if err == nil {
 		t.Error("Repositories.DownloadContentsWithMeta did not return expected error")
 	}
 
+	if reader != nil {
+		t.Error("Repositories.DownloadContentsWithMeta returned unexpected reader")
+	}
+
 	if resp == nil {
 		t.Error("Repositories.DownloadContentsWithMeta did not return expected response")
+	}
+
+	if contents != nil {
+		t.Error("Repositories.DownloadContentsWithMeta returned unexpected content")
 	}
 }
 

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -126,17 +126,18 @@ func TestRepositoriesService_GetReadme(t *testing.T) {
 	})
 }
 
-func TestRepositoriesService_DownloadContents_Success(t *testing.T) {
+func TestRepositoriesService_DownloadContents_SuccessWithContent(t *testing.T) {
 	t.Parallel()
-	client, mux, _ := setup(t)
+	client, mux, serverURL := setup(t)
 
 	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{
+		fmt.Fprintf(w, `{
   "type": "file",
   "name": "f",
-  "content": "foo"
-}`)
+  "content": "foo",
+  "download_url": "%v/download/f"
+}`, serverURL+baseURLPath)
 	})
 
 	ctx := t.Context()
@@ -174,6 +175,100 @@ func TestRepositoriesService_DownloadContents_Success(t *testing.T) {
 	})
 }
 
+func TestRepositoriesService_DownloadContents_SuccessByDownload(t *testing.T) {
+	t.Parallel()
+	client, mux, serverURL := setup(t)
+
+	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprintf(w, `{
+  "type": "file",
+  "name": "f",
+  "content": "",
+  "download_url": "%v/download/f"
+}`, serverURL+baseURLPath)
+	})
+
+	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, "foo")
+	})
+
+	ctx := t.Context()
+	r, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
+	if err != nil {
+		t.Errorf("Repositories.DownloadContents returned error: %v", err)
+	}
+
+	if got, want := resp.Response.StatusCode, http.StatusOK; got != want {
+		t.Errorf("Repositories.DownloadContents returned status code %v, want %v", got, want)
+	}
+
+	bytes, err := io.ReadAll(r)
+	if err != nil {
+		t.Errorf("Error reading response body: %v", err)
+	}
+	r.Close()
+
+	if got, want := string(bytes), "foo"; got != want {
+		t.Errorf("Repositories.DownloadContents returned %v, want %v", got, want)
+	}
+
+	const methodName = "DownloadContents"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Repositories.DownloadContents(ctx, "\n", "\n", "\n", nil)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestRepositoriesService_DownloadContents_FailedResponse(t *testing.T) {
+	t.Parallel()
+	client, mux, serverURL := setup(t)
+
+	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprintf(w, `{
+  "type": "file",
+  "name": "f",
+  "content": "",
+  "download_url": "%v/download/f"
+}`, serverURL+baseURLPath)
+	})
+	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "foo error")
+	})
+
+	ctx := t.Context()
+	r, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d/f", nil)
+	if err != nil {
+		t.Errorf("Repositories.DownloadContents returned error: %v", err)
+	}
+
+	if got, want := resp.Response.StatusCode, http.StatusInternalServerError; got != want {
+		t.Errorf("Repositories.DownloadContents returned status code %v, want %v", got, want)
+	}
+
+	bytes, err := io.ReadAll(r)
+	if err != nil {
+		t.Errorf("Error reading response body: %v", err)
+	}
+	r.Close()
+
+	if got, want := string(bytes), "foo error"; got != want {
+		t.Errorf("Repositories.DownloadContents returned %v, want %v", got, want)
+	}
+}
+
 func TestRepositoriesService_DownloadContents_NoDownloadURL(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
@@ -182,7 +277,8 @@ func TestRepositoriesService_DownloadContents_NoDownloadURL(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
   "type": "file",
-  "name": "f"
+  "name": "f",
+  "content": ""
 }`)
 	})
 
@@ -197,11 +293,11 @@ func TestRepositoriesService_DownloadContents_NoDownloadURL(t *testing.T) {
 	}
 
 	if reader != nil {
-		t.Error("Repositories.DownloadContents returned unexpected reader")
+		t.Error("Repositories.DownloadContents did not return expected reader")
 	}
 }
 
-func TestRepositoriesService_DownloadContents_GetContentsError(t *testing.T) {
+func TestRepositoriesService_DownloadContents_NoFile(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -221,21 +317,22 @@ func TestRepositoriesService_DownloadContents_GetContentsError(t *testing.T) {
 	}
 
 	if reader != nil {
-		t.Error("Repositories.DownloadContents returned unexpected reader")
+		t.Error("Repositories.DownloadContents did not return expected reader")
 	}
 }
 
 func TestRepositoriesService_DownloadContentsWithMeta_SuccessWithContent(t *testing.T) {
 	t.Parallel()
-	client, mux, _ := setup(t)
+	client, mux, serverURL := setup(t)
 
 	mux.HandleFunc("/repos/o/r/contents/d/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{
+		fmt.Fprintf(w, `{
   "type": "file",
   "name": "f",
-  "content": "foo"
-}`)
+  "content": "foo",
+  "download_url": "%v/download/f"
+}`, serverURL+baseURLPath)
 	})
 
 	ctx := t.Context()
@@ -284,7 +381,7 @@ func TestRepositoriesService_DownloadContentsWithMeta_SuccessWithContent(t *test
 	})
 }
 
-func TestRepositoriesService_DownloadContentsWithMeta_SuccessViaDownloadURL(t *testing.T) {
+func TestRepositoriesService_DownloadContentsWithMeta_SuccessByDownload(t *testing.T) {
 	t.Parallel()
 	client, mux, serverURL := setup(t)
 
@@ -296,6 +393,7 @@ func TestRepositoriesService_DownloadContentsWithMeta_SuccessViaDownloadURL(t *t
   "download_url": "%v/download/f"
 }`, serverURL+baseURLPath)
 	})
+
 	mux.HandleFunc("/download/f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, "foo")
@@ -385,7 +483,8 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoDownloadURL(t *testing.T
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
   "type": "file",
-  "name": "f"
+  "name": "f",
+  "content": ""
 }`)
 	})
 
@@ -396,7 +495,7 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoDownloadURL(t *testing.T
 	}
 
 	if reader != nil {
-		t.Error("Repositories.DownloadContentsWithMeta returned unexpected reader")
+		t.Error("Repositories.DownloadContentsWithMeta did not return expected reader")
 	}
 
 	if resp == nil {
@@ -408,7 +507,7 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoDownloadURL(t *testing.T
 	}
 }
 
-func TestRepositoriesService_DownloadContentsWithMeta_GetContentsError(t *testing.T) {
+func TestRepositoriesService_DownloadContentsWithMeta_NoFile(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -418,52 +517,13 @@ func TestRepositoriesService_DownloadContentsWithMeta_GetContentsError(t *testin
 	})
 
 	ctx := t.Context()
-	reader, contents, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
+	_, _, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
 	if err == nil {
 		t.Error("Repositories.DownloadContentsWithMeta did not return expected error")
 	}
 
-	if reader != nil {
-		t.Error("Repositories.DownloadContentsWithMeta returned unexpected reader")
-	}
-
 	if resp == nil {
 		t.Error("Repositories.DownloadContentsWithMeta did not return expected response")
-	}
-
-	if contents != nil {
-		t.Error("Repositories.DownloadContentsWithMeta returned unexpected content")
-	}
-}
-
-func TestRepositoriesService_DownloadContentsWithMeta_NilFileContent(t *testing.T) {
-	t.Parallel()
-	client, mux, _ := setup(t)
-
-	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
-  "type": "file",
-  "name": "f"
-}]`)
-	})
-
-	ctx := t.Context()
-	reader, contents, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d", nil)
-	if err == nil {
-		t.Error("Repositories.DownloadContentsWithMeta did not return expected error")
-	}
-
-	if reader != nil {
-		t.Error("Repositories.DownloadContentsWithMeta returned unexpected reader")
-	}
-
-	if resp == nil {
-		t.Error("Repositories.DownloadContentsWithMeta did not return expected response")
-	}
-
-	if contents != nil {
-		t.Error("Repositories.DownloadContentsWithMeta returned unexpected content")
 	}
 }
 

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -321,6 +321,34 @@ func TestRepositoriesService_DownloadContents_NoFile(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_DownloadContents_NotFile(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{
+  "type": "file",
+  "name": "f",
+  "content": ""
+}]`)
+	})
+
+	ctx := t.Context()
+	reader, resp, err := client.Repositories.DownloadContents(ctx, "o", "r", "d", nil)
+	if err == nil {
+		t.Error("Repositories.DownloadContents did not return expected error")
+	}
+
+	if resp == nil {
+		t.Error("Repositories.DownloadContents did not return expected response")
+	}
+
+	if reader != nil {
+		t.Error("Repositories.DownloadContents did not return expected reader")
+	}
+}
+
 func TestRepositoriesService_DownloadContentsWithMeta_SuccessWithContent(t *testing.T) {
 	t.Parallel()
 	client, mux, serverURL := setup(t)
@@ -518,6 +546,30 @@ func TestRepositoriesService_DownloadContentsWithMeta_NoFile(t *testing.T) {
 
 	ctx := t.Context()
 	_, _, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d/f", nil)
+	if err == nil {
+		t.Error("Repositories.DownloadContentsWithMeta did not return expected error")
+	}
+
+	if resp == nil {
+		t.Error("Repositories.DownloadContentsWithMeta did not return expected response")
+	}
+}
+
+func TestRepositoriesService_DownloadContentsWithMeta_NotFile(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/repos/o/r/contents/d", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{
+  "type": "file",
+  "name": "f",
+  "content": ""
+}]`)
+	})
+
+	ctx := t.Context()
+	_, _, resp, err := client.Repositories.DownloadContentsWithMeta(ctx, "o", "r", "d", nil)
 	if err == nil {
 		t.Error("Repositories.DownloadContentsWithMeta did not return expected error")
 	}

--- a/tools/metadata/main_test.go
+++ b/tools/metadata/main_test.go
@@ -367,7 +367,7 @@ func newTestServer(t *testing.T, ref string, files map[string]any) *httptest.Ser
 			path.Join(repoPath, "contents/descriptions", name),
 			jsonHandler(refQuery, &github.RepositoryContent{
 				Name:        github.Ptr(path.Base(name)),
-				DownloadURL: github.Ptr(dlURL),
+				DownloadURL: &dlURL,
 			}),
 		)
 		mux.HandleFunc(

--- a/tools/metadata/main_test.go
+++ b/tools/metadata/main_test.go
@@ -362,13 +362,12 @@ func newTestServer(t *testing.T, ref string, files map[string]any) *httptest.Ser
 		descriptionsContent = append(descriptionsContent, &github.RepositoryContent{
 			Name: github.Ptr(path.Base(path.Dir(name))),
 		})
+		dlURL := server.URL + "/dl/" + name
 		mux.HandleFunc(
-			path.Join(repoPath, "contents/descriptions", path.Dir(name)),
-			jsonHandler(refQuery, []*github.RepositoryContent{
-				{
-					Name:        github.Ptr(path.Base(name)),
-					DownloadURL: github.Ptr(server.URL + "/dl/" + name),
-				},
+			path.Join(repoPath, "contents/descriptions", name),
+			jsonHandler(refQuery, &github.RepositoryContent{
+				Name:        github.Ptr(path.Base(name)),
+				DownloadURL: github.Ptr(dlURL),
 			}),
 		)
 		mux.HandleFunc(

--- a/tools/metadata/main_test.go
+++ b/tools/metadata/main_test.go
@@ -362,12 +362,11 @@ func newTestServer(t *testing.T, ref string, files map[string]any) *httptest.Ser
 		descriptionsContent = append(descriptionsContent, &github.RepositoryContent{
 			Name: github.Ptr(path.Base(path.Dir(name))),
 		})
-		dlURL := server.URL + "/dl/" + name
 		mux.HandleFunc(
 			path.Join(repoPath, "contents/descriptions", name),
 			jsonHandler(refQuery, &github.RepositoryContent{
 				Name:        github.Ptr(path.Base(name)),
-				DownloadURL: &dlURL,
+				DownloadURL: github.Ptr(server.URL + "/dl/" + name),
 			}),
 		)
 		mux.HandleFunc(


### PR DESCRIPTION
This PR refactors the behaviour of `DownloadContents` & `DownloadContentsWithMeta` with the former now being a direct passthrough to the latter as the only difference was the signature. The code has been refactored to use the API directly instead of via an unnecessary layer of indirection.

I've added an OpenAPI update to this PR as it proves that the updated code works against GitHub.

This change is required for #4151.