### PR TITLE
feat: Add `WithRateLimitSleepCallback` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,19 @@ method to block until the rate limit is reset.
 repos, _, err := client.Repositories.List(context.WithValue(ctx, github.SleepUntilPrimaryRateLimitResetWhenRateLimited, true), "", nil)
 ```
 
+To be notified when such a sleep is about to happen (for example to log a
+message so it doesn't look like the program is stuck), configure the client with
+`WithRateLimitSleepCallback`. The callback is invoked just before the client
+sleeps waiting for the primary rate limit to reset.
+
+```go
+client, err := github.NewClient(github.WithRateLimitSleepCallback(
+	func(ctx context.Context, info github.RateLimitSleepInfo) {
+		log.Printf("sleeping until rate limit resets at %v\n", info.Rate.Reset)
+	},
+))
+```
+
 If you need to make a request even if the rate limit has been hit you can use
 the `BypassRateLimitCheck` method to bypass the rate limit check and make the
 request anyway.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -31966,6 +31966,14 @@ func (r *RateLimits) GetSourceImport() *Rate {
 	return r.SourceImport
 }
 
+// GetRate returns the Rate field.
+func (r *RateLimitSleepInfo) GetRate() Rate {
+	if r == nil {
+		return Rate{}
+	}
+	return r.Rate
+}
+
 // GetType returns the Type field.
 func (r *RawOptions) GetType() RawType {
 	if r == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -40157,6 +40157,14 @@ func TestRateLimits_GetSourceImport(tt *testing.T) {
 	r.GetSourceImport()
 }
 
+func TestRateLimitSleepInfo_GetRate(tt *testing.T) {
+	tt.Parallel()
+	r := &RateLimitSleepInfo{}
+	r.GetRate()
+	r = nil
+	r.GetRate()
+}
+
 func TestRawOptions_GetType(tt *testing.T) {
 	tt.Parallel()
 	r := &RawOptions{}

--- a/github/github.go
+++ b/github/github.go
@@ -202,6 +202,10 @@ type Client struct {
 	// Whether to respect rate limit headers on endpoints that return 302 redirections to artifacts
 	rateLimitRedirectionalEndpoints bool
 
+	// rateLimitSleepCallback, if set, is called just before the client sleeps
+	// waiting for a primary rate limit to reset.
+	rateLimitSleepCallback RateLimitSleepCallback
+
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
 
 	// Services used for talking to different parts of the GitHub API.
@@ -363,6 +367,7 @@ type clientOptions struct {
 	disableRateLimitCheck                   bool
 	rateLimitRedirectionalEndpoints         bool
 	maxSecondaryRateLimitRetryAfterDuration *time.Duration
+	rateLimitSleepCallback                  RateLimitSleepCallback
 	marketplaceStubbed                      bool
 }
 
@@ -538,6 +543,33 @@ func WithMaxSecondaryRateLimitRetryAfterDuration(duration time.Duration) ClientO
 	}
 }
 
+// RateLimitSleepInfo provides information to a RateLimitSleepCallback about a
+// primary rate limit sleep that is about to happen.
+type RateLimitSleepInfo struct {
+	// Request is the request whose rate limit triggered the sleep.
+	Request *http.Request
+	// Rate is the primary rate limit that triggered the sleep. The client sleeps
+	// until shortly after Rate.Reset before continuing.
+	Rate Rate
+}
+
+// RateLimitSleepCallback is invoked just before the client sleeps waiting for a
+// primary rate limit to reset. Sleeping is enabled per request via the
+// SleepUntilPrimaryRateLimitResetWhenRateLimited context key. The callback is
+// for notification only (e.g. logging that a sleep is occurring).
+type RateLimitSleepCallback func(ctx context.Context, info RateLimitSleepInfo)
+
+// WithRateLimitSleepCallback returns a ClientOptionsFunc that sets a callback
+// invoked just before the client sleeps waiting for a primary rate limit to
+// reset. Sleeping must also be enabled per request via the
+// SleepUntilPrimaryRateLimitResetWhenRateLimited context key.
+func WithRateLimitSleepCallback(callback RateLimitSleepCallback) ClientOptionsFunc {
+	return func(o *clientOptions) error {
+		o.rateLimitSleepCallback = callback
+		return nil
+	}
+}
+
 // NewClient returns a new GitHub API client configured with the provided
 // options. The default configuration is suitable for making unauthenticated
 // requests to the public GitHub API.
@@ -648,6 +680,7 @@ func newClient(opts clientOptions) (*Client, error) {
 	}
 
 	c.disableRateLimitCheck = opts.disableRateLimitCheck
+	c.rateLimitSleepCallback = opts.rateLimitSleepCallback
 
 	if !c.disableRateLimitCheck {
 		c.rateLimitRedirectionalEndpoints = opts.rateLimitRedirectionalEndpoints
@@ -747,6 +780,7 @@ func (c *Client) Clone(opts ...ClientOptionsFunc) (*Client, error) {
 		disableRateLimitCheck:                   c.disableRateLimitCheck,
 		rateLimitRedirectionalEndpoints:         c.rateLimitRedirectionalEndpoints,
 		maxSecondaryRateLimitRetryAfterDuration: &c.maxSecondaryRateLimitRetryAfterDuration,
+		rateLimitSleepCallback:                  c.rateLimitSleepCallback,
 	}
 
 	if c.Marketplace != nil {
@@ -1279,6 +1313,9 @@ func (c *Client) bareDo(caller *http.Client, req *http.Request) (*Response, erro
 		var rateLimitError *RateLimitError
 		if errors.As(err, &rateLimitError) &&
 			ctx.Value(SleepUntilPrimaryRateLimitResetWhenRateLimited) != nil {
+			if c.rateLimitSleepCallback != nil {
+				c.rateLimitSleepCallback(ctx, RateLimitSleepInfo{Request: req, Rate: rateLimitError.Rate})
+			}
 			if err := sleepUntilResetWithBuffer(ctx, rateLimitError.Rate.Reset.Time); err != nil {
 				return response, err
 			}
@@ -1416,6 +1453,9 @@ func (c *Client) checkRateLimitBeforeDo(req *http.Request, rateLimitCategory Rat
 		}
 
 		if ctx.Value(SleepUntilPrimaryRateLimitResetWhenRateLimited) != nil {
+			if c.rateLimitSleepCallback != nil {
+				c.rateLimitSleepCallback(ctx, RateLimitSleepInfo{Request: req, Rate: rate})
+			}
 			if err := sleepUntilResetWithBuffer(ctx, rate.Reset.Time); err == nil {
 				return nil
 			}

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -2793,7 +2793,7 @@ func TestDo_rateLimit_sleepCallbackOnResponseResetLimit(t *testing.T) {
 	}
 
 	if callbackCount != 1 {
-		t.Errorf("rate limit sleep callback called %d times, want 1", callbackCount)
+		t.Errorf("rate limit sleep callback called %v times, want 1", callbackCount)
 	}
 	if got, want := gotInfo.Rate.Reset.Unix(), reset.Unix(); got != want {
 		t.Errorf("callback Rate.Reset = %v, want %v", got, want)
@@ -2835,7 +2835,7 @@ func TestDo_rateLimit_sleepCallbackOnClientResetLimit(t *testing.T) {
 	}
 
 	if callbackCount != 1 {
-		t.Errorf("rate limit sleep callback called %d times, want 1", callbackCount)
+		t.Errorf("rate limit sleep callback called %v times, want 1", callbackCount)
 	}
 	if got, want := gotInfo.Rate.Reset.Unix(), reset.Unix(); got != want {
 		t.Errorf("callback Rate.Reset = %v, want %v", got, want)

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -838,6 +838,20 @@ func TestWithDisableRateLimitCheck(t *testing.T) {
 	}
 }
 
+func TestWithRateLimitSleepCallback(t *testing.T) {
+	t.Parallel()
+
+	opts := clientOptions{}
+	err := WithRateLimitSleepCallback(func(_ context.Context, _ RateLimitSleepInfo) {})(&opts)
+	if err != nil {
+		t.Fatalf("WithRateLimitSleepCallback errored: %v", err)
+	}
+
+	if opts.rateLimitSleepCallback == nil {
+		t.Error("rateLimitSleepCallback is nil, want non-nil")
+	}
+}
+
 func TestWithRateLimitRedirectionalEndpoints(t *testing.T) {
 	t.Parallel()
 
@@ -2732,6 +2746,102 @@ func TestDo_rateLimit_sleepUntilClientResetLimit(t *testing.T) {
 	}
 	if got, want := int(requestCount.Load()), 1; got != want {
 		t.Errorf("Expected 1 request, got %v", got)
+	}
+}
+
+// Ensure the rate limit sleep callback is invoked before sleeping on the retry path.
+func TestDo_rateLimit_sleepCallbackOnResponseResetLimit(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	reset := time.Now().UTC().Add(time.Second)
+
+	var callbackCount int
+	var gotInfo RateLimitSleepInfo
+	client.rateLimitSleepCallback = func(_ context.Context, info RateLimitSleepInfo) {
+		callbackCount++
+		gotInfo = info
+	}
+
+	firstRequest := true
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		if firstRequest {
+			firstRequest = false
+			w.Header().Set(HeaderRateLimit, "60")
+			w.Header().Set(HeaderRateRemaining, "0")
+			w.Header().Set(HeaderRateUsed, "60")
+			w.Header().Set(HeaderRateReset, fmt.Sprint(reset.Unix()))
+			w.Header().Set(HeaderRateResource, "core")
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprintln(w, `{"message": "API rate limit exceeded"}`)
+			return
+		}
+		w.Header().Set(HeaderRateLimit, "5000")
+		w.Header().Set(HeaderRateRemaining, "5000")
+		w.Header().Set(HeaderRateUsed, "0")
+		w.Header().Set(HeaderRateReset, fmt.Sprint(reset.Add(time.Hour).Unix()))
+		w.Header().Set(HeaderRateResource, "core")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, `{}`)
+	})
+
+	req, _ := client.NewRequest(context.WithValue(t.Context(), SleepUntilPrimaryRateLimitResetWhenRateLimited, true), "GET", ".", nil)
+	if _, err := client.Do(req, nil); err != nil {
+		t.Errorf("Do returned unexpected error: %v", err)
+	}
+
+	if callbackCount != 1 {
+		t.Errorf("rate limit sleep callback called %d times, want 1", callbackCount)
+	}
+	if got, want := gotInfo.Rate.Reset.Unix(), reset.Unix(); got != want {
+		t.Errorf("callback Rate.Reset = %v, want %v", got, want)
+	}
+	if gotInfo.Request == nil {
+		t.Error("callback Request is nil, want non-nil")
+	}
+}
+
+// Ensure the rate limit sleep callback is invoked before sleeping on the pre-emptive path.
+func TestDo_rateLimit_sleepCallbackOnClientResetLimit(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	reset := time.Now().UTC().Add(time.Second)
+	client.rateLimits[CoreCategory] = Rate{Limit: 5000, Remaining: 0, Reset: Timestamp{reset}}
+
+	var callbackCount int
+	var gotInfo RateLimitSleepInfo
+	client.rateLimitSleepCallback = func(_ context.Context, info RateLimitSleepInfo) {
+		callbackCount++
+		gotInfo = info
+	}
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(HeaderRateLimit, "5000")
+		w.Header().Set(HeaderRateRemaining, "5000")
+		w.Header().Set(HeaderRateUsed, "0")
+		w.Header().Set(HeaderRateReset, fmt.Sprint(reset.Add(time.Hour).Unix()))
+		w.Header().Set(HeaderRateResource, "core")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, `{}`)
+	})
+
+	req, _ := client.NewRequest(context.WithValue(t.Context(), SleepUntilPrimaryRateLimitResetWhenRateLimited, true), "GET", ".", nil)
+	if _, err := client.Do(req, nil); err != nil {
+		t.Errorf("Do returned unexpected error: %v", err)
+	}
+
+	if callbackCount != 1 {
+		t.Errorf("rate limit sleep callback called %d times, want 1", callbackCount)
+	}
+	if got, want := gotInfo.Rate.Reset.Unix(), reset.Unix(); got != want {
+		t.Errorf("callback Rate.Reset = %v, want %v", got, want)
+	}
+	if gotInfo.Request == nil {
+		t.Error("callback Request is nil, want non-nil")
 	}
 }
 


### PR DESCRIPTION
When `SleepUntilPrimaryRateLimitResetWhenRateLimited` is set, the client sleeps until the primary rate limit resets, but it never signals that the sleep is happening — so callers cannot log a message or otherwise react, and the program can appear stuck. This was noted as a possible future improvement in #3117.

This adds `WithRateLimitSleepCallback`, a `ClientOptionsFunc` (as suggested by @erezrokah in the issue) that registers a callback invoked just before the client sleeps, on both the pre-emptive (`checkRateLimitBeforeDo`) and the retry (`bareDo`) paths. The callback receives a `RateLimitSleepInfo` carrying the triggering request and the `Rate`, and is notification-only.

Behavior is unchanged when no callback is set (nil-guarded). The option is carried over by `Clone`. Tests cover the option, both sleep paths, and the existing no-callback paths.

Fixes #3220.