### PR TITLE
feat: Add typed Copilot metrics download helpers

### DIFF
--- a/github/copilot.go
+++ b/github/copilot.go
@@ -854,45 +854,56 @@ func (s *CopilotService) DownloadCopilotMetrics(ctx context.Context, url string)
 
 // CopilotMetricsPullRequests represents pull request totals in a Copilot metrics report.
 type CopilotMetricsPullRequests struct {
-	TotalReviewed                       int     `json:"total_reviewed"`
-	TotalCreated                        int     `json:"total_created"`
-	TotalCreatedByCopilot               int     `json:"total_created_by_copilot"`
-	TotalReviewedByCopilot              int     `json:"total_reviewed_by_copilot"`
-	TotalMerged                         int     `json:"total_merged"`
-	MedianMinutesToMerge                float64 `json:"median_minutes_to_merge"`
-	TotalSuggestions                    int     `json:"total_suggestions"`
-	TotalAppliedSuggestions             int     `json:"total_applied_suggestions"`
-	TotalMergedCreatedByCopilot         int     `json:"total_merged_created_by_copilot"`
-	MedianMinutesToMergeCopilotAuthored float64 `json:"median_minutes_to_merge_copilot_authored"`
-	TotalCopilotSuggestions             int     `json:"total_copilot_suggestions"`
-	TotalCopilotAppliedSuggestions      int     `json:"total_copilot_applied_suggestions"`
-	MedianMinutesToMergeCopilotReviewed float64 `json:"median_minutes_to_merge_copilot_reviewed"`
-	TotalMergedReviewedByCopilot        int     `json:"total_merged_reviewed_by_copilot"`
+	TotalReviewed                       *int     `json:"total_reviewed,omitempty"`
+	TotalCreated                        *int     `json:"total_created,omitempty"`
+	TotalCreatedByCopilot               *int     `json:"total_created_by_copilot,omitempty"`
+	TotalReviewedByCopilot              *int     `json:"total_reviewed_by_copilot,omitempty"`
+	TotalMerged                         *int     `json:"total_merged,omitempty"`
+	MedianMinutesToMerge                *float64 `json:"median_minutes_to_merge,omitempty"`
+	TotalSuggestions                    *int     `json:"total_suggestions,omitempty"`
+	TotalAppliedSuggestions             *int     `json:"total_applied_suggestions,omitempty"`
+	TotalMergedCreatedByCopilot         *int     `json:"total_merged_created_by_copilot,omitempty"`
+	MedianMinutesToMergeCopilotAuthored *float64 `json:"median_minutes_to_merge_copilot_authored,omitempty"`
+	TotalCopilotSuggestions             *int     `json:"total_copilot_suggestions,omitempty"`
+	TotalCopilotAppliedSuggestions      *int     `json:"total_copilot_applied_suggestions,omitempty"`
+	MedianMinutesToMergeCopilotReviewed *float64 `json:"median_minutes_to_merge_copilot_reviewed,omitempty"`
+	TotalMergedReviewedByCopilot        *int     `json:"total_merged_reviewed_by_copilot,omitempty"`
 }
 
 // CopilotMetricsCodeActivity captures the code-generation activity counts and lines-of-code (LOC)
 // suggestion totals shared across the per-IDE, per-feature, per-language, and per-model breakdowns
 // in a Copilot metrics report.
 type CopilotMetricsCodeActivity struct {
-	CodeGenerationActivityCount int `json:"code_generation_activity_count"`
-	CodeAcceptanceActivityCount int `json:"code_acceptance_activity_count"`
-	LOCSuggestedToAddSum        int `json:"loc_suggested_to_add_sum"`
-	LOCSuggestedToDeleteSum     int `json:"loc_suggested_to_delete_sum"`
-	LOCAddedSum                 int `json:"loc_added_sum"`
-	LOCDeletedSum               int `json:"loc_deleted_sum"`
+	CodeGenerationActivityCount *int `json:"code_generation_activity_count,omitempty"`
+	CodeAcceptanceActivityCount *int `json:"code_acceptance_activity_count,omitempty"`
+	LOCSuggestedToAddSum        *int `json:"loc_suggested_to_add_sum,omitempty"`
+	LOCSuggestedToDeleteSum     *int `json:"loc_suggested_to_delete_sum,omitempty"`
+	LOCAddedSum                 *int `json:"loc_added_sum,omitempty"`
+	LOCDeletedSum               *int `json:"loc_deleted_sum,omitempty"`
+}
+
+// CopilotMetricsChatPanel captures per-mode chat panel interaction counts shared across daily,
+// periodic, and user metrics reports. Each field is a subset of user_initiated_interaction_count
+// attributed to that chat panel mode.
+type CopilotMetricsChatPanel struct {
+	ChatPanelAgentMode   *int `json:"chat_panel_agent_mode,omitempty"`
+	ChatPanelAskMode     *int `json:"chat_panel_ask_mode,omitempty"`
+	ChatPanelCustomMode  *int `json:"chat_panel_custom_mode,omitempty"`
+	ChatPanelEditMode    *int `json:"chat_panel_edit_mode,omitempty"`
+	ChatPanelUnknownMode *int `json:"chat_panel_unknown_mode,omitempty"`
 }
 
 // CopilotMetricsIDE represents per-IDE aggregate totals in a Copilot metrics report.
 type CopilotMetricsIDE struct {
 	IDE                           string `json:"ide"`
-	UserInitiatedInteractionCount int    `json:"user_initiated_interaction_count"`
+	UserInitiatedInteractionCount *int   `json:"user_initiated_interaction_count,omitempty"`
 	CopilotMetricsCodeActivity
 }
 
 // CopilotMetricsFeature represents per-feature aggregate totals in a Copilot metrics report.
 type CopilotMetricsFeature struct {
 	Feature                       string `json:"feature"`
-	UserInitiatedInteractionCount int    `json:"user_initiated_interaction_count"`
+	UserInitiatedInteractionCount *int   `json:"user_initiated_interaction_count,omitempty"`
 	CopilotMetricsCodeActivity
 }
 
