### PR TITLE
fix: Close `httptest` server to prevent test flakiness

### DIFF
--- a/github/github_test.go
+++ b/github/github_test.go
@@ -477,7 +477,7 @@ func TestWithAuthToken(t *testing.T) {
 			gotReq = true
 			headerVal = r.Header.Get("Authorization")
 		}))
-		defer srv.Close()
+		t.Cleanup(srv.Close)
 		_, err := c.Get(srv.URL)
 		assertNilError(t, err)
 		if !gotReq {
@@ -518,7 +518,7 @@ func TestWithAuthToken(t *testing.T) {
 			gotReq = true
 			_, ifAuthorizationSet = r.Header["Authorization"]
 		}))
-		defer srv.Close()
+		t.Cleanup(srv.Close)
 		_, err := c.client.Get(srv.URL)
 		assertNilError(t, err)
 		if !gotReq {

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -477,6 +477,7 @@ func TestWithAuthToken(t *testing.T) {
 			gotReq = true
 			headerVal = r.Header.Get("Authorization")
 		}))
+		defer srv.Close()
 		_, err := c.Get(srv.URL)
 		assertNilError(t, err)
 		if !gotReq {
@@ -517,6 +518,7 @@ func TestWithAuthToken(t *testing.T) {
 			gotReq = true
 			_, ifAuthorizationSet = r.Header["Authorization"]
 		}))
+		defer srv.Close()
 		_, err := c.client.Get(srv.URL)
 		assertNilError(t, err)
 		if !gotReq {


### PR DESCRIPTION
This PR should address the test flakiness demonstrated here:
https://github.com/google/go-github/actions/runs/25682256160/job/75396628089

The `httptest.Server` instances in `TestWithAuthToken` were never explicitly closed, relying on garbage collection finalizers to clean up. The GC finalizer calls `Close() → CloseIdleConnections()` on the transport, which races with the HTTP client's connection pool, producing:

> net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called

This was especially likely under `-race` and on the Linux runner. Adding `defer srv.Close()` to both `httptest.NewServer` calls causes the server is shut down deterministically before the test returns, preventing the broken-connection race.