### PR TITLE
chore: Remove 'munlicode' from REVIEWERS

### DIFF
--- a/REVIEWERS
+++ b/REVIEWERS
@@ -2,4 +2,3 @@ stevehipwell
 alexandear
 zyfy29
 Not-Dhananjay-Mishra
-munlicode


### PR DESCRIPTION
Removed 'munlicode' from the list of reviewers.

REASON: Exams and many other things are coming up.

Thanks for experience :D