@@ -914,7 +925,7 @@ type CopilotMetricsLanguageModel struct {
 type CopilotMetricsModelFeature struct {
 	Model                         string `json:"model"`
 	Feature                       string `json:"feature"`
-	UserInitiatedInteractionCount int    `json:"user_initiated_interaction_count"`
+	UserInitiatedInteractionCount *int   `json:"user_initiated_interaction_count,omitempty"`
 	CopilotMetricsCodeActivity
 }
 
@@ -926,48 +937,49 @@ type CopilotMetricsCLIVersion struct {
 
 // CopilotMetricsCLITokenUsage represents Copilot CLI token totals in a metrics report.
 type CopilotMetricsCLITokenUsage struct {
-	AvgTokensPerRequest float64 `json:"avg_tokens_per_request"`
-	OutputTokensSum     int     `json:"output_tokens_sum"`
-	PromptTokensSum     int     `json:"prompt_tokens_sum"`
+	AvgTokensPerRequest *float64 `json:"avg_tokens_per_request,omitempty"`
+	OutputTokensSum     *int     `json:"output_tokens_sum,omitempty"`
+	PromptTokensSum     *int     `json:"prompt_tokens_sum,omitempty"`
 }
 
 // CopilotMetricsCLI represents Copilot CLI totals in a metrics report.
 type CopilotMetricsCLI struct {
-	SessionCount        int                          `json:"session_count"`
-	RequestCount        int                          `json:"request_count"`
-	PromptCount         int                          `json:"prompt_count"`
+	SessionCount        *int                         `json:"session_count,omitempty"`
+	RequestCount        *int                         `json:"request_count,omitempty"`
+	PromptCount         *int                         `json:"prompt_count,omitempty"`
 	TokenUsage          *CopilotMetricsCLITokenUsage `json:"token_usage,omitempty"`
 	LastKnownCLIVersion *CopilotMetricsCLIVersion    `json:"last_known_cli_version,omitempty"`
 }
 
 // CopilotDailyMetrics represents the payload downloaded from a 1-day Copilot usage metrics report.
 type CopilotDailyMetrics struct {
-	Day                                 string                           `json:"day"`
-	OrganizationID                      string                           `json:"organization_id"`
-	EnterpriseID                        string                           `json:"enterprise_id"`
-	DailyActiveCLIUsers                 int                              `json:"daily_active_cli_users"`
-	DailyActiveUsers                    int                              `json:"daily_active_users"`
-	DailyActiveCopilotCloudAgentUsers   int                              `json:"daily_active_copilot_cloud_agent_users"`
-	WeeklyActiveUsers                   int                              `json:"weekly_active_users"`
-	WeeklyActiveCopilotCloudAgentUsers  int                              `json:"weekly_active_copilot_cloud_agent_users"`
-	MonthlyActiveUsers                  int                              `json:"monthly_active_users"`
-	MonthlyActiveChatUsers              int                              `json:"monthly_active_chat_users"`
-	MonthlyActiveAgentUsers             int                              `json:"monthly_active_agent_users"`
-	MonthlyActiveCopilotCloudAgentUsers int                              `json:"monthly_active_copilot_cloud_agent_users"`
-	UserInitiatedInteractionCount       int                              `json:"user_initiated_interaction_count"`
-	CodeGenerationActivityCount         int                              `json:"code_generation_activity_count"`
-	CodeAcceptanceActivityCount         int                              `json:"code_acceptance_activity_count"`
-	TotalsByIDE                         []*CopilotMetricsIDE             `json:"totals_by_ide,omitempty"`
-	TotalsByFeature                     []*CopilotMetricsFeature         `json:"totals_by_feature,omitempty"`
-	TotalsByLanguageFeature             []*CopilotMetricsLanguageFeature `json:"totals_by_language_feature,omitempty"`
-	TotalsByLanguageModel               []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
-	TotalsByModelFeature                []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
-	TotalsByCLI                         *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
-	LOCSuggestedToAddSum                int                              `json:"loc_suggested_to_add_sum"`
-	LOCSuggestedToDeleteSum             int                              `json:"loc_suggested_to_delete_sum"`
-	LOCAddedSum                         int                              `json:"loc_added_sum"`
-	LOCDeletedSum                       int                              `json:"loc_deleted_sum"`
-	PullRequests                        *CopilotMetricsPullRequests      `json:"pull_requests,omitempty"`
+	Day                                 string  `json:"day"`
+	OrganizationID                      *string `json:"organization_id,omitempty"`
+	EnterpriseID                        *string `json:"enterprise_id,omitempty"`
+	DailyActiveCLIUsers                 *int    `json:"daily_active_cli_users,omitempty"`
+	DailyActiveUsers                    *int    `json:"daily_active_users,omitempty"`
+	DailyActiveCopilotCloudAgentUsers   *int    `json:"daily_active_copilot_cloud_agent_users,omitempty"`
+	WeeklyActiveUsers                   *int    `json:"weekly_active_users,omitempty"`
+	WeeklyActiveCopilotCloudAgentUsers  *int    `json:"weekly_active_copilot_cloud_agent_users,omitempty"`
+	MonthlyActiveUsers                  *int    `json:"monthly_active_users,omitempty"`
+	MonthlyActiveChatUsers              *int    `json:"monthly_active_chat_users,omitempty"`
+	MonthlyActiveAgentUsers             *int    `json:"monthly_active_agent_users,omitempty"`
+	MonthlyActiveCopilotCloudAgentUsers *int    `json:"monthly_active_copilot_cloud_agent_users,omitempty"`
+	UserInitiatedInteractionCount       *int    `json:"user_initiated_interaction_count,omitempty"`
+	CopilotMetricsChatPanel
+	CodeGenerationActivityCount *int                             `json:"code_generation_activity_count,omitempty"`
+	CodeAcceptanceActivityCount *int                             `json:"code_acceptance_activity_count,omitempty"`
+	TotalsByIDE                 []*CopilotMetricsIDE             `json:"totals_by_ide,omitempty"`
+	TotalsByFeature             []*CopilotMetricsFeature         `json:"totals_by_feature,omitempty"`
+	TotalsByLanguageFeature     []*CopilotMetricsLanguageFeature `json:"totals_by_language_feature,omitempty"`
+	TotalsByLanguageModel       []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
+	TotalsByModelFeature        []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
+	TotalsByCLI                 *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
+	LOCSuggestedToAddSum        *int                             `json:"loc_suggested_to_add_sum,omitempty"`
+	LOCSuggestedToDeleteSum     *int                             `json:"loc_suggested_to_delete_sum,omitempty"`
+	LOCAddedSum                 *int                             `json:"loc_added_sum,omitempty"`
+	LOCDeletedSum               *int                             `json:"loc_deleted_sum,omitempty"`
+	PullRequests                *CopilotMetricsPullRequests      `json:"pull_requests,omitempty"`
 }
 
 // CopilotPeriodicMetrics represents the payload downloaded from a multi-day (e.g. 28-day rolling)
@@ -977,8 +989,8 @@ type CopilotDailyMetrics struct {
 type CopilotPeriodicMetrics struct {
 	ReportStartDay string                 `json:"report_start_day"`
 	ReportEndDay   string                 `json:"report_end_day"`
-	OrganizationID string                 `json:"organization_id"`
-	EnterpriseID   string                 `json:"enterprise_id"`
+	OrganizationID *string                `json:"organization_id,omitempty"`
+	EnterpriseID   *string                `json:"enterprise_id,omitempty"`
 	CreatedAt      *Timestamp             `json:"created_at,omitempty"`
 	DayTotals      []*CopilotDailyMetrics `json:"day_totals,omitempty"`
 }
@@ -999,7 +1011,7 @@ type CopilotUserMetricsIDEVersion struct {
 // CopilotUserMetricsIDE represents per-IDE totals for a single Copilot user in a user metrics report.
 type CopilotUserMetricsIDE struct {
 	IDE                           string `json:"ide"`
-	UserInitiatedInteractionCount int    `json:"user_initiated_interaction_count"`
+	UserInitiatedInteractionCount *int   `json:"user_initiated_interaction_count,omitempty"`
 	CopilotMetricsCodeActivity
 	LastKnownPluginVersion *CopilotUserMetricsPluginVersion `json:"last_known_plugin_version,omitempty"`
 	LastKnownIDEVersion    *CopilotUserMetricsIDEVersion    `json:"last_known_ide_version,omitempty"`
@@ -1008,62 +1020,64 @@ type CopilotUserMetricsIDE struct {
 // CopilotUserDailyMetrics represents a single user's per-day Copilot usage metrics record from a
 // 1-day user metrics report. User metrics reports are served as newline-delimited JSON.
 type CopilotUserDailyMetrics struct {
-	UserID                        int                              `json:"user_id"`
-	UserLogin                     string                           `json:"user_login"`
-	Day                           string                           `json:"day"`
-	OrganizationID                string                           `json:"organization_id"`
-	EnterpriseID                  string                           `json:"enterprise_id"`
-	UserInitiatedInteractionCount int                              `json:"user_initiated_interaction_count"`
-	CodeGenerationActivityCount   int                              `json:"code_generation_activity_count"`
-	CodeAcceptanceActivityCount   int                              `json:"code_acceptance_activity_count"`
-	TotalsByIDE                   []*CopilotUserMetricsIDE         `json:"totals_by_ide,omitempty"`
-	TotalsByFeature               []*CopilotMetricsFeature         `json:"totals_by_feature,omitempty"`
-	TotalsByLanguageFeature       []*CopilotMetricsLanguageFeature `json:"totals_by_language_feature,omitempty"`
-	TotalsByLanguageModel         []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
-	TotalsByModelFeature          []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
-	TotalsByCLI                   *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
-	UsedAgent                     bool                             `json:"used_agent"`
-	UsedChat                      bool                             `json:"used_chat"`
-	UsedCLI                       bool                             `json:"used_cli"`
-	UsedCopilotCodeReviewActive   bool                             `json:"used_copilot_code_review_active"`
-	UsedCopilotCodeReviewPassive  bool                             `json:"used_copilot_code_review_passive"`
-	UsedCopilotCodingAgent        bool                             `json:"used_copilot_coding_agent"`
-	LOCSuggestedToAddSum          int                              `json:"loc_suggested_to_add_sum"`
-	LOCSuggestedToDeleteSum       int                              `json:"loc_suggested_to_delete_sum"`
-	LOCAddedSum                   int                              `json:"loc_added_sum"`
-	LOCDeletedSum                 int                              `json:"loc_deleted_sum"`
+	UserID                        int     `json:"user_id"`
+	UserLogin                     string  `json:"user_login"`
+	Day                           string  `json:"day"`
+	OrganizationID                *string `json:"organization_id,omitempty"`
+	EnterpriseID                  *string `json:"enterprise_id,omitempty"`
+	UserInitiatedInteractionCount *int    `json:"user_initiated_interaction_count,omitempty"`
+	CopilotMetricsChatPanel
+	CodeGenerationActivityCount  *int                             `json:"code_generation_activity_count,omitempty"`
+	CodeAcceptanceActivityCount  *int                             `json:"code_acceptance_activity_count,omitempty"`
+	TotalsByIDE                  []*CopilotUserMetricsIDE         `json:"totals_by_ide,omitempty"`
+	TotalsByFeature              []*CopilotMetricsFeature         `json:"totals_by_feature,omitempty"`
+	TotalsByLanguageFeature      []*CopilotMetricsLanguageFeature `json:"totals_by_language_feature,omitempty"`
+	TotalsByLanguageModel        []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
+	TotalsByModelFeature         []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
+	TotalsByCLI                  *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
+	UsedAgent                    *bool                            `json:"used_agent,omitempty"`
+	UsedChat                     *bool                            `json:"used_chat,omitempty"`
+	UsedCLI                      *bool                            `json:"used_cli,omitempty"`
+	UsedCopilotCodeReviewActive  *bool                            `json:"used_copilot_code_review_active,omitempty"`
+	UsedCopilotCodeReviewPassive *bool                            `json:"used_copilot_code_review_passive,omitempty"`
+	UsedCopilotCodingAgent       *bool                            `json:"used_copilot_coding_agent,omitempty"`
+	LOCSuggestedToAddSum         *int                             `json:"loc_suggested_to_add_sum,omitempty"`
+	LOCSuggestedToDeleteSum      *int                             `json:"loc_suggested_to_delete_sum,omitempty"`
+	LOCAddedSum                  *int                             `json:"loc_added_sum,omitempty"`
+	LOCDeletedSum                *int                             `json:"loc_deleted_sum,omitempty"`
 }
 
 // CopilotUserPeriodicMetrics represents a single user's per-day Copilot usage metrics record from a
 // multi-day (e.g. 28-day rolling) user metrics report. User metrics reports are served as
 // newline-delimited JSON.
 type CopilotUserPeriodicMetrics struct {
-	ReportStartDay                string                           `json:"report_start_day"`
-	ReportEndDay                  string                           `json:"report_end_day"`
-	Day                           string                           `json:"day"`
-	OrganizationID                string                           `json:"organization_id"`
-	EnterpriseID                  string                           `json:"enterprise_id"`
-	UserID                        int                              `json:"user_id"`
-	UserLogin                     string                           `json:"user_login"`
-	UserInitiatedInteractionCount int                              `json:"user_initiated_interaction_count"`
-	CodeGenerationActivityCount   int                              `json:"code_generation_activity_count"`
-	CodeAcceptanceActivityCount   int                              `json:"code_acceptance_activity_count"`
-	TotalsByIDE                   []*CopilotUserMetricsIDE         `json:"totals_by_ide,omitempty"`
-	TotalsByFeature               []*CopilotMetricsFeature         `json:"totals_by_feature,omitempty"`
-	TotalsByLanguageFeature       []*CopilotMetricsLanguageFeature `json:"totals_by_language_feature,omitempty"`
-	TotalsByLanguageModel         []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
-	TotalsByModelFeature          []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
-	TotalsByCLI                   *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
-	UsedAgent                     bool                             `json:"used_agent"`
-	UsedChat                      bool                             `json:"used_chat"`
-	UsedCLI                       bool                             `json:"used_cli"`
-	UsedCopilotCodeReviewActive   bool                             `json:"used_copilot_code_review_active"`
-	UsedCopilotCodeReviewPassive  bool                             `json:"used_copilot_code_review_passive"`
-	UsedCopilotCodingAgent        bool                             `json:"used_copilot_coding_agent"`
-	LOCSuggestedToAddSum          int                              `json:"loc_suggested_to_add_sum"`
-	LOCSuggestedToDeleteSum       int                              `json:"loc_suggested_to_delete_sum"`
-	LOCAddedSum                   int                              `json:"loc_added_sum"`
-	LOCDeletedSum                 int                              `json:"loc_deleted_sum"`
+	ReportStartDay                string  `json:"report_start_day"`
+	ReportEndDay                  string  `json:"report_end_day"`
+	Day                           string  `json:"day"`
+	OrganizationID                *string `json:"organization_id,omitempty"`
+	EnterpriseID                  *string `json:"enterprise_id,omitempty"`
+	UserID                        int     `json:"user_id"`
+	UserLogin                     string  `json:"user_login"`
+	UserInitiatedInteractionCount *int    `json:"user_initiated_interaction_count,omitempty"`
+	CopilotMetricsChatPanel
+	CodeGenerationActivityCount  *int                             `json:"code_generation_activity_count,omitempty"`
+	CodeAcceptanceActivityCount  *int                             `json:"code_acceptance_activity_count,omitempty"`
+	TotalsByIDE                  []*CopilotUserMetricsIDE         `json:"totals_by_ide,omitempty"`
+	TotalsByFeature              []*CopilotMetricsFeature         `json:"totals_by_feature,omitempty"`
+	TotalsByLanguageFeature      []*CopilotMetricsLanguageFeature `json:"totals_by_language_feature,omitempty"`
+	TotalsByLanguageModel        []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
+	TotalsByModelFeature         []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
+	TotalsByCLI                  *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
+	UsedAgent                    *bool                            `json:"used_agent,omitempty"`
+	UsedChat                     *bool                            `json:"used_chat,omitempty"`
+	UsedCLI                      *bool                            `json:"used_cli,omitempty"`
+	UsedCopilotCodeReviewActive  *bool                            `json:"used_copilot_code_review_active,omitempty"`
+	UsedCopilotCodeReviewPassive *bool                            `json:"used_copilot_code_review_passive,omitempty"`
+	UsedCopilotCodingAgent       *bool                            `json:"used_copilot_coding_agent,omitempty"`
+	LOCSuggestedToAddSum         *int                             `json:"loc_suggested_to_add_sum,omitempty"`
+	LOCSuggestedToDeleteSum      *int                             `json:"loc_suggested_to_delete_sum,omitempty"`
+	LOCAddedSum                  *int                             `json:"loc_added_sum,omitempty"`
+	LOCDeletedSum                *int                             `json:"loc_deleted_sum,omitempty"`
 }
 
 // fetchMetricsReport performs a GET against the provided download URL and returns the raw

--- a/github/copilot.go
+++ b/github/copilot.go
@@ -931,26 +931,26 @@ type CopilotMetricsModelFeature struct {
 	LocDeletedSum                 int    `json:"loc_deleted_sum"`
 }
 
-// CopilotMetricsCliVersion represents the last known Copilot CLI version seen in a metrics report.
-type CopilotMetricsCliVersion struct {
+// CopilotMetricsCLIVersion represents the last known Copilot CLI version seen in a metrics report.
+type CopilotMetricsCLIVersion struct {
 	SampledAt  *Timestamp `json:"sampled_at,omitempty"`
-	CliVersion string     `json:"cli_version"`
+	CLIVersion string     `json:"cli_version"`
 }
 
-// CopilotMetricsCliTokenUsage represents Copilot CLI token totals in a metrics report.
-type CopilotMetricsCliTokenUsage struct {
+// CopilotMetricsCLITokenUsage represents Copilot CLI token totals in a metrics report.
+type CopilotMetricsCLITokenUsage struct {
 	AvgTokensPerRequest float64 `json:"avg_tokens_per_request"`
 	OutputTokensSum     int     `json:"output_tokens_sum"`
 	PromptTokensSum     int     `json:"prompt_tokens_sum"`
 }
 
-// CopilotMetricsCli represents Copilot CLI totals in a metrics report.
-type CopilotMetricsCli struct {
+// CopilotMetricsCLI represents Copilot CLI totals in a metrics report.
+type CopilotMetricsCLI struct {
 	SessionCount        int                          `json:"session_count"`
 	RequestCount        int                          `json:"request_count"`
 	PromptCount         int                          `json:"prompt_count"`
-	TokenUsage          *CopilotMetricsCliTokenUsage `json:"token_usage,omitempty"`
-	LastKnownCliVersion *CopilotMetricsCliVersion    `json:"last_known_cli_version,omitempty"`
+	TokenUsage          *CopilotMetricsCLITokenUsage `json:"token_usage,omitempty"`
+	LastKnownCLIVersion *CopilotMetricsCLIVersion    `json:"last_known_cli_version,omitempty"`
 }
 
 // CopilotDailyMetrics represents the payload downloaded from a 1-day Copilot usage metrics report.
@@ -958,7 +958,7 @@ type CopilotDailyMetrics struct {
 	Day                                 string                           `json:"day"`
 	OrganizationID                      string                           `json:"organization_id"`
 	EnterpriseID                        string                           `json:"enterprise_id"`
-	DailyActiveCliUsers                 int                              `json:"daily_active_cli_users"`
+	DailyActiveCLIUsers                 int                              `json:"daily_active_cli_users"`
 	DailyActiveUsers                    int                              `json:"daily_active_users"`
 	DailyActiveCopilotCloudAgentUsers   int                              `json:"daily_active_copilot_cloud_agent_users"`
 	WeeklyActiveUsers                   int                              `json:"weekly_active_users"`
@@ -975,7 +975,7 @@ type CopilotDailyMetrics struct {
 	TotalsByLanguageFeature             []*CopilotMetricsLanguageFeature `json:"totals_by_language_feature,omitempty"`
 	TotalsByLanguageModel               []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
 	TotalsByModelFeature                []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
-	TotalsByCli                         *CopilotMetricsCli               `json:"totals_by_cli,omitempty"`
+	TotalsByCLI                         *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
 	LocSuggestedToAddSum                int                              `json:"loc_suggested_to_add_sum"`
 	LocSuggestedToDeleteSum             int                              `json:"loc_suggested_to_delete_sum"`
 	LocAddedSum                         int                              `json:"loc_added_sum"`
@@ -1039,10 +1039,10 @@ type CopilotUserDailyMetrics struct {
 	TotalsByLanguageFeature       []*CopilotMetricsLanguageFeature `json:"totals_by_language_feature,omitempty"`
 	TotalsByLanguageModel         []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
 	TotalsByModelFeature          []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
-	TotalsByCli                   *CopilotMetricsCli               `json:"totals_by_cli,omitempty"`
+	TotalsByCLI                   *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
 	UsedAgent                     bool                             `json:"used_agent"`
 	UsedChat                      bool                             `json:"used_chat"`
-	UsedCli                       bool                             `json:"used_cli"`
+	UsedCLI                       bool                             `json:"used_cli"`
 	UsedCopilotCodeReviewActive   bool                             `json:"used_copilot_code_review_active"`
 	UsedCopilotCodeReviewPassive  bool                             `json:"used_copilot_code_review_passive"`
 	UsedCopilotCodingAgent        bool                             `json:"used_copilot_coding_agent"`
@@ -1071,10 +1071,10 @@ type CopilotUserPeriodicMetrics struct {
 	TotalsByLanguageFeature       []*CopilotMetricsLanguageFeature `json:"totals_by_language_feature,omitempty"`
 	TotalsByLanguageModel         []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
 	TotalsByModelFeature          []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
-	TotalsByCli                   *CopilotMetricsCli               `json:"totals_by_cli,omitempty"`
+	TotalsByCLI                   *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
 	UsedAgent                     bool                             `json:"used_agent"`
 	UsedChat                      bool                             `json:"used_chat"`
-	UsedCli                       bool                             `json:"used_cli"`
+	UsedCLI                       bool                             `json:"used_cli"`
 	UsedCopilotCodeReviewActive   bool                             `json:"used_copilot_code_review_active"`
 	UsedCopilotCodeReviewPassive  bool                             `json:"used_copilot_code_review_passive"`
 	UsedCopilotCodingAgent        bool                             `json:"used_copilot_coding_agent"`

--- a/github/copilot.go
+++ b/github/copilot.go
@@ -1102,6 +1102,24 @@ func (s *CopilotService) fetchMetricsReport(ctx context.Context, url string) (*h
 	return resp, newResponse(resp), nil
 }
 
+// decodeNDJSONMetrics streams a newline-delimited JSON response body into a slice of *T,
+// returning a nil slice when the body is empty.
+func decodeNDJSONMetrics[T any](r io.Reader) ([]*T, error) {
+	var records []*T
+	dec := json.NewDecoder(r)
+	for {
+		var rec *T
+		if err := dec.Decode(&rec); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
 // DownloadDailyMetrics downloads the payload of a 1-day Copilot usage metrics report from a
 // download link returned by GetEnterpriseDailyMetricsReport or GetOrganizationDailyMetricsReport.
 func (s *CopilotService) DownloadDailyMetrics(ctx context.Context, url string) (*CopilotDailyMetrics, *Response, error) {
@@ -1149,19 +1167,10 @@ func (s *CopilotService) DownloadUserDailyMetrics(ctx context.Context, url strin
 	}
 	defer resp.Body.Close()
 
-	var records []*CopilotUserDailyMetrics
-	dec := json.NewDecoder(resp.Body)
-	for {
-		var rec *CopilotUserDailyMetrics
-		if err := dec.Decode(&rec); err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			return nil, r, err
-		}
-		records = append(records, rec)
+	records, err := decodeNDJSONMetrics[CopilotUserDailyMetrics](resp.Body)
+	if err != nil {
+		return nil, r, err
 	}
-
 	return records, r, nil
 }
 
@@ -1178,18 +1187,9 @@ func (s *CopilotService) DownloadUserPeriodicMetrics(ctx context.Context, url st
 	}
 	defer resp.Body.Close()
 
-	var records []*CopilotUserPeriodicMetrics
-	dec := json.NewDecoder(resp.Body)
-	for {
-		var rec *CopilotUserPeriodicMetrics
-		if err := dec.Decode(&rec); err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			return nil, r, err
-		}
-		records = append(records, rec)
+	records, err := decodeNDJSONMetrics[CopilotUserPeriodicMetrics](resp.Body)
+	if err != nil {
+		return nil, r, err
 	}
-
 	return records, r, nil
 }

--- a/github/copilot.go
+++ b/github/copilot.go
@@ -870,52 +870,44 @@ type CopilotMetricsPullRequests struct {
 	TotalMergedReviewedByCopilot        int     `json:"total_merged_reviewed_by_copilot"`
 }
 
+// CopilotMetricsCodeActivity captures the code-generation activity counts and lines-of-code (LOC)
+// suggestion totals shared across the per-IDE, per-feature, per-language, and per-model breakdowns
+// in a Copilot metrics report.
+type CopilotMetricsCodeActivity struct {
+	CodeGenerationActivityCount int `json:"code_generation_activity_count"`
+	CodeAcceptanceActivityCount int `json:"code_acceptance_activity_count"`
+	LOCSuggestedToAddSum        int `json:"loc_suggested_to_add_sum"`
+	LOCSuggestedToDeleteSum     int `json:"loc_suggested_to_delete_sum"`
+	LOCAddedSum                 int `json:"loc_added_sum"`
+	LOCDeletedSum               int `json:"loc_deleted_sum"`
+}
+
 // CopilotMetricsIDE represents per-IDE aggregate totals in a Copilot metrics report.
 type CopilotMetricsIDE struct {
 	IDE                           string `json:"ide"`
 	UserInitiatedInteractionCount int    `json:"user_initiated_interaction_count"`
-	CodeGenerationActivityCount   int    `json:"code_generation_activity_count"`
-	CodeAcceptanceActivityCount   int    `json:"code_acceptance_activity_count"`
-	LocSuggestedToAddSum          int    `json:"loc_suggested_to_add_sum"`
-	LocSuggestedToDeleteSum       int    `json:"loc_suggested_to_delete_sum"`
-	LocAddedSum                   int    `json:"loc_added_sum"`
-	LocDeletedSum                 int    `json:"loc_deleted_sum"`
+	CopilotMetricsCodeActivity
 }
 
 // CopilotMetricsFeature represents per-feature aggregate totals in a Copilot metrics report.
 type CopilotMetricsFeature struct {
 	Feature                       string `json:"feature"`
 	UserInitiatedInteractionCount int    `json:"user_initiated_interaction_count"`
-	CodeGenerationActivityCount   int    `json:"code_generation_activity_count"`
-	CodeAcceptanceActivityCount   int    `json:"code_acceptance_activity_count"`
-	LocSuggestedToAddSum          int    `json:"loc_suggested_to_add_sum"`
-	LocSuggestedToDeleteSum       int    `json:"loc_suggested_to_delete_sum"`
-	LocAddedSum                   int    `json:"loc_added_sum"`
-	LocDeletedSum                 int    `json:"loc_deleted_sum"`
+	CopilotMetricsCodeActivity
 }
 
 // CopilotMetricsLanguageFeature represents per-language-feature totals in a Copilot metrics report.
 type CopilotMetricsLanguageFeature struct {
-	Language                    string `json:"language"`
-	Feature                     string `json:"feature"`
-	CodeGenerationActivityCount int    `json:"code_generation_activity_count"`
-	CodeAcceptanceActivityCount int    `json:"code_acceptance_activity_count"`
-	LocSuggestedToAddSum        int    `json:"loc_suggested_to_add_sum"`
-	LocSuggestedToDeleteSum     int    `json:"loc_suggested_to_delete_sum"`
-	LocAddedSum                 int    `json:"loc_added_sum"`
-	LocDeletedSum               int    `json:"loc_deleted_sum"`
+	Language string `json:"language"`
+	Feature  string `json:"feature"`
+	CopilotMetricsCodeActivity
 }
 
 // CopilotMetricsLanguageModel represents per-language-model totals in a Copilot metrics report.
 type CopilotMetricsLanguageModel struct {
-	Language                    string `json:"language"`
-	Model                       string `json:"model"`
-	CodeGenerationActivityCount int    `json:"code_generation_activity_count"`
-	CodeAcceptanceActivityCount int    `json:"code_acceptance_activity_count"`
-	LocSuggestedToAddSum        int    `json:"loc_suggested_to_add_sum"`
-	LocSuggestedToDeleteSum     int    `json:"loc_suggested_to_delete_sum"`
-	LocAddedSum                 int    `json:"loc_added_sum"`
-	LocDeletedSum               int    `json:"loc_deleted_sum"`
+	Language string `json:"language"`
+	Model    string `json:"model"`
+	CopilotMetricsCodeActivity
 }
 
 // CopilotMetricsModelFeature represents per-model-feature totals in a Copilot metrics report.
@@ -923,12 +915,7 @@ type CopilotMetricsModelFeature struct {
 	Model                         string `json:"model"`
 	Feature                       string `json:"feature"`
 	UserInitiatedInteractionCount int    `json:"user_initiated_interaction_count"`
-	CodeGenerationActivityCount   int    `json:"code_generation_activity_count"`
-	CodeAcceptanceActivityCount   int    `json:"code_acceptance_activity_count"`
-	LocSuggestedToAddSum          int    `json:"loc_suggested_to_add_sum"`
-	LocSuggestedToDeleteSum       int    `json:"loc_suggested_to_delete_sum"`
-	LocAddedSum                   int    `json:"loc_added_sum"`
-	LocDeletedSum                 int    `json:"loc_deleted_sum"`
+	CopilotMetricsCodeActivity
 }
 
 // CopilotMetricsCLIVersion represents the last known Copilot CLI version seen in a metrics report.
@@ -976,10 +963,10 @@ type CopilotDailyMetrics struct {
 	TotalsByLanguageModel               []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
 	TotalsByModelFeature                []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
 	TotalsByCLI                         *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
-	LocSuggestedToAddSum                int                              `json:"loc_suggested_to_add_sum"`
-	LocSuggestedToDeleteSum             int                              `json:"loc_suggested_to_delete_sum"`
-	LocAddedSum                         int                              `json:"loc_added_sum"`
-	LocDeletedSum                       int                              `json:"loc_deleted_sum"`
+	LOCSuggestedToAddSum                int                              `json:"loc_suggested_to_add_sum"`
+	LOCSuggestedToDeleteSum             int                              `json:"loc_suggested_to_delete_sum"`
+	LOCAddedSum                         int                              `json:"loc_added_sum"`
+	LOCDeletedSum                       int                              `json:"loc_deleted_sum"`
 	PullRequests                        *CopilotMetricsPullRequests      `json:"pull_requests,omitempty"`
 }
 
@@ -1011,16 +998,11 @@ type CopilotUserMetricsIDEVersion struct {
 
 // CopilotUserMetricsIDE represents per-IDE totals for a single Copilot user in a user metrics report.
 type CopilotUserMetricsIDE struct {
-	IDE                           string                           `json:"ide"`
-	UserInitiatedInteractionCount int                              `json:"user_initiated_interaction_count"`
-	CodeGenerationActivityCount   int                              `json:"code_generation_activity_count"`
-	CodeAcceptanceActivityCount   int                              `json:"code_acceptance_activity_count"`
-	LocSuggestedToAddSum          int                              `json:"loc_suggested_to_add_sum"`
-	LocSuggestedToDeleteSum       int                              `json:"loc_suggested_to_delete_sum"`
-	LocAddedSum                   int                              `json:"loc_added_sum"`
-	LocDeletedSum                 int                              `json:"loc_deleted_sum"`
-	LastKnownPluginVersion        *CopilotUserMetricsPluginVersion `json:"last_known_plugin_version,omitempty"`
-	LastKnownIDEVersion           *CopilotUserMetricsIDEVersion    `json:"last_known_ide_version,omitempty"`
+	IDE                           string `json:"ide"`
+	UserInitiatedInteractionCount int    `json:"user_initiated_interaction_count"`
+	CopilotMetricsCodeActivity
+	LastKnownPluginVersion *CopilotUserMetricsPluginVersion `json:"last_known_plugin_version,omitempty"`
+	LastKnownIDEVersion    *CopilotUserMetricsIDEVersion    `json:"last_known_ide_version,omitempty"`
 }
 
 // CopilotUserDailyMetrics represents a single user's per-day Copilot usage metrics record from a
@@ -1046,10 +1028,10 @@ type CopilotUserDailyMetrics struct {
 	UsedCopilotCodeReviewActive   bool                             `json:"used_copilot_code_review_active"`
 	UsedCopilotCodeReviewPassive  bool                             `json:"used_copilot_code_review_passive"`
 	UsedCopilotCodingAgent        bool                             `json:"used_copilot_coding_agent"`
-	LocSuggestedToAddSum          int                              `json:"loc_suggested_to_add_sum"`
-	LocSuggestedToDeleteSum       int                              `json:"loc_suggested_to_delete_sum"`
-	LocAddedSum                   int                              `json:"loc_added_sum"`
-	LocDeletedSum                 int                              `json:"loc_deleted_sum"`
+	LOCSuggestedToAddSum          int                              `json:"loc_suggested_to_add_sum"`
+	LOCSuggestedToDeleteSum       int                              `json:"loc_suggested_to_delete_sum"`
+	LOCAddedSum                   int                              `json:"loc_added_sum"`
+	LOCDeletedSum                 int                              `json:"loc_deleted_sum"`
 }
 
 // CopilotUserPeriodicMetrics represents a single user's per-day Copilot usage metrics record from a
@@ -1078,10 +1060,10 @@ type CopilotUserPeriodicMetrics struct {
 	UsedCopilotCodeReviewActive   bool                             `json:"used_copilot_code_review_active"`
 	UsedCopilotCodeReviewPassive  bool                             `json:"used_copilot_code_review_passive"`
 	UsedCopilotCodingAgent        bool                             `json:"used_copilot_coding_agent"`
-	LocSuggestedToAddSum          int                              `json:"loc_suggested_to_add_sum"`
-	LocSuggestedToDeleteSum       int                              `json:"loc_suggested_to_delete_sum"`
-	LocAddedSum                   int                              `json:"loc_added_sum"`
-	LocDeletedSum                 int                              `json:"loc_deleted_sum"`
+	LOCSuggestedToAddSum          int                              `json:"loc_suggested_to_add_sum"`
+	LOCSuggestedToDeleteSum       int                              `json:"loc_suggested_to_delete_sum"`
+	LOCAddedSum                   int                              `json:"loc_added_sum"`
+	LOCDeletedSum                 int                              `json:"loc_deleted_sum"`
 }
 
 // fetchMetricsReport performs a GET against the provided download URL and returns the raw

--- a/github/copilot.go
+++ b/github/copilot.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -612,6 +613,8 @@ func (s *CopilotService) GetOrganizationTeamMetrics(ctx context.Context, org, te
 
 // GetEnterpriseDailyMetricsReport gets a report containing Copilot metrics for a single day for an enterprise.
 //
+// Use DownloadDailyMetrics to decode the payloads served at the returned download links.
+//
 // GitHub API docs: https://docs.github.com/rest/copilot/copilot-usage-metrics?apiVersion=2022-11-28#get-copilot-enterprise-usage-metrics-for-a-specific-day
 //
 //meta:operation GET /enterprises/{enterprise}/copilot/metrics/reports/enterprise-1-day
@@ -638,6 +641,8 @@ func (s *CopilotService) GetEnterpriseDailyMetricsReport(ctx context.Context, en
 
 // GetEnterpriseMetricsReport gets a report containing Copilot metrics for a 28-day rolling window for an enterprise.
 //
+// Use DownloadPeriodicMetrics to decode the payloads served at the returned download links.
+//
 // GitHub API docs: https://docs.github.com/rest/copilot/copilot-usage-metrics?apiVersion=2022-11-28#get-copilot-enterprise-usage-metrics
 //
 //meta:operation GET /enterprises/{enterprise}/copilot/metrics/reports/enterprise-28-day/latest
@@ -659,6 +664,8 @@ func (s *CopilotService) GetEnterpriseMetricsReport(ctx context.Context, enterpr
 }
 
 // GetEnterpriseUsersDailyMetricsReport gets a report containing Copilot user metrics for a single day for an enterprise.
+//
+// Use DownloadUserDailyMetrics to decode the payloads served at the returned download links.
 //
 // GitHub API docs: https://docs.github.com/rest/copilot/copilot-usage-metrics?apiVersion=2022-11-28#get-copilot-users-usage-metrics-for-a-specific-day
 //
@@ -686,6 +693,8 @@ func (s *CopilotService) GetEnterpriseUsersDailyMetricsReport(ctx context.Contex
 
 // GetEnterpriseUsersMetricsReport gets a report containing Copilot user metrics for a 28-day rolling window for an enterprise.
 //
+// Use DownloadUserPeriodicMetrics to decode the payloads served at the returned download links.
+//
 // GitHub API docs: https://docs.github.com/rest/copilot/copilot-usage-metrics?apiVersion=2022-11-28#get-copilot-users-usage-metrics
 //
 //meta:operation GET /enterprises/{enterprise}/copilot/metrics/reports/users-28-day/latest
@@ -707,6 +716,8 @@ func (s *CopilotService) GetEnterpriseUsersMetricsReport(ctx context.Context, en
 }
 
 // GetOrganizationDailyMetricsReport gets a report containing Copilot metrics for a single day for an organization.
+//
+// Use DownloadDailyMetrics to decode the payloads served at the returned download links.
 //
 // GitHub API docs: https://docs.github.com/rest/copilot/copilot-usage-metrics?apiVersion=2022-11-28#get-copilot-organization-usage-metrics-for-a-specific-day
 //
@@ -734,6 +745,8 @@ func (s *CopilotService) GetOrganizationDailyMetricsReport(ctx context.Context, 
 
 // GetOrganizationMetricsReport gets a report containing Copilot metrics for a 28-day rolling window for an organization.
 //
+// Use DownloadPeriodicMetrics to decode the payloads served at the returned download links.
+//
 // GitHub API docs: https://docs.github.com/rest/copilot/copilot-usage-metrics?apiVersion=2022-11-28#get-copilot-organization-usage-metrics
 //
 //meta:operation GET /orgs/{org}/copilot/metrics/reports/organization-28-day/latest
@@ -755,6 +768,8 @@ func (s *CopilotService) GetOrganizationMetricsReport(ctx context.Context, org s
 }
 
 // GetOrganizationUsersDailyMetricsReport gets a report containing Copilot user metrics for a single day for an organization.
+//
+// Use DownloadUserDailyMetrics to decode the payloads served at the returned download links.
 //
 // GitHub API docs: https://docs.github.com/rest/copilot/copilot-usage-metrics?apiVersion=2022-11-28#get-copilot-organization-users-usage-metrics-for-a-specific-day
 //
@@ -782,6 +797,8 @@ func (s *CopilotService) GetOrganizationUsersDailyMetricsReport(ctx context.Cont
 
 // GetOrganizationUsersMetricsReport gets a report containing Copilot user metrics for a 28-day rolling window for an organization.
 //
+// Use DownloadUserPeriodicMetrics to decode the payloads served at the returned download links.
+//
 // GitHub API docs: https://docs.github.com/rest/copilot/copilot-usage-metrics?apiVersion=2022-11-28#get-copilot-organization-users-usage-metrics
 //
 //meta:operation GET /orgs/{org}/copilot/metrics/reports/users-28-day/latest
@@ -803,10 +820,14 @@ func (s *CopilotService) GetOrganizationUsersMetricsReport(ctx context.Context, 
 }
 
 // DownloadCopilotMetrics downloads a Copilot metrics report from the provided download link
-// and returns the metric data. This can be used to download metrics from a link returned by
-// GetEnterpriseDailyMetricsReport, GetEnterpriseMetricsReport, GetEnterpriseUsersDailyMetricsReport,
-// GetEnterpriseUsersMetricsReport, GetOrganizationDailyMetricsReport, GetOrganizationMetricsReport,
-// GetOrganizationUsersDailyMetricsReport, GetOrganizationUsersMetricsReport.
+// and decodes it as a []*CopilotMetrics.
+//
+// Deprecated: the payloads served at the download links returned by the new
+// Get*MetricsReport endpoints on GitHub.com do not match the CopilotMetrics shape
+// (see https://github.com/google/go-github/issues/4136). Use DownloadDailyMetrics,
+// DownloadPeriodicMetrics, DownloadUserDailyMetrics, or DownloadUserPeriodicMetrics
+// depending on which Get*MetricsReport produced the link. This method is retained
+// for GitHub Enterprise Server installations that may still serve the legacy shape.
 func (s *CopilotService) DownloadCopilotMetrics(ctx context.Context, url string) ([]*CopilotMetrics, *Response, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
@@ -829,4 +850,349 @@ func (s *CopilotService) DownloadCopilotMetrics(ctx context.Context, url string)
 	}
 
 	return metrics, newResponse(resp), nil
+}
+
+// CopilotMetricsPullRequests represents pull request totals in a Copilot metrics report.
+type CopilotMetricsPullRequests struct {
+	TotalReviewed                       int     `json:"total_reviewed"`
+	TotalCreated                        int     `json:"total_created"`
+	TotalCreatedByCopilot               int     `json:"total_created_by_copilot"`
+	TotalReviewedByCopilot              int     `json:"total_reviewed_by_copilot"`
+	TotalMerged                         int     `json:"total_merged"`
+	MedianMinutesToMerge                float64 `json:"median_minutes_to_merge"`
+	TotalSuggestions                    int     `json:"total_suggestions"`
+	TotalAppliedSuggestions             int     `json:"total_applied_suggestions"`
+	TotalMergedCreatedByCopilot         int     `json:"total_merged_created_by_copilot"`
+	MedianMinutesToMergeCopilotAuthored float64 `json:"median_minutes_to_merge_copilot_authored"`
+	TotalCopilotSuggestions             int     `json:"total_copilot_suggestions"`
+	TotalCopilotAppliedSuggestions      int     `json:"total_copilot_applied_suggestions"`
+	MedianMinutesToMergeCopilotReviewed float64 `json:"median_minutes_to_merge_copilot_reviewed"`
+	TotalMergedReviewedByCopilot        int     `json:"total_merged_reviewed_by_copilot"`
+}
+
+// CopilotMetricsIDE represents per-IDE aggregate totals in a Copilot metrics report.
+type CopilotMetricsIDE struct {
+	IDE                           string `json:"ide"`
+	UserInitiatedInteractionCount int    `json:"user_initiated_interaction_count"`
+	CodeGenerationActivityCount   int    `json:"code_generation_activity_count"`
+	CodeAcceptanceActivityCount   int    `json:"code_acceptance_activity_count"`
+	LocSuggestedToAddSum          int    `json:"loc_suggested_to_add_sum"`
+	LocSuggestedToDeleteSum       int    `json:"loc_suggested_to_delete_sum"`
+	LocAddedSum                   int    `json:"loc_added_sum"`
+	LocDeletedSum                 int    `json:"loc_deleted_sum"`
+}
+
+// CopilotMetricsFeature represents per-feature aggregate totals in a Copilot metrics report.
+type CopilotMetricsFeature struct {
+	Feature                       string `json:"feature"`
+	UserInitiatedInteractionCount int    `json:"user_initiated_interaction_count"`
+	CodeGenerationActivityCount   int    `json:"code_generation_activity_count"`
+	CodeAcceptanceActivityCount   int    `json:"code_acceptance_activity_count"`
+	LocSuggestedToAddSum          int    `json:"loc_suggested_to_add_sum"`
+	LocSuggestedToDeleteSum       int    `json:"loc_suggested_to_delete_sum"`
+	LocAddedSum                   int    `json:"loc_added_sum"`
+	LocDeletedSum                 int    `json:"loc_deleted_sum"`
+}
+
+// CopilotMetricsLanguageFeature represents per-language-feature totals in a Copilot metrics report.
+type CopilotMetricsLanguageFeature struct {
+	Language                    string `json:"language"`
+	Feature                     string `json:"feature"`
+	CodeGenerationActivityCount int    `json:"code_generation_activity_count"`
+	CodeAcceptanceActivityCount int    `json:"code_acceptance_activity_count"`
+	LocSuggestedToAddSum        int    `json:"loc_suggested_to_add_sum"`
+	LocSuggestedToDeleteSum     int    `json:"loc_suggested_to_delete_sum"`
+	LocAddedSum                 int    `json:"loc_added_sum"`
+	LocDeletedSum               int    `json:"loc_deleted_sum"`
+}
+
+// CopilotMetricsLanguageModel represents per-language-model totals in a Copilot metrics report.
+type CopilotMetricsLanguageModel struct {
+	Language                    string `json:"language"`
+	Model                       string `json:"model"`
+	CodeGenerationActivityCount int    `json:"code_generation_activity_count"`
+	CodeAcceptanceActivityCount int    `json:"code_acceptance_activity_count"`
+	LocSuggestedToAddSum        int    `json:"loc_suggested_to_add_sum"`
+	LocSuggestedToDeleteSum     int    `json:"loc_suggested_to_delete_sum"`
+	LocAddedSum                 int    `json:"loc_added_sum"`
+	LocDeletedSum               int    `json:"loc_deleted_sum"`
+}
+
+// CopilotMetricsModelFeature represents per-model-feature totals in a Copilot metrics report.
+type CopilotMetricsModelFeature struct {
+	Model                         string `json:"model"`
+	Feature                       string `json:"feature"`
+	UserInitiatedInteractionCount int    `json:"user_initiated_interaction_count"`
+	CodeGenerationActivityCount   int    `json:"code_generation_activity_count"`
+	CodeAcceptanceActivityCount   int    `json:"code_acceptance_activity_count"`
+	LocSuggestedToAddSum          int    `json:"loc_suggested_to_add_sum"`
+	LocSuggestedToDeleteSum       int    `json:"loc_suggested_to_delete_sum"`
+	LocAddedSum                   int    `json:"loc_added_sum"`
+	LocDeletedSum                 int    `json:"loc_deleted_sum"`
+}
+
+// CopilotMetricsCliVersion represents the last known Copilot CLI version seen in a metrics report.
+type CopilotMetricsCliVersion struct {
+	SampledAt  *Timestamp `json:"sampled_at,omitempty"`
+	CliVersion string     `json:"cli_version"`
+}
+
+// CopilotMetricsCliTokenUsage represents Copilot CLI token totals in a metrics report.
+type CopilotMetricsCliTokenUsage struct {
+	AvgTokensPerRequest float64 `json:"avg_tokens_per_request"`
+	OutputTokensSum     int     `json:"output_tokens_sum"`
+	PromptTokensSum     int     `json:"prompt_tokens_sum"`
+}
+
+// CopilotMetricsCli represents Copilot CLI totals in a metrics report.
+type CopilotMetricsCli struct {
+	SessionCount        int                          `json:"session_count"`
+	RequestCount        int                          `json:"request_count"`
+	PromptCount         int                          `json:"prompt_count"`
+	TokenUsage          *CopilotMetricsCliTokenUsage `json:"token_usage,omitempty"`
+	LastKnownCliVersion *CopilotMetricsCliVersion    `json:"last_known_cli_version,omitempty"`
+}
+
+// CopilotDailyMetrics represents the payload downloaded from a 1-day Copilot usage metrics report.
+type CopilotDailyMetrics struct {
+	Day                                 string                           `json:"day"`
+	OrganizationID                      string                           `json:"organization_id"`
+	EnterpriseID                        string                           `json:"enterprise_id"`
+	DailyActiveCliUsers                 int                              `json:"daily_active_cli_users"`
+	DailyActiveUsers                    int                              `json:"daily_active_users"`
+	DailyActiveCopilotCloudAgentUsers   int                              `json:"daily_active_copilot_cloud_agent_users"`
+	WeeklyActiveUsers                   int                              `json:"weekly_active_users"`
+	WeeklyActiveCopilotCloudAgentUsers  int                              `json:"weekly_active_copilot_cloud_agent_users"`
+	MonthlyActiveUsers                  int                              `json:"monthly_active_users"`
+	MonthlyActiveChatUsers              int                              `json:"monthly_active_chat_users"`
+	MonthlyActiveAgentUsers             int                              `json:"monthly_active_agent_users"`
+	MonthlyActiveCopilotCloudAgentUsers int                              `json:"monthly_active_copilot_cloud_agent_users"`
+	UserInitiatedInteractionCount       int                              `json:"user_initiated_interaction_count"`
+	CodeGenerationActivityCount         int                              `json:"code_generation_activity_count"`
+	CodeAcceptanceActivityCount         int                              `json:"code_acceptance_activity_count"`
+	TotalsByIDE                         []*CopilotMetricsIDE             `json:"totals_by_ide,omitempty"`
+	TotalsByFeature                     []*CopilotMetricsFeature         `json:"totals_by_feature,omitempty"`
+	TotalsByLanguageFeature             []*CopilotMetricsLanguageFeature `json:"totals_by_language_feature,omitempty"`
+	TotalsByLanguageModel               []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
+	TotalsByModelFeature                []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
+	TotalsByCli                         *CopilotMetricsCli               `json:"totals_by_cli,omitempty"`
+	LocSuggestedToAddSum                int                              `json:"loc_suggested_to_add_sum"`
+	LocSuggestedToDeleteSum             int                              `json:"loc_suggested_to_delete_sum"`
+	LocAddedSum                         int                              `json:"loc_added_sum"`
+	LocDeletedSum                       int                              `json:"loc_deleted_sum"`
+	PullRequests                        *CopilotMetricsPullRequests      `json:"pull_requests,omitempty"`
+}
+
+// CopilotPeriodicMetrics represents the payload downloaded from a multi-day (e.g. 28-day rolling)
+// Copilot usage metrics report. The DayTotals field contains one CopilotDailyMetrics entry per day
+// in the reporting window. Window-level metadata (ReportStartDay, ReportEndDay, CreatedAt) lives on
+// this parent struct; each DayTotals entry only populates fields scoped to that day.
+type CopilotPeriodicMetrics struct {
+	ReportStartDay string                 `json:"report_start_day"`
+	ReportEndDay   string                 `json:"report_end_day"`
+	OrganizationID string                 `json:"organization_id"`
+	EnterpriseID   string                 `json:"enterprise_id"`
+	CreatedAt      *Timestamp             `json:"created_at,omitempty"`
+	DayTotals      []*CopilotDailyMetrics `json:"day_totals,omitempty"`
+}
+
+// CopilotUserMetricsPluginVersion represents the last known plugin version used in an IDE by a Copilot user.
+type CopilotUserMetricsPluginVersion struct {
+	SampledAt     *Timestamp `json:"sampled_at,omitempty"`
+	Plugin        string     `json:"plugin"`
+	PluginVersion string     `json:"plugin_version"`
+}
+
+// CopilotUserMetricsIDEVersion represents the last known IDE version used by a Copilot user.
+type CopilotUserMetricsIDEVersion struct {
+	SampledAt  *Timestamp `json:"sampled_at,omitempty"`
+	IDEVersion string     `json:"ide_version"`
+}
+
+// CopilotUserMetricsIDE represents per-IDE totals for a single Copilot user in a user metrics report.
+type CopilotUserMetricsIDE struct {
+	IDE                           string                           `json:"ide"`
+	UserInitiatedInteractionCount int                              `json:"user_initiated_interaction_count"`
+	CodeGenerationActivityCount   int                              `json:"code_generation_activity_count"`
+	CodeAcceptanceActivityCount   int                              `json:"code_acceptance_activity_count"`
+	LocSuggestedToAddSum          int                              `json:"loc_suggested_to_add_sum"`
+	LocSuggestedToDeleteSum       int                              `json:"loc_suggested_to_delete_sum"`
+	LocAddedSum                   int                              `json:"loc_added_sum"`
+	LocDeletedSum                 int                              `json:"loc_deleted_sum"`
+	LastKnownPluginVersion        *CopilotUserMetricsPluginVersion `json:"last_known_plugin_version,omitempty"`
+	LastKnownIDEVersion           *CopilotUserMetricsIDEVersion    `json:"last_known_ide_version,omitempty"`
+}
+
+// CopilotUserDailyMetrics represents a single user's per-day Copilot usage metrics record from a
+// 1-day user metrics report. User metrics reports are served as newline-delimited JSON.
+type CopilotUserDailyMetrics struct {
+	UserID                        int                              `json:"user_id"`
+	UserLogin                     string                           `json:"user_login"`
+	Day                           string                           `json:"day"`
+	OrganizationID                string                           `json:"organization_id"`
+	EnterpriseID                  string                           `json:"enterprise_id"`
+	UserInitiatedInteractionCount int                              `json:"user_initiated_interaction_count"`
+	CodeGenerationActivityCount   int                              `json:"code_generation_activity_count"`
+	CodeAcceptanceActivityCount   int                              `json:"code_acceptance_activity_count"`
+	TotalsByIDE                   []*CopilotUserMetricsIDE         `json:"totals_by_ide,omitempty"`
+	TotalsByFeature               []*CopilotMetricsFeature         `json:"totals_by_feature,omitempty"`
+	TotalsByLanguageFeature       []*CopilotMetricsLanguageFeature `json:"totals_by_language_feature,omitempty"`
+	TotalsByLanguageModel         []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
+	TotalsByModelFeature          []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
+	TotalsByCli                   *CopilotMetricsCli               `json:"totals_by_cli,omitempty"`
+	UsedAgent                     bool                             `json:"used_agent"`
+	UsedChat                      bool                             `json:"used_chat"`
+	UsedCli                       bool                             `json:"used_cli"`
+	UsedCopilotCodeReviewActive   bool                             `json:"used_copilot_code_review_active"`
+	UsedCopilotCodeReviewPassive  bool                             `json:"used_copilot_code_review_passive"`
+	UsedCopilotCodingAgent        bool                             `json:"used_copilot_coding_agent"`
+	LocSuggestedToAddSum          int                              `json:"loc_suggested_to_add_sum"`
+	LocSuggestedToDeleteSum       int                              `json:"loc_suggested_to_delete_sum"`
+	LocAddedSum                   int                              `json:"loc_added_sum"`
+	LocDeletedSum                 int                              `json:"loc_deleted_sum"`
+}
+
+// CopilotUserPeriodicMetrics represents a single user's per-day Copilot usage metrics record from a
+// multi-day (e.g. 28-day rolling) user metrics report. User metrics reports are served as
+// newline-delimited JSON.
+type CopilotUserPeriodicMetrics struct {
+	ReportStartDay                string                           `json:"report_start_day"`
+	ReportEndDay                  string                           `json:"report_end_day"`
+	Day                           string                           `json:"day"`
+	OrganizationID                string                           `json:"organization_id"`
+	EnterpriseID                  string                           `json:"enterprise_id"`
+	UserID                        int                              `json:"user_id"`
+	UserLogin                     string                           `json:"user_login"`
+	UserInitiatedInteractionCount int                              `json:"user_initiated_interaction_count"`
+	CodeGenerationActivityCount   int                              `json:"code_generation_activity_count"`
+	CodeAcceptanceActivityCount   int                              `json:"code_acceptance_activity_count"`
+	TotalsByIDE                   []*CopilotUserMetricsIDE         `json:"totals_by_ide,omitempty"`
+	TotalsByFeature               []*CopilotMetricsFeature         `json:"totals_by_feature,omitempty"`
+	TotalsByLanguageFeature       []*CopilotMetricsLanguageFeature `json:"totals_by_language_feature,omitempty"`
+	TotalsByLanguageModel         []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
+	TotalsByModelFeature          []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
+	TotalsByCli                   *CopilotMetricsCli               `json:"totals_by_cli,omitempty"`
+	UsedAgent                     bool                             `json:"used_agent"`
+	UsedChat                      bool                             `json:"used_chat"`
+	UsedCli                       bool                             `json:"used_cli"`
+	UsedCopilotCodeReviewActive   bool                             `json:"used_copilot_code_review_active"`
+	UsedCopilotCodeReviewPassive  bool                             `json:"used_copilot_code_review_passive"`
+	UsedCopilotCodingAgent        bool                             `json:"used_copilot_coding_agent"`
+	LocSuggestedToAddSum          int                              `json:"loc_suggested_to_add_sum"`
+	LocSuggestedToDeleteSum       int                              `json:"loc_suggested_to_delete_sum"`
+	LocAddedSum                   int                              `json:"loc_added_sum"`
+	LocDeletedSum                 int                              `json:"loc_deleted_sum"`
+}
+
+// fetchMetricsReport performs a GET against the provided download URL and returns the raw
+// http.Response. The caller is responsible for closing the body.
+func (s *CopilotService) fetchMetricsReport(ctx context.Context, url string) (*http.Response, *Response, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := s.client.client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := CheckResponse(resp); err != nil {
+		resp.Body.Close()
+		return nil, newResponse(resp), err
+	}
+
+	return resp, newResponse(resp), nil
+}
+
+// DownloadDailyMetrics downloads the payload of a 1-day Copilot usage metrics report from a
+// download link returned by GetEnterpriseDailyMetricsReport or GetOrganizationDailyMetricsReport.
+func (s *CopilotService) DownloadDailyMetrics(ctx context.Context, url string) (*CopilotDailyMetrics, *Response, error) {
+	resp, r, err := s.fetchMetricsReport(ctx, url)
+	if err != nil {
+		return nil, r, err
+	}
+	defer resp.Body.Close()
+
+	var metrics *CopilotDailyMetrics
+	if err := json.NewDecoder(resp.Body).Decode(&metrics); err != nil {
+		return nil, r, err
+	}
+
+	return metrics, r, nil
+}
+
+// DownloadPeriodicMetrics downloads the payload of a multi-day (e.g. 28-day rolling) Copilot
+// usage metrics report from a download link returned by GetEnterpriseMetricsReport or
+// GetOrganizationMetricsReport.
+func (s *CopilotService) DownloadPeriodicMetrics(ctx context.Context, url string) (*CopilotPeriodicMetrics, *Response, error) {
+	resp, r, err := s.fetchMetricsReport(ctx, url)
+	if err != nil {
+		return nil, r, err
+	}
+	defer resp.Body.Close()
+
+	var metrics *CopilotPeriodicMetrics
+	if err := json.NewDecoder(resp.Body).Decode(&metrics); err != nil {
+		return nil, r, err
+	}
+
+	return metrics, r, nil
+}
+
+// DownloadUserDailyMetrics downloads the payload of a 1-day Copilot user metrics report from a
+// download link returned by GetEnterpriseUsersDailyMetricsReport or
+// GetOrganizationUsersDailyMetricsReport.
+//
+// The response is newline-delimited JSON, with one CopilotUserDailyMetrics record per line.
+func (s *CopilotService) DownloadUserDailyMetrics(ctx context.Context, url string) ([]*CopilotUserDailyMetrics, *Response, error) {
+	resp, r, err := s.fetchMetricsReport(ctx, url)
+	if err != nil {
+		return nil, r, err
+	}
+	defer resp.Body.Close()
+
+	var records []*CopilotUserDailyMetrics
+	dec := json.NewDecoder(resp.Body)
+	for {
+		var rec *CopilotUserDailyMetrics
+		if err := dec.Decode(&rec); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, r, err
+		}
+		records = append(records, rec)
+	}
+
+	return records, r, nil
+}
+
+// DownloadUserPeriodicMetrics downloads the payload of a multi-day (e.g. 28-day rolling) Copilot
+// user metrics report from a download link returned by GetEnterpriseUsersMetricsReport or
+// GetOrganizationUsersMetricsReport.
+//
+// The response is newline-delimited JSON, with one CopilotUserPeriodicMetrics record per
+// user-day in the reporting window.
+func (s *CopilotService) DownloadUserPeriodicMetrics(ctx context.Context, url string) ([]*CopilotUserPeriodicMetrics, *Response, error) {
+	resp, r, err := s.fetchMetricsReport(ctx, url)
+	if err != nil {
+		return nil, r, err
+	}
+	defer resp.Body.Close()
+
+	var records []*CopilotUserPeriodicMetrics
+	dec := json.NewDecoder(resp.Body)
+	for {
+		var rec *CopilotUserPeriodicMetrics
+		if err := dec.Decode(&rec); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, r, err
+		}
+		records = append(records, rec)
+	}
+
+	return records, r, nil
 }

--- a/github/copilot.go
+++ b/github/copilot.go
@@ -822,11 +822,12 @@ func (s *CopilotService) GetOrganizationUsersMetricsReport(ctx context.Context, 
 // DownloadCopilotMetrics downloads a Copilot metrics report from the provided download link
 // and decodes it as a []*CopilotMetrics.
 //
-// Deprecated: the payloads served at the download links returned by the new
+// Deprecated: Use DownloadDailyMetrics,
+// DownloadPeriodicMetrics, DownloadUserDailyMetrics, DownloadUserPeriodicMetrics instead.
+// The payloads served at the download links returned by the new
 // Get*MetricsReport endpoints on GitHub.com do not match the CopilotMetrics shape
-// (see https://github.com/google/go-github/issues/4136). Use DownloadDailyMetrics,
-// DownloadPeriodicMetrics, DownloadUserDailyMetrics, or DownloadUserPeriodicMetrics
-// depending on which Get*MetricsReport produced the link. This method is retained
+// (see https://github.com/google/go-github/issues/4136).
+// This method is retained
 // for GitHub Enterprise Server installations that may still serve the legacy shape.
 func (s *CopilotService) DownloadCopilotMetrics(ctx context.Context, url string) ([]*CopilotMetrics, *Response, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -2977,7 +2977,7 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 	want := &CopilotDailyMetrics{
 		Day:                 "2026-04-01",
 		OrganizationID:      "123",
-		DailyActiveCliUsers: 2,
+		DailyActiveCLIUsers: 2,
 		DailyActiveUsers:    10,
 		WeeklyActiveUsers:   20,
 		MonthlyActiveUsers:  30,
@@ -2996,11 +2996,11 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 		TotalsByModelFeature: []*CopilotMetricsModelFeature{
 			{Model: "m1", Feature: "completion", UserInitiatedInteractionCount: 5},
 		},
-		TotalsByCli: &CopilotMetricsCli{
+		TotalsByCLI: &CopilotMetricsCLI{
 			SessionCount: 3,
 			RequestCount: 4,
 			PromptCount:  2,
-			TokenUsage: &CopilotMetricsCliTokenUsage{
+			TokenUsage: &CopilotMetricsCLITokenUsage{
 				AvgTokensPerRequest: 4123.5,
 				OutputTokensSum:     7000,
 				PromptTokensSum:     9494,
@@ -3098,13 +3098,13 @@ func TestCopilotService_DownloadPeriodicMetrics(t *testing.T) {
 		DayTotals: []*CopilotDailyMetrics{
 			{
 				Day:                 "2026-03-05",
-				DailyActiveCliUsers: 2,
+				DailyActiveCLIUsers: 2,
 				DailyActiveUsers:    5,
-				TotalsByCli: &CopilotMetricsCli{
+				TotalsByCLI: &CopilotMetricsCLI{
 					SessionCount: 1,
 					RequestCount: 2,
 					PromptCount:  1,
-					TokenUsage: &CopilotMetricsCliTokenUsage{
+					TokenUsage: &CopilotMetricsCLITokenUsage{
 						AvgTokensPerRequest: 4000.0,
 						OutputTokensSum:     5000,
 						PromptTokensSum:     3000,
@@ -3175,15 +3175,15 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 			Day:                           "2026-04-01",
 			UserInitiatedInteractionCount: 5,
 			UsedChat:                      true,
-			UsedCli:                       true,
+			UsedCLI:                       true,
 			UsedCopilotCodeReviewActive:   true,
-			TotalsByCli: &CopilotMetricsCli{
+			TotalsByCLI: &CopilotMetricsCLI{
 				SessionCount: 2,
 				RequestCount: 2,
 				PromptCount:  1,
-				LastKnownCliVersion: &CopilotMetricsCliVersion{
+				LastKnownCLIVersion: &CopilotMetricsCLIVersion{
 					SampledAt:  &Timestamp{time.Date(2026, 4, 1, 12, 30, 0, 0, time.UTC)},
-					CliVersion: "1.0.8",
+					CLIVersion: "1.0.8",
 				},
 			},
 			TotalsByIDE: []*CopilotUserMetricsIDE{
@@ -3288,14 +3288,14 @@ func TestCopilotService_DownloadUserPeriodicMetrics(t *testing.T) {
 			Day:                          "2026-03-06",
 			UserID:                       1,
 			UserLogin:                    "alice",
-			UsedCli:                      true,
+			UsedCLI:                      true,
 			UsedCopilotCodeReviewPassive: true,
 			UsedCopilotCodingAgent:       true,
-			TotalsByCli: &CopilotMetricsCli{
+			TotalsByCLI: &CopilotMetricsCLI{
 				SessionCount: 1,
 				RequestCount: 3,
 				PromptCount:  2,
-				TokenUsage: &CopilotMetricsCliTokenUsage{
+				TokenUsage: &CopilotMetricsCLITokenUsage{
 					AvgTokensPerRequest: 1200.5,
 					OutputTokensSum:     2400,
 					PromptTokensSum:     1201,

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -2914,3 +2914,431 @@ func TestCopilotService_DownloadCopilotMetrics(t *testing.T) {
 		t.Error("Copilot.DownloadCopilotMetrics expected error for bad JSON, got none")
 	}
 }
+
+func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/path/to/daily", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"day": "2026-04-01",
+			"organization_id": "123",
+			"daily_active_cli_users": 2,
+			"daily_active_users": 10,
+			"weekly_active_users": 20,
+			"monthly_active_users": 30,
+			"totals_by_ide": [
+				{"ide": "vscode", "user_initiated_interaction_count": 5, "loc_added_sum": 100}
+			],
+			"totals_by_feature": [
+				{"feature": "completion", "user_initiated_interaction_count": 5}
+			],
+			"totals_by_language_feature": [
+				{"language": "go", "feature": "completion", "code_generation_activity_count": 3}
+			],
+			"totals_by_language_model": [
+				{"language": "go", "model": "m1", "code_generation_activity_count": 3}
+			],
+			"totals_by_model_feature": [
+				{"model": "m1", "feature": "completion", "user_initiated_interaction_count": 5}
+			],
+			"totals_by_cli": {
+				"session_count": 3,
+				"request_count": 4,
+				"prompt_count": 2,
+				"token_usage": {
+					"avg_tokens_per_request": 4123.5,
+					"output_tokens_sum": 7000,
+					"prompt_tokens_sum": 9494
+				}
+			},
+			"loc_added_sum": 100,
+			"pull_requests": {
+				"total_reviewed": 1,
+				"total_created": 2,
+				"median_minutes_to_merge": 12.5,
+				"median_minutes_to_merge_copilot_authored": 4.5,
+				"median_minutes_to_merge_copilot_reviewed": 6.5
+			}
+		}`)
+	})
+
+	ctx := t.Context()
+	url := client.BaseURL.String() + "path/to/daily"
+	got, resp, err := client.Copilot.DownloadDailyMetrics(ctx, url)
+	if err != nil {
+		t.Errorf("Copilot.DownloadDailyMetrics returned error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Copilot.DownloadDailyMetrics returned status code: %v", resp.StatusCode)
+	}
+
+	want := &CopilotDailyMetrics{
+		Day:                 "2026-04-01",
+		OrganizationID:      "123",
+		DailyActiveCliUsers: 2,
+		DailyActiveUsers:    10,
+		WeeklyActiveUsers:   20,
+		MonthlyActiveUsers:  30,
+		TotalsByIDE: []*CopilotMetricsIDE{
+			{IDE: "vscode", UserInitiatedInteractionCount: 5, LocAddedSum: 100},
+		},
+		TotalsByFeature: []*CopilotMetricsFeature{
+			{Feature: "completion", UserInitiatedInteractionCount: 5},
+		},
+		TotalsByLanguageFeature: []*CopilotMetricsLanguageFeature{
+			{Language: "go", Feature: "completion", CodeGenerationActivityCount: 3},
+		},
+		TotalsByLanguageModel: []*CopilotMetricsLanguageModel{
+			{Language: "go", Model: "m1", CodeGenerationActivityCount: 3},
+		},
+		TotalsByModelFeature: []*CopilotMetricsModelFeature{
+			{Model: "m1", Feature: "completion", UserInitiatedInteractionCount: 5},
+		},
+		TotalsByCli: &CopilotMetricsCli{
+			SessionCount: 3,
+			RequestCount: 4,
+			PromptCount:  2,
+			TokenUsage: &CopilotMetricsCliTokenUsage{
+				AvgTokensPerRequest: 4123.5,
+				OutputTokensSum:     7000,
+				PromptTokensSum:     9494,
+			},
+		},
+		LocAddedSum: 100,
+		PullRequests: &CopilotMetricsPullRequests{
+			TotalReviewed:                       1,
+			TotalCreated:                        2,
+			MedianMinutesToMerge:                12.5,
+			MedianMinutesToMergeCopilotAuthored: 4.5,
+			MedianMinutesToMergeCopilotReviewed: 6.5,
+		},
+	}
+
+	if !cmp.Equal(got, want) {
+		t.Errorf("Copilot.DownloadDailyMetrics returned %+v, want %+v", got, want)
+	}
+
+	mux.HandleFunc("/path/to/daily/error", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.WriteHeader(http.StatusNotFound)
+	})
+	if _, _, err := client.Copilot.DownloadDailyMetrics(ctx, client.BaseURL.String()+"path/to/daily/error"); err == nil {
+		t.Error("Copilot.DownloadDailyMetrics expected error but got none")
+	}
+	if _, _, err := client.Copilot.DownloadDailyMetrics(ctx, "\n"); err == nil {
+		t.Error("Copilot.DownloadDailyMetrics expected error for invalid URL, got none")
+	}
+	if _, _, err := client.Copilot.DownloadDailyMetrics(ctx, "invalid-scheme://test"); err == nil {
+		t.Error("Copilot.DownloadDailyMetrics expected error for invalid scheme, got none")
+	}
+
+	mux.HandleFunc("/path/to/daily/badjson", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{invalid`)
+	})
+	if _, _, err := client.Copilot.DownloadDailyMetrics(ctx, client.BaseURL.String()+"path/to/daily/badjson"); err == nil {
+		t.Error("Copilot.DownloadDailyMetrics expected error for bad JSON, got none")
+	}
+}
+
+func TestCopilotService_DownloadPeriodicMetrics(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/path/to/periodic", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"report_start_day": "2026-03-05",
+			"report_end_day": "2026-04-01",
+			"organization_id": "123",
+			"created_at": "2026-04-02T00:00:00Z",
+			"day_totals": [
+				{
+					"day": "2026-03-05",
+					"daily_active_cli_users": 2,
+					"daily_active_users": 5,
+					"totals_by_cli": {
+						"session_count": 1,
+						"request_count": 2,
+						"prompt_count": 1,
+						"token_usage": {
+							"avg_tokens_per_request": 4000.0,
+							"output_tokens_sum": 5000,
+							"prompt_tokens_sum": 3000
+						}
+					},
+					"pull_requests": {
+						"median_minutes_to_merge": 8.5,
+						"median_minutes_to_merge_copilot_authored": 5.0,
+						"median_minutes_to_merge_copilot_reviewed": 7.0
+					}
+				},
+				{"day": "2026-03-06", "daily_active_users": 7}
+			]
+		}`)
+	})
+
+	ctx := t.Context()
+	url := client.BaseURL.String() + "path/to/periodic"
+	got, resp, err := client.Copilot.DownloadPeriodicMetrics(ctx, url)
+	if err != nil {
+		t.Errorf("Copilot.DownloadPeriodicMetrics returned error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Copilot.DownloadPeriodicMetrics returned status code: %v", resp.StatusCode)
+	}
+
+	want := &CopilotPeriodicMetrics{
+		ReportStartDay: "2026-03-05",
+		ReportEndDay:   "2026-04-01",
+		OrganizationID: "123",
+		CreatedAt:      &Timestamp{time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)},
+		DayTotals: []*CopilotDailyMetrics{
+			{
+				Day:                 "2026-03-05",
+				DailyActiveCliUsers: 2,
+				DailyActiveUsers:    5,
+				TotalsByCli: &CopilotMetricsCli{
+					SessionCount: 1,
+					RequestCount: 2,
+					PromptCount:  1,
+					TokenUsage: &CopilotMetricsCliTokenUsage{
+						AvgTokensPerRequest: 4000.0,
+						OutputTokensSum:     5000,
+						PromptTokensSum:     3000,
+					},
+				},
+				PullRequests: &CopilotMetricsPullRequests{
+					MedianMinutesToMerge:                8.5,
+					MedianMinutesToMergeCopilotAuthored: 5.0,
+					MedianMinutesToMergeCopilotReviewed: 7.0,
+				},
+			},
+			{Day: "2026-03-06", DailyActiveUsers: 7},
+		},
+	}
+
+	if !cmp.Equal(got, want) {
+		t.Errorf("Copilot.DownloadPeriodicMetrics returned %+v, want %+v", got, want)
+	}
+
+	mux.HandleFunc("/path/to/periodic/error", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.WriteHeader(http.StatusNotFound)
+	})
+	if _, _, err := client.Copilot.DownloadPeriodicMetrics(ctx, client.BaseURL.String()+"path/to/periodic/error"); err == nil {
+		t.Error("Copilot.DownloadPeriodicMetrics expected error but got none")
+	}
+	if _, _, err := client.Copilot.DownloadPeriodicMetrics(ctx, "\n"); err == nil {
+		t.Error("Copilot.DownloadPeriodicMetrics expected error for invalid URL, got none")
+	}
+	if _, _, err := client.Copilot.DownloadPeriodicMetrics(ctx, "invalid-scheme://test"); err == nil {
+		t.Error("Copilot.DownloadPeriodicMetrics expected error for invalid scheme, got none")
+	}
+
+	mux.HandleFunc("/path/to/periodic/badjson", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{invalid`)
+	})
+	if _, _, err := client.Copilot.DownloadPeriodicMetrics(ctx, client.BaseURL.String()+"path/to/periodic/badjson"); err == nil {
+		t.Error("Copilot.DownloadPeriodicMetrics expected error for bad JSON, got none")
+	}
+}
+
+func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/path/to/users-daily", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"user_id":1,"user_login":"alice","day":"2026-04-01","user_initiated_interaction_count":5,"used_chat":true,"used_cli":true,"used_copilot_code_review_active":true,"totals_by_cli":{"session_count":2,"request_count":2,"prompt_count":1,"last_known_cli_version":{"sampled_at":"2026-04-01T12:30:00Z","cli_version":"1.0.8"}},"totals_by_ide":[{"ide":"vscode","user_initiated_interaction_count":5,"last_known_plugin_version":{"sampled_at":"2026-04-01T12:00:00Z","plugin":"copilot","plugin_version":"1.0.0"},"last_known_ide_version":{"sampled_at":"2026-04-01T12:00:00Z","ide_version":"1.90"}}]}
+{"user_id":2,"user_login":"bob","day":"2026-04-01","used_agent":true,"used_copilot_code_review_passive":true}
+`)
+	})
+
+	ctx := t.Context()
+	url := client.BaseURL.String() + "path/to/users-daily"
+	got, resp, err := client.Copilot.DownloadUserDailyMetrics(ctx, url)
+	if err != nil {
+		t.Errorf("Copilot.DownloadUserDailyMetrics returned error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Copilot.DownloadUserDailyMetrics returned status code: %v", resp.StatusCode)
+	}
+
+	want := []*CopilotUserDailyMetrics{
+		{
+			UserID:                        1,
+			UserLogin:                     "alice",
+			Day:                           "2026-04-01",
+			UserInitiatedInteractionCount: 5,
+			UsedChat:                      true,
+			UsedCli:                       true,
+			UsedCopilotCodeReviewActive:   true,
+			TotalsByCli: &CopilotMetricsCli{
+				SessionCount: 2,
+				RequestCount: 2,
+				PromptCount:  1,
+				LastKnownCliVersion: &CopilotMetricsCliVersion{
+					SampledAt:  &Timestamp{time.Date(2026, 4, 1, 12, 30, 0, 0, time.UTC)},
+					CliVersion: "1.0.8",
+				},
+			},
+			TotalsByIDE: []*CopilotUserMetricsIDE{
+				{
+					IDE:                           "vscode",
+					UserInitiatedInteractionCount: 5,
+					LastKnownPluginVersion: &CopilotUserMetricsPluginVersion{
+						SampledAt:     &Timestamp{time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)},
+						Plugin:        "copilot",
+						PluginVersion: "1.0.0",
+					},
+					LastKnownIDEVersion: &CopilotUserMetricsIDEVersion{
+						SampledAt:  &Timestamp{time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)},
+						IDEVersion: "1.90",
+					},
+				},
+			},
+		},
+		{
+			UserID:                       2,
+			UserLogin:                    "bob",
+			Day:                          "2026-04-01",
+			UsedAgent:                    true,
+			UsedCopilotCodeReviewPassive: true,
+		},
+	}
+
+	if !cmp.Equal(got, want) {
+		t.Errorf("Copilot.DownloadUserDailyMetrics returned %+v, want %+v", got, want)
+	}
+
+	// Empty body parses to a nil slice (no records).
+	mux.HandleFunc("/path/to/users-daily/empty", func(_ http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+	})
+	gotEmpty, _, err := client.Copilot.DownloadUserDailyMetrics(ctx, client.BaseURL.String()+"path/to/users-daily/empty")
+	if err != nil {
+		t.Errorf("Copilot.DownloadUserDailyMetrics empty body returned error: %v", err)
+	}
+	if gotEmpty != nil {
+		t.Errorf("Copilot.DownloadUserDailyMetrics empty body returned %+v, want nil", gotEmpty)
+	}
+
+	mux.HandleFunc("/path/to/users-daily/error", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.WriteHeader(http.StatusNotFound)
+	})
+	if _, _, err := client.Copilot.DownloadUserDailyMetrics(ctx, client.BaseURL.String()+"path/to/users-daily/error"); err == nil {
+		t.Error("Copilot.DownloadUserDailyMetrics expected error but got none")
+	}
+	if _, _, err := client.Copilot.DownloadUserDailyMetrics(ctx, "\n"); err == nil {
+		t.Error("Copilot.DownloadUserDailyMetrics expected error for invalid URL, got none")
+	}
+	if _, _, err := client.Copilot.DownloadUserDailyMetrics(ctx, "invalid-scheme://test"); err == nil {
+		t.Error("Copilot.DownloadUserDailyMetrics expected error for invalid scheme, got none")
+	}
+
+	// A malformed line causes the stream decode to fail.
+	mux.HandleFunc("/path/to/users-daily/badjson", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, "{\"user_id\":1,\"day\":\"2026-04-01\"}\n{bad\n")
+	})
+	if _, _, err := client.Copilot.DownloadUserDailyMetrics(ctx, client.BaseURL.String()+"path/to/users-daily/badjson"); err == nil {
+		t.Error("Copilot.DownloadUserDailyMetrics expected error for bad JSON, got none")
+	}
+}
+
+func TestCopilotService_DownloadUserPeriodicMetrics(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/path/to/users-periodic", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"report_start_day":"2026-03-05","report_end_day":"2026-04-01","day":"2026-03-05","user_id":1,"user_login":"alice","user_initiated_interaction_count":3,"used_copilot_code_review_active":true}
+{"report_start_day":"2026-03-05","report_end_day":"2026-04-01","day":"2026-03-06","user_id":1,"user_login":"alice","used_cli":true,"used_copilot_code_review_passive":true,"used_copilot_coding_agent":true,"totals_by_cli":{"session_count":1,"request_count":3,"prompt_count":2,"token_usage":{"avg_tokens_per_request":1200.5,"output_tokens_sum":2400,"prompt_tokens_sum":1201}}}
+`)
+	})
+
+	ctx := t.Context()
+	url := client.BaseURL.String() + "path/to/users-periodic"
+	got, resp, err := client.Copilot.DownloadUserPeriodicMetrics(ctx, url)
+	if err != nil {
+		t.Errorf("Copilot.DownloadUserPeriodicMetrics returned error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Copilot.DownloadUserPeriodicMetrics returned status code: %v", resp.StatusCode)
+	}
+
+	want := []*CopilotUserPeriodicMetrics{
+		{
+			ReportStartDay:                "2026-03-05",
+			ReportEndDay:                  "2026-04-01",
+			Day:                           "2026-03-05",
+			UserID:                        1,
+			UserLogin:                     "alice",
+			UserInitiatedInteractionCount: 3,
+			UsedCopilotCodeReviewActive:   true,
+		},
+		{
+			ReportStartDay:               "2026-03-05",
+			ReportEndDay:                 "2026-04-01",
+			Day:                          "2026-03-06",
+			UserID:                       1,
+			UserLogin:                    "alice",
+			UsedCli:                      true,
+			UsedCopilotCodeReviewPassive: true,
+			UsedCopilotCodingAgent:       true,
+			TotalsByCli: &CopilotMetricsCli{
+				SessionCount: 1,
+				RequestCount: 3,
+				PromptCount:  2,
+				TokenUsage: &CopilotMetricsCliTokenUsage{
+					AvgTokensPerRequest: 1200.5,
+					OutputTokensSum:     2400,
+					PromptTokensSum:     1201,
+				},
+			},
+		},
+	}
+
+	if !cmp.Equal(got, want) {
+		t.Errorf("Copilot.DownloadUserPeriodicMetrics returned %+v, want %+v", got, want)
+	}
+
+	// Empty body parses to a nil slice (no records).
+	mux.HandleFunc("/path/to/users-periodic/empty", func(_ http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+	})
+	gotEmpty, _, err := client.Copilot.DownloadUserPeriodicMetrics(ctx, client.BaseURL.String()+"path/to/users-periodic/empty")
+	if err != nil {
+		t.Errorf("Copilot.DownloadUserPeriodicMetrics empty body returned error: %v", err)
+	}
+	if gotEmpty != nil {
+		t.Errorf("Copilot.DownloadUserPeriodicMetrics empty body returned %+v, want nil", gotEmpty)
+	}
+
+	mux.HandleFunc("/path/to/users-periodic/error", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.WriteHeader(http.StatusNotFound)
+	})
+	if _, _, err := client.Copilot.DownloadUserPeriodicMetrics(ctx, client.BaseURL.String()+"path/to/users-periodic/error"); err == nil {
+		t.Error("Copilot.DownloadUserPeriodicMetrics expected error but got none")
+	}
+	if _, _, err := client.Copilot.DownloadUserPeriodicMetrics(ctx, "\n"); err == nil {
+		t.Error("Copilot.DownloadUserPeriodicMetrics expected error for invalid URL, got none")
+	}
+	if _, _, err := client.Copilot.DownloadUserPeriodicMetrics(ctx, "invalid-scheme://test"); err == nil {
+		t.Error("Copilot.DownloadUserPeriodicMetrics expected error for invalid scheme, got none")
+	}
+
+	mux.HandleFunc("/path/to/users-periodic/badjson", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, "{not json\n")
+	})
+	if _, _, err := client.Copilot.DownloadUserPeriodicMetrics(ctx, client.BaseURL.String()+"path/to/users-periodic/badjson"); err == nil {
+		t.Error("Copilot.DownloadUserPeriodicMetrics expected error for bad JSON, got none")
+	}
+}

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -2928,11 +2928,13 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 			"daily_active_users": 10,
 			"weekly_active_users": 20,
 			"monthly_active_users": 30,
+			"chat_panel_ask_mode": 4,
 			"totals_by_ide": [
 				{"ide": "vscode", "user_initiated_interaction_count": 5, "loc_added_sum": 100}
 			],
 			"totals_by_feature": [
-				{"feature": "completion", "user_initiated_interaction_count": 5}
+				{"feature": "completion", "user_initiated_interaction_count": 5},
+				{"feature": "agent_edit", "loc_added_sum": 7, "loc_deleted_sum": 2}
 			],
 			"totals_by_language_feature": [
 				{"language": "go", "feature": "completion", "code_generation_activity_count": 3}
@@ -2976,43 +2978,47 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 
 	want := &CopilotDailyMetrics{
 		Day:                 "2026-04-01",
-		OrganizationID:      "123",
-		DailyActiveCLIUsers: 2,
-		DailyActiveUsers:    10,
-		WeeklyActiveUsers:   20,
-		MonthlyActiveUsers:  30,
+		OrganizationID:      String("123"),
+		DailyActiveCLIUsers: Int(2),
+		DailyActiveUsers:    Int(10),
+		WeeklyActiveUsers:   Int(20),
+		MonthlyActiveUsers:  Int(30),
+		CopilotMetricsChatPanel: CopilotMetricsChatPanel{
+			ChatPanelAskMode: Int(4),
+		},
 		TotalsByIDE: []*CopilotMetricsIDE{
-			{IDE: "vscode", UserInitiatedInteractionCount: 5, CopilotMetricsCodeActivity: CopilotMetricsCodeActivity{LOCAddedSum: 100}},
+			{IDE: "vscode", UserInitiatedInteractionCount: Int(5), CopilotMetricsCodeActivity: CopilotMetricsCodeActivity{LOCAddedSum: Int(100)}},
 		},
 		TotalsByFeature: []*CopilotMetricsFeature{
-			{Feature: "completion", UserInitiatedInteractionCount: 5},
+			{Feature: "completion", UserInitiatedInteractionCount: Int(5)},
+			{Feature: "agent_edit", CopilotMetricsCodeActivity: CopilotMetricsCodeActivity{LOCAddedSum: Int(7), LOCDeletedSum: Int(2)}},
 		},
 		TotalsByLanguageFeature: []*CopilotMetricsLanguageFeature{
-			{Language: "go", Feature: "completion", CopilotMetricsCodeActivity: CopilotMetricsCodeActivity{CodeGenerationActivityCount: 3}},
+			{Language: "go", Feature: "completion", CopilotMetricsCodeActivity: CopilotMetricsCodeActivity{CodeGenerationActivityCount: Int(3)}},
 		},
 		TotalsByLanguageModel: []*CopilotMetricsLanguageModel{
-			{Language: "go", Model: "m1", CopilotMetricsCodeActivity: CopilotMetricsCodeActivity{CodeGenerationActivityCount: 3}},
+			{Language: "go", Model: "m1", CopilotMetricsCodeActivity: CopilotMetricsCodeActivity{CodeGenerationActivityCount: Int(3)}},
 		},
 		TotalsByModelFeature: []*CopilotMetricsModelFeature{
-			{Model: "m1", Feature: "completion", UserInitiatedInteractionCount: 5},
+			{Model: "m1", Feature: "completion", UserInitiatedInteractionCount: Int(5)},
 		},
 		TotalsByCLI: &CopilotMetricsCLI{
-			SessionCount: 3,
-			RequestCount: 4,
-			PromptCount:  2,
+			SessionCount: Int(3),
+			RequestCount: Int(4),
+			PromptCount:  Int(2),
 			TokenUsage: &CopilotMetricsCLITokenUsage{
-				AvgTokensPerRequest: 4123.5,
-				OutputTokensSum:     7000,
-				PromptTokensSum:     9494,
+				AvgTokensPerRequest: Ptr(4123.5),
+				OutputTokensSum:     Int(7000),
+				PromptTokensSum:     Int(9494),
 			},
 		},
-		LOCAddedSum: 100,
+		LOCAddedSum: Int(100),
 		PullRequests: &CopilotMetricsPullRequests{
-			TotalReviewed:                       1,
-			TotalCreated:                        2,
-			MedianMinutesToMerge:                12.5,
-			MedianMinutesToMergeCopilotAuthored: 4.5,
-			MedianMinutesToMergeCopilotReviewed: 6.5,
+			TotalReviewed:                       Int(1),
+			TotalCreated:                        Int(2),
+			MedianMinutesToMerge:                Ptr(12.5),
+			MedianMinutesToMergeCopilotAuthored: Ptr(4.5),
+			MedianMinutesToMergeCopilotReviewed: Ptr(6.5),
 		},
 	}
 
@@ -3093,30 +3099,30 @@ func TestCopilotService_DownloadPeriodicMetrics(t *testing.T) {
 	want := &CopilotPeriodicMetrics{
 		ReportStartDay: "2026-03-05",
 		ReportEndDay:   "2026-04-01",
-		OrganizationID: "123",
+		OrganizationID: String("123"),
 		CreatedAt:      &Timestamp{time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)},
 		DayTotals: []*CopilotDailyMetrics{
 			{
 				Day:                 "2026-03-05",
-				DailyActiveCLIUsers: 2,
-				DailyActiveUsers:    5,
+				DailyActiveCLIUsers: Int(2),
+				DailyActiveUsers:    Int(5),
 				TotalsByCLI: &CopilotMetricsCLI{
-					SessionCount: 1,
-					RequestCount: 2,
-					PromptCount:  1,
+					SessionCount: Int(1),
+					RequestCount: Int(2),
+					PromptCount:  Int(1),
 					TokenUsage: &CopilotMetricsCLITokenUsage{
-						AvgTokensPerRequest: 4000.0,
-						OutputTokensSum:     5000,
-						PromptTokensSum:     3000,
+						AvgTokensPerRequest: Ptr(4000.0),
+						OutputTokensSum:     Int(5000),
+						PromptTokensSum:     Int(3000),
 					},
 				},
 				PullRequests: &CopilotMetricsPullRequests{
-					MedianMinutesToMerge:                8.5,
-					MedianMinutesToMergeCopilotAuthored: 5.0,
-					MedianMinutesToMergeCopilotReviewed: 7.0,
+					MedianMinutesToMerge:                Ptr(8.5),
+					MedianMinutesToMergeCopilotAuthored: Ptr(5.0),
+					MedianMinutesToMergeCopilotReviewed: Ptr(7.0),
 				},
 			},
-			{Day: "2026-03-06", DailyActiveUsers: 7},
+			{Day: "2026-03-06", DailyActiveUsers: Int(7)},
 		},
 	}
 
@@ -3153,7 +3159,7 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 
 	mux.HandleFunc("/path/to/users-daily", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"user_id":1,"user_login":"alice","day":"2026-04-01","user_initiated_interaction_count":5,"used_chat":true,"used_cli":true,"used_copilot_code_review_active":true,"totals_by_cli":{"session_count":2,"request_count":2,"prompt_count":1,"last_known_cli_version":{"sampled_at":"2026-04-01T12:30:00Z","cli_version":"1.0.8"}},"totals_by_ide":[{"ide":"vscode","user_initiated_interaction_count":5,"last_known_plugin_version":{"sampled_at":"2026-04-01T12:00:00Z","plugin":"copilot","plugin_version":"1.0.0"},"last_known_ide_version":{"sampled_at":"2026-04-01T12:00:00Z","ide_version":"1.90"}}]}
+		fmt.Fprint(w, `{"user_id":1,"user_login":"alice","day":"2026-04-01","user_initiated_interaction_count":5,"chat_panel_edit_mode":2,"used_chat":true,"used_cli":true,"used_copilot_code_review_active":true,"totals_by_cli":{"session_count":2,"request_count":2,"prompt_count":1,"last_known_cli_version":{"sampled_at":"2026-04-01T12:30:00Z","cli_version":"1.0.8"}},"totals_by_ide":[{"ide":"vscode","user_initiated_interaction_count":5,"last_known_plugin_version":{"sampled_at":"2026-04-01T12:00:00Z","plugin":"copilot","plugin_version":"1.0.0"},"last_known_ide_version":{"sampled_at":"2026-04-01T12:00:00Z","ide_version":"1.90"}}]}
 {"user_id":2,"user_login":"bob","day":"2026-04-01","used_agent":true,"used_copilot_code_review_passive":true}
 `)
 	})
@@ -3173,14 +3179,17 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 			UserID:                        1,
 			UserLogin:                     "alice",
 			Day:                           "2026-04-01",
-			UserInitiatedInteractionCount: 5,
-			UsedChat:                      true,
-			UsedCLI:                       true,
-			UsedCopilotCodeReviewActive:   true,
+			UserInitiatedInteractionCount: Int(5),
+			CopilotMetricsChatPanel: CopilotMetricsChatPanel{
+				ChatPanelEditMode: Int(2),
+			},
+			UsedChat:                    Bool(true),
+			UsedCLI:                     Bool(true),
+			UsedCopilotCodeReviewActive: Bool(true),
 			TotalsByCLI: &CopilotMetricsCLI{
-				SessionCount: 2,
-				RequestCount: 2,
-				PromptCount:  1,
+				SessionCount: Int(2),
+				RequestCount: Int(2),
+				PromptCount:  Int(1),
 				LastKnownCLIVersion: &CopilotMetricsCLIVersion{
 					SampledAt:  &Timestamp{time.Date(2026, 4, 1, 12, 30, 0, 0, time.UTC)},
 					CLIVersion: "1.0.8",
@@ -3189,7 +3198,7 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 			TotalsByIDE: []*CopilotUserMetricsIDE{
 				{
 					IDE:                           "vscode",
-					UserInitiatedInteractionCount: 5,
+					UserInitiatedInteractionCount: Int(5),
 					LastKnownPluginVersion: &CopilotUserMetricsPluginVersion{
 						SampledAt:     &Timestamp{time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)},
 						Plugin:        "copilot",
@@ -3206,8 +3215,8 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 			UserID:                       2,
 			UserLogin:                    "bob",
 			Day:                          "2026-04-01",
-			UsedAgent:                    true,
-			UsedCopilotCodeReviewPassive: true,
+			UsedAgent:                    Bool(true),
+			UsedCopilotCodeReviewPassive: Bool(true),
 		},
 	}
 
@@ -3279,8 +3288,8 @@ func TestCopilotService_DownloadUserPeriodicMetrics(t *testing.T) {
 			Day:                           "2026-03-05",
 			UserID:                        1,
 			UserLogin:                     "alice",
-			UserInitiatedInteractionCount: 3,
-			UsedCopilotCodeReviewActive:   true,
+			UserInitiatedInteractionCount: Int(3),
+			UsedCopilotCodeReviewActive:   Bool(true),
 		},
 		{
 			ReportStartDay:               "2026-03-05",
@@ -3288,17 +3297,17 @@ func TestCopilotService_DownloadUserPeriodicMetrics(t *testing.T) {
 			Day:                          "2026-03-06",
 			UserID:                       1,
 			UserLogin:                    "alice",
-			UsedCLI:                      true,
-			UsedCopilotCodeReviewPassive: true,
-			UsedCopilotCodingAgent:       true,
+			UsedCLI:                      Bool(true),
+			UsedCopilotCodeReviewPassive: Bool(true),
+			UsedCopilotCodingAgent:       Bool(true),
 			TotalsByCLI: &CopilotMetricsCLI{
-				SessionCount: 1,
-				RequestCount: 3,
-				PromptCount:  2,
+				SessionCount: Int(1),
+				RequestCount: Int(3),
+				PromptCount:  Int(2),
 				TokenUsage: &CopilotMetricsCLITokenUsage{
-					AvgTokensPerRequest: 1200.5,
-					OutputTokensSum:     2400,
-					PromptTokensSum:     1201,
+					AvgTokensPerRequest: Ptr(1200.5),
+					OutputTokensSum:     Int(2400),
+					PromptTokensSum:     Int(1201),
 				},
 			},
 		},

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -2982,16 +2982,16 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 		WeeklyActiveUsers:   20,
 		MonthlyActiveUsers:  30,
 		TotalsByIDE: []*CopilotMetricsIDE{
-			{IDE: "vscode", UserInitiatedInteractionCount: 5, LocAddedSum: 100},
+			{IDE: "vscode", UserInitiatedInteractionCount: 5, CopilotMetricsCodeActivity: CopilotMetricsCodeActivity{LOCAddedSum: 100}},
 		},
 		TotalsByFeature: []*CopilotMetricsFeature{
 			{Feature: "completion", UserInitiatedInteractionCount: 5},
 		},
 		TotalsByLanguageFeature: []*CopilotMetricsLanguageFeature{
-			{Language: "go", Feature: "completion", CodeGenerationActivityCount: 3},
+			{Language: "go", Feature: "completion", CopilotMetricsCodeActivity: CopilotMetricsCodeActivity{CodeGenerationActivityCount: 3}},
 		},
 		TotalsByLanguageModel: []*CopilotMetricsLanguageModel{
-			{Language: "go", Model: "m1", CodeGenerationActivityCount: 3},
+			{Language: "go", Model: "m1", CopilotMetricsCodeActivity: CopilotMetricsCodeActivity{CodeGenerationActivityCount: 3}},
 		},
 		TotalsByModelFeature: []*CopilotMetricsModelFeature{
 			{Model: "m1", Feature: "completion", UserInitiatedInteractionCount: 5},
@@ -3006,7 +3006,7 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 				PromptTokensSum:     9494,
 			},
 		},
-		LocAddedSum: 100,
+		LOCAddedSum: 100,
 		PullRequests: &CopilotMetricsPullRequests{
 			TotalReviewed:                       1,
 			TotalCreated:                        2,

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -8198,6 +8198,214 @@ func (c *CopilotCodeReviewRuleParameters) GetReviewOnPush() bool {
 	return c.ReviewOnPush
 }
 
+// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
+func (c *CopilotDailyMetrics) GetCodeAcceptanceActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeAcceptanceActivityCount
+}
+
+// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
+func (c *CopilotDailyMetrics) GetCodeGenerationActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeGenerationActivityCount
+}
+
+// GetDailyActiveCliUsers returns the DailyActiveCliUsers field.
+func (c *CopilotDailyMetrics) GetDailyActiveCliUsers() int {
+	if c == nil {
+		return 0
+	}
+	return c.DailyActiveCliUsers
+}
+
+// GetDailyActiveCopilotCloudAgentUsers returns the DailyActiveCopilotCloudAgentUsers field.
+func (c *CopilotDailyMetrics) GetDailyActiveCopilotCloudAgentUsers() int {
+	if c == nil {
+		return 0
+	}
+	return c.DailyActiveCopilotCloudAgentUsers
+}
+
+// GetDailyActiveUsers returns the DailyActiveUsers field.
+func (c *CopilotDailyMetrics) GetDailyActiveUsers() int {
+	if c == nil {
+		return 0
+	}
+	return c.DailyActiveUsers
+}
+
+// GetDay returns the Day field.
+func (c *CopilotDailyMetrics) GetDay() string {
+	if c == nil {
+		return ""
+	}
+	return c.Day
+}
+
+// GetEnterpriseID returns the EnterpriseID field.
+func (c *CopilotDailyMetrics) GetEnterpriseID() string {
+	if c == nil {
+		return ""
+	}
+	return c.EnterpriseID
+}
+
+// GetLocAddedSum returns the LocAddedSum field.
+func (c *CopilotDailyMetrics) GetLocAddedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocAddedSum
+}
+
+// GetLocDeletedSum returns the LocDeletedSum field.
+func (c *CopilotDailyMetrics) GetLocDeletedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocDeletedSum
+}
+
+// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
+func (c *CopilotDailyMetrics) GetLocSuggestedToAddSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToAddSum
+}
+
+// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
+func (c *CopilotDailyMetrics) GetLocSuggestedToDeleteSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToDeleteSum
+}
+
+// GetMonthlyActiveAgentUsers returns the MonthlyActiveAgentUsers field.
+func (c *CopilotDailyMetrics) GetMonthlyActiveAgentUsers() int {
+	if c == nil {
+		return 0
+	}
+	return c.MonthlyActiveAgentUsers
+}
+
+// GetMonthlyActiveChatUsers returns the MonthlyActiveChatUsers field.
+func (c *CopilotDailyMetrics) GetMonthlyActiveChatUsers() int {
+	if c == nil {
+		return 0
+	}
+	return c.MonthlyActiveChatUsers
+}
+
+// GetMonthlyActiveCopilotCloudAgentUsers returns the MonthlyActiveCopilotCloudAgentUsers field.
+func (c *CopilotDailyMetrics) GetMonthlyActiveCopilotCloudAgentUsers() int {
+	if c == nil {
+		return 0
+	}
+	return c.MonthlyActiveCopilotCloudAgentUsers
+}
+
+// GetMonthlyActiveUsers returns the MonthlyActiveUsers field.
+func (c *CopilotDailyMetrics) GetMonthlyActiveUsers() int {
+	if c == nil {
+		return 0
+	}
+	return c.MonthlyActiveUsers
+}
+
+// GetOrganizationID returns the OrganizationID field.
+func (c *CopilotDailyMetrics) GetOrganizationID() string {
+	if c == nil {
+		return ""
+	}
+	return c.OrganizationID
+}
+
+// GetPullRequests returns the PullRequests field.
+func (c *CopilotDailyMetrics) GetPullRequests() *CopilotMetricsPullRequests {
+	if c == nil {
+		return nil
+	}
+	return c.PullRequests
+}
+
+// GetTotalsByCli returns the TotalsByCli field.
+func (c *CopilotDailyMetrics) GetTotalsByCli() *CopilotMetricsCli {
+	if c == nil {
+		return nil
+	}
+	return c.TotalsByCli
+}
+
+// GetTotalsByFeature returns the TotalsByFeature slice if it's non-nil, nil otherwise.
+func (c *CopilotDailyMetrics) GetTotalsByFeature() []*CopilotMetricsFeature {
+	if c == nil || c.TotalsByFeature == nil {
+		return nil
+	}
+	return c.TotalsByFeature
+}
+
+// GetTotalsByIDE returns the TotalsByIDE slice if it's non-nil, nil otherwise.
+func (c *CopilotDailyMetrics) GetTotalsByIDE() []*CopilotMetricsIDE {
+	if c == nil || c.TotalsByIDE == nil {
+		return nil
+	}
+	return c.TotalsByIDE
+}
+
+// GetTotalsByLanguageFeature returns the TotalsByLanguageFeature slice if it's non-nil, nil otherwise.
+func (c *CopilotDailyMetrics) GetTotalsByLanguageFeature() []*CopilotMetricsLanguageFeature {
+	if c == nil || c.TotalsByLanguageFeature == nil {
+		return nil
+	}
+	return c.TotalsByLanguageFeature
+}
+
+// GetTotalsByLanguageModel returns the TotalsByLanguageModel slice if it's non-nil, nil otherwise.
+func (c *CopilotDailyMetrics) GetTotalsByLanguageModel() []*CopilotMetricsLanguageModel {
+	if c == nil || c.TotalsByLanguageModel == nil {
+		return nil
+	}
+	return c.TotalsByLanguageModel
+}
+
+// GetTotalsByModelFeature returns the TotalsByModelFeature slice if it's non-nil, nil otherwise.
+func (c *CopilotDailyMetrics) GetTotalsByModelFeature() []*CopilotMetricsModelFeature {
+	if c == nil || c.TotalsByModelFeature == nil {
+		return nil
+	}
+	return c.TotalsByModelFeature
+}
+
+// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
+func (c *CopilotDailyMetrics) GetUserInitiatedInteractionCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.UserInitiatedInteractionCount
+}
+
+// GetWeeklyActiveCopilotCloudAgentUsers returns the WeeklyActiveCopilotCloudAgentUsers field.
+func (c *CopilotDailyMetrics) GetWeeklyActiveCopilotCloudAgentUsers() int {
+	if c == nil {
+		return 0
+	}
+	return c.WeeklyActiveCopilotCloudAgentUsers
+}
+
+// GetWeeklyActiveUsers returns the WeeklyActiveUsers field.
+func (c *CopilotDailyMetrics) GetWeeklyActiveUsers() int {
+	if c == nil {
+		return 0
+	}
+	return c.WeeklyActiveUsers
+}
+
 // GetDownloadLinks returns the DownloadLinks slice if it's non-nil, nil otherwise.
 func (c *CopilotDailyMetricsReport) GetDownloadLinks() []string {
 	if c == nil || c.DownloadLinks == nil {
@@ -8654,6 +8862,342 @@ func (c *CopilotMetrics) GetTotalEngagedUsers() int {
 	return *c.TotalEngagedUsers
 }
 
+// GetLastKnownCliVersion returns the LastKnownCliVersion field.
+func (c *CopilotMetricsCli) GetLastKnownCliVersion() *CopilotMetricsCliVersion {
+	if c == nil {
+		return nil
+	}
+	return c.LastKnownCliVersion
+}
+
+// GetPromptCount returns the PromptCount field.
+func (c *CopilotMetricsCli) GetPromptCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.PromptCount
+}
+
+// GetRequestCount returns the RequestCount field.
+func (c *CopilotMetricsCli) GetRequestCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.RequestCount
+}
+
+// GetSessionCount returns the SessionCount field.
+func (c *CopilotMetricsCli) GetSessionCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.SessionCount
+}
+
+// GetTokenUsage returns the TokenUsage field.
+func (c *CopilotMetricsCli) GetTokenUsage() *CopilotMetricsCliTokenUsage {
+	if c == nil {
+		return nil
+	}
+	return c.TokenUsage
+}
+
+// GetAvgTokensPerRequest returns the AvgTokensPerRequest field.
+func (c *CopilotMetricsCliTokenUsage) GetAvgTokensPerRequest() float64 {
+	if c == nil {
+		return 0
+	}
+	return c.AvgTokensPerRequest
+}
+
+// GetOutputTokensSum returns the OutputTokensSum field.
+func (c *CopilotMetricsCliTokenUsage) GetOutputTokensSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.OutputTokensSum
+}
+
+// GetPromptTokensSum returns the PromptTokensSum field.
+func (c *CopilotMetricsCliTokenUsage) GetPromptTokensSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.PromptTokensSum
+}
+
+// GetCliVersion returns the CliVersion field.
+func (c *CopilotMetricsCliVersion) GetCliVersion() string {
+	if c == nil {
+		return ""
+	}
+	return c.CliVersion
+}
+
+// GetSampledAt returns the SampledAt field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsCliVersion) GetSampledAt() Timestamp {
+	if c == nil || c.SampledAt == nil {
+		return Timestamp{}
+	}
+	return *c.SampledAt
+}
+
+// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
+func (c *CopilotMetricsFeature) GetCodeAcceptanceActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeAcceptanceActivityCount
+}
+
+// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
+func (c *CopilotMetricsFeature) GetCodeGenerationActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeGenerationActivityCount
+}
+
+// GetFeature returns the Feature field.
+func (c *CopilotMetricsFeature) GetFeature() string {
+	if c == nil {
+		return ""
+	}
+	return c.Feature
+}
+
+// GetLocAddedSum returns the LocAddedSum field.
+func (c *CopilotMetricsFeature) GetLocAddedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocAddedSum
+}
+
+// GetLocDeletedSum returns the LocDeletedSum field.
+func (c *CopilotMetricsFeature) GetLocDeletedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocDeletedSum
+}
+
+// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
+func (c *CopilotMetricsFeature) GetLocSuggestedToAddSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToAddSum
+}
+
+// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
+func (c *CopilotMetricsFeature) GetLocSuggestedToDeleteSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToDeleteSum
+}
+
+// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
+func (c *CopilotMetricsFeature) GetUserInitiatedInteractionCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.UserInitiatedInteractionCount
+}
+
+// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
+func (c *CopilotMetricsIDE) GetCodeAcceptanceActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeAcceptanceActivityCount
+}
+
+// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
+func (c *CopilotMetricsIDE) GetCodeGenerationActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeGenerationActivityCount
+}
+
+// GetIDE returns the IDE field.
+func (c *CopilotMetricsIDE) GetIDE() string {
+	if c == nil {
+		return ""
+	}
+	return c.IDE
+}
+
+// GetLocAddedSum returns the LocAddedSum field.
+func (c *CopilotMetricsIDE) GetLocAddedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocAddedSum
+}
+
+// GetLocDeletedSum returns the LocDeletedSum field.
+func (c *CopilotMetricsIDE) GetLocDeletedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocDeletedSum
+}
+
+// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
+func (c *CopilotMetricsIDE) GetLocSuggestedToAddSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToAddSum
+}
+
+// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
+func (c *CopilotMetricsIDE) GetLocSuggestedToDeleteSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToDeleteSum
+}
+
+// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
+func (c *CopilotMetricsIDE) GetUserInitiatedInteractionCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.UserInitiatedInteractionCount
+}
+
+// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
+func (c *CopilotMetricsLanguageFeature) GetCodeAcceptanceActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeAcceptanceActivityCount
+}
+
+// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
+func (c *CopilotMetricsLanguageFeature) GetCodeGenerationActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeGenerationActivityCount
+}
+
+// GetFeature returns the Feature field.
+func (c *CopilotMetricsLanguageFeature) GetFeature() string {
+	if c == nil {
+		return ""
+	}
+	return c.Feature
+}
+
+// GetLanguage returns the Language field.
+func (c *CopilotMetricsLanguageFeature) GetLanguage() string {
+	if c == nil {
+		return ""
+	}
+	return c.Language
+}
+
+// GetLocAddedSum returns the LocAddedSum field.
+func (c *CopilotMetricsLanguageFeature) GetLocAddedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocAddedSum
+}
+
+// GetLocDeletedSum returns the LocDeletedSum field.
+func (c *CopilotMetricsLanguageFeature) GetLocDeletedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocDeletedSum
+}
+
+// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
+func (c *CopilotMetricsLanguageFeature) GetLocSuggestedToAddSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToAddSum
+}
+
+// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
+func (c *CopilotMetricsLanguageFeature) GetLocSuggestedToDeleteSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToDeleteSum
+}
+
+// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
+func (c *CopilotMetricsLanguageModel) GetCodeAcceptanceActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeAcceptanceActivityCount
+}
+
+// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
+func (c *CopilotMetricsLanguageModel) GetCodeGenerationActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeGenerationActivityCount
+}
+
+// GetLanguage returns the Language field.
+func (c *CopilotMetricsLanguageModel) GetLanguage() string {
+	if c == nil {
+		return ""
+	}
+	return c.Language
+}
+
+// GetLocAddedSum returns the LocAddedSum field.
+func (c *CopilotMetricsLanguageModel) GetLocAddedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocAddedSum
+}
+
+// GetLocDeletedSum returns the LocDeletedSum field.
+func (c *CopilotMetricsLanguageModel) GetLocDeletedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocDeletedSum
+}
+
+// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
+func (c *CopilotMetricsLanguageModel) GetLocSuggestedToAddSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToAddSum
+}
+
+// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
+func (c *CopilotMetricsLanguageModel) GetLocSuggestedToDeleteSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToDeleteSum
+}
+
+// GetModel returns the Model field.
+func (c *CopilotMetricsLanguageModel) GetModel() string {
+	if c == nil {
+		return ""
+	}
+	return c.Model
+}
+
 // GetSince returns the Since field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsListOptions) GetSince() time.Time {
 	if c == nil || c.Since == nil {
@@ -8668,6 +9212,190 @@ func (c *CopilotMetricsListOptions) GetUntil() time.Time {
 		return time.Time{}
 	}
 	return *c.Until
+}
+
+// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
+func (c *CopilotMetricsModelFeature) GetCodeAcceptanceActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeAcceptanceActivityCount
+}
+
+// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
+func (c *CopilotMetricsModelFeature) GetCodeGenerationActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeGenerationActivityCount
+}
+
+// GetFeature returns the Feature field.
+func (c *CopilotMetricsModelFeature) GetFeature() string {
+	if c == nil {
+		return ""
+	}
+	return c.Feature
+}
+
+// GetLocAddedSum returns the LocAddedSum field.
+func (c *CopilotMetricsModelFeature) GetLocAddedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocAddedSum
+}
+
+// GetLocDeletedSum returns the LocDeletedSum field.
+func (c *CopilotMetricsModelFeature) GetLocDeletedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocDeletedSum
+}
+
+// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
+func (c *CopilotMetricsModelFeature) GetLocSuggestedToAddSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToAddSum
+}
+
+// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
+func (c *CopilotMetricsModelFeature) GetLocSuggestedToDeleteSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToDeleteSum
+}
+
+// GetModel returns the Model field.
+func (c *CopilotMetricsModelFeature) GetModel() string {
+	if c == nil {
+		return ""
+	}
+	return c.Model
+}
+
+// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
+func (c *CopilotMetricsModelFeature) GetUserInitiatedInteractionCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.UserInitiatedInteractionCount
+}
+
+// GetMedianMinutesToMerge returns the MedianMinutesToMerge field.
+func (c *CopilotMetricsPullRequests) GetMedianMinutesToMerge() float64 {
+	if c == nil {
+		return 0
+	}
+	return c.MedianMinutesToMerge
+}
+
+// GetMedianMinutesToMergeCopilotAuthored returns the MedianMinutesToMergeCopilotAuthored field.
+func (c *CopilotMetricsPullRequests) GetMedianMinutesToMergeCopilotAuthored() float64 {
+	if c == nil {
+		return 0
+	}
+	return c.MedianMinutesToMergeCopilotAuthored
+}
+
+// GetMedianMinutesToMergeCopilotReviewed returns the MedianMinutesToMergeCopilotReviewed field.
+func (c *CopilotMetricsPullRequests) GetMedianMinutesToMergeCopilotReviewed() float64 {
+	if c == nil {
+		return 0
+	}
+	return c.MedianMinutesToMergeCopilotReviewed
+}
+
+// GetTotalAppliedSuggestions returns the TotalAppliedSuggestions field.
+func (c *CopilotMetricsPullRequests) GetTotalAppliedSuggestions() int {
+	if c == nil {
+		return 0
+	}
+	return c.TotalAppliedSuggestions
+}
+
+// GetTotalCopilotAppliedSuggestions returns the TotalCopilotAppliedSuggestions field.
+func (c *CopilotMetricsPullRequests) GetTotalCopilotAppliedSuggestions() int {
+	if c == nil {
+		return 0
+	}
+	return c.TotalCopilotAppliedSuggestions
+}
+
+// GetTotalCopilotSuggestions returns the TotalCopilotSuggestions field.
+func (c *CopilotMetricsPullRequests) GetTotalCopilotSuggestions() int {
+	if c == nil {
+		return 0
+	}
+	return c.TotalCopilotSuggestions
+}
+
+// GetTotalCreated returns the TotalCreated field.
+func (c *CopilotMetricsPullRequests) GetTotalCreated() int {
+	if c == nil {
+		return 0
+	}
+	return c.TotalCreated
+}
+
+// GetTotalCreatedByCopilot returns the TotalCreatedByCopilot field.
+func (c *CopilotMetricsPullRequests) GetTotalCreatedByCopilot() int {
+	if c == nil {
+		return 0
+	}
+	return c.TotalCreatedByCopilot
+}
+
+// GetTotalMerged returns the TotalMerged field.
+func (c *CopilotMetricsPullRequests) GetTotalMerged() int {
+	if c == nil {
+		return 0
+	}
+	return c.TotalMerged
+}
+
+// GetTotalMergedCreatedByCopilot returns the TotalMergedCreatedByCopilot field.
+func (c *CopilotMetricsPullRequests) GetTotalMergedCreatedByCopilot() int {
+	if c == nil {
+		return 0
+	}
+	return c.TotalMergedCreatedByCopilot
+}
+
+// GetTotalMergedReviewedByCopilot returns the TotalMergedReviewedByCopilot field.
+func (c *CopilotMetricsPullRequests) GetTotalMergedReviewedByCopilot() int {
+	if c == nil {
+		return 0
+	}
+	return c.TotalMergedReviewedByCopilot
+}
+
+// GetTotalReviewed returns the TotalReviewed field.
+func (c *CopilotMetricsPullRequests) GetTotalReviewed() int {
+	if c == nil {
+		return 0
+	}
+	return c.TotalReviewed
+}
+
+// GetTotalReviewedByCopilot returns the TotalReviewedByCopilot field.
+func (c *CopilotMetricsPullRequests) GetTotalReviewedByCopilot() int {
+	if c == nil {
+		return 0
+	}
+	return c.TotalReviewedByCopilot
+}
+
+// GetTotalSuggestions returns the TotalSuggestions field.
+func (c *CopilotMetricsPullRequests) GetTotalSuggestions() int {
+	if c == nil {
+		return 0
+	}
+	return c.TotalSuggestions
 }
 
 // GetDownloadLinks returns the DownloadLinks slice if it's non-nil, nil otherwise.
