### PR TITLE
fix!: Support omitting `EnforceAdmins`

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -28678,12 +28678,12 @@ func (p *ProtectionRequest) GetBlockCreations() bool {
 	return *p.BlockCreations
 }
 
-// GetEnforceAdmins returns the EnforceAdmins field.
+// GetEnforceAdmins returns the EnforceAdmins field if it's non-nil, zero value otherwise.
 func (p *ProtectionRequest) GetEnforceAdmins() bool {
-	if p == nil {
+	if p == nil || p.EnforceAdmins == nil {
 		return false
 	}
-	return p.EnforceAdmins
+	return *p.EnforceAdmins
 }
 
 // GetLockBranch returns the LockBranch field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -36226,7 +36226,10 @@ func TestProtectionRequest_GetBlockCreations(tt *testing.T) {
 
 func TestProtectionRequest_GetEnforceAdmins(tt *testing.T) {
 	tt.Parallel()
-	p := &ProtectionRequest{}
+	var zeroValue bool
+	p := &ProtectionRequest{EnforceAdmins: &zeroValue}
+	p.GetEnforceAdmins()
+	p = &ProtectionRequest{}
 	p.GetEnforceAdmins()
 	p = nil
 	p.GetEnforceAdmins()

--- a/github/repos.go
+++ b/github/repos.go
@@ -1204,8 +1204,9 @@ type RequireLastPushApprovalChanges struct {
 type ProtectionRequest struct {
 	RequiredStatusChecks       *RequiredStatusChecks                 `json:"required_status_checks"`
 	RequiredPullRequestReviews *PullRequestReviewsEnforcementRequest `json:"required_pull_request_reviews"`
-	EnforceAdmins              bool                                  `json:"enforce_admins"`
-	Restrictions               *BranchRestrictionsRequest            `json:"restrictions"`
+	// Set to true to enforce branch protection for admins; leave null to not enforce.
+	EnforceAdmins *bool                      `json:"enforce_admins,omitempty"`
+	Restrictions  *BranchRestrictionsRequest `json:"restrictions"`
 	// Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch.
 	RequireLinearHistory *bool `json:"required_linear_history,omitempty"`
 	// Permits force pushes to the protected branch by anyone with write access to the repository.

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -94,7 +94,7 @@ func TestRepositories_EditBranches(t *testing.T) {
 		RequiredPullRequestReviews: &github.PullRequestReviewsEnforcementRequest{
 			DismissStaleReviews: true,
 		},
-		EnforceAdmins: true,
+		EnforceAdmins: github.Ptr(true),
 		// TODO: Only organization repositories can have users and team restrictions.
 		//       In order to be able to test these Restrictions, need to add support
 		//       for creating temporary organization repositories.


### PR DESCRIPTION
https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2026-03-10

<img width="603" height="101" alt="image" src="https://github.com/user-attachments/assets/3a689b90-c23f-4bf4-96a4-e79db6e86ba1" />

I think it's worth noting that this does change the default behaviour of the request. Because it previously would send `false` even if not explicitly set by user, this would toggle the setting to true (as not null). Whereas here, not setting the field will send null, and thus true.

You could flip that logic by having it be `DoNotEnforceAdmins *bool` but then there would need to be a translation between the ProtectionRequest that the user uses and the one that is JSON-marshalled to the API.

With that in mind I am happy for you to adapt this PR to a different approach if it seems better to you.