### PR TITLE
feat: Add enterprise app installation lookup

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -457,6 +457,15 @@ func (s *AppsService) FindOrganizationInstallation(ctx context.Context, org stri
 	return s.getInstallation(ctx, fmt.Sprintf("orgs/%v/installation", org))
 }
 
+// FindEnterpriseInstallation finds the enterprise's installation information.
+//
+// GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/apps/apps#get-an-enterprise-installation-for-the-authenticated-app
+//
+//meta:operation GET /enterprises/{enterprise}/installation
+func (s *AppsService) FindEnterpriseInstallation(ctx context.Context, enterprise string) (*Installation, *Response, error) {
+	return s.getInstallation(ctx, fmt.Sprintf("enterprises/%v/installation", enterprise))
+}
+
 // FindRepositoryInstallation finds the repository's installation information.
 //
 // GitHub API docs: https://docs.github.com/rest/apps/apps?apiVersion=2022-11-28#get-a-repository-installation-for-the-authenticated-app

--- a/github/apps.go
+++ b/github/apps.go
@@ -459,7 +459,7 @@ func (s *AppsService) FindOrganizationInstallation(ctx context.Context, org stri
 
 // FindEnterpriseInstallation finds the enterprise's installation information.
 //
-// GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/apps/apps#get-an-enterprise-installation-for-the-authenticated-app
+// GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/apps/apps?apiVersion=2022-11-28#get-an-enterprise-installation-for-the-authenticated-app
 //
 //meta:operation GET /enterprises/{enterprise}/installation
 func (s *AppsService) FindEnterpriseInstallation(ctx context.Context, enterprise string) (*Installation, *Response, error) {

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -604,6 +604,41 @@ func TestAppsService_FindOrganizationInstallation(t *testing.T) {
 	})
 }
 
+func TestAppsService_FindEnterpriseInstallation(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/enterprises/e/installation", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":1, "app_id":1, "target_id":1, "target_type": "Enterprise"}`)
+	})
+
+	ctx := t.Context()
+	installation, _, err := client.Apps.FindEnterpriseInstallation(ctx, "e")
+	if err != nil {
+		t.Errorf("Apps.FindEnterpriseInstallation returned error: %v", err)
+	}
+
+	want := &Installation{ID: Ptr(int64(1)), AppID: Ptr(int64(1)), TargetID: Ptr(int64(1)), TargetType: Ptr("Enterprise")}
+	if !cmp.Equal(installation, want) {
+		t.Errorf("Apps.FindEnterpriseInstallation returned %+v, want %+v", installation, want)
+	}
+
+	const methodName = "FindEnterpriseInstallation"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Apps.FindEnterpriseInstallation(ctx, "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Apps.FindEnterpriseInstallation(ctx, "e")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
 func TestAppsService_FindRepositoryInstallation(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)


### PR DESCRIPTION
## Summary

Adds support for looking up a GitHub App installation for an enterprise.

This implements the new `AppsService.FindEnterpriseInstallation` helper for:

```http
GET /enterprises/{enterprise}/installation
```

The method follows the existing app installation lookup pattern already used for organization, repository, and user installations.

## Details

- Added `FindEnterpriseInstallation(ctx, enterprise)` to `AppsService`
- Uses the enterprise installation endpoint:
  - `GET /enterprises/{enterprise}/installation`
- Reuses the existing `Installation` model
- Keeps the implementation aligned with the existing installation lookup helpers
- Adds coverage for:
  - successful enterprise installation lookup
  - bad options handling
  - request/do failure handling

## Testing

```bash
gofmt -w github/apps.go github/apps_test.go
go test ./github -run 'Apps|Installation'
go test ./...
```

All tests passed locally.

Fixes #4212
