### PR TITLE
feat: Add `CodeSecurity` to `SecurityAndAnalysis`

### DIFF
--- a/github/event_types_test.go
+++ b/github/event_types_test.go
@@ -18215,6 +18215,9 @@ func TestSecurityAndAnalysisEvent_Marshal(t *testing.T) {
 					DependabotSecurityUpdates: &DependabotSecurityUpdates{
 						Status: Ptr("enabled"),
 					},
+					CodeSecurity: &CodeSecurity{
+						Status: Ptr("enabled"),
+					},
 				},
 			},
 		},
@@ -18376,6 +18379,9 @@ func TestSecurityAndAnalysisEvent_Marshal(t *testing.T) {
 						"status": "enabled"
 					},
 					"dependabot_security_updates": {
+						"status": "enabled"
+					},
+					"code_security": {
 						"status": "enabled"
 					}
 				}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -4990,6 +4990,14 @@ func (c *CodeSearchResult) GetTotal() int {
 	return *c.Total
 }
 
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (c *CodeSecurity) GetStatus() string {
+	if c == nil || c.Status == nil {
+		return ""
+	}
+	return *c.Status
+}
+
 // GetAdvancedSecurity returns the AdvancedSecurity field if it's non-nil, zero value otherwise.
 func (c *CodeSecurityConfiguration) GetAdvancedSecurity() string {
 	if c == nil || c.AdvancedSecurity == nil {
@@ -36892,6 +36900,14 @@ func (s *SecurityAndAnalysis) GetAdvancedSecurity() *AdvancedSecurity {
 		return nil
 	}
 	return s.AdvancedSecurity
+}
+
+// GetCodeSecurity returns the CodeSecurity field.
+func (s *SecurityAndAnalysis) GetCodeSecurity() *CodeSecurity {
+	if s == nil {
+		return nil
+	}
+	return s.CodeSecurity
 }
 
 // GetDependabotSecurityUpdates returns the DependabotSecurityUpdates field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -6362,6 +6362,17 @@ func TestCodeSearchResult_GetTotal(tt *testing.T) {
 	c.GetTotal()
 }
 
