### PR TITLE
fix: Include `RetryAfter` in `AbuseRateLimitError.Error` output

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -1363,9 +1363,13 @@ type AbuseRateLimitError struct {
 }
 
 func (r *AbuseRateLimitError) Error() string {
-	return fmt.Sprintf("%v %v: %v %v",
+	retryInfo := ""
+	if r.RetryAfter != nil && *r.RetryAfter > 0 {
+		retryInfo = fmt.Sprintf(" [retry after %v]", r.RetryAfter.Round(time.Second))
+	}
+	return fmt.Sprintf("%v %v: %v %v%v",
 		r.Response.Request.Method, sanitizeURL(r.Response.Request.URL),
-		r.Response.StatusCode, r.Message)
+		r.Response.StatusCode, r.Message, retryInfo)
 }
 
 // Is returns whether the provided error equals this error.

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -3277,16 +3277,51 @@ func TestAbuseRateLimitError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := &AbuseRateLimitError{
-		Response: &http.Response{
-			Request:    &http.Request{Method: "PUT", URL: u},
-			StatusCode: http.StatusTooManyRequests,
-		},
-		Message: "<msg>",
-	}
-	if got, want := r.Error(), "PUT https://example.com: 429 <msg>"; got != want {
-		t.Errorf("AbuseRateLimitError = %q, want %q", got, want)
-	}
+	t.Run("nil RetryAfter", func(t *testing.T) {
+		t.Parallel()
+		r := &AbuseRateLimitError{
+			Response: &http.Response{
+				Request:    &http.Request{Method: "PUT", URL: u},
+				StatusCode: http.StatusTooManyRequests,
+			},
+			Message: "<msg>",
+		}
+		if got, want := r.Error(), "PUT https://example.com: 429 <msg>"; got != want {
+			t.Errorf("AbuseRateLimitError = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("with RetryAfter", func(t *testing.T) {
+		t.Parallel()
+		d := 60 * time.Second
+		r := &AbuseRateLimitError{
+			Response: &http.Response{
+				Request:    &http.Request{Method: "GET", URL: u},
+				StatusCode: http.StatusForbidden,
+			},
+			Message:    "rate limited",
+			RetryAfter: &d,
+		}
+		if got, want := r.Error(), "GET https://example.com: 403 rate limited [retry after 1m0s]"; got != want {
+			t.Errorf("AbuseRateLimitError = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("zero RetryAfter", func(t *testing.T) {
+		t.Parallel()
+		d := 0 * time.Second
+		r := &AbuseRateLimitError{
+			Response: &http.Response{
+				Request:    &http.Request{Method: "POST", URL: u},
+				StatusCode: http.StatusForbidden,
+			},
+			Message:    "rate limited",
+			RetryAfter: &d,
+		}
+		if got, want := r.Error(), "POST https://example.com: 403 rate limited"; got != want {
+			t.Errorf("AbuseRateLimitError = %q, want %q", got, want)
+		}
+	})
 }
 
 func TestBareDo_returnsOpenBody(t *testing.T) {


### PR DESCRIPTION
When `AbuseRateLimitError` includes a populated `RetryAfter` field (from the `Retry-After` HTTP header), the `.Error()` string silently drops it:

```
GET https://api.github.com/search/code: 403 You have exceeded a secondary rate limit. Please retry your request again later.
```

This is inconsistent with `RateLimitError.Error()`, which already includes timing via `formatRateReset`:

```
GET https://api.github.com/search/code: 403 API rate limit exceeded. [rate reset in 2m59s]
```

### Why this matters now

This gap has existed since 2016, but was minor because Go callers can use `errors.As` to inspect `.RetryAfter` directly.

It has become more impactful with AI coding agents. The [github-mcp-server](https://github.com/github/github-mcp-server) exposes GitHub API operations as MCP tools, and AI agents receive tool results as plain strings — there is no way for the model to inspect the underlying Go struct. When an agent hits a secondary rate limit, it sees no retry duration and must choose between retrying immediately (worsening the situation) or waiting an arbitrary amount of time.

Including the duration in `.Error()` gives agent frameworks and models the information they need to back off correctly.

### After this change

```
GET https://api.github.com/search/code: 403 You have exceeded a secondary rate limit. Please retry your request again later. [retry after 1m0s]
```

When `RetryAfter` is nil or zero, the output is unchanged.

Fixes #4180.

> [!NOTE]
> This PR was authored with the assistance of GitHub Copilot.
