### PR TITLE
fix: Comparison of durations in `AbuseRateLimitError.Is`

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -1652,8 +1652,15 @@ func (r *AbuseRateLimitError) Is(target error) bool {
 	}
 
 	return r.Message == v.Message &&
-		r.RetryAfter == v.RetryAfter &&
+		equalDurationPtr(r.RetryAfter, v.RetryAfter) &&
 		compareHTTPResponse(r.Response, v.Response)
+}
+
+func equalDurationPtr(a, b *time.Duration) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 // RedirectionError represents a response that returned a redirect status code:

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -3865,6 +3865,37 @@ func TestAbuseRateLimitError_Is(t *testing.T) {
 			err:        err,
 			otherError: errors.New("github"),
 		},
+		"errors are same - RetryAfter equal value but distinct pointers": {
+			wantSame: true,
+			err:      err,
+			otherError: &AbuseRateLimitError{
+				Response:   &http.Response{},
+				Message:    "Github",
+				RetryAfter: &t1,
+			},
+		},
+		"errors are same - RetryAfter both nil": {
+			wantSame: true,
+			err: &AbuseRateLimitError{
+				Response:   &http.Response{},
+				Message:    "Github",
+				RetryAfter: nil,
+			},
+			otherError: &AbuseRateLimitError{
+				Response:   &http.Response{},
+				Message:    "Github",
+				RetryAfter: nil,
+			},
+		},
+		"errors differ - one RetryAfter nil, other non-nil": {
+			wantSame: false,
+			err:      err,
+			otherError: &AbuseRateLimitError{
+				Response:   &http.Response{},
+				Message:    "Github",
+				RetryAfter: nil,
+			},
+		},
 	}
 
 	for name, tc := range testcases {


### PR DESCRIPTION
This PR fixes the comparison of `RetryAfter` durations in the `AbuseRateLimitError.Is`. Two errors with the same `RetryAfter` value but distinct pointers should compare equal.