### PR TITLE
feat: Add `GetAICreditUsage` endpoint for organization AI credits

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -862,6 +862,134 @@ func (a *AdvisoryVulnerability) GetVulnerableVersionRange() string {
 	return *a.VulnerableVersionRange
 }
 
+// GetMonth returns the Month field.
+func (a *AICreditTimePeriod) GetMonth() int {
+	if a == nil {
+		return 0
+	}
+	return a.Month
+}
+
+// GetYear returns the Year field.
+func (a *AICreditTimePeriod) GetYear() int {
+	if a == nil {
+		return 0
+	}
+	return a.Year
+}
+
+// GetOrganization returns the Organization field.
+func (a *AICreditUsage) GetOrganization() string {
+	if a == nil {
+		return ""
+	}
+	return a.Organization
+}
+
+// GetTimePeriod returns the TimePeriod field.
+func (a *AICreditUsage) GetTimePeriod() AICreditTimePeriod {
+	if a == nil {
+		return AICreditTimePeriod{}
+	}
+	return a.TimePeriod
+}
+
+// GetUsageItems returns the UsageItems slice if it's non-nil, nil otherwise.
+func (a *AICreditUsage) GetUsageItems() []*AICreditUsageItem {
+	if a == nil || a.UsageItems == nil {
+		return nil
+	}
+	return a.UsageItems
+}
+
+// GetDiscountAmount returns the DiscountAmount field.
+func (a *AICreditUsageItem) GetDiscountAmount() float64 {
+	if a == nil {
+		return 0
+	}
+	return a.DiscountAmount
+}
+
+// GetDiscountQuantity returns the DiscountQuantity field.
+func (a *AICreditUsageItem) GetDiscountQuantity() float64 {
+	if a == nil {
+		return 0
+	}
+	return a.DiscountQuantity
+}
+
+// GetGrossAmount returns the GrossAmount field.
+func (a *AICreditUsageItem) GetGrossAmount() float64 {
+	if a == nil {
+		return 0
+	}
+	return a.GrossAmount
+}
+
+// GetGrossQuantity returns the GrossQuantity field.
+func (a *AICreditUsageItem) GetGrossQuantity() float64 {
+	if a == nil {
+		return 0
+	}
+	return a.GrossQuantity
+}
+
+// GetModel returns the Model field.
+func (a *AICreditUsageItem) GetModel() string {
+	if a == nil {
+		return ""
+	}
+	return a.Model
+}
+
+// GetNetAmount returns the NetAmount field.
+func (a *AICreditUsageItem) GetNetAmount() float64 {
+	if a == nil {
+		return 0
+	}
+	return a.NetAmount
+}
+
+// GetNetQuantity returns the NetQuantity field.
+func (a *AICreditUsageItem) GetNetQuantity() float64 {
+	if a == nil {
+		return 0
+	}
+	return a.NetQuantity
+}
+
+// GetPricePerUnit returns the PricePerUnit field.
+func (a *AICreditUsageItem) GetPricePerUnit() float64 {
+	if a == nil {
+		return 0
+	}
+	return a.PricePerUnit
+}
+
+// GetProduct returns the Product field.
+func (a *AICreditUsageItem) GetProduct() string {
+	if a == nil {
+		return ""
+	}
+	return a.Product
+}
+
+// GetSKU returns the SKU field.
+func (a *AICreditUsageItem) GetSKU() string {
+	if a == nil {
+		return ""
+	}
+	return a.SKU
+}
+
+// GetUnitType returns the UnitType field.
+func (a *AICreditUsageItem) GetUnitType() string {
+	if a == nil {
+		return ""
+	}
+	return a.UnitType
+}
+
 // GetClosedAt returns the ClosedAt field if it's non-nil, zero value otherwise.
 func (a *Alert) GetClosedAt() Timestamp {
 	if a == nil || a.ClosedAt == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -862,12 +862,20 @@ func (a *AdvisoryVulnerability) GetVulnerableVersionRange() string {
 	return *a.VulnerableVersionRange
 }
 
-// GetMonth returns the Month field.
-func (a *AICreditTimePeriod) GetMonth() int {
-	if a == nil {
+// GetDay returns the Day field if it's non-nil, zero value otherwise.
+func (a *AICreditTimePeriod) GetDay() int {
+	if a == nil || a.Day == nil {
 		return 0
 	}
-	return a.Month
+	return *a.Day
+}
+
+// GetMonth returns the Month field if it's non-nil, zero value otherwise.
+func (a *AICreditTimePeriod) GetMonth() int {
+	if a == nil || a.Month == nil {
+		return 0
+	}
+	return *a.Month
 }
 
 // GetYear returns the Year field.
@@ -988,6 +996,54 @@ func (a *AICreditUsageItem) GetUnitType() string {
 		return ""
 	}
 	return a.UnitType
+}
+
+// GetDay returns the Day field.
+func (a *AICreditUsageOptions) GetDay() int {
+	if a == nil {
+		return 0
+	}
+	return a.Day
+}
+
+// GetModel returns the Model field.
+func (a *AICreditUsageOptions) GetModel() string {
+	if a == nil {
+		return ""
+	}
+	return a.Model
+}
+
+// GetMonth returns the Month field.
+func (a *AICreditUsageOptions) GetMonth() int {
+	if a == nil {
+		return 0
+	}
+	return a.Month
+}
+
+// GetProduct returns the Product field.
+func (a *AICreditUsageOptions) GetProduct() string {
+	if a == nil {
+		return ""
+	}
+	return a.Product
+}
+
+// GetUser returns the User field.
+func (a *AICreditUsageOptions) GetUser() string {
+	if a == nil {
+		return ""
+	}
+	return a.User
+}
+
+// GetYear returns the Year field.
+func (a *AICreditUsageOptions) GetYear() int {
+	if a == nil {
+		return 0
+	}
+	return a.Year
 }
 
 // GetClosedAt returns the ClosedAt field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -1067,9 +1067,23 @@ func TestAdvisoryVulnerability_GetVulnerableVersionRange(tt *testing.T) {
 	a.GetVulnerableVersionRange()
 }
 
+func TestAICreditTimePeriod_GetDay(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	a := &AICreditTimePeriod{Day: &zeroValue}
+	a.GetDay()
+	a = &AICreditTimePeriod{}
+	a.GetDay()
+	a = nil
+	a.GetDay()
+}
+
 func TestAICreditTimePeriod_GetMonth(tt *testing.T) {
 	tt.Parallel()
-	a := &AICreditTimePeriod{}
+	var zeroValue int
+	a := &AICreditTimePeriod{Month: &zeroValue}
+	a.GetMonth()
+	a = &AICreditTimePeriod{}
 	a.GetMonth()
 	a = nil
 	a.GetMonth()
@@ -1196,6 +1210,54 @@ func TestAICreditUsageItem_GetUnitType(tt *testing.T) {
 	a.GetUnitType()
 	a = nil
 	a.GetUnitType()
+}
+
+func TestAICreditUsageOptions_GetDay(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageOptions{}
+	a.GetDay()
+	a = nil
+	a.GetDay()
+}
+
+func TestAICreditUsageOptions_GetModel(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageOptions{}
+	a.GetModel()
+	a = nil
+	a.GetModel()
+}
+
+func TestAICreditUsageOptions_GetMonth(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageOptions{}
+	a.GetMonth()
+	a = nil
+	a.GetMonth()
+}
+
+func TestAICreditUsageOptions_GetProduct(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageOptions{}
+	a.GetProduct()
+	a = nil
+	a.GetProduct()
+}
+
+func TestAICreditUsageOptions_GetUser(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageOptions{}
+	a.GetUser()
+	a = nil
+	a.GetUser()
+}
+
+func TestAICreditUsageOptions_GetYear(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageOptions{}
+	a.GetYear()
+	a = nil
+	a.GetYear()
 }
 
 func TestAlert_GetClosedAt(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -1067,6 +1067,137 @@ func TestAdvisoryVulnerability_GetVulnerableVersionRange(tt *testing.T) {
 	a.GetVulnerableVersionRange()
 }
 
+func TestAICreditTimePeriod_GetMonth(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditTimePeriod{}
+	a.GetMonth()
+	a = nil
+	a.GetMonth()
+}
+
+func TestAICreditTimePeriod_GetYear(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditTimePeriod{}
+	a.GetYear()
+	a = nil
+	a.GetYear()
+}
+
+func TestAICreditUsage_GetOrganization(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsage{}
+	a.GetOrganization()
+	a = nil
+	a.GetOrganization()
+}
+
+func TestAICreditUsage_GetTimePeriod(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsage{}
+	a.GetTimePeriod()
+	a = nil
+	a.GetTimePeriod()
+}
+
+func TestAICreditUsage_GetUsageItems(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*AICreditUsageItem{}
+	a := &AICreditUsage{UsageItems: zeroValue}
+	a.GetUsageItems()
+	a = &AICreditUsage{}
+	a.GetUsageItems()
+	a = nil
+	a.GetUsageItems()
+}
+
+func TestAICreditUsageItem_GetDiscountAmount(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageItem{}
+	a.GetDiscountAmount()
+	a = nil
+	a.GetDiscountAmount()
+}
+
+func TestAICreditUsageItem_GetDiscountQuantity(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageItem{}
+	a.GetDiscountQuantity()
+	a = nil
+	a.GetDiscountQuantity()
+}
+
+func TestAICreditUsageItem_GetGrossAmount(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageItem{}
+	a.GetGrossAmount()
+	a = nil
+	a.GetGrossAmount()
+}
+
+func TestAICreditUsageItem_GetGrossQuantity(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageItem{}
+	a.GetGrossQuantity()
+	a = nil
+	a.GetGrossQuantity()
+}
+
+func TestAICreditUsageItem_GetModel(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageItem{}
+	a.GetModel()
+	a = nil
+	a.GetModel()
+}
+
+func TestAICreditUsageItem_GetNetAmount(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageItem{}
+	a.GetNetAmount()
+	a = nil
+	a.GetNetAmount()
+}
+
+func TestAICreditUsageItem_GetNetQuantity(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageItem{}
+	a.GetNetQuantity()
+	a = nil
+	a.GetNetQuantity()
+}
+
+func TestAICreditUsageItem_GetPricePerUnit(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageItem{}
+	a.GetPricePerUnit()
+	a = nil
+	a.GetPricePerUnit()
+}
+
+func TestAICreditUsageItem_GetProduct(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageItem{}
+	a.GetProduct()
+	a = nil
+	a.GetProduct()
+}
+
+func TestAICreditUsageItem_GetSKU(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageItem{}
+	a.GetSKU()
+	a = nil
+	a.GetSKU()
+}
+
+func TestAICreditUsageItem_GetUnitType(tt *testing.T) {
+	tt.Parallel()
+	a := &AICreditUsageItem{}
+	a.GetUnitType()
+	a = nil
+	a.GetUnitType()
+}
+
 func TestAlert_GetClosedAt(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp

--- a/github/organizations_billing_ai_credit.go
+++ b/github/organizations_billing_ai_credit.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// AICreditTimePeriod represents the billing time period for AI credit usage.
+type AICreditTimePeriod struct {
+	Year  int `json:"year"`
+	Month int `json:"month"`
+}
+
+// AICreditUsageItem represents a single line item in the AI credit usage report.
+type AICreditUsageItem struct {
+	Product          string  `json:"product"`
+	SKU              string  `json:"sku"`
+	Model            string  `json:"model"`
+	UnitType         string  `json:"unitType"`
+	PricePerUnit     float64 `json:"pricePerUnit"`
+	GrossQuantity    float64 `json:"grossQuantity"`
+	GrossAmount      float64 `json:"grossAmount"`
+	DiscountQuantity float64 `json:"discountQuantity"`
+	DiscountAmount   float64 `json:"discountAmount"`
+	NetQuantity      float64 `json:"netQuantity"`
+	NetAmount        float64 `json:"netAmount"`
+}
+
+// AICreditUsage represents the AI credit billing usage for an organization.
+type AICreditUsage struct {
+	TimePeriod   AICreditTimePeriod   `json:"timePeriod"`
+	Organization string               `json:"organization"`
+	UsageItems   []*AICreditUsageItem `json:"usageItems,omitempty"`
+}
+
+// GetAICreditUsage returns the AI credit billing usage for an organization.
+//
+//meta:operation GET /organizations/{org}/settings/billing/ai_credit/usage
+func (s *BillingService) GetAICreditUsage(ctx context.Context, org string) (*AICreditUsage, *Response, error) {
+	u := fmt.Sprintf("organizations/%v/settings/billing/ai_credit/usage", org)
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var result *AICreditUsage
+	resp, err := s.client.Do(req, &result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}

--- a/github/organizations_billing_ai_credit.go
+++ b/github/organizations_billing_ai_credit.go
@@ -12,8 +12,9 @@ import (
 
 // AICreditTimePeriod represents the billing time period for AI credit usage.
 type AICreditTimePeriod struct {
-	Year  int `json:"year"`
-	Month int `json:"month"`
+	Year  int  `json:"year"`
+	Month *int `json:"month,omitempty"`
+	Day   *int `json:"day,omitempty"`
 }
 
 // AICreditUsageItem represents a single line item in the AI credit usage report.
@@ -35,14 +36,32 @@ type AICreditUsageItem struct {
 type AICreditUsage struct {
 	TimePeriod   AICreditTimePeriod   `json:"timePeriod"`
 	Organization string               `json:"organization"`
-	UsageItems   []*AICreditUsageItem `json:"usageItems,omitempty"`
+	UsageItems   []*AICreditUsageItem `json:"usageItems"`
+}
+
+// AICreditUsageOptions specifies the optional parameters to the
+// BillingService.GetAICreditUsage endpoint.
+type AICreditUsageOptions struct {
+	Year    int    `url:"year,omitempty"`
+	Month   int    `url:"month,omitempty"`
+	Day     int    `url:"day,omitempty"`
+	User    string `url:"user,omitempty"`
+	Model   string `url:"model,omitempty"`
+	Product string `url:"product,omitempty"`
 }
 
 // GetAICreditUsage returns the AI credit billing usage for an organization.
 //
+// GitHub API docs: https://docs.github.com/rest/billing/usage?apiVersion=2022-11-28#get-billing-ai-credit-usage-report-for-an-organization
+//
 //meta:operation GET /organizations/{org}/settings/billing/ai_credit/usage
-func (s *BillingService) GetAICreditUsage(ctx context.Context, org string) (*AICreditUsage, *Response, error) {
-	u := fmt.Sprintf("organizations/%v/settings/billing/ai_credit/usage", org)
+func (s *BillingService) GetAICreditUsage(ctx context.Context, org string, opts *AICreditUsageOptions) (*AICreditUsage, *Response, error) {
+	u := fmt.Sprintf("/organizations/%v/settings/billing/ai_credit/usage", org)
+
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {

--- a/github/organizations_billing_ai_credit_test.go
+++ b/github/organizations_billing_ai_credit_test.go
@@ -17,8 +17,17 @@ func TestBillingService_GetAICreditUsage(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
+	opts := &AICreditUsageOptions{
+		Year:  2026,
+		Month: 6,
+	}
+
 	mux.HandleFunc("/organizations/o/settings/billing/ai_credit/usage", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"year":  "2026",
+			"month": "6",
+		})
 		fmt.Fprint(w, `{
 			"timePeriod": {
 				"year": 2026,
@@ -57,15 +66,16 @@ func TestBillingService_GetAICreditUsage(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	usage, _, err := client.Billing.GetAICreditUsage(ctx, "o")
+	usage, _, err := client.Billing.GetAICreditUsage(ctx, "o", opts)
 	if err != nil {
 		t.Errorf("Billing.GetAICreditUsage returned error: %v", err)
 	}
 
+	month := 6
 	want := &AICreditUsage{
 		TimePeriod: AICreditTimePeriod{
 			Year:  2026,
-			Month: 6,
+			Month: &month,
 		},
 		Organization: "o",
 		UsageItems: []*AICreditUsageItem{
@@ -103,12 +113,12 @@ func TestBillingService_GetAICreditUsage(t *testing.T) {
 
 	const methodName = "GetAICreditUsage"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Billing.GetAICreditUsage(ctx, "\n")
+		_, _, err = client.Billing.GetAICreditUsage(ctx, "\n", nil)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Billing.GetAICreditUsage(ctx, "o")
+		got, resp, err := client.Billing.GetAICreditUsage(ctx, "o", nil)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -121,22 +131,78 @@ func TestBillingService_GetAICreditUsage_invalidOrg(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Billing.GetAICreditUsage(ctx, "%")
+	_, _, err := client.Billing.GetAICreditUsage(ctx, "%", nil)
 	testURLParseError(t, err)
+}
+
+func TestBillingService_GetAICreditUsage_WithOptionalParams(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	opts := &AICreditUsageOptions{
+		Year:  2026,
+		Model: "Claude Sonnet 4.6",
+	}
+
+	mux.HandleFunc("/organizations/o/settings/billing/ai_credit/usage", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"year":  "2026",
+			"model": "Claude Sonnet 4.6",
+		})
+		fmt.Fprint(w, `{
+			"timePeriod": {
+				"year": 2026,
+				"month": 6
+			},
+			"organization": "o",
+			"usageItems": []
+		}`)
+	})
+
+	ctx := t.Context()
+	usage, _, err := client.Billing.GetAICreditUsage(ctx, "o", opts)
+	if err != nil {
+		t.Errorf("Billing.GetAICreditUsage with optional params returned error: %v", err)
+	}
+
+	if usage.Organization != "o" {
+		t.Errorf("Expected organization 'o', got %v", usage.Organization)
+	}
 }
 
 func TestAICreditTimePeriod_Marshal(t *testing.T) {
 	t.Parallel()
-	testJSONMarshal(t, &AICreditTimePeriod{}, `{"year":0,"month":0}`)
+	testJSONMarshal(t, &AICreditTimePeriod{}, `{"year":0}`)
 
+	month := 6
 	u := &AICreditTimePeriod{
 		Year:  2026,
-		Month: 6,
+		Month: &month,
 	}
 
 	want := `{
 		"year": 2026,
 		"month": 6
+	}`
+
+	testJSONMarshal(t, u, want)
+}
+
+func TestAICreditTimePeriod_Marshal_WithDay(t *testing.T) {
+	t.Parallel()
+	month := 6
+	day := 15
+	u := &AICreditTimePeriod{
+		Year:  2026,
+		Month: &month,
+		Day:   &day,
+	}
+
+	want := `{
+		"year": 2026,
+		"month": 6,
+		"day": 15
 	}`
 
 	testJSONMarshal(t, u, want)
@@ -179,12 +245,13 @@ func TestAICreditUsageItem_Marshal(t *testing.T) {
 
 func TestAICreditUsage_Marshal(t *testing.T) {
 	t.Parallel()
-	testJSONMarshal(t, &AICreditUsage{}, `{"timePeriod":{"year":0,"month":0},"organization":""}`)
+	testJSONMarshal(t, &AICreditUsage{}, `{"timePeriod":{"year":0},"organization":""}`)
 
+	month := 6
 	u := &AICreditUsage{
 		TimePeriod: AICreditTimePeriod{
 			Year:  2026,
-			Month: 6,
+			Month: &month,
 		},
 		Organization: "test-org",
 		UsageItems: []*AICreditUsageItem{
@@ -205,27 +272,27 @@ func TestAICreditUsage_Marshal(t *testing.T) {
 	}
 
 	want := `{
-        "timePeriod": {
-            "year": 2026,
-            "month": 6
-        },
-        "organization": "test-org",
-        "usageItems": [
-            {
-                "product": "Copilot",
-                "sku": "Copilot AI Credits",
-                "model": "Auto: Claude Haiku 4.5",
-                "unitType": "ai-credits",
-                "pricePerUnit": 0.01,
-                "grossQuantity": 3956.1799545,
-                "grossAmount": 39.561799545,
-                "discountQuantity": 3956.1799545,
-                "discountAmount": 39.561799545,
-                "netQuantity": 0,
-                "netAmount": 0
-            }
-        ]
-    }`
+		"timePeriod": {
+			"year": 2026,
+			"month": 6
+		},
+		"organization": "test-org",
+		"usageItems": [
+			{
+				"product": "Copilot",
+				"sku": "Copilot AI Credits",
+				"model": "Auto: Claude Haiku 4.5",
+				"unitType": "ai-credits",
+				"pricePerUnit": 0.01,
+				"grossQuantity": 3956.1799545,
+				"grossAmount": 39.561799545,
+				"discountQuantity": 3956.1799545,
+				"discountAmount": 39.561799545,
+				"netQuantity": 0,
+				"netAmount": 0
+			}
+		]
+	}`
 
 	testJSONMarshal(t, u, want)
 }

--- a/github/organizations_billing_ai_credit_test.go
+++ b/github/organizations_billing_ai_credit_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestBillingService_GetAICreditUsage(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/organizations/o/settings/billing/ai_credit/usage", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"timePeriod": {
+				"year": 2026,
+				"month": 6
+			},
+			"organization": "o",
+			"usageItems": [
+				{
+					"product": "Copilot",
+					"sku": "Copilot AI Credits",
+					"model": "Auto: Claude Haiku 4.5",
+					"unitType": "ai-credits",
+					"pricePerUnit": 0.01,
+					"grossQuantity": 3956.1799545,
+					"grossAmount": 39.561799545,
+					"discountQuantity": 3956.1799545,
+					"discountAmount": 39.561799545,
+					"netQuantity": 0.0,
+					"netAmount": 0.0
+				},
+				{
+					"product": "Copilot",
+					"sku": "Copilot AI Credits",
+					"model": "Auto: Claude Sonnet 4.6",
+					"unitType": "ai-credits",
+					"pricePerUnit": 0.01,
+					"grossQuantity": 9498.6969165,
+					"grossAmount": 94.986969165,
+					"discountQuantity": 9564.710256,
+					"discountAmount": 95.64710256,
+					"netQuantity": 0.0,
+					"netAmount": 0.0
+				}
+			]
+		}`)
+	})
+
+	ctx := t.Context()
+	usage, _, err := client.Billing.GetAICreditUsage(ctx, "o")
+	if err != nil {
+		t.Errorf("Billing.GetAICreditUsage returned error: %v", err)
+	}
+
+	want := &AICreditUsage{
+		TimePeriod: AICreditTimePeriod{
+			Year:  2026,
+			Month: 6,
+		},
+		Organization: "o",
+		UsageItems: []*AICreditUsageItem{
+			{
+				Product:          "Copilot",
+				SKU:              "Copilot AI Credits",
+				Model:            "Auto: Claude Haiku 4.5",
+				UnitType:         "ai-credits",
+				PricePerUnit:     0.01,
+				GrossQuantity:    3956.1799545,
+				GrossAmount:      39.561799545,
+				DiscountQuantity: 3956.1799545,
+				DiscountAmount:   39.561799545,
+				NetQuantity:      0.0,
+				NetAmount:        0.0,
+			},
+			{
+				Product:          "Copilot",
+				SKU:              "Copilot AI Credits",
+				Model:            "Auto: Claude Sonnet 4.6",
+				UnitType:         "ai-credits",
+				PricePerUnit:     0.01,
+				GrossQuantity:    9498.6969165,
+				GrossAmount:      94.986969165,
+				DiscountQuantity: 9564.710256,
+				DiscountAmount:   95.64710256,
+				NetQuantity:      0.0,
+				NetAmount:        0.0,
+			},
+		},
+	}
+	if !cmp.Equal(usage, want) {
+		t.Errorf("Billing.GetAICreditUsage returned %+v, want %+v", usage, want)
+	}
+
+	const methodName = "GetAICreditUsage"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Billing.GetAICreditUsage(ctx, "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Billing.GetAICreditUsage(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestBillingService_GetAICreditUsage_invalidOrg(t *testing.T) {
+	t.Parallel()
+	client, _, _ := setup(t)
+
+	ctx := t.Context()
+	_, _, err := client.Billing.GetAICreditUsage(ctx, "%")
+	testURLParseError(t, err)
+}
+
+func TestAICreditTimePeriod_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &AICreditTimePeriod{}, `{"year":0,"month":0}`)
+
+	u := &AICreditTimePeriod{
+		Year:  2026,
+		Month: 6,
+	}
+
+	want := `{
+		"year": 2026,
+		"month": 6
+	}`
+
+	testJSONMarshal(t, u, want)
+}
+
+func TestAICreditUsageItem_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &AICreditUsageItem{}, `{"product":"","sku":"","model":"","unitType":"","pricePerUnit":0,"grossQuantity":0,"grossAmount":0,"discountQuantity":0,"discountAmount":0,"netQuantity":0,"netAmount":0}`)
+
+	u := &AICreditUsageItem{
+		Product:          "Copilot",
+		SKU:              "Copilot AI Credits",
+		Model:            "Auto: Claude Haiku 4.5",
+		UnitType:         "ai-credits",
+		PricePerUnit:     0.01,
+		GrossQuantity:    3956.1799545,
+		GrossAmount:      39.561799545,
+		DiscountQuantity: 3956.1799545,
+		DiscountAmount:   39.561799545,
+		NetQuantity:      0.0,
+		NetAmount:        0.0,
+	}
+
+	want := `{
+		"product": "Copilot",
+		"sku": "Copilot AI Credits",
+		"model": "Auto: Claude Haiku 4.5",
+		"unitType": "ai-credits",
+		"pricePerUnit": 0.01,
+		"grossQuantity": 3956.1799545,
+		"grossAmount": 39.561799545,
+		"discountQuantity": 3956.1799545,
+		"discountAmount": 39.561799545,
+		"netQuantity": 0,
+		"netAmount": 0
+	}`
+
+	testJSONMarshal(t, u, want)
+}
+
+func TestAICreditUsage_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &AICreditUsage{}, `{"timePeriod":{"year":0,"month":0},"organization":""}`)
+
+	u := &AICreditUsage{
+		TimePeriod: AICreditTimePeriod{
+			Year:  2026,
+			Month: 6,
+		},
+		Organization: "test-org",
+		UsageItems: []*AICreditUsageItem{
+			{
+				Product:          "Copilot",
+				SKU:              "Copilot AI Credits",
+				Model:            "Auto: Claude Haiku 4.5",
+				UnitType:         "ai-credits",
+				PricePerUnit:     0.01,
+				GrossQuantity:    3956.1799545,
+				GrossAmount:      39.561799545,
+				DiscountQuantity: 3956.1799545,
+				DiscountAmount:   39.561799545,
+				NetQuantity:      0.0,
+				NetAmount:        0.0,
+			},
+		},
+	}
+
+	want := `{
+        "timePeriod": {
+            "year": 2026,
+            "month": 6
+        },
+        "organization": "test-org",
+        "usageItems": [
+            {
+                "product": "Copilot",
+                "sku": "Copilot AI Credits",
+                "model": "Auto: Claude Haiku 4.5",
+                "unitType": "ai-credits",
+                "pricePerUnit": 0.01,
+                "grossQuantity": 3956.1799545,
+                "grossAmount": 39.561799545,
+                "discountQuantity": 3956.1799545,
+                "discountAmount": 39.561799545,
+                "netQuantity": 0,
+                "netAmount": 0
+            }
+        ]
+    }`
+
+	testJSONMarshal(t, u, want)
+}


### PR DESCRIPTION
## Description
Closes  #4262 

This PR implements the missing GitHub AI credit billing usage API endpoint for organizations. It introduces the `GetAICreditUsage` method to the `BillingService`, along with its supporting request/response structures and comprehensive unit tests.

## Proposed Changes
- Added `AICreditTimePeriod`, `AICreditUsageItem`, and `AICreditUsage` structs to match the GitHub AI credit billing payload.
- Added `GetAICreditUsage(ctx context.Context, org string)` method to `BillingService`.
- Added unit tests covering successful API invocation, JSON marshaling behavior, and error handling (such as invalid organization names).

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes (`script/test.sh`).