### PR TITLE
feat: Add client API version support

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -159,9 +159,6 @@ const (
 	mediaTypeContentAttachmentsPreview = "application/vnd.github.corsair-preview+json"
 )
 
-// apiVersionRegexp is a regular expression to validate API version strings.
-var apiVersionRegexp = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
-
 // ErrPathForbidden is returned when a URL path contains ".." as a path
 // segment, which could allow path traversal attacks.
 var ErrPathForbidden = errors.New("path must not contain '..' due to auth vulnerability issue")

--- a/github/github.go
+++ b/github/github.go
@@ -161,6 +161,9 @@ const (
 	mediaTypeContentAttachmentsPreview = "application/vnd.github.corsair-preview+json"
 )
 
+// apiVersionRegexp is a regular expression to validate API version strings.
+var apiVersionRegexp = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+
 // ErrPathForbidden is returned when a URL path contains ".." as a path
 // segment, which could allow path traversal attacks.
 var ErrPathForbidden = errors.New("path must not contain '..' due to auth vulnerability issue")
@@ -177,6 +180,9 @@ type Client struct {
 
 	// Base URL for uploading files.
 	uploadURL *url.URL
+
+	// API version to set in the X-Github-Api-Version header.
+	apiVersion string
 
 	// User agent used when communicating with the GitHub API.
 	userAgent string
@@ -347,6 +353,7 @@ type clientOptions struct {
 	httpClient                              *http.Client
 	transport                               http.RoundTripper
 	timeout                                 *time.Duration
+	apiVersion                              *string
 	userAgent                               *string
 	envProxy                                bool
 	token                                   *string
@@ -401,6 +408,27 @@ func WithTimeout(timeout time.Duration) ClientOptionsFunc {
 		}
 
 		o.timeout = &timeout
+		return nil
+	}
+}
+
+// WithAPIVersion returns a ClientOptionsFunc that sets the API version for a
+// Client. The API version should be in the format "YYYY-MM-DD" as specified by
+// GitHub's API versioning scheme. If not set, the default API version will be
+// used.
+// Warning: Setting the API version to anything other than [defaultAPIVersion]
+// is not recommended and may cause compatibility issues with this package.
+func WithAPIVersion(apiVersion string) ClientOptionsFunc {
+	return func(o *clientOptions) error {
+		if apiVersion == "" {
+			return errors.New("api version must not be empty")
+		}
+
+		if !apiVersionRegexp.MatchString(apiVersion) {
+			return errors.New("invalid api version")
+		}
+
+		o.apiVersion = &apiVersion
 		return nil
 	}
 }
@@ -609,6 +637,12 @@ func newClient(opts clientOptions) (*Client, error) {
 		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
 	}
 
