### PR TITLE
feat: Add issue field values support for write and read

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -19062,6 +19062,14 @@ func (i *Issue) GetID() int64 {
 	return *i.ID
 }
 
+// GetIssueFieldValues returns the IssueFieldValues slice if it's non-nil, nil otherwise.
+func (i *Issue) GetIssueFieldValues() []*IssueFieldValue {
+	if i == nil || i.IssueFieldValues == nil {
+		return nil
+	}
+	return i.IssueFieldValues
+}
+
 // GetLabels returns the Labels slice if it's non-nil, nil otherwise.
 func (i *Issue) GetLabels() []*Label {
 	if i == nil || i.Labels == nil {
@@ -19526,6 +19534,70 @@ func (i *IssueEvent) GetURL() string {
 	return *i.URL
 }
 
+// GetDataType returns the DataType field if it's non-nil, zero value otherwise.
+func (i *IssueFieldValue) GetDataType() string {
+	if i == nil || i.DataType == nil {
+		return ""
+	}
+	return *i.DataType
+}
+
+// GetIssueFieldID returns the IssueFieldID field if it's non-nil, zero value otherwise.
+func (i *IssueFieldValue) GetIssueFieldID() int64 {
+	if i == nil || i.IssueFieldID == nil {
+		return 0
+	}
+	return *i.IssueFieldID
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (i *IssueFieldValue) GetNodeID() string {
+	if i == nil || i.NodeID == nil {
+		return ""
+	}
+	return *i.NodeID
+}
+
+// GetSingleSelectOption returns the SingleSelectOption field.
+func (i *IssueFieldValue) GetSingleSelectOption() *IssueFieldValueSingleSelectOption {
+	if i == nil {
+		return nil
+	}
+	return i.SingleSelectOption
+}
+
+// GetValue returns the Value field.
+func (i *IssueFieldValue) GetValue() any {
+	if i == nil {
+		return nil
+	}
+	return i.Value
+}
+
+// GetColor returns the Color field if it's non-nil, zero value otherwise.
+func (i *IssueFieldValueSingleSelectOption) GetColor() string {
+	if i == nil || i.Color == nil {
+		return ""
+	}
+	return *i.Color
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (i *IssueFieldValueSingleSelectOption) GetID() int64 {
+	if i == nil || i.ID == nil {
+		return 0
+	}
+	return *i.ID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (i *IssueFieldValueSingleSelectOption) GetName() string {
+	if i == nil || i.Name == nil {
+		return ""
+	}
+	return *i.Name
+}
+
 // GetAssignee returns the Assignee field if it's non-nil, zero value otherwise.
 func (i *IssueImport) GetAssignee() string {
 	if i == nil || i.Assignee == nil {
@@ -19916,6 +19988,14 @@ func (i *IssueRequest) GetBody() string {
 		return ""
 	}
 	return *i.Body
+}
+
+// GetIssueFieldValues returns the IssueFieldValues slice if it's non-nil, nil otherwise.
+func (i *IssueRequest) GetIssueFieldValues() []*IssueFieldValue {
+	if i == nil || i.IssueFieldValues == nil {
+		return nil
+	}
+	return i.IssueFieldValues
 }
 
 // GetLabels returns the Labels field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -24169,6 +24169,17 @@ func TestIssue_GetID(tt *testing.T) {
 	i.GetID()
 }
 
+func TestIssue_GetIssueFieldValues(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*IssueFieldValue{}
+	i := &Issue{IssueFieldValues: zeroValue}
+	i.GetIssueFieldValues()
+	i = &Issue{}
+	i.GetIssueFieldValues()
+	i = nil
+	i.GetIssueFieldValues()
+}
+
 func TestIssue_GetLabels(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []*Label{}
@@ -24720,6 +24731,88 @@ func TestIssueEvent_GetURL(tt *testing.T) {
 	i.GetURL()
 }
 
+func TestIssueFieldValue_GetDataType(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &IssueFieldValue{DataType: &zeroValue}
+	i.GetDataType()
+	i = &IssueFieldValue{}
+	i.GetDataType()
+	i = nil
+	i.GetDataType()
+}
+
+func TestIssueFieldValue_GetIssueFieldID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int64
+	i := &IssueFieldValue{IssueFieldID: &zeroValue}
+	i.GetIssueFieldID()
+	i = &IssueFieldValue{}
+	i.GetIssueFieldID()
+	i = nil
+	i.GetIssueFieldID()
+}
+
+func TestIssueFieldValue_GetNodeID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &IssueFieldValue{NodeID: &zeroValue}
+	i.GetNodeID()
+	i = &IssueFieldValue{}
+	i.GetNodeID()
+	i = nil
+	i.GetNodeID()
+}
+
+func TestIssueFieldValue_GetSingleSelectOption(tt *testing.T) {
+	tt.Parallel()
+	i := &IssueFieldValue{}
+	i.GetSingleSelectOption()
+	i = nil
+	i.GetSingleSelectOption()
+}
+
+func TestIssueFieldValue_GetValue(tt *testing.T) {
+	tt.Parallel()
+	i := &IssueFieldValue{}
+	i.GetValue()
+	i = nil
+	i.GetValue()
+}
+
+func TestIssueFieldValueSingleSelectOption_GetColor(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &IssueFieldValueSingleSelectOption{Color: &zeroValue}
+	i.GetColor()
+	i = &IssueFieldValueSingleSelectOption{}
+	i.GetColor()
+	i = nil
+	i.GetColor()
+}
+
+func TestIssueFieldValueSingleSelectOption_GetID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int64
+	i := &IssueFieldValueSingleSelectOption{ID: &zeroValue}
+	i.GetID()
+	i = &IssueFieldValueSingleSelectOption{}
+	i.GetID()
+	i = nil
+	i.GetID()
+}
+
+func TestIssueFieldValueSingleSelectOption_GetName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &IssueFieldValueSingleSelectOption{Name: &zeroValue}
+	i.GetName()
+	i = &IssueFieldValueSingleSelectOption{}
+	i.GetName()
+	i = nil
+	i.GetName()
+}
+
 func TestIssueImport_GetAssignee(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -25203,6 +25296,17 @@ func TestIssueRequest_GetBody(tt *testing.T) {
 	i.GetBody()
 	i = nil
 	i.GetBody()
+}
+
+func TestIssueRequest_GetIssueFieldValues(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*IssueFieldValue{}
+	i := &IssueRequest{IssueFieldValues: zeroValue}
+	i.GetIssueFieldValues()
+	i = &IssueRequest{}
+	i.GetIssueFieldValues()
+	i = nil
+	i.GetIssueFieldValues()
 }
 
 func TestIssueRequest_GetLabels(tt *testing.T) {

--- a/github/issues.go
+++ b/github/issues.go
@@ -39,30 +39,31 @@ type Issue struct {
 	// Deprecated: GitHub will remove this field from Events API payloads on October 7, 2025.
 	// Use the Issues REST API endpoint to retrieve this information.
 	// See: https://docs.github.com/rest/issues/issues?apiVersion=2022-11-28#get-an-issue
-	AuthorAssociation *string           `json:"author_association,omitempty"`
-	User              *User             `json:"user,omitempty"`
-	Labels            []*Label          `json:"labels,omitempty"`
-	Assignee          *User             `json:"assignee,omitempty"`
-	Comments          *int              `json:"comments,omitempty"`
-	ClosedAt          *Timestamp        `json:"closed_at,omitempty"`
-	CreatedAt         *Timestamp        `json:"created_at,omitempty"`
-	UpdatedAt         *Timestamp        `json:"updated_at,omitempty"`
-	ClosedBy          *User             `json:"closed_by,omitempty"`
-	URL               *string           `json:"url,omitempty"`
-	HTMLURL           *string           `json:"html_url,omitempty"`
-	CommentsURL       *string           `json:"comments_url,omitempty"`
-	EventsURL         *string           `json:"events_url,omitempty"`
-	LabelsURL         *string           `json:"labels_url,omitempty"`
-	RepositoryURL     *string           `json:"repository_url,omitempty"`
-	ParentIssueURL    *string           `json:"parent_issue_url,omitempty"`
-	Milestone         *Milestone        `json:"milestone,omitempty"`
-	PullRequestLinks  *PullRequestLinks `json:"pull_request,omitempty"`
-	Repository        *Repository       `json:"repository,omitempty"`
-	Reactions         *Reactions        `json:"reactions,omitempty"`
-	Assignees         []*User           `json:"assignees,omitempty"`
-	NodeID            *string           `json:"node_id,omitempty"`
-	Draft             *bool             `json:"draft,omitempty"`
-	Type              *IssueType        `json:"type,omitempty"`
+	AuthorAssociation *string            `json:"author_association,omitempty"`
+	User              *User              `json:"user,omitempty"`
+	Labels            []*Label           `json:"labels,omitempty"`
+	Assignee          *User              `json:"assignee,omitempty"`
+	Comments          *int               `json:"comments,omitempty"`
+	ClosedAt          *Timestamp         `json:"closed_at,omitempty"`
+	CreatedAt         *Timestamp         `json:"created_at,omitempty"`
+	UpdatedAt         *Timestamp         `json:"updated_at,omitempty"`
+	ClosedBy          *User              `json:"closed_by,omitempty"`
+	URL               *string            `json:"url,omitempty"`
+	HTMLURL           *string            `json:"html_url,omitempty"`
+	CommentsURL       *string            `json:"comments_url,omitempty"`
+	EventsURL         *string            `json:"events_url,omitempty"`
+	LabelsURL         *string            `json:"labels_url,omitempty"`
+	RepositoryURL     *string            `json:"repository_url,omitempty"`
+	ParentIssueURL    *string            `json:"parent_issue_url,omitempty"`
+	Milestone         *Milestone         `json:"milestone,omitempty"`
+	PullRequestLinks  *PullRequestLinks  `json:"pull_request,omitempty"`
+	Repository        *Repository        `json:"repository,omitempty"`
+	Reactions         *Reactions         `json:"reactions,omitempty"`
+	Assignees         []*User            `json:"assignees,omitempty"`
+	NodeID            *string            `json:"node_id,omitempty"`
+	Draft             *bool              `json:"draft,omitempty"`
+	Type              *IssueType         `json:"type,omitempty"`
+	IssueFieldValues  []*IssueFieldValue `json:"issue_field_values,omitempty"`
 
 	// TextMatches is only populated from search results that request text matches
 	// See: search.go and https://docs.github.com/rest/search/#text-match-metadata
@@ -94,10 +95,11 @@ type IssueRequest struct {
 	Assignee *string   `json:"assignee,omitempty"`
 	State    *string   `json:"state,omitempty"`
 	// StateReason can be 'completed' or 'not_planned'.
-	StateReason *string   `json:"state_reason,omitempty"`
-	Milestone   *int      `json:"milestone,omitempty"`
-	Assignees   *[]string `json:"assignees,omitempty"`
-	Type        *string   `json:"type,omitempty"`
+	StateReason      *string            `json:"state_reason,omitempty"`
+	Milestone        *int               `json:"milestone,omitempty"`
+	Assignees        *[]string          `json:"assignees,omitempty"`
+	Type             *string            `json:"type,omitempty"`
+	IssueFieldValues []*IssueFieldValue `json:"issue_field_values,omitempty"`
 }
 
 // PullRequestLinks object is added to the Issue object when it's an issue included
@@ -120,6 +122,28 @@ type IssueType struct {
 	Color       *string    `json:"color,omitempty"`
 	CreatedAt   *Timestamp `json:"created_at,omitempty"`
 	UpdatedAt   *Timestamp `json:"updated_at,omitempty"`
+}
+
+// IssueFieldValueSingleSelectOption represents a single-select option for an issue field value.
+//
+// GitHub API docs: https://docs.github.com/rest/issues/issues#get-an-issue
+type IssueFieldValueSingleSelectOption struct {
+	ID    *int64  `json:"id,omitempty"`
+	Name  *string `json:"name,omitempty"`
+	Color *string `json:"color,omitempty"`
+}
+
+// IssueFieldValue represents a custom field value attached to an issue.
+// The Value field contains a string for text, single_select, and date fields,
+// or a number for numeric fields.
+//
+// GitHub API docs: https://docs.github.com/rest/issues/issues#get-an-issue
+type IssueFieldValue struct {
+	IssueFieldID       *int64                             `json:"issue_field_id,omitempty"`
+	NodeID             *string                            `json:"node_id,omitempty"`
+	DataType           *string                            `json:"data_type,omitempty"`
+	Value              any                                `json:"value,omitempty"`
+	SingleSelectOption *IssueFieldValueSingleSelectOption `json:"single_select_option,omitempty"`
 }
 
 // ListAllIssuesOptions specifies the optional parameters to the


### PR DESCRIPTION
Issue Fields are a new feature that is about to GA for GitHub. The Rest API provides support for reading fields on an issue or setting them, as mentioned in https://github.com/google/go-github/issues/4194. 

Updating the structures in this lib will enable support for fields for all the consumers, enabling discovery of this feature. 

- fixes https://github.com/google/go-github/issues/4194

