### PR TITLE
chore: Bump version of `go-github` to `v86.0.0`

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,12 +1,12 @@
 version: v2.10.1 # this is the version of golangci-lint
 plugins:
-  - module: "github.com/google/go-github/v85/tools/extraneousnew"
+  - module: "github.com/google/go-github/v86/tools/extraneousnew"
     path: ./tools/extraneousnew
-  - module: "github.com/google/go-github/v85/tools/fmtpercentv"
+  - module: "github.com/google/go-github/v86/tools/fmtpercentv"
     path: ./tools/fmtpercentv
-  - module: "github.com/google/go-github/v85/tools/redundantptr"
+  - module: "github.com/google/go-github/v86/tools/redundantptr"
     path: ./tools/redundantptr
-  - module: "github.com/google/go-github/v85/tools/sliceofpointers"
+  - module: "github.com/google/go-github/v86/tools/sliceofpointers"
     path: ./tools/sliceofpointers
-  - module: "github.com/google/go-github/v85/tools/structfield"
+  - module: "github.com/google/go-github/v86/tools/structfield"
     path: ./tools/structfield

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -185,7 +185,7 @@ linters:
       extraneousnew:
         type: module
         description: Reports problematic usage of 'new' or '&SomeStruct{}' when a more idiomatic 'var' pointer would be more appropriate.
-        original-url: github.com/google/go-github/v85/tools/extraneousnew
+        original-url: github.com/google/go-github/v86/tools/extraneousnew
         settings:
           ignored-methods:
             - RateLimitService.Get
@@ -193,19 +193,19 @@ linters:
       fmtpercentv:
         type: module
         description: Reports usage of %d or %s in format strings.
-        original-url: github.com/google/go-github/v85/tools/fmtpercentv
+        original-url: github.com/google/go-github/v86/tools/fmtpercentv
       redundantptr:
         type: module
         description: Reports github.Ptr(x) calls that can be replaced with &x.
-        original-url: github.com/google/go-github/v85/tools/redundantptr
+        original-url: github.com/google/go-github/v86/tools/redundantptr
       sliceofpointers:
         type: module
         description: Reports usage of []*string and slices of structs without pointers.
-        original-url: github.com/google/go-github/v85/tools/sliceofpointers
+        original-url: github.com/google/go-github/v86/tools/sliceofpointers
       structfield:
         type: module
         description: Reports mismatches between Go field and JSON, URL tag names and types.