+	if opts.apiVersion != nil {
+		c.apiVersion = *opts.apiVersion
+	} else {
+		c.apiVersion = defaultAPIVersion
+	}
+
 	if opts.userAgent != nil {
 		c.userAgent = *opts.userAgent
 	} else {
@@ -684,6 +718,18 @@ func newClient(opts clientOptions) (*Client, error) {
 	return c, nil
 }
 
+// APIVersion returns the API version set in the X-Github-Api-Version header
+// for the client.
+func (c *Client) APIVersion() string {
+	return c.apiVersion
+}
+
+// CheckAPIVersion checks if the client's API version is compatible with the
+// provided minimum version.
+func (c *Client) CheckAPIVersion(minVersion string) bool {
+	return minVersion <= c.apiVersion
+}
+
 // UserAgent returns the User-Agent header value for the client.
 func (c *Client) UserAgent() string {
 	return c.userAgent
@@ -718,6 +764,7 @@ func (c *Client) Clone(opts ...ClientOptionsFunc) (*Client, error) {
 	}
 
 	o := clientOptions{
+		apiVersion:                              &c.apiVersion,
 		userAgent:                               &c.userAgent,
 		baseURL:                                 Ptr(*c.baseURL),
 		uploadURL:                               Ptr(*c.uploadURL),
@@ -814,7 +861,7 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body any
 	if c.userAgent != "" {
 		req.Header.Set("User-Agent", c.userAgent)
 	}
-	req.Header.Set(headerAPIVersion, defaultAPIVersion)
+	req.Header.Set(headerAPIVersion, c.apiVersion)
 
 	for _, opt := range opts {
 		opt(req)
@@ -851,7 +898,7 @@ func (c *Client) NewFormRequest(ctx context.Context, urlStr string, body io.Read
 	if c.userAgent != "" {
 		req.Header.Set("User-Agent", c.userAgent)
 	}
-	req.Header.Set(headerAPIVersion, defaultAPIVersion)
+	req.Header.Set(headerAPIVersion, c.apiVersion)
 
 	for _, opt := range opts {
 		opt(req)
@@ -922,7 +969,7 @@ func (c *Client) NewUploadRequest(ctx context.Context, urlStr string, reader io.
 	req.Header.Set("Content-Type", mediaType)
 	req.Header.Set("Accept", mediaTypeV3)
 	req.Header.Set("User-Agent", c.userAgent)
-	req.Header.Set(headerAPIVersion, defaultAPIVersion)
+	req.Header.Set(headerAPIVersion, c.apiVersion)
 
 	for _, opt := range opts {
 		opt(req)

--- a/github/github.go
+++ b/github/github.go
@@ -620,6 +620,14 @@ func newClient(opts clientOptions) (*Client, error) {
 		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
 	}
 
+	if opts.apiVersionMin != nil {
+		c.apiVersionMin = *opts.apiVersionMin
+	}
+
+	if opts.apiVersionMax != nil {
+		c.apiVersionMax = *opts.apiVersionMax
+	}
+
 	if opts.userAgent != nil {
 		c.userAgent = *opts.userAgent
 	} else {

--- a/github/github.go
+++ b/github/github.go
@@ -40,10 +40,8 @@ const (
 	HeaderRequestID     = "X-Github-Request-Id"
 
 	// https://docs.github.com/en/rest/about-the-rest-api/api-versions#about-api-versioning
-	defaultAPIVersion = api20221128
-	latestAPIVersion  = api20260310
-	api20221128       = "2022-11-28"
-	api20260310       = "2026-03-10"
+	api20221128 = "2022-11-28"
+	api20260310 = "2026-03-10"
 
 	defaultBaseURL   = "https://api.github.com/"
 	defaultUserAgent = "go-github" + "/" + Version
@@ -181,8 +179,12 @@ type Client struct {
 	// Base URL for uploading files.
 	uploadURL *url.URL
 
-	// API version to set in the X-Github-Api-Version header.
-	apiVersion string
+	// Default API version to set in the X-Github-Api-Version header.
+	apiVersionDefault string
+	// Minimum API version that the client can use.
+	apiVersionMin string
+	// Maximum API version that the client can use.
+	apiVersionMax string
 
 	// User agent used when communicating with the GitHub API.
 	userAgent string
@@ -353,7 +355,8 @@ type clientOptions struct {
 	httpClient                              *http.Client
 	transport                               http.RoundTripper
 	timeout                                 *time.Duration
-	apiVersion                              *string
+	apiVersionMin                           *string
+	apiVersionMax                           *string
 	userAgent                               *string
 	envProxy                                bool
 	token                                   *string
@@ -408,27 +411,6 @@ func WithTimeout(timeout time.Duration) ClientOptionsFunc {
 		}
 
 		o.timeout = &timeout
-		return nil
-	}
-}
-
-// WithAPIVersion returns a ClientOptionsFunc that sets the API version for a
-// Client. The API version should be in the format "YYYY-MM-DD" as specified by
-// GitHub's API versioning scheme. If not set, the default API version will be
-// used.
-// Warning: Setting the API version to anything other than [defaultAPIVersion]
-// is not recommended and may cause compatibility issues with this package.
-func WithAPIVersion(apiVersion string) ClientOptionsFunc {
-	return func(o *clientOptions) error {
-		if apiVersion == "" {
-			return errors.New("api version must not be empty")
-		}
-
-		if !apiVersionRegexp.MatchString(apiVersion) {
-			return errors.New("invalid api version")
-		}
-
-		o.apiVersion = &apiVersion
 		return nil
 	}
 }
@@ -586,7 +568,11 @@ func NewClient(opts ...ClientOptionsFunc) (*Client, error) {
 // newClient creates a new Client with the provided options. This is an internal
 // helper function that is called by [NewClient] and [Client.Clone].
 func newClient(opts clientOptions) (*Client, error) {
-	c := &Client{}
+	c := &Client{
+		apiVersionDefault: api20221128,
+		apiVersionMin:     api20221128,
+		apiVersionMax:     api20260310,
+	}
 
 	if opts.httpClient != nil {
 		c.client = opts.httpClient
@@ -635,12 +621,6 @@ func newClient(opts clientOptions) (*Client, error) {
 		Timeout:       c.client.Timeout,
 		Jar:           c.client.Jar,
 		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
-	}
-
-	if opts.apiVersion != nil {
-		c.apiVersion = *opts.apiVersion
-	} else {
-		c.apiVersion = defaultAPIVersion
 	}
 
 	if opts.userAgent != nil {
@@ -718,18 +698,6 @@ func newClient(opts clientOptions) (*Client, error) {
 	return c, nil
 }
 
-// APIVersion returns the API version set in the X-Github-Api-Version header
-// for the client.
-func (c *Client) APIVersion() string {
-	return c.apiVersion
-}
-
-// CheckAPIVersion checks if the client's API version is compatible with the
-// provided minimum version.
-func (c *Client) CheckAPIVersion(minVersion string) bool {
-	return minVersion <= c.apiVersion
-}
-
 // UserAgent returns the User-Agent header value for the client.
 func (c *Client) UserAgent() string {
 	return c.userAgent
@@ -764,7 +732,8 @@ func (c *Client) Clone(opts ...ClientOptionsFunc) (*Client, error) {
 	}
 
 	o := clientOptions{
-		apiVersion:                              &c.apiVersion,
+		apiVersionMin:                           &c.apiVersionMin,
+		apiVersionMax:                           &c.apiVersionMax,
 		userAgent:                               &c.userAgent,
 		baseURL:                                 Ptr(*c.baseURL),
 		uploadURL:                               Ptr(*c.uploadURL),
@@ -861,7 +830,7 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body any
 	if c.userAgent != "" {
 		req.Header.Set("User-Agent", c.userAgent)
 	}
-	req.Header.Set(headerAPIVersion, c.apiVersion)
+	req.Header.Set(headerAPIVersion, c.apiVersionDefault)
 
 	for _, opt := range opts {
 		opt(req)
@@ -898,7 +867,7 @@ func (c *Client) NewFormRequest(ctx context.Context, urlStr string, body io.Read
 	if c.userAgent != "" {
 		req.Header.Set("User-Agent", c.userAgent)
 	}
-	req.Header.Set(headerAPIVersion, c.apiVersion)
+	req.Header.Set(headerAPIVersion, c.apiVersionDefault)
 
 	for _, opt := range opts {
 		opt(req)
@@ -969,7 +938,7 @@ func (c *Client) NewUploadRequest(ctx context.Context, urlStr string, reader io.
 	req.Header.Set("Content-Type", mediaType)
 	req.Header.Set("Accept", mediaTypeV3)
 	req.Header.Set("User-Agent", c.userAgent)
-	req.Header.Set(headerAPIVersion, c.apiVersion)
+	req.Header.Set(headerAPIVersion, c.apiVersionDefault)
 
 	for _, opt := range opts {
 		opt(req)
@@ -1190,6 +1159,21 @@ const (
 // unexpectedly large error body.
 const maxErrorBodySize = 1 * 1024 * 1024 // 1 MiB
 
+// ErrUnsupportedAPIVersion is returned when the API version specified in the
+// request is not supported by the client.
+var ErrUnsupportedAPIVersion = errors.New("unsupported api version")
+
+// checkRequestAPIVersionBeforeDo checks if the API version specified in the
+// request is supported by the client before making the API call. If the
+// version is not supported, it returns [ErrUnsupportedAPIVersion].
+func (c *Client) checkRequestAPIVersionBeforeDo(req *http.Request) error {
+	reqAPIVersion := req.Header.Get(headerAPIVersion)
+	if reqAPIVersion < c.apiVersionMin || reqAPIVersion > c.apiVersionMax {
+		return ErrUnsupportedAPIVersion
+	}
+	return nil
+}
+
 // bareDo sends an API request using `caller` http.Client passed in the parameters
 // and lets you handle the api response. If an error or API Error occurs, the error
 // will contain more information. Otherwise, you are supposed to read and close the
@@ -1197,6 +1181,10 @@ const maxErrorBodySize = 1 * 1024 * 1024 // 1 MiB
 // bareDo returns *RateLimitError immediately without making a network API call.
 func (c *Client) bareDo(caller *http.Client, req *http.Request) (*Response, error) {
 	ctx := req.Context()
+
+	if err := c.checkRequestAPIVersionBeforeDo(req); err != nil {
+		return nil, err
+	}
 
 	rateLimitCategory := CoreCategory
 

--- a/github/github.go
+++ b/github/github.go
@@ -1162,12 +1162,19 @@ var ErrUnsupportedAPIVersion = errors.New("unsupported api version")
 
 // checkRequestAPIVersionBeforeDo checks if the API version specified in the
 // request is supported by the client before making the API call. If the
-// version is not supported, it returns [ErrUnsupportedAPIVersion].
+// version is not supported, it returns [ErrUnsupportedAPIVersion]. If the
+// version is empty it returns nil.
 func (c *Client) checkRequestAPIVersionBeforeDo(req *http.Request) error {
 	reqAPIVersion := req.Header.Get(headerAPIVersion)
+
+	if reqAPIVersion == "" {
+		return nil
+	}
+
 	if reqAPIVersion < c.apiVersionMin || reqAPIVersion > c.apiVersionMax {
 		return ErrUnsupportedAPIVersion
 	}
+
 	return nil
 }
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -3159,7 +3159,7 @@ func TestClient_checkRequestAPIVersionBeforeDo(t *testing.T) {
 			version:    "",
 			versionMin: api20221128,
 			versionMax: api20260310,
-			wantErr:    true,
+			wantErr:    false,
 		},
 		{
 			name:       "version_less_than_min",

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1685,13 +1685,13 @@ func TestNewRequest_errorForNoTrailingSlash(t *testing.T) {
 	for _, test := range tests {
 		u, err := url.Parse(test.rawurl)
 		if err != nil {
-			t.Fatalf("url.Parse returned unexpected error: %v.", err)
+			t.Fatalf("url.Parse returned unexpected error: %v", err)
 		}
 		c.baseURL = u
 		if _, err := c.NewRequest(t.Context(), "GET", "test", nil); test.wantError && err == nil {
 			t.Fatal("Expected error to be returned.")
 		} else if !test.wantError && err != nil {
-			t.Fatalf("NewRequest returned unexpected error: %v.", err)
+			t.Fatalf("NewRequest returned unexpected error: %v", err)
 		}
 	}
 }
@@ -1865,13 +1865,13 @@ func TestNewFormRequest_errorForNoTrailingSlash(t *testing.T) {
 	for _, test := range tests {
 		u, err := url.Parse(test.rawURL)
 		if err != nil {
-			t.Fatalf("url.Parse returned unexpected error: %v.", err)
+			t.Fatalf("url.Parse returned unexpected error: %v", err)
 		}
 		c.baseURL = u
 		if _, err := c.NewFormRequest(t.Context(), "test", nil); test.wantError && err == nil {
 			t.Fatal("Expected error to be returned.")
 		} else if !test.wantError && err != nil {
-			t.Fatalf("NewFormRequest returned unexpected error: %v.", err)
+			t.Fatalf("NewFormRequest returned unexpected error: %v", err)
 		}
 	}
 }
@@ -1919,13 +1919,13 @@ func TestNewUploadRequest_errorForNoTrailingSlash(t *testing.T) {
 	for _, test := range tests {
 		u, err := url.Parse(test.rawurl)
 		if err != nil {
-			t.Fatalf("url.Parse returned unexpected error: %v.", err)
+			t.Fatalf("url.Parse returned unexpected error: %v", err)
 		}
 		c.uploadURL = u
 		if _, err = c.NewUploadRequest(t.Context(), "test", nil, 0, ""); test.wantError && err == nil {
 			t.Fatal("Expected error to be returned.")
 		} else if !test.wantError && err != nil {
-			t.Fatalf("NewUploadRequest returned unexpected error: %v.", err)
+			t.Fatalf("NewUploadRequest returned unexpected error: %v", err)
 		}
 	}
 }
@@ -2243,7 +2243,7 @@ func TestDo_redirectLoop(t *testing.T) {
 		t.Error("Expected error to be returned.")
 	}
 	if !errors.As(err, new(*url.Error)) {
-		t.Errorf("Expected a URL error; got %#v.", err)
+		t.Errorf("Expected a URL error; got %#v", err)
 	}
 }
 
@@ -2482,7 +2482,7 @@ func TestDo_rateLimit_errorResponse(t *testing.T) {
 		t.Error("Expected error to be returned.")
 	}
 	if errors.As(err, new(*RateLimitError)) {
-		t.Errorf("Did not expect a *RateLimitError error; got %#v.", err)
+		t.Errorf("Did not expect a *RateLimitError error; got %#v", err)
 	}
 	if got, want := resp.Rate.Limit, 60; got != want {
 		t.Errorf("Client rate limit = %v, want %v", got, want)
@@ -2529,7 +2529,7 @@ func TestDo_rateLimit_rateLimitError(t *testing.T) {
 	}
 	var rateLimitErr *RateLimitError
 	if !errors.As(err, &rateLimitErr) {
-		t.Fatalf("Expected a *RateLimitError error; got %#v.", err)
+		t.Fatalf("Expected a *RateLimitError error; got %#v", err)
 	}
 	if got, want := rateLimitErr.Rate.Limit, 60; got != want {
 		t.Errorf("rateLimitErr rate limit = %v, want %v", got, want)
@@ -2596,7 +2596,7 @@ func TestDo_rateLimit_noNetworkCall(t *testing.T) {
 	}
 	var rateLimitErr *RateLimitError
 	if !errors.As(err, &rateLimitErr) {
-		t.Fatalf("Expected a *RateLimitError error; got %#v.", err)
+		t.Fatalf("Expected a *RateLimitError error; got %#v", err)
 	}
 	if got, want := rateLimitErr.Rate.Limit, 60; got != want {
 		t.Errorf("rateLimitErr rate limit = %v, want %v", got, want)
@@ -2831,7 +2831,7 @@ func TestDo_rateLimit_abortSleepContextCancelledClientLimit(t *testing.T) {
 	_, err := client.Do(req, nil)
 	var rateLimitError *RateLimitError
 	if !errors.As(err, &rateLimitError) {
-		t.Fatalf("Expected a *rateLimitError error; got %#v.", err)
+		t.Fatalf("Expected a *rateLimitError error; got %#v", err)
 	}
 	if got, wantSuffix := rateLimitError.Message, "Context cancelled while waiting for rate limit to reset until"; !strings.HasPrefix(got, wantSuffix) {
 		t.Errorf("Expected request to be prevented because context cancellation, got: %v.", got)
@@ -2866,7 +2866,7 @@ func TestDo_rateLimit_abuseRateLimitError(t *testing.T) {
 	}
 	var abuseRateLimitErr *AbuseRateLimitError
 	if !errors.As(err, &abuseRateLimitErr) {
-		t.Fatalf("Expected a *AbuseRateLimitError error; got %#v.", err)
+		t.Fatalf("Expected a *AbuseRateLimitError error; got %#v", err)
 	}
 	if got, want := abuseRateLimitErr.RetryAfter, (*time.Duration)(nil); got != want {
 		t.Errorf("abuseRateLimitErr RetryAfter = %v, want %v", got, want)
@@ -2900,7 +2900,7 @@ func TestDo_rateLimit_abuseRateLimitErrorEnterprise(t *testing.T) {
 	}
 	var abuseRateLimitErr *AbuseRateLimitError
 	if !errors.As(err, &abuseRateLimitErr) {
-		t.Fatalf("Expected a *AbuseRateLimitError error; got %#v.", err)
+		t.Fatalf("Expected a *AbuseRateLimitError error; got %#v", err)
 	}
 	if got, want := abuseRateLimitErr.RetryAfter, (*time.Duration)(nil); got != want {
 		t.Errorf("abuseRateLimitErr RetryAfter = %v, want %v", got, want)
@@ -2931,7 +2931,7 @@ func TestDo_rateLimit_abuseRateLimitError_retryAfter(t *testing.T) {
 		}
 		var abuseRateLimitErr *AbuseRateLimitError
 		if !errors.As(err, &abuseRateLimitErr) {
-			t.Fatalf("Expected a *AbuseRateLimitError error; got %#v.", err)
+			t.Fatalf("Expected a *AbuseRateLimitError error; got %#v", err)
 		}
 		if abuseRateLimitErr.RetryAfter == nil {
 			t.Fatal("abuseRateLimitErr RetryAfter is nil, expected not-nil")
@@ -2945,7 +2945,7 @@ func TestDo_rateLimit_abuseRateLimitError_retryAfter(t *testing.T) {
 			t.Error("Expected error to be returned.")
 		}
 		if !errors.As(err, &abuseRateLimitErr) {
-			t.Fatalf("Expected a *AbuseRateLimitError error; got %#v.", err)
+			t.Fatalf("Expected a *AbuseRateLimitError error; got %#v", err)
 		}
 		if abuseRateLimitErr.RetryAfter == nil {
 			t.Fatal("abuseRateLimitErr RetryAfter is nil, expected not-nil")
@@ -2987,7 +2987,7 @@ func TestDo_rateLimit_abuseRateLimitError_xRateLimitReset(t *testing.T) {
 		}
 		var abuseRateLimitErr *AbuseRateLimitError
 		if !errors.As(err, &abuseRateLimitErr) {
-			t.Fatalf("Expected a *AbuseRateLimitError error; got %#v.", err)
+			t.Fatalf("Expected a *AbuseRateLimitError error; got %#v", err)
 		}
 		if abuseRateLimitErr.RetryAfter == nil {
 			t.Fatal("abuseRateLimitErr RetryAfter is nil, expected not-nil")
@@ -3002,7 +3002,7 @@ func TestDo_rateLimit_abuseRateLimitError_xRateLimitReset(t *testing.T) {
 			t.Error("Expected error to be returned.")
 		}
 		if !errors.As(err, &abuseRateLimitErr) {
-			t.Fatalf("Expected a *AbuseRateLimitError error; got %#v.", err)
+			t.Fatalf("Expected a *AbuseRateLimitError error; got %#v", err)
 		}
 		if abuseRateLimitErr.RetryAfter == nil {
 			t.Fatal("abuseRateLimitErr RetryAfter is nil, expected not-nil")
@@ -3045,7 +3045,7 @@ func TestDo_rateLimit_abuseRateLimitError_maxDuration(t *testing.T) {
 	}
 	var abuseRateLimitErr *AbuseRateLimitError
 	if !errors.As(err, &abuseRateLimitErr) {
-		t.Fatalf("Expected a *AbuseRateLimitError error; got %#v.", err)
+		t.Fatalf("Expected a *AbuseRateLimitError error; got %#v", err)
 	}
 	if abuseRateLimitErr.RetryAfter == nil {
 		t.Fatal("abuseRateLimitErr RetryAfter is nil, expected not-nil")
@@ -3210,10 +3210,10 @@ func TestClient_checkRequestAPIVersionBeforeDo(t *testing.T) {
 			err := client.checkRequestAPIVersionBeforeDo(req)
 			if tt.wantErr {
 				if err == nil {
-					t.Fatal("Expected error to be returned, got nil.")
+					t.Fatal("Expected error to be returned, got nil")
 				}
 				if !errors.Is(err, ErrUnsupportedAPIVersion) {
-					t.Errorf("Expected ErrUnsupportedAPIVersion; got %#v.", err)
+					t.Errorf("Expected ErrUnsupportedAPIVersion; got %#v", err)
 				}
 				return
 			}
@@ -3237,10 +3237,10 @@ func TestClient_bareDo_errors_with_unsupported_api_version(t *testing.T) {
 
 	_, err := c.bareDo(c.client, req)
 	if err == nil {
-		t.Fatal("Expected error to be returned, got nil.")
+		t.Fatal("Expected error to be returned, got nil")
 	}
 	if !errors.Is(err, ErrUnsupportedAPIVersion) {
-		t.Errorf("Expected ErrUnsupportedAPIVersion; got %#v.", err)
+		t.Errorf("Expected ErrUnsupportedAPIVersion; got %#v", err)
 	}
 }
 
@@ -3259,7 +3259,7 @@ func TestBareDoUntilFound_redirectLoop(t *testing.T) {
 		t.Error("Expected error to be returned.")
 	}
 	if !errors.As(err, new(*RedirectionError)) {
-		t.Errorf("Expected a Redirection error; got %#v.", err)
+		t.Errorf("Expected a Redirection error; got %#v", err)
 	}
 }
 
@@ -3278,7 +3278,7 @@ func TestBareDoUntilFound_UnexpectedRedirection(t *testing.T) {
 		t.Error("Expected error to be returned.")
 	}
 	if !errors.As(err, new(*RedirectionError)) {
-		t.Errorf("Expected a Redirection error; got %#v.", err)
+		t.Errorf("Expected a Redirection error; got %#v", err)
 	}
 }
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -560,57 +560,6 @@ func TestWithTimeout(t *testing.T) {
 	})
 }
 
-func TestWithAPIVersion(t *testing.T) {
-	t.Parallel()
-
-	for _, tt := range []struct {
-		name        string
-		version     string
-		wantVersion string
-		wantErr     string
-	}{
-		{
-			name:    "empty_version",
-			version: "",
-			wantErr: "api version must not be empty",
-		},
-		{
-			name:    "invalid_version",
-			version: "1.0.0",
-			wantErr: "invalid api version",
-		},
-		{
-			name:        "valid_version",
-			version:     defaultAPIVersion,
-			wantVersion: defaultAPIVersion,
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			opts := clientOptions{}
-			err := WithAPIVersion(tt.version)(&opts)
-			if err != nil {
-				if tt.wantErr == "" {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if err.Error() != tt.wantErr {
-					t.Fatalf("want error %v, got %v", tt.wantErr, err)
-				}
-				return
-			}
-
-			if tt.wantErr != "" {
-				t.Fatalf("want error %v, got nil", tt.wantErr)
-			}
-
-			if opts.apiVersion != nil && *opts.apiVersion != tt.wantVersion {
-				t.Errorf("want apiVersion %v, got %v", tt.wantVersion, *opts.apiVersion)
-			}
-		})
-	}
-}
-
 func TestWithUserAgent(t *testing.T) {
 	t.Parallel()
 
@@ -1061,7 +1010,8 @@ func Test_newClient(t *testing.T) {
 				httpClient:                              &http.Client{Transport: &http.Transport{IdleConnTimeout: 5 * time.Second}},
 				transport:                               &http.Transport{IdleConnTimeout: 10 * time.Second},
 				timeout:                                 Ptr(15 * time.Second),
-				apiVersion:                              Ptr(latestAPIVersion),
+				apiVersionMin:                           Ptr(api20221128),
+				apiVersionMax:                           Ptr(api20221128),
 				userAgent:                               Ptr("CustomUserAgent/1.0"),
 				baseURL:                                 mustParseURL(t, "https://custom-url/api/v3/"),
 				uploadURL:                               mustParseURL(t, "https://custom-upload-url/api/uploads/"),
@@ -1144,11 +1094,18 @@ func Test_newClient(t *testing.T) {
 				t.Error("newClient http.Client used for redirects should have a CheckRedirect function")
 			}
 
-			if tt.opts.apiVersion != nil && c.apiVersion != *tt.opts.apiVersion {
-				t.Errorf("newClient apiVersion is %v, want %v", c.apiVersion, *tt.opts.apiVersion)
+			if tt.opts.apiVersionMin != nil && c.apiVersionMin != *tt.opts.apiVersionMin {
+				t.Errorf("newClient apiVersionMin is %v, want %v", c.apiVersionMin, *tt.opts.apiVersionMin)
 			}
-			if tt.opts.apiVersion == nil && c.apiVersion != defaultAPIVersion {
-				t.Errorf("newClient apiVersion is %v, want %v", c.apiVersion, defaultAPIVersion)
+			if tt.opts.apiVersionMin == nil && c.apiVersionMin != api20221128 {
+				t.Errorf("newClient apiVersionMin is %v, want %v", c.apiVersionMin, api20221128)
+			}
+
+			if tt.opts.apiVersionMax != nil && c.apiVersionMax != *tt.opts.apiVersionMax {
+				t.Errorf("newClient apiVersionMax is %v, want %v", c.apiVersionMax, *tt.opts.apiVersionMax)
+			}
+			if tt.opts.apiVersionMax == nil && c.apiVersionMax != api20260310 {
+				t.Errorf("newClient apiVersionMax is %v, want %v", c.apiVersionMax, api20260310)
 			}
 
 			if tt.opts.userAgent != nil && c.userAgent != *tt.opts.userAgent {
@@ -1195,58 +1152,6 @@ func Test_newClient(t *testing.T) {
 
 			if c.Marketplace.Stubbed != tt.opts.marketplaceStubbed {
 				t.Errorf("newClient marketplaceStubbed is %v, want %v", c.Marketplace.Stubbed, tt.opts.marketplaceStubbed)
-			}
-		})
-	}
-}
-
-func TestClient_APIVersion(t *testing.T) {
-	t.Parallel()
-
-	c := mustNewClient(t)
-	c.apiVersion = defaultAPIVersion
-
-	if got, want := c.APIVersion(), defaultAPIVersion; got != want {
-		t.Errorf("got %v, want %v", got, want)
-	}
-}
-
-func TestClient_CheckAPIVersion(t *testing.T) {
-	t.Parallel()
-
-	for _, tt := range []struct {
-		name       string
-		apiVersion string
-		minVersion string
-		want       bool
-	}{
-		{
-			name:       "version_equal_to_min",
-			apiVersion: defaultAPIVersion,
-			minVersion: defaultAPIVersion,
-			want:       true,
-		},
-		{
-			name:       "version_greater_than_min",
-			apiVersion: latestAPIVersion,
-			minVersion: defaultAPIVersion,
-			want:       true,
-		},
-		{
-			name:       "version_less_than_min",
-			apiVersion: defaultAPIVersion,
-			minVersion: latestAPIVersion,
-			want:       false,
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			c := mustNewClient(t)
-			c.apiVersion = tt.apiVersion
-
-			if got := c.CheckAPIVersion(tt.minVersion); got != tt.want {
-				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -1385,7 +1290,8 @@ func TestClient_Clone(t *testing.T) {
 		t.Parallel()
 
 		c := mustNewClient(t)
-		c.apiVersion = latestAPIVersion
+		c.apiVersionMin = api20221128
+		c.apiVersionMax = api20221128
 		c.userAgent = "CustomUserAgent/1.0"
 		c.baseURL.Path = "/custom/"
 		c.uploadURL.Path = "/custom-upload/"
@@ -1693,7 +1599,7 @@ func TestNewRequest(t *testing.T) {
 	}
 
 	apiVersion := req.Header.Get(headerAPIVersion)
-	if got, want := apiVersion, defaultAPIVersion; got != want {
+	if got, want := apiVersion, api20221128; got != want {
 		t.Errorf("NewRequest() %v header is %v, want %v", headerAPIVersion, got, want)
 	}
 
@@ -1900,7 +1806,7 @@ func TestNewFormRequest(t *testing.T) {
 	}
 
 	apiVersion := req.Header.Get(headerAPIVersion)
-	if got, want := apiVersion, defaultAPIVersion; got != want {
+	if got, want := apiVersion, api20221128; got != want {
 		t.Errorf("NewFormRequest() %v header is %v, want %v", headerAPIVersion, got, want)
 	}
 
@@ -1976,7 +1882,7 @@ func TestNewUploadRequest_WithVersion(t *testing.T) {
 	req, _ := c.NewUploadRequest(t.Context(), "https://example.com/", nil, 0, "")
 
 	apiVersion := req.Header.Get(headerAPIVersion)
-	if got, want := apiVersion, defaultAPIVersion; got != want {
+	if got, want := apiVersion, api20221128; got != want {
 		t.Errorf("NewRequest() %v header is %v, want %v", headerAPIVersion, got, want)
 	}
 
@@ -3235,6 +3141,106 @@ func TestDo_noContent(t *testing.T) {
 	_, err := client.Do(req, &body)
 	if err != nil {
 		t.Fatalf("Do returned unexpected error: %v", err)
+	}
+}
+
+func TestClient_checkRequestAPIVersionBeforeDo(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name       string
+		version    string
+		versionMin string
+		versionMax string
+		wantErr    bool
+	}{
+		{
+			name:       "version_not_set",
+			version:    "",
+			versionMin: api20221128,
+			versionMax: api20260310,
+			wantErr:    true,
+		},
+		{
+			name:       "version_less_than_min",
+			version:    "2022-01-01",
+			versionMin: api20221128,
+			versionMax: api20260310,
+			wantErr:    true,
+		},
+		{
+			name:       "version_equal_to_min",
+			version:    api20221128,
+			versionMin: api20221128,
+			versionMax: api20260310,
+			wantErr:    false,
+		},
+		{
+			name:       "version_between_min_and_max",
+			version:    "2023-01-01",
+			versionMin: api20221128,
+			versionMax: api20260310,
+			wantErr:    false,
+		},
+		{
+			name:       "version_equal_to_max",
+			version:    api20260310,
+			versionMin: api20221128,
+			versionMax: api20260310,
+			wantErr:    false,
+		},
+		{
+			name:       "version_greater_than_max",
+			version:    api20260310,
+			versionMin: api20221128,
+			versionMax: api20221128,
+			wantErr:    true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := mustNewClient(t)
+			client.apiVersionMin = tt.versionMin
+			client.apiVersionMax = tt.versionMax
+
+			req, _ := http.NewRequestWithContext(t.Context(), "GET", ".", nil)
+			req.Header.Set(headerAPIVersion, tt.version)
+
+			err := client.checkRequestAPIVersionBeforeDo(req)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Expected error to be returned, got nil.")
+				}
+				if !errors.Is(err, ErrUnsupportedAPIVersion) {
+					t.Errorf("Expected ErrUnsupportedAPIVersion; got %#v.", err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Expected no error to be returned, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestClient_bareDo_errors_with_unsupported_api_version(t *testing.T) {
+	t.Parallel()
+
+	c := mustNewClient(t)
+	c.apiVersionMin = api20221128
+	c.apiVersionMax = api20221128
+
+	req, _ := http.NewRequestWithContext(t.Context(), "GET", ".", nil)
+	req.Header.Set(headerAPIVersion, api20260310)
+
+	_, err := c.bareDo(c.client, req)
+	if err == nil {
+		t.Fatal("Expected error to be returned, got nil.")
+	}
+	if !errors.Is(err, ErrUnsupportedAPIVersion) {
+		t.Errorf("Expected ErrUnsupportedAPIVersion; got %#v.", err)
 	}
 }
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -560,6 +560,57 @@ func TestWithTimeout(t *testing.T) {
 	})
 }
 
+func TestWithAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name        string
+		version     string
+		wantVersion string
+		wantErr     string
+	}{
+		{
+			name:    "empty_version",
+			version: "",
+			wantErr: "api version must not be empty",
+		},
+		{
+			name:    "invalid_version",
+			version: "1.0.0",
+			wantErr: "invalid api version",
+		},
+		{
+			name:        "valid_version",
+			version:     defaultAPIVersion,
+			wantVersion: defaultAPIVersion,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := clientOptions{}
+			err := WithAPIVersion(tt.version)(&opts)
+			if err != nil {
+				if tt.wantErr == "" {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if err.Error() != tt.wantErr {
+					t.Fatalf("want error %v, got %v", tt.wantErr, err)
+				}
+				return
+			}
+
+			if tt.wantErr != "" {
+				t.Fatalf("want error %v, got nil", tt.wantErr)
+			}
+
+			if opts.apiVersion != nil && *opts.apiVersion != tt.wantVersion {
+				t.Errorf("want apiVersion %v, got %v", tt.wantVersion, *opts.apiVersion)
+			}
+		})
+	}
+}
+
 func TestWithUserAgent(t *testing.T) {
 	t.Parallel()
 
@@ -1010,6 +1061,7 @@ func Test_newClient(t *testing.T) {
 				httpClient:                              &http.Client{Transport: &http.Transport{IdleConnTimeout: 5 * time.Second}},
 				transport:                               &http.Transport{IdleConnTimeout: 10 * time.Second},
 				timeout:                                 Ptr(15 * time.Second),
+				apiVersion:                              Ptr(latestAPIVersion),
 				userAgent:                               Ptr("CustomUserAgent/1.0"),
 				baseURL:                                 mustParseURL(t, "https://custom-url/api/v3/"),
 				uploadURL:                               mustParseURL(t, "https://custom-upload-url/api/uploads/"),
@@ -1092,6 +1144,13 @@ func Test_newClient(t *testing.T) {
 				t.Error("newClient http.Client used for redirects should have a CheckRedirect function")
 			}
 
+			if tt.opts.apiVersion != nil && c.apiVersion != *tt.opts.apiVersion {
+				t.Errorf("newClient apiVersion is %v, want %v", c.apiVersion, *tt.opts.apiVersion)
+			}
+			if tt.opts.apiVersion == nil && c.apiVersion != defaultAPIVersion {
+				t.Errorf("newClient apiVersion is %v, want %v", c.apiVersion, defaultAPIVersion)
+			}
+
 			if tt.opts.userAgent != nil && c.userAgent != *tt.opts.userAgent {
 				t.Errorf("newClient userAgent is %v, want %v", c.userAgent, *tt.opts.userAgent)
 			}
@@ -1136,6 +1195,58 @@ func Test_newClient(t *testing.T) {
 
 			if c.Marketplace.Stubbed != tt.opts.marketplaceStubbed {
 				t.Errorf("newClient marketplaceStubbed is %v, want %v", c.Marketplace.Stubbed, tt.opts.marketplaceStubbed)
+			}
+		})
+	}
+}
+
+func TestClient_APIVersion(t *testing.T) {
+	t.Parallel()
+
+	c := mustNewClient(t)
+	c.apiVersion = defaultAPIVersion
+
+	if got, want := c.APIVersion(), defaultAPIVersion; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestClient_CheckAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name       string
+		apiVersion string
+		minVersion string
+		want       bool
+	}{
+		{
+			name:       "version_equal_to_min",
+			apiVersion: defaultAPIVersion,
+			minVersion: defaultAPIVersion,
+			want:       true,
+		},
+		{
+			name:       "version_greater_than_min",
+			apiVersion: latestAPIVersion,
+			minVersion: defaultAPIVersion,
+			want:       true,
+		},
+		{
+			name:       "version_less_than_min",
+			apiVersion: defaultAPIVersion,
+			minVersion: latestAPIVersion,
+			want:       false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := mustNewClient(t)
+			c.apiVersion = tt.apiVersion
+
+			if got := c.CheckAPIVersion(tt.minVersion); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -1274,6 +1385,7 @@ func TestClient_Clone(t *testing.T) {
 		t.Parallel()
 
 		c := mustNewClient(t)
+		c.apiVersion = latestAPIVersion
 		c.userAgent = "CustomUserAgent/1.0"
 		c.baseURL.Path = "/custom/"
 		c.uploadURL.Path = "/custom-upload/"

--- a/github/private_registries.go
+++ b/github/private_registries.go
@@ -244,7 +244,13 @@ func (s *PrivateRegistriesService) ListOrganizationPrivateRegistries(ctx context
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "GET", u, nil, WithVersion(api20260310))
+	minVersion := api20260310
+	reqOpts := []RequestOption{}
+	if !s.client.CheckAPIVersion(minVersion) {
+		reqOpts = append(reqOpts, WithVersion(minVersion))
+	}
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil, reqOpts...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -265,7 +271,13 @@ func (s *PrivateRegistriesService) ListOrganizationPrivateRegistries(ctx context
 func (s *PrivateRegistriesService) CreateOrganizationPrivateRegistry(ctx context.Context, org string, privateRegistry CreateOrganizationPrivateRegistry) (*PrivateRegistry, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries", org)
 
-	req, err := s.client.NewRequest(ctx, "POST", u, privateRegistry, WithVersion(api20260310))
+	minVersion := api20260310
+	reqOpts := []RequestOption{}
+	if !s.client.CheckAPIVersion(minVersion) {
+		reqOpts = append(reqOpts, WithVersion(minVersion))
+	}
+
+	req, err := s.client.NewRequest(ctx, "POST", u, privateRegistry, reqOpts...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -286,7 +298,13 @@ func (s *PrivateRegistriesService) CreateOrganizationPrivateRegistry(ctx context
 func (s *PrivateRegistriesService) GetOrganizationPrivateRegistriesPublicKey(ctx context.Context, org string) (*PublicKey, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/public-key", org)
 
-	req, err := s.client.NewRequest(ctx, "GET", u, nil, WithVersion(api20260310))
+	minVersion := api20260310
+	reqOpts := []RequestOption{}
+	if !s.client.CheckAPIVersion(minVersion) {
+		reqOpts = append(reqOpts, WithVersion(minVersion))
+	}
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil, reqOpts...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -308,7 +326,13 @@ func (s *PrivateRegistriesService) GetOrganizationPrivateRegistriesPublicKey(ctx
 func (s *PrivateRegistriesService) GetOrganizationPrivateRegistry(ctx context.Context, org, secretName string) (*PrivateRegistry, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/%v", org, secretName)
 
-	req, err := s.client.NewRequest(ctx, "GET", u, nil, WithVersion(api20260310))
+	minVersion := api20260310
+	reqOpts := []RequestOption{}
+	if !s.client.CheckAPIVersion(minVersion) {
+		reqOpts = append(reqOpts, WithVersion(minVersion))
+	}
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil, reqOpts...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -331,7 +355,13 @@ func (s *PrivateRegistriesService) GetOrganizationPrivateRegistry(ctx context.Co
 func (s *PrivateRegistriesService) UpdateOrganizationPrivateRegistry(ctx context.Context, org, secretName string, privateRegistry UpdateOrganizationPrivateRegistry) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/%v", org, secretName)
 
-	req, err := s.client.NewRequest(ctx, "PATCH", u, privateRegistry, WithVersion(api20260310))
+	minVersion := api20260310
+	reqOpts := []RequestOption{}
+	if !s.client.CheckAPIVersion(minVersion) {
+		reqOpts = append(reqOpts, WithVersion(minVersion))
+	}
+
+	req, err := s.client.NewRequest(ctx, "PATCH", u, privateRegistry, reqOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +378,13 @@ func (s *PrivateRegistriesService) UpdateOrganizationPrivateRegistry(ctx context
 func (s *PrivateRegistriesService) DeleteOrganizationPrivateRegistry(ctx context.Context, org, secretName string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/%v", org, secretName)
 
-	req, err := s.client.NewRequest(ctx, "DELETE", u, nil, WithVersion(api20260310))
+	minVersion := api20260310
+	reqOpts := []RequestOption{}
+	if !s.client.CheckAPIVersion(minVersion) {
+		reqOpts = append(reqOpts, WithVersion(minVersion))
+	}
+
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil, reqOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/github/private_registries.go
+++ b/github/private_registries.go
@@ -244,13 +244,7 @@ func (s *PrivateRegistriesService) ListOrganizationPrivateRegistries(ctx context
 		return nil, nil, err
 	}
 
-	minVersion := api20260310
-	reqOpts := []RequestOption{}
-	if !s.client.CheckAPIVersion(minVersion) {
-		reqOpts = append(reqOpts, WithVersion(minVersion))
-	}
-
-	req, err := s.client.NewRequest(ctx, "GET", u, nil, reqOpts...)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil, WithVersion(api20260310))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -271,13 +265,7 @@ func (s *PrivateRegistriesService) ListOrganizationPrivateRegistries(ctx context
 func (s *PrivateRegistriesService) CreateOrganizationPrivateRegistry(ctx context.Context, org string, privateRegistry CreateOrganizationPrivateRegistry) (*PrivateRegistry, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries", org)
 
-	minVersion := api20260310
-	reqOpts := []RequestOption{}
-	if !s.client.CheckAPIVersion(minVersion) {
-		reqOpts = append(reqOpts, WithVersion(minVersion))
-	}
-
-	req, err := s.client.NewRequest(ctx, "POST", u, privateRegistry, reqOpts...)
+	req, err := s.client.NewRequest(ctx, "POST", u, privateRegistry, WithVersion(api20260310))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -298,13 +286,7 @@ func (s *PrivateRegistriesService) CreateOrganizationPrivateRegistry(ctx context
 func (s *PrivateRegistriesService) GetOrganizationPrivateRegistriesPublicKey(ctx context.Context, org string) (*PublicKey, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/public-key", org)
 
-	minVersion := api20260310
-	reqOpts := []RequestOption{}
-	if !s.client.CheckAPIVersion(minVersion) {
-		reqOpts = append(reqOpts, WithVersion(minVersion))
-	}
-
-	req, err := s.client.NewRequest(ctx, "GET", u, nil, reqOpts...)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil, WithVersion(api20260310))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -326,13 +308,7 @@ func (s *PrivateRegistriesService) GetOrganizationPrivateRegistriesPublicKey(ctx
 func (s *PrivateRegistriesService) GetOrganizationPrivateRegistry(ctx context.Context, org, secretName string) (*PrivateRegistry, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/%v", org, secretName)
 
-	minVersion := api20260310
-	reqOpts := []RequestOption{}
-	if !s.client.CheckAPIVersion(minVersion) {
-		reqOpts = append(reqOpts, WithVersion(minVersion))
-	}
-
-	req, err := s.client.NewRequest(ctx, "GET", u, nil, reqOpts...)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil, WithVersion(api20260310))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -355,13 +331,7 @@ func (s *PrivateRegistriesService) GetOrganizationPrivateRegistry(ctx context.Co
 func (s *PrivateRegistriesService) UpdateOrganizationPrivateRegistry(ctx context.Context, org, secretName string, privateRegistry UpdateOrganizationPrivateRegistry) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/%v", org, secretName)
 
-	minVersion := api20260310
-	reqOpts := []RequestOption{}
-	if !s.client.CheckAPIVersion(minVersion) {
-		reqOpts = append(reqOpts, WithVersion(minVersion))
-	}
-
-	req, err := s.client.NewRequest(ctx, "PATCH", u, privateRegistry, reqOpts...)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, privateRegistry, WithVersion(api20260310))
 	if err != nil {
 		return nil, err
 	}
@@ -378,13 +348,7 @@ func (s *PrivateRegistriesService) UpdateOrganizationPrivateRegistry(ctx context
 func (s *PrivateRegistriesService) DeleteOrganizationPrivateRegistry(ctx context.Context, org, secretName string) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/private-registries/%v", org, secretName)
 
-	minVersion := api20260310
-	reqOpts := []RequestOption{}
-	if !s.client.CheckAPIVersion(minVersion) {
-		reqOpts = append(reqOpts, WithVersion(minVersion))
-	}
-
-	req, err := s.client.NewRequest(ctx, "DELETE", u, nil, reqOpts...)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil, WithVersion(api20260310))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
~~This PR makes the API version used by the client configurable via the new `github.WithAPIVersion` option function. There is also a new `Client.CheckAPIVersion` method to validate if the client is currently configured to support a minimum version. I've used this new pattern in the service methods which require the latest API version.~~

This PR moves the API version selection logic into the client and adds support for setting a min and a max version to constrain the default value. The intended behaviour is that the library maintainers explicitly set the client default version in code and add overrides to the functions where a non-default version is required. Library consumers will then be able to constrain the max and min versions so they get a sentinel error response when they attempt to call an unsupported endpoint.

As it currently stands no behaviour has been changed and this PR just introduces the primitives to extend in future PRs. The first of which I suggest adds `github.WithAdvancedServer` to set the URLs with correct suffixes and the max version to `2022-11-28`.

This is the first part of the implementation for #4237.