### PR TITLE
feat: Add Copilot coding agent and content exclusion org endpoints

### DIFF
--- a/github/copilot.go
+++ b/github/copilot.go
@@ -356,19 +356,19 @@ func (s *CopilotService) ListCopilotEnterpriseSeats(ctx context.Context, enterpr
 	return copilotSeats, resp, nil
 }
 
-// ListCopilotCodingAgentRepositoriesResponse represents the response from listing
+// ListOrganizationCopilotCodingAgentRepositoriesResponse represents the response from listing
 // repositories enabled for the Copilot coding agent in an organization.
-type ListCopilotCodingAgentRepositoriesResponse struct {
+type ListOrganizationCopilotCodingAgentRepositoriesResponse struct {
 	TotalCount   int           `json:"total_count"`
 	Repositories []*Repository `json:"repositories"`
 }
 
-// ListCopilotCodingAgentRepositories lists repositories enabled for the Copilot coding agent in an organization.
+// ListOrganizationCodingAgentRepositories lists repositories enabled for the Copilot coding agent in an organization.
 //
 // GitHub API docs: https://docs.github.com/rest/copilot/copilot-coding-agent-management?apiVersion=2022-11-28#list-repositories-enabled-for-copilot-coding-agent-in-an-organization
 //
 //meta:operation GET /orgs/{org}/copilot/coding-agent/permissions/repositories
-func (s *CopilotService) ListCopilotCodingAgentRepositories(ctx context.Context, org string, opts *ListOptions) (*ListCopilotCodingAgentRepositoriesResponse, *Response, error) {
+func (s *CopilotService) ListOrganizationCodingAgentRepositories(ctx context.Context, org string, opts *ListOptions) (*ListOrganizationCopilotCodingAgentRepositoriesResponse, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/copilot/coding-agent/permissions/repositories", org)
 	u, err := addOptions(u, opts)
 	if err != nil {
@@ -380,7 +380,7 @@ func (s *CopilotService) ListCopilotCodingAgentRepositories(ctx context.Context,
 		return nil, nil, err
 	}
 
-	var result *ListCopilotCodingAgentRepositoriesResponse
+	var result *ListOrganizationCopilotCodingAgentRepositoriesResponse
 	resp, err := s.client.Do(ctx, req, &result)
 	if err != nil {
 		return nil, resp, err
@@ -394,12 +394,12 @@ func (s *CopilotService) ListCopilotCodingAgentRepositories(ctx context.Context,
 // list of file paths excluded from Copilot for that repository.
 type CopilotOrganizationContentExclusionDetails map[string][]string
 
-// GetCopilotOrganizationContentExclusionDetails gets the Copilot content exclusion rules for an organization.
+// GetOrganizationContentExclusionDetails gets the Copilot content exclusion rules for an organization.
 //
 // GitHub API docs: https://docs.github.com/rest/copilot/copilot-content-exclusion-management?apiVersion=2022-11-28#get-copilot-content-exclusion-rules-for-an-organization
 //
 //meta:operation GET /orgs/{org}/copilot/content_exclusion
-func (s *CopilotService) GetCopilotOrganizationContentExclusionDetails(ctx context.Context, org string) (CopilotOrganizationContentExclusionDetails, *Response, error) {
+func (s *CopilotService) GetOrganizationContentExclusionDetails(ctx context.Context, org string) (CopilotOrganizationContentExclusionDetails, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/copilot/content_exclusion", org)
 
 	req, err := s.client.NewRequest("GET", u, nil)

--- a/github/copilot.go
+++ b/github/copilot.go
@@ -356,6 +356,66 @@ func (s *CopilotService) ListCopilotEnterpriseSeats(ctx context.Context, enterpr
 	return copilotSeats, resp, nil
 }
 
+// ListCopilotCodingAgentRepositoriesResponse represents the response from listing
+// repositories enabled for the Copilot coding agent in an organization.
+type ListCopilotCodingAgentRepositoriesResponse struct {
+	TotalCount   int           `json:"total_count"`
+	Repositories []*Repository `json:"repositories"`
+}
+
+// ListCopilotCodingAgentRepositories lists repositories enabled for the Copilot coding agent in an organization.
+//
+// GitHub API docs: https://docs.github.com/rest/copilot/copilot-coding-agent-management?apiVersion=2022-11-28#list-repositories-enabled-for-copilot-coding-agent-in-an-organization
+//
+//meta:operation GET /orgs/{org}/copilot/coding-agent/permissions/repositories
+func (s *CopilotService) ListCopilotCodingAgentRepositories(ctx context.Context, org string, opts *ListOptions) (*ListCopilotCodingAgentRepositoriesResponse, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/copilot/coding-agent/permissions/repositories", org)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var result *ListCopilotCodingAgentRepositoriesResponse
+	resp, err := s.client.Do(ctx, req, &result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// CopilotOrganizationContentExclusionDetails lists all Copilot content exclusion
+// rules for an organization, keyed by repository full name. Each value is the
+// list of file paths excluded from Copilot for that repository.
+type CopilotOrganizationContentExclusionDetails map[string][]string
+
+// GetCopilotOrganizationContentExclusionDetails gets the Copilot content exclusion rules for an organization.
+//
+// GitHub API docs: https://docs.github.com/rest/copilot/copilot-content-exclusion-management?apiVersion=2022-11-28#get-copilot-content-exclusion-rules-for-an-organization
+//
+//meta:operation GET /orgs/{org}/copilot/content_exclusion
+func (s *CopilotService) GetCopilotOrganizationContentExclusionDetails(ctx context.Context, org string) (CopilotOrganizationContentExclusionDetails, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/copilot/content_exclusion", org)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	details := CopilotOrganizationContentExclusionDetails{}
+	resp, err := s.client.Do(ctx, req, &details)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return details, resp, nil
+}
+
 // AddCopilotTeams adds teams to the Copilot for Business subscription for an organization.
 //
 // GitHub API docs: https://docs.github.com/rest/copilot/copilot-user-management?apiVersion=2022-11-28#add-teams-to-the-copilot-subscription-for-an-organization

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -776,6 +776,130 @@ func TestCopilotService_ListCopilotEnterpriseSeats(t *testing.T) {
 	})
 }
 
+func TestCopilotService_ListCopilotCodingAgentRepositories(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/copilot/coding-agent/permissions/repositories", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"per_page": "100",
+			"page":     "1",
+		})
+		fmt.Fprint(w, `{
+			"total_count": 2,
+			"repositories": [
+				{"id": 1, "name": "Hello-World", "full_name": "octocat/Hello-World"},
+				{"id": 2, "name": "Hello-World-2", "full_name": "octocat/Hello-World-2"}
+			]
+		}`)
+	})
+
+	ctx := t.Context()
+	opts := &ListOptions{Page: 1, PerPage: 100}
+	got, _, err := client.Copilot.ListCopilotCodingAgentRepositories(ctx, "o", opts)
+	if err != nil {
+		t.Errorf("Copilot.ListCopilotCodingAgentRepositories returned error: %v", err)
+	}
+
+	want := &ListCopilotCodingAgentRepositoriesResponse{
+		TotalCount: 2,
+		Repositories: []*Repository{
+			{ID: Ptr(int64(1)), Name: Ptr("Hello-World"), FullName: Ptr("octocat/Hello-World")},
+			{ID: Ptr(int64(2)), Name: Ptr("Hello-World-2"), FullName: Ptr("octocat/Hello-World-2")},
+		},
+	}
+	if !cmp.Equal(got, want) {
+		t.Errorf("Copilot.ListCopilotCodingAgentRepositories returned %+v, want %+v", got, want)
+	}
+
+	const methodName = "ListCopilotCodingAgentRepositories"
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Copilot.ListCopilotCodingAgentRepositories(ctx, "\n", opts)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Copilot.ListCopilotCodingAgentRepositories(ctx, "o", opts)
+		if got != nil {
+			t.Errorf("Copilot.ListCopilotCodingAgentRepositories returned %+v, want nil", got)
+		}
+		return resp, err
+	})
+}
+
+func TestCopilotService_GetCopilotOrganizationContentExclusionDetails(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/copilot/content_exclusion", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"octo-repo": ["/src/some-dir/kernel.rs"],
+			"octo-repo-2": ["/docs/secret.md", "**/*.env"]
+		}`)
+	})
+
+	ctx := t.Context()
+	got, _, err := client.Copilot.GetCopilotOrganizationContentExclusionDetails(ctx, "o")
+	if err != nil {
+		t.Errorf("Copilot.GetCopilotOrganizationContentExclusionDetails returned error: %v", err)
+	}
+
+	want := CopilotOrganizationContentExclusionDetails{
+		"octo-repo":   {"/src/some-dir/kernel.rs"},
+		"octo-repo-2": {"/docs/secret.md", "**/*.env"},
+	}
+	if !cmp.Equal(got, want) {
+		t.Errorf("Copilot.GetCopilotOrganizationContentExclusionDetails returned %+v, want %+v", got, want)
+	}
+
+	const methodName = "GetCopilotOrganizationContentExclusionDetails"
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Copilot.GetCopilotOrganizationContentExclusionDetails(ctx, "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Copilot.GetCopilotOrganizationContentExclusionDetails(ctx, "o")
+		if got != nil {
+			t.Errorf("Copilot.GetCopilotOrganizationContentExclusionDetails returned %+v, want nil", got)
+		}
+		return resp, err
+	})
+}
+
+func TestListCopilotCodingAgentRepositoriesResponse_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &ListCopilotCodingAgentRepositoriesResponse{}, `{"total_count":0,"repositories":null}`)
+
+	r := &ListCopilotCodingAgentRepositoriesResponse{
+		TotalCount: 1,
+		Repositories: []*Repository{
+			{ID: Ptr(int64(1)), Name: Ptr("Hello-World"), FullName: Ptr("octocat/Hello-World")},
+		},
+	}
+	want := `{
+		"total_count": 1,
+		"repositories": [
+			{"id": 1, "name": "Hello-World", "full_name": "octocat/Hello-World"}
+		]
+	}`
+	testJSONMarshal(t, r, want)
+}
+
+func TestCopilotOrganizationContentExclusionDetails_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, CopilotOrganizationContentExclusionDetails{}, `{}`)
+
+	d := CopilotOrganizationContentExclusionDetails{
+		"octo-repo": {"/src/some-dir/kernel.rs"},
+	}
+	testJSONMarshal(t, d, `{"octo-repo":["/src/some-dir/kernel.rs"]}`)
+}
+
 func TestCopilotService_AddCopilotTeams(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -776,7 +776,7 @@ func TestCopilotService_ListCopilotEnterpriseSeats(t *testing.T) {
 	})
 }
 
-func TestCopilotService_ListCopilotCodingAgentRepositories(t *testing.T) {
+func TestCopilotService_ListOrganizationCodingAgentRepositories(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -797,12 +797,12 @@ func TestCopilotService_ListCopilotCodingAgentRepositories(t *testing.T) {
 
 	ctx := t.Context()
 	opts := &ListOptions{Page: 1, PerPage: 100}
-	got, _, err := client.Copilot.ListCopilotCodingAgentRepositories(ctx, "o", opts)
+	got, _, err := client.Copilot.ListOrganizationCodingAgentRepositories(ctx, "o", opts)
 	if err != nil {
-		t.Errorf("Copilot.ListCopilotCodingAgentRepositories returned error: %v", err)
+		t.Errorf("Copilot.ListOrganizationCodingAgentRepositories returned error: %v", err)
 	}
 
-	want := &ListCopilotCodingAgentRepositoriesResponse{
+	want := &ListOrganizationCopilotCodingAgentRepositoriesResponse{
 		TotalCount: 2,
 		Repositories: []*Repository{
 			{ID: Ptr(int64(1)), Name: Ptr("Hello-World"), FullName: Ptr("octocat/Hello-World")},
@@ -810,26 +810,26 @@ func TestCopilotService_ListCopilotCodingAgentRepositories(t *testing.T) {
 		},
 	}
 	if !cmp.Equal(got, want) {
-		t.Errorf("Copilot.ListCopilotCodingAgentRepositories returned %+v, want %+v", got, want)
+		t.Errorf("Copilot.ListOrganizationCodingAgentRepositories returned %+v, want %+v", got, want)
 	}
 
-	const methodName = "ListCopilotCodingAgentRepositories"
+	const methodName = "ListOrganizationCodingAgentRepositories"
 
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Copilot.ListCopilotCodingAgentRepositories(ctx, "\n", opts)
+		_, _, err = client.Copilot.ListOrganizationCodingAgentRepositories(ctx, "\n", opts)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Copilot.ListCopilotCodingAgentRepositories(ctx, "o", opts)
+		got, resp, err := client.Copilot.ListOrganizationCodingAgentRepositories(ctx, "o", opts)
 		if got != nil {
-			t.Errorf("Copilot.ListCopilotCodingAgentRepositories returned %+v, want nil", got)
+			t.Errorf("Copilot.ListOrganizationCodingAgentRepositories returned %+v, want nil", got)
 		}
 		return resp, err
 	})
 }
 
-func TestCopilotService_GetCopilotOrganizationContentExclusionDetails(t *testing.T) {
+func TestCopilotService_GetOrganizationContentExclusionDetails(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -842,9 +842,9 @@ func TestCopilotService_GetCopilotOrganizationContentExclusionDetails(t *testing
 	})
 
 	ctx := t.Context()
-	got, _, err := client.Copilot.GetCopilotOrganizationContentExclusionDetails(ctx, "o")
+	got, _, err := client.Copilot.GetOrganizationContentExclusionDetails(ctx, "o")
 	if err != nil {
-		t.Errorf("Copilot.GetCopilotOrganizationContentExclusionDetails returned error: %v", err)
+		t.Errorf("Copilot.GetOrganizationContentExclusionDetails returned error: %v", err)
 	}
 
 	want := CopilotOrganizationContentExclusionDetails{
@@ -852,30 +852,30 @@ func TestCopilotService_GetCopilotOrganizationContentExclusionDetails(t *testing
 		"octo-repo-2": {"/docs/secret.md", "**/*.env"},
 	}
 	if !cmp.Equal(got, want) {
-		t.Errorf("Copilot.GetCopilotOrganizationContentExclusionDetails returned %+v, want %+v", got, want)
+		t.Errorf("Copilot.GetOrganizationContentExclusionDetails returned %+v, want %+v", got, want)
 	}
 
-	const methodName = "GetCopilotOrganizationContentExclusionDetails"
+	const methodName = "GetOrganizationContentExclusionDetails"
 
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Copilot.GetCopilotOrganizationContentExclusionDetails(ctx, "\n")
+		_, _, err = client.Copilot.GetOrganizationContentExclusionDetails(ctx, "\n")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Copilot.GetCopilotOrganizationContentExclusionDetails(ctx, "o")
+		got, resp, err := client.Copilot.GetOrganizationContentExclusionDetails(ctx, "o")
 		if got != nil {
-			t.Errorf("Copilot.GetCopilotOrganizationContentExclusionDetails returned %+v, want nil", got)
+			t.Errorf("Copilot.GetOrganizationContentExclusionDetails returned %+v, want nil", got)
 		}
 		return resp, err
 	})
 }
 
-func TestListCopilotCodingAgentRepositoriesResponse_Marshal(t *testing.T) {
+func TestListOrganizationCopilotCodingAgentRepositoriesResponse_Marshal(t *testing.T) {
 	t.Parallel()
-	testJSONMarshal(t, &ListCopilotCodingAgentRepositoriesResponse{}, `{"total_count":0,"repositories":null}`)
+	testJSONMarshal(t, &ListOrganizationCopilotCodingAgentRepositoriesResponse{}, `{"total_count":0,"repositories":null}`)
 
-	r := &ListCopilotCodingAgentRepositoriesResponse{
+	r := &ListOrganizationCopilotCodingAgentRepositoriesResponse{
 		TotalCount: 1,
 		Repositories: []*Repository{
 			{ID: Ptr(int64(1)), Name: Ptr("Hello-World"), FullName: Ptr("octocat/Hello-World")},

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -19886,22 +19886,6 @@ func (l *ListContributorsOptions) GetAnon() string {
 	return l.Anon
 }
 
-// GetRepositories returns the Repositories slice if it's non-nil, nil otherwise.
-func (l *ListCopilotCodingAgentRepositoriesResponse) GetRepositories() []*Repository {
-	if l == nil || l.Repositories == nil {
-		return nil
-	}
-	return l.Repositories
-}
-
-// GetTotalCount returns the TotalCount field.
-func (l *ListCopilotCodingAgentRepositoriesResponse) GetTotalCount() int {
-	if l == nil {
-		return 0
-	}
-	return l.TotalCount
-}
-
 // GetSeats returns the Seats slice if it's non-nil, nil otherwise.
 func (l *ListCopilotSeatsResponse) GetSeats() []*CopilotSeatDetails {
 	if l == nil || l.Seats == nil {
@@ -20268,6 +20252,22 @@ func (l *ListOptions) GetPerPage() int {
 		return 0
 	}
 	return l.PerPage
+}
+
+// GetRepositories returns the Repositories slice if it's non-nil, nil otherwise.
+func (l *ListOrganizationCopilotCodingAgentRepositoriesResponse) GetRepositories() []*Repository {
+	if l == nil || l.Repositories == nil {
+		return nil
+	}
+	return l.Repositories
+}
+
+// GetTotalCount returns the TotalCount field.
+func (l *ListOrganizationCopilotCodingAgentRepositoriesResponse) GetTotalCount() int {
+	if l == nil {
+		return 0
+	}
+	return l.TotalCount
 }
 
 // GetOrganizations returns the Organizations slice if it's non-nil, nil otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -19886,6 +19886,22 @@ func (l *ListContributorsOptions) GetAnon() string {
 	return l.Anon
 }
 
+// GetRepositories returns the Repositories slice if it's non-nil, nil otherwise.
+func (l *ListCopilotCodingAgentRepositoriesResponse) GetRepositories() []*Repository {
+	if l == nil || l.Repositories == nil {
+		return nil
+	}
+	return l.Repositories
+}
+
+// GetTotalCount returns the TotalCount field.
+func (l *ListCopilotCodingAgentRepositoriesResponse) GetTotalCount() int {
+	if l == nil {
+		return 0
+	}
+	return l.TotalCount
+}
+
 // GetSeats returns the Seats slice if it's non-nil, nil otherwise.
 func (l *ListCopilotSeatsResponse) GetSeats() []*CopilotSeatDetails {
 	if l == nil || l.Seats == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -25140,25 +25140,6 @@ func TestListContributorsOptions_GetAnon(tt *testing.T) {
 	l.GetAnon()
 }
 
-func TestListCopilotCodingAgentRepositoriesResponse_GetRepositories(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := []*Repository{}
-	l := &ListCopilotCodingAgentRepositoriesResponse{Repositories: zeroValue}
-	l.GetRepositories()
-	l = &ListCopilotCodingAgentRepositoriesResponse{}
-	l.GetRepositories()
-	l = nil
-	l.GetRepositories()
-}
-
-func TestListCopilotCodingAgentRepositoriesResponse_GetTotalCount(tt *testing.T) {
-	tt.Parallel()
-	l := &ListCopilotCodingAgentRepositoriesResponse{}
-	l.GetTotalCount()
-	l = nil
-	l.GetTotalCount()
-}
-
 func TestListCopilotSeatsResponse_GetSeats(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []*CopilotSeatDetails{}
@@ -25588,6 +25569,25 @@ func TestListOptions_GetPerPage(tt *testing.T) {
 	l.GetPerPage()
 	l = nil
 	l.GetPerPage()
+}
+
+func TestListOrganizationCopilotCodingAgentRepositoriesResponse_GetRepositories(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*Repository{}
+	l := &ListOrganizationCopilotCodingAgentRepositoriesResponse{Repositories: zeroValue}
+	l.GetRepositories()
+	l = &ListOrganizationCopilotCodingAgentRepositoriesResponse{}
+	l.GetRepositories()
+	l = nil
+	l.GetRepositories()
+}
+
+func TestListOrganizationCopilotCodingAgentRepositoriesResponse_GetTotalCount(tt *testing.T) {
+	tt.Parallel()
+	l := &ListOrganizationCopilotCodingAgentRepositoriesResponse{}
+	l.GetTotalCount()
+	l = nil
+	l.GetTotalCount()
 }
 
 func TestListOrganizations_GetOrganizations(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -25140,6 +25140,25 @@ func TestListContributorsOptions_GetAnon(tt *testing.T) {
 	l.GetAnon()
 }
 
+func TestListCopilotCodingAgentRepositoriesResponse_GetRepositories(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*Repository{}
+	l := &ListCopilotCodingAgentRepositoriesResponse{Repositories: zeroValue}
+	l.GetRepositories()
+	l = &ListCopilotCodingAgentRepositoriesResponse{}
+	l.GetRepositories()
+	l = nil
+	l.GetRepositories()
+}
+
+func TestListCopilotCodingAgentRepositoriesResponse_GetTotalCount(tt *testing.T) {
+	tt.Parallel()
+	l := &ListCopilotCodingAgentRepositoriesResponse{}
+	l.GetTotalCount()
+	l = nil
+	l.GetTotalCount()
+}
+
 func TestListCopilotSeatsResponse_GetSeats(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []*CopilotSeatDetails{}

--- a/github/github-iterators.go
+++ b/github/github-iterators.go
@@ -2397,41 +2397,6 @@ func (s *CodespacesService) ListUserSecretsIter(ctx context.Context, opts *ListO
 	}
 }
 
-// ListCopilotCodingAgentRepositoriesIter returns an iterator that paginates through all results of ListCopilotCodingAgentRepositories.
-func (s *CopilotService) ListCopilotCodingAgentRepositoriesIter(ctx context.Context, org string, opts *ListOptions) iter.Seq2[*Repository, error] {
-	return func(yield func(*Repository, error) bool) {
-		// Create a copy of opts to avoid mutating the caller's struct
-		if opts == nil {
-			opts = &ListOptions{}
-		} else {
-			opts = Ptr(*opts)
-		}
-
-		for {
-			results, resp, err := s.ListCopilotCodingAgentRepositories(ctx, org, opts)
-			if err != nil {
-				yield(nil, err)
-				return
-			}
-
-			var iterItems []*Repository
-			if results != nil {
-				iterItems = results.Repositories
-			}
-			for _, item := range iterItems {
-				if !yield(item, nil) {
-					return
-				}
-			}
-
-			if resp.NextPage == 0 {
-				break
-			}
-			opts.Page = resp.NextPage
-		}
-	}
-}
-
 // ListCopilotEnterpriseSeatsIter returns an iterator that paginates through all results of ListCopilotEnterpriseSeats.
 func (s *CopilotService) ListCopilotEnterpriseSeatsIter(ctx context.Context, enterprise string, opts *ListOptions) iter.Seq2[*CopilotSeatDetails, error] {
 	return func(yield func(*CopilotSeatDetails, error) bool) {
@@ -2487,6 +2452,41 @@ func (s *CopilotService) ListCopilotSeatsIter(ctx context.Context, org string, o
 			var iterItems []*CopilotSeatDetails
 			if results != nil {
 				iterItems = results.Seats
+			}
+			for _, item := range iterItems {
+				if !yield(item, nil) {
+					return
+				}
+			}
+
+			if resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
+		}
+	}
+}
+
+// ListOrganizationCodingAgentRepositoriesIter returns an iterator that paginates through all results of ListOrganizationCodingAgentRepositories.
+func (s *CopilotService) ListOrganizationCodingAgentRepositoriesIter(ctx context.Context, org string, opts *ListOptions) iter.Seq2[*Repository, error] {
+	return func(yield func(*Repository, error) bool) {
+		// Create a copy of opts to avoid mutating the caller's struct
+		if opts == nil {
+			opts = &ListOptions{}
+		} else {
+			opts = Ptr(*opts)
+		}
+
+		for {
+			results, resp, err := s.ListOrganizationCodingAgentRepositories(ctx, org, opts)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			var iterItems []*Repository
+			if results != nil {
+				iterItems = results.Repositories
 			}
 			for _, item := range iterItems {
 				if !yield(item, nil) {

--- a/github/github-iterators.go
+++ b/github/github-iterators.go
@@ -2397,6 +2397,41 @@ func (s *CodespacesService) ListUserSecretsIter(ctx context.Context, opts *ListO
 	}
 }
 
+// ListCopilotCodingAgentRepositoriesIter returns an iterator that paginates through all results of ListCopilotCodingAgentRepositories.
+func (s *CopilotService) ListCopilotCodingAgentRepositoriesIter(ctx context.Context, org string, opts *ListOptions) iter.Seq2[*Repository, error] {
+	return func(yield func(*Repository, error) bool) {
+		// Create a copy of opts to avoid mutating the caller's struct
+		if opts == nil {
+			opts = &ListOptions{}
+		} else {
+			opts = Ptr(*opts)
+		}
+
+		for {
+			results, resp, err := s.ListCopilotCodingAgentRepositories(ctx, org, opts)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			var iterItems []*Repository
+			if results != nil {
+				iterItems = results.Repositories
+			}
+			for _, item := range iterItems {
+				if !yield(item, nil) {
+					return
+				}
+			}
+
+			if resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
+		}
+	}
+}
+
 // ListCopilotEnterpriseSeatsIter returns an iterator that paginates through all results of ListCopilotEnterpriseSeats.
 func (s *CopilotService) ListCopilotEnterpriseSeatsIter(ctx context.Context, enterprise string, opts *ListOptions) iter.Seq2[*CopilotSeatDetails, error] {
 	return func(yield func(*CopilotSeatDetails, error) bool) {

--- a/github/github-iterators_test.go
+++ b/github/github-iterators_test.go
@@ -5127,78 +5127,6 @@ func TestCodespacesService_ListUserSecretsIter(t *testing.T) {
 	}
 }
 
-func TestCopilotService_ListCopilotCodingAgentRepositoriesIter(t *testing.T) {
-	t.Parallel()
-	client, mux, _ := setup(t)
-	var callNum int
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		callNum++
-		switch callNum {
-		case 1:
-			w.Header().Set("Link", `<https://api.github.com/?page=1>; rel="next"`)
-			fmt.Fprint(w, `{"repositories": [{},{},{}]}`)
-		case 2:
-			fmt.Fprint(w, `{"repositories": [{},{},{},{}]}`)
-		case 3:
-			fmt.Fprint(w, `{"repositories": [{},{}]}`)
-		case 4:
-			w.WriteHeader(http.StatusNotFound)
-		case 5:
-			fmt.Fprint(w, `{"repositories": [{},{}]}`)
-		}
-	})
-
-	iter := client.Copilot.ListCopilotCodingAgentRepositoriesIter(t.Context(), "", nil)
-	var gotItems int
-	for _, err := range iter {
-		gotItems++
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-	}
-	if want := 7; gotItems != want {
-		t.Errorf("client.Copilot.ListCopilotCodingAgentRepositoriesIter call 1 got %v items; want %v", gotItems, want)
-	}
-
-	opts := &ListOptions{}
-	iter = client.Copilot.ListCopilotCodingAgentRepositoriesIter(t.Context(), "", opts)
-	gotItems = 0
-	for _, err := range iter {
-		gotItems++
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-	}
-	if want := 2; gotItems != want {
-		t.Errorf("client.Copilot.ListCopilotCodingAgentRepositoriesIter call 2 got %v items; want %v", gotItems, want)
-	}
-
-	iter = client.Copilot.ListCopilotCodingAgentRepositoriesIter(t.Context(), "", nil)
-	gotItems = 0
-	for _, err := range iter {
-		gotItems++
-		if err == nil {
-			t.Error("expected error; got nil")
-		}
-	}
-	if gotItems != 1 {
-		t.Errorf("client.Copilot.ListCopilotCodingAgentRepositoriesIter call 3 got %v items; want 1 (an error)", gotItems)
-	}
-
-	iter = client.Copilot.ListCopilotCodingAgentRepositoriesIter(t.Context(), "", nil)
-	gotItems = 0
-	iter(func(item *Repository, err error) bool {
-		gotItems++
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-		return false
-	})
-	if gotItems != 1 {
-		t.Errorf("client.Copilot.ListCopilotCodingAgentRepositoriesIter call 4 got %v items; want 1 (an error)", gotItems)
-	}
-}
-
 func TestCopilotService_ListCopilotEnterpriseSeatsIter(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
@@ -5340,6 +5268,78 @@ func TestCopilotService_ListCopilotSeatsIter(t *testing.T) {
 	})
 	if gotItems != 1 {
 		t.Errorf("client.Copilot.ListCopilotSeatsIter call 4 got %v items; want 1 (an error)", gotItems)
+	}
+}
+
+func TestCopilotService_ListOrganizationCodingAgentRepositoriesIter(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+	var callNum int
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		callNum++
+		switch callNum {
+		case 1:
+			w.Header().Set("Link", `<https://api.github.com/?page=1>; rel="next"`)
+			fmt.Fprint(w, `{"repositories": [{},{},{}]}`)
+		case 2:
+			fmt.Fprint(w, `{"repositories": [{},{},{},{}]}`)
+		case 3:
+			fmt.Fprint(w, `{"repositories": [{},{}]}`)
+		case 4:
+			w.WriteHeader(http.StatusNotFound)
+		case 5:
+			fmt.Fprint(w, `{"repositories": [{},{}]}`)
+		}
+	})
+
+	iter := client.Copilot.ListOrganizationCodingAgentRepositoriesIter(t.Context(), "", nil)
+	var gotItems int
+	for _, err := range iter {
+		gotItems++
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+	if want := 7; gotItems != want {
+		t.Errorf("client.Copilot.ListOrganizationCodingAgentRepositoriesIter call 1 got %v items; want %v", gotItems, want)
+	}
+
+	opts := &ListOptions{}
+	iter = client.Copilot.ListOrganizationCodingAgentRepositoriesIter(t.Context(), "", opts)
+	gotItems = 0
+	for _, err := range iter {
+		gotItems++
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+	if want := 2; gotItems != want {
+		t.Errorf("client.Copilot.ListOrganizationCodingAgentRepositoriesIter call 2 got %v items; want %v", gotItems, want)
+	}
+
+	iter = client.Copilot.ListOrganizationCodingAgentRepositoriesIter(t.Context(), "", nil)
+	gotItems = 0
+	for _, err := range iter {
+		gotItems++
+		if err == nil {
+			t.Error("expected error; got nil")
+		}
+	}
+	if gotItems != 1 {
+		t.Errorf("client.Copilot.ListOrganizationCodingAgentRepositoriesIter call 3 got %v items; want 1 (an error)", gotItems)
+	}
+
+	iter = client.Copilot.ListOrganizationCodingAgentRepositoriesIter(t.Context(), "", nil)
+	gotItems = 0
+	iter(func(item *Repository, err error) bool {
+		gotItems++
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		return false
+	})
+	if gotItems != 1 {
+		t.Errorf("client.Copilot.ListOrganizationCodingAgentRepositoriesIter call 4 got %v items; want 1 (an error)", gotItems)
 	}
 }
 

--- a/github/github-iterators_test.go
+++ b/github/github-iterators_test.go
@@ -5127,6 +5127,78 @@ func TestCodespacesService_ListUserSecretsIter(t *testing.T) {
 	}
 }
 
