### PR TITLE
fix!: Align `IssueFieldValues` with schema 

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -19991,7 +19991,7 @@ func (i *IssueRequest) GetBody() string {
 }
 
 // GetIssueFieldValues returns the IssueFieldValues slice if it's non-nil, nil otherwise.
-func (i *IssueRequest) GetIssueFieldValues() []*IssueFieldValue {
+func (i *IssueRequest) GetIssueFieldValues() []*IssueRequestFieldValue {
 	if i == nil || i.IssueFieldValues == nil {
 		return nil
 	}
@@ -20044,6 +20044,22 @@ func (i *IssueRequest) GetType() string {
 		return ""
 	}
 	return *i.Type
+}
+
+// GetFieldID returns the FieldID field.
+func (i *IssueRequestFieldValue) GetFieldID() int64 {
+	if i == nil {
+		return 0
+	}
+	return i.FieldID
+}
+
+// GetValue returns the Value field.
+func (i *IssueRequestFieldValue) GetValue() any {
+	if i == nil {
+		return nil
+	}
+	return i.Value
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -19534,28 +19534,28 @@ func (i *IssueEvent) GetURL() string {
 	return *i.URL
 }
 
-// GetDataType returns the DataType field if it's non-nil, zero value otherwise.
+// GetDataType returns the DataType field.
 func (i *IssueFieldValue) GetDataType() string {
-	if i == nil || i.DataType == nil {
+	if i == nil {
 		return ""
 	}
-	return *i.DataType
+	return i.DataType
 }
 
-// GetIssueFieldID returns the IssueFieldID field if it's non-nil, zero value otherwise.
+// GetIssueFieldID returns the IssueFieldID field.
 func (i *IssueFieldValue) GetIssueFieldID() int64 {
-	if i == nil || i.IssueFieldID == nil {
+	if i == nil {
 		return 0
 	}
-	return *i.IssueFieldID
+	return i.IssueFieldID
 }
 
-// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+// GetNodeID returns the NodeID field.
 func (i *IssueFieldValue) GetNodeID() string {
-	if i == nil || i.NodeID == nil {
+	if i == nil {
 		return ""
 	}
-	return *i.NodeID
+	return i.NodeID
 }
 
 // GetSingleSelectOption returns the SingleSelectOption field.
@@ -19574,28 +19574,28 @@ func (i *IssueFieldValue) GetValue() any {
 	return i.Value
 }
 
-// GetColor returns the Color field if it's non-nil, zero value otherwise.
+// GetColor returns the Color field.
 func (i *IssueFieldValueSingleSelectOption) GetColor() string {
-	if i == nil || i.Color == nil {
+	if i == nil {
 		return ""
 	}
-	return *i.Color
+	return i.Color
 }
 
-// GetID returns the ID field if it's non-nil, zero value otherwise.
+// GetID returns the ID field.
 func (i *IssueFieldValueSingleSelectOption) GetID() int64 {
-	if i == nil || i.ID == nil {
+	if i == nil {
 		return 0
 	}
-	return *i.ID
+	return i.ID
 }
 
-// GetName returns the Name field if it's non-nil, zero value otherwise.
+// GetName returns the Name field.
 func (i *IssueFieldValueSingleSelectOption) GetName() string {
-	if i == nil || i.Name == nil {
+	if i == nil {
 		return ""
 	}
-	return *i.Name
+	return i.Name
 }
 
 // GetAssignee returns the Assignee field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -25300,7 +25300,7 @@ func TestIssueRequest_GetBody(tt *testing.T) {
 
 func TestIssueRequest_GetIssueFieldValues(tt *testing.T) {
 	tt.Parallel()
-	zeroValue := []*IssueFieldValue{}
+	zeroValue := []*IssueRequestFieldValue{}
 	i := &IssueRequest{IssueFieldValues: zeroValue}
 	i.GetIssueFieldValues()
 	i = &IssueRequest{}
@@ -25373,6 +25373,22 @@ func TestIssueRequest_GetType(tt *testing.T) {
 	i.GetType()
 	i = nil
 	i.GetType()
+}
+
+func TestIssueRequestFieldValue_GetFieldID(tt *testing.T) {
+	tt.Parallel()
+	i := &IssueRequestFieldValue{}
+	i.GetFieldID()
+	i = nil
+	i.GetFieldID()
+}
+
+func TestIssueRequestFieldValue_GetValue(tt *testing.T) {
+	tt.Parallel()
+	i := &IssueRequestFieldValue{}
+	i.GetValue()
+	i = nil
+	i.GetValue()
 }
 
 func TestIssuesEvent_GetAction(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -24733,10 +24733,7 @@ func TestIssueEvent_GetURL(tt *testing.T) {
 
 func TestIssueFieldValue_GetDataType(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	i := &IssueFieldValue{DataType: &zeroValue}
-	i.GetDataType()
-	i = &IssueFieldValue{}
+	i := &IssueFieldValue{}
 	i.GetDataType()
 	i = nil
 	i.GetDataType()
@@ -24744,10 +24741,7 @@ func TestIssueFieldValue_GetDataType(tt *testing.T) {
 
 func TestIssueFieldValue_GetIssueFieldID(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue int64
-	i := &IssueFieldValue{IssueFieldID: &zeroValue}
-	i.GetIssueFieldID()
-	i = &IssueFieldValue{}
+	i := &IssueFieldValue{}
 	i.GetIssueFieldID()
 	i = nil
 	i.GetIssueFieldID()
@@ -24755,10 +24749,7 @@ func TestIssueFieldValue_GetIssueFieldID(tt *testing.T) {
 
 func TestIssueFieldValue_GetNodeID(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	i := &IssueFieldValue{NodeID: &zeroValue}
-	i.GetNodeID()
-	i = &IssueFieldValue{}
+	i := &IssueFieldValue{}
 	i.GetNodeID()
 	i = nil
 	i.GetNodeID()
@@ -24782,10 +24773,7 @@ func TestIssueFieldValue_GetValue(tt *testing.T) {
 
 func TestIssueFieldValueSingleSelectOption_GetColor(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	i := &IssueFieldValueSingleSelectOption{Color: &zeroValue}
-	i.GetColor()
-	i = &IssueFieldValueSingleSelectOption{}
+	i := &IssueFieldValueSingleSelectOption{}
 	i.GetColor()
 	i = nil
 	i.GetColor()
@@ -24793,10 +24781,7 @@ func TestIssueFieldValueSingleSelectOption_GetColor(tt *testing.T) {
 
 func TestIssueFieldValueSingleSelectOption_GetID(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue int64
-	i := &IssueFieldValueSingleSelectOption{ID: &zeroValue}
-	i.GetID()
-	i = &IssueFieldValueSingleSelectOption{}
+	i := &IssueFieldValueSingleSelectOption{}
 	i.GetID()
 	i = nil
 	i.GetID()
@@ -24804,10 +24789,7 @@ func TestIssueFieldValueSingleSelectOption_GetID(tt *testing.T) {
 
 func TestIssueFieldValueSingleSelectOption_GetName(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	i := &IssueFieldValueSingleSelectOption{Name: &zeroValue}
-	i.GetName()
-	i = &IssueFieldValueSingleSelectOption{}
+	i := &IssueFieldValueSingleSelectOption{}
 	i.GetName()
 	i = nil
 	i.GetName()

--- a/github/issues.go
+++ b/github/issues.go
@@ -147,9 +147,9 @@ type IssueRequestFieldValue struct {
 //
 // GitHub API docs: https://docs.github.com/rest/issues/issues?apiVersion=2022-11-28#get-an-issue
 type IssueFieldValue struct {
-	IssueFieldID       int64                             `json:"issue_field_id"`
-	NodeID             string                            `json:"node_id"`
-	DataType           string                            `json:"data_type"`
+	IssueFieldID       int64                              `json:"issue_field_id"`
+	NodeID             string                             `json:"node_id"`
+	DataType           string                             `json:"data_type"`
 	Value              any                                `json:"value"`
 	SingleSelectOption *IssueFieldValueSingleSelectOption `json:"single_select_option,omitempty"`
 }

--- a/github/issues.go
+++ b/github/issues.go
@@ -128,9 +128,9 @@ type IssueType struct {
 //
 // GitHub API docs: https://docs.github.com/rest/issues/issues?apiVersion=2022-11-28#get-an-issue
 type IssueFieldValueSingleSelectOption struct {
-	ID    *int64  `json:"id"`
-	Name  *string `json:"name"`
-	Color *string `json:"color"`
+	ID    int64  `json:"id"`
+	Name  string `json:"name"`
+	Color string `json:"color"`
 }
 
 // IssueRequestFieldValue represents a custom field value to set on an issue.
@@ -147,9 +147,9 @@ type IssueRequestFieldValue struct {
 //
 // GitHub API docs: https://docs.github.com/rest/issues/issues?apiVersion=2022-11-28#get-an-issue
 type IssueFieldValue struct {
-	IssueFieldID       *int64                             `json:"issue_field_id"`
-	NodeID             *string                            `json:"node_id"`
-	DataType           *string                            `json:"data_type"`
+	IssueFieldID       int64                             `json:"issue_field_id"`
+	NodeID             string                            `json:"node_id"`
+	DataType           string                            `json:"data_type"`
 	Value              any                                `json:"value"`
 	SingleSelectOption *IssueFieldValueSingleSelectOption `json:"single_select_option,omitempty"`
 }

--- a/github/issues.go
+++ b/github/issues.go
@@ -95,11 +95,11 @@ type IssueRequest struct {
 	Assignee *string   `json:"assignee,omitempty"`
 	State    *string   `json:"state,omitempty"`
 	// StateReason can be 'completed' or 'not_planned'.
-	StateReason      *string            `json:"state_reason,omitempty"`
-	Milestone        *int               `json:"milestone,omitempty"`
-	Assignees        *[]string          `json:"assignees,omitempty"`
-	Type             *string            `json:"type,omitempty"`
-	IssueFieldValues []*IssueFieldValue `json:"issue_field_values,omitempty"`
+	StateReason      *string                   `json:"state_reason,omitempty"`
+	Milestone        *int                      `json:"milestone,omitempty"`
+	Assignees        *[]string                 `json:"assignees,omitempty"`
+	Type             *string                   `json:"type,omitempty"`
+	IssueFieldValues []*IssueRequestFieldValue `json:"issue_field_values,omitempty"`
 }
 
 // PullRequestLinks object is added to the Issue object when it's an issue included
@@ -126,23 +126,31 @@ type IssueType struct {
 
 // IssueFieldValueSingleSelectOption represents a single-select option for an issue field value.
 //
-// GitHub API docs: https://docs.github.com/rest/issues/issues#get-an-issue
+// GitHub API docs: https://docs.github.com/rest/issues/issues?apiVersion=2022-11-28#get-an-issue
 type IssueFieldValueSingleSelectOption struct {
-	ID    *int64  `json:"id,omitempty"`
-	Name  *string `json:"name,omitempty"`
-	Color *string `json:"color,omitempty"`
+	ID    *int64  `json:"id"`
+	Name  *string `json:"name"`
+	Color *string `json:"color"`
+}
+
+// IssueRequestFieldValue represents a custom field value to set on an issue.
+//
+// GitHub API docs: https://docs.github.com/rest/issues/issues?apiVersion=2022-11-28#update-an-issue
+type IssueRequestFieldValue struct {
+	FieldID int64 `json:"field_id"`
+	Value   any   `json:"value"`
 }
 
 // IssueFieldValue represents a custom field value attached to an issue.
 // The Value field contains a string for text, single_select, and date fields,
 // or a number for numeric fields.
 //
-// GitHub API docs: https://docs.github.com/rest/issues/issues#get-an-issue
+// GitHub API docs: https://docs.github.com/rest/issues/issues?apiVersion=2022-11-28#get-an-issue
 type IssueFieldValue struct {
-	IssueFieldID       *int64                             `json:"issue_field_id,omitempty"`
-	NodeID             *string                            `json:"node_id,omitempty"`
-	DataType           *string                            `json:"data_type,omitempty"`
-	Value              any                                `json:"value,omitempty"`
+	IssueFieldID       *int64                             `json:"issue_field_id"`
+	NodeID             *string                            `json:"node_id"`
+	DataType           *string                            `json:"data_type"`
+	Value              any                                `json:"value"`
 	SingleSelectOption *IssueFieldValueSingleSelectOption `json:"single_select_option,omitempty"`
 }
 


### PR DESCRIPTION
BREAKING CHANGE: `IssueRequest.IssueFieldValues` type is changed.

Follow-up update after https://github.com/google/go-github/pull/4200:
 
- Split read vs write models for clarity and API correctness:
  - Added `IssueRequestFieldValue` for update/create payloads (`field_id`, `value`).
  - Kept IssueFieldValue for response decoding.
- Aligned response model style with existing conventions:
  - Response fields remain pointer-based for resilience
- Aligned required/optional fields with the published schema 