### PR TITLE
test: Fix invalid JSON payloads in actions workflow runs tests

### DIFF
--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -109,7 +109,7 @@ func TestActionsService_GetWorkflowRunByID(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/actions/runs/29679449", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"id":399444496,"run_number":296,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}}`)
+		fmt.Fprint(w, `{"id":399444496,"run_number":296,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
 	})
 
 	ctx := t.Context()
@@ -151,7 +151,7 @@ func TestActionsService_GetWorkflowRunAttempt(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/actions/runs/29679449/attempts/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"exclude_pull_requests": "true"})
-		fmt.Fprint(w, `{"id":399444496,"run_number":296,"run_attempt":3,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}}`)
+		fmt.Fprint(w, `{"id":399444496,"run_number":296,"run_attempt":3,"created_at":"2019-01-02T15:04:05Z","updated_at":"2020-01-02T15:04:05Z"}`)
 	})
 
 	opts := &WorkflowRunAttemptOptions{ExcludePullRequests: Ptr(true)}


### PR DESCRIPTION
Fixes #4196

### Description
Removes the invalid trailing `}}` braces from the mock HTTP server JSON payloads in `actions_workflow_runs_test.go`.

### Motivation
This bug was silently masked by `json.NewDecoder()`. By correcting the test payloads, we ensure the tests are generating valid JSON, clearing the way for stricter memory-pooling and performance optimizations in the core client.

### Verification
- [x] Validated JSON structure.