### PR TITLE
chore: Fix `otel` module name

### DIFF
--- a/example/go.mod
+++ b/example/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0
 	github.com/gofri/go-github-pagination v1.0.1
 	github.com/gofri/go-github-ratelimit/v2 v2.0.2
+	github.com/google/go-github/otel/v85 v85.0.0-00010101000000-000000000000
 	github.com/google/go-github/v85 v85.0.0
-	github.com/google/go-github/v85/otel v0.0.0-00010101000000-000000000000
 	github.com/sigstore/sigstore-go v1.1.4
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
@@ -90,4 +90,4 @@ require (
 // Use version at HEAD, not the latest published.
 replace github.com/google/go-github/v85 => ../
 
-replace github.com/google/go-github/v85/otel => ../otel
+replace github.com/google/go-github/otel/v85 => ../otel

--- a/example/go.mod
+++ b/example/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0
 	github.com/gofri/go-github-pagination v1.0.1
 	github.com/gofri/go-github-ratelimit/v2 v2.0.2
-	github.com/google/go-github/otel/v85 v85.0.0-00010101000000-000000000000
+	github.com/google/go-github/otel/v85 v85.0.0
 	github.com/google/go-github/v85 v85.0.0
 	github.com/sigstore/sigstore-go v1.1.4
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0

--- a/example/otel/main.go
+++ b/example/otel/main.go
@@ -13,8 +13,8 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/google/go-github/otel/v85"
 	"github.com/google/go-github/v85/github"
-	"github.com/google/go-github/v85/otel"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/trace"
 )

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v85/otel
+module github.com/google/go-github/otel/v85
 
 go 1.25.0
 


### PR DESCRIPTION
Fixes: #4185
Closes: #4186

I think the issue is the `otel` module name: it should be `github.com/google/go-github/otel/v85`, not `github.com/google/go-github/v85/otel`.

See modules and tags in https://github.com/thepudds/nested-module-example