@@ -8732,6 +9460,54 @@ func (c *CopilotOrganizationDetails) GetSeatManagementSetting() string {
 		return ""
 	}
 	return c.SeatManagementSetting
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (c *CopilotPeriodicMetrics) GetCreatedAt() Timestamp {
+	if c == nil || c.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *c.CreatedAt
+}
+
+// GetDayTotals returns the DayTotals slice if it's non-nil, nil otherwise.
+func (c *CopilotPeriodicMetrics) GetDayTotals() []*CopilotDailyMetrics {
+	if c == nil || c.DayTotals == nil {
+		return nil
+	}
+	return c.DayTotals
+}
+
+// GetEnterpriseID returns the EnterpriseID field.
+func (c *CopilotPeriodicMetrics) GetEnterpriseID() string {
+	if c == nil {
+		return ""
+	}
+	return c.EnterpriseID
+}
+
+// GetOrganizationID returns the OrganizationID field.
+func (c *CopilotPeriodicMetrics) GetOrganizationID() string {
+	if c == nil {
+		return ""
+	}
+	return c.OrganizationID
+}
+
+// GetReportEndDay returns the ReportEndDay field.
+func (c *CopilotPeriodicMetrics) GetReportEndDay() string {
+	if c == nil {
+		return ""
+	}
+	return c.ReportEndDay
+}
+
+// GetReportStartDay returns the ReportStartDay field.
+func (c *CopilotPeriodicMetrics) GetReportStartDay() string {
+	if c == nil {
+		return ""
+	}
+	return c.ReportStartDay
 }
 
 // GetActiveThisCycle returns the ActiveThisCycle field.
