### PR TITLE
refactor: Use `testJSONBody` helper for request body assertions in tests

### DIFF
--- a/github/actions_oidc_test.go
+++ b/github/actions_oidc_test.go
@@ -87,16 +87,17 @@ func TestActionsService_SetOrgOIDCSubjectClaimCustomTemplate(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/actions/oidc/customization/sub", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-		testHeader(t, r, "Content-Type", "application/json")
-		testBody(t, r, `{"include_claim_keys":["repo","context"]}`+"\n")
-		w.WriteHeader(http.StatusCreated)
-	})
-
 	input := &OIDCSubjectClaimCustomTemplate{
 		IncludeClaimKeys: []string{"repo", "context"},
 	}
+
+	mux.HandleFunc("/orgs/o/actions/oidc/customization/sub", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Content-Type", "application/json")
+		testJSONBody(t, r, input)
+		w.WriteHeader(http.StatusCreated)
+	})
+
 	ctx := t.Context()
 	_, err := client.Actions.SetOrgOIDCSubjectClaimCustomTemplate(ctx, "o", input)
 	if err != nil {
@@ -119,17 +120,18 @@ func TestActionsService_SetRepoOIDCSubjectClaimCustomTemplate(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/actions/oidc/customization/sub", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-		testHeader(t, r, "Content-Type", "application/json")
-		testBody(t, r, `{"use_default":false,"include_claim_keys":["repo","context"]}`+"\n")
-		w.WriteHeader(http.StatusCreated)
-	})
-
 	input := &OIDCSubjectClaimCustomTemplate{
 		UseDefault:       Ptr(false),
 		IncludeClaimKeys: []string{"repo", "context"},
 	}
+
+	mux.HandleFunc("/repos/o/r/actions/oidc/customization/sub", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Content-Type", "application/json")
+		testJSONBody(t, r, input)
+		w.WriteHeader(http.StatusCreated)
+	})
+
 	ctx := t.Context()
 	_, err := client.Actions.SetRepoOIDCSubjectClaimCustomTemplate(ctx, "o", "r", input)
 	if err != nil {
@@ -152,16 +154,17 @@ func TestActionService_SetRepoOIDCSubjectClaimCustomTemplateToDefault(t *testing
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/actions/oidc/customization/sub", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-		testHeader(t, r, "Content-Type", "application/json")
-		testBody(t, r, `{"use_default":true}`+"\n")
-		w.WriteHeader(http.StatusCreated)
-	})
-
 	input := &OIDCSubjectClaimCustomTemplate{
 		UseDefault: Ptr(true),
 	}
