### PR TITLE
test: Cover CodeResult JSON marshaling

### DIFF
--- a/github/search_test.go
+++ b/github/search_test.go
@@ -1069,6 +1069,39 @@ func TestUsersSearchResult_Marshal(t *testing.T) {
 	testJSONMarshal(t, u, want)
 }
 
+func TestCodeResult_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &CodeResult{}, "{}")
+
+	u := &CodeResult{
+		Name:       Ptr("main.go"),
+		Path:       Ptr("cmd/main.go"),
+		SHA:        Ptr("abc123"),
+		HTMLURL:    Ptr("https://github.com/o/r/blob/main/cmd/main.go"),
+		Repository: &Repository{ID: Ptr(int64(1))},
+		TextMatches: []*TextMatch{
+			{ObjectURL: Ptr("https://api.github.com/search/code")},
+		},
+	}
+
+	want := `{
+		"name": "main.go",
+		"path": "cmd/main.go",
+		"sha": "abc123",
+		"html_url": "https://github.com/o/r/blob/main/cmd/main.go",
+		"repository": {
+			"id": 1
+		},
+		"text_matches": [
+			{
+				"object_url": "https://api.github.com/search/code"
+			}
+		]
+	}`
+
+	testJSONMarshal(t, u, want)
+}
+
 func TestCodeSearchResult_Marshal(t *testing.T) {
 	t.Parallel()
 	testJSONMarshal(t, &CodeSearchResult{}, "{}")


### PR DESCRIPTION
Adds standalone JSON marshal coverage for CodeResult.

CodeSearchResult already had marshal coverage for the outer response shape. This adds direct coverage for the exported result type and its nested repository/text match fields.

Tests:
- gofmt -w github/search_test.go
- go test ./github -run 'TestCode(Result|SearchResult)_Marshal'
- go test ./github
- git diff --check

Refs #55.