### PR TITLE
fix: Set `GetBody` on uploads for HTTP/2 retry

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -937,6 +937,29 @@ func (c *Client) NewUploadRequest(ctx context.Context, urlStr string, reader io.
 
 	req.ContentLength = size
 
+	// Set GetBody so HTTP/2 transports can retry the request when a stream is
+	// refused (REFUSED_STREAM / GOAWAY) after the body has been written. Without
+	// GetBody, net/http2 fails with "cannot retry ... after Request.Body was
+	// written". See https://github.com/google/go-github/issues/2113.
+	//
+	// http.Request.GetBody must return an independent copy of the body, so we
+	// require io.ReaderAt (to read without moving the original body's position)
+	// in addition to io.Seeker (to record the body's starting offset). This is
+	// satisfied by *os.File, *bytes.Reader and *strings.Reader. Readers that
+	// cannot provide an independent, rewindable view are left without GetBody so
+	// that large uploads are never buffered in memory.
+	seeker, isSeeker := reader.(io.Seeker)
+	readerAt, isReaderAt := reader.(io.ReaderAt)
+	if isSeeker && isReaderAt {
+		offset, err := seeker.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return nil, err
+		}
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(uploadRequestBodyReader{Reader: io.NewSectionReader(readerAt, offset, size)}), nil
+		}
+	}
+
 	if mediaType == "" {
 		mediaType = defaultMediaType
 	}

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -6,6 +6,7 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1735,6 +1736,93 @@ func TestNewUploadRequest_pathTraversal(t *testing.T) {
 	_, err := c.NewUploadRequest(t.Context(), "repos/x/../../../admin", nil, 0, "")
 	if !errors.Is(err, ErrPathForbidden) {
 		t.Fatalf("NewUploadRequest with path traversal: want ErrPathForbidden, got %v", err)
+	}
+}
+
+func TestNewUploadRequest_setsGetBodyForSeekableReader(t *testing.T) {
+	t.Parallel()
+	c := mustNewClient(t)
+
+	const content = "upload content"
+	file := openTestFile(t, "upload.txt", content)
+
+	req, err := c.NewUploadRequest(t.Context(), "https://example.com/", file, int64(len(content)), "text/plain")
+	if err != nil {
+		t.Fatalf("NewUploadRequest returned unexpected error: %v", err)
+	}
+
+	// GetBody must be set for rewindable readers so HTTP/2 can retry the request
+	// after a refused stream. See issue #2113.
+	if req.GetBody == nil {
+		t.Fatal("NewUploadRequest did not set req.GetBody for a seekable/ReaderAt reader")
+	}
+
+	// Each GetBody call must return an independent copy yielding the identical
+	// body so retries send the same bytes.
+	for i := range 2 {
+		body, err := req.GetBody()
+		if err != nil {
+			t.Fatalf("GetBody call %v returned unexpected error: %v", i, err)
+		}
+		got, err := io.ReadAll(body)
+		body.Close()
+		if err != nil {
+			t.Fatalf("reading GetBody result on call %v: %v", i, err)
+		}
+		if string(got) != content {
+			t.Errorf("GetBody call %v body = %q, want %q", i, got, content)
+		}
+	}
+
+	// Reading via GetBody must not have disturbed the original body's read
+	// position: req.Body must still yield the full content.
+	gotBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("reading req.Body: %v", err)
+	}
+	if string(gotBody) != content {
+		t.Errorf("req.Body after GetBody calls = %q, want %q", gotBody, content)
+	}
+}
+
+// seekerOnlyReader implements io.Reader and io.Seeker but deliberately not
+// io.ReaderAt, so it cannot provide an independent body copy.
+type seekerOnlyReader struct {
+	r *strings.Reader
+}
+
+func (s *seekerOnlyReader) Read(p []byte) (int, error) { return s.r.Read(p) }
+
+func (s *seekerOnlyReader) Seek(offset int64, whence int) (int64, error) {
+	return s.r.Seek(offset, whence)
+}
+
+func TestNewUploadRequest_noGetBodyWithoutReaderAt(t *testing.T) {
+	t.Parallel()
+	c := mustNewClient(t)
+
+	tests := []struct {
+		name   string
+		reader io.Reader
+	}{
+		// *bytes.Buffer is neither io.Seeker nor io.ReaderAt.
+		{"non-seekable", bytes.NewBufferString("upload content")},
+		// io.Seeker alone is insufficient: without io.ReaderAt we cannot return
+		// an independent body copy, so GetBody must stay nil rather than risk
+		// disturbing the original body's read position.
+		{"seeker without ReaderAt", &seekerOnlyReader{strings.NewReader("upload content")}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req, err := c.NewUploadRequest(t.Context(), "https://example.com/", tt.reader, 14, "text/plain")
+			if err != nil {
+				t.Fatalf("NewUploadRequest returned unexpected error: %v", err)
+			}
+			if req.GetBody != nil {
+				t.Errorf("NewUploadRequest set req.GetBody for %v reader, want nil", tt.name)
+			}
+		})
 	}
 }
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1826,6 +1826,24 @@ func TestNewUploadRequest_noGetBodyWithoutReaderAt(t *testing.T) {
 	}
 }
 
