### PR TITLE
fix: Use value receiver for `MarshalJSON`

### DIFF
--- a/github/git_trees.go
+++ b/github/git_trees.go
@@ -66,7 +66,7 @@ type treeEntryWithFileDelete struct {
 }
 
 // MarshalJSON implements the json.Marshaler interface.
-func (t *TreeEntry) MarshalJSON() ([]byte, error) {
+func (t TreeEntry) MarshalJSON() ([]byte, error) {
 	if t.SHA == nil && t.Content == nil {
 		return json.Marshal(struct {
 			SHA  *string `json:"sha"`

--- a/github/git_trees_test.go
+++ b/github/git_trees_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestMarshalJSON_withNilContentAndSHA(t *testing.T) {
 	t.Parallel()
-	te := &TreeEntry{
+	te := TreeEntry{
 		Path: Ptr("path"),
 		Mode: Ptr("mode"),
 		Type: Ptr("type"),
@@ -25,15 +25,9 @@ func TestMarshalJSON_withNilContentAndSHA(t *testing.T) {
 		URL:  Ptr("url"),
 	}
 
-	got, err := te.MarshalJSON()
-	if err != nil {
-		t.Errorf("MarshalJSON: %v", err)
-	}
-
 	want := `{"sha":null,"path":"path","mode":"mode","type":"type"}`
-	if string(got) != want {
-		t.Errorf("MarshalJSON = %v, want %v", got, want)
-	}
+	testJSONMarshalOnly(t, te, want)
+	testJSONMarshalOnly(t, &te, want)
 }
 
 func TestGitService_GetTree(t *testing.T) {

--- a/github/orgs_audit_log.go
+++ b/github/orgs_audit_log.go
@@ -91,9 +91,9 @@ func (a *AuditEntry) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON implements the json.Marshaler interface.
-func (a *AuditEntry) MarshalJSON() ([]byte, error) {
+func (a AuditEntry) MarshalJSON() ([]byte, error) {
 	type entryAlias AuditEntry
-	v := entryAlias(*a)
+	v := entryAlias(a)
 	defBytes, err := json.Marshal(v)
 	if err != nil {
 		return nil, err

--- a/github/orgs_audit_log_test.go
+++ b/github/orgs_audit_log_test.go
@@ -189,7 +189,7 @@ func TestAuditEntry_Marshal(t *testing.T) {
 	t.Parallel()
 	testJSONMarshal(t, &AuditEntry{}, "{}")
 
-	u := &AuditEntry{
+	u := AuditEntry{
 		Action:                   Ptr("a"),
 		Actor:                    Ptr("ac"),
 		ActorLocation:            &ActorLocation{CountryCode: Ptr("alcc")},
@@ -384,5 +384,6 @@ func TestAuditEntry_Marshal(t *testing.T) {
 	}`
 
 	testJSONMarshalOnly(t, u, want)
+	testJSONMarshalOnly(t, &u, want)
 	// can't unmarshal AdditionalFields back into map[string]any, so skip testJSONUnmarshalOnly
 }

--- a/github/projects.go
+++ b/github/projects.go
@@ -164,7 +164,7 @@ type ProjectV2ItemContent struct {
 }
 
 // MarshalJSON implements custom marshaling for ProjectV2ItemContent.
-func (c *ProjectV2ItemContent) MarshalJSON() ([]byte, error) {
+func (c ProjectV2ItemContent) MarshalJSON() ([]byte, error) {
 	if c.Issue != nil {
 		return json.Marshal(c.Issue)
 	}

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -1592,9 +1592,9 @@ func TestProjectV2Item_Marshal_Issue(t *testing.T) {
 
 func TestProjectV2Item_Marshal_PullRequest(t *testing.T) {
 	t.Parallel()
-	testJSONMarshal(t, &ProjectV2Item{}, "{}")
+	testJSONMarshal(t, ProjectV2Item{}, "{}")
 
-	item := &ProjectV2Item{
+	item := ProjectV2Item{
 		ContentType: Ptr(ProjectV2ItemContentTypePullRequest),
 		Content: &ProjectV2ItemContent{
 			PullRequest: &PullRequest{
@@ -1661,4 +1661,63 @@ func TestProjectV2Item_Marshal_MissingContent(t *testing.T) {
 	}`
 
 	testJSONMarshal(t, item, want)
+}
+
+func TestProjectV2ItemContent_Marshal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("issue", func(t *testing.T) {
+		content := ProjectV2ItemContent{
+			Issue: &Issue{
+				Number: Ptr(42),
+				Title:  Ptr("Bug report"),
+				State:  Ptr("open"),
+			},
+		}
+
+		want := `{
+			"number":42,
+			"state":"open",
+			"title":"Bug report"
+		}`
+
+		testJSONMarshalOnly(t, content, want)
+		testJSONMarshalOnly(t, &content, want)
+	})
+
+	t.Run("pull request", func(t *testing.T) {
+		content := ProjectV2ItemContent{
+			PullRequest: &PullRequest{
+				Number: Ptr(99),
+				Title:  Ptr("Feature addition"),
+				State:  Ptr("closed"),
+			},
+		}
+
+		want := `{
+			"number":99,
+			"state":"closed",
+			"title":"Feature addition"
+		}`
+
+		testJSONMarshalOnly(t, content, want)
+		testJSONMarshalOnly(t, &content, want)
+	})
+
+	t.Run("draft issue", func(t *testing.T) {
+		content := ProjectV2ItemContent{
+			DraftIssue: &ProjectV2DraftIssue{
+				Title: Ptr("Draft task"),
+				Body:  Ptr("Work in progress"),
+			},
+		}
+
+		want := `{
+			"body":"Work in progress",
+			"title":"Draft task"
+		}`
+
+		testJSONMarshalOnly(t, content, want)
+		testJSONMarshalOnly(t, &content, want)
+	})
 }

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -1667,6 +1667,8 @@ func TestProjectV2ItemContent_Marshal(t *testing.T) {
 	t.Parallel()
 
 	t.Run("issue", func(t *testing.T) {
+		t.Parallel()
+
 		content := ProjectV2ItemContent{
 			Issue: &Issue{
 				Number: Ptr(42),
@@ -1686,6 +1688,8 @@ func TestProjectV2ItemContent_Marshal(t *testing.T) {
 	})
 
 	t.Run("pull request", func(t *testing.T) {
+		t.Parallel()
+
 		content := ProjectV2ItemContent{
 			PullRequest: &PullRequest{
 				Number: Ptr(99),
@@ -1705,6 +1709,8 @@ func TestProjectV2ItemContent_Marshal(t *testing.T) {
 	})
 
 	t.Run("draft issue", func(t *testing.T) {
+		t.Parallel()
+
 		content := ProjectV2ItemContent{
 			DraftIssue: &ProjectV2DraftIssue{
 				Title: Ptr("Draft task"),

--- a/github/repos_environments.go
+++ b/github/repos_environments.go
@@ -153,8 +153,8 @@ func (s *RepositoriesService) GetEnvironment(ctx context.Context, owner, repo, n
 // MarshalJSON implements the json.Marshaler interface.
 // As the only way to clear a WaitTimer is to set it to 0, a missing WaitTimer object should default to 0, not null.
 // As the default value for CanAdminsBypass is true, a nil value here marshals to true.
-func (c *CreateUpdateEnvironment) MarshalJSON() ([]byte, error) {
-	type Alias CreateUpdateEnvironment
+func (c CreateUpdateEnvironment) MarshalJSON() ([]byte, error) {
+	type alias CreateUpdateEnvironment
 	if c.WaitTimer == nil {
 		c.WaitTimer = Ptr(0)
 	}
@@ -162,9 +162,9 @@ func (c *CreateUpdateEnvironment) MarshalJSON() ([]byte, error) {
 		c.CanAdminsBypass = Ptr(true)
 	}
 	return json.Marshal(&struct {
-		*Alias
+		alias
 	}{
-		Alias: (*Alias)(c),
+		alias: alias(c),
 	})
 }
 

--- a/github/repos_environments_test.go
+++ b/github/repos_environments_test.go
@@ -88,17 +88,11 @@ func TestRequiredReviewer_UnmarshalJSON(t *testing.T) {
 
 func TestCreateUpdateEnvironment_MarshalJSON(t *testing.T) {
 	t.Parallel()
-	cu := &CreateUpdateEnvironment{}
-
-	got, err := cu.MarshalJSON()
-	if err != nil {
-		t.Errorf("MarshalJSON: %v", err)
-	}
+	cu := CreateUpdateEnvironment{}
 
 	want := `{"wait_timer":0,"reviewers":null,"can_admins_bypass":true,"deployment_branch_policy":null}`
-	if string(got) != want {
-		t.Errorf("MarshalJSON = %v, want %v", got, want)
-	}
+	testJSONMarshalOnly(t, cu, want)
+	testJSONMarshalOnly(t, &cu, want)
 }
 
 func TestRepositoriesService_ListEnvironments(t *testing.T) {

--- a/github/rules.go
+++ b/github/rules.go
@@ -611,7 +611,7 @@ type repositoryRulesetRuleWrapper struct {
 }
 
 // MarshalJSON is a custom JSON marshaler for RulesetRules.
-func (r *RepositoryRulesetRules) MarshalJSON() ([]byte, error) {
+func (r RepositoryRulesetRules) MarshalJSON() ([]byte, error) {
 	var rawRules []json.RawMessage
 
 	if r.Creation != nil {

--- a/github/rules_test.go
+++ b/github/rules_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestRulesetRules(t *testing.T) {
+func TestRepositoryRulesetRules(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name  string
@@ -259,19 +259,8 @@ func TestRulesetRules(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				t.Parallel()
 
-				got, err := json.Marshal(test.rules)
-				if err != nil {
-					t.Errorf("Unable to marshal JSON for %#v", test.rules)
-				}
-
-				if diff := cmp.Diff(test.json, string(got)); diff != "" {
-					t.Errorf(
-						"json.Marshal returned:\n%v\nwant:\n%v\ndiff:\n%v",
-						got,
-						test.json,
-						diff,
-					)
-				}
+				testJSONMarshalOnly(t, test.rules, test.json)
+				testJSONMarshalOnly(t, *test.rules, test.json)
 			})
 		}
 	})


### PR DESCRIPTION
Consistently use value receivers for `MarshalJSON` methods.

The issue is clearly illustrated by the following program, where `panic` is never called. However, if we change `p := Person{"Bob"}` to `p := &Person{"Bob"}`, everything works as expected, and the panic occurs.

```go
package main

import (
	"encoding/json"
	"fmt"
)

type Person struct {
	Name string
}

func (p *Person) MarshalJSON() ([]byte, error) {
	panic("unexpected")
}

func main() {
	p := Person{"Bob"}
	b, err := json.Marshal(p)
	if err != nil {
		panic(err)
	}
	fmt.Printf("%s\n", b)
}
```

The issue exists only in `encoding/json` v1. The experimental `encoding/json/v2` package does not have this issue.

See https://go.dev/issue/22967 for more details.

I think this is a non-breaking change.