### PR TITLE
feat: Add `deploy_keys_enabled_for_repositories` and secret scanning custom link fields to `Organization` struct

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -22950,6 +22950,14 @@ func (o *Organization) GetDependencyGraphEnabledForNewRepos() bool {
 	return *o.DependencyGraphEnabledForNewRepos
 }
 
+// GetDeployKeysEnabledForRepositories returns the DeployKeysEnabledForRepositories field if it's non-nil, zero value otherwise.
+func (o *Organization) GetDeployKeysEnabledForRepositories() bool {
+	if o == nil || o.DeployKeysEnabledForRepositories == nil {
+		return false
+	}
+	return *o.DeployKeysEnabledForRepositories
+}
+
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
 func (o *Organization) GetDescription() string {
 	if o == nil || o.Description == nil {
@@ -23292,6 +23300,22 @@ func (o *Organization) GetSecretScanningEnabledForNewRepos() bool {
 		return false
 	}
 	return *o.SecretScanningEnabledForNewRepos
+}
+
+// GetSecretScanningPushProtectionCustomLink returns the SecretScanningPushProtectionCustomLink field if it's non-nil, zero value otherwise.
+func (o *Organization) GetSecretScanningPushProtectionCustomLink() string {
+	if o == nil || o.SecretScanningPushProtectionCustomLink == nil {
+		return ""
+	}
+	return *o.SecretScanningPushProtectionCustomLink
+}
+
+// GetSecretScanningPushProtectionCustomLinkEnabled returns the SecretScanningPushProtectionCustomLinkEnabled field if it's non-nil, zero value otherwise.
+func (o *Organization) GetSecretScanningPushProtectionCustomLinkEnabled() bool {
+	if o == nil || o.SecretScanningPushProtectionCustomLinkEnabled == nil {
+		return false
+	}
+	return *o.SecretScanningPushProtectionCustomLinkEnabled
 }
 
 // GetSecretScanningPushProtectionEnabledForNewRepos returns the SecretScanningPushProtectionEnabledForNewRepos field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -28936,6 +28936,17 @@ func TestOrganization_GetDependencyGraphEnabledForNewRepos(tt *testing.T) {
 	o.GetDependencyGraphEnabledForNewRepos()
 }
 
