### PR TITLE
feat: Add two new fields to org `CodeSecurityConfiguration`

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -5062,6 +5062,14 @@ func (c *CodeSecurityConfiguration) GetDependabotAlerts() string {
 	return *c.DependabotAlerts
 }
 
+// GetDependabotDelegatedAlertDismissal returns the DependabotDelegatedAlertDismissal field if it's non-nil, zero value otherwise.
+func (c *CodeSecurityConfiguration) GetDependabotDelegatedAlertDismissal() string {
+	if c == nil || c.DependabotDelegatedAlertDismissal == nil {
+		return ""
+	}
+	return *c.DependabotDelegatedAlertDismissal
+}
+
 // GetDependabotSecurityUpdates returns the DependabotSecurityUpdates field if it's non-nil, zero value otherwise.
 func (c *CodeSecurityConfiguration) GetDependabotSecurityUpdates() string {
 	if c == nil || c.DependabotSecurityUpdates == nil {
@@ -5180,6 +5188,14 @@ func (c *CodeSecurityConfiguration) GetSecretScanningDelegatedBypassOptions() *S
 		return nil
 	}
 	return c.SecretScanningDelegatedBypassOptions
+}
+
+// GetSecretScanningExtendedMetadata returns the SecretScanningExtendedMetadata field if it's non-nil, zero value otherwise.
+func (c *CodeSecurityConfiguration) GetSecretScanningExtendedMetadata() string {
+	if c == nil || c.SecretScanningExtendedMetadata == nil {
+		return ""
+	}
+	return *c.SecretScanningExtendedMetadata
 }
 
 // GetSecretScanningGenericSecrets returns the SecretScanningGenericSecrets field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -6455,6 +6455,17 @@ func TestCodeSecurityConfiguration_GetDependabotAlerts(tt *testing.T) {
 	c.GetDependabotAlerts()
 }
 
+func TestCodeSecurityConfiguration_GetDependabotDelegatedAlertDismissal(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CodeSecurityConfiguration{DependabotDelegatedAlertDismissal: &zeroValue}
+	c.GetDependabotDelegatedAlertDismissal()
+	c = &CodeSecurityConfiguration{}
+	c.GetDependabotDelegatedAlertDismissal()
+	c = nil
+	c.GetDependabotDelegatedAlertDismissal()
+}
+
 func TestCodeSecurityConfiguration_GetDependabotSecurityUpdates(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -6606,6 +6617,17 @@ func TestCodeSecurityConfiguration_GetSecretScanningDelegatedBypassOptions(tt *t
 	c.GetSecretScanningDelegatedBypassOptions()
 	c = nil
 	c.GetSecretScanningDelegatedBypassOptions()
+}
+
+func TestCodeSecurityConfiguration_GetSecretScanningExtendedMetadata(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CodeSecurityConfiguration{SecretScanningExtendedMetadata: &zeroValue}
+	c.GetSecretScanningExtendedMetadata()
+	c = &CodeSecurityConfiguration{}
+	c.GetSecretScanningExtendedMetadata()
+	c = nil
+	c.GetSecretScanningExtendedMetadata()
 }
 
 func TestCodeSecurityConfiguration_GetSecretScanningGenericSecrets(tt *testing.T) {

--- a/github/orgs_codesecurity_configurations.go
+++ b/github/orgs_codesecurity_configurations.go
@@ -57,6 +57,7 @@ type CodeSecurityConfiguration struct {
 	DependencyGraphAutosubmitAction        *string                                 `json:"dependency_graph_autosubmit_action,omitempty"`
 	DependencyGraphAutosubmitActionOptions *DependencyGraphAutosubmitActionOptions `json:"dependency_graph_autosubmit_action_options,omitempty"`
 	DependabotAlerts                       *string                                 `json:"dependabot_alerts,omitempty"`
+	DependabotDelegatedAlertDismissal      *string                                 `json:"dependabot_delegated_alert_dismissal,omitempty"`
 	DependabotSecurityUpdates              *string                                 `json:"dependabot_security_updates,omitempty"`
 	CodeScanningDefaultSetup               *string                                 `json:"code_scanning_default_setup,omitempty"`
 	CodeScanningDefaultSetupOptions        *CodeScanningDefaultSetupOptions        `json:"code_scanning_default_setup_options,omitempty"`
@@ -71,6 +72,7 @@ type CodeSecurityConfiguration struct {
 	SecretScanningNonProviderPatterns      *string                                 `json:"secret_scanning_non_provider_patterns,omitempty"`
 	SecretScanningGenericSecrets           *string                                 `json:"secret_scanning_generic_secrets,omitempty"`
 	SecretScanningDelegatedAlertDismissal  *string                                 `json:"secret_scanning_delegated_alert_dismissal,omitempty"`
+	SecretScanningExtendedMetadata         *string                                 `json:"secret_scanning_extended_metadata,omitempty"`
 	SecretProtection                       *string                                 `json:"secret_protection,omitempty"`
 	PrivateVulnerabilityReporting          *string                                 `json:"private_vulnerability_reporting,omitempty"`
 	Enforcement                            *string                                 `json:"enforcement,omitempty"`


### PR DESCRIPTION
This PR updates support for organization-level code security configurations to match the latest REST API schema.

Specifically, it adds the following fields to `CodeSecurityConfiguration` in `github/orgs_codesecurity_configurations.go`:

- `dependabot_delegated_alert_dismissal`
- `secret_scanning_extended_metadata`

These fields are documented in the GitHub REST API for creating/updating code security configurations:
https://docs.github.com/en/enterprise-cloud@latest/rest/code-security/configurations?apiVersion=2026-03-10#create-a-code-security-configuration