@@ -8844,6 +9620,526 @@ func (c *CopilotSeatDetails) GetUpdatedAt() Timestamp {
 		return Timestamp{}
 	}
 	return *c.UpdatedAt
+}
+
+// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
+func (c *CopilotUserDailyMetrics) GetCodeAcceptanceActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeAcceptanceActivityCount
+}
+
+// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
+func (c *CopilotUserDailyMetrics) GetCodeGenerationActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeGenerationActivityCount
+}
+
+// GetDay returns the Day field.
+func (c *CopilotUserDailyMetrics) GetDay() string {
+	if c == nil {
+		return ""
+	}
+	return c.Day
+}
+
+// GetEnterpriseID returns the EnterpriseID field.
+func (c *CopilotUserDailyMetrics) GetEnterpriseID() string {
+	if c == nil {
+		return ""
+	}
+	return c.EnterpriseID
+}
+
+// GetLocAddedSum returns the LocAddedSum field.
+func (c *CopilotUserDailyMetrics) GetLocAddedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocAddedSum
+}
+
+// GetLocDeletedSum returns the LocDeletedSum field.
+func (c *CopilotUserDailyMetrics) GetLocDeletedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocDeletedSum
+}
+
+// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
+func (c *CopilotUserDailyMetrics) GetLocSuggestedToAddSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToAddSum
+}
+
+// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
+func (c *CopilotUserDailyMetrics) GetLocSuggestedToDeleteSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToDeleteSum
+}
+
+// GetOrganizationID returns the OrganizationID field.
+func (c *CopilotUserDailyMetrics) GetOrganizationID() string {
+	if c == nil {
+		return ""
+	}
+	return c.OrganizationID
+}
+
+// GetTotalsByCli returns the TotalsByCli field.
+func (c *CopilotUserDailyMetrics) GetTotalsByCli() *CopilotMetricsCli {
+	if c == nil {
+		return nil
+	}
+	return c.TotalsByCli
+}
+
+// GetTotalsByFeature returns the TotalsByFeature slice if it's non-nil, nil otherwise.
+func (c *CopilotUserDailyMetrics) GetTotalsByFeature() []*CopilotMetricsFeature {
+	if c == nil || c.TotalsByFeature == nil {
+		return nil
+	}
+	return c.TotalsByFeature
+}
+
+// GetTotalsByIDE returns the TotalsByIDE slice if it's non-nil, nil otherwise.
+func (c *CopilotUserDailyMetrics) GetTotalsByIDE() []*CopilotUserMetricsIDE {
+	if c == nil || c.TotalsByIDE == nil {
+		return nil
+	}
+	return c.TotalsByIDE
+}
+
+// GetTotalsByLanguageFeature returns the TotalsByLanguageFeature slice if it's non-nil, nil otherwise.
+func (c *CopilotUserDailyMetrics) GetTotalsByLanguageFeature() []*CopilotMetricsLanguageFeature {
+	if c == nil || c.TotalsByLanguageFeature == nil {
+		return nil
+	}
+	return c.TotalsByLanguageFeature
+}
+
+// GetTotalsByLanguageModel returns the TotalsByLanguageModel slice if it's non-nil, nil otherwise.
+func (c *CopilotUserDailyMetrics) GetTotalsByLanguageModel() []*CopilotMetricsLanguageModel {
+	if c == nil || c.TotalsByLanguageModel == nil {
+		return nil
+	}
+	return c.TotalsByLanguageModel
+}
+
+// GetTotalsByModelFeature returns the TotalsByModelFeature slice if it's non-nil, nil otherwise.
+func (c *CopilotUserDailyMetrics) GetTotalsByModelFeature() []*CopilotMetricsModelFeature {
+	if c == nil || c.TotalsByModelFeature == nil {
+		return nil
+	}
+	return c.TotalsByModelFeature
+}
+
+// GetUsedAgent returns the UsedAgent field.
+func (c *CopilotUserDailyMetrics) GetUsedAgent() bool {
+	if c == nil {
+		return false
+	}
+	return c.UsedAgent
+}
+
+// GetUsedChat returns the UsedChat field.
+func (c *CopilotUserDailyMetrics) GetUsedChat() bool {
+	if c == nil {
+		return false
+	}
+	return c.UsedChat
+}
+
+// GetUsedCli returns the UsedCli field.
+func (c *CopilotUserDailyMetrics) GetUsedCli() bool {
+	if c == nil {
+		return false
+	}
+	return c.UsedCli
+}
+
+// GetUsedCopilotCodeReviewActive returns the UsedCopilotCodeReviewActive field.
+func (c *CopilotUserDailyMetrics) GetUsedCopilotCodeReviewActive() bool {
+	if c == nil {
+		return false
+	}
+	return c.UsedCopilotCodeReviewActive
+}
+
+// GetUsedCopilotCodeReviewPassive returns the UsedCopilotCodeReviewPassive field.
+func (c *CopilotUserDailyMetrics) GetUsedCopilotCodeReviewPassive() bool {
+	if c == nil {
+		return false
+	}
+	return c.UsedCopilotCodeReviewPassive
+}
+
+// GetUsedCopilotCodingAgent returns the UsedCopilotCodingAgent field.
+func (c *CopilotUserDailyMetrics) GetUsedCopilotCodingAgent() bool {
+	if c == nil {
+		return false
+	}
+	return c.UsedCopilotCodingAgent
+}
+
+// GetUserID returns the UserID field.
+func (c *CopilotUserDailyMetrics) GetUserID() int {
+	if c == nil {
+		return 0
+	}
+	return c.UserID
+}
+
+// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
+func (c *CopilotUserDailyMetrics) GetUserInitiatedInteractionCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.UserInitiatedInteractionCount
+}
+
+// GetUserLogin returns the UserLogin field.
+func (c *CopilotUserDailyMetrics) GetUserLogin() string {
+	if c == nil {
+		return ""
+	}
+	return c.UserLogin
+}
+
+// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
+func (c *CopilotUserMetricsIDE) GetCodeAcceptanceActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeAcceptanceActivityCount
+}
+
+// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
+func (c *CopilotUserMetricsIDE) GetCodeGenerationActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeGenerationActivityCount
+}
+
+// GetIDE returns the IDE field.
+func (c *CopilotUserMetricsIDE) GetIDE() string {
+	if c == nil {
+		return ""
+	}
+	return c.IDE
+}
+
+// GetLastKnownIDEVersion returns the LastKnownIDEVersion field.
+func (c *CopilotUserMetricsIDE) GetLastKnownIDEVersion() *CopilotUserMetricsIDEVersion {
+	if c == nil {
+		return nil
+	}
+	return c.LastKnownIDEVersion
+}
+
+// GetLastKnownPluginVersion returns the LastKnownPluginVersion field.
+func (c *CopilotUserMetricsIDE) GetLastKnownPluginVersion() *CopilotUserMetricsPluginVersion {
+	if c == nil {
+		return nil
+	}
+	return c.LastKnownPluginVersion
+}
+
+// GetLocAddedSum returns the LocAddedSum field.
+func (c *CopilotUserMetricsIDE) GetLocAddedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocAddedSum
+}
+
+// GetLocDeletedSum returns the LocDeletedSum field.
+func (c *CopilotUserMetricsIDE) GetLocDeletedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocDeletedSum
+}
+
+// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
+func (c *CopilotUserMetricsIDE) GetLocSuggestedToAddSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToAddSum
+}
+
+// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
+func (c *CopilotUserMetricsIDE) GetLocSuggestedToDeleteSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToDeleteSum
+}
+
+// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
+func (c *CopilotUserMetricsIDE) GetUserInitiatedInteractionCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.UserInitiatedInteractionCount
+}
+
+// GetIDEVersion returns the IDEVersion field.
+func (c *CopilotUserMetricsIDEVersion) GetIDEVersion() string {
+	if c == nil {
+		return ""
+	}
+	return c.IDEVersion
+}
+
+// GetSampledAt returns the SampledAt field if it's non-nil, zero value otherwise.
+func (c *CopilotUserMetricsIDEVersion) GetSampledAt() Timestamp {
+	if c == nil || c.SampledAt == nil {
+		return Timestamp{}
+	}
+	return *c.SampledAt
+}
+
+// GetPlugin returns the Plugin field.
+func (c *CopilotUserMetricsPluginVersion) GetPlugin() string {
+	if c == nil {
+		return ""
+	}
+	return c.Plugin
+}
+
+// GetPluginVersion returns the PluginVersion field.
+func (c *CopilotUserMetricsPluginVersion) GetPluginVersion() string {
+	if c == nil {
+		return ""
+	}
+	return c.PluginVersion
+}
+
+// GetSampledAt returns the SampledAt field if it's non-nil, zero value otherwise.
+func (c *CopilotUserMetricsPluginVersion) GetSampledAt() Timestamp {
+	if c == nil || c.SampledAt == nil {
+		return Timestamp{}
+	}
+	return *c.SampledAt
+}
+
+// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
+func (c *CopilotUserPeriodicMetrics) GetCodeAcceptanceActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeAcceptanceActivityCount
+}
+
+// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
+func (c *CopilotUserPeriodicMetrics) GetCodeGenerationActivityCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.CodeGenerationActivityCount
+}
+
+// GetDay returns the Day field.
+func (c *CopilotUserPeriodicMetrics) GetDay() string {
+	if c == nil {
+		return ""
+	}
+	return c.Day
+}
+
+// GetEnterpriseID returns the EnterpriseID field.
+func (c *CopilotUserPeriodicMetrics) GetEnterpriseID() string {
+	if c == nil {
+		return ""
+	}
+	return c.EnterpriseID
+}
+
+// GetLocAddedSum returns the LocAddedSum field.
+func (c *CopilotUserPeriodicMetrics) GetLocAddedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocAddedSum
+}
+
+// GetLocDeletedSum returns the LocDeletedSum field.
+func (c *CopilotUserPeriodicMetrics) GetLocDeletedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocDeletedSum
+}
+
+// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
+func (c *CopilotUserPeriodicMetrics) GetLocSuggestedToAddSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToAddSum
+}
+
+// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
+func (c *CopilotUserPeriodicMetrics) GetLocSuggestedToDeleteSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LocSuggestedToDeleteSum
+}
+
+// GetOrganizationID returns the OrganizationID field.
+func (c *CopilotUserPeriodicMetrics) GetOrganizationID() string {
+	if c == nil {
+		return ""
+	}
+	return c.OrganizationID
+}
+
+// GetReportEndDay returns the ReportEndDay field.
+func (c *CopilotUserPeriodicMetrics) GetReportEndDay() string {
+	if c == nil {
+		return ""
+	}
+	return c.ReportEndDay
+}
+
+// GetReportStartDay returns the ReportStartDay field.
+func (c *CopilotUserPeriodicMetrics) GetReportStartDay() string {
+	if c == nil {
+		return ""
+	}
+	return c.ReportStartDay
+}
+
+// GetTotalsByCli returns the TotalsByCli field.
+func (c *CopilotUserPeriodicMetrics) GetTotalsByCli() *CopilotMetricsCli {
+	if c == nil {
+		return nil
+	}
+	return c.TotalsByCli
+}
+
+// GetTotalsByFeature returns the TotalsByFeature slice if it's non-nil, nil otherwise.
+func (c *CopilotUserPeriodicMetrics) GetTotalsByFeature() []*CopilotMetricsFeature {
+	if c == nil || c.TotalsByFeature == nil {
+		return nil
+	}
+	return c.TotalsByFeature
+}
+
+// GetTotalsByIDE returns the TotalsByIDE slice if it's non-nil, nil otherwise.
+func (c *CopilotUserPeriodicMetrics) GetTotalsByIDE() []*CopilotUserMetricsIDE {
+	if c == nil || c.TotalsByIDE == nil {
+		return nil
+	}
+	return c.TotalsByIDE
+}
+
+// GetTotalsByLanguageFeature returns the TotalsByLanguageFeature slice if it's non-nil, nil otherwise.
+func (c *CopilotUserPeriodicMetrics) GetTotalsByLanguageFeature() []*CopilotMetricsLanguageFeature {
+	if c == nil || c.TotalsByLanguageFeature == nil {
+		return nil
+	}
+	return c.TotalsByLanguageFeature
+}
+
+// GetTotalsByLanguageModel returns the TotalsByLanguageModel slice if it's non-nil, nil otherwise.
+func (c *CopilotUserPeriodicMetrics) GetTotalsByLanguageModel() []*CopilotMetricsLanguageModel {
+	if c == nil || c.TotalsByLanguageModel == nil {
+		return nil
+	}
+	return c.TotalsByLanguageModel
+}
+
+// GetTotalsByModelFeature returns the TotalsByModelFeature slice if it's non-nil, nil otherwise.
+func (c *CopilotUserPeriodicMetrics) GetTotalsByModelFeature() []*CopilotMetricsModelFeature {
+	if c == nil || c.TotalsByModelFeature == nil {
+		return nil
+	}
+	return c.TotalsByModelFeature
+}
+
+// GetUsedAgent returns the UsedAgent field.
+func (c *CopilotUserPeriodicMetrics) GetUsedAgent() bool {
+	if c == nil {
+		return false
+	}
+	return c.UsedAgent
+}
+
+// GetUsedChat returns the UsedChat field.
+func (c *CopilotUserPeriodicMetrics) GetUsedChat() bool {
+	if c == nil {
+		return false
+	}
+	return c.UsedChat
+}
+
+// GetUsedCli returns the UsedCli field.
+func (c *CopilotUserPeriodicMetrics) GetUsedCli() bool {
+	if c == nil {
+		return false
+	}
+	return c.UsedCli
+}
+
+// GetUsedCopilotCodeReviewActive returns the UsedCopilotCodeReviewActive field.
+func (c *CopilotUserPeriodicMetrics) GetUsedCopilotCodeReviewActive() bool {
+	if c == nil {
+		return false
+	}
+	return c.UsedCopilotCodeReviewActive
+}
+
+// GetUsedCopilotCodeReviewPassive returns the UsedCopilotCodeReviewPassive field.
+func (c *CopilotUserPeriodicMetrics) GetUsedCopilotCodeReviewPassive() bool {
+	if c == nil {
+		return false
+	}
+	return c.UsedCopilotCodeReviewPassive
+}
+
+// GetUsedCopilotCodingAgent returns the UsedCopilotCodingAgent field.
+func (c *CopilotUserPeriodicMetrics) GetUsedCopilotCodingAgent() bool {
+	if c == nil {
+		return false
+	}
+	return c.UsedCopilotCodingAgent
+}
+
+// GetUserID returns the UserID field.
+func (c *CopilotUserPeriodicMetrics) GetUserID() int {
+	if c == nil {
+		return 0
+	}
+	return c.UserID
+}
+
+// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
+func (c *CopilotUserPeriodicMetrics) GetUserInitiatedInteractionCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.UserInitiatedInteractionCount
+}
+
+// GetUserLogin returns the UserLogin field.
+func (c *CopilotUserPeriodicMetrics) GetUserLogin() string {
+	if c == nil {
+		return ""
+	}
+	return c.UserLogin
 }
 
 // GetAzureSubscription returns the AzureSubscription field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -8214,12 +8214,12 @@ func (c *CopilotDailyMetrics) GetCodeGenerationActivityCount() int {
 	return c.CodeGenerationActivityCount
 }
 
