### PR TITLE
feat!: Add OIDC authentication support to `PrivateRegistries`

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9599,7 +9599,7 @@ func (c *CreateOrganizationPrivateRegistry) GetKeyID() string {
 }
 
 // GetRegistryType returns the RegistryType field.
-func (c *CreateOrganizationPrivateRegistry) GetRegistryType() string {
+func (c *CreateOrganizationPrivateRegistry) GetRegistryType() PrivateRegistryType {
 	if c == nil {
 		return ""
 	}
@@ -26118,6 +26118,78 @@ func (p *PrivateRegistry) GetCreatedAt() Timestamp {
 	return *p.CreatedAt
 }
 
+// GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetAccountID() string {
+	if p == nil || p.AccountID == nil {
+		return ""
+	}
+	return *p.AccountID
+}
+
+// GetAudience returns the Audience field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetAudience() string {
+	if p == nil || p.Audience == nil {
+		return ""
+	}
+	return *p.Audience
+}
+
+// GetAuthType returns the AuthType field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetAuthType() PrivateRegistryAuthType {
+	if p == nil || p.AuthType == nil {
+		return ""
+	}
+	return *p.AuthType
+}
+
+// GetAwsRegion returns the AwsRegion field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetAwsRegion() string {
+	if p == nil || p.AwsRegion == nil {
+		return ""
+	}
+	return *p.AwsRegion
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetClientID() string {
+	if p == nil || p.ClientID == nil {
+		return ""
+	}
+	return *p.ClientID
+}
+
+// GetDomain returns the Domain field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetDomain() string {
+	if p == nil || p.Domain == nil {
+		return ""
+	}
+	return *p.Domain
+}
+
+// GetDomainOwner returns the DomainOwner field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetDomainOwner() string {
+	if p == nil || p.DomainOwner == nil {
+		return ""
+	}
+	return *p.DomainOwner
+}
+
+// GetIdentityMappingName returns the IdentityMappingName field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetIdentityMappingName() string {
+	if p == nil || p.IdentityMappingName == nil {
+		return ""
+	}
+	return *p.IdentityMappingName
+}
+
+// GetJfrogOidcProviderName returns the JfrogOidcProviderName field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetJfrogOidcProviderName() string {
+	if p == nil || p.JfrogOidcProviderName == nil {
+		return ""
+	}
+	return *p.JfrogOidcProviderName
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (p *PrivateRegistry) GetName() string {
 	if p == nil || p.Name == nil {
@@ -26127,7 +26199,7 @@ func (p *PrivateRegistry) GetName() string {
 }
 
 // GetRegistryType returns the RegistryType field if it's non-nil, zero value otherwise.
-func (p *PrivateRegistry) GetRegistryType() string {
+func (p *PrivateRegistry) GetRegistryType() PrivateRegistryType {
 	if p == nil || p.RegistryType == nil {
 		return ""
 	}
@@ -26140,6 +26212,38 @@ func (p *PrivateRegistry) GetSelectedRepositoryIDs() []int64 {
 		return nil
 	}
 	return p.SelectedRepositoryIDs
+}
+
+// GetReplacesBase returns the ReplacesBase field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetReplacesBase() bool {
+	if p == nil || p.ReplacesBase == nil {
+		return false
+	}
+	return *p.ReplacesBase
+}
+
+// GetRoleName returns the RoleName field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetRoleName() string {
+	if p == nil || p.RoleName == nil {
+		return ""
+	}
+	return *p.RoleName
+}
+
+// GetTenantID returns the TenantID field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetTenantID() string {
+	if p == nil || p.TenantID == nil {
+		return ""
+	}
+	return *p.TenantID
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetURL() string {
+	if p == nil || p.URL == nil {
+		return ""
+	}
+	return *p.URL
 }
 
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
@@ -39823,7 +39927,7 @@ func (u *UpdateOrganizationPrivateRegistry) GetKeyID() string {
 }
 
 // GetRegistryType returns the RegistryType field if it's non-nil, zero value otherwise.
-func (u *UpdateOrganizationPrivateRegistry) GetRegistryType() string {
+func (u *UpdateOrganizationPrivateRegistry) GetRegistryType() PrivateRegistryType {
 	if u == nil || u.RegistryType == nil {
 		return ""
 	}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9510,20 +9510,92 @@ func (c *CreateHostedRunnerRequest) GetSize() string {
 	return c.Size
 }
 
-// GetEncryptedValue returns the EncryptedValue field.
-func (c *CreateOrganizationPrivateRegistry) GetEncryptedValue() string {
-	if c == nil {
+// GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetAccountID() string {
+	if c == nil || c.AccountID == nil {
 		return ""
 	}
-	return c.EncryptedValue
+	return *c.AccountID
 }
 
-// GetKeyID returns the KeyID field.
-func (c *CreateOrganizationPrivateRegistry) GetKeyID() string {
-	if c == nil {
+// GetAudience returns the Audience field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetAudience() string {
+	if c == nil || c.Audience == nil {
 		return ""
 	}
-	return c.KeyID
+	return *c.Audience
+}
+
+// GetAuthType returns the AuthType field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetAuthType() string {
+	if c == nil || c.AuthType == nil {
+		return ""
+	}
+	return *c.AuthType
+}
+
+// GetAwsRegion returns the AwsRegion field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetAwsRegion() string {
+	if c == nil || c.AwsRegion == nil {
+		return ""
+	}
+	return *c.AwsRegion
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetClientID() string {
+	if c == nil || c.ClientID == nil {
+		return ""
+	}
+	return *c.ClientID
+}
+
+// GetDomain returns the Domain field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetDomain() string {
+	if c == nil || c.Domain == nil {
+		return ""
+	}
+	return *c.Domain
+}
+
+// GetDomainOwner returns the DomainOwner field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetDomainOwner() string {
+	if c == nil || c.DomainOwner == nil {
+		return ""
+	}
+	return *c.DomainOwner
+}
+
+// GetEncryptedValue returns the EncryptedValue field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetEncryptedValue() string {
+	if c == nil || c.EncryptedValue == nil {
+		return ""
+	}
+	return *c.EncryptedValue
+}
+
+// GetIdentityMappingName returns the IdentityMappingName field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetIdentityMappingName() string {
+	if c == nil || c.IdentityMappingName == nil {
+		return ""
+	}
+	return *c.IdentityMappingName
+}
+
+// GetJfrogOidcProviderName returns the JfrogOidcProviderName field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetJfrogOidcProviderName() string {
+	if c == nil || c.JfrogOidcProviderName == nil {
+		return ""
+	}
+	return *c.JfrogOidcProviderName
+}
+
+// GetKeyID returns the KeyID field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetKeyID() string {
+	if c == nil || c.KeyID == nil {
+		return ""
+	}
+	return *c.KeyID
 }
 
 // GetRegistryType returns the RegistryType field.
@@ -9534,12 +9606,36 @@ func (c *CreateOrganizationPrivateRegistry) GetRegistryType() string {
 	return c.RegistryType
 }
 
+// GetReplacesBase returns the ReplacesBase field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetReplacesBase() bool {
+	if c == nil || c.ReplacesBase == nil {
+		return false
+	}
+	return *c.ReplacesBase
+}
+
+// GetRoleName returns the RoleName field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetRoleName() string {
+	if c == nil || c.RoleName == nil {
+		return ""
+	}
+	return *c.RoleName
+}
+
 // GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
 func (c *CreateOrganizationPrivateRegistry) GetSelectedRepositoryIDs() []int64 {
 	if c == nil || c.SelectedRepositoryIDs == nil {
 		return nil
 	}
 	return c.SelectedRepositoryIDs
+}
+
+// GetTenantID returns the TenantID field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetTenantID() string {
+	if c == nil || c.TenantID == nil {
+		return ""
+	}
+	return *c.TenantID
 }
 
 // GetURL returns the URL field.
@@ -26038,6 +26134,14 @@ func (p *PrivateRegistry) GetRegistryType() string {
 	return *p.RegistryType
 }
 
+// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
+func (p *PrivateRegistry) GetSelectedRepositoryIDs() []int64 {
+	if p == nil || p.SelectedRepositoryIDs == nil {
+		return nil
+	}
+	return p.SelectedRepositoryIDs
+}
+
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (p *PrivateRegistry) GetUpdatedAt() Timestamp {
 	if p == nil || p.UpdatedAt == nil {
@@ -39630,12 +39734,84 @@ func (u *UpdateHostedRunnerRequest) GetSize() string {
 	return *u.Size
 }
 
+// GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetAccountID() string {
+	if u == nil || u.AccountID == nil {
+		return ""
+	}
+	return *u.AccountID
+}
+
+// GetAudience returns the Audience field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetAudience() string {
+	if u == nil || u.Audience == nil {
+		return ""
+	}
+	return *u.Audience
+}
+
+// GetAuthType returns the AuthType field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetAuthType() string {
+	if u == nil || u.AuthType == nil {
+		return ""
+	}
+	return *u.AuthType
+}
+
+// GetAwsRegion returns the AwsRegion field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetAwsRegion() string {
+	if u == nil || u.AwsRegion == nil {
+		return ""
+	}
+	return *u.AwsRegion
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetClientID() string {
+	if u == nil || u.ClientID == nil {
+		return ""
+	}
+	return *u.ClientID
+}
+
+// GetDomain returns the Domain field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetDomain() string {
+	if u == nil || u.Domain == nil {
+		return ""
+	}
+	return *u.Domain
+}
+
+// GetDomainOwner returns the DomainOwner field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetDomainOwner() string {
+	if u == nil || u.DomainOwner == nil {
+		return ""
+	}
+	return *u.DomainOwner
+}
+
 // GetEncryptedValue returns the EncryptedValue field if it's non-nil, zero value otherwise.
 func (u *UpdateOrganizationPrivateRegistry) GetEncryptedValue() string {
 	if u == nil || u.EncryptedValue == nil {
 		return ""
 	}
 	return *u.EncryptedValue
+}
+
+// GetIdentityMappingName returns the IdentityMappingName field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetIdentityMappingName() string {
+	if u == nil || u.IdentityMappingName == nil {
+		return ""
+	}
+	return *u.IdentityMappingName
+}
+
+// GetJfrogOidcProviderName returns the JfrogOidcProviderName field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetJfrogOidcProviderName() string {
+	if u == nil || u.JfrogOidcProviderName == nil {
+		return ""
+	}
+	return *u.JfrogOidcProviderName
 }
 
 // GetKeyID returns the KeyID field if it's non-nil, zero value otherwise.
@@ -39654,12 +39830,36 @@ func (u *UpdateOrganizationPrivateRegistry) GetRegistryType() string {
 	return *u.RegistryType
 }
 
+// GetReplacesBase returns the ReplacesBase field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetReplacesBase() bool {
+	if u == nil || u.ReplacesBase == nil {
+		return false
+	}
+	return *u.ReplacesBase
+}
+
+// GetRoleName returns the RoleName field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetRoleName() string {
+	if u == nil || u.RoleName == nil {
+		return ""
+	}
+	return *u.RoleName
+}
+
 // GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
 func (u *UpdateOrganizationPrivateRegistry) GetSelectedRepositoryIDs() []int64 {
 	if u == nil || u.SelectedRepositoryIDs == nil {
 		return nil
 	}
 	return u.SelectedRepositoryIDs
+}
+
+// GetTenantID returns the TenantID field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetTenantID() string {
+	if u == nil || u.TenantID == nil {
+		return ""
+	}
+	return *u.TenantID
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -26110,14 +26110,6 @@ func (p *PrivateRegistries) GetTotalCount() int {
 	return *p.TotalCount
 }
 
-// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
-func (p *PrivateRegistry) GetCreatedAt() Timestamp {
-	if p == nil || p.CreatedAt == nil {
-		return Timestamp{}
-	}
-	return *p.CreatedAt
-}
-
 // GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.
 func (p *PrivateRegistry) GetAccountID() string {
 	if p == nil || p.AccountID == nil {
@@ -26134,12 +26126,12 @@ func (p *PrivateRegistry) GetAudience() string {
 	return *p.Audience
 }
 
-// GetAuthType returns the AuthType field if it's non-nil, zero value otherwise.
-func (p *PrivateRegistry) GetAuthType() PrivateRegistryAuthType {
-	if p == nil || p.AuthType == nil {
-		return ""
+// GetAuthType returns the AuthType field.
+func (p *PrivateRegistry) GetAuthType() *PrivateRegistryAuthType {
+	if p == nil {
+		return nil
 	}
-	return *p.AuthType
+	return p.AuthType
 }
 
 // GetAwsRegion returns the AwsRegion field if it's non-nil, zero value otherwise.
@@ -26156,6 +26148,14 @@ func (p *PrivateRegistry) GetClientID() string {
 		return ""
 	}
 	return *p.ClientID
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetCreatedAt() Timestamp {
+	if p == nil || p.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *p.CreatedAt
 }
 
 // GetDomain returns the Domain field if it's non-nil, zero value otherwise.
@@ -26198,20 +26198,12 @@ func (p *PrivateRegistry) GetName() string {
 	return *p.Name
 }
 
-// GetRegistryType returns the RegistryType field if it's non-nil, zero value otherwise.
-func (p *PrivateRegistry) GetRegistryType() PrivateRegistryType {
-	if p == nil || p.RegistryType == nil {
-		return ""
-	}
-	return *p.RegistryType
-}
-
-// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
-func (p *PrivateRegistry) GetSelectedRepositoryIDs() []int64 {
-	if p == nil || p.SelectedRepositoryIDs == nil {
+// GetRegistryType returns the RegistryType field.
+func (p *PrivateRegistry) GetRegistryType() *PrivateRegistryType {
+	if p == nil {
 		return nil
 	}
-	return p.SelectedRepositoryIDs
+	return p.RegistryType
 }
 
 // GetReplacesBase returns the ReplacesBase field if it's non-nil, zero value otherwise.
@@ -26230,6 +26222,14 @@ func (p *PrivateRegistry) GetRoleName() string {
 	return *p.RoleName
 }
 
+// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
+func (p *PrivateRegistry) GetSelectedRepositoryIDs() []int64 {
+	if p == nil || p.SelectedRepositoryIDs == nil {
+		return nil
+	}
+	return p.SelectedRepositoryIDs
+}
+
 // GetTenantID returns the TenantID field if it's non-nil, zero value otherwise.
 func (p *PrivateRegistry) GetTenantID() string {
 	if p == nil || p.TenantID == nil {
@@ -26238,20 +26238,20 @@ func (p *PrivateRegistry) GetTenantID() string {
 	return *p.TenantID
 }
 
-// GetURL returns the URL field if it's non-nil, zero value otherwise.
-func (p *PrivateRegistry) GetURL() string {
-	if p == nil || p.URL == nil {
-		return ""
-	}
-	return *p.URL
-}
-
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (p *PrivateRegistry) GetUpdatedAt() Timestamp {
 	if p == nil || p.UpdatedAt == nil {
 		return Timestamp{}
 	}
 	return *p.UpdatedAt
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetURL() string {
+	if p == nil || p.URL == nil {
+		return ""
+	}
+	return *p.URL
 }
 
 // GetUsername returns the Username field if it's non-nil, zero value otherwise.
@@ -39926,12 +39926,12 @@ func (u *UpdateOrganizationPrivateRegistry) GetKeyID() string {
 	return *u.KeyID
 }
 
-// GetRegistryType returns the RegistryType field if it's non-nil, zero value otherwise.
-func (u *UpdateOrganizationPrivateRegistry) GetRegistryType() PrivateRegistryType {
-	if u == nil || u.RegistryType == nil {
-		return ""
+// GetRegistryType returns the RegistryType field.
+func (u *UpdateOrganizationPrivateRegistry) GetRegistryType() *PrivateRegistryType {
+	if u == nil {
+		return nil
 	}
-	return *u.RegistryType
+	return u.RegistryType
 }
 
 // GetReplacesBase returns the ReplacesBase field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9607,7 +9607,7 @@ func (c *CreateOrganizationPrivateRegistry) GetKeyID() string {
 }
 
 // GetRegistryType returns the RegistryType field.
-func (c *CreateOrganizationPrivateRegistry) GetRegistryType() string {
+func (c *CreateOrganizationPrivateRegistry) GetRegistryType() PrivateRegistryType {
 	if c == nil {
 		return ""
 	}
@@ -26126,6 +26126,78 @@ func (p *PrivateRegistry) GetCreatedAt() Timestamp {
 	return *p.CreatedAt
 }
 
+// GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetAccountID() string {
+	if p == nil || p.AccountID == nil {
+		return ""
+	}
+	return *p.AccountID
+}
+
+// GetAudience returns the Audience field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetAudience() string {
+	if p == nil || p.Audience == nil {
+		return ""
+	}
+	return *p.Audience
+}
+
+// GetAuthType returns the AuthType field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetAuthType() PrivateRegistryAuthType {
+	if p == nil || p.AuthType == nil {
+		return ""
+	}
+	return *p.AuthType
+}
+
+// GetAwsRegion returns the AwsRegion field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetAwsRegion() string {
+	if p == nil || p.AwsRegion == nil {
+		return ""
+	}
+	return *p.AwsRegion
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetClientID() string {
+	if p == nil || p.ClientID == nil {
+		return ""
+	}
+	return *p.ClientID
+}
+
+// GetDomain returns the Domain field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetDomain() string {
+	if p == nil || p.Domain == nil {
+		return ""
+	}
+	return *p.Domain
+}
+
+// GetDomainOwner returns the DomainOwner field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetDomainOwner() string {
+	if p == nil || p.DomainOwner == nil {
+		return ""
+	}
+	return *p.DomainOwner
+}
+
+// GetIdentityMappingName returns the IdentityMappingName field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetIdentityMappingName() string {
+	if p == nil || p.IdentityMappingName == nil {
+		return ""
+	}
+	return *p.IdentityMappingName
+}
+
+// GetJfrogOidcProviderName returns the JfrogOidcProviderName field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetJfrogOidcProviderName() string {
+	if p == nil || p.JfrogOidcProviderName == nil {
+		return ""
+	}
+	return *p.JfrogOidcProviderName
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (p *PrivateRegistry) GetName() string {
 	if p == nil || p.Name == nil {
@@ -26135,7 +26207,7 @@ func (p *PrivateRegistry) GetName() string {
 }
 
 // GetRegistryType returns the RegistryType field if it's non-nil, zero value otherwise.
-func (p *PrivateRegistry) GetRegistryType() string {
+func (p *PrivateRegistry) GetRegistryType() PrivateRegistryType {
 	if p == nil || p.RegistryType == nil {
 		return ""
 	}
@@ -26148,6 +26220,38 @@ func (p *PrivateRegistry) GetSelectedRepositoryIDs() []int64 {
 		return nil
 	}
 	return p.SelectedRepositoryIDs
+}
+
+// GetReplacesBase returns the ReplacesBase field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetReplacesBase() bool {
+	if p == nil || p.ReplacesBase == nil {
+		return false
+	}
+	return *p.ReplacesBase
+}
+
+// GetRoleName returns the RoleName field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetRoleName() string {
+	if p == nil || p.RoleName == nil {
+		return ""
+	}
+	return *p.RoleName
+}
+
+// GetTenantID returns the TenantID field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetTenantID() string {
+	if p == nil || p.TenantID == nil {
+		return ""
+	}
+	return *p.TenantID
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetURL() string {
+	if p == nil || p.URL == nil {
+		return ""
+	}
+	return *p.URL
 }
 
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
@@ -39839,7 +39943,7 @@ func (u *UpdateOrganizationPrivateRegistry) GetKeyID() string {
 }
 
 // GetRegistryType returns the RegistryType field if it's non-nil, zero value otherwise.
-func (u *UpdateOrganizationPrivateRegistry) GetRegistryType() string {
+func (u *UpdateOrganizationPrivateRegistry) GetRegistryType() PrivateRegistryType {
 	if u == nil || u.RegistryType == nil {
 		return ""
 	}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -26118,14 +26118,6 @@ func (p *PrivateRegistries) GetTotalCount() int {
 	return *p.TotalCount
 }
 
-// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
-func (p *PrivateRegistry) GetCreatedAt() Timestamp {
-	if p == nil || p.CreatedAt == nil {
-		return Timestamp{}
-	}
-	return *p.CreatedAt
-}
-
 // GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.
 func (p *PrivateRegistry) GetAccountID() string {
 	if p == nil || p.AccountID == nil {
@@ -26142,12 +26134,12 @@ func (p *PrivateRegistry) GetAudience() string {
 	return *p.Audience
 }
 
-// GetAuthType returns the AuthType field if it's non-nil, zero value otherwise.
-func (p *PrivateRegistry) GetAuthType() PrivateRegistryAuthType {
-	if p == nil || p.AuthType == nil {
-		return ""
+// GetAuthType returns the AuthType field.
+func (p *PrivateRegistry) GetAuthType() *PrivateRegistryAuthType {
+	if p == nil {
+		return nil
 	}
-	return *p.AuthType
+	return p.AuthType
 }
 
 // GetAwsRegion returns the AwsRegion field if it's non-nil, zero value otherwise.
@@ -26164,6 +26156,14 @@ func (p *PrivateRegistry) GetClientID() string {
 		return ""
 	}
 	return *p.ClientID
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetCreatedAt() Timestamp {
+	if p == nil || p.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *p.CreatedAt
 }
 
 // GetDomain returns the Domain field if it's non-nil, zero value otherwise.
@@ -26206,20 +26206,12 @@ func (p *PrivateRegistry) GetName() string {
 	return *p.Name
 }
 
-// GetRegistryType returns the RegistryType field if it's non-nil, zero value otherwise.
-func (p *PrivateRegistry) GetRegistryType() PrivateRegistryType {
-	if p == nil || p.RegistryType == nil {
-		return ""
-	}
-	return *p.RegistryType
-}
-
-// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
-func (p *PrivateRegistry) GetSelectedRepositoryIDs() []int64 {
-	if p == nil || p.SelectedRepositoryIDs == nil {
+// GetRegistryType returns the RegistryType field.
+func (p *PrivateRegistry) GetRegistryType() *PrivateRegistryType {
+	if p == nil {
 		return nil
 	}
-	return p.SelectedRepositoryIDs
+	return p.RegistryType
 }
 
 // GetReplacesBase returns the ReplacesBase field if it's non-nil, zero value otherwise.
@@ -26238,6 +26230,14 @@ func (p *PrivateRegistry) GetRoleName() string {
 	return *p.RoleName
 }
 
+// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
+func (p *PrivateRegistry) GetSelectedRepositoryIDs() []int64 {
+	if p == nil || p.SelectedRepositoryIDs == nil {
+		return nil
+	}
+	return p.SelectedRepositoryIDs
+}
+
 // GetTenantID returns the TenantID field if it's non-nil, zero value otherwise.
 func (p *PrivateRegistry) GetTenantID() string {
 	if p == nil || p.TenantID == nil {
@@ -26246,20 +26246,20 @@ func (p *PrivateRegistry) GetTenantID() string {
 	return *p.TenantID
 }
 
-// GetURL returns the URL field if it's non-nil, zero value otherwise.
-func (p *PrivateRegistry) GetURL() string {
-	if p == nil || p.URL == nil {
-		return ""
-	}
-	return *p.URL
-}
-
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (p *PrivateRegistry) GetUpdatedAt() Timestamp {
 	if p == nil || p.UpdatedAt == nil {
 		return Timestamp{}
 	}
 	return *p.UpdatedAt
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetURL() string {
+	if p == nil || p.URL == nil {
+		return ""
+	}
+	return *p.URL
 }
 
 // GetUsername returns the Username field if it's non-nil, zero value otherwise.
@@ -39942,12 +39942,12 @@ func (u *UpdateOrganizationPrivateRegistry) GetKeyID() string {
 	return *u.KeyID
 }
 
-// GetRegistryType returns the RegistryType field if it's non-nil, zero value otherwise.
-func (u *UpdateOrganizationPrivateRegistry) GetRegistryType() PrivateRegistryType {
-	if u == nil || u.RegistryType == nil {
-		return ""
+// GetRegistryType returns the RegistryType field.
+func (u *UpdateOrganizationPrivateRegistry) GetRegistryType() *PrivateRegistryType {
+	if u == nil {
+		return nil
 	}
-	return *u.RegistryType
+	return u.RegistryType
 }
 
 // GetReplacesBase returns the ReplacesBase field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9542,12 +9542,12 @@ func (c *CreateOrganizationPrivateRegistry) GetAuthType() string {
 	return *c.AuthType
 }
 
-// GetAwsRegion returns the AwsRegion field if it's non-nil, zero value otherwise.
-func (c *CreateOrganizationPrivateRegistry) GetAwsRegion() string {
-	if c == nil || c.AwsRegion == nil {
+// GetAWSRegion returns the AWSRegion field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetAWSRegion() string {
+	if c == nil || c.AWSRegion == nil {
 		return ""
 	}
-	return *c.AwsRegion
+	return *c.AWSRegion
 }
 
 // GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
@@ -9590,12 +9590,12 @@ func (c *CreateOrganizationPrivateRegistry) GetIdentityMappingName() string {
 	return *c.IdentityMappingName
 }
 
-// GetJfrogOidcProviderName returns the JfrogOidcProviderName field if it's non-nil, zero value otherwise.
-func (c *CreateOrganizationPrivateRegistry) GetJfrogOidcProviderName() string {
-	if c == nil || c.JfrogOidcProviderName == nil {
+// GetJFrogOIDCProviderName returns the JFrogOIDCProviderName field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetJFrogOIDCProviderName() string {
+	if c == nil || c.JFrogOIDCProviderName == nil {
 		return ""
 	}
-	return *c.JfrogOidcProviderName
+	return *c.JFrogOIDCProviderName
 }
 
 // GetKeyID returns the KeyID field if it's non-nil, zero value otherwise.
@@ -26142,12 +26142,12 @@ func (p *PrivateRegistry) GetAuthType() *PrivateRegistryAuthType {
 	return p.AuthType
 }
 
-// GetAwsRegion returns the AwsRegion field if it's non-nil, zero value otherwise.
-func (p *PrivateRegistry) GetAwsRegion() string {
-	if p == nil || p.AwsRegion == nil {
+// GetAWSRegion returns the AWSRegion field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetAWSRegion() string {
+	if p == nil || p.AWSRegion == nil {
 		return ""
 	}
-	return *p.AwsRegion
+	return *p.AWSRegion
 }
 
 // GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
@@ -26190,12 +26190,12 @@ func (p *PrivateRegistry) GetIdentityMappingName() string {
 	return *p.IdentityMappingName
 }
 
-// GetJfrogOidcProviderName returns the JfrogOidcProviderName field if it's non-nil, zero value otherwise.
-func (p *PrivateRegistry) GetJfrogOidcProviderName() string {
-	if p == nil || p.JfrogOidcProviderName == nil {
+// GetJFrogOIDCProviderName returns the JFrogOIDCProviderName field if it's non-nil, zero value otherwise.
+func (p *PrivateRegistry) GetJFrogOIDCProviderName() string {
+	if p == nil || p.JFrogOIDCProviderName == nil {
 		return ""
 	}
-	return *p.JfrogOidcProviderName
+	return *p.JFrogOIDCProviderName
 }
 
 // GetName returns the Name field if it's non-nil, zero value otherwise.
@@ -39878,12 +39878,12 @@ func (u *UpdateOrganizationPrivateRegistry) GetAuthType() string {
 	return *u.AuthType
 }
 
-// GetAwsRegion returns the AwsRegion field if it's non-nil, zero value otherwise.
-func (u *UpdateOrganizationPrivateRegistry) GetAwsRegion() string {
-	if u == nil || u.AwsRegion == nil {
+// GetAWSRegion returns the AWSRegion field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetAWSRegion() string {
+	if u == nil || u.AWSRegion == nil {
 		return ""
 	}
-	return *u.AwsRegion
+	return *u.AWSRegion
 }
 
 // GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
@@ -39926,12 +39926,12 @@ func (u *UpdateOrganizationPrivateRegistry) GetIdentityMappingName() string {
 	return *u.IdentityMappingName
 }
 
-// GetJfrogOidcProviderName returns the JfrogOidcProviderName field if it's non-nil, zero value otherwise.
-func (u *UpdateOrganizationPrivateRegistry) GetJfrogOidcProviderName() string {
-	if u == nil || u.JfrogOidcProviderName == nil {
+// GetJFrogOIDCProviderName returns the JFrogOIDCProviderName field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetJFrogOIDCProviderName() string {
+	if u == nil || u.JFrogOIDCProviderName == nil {
 		return ""
 	}
-	return *u.JfrogOidcProviderName
+	return *u.JFrogOIDCProviderName
 }
 
 // GetKeyID returns the KeyID field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9518,20 +9518,92 @@ func (c *CreateHostedRunnerRequest) GetSize() string {
 	return c.Size
 }
 
-// GetEncryptedValue returns the EncryptedValue field.
-func (c *CreateOrganizationPrivateRegistry) GetEncryptedValue() string {
-	if c == nil {
+// GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetAccountID() string {
+	if c == nil || c.AccountID == nil {
 		return ""
 	}
-	return c.EncryptedValue
+	return *c.AccountID
 }
 
-// GetKeyID returns the KeyID field.
-func (c *CreateOrganizationPrivateRegistry) GetKeyID() string {
-	if c == nil {
+// GetAudience returns the Audience field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetAudience() string {
+	if c == nil || c.Audience == nil {
 		return ""
 	}
-	return c.KeyID
+	return *c.Audience
+}
+
+// GetAuthType returns the AuthType field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetAuthType() string {
+	if c == nil || c.AuthType == nil {
+		return ""
+	}
+	return *c.AuthType
+}
+
+// GetAwsRegion returns the AwsRegion field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetAwsRegion() string {
+	if c == nil || c.AwsRegion == nil {
+		return ""
+	}
+	return *c.AwsRegion
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetClientID() string {
+	if c == nil || c.ClientID == nil {
+		return ""
+	}
+	return *c.ClientID
+}
+
+// GetDomain returns the Domain field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetDomain() string {
+	if c == nil || c.Domain == nil {
+		return ""
+	}
+	return *c.Domain
+}
+
+// GetDomainOwner returns the DomainOwner field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetDomainOwner() string {
+	if c == nil || c.DomainOwner == nil {
+		return ""
+	}
+	return *c.DomainOwner
+}
+
+// GetEncryptedValue returns the EncryptedValue field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetEncryptedValue() string {
+	if c == nil || c.EncryptedValue == nil {
+		return ""
+	}
+	return *c.EncryptedValue
+}
+
+// GetIdentityMappingName returns the IdentityMappingName field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetIdentityMappingName() string {
+	if c == nil || c.IdentityMappingName == nil {
+		return ""
+	}
+	return *c.IdentityMappingName
+}
+
+// GetJfrogOidcProviderName returns the JfrogOidcProviderName field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetJfrogOidcProviderName() string {
+	if c == nil || c.JfrogOidcProviderName == nil {
+		return ""
+	}
+	return *c.JfrogOidcProviderName
+}
+
+// GetKeyID returns the KeyID field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetKeyID() string {
+	if c == nil || c.KeyID == nil {
+		return ""
+	}
+	return *c.KeyID
 }
 
 // GetRegistryType returns the RegistryType field.
@@ -9542,12 +9614,36 @@ func (c *CreateOrganizationPrivateRegistry) GetRegistryType() string {
 	return c.RegistryType
 }
 
+// GetReplacesBase returns the ReplacesBase field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetReplacesBase() bool {
+	if c == nil || c.ReplacesBase == nil {
+		return false
+	}
+	return *c.ReplacesBase
+}
+
+// GetRoleName returns the RoleName field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetRoleName() string {
+	if c == nil || c.RoleName == nil {
+		return ""
+	}
+	return *c.RoleName
+}
+
 // GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
 func (c *CreateOrganizationPrivateRegistry) GetSelectedRepositoryIDs() []int64 {
 	if c == nil || c.SelectedRepositoryIDs == nil {
 		return nil
 	}
 	return c.SelectedRepositoryIDs
+}
+
+// GetTenantID returns the TenantID field if it's non-nil, zero value otherwise.
+func (c *CreateOrganizationPrivateRegistry) GetTenantID() string {
+	if c == nil || c.TenantID == nil {
+		return ""
+	}
+	return *c.TenantID
 }
 
 // GetURL returns the URL field.
@@ -26046,6 +26142,14 @@ func (p *PrivateRegistry) GetRegistryType() string {
 	return *p.RegistryType
 }
 
+// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
+func (p *PrivateRegistry) GetSelectedRepositoryIDs() []int64 {
+	if p == nil || p.SelectedRepositoryIDs == nil {
+		return nil
+	}
+	return p.SelectedRepositoryIDs
+}
+
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (p *PrivateRegistry) GetUpdatedAt() Timestamp {
 	if p == nil || p.UpdatedAt == nil {
@@ -39646,12 +39750,84 @@ func (u *UpdateHostedRunnerRequest) GetSize() string {
 	return *u.Size
 }
 
+// GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetAccountID() string {
+	if u == nil || u.AccountID == nil {
+		return ""
+	}
+	return *u.AccountID
+}
+
+// GetAudience returns the Audience field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetAudience() string {
+	if u == nil || u.Audience == nil {
+		return ""
+	}
+	return *u.Audience
+}
+
+// GetAuthType returns the AuthType field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetAuthType() string {
+	if u == nil || u.AuthType == nil {
+		return ""
+	}
+	return *u.AuthType
+}
+
+// GetAwsRegion returns the AwsRegion field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetAwsRegion() string {
+	if u == nil || u.AwsRegion == nil {
+		return ""
+	}
+	return *u.AwsRegion
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetClientID() string {
+	if u == nil || u.ClientID == nil {
+		return ""
+	}
+	return *u.ClientID
+}
+
+// GetDomain returns the Domain field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetDomain() string {
+	if u == nil || u.Domain == nil {
+		return ""
+	}
+	return *u.Domain
+}
+
+// GetDomainOwner returns the DomainOwner field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetDomainOwner() string {
+	if u == nil || u.DomainOwner == nil {
+		return ""
+	}
+	return *u.DomainOwner
+}
+
 // GetEncryptedValue returns the EncryptedValue field if it's non-nil, zero value otherwise.
 func (u *UpdateOrganizationPrivateRegistry) GetEncryptedValue() string {
 	if u == nil || u.EncryptedValue == nil {
 		return ""
 	}
 	return *u.EncryptedValue
+}
+
+// GetIdentityMappingName returns the IdentityMappingName field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetIdentityMappingName() string {
+	if u == nil || u.IdentityMappingName == nil {
+		return ""
+	}
+	return *u.IdentityMappingName
+}
+
+// GetJfrogOidcProviderName returns the JfrogOidcProviderName field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetJfrogOidcProviderName() string {
+	if u == nil || u.JfrogOidcProviderName == nil {
+		return ""
+	}
+	return *u.JfrogOidcProviderName
 }
 
 // GetKeyID returns the KeyID field if it's non-nil, zero value otherwise.
@@ -39670,12 +39846,36 @@ func (u *UpdateOrganizationPrivateRegistry) GetRegistryType() string {
 	return *u.RegistryType
 }
 
+// GetReplacesBase returns the ReplacesBase field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetReplacesBase() bool {
+	if u == nil || u.ReplacesBase == nil {
+		return false
+	}
+	return *u.ReplacesBase
+}
+
+// GetRoleName returns the RoleName field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetRoleName() string {
+	if u == nil || u.RoleName == nil {
+		return ""
+	}
+	return *u.RoleName
+}
+
 // GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
 func (u *UpdateOrganizationPrivateRegistry) GetSelectedRepositoryIDs() []int64 {
 	if u == nil || u.SelectedRepositoryIDs == nil {
 		return nil
 	}
 	return u.SelectedRepositoryIDs
+}
+
+// GetTenantID returns the TenantID field if it's non-nil, zero value otherwise.
+func (u *UpdateOrganizationPrivateRegistry) GetTenantID() string {
+	if u == nil || u.TenantID == nil {
+		return ""
+	}
+	return *u.TenantID
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -33035,13 +33035,156 @@ func TestPrivateRegistry_GetName(tt *testing.T) {
 
 func TestPrivateRegistry_GetRegistryType(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
+	var zeroValue PrivateRegistryType
 	p := &PrivateRegistry{RegistryType: &zeroValue}
 	p.GetRegistryType()
 	p = &PrivateRegistry{}
 	p.GetRegistryType()
 	p = nil
 	p.GetRegistryType()
+}
+
+func TestPrivateRegistry_GetAccountID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{AccountID: &zeroValue}
+	p.GetAccountID()
+	p = &PrivateRegistry{}
+	p.GetAccountID()
+	p = nil
+	p.GetAccountID()
+}
+
+func TestPrivateRegistry_GetAudience(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{Audience: &zeroValue}
+	p.GetAudience()
+	p = &PrivateRegistry{}
+	p.GetAudience()
+	p = nil
+	p.GetAudience()
+}
+
+func TestPrivateRegistry_GetAuthType(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue PrivateRegistryAuthType
+	p := &PrivateRegistry{AuthType: &zeroValue}
+	p.GetAuthType()
+	p = &PrivateRegistry{}
+	p.GetAuthType()
+	p = nil
+	p.GetAuthType()
+}
+
+func TestPrivateRegistry_GetAwsRegion(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{AwsRegion: &zeroValue}
+	p.GetAwsRegion()
+	p = &PrivateRegistry{}
+	p.GetAwsRegion()
+	p = nil
+	p.GetAwsRegion()
+}
+
+func TestPrivateRegistry_GetClientID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{ClientID: &zeroValue}
+	p.GetClientID()
+	p = &PrivateRegistry{}
+	p.GetClientID()
+	p = nil
+	p.GetClientID()
+}
+
+func TestPrivateRegistry_GetDomain(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{Domain: &zeroValue}
+	p.GetDomain()
+	p = &PrivateRegistry{}
+	p.GetDomain()
+	p = nil
+	p.GetDomain()
+}
+
+func TestPrivateRegistry_GetDomainOwner(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{DomainOwner: &zeroValue}
+	p.GetDomainOwner()
+	p = &PrivateRegistry{}
+	p.GetDomainOwner()
+	p = nil
+	p.GetDomainOwner()
+}
+
+func TestPrivateRegistry_GetIdentityMappingName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{IdentityMappingName: &zeroValue}
+	p.GetIdentityMappingName()
+	p = &PrivateRegistry{}
+	p.GetIdentityMappingName()
+	p = nil
+	p.GetIdentityMappingName()
+}
+
+func TestPrivateRegistry_GetJfrogOidcProviderName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{JfrogOidcProviderName: &zeroValue}
+	p.GetJfrogOidcProviderName()
+	p = &PrivateRegistry{}
+	p.GetJfrogOidcProviderName()
+	p = nil
+	p.GetJfrogOidcProviderName()
+}
+
+func TestPrivateRegistry_GetReplacesBase(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	p := &PrivateRegistry{ReplacesBase: &zeroValue}
+	p.GetReplacesBase()
+	p = &PrivateRegistry{}
+	p.GetReplacesBase()
+	p = nil
+	p.GetReplacesBase()
+}
+
+func TestPrivateRegistry_GetRoleName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{RoleName: &zeroValue}
+	p.GetRoleName()
+	p = &PrivateRegistry{}
+	p.GetRoleName()
+	p = nil
+	p.GetRoleName()
+}
+
+func TestPrivateRegistry_GetTenantID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{TenantID: &zeroValue}
+	p.GetTenantID()
+	p = &PrivateRegistry{}
+	p.GetTenantID()
+	p = nil
+	p.GetTenantID()
+}
+
+func TestPrivateRegistry_GetURL(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{URL: &zeroValue}
+	p.GetURL()
+	p = &PrivateRegistry{}
+	p.GetURL()
+	p = nil
+	p.GetURL()
 }
 
 func TestPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.T) {
@@ -50082,7 +50225,7 @@ func TestUpdateOrganizationPrivateRegistry_GetKeyID(tt *testing.T) {
 
 func TestUpdateOrganizationPrivateRegistry_GetRegistryType(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
+	var zeroValue PrivateRegistryType
 	u := &UpdateOrganizationPrivateRegistry{RegistryType: &zeroValue}
 	u.GetRegistryType()
 	u = &UpdateOrganizationPrivateRegistry{}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -12079,17 +12079,122 @@ func TestCreateHostedRunnerRequest_GetSize(tt *testing.T) {
 	c.GetSize()
 }
 
+func TestCreateOrganizationPrivateRegistry_GetAccountID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{AccountID: &zeroValue}
+	c.GetAccountID()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetAccountID()
+	c = nil
+	c.GetAccountID()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetAudience(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{Audience: &zeroValue}
+	c.GetAudience()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetAudience()
+	c = nil
+	c.GetAudience()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetAuthType(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{AuthType: &zeroValue}
+	c.GetAuthType()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetAuthType()
+	c = nil
+	c.GetAuthType()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetAwsRegion(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{AwsRegion: &zeroValue}
+	c.GetAwsRegion()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetAwsRegion()
+	c = nil
+	c.GetAwsRegion()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetClientID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{ClientID: &zeroValue}
+	c.GetClientID()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetClientID()
+	c = nil
+	c.GetClientID()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetDomain(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{Domain: &zeroValue}
+	c.GetDomain()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetDomain()
+	c = nil
+	c.GetDomain()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetDomainOwner(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{DomainOwner: &zeroValue}
+	c.GetDomainOwner()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetDomainOwner()
+	c = nil
+	c.GetDomainOwner()
+}
+
 func TestCreateOrganizationPrivateRegistry_GetEncryptedValue(tt *testing.T) {
 	tt.Parallel()
-	c := &CreateOrganizationPrivateRegistry{}
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{EncryptedValue: &zeroValue}
+	c.GetEncryptedValue()
+	c = &CreateOrganizationPrivateRegistry{}
 	c.GetEncryptedValue()
 	c = nil
 	c.GetEncryptedValue()
 }
 
+func TestCreateOrganizationPrivateRegistry_GetIdentityMappingName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{IdentityMappingName: &zeroValue}
+	c.GetIdentityMappingName()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetIdentityMappingName()
+	c = nil
+	c.GetIdentityMappingName()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetJfrogOidcProviderName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{JfrogOidcProviderName: &zeroValue}
+	c.GetJfrogOidcProviderName()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetJfrogOidcProviderName()
+	c = nil
+	c.GetJfrogOidcProviderName()
+}
+
 func TestCreateOrganizationPrivateRegistry_GetKeyID(tt *testing.T) {
 	tt.Parallel()
-	c := &CreateOrganizationPrivateRegistry{}
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{KeyID: &zeroValue}
+	c.GetKeyID()
+	c = &CreateOrganizationPrivateRegistry{}
 	c.GetKeyID()
 	c = nil
 	c.GetKeyID()
@@ -12103,6 +12208,28 @@ func TestCreateOrganizationPrivateRegistry_GetRegistryType(tt *testing.T) {
 	c.GetRegistryType()
 }
 
+func TestCreateOrganizationPrivateRegistry_GetReplacesBase(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	c := &CreateOrganizationPrivateRegistry{ReplacesBase: &zeroValue}
+	c.GetReplacesBase()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetReplacesBase()
+	c = nil
+	c.GetReplacesBase()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetRoleName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{RoleName: &zeroValue}
+	c.GetRoleName()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetRoleName()
+	c = nil
+	c.GetRoleName()
+}
+
 func TestCreateOrganizationPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []int64{}
@@ -12112,6 +12239,17 @@ func TestCreateOrganizationPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.
 	c.GetSelectedRepositoryIDs()
 	c = nil
 	c.GetSelectedRepositoryIDs()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetTenantID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{TenantID: &zeroValue}
+	c.GetTenantID()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetTenantID()
+	c = nil
+	c.GetTenantID()
 }
 
 func TestCreateOrganizationPrivateRegistry_GetURL(tt *testing.T) {
@@ -32906,6 +33044,17 @@ func TestPrivateRegistry_GetRegistryType(tt *testing.T) {
 	p.GetRegistryType()
 }
 
+func TestPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []int64{}
+	p := &PrivateRegistry{SelectedRepositoryIDs: zeroValue}
+	p.GetSelectedRepositoryIDs()
+	p = &PrivateRegistry{}
+	p.GetSelectedRepositoryIDs()
+	p = nil
+	p.GetSelectedRepositoryIDs()
+}
+
 func TestPrivateRegistry_GetUpdatedAt(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp
@@ -49810,6 +49959,83 @@ func TestUpdateHostedRunnerRequest_GetSize(tt *testing.T) {
 	u.GetSize()
 }
 
+func TestUpdateOrganizationPrivateRegistry_GetAccountID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{AccountID: &zeroValue}
+	u.GetAccountID()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetAccountID()
+	u = nil
+	u.GetAccountID()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetAudience(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{Audience: &zeroValue}
+	u.GetAudience()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetAudience()
+	u = nil
+	u.GetAudience()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetAuthType(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{AuthType: &zeroValue}
+	u.GetAuthType()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetAuthType()
+	u = nil
+	u.GetAuthType()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetAwsRegion(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{AwsRegion: &zeroValue}
+	u.GetAwsRegion()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetAwsRegion()
+	u = nil
+	u.GetAwsRegion()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetClientID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{ClientID: &zeroValue}
+	u.GetClientID()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetClientID()
+	u = nil
+	u.GetClientID()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetDomain(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{Domain: &zeroValue}
+	u.GetDomain()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetDomain()
+	u = nil
+	u.GetDomain()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetDomainOwner(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{DomainOwner: &zeroValue}
+	u.GetDomainOwner()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetDomainOwner()
+	u = nil
+	u.GetDomainOwner()
+}
+
 func TestUpdateOrganizationPrivateRegistry_GetEncryptedValue(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -49819,6 +50045,28 @@ func TestUpdateOrganizationPrivateRegistry_GetEncryptedValue(tt *testing.T) {
 	u.GetEncryptedValue()
 	u = nil
 	u.GetEncryptedValue()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetIdentityMappingName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{IdentityMappingName: &zeroValue}
+	u.GetIdentityMappingName()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetIdentityMappingName()
+	u = nil
+	u.GetIdentityMappingName()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetJfrogOidcProviderName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{JfrogOidcProviderName: &zeroValue}
+	u.GetJfrogOidcProviderName()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetJfrogOidcProviderName()
+	u = nil
+	u.GetJfrogOidcProviderName()
 }
 
 func TestUpdateOrganizationPrivateRegistry_GetKeyID(tt *testing.T) {
@@ -49843,6 +50091,28 @@ func TestUpdateOrganizationPrivateRegistry_GetRegistryType(tt *testing.T) {
 	u.GetRegistryType()
 }
 
+func TestUpdateOrganizationPrivateRegistry_GetReplacesBase(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	u := &UpdateOrganizationPrivateRegistry{ReplacesBase: &zeroValue}
+	u.GetReplacesBase()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetReplacesBase()
+	u = nil
+	u.GetReplacesBase()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetRoleName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{RoleName: &zeroValue}
+	u.GetRoleName()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetRoleName()
+	u = nil
+	u.GetRoleName()
+}
+
 func TestUpdateOrganizationPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []int64{}
@@ -49852,6 +50122,17 @@ func TestUpdateOrganizationPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.
 	u.GetSelectedRepositoryIDs()
 	u = nil
 	u.GetSelectedRepositoryIDs()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetTenantID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{TenantID: &zeroValue}
+	u.GetTenantID()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetTenantID()
+	u = nil
+	u.GetTenantID()
 }
 
 func TestUpdateOrganizationPrivateRegistry_GetURL(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -33011,39 +33011,6 @@ func TestPrivateRegistries_GetTotalCount(tt *testing.T) {
 	p.GetTotalCount()
 }
 
-func TestPrivateRegistry_GetCreatedAt(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue Timestamp
-	p := &PrivateRegistry{CreatedAt: &zeroValue}
-	p.GetCreatedAt()
-	p = &PrivateRegistry{}
-	p.GetCreatedAt()
-	p = nil
-	p.GetCreatedAt()
-}
-
-func TestPrivateRegistry_GetName(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	p := &PrivateRegistry{Name: &zeroValue}
-	p.GetName()
-	p = &PrivateRegistry{}
-	p.GetName()
-	p = nil
-	p.GetName()
-}
-
-func TestPrivateRegistry_GetRegistryType(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue PrivateRegistryType
-	p := &PrivateRegistry{RegistryType: &zeroValue}
-	p.GetRegistryType()
-	p = &PrivateRegistry{}
-	p.GetRegistryType()
-	p = nil
-	p.GetRegistryType()
-}
-
 func TestPrivateRegistry_GetAccountID(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -33068,10 +33035,7 @@ func TestPrivateRegistry_GetAudience(tt *testing.T) {
 
 func TestPrivateRegistry_GetAuthType(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue PrivateRegistryAuthType
-	p := &PrivateRegistry{AuthType: &zeroValue}
-	p.GetAuthType()
-	p = &PrivateRegistry{}
+	p := &PrivateRegistry{}
 	p.GetAuthType()
 	p = nil
 	p.GetAuthType()
@@ -33097,6 +33061,17 @@ func TestPrivateRegistry_GetClientID(tt *testing.T) {
 	p.GetClientID()
 	p = nil
 	p.GetClientID()
+}
+
+func TestPrivateRegistry_GetCreatedAt(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue Timestamp
+	p := &PrivateRegistry{CreatedAt: &zeroValue}
+	p.GetCreatedAt()
+	p = &PrivateRegistry{}
+	p.GetCreatedAt()
+	p = nil
+	p.GetCreatedAt()
 }
 
 func TestPrivateRegistry_GetDomain(tt *testing.T) {
@@ -33143,6 +33118,25 @@ func TestPrivateRegistry_GetJfrogOidcProviderName(tt *testing.T) {
 	p.GetJfrogOidcProviderName()
 }
 
+func TestPrivateRegistry_GetName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{Name: &zeroValue}
+	p.GetName()
+	p = &PrivateRegistry{}
+	p.GetName()
+	p = nil
+	p.GetName()
+}
+
+func TestPrivateRegistry_GetRegistryType(tt *testing.T) {
+	tt.Parallel()
+	p := &PrivateRegistry{}
+	p.GetRegistryType()
+	p = nil
+	p.GetRegistryType()
+}
+
 func TestPrivateRegistry_GetReplacesBase(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
@@ -33165,28 +33159,6 @@ func TestPrivateRegistry_GetRoleName(tt *testing.T) {
 	p.GetRoleName()
 }
 
-func TestPrivateRegistry_GetTenantID(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	p := &PrivateRegistry{TenantID: &zeroValue}
-	p.GetTenantID()
-	p = &PrivateRegistry{}
-	p.GetTenantID()
-	p = nil
-	p.GetTenantID()
-}
-
-func TestPrivateRegistry_GetURL(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	p := &PrivateRegistry{URL: &zeroValue}
-	p.GetURL()
-	p = &PrivateRegistry{}
-	p.GetURL()
-	p = nil
-	p.GetURL()
-}
-
 func TestPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []int64{}
@@ -33198,6 +33170,17 @@ func TestPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.T) {
 	p.GetSelectedRepositoryIDs()
 }
 
+func TestPrivateRegistry_GetTenantID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{TenantID: &zeroValue}
+	p.GetTenantID()
+	p = &PrivateRegistry{}
+	p.GetTenantID()
+	p = nil
+	p.GetTenantID()
+}
+
 func TestPrivateRegistry_GetUpdatedAt(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp
@@ -33207,6 +33190,17 @@ func TestPrivateRegistry_GetUpdatedAt(tt *testing.T) {
 	p.GetUpdatedAt()
 	p = nil
 	p.GetUpdatedAt()
+}
+
+func TestPrivateRegistry_GetURL(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{URL: &zeroValue}
+	p.GetURL()
+	p = &PrivateRegistry{}
+	p.GetURL()
+	p = nil
+	p.GetURL()
 }
 
 func TestPrivateRegistry_GetUsername(tt *testing.T) {
@@ -50225,10 +50219,7 @@ func TestUpdateOrganizationPrivateRegistry_GetKeyID(tt *testing.T) {
 
 func TestUpdateOrganizationPrivateRegistry_GetRegistryType(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue PrivateRegistryType
-	u := &UpdateOrganizationPrivateRegistry{RegistryType: &zeroValue}
-	u.GetRegistryType()
-	u = &UpdateOrganizationPrivateRegistry{}
+	u := &UpdateOrganizationPrivateRegistry{}
 	u.GetRegistryType()
 	u = nil
 	u.GetRegistryType()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -33022,39 +33022,6 @@ func TestPrivateRegistries_GetTotalCount(tt *testing.T) {
 	p.GetTotalCount()
 }
 
-func TestPrivateRegistry_GetCreatedAt(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue Timestamp
-	p := &PrivateRegistry{CreatedAt: &zeroValue}
-	p.GetCreatedAt()
-	p = &PrivateRegistry{}
-	p.GetCreatedAt()
-	p = nil
-	p.GetCreatedAt()
-}
-
-func TestPrivateRegistry_GetName(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	p := &PrivateRegistry{Name: &zeroValue}
-	p.GetName()
-	p = &PrivateRegistry{}
-	p.GetName()
-	p = nil
-	p.GetName()
-}
-
-func TestPrivateRegistry_GetRegistryType(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue PrivateRegistryType
-	p := &PrivateRegistry{RegistryType: &zeroValue}
-	p.GetRegistryType()
-	p = &PrivateRegistry{}
-	p.GetRegistryType()
-	p = nil
-	p.GetRegistryType()
-}
-
 func TestPrivateRegistry_GetAccountID(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -33079,10 +33046,7 @@ func TestPrivateRegistry_GetAudience(tt *testing.T) {
 
 func TestPrivateRegistry_GetAuthType(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue PrivateRegistryAuthType
-	p := &PrivateRegistry{AuthType: &zeroValue}
-	p.GetAuthType()
-	p = &PrivateRegistry{}
+	p := &PrivateRegistry{}
 	p.GetAuthType()
 	p = nil
 	p.GetAuthType()
@@ -33108,6 +33072,17 @@ func TestPrivateRegistry_GetClientID(tt *testing.T) {
 	p.GetClientID()
 	p = nil
 	p.GetClientID()
+}
+
+func TestPrivateRegistry_GetCreatedAt(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue Timestamp
+	p := &PrivateRegistry{CreatedAt: &zeroValue}
+	p.GetCreatedAt()
+	p = &PrivateRegistry{}
+	p.GetCreatedAt()
+	p = nil
+	p.GetCreatedAt()
 }
 
 func TestPrivateRegistry_GetDomain(tt *testing.T) {
@@ -33154,6 +33129,25 @@ func TestPrivateRegistry_GetJfrogOidcProviderName(tt *testing.T) {
 	p.GetJfrogOidcProviderName()
 }
 
+func TestPrivateRegistry_GetName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{Name: &zeroValue}
+	p.GetName()
+	p = &PrivateRegistry{}
+	p.GetName()
+	p = nil
+	p.GetName()
+}
+
+func TestPrivateRegistry_GetRegistryType(tt *testing.T) {
+	tt.Parallel()
+	p := &PrivateRegistry{}
+	p.GetRegistryType()
+	p = nil
+	p.GetRegistryType()
+}
+
 func TestPrivateRegistry_GetReplacesBase(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
@@ -33176,28 +33170,6 @@ func TestPrivateRegistry_GetRoleName(tt *testing.T) {
 	p.GetRoleName()
 }
 
-func TestPrivateRegistry_GetTenantID(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	p := &PrivateRegistry{TenantID: &zeroValue}
-	p.GetTenantID()
-	p = &PrivateRegistry{}
-	p.GetTenantID()
-	p = nil
-	p.GetTenantID()
-}
-
-func TestPrivateRegistry_GetURL(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	p := &PrivateRegistry{URL: &zeroValue}
-	p.GetURL()
-	p = &PrivateRegistry{}
-	p.GetURL()
-	p = nil
-	p.GetURL()
-}
-
 func TestPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []int64{}
@@ -33209,6 +33181,17 @@ func TestPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.T) {
 	p.GetSelectedRepositoryIDs()
 }
 
+func TestPrivateRegistry_GetTenantID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{TenantID: &zeroValue}
+	p.GetTenantID()
+	p = &PrivateRegistry{}
+	p.GetTenantID()
+	p = nil
+	p.GetTenantID()
+}
+
 func TestPrivateRegistry_GetUpdatedAt(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp
@@ -33218,6 +33201,17 @@ func TestPrivateRegistry_GetUpdatedAt(tt *testing.T) {
 	p.GetUpdatedAt()
 	p = nil
 	p.GetUpdatedAt()
+}
+
+func TestPrivateRegistry_GetURL(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{URL: &zeroValue}
+	p.GetURL()
+	p = &PrivateRegistry{}
+	p.GetURL()
+	p = nil
+	p.GetURL()
 }
 
 func TestPrivateRegistry_GetUsername(tt *testing.T) {
@@ -50244,10 +50238,7 @@ func TestUpdateOrganizationPrivateRegistry_GetKeyID(tt *testing.T) {
 
 func TestUpdateOrganizationPrivateRegistry_GetRegistryType(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue PrivateRegistryType
-	u := &UpdateOrganizationPrivateRegistry{RegistryType: &zeroValue}
-	u.GetRegistryType()
-	u = &UpdateOrganizationPrivateRegistry{}
+	u := &UpdateOrganizationPrivateRegistry{}
 	u.GetRegistryType()
 	u = nil
 	u.GetRegistryType()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -12123,15 +12123,15 @@ func TestCreateOrganizationPrivateRegistry_GetAuthType(tt *testing.T) {
 	c.GetAuthType()
 }
 
-func TestCreateOrganizationPrivateRegistry_GetAwsRegion(tt *testing.T) {
+func TestCreateOrganizationPrivateRegistry_GetAWSRegion(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
-	c := &CreateOrganizationPrivateRegistry{AwsRegion: &zeroValue}
-	c.GetAwsRegion()
+	c := &CreateOrganizationPrivateRegistry{AWSRegion: &zeroValue}
+	c.GetAWSRegion()
 	c = &CreateOrganizationPrivateRegistry{}
-	c.GetAwsRegion()
+	c.GetAWSRegion()
 	c = nil
-	c.GetAwsRegion()
+	c.GetAWSRegion()
 }
 
 func TestCreateOrganizationPrivateRegistry_GetClientID(tt *testing.T) {
@@ -12189,15 +12189,15 @@ func TestCreateOrganizationPrivateRegistry_GetIdentityMappingName(tt *testing.T)
 	c.GetIdentityMappingName()
 }
 
-func TestCreateOrganizationPrivateRegistry_GetJfrogOidcProviderName(tt *testing.T) {
+func TestCreateOrganizationPrivateRegistry_GetJFrogOIDCProviderName(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
-	c := &CreateOrganizationPrivateRegistry{JfrogOidcProviderName: &zeroValue}
-	c.GetJfrogOidcProviderName()
+	c := &CreateOrganizationPrivateRegistry{JFrogOIDCProviderName: &zeroValue}
+	c.GetJFrogOIDCProviderName()
 	c = &CreateOrganizationPrivateRegistry{}
-	c.GetJfrogOidcProviderName()
+	c.GetJFrogOIDCProviderName()
 	c = nil
-	c.GetJfrogOidcProviderName()
+	c.GetJFrogOIDCProviderName()
 }
 
 func TestCreateOrganizationPrivateRegistry_GetKeyID(tt *testing.T) {
@@ -33052,15 +33052,15 @@ func TestPrivateRegistry_GetAuthType(tt *testing.T) {
 	p.GetAuthType()
 }
 
-func TestPrivateRegistry_GetAwsRegion(tt *testing.T) {
+func TestPrivateRegistry_GetAWSRegion(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
-	p := &PrivateRegistry{AwsRegion: &zeroValue}
-	p.GetAwsRegion()
+	p := &PrivateRegistry{AWSRegion: &zeroValue}
+	p.GetAWSRegion()
 	p = &PrivateRegistry{}
-	p.GetAwsRegion()
+	p.GetAWSRegion()
 	p = nil
-	p.GetAwsRegion()
+	p.GetAWSRegion()
 }
 
 func TestPrivateRegistry_GetClientID(tt *testing.T) {
@@ -33118,15 +33118,15 @@ func TestPrivateRegistry_GetIdentityMappingName(tt *testing.T) {
 	p.GetIdentityMappingName()
 }
 
-func TestPrivateRegistry_GetJfrogOidcProviderName(tt *testing.T) {
+func TestPrivateRegistry_GetJFrogOIDCProviderName(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
-	p := &PrivateRegistry{JfrogOidcProviderName: &zeroValue}
-	p.GetJfrogOidcProviderName()
+	p := &PrivateRegistry{JFrogOIDCProviderName: &zeroValue}
+	p.GetJFrogOIDCProviderName()
 	p = &PrivateRegistry{}
-	p.GetJfrogOidcProviderName()
+	p.GetJFrogOIDCProviderName()
 	p = nil
-	p.GetJfrogOidcProviderName()
+	p.GetJFrogOIDCProviderName()
 }
 
 func TestPrivateRegistry_GetName(tt *testing.T) {
@@ -50148,15 +50148,15 @@ func TestUpdateOrganizationPrivateRegistry_GetAuthType(tt *testing.T) {
 	u.GetAuthType()
 }
 
-func TestUpdateOrganizationPrivateRegistry_GetAwsRegion(tt *testing.T) {
+func TestUpdateOrganizationPrivateRegistry_GetAWSRegion(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
-	u := &UpdateOrganizationPrivateRegistry{AwsRegion: &zeroValue}
-	u.GetAwsRegion()
+	u := &UpdateOrganizationPrivateRegistry{AWSRegion: &zeroValue}
+	u.GetAWSRegion()
 	u = &UpdateOrganizationPrivateRegistry{}
-	u.GetAwsRegion()
+	u.GetAWSRegion()
 	u = nil
-	u.GetAwsRegion()
+	u.GetAWSRegion()
 }
 
 func TestUpdateOrganizationPrivateRegistry_GetClientID(tt *testing.T) {
@@ -50214,15 +50214,15 @@ func TestUpdateOrganizationPrivateRegistry_GetIdentityMappingName(tt *testing.T)
 	u.GetIdentityMappingName()
 }
 
-func TestUpdateOrganizationPrivateRegistry_GetJfrogOidcProviderName(tt *testing.T) {
+func TestUpdateOrganizationPrivateRegistry_GetJFrogOIDCProviderName(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
-	u := &UpdateOrganizationPrivateRegistry{JfrogOidcProviderName: &zeroValue}
-	u.GetJfrogOidcProviderName()
+	u := &UpdateOrganizationPrivateRegistry{JFrogOIDCProviderName: &zeroValue}
+	u.GetJFrogOIDCProviderName()
 	u = &UpdateOrganizationPrivateRegistry{}
-	u.GetJfrogOidcProviderName()
+	u.GetJFrogOIDCProviderName()
 	u = nil
-	u.GetJfrogOidcProviderName()
+	u.GetJFrogOIDCProviderName()
 }
 
 func TestUpdateOrganizationPrivateRegistry_GetKeyID(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -33046,13 +33046,156 @@ func TestPrivateRegistry_GetName(tt *testing.T) {
 
 func TestPrivateRegistry_GetRegistryType(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
+	var zeroValue PrivateRegistryType
 	p := &PrivateRegistry{RegistryType: &zeroValue}
 	p.GetRegistryType()
 	p = &PrivateRegistry{}
 	p.GetRegistryType()
 	p = nil
 	p.GetRegistryType()
+}
+
+func TestPrivateRegistry_GetAccountID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{AccountID: &zeroValue}
+	p.GetAccountID()
+	p = &PrivateRegistry{}
+	p.GetAccountID()
+	p = nil
+	p.GetAccountID()
+}
+
+func TestPrivateRegistry_GetAudience(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{Audience: &zeroValue}
+	p.GetAudience()
+	p = &PrivateRegistry{}
+	p.GetAudience()
+	p = nil
+	p.GetAudience()
+}
+
+func TestPrivateRegistry_GetAuthType(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue PrivateRegistryAuthType
+	p := &PrivateRegistry{AuthType: &zeroValue}
+	p.GetAuthType()
+	p = &PrivateRegistry{}
+	p.GetAuthType()
+	p = nil
+	p.GetAuthType()
+}
+
+func TestPrivateRegistry_GetAwsRegion(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{AwsRegion: &zeroValue}
+	p.GetAwsRegion()
+	p = &PrivateRegistry{}
+	p.GetAwsRegion()
+	p = nil
+	p.GetAwsRegion()
+}
+
+func TestPrivateRegistry_GetClientID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{ClientID: &zeroValue}
+	p.GetClientID()
+	p = &PrivateRegistry{}
+	p.GetClientID()
+	p = nil
+	p.GetClientID()
+}
+
+func TestPrivateRegistry_GetDomain(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{Domain: &zeroValue}
+	p.GetDomain()
+	p = &PrivateRegistry{}
+	p.GetDomain()
+	p = nil
+	p.GetDomain()
+}
+
+func TestPrivateRegistry_GetDomainOwner(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{DomainOwner: &zeroValue}
+	p.GetDomainOwner()
+	p = &PrivateRegistry{}
+	p.GetDomainOwner()
+	p = nil
+	p.GetDomainOwner()
+}
+
+func TestPrivateRegistry_GetIdentityMappingName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{IdentityMappingName: &zeroValue}
+	p.GetIdentityMappingName()
+	p = &PrivateRegistry{}
+	p.GetIdentityMappingName()
+	p = nil
+	p.GetIdentityMappingName()
+}
+
+func TestPrivateRegistry_GetJfrogOidcProviderName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{JfrogOidcProviderName: &zeroValue}
+	p.GetJfrogOidcProviderName()
+	p = &PrivateRegistry{}
+	p.GetJfrogOidcProviderName()
+	p = nil
+	p.GetJfrogOidcProviderName()
+}
+
+func TestPrivateRegistry_GetReplacesBase(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	p := &PrivateRegistry{ReplacesBase: &zeroValue}
+	p.GetReplacesBase()
+	p = &PrivateRegistry{}
+	p.GetReplacesBase()
+	p = nil
+	p.GetReplacesBase()
+}
+
+func TestPrivateRegistry_GetRoleName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{RoleName: &zeroValue}
+	p.GetRoleName()
+	p = &PrivateRegistry{}
+	p.GetRoleName()
+	p = nil
+	p.GetRoleName()
+}
+
+func TestPrivateRegistry_GetTenantID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{TenantID: &zeroValue}
+	p.GetTenantID()
+	p = &PrivateRegistry{}
+	p.GetTenantID()
+	p = nil
+	p.GetTenantID()
+}
+
+func TestPrivateRegistry_GetURL(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PrivateRegistry{URL: &zeroValue}
+	p.GetURL()
+	p = &PrivateRegistry{}
+	p.GetURL()
+	p = nil
+	p.GetURL()
 }
 
 func TestPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.T) {
@@ -50101,7 +50244,7 @@ func TestUpdateOrganizationPrivateRegistry_GetKeyID(tt *testing.T) {
 
 func TestUpdateOrganizationPrivateRegistry_GetRegistryType(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
+	var zeroValue PrivateRegistryType
 	u := &UpdateOrganizationPrivateRegistry{RegistryType: &zeroValue}
 	u.GetRegistryType()
 	u = &UpdateOrganizationPrivateRegistry{}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -12090,17 +12090,122 @@ func TestCreateHostedRunnerRequest_GetSize(tt *testing.T) {
 	c.GetSize()
 }
 
+func TestCreateOrganizationPrivateRegistry_GetAccountID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{AccountID: &zeroValue}
+	c.GetAccountID()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetAccountID()
+	c = nil
+	c.GetAccountID()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetAudience(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{Audience: &zeroValue}
+	c.GetAudience()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetAudience()
+	c = nil
+	c.GetAudience()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetAuthType(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{AuthType: &zeroValue}
+	c.GetAuthType()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetAuthType()
+	c = nil
+	c.GetAuthType()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetAwsRegion(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{AwsRegion: &zeroValue}
+	c.GetAwsRegion()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetAwsRegion()
+	c = nil
+	c.GetAwsRegion()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetClientID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{ClientID: &zeroValue}
+	c.GetClientID()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetClientID()
+	c = nil
+	c.GetClientID()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetDomain(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{Domain: &zeroValue}
+	c.GetDomain()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetDomain()
+	c = nil
+	c.GetDomain()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetDomainOwner(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{DomainOwner: &zeroValue}
+	c.GetDomainOwner()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetDomainOwner()
+	c = nil
+	c.GetDomainOwner()
+}
+
 func TestCreateOrganizationPrivateRegistry_GetEncryptedValue(tt *testing.T) {
 	tt.Parallel()
-	c := &CreateOrganizationPrivateRegistry{}
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{EncryptedValue: &zeroValue}
+	c.GetEncryptedValue()
+	c = &CreateOrganizationPrivateRegistry{}
 	c.GetEncryptedValue()
 	c = nil
 	c.GetEncryptedValue()
 }
 
+func TestCreateOrganizationPrivateRegistry_GetIdentityMappingName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{IdentityMappingName: &zeroValue}
+	c.GetIdentityMappingName()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetIdentityMappingName()
+	c = nil
+	c.GetIdentityMappingName()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetJfrogOidcProviderName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{JfrogOidcProviderName: &zeroValue}
+	c.GetJfrogOidcProviderName()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetJfrogOidcProviderName()
+	c = nil
+	c.GetJfrogOidcProviderName()
+}
+
 func TestCreateOrganizationPrivateRegistry_GetKeyID(tt *testing.T) {
 	tt.Parallel()
-	c := &CreateOrganizationPrivateRegistry{}
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{KeyID: &zeroValue}
+	c.GetKeyID()
+	c = &CreateOrganizationPrivateRegistry{}
 	c.GetKeyID()
 	c = nil
 	c.GetKeyID()
@@ -12114,6 +12219,28 @@ func TestCreateOrganizationPrivateRegistry_GetRegistryType(tt *testing.T) {
 	c.GetRegistryType()
 }
 
+func TestCreateOrganizationPrivateRegistry_GetReplacesBase(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	c := &CreateOrganizationPrivateRegistry{ReplacesBase: &zeroValue}
+	c.GetReplacesBase()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetReplacesBase()
+	c = nil
+	c.GetReplacesBase()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetRoleName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{RoleName: &zeroValue}
+	c.GetRoleName()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetRoleName()
+	c = nil
+	c.GetRoleName()
+}
+
 func TestCreateOrganizationPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []int64{}
@@ -12123,6 +12250,17 @@ func TestCreateOrganizationPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.
 	c.GetSelectedRepositoryIDs()
 	c = nil
 	c.GetSelectedRepositoryIDs()
+}
+
+func TestCreateOrganizationPrivateRegistry_GetTenantID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateOrganizationPrivateRegistry{TenantID: &zeroValue}
+	c.GetTenantID()
+	c = &CreateOrganizationPrivateRegistry{}
+	c.GetTenantID()
+	c = nil
+	c.GetTenantID()
 }
 
 func TestCreateOrganizationPrivateRegistry_GetURL(tt *testing.T) {
@@ -32917,6 +33055,17 @@ func TestPrivateRegistry_GetRegistryType(tt *testing.T) {
 	p.GetRegistryType()
 }
 
+func TestPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []int64{}
+	p := &PrivateRegistry{SelectedRepositoryIDs: zeroValue}
+	p.GetSelectedRepositoryIDs()
+	p = &PrivateRegistry{}
+	p.GetSelectedRepositoryIDs()
+	p = nil
+	p.GetSelectedRepositoryIDs()
+}
+
 func TestPrivateRegistry_GetUpdatedAt(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp
@@ -49829,6 +49978,83 @@ func TestUpdateHostedRunnerRequest_GetSize(tt *testing.T) {
 	u.GetSize()
 }
 
+func TestUpdateOrganizationPrivateRegistry_GetAccountID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{AccountID: &zeroValue}
+	u.GetAccountID()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetAccountID()
+	u = nil
+	u.GetAccountID()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetAudience(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{Audience: &zeroValue}
+	u.GetAudience()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetAudience()
+	u = nil
+	u.GetAudience()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetAuthType(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{AuthType: &zeroValue}
+	u.GetAuthType()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetAuthType()
+	u = nil
+	u.GetAuthType()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetAwsRegion(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{AwsRegion: &zeroValue}
+	u.GetAwsRegion()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetAwsRegion()
+	u = nil
+	u.GetAwsRegion()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetClientID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{ClientID: &zeroValue}
+	u.GetClientID()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetClientID()
+	u = nil
+	u.GetClientID()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetDomain(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{Domain: &zeroValue}
+	u.GetDomain()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetDomain()
+	u = nil
+	u.GetDomain()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetDomainOwner(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{DomainOwner: &zeroValue}
+	u.GetDomainOwner()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetDomainOwner()
+	u = nil
+	u.GetDomainOwner()
+}
+
 func TestUpdateOrganizationPrivateRegistry_GetEncryptedValue(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -49838,6 +50064,28 @@ func TestUpdateOrganizationPrivateRegistry_GetEncryptedValue(tt *testing.T) {
 	u.GetEncryptedValue()
 	u = nil
 	u.GetEncryptedValue()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetIdentityMappingName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{IdentityMappingName: &zeroValue}
+	u.GetIdentityMappingName()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetIdentityMappingName()
+	u = nil
+	u.GetIdentityMappingName()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetJfrogOidcProviderName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{JfrogOidcProviderName: &zeroValue}
+	u.GetJfrogOidcProviderName()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetJfrogOidcProviderName()
+	u = nil
+	u.GetJfrogOidcProviderName()
 }
 
 func TestUpdateOrganizationPrivateRegistry_GetKeyID(tt *testing.T) {
@@ -49862,6 +50110,28 @@ func TestUpdateOrganizationPrivateRegistry_GetRegistryType(tt *testing.T) {
 	u.GetRegistryType()
 }
 
+func TestUpdateOrganizationPrivateRegistry_GetReplacesBase(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	u := &UpdateOrganizationPrivateRegistry{ReplacesBase: &zeroValue}
+	u.GetReplacesBase()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetReplacesBase()
+	u = nil
+	u.GetReplacesBase()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetRoleName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{RoleName: &zeroValue}
+	u.GetRoleName()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetRoleName()
+	u = nil
+	u.GetRoleName()
+}
+
 func TestUpdateOrganizationPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []int64{}
@@ -49871,6 +50141,17 @@ func TestUpdateOrganizationPrivateRegistry_GetSelectedRepositoryIDs(tt *testing.
 	u.GetSelectedRepositoryIDs()
 	u = nil
 	u.GetSelectedRepositoryIDs()
+}
+
+func TestUpdateOrganizationPrivateRegistry_GetTenantID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateOrganizationPrivateRegistry{TenantID: &zeroValue}
+	u.GetTenantID()
+	u = &UpdateOrganizationPrivateRegistry{}
+	u.GetTenantID()
+	u = nil
+	u.GetTenantID()
 }
 
 func TestUpdateOrganizationPrivateRegistry_GetURL(tt *testing.T) {

--- a/github/private_registries.go
+++ b/github/private_registries.go
@@ -218,7 +218,7 @@ func (s *PrivateRegistriesService) ListOrganizationPrivateRegistries(ctx context
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil, WithVersion("2026-03-10"))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -239,7 +239,7 @@ func (s *PrivateRegistriesService) ListOrganizationPrivateRegistries(ctx context
 func (s *PrivateRegistriesService) CreateOrganizationPrivateRegistry(ctx context.Context, org string, privateRegistry CreateOrganizationPrivateRegistry) (*PrivateRegistry, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries", org)
 
-	req, err := s.client.NewRequest("POST", u, privateRegistry)
+	req, err := s.client.NewRequest("POST", u, privateRegistry, WithVersion("2026-03-10"))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -260,7 +260,7 @@ func (s *PrivateRegistriesService) CreateOrganizationPrivateRegistry(ctx context
 func (s *PrivateRegistriesService) GetOrganizationPrivateRegistriesPublicKey(ctx context.Context, org string) (*PublicKey, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/public-key", org)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil, WithVersion("2026-03-10"))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -282,7 +282,7 @@ func (s *PrivateRegistriesService) GetOrganizationPrivateRegistriesPublicKey(ctx
 func (s *PrivateRegistriesService) GetOrganizationPrivateRegistry(ctx context.Context, org, secretName string) (*PrivateRegistry, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/%v", org, secretName)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil, WithVersion("2026-03-10"))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -305,7 +305,7 @@ func (s *PrivateRegistriesService) GetOrganizationPrivateRegistry(ctx context.Co
 func (s *PrivateRegistriesService) UpdateOrganizationPrivateRegistry(ctx context.Context, org, secretName string, privateRegistry UpdateOrganizationPrivateRegistry) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/%v", org, secretName)
 
-	req, err := s.client.NewRequest("PATCH", u, privateRegistry)
+	req, err := s.client.NewRequest("PATCH", u, privateRegistry, WithVersion("2026-03-10"))
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +322,7 @@ func (s *PrivateRegistriesService) UpdateOrganizationPrivateRegistry(ctx context
 func (s *PrivateRegistriesService) DeleteOrganizationPrivateRegistry(ctx context.Context, org, secretName string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/%v", org, secretName)
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil, WithVersion("2026-03-10"))
 	if err != nil {
 		return nil, err
 	}

--- a/github/private_registries.go
+++ b/github/private_registries.go
@@ -13,7 +13,7 @@ import (
 // PrivateRegistriesService handles communication with the private registries
 // methods of the GitHub API.
 //
-// GitHub API docs: https://docs.github.com/rest/private-registries?apiVersion=2022-11-28
+// GitHub API docs: https://docs.github.com/rest/private-registries?apiVersion=2026-03-10
 type PrivateRegistriesService service
 
 // PrivateRegistryType represents the type of private registry.
@@ -46,6 +46,17 @@ const (
 	PrivateRegistryVisibilitySelected PrivateRegistryVisibility = "selected"
 )
 
+// PrivateRegistryAuthType represents the authentication type for a private registry.
+type PrivateRegistryAuthType string
+
+const (
+	PrivateRegistryAuthTypeToken            PrivateRegistryAuthType = "token"
+	PrivateRegistryAuthTypeUsernamePassword PrivateRegistryAuthType = "username_password"
+	PrivateRegistryAuthTypeOIDCAzure        PrivateRegistryAuthType = "oidc_azure"
+	PrivateRegistryAuthTypeOIDCAWS          PrivateRegistryAuthType = "oidc_aws"
+	PrivateRegistryAuthTypeOIDCJFrog        PrivateRegistryAuthType = "oidc_jfrog"
+)
+
 // PrivateRegistry represents a private registry configuration.
 type PrivateRegistry struct {
 	// Name of the private registry.
@@ -61,6 +72,8 @@ type PrivateRegistry struct {
 	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
 	// Visibility is the visibility of the private registry. Possible values are: "private", "all", and "selected".
 	Visibility *PrivateRegistryVisibility `json:"visibility,omitempty"`
+	// SelectedRepositoryIDs is an array of repository IDs that can access the organization private registry.
+	SelectedRepositoryIDs []int64 `json:"selected_repository_ids,omitempty"`
 }
 
 // PrivateRegistries represents a list of private registries.
@@ -84,11 +97,17 @@ type CreateOrganizationPrivateRegistry struct {
 	// This field should be omitted if the private registry does not require a username for authentication.
 	Username *string `json:"username,omitempty"`
 
+	// ReplacesBase indicates whether this private registry should replace the base registry
+	// (e.g., npmjs.org for npm, rubygems.org for rubygems).
+	ReplacesBase *bool `json:"replaces_base,omitempty"`
+
 	// The value for your secret, encrypted with [LibSodium](https://libsodium.gitbook.io/doc/bindings_for_other_languages)
 	// using the public key retrieved from the PrivateRegistriesService.GetOrganizationPrivateRegistriesPublicKey.
-	EncryptedValue string `json:"encrypted_value"`
+	// Required when AuthType is "token" or "username_password". Should be omitted for OIDC auth types.
+	EncryptedValue *string `json:"encrypted_value,omitempty"`
 	// KeyID is the ID of the public key used to encrypt the secret.
-	KeyID string `json:"key_id"`
+	// Required when AuthType is "token" or "username_password". Should be omitted for OIDC auth types.
+	KeyID *string `json:"key_id,omitempty"`
 	// Visibility is the visibility of the private registry.
 	// Possible values are: "private", "all", and "selected".
 	Visibility PrivateRegistryVisibility `json:"visibility"`
@@ -97,6 +116,34 @@ type CreateOrganizationPrivateRegistry struct {
 	// You can only provide a list of repository IDs when CreateOrganizationPrivateRegistry.Visibility is set to PrivateRegistryVisibilitySelected.
 	// This field should be omitted if visibility is set to PrivateRegistryVisibilityAll or PrivateRegistryVisibilityPrivate.
 	SelectedRepositoryIDs []int64 `json:"selected_repository_ids,omitempty"`
+
+	// AuthType is the authentication type for the private registry.
+	// Defaults to "token" if not specified. Use "oidc_azure", "oidc_aws", or "oidc_jfrog" for OIDC authentication.
+	AuthType *string `json:"auth_type,omitempty"`
+
+	// TenantID is the tenant ID of the Azure AD application. Required when AuthType is "oidc_azure".
+	TenantID *string `json:"tenant_id,omitempty"`
+	// ClientID is the client ID of the Azure AD application. Required when AuthType is "oidc_azure".
+	ClientID *string `json:"client_id,omitempty"`
+
+	// AwsRegion is the AWS region. Required when AuthType is "oidc_aws".
+	AwsRegion *string `json:"aws_region,omitempty"`
+	// AccountID is the AWS account ID. Required when AuthType is "oidc_aws".
+	AccountID *string `json:"account_id,omitempty"`
+	// RoleName is the AWS IAM role name. Required when AuthType is "oidc_aws".
+	RoleName *string `json:"role_name,omitempty"`
+	// Domain is the CodeArtifact domain. Required when AuthType is "oidc_aws".
+	Domain *string `json:"domain,omitempty"`
+	// DomainOwner is the CodeArtifact domain owner (AWS account ID). Required when AuthType is "oidc_aws".
+	DomainOwner *string `json:"domain_owner,omitempty"`
+
+	// JfrogOidcProviderName is the JFrog OIDC provider name. Required when AuthType is "oidc_jfrog".
+	JfrogOidcProviderName *string `json:"jfrog_oidc_provider_name,omitempty"`
+
+	// Audience is the OIDC audience. Optional for "oidc_aws" and "oidc_jfrog" auth types.
+	Audience *string `json:"audience,omitempty"`
+	// IdentityMappingName is the JFrog identity mapping name. Optional for "oidc_jfrog" auth type.
+	IdentityMappingName *string `json:"identity_mapping_name,omitempty"`
 }
 
 // UpdateOrganizationPrivateRegistry represents the payload to update a private registry.
@@ -112,6 +159,10 @@ type UpdateOrganizationPrivateRegistry struct {
 	// This field should be omitted if the private registry does not require a username for authentication.
 	Username *string `json:"username,omitempty"`
 
+	// ReplacesBase indicates whether this private registry should replace the base registry
+	// (e.g., npmjs.org for npm, rubygems.org for rubygems).
+	ReplacesBase *bool `json:"replaces_base,omitempty"`
+
 	// The value for your secret, encrypted with [LibSodium](https://libsodium.gitbook.io/doc/bindings_for_other_languages)
 	// using the public key retrieved from the PrivateRegistriesService.GetOrganizationPrivateRegistriesPublicKey.
 	EncryptedValue *string `json:"encrypted_value,omitempty"`
@@ -122,9 +173,37 @@ type UpdateOrganizationPrivateRegistry struct {
 	Visibility *PrivateRegistryVisibility `json:"visibility,omitempty"`
 
 	// An array of repository IDs that can access the organization private registry.
-	// You can only provide a list of repository IDs when CreateOrganizationPrivateRegistry.Visibility is set to PrivateRegistryVisibilitySelected.
+	// You can only provide a list of repository IDs when UpdateOrganizationPrivateRegistry.Visibility is set to PrivateRegistryVisibilitySelected.
 	// This field should be omitted if visibility is set to PrivateRegistryVisibilityAll or PrivateRegistryVisibilityPrivate.
 	SelectedRepositoryIDs []int64 `json:"selected_repository_ids,omitempty"`
+
+	// AuthType is the authentication type for the private registry.
+	// This field cannot be changed after creation. If provided, it must match the existing auth_type.
+	AuthType *string `json:"auth_type,omitempty"`
+
+	// TenantID is the tenant ID of the Azure AD application. Required when AuthType is "oidc_azure".
+	TenantID *string `json:"tenant_id,omitempty"`
+	// ClientID is the client ID of the Azure AD application. Required when AuthType is "oidc_azure".
+	ClientID *string `json:"client_id,omitempty"`
+
+	// AwsRegion is the AWS region. Required when AuthType is "oidc_aws".
+	AwsRegion *string `json:"aws_region,omitempty"`
+	// AccountID is the AWS account ID. Required when AuthType is "oidc_aws".
+	AccountID *string `json:"account_id,omitempty"`
+	// RoleName is the AWS IAM role name. Required when AuthType is "oidc_aws".
+	RoleName *string `json:"role_name,omitempty"`
+	// Domain is the CodeArtifact domain. Required when AuthType is "oidc_aws".
+	Domain *string `json:"domain,omitempty"`
+	// DomainOwner is the CodeArtifact domain owner (AWS account ID). Required when AuthType is "oidc_aws".
+	DomainOwner *string `json:"domain_owner,omitempty"`
+
+	// JfrogOidcProviderName is the JFrog OIDC provider name. Required when AuthType is "oidc_jfrog".
+	JfrogOidcProviderName *string `json:"jfrog_oidc_provider_name,omitempty"`
+
+	// Audience is the OIDC audience. Optional for "oidc_aws" and "oidc_jfrog" auth types.
+	Audience *string `json:"audience,omitempty"`
+	// IdentityMappingName is the JFrog identity mapping name. Optional for "oidc_jfrog" auth type.
+	IdentityMappingName *string `json:"identity_mapping_name,omitempty"`
 }
 
 // ListOrganizationPrivateRegistries lists private registries for an organization.
@@ -223,21 +302,15 @@ func (s *PrivateRegistriesService) GetOrganizationPrivateRegistry(ctx context.Co
 // GitHub API docs: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2022-11-28#update-a-private-registry-for-an-organization
 //
 //meta:operation PATCH /orgs/{org}/private-registries/{secret_name}
-func (s *PrivateRegistriesService) UpdateOrganizationPrivateRegistry(ctx context.Context, org, secretName string, privateRegistry UpdateOrganizationPrivateRegistry) (*PrivateRegistry, *Response, error) {
+func (s *PrivateRegistriesService) UpdateOrganizationPrivateRegistry(ctx context.Context, org, secretName string, privateRegistry UpdateOrganizationPrivateRegistry) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/%v", org, secretName)
 
 	req, err := s.client.NewRequest("PATCH", u, privateRegistry)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	var updatedRegistry PrivateRegistry
-	resp, err := s.client.Do(ctx, req, &updatedRegistry)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return &updatedRegistry, resp, nil
+	return s.client.Do(ctx, req, nil)
 }
 
 // DeleteOrganizationPrivateRegistry deletes a specific private registry for an organization.

--- a/github/private_registries.go
+++ b/github/private_registries.go
@@ -62,18 +62,44 @@ type PrivateRegistry struct {
 	// Name of the private registry.
 	Name *string `json:"name,omitempty"`
 	// RegistryType is the type of private registry. You can find the list of supported types in PrivateRegistryType.
-	RegistryType *string `json:"registry_type,omitempty"`
+	RegistryType *PrivateRegistryType `json:"registry_type,omitempty"`
+	// AuthType is the authentication type for the private registry.
+	AuthType *PrivateRegistryAuthType `json:"auth_type,omitempty"`
+	// URL is the URL of the private registry.
+	URL *string `json:"url,omitempty"`
 	// Username to use when authenticating with the private registry.
 	// This field is omitted if the private registry does not require a username for authentication.
 	Username *string `json:"username,omitempty"`
-	// CreatedAt is the timestamp when the private registry was created.
-	CreatedAt *Timestamp `json:"created_at,omitempty"`
-	// UpdatedAt is the timestamp when the private registry was last updated.
-	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
+	// ReplacesBase indicates whether this private registry should replace the base registry.
+	ReplacesBase *bool `json:"replaces_base,omitempty"`
 	// Visibility is the visibility of the private registry. Possible values are: "private", "all", and "selected".
 	Visibility *PrivateRegistryVisibility `json:"visibility,omitempty"`
 	// SelectedRepositoryIDs is an array of repository IDs that can access the organization private registry.
 	SelectedRepositoryIDs []int64 `json:"selected_repository_ids,omitempty"`
+	// TenantID is the tenant ID of the Azure AD application.
+	TenantID *string `json:"tenant_id,omitempty"`
+	// ClientID is the client ID of the Azure AD application.
+	ClientID *string `json:"client_id,omitempty"`
+	// AwsRegion is the AWS region.
+	AwsRegion *string `json:"aws_region,omitempty"`
+	// AccountID is the AWS account ID.
+	AccountID *string `json:"account_id,omitempty"`
+	// RoleName is the AWS IAM role name.
+	RoleName *string `json:"role_name,omitempty"`
+	// Domain is the CodeArtifact domain.
+	Domain *string `json:"domain,omitempty"`
+	// DomainOwner is the CodeArtifact domain owner.
+	DomainOwner *string `json:"domain_owner,omitempty"`
+	// JfrogOidcProviderName is the JFrog OIDC provider name.
+	JfrogOidcProviderName *string `json:"jfrog_oidc_provider_name,omitempty"`
+	// Audience is the OIDC audience.
+	Audience *string `json:"audience,omitempty"`
+	// IdentityMappingName is the JFrog identity mapping name.
+	IdentityMappingName *string `json:"identity_mapping_name,omitempty"`
+	// CreatedAt is the timestamp when the private registry was created.
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
+	// UpdatedAt is the timestamp when the private registry was last updated.
+	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
 }
 
 // PrivateRegistries represents a list of private registries.
@@ -88,7 +114,7 @@ type PrivateRegistries struct {
 type CreateOrganizationPrivateRegistry struct {
 	// RegistryType is the type of private registry.
 	// You can find the list of supported types in PrivateRegistryType.
-	RegistryType string `json:"registry_type"`
+	RegistryType PrivateRegistryType `json:"registry_type"`
 
 	// URL is the URL of the private registry.
 	URL string `json:"url"`
@@ -150,7 +176,7 @@ type CreateOrganizationPrivateRegistry struct {
 type UpdateOrganizationPrivateRegistry struct {
 	// RegistryType is the type of private registry.
 	// You can find the list of supported types in PrivateRegistryType.
-	RegistryType *string `json:"registry_type,omitempty"`
+	RegistryType *PrivateRegistryType `json:"registry_type,omitempty"`
 
 	// URL is the URL of the private registry.
 	URL *string `json:"url,omitempty"`

--- a/github/private_registries.go
+++ b/github/private_registries.go
@@ -80,8 +80,8 @@ type PrivateRegistry struct {
 	TenantID *string `json:"tenant_id,omitempty"`
 	// ClientID is the client ID of the Azure AD application.
 	ClientID *string `json:"client_id,omitempty"`
-	// AwsRegion is the AWS region.
-	AwsRegion *string `json:"aws_region,omitempty"`
+	// AWSRegion is the AWS region.
+	AWSRegion *string `json:"aws_region,omitempty"`
 	// AccountID is the AWS account ID.
 	AccountID *string `json:"account_id,omitempty"`
 	// RoleName is the AWS IAM role name.
@@ -90,8 +90,8 @@ type PrivateRegistry struct {
 	Domain *string `json:"domain,omitempty"`
 	// DomainOwner is the CodeArtifact domain owner.
 	DomainOwner *string `json:"domain_owner,omitempty"`
-	// JfrogOidcProviderName is the JFrog OIDC provider name.
-	JfrogOidcProviderName *string `json:"jfrog_oidc_provider_name,omitempty"`
+	// JFrogOIDCProviderName is the JFrog OIDC provider name.
+	JFrogOIDCProviderName *string `json:"jfrog_oidc_provider_name,omitempty"`
 	// Audience is the OIDC audience.
 	Audience *string `json:"audience,omitempty"`
 	// IdentityMappingName is the JFrog identity mapping name.
@@ -152,8 +152,8 @@ type CreateOrganizationPrivateRegistry struct {
 	// ClientID is the client ID of the Azure AD application. Required when AuthType is "oidc_azure".
 	ClientID *string `json:"client_id,omitempty"`
 
-	// AwsRegion is the AWS region. Required when AuthType is "oidc_aws".
-	AwsRegion *string `json:"aws_region,omitempty"`
+	// AWSRegion is the AWS region. Required when AuthType is "oidc_aws".
+	AWSRegion *string `json:"aws_region,omitempty"`
 	// AccountID is the AWS account ID. Required when AuthType is "oidc_aws".
 	AccountID *string `json:"account_id,omitempty"`
 	// RoleName is the AWS IAM role name. Required when AuthType is "oidc_aws".
@@ -163,8 +163,8 @@ type CreateOrganizationPrivateRegistry struct {
 	// DomainOwner is the CodeArtifact domain owner (AWS account ID). Required when AuthType is "oidc_aws".
 	DomainOwner *string `json:"domain_owner,omitempty"`
 
-	// JfrogOidcProviderName is the JFrog OIDC provider name. Required when AuthType is "oidc_jfrog".
-	JfrogOidcProviderName *string `json:"jfrog_oidc_provider_name,omitempty"`
+	// JFrogOIDCProviderName is the JFrog OIDC provider name. Required when AuthType is "oidc_jfrog".
+	JFrogOIDCProviderName *string `json:"jfrog_oidc_provider_name,omitempty"`
 
 	// Audience is the OIDC audience. Optional for "oidc_aws" and "oidc_jfrog" auth types.
 	Audience *string `json:"audience,omitempty"`
@@ -212,8 +212,8 @@ type UpdateOrganizationPrivateRegistry struct {
 	// ClientID is the client ID of the Azure AD application. Required when AuthType is "oidc_azure".
 	ClientID *string `json:"client_id,omitempty"`
 
-	// AwsRegion is the AWS region. Required when AuthType is "oidc_aws".
-	AwsRegion *string `json:"aws_region,omitempty"`
+	// AWSRegion is the AWS region. Required when AuthType is "oidc_aws".
+	AWSRegion *string `json:"aws_region,omitempty"`
 	// AccountID is the AWS account ID. Required when AuthType is "oidc_aws".
 	AccountID *string `json:"account_id,omitempty"`
 	// RoleName is the AWS IAM role name. Required when AuthType is "oidc_aws".
@@ -223,8 +223,8 @@ type UpdateOrganizationPrivateRegistry struct {
 	// DomainOwner is the CodeArtifact domain owner (AWS account ID). Required when AuthType is "oidc_aws".
 	DomainOwner *string `json:"domain_owner,omitempty"`
 
-	// JfrogOidcProviderName is the JFrog OIDC provider name. Required when AuthType is "oidc_jfrog".
-	JfrogOidcProviderName *string `json:"jfrog_oidc_provider_name,omitempty"`
+	// JFrogOIDCProviderName is the JFrog OIDC provider name. Required when AuthType is "oidc_jfrog".
+	JFrogOIDCProviderName *string `json:"jfrog_oidc_provider_name,omitempty"`
 
 	// Audience is the OIDC audience. Optional for "oidc_aws" and "oidc_jfrog" auth types.
 	Audience *string `json:"audience,omitempty"`

--- a/github/private_registries.go
+++ b/github/private_registries.go
@@ -234,7 +234,7 @@ type UpdateOrganizationPrivateRegistry struct {
 
 // ListOrganizationPrivateRegistries lists private registries for an organization.
 //
-// GitHub API docs: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2022-11-28#list-private-registries-for-an-organization
+// GitHub API docs: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#list-private-registries-for-an-organization
 //
 //meta:operation GET /orgs/{org}/private-registries
 func (s *PrivateRegistriesService) ListOrganizationPrivateRegistries(ctx context.Context, org string, opts *ListOptions) (*PrivateRegistries, *Response, error) {
@@ -259,7 +259,7 @@ func (s *PrivateRegistriesService) ListOrganizationPrivateRegistries(ctx context
 
 // CreateOrganizationPrivateRegistry creates a private registry configuration with an encrypted value for an organization.
 //
-// GitHub API docs: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2022-11-28#create-a-private-registry-for-an-organization
+// GitHub API docs: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#create-a-private-registry-for-an-organization
 //
 //meta:operation POST /orgs/{org}/private-registries
 func (s *PrivateRegistriesService) CreateOrganizationPrivateRegistry(ctx context.Context, org string, privateRegistry CreateOrganizationPrivateRegistry) (*PrivateRegistry, *Response, error) {
@@ -280,7 +280,7 @@ func (s *PrivateRegistriesService) CreateOrganizationPrivateRegistry(ctx context
 
 // GetOrganizationPrivateRegistriesPublicKey retrieves the public key for encrypting secrets for an organization's private registries.
 //
-// GitHub API docs: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2022-11-28#get-private-registries-public-key-for-an-organization
+// GitHub API docs: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#get-private-registries-public-key-for-an-organization
 //
 //meta:operation GET /orgs/{org}/private-registries/public-key
 func (s *PrivateRegistriesService) GetOrganizationPrivateRegistriesPublicKey(ctx context.Context, org string) (*PublicKey, *Response, error) {
@@ -302,7 +302,7 @@ func (s *PrivateRegistriesService) GetOrganizationPrivateRegistriesPublicKey(ctx
 // GetOrganizationPrivateRegistry gets a specific private registry for an organization.
 // The `name` parameter is the name of the private registry to retrieve. It is the same as PrivateRegistry.Name.
 //
-// GitHub API docs: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2022-11-28#get-a-private-registry-for-an-organization
+// GitHub API docs: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#get-a-private-registry-for-an-organization
 //
 //meta:operation GET /orgs/{org}/private-registries/{secret_name}
 func (s *PrivateRegistriesService) GetOrganizationPrivateRegistry(ctx context.Context, org, secretName string) (*PrivateRegistry, *Response, error) {
@@ -325,7 +325,7 @@ func (s *PrivateRegistriesService) GetOrganizationPrivateRegistry(ctx context.Co
 // UpdateOrganizationPrivateRegistry updates a specific private registry for an organization.
 // The `name` parameter is the name of the private registry to update. It is the same as PrivateRegistry.Name.
 //
-// GitHub API docs: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2022-11-28#update-a-private-registry-for-an-organization
+// GitHub API docs: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#update-a-private-registry-for-an-organization
 //
 //meta:operation PATCH /orgs/{org}/private-registries/{secret_name}
 func (s *PrivateRegistriesService) UpdateOrganizationPrivateRegistry(ctx context.Context, org, secretName string, privateRegistry UpdateOrganizationPrivateRegistry) (*Response, error) {
@@ -342,7 +342,7 @@ func (s *PrivateRegistriesService) UpdateOrganizationPrivateRegistry(ctx context
 // DeleteOrganizationPrivateRegistry deletes a specific private registry for an organization.
 // The `name` parameter is the name of the private registry to delete. It is the same as PrivateRegistry.Name.
 //
-// GitHub API docs: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2022-11-28#delete-a-private-registry-for-an-organization
+// GitHub API docs: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#delete-a-private-registry-for-an-organization
 //
 //meta:operation DELETE /orgs/{org}/private-registries/{secret_name}
 func (s *PrivateRegistriesService) DeleteOrganizationPrivateRegistry(ctx context.Context, org, secretName string) (*Response, error) {

--- a/github/private_registries_test.go
+++ b/github/private_registries_test.go
@@ -154,6 +154,145 @@ func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry(t *testing.T
 	})
 }
 
+func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry_OIDC(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	input := &CreateOrganizationPrivateRegistry{
+		RegistryType:          "maven_repository",
+		URL:                   "https://maven.pkg.github.com/OWNER/REPOSITORY",
+		AuthType:              Ptr("oidc_azure"),
+		TenantID:              Ptr("my-tenant-id"),
+		ClientID:              Ptr("my-client-id"),
+		ReplacesBase:          Ptr(true),
+		Visibility:            PrivateRegistryVisibilitySelected,
+		SelectedRepositoryIDs: []int64{1, 2, 3},
+	}
+
+	mux.HandleFunc("/orgs/o/private-registries", func(w http.ResponseWriter, r *http.Request) {
+		var v *CreateOrganizationPrivateRegistry
+		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
+
+		testMethod(t, r, "POST")
+		if !cmp.Equal(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{
+  "name": "MAVEN_REPOSITORY_SECRET",
+  "registry_type": "maven_repository",
+  "visibility": "selected",
+  "selected_repository_ids": [1, 2, 3],
+  "created_at": "2019-08-10T14:59:22Z",
+  "updated_at": "2020-01-10T14:59:22Z"
+}`)
+	})
+
+	ctx := t.Context()
+	privateRegistry, _, err := client.PrivateRegistries.CreateOrganizationPrivateRegistry(ctx, "o", *input)
+	if err != nil {
+		t.Fatalf("PrivateRegistries.CreateOrganizationPrivateRegistry (OIDC) returned error: %v", err)
+	}
+
+	want := &PrivateRegistry{
+		Name:                  Ptr("MAVEN_REPOSITORY_SECRET"),
+		RegistryType:          Ptr("maven_repository"),
+		CreatedAt:             &Timestamp{time.Date(2019, time.August, 10, 14, 59, 22, 0, time.UTC)},
+		UpdatedAt:             &Timestamp{time.Date(2020, time.January, 10, 14, 59, 22, 0, time.UTC)},
+		Visibility:            Ptr(PrivateRegistryVisibilitySelected),
+		SelectedRepositoryIDs: []int64{1, 2, 3},
+	}
+	if diff := cmp.Diff(want, privateRegistry); diff != "" {
+		t.Errorf("PrivateRegistries.CreateOrganizationPrivateRegistry (OIDC) mismatch (-want +got):\\n%v", diff)
+	}
+}
+
+func TestPrivateRegistries_UpdateOrganizationPrivateRegistry_OIDC(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	input := &UpdateOrganizationPrivateRegistry{
+		AuthType:    Ptr("oidc_aws"),
+		AwsRegion:   Ptr("us-east-1"),
+		AccountID:   Ptr("123456789012"),
+		RoleName:    Ptr("my-role"),
+		Domain:      Ptr("my-domain"),
+		DomainOwner: Ptr("123456789012"),
+		Audience:    Ptr("sts.amazonaws.com"),
+		Visibility:  Ptr(PrivateRegistryVisibilitySelected),
+	}
+
+	mux.HandleFunc("/orgs/o/private-registries/AWS_REGISTRY_SECRET", func(w http.ResponseWriter, r *http.Request) {
+		var v *UpdateOrganizationPrivateRegistry
+		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
+
+		testMethod(t, r, "PATCH")
+		if !cmp.Equal(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := t.Context()
+	_, err := client.PrivateRegistries.UpdateOrganizationPrivateRegistry(ctx, "o", "AWS_REGISTRY_SECRET", *input)
+	if err != nil {
+		t.Fatalf("PrivateRegistries.UpdateOrganizationPrivateRegistry (OIDC) returned error: %v", err)
+	}
+}
+
+func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry_OIDCJFrog(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	input := &CreateOrganizationPrivateRegistry{
+		RegistryType:          "npm_registry",
+		URL:                   "https://my.jfrog.io/artifactory/api/npm/npm-remote",
+		AuthType:              Ptr("oidc_jfrog"),
+		JfrogOidcProviderName: Ptr("my-jfrog-provider"),
+		Audience:              Ptr("jfrog"),
+		IdentityMappingName:   Ptr("my-identity-mapping"),
+		Visibility:            PrivateRegistryVisibilityPrivate,
+	}
+
+	mux.HandleFunc("/orgs/o/private-registries", func(w http.ResponseWriter, r *http.Request) {
+		var v *CreateOrganizationPrivateRegistry
+		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
+
+		testMethod(t, r, "POST")
+		if !cmp.Equal(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{
+  "name": "NPM_REGISTRY_SECRET",
+  "registry_type": "npm_registry",
+  "visibility": "private",
+  "created_at": "2019-08-10T14:59:22Z",
+  "updated_at": "2020-01-10T14:59:22Z"
+}`)
+	})
+
+	ctx := t.Context()
+	privateRegistry, _, err := client.PrivateRegistries.CreateOrganizationPrivateRegistry(ctx, "o", *input)
+	if err != nil {
+		t.Fatalf("PrivateRegistries.CreateOrganizationPrivateRegistry (OIDC JFrog) returned error: %v", err)
+	}
+
+	want := &PrivateRegistry{
+		Name:         Ptr("NPM_REGISTRY_SECRET"),
+		RegistryType: Ptr("npm_registry"),
+		CreatedAt:    &Timestamp{time.Date(2019, time.August, 10, 14, 59, 22, 0, time.UTC)},
+		UpdatedAt:    &Timestamp{time.Date(2020, time.January, 10, 14, 59, 22, 0, time.UTC)},
+		Visibility:   Ptr(PrivateRegistryVisibilityPrivate),
+	}
+	if diff := cmp.Diff(want, privateRegistry); diff != "" {
+		t.Errorf("PrivateRegistries.CreateOrganizationPrivateRegistry (OIDC JFrog) mismatch (-want +got):\\n%v", diff)
+	}
+}
+
 func TestPrivateRegistriesService_GetOrganizationPrivateRegistriesPublicKey(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)

--- a/github/private_registries_test.go
+++ b/github/private_registries_test.go
@@ -93,8 +93,8 @@ func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry(t *testing.T
 		RegistryType:          "maven_repository",
 		URL:                   "https://maven.pkg.github.com/OWNER/REPOSITORY",
 		Username:              Ptr("monalisa"),
-		EncryptedValue:        "encrypted_value",
-		KeyID:                 "key_id",
+		EncryptedValue:        Ptr("encrypted_value"),
+		KeyID:                 Ptr("key_id"),
 		Visibility:            PrivateRegistryVisibilitySelected,
 		SelectedRepositoryIDs: []int64{1, 2, 3},
 	}
@@ -108,13 +108,15 @@ func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry(t *testing.T
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
+		w.WriteHeader(http.StatusCreated)
 		fmt.Fprint(w, `{
   "name": "MAVEN_REPOSITORY_SECRET",
   "registry_type": "maven_repository",
   "username": "monalisa",
+  "visibility": "selected",
+  "selected_repository_ids": [1, 2, 3],
   "created_at": "2019-08-10T14:59:22Z",
-  "updated_at": "2020-01-10T14:59:22Z",
-  "visibility": "selected"
+  "updated_at": "2020-01-10T14:59:22Z"
 }`)
 	})
 
@@ -125,12 +127,13 @@ func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry(t *testing.T
 	}
 
 	want := &PrivateRegistry{
-		Name:         Ptr("MAVEN_REPOSITORY_SECRET"),
-		RegistryType: Ptr("maven_repository"),
-		Username:     Ptr("monalisa"),
-		CreatedAt:    &Timestamp{time.Date(2019, time.August, 10, 14, 59, 22, 0, time.UTC)},
-		UpdatedAt:    &Timestamp{time.Date(2020, time.January, 10, 14, 59, 22, 0, time.UTC)},
-		Visibility:   Ptr(PrivateRegistryVisibilitySelected),
+		Name:                  Ptr("MAVEN_REPOSITORY_SECRET"),
+		RegistryType:          Ptr("maven_repository"),
+		Username:              Ptr("monalisa"),
+		CreatedAt:             &Timestamp{time.Date(2019, time.August, 10, 14, 59, 22, 0, time.UTC)},
+		UpdatedAt:             &Timestamp{time.Date(2020, time.January, 10, 14, 59, 22, 0, time.UTC)},
+		Visibility:            Ptr(PrivateRegistryVisibilitySelected),
+		SelectedRepositoryIDs: []int64{1, 2, 3},
 	}
 	if diff := cmp.Diff(want, privateRegistry); diff != "" {
 		t.Errorf("PrivateRegistries.CreateOrganizationPrivateRegistries mismatch (-want +got):\\n%v", diff)
@@ -258,46 +261,23 @@ func TestPrivateRegistries_UpdateOrganizationPrivateRegistry(t *testing.T) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 
-		fmt.Fprint(w, `{
-  "name": "MAVEN_REPOSITORY_SECRET",
-  "registry_type": "maven_repository",
-  "username": "monalisa",
-  "created_at": "2019-08-10T14:59:22Z",
-  "updated_at": "2020-01-10T14:59:22Z",
-  "visibility": "selected"
-}`)
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	ctx := t.Context()
-	privateRegistry, _, err := client.PrivateRegistries.UpdateOrganizationPrivateRegistry(ctx, "o", "MAVEN_REPOSITORY_SECRET", *input)
+	_, err := client.PrivateRegistries.UpdateOrganizationPrivateRegistry(ctx, "o", "MAVEN_REPOSITORY_SECRET", *input)
 	if err != nil {
 		t.Fatalf("PrivateRegistries.UpdateOrganizationPrivateRegistry returned error: %v", err)
 	}
 
-	want := &PrivateRegistry{
-		Name:         Ptr("MAVEN_REPOSITORY_SECRET"),
-		RegistryType: Ptr("maven_repository"),
-		Username:     Ptr("monalisa"),
-		CreatedAt:    &Timestamp{time.Date(2019, time.August, 10, 14, 59, 22, 0, time.UTC)},
-		UpdatedAt:    &Timestamp{time.Date(2020, time.January, 10, 14, 59, 22, 0, time.UTC)},
-		Visibility:   Ptr(PrivateRegistryVisibilitySelected),
-	}
-	if diff := cmp.Diff(want, privateRegistry); diff != "" {
-		t.Errorf("PrivateRegistries.UpdateOrganizationPrivateRegistry mismatch (-want +got):\\n%v", diff)
-	}
-
 	const methodName = "UpdateOrganizationPrivateRegistry"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.PrivateRegistries.UpdateOrganizationPrivateRegistry(ctx, "\n", "MAVEN_REPOSITORY_SECRET", *input)
+		_, err = client.PrivateRegistries.UpdateOrganizationPrivateRegistry(ctx, "\n", "MAVEN_REPOSITORY_SECRET", *input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.PrivateRegistries.UpdateOrganizationPrivateRegistry(ctx, "o", "MAVEN_REPOSITORY_SECRET", *input)
-		if got != nil {
-			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
-		}
-		return resp, err
+		return client.PrivateRegistries.UpdateOrganizationPrivateRegistry(ctx, "o", "MAVEN_REPOSITORY_SECRET", *input)
 	})
 }
 

--- a/github/private_registries_test.go
+++ b/github/private_registries_test.go
@@ -22,6 +22,7 @@ func TestPrivateRegistriesService_ListOrganizationPrivateRegistries(t *testing.T
 
 	mux.HandleFunc("/orgs/o/private-registries", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "X-Github-Api-Version", "2026-03-10")
 		testFormValues(t, r, values{
 			"page": "2",
 		})
@@ -104,6 +105,7 @@ func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry(t *testing.T
 		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
 
 		testMethod(t, r, "POST")
+		testHeader(t, r, "X-Github-Api-Version", "2026-03-10")
 		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -174,6 +176,7 @@ func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry_OIDC(t *test
 		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
 
 		testMethod(t, r, "POST")
+		testHeader(t, r, "X-Github-Api-Version", "2026-03-10")
 		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -228,6 +231,7 @@ func TestPrivateRegistries_UpdateOrganizationPrivateRegistry_OIDC(t *testing.T) 
 		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
 
 		testMethod(t, r, "PATCH")
+		testHeader(t, r, "X-Github-Api-Version", "2026-03-10")
 		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -261,6 +265,7 @@ func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry_OIDCJFrog(t 
 		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
 
 		testMethod(t, r, "POST")
+		testHeader(t, r, "X-Github-Api-Version", "2026-03-10")
 		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -299,6 +304,7 @@ func TestPrivateRegistriesService_GetOrganizationPrivateRegistriesPublicKey(t *t
 
 	mux.HandleFunc("/orgs/o/private-registries/public-key", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "X-Github-Api-Version", "2026-03-10")
 		fmt.Fprint(w, `{
   "key_id": "0123456789",
   "key": "public_key"
@@ -339,6 +345,7 @@ func TestPrivateRegistriesService_GetOrganizationPrivateRegistry(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/private-registries/MAVEN_REPOSITORY_SECRET", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "X-Github-Api-Version", "2026-03-10")
 		fmt.Fprint(w, `{
   "name": "MAVEN_REPOSITORY_SECRET",
   "registry_type": "maven_repository",
@@ -396,6 +403,7 @@ func TestPrivateRegistries_UpdateOrganizationPrivateRegistry(t *testing.T) {
 		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
 
 		testMethod(t, r, "PATCH")
+		testHeader(t, r, "X-Github-Api-Version", "2026-03-10")
 		if !cmp.Equal(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -426,6 +434,7 @@ func TestPrivateRegistriesService_DeleteOrganizationPrivateRegistry(t *testing.T
 
 	mux.HandleFunc("/orgs/o/private-registries/MAVEN_REPOSITORY_SECRET", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
+		testHeader(t, r, "X-Github-Api-Version", "2026-03-10")
 		w.WriteHeader(http.StatusNoContent)
 	})
 	ctx := t.Context()

--- a/github/private_registries_test.go
+++ b/github/private_registries_test.go
@@ -53,7 +53,7 @@ func TestPrivateRegistriesService_ListOrganizationPrivateRegistries(t *testing.T
 		Configurations: []*PrivateRegistry{
 			{
 				Name:         Ptr("MAVEN_REPOSITORY_SECRET"),
-				RegistryType: Ptr("maven_repository"),
+				RegistryType: Ptr(PrivateRegistryTypeMavenRepository),
 				Username:     Ptr("monalisa"),
 				CreatedAt:    &Timestamp{time.Date(2019, time.August, 10, 14, 59, 22, 0, time.UTC)},
 				UpdatedAt:    &Timestamp{time.Date(2020, time.January, 10, 14, 59, 22, 0, time.UTC)},
@@ -91,7 +91,7 @@ func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry(t *testing.T
 	client, mux, _ := setup(t)
 
 	input := &CreateOrganizationPrivateRegistry{
-		RegistryType:          "maven_repository",
+		RegistryType:          PrivateRegistryTypeMavenRepository,
 		URL:                   "https://maven.pkg.github.com/OWNER/REPOSITORY",
 		Username:              Ptr("monalisa"),
 		EncryptedValue:        Ptr("encrypted_value"),
@@ -130,7 +130,7 @@ func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry(t *testing.T
 
 	want := &PrivateRegistry{
 		Name:                  Ptr("MAVEN_REPOSITORY_SECRET"),
-		RegistryType:          Ptr("maven_repository"),
+		RegistryType:          Ptr(PrivateRegistryTypeMavenRepository),
 		Username:              Ptr("monalisa"),
 		CreatedAt:             &Timestamp{time.Date(2019, time.August, 10, 14, 59, 22, 0, time.UTC)},
 		UpdatedAt:             &Timestamp{time.Date(2020, time.January, 10, 14, 59, 22, 0, time.UTC)},
@@ -161,8 +161,8 @@ func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry_OIDC(t *test
 	client, mux, _ := setup(t)
 
 	input := &CreateOrganizationPrivateRegistry{
-		RegistryType:          "maven_repository",
-		URL:                   "https://maven.pkg.github.com/OWNER/REPOSITORY",
+		RegistryType:          PrivateRegistryTypeMavenRepository,
+		URL:                   "https://example.com/maven",
 		AuthType:              Ptr("oidc_azure"),
 		TenantID:              Ptr("my-tenant-id"),
 		ClientID:              Ptr("my-client-id"),
@@ -200,7 +200,7 @@ func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry_OIDC(t *test
 
 	want := &PrivateRegistry{
 		Name:                  Ptr("MAVEN_REPOSITORY_SECRET"),
-		RegistryType:          Ptr("maven_repository"),
+		RegistryType:          Ptr(PrivateRegistryTypeMavenRepository),
 		CreatedAt:             &Timestamp{time.Date(2019, time.August, 10, 14, 59, 22, 0, time.UTC)},
 		UpdatedAt:             &Timestamp{time.Date(2020, time.January, 10, 14, 59, 22, 0, time.UTC)},
 		Visibility:            Ptr(PrivateRegistryVisibilitySelected),
@@ -251,8 +251,8 @@ func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry_OIDCJFrog(t 
 	client, mux, _ := setup(t)
 
 	input := &CreateOrganizationPrivateRegistry{
-		RegistryType:          "npm_registry",
-		URL:                   "https://my.jfrog.io/artifactory/api/npm/npm-remote",
+		RegistryType:          PrivateRegistryTypeNpmRegistry,
+		URL:                   "https://example.com/npm",
 		AuthType:              Ptr("oidc_jfrog"),
 		JfrogOidcProviderName: Ptr("my-jfrog-provider"),
 		Audience:              Ptr("jfrog"),
@@ -288,7 +288,7 @@ func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry_OIDCJFrog(t 
 
 	want := &PrivateRegistry{
 		Name:         Ptr("NPM_REGISTRY_SECRET"),
-		RegistryType: Ptr("npm_registry"),
+		RegistryType: Ptr(PrivateRegistryTypeNpmRegistry),
 		CreatedAt:    &Timestamp{time.Date(2019, time.August, 10, 14, 59, 22, 0, time.UTC)},
 		UpdatedAt:    &Timestamp{time.Date(2020, time.January, 10, 14, 59, 22, 0, time.UTC)},
 		Visibility:   Ptr(PrivateRegistryVisibilityPrivate),
@@ -363,7 +363,7 @@ func TestPrivateRegistriesService_GetOrganizationPrivateRegistry(t *testing.T) {
 
 	want := &PrivateRegistry{
 		Name:         Ptr("MAVEN_REPOSITORY_SECRET"),
-		RegistryType: Ptr("maven_repository"),
+		RegistryType: Ptr(PrivateRegistryTypeMavenRepository),
 		Username:     Ptr("monalisa"),
 		CreatedAt:    &Timestamp{time.Date(2019, time.August, 10, 14, 59, 22, 0, time.UTC)},
 		UpdatedAt:    &Timestamp{time.Date(2020, time.January, 10, 14, 59, 22, 0, time.UTC)},

--- a/github/private_registries_test.go
+++ b/github/private_registries_test.go
@@ -222,7 +222,7 @@ func TestPrivateRegistries_UpdateOrganizationPrivateRegistry_OIDC(t *testing.T) 
 		RoleName:    Ptr("my-role"),
 		Domain:      Ptr("my-domain"),
 		DomainOwner: Ptr("123456789012"),
-		Audience:    Ptr("sts.amazonaws.com"),
+		Audience:    Ptr("example.com"),
 		Visibility:  Ptr(PrivateRegistryVisibilitySelected),
 	}
 

--- a/github/private_registries_test.go
+++ b/github/private_registries_test.go
@@ -92,7 +92,7 @@ func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry(t *testing.T
 
 	input := &CreateOrganizationPrivateRegistry{
 		RegistryType:          PrivateRegistryTypeMavenRepository,
-		URL:                   "https://maven.pkg.github.com/OWNER/REPOSITORY",
+		URL:                   "https://example.com/OWNER/REPOSITORY",
 		Username:              Ptr("monalisa"),
 		EncryptedValue:        Ptr("encrypted_value"),
 		KeyID:                 Ptr("key_id"),

--- a/github/private_registries_test.go
+++ b/github/private_registries_test.go
@@ -217,7 +217,7 @@ func TestPrivateRegistries_UpdateOrganizationPrivateRegistry_OIDC(t *testing.T) 
 
 	input := &UpdateOrganizationPrivateRegistry{
 		AuthType:    Ptr("oidc_aws"),
-		AwsRegion:   Ptr("us-east-1"),
+		AWSRegion:   Ptr("us-east-1"),
 		AccountID:   Ptr("123456789012"),
 		RoleName:    Ptr("my-role"),
 		Domain:      Ptr("my-domain"),
@@ -254,7 +254,7 @@ func TestPrivateRegistriesService_CreateOrganizationPrivateRegistry_OIDCJFrog(t 
 		RegistryType:          PrivateRegistryTypeNpmRegistry,
 		URL:                   "https://example.com/npm",
 		AuthType:              Ptr("oidc_jfrog"),
-		JfrogOidcProviderName: Ptr("my-jfrog-provider"),
+		JFrogOIDCProviderName: Ptr("my-jfrog-provider"),
 		Audience:              Ptr("jfrog"),
 		IdentityMappingName:   Ptr("my-identity-mapping"),
 		Visibility:            PrivateRegistryVisibilityPrivate,

--- a/openapi_operations.yaml
+++ b/openapi_operations.yaml
@@ -3439,37 +3439,37 @@ openapi_operations:
     openapi_files:
       - descriptions/ghes-3.20/ghes-3.20.json
   - name: GET /orgs/{org}/private-registries
-    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations#list-private-registries-for-an-organization
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#list-private-registries-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.20/ghes-3.20.json
   - name: POST /orgs/{org}/private-registries
-    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations#create-a-private-registry-for-an-organization
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#create-a-private-registry-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.20/ghes-3.20.json
   - name: GET /orgs/{org}/private-registries/public-key
-    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations#get-private-registries-public-key-for-an-organization
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#get-private-registries-public-key-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.20/ghes-3.20.json
   - name: DELETE /orgs/{org}/private-registries/{secret_name}
-    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations#delete-a-private-registry-for-an-organization
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#delete-a-private-registry-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.20/ghes-3.20.json
   - name: GET /orgs/{org}/private-registries/{secret_name}
-    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations#get-a-private-registry-for-an-organization
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#get-a-private-registry-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.20/ghes-3.20.json
   - name: PATCH /orgs/{org}/private-registries/{secret_name}
-    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations#update-a-private-registry-for-an-organization
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#update-a-private-registry-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json

--- a/openapi_operations.yaml
+++ b/openapi_operations.yaml
@@ -13,6 +13,18 @@ operations:
 operation_overrides:
   - name: GET /meta
     documentation_url: https://docs.github.com/rest/meta/meta#get-github-meta-information
+  - name: GET /orgs/{org}/private-registries
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#list-private-registries-for-an-organization
+  - name: POST /orgs/{org}/private-registries
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#create-a-private-registry-for-an-organization
+  - name: GET /orgs/{org}/private-registries/public-key
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#get-private-registries-public-key-for-an-organization
+  - name: DELETE /orgs/{org}/private-registries/{secret_name}
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#delete-a-private-registry-for-an-organization
+  - name: GET /orgs/{org}/private-registries/{secret_name}
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#get-a-private-registry-for-an-organization
+  - name: PATCH /orgs/{org}/private-registries/{secret_name}
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#update-a-private-registry-for-an-organization
   - name: DELETE /repos/{owner}/{repo}/pages
     documentation_url: https://docs.github.com/rest/pages/pages#delete-a-github-pages-site
   - name: GET /repos/{owner}/{repo}/pages
@@ -3439,37 +3451,37 @@ openapi_operations:
     openapi_files:
       - descriptions/ghes-3.20/ghes-3.20.json
   - name: GET /orgs/{org}/private-registries
-    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#list-private-registries-for-an-organization
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations#list-private-registries-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.20/ghes-3.20.json
   - name: POST /orgs/{org}/private-registries
-    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#create-a-private-registry-for-an-organization
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations#create-a-private-registry-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.20/ghes-3.20.json
   - name: GET /orgs/{org}/private-registries/public-key
-    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#get-private-registries-public-key-for-an-organization
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations#get-private-registries-public-key-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.20/ghes-3.20.json
   - name: DELETE /orgs/{org}/private-registries/{secret_name}
-    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#delete-a-private-registry-for-an-organization
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations#delete-a-private-registry-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.20/ghes-3.20.json
   - name: GET /orgs/{org}/private-registries/{secret_name}
-    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#get-a-private-registry-for-an-organization
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations#get-a-private-registry-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
       - descriptions/ghes-3.20/ghes-3.20.json
   - name: PATCH /orgs/{org}/private-registries/{secret_name}
-    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#update-a-private-registry-for-an-organization
+    documentation_url: https://docs.github.com/rest/private-registries/organization-configurations#update-a-private-registry-for-an-organization
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json

--- a/tools/metadata/metadata.go
+++ b/tools/metadata/metadata.go
@@ -502,7 +502,9 @@ func normalizeDocURL(docURL string) string {
 
 	u.Path = cleanPath
 	q := u.Query()
-	q.Set("apiVersion", metadataDocsAPIVersion)
+	if q.Get("apiVersion") == "" {
+		q.Set("apiVersion", metadataDocsAPIVersion)
+	}
 	u.RawQuery = q.Encode()
 	return u.String()
 }

--- a/tools/metadata/metadata_test.go
+++ b/tools/metadata/metadata_test.go
@@ -53,9 +53,14 @@ func Test_normalizeDocURL(t *testing.T) {
 			want:   "https://docs.github.com/rest/repos/repos?apiVersion=2022-11-28&foo=bar",
 		},
 		{
-			name:   "replace existing api version",
+			name:   "preserve existing api version",
 			docURL: "https://docs.github.com/rest/repos/repos?apiVersion=2021-01-01&foo=bar",
-			want:   "https://docs.github.com/rest/repos/repos?apiVersion=2022-11-28&foo=bar",
+			want:   "https://docs.github.com/rest/repos/repos?apiVersion=2021-01-01&foo=bar",
+		},
+		{
+			name:   "preserve non-default api version",
+			docURL: "https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#list-private-registries-for-an-organization",
+			want:   "https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10#list-private-registries-for-an-organization",
 		},
 		{
 			name:   "enterprise cloud latest rest is normalized",

--- a/tools/structfield/structfield.go
+++ b/tools/structfield/structfield.go
@@ -410,7 +410,7 @@ func tagNameToPascal(tagName string) (want, alternate string) {
 
 // Common Go initialisms that should be all caps.
 var initialisms = map[string]bool{
-	"API": true, "ASCII": true,
+	"API": true, "ASCII": true, "AWS": true,
 	"CAA": true, "CAS": true, "CNAME": true, "CPU": true,
 	"CSS": true, "CWE": true, "CVE": true, "CVSS": true,
 	"DN": true, "DNS": true,
@@ -419,6 +419,7 @@ var initialisms = map[string]bool{
 	"HTML": true, "HTTP": true, "HTTPS": true,
 	"ID": true, "IDE": true, "IDP": true, "IP": true, "JIT": true,
 	"JSON": true,
+	"OIDC": true,
 	"LDAP": true, "LFS": true, "LHS": true,
 	"MD5": true, "MS": true, "MX": true,
 	"NPM": true, "NTP": true, "NVD": true,
@@ -440,6 +441,7 @@ var initialisms = map[string]bool{
 var specialCases = map[string]string{
 	"CPUS":    "CPUs",
 	"CWES":    "CWEs",
+	"JFROG":   "JFrog",
 	"GRAPHQL": "GraphQL",
 	"HREF":    "HRef",
 	"IDS":     "IDs",


### PR DESCRIPTION
BREAKING CHANGE: `PrivateRegistriesService` is updated to API version `2026-03-10` with struct and response changes.

Update the `PrivateRegistriesService` to align with the GitHub Private Registries
API version `2026-03-10`.

**Changes:**
- Add `PrivateRegistryAuthType` type with constants for `token`, `username_password`,
  `oidc_azure`, `oidc_aws`, and `oidc_jfrog`
- Add OIDC-related fields to `CreateOrganizationPrivateRegistry` and
  `UpdateOrganizationPrivateRegistry`: `AuthType`, `TenantID`, `ClientID`,
  `AWSRegion`, `AccountID`, `RoleName`, `Domain`, `DomainOwner`,
  `JFrogOIDCProviderName `, `Audience`, `IdentityMappingName`
- Add `ReplacesBase` field to both Create and Update request structs
- Add `SelectedRepositoryIDs` field to `PrivateRegistry` response struct
- Change `EncryptedValue` and `KeyID` in `CreateOrganizationPrivateRegistry`
  to `*string` with `omitempty` (should be omitted for OIDC auth types)
- Change `UpdateOrganizationPrivateRegistry()` to return `(*Response, error)`
  since the API now returns 204 No Content

API docs: https://docs.github.com/rest/private-registries/organization-configurations?apiVersion=2026-03-10

Fixes: #4158.