### PR TITLE
refactor!: Change `GetAllRepositoryRulesets` to `ListAllRepositoryRulesets`

### DIFF
--- a/github/github-iterators.go
+++ b/github/github-iterators.go
@@ -3998,6 +3998,37 @@ func (s *OrganizationsService) ListIter(ctx context.Context, user string, opts *
 	}
 }
 
+// ListAllRepositoryRulesetsIter returns an iterator that paginates through all results of ListAllRepositoryRulesets.
+func (s *OrganizationsService) ListAllRepositoryRulesetsIter(ctx context.Context, org string, opts *ListOptions) iter.Seq2[*RepositoryRuleset, error] {
+	return func(yield func(*RepositoryRuleset, error) bool) {
+		// Create a copy of opts to avoid mutating the caller's struct
+		if opts == nil {
+			opts = &ListOptions{}
+		} else {
+			opts = Ptr(*opts)
+		}
+
+		for {
+			results, resp, err := s.ListAllRepositoryRulesets(ctx, org, opts)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			for _, item := range results {
+				if !yield(item, nil) {
+					return
+				}
+			}
+
+			if resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
+		}
+	}
+}
+
 // ListAttestationsIter returns an iterator that paginates through all results of ListAttestations.
 func (s *OrganizationsService) ListAttestationsIter(ctx context.Context, org string, subjectDigest string, opts *ListOptions) iter.Seq2[*Attestation, error] {
 	return func(yield func(*Attestation, error) bool) {

--- a/github/github-iterators_test.go
+++ b/github/github-iterators_test.go
@@ -8727,6 +8727,78 @@ func TestOrganizationsService_ListIter(t *testing.T) {
 	}
 }
 
+func TestOrganizationsService_ListAllRepositoryRulesetsIter(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+	var callNum int
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		callNum++
+		switch callNum {
+		case 1:
+			w.Header().Set("Link", `<https://api.github.com/?page=1>; rel="next"`)
+			fmt.Fprint(w, `[{},{},{}]`)
+		case 2:
+			fmt.Fprint(w, `[{},{},{},{}]`)
+		case 3:
+			fmt.Fprint(w, `[{},{}]`)
+		case 4:
+			w.WriteHeader(http.StatusNotFound)
+		case 5:
+			fmt.Fprint(w, `[{},{}]`)
+		}
+	})
+
+	iter := client.Organizations.ListAllRepositoryRulesetsIter(t.Context(), "", nil)
+	var gotItems int
+	for _, err := range iter {
+		gotItems++
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+	if want := 7; gotItems != want {
+		t.Errorf("client.Organizations.ListAllRepositoryRulesetsIter call 1 got %v items; want %v", gotItems, want)
+	}
+
+	opts := &ListOptions{}
+	iter = client.Organizations.ListAllRepositoryRulesetsIter(t.Context(), "", opts)
+	gotItems = 0
+	for _, err := range iter {
+		gotItems++
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+	if want := 2; gotItems != want {
+		t.Errorf("client.Organizations.ListAllRepositoryRulesetsIter call 2 got %v items; want %v", gotItems, want)
+	}
+
+	iter = client.Organizations.ListAllRepositoryRulesetsIter(t.Context(), "", nil)
+	gotItems = 0
+	for _, err := range iter {
+		gotItems++
+		if err == nil {
+			t.Error("expected error; got nil")
+		}
+	}
+	if gotItems != 1 {
+		t.Errorf("client.Organizations.ListAllRepositoryRulesetsIter call 3 got %v items; want 1 (an error)", gotItems)
+	}
+
+	iter = client.Organizations.ListAllRepositoryRulesetsIter(t.Context(), "", nil)
+	gotItems = 0
+	iter(func(item *RepositoryRuleset, err error) bool {
+		gotItems++
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		return false
+	})
+	if gotItems != 1 {
+		t.Errorf("client.Organizations.ListAllRepositoryRulesetsIter call 4 got %v items; want 1 (an error)", gotItems)
+	}
+}
+
 func TestOrganizationsService_ListAttestationsIter(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)

--- a/github/orgs_rules.go
+++ b/github/orgs_rules.go
@@ -10,12 +10,12 @@ import (
 	"fmt"
 )
 
-// GetAllRepositoryRulesets gets all the repository rulesets for the specified organization.
+// ListAllRepositoryRulesets gets all the repository rulesets for the specified organization.
 //
 // GitHub API docs: https://docs.github.com/rest/orgs/rules?apiVersion=2022-11-28#get-all-organization-repository-rulesets
 //
 //meta:operation GET /orgs/{org}/rulesets
-func (s *OrganizationsService) GetAllRepositoryRulesets(ctx context.Context, org string, opts *ListOptions) ([]*RepositoryRuleset, *Response, error) {
+func (s *OrganizationsService) ListAllRepositoryRulesets(ctx context.Context, org string, opts *ListOptions) ([]*RepositoryRuleset, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/rulesets", org)
 
 	u, err := addOptions(u, opts)

--- a/github/orgs_rules_test.go
+++ b/github/orgs_rules_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestOrganizationsService_GetAllRepositoryRulesets(t *testing.T) {
+func TestOrganizationsService_ListAllRepositoryRulesets(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -38,9 +38,9 @@ func TestOrganizationsService_GetAllRepositoryRulesets(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	rulesets, _, err := client.Organizations.GetAllRepositoryRulesets(ctx, "o", nil)
+	rulesets, _, err := client.Organizations.ListAllRepositoryRulesets(ctx, "o", nil)
 	if err != nil {
-		t.Errorf("Organizations.GetAllRepositoryRulesets returned error: %v", err)
+		t.Errorf("Organizations.ListAllRepositoryRulesets returned error: %v", err)
 	}
 
 	want := []*RepositoryRuleset{{
@@ -56,12 +56,12 @@ func TestOrganizationsService_GetAllRepositoryRulesets(t *testing.T) {
 		},
 	}}
 	if !cmp.Equal(rulesets, want) {
-		t.Errorf("Organizations.GetAllRepositoryRulesets returned %+v, want %+v", rulesets, want)
+		t.Errorf("Organizations.ListAllRepositoryRulesets returned %+v, want %+v", rulesets, want)
 	}
 
-	const methodName = "GetAllRepositoryRulesets"
+	const methodName = "ListAllRepositoryRulesets"
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Organizations.GetAllRepositoryRulesets(ctx, "o", nil)
+		got, resp, err := client.Organizations.ListAllRepositoryRulesets(ctx, "o", nil)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -69,7 +69,7 @@ func TestOrganizationsService_GetAllRepositoryRulesets(t *testing.T) {
 	})
 }
 
-func TestOrganizationsService_GetAllRepositoryRulesets_ListOptions(t *testing.T) {
+func TestOrganizationsService_ListAllRepositoryRulesets_ListOptions(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -86,26 +86,26 @@ func TestOrganizationsService_GetAllRepositoryRulesets_ListOptions(t *testing.T)
 
 	opts := &ListOptions{Page: 2, PerPage: 35}
 	ctx := t.Context()
-	rulesets, _, err := client.Organizations.GetAllRepositoryRulesets(ctx, "o", opts)
+	rulesets, _, err := client.Organizations.ListAllRepositoryRulesets(ctx, "o", opts)
 	if err != nil {
-		t.Errorf("Organizations.GetAllRepositoryRulesets returned error: %v", err)
+		t.Errorf("Organizations.ListAllRepositoryRulesets returned error: %v", err)
 	}
 
 	want := []*RepositoryRuleset{{
 		ID: Ptr(int64(21)),
 	}}
 	if !cmp.Equal(rulesets, want) {
-		t.Errorf("Organizations.GetAllRepositoryRulesets returned %+v, want %+v", rulesets, want)
+		t.Errorf("Organizations.ListAllRepositoryRulesets returned %+v, want %+v", rulesets, want)
 	}
 
-	const methodName = "GetAllRepositoryRulesets"
+	const methodName = "ListAllRepositoryRulesets"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Organizations.GetAllRepositoryRulesets(ctx, "\n", opts)
+		_, _, err = client.Organizations.ListAllRepositoryRulesets(ctx, "\n", opts)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Organizations.GetAllRepositoryRulesets(ctx, "o", opts)
+		got, resp, err := client.Organizations.ListAllRepositoryRulesets(ctx, "o", opts)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}


### PR DESCRIPTION
BREAKING CHANGE: `OrganizationsService.GetAllRepositoryRulesets` is now `OrganizationsService.ListAllRepositoryRulesets`.

Relates to: #4117.

cc: @stevehipwell - @alexandear - @zyfy29 - @Not-Dhananjay-Mishra - @munlicode 