+func TestCodeSecurity_GetStatus(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CodeSecurity{Status: &zeroValue}
+	c.GetStatus()
+	c = &CodeSecurity{}
+	c.GetStatus()
+	c = nil
+	c.GetStatus()
+}
+
 func TestCodeSecurityConfiguration_GetAdvancedSecurity(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -46364,6 +46375,14 @@ func TestSecurityAndAnalysis_GetAdvancedSecurity(tt *testing.T) {
 	s.GetAdvancedSecurity()
 	s = nil
 	s.GetAdvancedSecurity()
+}
+
+func TestSecurityAndAnalysis_GetCodeSecurity(tt *testing.T) {
+	tt.Parallel()
+	s := &SecurityAndAnalysis{}
+	s.GetCodeSecurity()
+	s = nil
+	s.GetCodeSecurity()
 }
 
 func TestSecurityAndAnalysis_GetDependabotSecurityUpdates(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -355,6 +355,17 @@ func TestCodeResult_String(t *testing.T) {
 	}
 }
 
+func TestCodeSecurity_String(t *testing.T) {
+	t.Parallel()
+	v := CodeSecurity{
+		Status: Ptr(""),
+	}
+	want := `github.CodeSecurity{Status:""}`
+	if got := v.String(); got != want {
+		t.Errorf("CodeSecurity.String = %v, want %v", got, want)
+	}
+}
+
 func TestCombinedStatus_String(t *testing.T) {
 	t.Parallel()
 	v := CombinedStatus{

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -2201,8 +2201,9 @@ func TestSecurityAndAnalysis_String(t *testing.T) {
 		SecretScanningPushProtection: &SecretScanningPushProtection{},
 		DependabotSecurityUpdates:    &DependabotSecurityUpdates{},
 		SecretScanningValidityChecks: &SecretScanningValidityChecks{},
+		CodeSecurity:                 &CodeSecurity{},
 	}
-	want := `github.SecurityAndAnalysis{AdvancedSecurity:github.AdvancedSecurity{}, SecretScanning:github.SecretScanning{}, SecretScanningPushProtection:github.SecretScanningPushProtection{}, DependabotSecurityUpdates:github.DependabotSecurityUpdates{}, SecretScanningValidityChecks:github.SecretScanningValidityChecks{}}`
+	want := `github.SecurityAndAnalysis{AdvancedSecurity:github.AdvancedSecurity{}, SecretScanning:github.SecretScanning{}, SecretScanningPushProtection:github.SecretScanningPushProtection{}, DependabotSecurityUpdates:github.DependabotSecurityUpdates{}, SecretScanningValidityChecks:github.SecretScanningValidityChecks{}, CodeSecurity:github.CodeSecurity{}}`
 	if got := v.String(); got != want {
 		t.Errorf("SecurityAndAnalysis.String = %v, want %v", got, want)
 	}

--- a/github/repos.go
+++ b/github/repos.go
@@ -200,6 +200,7 @@ type SecurityAndAnalysis struct {
 	SecretScanningPushProtection *SecretScanningPushProtection `json:"secret_scanning_push_protection,omitempty"`
 	DependabotSecurityUpdates    *DependabotSecurityUpdates    `json:"dependabot_security_updates,omitempty"`
 	SecretScanningValidityChecks *SecretScanningValidityChecks `json:"secret_scanning_validity_checks,omitempty"`
+	CodeSecurity                 *CodeSecurity                 `json:"code_security,omitempty"`
 }
 
 // RepositoryPermissions represents the permissions a user has for a repository.
@@ -263,6 +264,11 @@ func (d DependabotSecurityUpdates) String() string {
 //
 // GitHub API docs: https://docs.github.com/en/enterprise-cloud@latest/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-security-and-analysis-settings-for-your-repository#allowing-validity-checks-for-partner-patterns-in-a-repository
 type SecretScanningValidityChecks struct {
+	Status *string `json:"status,omitempty"`
+}
+
+// CodeSecurity represents the state of code security on a repository.
+type CodeSecurity struct {
 	Status *string `json:"status,omitempty"`
 }
 

--- a/github/repos.go
+++ b/github/repos.go
@@ -268,8 +268,14 @@ type SecretScanningValidityChecks struct {
 }
 
 // CodeSecurity represents the state of code security on a repository.
+//
+// GitHub API docs: https://docs.github.com/en/code-security/getting-started/github-security-features#available-with-github-code-security
 type CodeSecurity struct {
 	Status *string `json:"status,omitempty"`
+}
+
+func (c CodeSecurity) String() string {
+	return Stringify(c)
 }
 
 // List calls either RepositoriesService.ListByUser or RepositoriesService.ListByAuthenticatedUser

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -411,7 +411,7 @@ func TestRepositoriesService_Get(t *testing.T) {
 	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		fmt.Fprint(w, `{"id":1,"name":"n","description":"d","owner":{"login":"l"},"license":{"key":"mit"},"security_and_analysis":{"advanced_security":{"status":"enabled"},"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"},"dependabot_security_updates":{"status": "enabled"}, "secret_scanning_validity_checks":{"status":"enabled"}}}`)
+		fmt.Fprint(w, `{"id":1,"name":"n","description":"d","owner":{"login":"l"},"license":{"key":"mit"},"security_and_analysis":{"advanced_security":{"status":"enabled"},"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"},"dependabot_security_updates":{"status": "enabled"}, "secret_scanning_validity_checks":{"status":"enabled"}, "code_security":{"status":"enabled"}}}`)
 	})
 
 	ctx := t.Context()
@@ -420,7 +420,7 @@ func TestRepositoriesService_Get(t *testing.T) {
 		t.Errorf("Repositories.Get returned error: %v", err)
 	}
 
-	want := &Repository{ID: Ptr(int64(1)), Name: Ptr("n"), Description: Ptr("d"), Owner: &User{Login: Ptr("l")}, License: &License{Key: Ptr("mit")}, SecurityAndAnalysis: &SecurityAndAnalysis{AdvancedSecurity: &AdvancedSecurity{Status: Ptr("enabled")}, SecretScanning: &SecretScanning{Ptr("enabled")}, SecretScanningPushProtection: &SecretScanningPushProtection{Ptr("enabled")}, DependabotSecurityUpdates: &DependabotSecurityUpdates{Ptr("enabled")}, SecretScanningValidityChecks: &SecretScanningValidityChecks{Ptr("enabled")}}}
+	want := &Repository{ID: Ptr(int64(1)), Name: Ptr("n"), Description: Ptr("d"), Owner: &User{Login: Ptr("l")}, License: &License{Key: Ptr("mit")}, SecurityAndAnalysis: &SecurityAndAnalysis{AdvancedSecurity: &AdvancedSecurity{Status: Ptr("enabled")}, SecretScanning: &SecretScanning{Ptr("enabled")}, SecretScanningPushProtection: &SecretScanningPushProtection{Ptr("enabled")}, DependabotSecurityUpdates: &DependabotSecurityUpdates{Ptr("enabled")}, SecretScanningValidityChecks: &SecretScanningValidityChecks{Ptr("enabled")}, CodeSecurity: &CodeSecurity{Ptr("enabled")}}}
 	if !cmp.Equal(got, want) {
 		t.Errorf("Repositories.Get returned %+v, want %+v", got, want)
 	}


### PR DESCRIPTION
## Summary
- Add missing `code_security` field to `SecurityAndAnalysis` struct to match the GitHub API response
- Add `CodeSecurity` struct with `Status` field (same pattern as other security fields like `DependabotSecurityUpdates`)
- Auto-generated accessor methods via `script/generate.sh`

Fixes #4154