### PR TITLE
fix!: Fix `LicenseStatus` response and `Supportkey` type

### DIFF
--- a/github/enterprise_manage_ghes_config.go
+++ b/github/enterprise_manage_ghes_config.go
@@ -89,7 +89,9 @@ type LicenseStatus struct {
 	ReferenceNumber              *string    `json:"referenceNumber,omitempty"`
 	Seats                        *int       `json:"seats,omitempty"`
 	SSHAllowed                   *bool      `json:"sshAllowed,omitempty"`
-	SupportKey                   *bool      `json:"supportKey,omitempty"`
+	// SupportKey is documented as a string, but the actual response is a bool.
+	// TODO: Remove this note once GitHub corrects the schema documentation.
+	SupportKey       *bool `json:"supportKey,omitempty"`
 	UnlimitedSeating             *bool      `json:"unlimitedSeating,omitempty"`
 }
 

--- a/github/enterprise_manage_ghes_config.go
+++ b/github/enterprise_manage_ghes_config.go
@@ -89,7 +89,7 @@ type LicenseStatus struct {
 	ReferenceNumber              *string    `json:"referenceNumber,omitempty"`
 	Seats                        *int       `json:"seats,omitempty"`
 	SSHAllowed                   *bool      `json:"sshAllowed,omitempty"`
-	SupportKey                   *bool `json:"supportKey,omitempty"`
+	SupportKey                   *bool      `json:"supportKey,omitempty"`
 	UnlimitedSeating             *bool      `json:"unlimitedSeating,omitempty"`
 }
 

--- a/github/enterprise_manage_ghes_config.go
+++ b/github/enterprise_manage_ghes_config.go
@@ -70,8 +70,8 @@ type InitialConfigOptions struct {
 }
 
 // LicenseStatus is a struct to hold the response from the License API.