+func TestCopilotService_ListCopilotCodingAgentRepositoriesIter(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+	var callNum int
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		callNum++
+		switch callNum {
+		case 1:
+			w.Header().Set("Link", `<https://api.github.com/?page=1>; rel="next"`)
+			fmt.Fprint(w, `{"repositories": [{},{},{}]}`)
+		case 2:
+			fmt.Fprint(w, `{"repositories": [{},{},{},{}]}`)
+		case 3:
+			fmt.Fprint(w, `{"repositories": [{},{}]}`)
+		case 4:
+			w.WriteHeader(http.StatusNotFound)
+		case 5:
+			fmt.Fprint(w, `{"repositories": [{},{}]}`)
+		}
+	})
+
+	iter := client.Copilot.ListCopilotCodingAgentRepositoriesIter(t.Context(), "", nil)
+	var gotItems int
+	for _, err := range iter {
+		gotItems++
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+	if want := 7; gotItems != want {
+		t.Errorf("client.Copilot.ListCopilotCodingAgentRepositoriesIter call 1 got %v items; want %v", gotItems, want)
+	}
+
+	opts := &ListOptions{}
+	iter = client.Copilot.ListCopilotCodingAgentRepositoriesIter(t.Context(), "", opts)
+	gotItems = 0
+	for _, err := range iter {
+		gotItems++
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+	if want := 2; gotItems != want {
+		t.Errorf("client.Copilot.ListCopilotCodingAgentRepositoriesIter call 2 got %v items; want %v", gotItems, want)
+	}
+
+	iter = client.Copilot.ListCopilotCodingAgentRepositoriesIter(t.Context(), "", nil)
+	gotItems = 0
+	for _, err := range iter {
+		gotItems++
+		if err == nil {
+			t.Error("expected error; got nil")
+		}
+	}
+	if gotItems != 1 {
+		t.Errorf("client.Copilot.ListCopilotCodingAgentRepositoriesIter call 3 got %v items; want 1 (an error)", gotItems)
+	}
+
+	iter = client.Copilot.ListCopilotCodingAgentRepositoriesIter(t.Context(), "", nil)
+	gotItems = 0
+	iter(func(item *Repository, err error) bool {
+		gotItems++
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		return false
+	})
+	if gotItems != 1 {
+		t.Errorf("client.Copilot.ListCopilotCodingAgentRepositoriesIter call 4 got %v items; want 1 (an error)", gotItems)
+	}
+}
+
 func TestCopilotService_ListCopilotEnterpriseSeatsIter(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)


### PR DESCRIPTION
Implement support for two Copilot organization management endpoints under the CopilotService.

- Add ListCopilotCodingAgentRepositories for GET /orgs/{org}/copilot/coding-agent/permissions/repositories.
- Add GetCopilotOrganizationContentExclusionDetails for GET /orgs/{org}/copilot/content_exclusion.
- Add tests covering both endpoints, JSON round-trip tests for the new types, and regenerate accessors and iterators.

API docs:
- https://docs.github.com/rest/copilot/copilot-coding-agent-management#list-repositories-enabled-for-copilot-coding-agent-in-an-organization
- https://docs.github.com/rest/copilot/copilot-content-exclusion-management#get-copilot-content-exclusion-rules-for-an-organization

Fixes: #4175