### PR TITLE
test: Add attestation marshal tests

### DIFF
--- a/github/attestations_test.go
+++ b/github/attestations_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The go-github AUTHORS. All rights reserved.
+// Copyright 2026 The go-github AUTHORS. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/github/attestations_test.go
+++ b/github/attestations_test.go
@@ -1,0 +1,71 @@
+// Copyright 2024 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAttestation_Marshal(t *testing.T) {
+	testJSONMarshalOnly(t, &Attestation{}, `{"bundle": null, "repository_id": 0}`)
+
+	u := &Attestation{
+		Bundle:       json.RawMessage(`{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}`),
+		RepositoryID: 1,
+	}
+
+	want := `{
+		"bundle": {
+			"mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json"
+		},
+		"repository_id": 1
+	}`
+
+	testJSONMarshal(t, u, want, cmpJSONRawMessageComparator())
+}
+
+func TestAttestationsResponse_Marshal(t *testing.T) {
+	testJSONMarshal(t, &AttestationsResponse{}, `{"attestations": null}`)
+
+	u := &AttestationsResponse{
+		Attestations: []*Attestation{
+			{
+				Bundle:       json.RawMessage(`{"verificationMaterial":{"certificate":{"rawBytes":"abc"}}}`),
+				RepositoryID: 1,
+			},
+			{
+				Bundle:       json.RawMessage(`{"dsseEnvelope":{"payload":"def"}}`),
+				RepositoryID: 2,
+			},
+		},
+	}
+
+	want := `{
+		"attestations": [
+			{
+				"bundle": {
+					"verificationMaterial": {
+						"certificate": {
+							"rawBytes": "abc"
+						}
+					}
+				},
+				"repository_id": 1
+			},
+			{
+				"bundle": {
+					"dsseEnvelope": {
+						"payload": "def"
+					}
+				},
+				"repository_id": 2
+			}
+		]
+	}`
+
+	testJSONMarshal(t, u, want, cmpJSONRawMessageComparator())
+}


### PR DESCRIPTION
Problem
Artifact attestation payload types are shared by organization, repository, and user attestation APIs, but the shared resource structs did not have dedicated JSON marshal coverage tracked by #55.

Root cause
Existing service tests exercise API decoding paths, while the resource-level marshal round-trip tests skipped Attestation and AttestationsResponse.

Solution
Add marshal tests for empty and populated Attestation and AttestationsResponse values. The populated cases use the existing json.RawMessage comparator so Sigstore bundle JSON is compared semantically.

Tests run
- gofmt -w github/attestations_test.go
- go test ./github -run 'TestAttestation(sResponse)?_Marshal'
- go test ./github
- go test ./...
- git diff --cached --check

Linked issue
Part of #55