### PR TITLE
chore: Fix zizmor security issues in GHA workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,24 +4,34 @@ updates:
   directory: /
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 7
 - package-ecosystem: gomod
   directory: otel
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 7
 - package-ecosystem: gomod
   directory: scrape
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 7
 - package-ecosystem: gomod
   directories:
     - /tools
     - /tools/**
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 7
 - package-ecosystem: gomod
   directory: example
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 7
 - package-ecosystem: github-actions
   directory: /
   schedule:
@@ -30,3 +40,5 @@ updates:
     actions:
       patterns:
       - "actions/*"
+  cooldown:
+    default-days: 7

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: stable
@@ -20,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: stable
@@ -33,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: stable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}


### PR DESCRIPTION
This PR improves the security of our GitHub Actions workflows.

I use [zizmor](https://github.com/zizmorcore/zizmor) to detect issues.

Changes:

- Add `persist-credentials: false` to all `actions/checkout` steps to prevent credential leakage.
- Add `cooldown: default-days: 7` to all Dependabot update entries to reduce PR noise.