### PR TITLE
fix!: Send request body in SCIM update methods

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -41550,16 +41550,16 @@ func (u *UpdateAttributeForSCIMUserOperations) GetValue() json.RawMessage {
 	return u.Value
 }
 
-// GetOperations returns the Operations field.
-func (u *UpdateAttributeForSCIMUserOptions) GetOperations() UpdateAttributeForSCIMUserOperations {
-	if u == nil {
-		return UpdateAttributeForSCIMUserOperations{}
+// GetOperations returns the Operations slice if it's non-nil, nil otherwise.
+func (u *UpdateAttributeForSCIMUserRequest) GetOperations() []*UpdateAttributeForSCIMUserOperations {
+	if u == nil || u.Operations == nil {
+		return nil
 	}
 	return u.Operations
 }
 
 // GetSchemas returns the Schemas slice if it's non-nil, nil otherwise.
-func (u *UpdateAttributeForSCIMUserOptions) GetSchemas() []string {
+func (u *UpdateAttributeForSCIMUserRequest) GetSchemas() []string {
 	if u == nil || u.Schemas == nil {
 		return nil
 	}
@@ -42012,6 +42012,78 @@ func (u *UpdateProjectV2Field) GetValue() any {
 		return nil
 	}
 	return u.Value
+}
+
+// GetActive returns the Active field if it's non-nil, zero value otherwise.
+func (u *UpdateProvisionedOrgMembershipRequest) GetActive() bool {
+	if u == nil || u.Active == nil {
+		return false
+	}
+	return *u.Active
+}
+
+// GetDisplayName returns the DisplayName field if it's non-nil, zero value otherwise.
+func (u *UpdateProvisionedOrgMembershipRequest) GetDisplayName() string {
+	if u == nil || u.DisplayName == nil {
+		return ""
+	}
+	return *u.DisplayName
+}
+
+// GetEmails returns the Emails slice if it's non-nil, nil otherwise.
+func (u *UpdateProvisionedOrgMembershipRequest) GetEmails() []*SCIMUserEmail {
+	if u == nil || u.Emails == nil {
+		return nil
+	}
+	return u.Emails
+}
+
+// GetExternalID returns the ExternalID field if it's non-nil, zero value otherwise.
+func (u *UpdateProvisionedOrgMembershipRequest) GetExternalID() string {
+	if u == nil || u.ExternalID == nil {
+		return ""
+	}
+	return *u.ExternalID
+}
+
+// GetGroups returns the Groups slice if it's non-nil, nil otherwise.
+func (u *UpdateProvisionedOrgMembershipRequest) GetGroups() []string {
+	if u == nil || u.Groups == nil {
+		return nil
+	}
+	return u.Groups
+}
+
+// GetName returns the Name field.
+func (u *UpdateProvisionedOrgMembershipRequest) GetName() SCIMUserName {
+	if u == nil {
+		return SCIMUserName{}
+	}
+	return u.Name
+}
+
+// GetRoles returns the Roles slice if it's non-nil, nil otherwise.
+func (u *UpdateProvisionedOrgMembershipRequest) GetRoles() []*SCIMUserRole {
+	if u == nil || u.Roles == nil {
+		return nil
+	}
+	return u.Roles
+}
+
+// GetSchemas returns the Schemas slice if it's non-nil, nil otherwise.
+func (u *UpdateProvisionedOrgMembershipRequest) GetSchemas() []string {
+	if u == nil || u.Schemas == nil {
+		return nil
+	}
+	return u.Schemas
+}
+
+// GetUserName returns the UserName field.
+func (u *UpdateProvisionedOrgMembershipRequest) GetUserName() string {
+	if u == nil {
+		return ""
+	}
+	return u.UserName
 }
 
 // GetForce returns the Force field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -42062,14 +42062,6 @@ func (u *UpdateProvisionedOrgMembershipRequest) GetName() SCIMUserName {
 	return u.Name
 }
 
-// GetRoles returns the Roles slice if it's non-nil, nil otherwise.
-func (u *UpdateProvisionedOrgMembershipRequest) GetRoles() []*SCIMUserRole {
-	if u == nil || u.Roles == nil {
-		return nil
-	}
-	return u.Roles
-}
-
 // GetSchemas returns the Schemas slice if it's non-nil, nil otherwise.
 func (u *UpdateProvisionedOrgMembershipRequest) GetSchemas() []string {
 	if u == nil || u.Schemas == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -52827,17 +52827,6 @@ func TestUpdateProvisionedOrgMembershipRequest_GetName(tt *testing.T) {
 	u.GetName()
 }
 
-func TestUpdateProvisionedOrgMembershipRequest_GetRoles(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := []*SCIMUserRole{}
-	u := &UpdateProvisionedOrgMembershipRequest{Roles: zeroValue}
-	u.GetRoles()
-	u = &UpdateProvisionedOrgMembershipRequest{}
-	u.GetRoles()
-	u = nil
-	u.GetRoles()
-}
-
 func TestUpdateProvisionedOrgMembershipRequest_GetSchemas(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []string{}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -52150,20 +52150,23 @@ func TestUpdateAttributeForSCIMUserOperations_GetValue(tt *testing.T) {
 	u.GetValue()
 }
 
-func TestUpdateAttributeForSCIMUserOptions_GetOperations(tt *testing.T) {
+func TestUpdateAttributeForSCIMUserRequest_GetOperations(tt *testing.T) {
 	tt.Parallel()
-	u := &UpdateAttributeForSCIMUserOptions{}
+	zeroValue := []*UpdateAttributeForSCIMUserOperations{}
+	u := &UpdateAttributeForSCIMUserRequest{Operations: zeroValue}
+	u.GetOperations()
+	u = &UpdateAttributeForSCIMUserRequest{}
 	u.GetOperations()
 	u = nil
 	u.GetOperations()
 }
 
-func TestUpdateAttributeForSCIMUserOptions_GetSchemas(tt *testing.T) {
+func TestUpdateAttributeForSCIMUserRequest_GetSchemas(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []string{}
-	u := &UpdateAttributeForSCIMUserOptions{Schemas: zeroValue}
+	u := &UpdateAttributeForSCIMUserRequest{Schemas: zeroValue}
 	u.GetSchemas()
-	u = &UpdateAttributeForSCIMUserOptions{}
+	u = &UpdateAttributeForSCIMUserRequest{}
 	u.GetSchemas()
 	u = nil
 	u.GetSchemas()
@@ -52759,6 +52762,99 @@ func TestUpdateProjectV2Field_GetValue(tt *testing.T) {
 	u.GetValue()
 	u = nil
 	u.GetValue()
+}
+
+func TestUpdateProvisionedOrgMembershipRequest_GetActive(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	u := &UpdateProvisionedOrgMembershipRequest{Active: &zeroValue}
+	u.GetActive()
+	u = &UpdateProvisionedOrgMembershipRequest{}
+	u.GetActive()
+	u = nil
+	u.GetActive()
+}
+
+func TestUpdateProvisionedOrgMembershipRequest_GetDisplayName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateProvisionedOrgMembershipRequest{DisplayName: &zeroValue}
+	u.GetDisplayName()
+	u = &UpdateProvisionedOrgMembershipRequest{}
+	u.GetDisplayName()
+	u = nil
+	u.GetDisplayName()
+}
+
+func TestUpdateProvisionedOrgMembershipRequest_GetEmails(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*SCIMUserEmail{}
+	u := &UpdateProvisionedOrgMembershipRequest{Emails: zeroValue}
+	u.GetEmails()
+	u = &UpdateProvisionedOrgMembershipRequest{}
+	u.GetEmails()
+	u = nil
+	u.GetEmails()
+}
+
+func TestUpdateProvisionedOrgMembershipRequest_GetExternalID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateProvisionedOrgMembershipRequest{ExternalID: &zeroValue}
+	u.GetExternalID()
+	u = &UpdateProvisionedOrgMembershipRequest{}
+	u.GetExternalID()
+	u = nil
+	u.GetExternalID()
+}
+
+func TestUpdateProvisionedOrgMembershipRequest_GetGroups(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []string{}
+	u := &UpdateProvisionedOrgMembershipRequest{Groups: zeroValue}
+	u.GetGroups()
+	u = &UpdateProvisionedOrgMembershipRequest{}
+	u.GetGroups()
+	u = nil
+	u.GetGroups()
+}
+
+func TestUpdateProvisionedOrgMembershipRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	u := &UpdateProvisionedOrgMembershipRequest{}
+	u.GetName()
+	u = nil
+	u.GetName()
+}
+
+func TestUpdateProvisionedOrgMembershipRequest_GetRoles(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*SCIMUserRole{}
+	u := &UpdateProvisionedOrgMembershipRequest{Roles: zeroValue}
+	u.GetRoles()
+	u = &UpdateProvisionedOrgMembershipRequest{}
+	u.GetRoles()
+	u = nil
+	u.GetRoles()
+}
+
+func TestUpdateProvisionedOrgMembershipRequest_GetSchemas(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []string{}
+	u := &UpdateProvisionedOrgMembershipRequest{Schemas: zeroValue}
+	u.GetSchemas()
+	u = &UpdateProvisionedOrgMembershipRequest{}
+	u.GetSchemas()
+	u = nil
+	u.GetSchemas()
+}
+
+func TestUpdateProvisionedOrgMembershipRequest_GetUserName(tt *testing.T) {
+	tt.Parallel()
+	u := &UpdateProvisionedOrgMembershipRequest{}
+	u.GetUserName()
+	u = nil
+	u.GetUserName()
 }
 
 func TestUpdateRef_GetForce(tt *testing.T) {

--- a/github/scim.go
+++ b/github/scim.go
@@ -172,7 +172,6 @@ type UpdateProvisionedOrgMembershipRequest struct {
 	Schemas     []string         `json:"schemas,omitempty"`     // (Optional.)
 	ExternalID  *string          `json:"externalId,omitempty"`  // (Optional.)
 	Groups      []string         `json:"groups,omitempty"`      // (Optional.)
-	Roles       []*SCIMUserRole  `json:"roles,omitempty"`       // (Optional, GHES only.)
 	Active      *bool            `json:"active,omitempty"`      // (Optional.)
 }
 

--- a/github/scim.go
+++ b/github/scim.go
@@ -162,32 +162,48 @@ func (s *SCIMService) GetSCIMProvisioningInfoForUser(ctx context.Context, org, s
 	return user, resp, nil
 }
 
+// UpdateProvisionedOrgMembershipRequest represents the body of a request to
+// update a provisioned organization membership.
+type UpdateProvisionedOrgMembershipRequest struct {
+	UserName    string           `json:"userName"`              // Configured by the admin. Could be an email, login, or username. (Required.)
+	Name        SCIMUserName     `json:"name"`                  // (Required.)
+	DisplayName *string          `json:"displayName,omitempty"` // The name of the user, suitable for display to end-users. (Optional.)
+	Emails      []*SCIMUserEmail `json:"emails"`                // User emails. (Required.)
+	Schemas     []string         `json:"schemas,omitempty"`     // (Optional.)
+	ExternalID  *string          `json:"externalId,omitempty"`  // (Optional.)
+	Groups      []string         `json:"groups,omitempty"`      // (Optional.)
+	Roles       []*SCIMUserRole  `json:"roles,omitempty"`       // (Optional, GHES only.)
+	Active      *bool            `json:"active,omitempty"`      // (Optional.)
+}
+
 // UpdateProvisionedOrgMembership updates a provisioned organization membership.
 //
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/scim/scim?apiVersion=2022-11-28#update-a-provisioned-organization-membership
 //
 //meta:operation PUT /scim/v2/organizations/{org}/Users/{scim_user_id}
-func (s *SCIMService) UpdateProvisionedOrgMembership(ctx context.Context, org, scimUserID string, opts *SCIMUserAttributes) (*Response, error) { //nolint:paramcheck // see https://github.com/google/go-github/issues/4301
+func (s *SCIMService) UpdateProvisionedOrgMembership(ctx context.Context, org, scimUserID string, body UpdateProvisionedOrgMembershipRequest) (*SCIMUserAttributes, *Response, error) {
 	u := fmt.Sprintf("scim/v2/organizations/%v/Users/%v", org, scimUserID)
-	u, err := addOptions(u, opts)
+	req, err := s.client.NewRequest(ctx, "PUT", u, body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
+	var user *SCIMUserAttributes
+	resp, err := s.client.Do(req, &user)
 	if err != nil {
-		return nil, err
+		return nil, resp, err
 	}
 
-	return s.client.Do(req, nil)
+	return user, resp, nil
 }
 
-// UpdateAttributeForSCIMUserOptions represents options for UpdateAttributeForSCIMUser.
+// UpdateAttributeForSCIMUserRequest represents the body of a request to update an
+// attribute for a SCIM user.
 //
 // GitHub API docs: https://docs.github.com/rest/scim#update-an-attribute-for-a-scim-user--parameters
-type UpdateAttributeForSCIMUserOptions struct {
-	Schemas    []string                             `json:"schemas,omitempty"` // (Optional.)
-	Operations UpdateAttributeForSCIMUserOperations `json:"operations"`        // Set of operations to be performed. (Required.)
+type UpdateAttributeForSCIMUserRequest struct {
+	Schemas    []string                                `json:"schemas,omitempty"` // (Optional.)
+	Operations []*UpdateAttributeForSCIMUserOperations `json:"Operations"`        // Set of operations to be performed. (Required.)
 }
 
 // UpdateAttributeForSCIMUserOperations represents operations for UpdateAttributeForSCIMUser.
@@ -202,19 +218,20 @@ type UpdateAttributeForSCIMUserOperations struct {
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/scim/scim?apiVersion=2022-11-28#update-an-attribute-for-a-scim-user
 //
 //meta:operation PATCH /scim/v2/organizations/{org}/Users/{scim_user_id}
-func (s *SCIMService) UpdateAttributeForSCIMUser(ctx context.Context, org, scimUserID string, opts *UpdateAttributeForSCIMUserOptions) (*Response, error) {
+func (s *SCIMService) UpdateAttributeForSCIMUser(ctx context.Context, org, scimUserID string, body UpdateAttributeForSCIMUserRequest) (*SCIMUserAttributes, *Response, error) {
 	u := fmt.Sprintf("scim/v2/organizations/%v/Users/%v", org, scimUserID)
-	u, err := addOptions(u, opts)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, "PATCH", u, nil)
+	var user *SCIMUserAttributes
+	resp, err := s.client.Do(req, &user)
 	if err != nil {
-		return nil, err
+		return nil, resp, err
 	}
 
-	return s.client.Do(req, nil)
+	return user, resp, nil
 }
 
 // DeleteSCIMUserFromOrg deletes SCIM user from an organization.

--- a/github/scim_test.go
+++ b/github/scim_test.go
@@ -6,6 +6,7 @@
 package github
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -273,13 +274,7 @@ func TestSCIMService_UpdateProvisionedOrgMembership(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/scim/v2/organizations/o/Users/123", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-		w.WriteHeader(http.StatusOK)
-	})
-
-	ctx := t.Context()
-	opts := &SCIMUserAttributes{
+	body := UpdateProvisionedOrgMembershipRequest{
 		UserName: "userName",
 		Name: SCIMUserName{
 			GivenName:  "givenName",
@@ -291,19 +286,40 @@ func TestSCIMService_UpdateProvisionedOrgMembership(t *testing.T) {
 			},
 		},
 	}
-	_, err := client.SCIM.UpdateProvisionedOrgMembership(ctx, "o", "123", opts)
+
+	mux.HandleFunc("/scim/v2/organizations/o/Users/123", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testJSONBody(t, r, body)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"123","userName":"userName"}`)
+	})
+
+	ctx := t.Context()
+	user, _, err := client.SCIM.UpdateProvisionedOrgMembership(ctx, "o", "123", body)
 	if err != nil {
 		t.Errorf("SCIM.UpdateProvisionedOrgMembership returned error: %v", err)
 	}
 
+	want := &SCIMUserAttributes{
+		ID:       Ptr("123"),
+		UserName: "userName",
+	}
+	if !cmp.Equal(user, want) {
+		t.Errorf("SCIM.UpdateProvisionedOrgMembership returned %+v, want %+v", user, want)
+	}
+
 	const methodName = "UpdateProvisionedOrgMembership"
-	testBadOptions(t, methodName, func() error {
-		_, err := client.SCIM.UpdateProvisionedOrgMembership(ctx, "\n", "123", opts)
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.SCIM.UpdateProvisionedOrgMembership(ctx, "\n", "123", body)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.SCIM.UpdateProvisionedOrgMembership(ctx, "o", "123", opts)
+		got, resp, err := client.SCIM.UpdateProvisionedOrgMembership(ctx, "o", "123", body)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
 	})
 }
 
@@ -311,26 +327,64 @@ func TestSCIMService_UpdateAttributeForSCIMUser(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
+	body := UpdateAttributeForSCIMUserRequest{
+		Schemas: []string{SCIMSchemasURINamespacesPatchOp},
+		Operations: []*UpdateAttributeForSCIMUserOperations{
+			{
+				Op:    "replace",
+				Path:  Ptr("displayName"),
+				Value: json.RawMessage(`"NewDisplayName"`),
+			},
+		},
+	}
+
+	// Verify the wire format against an expected map (not the same struct) so
+	// that JSON key names are pinned. Per the SCIM PatchOp schema the request
+	// uses a capitalized "Operations" key (and lowercase "schemas").
+	wantBody := map[string]any{
+		"schemas": []any{SCIMSchemasURINamespacesPatchOp},
+		"Operations": []any{
+			map[string]any{
+				"op":    "replace",
+				"path":  "displayName",
+				"value": "NewDisplayName",
+			},
+		},
+	}
+
 	mux.HandleFunc("/scim/v2/organizations/o/Users/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		w.WriteHeader(http.StatusNoContent)
+		testJSONBody(t, r, wantBody)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"123","userName":"userName"}`)
 	})
 
 	ctx := t.Context()
-	opts := &UpdateAttributeForSCIMUserOptions{}
-	_, err := client.SCIM.UpdateAttributeForSCIMUser(ctx, "o", "123", opts)
+	user, _, err := client.SCIM.UpdateAttributeForSCIMUser(ctx, "o", "123", body)
 	if err != nil {
 		t.Errorf("SCIM.UpdateAttributeForSCIMUser returned error: %v", err)
 	}
 
+	want := &SCIMUserAttributes{
+		ID:       Ptr("123"),
+		UserName: "userName",
+	}
+	if !cmp.Equal(user, want) {
+		t.Errorf("SCIM.UpdateAttributeForSCIMUser returned %+v, want %+v", user, want)
+	}
+
 	const methodName = "UpdateAttributeForSCIMUser"
-	testBadOptions(t, methodName, func() error {
-		_, err := client.SCIM.UpdateAttributeForSCIMUser(ctx, "\n", "123", opts)
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.SCIM.UpdateAttributeForSCIMUser(ctx, "\n", "123", body)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.SCIM.UpdateAttributeForSCIMUser(ctx, "o", "123", opts)
+		got, resp, err := client.SCIM.UpdateAttributeForSCIMUser(ctx, "o", "123", body)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
 	})
 }
 


### PR DESCRIPTION
BREAKING CHANGE: `UpdateProvisionedOrgMembership` and `UpdateAttributeForSCIMUser` params and return values changed.

`SCIMService.UpdateProvisionedOrgMembership` and `UpdateAttributeForSCIMUser` passed their parameters through `addOptions`, which only serializes `url`-tagged fields. The SCIM types are `json`-tagged, so nothing was actually sent and both calls were effectively no-ops. They also discarded the user object the API returns.

Both methods now send the payload as the request body and return the updated `*SCIMUserAttributes`, following the existing `ProvisionAndInviteSCIMUser` pattern.

The body is taken by value via dedicated request types:

- new `UpdateProvisionedOrgMembershipRequest`
- `UpdateAttributeForSCIMUserRequest` (renamed from `UpdateAttributeForSCIMUserOptions`), whose `Operations` field is now a slice (`[]*UpdateAttributeForSCIMUserOperations`) with the `json:"Operations"` key required by the SCIM PatchOp schema, matching the existing enterprise SCIM implementation.

The `//nolint:paramcheck` workaround is removed. Tests verify the request body wire format and the decoded response.

This is a breaking API change.

Fixes: #4301.