### PR TITLE
fix: Handle missing reviewer type in `RequiredReviewer` unmarshal

### DIFF
--- a/github/repos_environments.go
+++ b/github/repos_environments.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -82,6 +83,10 @@ func (r *RequiredReviewer) UnmarshalJSON(data []byte) error {
 	}
 
 	r.Type = reviewer.Type
+	if reviewer.Type == nil {
+		r.Reviewer = nil
+		return errors.New("reviewer.Type is nil, not a string of 'User' or 'Team', unable to unmarshal")
+	}
 
 	switch *reviewer.Type {
 	case "User":

--- a/github/repos_environments_test.go
+++ b/github/repos_environments_test.go
@@ -51,6 +51,16 @@ func TestRequiredReviewer_UnmarshalJSON(t *testing.T) {
 			wantRule:  []*RequiredReviewer{{Type: nil, Reviewer: nil}},
 			wantError: true,
 		},
+		"Missing Type in Reviewer Object": {
+			data:      []byte(`[{"reviewer": {"id": 1}}]`),
+			wantRule:  []*RequiredReviewer{{Type: nil, Reviewer: nil}},
+			wantError: true,
+		},
+		"Null Type in Reviewer Object": {
+			data:      []byte(`[{"type": null, "reviewer": {"id": 1}}]`),
+			wantRule:  []*RequiredReviewer{{Type: nil, Reviewer: nil}},
+			wantError: true,
+		},
 		"Wrong ID Type in User Object": {
 			data:      []byte(`[{"type": "User", "reviewer": {"id": "string"}}]`),
 			wantRule:  []*RequiredReviewer{{Type: Ptr("User"), Reviewer: nil}},


### PR DESCRIPTION
## Summary

Handle missing or null required reviewer type values without panicking during JSON unmarshalling.

Previously, RequiredReviewer.UnmarshalJSON dereferenced reviewer.Type directly after decoding. If the API response contained a missing or null type field, unmarshalling could panic with a nil pointer dereference instead of returning a normal unmarshal error.

### Changes

- Return a normal error when reviewer.Type is nil
- Add regression coverage for missing and null reviewer type values

### Testing

- go test ./github -run TestRequiredReviewer_UnmarshalJSON
- go test ./github
- go test -race -covermode atomic ./github
- script/fmt.sh
- script/test.sh ./...
- script/lint.sh
- git diff --check