### PR TITLE
test: Replace `&x` variables with inline `Ptr(value)` calls

### DIFF
--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -1332,13 +1332,11 @@ func TestCopilotService_GetEnterpriseMetrics(t *testing.T) {
 		t.Errorf("Copilot.GetEnterpriseMetrics returned error: %v", err)
 	}
 
-	totalActiveUsers := 24
-	totalEngagedUsers := 20
 	want := []*CopilotMetrics{
 		{
 			Date:              "2024-06-24",
-			TotalActiveUsers:  &totalActiveUsers,
-			TotalEngagedUsers: &totalEngagedUsers,
+			TotalActiveUsers:  Ptr(24),
+			TotalEngagedUsers: Ptr(20),
 			CopilotIDECodeCompletions: &CopilotIDECodeCompletions{
 				TotalEngagedUsers: 20,
 				Languages: []*CopilotIDECodeCompletionsLanguage{
@@ -1675,13 +1673,11 @@ func TestCopilotService_GetEnterpriseTeamMetrics(t *testing.T) {
 		t.Errorf("Copilot.GetEnterpriseTeamMetrics returned error: %v", err)
 	}
 
-	totalActiveUsers := 24
-	totalEngagedUsers := 20
 	want := []*CopilotMetrics{
 		{
 			Date:              "2024-06-24",
-			TotalActiveUsers:  &totalActiveUsers,
-			TotalEngagedUsers: &totalEngagedUsers,
+			TotalActiveUsers:  Ptr(24),
+			TotalEngagedUsers: Ptr(20),
 			CopilotIDECodeCompletions: &CopilotIDECodeCompletions{
 				TotalEngagedUsers: 20,
 				Languages: []*CopilotIDECodeCompletionsLanguage{
@@ -2018,13 +2014,11 @@ func TestCopilotService_GetOrganizationMetrics(t *testing.T) {
 		t.Errorf("Copilot.GetOrganizationMetrics returned error: %v", err)
 	}
 
-	totalActiveUsers := 24
-	totalEngagedUsers := 20
 	want := []*CopilotMetrics{
 		{
 			Date:              "2024-06-24",
-			TotalActiveUsers:  &totalActiveUsers,
-			TotalEngagedUsers: &totalEngagedUsers,
+			TotalActiveUsers:  Ptr(24),
+			TotalEngagedUsers: Ptr(20),
 			CopilotIDECodeCompletions: &CopilotIDECodeCompletions{
 				TotalEngagedUsers: 20,
 				Languages: []*CopilotIDECodeCompletionsLanguage{
@@ -2361,13 +2355,11 @@ func TestCopilotService_GetOrganizationTeamMetrics(t *testing.T) {
 		t.Errorf("Copilot.GetOrganizationTeamMetrics returned error: %v", err)
 	}
 
-	totalActiveUsers := 24
-	totalEngagedUsers := 20
 	want := []*CopilotMetrics{
 		{
 			Date:              "2024-06-24",
-			TotalActiveUsers:  &totalActiveUsers,
-			TotalEngagedUsers: &totalEngagedUsers,
+			TotalActiveUsers:  Ptr(24),
+			TotalEngagedUsers: Ptr(20),
 			CopilotIDECodeCompletions: &CopilotIDECodeCompletions{
 				TotalEngagedUsers: 20,
 				Languages: []*CopilotIDECodeCompletionsLanguage{

--- a/github/enterprise_licenses_test.go
+++ b/github/enterprise_licenses_test.go
@@ -54,36 +54,28 @@ func TestEnterpriseService_ListConsumedLicenses(t *testing.T) {
 		t.Errorf("Enterprise.ListConsumedLicenses returned error: %v", err)
 	}
 
-	userName := "User One"
-	serverUser := false
-	profile := "https://github.com/user1"
-	samlNameID := "saml123"
-	twoFactorAuth := true
-	licenseStatus := "active"
-	vsEmail := "user1@example.com"
-
 	want := &EnterpriseConsumedLicenses{
 		TotalSeatsConsumed:  20,
 		TotalSeatsPurchased: 25,
 		Users: []*EnterpriseLicensedUsers{
 			{
 				GithubComLogin:                  "user1",
-				GithubComName:                   &userName,
+				GithubComName:                   Ptr("User One"),
 				EnterpriseServerUserIDs:         []string{"123", "456"},
 				GithubComUser:                   true,
-				EnterpriseServerUser:            &serverUser,
+				EnterpriseServerUser:            Ptr(false),
 				VisualStudioSubscriptionUser:    false,
 				LicenseType:                     "Enterprise",
-				GithubComProfile:                &profile,
+				GithubComProfile:                Ptr("https://github.com/user1"),
 				GithubComMemberRoles:            []string{"member"},
 				GithubComEnterpriseRoles:        []string{"member"},
 				GithubComVerifiedDomainEmails:   []string{"user1@example.com"},
-				GithubComSamlNameID:             &samlNameID,
+				GithubComSamlNameID:             Ptr("saml123"),
 				GithubComOrgsWithPendingInvites: []string{},
-				GithubComTwoFactorAuth:          &twoFactorAuth,
+				GithubComTwoFactorAuth:          Ptr(true),
 				EnterpriseServerEmails:          []string{"user1@example.com"},
-				VisualStudioLicenseStatus:       &licenseStatus,
-				VisualStudioSubscriptionEmail:   &vsEmail,
+				VisualStudioLicenseStatus:       Ptr("active"),
+				VisualStudioSubscriptionEmail:   Ptr("user1@example.com"),
 				TotalUserAccounts:               1,
 			},
 		},

--- a/github/event_test.go
+++ b/github/event_test.go
@@ -18,17 +18,15 @@ func TestPayload_Panic(t *testing.T) {
 		}
 	}()
 
-	name := "UserEvent"
 	body := json.RawMessage("[") // bogus JSON
-	e := &Event{Type: &name, RawPayload: &body}
+	e := &Event{Type: Ptr("UserEvent"), RawPayload: &body}
 	e.Payload()
 }
 
 func TestPayload_NoPanic(t *testing.T) {
 	t.Parallel()
-	name := "UserEvent"
 	body := json.RawMessage("{}")
-	e := &Event{Type: &name, RawPayload: &body}
+	e := &Event{Type: Ptr("UserEvent"), RawPayload: &body}
 	e.Payload()
 }
 

--- a/github/git_commits_test.go
+++ b/github/git_commits_test.go
@@ -131,14 +131,12 @@ func TestGitService_CreateSignedCommit(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	signature := "----- BEGIN PGP SIGNATURE -----\n\naaaa\naaaa\n----- END PGP SIGNATURE -----"
-
 	input := Commit{
 		Message: Ptr("Commit Message."),
 		Tree:    &Tree{SHA: Ptr("t")},
 		Parents: []*Commit{{SHA: Ptr("p")}},
 		Verification: &SignatureVerification{
-			Signature: &signature,
+			Signature: Ptr("----- BEGIN PGP SIGNATURE -----\n\naaaa\naaaa\n----- END PGP SIGNATURE -----"),
 		},
 	}
 
@@ -316,9 +314,8 @@ func TestGitService_createSignatureMessage_nilMessage(t *testing.T) {
 func TestGitService_createSignatureMessage_emptyMessage(t *testing.T) {
 	t.Parallel()
 	date, _ := time.Parse("Mon Jan 02 15:04:05 2006 -0700", "Thu May 04 00:03:43 2017 +0200")
-	emptyString := ""
 	_, err := createSignatureMessage(&createCommit{
-		Message: &emptyString,
+		Message: Ptr(""),
 		Parents: []string{"p"},
 		Author: &CommitAuthor{
 			Name:  Ptr("go-github"),

--- a/github/orgs_immutable_releases_test.go
+++ b/github/orgs_immutable_releases_test.go
@@ -31,10 +31,9 @@ func TestOrganizationsService_GetImmutableReleasesSettings(t *testing.T) {
 		t.Errorf("Organizations.GetImmutableReleasesSettings returned error: %v", err)
 	}
 
-	wantURL := "https://api.github.com/orgs/o/r"
 	want := &ImmutableReleaseSettings{
 		EnforcedRepositories:    Ptr("selected"),
-		SelectedRepositoriesURL: &wantURL,
+		SelectedRepositoriesURL: Ptr("https://api.github.com/orgs/o/r"),
 	}
 
 	if !cmp.Equal(settings, want) {

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -997,11 +997,10 @@ func TestProjectsService_UpdateUserProjectItem_error(t *testing.T) {
 		testMethod(t, r, "PATCH")
 		fmt.Fprint(w, `{"id":55}`)
 	})
-	archived := false
 	ctx := t.Context()
 	const methodName = "UpdateUserProjectItem"
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Projects.UpdateUserProjectItem(ctx, "u", 2, 55, &UpdateProjectItemOptions{Archived: &archived})
+		got, resp, err := client.Projects.UpdateUserProjectItem(ctx, "u", 2, 55, &UpdateProjectItemOptions{Archived: Ptr(false)})
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/github/pulls_reviews_test.go
+++ b/github/pulls_reviews_test.go
@@ -413,19 +413,16 @@ func TestPullRequestsService_CreateReview_badReview(t *testing.T) {
 
 	path := "path/to/file.go"
 	body := "this is a comment body"
-	right := "RIGHT"
-	pos1 := 1
-	line1 := 11
 	badReview := &PullRequestReviewRequest{
 		Comments: []*DraftReviewComment{{
 			Path: &path,
 			Body: &body,
-			Side: &right,
-			Line: &line1,
+			Side: Ptr("RIGHT"),
+			Line: Ptr(11),
 		}, {
 			Path:     &path,
 			Body:     &body,
-			Position: &pos1,
+			Position: Ptr(1),
 		}},
 	}
 

--- a/github/repos_contents_test.go
+++ b/github/repos_contents_test.go
@@ -806,11 +806,9 @@ func TestRepositoriesService_CreateFile(t *testing.T) {
 			}
 		}`)
 	})
-	message := "m"
-	content := []byte("c")
 	repositoryContentsOptions := &RepositoryContentFileOptions{
-		Message:   &message,
-		Content:   content,
+		Message:   Ptr("m"),
+		Content:   []byte("c"),
 		Committer: &CommitAuthor{Name: Ptr("n"), Email: Ptr("e")},
 	}
 	ctx := t.Context()
@@ -860,13 +858,10 @@ func TestRepositoriesService_UpdateFile(t *testing.T) {
 			}
 		}`)
 	})
-	message := "m"
-	content := []byte("c")
-	sha := "f5f369044773ff9c6383c087466d12adb6fa0828"
 	repositoryContentsOptions := &RepositoryContentFileOptions{
-		Message:   &message,
-		Content:   content,
-		SHA:       &sha,
+		Message:   Ptr("m"),
+		Content:   []byte("c"),
+		SHA:       Ptr("f5f369044773ff9c6383c087466d12adb6fa0828"),
 		Committer: &CommitAuthor{Name: Ptr("n"), Email: Ptr("e")},
 	}
 	ctx := t.Context()
@@ -914,11 +909,9 @@ func TestRepositoriesService_DeleteFile(t *testing.T) {
 			}
 		}`)
 	})
-	message := "m"
-	sha := "f5f369044773ff9c6383c087466d12adb6fa0828"
 	repositoryContentsOptions := &RepositoryContentFileOptions{
-		Message:   &message,
-		SHA:       &sha,
+		Message:   Ptr("m"),
+		SHA:       Ptr("f5f369044773ff9c6383c087466d12adb6fa0828"),
 		Committer: &CommitAuthor{Name: Ptr("n"), Email: Ptr("e")},
 	}
 	ctx := t.Context()

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -800,9 +800,8 @@ func TestRepositoriesService_UploadReleaseAssetFromRelease(t *testing.T) {
 	size := int64(len(body))
 
 	// Provide a templated upload URL like GitHub returns.
-	uploadURL := "/repos/o/r/releases/1/assets{?name,label}"
 	release := &RepositoryRelease{
-		UploadURL: &uploadURL,
+		UploadURL: Ptr("/repos/o/r/releases/1/assets{?name,label}"),
 	}
 
 	ctx := t.Context()
@@ -871,8 +870,7 @@ func TestRepositoriesService_UploadReleaseAssetFromRelease_NilReader(t *testing.
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	uploadURL := "/repos/o/r/releases/1/assets{?name,label}"
-	release := &RepositoryRelease{UploadURL: &uploadURL}
+	release := &RepositoryRelease{UploadURL: Ptr("/repos/o/r/releases/1/assets{?name,label}")}
 
 	ctx := t.Context()
 	_, _, err := client.Repositories.UploadReleaseAssetFromRelease(ctx, release, &UploadOptions{Name: "n.txt"}, nil, 12)
@@ -891,8 +889,7 @@ func TestRepositoriesService_UploadReleaseAssetFromRelease_NegativeSize(t *testi
 	t.Parallel()
 	client, _, _ := setup(t)
 
-	uploadURL := "/repos/o/r/releases/1/assets{?name,label}"
-	release := &RepositoryRelease{UploadURL: &uploadURL}
+	release := &RepositoryRelease{UploadURL: Ptr("/repos/o/r/releases/1/assets{?name,label}")}
 
 	body := []byte("Upload me !\n")
 	reader := bytes.NewReader(body)
@@ -919,8 +916,7 @@ func TestRepositoriesService_UploadReleaseAssetFromRelease_NoOpts(t *testing.T) 
 	reader := bytes.NewReader(body)
 	size := int64(len(body))
 
-	uploadURL := "/repos/o/r/releases/1/assets{?name,label}"
-	release := &RepositoryRelease{UploadURL: &uploadURL}
+	release := &RepositoryRelease{UploadURL: Ptr("/repos/o/r/releases/1/assets{?name,label}")}
 
 	ctx := t.Context()
 	asset, _, err := client.Repositories.UploadReleaseAssetFromRelease(ctx, release, nil, reader, size)
@@ -957,8 +953,7 @@ func TestRepositoriesService_UploadReleaseAssetFromRelease_WithMediaType(t *test
 	reader := bytes.NewReader(body)
 	size := int64(len(body))
 
-	uploadURL := "/repos/o/r/releases/1/assets{?name,label}"
-	release := &RepositoryRelease{UploadURL: &uploadURL}
+	release := &RepositoryRelease{UploadURL: Ptr("/repos/o/r/releases/1/assets{?name,label}")}
 
 	opts := &UploadOptions{Name: "n.txt", MediaType: "image/png"}
 

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -499,8 +499,7 @@ func TestRepositoriesService_Edit(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	i := true
-	input := &Repository{HasIssues: &i}
+	input := &Repository{HasIssues: Ptr(true)}
 
 	wantAcceptHeaders := []string{mediaTypeRepositoryTemplatePreview, mediaTypeRepositoryVisibilityPreview}
 	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This PR refactors tests. It replaces the pattern of declaring a temporary variable only to take its address:

```
name := "User One"
// ...
field: &name,
```

with an inline `Ptr()` call:

```
field: Ptr("User One"),
```

I created a custom golangci-lint linter to detect such cases, but it is not worth adding it because it increases the maintenance overhead.