### PR TITLE
test: Cover actions permission JSON marshaling

### DIFF
--- a/github/actions_artifacts_test.go
+++ b/github/actions_artifacts_test.go
@@ -688,3 +688,20 @@ func TestArtifactList_Marshal(t *testing.T) {
 
 	testJSONMarshal(t, u, want)
 }
+
+func TestArtifactPeriod_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &ArtifactPeriod{}, "{}")
+
+	u := &ArtifactPeriod{
+		Days:               Ptr(90),
+		MaximumAllowedDays: Ptr(365),
+	}
+
+	want := `{
+		"days": 90,
+		"maximum_allowed_days": 365
+	}`
+
+	testJSONMarshal(t, u, want)
+}

--- a/github/actions_permissions_enterprise_test.go
+++ b/github/actions_permissions_enterprise_test.go
@@ -642,3 +642,37 @@ func TestActionsService_UpdateEnterpriseForkPRContributorApprovalPermissions(t *
 		return client.Actions.UpdateEnterpriseForkPRContributorApprovalPermissions(ctx, "e", input)
 	})
 }
+
+func TestActionsPermissionsEnterprise_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &ActionsPermissionsEnterprise{}, "{}")
+
+	u := &ActionsPermissionsEnterprise{
+		EnabledOrganizations: Ptr("selected"),
+		AllowedActions:       Ptr("selected"),
+		SelectedActionsURL:   Ptr("u"),
+	}
+
+	want := `{
+		"enabled_organizations": "selected",
+		"allowed_actions": "selected",
+		"selected_actions_url": "u"
+	}`
+
+	testJSONMarshal(t, u, want)
+}
+
+func TestSelfHostRunnerPermissionsEnterprise_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &SelfHostRunnerPermissionsEnterprise{}, "{}")
+
+	u := &SelfHostRunnerPermissionsEnterprise{
+		DisableSelfHostedRunnersForAllOrgs: Ptr(false),
+	}
+
+	want := `{
+		"disable_self_hosted_runners_for_all_orgs": false
+	}`
+
+	testJSONMarshal(t, u, want)
+}

--- a/github/actions_permissions_orgs_test.go
+++ b/github/actions_permissions_orgs_test.go
@@ -820,3 +820,20 @@ func TestActionsService_UpdateOrganizationForkPRContributorApprovalPermissions(t
 		return client.Actions.UpdateOrganizationForkPRContributorApprovalPermissions(ctx, "o", input)
 	})
 }
+
+func TestSelfHostedRunnersSettingsOrganization_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &SelfHostedRunnersSettingsOrganization{}, "{}")
+
+	u := &SelfHostedRunnersSettingsOrganization{
+		EnabledRepositories:     Ptr("selected"),
+		SelectedRepositoriesURL: Ptr("u"),
+	}
+
+	want := `{
+		"enabled_repositories": "selected",
+		"selected_repositories_url": "u"
+	}`
+
+	testJSONMarshal(t, u, want)
+}

--- a/github/actions_workflows_test.go
+++ b/github/actions_workflows_test.go
@@ -709,3 +709,39 @@ func TestCreateWorkflowDispatchEventRequest_Marshal(t *testing.T) {
 
 	testJSONMarshal(t, u, want)
 }
+
+func TestWorkflowsPermissions_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &WorkflowsPermissions{}, "{}")
+
+	u := &WorkflowsPermissions{
+		RunWorkflowsFromForkPullRequests:  Ptr(true),
+		SendWriteTokensToWorkflows:        Ptr(false),
+		SendSecretsAndVariables:           Ptr(true),
+		RequireApprovalForForkPRWorkflows: Ptr(false),
+	}
+
+	want := `{
+		"run_workflows_from_fork_pull_requests": true,
+		"send_write_tokens_to_workflows": false,
+		"send_secrets_and_variables": true,
+		"require_approval_for_fork_pr_workflows": false
+	}`
+
+	testJSONMarshal(t, u, want)
+}
+
+func TestContributorApprovalPermissions_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &ContributorApprovalPermissions{}, `{"approval_policy": ""}`)
+
+	u := &ContributorApprovalPermissions{
+		ApprovalPolicy: "require_approval",
+	}
+
+	want := `{
+		"approval_policy": "require_approval"
+	}`
+
+	testJSONMarshal(t, u, want)
+}


### PR DESCRIPTION
## Problem
Issue #55 tracks adding JSON marshal coverage for public resource types that implement `String()`.

## Root cause
Several Actions permission-related response types had `String()` implementations but no matching marshal tests, leaving their JSON field names and omitted-empty behavior uncovered.

## Solution
Add marshal tests for the remaining Actions permission and retention structs in the existing test files:
- `ArtifactPeriod`
- `ActionsPermissionsEnterprise`
- `SelfHostRunnerPermissionsEnterprise`
- `SelfHostedRunnersSettingsOrganization`
- `WorkflowsPermissions`
- `ContributorApprovalPermissions`

## Tests
- `go test ./github -run 'Test(ArtifactPeriod|ActionsPermissionsEnterprise|SelfHostRunnerPermissionsEnterprise|SelfHostedRunnersSettingsOrganization|WorkflowsPermissions|ContributorApprovalPermissions)_Marshal'`
- `go test ./github`
- `go test ./...`
- `git diff --check`

Fixes part of #55.