### PR TITLE
test: Cover ClassroomUser JSON marshaling

### DIFF
--- a/github/classroom_test.go
+++ b/github/classroom_test.go
@@ -51,6 +51,27 @@ func TestClassroom_Marshal(t *testing.T) {
 	testJSONMarshal(t, c, want)
 }
 
+func TestClassroomUser_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &ClassroomUser{}, "{}")
+
+	u := &ClassroomUser{
+		ID:        Ptr(int64(1)),
+		Login:     Ptr("octocat"),
+		AvatarURL: Ptr("https://github.com/images/error/octocat_happy.gif"),
+		HTMLURL:   Ptr("https://github.com/octocat"),
+	}
+
+	want := `{
+		"id": 1,
+		"login": "octocat",
+		"avatar_url": "https://github.com/images/error/octocat_happy.gif",
+		"html_url": "https://github.com/octocat"
+	}`
+
+	testJSONMarshal(t, u, want)
+}
+
 func TestClassroomAssignment_Marshal(t *testing.T) {
 	t.Parallel()
 	testJSONMarshal(t, &ClassroomAssignment{}, "{}")


### PR DESCRIPTION
Adds a standalone JSON marshal test for ClassroomUser, matching the existing Classroom tests.

ClassroomUser is exported and used inside AcceptedAssignment responses, but it did not have its own marshal coverage.

Tests:
- script/fmt.sh
- go test ./github -run 'TestClassroom(User)?_Marshal|TestClassroomAssignment_Marshal|TestAcceptedAssignment_Marshal|TestAssignmentGrade_Marshal'
- script/test.sh
- script/lint.sh

Refs #55.