+
+	mux.HandleFunc("/repos/o/r/actions/oidc/customization/sub", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Content-Type", "application/json")
+		testJSONBody(t, r, input)
+		w.WriteHeader(http.StatusCreated)
+	})
+
 	ctx := t.Context()
 	_, err := client.Actions.SetRepoOIDCSubjectClaimCustomTemplate(ctx, "o", "r", input)
 	if err != nil {

--- a/github/actions_permissions_enterprise_test.go
+++ b/github/actions_permissions_enterprise_test.go
@@ -55,14 +55,8 @@ func TestActionsService_UpdateActionsPermissionsInEnterprise(t *testing.T) {
 	input := &ActionsPermissionsEnterprise{EnabledOrganizations: Ptr("all"), AllowedActions: Ptr("selected")}
 
 	mux.HandleFunc("/enterprises/e/actions/permissions", func(w http.ResponseWriter, r *http.Request) {
-		var v *ActionsPermissionsEnterprise
-		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
-
 		testMethod(t, r, "PUT")
-		if !cmp.Equal(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
-		}
-
+		testJSONBody(t, r, input)
 		fmt.Fprint(w, `{"enabled_organizations": "all", "allowed_actions": "selected"}`)
 	})
 
@@ -140,15 +134,21 @@ func TestActionsService_SetEnabledOrgsInEnterprise(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
+	input := []int64{123, 1234}
+
 	mux.HandleFunc("/enterprises/e/actions/permissions/organizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
-		testBody(t, r, `{"selected_organization_ids":[123,1234]}`+"\n")
+		testJSONBody(t, r, struct {
+			IDs []int64 `json:"selected_organization_ids"`
+		}{
+			IDs: input,
+		})
 		w.WriteHeader(http.StatusNoContent)
 	})
 
 	ctx := t.Context()
-	_, err := client.Actions.SetEnabledOrgsInEnterprise(ctx, "e", []int64{123, 1234})
+	_, err := client.Actions.SetEnabledOrgsInEnterprise(ctx, "e", input)
 	if err != nil {
 		t.Errorf("Actions.SetEnabledOrgsInEnterprise returned error: %v", err)
 	}
@@ -156,12 +156,12 @@ func TestActionsService_SetEnabledOrgsInEnterprise(t *testing.T) {
 	const methodName = "SetEnabledOrgsInEnterprise"
 
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.SetEnabledOrgsInEnterprise(ctx, "\n", []int64{123, 1234})
+		_, err = client.Actions.SetEnabledOrgsInEnterprise(ctx, "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.SetEnabledOrgsInEnterprise(ctx, "e", []int64{123, 1234})
+		return client.Actions.SetEnabledOrgsInEnterprise(ctx, "e", input)
 	})
 }
 
@@ -260,14 +260,8 @@ func TestActionsService_UpdateActionsAllowedInEnterprise(t *testing.T) {
 	input := &ActionsAllowed{GithubOwnedAllowed: Ptr(true), VerifiedAllowed: Ptr(false), PatternsAllowed: []string{"a/b"}}
 
 	mux.HandleFunc("/enterprises/e/actions/permissions/selected-actions", func(w http.ResponseWriter, r *http.Request) {
-		var v *ActionsAllowed
-		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
-
 		testMethod(t, r, "PUT")
-		if !cmp.Equal(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
-		}
-
+		testJSONBody(t, r, input)
 		fmt.Fprint(w, `{"github_owned_allowed":true, "verified_allowed":false, "patterns_allowed":["a/b"]}`)
 	})
 
@@ -338,14 +332,8 @@ func TestActionsService_UpdateDefaultWorkflowPermissionsInEnterprise(t *testing.
 	input := &DefaultWorkflowPermissionEnterprise{DefaultWorkflowPermissions: Ptr("read"), CanApprovePullRequestReviews: Ptr(true)}
 
 	mux.HandleFunc("/enterprises/e/actions/permissions/workflow", func(w http.ResponseWriter, r *http.Request) {
-		var v *DefaultWorkflowPermissionEnterprise
-		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
-
 		testMethod(t, r, "PUT")
-		if !cmp.Equal(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
-		}
-
+		testJSONBody(t, r, input)
 		fmt.Fprint(w, `{ "default_workflow_permissions": "read", "can_approve_pull_request_reviews": true }`)
 	})
 
@@ -492,13 +480,8 @@ func TestActionsService_UpdateSelfHostedRunnerPermissionsInEnterprise(t *testing
 	input := &SelfHostRunnerPermissionsEnterprise{DisableSelfHostedRunnersForAllOrgs: Ptr(false)}
 
 	mux.HandleFunc("/enterprises/e/actions/permissions/self-hosted-runners", func(w http.ResponseWriter, r *http.Request) {
-		var v *SelfHostRunnerPermissionsEnterprise
-		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
-
 		testMethod(t, r, "PUT")
-		if !cmp.Equal(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
-		}
+		testJSONBody(t, r, input)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -573,13 +556,8 @@ func TestActionsService_UpdatePrivateRepoForkPRWorkflowSettingsInEnterprise(t *t
 	}
 
 	mux.HandleFunc("/enterprises/e/actions/permissions/fork-pr-workflows-private-repos", func(w http.ResponseWriter, r *http.Request) {
-		var v *WorkflowsPermissionsOpt
-		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
-
 		testMethod(t, r, "PUT")
-		if !cmp.Equal(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
-		}
+		testJSONBody(t, r, input)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -645,13 +623,8 @@ func TestActionsService_UpdateEnterpriseForkPRContributorApprovalPermissions(t *
 	input := ContributorApprovalPermissions{ApprovalPolicy: "require_approval"}
 
 	mux.HandleFunc("/enterprises/e/actions/permissions/fork-pr-contributor-approval", func(w http.ResponseWriter, r *http.Request) {
-		var v *ContributorApprovalPermissions
-		assertNilError(t, json.NewDecoder(r.Body).Decode(&v))
-
 		testMethod(t, r, "PUT")
-		if !cmp.Equal(v, &input) {
-			t.Errorf("Request body = %+v, want %+v", v, &input)
-		}
+		testJSONBody(t, r, input)
 		w.WriteHeader(http.StatusNoContent)
 	})
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -212,6 +212,7 @@ func testJSONBody[T any](t *testing.T, r *http.Request, want T) {
 	if err := json.Unmarshal(b, &got); err != nil {
 		t.Errorf("Error unmarshaling request body JSON: %v", err)
 	}
+
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("request JSON body mismatch (-want +got):\n%v", diff)
 	}

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -200,6 +200,23 @@ func testBody(t *testing.T, r *http.Request, want string) {
 	}
 }
 
+func testJSONBody[T any](t *testing.T, r *http.Request, want T) {
+	t.Helper()
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("Error reading request body: %v", err)
+	}
+
+	var got T
+
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Errorf("Error unmarshaling request body JSON: %v", err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("request JSON body mismatch (-want +got):\n%v", diff)
+	}
+}
+
 // testJSONMarshal tests both JSON marshaling and unmarshaling of a value by comparing
 // the marshaled output with the expected JSON string.
 //


### PR DESCRIPTION
An alternate implementation of #4170 that uses a generic `testJSONBody` helper.