-// GetDailyActiveCliUsers returns the DailyActiveCliUsers field.
-func (c *CopilotDailyMetrics) GetDailyActiveCliUsers() int {
+// GetDailyActiveCLIUsers returns the DailyActiveCLIUsers field.
+func (c *CopilotDailyMetrics) GetDailyActiveCLIUsers() int {
 	if c == nil {
 		return 0
 	}
-	return c.DailyActiveCliUsers
+	return c.DailyActiveCLIUsers
 }
 
 // GetDailyActiveCopilotCloudAgentUsers returns the DailyActiveCopilotCloudAgentUsers field.
@@ -8334,12 +8334,12 @@ func (c *CopilotDailyMetrics) GetPullRequests() *CopilotMetricsPullRequests {
 	return c.PullRequests
 }
 
-// GetTotalsByCli returns the TotalsByCli field.
-func (c *CopilotDailyMetrics) GetTotalsByCli() *CopilotMetricsCli {
+// GetTotalsByCLI returns the TotalsByCLI field.
+func (c *CopilotDailyMetrics) GetTotalsByCLI() *CopilotMetricsCLI {
 	if c == nil {
 		return nil
 	}
-	return c.TotalsByCli
+	return c.TotalsByCLI
 }
 
 // GetTotalsByFeature returns the TotalsByFeature slice if it's non-nil, nil otherwise.
@@ -8862,16 +8862,16 @@ func (c *CopilotMetrics) GetTotalEngagedUsers() int {
 	return *c.TotalEngagedUsers
 }
 
-// GetLastKnownCliVersion returns the LastKnownCliVersion field.
-func (c *CopilotMetricsCli) GetLastKnownCliVersion() *CopilotMetricsCliVersion {
+// GetLastKnownCLIVersion returns the LastKnownCLIVersion field.
+func (c *CopilotMetricsCLI) GetLastKnownCLIVersion() *CopilotMetricsCLIVersion {
 	if c == nil {
 		return nil
 	}
-	return c.LastKnownCliVersion
+	return c.LastKnownCLIVersion
 }
 
 // GetPromptCount returns the PromptCount field.
-func (c *CopilotMetricsCli) GetPromptCount() int {
+func (c *CopilotMetricsCLI) GetPromptCount() int {
 	if c == nil {
 		return 0
 	}
@@ -8879,7 +8879,7 @@ func (c *CopilotMetricsCli) GetPromptCount() int {
 }
 
 // GetRequestCount returns the RequestCount field.
-func (c *CopilotMetricsCli) GetRequestCount() int {
+func (c *CopilotMetricsCLI) GetRequestCount() int {
 	if c == nil {
 		return 0
 	}
@@ -8887,7 +8887,7 @@ func (c *CopilotMetricsCli) GetRequestCount() int {
 }
 
 // GetSessionCount returns the SessionCount field.
-func (c *CopilotMetricsCli) GetSessionCount() int {
+func (c *CopilotMetricsCLI) GetSessionCount() int {
 	if c == nil {
 		return 0
 	}
@@ -8895,7 +8895,7 @@ func (c *CopilotMetricsCli) GetSessionCount() int {
 }
 
 // GetTokenUsage returns the TokenUsage field.
-func (c *CopilotMetricsCli) GetTokenUsage() *CopilotMetricsCliTokenUsage {
+func (c *CopilotMetricsCLI) GetTokenUsage() *CopilotMetricsCLITokenUsage {
 	if c == nil {
 		return nil
 	}
@@ -8903,7 +8903,7 @@ func (c *CopilotMetricsCli) GetTokenUsage() *CopilotMetricsCliTokenUsage {
 }
 
 // GetAvgTokensPerRequest returns the AvgTokensPerRequest field.
-func (c *CopilotMetricsCliTokenUsage) GetAvgTokensPerRequest() float64 {
+func (c *CopilotMetricsCLITokenUsage) GetAvgTokensPerRequest() float64 {
 	if c == nil {
 		return 0
 	}
@@ -8911,7 +8911,7 @@ func (c *CopilotMetricsCliTokenUsage) GetAvgTokensPerRequest() float64 {
 }
 
 // GetOutputTokensSum returns the OutputTokensSum field.
-func (c *CopilotMetricsCliTokenUsage) GetOutputTokensSum() int {
+func (c *CopilotMetricsCLITokenUsage) GetOutputTokensSum() int {
 	if c == nil {
 		return 0
 	}
@@ -8919,23 +8919,23 @@ func (c *CopilotMetricsCliTokenUsage) GetOutputTokensSum() int {
 }
 
 // GetPromptTokensSum returns the PromptTokensSum field.
-func (c *CopilotMetricsCliTokenUsage) GetPromptTokensSum() int {
+func (c *CopilotMetricsCLITokenUsage) GetPromptTokensSum() int {
 	if c == nil {
 		return 0
 	}
 	return c.PromptTokensSum
 }
 
-// GetCliVersion returns the CliVersion field.
-func (c *CopilotMetricsCliVersion) GetCliVersion() string {
+// GetCLIVersion returns the CLIVersion field.
+func (c *CopilotMetricsCLIVersion) GetCLIVersion() string {
 	if c == nil {
 		return ""
 	}
-	return c.CliVersion
+	return c.CLIVersion
 }
 
 // GetSampledAt returns the SampledAt field if it's non-nil, zero value otherwise.
-func (c *CopilotMetricsCliVersion) GetSampledAt() Timestamp {
+func (c *CopilotMetricsCLIVersion) GetSampledAt() Timestamp {
 	if c == nil || c.SampledAt == nil {
 		return Timestamp{}
 	}
@@ -9694,12 +9694,12 @@ func (c *CopilotUserDailyMetrics) GetOrganizationID() string {
 	return c.OrganizationID
 }
 
-// GetTotalsByCli returns the TotalsByCli field.
-func (c *CopilotUserDailyMetrics) GetTotalsByCli() *CopilotMetricsCli {
+// GetTotalsByCLI returns the TotalsByCLI field.
+func (c *CopilotUserDailyMetrics) GetTotalsByCLI() *CopilotMetricsCLI {
 	if c == nil {
 		return nil
 	}
-	return c.TotalsByCli
+	return c.TotalsByCLI
 }
 
 // GetTotalsByFeature returns the TotalsByFeature slice if it's non-nil, nil otherwise.
@@ -9758,12 +9758,12 @@ func (c *CopilotUserDailyMetrics) GetUsedChat() bool {
 	return c.UsedChat
 }
 
-// GetUsedCli returns the UsedCli field.
-func (c *CopilotUserDailyMetrics) GetUsedCli() bool {
+// GetUsedCLI returns the UsedCLI field.
+func (c *CopilotUserDailyMetrics) GetUsedCLI() bool {
 	if c == nil {
 		return false
 	}
-	return c.UsedCli
+	return c.UsedCLI
 }
 
 // GetUsedCopilotCodeReviewActive returns the UsedCopilotCodeReviewActive field.
@@ -10022,12 +10022,12 @@ func (c *CopilotUserPeriodicMetrics) GetReportStartDay() string {
 	return c.ReportStartDay
 }
 
-// GetTotalsByCli returns the TotalsByCli field.
-func (c *CopilotUserPeriodicMetrics) GetTotalsByCli() *CopilotMetricsCli {
+// GetTotalsByCLI returns the TotalsByCLI field.
+func (c *CopilotUserPeriodicMetrics) GetTotalsByCLI() *CopilotMetricsCLI {
 	if c == nil {
 		return nil
 	}
-	return c.TotalsByCli
+	return c.TotalsByCLI
 }
 
 // GetTotalsByFeature returns the TotalsByFeature slice if it's non-nil, nil otherwise.
@@ -10086,12 +10086,12 @@ func (c *CopilotUserPeriodicMetrics) GetUsedChat() bool {
 	return c.UsedChat
 }
 
-// GetUsedCli returns the UsedCli field.
-func (c *CopilotUserPeriodicMetrics) GetUsedCli() bool {
+// GetUsedCLI returns the UsedCLI field.
+func (c *CopilotUserPeriodicMetrics) GetUsedCLI() bool {
 	if c == nil {
 		return false
 	}
-	return c.UsedCli
+	return c.UsedCLI
 }
 
 // GetUsedCopilotCodeReviewActive returns the UsedCopilotCodeReviewActive field.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -8198,44 +8198,44 @@ func (c *CopilotCodeReviewRuleParameters) GetReviewOnPush() bool {
 	return c.ReviewOnPush
 }
 
-// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
+// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetCodeAcceptanceActivityCount() int {
-	if c == nil {
+	if c == nil || c.CodeAcceptanceActivityCount == nil {
 		return 0
 	}
-	return c.CodeAcceptanceActivityCount
+	return *c.CodeAcceptanceActivityCount
 }
 
-// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
+// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetCodeGenerationActivityCount() int {
-	if c == nil {
+	if c == nil || c.CodeGenerationActivityCount == nil {
 		return 0
 	}
-	return c.CodeGenerationActivityCount
+	return *c.CodeGenerationActivityCount
 }
 
-// GetDailyActiveCLIUsers returns the DailyActiveCLIUsers field.
+// GetDailyActiveCLIUsers returns the DailyActiveCLIUsers field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetDailyActiveCLIUsers() int {
-	if c == nil {
+	if c == nil || c.DailyActiveCLIUsers == nil {
 		return 0
 	}
-	return c.DailyActiveCLIUsers
+	return *c.DailyActiveCLIUsers
 }
 
-// GetDailyActiveCopilotCloudAgentUsers returns the DailyActiveCopilotCloudAgentUsers field.
+// GetDailyActiveCopilotCloudAgentUsers returns the DailyActiveCopilotCloudAgentUsers field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetDailyActiveCopilotCloudAgentUsers() int {
-	if c == nil {
+	if c == nil || c.DailyActiveCopilotCloudAgentUsers == nil {
 		return 0
 	}
-	return c.DailyActiveCopilotCloudAgentUsers
+	return *c.DailyActiveCopilotCloudAgentUsers
 }
 
-// GetDailyActiveUsers returns the DailyActiveUsers field.
+// GetDailyActiveUsers returns the DailyActiveUsers field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetDailyActiveUsers() int {
-	if c == nil {
+	if c == nil || c.DailyActiveUsers == nil {
 		return 0
 	}
-	return c.DailyActiveUsers
+	return *c.DailyActiveUsers
 }
 
 // GetDay returns the Day field.
@@ -8246,84 +8246,84 @@ func (c *CopilotDailyMetrics) GetDay() string {
 	return c.Day
 }
 
-// GetEnterpriseID returns the EnterpriseID field.
+// GetEnterpriseID returns the EnterpriseID field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetEnterpriseID() string {
-	if c == nil {
+	if c == nil || c.EnterpriseID == nil {
 		return ""
 	}
-	return c.EnterpriseID
+	return *c.EnterpriseID
 }
 
-// GetLOCAddedSum returns the LOCAddedSum field.
+// GetLOCAddedSum returns the LOCAddedSum field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetLOCAddedSum() int {
-	if c == nil {
+	if c == nil || c.LOCAddedSum == nil {
 		return 0
 	}
-	return c.LOCAddedSum
+	return *c.LOCAddedSum
 }
 
-// GetLOCDeletedSum returns the LOCDeletedSum field.
+// GetLOCDeletedSum returns the LOCDeletedSum field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetLOCDeletedSum() int {
-	if c == nil {
+	if c == nil || c.LOCDeletedSum == nil {
 		return 0
 	}
-	return c.LOCDeletedSum
+	return *c.LOCDeletedSum
 }
 
-// GetLOCSuggestedToAddSum returns the LOCSuggestedToAddSum field.
+// GetLOCSuggestedToAddSum returns the LOCSuggestedToAddSum field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetLOCSuggestedToAddSum() int {
-	if c == nil {
+	if c == nil || c.LOCSuggestedToAddSum == nil {
 		return 0
 	}
-	return c.LOCSuggestedToAddSum
+	return *c.LOCSuggestedToAddSum
 }
 
-// GetLOCSuggestedToDeleteSum returns the LOCSuggestedToDeleteSum field.
+// GetLOCSuggestedToDeleteSum returns the LOCSuggestedToDeleteSum field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetLOCSuggestedToDeleteSum() int {
-	if c == nil {
+	if c == nil || c.LOCSuggestedToDeleteSum == nil {
 		return 0
 	}
-	return c.LOCSuggestedToDeleteSum
+	return *c.LOCSuggestedToDeleteSum
 }
 
-// GetMonthlyActiveAgentUsers returns the MonthlyActiveAgentUsers field.
+// GetMonthlyActiveAgentUsers returns the MonthlyActiveAgentUsers field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetMonthlyActiveAgentUsers() int {
-	if c == nil {
+	if c == nil || c.MonthlyActiveAgentUsers == nil {
 		return 0
 	}
-	return c.MonthlyActiveAgentUsers
+	return *c.MonthlyActiveAgentUsers
 }
 
-// GetMonthlyActiveChatUsers returns the MonthlyActiveChatUsers field.
+// GetMonthlyActiveChatUsers returns the MonthlyActiveChatUsers field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetMonthlyActiveChatUsers() int {
-	if c == nil {
+	if c == nil || c.MonthlyActiveChatUsers == nil {
 		return 0
 	}
-	return c.MonthlyActiveChatUsers
+	return *c.MonthlyActiveChatUsers
 }
 
-// GetMonthlyActiveCopilotCloudAgentUsers returns the MonthlyActiveCopilotCloudAgentUsers field.
+// GetMonthlyActiveCopilotCloudAgentUsers returns the MonthlyActiveCopilotCloudAgentUsers field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetMonthlyActiveCopilotCloudAgentUsers() int {
-	if c == nil {
+	if c == nil || c.MonthlyActiveCopilotCloudAgentUsers == nil {
 		return 0
 	}
-	return c.MonthlyActiveCopilotCloudAgentUsers
+	return *c.MonthlyActiveCopilotCloudAgentUsers
 }
 
-// GetMonthlyActiveUsers returns the MonthlyActiveUsers field.
+// GetMonthlyActiveUsers returns the MonthlyActiveUsers field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetMonthlyActiveUsers() int {
-	if c == nil {
+	if c == nil || c.MonthlyActiveUsers == nil {
 		return 0
 	}
-	return c.MonthlyActiveUsers
+	return *c.MonthlyActiveUsers
 }
 
-// GetOrganizationID returns the OrganizationID field.
+// GetOrganizationID returns the OrganizationID field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetOrganizationID() string {
-	if c == nil {
+	if c == nil || c.OrganizationID == nil {
 		return ""
 	}
-	return c.OrganizationID
+	return *c.OrganizationID
 }
 
 // GetPullRequests returns the PullRequests field.
@@ -8382,28 +8382,28 @@ func (c *CopilotDailyMetrics) GetTotalsByModelFeature() []*CopilotMetricsModelFe
 	return c.TotalsByModelFeature
 }
 
-// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
+// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetUserInitiatedInteractionCount() int {
-	if c == nil {
+	if c == nil || c.UserInitiatedInteractionCount == nil {
 		return 0
 	}
-	return c.UserInitiatedInteractionCount
+	return *c.UserInitiatedInteractionCount
 }
 
-// GetWeeklyActiveCopilotCloudAgentUsers returns the WeeklyActiveCopilotCloudAgentUsers field.
+// GetWeeklyActiveCopilotCloudAgentUsers returns the WeeklyActiveCopilotCloudAgentUsers field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetWeeklyActiveCopilotCloudAgentUsers() int {
-	if c == nil {
+	if c == nil || c.WeeklyActiveCopilotCloudAgentUsers == nil {
 		return 0
 	}
-	return c.WeeklyActiveCopilotCloudAgentUsers
+	return *c.WeeklyActiveCopilotCloudAgentUsers
 }
 
-// GetWeeklyActiveUsers returns the WeeklyActiveUsers field.
+// GetWeeklyActiveUsers returns the WeeklyActiveUsers field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetWeeklyActiveUsers() int {
-	if c == nil {
+	if c == nil || c.WeeklyActiveUsers == nil {
 		return 0
 	}
-	return c.WeeklyActiveUsers
+	return *c.WeeklyActiveUsers
 }
 
 // GetDownloadLinks returns the DownloadLinks slice if it's non-nil, nil otherwise.
@@ -8862,6 +8862,46 @@ func (c *CopilotMetrics) GetTotalEngagedUsers() int {
 	return *c.TotalEngagedUsers
 }
 
+// GetChatPanelAgentMode returns the ChatPanelAgentMode field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsChatPanel) GetChatPanelAgentMode() int {
+	if c == nil || c.ChatPanelAgentMode == nil {
+		return 0
+	}
+	return *c.ChatPanelAgentMode
+}
+
+// GetChatPanelAskMode returns the ChatPanelAskMode field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsChatPanel) GetChatPanelAskMode() int {
+	if c == nil || c.ChatPanelAskMode == nil {
+		return 0
+	}
+	return *c.ChatPanelAskMode
+}
+
+// GetChatPanelCustomMode returns the ChatPanelCustomMode field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsChatPanel) GetChatPanelCustomMode() int {
+	if c == nil || c.ChatPanelCustomMode == nil {
+		return 0
+	}
+	return *c.ChatPanelCustomMode
+}
+
+// GetChatPanelEditMode returns the ChatPanelEditMode field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsChatPanel) GetChatPanelEditMode() int {
+	if c == nil || c.ChatPanelEditMode == nil {
+		return 0
+	}
+	return *c.ChatPanelEditMode
+}
+
+// GetChatPanelUnknownMode returns the ChatPanelUnknownMode field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsChatPanel) GetChatPanelUnknownMode() int {
+	if c == nil || c.ChatPanelUnknownMode == nil {
+		return 0
+	}
+	return *c.ChatPanelUnknownMode
+}
+
 // GetLastKnownCLIVersion returns the LastKnownCLIVersion field.
 func (c *CopilotMetricsCLI) GetLastKnownCLIVersion() *CopilotMetricsCLIVersion {
 	if c == nil {
@@ -8870,28 +8910,28 @@ func (c *CopilotMetricsCLI) GetLastKnownCLIVersion() *CopilotMetricsCLIVersion {
 	return c.LastKnownCLIVersion
 }
 
-// GetPromptCount returns the PromptCount field.
+// GetPromptCount returns the PromptCount field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsCLI) GetPromptCount() int {
-	if c == nil {
+	if c == nil || c.PromptCount == nil {
 		return 0
 	}
-	return c.PromptCount
+	return *c.PromptCount
 }
 
-// GetRequestCount returns the RequestCount field.
+// GetRequestCount returns the RequestCount field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsCLI) GetRequestCount() int {
-	if c == nil {
+	if c == nil || c.RequestCount == nil {
 		return 0
 	}
-	return c.RequestCount
+	return *c.RequestCount
 }
 
-// GetSessionCount returns the SessionCount field.
+// GetSessionCount returns the SessionCount field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsCLI) GetSessionCount() int {
-	if c == nil {
+	if c == nil || c.SessionCount == nil {
 		return 0
 	}
-	return c.SessionCount
+	return *c.SessionCount
 }
 
 // GetTokenUsage returns the TokenUsage field.
@@ -8902,28 +8942,28 @@ func (c *CopilotMetricsCLI) GetTokenUsage() *CopilotMetricsCLITokenUsage {
 	return c.TokenUsage
 }
 
-// GetAvgTokensPerRequest returns the AvgTokensPerRequest field.
+// GetAvgTokensPerRequest returns the AvgTokensPerRequest field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsCLITokenUsage) GetAvgTokensPerRequest() float64 {
-	if c == nil {
+	if c == nil || c.AvgTokensPerRequest == nil {
 		return 0
 	}
-	return c.AvgTokensPerRequest
+	return *c.AvgTokensPerRequest
 }
 
-// GetOutputTokensSum returns the OutputTokensSum field.
+// GetOutputTokensSum returns the OutputTokensSum field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsCLITokenUsage) GetOutputTokensSum() int {
-	if c == nil {
+	if c == nil || c.OutputTokensSum == nil {
 		return 0
 	}
-	return c.OutputTokensSum
+	return *c.OutputTokensSum
 }
 
-// GetPromptTokensSum returns the PromptTokensSum field.
+// GetPromptTokensSum returns the PromptTokensSum field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsCLITokenUsage) GetPromptTokensSum() int {
-	if c == nil {
+	if c == nil || c.PromptTokensSum == nil {
 		return 0
 	}
-	return c.PromptTokensSum
+	return *c.PromptTokensSum
 }
 
 // GetCLIVersion returns the CLIVersion field.
@@ -8942,52 +8982,52 @@ func (c *CopilotMetricsCLIVersion) GetSampledAt() Timestamp {
 	return *c.SampledAt
 }
 
-// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
+// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsCodeActivity) GetCodeAcceptanceActivityCount() int {
-	if c == nil {
+	if c == nil || c.CodeAcceptanceActivityCount == nil {
 		return 0
 	}
-	return c.CodeAcceptanceActivityCount
+	return *c.CodeAcceptanceActivityCount
 }
 
-// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
+// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsCodeActivity) GetCodeGenerationActivityCount() int {
-	if c == nil {
+	if c == nil || c.CodeGenerationActivityCount == nil {
 		return 0
 	}
-	return c.CodeGenerationActivityCount
+	return *c.CodeGenerationActivityCount
 }
 
-// GetLOCAddedSum returns the LOCAddedSum field.
+// GetLOCAddedSum returns the LOCAddedSum field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsCodeActivity) GetLOCAddedSum() int {
-	if c == nil {
+	if c == nil || c.LOCAddedSum == nil {
 		return 0
 	}
-	return c.LOCAddedSum
+	return *c.LOCAddedSum
 }
 
-// GetLOCDeletedSum returns the LOCDeletedSum field.
+// GetLOCDeletedSum returns the LOCDeletedSum field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsCodeActivity) GetLOCDeletedSum() int {
-	if c == nil {
+	if c == nil || c.LOCDeletedSum == nil {
 		return 0
 	}
-	return c.LOCDeletedSum
+	return *c.LOCDeletedSum
 }
 
-// GetLOCSuggestedToAddSum returns the LOCSuggestedToAddSum field.
+// GetLOCSuggestedToAddSum returns the LOCSuggestedToAddSum field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsCodeActivity) GetLOCSuggestedToAddSum() int {
-	if c == nil {
+	if c == nil || c.LOCSuggestedToAddSum == nil {
 		return 0
 	}
-	return c.LOCSuggestedToAddSum
+	return *c.LOCSuggestedToAddSum
 }
 
-// GetLOCSuggestedToDeleteSum returns the LOCSuggestedToDeleteSum field.
+// GetLOCSuggestedToDeleteSum returns the LOCSuggestedToDeleteSum field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsCodeActivity) GetLOCSuggestedToDeleteSum() int {
-	if c == nil {
+	if c == nil || c.LOCSuggestedToDeleteSum == nil {
 		return 0
 	}
-	return c.LOCSuggestedToDeleteSum
+	return *c.LOCSuggestedToDeleteSum
 }
 
 // GetFeature returns the Feature field.
@@ -8998,12 +9038,12 @@ func (c *CopilotMetricsFeature) GetFeature() string {
 	return c.Feature
 }
 
-// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
+// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsFeature) GetUserInitiatedInteractionCount() int {
-	if c == nil {
+	if c == nil || c.UserInitiatedInteractionCount == nil {
 		return 0
 	}
-	return c.UserInitiatedInteractionCount
+	return *c.UserInitiatedInteractionCount
 }
 
 // GetIDE returns the IDE field.
@@ -9014,12 +9054,12 @@ func (c *CopilotMetricsIDE) GetIDE() string {
 	return c.IDE
 }
 
-// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
+// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsIDE) GetUserInitiatedInteractionCount() int {
-	if c == nil {
+	if c == nil || c.UserInitiatedInteractionCount == nil {
 		return 0
 	}
-	return c.UserInitiatedInteractionCount
+	return *c.UserInitiatedInteractionCount
 }
 
 // GetFeature returns the Feature field.
@@ -9086,124 +9126,124 @@ func (c *CopilotMetricsModelFeature) GetModel() string {
 	return c.Model
 }
 
-// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
+// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsModelFeature) GetUserInitiatedInteractionCount() int {
-	if c == nil {
+	if c == nil || c.UserInitiatedInteractionCount == nil {
 		return 0
 	}
-	return c.UserInitiatedInteractionCount
+	return *c.UserInitiatedInteractionCount
 }
 
-// GetMedianMinutesToMerge returns the MedianMinutesToMerge field.
+// GetMedianMinutesToMerge returns the MedianMinutesToMerge field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsPullRequests) GetMedianMinutesToMerge() float64 {
-	if c == nil {
+	if c == nil || c.MedianMinutesToMerge == nil {
 		return 0
 	}
-	return c.MedianMinutesToMerge
+	return *c.MedianMinutesToMerge
 }
 
-// GetMedianMinutesToMergeCopilotAuthored returns the MedianMinutesToMergeCopilotAuthored field.
+// GetMedianMinutesToMergeCopilotAuthored returns the MedianMinutesToMergeCopilotAuthored field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsPullRequests) GetMedianMinutesToMergeCopilotAuthored() float64 {
-	if c == nil {
+	if c == nil || c.MedianMinutesToMergeCopilotAuthored == nil {
 		return 0
 	}
-	return c.MedianMinutesToMergeCopilotAuthored
+	return *c.MedianMinutesToMergeCopilotAuthored
 }
 
-// GetMedianMinutesToMergeCopilotReviewed returns the MedianMinutesToMergeCopilotReviewed field.
+// GetMedianMinutesToMergeCopilotReviewed returns the MedianMinutesToMergeCopilotReviewed field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsPullRequests) GetMedianMinutesToMergeCopilotReviewed() float64 {
-	if c == nil {
+	if c == nil || c.MedianMinutesToMergeCopilotReviewed == nil {
 		return 0
 	}
-	return c.MedianMinutesToMergeCopilotReviewed
+	return *c.MedianMinutesToMergeCopilotReviewed
 }
 
-// GetTotalAppliedSuggestions returns the TotalAppliedSuggestions field.
+// GetTotalAppliedSuggestions returns the TotalAppliedSuggestions field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsPullRequests) GetTotalAppliedSuggestions() int {
-	if c == nil {
+	if c == nil || c.TotalAppliedSuggestions == nil {
 		return 0
 	}
-	return c.TotalAppliedSuggestions
+	return *c.TotalAppliedSuggestions
 }
 
-// GetTotalCopilotAppliedSuggestions returns the TotalCopilotAppliedSuggestions field.
+// GetTotalCopilotAppliedSuggestions returns the TotalCopilotAppliedSuggestions field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsPullRequests) GetTotalCopilotAppliedSuggestions() int {
-	if c == nil {
+	if c == nil || c.TotalCopilotAppliedSuggestions == nil {
 		return 0
 	}
-	return c.TotalCopilotAppliedSuggestions
+	return *c.TotalCopilotAppliedSuggestions
 }
 
-// GetTotalCopilotSuggestions returns the TotalCopilotSuggestions field.
+// GetTotalCopilotSuggestions returns the TotalCopilotSuggestions field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsPullRequests) GetTotalCopilotSuggestions() int {
-	if c == nil {
+	if c == nil || c.TotalCopilotSuggestions == nil {
 		return 0
 	}
-	return c.TotalCopilotSuggestions
+	return *c.TotalCopilotSuggestions
 }
 
-// GetTotalCreated returns the TotalCreated field.
+// GetTotalCreated returns the TotalCreated field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsPullRequests) GetTotalCreated() int {
-	if c == nil {
+	if c == nil || c.TotalCreated == nil {
 		return 0
 	}
-	return c.TotalCreated
+	return *c.TotalCreated
 }
 
-// GetTotalCreatedByCopilot returns the TotalCreatedByCopilot field.
+// GetTotalCreatedByCopilot returns the TotalCreatedByCopilot field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsPullRequests) GetTotalCreatedByCopilot() int {
-	if c == nil {
+	if c == nil || c.TotalCreatedByCopilot == nil {
 		return 0
 	}
-	return c.TotalCreatedByCopilot
+	return *c.TotalCreatedByCopilot
 }
 
-// GetTotalMerged returns the TotalMerged field.
+// GetTotalMerged returns the TotalMerged field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsPullRequests) GetTotalMerged() int {
-	if c == nil {
+	if c == nil || c.TotalMerged == nil {
 		return 0
 	}
-	return c.TotalMerged
+	return *c.TotalMerged
 }
 
-// GetTotalMergedCreatedByCopilot returns the TotalMergedCreatedByCopilot field.
+// GetTotalMergedCreatedByCopilot returns the TotalMergedCreatedByCopilot field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsPullRequests) GetTotalMergedCreatedByCopilot() int {
-	if c == nil {
+	if c == nil || c.TotalMergedCreatedByCopilot == nil {
 		return 0
 	}
-	return c.TotalMergedCreatedByCopilot
+	return *c.TotalMergedCreatedByCopilot
 }
 
-// GetTotalMergedReviewedByCopilot returns the TotalMergedReviewedByCopilot field.
+// GetTotalMergedReviewedByCopilot returns the TotalMergedReviewedByCopilot field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsPullRequests) GetTotalMergedReviewedByCopilot() int {
-	if c == nil {
+	if c == nil || c.TotalMergedReviewedByCopilot == nil {
 		return 0
 	}
-	return c.TotalMergedReviewedByCopilot
+	return *c.TotalMergedReviewedByCopilot
 }
 
-// GetTotalReviewed returns the TotalReviewed field.
+// GetTotalReviewed returns the TotalReviewed field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsPullRequests) GetTotalReviewed() int {
-	if c == nil {
+	if c == nil || c.TotalReviewed == nil {
 		return 0
 	}
-	return c.TotalReviewed
+	return *c.TotalReviewed
 }
 
-// GetTotalReviewedByCopilot returns the TotalReviewedByCopilot field.
+// GetTotalReviewedByCopilot returns the TotalReviewedByCopilot field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsPullRequests) GetTotalReviewedByCopilot() int {
-	if c == nil {
+	if c == nil || c.TotalReviewedByCopilot == nil {
 		return 0
 	}
-	return c.TotalReviewedByCopilot
+	return *c.TotalReviewedByCopilot
 }
 
-// GetTotalSuggestions returns the TotalSuggestions field.
+// GetTotalSuggestions returns the TotalSuggestions field if it's non-nil, zero value otherwise.
 func (c *CopilotMetricsPullRequests) GetTotalSuggestions() int {
-	if c == nil {
+	if c == nil || c.TotalSuggestions == nil {
 		return 0
 	}
-	return c.TotalSuggestions
+	return *c.TotalSuggestions
 }
 
 // GetDownloadLinks returns the DownloadLinks slice if it's non-nil, nil otherwise.
@@ -9286,20 +9326,20 @@ func (c *CopilotPeriodicMetrics) GetDayTotals() []*CopilotDailyMetrics {
 	return c.DayTotals
 }
 
-// GetEnterpriseID returns the EnterpriseID field.
+// GetEnterpriseID returns the EnterpriseID field if it's non-nil, zero value otherwise.
 func (c *CopilotPeriodicMetrics) GetEnterpriseID() string {
-	if c == nil {
+	if c == nil || c.EnterpriseID == nil {
 		return ""
 	}
-	return c.EnterpriseID
+	return *c.EnterpriseID
 }
 
-// GetOrganizationID returns the OrganizationID field.
+// GetOrganizationID returns the OrganizationID field if it's non-nil, zero value otherwise.
 func (c *CopilotPeriodicMetrics) GetOrganizationID() string {
-	if c == nil {
+	if c == nil || c.OrganizationID == nil {
 		return ""
 	}
-	return c.OrganizationID
+	return *c.OrganizationID
 }
 
 // GetReportEndDay returns the ReportEndDay field.
@@ -9430,20 +9470,20 @@ func (c *CopilotSeatDetails) GetUpdatedAt() Timestamp {
 	return *c.UpdatedAt
 }
 
-// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
+// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetCodeAcceptanceActivityCount() int {
-	if c == nil {
+	if c == nil || c.CodeAcceptanceActivityCount == nil {
 		return 0
 	}
-	return c.CodeAcceptanceActivityCount
+	return *c.CodeAcceptanceActivityCount
 }
 
-// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
+// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetCodeGenerationActivityCount() int {
-	if c == nil {
+	if c == nil || c.CodeGenerationActivityCount == nil {
 		return 0
 	}
-	return c.CodeGenerationActivityCount
+	return *c.CodeGenerationActivityCount
 }
 
 // GetDay returns the Day field.
@@ -9454,52 +9494,52 @@ func (c *CopilotUserDailyMetrics) GetDay() string {
 	return c.Day
 }
 
-// GetEnterpriseID returns the EnterpriseID field.
+// GetEnterpriseID returns the EnterpriseID field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetEnterpriseID() string {
-	if c == nil {
+	if c == nil || c.EnterpriseID == nil {
 		return ""
 	}
-	return c.EnterpriseID
+	return *c.EnterpriseID
 }
 
-// GetLOCAddedSum returns the LOCAddedSum field.
+// GetLOCAddedSum returns the LOCAddedSum field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetLOCAddedSum() int {
-	if c == nil {
+	if c == nil || c.LOCAddedSum == nil {
 		return 0
 	}
-	return c.LOCAddedSum
+	return *c.LOCAddedSum
 }
 
-// GetLOCDeletedSum returns the LOCDeletedSum field.
+// GetLOCDeletedSum returns the LOCDeletedSum field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetLOCDeletedSum() int {
-	if c == nil {
+	if c == nil || c.LOCDeletedSum == nil {
 		return 0
 	}
-	return c.LOCDeletedSum
+	return *c.LOCDeletedSum
 }
 
-// GetLOCSuggestedToAddSum returns the LOCSuggestedToAddSum field.
+// GetLOCSuggestedToAddSum returns the LOCSuggestedToAddSum field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetLOCSuggestedToAddSum() int {
-	if c == nil {
+	if c == nil || c.LOCSuggestedToAddSum == nil {
 		return 0
 	}
-	return c.LOCSuggestedToAddSum
+	return *c.LOCSuggestedToAddSum
 }
 
-// GetLOCSuggestedToDeleteSum returns the LOCSuggestedToDeleteSum field.
+// GetLOCSuggestedToDeleteSum returns the LOCSuggestedToDeleteSum field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetLOCSuggestedToDeleteSum() int {
-	if c == nil {
+	if c == nil || c.LOCSuggestedToDeleteSum == nil {
 		return 0
 	}
-	return c.LOCSuggestedToDeleteSum
+	return *c.LOCSuggestedToDeleteSum
 }
 
-// GetOrganizationID returns the OrganizationID field.
+// GetOrganizationID returns the OrganizationID field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetOrganizationID() string {
-	if c == nil {
+	if c == nil || c.OrganizationID == nil {
 		return ""
 	}
-	return c.OrganizationID
+	return *c.OrganizationID
 }
 
 // GetTotalsByCLI returns the TotalsByCLI field.
@@ -9550,52 +9590,52 @@ func (c *CopilotUserDailyMetrics) GetTotalsByModelFeature() []*CopilotMetricsMod
 	return c.TotalsByModelFeature
 }
 
-// GetUsedAgent returns the UsedAgent field.
+// GetUsedAgent returns the UsedAgent field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetUsedAgent() bool {
-	if c == nil {
+	if c == nil || c.UsedAgent == nil {
 		return false
 	}
-	return c.UsedAgent
+	return *c.UsedAgent
 }
 
-// GetUsedChat returns the UsedChat field.
+// GetUsedChat returns the UsedChat field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetUsedChat() bool {
-	if c == nil {
+	if c == nil || c.UsedChat == nil {
 		return false
 	}
-	return c.UsedChat
+	return *c.UsedChat
 }
 
-// GetUsedCLI returns the UsedCLI field.
+// GetUsedCLI returns the UsedCLI field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetUsedCLI() bool {
-	if c == nil {
+	if c == nil || c.UsedCLI == nil {
 		return false
 	}
-	return c.UsedCLI
+	return *c.UsedCLI
 }
 
-// GetUsedCopilotCodeReviewActive returns the UsedCopilotCodeReviewActive field.
+// GetUsedCopilotCodeReviewActive returns the UsedCopilotCodeReviewActive field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetUsedCopilotCodeReviewActive() bool {
-	if c == nil {
+	if c == nil || c.UsedCopilotCodeReviewActive == nil {
 		return false
 	}
-	return c.UsedCopilotCodeReviewActive
+	return *c.UsedCopilotCodeReviewActive
 }
 
-// GetUsedCopilotCodeReviewPassive returns the UsedCopilotCodeReviewPassive field.
+// GetUsedCopilotCodeReviewPassive returns the UsedCopilotCodeReviewPassive field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetUsedCopilotCodeReviewPassive() bool {
-	if c == nil {
+	if c == nil || c.UsedCopilotCodeReviewPassive == nil {
 		return false
 	}
-	return c.UsedCopilotCodeReviewPassive
+	return *c.UsedCopilotCodeReviewPassive
 }
 
-// GetUsedCopilotCodingAgent returns the UsedCopilotCodingAgent field.
+// GetUsedCopilotCodingAgent returns the UsedCopilotCodingAgent field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetUsedCopilotCodingAgent() bool {
-	if c == nil {
+	if c == nil || c.UsedCopilotCodingAgent == nil {
 		return false
 	}
-	return c.UsedCopilotCodingAgent
+	return *c.UsedCopilotCodingAgent
 }
 
 // GetUserID returns the UserID field.
@@ -9606,12 +9646,12 @@ func (c *CopilotUserDailyMetrics) GetUserID() int {
 	return c.UserID
 }
 
-// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
+// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetUserInitiatedInteractionCount() int {
-	if c == nil {
+	if c == nil || c.UserInitiatedInteractionCount == nil {
 		return 0
 	}
-	return c.UserInitiatedInteractionCount
+	return *c.UserInitiatedInteractionCount
 }
 
 // GetUserLogin returns the UserLogin field.
@@ -9646,12 +9686,12 @@ func (c *CopilotUserMetricsIDE) GetLastKnownPluginVersion() *CopilotUserMetricsP
 	return c.LastKnownPluginVersion
 }
 
-// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
+// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field if it's non-nil, zero value otherwise.
 func (c *CopilotUserMetricsIDE) GetUserInitiatedInteractionCount() int {
-	if c == nil {
+	if c == nil || c.UserInitiatedInteractionCount == nil {
 		return 0
 	}
-	return c.UserInitiatedInteractionCount
+	return *c.UserInitiatedInteractionCount
 }
 
 // GetIDEVersion returns the IDEVersion field.
@@ -9694,20 +9734,20 @@ func (c *CopilotUserMetricsPluginVersion) GetSampledAt() Timestamp {
 	return *c.SampledAt
 }
 
-// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
+// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field if it's non-nil, zero value otherwise.
 func (c *CopilotUserPeriodicMetrics) GetCodeAcceptanceActivityCount() int {
-	if c == nil {
+	if c == nil || c.CodeAcceptanceActivityCount == nil {
 		return 0
 	}
-	return c.CodeAcceptanceActivityCount
+	return *c.CodeAcceptanceActivityCount
 }
 
-// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
+// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field if it's non-nil, zero value otherwise.
 func (c *CopilotUserPeriodicMetrics) GetCodeGenerationActivityCount() int {
-	if c == nil {
+	if c == nil || c.CodeGenerationActivityCount == nil {
 		return 0
 	}
-	return c.CodeGenerationActivityCount
+	return *c.CodeGenerationActivityCount
 }
 
 // GetDay returns the Day field.
@@ -9718,52 +9758,52 @@ func (c *CopilotUserPeriodicMetrics) GetDay() string {
 	return c.Day
 }
 
-// GetEnterpriseID returns the EnterpriseID field.
+// GetEnterpriseID returns the EnterpriseID field if it's non-nil, zero value otherwise.
 func (c *CopilotUserPeriodicMetrics) GetEnterpriseID() string {
-	if c == nil {
+	if c == nil || c.EnterpriseID == nil {
 		return ""
 	}
-	return c.EnterpriseID
+	return *c.EnterpriseID
 }
 
-// GetLOCAddedSum returns the LOCAddedSum field.
+// GetLOCAddedSum returns the LOCAddedSum field if it's non-nil, zero value otherwise.
 func (c *CopilotUserPeriodicMetrics) GetLOCAddedSum() int {
-	if c == nil {
+	if c == nil || c.LOCAddedSum == nil {
 		return 0
 	}
-	return c.LOCAddedSum
+	return *c.LOCAddedSum
 }
 
-// GetLOCDeletedSum returns the LOCDeletedSum field.
+// GetLOCDeletedSum returns the LOCDeletedSum field if it's non-nil, zero value otherwise.
 func (c *CopilotUserPeriodicMetrics) GetLOCDeletedSum() int {
-	if c == nil {
+	if c == nil || c.LOCDeletedSum == nil {
 		return 0
 	}
-	return c.LOCDeletedSum
+	return *c.LOCDeletedSum
 }
 
-// GetLOCSuggestedToAddSum returns the LOCSuggestedToAddSum field.
+// GetLOCSuggestedToAddSum returns the LOCSuggestedToAddSum field if it's non-nil, zero value otherwise.
 func (c *CopilotUserPeriodicMetrics) GetLOCSuggestedToAddSum() int {
-	if c == nil {
+	if c == nil || c.LOCSuggestedToAddSum == nil {
 		return 0
 	}
-	return c.LOCSuggestedToAddSum
+	return *c.LOCSuggestedToAddSum
 }
 
-// GetLOCSuggestedToDeleteSum returns the LOCSuggestedToDeleteSum field.
+// GetLOCSuggestedToDeleteSum returns the LOCSuggestedToDeleteSum field if it's non-nil, zero value otherwise.
 func (c *CopilotUserPeriodicMetrics) GetLOCSuggestedToDeleteSum() int {
-	if c == nil {
+	if c == nil || c.LOCSuggestedToDeleteSum == nil {
 		return 0
 	}
-	return c.LOCSuggestedToDeleteSum
+	return *c.LOCSuggestedToDeleteSum
 }
 
-// GetOrganizationID returns the OrganizationID field.
+// GetOrganizationID returns the OrganizationID field if it's non-nil, zero value otherwise.
 func (c *CopilotUserPeriodicMetrics) GetOrganizationID() string {
-	if c == nil {
+	if c == nil || c.OrganizationID == nil {
 		return ""
 	}
-	return c.OrganizationID
+	return *c.OrganizationID
 }
 
 // GetReportEndDay returns the ReportEndDay field.
@@ -9830,52 +9870,52 @@ func (c *CopilotUserPeriodicMetrics) GetTotalsByModelFeature() []*CopilotMetrics
 	return c.TotalsByModelFeature
 }
 
-// GetUsedAgent returns the UsedAgent field.
+// GetUsedAgent returns the UsedAgent field if it's non-nil, zero value otherwise.
 func (c *CopilotUserPeriodicMetrics) GetUsedAgent() bool {
-	if c == nil {
+	if c == nil || c.UsedAgent == nil {
 		return false
 	}
-	return c.UsedAgent
+	return *c.UsedAgent
 }
 
-// GetUsedChat returns the UsedChat field.
+// GetUsedChat returns the UsedChat field if it's non-nil, zero value otherwise.
 func (c *CopilotUserPeriodicMetrics) GetUsedChat() bool {
-	if c == nil {
+	if c == nil || c.UsedChat == nil {
 		return false
 	}
-	return c.UsedChat
+	return *c.UsedChat
 }
 
-// GetUsedCLI returns the UsedCLI field.
+// GetUsedCLI returns the UsedCLI field if it's non-nil, zero value otherwise.
 func (c *CopilotUserPeriodicMetrics) GetUsedCLI() bool {
-	if c == nil {
+	if c == nil || c.UsedCLI == nil {
 		return false
 	}
-	return c.UsedCLI
+	return *c.UsedCLI
 }
 
-// GetUsedCopilotCodeReviewActive returns the UsedCopilotCodeReviewActive field.
+// GetUsedCopilotCodeReviewActive returns the UsedCopilotCodeReviewActive field if it's non-nil, zero value otherwise.
 func (c *CopilotUserPeriodicMetrics) GetUsedCopilotCodeReviewActive() bool {
-	if c == nil {
+	if c == nil || c.UsedCopilotCodeReviewActive == nil {
 		return false
 	}
-	return c.UsedCopilotCodeReviewActive
+	return *c.UsedCopilotCodeReviewActive
 }
 
-// GetUsedCopilotCodeReviewPassive returns the UsedCopilotCodeReviewPassive field.
+// GetUsedCopilotCodeReviewPassive returns the UsedCopilotCodeReviewPassive field if it's non-nil, zero value otherwise.
 func (c *CopilotUserPeriodicMetrics) GetUsedCopilotCodeReviewPassive() bool {
-	if c == nil {
+	if c == nil || c.UsedCopilotCodeReviewPassive == nil {
 		return false
 	}
-	return c.UsedCopilotCodeReviewPassive
+	return *c.UsedCopilotCodeReviewPassive
 }
 
-// GetUsedCopilotCodingAgent returns the UsedCopilotCodingAgent field.
+// GetUsedCopilotCodingAgent returns the UsedCopilotCodingAgent field if it's non-nil, zero value otherwise.
 func (c *CopilotUserPeriodicMetrics) GetUsedCopilotCodingAgent() bool {
-	if c == nil {
+	if c == nil || c.UsedCopilotCodingAgent == nil {
 		return false
 	}
-	return c.UsedCopilotCodingAgent
+	return *c.UsedCopilotCodingAgent
 }
 
 // GetUserID returns the UserID field.
@@ -9886,12 +9926,12 @@ func (c *CopilotUserPeriodicMetrics) GetUserID() int {
 	return c.UserID
 }
 
-// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
+// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field if it's non-nil, zero value otherwise.
 func (c *CopilotUserPeriodicMetrics) GetUserInitiatedInteractionCount() int {
-	if c == nil {
+	if c == nil || c.UserInitiatedInteractionCount == nil {
 		return 0
 	}
-	return c.UserInitiatedInteractionCount
+	return *c.UserInitiatedInteractionCount
 }
 
 // GetUserLogin returns the UserLogin field.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -8254,36 +8254,36 @@ func (c *CopilotDailyMetrics) GetEnterpriseID() string {
 	return c.EnterpriseID
 }
 
-// GetLocAddedSum returns the LocAddedSum field.
-func (c *CopilotDailyMetrics) GetLocAddedSum() int {
+// GetLOCAddedSum returns the LOCAddedSum field.
+func (c *CopilotDailyMetrics) GetLOCAddedSum() int {
 	if c == nil {
 		return 0
 	}
-	return c.LocAddedSum
+	return c.LOCAddedSum
 }
 
-// GetLocDeletedSum returns the LocDeletedSum field.
-func (c *CopilotDailyMetrics) GetLocDeletedSum() int {
+// GetLOCDeletedSum returns the LOCDeletedSum field.
+func (c *CopilotDailyMetrics) GetLOCDeletedSum() int {
 	if c == nil {
 		return 0
 	}
-	return c.LocDeletedSum
+	return c.LOCDeletedSum
 }
 
-// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
-func (c *CopilotDailyMetrics) GetLocSuggestedToAddSum() int {
+// GetLOCSuggestedToAddSum returns the LOCSuggestedToAddSum field.
+func (c *CopilotDailyMetrics) GetLOCSuggestedToAddSum() int {
 	if c == nil {
 		return 0
 	}
-	return c.LocSuggestedToAddSum
+	return c.LOCSuggestedToAddSum
 }
 
-// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
-func (c *CopilotDailyMetrics) GetLocSuggestedToDeleteSum() int {
+// GetLOCSuggestedToDeleteSum returns the LOCSuggestedToDeleteSum field.
+func (c *CopilotDailyMetrics) GetLOCSuggestedToDeleteSum() int {
 	if c == nil {
 		return 0
 	}
-	return c.LocSuggestedToDeleteSum
+	return c.LOCSuggestedToDeleteSum
 }
 
 // GetMonthlyActiveAgentUsers returns the MonthlyActiveAgentUsers field.
@@ -8943,7 +8943,7 @@ func (c *CopilotMetricsCLIVersion) GetSampledAt() Timestamp {
 }
 
 // GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
-func (c *CopilotMetricsFeature) GetCodeAcceptanceActivityCount() int {
+func (c *CopilotMetricsCodeActivity) GetCodeAcceptanceActivityCount() int {
 	if c == nil {
 		return 0
 	}
@@ -8951,11 +8951,43 @@ func (c *CopilotMetricsFeature) GetCodeAcceptanceActivityCount() int {
 }
 
 // GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
-func (c *CopilotMetricsFeature) GetCodeGenerationActivityCount() int {
+func (c *CopilotMetricsCodeActivity) GetCodeGenerationActivityCount() int {
 	if c == nil {
 		return 0
 	}
 	return c.CodeGenerationActivityCount
+}
+
+// GetLOCAddedSum returns the LOCAddedSum field.
+func (c *CopilotMetricsCodeActivity) GetLOCAddedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LOCAddedSum
+}
+
+// GetLOCDeletedSum returns the LOCDeletedSum field.
+func (c *CopilotMetricsCodeActivity) GetLOCDeletedSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LOCDeletedSum
+}
+
+// GetLOCSuggestedToAddSum returns the LOCSuggestedToAddSum field.
+func (c *CopilotMetricsCodeActivity) GetLOCSuggestedToAddSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LOCSuggestedToAddSum
+}
+
+// GetLOCSuggestedToDeleteSum returns the LOCSuggestedToDeleteSum field.
+func (c *CopilotMetricsCodeActivity) GetLOCSuggestedToDeleteSum() int {
+	if c == nil {
+		return 0
+	}
+	return c.LOCSuggestedToDeleteSum
 }
 
 // GetFeature returns the Feature field.
@@ -8966,60 +8998,12 @@ func (c *CopilotMetricsFeature) GetFeature() string {
 	return c.Feature
 }
 
-// GetLocAddedSum returns the LocAddedSum field.
-func (c *CopilotMetricsFeature) GetLocAddedSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocAddedSum
-}
-
-// GetLocDeletedSum returns the LocDeletedSum field.
-func (c *CopilotMetricsFeature) GetLocDeletedSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocDeletedSum
-}
-
-// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
-func (c *CopilotMetricsFeature) GetLocSuggestedToAddSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocSuggestedToAddSum
-}
-
-// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
-func (c *CopilotMetricsFeature) GetLocSuggestedToDeleteSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocSuggestedToDeleteSum
-}
-
 // GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
 func (c *CopilotMetricsFeature) GetUserInitiatedInteractionCount() int {
 	if c == nil {
 		return 0
 	}
 	return c.UserInitiatedInteractionCount
-}
-
-// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
-func (c *CopilotMetricsIDE) GetCodeAcceptanceActivityCount() int {
-	if c == nil {
-		return 0
-	}
-	return c.CodeAcceptanceActivityCount
-}
-
-// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
-func (c *CopilotMetricsIDE) GetCodeGenerationActivityCount() int {
-	if c == nil {
-		return 0
-	}
-	return c.CodeGenerationActivityCount
 }
 
 // GetIDE returns the IDE field.
@@ -9030,60 +9014,12 @@ func (c *CopilotMetricsIDE) GetIDE() string {
 	return c.IDE
 }
 
-// GetLocAddedSum returns the LocAddedSum field.
-func (c *CopilotMetricsIDE) GetLocAddedSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocAddedSum
-}
-
-// GetLocDeletedSum returns the LocDeletedSum field.
-func (c *CopilotMetricsIDE) GetLocDeletedSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocDeletedSum
-}
-
-// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
-func (c *CopilotMetricsIDE) GetLocSuggestedToAddSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocSuggestedToAddSum
-}
-
-// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
-func (c *CopilotMetricsIDE) GetLocSuggestedToDeleteSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocSuggestedToDeleteSum
-}
-
 // GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
 func (c *CopilotMetricsIDE) GetUserInitiatedInteractionCount() int {
 	if c == nil {
 		return 0
 	}
 	return c.UserInitiatedInteractionCount
-}
-
-// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
-func (c *CopilotMetricsLanguageFeature) GetCodeAcceptanceActivityCount() int {
-	if c == nil {
-		return 0
-	}
-	return c.CodeAcceptanceActivityCount
-}
-
-// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
-func (c *CopilotMetricsLanguageFeature) GetCodeGenerationActivityCount() int {
-	if c == nil {
-		return 0
-	}
-	return c.CodeGenerationActivityCount
 }
 
 // GetFeature returns the Feature field.
@@ -9102,92 +9038,12 @@ func (c *CopilotMetricsLanguageFeature) GetLanguage() string {
 	return c.Language
 }
 
-// GetLocAddedSum returns the LocAddedSum field.
-func (c *CopilotMetricsLanguageFeature) GetLocAddedSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocAddedSum
-}
-
-// GetLocDeletedSum returns the LocDeletedSum field.
-func (c *CopilotMetricsLanguageFeature) GetLocDeletedSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocDeletedSum
-}
-
-// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
-func (c *CopilotMetricsLanguageFeature) GetLocSuggestedToAddSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocSuggestedToAddSum
-}
-
-// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
-func (c *CopilotMetricsLanguageFeature) GetLocSuggestedToDeleteSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocSuggestedToDeleteSum
-}
-
-// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
-func (c *CopilotMetricsLanguageModel) GetCodeAcceptanceActivityCount() int {
-	if c == nil {
-		return 0
-	}
-	return c.CodeAcceptanceActivityCount
-}
-
-// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
-func (c *CopilotMetricsLanguageModel) GetCodeGenerationActivityCount() int {
-	if c == nil {
-		return 0
-	}
-	return c.CodeGenerationActivityCount
-}
-
 // GetLanguage returns the Language field.
 func (c *CopilotMetricsLanguageModel) GetLanguage() string {
 	if c == nil {
 		return ""
 	}
 	return c.Language
-}
-
-// GetLocAddedSum returns the LocAddedSum field.
-func (c *CopilotMetricsLanguageModel) GetLocAddedSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocAddedSum
-}
-
-// GetLocDeletedSum returns the LocDeletedSum field.
-func (c *CopilotMetricsLanguageModel) GetLocDeletedSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocDeletedSum
-}
-
-// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
-func (c *CopilotMetricsLanguageModel) GetLocSuggestedToAddSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocSuggestedToAddSum
-}
-
-// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
-func (c *CopilotMetricsLanguageModel) GetLocSuggestedToDeleteSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocSuggestedToDeleteSum
 }
 
 // GetModel returns the Model field.
@@ -9214,60 +9070,12 @@ func (c *CopilotMetricsListOptions) GetUntil() time.Time {
 	return *c.Until
 }
 
-// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
-func (c *CopilotMetricsModelFeature) GetCodeAcceptanceActivityCount() int {
-	if c == nil {
-		return 0
-	}
-	return c.CodeAcceptanceActivityCount
-}
-
-// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
-func (c *CopilotMetricsModelFeature) GetCodeGenerationActivityCount() int {
-	if c == nil {
-		return 0
-	}
-	return c.CodeGenerationActivityCount
-}
-
 // GetFeature returns the Feature field.
 func (c *CopilotMetricsModelFeature) GetFeature() string {
 	if c == nil {
 		return ""
 	}
 	return c.Feature
-}
-
-// GetLocAddedSum returns the LocAddedSum field.
-func (c *CopilotMetricsModelFeature) GetLocAddedSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocAddedSum
-}
-
-// GetLocDeletedSum returns the LocDeletedSum field.
-func (c *CopilotMetricsModelFeature) GetLocDeletedSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocDeletedSum
-}
-
-// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
-func (c *CopilotMetricsModelFeature) GetLocSuggestedToAddSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocSuggestedToAddSum
-}
-
-// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
-func (c *CopilotMetricsModelFeature) GetLocSuggestedToDeleteSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocSuggestedToDeleteSum
 }
 
 // GetModel returns the Model field.
@@ -9654,36 +9462,36 @@ func (c *CopilotUserDailyMetrics) GetEnterpriseID() string {
 	return c.EnterpriseID
 }
 
-// GetLocAddedSum returns the LocAddedSum field.
-func (c *CopilotUserDailyMetrics) GetLocAddedSum() int {
+// GetLOCAddedSum returns the LOCAddedSum field.
+func (c *CopilotUserDailyMetrics) GetLOCAddedSum() int {
 	if c == nil {
 		return 0
 	}
-	return c.LocAddedSum
+	return c.LOCAddedSum
 }
 
-// GetLocDeletedSum returns the LocDeletedSum field.
-func (c *CopilotUserDailyMetrics) GetLocDeletedSum() int {
+// GetLOCDeletedSum returns the LOCDeletedSum field.
+func (c *CopilotUserDailyMetrics) GetLOCDeletedSum() int {
 	if c == nil {
 		return 0
 	}
-	return c.LocDeletedSum
+	return c.LOCDeletedSum
 }
 
-// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
-func (c *CopilotUserDailyMetrics) GetLocSuggestedToAddSum() int {
+// GetLOCSuggestedToAddSum returns the LOCSuggestedToAddSum field.
+func (c *CopilotUserDailyMetrics) GetLOCSuggestedToAddSum() int {
 	if c == nil {
 		return 0
 	}
-	return c.LocSuggestedToAddSum
+	return c.LOCSuggestedToAddSum
 }
 
-// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
-func (c *CopilotUserDailyMetrics) GetLocSuggestedToDeleteSum() int {
+// GetLOCSuggestedToDeleteSum returns the LOCSuggestedToDeleteSum field.
+func (c *CopilotUserDailyMetrics) GetLOCSuggestedToDeleteSum() int {
 	if c == nil {
 		return 0
 	}
-	return c.LocSuggestedToDeleteSum
+	return c.LOCSuggestedToDeleteSum
 }
 
 // GetOrganizationID returns the OrganizationID field.
@@ -9814,22 +9622,6 @@ func (c *CopilotUserDailyMetrics) GetUserLogin() string {
 	return c.UserLogin
 }
 
-// GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field.
-func (c *CopilotUserMetricsIDE) GetCodeAcceptanceActivityCount() int {
-	if c == nil {
-		return 0
-	}
-	return c.CodeAcceptanceActivityCount
-}
-
-// GetCodeGenerationActivityCount returns the CodeGenerationActivityCount field.
-func (c *CopilotUserMetricsIDE) GetCodeGenerationActivityCount() int {
-	if c == nil {
-		return 0
-	}
-	return c.CodeGenerationActivityCount
-}
-
 // GetIDE returns the IDE field.
 func (c *CopilotUserMetricsIDE) GetIDE() string {
 	if c == nil {
@@ -9852,38 +9644,6 @@ func (c *CopilotUserMetricsIDE) GetLastKnownPluginVersion() *CopilotUserMetricsP
 		return nil
 	}
 	return c.LastKnownPluginVersion
-}
-
-// GetLocAddedSum returns the LocAddedSum field.
-func (c *CopilotUserMetricsIDE) GetLocAddedSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocAddedSum
-}
-
-// GetLocDeletedSum returns the LocDeletedSum field.
-func (c *CopilotUserMetricsIDE) GetLocDeletedSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocDeletedSum
-}
-
-// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
-func (c *CopilotUserMetricsIDE) GetLocSuggestedToAddSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocSuggestedToAddSum
-}
-
-// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
-func (c *CopilotUserMetricsIDE) GetLocSuggestedToDeleteSum() int {
-	if c == nil {
-		return 0
-	}
-	return c.LocSuggestedToDeleteSum
 }
 
 // GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field.
@@ -9966,36 +9726,36 @@ func (c *CopilotUserPeriodicMetrics) GetEnterpriseID() string {
 	return c.EnterpriseID
 }
 
-// GetLocAddedSum returns the LocAddedSum field.
-func (c *CopilotUserPeriodicMetrics) GetLocAddedSum() int {
+// GetLOCAddedSum returns the LOCAddedSum field.
+func (c *CopilotUserPeriodicMetrics) GetLOCAddedSum() int {
 	if c == nil {
 		return 0
 	}
-	return c.LocAddedSum
+	return c.LOCAddedSum
 }
 
-// GetLocDeletedSum returns the LocDeletedSum field.
-func (c *CopilotUserPeriodicMetrics) GetLocDeletedSum() int {
+// GetLOCDeletedSum returns the LOCDeletedSum field.
+func (c *CopilotUserPeriodicMetrics) GetLOCDeletedSum() int {
 	if c == nil {
 		return 0
 	}
-	return c.LocDeletedSum
+	return c.LOCDeletedSum
 }
 
-// GetLocSuggestedToAddSum returns the LocSuggestedToAddSum field.
-func (c *CopilotUserPeriodicMetrics) GetLocSuggestedToAddSum() int {
+// GetLOCSuggestedToAddSum returns the LOCSuggestedToAddSum field.
+func (c *CopilotUserPeriodicMetrics) GetLOCSuggestedToAddSum() int {
 	if c == nil {
 		return 0
 	}
-	return c.LocSuggestedToAddSum
+	return c.LOCSuggestedToAddSum
 }
 
-// GetLocSuggestedToDeleteSum returns the LocSuggestedToDeleteSum field.
-func (c *CopilotUserPeriodicMetrics) GetLocSuggestedToDeleteSum() int {
+// GetLOCSuggestedToDeleteSum returns the LOCSuggestedToDeleteSum field.
+func (c *CopilotUserPeriodicMetrics) GetLOCSuggestedToDeleteSum() int {
 	if c == nil {
 		return 0
 	}
-	return c.LocSuggestedToDeleteSum
+	return c.LOCSuggestedToDeleteSum
 }
 
 // GetOrganizationID returns the OrganizationID field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -10580,36 +10580,36 @@ func TestCopilotDailyMetrics_GetEnterpriseID(tt *testing.T) {
 	c.GetEnterpriseID()
 }
 
-func TestCopilotDailyMetrics_GetLocAddedSum(tt *testing.T) {
+func TestCopilotDailyMetrics_GetLOCAddedSum(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotDailyMetrics{}
-	c.GetLocAddedSum()
+	c.GetLOCAddedSum()
 	c = nil
-	c.GetLocAddedSum()
+	c.GetLOCAddedSum()
 }
 
-func TestCopilotDailyMetrics_GetLocDeletedSum(tt *testing.T) {
+func TestCopilotDailyMetrics_GetLOCDeletedSum(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotDailyMetrics{}
-	c.GetLocDeletedSum()
+	c.GetLOCDeletedSum()
 	c = nil
-	c.GetLocDeletedSum()
+	c.GetLOCDeletedSum()
 }
 
-func TestCopilotDailyMetrics_GetLocSuggestedToAddSum(tt *testing.T) {
+func TestCopilotDailyMetrics_GetLOCSuggestedToAddSum(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotDailyMetrics{}
-	c.GetLocSuggestedToAddSum()
+	c.GetLOCSuggestedToAddSum()
 	c = nil
-	c.GetLocSuggestedToAddSum()
+	c.GetLOCSuggestedToAddSum()
 }
 
-func TestCopilotDailyMetrics_GetLocSuggestedToDeleteSum(tt *testing.T) {
+func TestCopilotDailyMetrics_GetLOCSuggestedToDeleteSum(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotDailyMetrics{}
-	c.GetLocSuggestedToDeleteSum()
+	c.GetLOCSuggestedToDeleteSum()
 	c = nil
-	c.GetLocSuggestedToDeleteSum()
+	c.GetLOCSuggestedToDeleteSum()
 }
 
 func TestCopilotDailyMetrics_GetMonthlyActiveAgentUsers(tt *testing.T) {
@@ -11334,20 +11334,52 @@ func TestCopilotMetricsCLIVersion_GetSampledAt(tt *testing.T) {
 	c.GetSampledAt()
 }
 
-func TestCopilotMetricsFeature_GetCodeAcceptanceActivityCount(tt *testing.T) {
+func TestCopilotMetricsCodeActivity_GetCodeAcceptanceActivityCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsFeature{}
+	c := &CopilotMetricsCodeActivity{}
 	c.GetCodeAcceptanceActivityCount()
 	c = nil
 	c.GetCodeAcceptanceActivityCount()
 }
 
-func TestCopilotMetricsFeature_GetCodeGenerationActivityCount(tt *testing.T) {
+func TestCopilotMetricsCodeActivity_GetCodeGenerationActivityCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsFeature{}
+	c := &CopilotMetricsCodeActivity{}
 	c.GetCodeGenerationActivityCount()
 	c = nil
 	c.GetCodeGenerationActivityCount()
+}
+
+func TestCopilotMetricsCodeActivity_GetLOCAddedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsCodeActivity{}
+	c.GetLOCAddedSum()
+	c = nil
+	c.GetLOCAddedSum()
+}
+
+func TestCopilotMetricsCodeActivity_GetLOCDeletedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsCodeActivity{}
+	c.GetLOCDeletedSum()
+	c = nil
+	c.GetLOCDeletedSum()
+}
+
+func TestCopilotMetricsCodeActivity_GetLOCSuggestedToAddSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsCodeActivity{}
+	c.GetLOCSuggestedToAddSum()
+	c = nil
+	c.GetLOCSuggestedToAddSum()
+}
+
+func TestCopilotMetricsCodeActivity_GetLOCSuggestedToDeleteSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsCodeActivity{}
+	c.GetLOCSuggestedToDeleteSum()
+	c = nil
+	c.GetLOCSuggestedToDeleteSum()
 }
 
 func TestCopilotMetricsFeature_GetFeature(tt *testing.T) {
@@ -11358,60 +11390,12 @@ func TestCopilotMetricsFeature_GetFeature(tt *testing.T) {
 	c.GetFeature()
 }
 
-func TestCopilotMetricsFeature_GetLocAddedSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsFeature{}
-	c.GetLocAddedSum()
-	c = nil
-	c.GetLocAddedSum()
-}
-
-func TestCopilotMetricsFeature_GetLocDeletedSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsFeature{}
-	c.GetLocDeletedSum()
-	c = nil
-	c.GetLocDeletedSum()
-}
-
-func TestCopilotMetricsFeature_GetLocSuggestedToAddSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsFeature{}
-	c.GetLocSuggestedToAddSum()
-	c = nil
-	c.GetLocSuggestedToAddSum()
-}
-
-func TestCopilotMetricsFeature_GetLocSuggestedToDeleteSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsFeature{}
-	c.GetLocSuggestedToDeleteSum()
-	c = nil
-	c.GetLocSuggestedToDeleteSum()
-}
-
 func TestCopilotMetricsFeature_GetUserInitiatedInteractionCount(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotMetricsFeature{}
 	c.GetUserInitiatedInteractionCount()
 	c = nil
 	c.GetUserInitiatedInteractionCount()
-}
-
-func TestCopilotMetricsIDE_GetCodeAcceptanceActivityCount(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsIDE{}
-	c.GetCodeAcceptanceActivityCount()
-	c = nil
-	c.GetCodeAcceptanceActivityCount()
-}
-
-func TestCopilotMetricsIDE_GetCodeGenerationActivityCount(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsIDE{}
-	c.GetCodeGenerationActivityCount()
-	c = nil
-	c.GetCodeGenerationActivityCount()
 }
 
 func TestCopilotMetricsIDE_GetIDE(tt *testing.T) {
@@ -11422,60 +11406,12 @@ func TestCopilotMetricsIDE_GetIDE(tt *testing.T) {
 	c.GetIDE()
 }
 
-func TestCopilotMetricsIDE_GetLocAddedSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsIDE{}
-	c.GetLocAddedSum()
-	c = nil
-	c.GetLocAddedSum()
-}
-
-func TestCopilotMetricsIDE_GetLocDeletedSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsIDE{}
-	c.GetLocDeletedSum()
-	c = nil
-	c.GetLocDeletedSum()
-}
-
-func TestCopilotMetricsIDE_GetLocSuggestedToAddSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsIDE{}
-	c.GetLocSuggestedToAddSum()
-	c = nil
-	c.GetLocSuggestedToAddSum()
-}
-
-func TestCopilotMetricsIDE_GetLocSuggestedToDeleteSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsIDE{}
-	c.GetLocSuggestedToDeleteSum()
-	c = nil
-	c.GetLocSuggestedToDeleteSum()
-}
-
 func TestCopilotMetricsIDE_GetUserInitiatedInteractionCount(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotMetricsIDE{}
 	c.GetUserInitiatedInteractionCount()
 	c = nil
 	c.GetUserInitiatedInteractionCount()
-}
-
-func TestCopilotMetricsLanguageFeature_GetCodeAcceptanceActivityCount(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsLanguageFeature{}
-	c.GetCodeAcceptanceActivityCount()
-	c = nil
-	c.GetCodeAcceptanceActivityCount()
-}
-
-func TestCopilotMetricsLanguageFeature_GetCodeGenerationActivityCount(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsLanguageFeature{}
-	c.GetCodeGenerationActivityCount()
-	c = nil
-	c.GetCodeGenerationActivityCount()
 }
 
 func TestCopilotMetricsLanguageFeature_GetFeature(tt *testing.T) {
@@ -11494,92 +11430,12 @@ func TestCopilotMetricsLanguageFeature_GetLanguage(tt *testing.T) {
 	c.GetLanguage()
 }
 
-func TestCopilotMetricsLanguageFeature_GetLocAddedSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsLanguageFeature{}
-	c.GetLocAddedSum()
-	c = nil
-	c.GetLocAddedSum()
-}
-
-func TestCopilotMetricsLanguageFeature_GetLocDeletedSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsLanguageFeature{}
-	c.GetLocDeletedSum()
-	c = nil
-	c.GetLocDeletedSum()
-}
-
-func TestCopilotMetricsLanguageFeature_GetLocSuggestedToAddSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsLanguageFeature{}
-	c.GetLocSuggestedToAddSum()
-	c = nil
-	c.GetLocSuggestedToAddSum()
-}
-
-func TestCopilotMetricsLanguageFeature_GetLocSuggestedToDeleteSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsLanguageFeature{}
-	c.GetLocSuggestedToDeleteSum()
-	c = nil
-	c.GetLocSuggestedToDeleteSum()
-}
-
-func TestCopilotMetricsLanguageModel_GetCodeAcceptanceActivityCount(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsLanguageModel{}
-	c.GetCodeAcceptanceActivityCount()
-	c = nil
-	c.GetCodeAcceptanceActivityCount()
-}
-
-func TestCopilotMetricsLanguageModel_GetCodeGenerationActivityCount(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsLanguageModel{}
-	c.GetCodeGenerationActivityCount()
-	c = nil
-	c.GetCodeGenerationActivityCount()
-}
-
 func TestCopilotMetricsLanguageModel_GetLanguage(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotMetricsLanguageModel{}
 	c.GetLanguage()
 	c = nil
 	c.GetLanguage()
-}
-
-func TestCopilotMetricsLanguageModel_GetLocAddedSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsLanguageModel{}
-	c.GetLocAddedSum()
-	c = nil
-	c.GetLocAddedSum()
-}
-
-func TestCopilotMetricsLanguageModel_GetLocDeletedSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsLanguageModel{}
-	c.GetLocDeletedSum()
-	c = nil
-	c.GetLocDeletedSum()
-}
-
-func TestCopilotMetricsLanguageModel_GetLocSuggestedToAddSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsLanguageModel{}
-	c.GetLocSuggestedToAddSum()
-	c = nil
-	c.GetLocSuggestedToAddSum()
-}
-
-func TestCopilotMetricsLanguageModel_GetLocSuggestedToDeleteSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsLanguageModel{}
-	c.GetLocSuggestedToDeleteSum()
-	c = nil
-	c.GetLocSuggestedToDeleteSum()
 }
 
 func TestCopilotMetricsLanguageModel_GetModel(tt *testing.T) {
@@ -11612,60 +11468,12 @@ func TestCopilotMetricsListOptions_GetUntil(tt *testing.T) {
 	c.GetUntil()
 }
 
-func TestCopilotMetricsModelFeature_GetCodeAcceptanceActivityCount(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsModelFeature{}
-	c.GetCodeAcceptanceActivityCount()
-	c = nil
-	c.GetCodeAcceptanceActivityCount()
-}
-
-func TestCopilotMetricsModelFeature_GetCodeGenerationActivityCount(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsModelFeature{}
-	c.GetCodeGenerationActivityCount()
-	c = nil
-	c.GetCodeGenerationActivityCount()
-}
-
 func TestCopilotMetricsModelFeature_GetFeature(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotMetricsModelFeature{}
 	c.GetFeature()
 	c = nil
 	c.GetFeature()
-}
-
-func TestCopilotMetricsModelFeature_GetLocAddedSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsModelFeature{}
-	c.GetLocAddedSum()
-	c = nil
-	c.GetLocAddedSum()
-}
-
-func TestCopilotMetricsModelFeature_GetLocDeletedSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsModelFeature{}
-	c.GetLocDeletedSum()
-	c = nil
-	c.GetLocDeletedSum()
-}
-
-func TestCopilotMetricsModelFeature_GetLocSuggestedToAddSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsModelFeature{}
-	c.GetLocSuggestedToAddSum()
-	c = nil
-	c.GetLocSuggestedToAddSum()
-}
-
-func TestCopilotMetricsModelFeature_GetLocSuggestedToDeleteSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotMetricsModelFeature{}
-	c.GetLocSuggestedToDeleteSum()
-	c = nil
-	c.GetLocSuggestedToDeleteSum()
 }
 
 func TestCopilotMetricsModelFeature_GetModel(tt *testing.T) {
@@ -12079,36 +11887,36 @@ func TestCopilotUserDailyMetrics_GetEnterpriseID(tt *testing.T) {
 	c.GetEnterpriseID()
 }
 
-func TestCopilotUserDailyMetrics_GetLocAddedSum(tt *testing.T) {
+func TestCopilotUserDailyMetrics_GetLOCAddedSum(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotUserDailyMetrics{}
-	c.GetLocAddedSum()
+	c.GetLOCAddedSum()
 	c = nil
-	c.GetLocAddedSum()
+	c.GetLOCAddedSum()
 }
 
-func TestCopilotUserDailyMetrics_GetLocDeletedSum(tt *testing.T) {
+func TestCopilotUserDailyMetrics_GetLOCDeletedSum(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotUserDailyMetrics{}
-	c.GetLocDeletedSum()
+	c.GetLOCDeletedSum()
 	c = nil
-	c.GetLocDeletedSum()
+	c.GetLOCDeletedSum()
 }
 
-func TestCopilotUserDailyMetrics_GetLocSuggestedToAddSum(tt *testing.T) {
+func TestCopilotUserDailyMetrics_GetLOCSuggestedToAddSum(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotUserDailyMetrics{}
-	c.GetLocSuggestedToAddSum()
+	c.GetLOCSuggestedToAddSum()
 	c = nil
-	c.GetLocSuggestedToAddSum()
+	c.GetLOCSuggestedToAddSum()
 }
 
-func TestCopilotUserDailyMetrics_GetLocSuggestedToDeleteSum(tt *testing.T) {
+func TestCopilotUserDailyMetrics_GetLOCSuggestedToDeleteSum(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotUserDailyMetrics{}
-	c.GetLocSuggestedToDeleteSum()
+	c.GetLOCSuggestedToDeleteSum()
 	c = nil
-	c.GetLocSuggestedToDeleteSum()
+	c.GetLOCSuggestedToDeleteSum()
 }
 
 func TestCopilotUserDailyMetrics_GetOrganizationID(tt *testing.T) {
@@ -12254,22 +12062,6 @@ func TestCopilotUserDailyMetrics_GetUserLogin(tt *testing.T) {
 	c.GetUserLogin()
 }
 
-func TestCopilotUserMetricsIDE_GetCodeAcceptanceActivityCount(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotUserMetricsIDE{}
-	c.GetCodeAcceptanceActivityCount()
-	c = nil
-	c.GetCodeAcceptanceActivityCount()
-}
-
-func TestCopilotUserMetricsIDE_GetCodeGenerationActivityCount(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotUserMetricsIDE{}
-	c.GetCodeGenerationActivityCount()
-	c = nil
-	c.GetCodeGenerationActivityCount()
-}
-
 func TestCopilotUserMetricsIDE_GetIDE(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotUserMetricsIDE{}
@@ -12292,38 +12084,6 @@ func TestCopilotUserMetricsIDE_GetLastKnownPluginVersion(tt *testing.T) {
 	c.GetLastKnownPluginVersion()
 	c = nil
 	c.GetLastKnownPluginVersion()
-}
-
-func TestCopilotUserMetricsIDE_GetLocAddedSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotUserMetricsIDE{}
-	c.GetLocAddedSum()
-	c = nil
-	c.GetLocAddedSum()
-}
-
-func TestCopilotUserMetricsIDE_GetLocDeletedSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotUserMetricsIDE{}
-	c.GetLocDeletedSum()
-	c = nil
-	c.GetLocDeletedSum()
-}
-
-func TestCopilotUserMetricsIDE_GetLocSuggestedToAddSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotUserMetricsIDE{}
-	c.GetLocSuggestedToAddSum()
-	c = nil
-	c.GetLocSuggestedToAddSum()
-}
-
-func TestCopilotUserMetricsIDE_GetLocSuggestedToDeleteSum(tt *testing.T) {
-	tt.Parallel()
-	c := &CopilotUserMetricsIDE{}
-	c.GetLocSuggestedToDeleteSum()
-	c = nil
-	c.GetLocSuggestedToDeleteSum()
 }
 
 func TestCopilotUserMetricsIDE_GetUserInitiatedInteractionCount(tt *testing.T) {
@@ -12412,36 +12172,36 @@ func TestCopilotUserPeriodicMetrics_GetEnterpriseID(tt *testing.T) {
 	c.GetEnterpriseID()
 }
 
-func TestCopilotUserPeriodicMetrics_GetLocAddedSum(tt *testing.T) {
+func TestCopilotUserPeriodicMetrics_GetLOCAddedSum(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotUserPeriodicMetrics{}
-	c.GetLocAddedSum()
+	c.GetLOCAddedSum()
 	c = nil
-	c.GetLocAddedSum()
+	c.GetLOCAddedSum()
 }
 
-func TestCopilotUserPeriodicMetrics_GetLocDeletedSum(tt *testing.T) {
+func TestCopilotUserPeriodicMetrics_GetLOCDeletedSum(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotUserPeriodicMetrics{}
-	c.GetLocDeletedSum()
+	c.GetLOCDeletedSum()
 	c = nil
-	c.GetLocDeletedSum()
+	c.GetLOCDeletedSum()
 }
 
-func TestCopilotUserPeriodicMetrics_GetLocSuggestedToAddSum(tt *testing.T) {
+func TestCopilotUserPeriodicMetrics_GetLOCSuggestedToAddSum(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotUserPeriodicMetrics{}
-	c.GetLocSuggestedToAddSum()
+	c.GetLOCSuggestedToAddSum()
 	c = nil
-	c.GetLocSuggestedToAddSum()
+	c.GetLOCSuggestedToAddSum()
 }
 
-func TestCopilotUserPeriodicMetrics_GetLocSuggestedToDeleteSum(tt *testing.T) {
+func TestCopilotUserPeriodicMetrics_GetLOCSuggestedToDeleteSum(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotUserPeriodicMetrics{}
-	c.GetLocSuggestedToDeleteSum()
+	c.GetLOCSuggestedToDeleteSum()
 	c = nil
-	c.GetLocSuggestedToDeleteSum()
+	c.GetLOCSuggestedToDeleteSum()
 }
 
 func TestCopilotUserPeriodicMetrics_GetOrganizationID(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -10540,12 +10540,12 @@ func TestCopilotDailyMetrics_GetCodeGenerationActivityCount(tt *testing.T) {
 	c.GetCodeGenerationActivityCount()
 }
 
-func TestCopilotDailyMetrics_GetDailyActiveCliUsers(tt *testing.T) {
+func TestCopilotDailyMetrics_GetDailyActiveCLIUsers(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotDailyMetrics{}
-	c.GetDailyActiveCliUsers()
+	c.GetDailyActiveCLIUsers()
 	c = nil
-	c.GetDailyActiveCliUsers()
+	c.GetDailyActiveCLIUsers()
 }
 
 func TestCopilotDailyMetrics_GetDailyActiveCopilotCloudAgentUsers(tt *testing.T) {
@@ -10660,12 +10660,12 @@ func TestCopilotDailyMetrics_GetPullRequests(tt *testing.T) {
 	c.GetPullRequests()
 }
 
-func TestCopilotDailyMetrics_GetTotalsByCli(tt *testing.T) {
+func TestCopilotDailyMetrics_GetTotalsByCLI(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotDailyMetrics{}
-	c.GetTotalsByCli()
+	c.GetTotalsByCLI()
 	c = nil
-	c.GetTotalsByCli()
+	c.GetTotalsByCLI()
 }
 
 func TestCopilotDailyMetrics_GetTotalsByFeature(tt *testing.T) {
@@ -11251,84 +11251,84 @@ func TestCopilotMetrics_GetTotalEngagedUsers(tt *testing.T) {
 	c.GetTotalEngagedUsers()
 }
 
-func TestCopilotMetricsCli_GetLastKnownCliVersion(tt *testing.T) {
+func TestCopilotMetricsCLI_GetLastKnownCLIVersion(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCli{}
-	c.GetLastKnownCliVersion()
+	c := &CopilotMetricsCLI{}
+	c.GetLastKnownCLIVersion()
 	c = nil
-	c.GetLastKnownCliVersion()
+	c.GetLastKnownCLIVersion()
 }
 
-func TestCopilotMetricsCli_GetPromptCount(tt *testing.T) {
+func TestCopilotMetricsCLI_GetPromptCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCli{}
+	c := &CopilotMetricsCLI{}
 	c.GetPromptCount()
 	c = nil
 	c.GetPromptCount()
 }
 
-func TestCopilotMetricsCli_GetRequestCount(tt *testing.T) {
+func TestCopilotMetricsCLI_GetRequestCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCli{}
+	c := &CopilotMetricsCLI{}
 	c.GetRequestCount()
 	c = nil
 	c.GetRequestCount()
 }
 
-func TestCopilotMetricsCli_GetSessionCount(tt *testing.T) {
+func TestCopilotMetricsCLI_GetSessionCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCli{}
+	c := &CopilotMetricsCLI{}
 	c.GetSessionCount()
 	c = nil
 	c.GetSessionCount()
 }
 
-func TestCopilotMetricsCli_GetTokenUsage(tt *testing.T) {
+func TestCopilotMetricsCLI_GetTokenUsage(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCli{}
+	c := &CopilotMetricsCLI{}
 	c.GetTokenUsage()
 	c = nil
 	c.GetTokenUsage()
 }
 
-func TestCopilotMetricsCliTokenUsage_GetAvgTokensPerRequest(tt *testing.T) {
+func TestCopilotMetricsCLITokenUsage_GetAvgTokensPerRequest(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCliTokenUsage{}
+	c := &CopilotMetricsCLITokenUsage{}
 	c.GetAvgTokensPerRequest()
 	c = nil
 	c.GetAvgTokensPerRequest()
 }
 
-func TestCopilotMetricsCliTokenUsage_GetOutputTokensSum(tt *testing.T) {
+func TestCopilotMetricsCLITokenUsage_GetOutputTokensSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCliTokenUsage{}
+	c := &CopilotMetricsCLITokenUsage{}
 	c.GetOutputTokensSum()
 	c = nil
 	c.GetOutputTokensSum()
 }
 
-func TestCopilotMetricsCliTokenUsage_GetPromptTokensSum(tt *testing.T) {
+func TestCopilotMetricsCLITokenUsage_GetPromptTokensSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCliTokenUsage{}
+	c := &CopilotMetricsCLITokenUsage{}
 	c.GetPromptTokensSum()
 	c = nil
 	c.GetPromptTokensSum()
 }
 
-func TestCopilotMetricsCliVersion_GetCliVersion(tt *testing.T) {
+func TestCopilotMetricsCLIVersion_GetCLIVersion(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCliVersion{}
-	c.GetCliVersion()
+	c := &CopilotMetricsCLIVersion{}
+	c.GetCLIVersion()
 	c = nil
-	c.GetCliVersion()
+	c.GetCLIVersion()
 }
 
-func TestCopilotMetricsCliVersion_GetSampledAt(tt *testing.T) {
+func TestCopilotMetricsCLIVersion_GetSampledAt(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp
-	c := &CopilotMetricsCliVersion{SampledAt: &zeroValue}
+	c := &CopilotMetricsCLIVersion{SampledAt: &zeroValue}
 	c.GetSampledAt()
-	c = &CopilotMetricsCliVersion{}
+	c = &CopilotMetricsCLIVersion{}
 	c.GetSampledAt()
 	c = nil
 	c.GetSampledAt()
@@ -12119,12 +12119,12 @@ func TestCopilotUserDailyMetrics_GetOrganizationID(tt *testing.T) {
 	c.GetOrganizationID()
 }
 
-func TestCopilotUserDailyMetrics_GetTotalsByCli(tt *testing.T) {
+func TestCopilotUserDailyMetrics_GetTotalsByCLI(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotUserDailyMetrics{}
-	c.GetTotalsByCli()
+	c.GetTotalsByCLI()
 	c = nil
-	c.GetTotalsByCli()
+	c.GetTotalsByCLI()
 }
 
 func TestCopilotUserDailyMetrics_GetTotalsByFeature(tt *testing.T) {
@@ -12198,12 +12198,12 @@ func TestCopilotUserDailyMetrics_GetUsedChat(tt *testing.T) {
 	c.GetUsedChat()
 }
 
-func TestCopilotUserDailyMetrics_GetUsedCli(tt *testing.T) {
+func TestCopilotUserDailyMetrics_GetUsedCLI(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotUserDailyMetrics{}
-	c.GetUsedCli()
+	c.GetUsedCLI()
 	c = nil
-	c.GetUsedCli()
+	c.GetUsedCLI()
 }
 
 func TestCopilotUserDailyMetrics_GetUsedCopilotCodeReviewActive(tt *testing.T) {
@@ -12468,12 +12468,12 @@ func TestCopilotUserPeriodicMetrics_GetReportStartDay(tt *testing.T) {
 	c.GetReportStartDay()
 }
 
-func TestCopilotUserPeriodicMetrics_GetTotalsByCli(tt *testing.T) {
+func TestCopilotUserPeriodicMetrics_GetTotalsByCLI(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotUserPeriodicMetrics{}
-	c.GetTotalsByCli()
+	c.GetTotalsByCLI()
 	c = nil
-	c.GetTotalsByCli()
+	c.GetTotalsByCLI()
 }
 
 func TestCopilotUserPeriodicMetrics_GetTotalsByFeature(tt *testing.T) {
@@ -12547,12 +12547,12 @@ func TestCopilotUserPeriodicMetrics_GetUsedChat(tt *testing.T) {
 	c.GetUsedChat()
 }
 
-func TestCopilotUserPeriodicMetrics_GetUsedCli(tt *testing.T) {
+func TestCopilotUserPeriodicMetrics_GetUsedCLI(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotUserPeriodicMetrics{}
-	c.GetUsedCli()
+	c.GetUsedCLI()
 	c = nil
-	c.GetUsedCli()
+	c.GetUsedCLI()
 }
 
 func TestCopilotUserPeriodicMetrics_GetUsedCopilotCodeReviewActive(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -10526,7 +10526,10 @@ func TestCopilotCodeReviewRuleParameters_GetReviewOnPush(tt *testing.T) {
 
 func TestCopilotDailyMetrics_GetCodeAcceptanceActivityCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{CodeAcceptanceActivityCount: &zeroValue}
+	c.GetCodeAcceptanceActivityCount()
+	c = &CopilotDailyMetrics{}
 	c.GetCodeAcceptanceActivityCount()
 	c = nil
 	c.GetCodeAcceptanceActivityCount()
@@ -10534,7 +10537,10 @@ func TestCopilotDailyMetrics_GetCodeAcceptanceActivityCount(tt *testing.T) {
 
 func TestCopilotDailyMetrics_GetCodeGenerationActivityCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{CodeGenerationActivityCount: &zeroValue}
+	c.GetCodeGenerationActivityCount()
+	c = &CopilotDailyMetrics{}
 	c.GetCodeGenerationActivityCount()
 	c = nil
 	c.GetCodeGenerationActivityCount()
@@ -10542,7 +10548,10 @@ func TestCopilotDailyMetrics_GetCodeGenerationActivityCount(tt *testing.T) {
 
 func TestCopilotDailyMetrics_GetDailyActiveCLIUsers(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{DailyActiveCLIUsers: &zeroValue}
+	c.GetDailyActiveCLIUsers()
+	c = &CopilotDailyMetrics{}
 	c.GetDailyActiveCLIUsers()
 	c = nil
 	c.GetDailyActiveCLIUsers()
@@ -10550,7 +10559,10 @@ func TestCopilotDailyMetrics_GetDailyActiveCLIUsers(tt *testing.T) {
 
 func TestCopilotDailyMetrics_GetDailyActiveCopilotCloudAgentUsers(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{DailyActiveCopilotCloudAgentUsers: &zeroValue}
+	c.GetDailyActiveCopilotCloudAgentUsers()
+	c = &CopilotDailyMetrics{}
 	c.GetDailyActiveCopilotCloudAgentUsers()
 	c = nil
 	c.GetDailyActiveCopilotCloudAgentUsers()
@@ -10558,7 +10570,10 @@ func TestCopilotDailyMetrics_GetDailyActiveCopilotCloudAgentUsers(tt *testing.T)
 
 func TestCopilotDailyMetrics_GetDailyActiveUsers(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{DailyActiveUsers: &zeroValue}
+	c.GetDailyActiveUsers()
+	c = &CopilotDailyMetrics{}
 	c.GetDailyActiveUsers()
 	c = nil
 	c.GetDailyActiveUsers()
@@ -10574,7 +10589,10 @@ func TestCopilotDailyMetrics_GetDay(tt *testing.T) {
 
 func TestCopilotDailyMetrics_GetEnterpriseID(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue string
+	c := &CopilotDailyMetrics{EnterpriseID: &zeroValue}
+	c.GetEnterpriseID()
+	c = &CopilotDailyMetrics{}
 	c.GetEnterpriseID()
 	c = nil
 	c.GetEnterpriseID()
@@ -10582,7 +10600,10 @@ func TestCopilotDailyMetrics_GetEnterpriseID(tt *testing.T) {
 
 func TestCopilotDailyMetrics_GetLOCAddedSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{LOCAddedSum: &zeroValue}
+	c.GetLOCAddedSum()
+	c = &CopilotDailyMetrics{}
 	c.GetLOCAddedSum()
 	c = nil
 	c.GetLOCAddedSum()
@@ -10590,7 +10611,10 @@ func TestCopilotDailyMetrics_GetLOCAddedSum(tt *testing.T) {
 
 func TestCopilotDailyMetrics_GetLOCDeletedSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{LOCDeletedSum: &zeroValue}
+	c.GetLOCDeletedSum()
+	c = &CopilotDailyMetrics{}
 	c.GetLOCDeletedSum()
 	c = nil
 	c.GetLOCDeletedSum()
@@ -10598,7 +10622,10 @@ func TestCopilotDailyMetrics_GetLOCDeletedSum(tt *testing.T) {
 
 func TestCopilotDailyMetrics_GetLOCSuggestedToAddSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{LOCSuggestedToAddSum: &zeroValue}
+	c.GetLOCSuggestedToAddSum()
+	c = &CopilotDailyMetrics{}
 	c.GetLOCSuggestedToAddSum()
 	c = nil
 	c.GetLOCSuggestedToAddSum()
@@ -10606,7 +10633,10 @@ func TestCopilotDailyMetrics_GetLOCSuggestedToAddSum(tt *testing.T) {
 
 func TestCopilotDailyMetrics_GetLOCSuggestedToDeleteSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{LOCSuggestedToDeleteSum: &zeroValue}
+	c.GetLOCSuggestedToDeleteSum()
+	c = &CopilotDailyMetrics{}
 	c.GetLOCSuggestedToDeleteSum()
 	c = nil
 	c.GetLOCSuggestedToDeleteSum()
@@ -10614,7 +10644,10 @@ func TestCopilotDailyMetrics_GetLOCSuggestedToDeleteSum(tt *testing.T) {
 
 func TestCopilotDailyMetrics_GetMonthlyActiveAgentUsers(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{MonthlyActiveAgentUsers: &zeroValue}
+	c.GetMonthlyActiveAgentUsers()
+	c = &CopilotDailyMetrics{}
 	c.GetMonthlyActiveAgentUsers()
 	c = nil
 	c.GetMonthlyActiveAgentUsers()
@@ -10622,7 +10655,10 @@ func TestCopilotDailyMetrics_GetMonthlyActiveAgentUsers(tt *testing.T) {
 
 func TestCopilotDailyMetrics_GetMonthlyActiveChatUsers(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{MonthlyActiveChatUsers: &zeroValue}
+	c.GetMonthlyActiveChatUsers()
+	c = &CopilotDailyMetrics{}
 	c.GetMonthlyActiveChatUsers()
 	c = nil
 	c.GetMonthlyActiveChatUsers()
@@ -10630,7 +10666,10 @@ func TestCopilotDailyMetrics_GetMonthlyActiveChatUsers(tt *testing.T) {
 
 func TestCopilotDailyMetrics_GetMonthlyActiveCopilotCloudAgentUsers(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{MonthlyActiveCopilotCloudAgentUsers: &zeroValue}
+	c.GetMonthlyActiveCopilotCloudAgentUsers()
+	c = &CopilotDailyMetrics{}
 	c.GetMonthlyActiveCopilotCloudAgentUsers()
 	c = nil
 	c.GetMonthlyActiveCopilotCloudAgentUsers()
@@ -10638,7 +10677,10 @@ func TestCopilotDailyMetrics_GetMonthlyActiveCopilotCloudAgentUsers(tt *testing.
 
 func TestCopilotDailyMetrics_GetMonthlyActiveUsers(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{MonthlyActiveUsers: &zeroValue}
+	c.GetMonthlyActiveUsers()
+	c = &CopilotDailyMetrics{}
 	c.GetMonthlyActiveUsers()
 	c = nil
 	c.GetMonthlyActiveUsers()
@@ -10646,7 +10688,10 @@ func TestCopilotDailyMetrics_GetMonthlyActiveUsers(tt *testing.T) {
 
 func TestCopilotDailyMetrics_GetOrganizationID(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue string
+	c := &CopilotDailyMetrics{OrganizationID: &zeroValue}
+	c.GetOrganizationID()
+	c = &CopilotDailyMetrics{}
 	c.GetOrganizationID()
 	c = nil
 	c.GetOrganizationID()
@@ -10725,7 +10770,10 @@ func TestCopilotDailyMetrics_GetTotalsByModelFeature(tt *testing.T) {
 
 func TestCopilotDailyMetrics_GetUserInitiatedInteractionCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{UserInitiatedInteractionCount: &zeroValue}
+	c.GetUserInitiatedInteractionCount()
+	c = &CopilotDailyMetrics{}
 	c.GetUserInitiatedInteractionCount()
 	c = nil
 	c.GetUserInitiatedInteractionCount()
@@ -10733,7 +10781,10 @@ func TestCopilotDailyMetrics_GetUserInitiatedInteractionCount(tt *testing.T) {
 
 func TestCopilotDailyMetrics_GetWeeklyActiveCopilotCloudAgentUsers(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{WeeklyActiveCopilotCloudAgentUsers: &zeroValue}
+	c.GetWeeklyActiveCopilotCloudAgentUsers()
+	c = &CopilotDailyMetrics{}
 	c.GetWeeklyActiveCopilotCloudAgentUsers()
 	c = nil
 	c.GetWeeklyActiveCopilotCloudAgentUsers()
@@ -10741,7 +10792,10 @@ func TestCopilotDailyMetrics_GetWeeklyActiveCopilotCloudAgentUsers(tt *testing.T
 
 func TestCopilotDailyMetrics_GetWeeklyActiveUsers(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotDailyMetrics{}
+	var zeroValue int
+	c := &CopilotDailyMetrics{WeeklyActiveUsers: &zeroValue}
+	c.GetWeeklyActiveUsers()
+	c = &CopilotDailyMetrics{}
 	c.GetWeeklyActiveUsers()
 	c = nil
 	c.GetWeeklyActiveUsers()
@@ -11251,6 +11305,61 @@ func TestCopilotMetrics_GetTotalEngagedUsers(tt *testing.T) {
 	c.GetTotalEngagedUsers()
 }
 
+func TestCopilotMetricsChatPanel_GetChatPanelAgentMode(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsChatPanel{ChatPanelAgentMode: &zeroValue}
+	c.GetChatPanelAgentMode()
+	c = &CopilotMetricsChatPanel{}
+	c.GetChatPanelAgentMode()
+	c = nil
+	c.GetChatPanelAgentMode()
+}
+
+func TestCopilotMetricsChatPanel_GetChatPanelAskMode(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsChatPanel{ChatPanelAskMode: &zeroValue}
+	c.GetChatPanelAskMode()
+	c = &CopilotMetricsChatPanel{}
+	c.GetChatPanelAskMode()
+	c = nil
+	c.GetChatPanelAskMode()
+}
+
+func TestCopilotMetricsChatPanel_GetChatPanelCustomMode(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsChatPanel{ChatPanelCustomMode: &zeroValue}
+	c.GetChatPanelCustomMode()
+	c = &CopilotMetricsChatPanel{}
+	c.GetChatPanelCustomMode()
+	c = nil
+	c.GetChatPanelCustomMode()
+}
+
+func TestCopilotMetricsChatPanel_GetChatPanelEditMode(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsChatPanel{ChatPanelEditMode: &zeroValue}
+	c.GetChatPanelEditMode()
+	c = &CopilotMetricsChatPanel{}
+	c.GetChatPanelEditMode()
+	c = nil
+	c.GetChatPanelEditMode()
+}
+
+func TestCopilotMetricsChatPanel_GetChatPanelUnknownMode(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsChatPanel{ChatPanelUnknownMode: &zeroValue}
+	c.GetChatPanelUnknownMode()
+	c = &CopilotMetricsChatPanel{}
+	c.GetChatPanelUnknownMode()
+	c = nil
+	c.GetChatPanelUnknownMode()
+}
+
 func TestCopilotMetricsCLI_GetLastKnownCLIVersion(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotMetricsCLI{}
@@ -11261,7 +11370,10 @@ func TestCopilotMetricsCLI_GetLastKnownCLIVersion(tt *testing.T) {
 
 func TestCopilotMetricsCLI_GetPromptCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCLI{}
+	var zeroValue int
+	c := &CopilotMetricsCLI{PromptCount: &zeroValue}
+	c.GetPromptCount()
+	c = &CopilotMetricsCLI{}
 	c.GetPromptCount()
 	c = nil
 	c.GetPromptCount()
@@ -11269,7 +11381,10 @@ func TestCopilotMetricsCLI_GetPromptCount(tt *testing.T) {
 
 func TestCopilotMetricsCLI_GetRequestCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCLI{}
+	var zeroValue int
+	c := &CopilotMetricsCLI{RequestCount: &zeroValue}
+	c.GetRequestCount()
+	c = &CopilotMetricsCLI{}
 	c.GetRequestCount()
 	c = nil
 	c.GetRequestCount()
@@ -11277,7 +11392,10 @@ func TestCopilotMetricsCLI_GetRequestCount(tt *testing.T) {
 
 func TestCopilotMetricsCLI_GetSessionCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCLI{}
+	var zeroValue int
+	c := &CopilotMetricsCLI{SessionCount: &zeroValue}
+	c.GetSessionCount()
+	c = &CopilotMetricsCLI{}
 	c.GetSessionCount()
 	c = nil
 	c.GetSessionCount()
@@ -11293,7 +11411,10 @@ func TestCopilotMetricsCLI_GetTokenUsage(tt *testing.T) {
 
 func TestCopilotMetricsCLITokenUsage_GetAvgTokensPerRequest(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCLITokenUsage{}
+	var zeroValue float64
+	c := &CopilotMetricsCLITokenUsage{AvgTokensPerRequest: &zeroValue}
+	c.GetAvgTokensPerRequest()
+	c = &CopilotMetricsCLITokenUsage{}
 	c.GetAvgTokensPerRequest()
 	c = nil
 	c.GetAvgTokensPerRequest()
@@ -11301,7 +11422,10 @@ func TestCopilotMetricsCLITokenUsage_GetAvgTokensPerRequest(tt *testing.T) {
 
 func TestCopilotMetricsCLITokenUsage_GetOutputTokensSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCLITokenUsage{}
+	var zeroValue int
+	c := &CopilotMetricsCLITokenUsage{OutputTokensSum: &zeroValue}
+	c.GetOutputTokensSum()
+	c = &CopilotMetricsCLITokenUsage{}
 	c.GetOutputTokensSum()
 	c = nil
 	c.GetOutputTokensSum()
@@ -11309,7 +11433,10 @@ func TestCopilotMetricsCLITokenUsage_GetOutputTokensSum(tt *testing.T) {
 
 func TestCopilotMetricsCLITokenUsage_GetPromptTokensSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCLITokenUsage{}
+	var zeroValue int
+	c := &CopilotMetricsCLITokenUsage{PromptTokensSum: &zeroValue}
+	c.GetPromptTokensSum()
+	c = &CopilotMetricsCLITokenUsage{}
 	c.GetPromptTokensSum()
 	c = nil
 	c.GetPromptTokensSum()
@@ -11336,7 +11463,10 @@ func TestCopilotMetricsCLIVersion_GetSampledAt(tt *testing.T) {
 
 func TestCopilotMetricsCodeActivity_GetCodeAcceptanceActivityCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCodeActivity{}
+	var zeroValue int
+	c := &CopilotMetricsCodeActivity{CodeAcceptanceActivityCount: &zeroValue}
+	c.GetCodeAcceptanceActivityCount()
+	c = &CopilotMetricsCodeActivity{}
 	c.GetCodeAcceptanceActivityCount()
 	c = nil
 	c.GetCodeAcceptanceActivityCount()
@@ -11344,7 +11474,10 @@ func TestCopilotMetricsCodeActivity_GetCodeAcceptanceActivityCount(tt *testing.T
 
 func TestCopilotMetricsCodeActivity_GetCodeGenerationActivityCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCodeActivity{}
+	var zeroValue int
+	c := &CopilotMetricsCodeActivity{CodeGenerationActivityCount: &zeroValue}
+	c.GetCodeGenerationActivityCount()
+	c = &CopilotMetricsCodeActivity{}
 	c.GetCodeGenerationActivityCount()
 	c = nil
 	c.GetCodeGenerationActivityCount()
@@ -11352,7 +11485,10 @@ func TestCopilotMetricsCodeActivity_GetCodeGenerationActivityCount(tt *testing.T
 
 func TestCopilotMetricsCodeActivity_GetLOCAddedSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCodeActivity{}
+	var zeroValue int
+	c := &CopilotMetricsCodeActivity{LOCAddedSum: &zeroValue}
+	c.GetLOCAddedSum()
+	c = &CopilotMetricsCodeActivity{}
 	c.GetLOCAddedSum()
 	c = nil
 	c.GetLOCAddedSum()
@@ -11360,7 +11496,10 @@ func TestCopilotMetricsCodeActivity_GetLOCAddedSum(tt *testing.T) {
 
 func TestCopilotMetricsCodeActivity_GetLOCDeletedSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCodeActivity{}
+	var zeroValue int
+	c := &CopilotMetricsCodeActivity{LOCDeletedSum: &zeroValue}
+	c.GetLOCDeletedSum()
+	c = &CopilotMetricsCodeActivity{}
 	c.GetLOCDeletedSum()
 	c = nil
 	c.GetLOCDeletedSum()
@@ -11368,7 +11507,10 @@ func TestCopilotMetricsCodeActivity_GetLOCDeletedSum(tt *testing.T) {
 
 func TestCopilotMetricsCodeActivity_GetLOCSuggestedToAddSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCodeActivity{}
+	var zeroValue int
+	c := &CopilotMetricsCodeActivity{LOCSuggestedToAddSum: &zeroValue}
+	c.GetLOCSuggestedToAddSum()
+	c = &CopilotMetricsCodeActivity{}
 	c.GetLOCSuggestedToAddSum()
 	c = nil
 	c.GetLOCSuggestedToAddSum()
@@ -11376,7 +11518,10 @@ func TestCopilotMetricsCodeActivity_GetLOCSuggestedToAddSum(tt *testing.T) {
 
 func TestCopilotMetricsCodeActivity_GetLOCSuggestedToDeleteSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsCodeActivity{}
+	var zeroValue int
+	c := &CopilotMetricsCodeActivity{LOCSuggestedToDeleteSum: &zeroValue}
+	c.GetLOCSuggestedToDeleteSum()
+	c = &CopilotMetricsCodeActivity{}
 	c.GetLOCSuggestedToDeleteSum()
 	c = nil
 	c.GetLOCSuggestedToDeleteSum()
@@ -11392,7 +11537,10 @@ func TestCopilotMetricsFeature_GetFeature(tt *testing.T) {
 
 func TestCopilotMetricsFeature_GetUserInitiatedInteractionCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsFeature{}
+	var zeroValue int
+	c := &CopilotMetricsFeature{UserInitiatedInteractionCount: &zeroValue}
+	c.GetUserInitiatedInteractionCount()
+	c = &CopilotMetricsFeature{}
 	c.GetUserInitiatedInteractionCount()
 	c = nil
 	c.GetUserInitiatedInteractionCount()
@@ -11408,7 +11556,10 @@ func TestCopilotMetricsIDE_GetIDE(tt *testing.T) {
 
 func TestCopilotMetricsIDE_GetUserInitiatedInteractionCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsIDE{}
+	var zeroValue int
+	c := &CopilotMetricsIDE{UserInitiatedInteractionCount: &zeroValue}
+	c.GetUserInitiatedInteractionCount()
+	c = &CopilotMetricsIDE{}
 	c.GetUserInitiatedInteractionCount()
 	c = nil
 	c.GetUserInitiatedInteractionCount()
@@ -11486,7 +11637,10 @@ func TestCopilotMetricsModelFeature_GetModel(tt *testing.T) {
 
 func TestCopilotMetricsModelFeature_GetUserInitiatedInteractionCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsModelFeature{}
+	var zeroValue int
+	c := &CopilotMetricsModelFeature{UserInitiatedInteractionCount: &zeroValue}
+	c.GetUserInitiatedInteractionCount()
+	c = &CopilotMetricsModelFeature{}
 	c.GetUserInitiatedInteractionCount()
 	c = nil
 	c.GetUserInitiatedInteractionCount()
@@ -11494,7 +11648,10 @@ func TestCopilotMetricsModelFeature_GetUserInitiatedInteractionCount(tt *testing
 
 func TestCopilotMetricsPullRequests_GetMedianMinutesToMerge(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsPullRequests{}
+	var zeroValue float64
+	c := &CopilotMetricsPullRequests{MedianMinutesToMerge: &zeroValue}
+	c.GetMedianMinutesToMerge()
+	c = &CopilotMetricsPullRequests{}
 	c.GetMedianMinutesToMerge()
 	c = nil
 	c.GetMedianMinutesToMerge()
@@ -11502,7 +11659,10 @@ func TestCopilotMetricsPullRequests_GetMedianMinutesToMerge(tt *testing.T) {
 
 func TestCopilotMetricsPullRequests_GetMedianMinutesToMergeCopilotAuthored(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsPullRequests{}
+	var zeroValue float64
+	c := &CopilotMetricsPullRequests{MedianMinutesToMergeCopilotAuthored: &zeroValue}
+	c.GetMedianMinutesToMergeCopilotAuthored()
+	c = &CopilotMetricsPullRequests{}
 	c.GetMedianMinutesToMergeCopilotAuthored()
 	c = nil
 	c.GetMedianMinutesToMergeCopilotAuthored()
@@ -11510,7 +11670,10 @@ func TestCopilotMetricsPullRequests_GetMedianMinutesToMergeCopilotAuthored(tt *t
 
 func TestCopilotMetricsPullRequests_GetMedianMinutesToMergeCopilotReviewed(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsPullRequests{}
+	var zeroValue float64
+	c := &CopilotMetricsPullRequests{MedianMinutesToMergeCopilotReviewed: &zeroValue}
+	c.GetMedianMinutesToMergeCopilotReviewed()
+	c = &CopilotMetricsPullRequests{}
 	c.GetMedianMinutesToMergeCopilotReviewed()
 	c = nil
 	c.GetMedianMinutesToMergeCopilotReviewed()
@@ -11518,7 +11681,10 @@ func TestCopilotMetricsPullRequests_GetMedianMinutesToMergeCopilotReviewed(tt *t
 
 func TestCopilotMetricsPullRequests_GetTotalAppliedSuggestions(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsPullRequests{}
+	var zeroValue int
+	c := &CopilotMetricsPullRequests{TotalAppliedSuggestions: &zeroValue}
+	c.GetTotalAppliedSuggestions()
+	c = &CopilotMetricsPullRequests{}
 	c.GetTotalAppliedSuggestions()
 	c = nil
 	c.GetTotalAppliedSuggestions()
@@ -11526,7 +11692,10 @@ func TestCopilotMetricsPullRequests_GetTotalAppliedSuggestions(tt *testing.T) {
 
 func TestCopilotMetricsPullRequests_GetTotalCopilotAppliedSuggestions(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsPullRequests{}
+	var zeroValue int
+	c := &CopilotMetricsPullRequests{TotalCopilotAppliedSuggestions: &zeroValue}
+	c.GetTotalCopilotAppliedSuggestions()
+	c = &CopilotMetricsPullRequests{}
 	c.GetTotalCopilotAppliedSuggestions()
 	c = nil
 	c.GetTotalCopilotAppliedSuggestions()
@@ -11534,7 +11703,10 @@ func TestCopilotMetricsPullRequests_GetTotalCopilotAppliedSuggestions(tt *testin
 
 func TestCopilotMetricsPullRequests_GetTotalCopilotSuggestions(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsPullRequests{}
+	var zeroValue int
+	c := &CopilotMetricsPullRequests{TotalCopilotSuggestions: &zeroValue}
+	c.GetTotalCopilotSuggestions()
+	c = &CopilotMetricsPullRequests{}
 	c.GetTotalCopilotSuggestions()
 	c = nil
 	c.GetTotalCopilotSuggestions()
@@ -11542,7 +11714,10 @@ func TestCopilotMetricsPullRequests_GetTotalCopilotSuggestions(tt *testing.T) {
 
 func TestCopilotMetricsPullRequests_GetTotalCreated(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsPullRequests{}
+	var zeroValue int
+	c := &CopilotMetricsPullRequests{TotalCreated: &zeroValue}
+	c.GetTotalCreated()
+	c = &CopilotMetricsPullRequests{}
 	c.GetTotalCreated()
 	c = nil
 	c.GetTotalCreated()
@@ -11550,7 +11725,10 @@ func TestCopilotMetricsPullRequests_GetTotalCreated(tt *testing.T) {
 
 func TestCopilotMetricsPullRequests_GetTotalCreatedByCopilot(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsPullRequests{}
+	var zeroValue int
+	c := &CopilotMetricsPullRequests{TotalCreatedByCopilot: &zeroValue}
+	c.GetTotalCreatedByCopilot()
+	c = &CopilotMetricsPullRequests{}
 	c.GetTotalCreatedByCopilot()
 	c = nil
 	c.GetTotalCreatedByCopilot()
@@ -11558,7 +11736,10 @@ func TestCopilotMetricsPullRequests_GetTotalCreatedByCopilot(tt *testing.T) {
 
 func TestCopilotMetricsPullRequests_GetTotalMerged(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsPullRequests{}
+	var zeroValue int
+	c := &CopilotMetricsPullRequests{TotalMerged: &zeroValue}
+	c.GetTotalMerged()
+	c = &CopilotMetricsPullRequests{}
 	c.GetTotalMerged()
 	c = nil
 	c.GetTotalMerged()
@@ -11566,7 +11747,10 @@ func TestCopilotMetricsPullRequests_GetTotalMerged(tt *testing.T) {
 
 func TestCopilotMetricsPullRequests_GetTotalMergedCreatedByCopilot(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsPullRequests{}
+	var zeroValue int
+	c := &CopilotMetricsPullRequests{TotalMergedCreatedByCopilot: &zeroValue}
+	c.GetTotalMergedCreatedByCopilot()
+	c = &CopilotMetricsPullRequests{}
 	c.GetTotalMergedCreatedByCopilot()
 	c = nil
 	c.GetTotalMergedCreatedByCopilot()
@@ -11574,7 +11758,10 @@ func TestCopilotMetricsPullRequests_GetTotalMergedCreatedByCopilot(tt *testing.T
 
 func TestCopilotMetricsPullRequests_GetTotalMergedReviewedByCopilot(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsPullRequests{}
+	var zeroValue int
+	c := &CopilotMetricsPullRequests{TotalMergedReviewedByCopilot: &zeroValue}
+	c.GetTotalMergedReviewedByCopilot()
+	c = &CopilotMetricsPullRequests{}
 	c.GetTotalMergedReviewedByCopilot()
 	c = nil
 	c.GetTotalMergedReviewedByCopilot()
@@ -11582,7 +11769,10 @@ func TestCopilotMetricsPullRequests_GetTotalMergedReviewedByCopilot(tt *testing.
 
 func TestCopilotMetricsPullRequests_GetTotalReviewed(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsPullRequests{}
+	var zeroValue int
+	c := &CopilotMetricsPullRequests{TotalReviewed: &zeroValue}
+	c.GetTotalReviewed()
+	c = &CopilotMetricsPullRequests{}
 	c.GetTotalReviewed()
 	c = nil
 	c.GetTotalReviewed()
@@ -11590,7 +11780,10 @@ func TestCopilotMetricsPullRequests_GetTotalReviewed(tt *testing.T) {
 
 func TestCopilotMetricsPullRequests_GetTotalReviewedByCopilot(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsPullRequests{}
+	var zeroValue int
+	c := &CopilotMetricsPullRequests{TotalReviewedByCopilot: &zeroValue}
+	c.GetTotalReviewedByCopilot()
+	c = &CopilotMetricsPullRequests{}
 	c.GetTotalReviewedByCopilot()
 	c = nil
 	c.GetTotalReviewedByCopilot()
@@ -11598,7 +11791,10 @@ func TestCopilotMetricsPullRequests_GetTotalReviewedByCopilot(tt *testing.T) {
 
 func TestCopilotMetricsPullRequests_GetTotalSuggestions(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotMetricsPullRequests{}
+	var zeroValue int
+	c := &CopilotMetricsPullRequests{TotalSuggestions: &zeroValue}
+	c.GetTotalSuggestions()
+	c = &CopilotMetricsPullRequests{}
 	c.GetTotalSuggestions()
 	c = nil
 	c.GetTotalSuggestions()
@@ -11695,7 +11891,10 @@ func TestCopilotPeriodicMetrics_GetDayTotals(tt *testing.T) {
 
 func TestCopilotPeriodicMetrics_GetEnterpriseID(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotPeriodicMetrics{}
+	var zeroValue string
+	c := &CopilotPeriodicMetrics{EnterpriseID: &zeroValue}
+	c.GetEnterpriseID()
+	c = &CopilotPeriodicMetrics{}
 	c.GetEnterpriseID()
 	c = nil
 	c.GetEnterpriseID()
@@ -11703,7 +11902,10 @@ func TestCopilotPeriodicMetrics_GetEnterpriseID(tt *testing.T) {
 
 func TestCopilotPeriodicMetrics_GetOrganizationID(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotPeriodicMetrics{}
+	var zeroValue string
+	c := &CopilotPeriodicMetrics{OrganizationID: &zeroValue}
+	c.GetOrganizationID()
+	c = &CopilotPeriodicMetrics{}
 	c.GetOrganizationID()
 	c = nil
 	c.GetOrganizationID()
@@ -11857,7 +12059,10 @@ func TestCopilotSeatDetails_GetUpdatedAt(tt *testing.T) {
 
 func TestCopilotUserDailyMetrics_GetCodeAcceptanceActivityCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserDailyMetrics{}
+	var zeroValue int
+	c := &CopilotUserDailyMetrics{CodeAcceptanceActivityCount: &zeroValue}
+	c.GetCodeAcceptanceActivityCount()
+	c = &CopilotUserDailyMetrics{}
 	c.GetCodeAcceptanceActivityCount()
 	c = nil
 	c.GetCodeAcceptanceActivityCount()
@@ -11865,7 +12070,10 @@ func TestCopilotUserDailyMetrics_GetCodeAcceptanceActivityCount(tt *testing.T) {
 
 func TestCopilotUserDailyMetrics_GetCodeGenerationActivityCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserDailyMetrics{}
+	var zeroValue int
+	c := &CopilotUserDailyMetrics{CodeGenerationActivityCount: &zeroValue}
+	c.GetCodeGenerationActivityCount()
+	c = &CopilotUserDailyMetrics{}
 	c.GetCodeGenerationActivityCount()
 	c = nil
 	c.GetCodeGenerationActivityCount()
@@ -11881,7 +12089,10 @@ func TestCopilotUserDailyMetrics_GetDay(tt *testing.T) {
 
 func TestCopilotUserDailyMetrics_GetEnterpriseID(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserDailyMetrics{}
+	var zeroValue string
+	c := &CopilotUserDailyMetrics{EnterpriseID: &zeroValue}
+	c.GetEnterpriseID()
+	c = &CopilotUserDailyMetrics{}
 	c.GetEnterpriseID()
 	c = nil
 	c.GetEnterpriseID()
@@ -11889,7 +12100,10 @@ func TestCopilotUserDailyMetrics_GetEnterpriseID(tt *testing.T) {
 
 func TestCopilotUserDailyMetrics_GetLOCAddedSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserDailyMetrics{}
+	var zeroValue int
+	c := &CopilotUserDailyMetrics{LOCAddedSum: &zeroValue}
+	c.GetLOCAddedSum()
+	c = &CopilotUserDailyMetrics{}
 	c.GetLOCAddedSum()
 	c = nil
 	c.GetLOCAddedSum()
@@ -11897,7 +12111,10 @@ func TestCopilotUserDailyMetrics_GetLOCAddedSum(tt *testing.T) {
 
 func TestCopilotUserDailyMetrics_GetLOCDeletedSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserDailyMetrics{}
+	var zeroValue int
+	c := &CopilotUserDailyMetrics{LOCDeletedSum: &zeroValue}
+	c.GetLOCDeletedSum()
+	c = &CopilotUserDailyMetrics{}
 	c.GetLOCDeletedSum()
 	c = nil
 	c.GetLOCDeletedSum()
@@ -11905,7 +12122,10 @@ func TestCopilotUserDailyMetrics_GetLOCDeletedSum(tt *testing.T) {
 
 func TestCopilotUserDailyMetrics_GetLOCSuggestedToAddSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserDailyMetrics{}
+	var zeroValue int
+	c := &CopilotUserDailyMetrics{LOCSuggestedToAddSum: &zeroValue}
+	c.GetLOCSuggestedToAddSum()
+	c = &CopilotUserDailyMetrics{}
 	c.GetLOCSuggestedToAddSum()
 	c = nil
 	c.GetLOCSuggestedToAddSum()
@@ -11913,7 +12133,10 @@ func TestCopilotUserDailyMetrics_GetLOCSuggestedToAddSum(tt *testing.T) {
 
 func TestCopilotUserDailyMetrics_GetLOCSuggestedToDeleteSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserDailyMetrics{}
+	var zeroValue int
+	c := &CopilotUserDailyMetrics{LOCSuggestedToDeleteSum: &zeroValue}
+	c.GetLOCSuggestedToDeleteSum()
+	c = &CopilotUserDailyMetrics{}
 	c.GetLOCSuggestedToDeleteSum()
 	c = nil
 	c.GetLOCSuggestedToDeleteSum()
@@ -11921,7 +12144,10 @@ func TestCopilotUserDailyMetrics_GetLOCSuggestedToDeleteSum(tt *testing.T) {
 
 func TestCopilotUserDailyMetrics_GetOrganizationID(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserDailyMetrics{}
+	var zeroValue string
+	c := &CopilotUserDailyMetrics{OrganizationID: &zeroValue}
+	c.GetOrganizationID()
+	c = &CopilotUserDailyMetrics{}
 	c.GetOrganizationID()
 	c = nil
 	c.GetOrganizationID()
@@ -11992,7 +12218,10 @@ func TestCopilotUserDailyMetrics_GetTotalsByModelFeature(tt *testing.T) {
 
 func TestCopilotUserDailyMetrics_GetUsedAgent(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserDailyMetrics{}
+	var zeroValue bool
+	c := &CopilotUserDailyMetrics{UsedAgent: &zeroValue}
+	c.GetUsedAgent()
+	c = &CopilotUserDailyMetrics{}
 	c.GetUsedAgent()
 	c = nil
 	c.GetUsedAgent()
@@ -12000,7 +12229,10 @@ func TestCopilotUserDailyMetrics_GetUsedAgent(tt *testing.T) {
 
 func TestCopilotUserDailyMetrics_GetUsedChat(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserDailyMetrics{}
+	var zeroValue bool
+	c := &CopilotUserDailyMetrics{UsedChat: &zeroValue}
+	c.GetUsedChat()
+	c = &CopilotUserDailyMetrics{}
 	c.GetUsedChat()
 	c = nil
 	c.GetUsedChat()
@@ -12008,7 +12240,10 @@ func TestCopilotUserDailyMetrics_GetUsedChat(tt *testing.T) {
 
 func TestCopilotUserDailyMetrics_GetUsedCLI(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserDailyMetrics{}
+	var zeroValue bool
+	c := &CopilotUserDailyMetrics{UsedCLI: &zeroValue}
+	c.GetUsedCLI()
+	c = &CopilotUserDailyMetrics{}
 	c.GetUsedCLI()
 	c = nil
 	c.GetUsedCLI()
@@ -12016,7 +12251,10 @@ func TestCopilotUserDailyMetrics_GetUsedCLI(tt *testing.T) {
 
 func TestCopilotUserDailyMetrics_GetUsedCopilotCodeReviewActive(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserDailyMetrics{}
+	var zeroValue bool
+	c := &CopilotUserDailyMetrics{UsedCopilotCodeReviewActive: &zeroValue}
+	c.GetUsedCopilotCodeReviewActive()
+	c = &CopilotUserDailyMetrics{}
 	c.GetUsedCopilotCodeReviewActive()
 	c = nil
 	c.GetUsedCopilotCodeReviewActive()
@@ -12024,7 +12262,10 @@ func TestCopilotUserDailyMetrics_GetUsedCopilotCodeReviewActive(tt *testing.T) {
 
 func TestCopilotUserDailyMetrics_GetUsedCopilotCodeReviewPassive(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserDailyMetrics{}
+	var zeroValue bool
+	c := &CopilotUserDailyMetrics{UsedCopilotCodeReviewPassive: &zeroValue}
+	c.GetUsedCopilotCodeReviewPassive()
+	c = &CopilotUserDailyMetrics{}
 	c.GetUsedCopilotCodeReviewPassive()
 	c = nil
 	c.GetUsedCopilotCodeReviewPassive()
@@ -12032,7 +12273,10 @@ func TestCopilotUserDailyMetrics_GetUsedCopilotCodeReviewPassive(tt *testing.T) 
 
 func TestCopilotUserDailyMetrics_GetUsedCopilotCodingAgent(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserDailyMetrics{}
+	var zeroValue bool
+	c := &CopilotUserDailyMetrics{UsedCopilotCodingAgent: &zeroValue}
+	c.GetUsedCopilotCodingAgent()
+	c = &CopilotUserDailyMetrics{}
 	c.GetUsedCopilotCodingAgent()
 	c = nil
 	c.GetUsedCopilotCodingAgent()
@@ -12048,7 +12292,10 @@ func TestCopilotUserDailyMetrics_GetUserID(tt *testing.T) {
 
 func TestCopilotUserDailyMetrics_GetUserInitiatedInteractionCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserDailyMetrics{}
+	var zeroValue int
+	c := &CopilotUserDailyMetrics{UserInitiatedInteractionCount: &zeroValue}
+	c.GetUserInitiatedInteractionCount()
+	c = &CopilotUserDailyMetrics{}
 	c.GetUserInitiatedInteractionCount()
 	c = nil
 	c.GetUserInitiatedInteractionCount()
@@ -12088,7 +12335,10 @@ func TestCopilotUserMetricsIDE_GetLastKnownPluginVersion(tt *testing.T) {
 
 func TestCopilotUserMetricsIDE_GetUserInitiatedInteractionCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserMetricsIDE{}
+	var zeroValue int
+	c := &CopilotUserMetricsIDE{UserInitiatedInteractionCount: &zeroValue}
+	c.GetUserInitiatedInteractionCount()
+	c = &CopilotUserMetricsIDE{}
 	c.GetUserInitiatedInteractionCount()
 	c = nil
 	c.GetUserInitiatedInteractionCount()
@@ -12142,7 +12392,10 @@ func TestCopilotUserMetricsPluginVersion_GetSampledAt(tt *testing.T) {
 
 func TestCopilotUserPeriodicMetrics_GetCodeAcceptanceActivityCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserPeriodicMetrics{}
+	var zeroValue int
+	c := &CopilotUserPeriodicMetrics{CodeAcceptanceActivityCount: &zeroValue}
+	c.GetCodeAcceptanceActivityCount()
+	c = &CopilotUserPeriodicMetrics{}
 	c.GetCodeAcceptanceActivityCount()
 	c = nil
 	c.GetCodeAcceptanceActivityCount()
@@ -12150,7 +12403,10 @@ func TestCopilotUserPeriodicMetrics_GetCodeAcceptanceActivityCount(tt *testing.T
 
 func TestCopilotUserPeriodicMetrics_GetCodeGenerationActivityCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserPeriodicMetrics{}
+	var zeroValue int
+	c := &CopilotUserPeriodicMetrics{CodeGenerationActivityCount: &zeroValue}
+	c.GetCodeGenerationActivityCount()
+	c = &CopilotUserPeriodicMetrics{}
 	c.GetCodeGenerationActivityCount()
 	c = nil
 	c.GetCodeGenerationActivityCount()
@@ -12166,7 +12422,10 @@ func TestCopilotUserPeriodicMetrics_GetDay(tt *testing.T) {
 
 func TestCopilotUserPeriodicMetrics_GetEnterpriseID(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserPeriodicMetrics{}
+	var zeroValue string
+	c := &CopilotUserPeriodicMetrics{EnterpriseID: &zeroValue}
+	c.GetEnterpriseID()
+	c = &CopilotUserPeriodicMetrics{}
 	c.GetEnterpriseID()
 	c = nil
 	c.GetEnterpriseID()
@@ -12174,7 +12433,10 @@ func TestCopilotUserPeriodicMetrics_GetEnterpriseID(tt *testing.T) {
 
 func TestCopilotUserPeriodicMetrics_GetLOCAddedSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserPeriodicMetrics{}
+	var zeroValue int
+	c := &CopilotUserPeriodicMetrics{LOCAddedSum: &zeroValue}
+	c.GetLOCAddedSum()
+	c = &CopilotUserPeriodicMetrics{}
 	c.GetLOCAddedSum()
 	c = nil
 	c.GetLOCAddedSum()
@@ -12182,7 +12444,10 @@ func TestCopilotUserPeriodicMetrics_GetLOCAddedSum(tt *testing.T) {
 
 func TestCopilotUserPeriodicMetrics_GetLOCDeletedSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserPeriodicMetrics{}
+	var zeroValue int
+	c := &CopilotUserPeriodicMetrics{LOCDeletedSum: &zeroValue}
+	c.GetLOCDeletedSum()
+	c = &CopilotUserPeriodicMetrics{}
 	c.GetLOCDeletedSum()
 	c = nil
 	c.GetLOCDeletedSum()
@@ -12190,7 +12455,10 @@ func TestCopilotUserPeriodicMetrics_GetLOCDeletedSum(tt *testing.T) {
 
 func TestCopilotUserPeriodicMetrics_GetLOCSuggestedToAddSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserPeriodicMetrics{}
+	var zeroValue int
+	c := &CopilotUserPeriodicMetrics{LOCSuggestedToAddSum: &zeroValue}
+	c.GetLOCSuggestedToAddSum()
+	c = &CopilotUserPeriodicMetrics{}
 	c.GetLOCSuggestedToAddSum()
 	c = nil
 	c.GetLOCSuggestedToAddSum()
@@ -12198,7 +12466,10 @@ func TestCopilotUserPeriodicMetrics_GetLOCSuggestedToAddSum(tt *testing.T) {
 
 func TestCopilotUserPeriodicMetrics_GetLOCSuggestedToDeleteSum(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserPeriodicMetrics{}
+	var zeroValue int
+	c := &CopilotUserPeriodicMetrics{LOCSuggestedToDeleteSum: &zeroValue}
+	c.GetLOCSuggestedToDeleteSum()
+	c = &CopilotUserPeriodicMetrics{}
 	c.GetLOCSuggestedToDeleteSum()
 	c = nil
 	c.GetLOCSuggestedToDeleteSum()
@@ -12206,7 +12477,10 @@ func TestCopilotUserPeriodicMetrics_GetLOCSuggestedToDeleteSum(tt *testing.T) {
 
 func TestCopilotUserPeriodicMetrics_GetOrganizationID(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserPeriodicMetrics{}
+	var zeroValue string
+	c := &CopilotUserPeriodicMetrics{OrganizationID: &zeroValue}
+	c.GetOrganizationID()
+	c = &CopilotUserPeriodicMetrics{}
 	c.GetOrganizationID()
 	c = nil
 	c.GetOrganizationID()
@@ -12293,7 +12567,10 @@ func TestCopilotUserPeriodicMetrics_GetTotalsByModelFeature(tt *testing.T) {
 
 func TestCopilotUserPeriodicMetrics_GetUsedAgent(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserPeriodicMetrics{}
+	var zeroValue bool
+	c := &CopilotUserPeriodicMetrics{UsedAgent: &zeroValue}
+	c.GetUsedAgent()
+	c = &CopilotUserPeriodicMetrics{}
 	c.GetUsedAgent()
 	c = nil
 	c.GetUsedAgent()
@@ -12301,7 +12578,10 @@ func TestCopilotUserPeriodicMetrics_GetUsedAgent(tt *testing.T) {
 
 func TestCopilotUserPeriodicMetrics_GetUsedChat(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserPeriodicMetrics{}
+	var zeroValue bool
+	c := &CopilotUserPeriodicMetrics{UsedChat: &zeroValue}
+	c.GetUsedChat()
+	c = &CopilotUserPeriodicMetrics{}
 	c.GetUsedChat()
 	c = nil
 	c.GetUsedChat()
@@ -12309,7 +12589,10 @@ func TestCopilotUserPeriodicMetrics_GetUsedChat(tt *testing.T) {
 
 func TestCopilotUserPeriodicMetrics_GetUsedCLI(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserPeriodicMetrics{}
+	var zeroValue bool
+	c := &CopilotUserPeriodicMetrics{UsedCLI: &zeroValue}
+	c.GetUsedCLI()
+	c = &CopilotUserPeriodicMetrics{}
 	c.GetUsedCLI()
 	c = nil
 	c.GetUsedCLI()
@@ -12317,7 +12600,10 @@ func TestCopilotUserPeriodicMetrics_GetUsedCLI(tt *testing.T) {
 
 func TestCopilotUserPeriodicMetrics_GetUsedCopilotCodeReviewActive(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserPeriodicMetrics{}
+	var zeroValue bool
+	c := &CopilotUserPeriodicMetrics{UsedCopilotCodeReviewActive: &zeroValue}
+	c.GetUsedCopilotCodeReviewActive()
+	c = &CopilotUserPeriodicMetrics{}
 	c.GetUsedCopilotCodeReviewActive()
 	c = nil
 	c.GetUsedCopilotCodeReviewActive()
@@ -12325,7 +12611,10 @@ func TestCopilotUserPeriodicMetrics_GetUsedCopilotCodeReviewActive(tt *testing.T
 
 func TestCopilotUserPeriodicMetrics_GetUsedCopilotCodeReviewPassive(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserPeriodicMetrics{}
+	var zeroValue bool
+	c := &CopilotUserPeriodicMetrics{UsedCopilotCodeReviewPassive: &zeroValue}
+	c.GetUsedCopilotCodeReviewPassive()
+	c = &CopilotUserPeriodicMetrics{}
 	c.GetUsedCopilotCodeReviewPassive()
 	c = nil
 	c.GetUsedCopilotCodeReviewPassive()
@@ -12333,7 +12622,10 @@ func TestCopilotUserPeriodicMetrics_GetUsedCopilotCodeReviewPassive(tt *testing.
 
 func TestCopilotUserPeriodicMetrics_GetUsedCopilotCodingAgent(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserPeriodicMetrics{}
+	var zeroValue bool
+	c := &CopilotUserPeriodicMetrics{UsedCopilotCodingAgent: &zeroValue}
+	c.GetUsedCopilotCodingAgent()
+	c = &CopilotUserPeriodicMetrics{}
 	c.GetUsedCopilotCodingAgent()
 	c = nil
 	c.GetUsedCopilotCodingAgent()
@@ -12349,7 +12641,10 @@ func TestCopilotUserPeriodicMetrics_GetUserID(tt *testing.T) {
 
 func TestCopilotUserPeriodicMetrics_GetUserInitiatedInteractionCount(tt *testing.T) {
 	tt.Parallel()
-	c := &CopilotUserPeriodicMetrics{}
+	var zeroValue int
+	c := &CopilotUserPeriodicMetrics{UserInitiatedInteractionCount: &zeroValue}
+	c.GetUserInitiatedInteractionCount()
+	c = &CopilotUserPeriodicMetrics{}
 	c.GetUserInitiatedInteractionCount()
 	c = nil
 	c.GetUserInitiatedInteractionCount()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -10524,6 +10524,229 @@ func TestCopilotCodeReviewRuleParameters_GetReviewOnPush(tt *testing.T) {
 	c.GetReviewOnPush()
 }
 
+func TestCopilotDailyMetrics_GetCodeAcceptanceActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetCodeAcceptanceActivityCount()
+	c = nil
+	c.GetCodeAcceptanceActivityCount()
+}
+
+func TestCopilotDailyMetrics_GetCodeGenerationActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetCodeGenerationActivityCount()
+	c = nil
+	c.GetCodeGenerationActivityCount()
+}
+
+func TestCopilotDailyMetrics_GetDailyActiveCliUsers(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetDailyActiveCliUsers()
+	c = nil
+	c.GetDailyActiveCliUsers()
+}
+
+func TestCopilotDailyMetrics_GetDailyActiveCopilotCloudAgentUsers(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetDailyActiveCopilotCloudAgentUsers()
+	c = nil
+	c.GetDailyActiveCopilotCloudAgentUsers()
+}
+
+func TestCopilotDailyMetrics_GetDailyActiveUsers(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetDailyActiveUsers()
+	c = nil
+	c.GetDailyActiveUsers()
+}
+
+func TestCopilotDailyMetrics_GetDay(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetDay()
+	c = nil
+	c.GetDay()
+}
+
+func TestCopilotDailyMetrics_GetEnterpriseID(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetEnterpriseID()
+	c = nil
+	c.GetEnterpriseID()
+}
+
+func TestCopilotDailyMetrics_GetLocAddedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetLocAddedSum()
+	c = nil
+	c.GetLocAddedSum()
+}
+
+func TestCopilotDailyMetrics_GetLocDeletedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetLocDeletedSum()
+	c = nil
+	c.GetLocDeletedSum()
+}
+
+func TestCopilotDailyMetrics_GetLocSuggestedToAddSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetLocSuggestedToAddSum()
+	c = nil
+	c.GetLocSuggestedToAddSum()
+}
+
+func TestCopilotDailyMetrics_GetLocSuggestedToDeleteSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetLocSuggestedToDeleteSum()
+	c = nil
+	c.GetLocSuggestedToDeleteSum()
+}
+
+func TestCopilotDailyMetrics_GetMonthlyActiveAgentUsers(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetMonthlyActiveAgentUsers()
+	c = nil
+	c.GetMonthlyActiveAgentUsers()
+}
+
+func TestCopilotDailyMetrics_GetMonthlyActiveChatUsers(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetMonthlyActiveChatUsers()
+	c = nil
+	c.GetMonthlyActiveChatUsers()
+}
+
+func TestCopilotDailyMetrics_GetMonthlyActiveCopilotCloudAgentUsers(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetMonthlyActiveCopilotCloudAgentUsers()
+	c = nil
+	c.GetMonthlyActiveCopilotCloudAgentUsers()
+}
+
+func TestCopilotDailyMetrics_GetMonthlyActiveUsers(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetMonthlyActiveUsers()
+	c = nil
+	c.GetMonthlyActiveUsers()
+}
+
+func TestCopilotDailyMetrics_GetOrganizationID(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetOrganizationID()
+	c = nil
+	c.GetOrganizationID()
+}
+
+func TestCopilotDailyMetrics_GetPullRequests(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetPullRequests()
+	c = nil
+	c.GetPullRequests()
+}
+
+func TestCopilotDailyMetrics_GetTotalsByCli(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetTotalsByCli()
+	c = nil
+	c.GetTotalsByCli()
+}
+
+func TestCopilotDailyMetrics_GetTotalsByFeature(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsFeature{}
+	c := &CopilotDailyMetrics{TotalsByFeature: zeroValue}
+	c.GetTotalsByFeature()
+	c = &CopilotDailyMetrics{}
+	c.GetTotalsByFeature()
+	c = nil
+	c.GetTotalsByFeature()
+}
+
+func TestCopilotDailyMetrics_GetTotalsByIDE(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsIDE{}
+	c := &CopilotDailyMetrics{TotalsByIDE: zeroValue}
+	c.GetTotalsByIDE()
+	c = &CopilotDailyMetrics{}
+	c.GetTotalsByIDE()
+	c = nil
+	c.GetTotalsByIDE()
+}
+
+func TestCopilotDailyMetrics_GetTotalsByLanguageFeature(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsLanguageFeature{}
+	c := &CopilotDailyMetrics{TotalsByLanguageFeature: zeroValue}
+	c.GetTotalsByLanguageFeature()
+	c = &CopilotDailyMetrics{}
+	c.GetTotalsByLanguageFeature()
+	c = nil
+	c.GetTotalsByLanguageFeature()
+}
+
+func TestCopilotDailyMetrics_GetTotalsByLanguageModel(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsLanguageModel{}
+	c := &CopilotDailyMetrics{TotalsByLanguageModel: zeroValue}
+	c.GetTotalsByLanguageModel()
+	c = &CopilotDailyMetrics{}
+	c.GetTotalsByLanguageModel()
+	c = nil
+	c.GetTotalsByLanguageModel()
+}
+
+func TestCopilotDailyMetrics_GetTotalsByModelFeature(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsModelFeature{}
+	c := &CopilotDailyMetrics{TotalsByModelFeature: zeroValue}
+	c.GetTotalsByModelFeature()
+	c = &CopilotDailyMetrics{}
+	c.GetTotalsByModelFeature()
+	c = nil
+	c.GetTotalsByModelFeature()
+}
+
+func TestCopilotDailyMetrics_GetUserInitiatedInteractionCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetUserInitiatedInteractionCount()
+	c = nil
+	c.GetUserInitiatedInteractionCount()
+}
+
+func TestCopilotDailyMetrics_GetWeeklyActiveCopilotCloudAgentUsers(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetWeeklyActiveCopilotCloudAgentUsers()
+	c = nil
+	c.GetWeeklyActiveCopilotCloudAgentUsers()
+}
+
+func TestCopilotDailyMetrics_GetWeeklyActiveUsers(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetWeeklyActiveUsers()
+	c = nil
+	c.GetWeeklyActiveUsers()
+}
+
 func TestCopilotDailyMetricsReport_GetDownloadLinks(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []string{}
@@ -11028,6 +11251,345 @@ func TestCopilotMetrics_GetTotalEngagedUsers(tt *testing.T) {
 	c.GetTotalEngagedUsers()
 }
 
+func TestCopilotMetricsCli_GetLastKnownCliVersion(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsCli{}
+	c.GetLastKnownCliVersion()
+	c = nil
+	c.GetLastKnownCliVersion()
+}
+
+func TestCopilotMetricsCli_GetPromptCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsCli{}
+	c.GetPromptCount()
+	c = nil
+	c.GetPromptCount()
+}
+
+func TestCopilotMetricsCli_GetRequestCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsCli{}
+	c.GetRequestCount()
+	c = nil
+	c.GetRequestCount()
+}
+
+func TestCopilotMetricsCli_GetSessionCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsCli{}
+	c.GetSessionCount()
+	c = nil
+	c.GetSessionCount()
+}
+
+func TestCopilotMetricsCli_GetTokenUsage(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsCli{}
+	c.GetTokenUsage()
+	c = nil
+	c.GetTokenUsage()
+}
+
+func TestCopilotMetricsCliTokenUsage_GetAvgTokensPerRequest(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsCliTokenUsage{}
+	c.GetAvgTokensPerRequest()
+	c = nil
+	c.GetAvgTokensPerRequest()
+}
+
+func TestCopilotMetricsCliTokenUsage_GetOutputTokensSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsCliTokenUsage{}
+	c.GetOutputTokensSum()
+	c = nil
+	c.GetOutputTokensSum()
+}
+
+func TestCopilotMetricsCliTokenUsage_GetPromptTokensSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsCliTokenUsage{}
+	c.GetPromptTokensSum()
+	c = nil
+	c.GetPromptTokensSum()
+}
+
+func TestCopilotMetricsCliVersion_GetCliVersion(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsCliVersion{}
+	c.GetCliVersion()
+	c = nil
+	c.GetCliVersion()
+}
+
+func TestCopilotMetricsCliVersion_GetSampledAt(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue Timestamp
+	c := &CopilotMetricsCliVersion{SampledAt: &zeroValue}
+	c.GetSampledAt()
+	c = &CopilotMetricsCliVersion{}
+	c.GetSampledAt()
+	c = nil
+	c.GetSampledAt()
+}
+
+func TestCopilotMetricsFeature_GetCodeAcceptanceActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsFeature{}
+	c.GetCodeAcceptanceActivityCount()
+	c = nil
+	c.GetCodeAcceptanceActivityCount()
+}
+
+func TestCopilotMetricsFeature_GetCodeGenerationActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsFeature{}
+	c.GetCodeGenerationActivityCount()
+	c = nil
+	c.GetCodeGenerationActivityCount()
+}
+
+func TestCopilotMetricsFeature_GetFeature(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsFeature{}
+	c.GetFeature()
+	c = nil
+	c.GetFeature()
+}
+
+func TestCopilotMetricsFeature_GetLocAddedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsFeature{}
+	c.GetLocAddedSum()
+	c = nil
+	c.GetLocAddedSum()
+}
+
+func TestCopilotMetricsFeature_GetLocDeletedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsFeature{}
+	c.GetLocDeletedSum()
+	c = nil
+	c.GetLocDeletedSum()
+}
+
+func TestCopilotMetricsFeature_GetLocSuggestedToAddSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsFeature{}
+	c.GetLocSuggestedToAddSum()
+	c = nil
+	c.GetLocSuggestedToAddSum()
+}
+
+func TestCopilotMetricsFeature_GetLocSuggestedToDeleteSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsFeature{}
+	c.GetLocSuggestedToDeleteSum()
+	c = nil
+	c.GetLocSuggestedToDeleteSum()
+}
+
+func TestCopilotMetricsFeature_GetUserInitiatedInteractionCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsFeature{}
+	c.GetUserInitiatedInteractionCount()
+	c = nil
+	c.GetUserInitiatedInteractionCount()
+}
+
+func TestCopilotMetricsIDE_GetCodeAcceptanceActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsIDE{}
+	c.GetCodeAcceptanceActivityCount()
+	c = nil
+	c.GetCodeAcceptanceActivityCount()
+}
+
+func TestCopilotMetricsIDE_GetCodeGenerationActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsIDE{}
+	c.GetCodeGenerationActivityCount()
+	c = nil
+	c.GetCodeGenerationActivityCount()
+}
+
+func TestCopilotMetricsIDE_GetIDE(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsIDE{}
+	c.GetIDE()
+	c = nil
+	c.GetIDE()
+}
+
+func TestCopilotMetricsIDE_GetLocAddedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsIDE{}
+	c.GetLocAddedSum()
+	c = nil
+	c.GetLocAddedSum()
+}
+
+func TestCopilotMetricsIDE_GetLocDeletedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsIDE{}
+	c.GetLocDeletedSum()
+	c = nil
+	c.GetLocDeletedSum()
+}
+
+func TestCopilotMetricsIDE_GetLocSuggestedToAddSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsIDE{}
+	c.GetLocSuggestedToAddSum()
+	c = nil
+	c.GetLocSuggestedToAddSum()
+}
+
+func TestCopilotMetricsIDE_GetLocSuggestedToDeleteSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsIDE{}
+	c.GetLocSuggestedToDeleteSum()
+	c = nil
+	c.GetLocSuggestedToDeleteSum()
+}
+
+func TestCopilotMetricsIDE_GetUserInitiatedInteractionCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsIDE{}
+	c.GetUserInitiatedInteractionCount()
+	c = nil
+	c.GetUserInitiatedInteractionCount()
+}
+
+func TestCopilotMetricsLanguageFeature_GetCodeAcceptanceActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageFeature{}
+	c.GetCodeAcceptanceActivityCount()
+	c = nil
+	c.GetCodeAcceptanceActivityCount()
+}
+
+func TestCopilotMetricsLanguageFeature_GetCodeGenerationActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageFeature{}
+	c.GetCodeGenerationActivityCount()
+	c = nil
+	c.GetCodeGenerationActivityCount()
+}
+
+func TestCopilotMetricsLanguageFeature_GetFeature(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageFeature{}
+	c.GetFeature()
+	c = nil
+	c.GetFeature()
+}
+
+func TestCopilotMetricsLanguageFeature_GetLanguage(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageFeature{}
+	c.GetLanguage()
+	c = nil
+	c.GetLanguage()
+}
+
+func TestCopilotMetricsLanguageFeature_GetLocAddedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageFeature{}
+	c.GetLocAddedSum()
+	c = nil
+	c.GetLocAddedSum()
+}
+
+func TestCopilotMetricsLanguageFeature_GetLocDeletedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageFeature{}
+	c.GetLocDeletedSum()
+	c = nil
+	c.GetLocDeletedSum()
+}
+
+func TestCopilotMetricsLanguageFeature_GetLocSuggestedToAddSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageFeature{}
+	c.GetLocSuggestedToAddSum()
+	c = nil
+	c.GetLocSuggestedToAddSum()
+}
+
+func TestCopilotMetricsLanguageFeature_GetLocSuggestedToDeleteSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageFeature{}
+	c.GetLocSuggestedToDeleteSum()
+	c = nil
+	c.GetLocSuggestedToDeleteSum()
+}
+
+func TestCopilotMetricsLanguageModel_GetCodeAcceptanceActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageModel{}
+	c.GetCodeAcceptanceActivityCount()
+	c = nil
+	c.GetCodeAcceptanceActivityCount()
+}
+
+func TestCopilotMetricsLanguageModel_GetCodeGenerationActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageModel{}
+	c.GetCodeGenerationActivityCount()
+	c = nil
+	c.GetCodeGenerationActivityCount()
+}
+
+func TestCopilotMetricsLanguageModel_GetLanguage(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageModel{}
+	c.GetLanguage()
+	c = nil
+	c.GetLanguage()
+}
+
+func TestCopilotMetricsLanguageModel_GetLocAddedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageModel{}
+	c.GetLocAddedSum()
+	c = nil
+	c.GetLocAddedSum()
+}
+
+func TestCopilotMetricsLanguageModel_GetLocDeletedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageModel{}
+	c.GetLocDeletedSum()
+	c = nil
+	c.GetLocDeletedSum()
+}
+
+func TestCopilotMetricsLanguageModel_GetLocSuggestedToAddSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageModel{}
+	c.GetLocSuggestedToAddSum()
+	c = nil
+	c.GetLocSuggestedToAddSum()
+}
+
+func TestCopilotMetricsLanguageModel_GetLocSuggestedToDeleteSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageModel{}
+	c.GetLocSuggestedToDeleteSum()
+	c = nil
+	c.GetLocSuggestedToDeleteSum()
+}
+
+func TestCopilotMetricsLanguageModel_GetModel(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsLanguageModel{}
+	c.GetModel()
+	c = nil
+	c.GetModel()
+}
+
 func TestCopilotMetricsListOptions_GetSince(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue time.Time
@@ -11048,6 +11610,190 @@ func TestCopilotMetricsListOptions_GetUntil(tt *testing.T) {
 	c.GetUntil()
 	c = nil
 	c.GetUntil()
+}
+
+func TestCopilotMetricsModelFeature_GetCodeAcceptanceActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsModelFeature{}
+	c.GetCodeAcceptanceActivityCount()
+	c = nil
+	c.GetCodeAcceptanceActivityCount()
+}
+
+func TestCopilotMetricsModelFeature_GetCodeGenerationActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsModelFeature{}
+	c.GetCodeGenerationActivityCount()
+	c = nil
+	c.GetCodeGenerationActivityCount()
+}
+
+func TestCopilotMetricsModelFeature_GetFeature(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsModelFeature{}
+	c.GetFeature()
+	c = nil
+	c.GetFeature()
+}
+
+func TestCopilotMetricsModelFeature_GetLocAddedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsModelFeature{}
+	c.GetLocAddedSum()
+	c = nil
+	c.GetLocAddedSum()
+}
+
+func TestCopilotMetricsModelFeature_GetLocDeletedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsModelFeature{}
+	c.GetLocDeletedSum()
+	c = nil
+	c.GetLocDeletedSum()
+}
+
+func TestCopilotMetricsModelFeature_GetLocSuggestedToAddSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsModelFeature{}
+	c.GetLocSuggestedToAddSum()
+	c = nil
+	c.GetLocSuggestedToAddSum()
+}
+
+func TestCopilotMetricsModelFeature_GetLocSuggestedToDeleteSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsModelFeature{}
+	c.GetLocSuggestedToDeleteSum()
+	c = nil
+	c.GetLocSuggestedToDeleteSum()
+}
+
+func TestCopilotMetricsModelFeature_GetModel(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsModelFeature{}
+	c.GetModel()
+	c = nil
+	c.GetModel()
+}
+
+func TestCopilotMetricsModelFeature_GetUserInitiatedInteractionCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsModelFeature{}
+	c.GetUserInitiatedInteractionCount()
+	c = nil
+	c.GetUserInitiatedInteractionCount()
+}
+
+func TestCopilotMetricsPullRequests_GetMedianMinutesToMerge(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsPullRequests{}
+	c.GetMedianMinutesToMerge()
+	c = nil
+	c.GetMedianMinutesToMerge()
+}
+
+func TestCopilotMetricsPullRequests_GetMedianMinutesToMergeCopilotAuthored(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsPullRequests{}
+	c.GetMedianMinutesToMergeCopilotAuthored()
+	c = nil
+	c.GetMedianMinutesToMergeCopilotAuthored()
+}
+
+func TestCopilotMetricsPullRequests_GetMedianMinutesToMergeCopilotReviewed(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsPullRequests{}
+	c.GetMedianMinutesToMergeCopilotReviewed()
+	c = nil
+	c.GetMedianMinutesToMergeCopilotReviewed()
+}
+
+func TestCopilotMetricsPullRequests_GetTotalAppliedSuggestions(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsPullRequests{}
+	c.GetTotalAppliedSuggestions()
+	c = nil
+	c.GetTotalAppliedSuggestions()
+}
+
+func TestCopilotMetricsPullRequests_GetTotalCopilotAppliedSuggestions(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsPullRequests{}
+	c.GetTotalCopilotAppliedSuggestions()
+	c = nil
+	c.GetTotalCopilotAppliedSuggestions()
+}
+
+func TestCopilotMetricsPullRequests_GetTotalCopilotSuggestions(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsPullRequests{}
+	c.GetTotalCopilotSuggestions()
+	c = nil
+	c.GetTotalCopilotSuggestions()
+}
+
+func TestCopilotMetricsPullRequests_GetTotalCreated(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsPullRequests{}
+	c.GetTotalCreated()
+	c = nil
+	c.GetTotalCreated()
+}
+
+func TestCopilotMetricsPullRequests_GetTotalCreatedByCopilot(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsPullRequests{}
+	c.GetTotalCreatedByCopilot()
+	c = nil
+	c.GetTotalCreatedByCopilot()
+}
+
+func TestCopilotMetricsPullRequests_GetTotalMerged(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsPullRequests{}
+	c.GetTotalMerged()
+	c = nil
+	c.GetTotalMerged()
+}
+
+func TestCopilotMetricsPullRequests_GetTotalMergedCreatedByCopilot(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsPullRequests{}
+	c.GetTotalMergedCreatedByCopilot()
+	c = nil
+	c.GetTotalMergedCreatedByCopilot()
+}
+
+func TestCopilotMetricsPullRequests_GetTotalMergedReviewedByCopilot(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsPullRequests{}
+	c.GetTotalMergedReviewedByCopilot()
+	c = nil
+	c.GetTotalMergedReviewedByCopilot()
+}
+
+func TestCopilotMetricsPullRequests_GetTotalReviewed(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsPullRequests{}
+	c.GetTotalReviewed()
+	c = nil
+	c.GetTotalReviewed()
+}
+
+func TestCopilotMetricsPullRequests_GetTotalReviewedByCopilot(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsPullRequests{}
+	c.GetTotalReviewedByCopilot()
+	c = nil
+	c.GetTotalReviewedByCopilot()
+}
+
+func TestCopilotMetricsPullRequests_GetTotalSuggestions(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsPullRequests{}
+	c.GetTotalSuggestions()
+	c = nil
+	c.GetTotalSuggestions()
 }
 
 func TestCopilotMetricsReport_GetDownloadLinks(tt *testing.T) {
@@ -11115,6 +11861,60 @@ func TestCopilotOrganizationDetails_GetSeatManagementSetting(tt *testing.T) {
 	c.GetSeatManagementSetting()
 	c = nil
 	c.GetSeatManagementSetting()
+}
+
+func TestCopilotPeriodicMetrics_GetCreatedAt(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue Timestamp
+	c := &CopilotPeriodicMetrics{CreatedAt: &zeroValue}
+	c.GetCreatedAt()
+	c = &CopilotPeriodicMetrics{}
+	c.GetCreatedAt()
+	c = nil
+	c.GetCreatedAt()
+}
+
+func TestCopilotPeriodicMetrics_GetDayTotals(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotDailyMetrics{}
+	c := &CopilotPeriodicMetrics{DayTotals: zeroValue}
+	c.GetDayTotals()
+	c = &CopilotPeriodicMetrics{}
+	c.GetDayTotals()
+	c = nil
+	c.GetDayTotals()
+}
+
+func TestCopilotPeriodicMetrics_GetEnterpriseID(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotPeriodicMetrics{}
+	c.GetEnterpriseID()
+	c = nil
+	c.GetEnterpriseID()
+}
+
+func TestCopilotPeriodicMetrics_GetOrganizationID(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotPeriodicMetrics{}
+	c.GetOrganizationID()
+	c = nil
+	c.GetOrganizationID()
+}
+
+func TestCopilotPeriodicMetrics_GetReportEndDay(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotPeriodicMetrics{}
+	c.GetReportEndDay()
+	c = nil
+	c.GetReportEndDay()
+}
+
+func TestCopilotPeriodicMetrics_GetReportStartDay(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotPeriodicMetrics{}
+	c.GetReportStartDay()
+	c = nil
+	c.GetReportStartDay()
 }
 
 func TestCopilotSeatBreakdown_GetActiveThisCycle(tt *testing.T) {
@@ -11245,6 +12045,562 @@ func TestCopilotSeatDetails_GetUpdatedAt(tt *testing.T) {
 	c.GetUpdatedAt()
 	c = nil
 	c.GetUpdatedAt()
+}
+
+func TestCopilotUserDailyMetrics_GetCodeAcceptanceActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetCodeAcceptanceActivityCount()
+	c = nil
+	c.GetCodeAcceptanceActivityCount()
+}
+
+func TestCopilotUserDailyMetrics_GetCodeGenerationActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetCodeGenerationActivityCount()
+	c = nil
+	c.GetCodeGenerationActivityCount()
+}
+
+func TestCopilotUserDailyMetrics_GetDay(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetDay()
+	c = nil
+	c.GetDay()
+}
+
+func TestCopilotUserDailyMetrics_GetEnterpriseID(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetEnterpriseID()
+	c = nil
+	c.GetEnterpriseID()
+}
+
+func TestCopilotUserDailyMetrics_GetLocAddedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetLocAddedSum()
+	c = nil
+	c.GetLocAddedSum()
+}
+
+func TestCopilotUserDailyMetrics_GetLocDeletedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetLocDeletedSum()
+	c = nil
+	c.GetLocDeletedSum()
+}
+
+func TestCopilotUserDailyMetrics_GetLocSuggestedToAddSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetLocSuggestedToAddSum()
+	c = nil
+	c.GetLocSuggestedToAddSum()
+}
+
+func TestCopilotUserDailyMetrics_GetLocSuggestedToDeleteSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetLocSuggestedToDeleteSum()
+	c = nil
+	c.GetLocSuggestedToDeleteSum()
+}
+
+func TestCopilotUserDailyMetrics_GetOrganizationID(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetOrganizationID()
+	c = nil
+	c.GetOrganizationID()
+}
+
+func TestCopilotUserDailyMetrics_GetTotalsByCli(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetTotalsByCli()
+	c = nil
+	c.GetTotalsByCli()
+}
+
+func TestCopilotUserDailyMetrics_GetTotalsByFeature(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsFeature{}
+	c := &CopilotUserDailyMetrics{TotalsByFeature: zeroValue}
+	c.GetTotalsByFeature()
+	c = &CopilotUserDailyMetrics{}
+	c.GetTotalsByFeature()
+	c = nil
+	c.GetTotalsByFeature()
+}
+
+func TestCopilotUserDailyMetrics_GetTotalsByIDE(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotUserMetricsIDE{}
+	c := &CopilotUserDailyMetrics{TotalsByIDE: zeroValue}
+	c.GetTotalsByIDE()
+	c = &CopilotUserDailyMetrics{}
+	c.GetTotalsByIDE()
+	c = nil
+	c.GetTotalsByIDE()
+}
+
+func TestCopilotUserDailyMetrics_GetTotalsByLanguageFeature(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsLanguageFeature{}
+	c := &CopilotUserDailyMetrics{TotalsByLanguageFeature: zeroValue}
+	c.GetTotalsByLanguageFeature()
+	c = &CopilotUserDailyMetrics{}
+	c.GetTotalsByLanguageFeature()
+	c = nil
+	c.GetTotalsByLanguageFeature()
+}
+
+func TestCopilotUserDailyMetrics_GetTotalsByLanguageModel(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsLanguageModel{}
+	c := &CopilotUserDailyMetrics{TotalsByLanguageModel: zeroValue}
+	c.GetTotalsByLanguageModel()
+	c = &CopilotUserDailyMetrics{}
+	c.GetTotalsByLanguageModel()
+	c = nil
+	c.GetTotalsByLanguageModel()
+}
+
+func TestCopilotUserDailyMetrics_GetTotalsByModelFeature(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsModelFeature{}
+	c := &CopilotUserDailyMetrics{TotalsByModelFeature: zeroValue}
+	c.GetTotalsByModelFeature()
+	c = &CopilotUserDailyMetrics{}
+	c.GetTotalsByModelFeature()
+	c = nil
+	c.GetTotalsByModelFeature()
+}
+
+func TestCopilotUserDailyMetrics_GetUsedAgent(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetUsedAgent()
+	c = nil
+	c.GetUsedAgent()
+}
+
+func TestCopilotUserDailyMetrics_GetUsedChat(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetUsedChat()
+	c = nil
+	c.GetUsedChat()
+}
+
+func TestCopilotUserDailyMetrics_GetUsedCli(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetUsedCli()
+	c = nil
+	c.GetUsedCli()
+}
+
+func TestCopilotUserDailyMetrics_GetUsedCopilotCodeReviewActive(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetUsedCopilotCodeReviewActive()
+	c = nil
+	c.GetUsedCopilotCodeReviewActive()
+}
+
+func TestCopilotUserDailyMetrics_GetUsedCopilotCodeReviewPassive(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetUsedCopilotCodeReviewPassive()
+	c = nil
+	c.GetUsedCopilotCodeReviewPassive()
+}
+
+func TestCopilotUserDailyMetrics_GetUsedCopilotCodingAgent(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetUsedCopilotCodingAgent()
+	c = nil
+	c.GetUsedCopilotCodingAgent()
+}
+
+func TestCopilotUserDailyMetrics_GetUserID(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetUserID()
+	c = nil
+	c.GetUserID()
+}
+
+func TestCopilotUserDailyMetrics_GetUserInitiatedInteractionCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetUserInitiatedInteractionCount()
+	c = nil
+	c.GetUserInitiatedInteractionCount()
+}
+
+func TestCopilotUserDailyMetrics_GetUserLogin(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetUserLogin()
+	c = nil
+	c.GetUserLogin()
+}
+
+func TestCopilotUserMetricsIDE_GetCodeAcceptanceActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserMetricsIDE{}
+	c.GetCodeAcceptanceActivityCount()
+	c = nil
+	c.GetCodeAcceptanceActivityCount()
+}
+
+func TestCopilotUserMetricsIDE_GetCodeGenerationActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserMetricsIDE{}
+	c.GetCodeGenerationActivityCount()
+	c = nil
+	c.GetCodeGenerationActivityCount()
+}
+
+func TestCopilotUserMetricsIDE_GetIDE(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserMetricsIDE{}
+	c.GetIDE()
+	c = nil
+	c.GetIDE()
+}
+
+func TestCopilotUserMetricsIDE_GetLastKnownIDEVersion(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserMetricsIDE{}
+	c.GetLastKnownIDEVersion()
+	c = nil
+	c.GetLastKnownIDEVersion()
+}
+
+func TestCopilotUserMetricsIDE_GetLastKnownPluginVersion(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserMetricsIDE{}
+	c.GetLastKnownPluginVersion()
+	c = nil
+	c.GetLastKnownPluginVersion()
+}
+
+func TestCopilotUserMetricsIDE_GetLocAddedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserMetricsIDE{}
+	c.GetLocAddedSum()
+	c = nil
+	c.GetLocAddedSum()
+}
+
+func TestCopilotUserMetricsIDE_GetLocDeletedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserMetricsIDE{}
+	c.GetLocDeletedSum()
+	c = nil
+	c.GetLocDeletedSum()
+}
+
+func TestCopilotUserMetricsIDE_GetLocSuggestedToAddSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserMetricsIDE{}
+	c.GetLocSuggestedToAddSum()
+	c = nil
+	c.GetLocSuggestedToAddSum()
+}
+
+func TestCopilotUserMetricsIDE_GetLocSuggestedToDeleteSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserMetricsIDE{}
+	c.GetLocSuggestedToDeleteSum()
+	c = nil
+	c.GetLocSuggestedToDeleteSum()
+}
+
+func TestCopilotUserMetricsIDE_GetUserInitiatedInteractionCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserMetricsIDE{}
+	c.GetUserInitiatedInteractionCount()
+	c = nil
+	c.GetUserInitiatedInteractionCount()
+}
+
+func TestCopilotUserMetricsIDEVersion_GetIDEVersion(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserMetricsIDEVersion{}
+	c.GetIDEVersion()
+	c = nil
+	c.GetIDEVersion()
+}
+
+func TestCopilotUserMetricsIDEVersion_GetSampledAt(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue Timestamp
+	c := &CopilotUserMetricsIDEVersion{SampledAt: &zeroValue}
+	c.GetSampledAt()
+	c = &CopilotUserMetricsIDEVersion{}
+	c.GetSampledAt()
+	c = nil
+	c.GetSampledAt()
+}
+
+func TestCopilotUserMetricsPluginVersion_GetPlugin(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserMetricsPluginVersion{}
+	c.GetPlugin()
+	c = nil
+	c.GetPlugin()
+}
+
+func TestCopilotUserMetricsPluginVersion_GetPluginVersion(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserMetricsPluginVersion{}
+	c.GetPluginVersion()
+	c = nil
+	c.GetPluginVersion()
+}
+
+func TestCopilotUserMetricsPluginVersion_GetSampledAt(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue Timestamp
+	c := &CopilotUserMetricsPluginVersion{SampledAt: &zeroValue}
+	c.GetSampledAt()
+	c = &CopilotUserMetricsPluginVersion{}
+	c.GetSampledAt()
+	c = nil
+	c.GetSampledAt()
+}
+
+func TestCopilotUserPeriodicMetrics_GetCodeAcceptanceActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetCodeAcceptanceActivityCount()
+	c = nil
+	c.GetCodeAcceptanceActivityCount()
+}
+
+func TestCopilotUserPeriodicMetrics_GetCodeGenerationActivityCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetCodeGenerationActivityCount()
+	c = nil
+	c.GetCodeGenerationActivityCount()
+}
+
+func TestCopilotUserPeriodicMetrics_GetDay(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetDay()
+	c = nil
+	c.GetDay()
+}
+
+func TestCopilotUserPeriodicMetrics_GetEnterpriseID(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetEnterpriseID()
+	c = nil
+	c.GetEnterpriseID()
+}
+
+func TestCopilotUserPeriodicMetrics_GetLocAddedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetLocAddedSum()
+	c = nil
+	c.GetLocAddedSum()
+}
+
+func TestCopilotUserPeriodicMetrics_GetLocDeletedSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetLocDeletedSum()
+	c = nil
+	c.GetLocDeletedSum()
+}
+
+func TestCopilotUserPeriodicMetrics_GetLocSuggestedToAddSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetLocSuggestedToAddSum()
+	c = nil
+	c.GetLocSuggestedToAddSum()
+}
+
+func TestCopilotUserPeriodicMetrics_GetLocSuggestedToDeleteSum(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetLocSuggestedToDeleteSum()
+	c = nil
+	c.GetLocSuggestedToDeleteSum()
+}
+
+func TestCopilotUserPeriodicMetrics_GetOrganizationID(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetOrganizationID()
+	c = nil
+	c.GetOrganizationID()
+}
+
+func TestCopilotUserPeriodicMetrics_GetReportEndDay(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetReportEndDay()
+	c = nil
+	c.GetReportEndDay()
+}
+
+func TestCopilotUserPeriodicMetrics_GetReportStartDay(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetReportStartDay()
+	c = nil
+	c.GetReportStartDay()
+}
+
+func TestCopilotUserPeriodicMetrics_GetTotalsByCli(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetTotalsByCli()
+	c = nil
+	c.GetTotalsByCli()
+}
+
+func TestCopilotUserPeriodicMetrics_GetTotalsByFeature(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsFeature{}
+	c := &CopilotUserPeriodicMetrics{TotalsByFeature: zeroValue}
+	c.GetTotalsByFeature()
+	c = &CopilotUserPeriodicMetrics{}
+	c.GetTotalsByFeature()
+	c = nil
+	c.GetTotalsByFeature()
+}
+
+func TestCopilotUserPeriodicMetrics_GetTotalsByIDE(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotUserMetricsIDE{}
+	c := &CopilotUserPeriodicMetrics{TotalsByIDE: zeroValue}
+	c.GetTotalsByIDE()
+	c = &CopilotUserPeriodicMetrics{}
+	c.GetTotalsByIDE()
+	c = nil
+	c.GetTotalsByIDE()
+}
+
+func TestCopilotUserPeriodicMetrics_GetTotalsByLanguageFeature(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsLanguageFeature{}
+	c := &CopilotUserPeriodicMetrics{TotalsByLanguageFeature: zeroValue}
+	c.GetTotalsByLanguageFeature()
+	c = &CopilotUserPeriodicMetrics{}
+	c.GetTotalsByLanguageFeature()
+	c = nil
+	c.GetTotalsByLanguageFeature()
+}
+
+func TestCopilotUserPeriodicMetrics_GetTotalsByLanguageModel(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsLanguageModel{}
+	c := &CopilotUserPeriodicMetrics{TotalsByLanguageModel: zeroValue}
+	c.GetTotalsByLanguageModel()
+	c = &CopilotUserPeriodicMetrics{}
+	c.GetTotalsByLanguageModel()
+	c = nil
+	c.GetTotalsByLanguageModel()
+}
+
+func TestCopilotUserPeriodicMetrics_GetTotalsByModelFeature(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsModelFeature{}
+	c := &CopilotUserPeriodicMetrics{TotalsByModelFeature: zeroValue}
+	c.GetTotalsByModelFeature()
+	c = &CopilotUserPeriodicMetrics{}
+	c.GetTotalsByModelFeature()
+	c = nil
+	c.GetTotalsByModelFeature()
+}
+
+func TestCopilotUserPeriodicMetrics_GetUsedAgent(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetUsedAgent()
+	c = nil
+	c.GetUsedAgent()
+}
+
+func TestCopilotUserPeriodicMetrics_GetUsedChat(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetUsedChat()
+	c = nil
+	c.GetUsedChat()
+}
+
+func TestCopilotUserPeriodicMetrics_GetUsedCli(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetUsedCli()
+	c = nil
+	c.GetUsedCli()
+}
+
+func TestCopilotUserPeriodicMetrics_GetUsedCopilotCodeReviewActive(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetUsedCopilotCodeReviewActive()
+	c = nil
+	c.GetUsedCopilotCodeReviewActive()
+}
+
+func TestCopilotUserPeriodicMetrics_GetUsedCopilotCodeReviewPassive(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetUsedCopilotCodeReviewPassive()
+	c = nil
+	c.GetUsedCopilotCodeReviewPassive()
+}
+
+func TestCopilotUserPeriodicMetrics_GetUsedCopilotCodingAgent(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetUsedCopilotCodingAgent()
+	c = nil
+	c.GetUsedCopilotCodingAgent()
+}
+
+func TestCopilotUserPeriodicMetrics_GetUserID(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetUserID()
+	c = nil
+	c.GetUserID()
+}
+
+func TestCopilotUserPeriodicMetrics_GetUserInitiatedInteractionCount(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetUserInitiatedInteractionCount()
+	c = nil
+	c.GetUserInitiatedInteractionCount()
+}
+
+func TestCopilotUserPeriodicMetrics_GetUserLogin(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetUserLogin()
+	c = nil
+	c.GetUserLogin()
 }
 
 func TestCostCenter_GetAzureSubscription(tt *testing.T) {

--- a/tools/metadata/metadata.go
+++ b/tools/metadata/metadata.go
@@ -550,4 +550,8 @@ var skipServiceMethod = map[string]bool{
 	"BillingService.GetPackagesBilling":             true,
 	"BillingService.GetStorageBilling":              true,
 	"CopilotService.DownloadCopilotMetrics":         true,
+	"CopilotService.DownloadDailyMetrics":           true,
+	"CopilotService.DownloadPeriodicMetrics":        true,
+	"CopilotService.DownloadUserDailyMetrics":       true,
+	"CopilotService.DownloadUserPeriodicMetrics":    true,
 }

--- a/tools/structfield/structfield.go
+++ b/tools/structfield/structfield.go
@@ -420,7 +420,7 @@ var initialisms = map[string]bool{
 	"ID": true, "IDE": true, "IDP": true, "IP": true, "JIT": true,
 	"JSON": true,
 	"OIDC": true,
-	"LDAP": true, "LFS": true, "LHS": true,
+	"LDAP": true, "LFS": true, "LHS": true, "LOC": true,
 	"MD5": true, "MS": true, "MX": true,
 	"NPM": true, "NTP": true, "NVD": true,
 	"OID": true, "OS": true,

--- a/tools/structfield/structfield.go
+++ b/tools/structfield/structfield.go
@@ -411,7 +411,7 @@ func tagNameToPascal(tagName string) (want, alternate string) {
 // Common Go initialisms that should be all caps.
 var initialisms = map[string]bool{
 	"API": true, "ASCII": true, "AWS": true,
-	"CAA": true, "CAS": true, "CNAME": true, "CPU": true,
+	"CAA": true, "CAS": true, "CLI": true, "CNAME": true, "CPU": true,
 	"CSS": true, "CWE": true, "CVE": true, "CVSS": true,
 	"DN": true, "DNS": true,
 	"EOF": true, "EPSS": true,


### PR DESCRIPTION
Fixes #4136

## Summary
The new Copilot usage metrics endpoints (`/copilot/metrics/reports/*`) return download links whose payloads do not match the `CopilotMetrics` shape, so the existing `DownloadCopilotMetrics` helper fails to decode live data from the eight `Get*MetricsReport` methods on public GitHub.

This PR adds four typed helpers and deprecates the legacy one:

| Link returned by | Use |
|---|---|
| `Get{Enterprise,Organization}DailyMetricsReport` | `DownloadDailyMetrics` |
| `Get{Enterprise,Organization}MetricsReport` | `DownloadPeriodicMetrics` |
| `Get{Enterprise,Organization}UsersDailyMetricsReport` | `DownloadUserDailyMetrics` |
| `Get{Enterprise,Organization}UsersMetricsReport` | `DownloadUserPeriodicMetrics` |

User metrics payloads are newline-delimited JSON; aggregate payloads are JSON objects (1-day) or a `{ day_totals: [...] }` wrapper (28-day).

## Payload schemas
GitHub's public OpenAPI and REST documentation only describe the top-level response (`download_links`, `report_start_day`/`end_day`) and do not publish the schema of the downloaded files. The struct definitions in this PR are based on the live-data structs posted by @Roemer in https://github.com/google/go-github/pull/4149#issuecomment-4287547798 and the official Copilot usage metrics documentation. Follow-up PRs can adjust any field names that differ from what live endpoints emit.

## Notes
- `DownloadCopilotMetrics` is kept with a `Deprecated:` comment so GitHub Enterprise Server installations that may still serve the legacy shape continue to work.
- The four new helpers are registered in `tools/metadata/metadata.go` skip list, following the same pattern as the existing `DownloadCopilotMetrics` (helper methods without direct GitHub v3 API correspondence).
- Most of the added lines are auto-generated accessors via `script/generate.sh` for the new typed structs.

## Testing
- `script/fmt.sh`, `script/generate.sh`, `script/lint.sh`, `script/test.sh` all pass locally.
- Each helper covers success, HTTP status error, invalid URL, invalid scheme, malformed JSON; the NDJSON helpers additionally cover empty-body → nil slice behaviour.

cc @gmlewis