-        original-url: github.com/google/go-github/v85/tools/structfield
+        original-url: github.com/google/go-github/v86/tools/structfield
         settings:
           allowed-tag-names:
             - ActionsCacheUsageList.RepoCacheUsage # TODO: RepoCacheUsages ?

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-github #
 
 [![go-github release (latest SemVer)](https://img.shields.io/github/v/release/google/go-github?sort=semver)](https://github.com/google/go-github/releases)
-[![Go Reference](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/google/go-github/v85/github)
+[![Go Reference](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/google/go-github/v86/github)
 [![Test Status](https://github.com/google/go-github/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/google/go-github/actions/workflows/tests.yml)
 [![Test Coverage](https://codecov.io/gh/google/go-github/branch/master/graph/badge.svg)](https://codecov.io/gh/google/go-github)
 [![Discuss at go-github@googlegroups.com](https://img.shields.io/badge/discuss-go--github%40googlegroups.com-blue.svg)](https://groups.google.com/group/go-github)
@@ -30,7 +30,7 @@ If you're interested in using the [GraphQL API v4][], the recommended library is
 go-github is compatible with modern Go releases in module mode, with Go installed:
 
 ```bash
-go get github.com/google/go-github/v85
+go get github.com/google/go-github/v86
 ```
 
 will resolve and add the package to the current development module, along with its dependencies.
@@ -38,7 +38,7 @@ will resolve and add the package to the current development module, along with i
 Alternatively the same can be achieved if you use import in a package:
 
 ```go
-import "github.com/google/go-github/v85/github"
+import "github.com/google/go-github/v86/github"
 ```
 
 and run `go get` without parameters.
@@ -46,20 +46,20 @@ and run `go get` without parameters.
 Finally, to use the top-of-trunk version of this repo, use the following command:
 
 ```bash
-go get github.com/google/go-github/v85@master
+go get github.com/google/go-github/v86@master
 ```
 
 To discover all the changes that have occurred since a prior release, you can
 first clone the repo, then run (for example):
 
 ```bash
-go run tools/gen-release-notes/main.go --tag v85.0.0
+go run tools/gen-release-notes/main.go --tag v86.0.0
 ```
 
 ## Usage ##
 
 ```go
-import "github.com/google/go-github/v85/github"
+import "github.com/google/go-github/v86/github"
 ```
 
 Construct a new GitHub client, then use the various services on the client to
@@ -108,7 +108,7 @@ include the specified OAuth token. Therefore, authenticated clients should
 almost never be shared between different users.
 
 For API methods that require HTTP Basic Authentication, use the
-[`BasicAuthTransport`](https://pkg.go.dev/github.com/google/go-github/v85/github#BasicAuthTransport).
+[`BasicAuthTransport`](https://pkg.go.dev/github.com/google/go-github/v86/github#BasicAuthTransport).
 
 #### As a GitHub App ####
 
@@ -131,7 +131,7 @@ import (
 	"net/http"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 func main() {
@@ -165,7 +165,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/jferrl/go-githubauth"
 	"golang.org/x/oauth2"
 )
@@ -434,7 +434,7 @@ For complete usage of go-github, see the full [package docs][].
 
 [GitHub API v3]: https://docs.github.com/en/rest
 [personal access token]: https://github.com/blog/1509-personal-api-tokens
-[package docs]: https://pkg.go.dev/github.com/google/go-github/v85/github
+[package docs]: https://pkg.go.dev/github.com/google/go-github/v86/github
 [GraphQL API v4]: https://developer.github.com/v4/
 [shurcooL/githubv4]: https://github.com/shurcooL/githubv4
 [GitHub webhook events]: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads
@@ -508,7 +508,7 @@ Versions prior to 48.2.0 are not listed.
 
 | go-github Version | GitHub v3 API Version |
 | ----------------- | --------------------- |
-| 85.0.0            | 2022-11-28            |
+| 86.0.0            | 2022-11-28            |
 | ...               | 2022-11-28            |
 | 48.2.0            | 2022-11-28            |
 

--- a/example/actionpermissions/main.go
+++ b/example/actionpermissions/main.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 var (

--- a/example/auditlogstream/main.go
+++ b/example/auditlogstream/main.go
@@ -37,7 +37,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/basicauth/main.go
+++ b/example/basicauth/main.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"golang.org/x/term"
 )
 

--- a/example/codespaces/newreposecretwithxcrypto/main.go
+++ b/example/codespaces/newreposecretwithxcrypto/main.go
@@ -37,7 +37,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/codespaces/newusersecretwithxcrypto/main.go
+++ b/example/codespaces/newusersecretwithxcrypto/main.go
@@ -38,7 +38,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -13,7 +13,7 @@
 //
 // Note, if you want to push a single file, you probably prefer to use the
 // content API. An example is available here:
-// https://pkg.go.dev/github.com/google/go-github/v85/github#example-RepositoriesService-CreateFile
+// https://pkg.go.dev/github.com/google/go-github/v86/github#example-RepositoriesService-CreateFile
 //
 // Note, for this to work at least 1 commit is needed, so you if you use this
 // after creating a repository you might want to make sure you set `AutoInit` to
@@ -33,7 +33,7 @@ import (
 	"time"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 var (
@@ -178,7 +178,7 @@ func pushCommit(ref *github.Reference, tree *github.Tree) (err error) {
 	return err
 }
 
-// createPR creates a pull request. Based on: https://pkg.go.dev/github.com/google/go-github/v85/github#example-PullRequestsService-Create
+// createPR creates a pull request. Based on: https://pkg.go.dev/github.com/google/go-github/v86/github#example-PullRequestsService-Create
 func createPR() (err error) {
 	if *prSubject == "" {
 		return errors.New("missing `-pr-title` flag; skipping PR creation")

--- a/example/contents/main.go
+++ b/example/contents/main.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 func main() {

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v85/example
+module github.com/google/go-github/v86/example
 
 go 1.25.5
 
@@ -7,8 +7,8 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0
 	github.com/gofri/go-github-pagination v1.0.1
 	github.com/gofri/go-github-ratelimit/v2 v2.0.2
-	github.com/google/go-github/otel/v85 v85.0.0
-	github.com/google/go-github/v85 v85.0.0
+	github.com/google/go-github/otel/v86 v86.0.0
+	github.com/google/go-github/v86 v86.0.0
 	github.com/sigstore/sigstore-go v1.1.4
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
@@ -88,6 +88,6 @@ require (
 )
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v85 => ../
+replace github.com/google/go-github/v86 => ../
 
-replace github.com/google/go-github/otel/v85 => ../otel
+replace github.com/google/go-github/otel/v86 => ../otel

--- a/example/listenvironments/main.go
+++ b/example/listenvironments/main.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 func main() {

--- a/example/migrations/main.go
+++ b/example/migrations/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 func fetchAllUserMigrations() ([]*github.UserMigration, error) {

--- a/example/newfilewithappauth/main.go
+++ b/example/newfilewithappauth/main.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 func main() {

--- a/example/newrepo/main.go
+++ b/example/newrepo/main.go
@@ -16,7 +16,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 var (

--- a/example/newreposecretwithxcrypto/main.go
+++ b/example/newreposecretwithxcrypto/main.go
@@ -37,7 +37,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/otel/main.go
+++ b/example/otel/main.go
@@ -13,8 +13,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/otel/v85"
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/otel/v86"
+	"github.com/google/go-github/v86/github"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/trace"
 )

--- a/example/ratelimit/main.go
+++ b/example/ratelimit/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit"
 	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit/github_primary_ratelimit"
 	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit/github_secondary_ratelimit"
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 func main() {

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 // Fetch all the public organizations' membership of a user.

--- a/example/tokenauth/main.go
+++ b/example/tokenauth/main.go
@@ -15,7 +15,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"golang.org/x/term"
 )
 

--- a/example/topics/main.go
+++ b/example/topics/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 // Fetch and lists all the public topics associated with the specified GitHub topic.

--- a/example/uploadreleaseassetfromrelease/main.go
+++ b/example/uploadreleaseassetfromrelease/main.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 func main() {

--- a/example/verifyartifact/main.go
+++ b/example/verifyartifact/main.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/verify"

--- a/github/doc.go
+++ b/github/doc.go
@@ -8,7 +8,7 @@ Package github provides a client for using the GitHub API.
 
 Usage:
 
-	import "github.com/google/go-github/v85/github"
+	import "github.com/google/go-github/v86/github"
 
 Construct a new GitHub client, then use the various services on the client to
 access different parts of the GitHub API. For example:

--- a/github/example_iterators_test.go
+++ b/github/example_iterators_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 func ExampleRepositoriesService_ListByUserIter() {

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 func ExampleMarkdownService_Render() {
@@ -72,7 +72,7 @@ func ExampleRepositoriesService_CreateFile() {
 	// so you will need to modify the example to provide an oauth client to
 	// github.NewClient() instead of nil. See the following documentation for more
 	// information on how to authenticate with the client:
-	// https://pkg.go.dev/github.com/google/go-github/v85/github#hdr-Authentication
+	// https://pkg.go.dev/github.com/google/go-github/v86/github#hdr-Authentication
 	client := github.NewClient(nil)
 
 	ctx := context.Background()
@@ -117,7 +117,7 @@ func ExamplePullRequestsService_Create() {
 	// so you will need to modify the example to provide an oauth client to
 	// github.NewClient() instead of nil. See the following documentation for more
 	// information on how to authenticate with the client:
-	// https://pkg.go.dev/github.com/google/go-github/v85/github#hdr-Authentication
+	// https://pkg.go.dev/github.com/google/go-github/v86/github#hdr-Authentication
 	client := github.NewClient(nil)
 
 	newPR := &github.NewPullRequest{
@@ -146,7 +146,7 @@ func ExampleTeamsService_ListTeams() {
 	// the example to provide an oauth client to github.NewClient() instead of nil.
 	// See the following documentation for more information on how to authenticate
 	// with the client:
-	// https://pkg.go.dev/github.com/google/go-github/v85/github#hdr-Authentication
+	// https://pkg.go.dev/github.com/google/go-github/v86/github#hdr-Authentication
 	client := github.NewClient(nil)
 
 	teamName := "Developers team"

--- a/github/github.go
+++ b/github/github.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	Version = "v85.0.0"
+	Version = "v86.0.0"
 
 	HeaderRateLimit     = "X-Ratelimit-Limit"
 	HeaderRateRemaining = "X-Ratelimit-Remaining"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v85
+module github.com/google/go-github/v86
 
 go 1.25.0
 

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -1,9 +1,9 @@
-module github.com/google/go-github/otel/v85
+module github.com/google/go-github/otel/v86
 
 go 1.25.0
 
 require (
-	github.com/google/go-github/v85 v85.0.0
+	github.com/google/go-github/v86 v86.0.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
@@ -20,4 +20,4 @@ require (
 	golang.org/x/sys v0.42.0 // indirect
 )
 
-replace github.com/google/go-github/v85 => ../
+replace github.com/google/go-github/v86 => ../

--- a/otel/transport.go
+++ b/otel/transport.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -22,7 +22,7 @@ import (
 
 const (
 	// instrumentationName is the name of this instrumentation package.
-	instrumentationName = "github.com/google/go-github/v85/otel"
+	instrumentationName = "github.com/google/go-github/v86/otel"
 )
 
 // Transport is an http.RoundTripper that instrument requests with OpenTelemetry.

--- a/test/fields/fields.go
+++ b/test/fields/fields.go
@@ -25,7 +25,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 var (

--- a/test/integration/activity_test.go
+++ b/test/integration/activity_test.go
@@ -10,7 +10,7 @@ package integration
 import (
 	"testing"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 const (

--- a/test/integration/authorizations_test.go
+++ b/test/integration/authorizations_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 const (

--- a/test/integration/github_test.go
+++ b/test/integration/github_test.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 // client is a github.Client with the default http.Client. It is authorized if auth is true.

--- a/test/integration/licences_test.go
+++ b/test/integration/licences_test.go
@@ -10,7 +10,7 @@ package integration
 import (
 	"testing"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 func TestLicenses_ListIter(t *testing.T) {

--- a/test/integration/pagination_test.go
+++ b/test/integration/pagination_test.go
@@ -10,7 +10,7 @@ package integration
 import (
 	"testing"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 func TestSecurityAdvisories_ListGlobalSecurityAdvisories(t *testing.T) {

--- a/test/integration/projects_test.go
+++ b/test/integration/projects_test.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 // Integration tests for Projects V2 endpoints defined in github/projects.go.

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 func TestRepositories_CRUD(t *testing.T) {

--- a/test/integration/users_test.go
+++ b/test/integration/users_test.go
@@ -12,7 +12,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 func TestUsers_Get(t *testing.T) {

--- a/tools/check-structfield-settings/go.mod
+++ b/tools/check-structfield-settings/go.mod
@@ -1,10 +1,10 @@
-module github.com/google/go-github/v85/tools/check-structfield-settings
+module github.com/google/go-github/v86/tools/check-structfield-settings
 
 go 1.25.0
 
 require (
 	github.com/golangci/plugin-module-register v0.1.2
-	github.com/google/go-github/v85/tools/structfield v0.0.0
+	github.com/google/go-github/v86/tools/structfield v0.0.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/tools v0.44.0
 )
@@ -15,4 +15,4 @@ require (
 )
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v85/tools/structfield v0.0.0 => ../structfield
+replace github.com/google/go-github/v86/tools/structfield v0.0.0 => ../structfield

--- a/tools/check-structfield-settings/main.go
+++ b/tools/check-structfield-settings/main.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/golangci/plugin-module-register/register"
-	"github.com/google/go-github/v85/tools/structfield"
+	"github.com/google/go-github/v86/tools/structfield"
 	"go.yaml.in/yaml/v3"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/checker"

--- a/tools/extraneousnew/go.mod
+++ b/tools/extraneousnew/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v85/tools/extraneousnew
+module github.com/google/go-github/v86/tools/extraneousnew
 
 go 1.25.0
 

--- a/tools/gen-release-notes/main.go
+++ b/tools/gen-release-notes/main.go
@@ -142,7 +142,8 @@ func newChangesSinceRelease(priorRelease string) string {
 
 func getPriorRelease() string {
 	cmdArgs := []string{"git", "describe", "--tags", "--abbrev=0"}
-	return runCommand(cmdArgs)
+	release := runCommand(cmdArgs)
+	return strings.ReplaceAll(release, "otel/", "")
 }
 
 const releaseNotesFmt = `

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/getkin/kin-openapi v0.137.0
 	github.com/google/go-cmp v0.7.0
-	github.com/google/go-github/v85 v85.0.0
+	github.com/google/go-github/v86 v86.0.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.20.0
 )
@@ -29,4 +29,4 @@ require (
 )
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v85 => ../
+replace github.com/google/go-github/v86 => ../

--- a/tools/metadata/main.go
+++ b/tools/metadata/main.go
@@ -16,7 +16,7 @@ import (
 	"path/filepath"
 
 	"github.com/alecthomas/kong"
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 var helpVars = kong.Vars{

--- a/tools/metadata/main_test.go
+++ b/tools/metadata/main_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 )
 
 func TestUpdateGo(t *testing.T) {

--- a/tools/metadata/metadata.go
+++ b/tools/metadata/metadata.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"go.yaml.in/yaml/v3"
 )
 

--- a/tools/metadata/openapi.go
+++ b/tools/metadata/openapi.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/tools/structfield/go.mod
+++ b/tools/structfield/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v85/tools/structfield
+module github.com/google/go-github/v86/tools/structfield
 
 go 1.25.0
 


### PR DESCRIPTION
This release contains the following breaking API changes:

* #4151
  BREAKING CHANGE: All internal calls now provide `Context` via the `Request` itself.
* #4159
  BREAKING CHANGE: `PrivateRegistriesService` is updated to API version `2026-03-10` with struct and response changes.

...and the following additional changes:

* #4197
* #4192
* #4187
* #4177
* #4188
* #4183
* #4184
* #4181
* #4178
* #4179
* #4176
* #4174