+func TestNewUploadRequest_returnsErrorWhenSeekFails(t *testing.T) {
+	t.Parallel()
+	c := mustNewClient(t)
+
+	const content = "upload content"
+	file := openTestFile(t, "upload.txt", content)
+	// Closing the file makes Seek fail, exercising the GetBody offset-probe
+	// error path (issue #2113).
+	if err := file.Close(); err != nil {
+		t.Fatalf("closing test file: %v", err)
+	}
+
+	_, err := c.NewUploadRequest(t.Context(), "https://example.com/", file, int64(len(content)), "text/plain")
+	if err == nil {
+		t.Error("NewUploadRequest returned nil error when Seek failed, want error")
+	}
+}
+
 func TestNewFormRequest(t *testing.T) {
 	t.Parallel()
 	c := mustNewClient(t)


### PR DESCRIPTION
Fixes #2113

## Problem

`NewUploadRequest` passed the body to `http.NewRequestWithContext` without setting `Request.GetBody`. Unlike the JSON `NewRequest` path (where the Go stdlib auto-populates `GetBody` for `*bytes.Buffer`), the upload path wraps the reader in `uploadRequestBodyReader` to hide concrete types, so `GetBody` stayed nil. As a result `net/http2` could not rewind the body and asset uploads failed with:

```
http2: Transport: cannot retry err ... after Request.Body was written; define Request.GetBody to avoid this error
```

when a stream was refused (REFUSED_STREAM / GOAWAY / idle-connection close). This has been reported by several downstream tools (ghr, goreleaser, go-release-action).

## Fix

Set `req.GetBody` when the reader implements **both** `io.Seeker` (to record the body's starting offset) and `io.ReaderAt`. `GetBody` returns an independent `io.SectionReader` (re-wrapped in `uploadRequestBodyReader` to preserve the existing race-safety behaviour), so each call yields a fresh copy **without** disturbing the original body's read position — honoring the `http.Request.GetBody` contract.

This is satisfied by `*os.File` (used by `UploadReleaseAsset`), `*bytes.Reader` and `*strings.Reader`. Readers that cannot provide an independent, rewindable view are intentionally left without `GetBody` so large uploads are never buffered in memory.

This is a backwards-compatible change (no signature changes).

## Tests

- `TestNewUploadRequest_setsGetBodyForSeekableReader` — asserts `GetBody` is set, returns identical bytes on repeated calls, and does not consume the original `req.Body`.
- `TestNewUploadRequest_noGetBodyWithoutReaderAt` — asserts `GetBody` stays nil for a non-seekable reader and for a seek-only reader without `io.ReaderAt`.

`go test -race ./github/`, `go vet`, and golangci-lint all pass.