-// SupportKey is documented as string but is actual a bool.
-// TODO: Remove comment after github updates schema documentation
+// SupportKey is documented as a string, but the actual response is a bool.
+// TODO: Remove this note once GitHub corrects the schema documentation.
 type LicenseStatus struct {
 	AdvancedSecurityEnabled      *bool      `json:"advancedSecurityEnabled,omitempty"`
 	AdvancedSecuritySeats        *int       `json:"advancedSecuritySeats,omitempty"`
@@ -89,9 +89,7 @@ type LicenseStatus struct {
 	ReferenceNumber              *string    `json:"referenceNumber,omitempty"`
 	Seats                        *int       `json:"seats,omitempty"`
 	SSHAllowed                   *bool      `json:"sshAllowed,omitempty"`
-	// SupportKey is documented as a string, but the actual response is a bool.
-	// TODO: Remove this note once GitHub corrects the schema documentation.
-	SupportKey       *bool `json:"supportKey,omitempty"`
+	SupportKey                   *bool `json:"supportKey,omitempty"`
 	UnlimitedSeating             *bool      `json:"unlimitedSeating,omitempty"`
 }
 

--- a/github/enterprise_manage_ghes_config.go
+++ b/github/enterprise_manage_ghes_config.go
@@ -70,6 +70,8 @@ type InitialConfigOptions struct {
 }
 
 // LicenseStatus is a struct to hold the response from the License API.
+// SupportKey is documented as string but is actual a bool.
+// TODO: Remove comment after github updates schema documentation
 type LicenseStatus struct {
 	AdvancedSecurityEnabled      *bool      `json:"advancedSecurityEnabled,omitempty"`
 	AdvancedSecuritySeats        *int       `json:"advancedSecuritySeats,omitempty"`
@@ -354,6 +356,8 @@ func (s *EnterpriseService) InitialConfig(ctx context.Context, license, password
 // GitHub API docs: https://docs.github.com/enterprise-server@3.21/rest/enterprise-admin/manage-ghes#get-the-enterprise-license-information
 //
 //meta:operation GET /manage/v1/config/license
+// Current Docs shouw incorrect return type. They list as [{...}] but actual is {...}
+// TODO: Remove comment after github updates schema documentation
 func (s *EnterpriseService) License(ctx context.Context) (*LicenseStatus, *Response, error) {
 	u := "manage/v1/config/license"
 	req, err := s.client.NewRequest(ctx, "GET", u, nil)

--- a/github/enterprise_manage_ghes_config.go
+++ b/github/enterprise_manage_ghes_config.go
@@ -87,7 +87,7 @@ type LicenseStatus struct {
 	ReferenceNumber              *string    `json:"referenceNumber,omitempty"`
 	Seats                        *int       `json:"seats,omitempty"`
 	SSHAllowed                   *bool      `json:"sshAllowed,omitempty"`
-	SupportKey                   *string    `json:"supportKey,omitempty"`
+	SupportKey                   *bool      `json:"supportKey,omitempty"`
 	UnlimitedSeating             *bool      `json:"unlimitedSeating,omitempty"`
 }
 
@@ -354,14 +354,14 @@ func (s *EnterpriseService) InitialConfig(ctx context.Context, license, password
 // GitHub API docs: https://docs.github.com/enterprise-server@3.21/rest/enterprise-admin/manage-ghes#get-the-enterprise-license-information
 //
 //meta:operation GET /manage/v1/config/license
-func (s *EnterpriseService) License(ctx context.Context) ([]*LicenseStatus, *Response, error) {
+func (s *EnterpriseService) License(ctx context.Context) (*LicenseStatus, *Response, error) {
 	u := "manage/v1/config/license"
 	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var licenseStatus []*LicenseStatus
+	var licenseStatus *LicenseStatus
 	resp, err := s.client.Do(req, &licenseStatus)
 	if err != nil {
 		return nil, resp, err

--- a/github/enterprise_manage_ghes_config.go
+++ b/github/enterprise_manage_ghes_config.go
@@ -89,8 +89,8 @@ type LicenseStatus struct {
 	SSHAllowed                   *bool      `json:"sshAllowed,omitempty"`
 	// SupportKey is documented as a string, but the actual response is a bool.
 	// TODO: Remove this note once GitHub corrects the schema documentation.
-	SupportKey                   *bool      `json:"supportKey,omitempty"`
-	UnlimitedSeating             *bool      `json:"unlimitedSeating,omitempty"`
+	SupportKey       *bool `json:"supportKey,omitempty"`
+	UnlimitedSeating *bool `json:"unlimitedSeating,omitempty"`
 }
 
 // UploadLicenseOptions is a struct to hold the options for the UploadLicense API.

--- a/github/enterprise_manage_ghes_config.go
+++ b/github/enterprise_manage_ghes_config.go
@@ -355,11 +355,13 @@ func (s *EnterpriseService) InitialConfig(ctx context.Context, license, password
 
 // License gets the current license information for the GitHub Enterprise instance.
 //
+// NOTE: The GitHub documentation incorrectly shows the return type as a list ([{...}]),
+// but the actual response is a single object ({...}).
+// TODO: Remove this note once GitHub corrects the schema documentation.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.21/rest/enterprise-admin/manage-ghes#get-the-enterprise-license-information
 //
 //meta:operation GET /manage/v1/config/license
-// Current Docs shouw incorrect return type. They list as [{...}] but actual is {...}
-// TODO: Remove comment after github updates schema documentation
 func (s *EnterpriseService) License(ctx context.Context) (*LicenseStatus, *Response, error) {
 	u := "manage/v1/config/license"
 	req, err := s.client.NewRequest(ctx, "GET", u, nil)

--- a/github/enterprise_manage_ghes_config.go
+++ b/github/enterprise_manage_ghes_config.go
@@ -70,8 +70,6 @@ type InitialConfigOptions struct {
 }
 
 // LicenseStatus is a struct to hold the response from the License API.
-// SupportKey is documented as a string, but the actual response is a bool.
-// TODO: Remove this note once GitHub corrects the schema documentation.
 type LicenseStatus struct {
 	AdvancedSecurityEnabled      *bool      `json:"advancedSecurityEnabled,omitempty"`
 	AdvancedSecuritySeats        *int       `json:"advancedSecuritySeats,omitempty"`
@@ -89,6 +87,8 @@ type LicenseStatus struct {
 	ReferenceNumber              *string    `json:"referenceNumber,omitempty"`
 	Seats                        *int       `json:"seats,omitempty"`
 	SSHAllowed                   *bool      `json:"sshAllowed,omitempty"`
+	// SupportKey is documented as a string, but the actual response is a bool.
+	// TODO: Remove this note once GitHub corrects the schema documentation.
 	SupportKey                   *bool      `json:"supportKey,omitempty"`
 	UnlimitedSeating             *bool      `json:"unlimitedSeating,omitempty"`
 }

--- a/github/enterprise_manage_ghes_config_test.go
+++ b/github/enterprise_manage_ghes_config_test.go
@@ -407,7 +407,7 @@ func TestEnterpriseService_License(t *testing.T) {
 
 	mux.HandleFunc("/manage/v1/config/license", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{
+		fmt.Fprint(w, `{
 			"advancedSecurityEnabled": true,
 			"advancedSecuritySeats": 0,
 			"clusterSupport": false,
@@ -424,9 +424,9 @@ func TestEnterpriseService_License(t *testing.T) {
 			"referenceNumber": "32a145",
 			"seats": 0,
 			"sshAllowed": true,
-			"supportKey": "",
+			"supportKey": true,
 			"unlimitedSeating": true
-		}]`)
+		}`)
 	})
 
 	ctx := t.Context()
@@ -435,7 +435,7 @@ func TestEnterpriseService_License(t *testing.T) {
 		t.Errorf("Enterprise.License returned error: %v", err)
 	}
 
-	want := []*LicenseStatus{{
+	want := &LicenseStatus{
 		AdvancedSecurityEnabled:      Ptr(true),
 		AdvancedSecuritySeats:        Ptr(0),
 		ClusterSupport:               Ptr(false),
@@ -452,9 +452,9 @@ func TestEnterpriseService_License(t *testing.T) {
 		ReferenceNumber:              Ptr("32a145"),
 		Seats:                        Ptr(0),
 		SSHAllowed:                   Ptr(true),
-		SupportKey:                   Ptr(""),
+		SupportKey:                   Ptr(true),
 		UnlimitedSeating:             Ptr(true),
-	}}
+	}
 	if diff := cmp.Diff(want, license); diff != "" {
 		t.Errorf("diff mismatch (-want +got):\n%v", diff)
 	}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -21039,9 +21039,9 @@ func (l *LicenseStatus) GetSSHAllowed() bool {
 }
 
 // GetSupportKey returns the SupportKey field if it's non-nil, zero value otherwise.
-func (l *LicenseStatus) GetSupportKey() string {
+func (l *LicenseStatus) GetSupportKey() bool {
 	if l == nil || l.SupportKey == nil {
-		return ""
+		return false
 	}
 	return *l.SupportKey
 }

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -26630,7 +26630,7 @@ func TestLicenseStatus_GetSSHAllowed(tt *testing.T) {
 
 func TestLicenseStatus_GetSupportKey(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
+	var zeroValue bool
 	l := &LicenseStatus{SupportKey: &zeroValue}
 	l.GetSupportKey()
 	l = &LicenseStatus{}


### PR DESCRIPTION
BREAKING CHANGE: `LicenseStatus.SupportKey` type changed from `*string` to `*bool` and `License` return type is no longer a slice.

Closes: https://github.com/google/go-github/issues/4296

License status response was implemented according to documentation, which is not according to actual response.

Fix:
Corrected the response
Fixed incorrect data type for SupportKey
Fixed tests