+func TestOrganization_GetDeployKeysEnabledForRepositories(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	o := &Organization{DeployKeysEnabledForRepositories: &zeroValue}
+	o.GetDeployKeysEnabledForRepositories()
+	o = &Organization{}
+	o.GetDeployKeysEnabledForRepositories()
+	o = nil
+	o.GetDeployKeysEnabledForRepositories()
+}
+
 func TestOrganization_GetDescription(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -29404,6 +29415,28 @@ func TestOrganization_GetSecretScanningEnabledForNewRepos(tt *testing.T) {
 	o.GetSecretScanningEnabledForNewRepos()
 	o = nil
 	o.GetSecretScanningEnabledForNewRepos()
+}
+
+func TestOrganization_GetSecretScanningPushProtectionCustomLink(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	o := &Organization{SecretScanningPushProtectionCustomLink: &zeroValue}
+	o.GetSecretScanningPushProtectionCustomLink()
+	o = &Organization{}
+	o.GetSecretScanningPushProtectionCustomLink()
+	o = nil
+	o.GetSecretScanningPushProtectionCustomLink()
+}
+
+func TestOrganization_GetSecretScanningPushProtectionCustomLinkEnabled(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	o := &Organization{SecretScanningPushProtectionCustomLinkEnabled: &zeroValue}
+	o.GetSecretScanningPushProtectionCustomLinkEnabled()
+	o = &Organization{}
+	o.GetSecretScanningPushProtectionCustomLinkEnabled()
+	o = nil
+	o.GetSecretScanningPushProtectionCustomLinkEnabled()
 }
 
 func TestOrganization_GetSecretScanningPushProtectionEnabledForNewRepos(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1256,6 +1256,7 @@ func TestOrganization_String(t *testing.T) {
 		MembersCanCreatePrivateRepos:         Ptr(false),
 		MembersCanCreateInternalRepos:        Ptr(false),
 		MembersCanForkPrivateRepos:           Ptr(false),
+		DeployKeysEnabledForRepositories:     Ptr(false),
 		MembersAllowedRepositoryCreationType: Ptr(""),
 		MembersCanCreatePages:                Ptr(false),
 		MembersCanCreatePublicPages:          Ptr(false),
@@ -1268,6 +1269,8 @@ func TestOrganization_String(t *testing.T) {
 		SecretScanningEnabledForNewRepos:               Ptr(false),
 		SecretScanningPushProtectionEnabledForNewRepos: Ptr(false),
 		SecretScanningValidityChecksEnabled:            Ptr(false),
+		SecretScanningPushProtectionCustomLinkEnabled:  Ptr(false),
+		SecretScanningPushProtectionCustomLink:         Ptr(""),
 		MembersCanDeleteRepositories:                   Ptr(false),
 		MembersCanChangeRepoVisibility:                 Ptr(false),
 		MembersCanInviteOutsideCollaborators:           Ptr(false),
@@ -1285,7 +1288,7 @@ func TestOrganization_String(t *testing.T) {
 		PublicMembersURL:                               Ptr(""),
 		ReposURL:                                       Ptr(""),
 	}
-	want := `github.Organization{Login:"", ID:0, NodeID:"", AvatarURL:"", HTMLURL:"", Name:"", Company:"", Blog:"", Location:"", Email:"", TwitterUsername:"", Description:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, ArchivedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, BillingEmail:"", Type:"", Plan:github.Plan{}, TwoFactorRequirementEnabled:false, IsVerified:false, HasOrganizationProjects:false, HasRepositoryProjects:false, DefaultRepoPermission:"", DefaultRepoSettings:"", MembersCanCreateRepos:false, MembersCanCreatePublicRepos:false, MembersCanCreatePrivateRepos:false, MembersCanCreateInternalRepos:false, MembersCanForkPrivateRepos:false, MembersAllowedRepositoryCreationType:"", MembersCanCreatePages:false, MembersCanCreatePublicPages:false, MembersCanCreatePrivatePages:false, WebCommitSignoffRequired:false, AdvancedSecurityEnabledForNewRepos:false, DependabotAlertsEnabledForNewRepos:false, DependabotSecurityUpdatesEnabledForNewRepos:false, DependencyGraphEnabledForNewRepos:false, SecretScanningEnabledForNewRepos:false, SecretScanningPushProtectionEnabledForNewRepos:false, SecretScanningValidityChecksEnabled:false, MembersCanDeleteRepositories:false, MembersCanChangeRepoVisibility:false, MembersCanInviteOutsideCollaborators:false, MembersCanDeleteIssues:false, DisplayCommenterFullNameSettingEnabled:false, ReadersCanCreateDiscussions:false, MembersCanCreateTeams:false, MembersCanViewDependencyInsights:false, DefaultRepositoryBranch:"", URL:"", EventsURL:"", HooksURL:"", IssuesURL:"", MembersURL:"", PublicMembersURL:"", ReposURL:""}`
+	want := `github.Organization{Login:"", ID:0, NodeID:"", AvatarURL:"", HTMLURL:"", Name:"", Company:"", Blog:"", Location:"", Email:"", TwitterUsername:"", Description:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, ArchivedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, BillingEmail:"", Type:"", Plan:github.Plan{}, TwoFactorRequirementEnabled:false, IsVerified:false, HasOrganizationProjects:false, HasRepositoryProjects:false, DefaultRepoPermission:"", DefaultRepoSettings:"", MembersCanCreateRepos:false, MembersCanCreatePublicRepos:false, MembersCanCreatePrivateRepos:false, MembersCanCreateInternalRepos:false, MembersCanForkPrivateRepos:false, DeployKeysEnabledForRepositories:false, MembersAllowedRepositoryCreationType:"", MembersCanCreatePages:false, MembersCanCreatePublicPages:false, MembersCanCreatePrivatePages:false, WebCommitSignoffRequired:false, AdvancedSecurityEnabledForNewRepos:false, DependabotAlertsEnabledForNewRepos:false, DependabotSecurityUpdatesEnabledForNewRepos:false, DependencyGraphEnabledForNewRepos:false, SecretScanningEnabledForNewRepos:false, SecretScanningPushProtectionEnabledForNewRepos:false, SecretScanningValidityChecksEnabled:false, SecretScanningPushProtectionCustomLinkEnabled:false, SecretScanningPushProtectionCustomLink:"", MembersCanDeleteRepositories:false, MembersCanChangeRepoVisibility:false, MembersCanInviteOutsideCollaborators:false, MembersCanDeleteIssues:false, DisplayCommenterFullNameSettingEnabled:false, ReadersCanCreateDiscussions:false, MembersCanCreateTeams:false, MembersCanViewDependencyInsights:false, DefaultRepositoryBranch:"", URL:"", EventsURL:"", HooksURL:"", IssuesURL:"", MembersURL:"", PublicMembersURL:"", ReposURL:""}`
 	if got := v.String(); got != want {
 		t.Errorf("Organization.String = %v, want %v", got, want)
 	}

--- a/github/orgs.go
+++ b/github/orgs.go
@@ -68,6 +68,9 @@ type Organization struct {
 	// MembersCanForkPrivateRepos toggles whether organization members can fork private organization repositories.
 	MembersCanForkPrivateRepos *bool `json:"members_can_fork_private_repositories,omitempty"`
 
+	// DeployKeysEnabledForRepositories toggles whether deploy keys may be added and used for repositories in the organization.
+	DeployKeysEnabledForRepositories *bool `json:"deploy_keys_enabled_for_repositories,omitempty"`
+
 	// MembersAllowedRepositoryCreationType denotes if organization members can create repositories
 	// and the type of repositories they can create. Possible values are: "all", "private", or "none".
 	//
@@ -98,6 +101,10 @@ type Organization struct {
 	SecretScanningPushProtectionEnabledForNewRepos *bool `json:"secret_scanning_push_protection_enabled_for_new_repositories,omitempty"`
 	// SecretScanningValidityChecksEnabled toggles whether secret scanning validity check is enabled.
 	SecretScanningValidityChecksEnabled *bool `json:"secret_scanning_validity_checks_enabled,omitempty"`
+	// SecretScanningPushProtectionCustomLinkEnabled toggles whether a custom link is shown to contributors blocked by secret scanning push protection.
+	SecretScanningPushProtectionCustomLinkEnabled *bool `json:"secret_scanning_push_protection_custom_link_enabled,omitempty"`
+	// SecretScanningPushProtectionCustomLink is the URL displayed to contributors blocked by secret scanning push protection.
+	SecretScanningPushProtectionCustomLink *string `json:"secret_scanning_push_protection_custom_link,omitempty"`
 	// MembersCanDeleteRepositories toggles whether members with admin permissions can delete a repository.
 	MembersCanDeleteRepositories *bool `json:"members_can_delete_repositories,omitempty"`
 	// MembersCanChangeRepoVisibility toggles whether members with admin permissions can change the visibility for a repository.


### PR DESCRIPTION
This PR adds three fields to the `Organization` struct that are returned by `GET /orgs/{org}` and accepted by `PATCH /orgs/{org}`, but are not currently represented in go-github:

- `deploy_keys_enabled_for_repositories` (`*bool`) — controls whether deploy keys may be added and used for repositories in the organization. This is documented as a writable parameter in the [Update an organization](https://docs.github.com/en/rest/orgs/orgs?apiVersion=2022-11-28#update-an-organization) REST docs.
- `secret_scanning_push_protection_custom_link_enabled` (`*bool`) — toggles whether a custom link is shown to contributors blocked by secret scanning push protection.
- `secret_scanning_push_protection_custom_link` (`*string`) — the URL displayed to contributors blocked by secret scanning push protection.

The latter two are not currently listed in the REST docs, but are observed in real `GET` and `PATCH` responses.

Verification: I confirmed against a real organization (`aletheia-works`) that `GET /orgs/{org}` and `PATCH /orgs/{org}` return all three of these fields. The new fields are placed alongside semantically related existing fields (`MembersCanForkPrivateRepos` and `SecretScanningValidityChecksEnabled`).

The accessor and stringify test files were regenerated with `go generate ./...`. `go test ./...` passes.

This follows the same minimal-diff pattern as #2389, which added `MembersCanForkPrivateRepositories`.