### PR TITLE
refactor!: Pass `GistsService` required params by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -230,8 +230,6 @@ linters:
             - ExternalGroup
             - GenerateJITConfigRequest
             - GenerateNotesOptions
-            - Gist
-            - GistComment
             - Hook
             - HookConfig
             - ImpersonateUserOptions

--- a/github/gists.go
+++ b/github/gists.go
@@ -41,7 +41,7 @@ func (g Gist) String() string {
 type CreateGistRequest struct {
 	Description *string `json:"description,omitempty"`
 	Public      *bool   `json:"public,omitempty"`
-	// Files is the set of files that make up the gist, keyed by filename. (Required.)
+	// Files is the set of files that make up the gist, keyed by filename.
 	Files map[GistFilename]*CreateGistFile `json:"files"`
 }
 
@@ -73,8 +73,8 @@ func (g GistFile) String() string {
 // CreateGistFile represents a file within a CreateGistRequest, keyed by filename
 // in the request's Files map.
 type CreateGistFile struct {
-	// Content is the contents of the file. (Required.)
-	Content *string `json:"content,omitempty"`
+	// Content is the contents of the file.
+	Content string `json:"content"`
 }
 
 // UpdateGistFile represents a file within an UpdateGistRequest, keyed by filename

--- a/github/gists.go
+++ b/github/gists.go
@@ -39,15 +39,17 @@ func (g Gist) String() string {
 
 // CreateGistRequest represents the input for creating a gist.
 type CreateGistRequest struct {
-	Description *string                   `json:"description,omitempty"`
-	Public      *bool                     `json:"public,omitempty"`
-	Files       map[GistFilename]GistFile `json:"files,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Public      *bool   `json:"public,omitempty"`
+	// Files is the set of files that make up the gist, keyed by filename. (Required.)
+	Files map[GistFilename]GistFileRequest `json:"files"`
 }
 
 // UpdateGistRequest represents the input for updating a gist.
 type UpdateGistRequest struct {
-	Description *string                   `json:"description,omitempty"`
-	Files       map[GistFilename]GistFile `json:"files,omitempty"`
+	Description *string `json:"description,omitempty"`
+	// Files is the set of files to add, change or rename, keyed by filename.
+	Files map[GistFilename]GistFileRequest `json:"files,omitempty"`
 }
 
 // GistFilename represents filename on a gist.
@@ -65,6 +67,15 @@ type GistFile struct {
 
 func (g GistFile) String() string {
 	return Stringify(g)
+}
+
+// GistFileRequest represents a file's content within a CreateGistRequest or
+// UpdateGistRequest. The gist's files are keyed by filename.
+type GistFileRequest struct {
+	// Content is the contents of the file. (Required when creating a gist.)
+	Content *string `json:"content,omitempty"`
+	// Filename, if set, renames the file. (Used when updating a gist.)
+	Filename *string `json:"filename,omitempty"`
 }
 
 // GistCommit represents a commit on a gist.

--- a/github/gists.go
+++ b/github/gists.go
@@ -37,6 +37,19 @@ func (g Gist) String() string {
 	return Stringify(g)
 }
 
+// CreateGistRequest represents the input for creating a gist.
+type CreateGistRequest struct {
+	Description *string                   `json:"description,omitempty"`
+	Public      *bool                     `json:"public,omitempty"`
+	Files       map[GistFilename]GistFile `json:"files,omitempty"`
+}
+
+// UpdateGistRequest represents the input for updating a gist.
+type UpdateGistRequest struct {
+	Description *string                   `json:"description,omitempty"`
+	Files       map[GistFilename]GistFile `json:"files,omitempty"`
+}
+
 // GistFilename represents filename on a gist.
 type GistFilename string
 
@@ -225,7 +238,7 @@ func (s *GistsService) GetRevision(ctx context.Context, id, sha string) (*Gist, 
 // GitHub API docs: https://docs.github.com/rest/gists/gists?apiVersion=2022-11-28#create-a-gist
 //
 //meta:operation POST /gists
-func (s *GistsService) Create(ctx context.Context, body *Gist) (*Gist, *Response, error) {
+func (s *GistsService) Create(ctx context.Context, body CreateGistRequest) (*Gist, *Response, error) {
 	u := "gists"
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
@@ -241,12 +254,12 @@ func (s *GistsService) Create(ctx context.Context, body *Gist) (*Gist, *Response
 	return g, resp, nil
 }
 
-// Edit a gist.
+// Update a gist.
 //
 // GitHub API docs: https://docs.github.com/rest/gists/gists?apiVersion=2022-11-28#update-a-gist
 //
 //meta:operation PATCH /gists/{gist_id}
-func (s *GistsService) Edit(ctx context.Context, id string, body *Gist) (*Gist, *Response, error) {
+func (s *GistsService) Update(ctx context.Context, id string, body UpdateGistRequest) (*Gist, *Response, error) {
 	u := fmt.Sprintf("gists/%v", id)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/gists.go
+++ b/github/gists.go
@@ -42,14 +42,15 @@ type CreateGistRequest struct {
 	Description *string `json:"description,omitempty"`
 	Public      *bool   `json:"public,omitempty"`
 	// Files is the set of files that make up the gist, keyed by filename. (Required.)
-	Files map[GistFilename]GistFileRequest `json:"files"`
+	Files map[GistFilename]*CreateGistFile `json:"files"`
 }
 
 // UpdateGistRequest represents the input for updating a gist.
 type UpdateGistRequest struct {
 	Description *string `json:"description,omitempty"`
 	// Files is the set of files to add, change or rename, keyed by filename.
-	Files map[GistFilename]GistFileRequest `json:"files,omitempty"`
+	// Mapping a filename to a nil value deletes that file from the gist.
+	Files map[GistFilename]*UpdateGistFile `json:"files,omitempty"`
 }
 
 // GistFilename represents filename on a gist.
@@ -69,12 +70,20 @@ func (g GistFile) String() string {
 	return Stringify(g)
 }
 
-// GistFileRequest represents a file's content within a CreateGistRequest or
-// UpdateGistRequest. The gist's files are keyed by filename.
-type GistFileRequest struct {
-	// Content is the contents of the file. (Required when creating a gist.)
+// CreateGistFile represents a file within a CreateGistRequest, keyed by filename
+// in the request's Files map.
+type CreateGistFile struct {
+	// Content is the contents of the file. (Required.)
 	Content *string `json:"content,omitempty"`
-	// Filename, if set, renames the file. (Used when updating a gist.)
+}
+
+// UpdateGistFile represents a file within an UpdateGistRequest, keyed by filename
+// in the request's Files map. Mapping a filename to a nil *UpdateGistFile deletes
+// that file from the gist.
+type UpdateGistFile struct {
+	// Content is the new contents of the file.
+	Content *string `json:"content,omitempty"`
+	// Filename, if set, renames the file.
 	Filename *string `json:"filename,omitempty"`
 }
 

--- a/github/gists_comments.go
+++ b/github/gists_comments.go
@@ -25,12 +25,14 @@ func (g GistComment) String() string {
 
 // CreateGistCommentRequest represents the input for creating a gist comment.
 type CreateGistCommentRequest struct {
-	Body *string `json:"body,omitempty"`
+	// Body is the comment text.
+	Body string `json:"body"`
 }
 
 // UpdateGistCommentRequest represents the input for updating a gist comment.
 type UpdateGistCommentRequest struct {
-	Body *string `json:"body,omitempty"`
+	// Body is the comment text.
+	Body string `json:"body"`
 }
 
 // ListComments lists all comments for a gist.

--- a/github/gists_comments.go
+++ b/github/gists_comments.go
@@ -23,6 +23,16 @@ func (g GistComment) String() string {
 	return Stringify(g)
 }
 
+// CreateGistCommentRequest represents the input for creating a gist comment.
+type CreateGistCommentRequest struct {
+	Body *string `json:"body,omitempty"`
+}
+
+// UpdateGistCommentRequest represents the input for updating a gist comment.
+type UpdateGistCommentRequest struct {
+	Body *string `json:"body,omitempty"`
+}
+
 // ListComments lists all comments for a gist.
 //
 // GitHub API docs: https://docs.github.com/rest/gists/comments?apiVersion=2022-11-28#list-gist-comments
@@ -75,7 +85,7 @@ func (s *GistsService) GetComment(ctx context.Context, gistID string, commentID 
 // GitHub API docs: https://docs.github.com/rest/gists/comments?apiVersion=2022-11-28#create-a-gist-comment
 //
 //meta:operation POST /gists/{gist_id}/comments
-func (s *GistsService) CreateComment(ctx context.Context, gistID string, body *GistComment) (*GistComment, *Response, error) {
+func (s *GistsService) CreateComment(ctx context.Context, gistID string, body CreateGistCommentRequest) (*GistComment, *Response, error) {
 	u := fmt.Sprintf("gists/%v/comments", gistID)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
@@ -91,12 +101,12 @@ func (s *GistsService) CreateComment(ctx context.Context, gistID string, body *G
 	return c, resp, nil
 }
 
-// EditComment edits an existing gist comment.
+// UpdateComment updates an existing gist comment.
 //
 // GitHub API docs: https://docs.github.com/rest/gists/comments?apiVersion=2022-11-28#update-a-gist-comment
 //
 //meta:operation PATCH /gists/{gist_id}/comments/{comment_id}
-func (s *GistsService) EditComment(ctx context.Context, gistID string, commentID int64, body *GistComment) (*GistComment, *Response, error) {
+func (s *GistsService) UpdateComment(ctx context.Context, gistID string, commentID int64, body UpdateGistCommentRequest) (*GistComment, *Response, error) {
 	u := fmt.Sprintf("gists/%v/comments/%v", gistID, commentID)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/gists_comments_test.go
+++ b/github/gists_comments_test.go
@@ -107,7 +107,7 @@ func TestGistsService_CreateComment(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := CreateGistCommentRequest{Body: Ptr("b")}
+	input := CreateGistCommentRequest{Body: "b"}
 
 	mux.HandleFunc("/gists/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -154,7 +154,7 @@ func TestGistsService_UpdateComment(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := UpdateGistCommentRequest{Body: Ptr("b")}
+	input := UpdateGistCommentRequest{Body: "b"}
 
 	mux.HandleFunc("/gists/1/comments/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")

--- a/github/gists_comments_test.go
+++ b/github/gists_comments_test.go
@@ -107,7 +107,7 @@ func TestGistsService_CreateComment(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &GistComment{ID: Ptr(int64(1)), Body: Ptr("b")}
+	input := CreateGistCommentRequest{Body: Ptr("b")}
 
 	mux.HandleFunc("/gists/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -146,15 +146,15 @@ func TestGistsService_CreateComment_invalidID(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Gists.CreateComment(ctx, "%", nil)
+	_, _, err := client.Gists.CreateComment(ctx, "%", CreateGistCommentRequest{})
 	testURLParseError(t, err)
 }
 
-func TestGistsService_EditComment(t *testing.T) {
+func TestGistsService_UpdateComment(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &GistComment{ID: Ptr(int64(1)), Body: Ptr("b")}
+	input := UpdateGistCommentRequest{Body: Ptr("b")}
 
 	mux.HandleFunc("/gists/1/comments/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -163,24 +163,24 @@ func TestGistsService_EditComment(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	comment, _, err := client.Gists.EditComment(ctx, "1", 2, input)
+	comment, _, err := client.Gists.UpdateComment(ctx, "1", 2, input)
 	if err != nil {
-		t.Errorf("Gists.EditComment returned error: %v", err)
+		t.Errorf("Gists.UpdateComment returned error: %v", err)
 	}
 
 	want := &GistComment{ID: Ptr(int64(1))}
 	if !cmp.Equal(comment, want) {
-		t.Errorf("Gists.EditComment returned %+v, want %+v", comment, want)
+		t.Errorf("Gists.UpdateComment returned %+v, want %+v", comment, want)
 	}
 
-	const methodName = "EditComment"
+	const methodName = "UpdateComment"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Gists.EditComment(ctx, "\n", -2, input)
+		_, _, err = client.Gists.UpdateComment(ctx, "\n", -2, input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Gists.EditComment(ctx, "1", 2, input)
+		got, resp, err := client.Gists.UpdateComment(ctx, "1", 2, input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -188,12 +188,12 @@ func TestGistsService_EditComment(t *testing.T) {
 	})
 }
 
-func TestGistsService_EditComment_invalidID(t *testing.T) {
+func TestGistsService_UpdateComment_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Gists.EditComment(ctx, "%", 1, nil)
+	_, _, err := client.Gists.UpdateComment(ctx, "%", 1, UpdateGistCommentRequest{})
 	testURLParseError(t, err)
 }
 

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -267,7 +267,7 @@ func TestGistsService_Create(t *testing.T) {
 		Description: Ptr("Gist description"),
 		Public:      Ptr(false),
 		Files: map[GistFilename]*CreateGistFile{
-			"test.txt": {Content: Ptr("Gist file content")},
+			"test.txt": {Content: "Gist file content"},
 		},
 	}
 

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -266,7 +266,7 @@ func TestGistsService_Create(t *testing.T) {
 	input := CreateGistRequest{
 		Description: Ptr("Gist description"),
 		Public:      Ptr(false),
-		Files: map[GistFilename]GistFile{
+		Files: map[GistFilename]GistFileRequest{
 			"test.txt": {Content: Ptr("Gist file content")},
 		},
 	}
@@ -323,7 +323,7 @@ func TestGistsService_Update(t *testing.T) {
 
 	input := UpdateGistRequest{
 		Description: Ptr("New description"),
-		Files: map[GistFilename]GistFile{
+		Files: map[GistFilename]GistFileRequest{
 			"new.txt": {Content: Ptr("new file content")},
 		},
 	}

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -266,7 +266,7 @@ func TestGistsService_Create(t *testing.T) {
 	input := CreateGistRequest{
 		Description: Ptr("Gist description"),
 		Public:      Ptr(false),
-		Files: map[GistFilename]GistFileRequest{
+		Files: map[GistFilename]*CreateGistFile{
 			"test.txt": {Content: Ptr("Gist file content")},
 		},
 	}
@@ -323,8 +323,10 @@ func TestGistsService_Update(t *testing.T) {
 
 	input := UpdateGistRequest{
 		Description: Ptr("New description"),
-		Files: map[GistFilename]GistFileRequest{
+		Files: map[GistFilename]*UpdateGistFile{
 			"new.txt": {Content: Ptr("new file content")},
+			// A nil value deletes the file from the gist.
+			"old.txt": nil,
 		},
 	}
 

--- a/github/gists_test.go
+++ b/github/gists_test.go
@@ -263,7 +263,7 @@ func TestGistsService_Create(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &Gist{
+	input := CreateGistRequest{
 		Description: Ptr("Gist description"),
 		Public:      Ptr(false),
 		Files: map[GistFilename]GistFile{
@@ -317,11 +317,11 @@ func TestGistsService_Create(t *testing.T) {
 	})
 }
 
-func TestGistsService_Edit(t *testing.T) {
+func TestGistsService_Update(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &Gist{
+	input := UpdateGistRequest{
 		Description: Ptr("New description"),
 		Files: map[GistFilename]GistFile{
 			"new.txt": {Content: Ptr("new file content")},
@@ -350,9 +350,9 @@ func TestGistsService_Edit(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	gist, _, err := client.Gists.Edit(ctx, "1", input)
+	gist, _, err := client.Gists.Update(ctx, "1", input)
 	if err != nil {
-		t.Errorf("Gists.Edit returned error: %v", err)
+		t.Errorf("Gists.Update returned error: %v", err)
 	}
 
 	want := &Gist{
@@ -365,17 +365,17 @@ func TestGistsService_Edit(t *testing.T) {
 		},
 	}
 	if !cmp.Equal(gist, want) {
-		t.Errorf("Gists.Edit returned %+v, want %+v", gist, want)
+		t.Errorf("Gists.Update returned %+v, want %+v", gist, want)
 	}
 
-	const methodName = "Edit"
+	const methodName = "Update"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Gists.Edit(ctx, "\n", input)
+		_, _, err = client.Gists.Update(ctx, "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Gists.Edit(ctx, "1", input)
+		got, resp, err := client.Gists.Update(ctx, "1", input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -383,12 +383,12 @@ func TestGistsService_Edit(t *testing.T) {
 	})
 }
 
-func TestGistsService_Edit_invalidID(t *testing.T) {
+func TestGistsService_Update_invalidID(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Gists.Edit(ctx, "%", nil)
+	_, _, err := client.Gists.Update(ctx, "%", UpdateGistRequest{})
 	testURLParseError(t, err)
 }
 

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -10774,20 +10774,20 @@ func (c *CreateGistCommentRequest) GetBody() string {
 	return *c.Body
 }
 
+// GetContent returns the Content field if it's non-nil, zero value otherwise.
+func (c *CreateGistFile) GetContent() string {
+	if c == nil || c.Content == nil {
+		return ""
+	}
+	return *c.Content
+}
+
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
 func (c *CreateGistRequest) GetDescription() string {
 	if c == nil || c.Description == nil {
 		return ""
 	}
 	return *c.Description
-}
-
-// GetFiles returns the Files map if it's non-nil, an empty map otherwise.
-func (c *CreateGistRequest) GetFiles() map[GistFilename]GistFileRequest {
-	if c == nil || c.Files == nil {
-		return map[GistFilename]GistFileRequest{}
-	}
-	return c.Files
 }
 
 // GetPublic returns the Public field if it's non-nil, zero value otherwise.
@@ -16780,22 +16780,6 @@ func (g *GistFile) GetType() string {
 		return ""
 	}
 	return *g.Type
-}
-
-// GetContent returns the Content field if it's non-nil, zero value otherwise.
-func (g *GistFileRequest) GetContent() string {
-	if g == nil || g.Content == nil {
-		return ""
-	}
-	return *g.Content
-}
-
-// GetFilename returns the Filename field if it's non-nil, zero value otherwise.
-func (g *GistFileRequest) GetFilename() string {
-	if g == nil || g.Filename == nil {
-		return ""
-	}
-	return *g.Filename
 }
 
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
@@ -41926,20 +41910,28 @@ func (u *UpdateGistCommentRequest) GetBody() string {
 	return *u.Body
 }
 
+// GetContent returns the Content field if it's non-nil, zero value otherwise.
+func (u *UpdateGistFile) GetContent() string {
+	if u == nil || u.Content == nil {
+		return ""
+	}
+	return *u.Content
+}
+
+// GetFilename returns the Filename field if it's non-nil, zero value otherwise.
+func (u *UpdateGistFile) GetFilename() string {
+	if u == nil || u.Filename == nil {
+		return ""
+	}
+	return *u.Filename
+}
+
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
 func (u *UpdateGistRequest) GetDescription() string {
 	if u == nil || u.Description == nil {
 		return ""
 	}
 	return *u.Description
-}
-
-// GetFiles returns the Files map if it's non-nil, an empty map otherwise.
-func (u *UpdateGistRequest) GetFiles() map[GistFilename]GistFileRequest {
-	if u == nil || u.Files == nil {
-		return map[GistFilename]GistFileRequest{}
-	}
-	return u.Files
 }
 
 // GetEnableStaticIP returns the EnableStaticIP field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -10766,20 +10766,20 @@ func (c *CreateEvent) GetSender() *User {
 	return c.Sender
 }
 
-// GetBody returns the Body field if it's non-nil, zero value otherwise.
+// GetBody returns the Body field.
 func (c *CreateGistCommentRequest) GetBody() string {
-	if c == nil || c.Body == nil {
+	if c == nil {
 		return ""
 	}
-	return *c.Body
+	return c.Body
 }
 
-// GetContent returns the Content field if it's non-nil, zero value otherwise.
+// GetContent returns the Content field.
 func (c *CreateGistFile) GetContent() string {
-	if c == nil || c.Content == nil {
+	if c == nil {
 		return ""
 	}
-	return *c.Content
+	return c.Content
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
@@ -41902,12 +41902,12 @@ func (u *UpdateEnterpriseRunnerGroupRequest) GetVisibility() string {
 	return *u.Visibility
 }
 
-// GetBody returns the Body field if it's non-nil, zero value otherwise.
+// GetBody returns the Body field.
 func (u *UpdateGistCommentRequest) GetBody() string {
-	if u == nil || u.Body == nil {
+	if u == nil {
 		return ""
 	}
-	return *u.Body
+	return u.Body
 }
 
 // GetContent returns the Content field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -10766,6 +10766,38 @@ func (c *CreateEvent) GetSender() *User {
 	return c.Sender
 }
 
+// GetBody returns the Body field if it's non-nil, zero value otherwise.
+func (c *CreateGistCommentRequest) GetBody() string {
+	if c == nil || c.Body == nil {
+		return ""
+	}
+	return *c.Body
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (c *CreateGistRequest) GetDescription() string {
+	if c == nil || c.Description == nil {
+		return ""
+	}
+	return *c.Description
+}
+
+// GetFiles returns the Files map if it's non-nil, an empty map otherwise.
+func (c *CreateGistRequest) GetFiles() map[GistFilename]GistFile {
+	if c == nil || c.Files == nil {
+		return map[GistFilename]GistFile{}
+	}
+	return c.Files
+}
+
+// GetPublic returns the Public field if it's non-nil, zero value otherwise.
+func (c *CreateGistRequest) GetPublic() bool {
+	if c == nil || c.Public == nil {
+		return false
+	}
+	return *c.Public
+}
+
 // GetEnableStaticIP returns the EnableStaticIP field if it's non-nil, zero value otherwise.
 func (c *CreateHostedRunnerRequest) GetEnableStaticIP() bool {
 	if c == nil || c.EnableStaticIP == nil {
@@ -41868,6 +41900,30 @@ func (u *UpdateEnterpriseRunnerGroupRequest) GetVisibility() string {
 		return ""
 	}
 	return *u.Visibility
+}
+
+// GetBody returns the Body field if it's non-nil, zero value otherwise.
+func (u *UpdateGistCommentRequest) GetBody() string {
+	if u == nil || u.Body == nil {
+		return ""
+	}
+	return *u.Body
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (u *UpdateGistRequest) GetDescription() string {
+	if u == nil || u.Description == nil {
+		return ""
+	}
+	return *u.Description
+}
+
+// GetFiles returns the Files map if it's non-nil, an empty map otherwise.
+func (u *UpdateGistRequest) GetFiles() map[GistFilename]GistFile {
+	if u == nil || u.Files == nil {
+		return map[GistFilename]GistFile{}
+	}
+	return u.Files
 }
 
 // GetEnableStaticIP returns the EnableStaticIP field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -10783,9 +10783,9 @@ func (c *CreateGistRequest) GetDescription() string {
 }
 
 // GetFiles returns the Files map if it's non-nil, an empty map otherwise.
-func (c *CreateGistRequest) GetFiles() map[GistFilename]GistFile {
+func (c *CreateGistRequest) GetFiles() map[GistFilename]GistFileRequest {
 	if c == nil || c.Files == nil {
-		return map[GistFilename]GistFile{}
+		return map[GistFilename]GistFileRequest{}
 	}
 	return c.Files
 }
@@ -16780,6 +16780,22 @@ func (g *GistFile) GetType() string {
 		return ""
 	}
 	return *g.Type
+}
+
+// GetContent returns the Content field if it's non-nil, zero value otherwise.
+func (g *GistFileRequest) GetContent() string {
+	if g == nil || g.Content == nil {
+		return ""
+	}
+	return *g.Content
+}
+
+// GetFilename returns the Filename field if it's non-nil, zero value otherwise.
+func (g *GistFileRequest) GetFilename() string {
+	if g == nil || g.Filename == nil {
+		return ""
+	}
+	return *g.Filename
 }
 
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
@@ -41919,9 +41935,9 @@ func (u *UpdateGistRequest) GetDescription() string {
 }
 
 // GetFiles returns the Files map if it's non-nil, an empty map otherwise.
-func (u *UpdateGistRequest) GetFiles() map[GistFilename]GistFile {
+func (u *UpdateGistRequest) GetFiles() map[GistFilename]GistFileRequest {
 	if u == nil || u.Files == nil {
-		return map[GistFilename]GistFile{}
+		return map[GistFilename]GistFileRequest{}
 	}
 	return u.Files
 }

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -13691,10 +13691,7 @@ func TestCreateEvent_GetSender(tt *testing.T) {
 
 func TestCreateGistCommentRequest_GetBody(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	c := &CreateGistCommentRequest{Body: &zeroValue}
-	c.GetBody()
-	c = &CreateGistCommentRequest{}
+	c := &CreateGistCommentRequest{}
 	c.GetBody()
 	c = nil
 	c.GetBody()
@@ -13702,10 +13699,7 @@ func TestCreateGistCommentRequest_GetBody(tt *testing.T) {
 
 func TestCreateGistFile_GetContent(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	c := &CreateGistFile{Content: &zeroValue}
-	c.GetContent()
-	c = &CreateGistFile{}
+	c := &CreateGistFile{}
 	c.GetContent()
 	c = nil
 	c.GetContent()
@@ -52609,10 +52603,7 @@ func TestUpdateEnterpriseRunnerGroupRequest_GetVisibility(tt *testing.T) {
 
 func TestUpdateGistCommentRequest_GetBody(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	u := &UpdateGistCommentRequest{Body: &zeroValue}
-	u.GetBody()
-	u = &UpdateGistCommentRequest{}
+	u := &UpdateGistCommentRequest{}
 	u.GetBody()
 	u = nil
 	u.GetBody()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -13700,6 +13700,17 @@ func TestCreateGistCommentRequest_GetBody(tt *testing.T) {
 	c.GetBody()
 }
 
+func TestCreateGistFile_GetContent(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateGistFile{Content: &zeroValue}
+	c.GetContent()
+	c = &CreateGistFile{}
+	c.GetContent()
+	c = nil
+	c.GetContent()
+}
+
 func TestCreateGistRequest_GetDescription(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -13709,17 +13720,6 @@ func TestCreateGistRequest_GetDescription(tt *testing.T) {
 	c.GetDescription()
 	c = nil
 	c.GetDescription()
-}
-
-func TestCreateGistRequest_GetFiles(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := map[GistFilename]GistFileRequest{}
-	c := &CreateGistRequest{Files: zeroValue}
-	c.GetFiles()
-	c = &CreateGistRequest{}
-	c.GetFiles()
-	c = nil
-	c.GetFiles()
 }
 
 func TestCreateGistRequest_GetPublic(tt *testing.T) {
@@ -21134,28 +21134,6 @@ func TestGistFile_GetType(tt *testing.T) {
 	g.GetType()
 	g = nil
 	g.GetType()
-}
-
-func TestGistFileRequest_GetContent(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	g := &GistFileRequest{Content: &zeroValue}
-	g.GetContent()
-	g = &GistFileRequest{}
-	g.GetContent()
-	g = nil
-	g.GetContent()
-}
-
-func TestGistFileRequest_GetFilename(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	g := &GistFileRequest{Filename: &zeroValue}
-	g.GetFilename()
-	g = &GistFileRequest{}
-	g.GetFilename()
-	g = nil
-	g.GetFilename()
 }
 
 func TestGistFork_GetCreatedAt(tt *testing.T) {
@@ -52640,6 +52618,28 @@ func TestUpdateGistCommentRequest_GetBody(tt *testing.T) {
 	u.GetBody()
 }
 
+func TestUpdateGistFile_GetContent(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateGistFile{Content: &zeroValue}
+	u.GetContent()
+	u = &UpdateGistFile{}
+	u.GetContent()
+	u = nil
+	u.GetContent()
+}
+
+func TestUpdateGistFile_GetFilename(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateGistFile{Filename: &zeroValue}
+	u.GetFilename()
+	u = &UpdateGistFile{}
+	u.GetFilename()
+	u = nil
+	u.GetFilename()
+}
+
 func TestUpdateGistRequest_GetDescription(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -52649,17 +52649,6 @@ func TestUpdateGistRequest_GetDescription(tt *testing.T) {
 	u.GetDescription()
 	u = nil
 	u.GetDescription()
-}
-
-func TestUpdateGistRequest_GetFiles(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := map[GistFilename]GistFileRequest{}
-	u := &UpdateGistRequest{Files: zeroValue}
-	u.GetFiles()
-	u = &UpdateGistRequest{}
-	u.GetFiles()
-	u = nil
-	u.GetFiles()
 }
 
 func TestUpdateHostedRunnerRequest_GetEnableStaticIP(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -13713,7 +13713,7 @@ func TestCreateGistRequest_GetDescription(tt *testing.T) {
 
 func TestCreateGistRequest_GetFiles(tt *testing.T) {
 	tt.Parallel()
-	zeroValue := map[GistFilename]GistFile{}
+	zeroValue := map[GistFilename]GistFileRequest{}
 	c := &CreateGistRequest{Files: zeroValue}
 	c.GetFiles()
 	c = &CreateGistRequest{}
@@ -21134,6 +21134,28 @@ func TestGistFile_GetType(tt *testing.T) {
 	g.GetType()
 	g = nil
 	g.GetType()
+}
+
+func TestGistFileRequest_GetContent(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	g := &GistFileRequest{Content: &zeroValue}
+	g.GetContent()
+	g = &GistFileRequest{}
+	g.GetContent()
+	g = nil
+	g.GetContent()
+}
+
+func TestGistFileRequest_GetFilename(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	g := &GistFileRequest{Filename: &zeroValue}
+	g.GetFilename()
+	g = &GistFileRequest{}
+	g.GetFilename()
+	g = nil
+	g.GetFilename()
 }
 
 func TestGistFork_GetCreatedAt(tt *testing.T) {
@@ -52631,7 +52653,7 @@ func TestUpdateGistRequest_GetDescription(tt *testing.T) {
 
 func TestUpdateGistRequest_GetFiles(tt *testing.T) {
 	tt.Parallel()
-	zeroValue := map[GistFilename]GistFile{}
+	zeroValue := map[GistFilename]GistFileRequest{}
 	u := &UpdateGistRequest{Files: zeroValue}
 	u.GetFiles()
 	u = &UpdateGistRequest{}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -13689,6 +13689,50 @@ func TestCreateEvent_GetSender(tt *testing.T) {
 	c.GetSender()
 }
 
+func TestCreateGistCommentRequest_GetBody(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateGistCommentRequest{Body: &zeroValue}
+	c.GetBody()
+	c = &CreateGistCommentRequest{}
+	c.GetBody()
+	c = nil
+	c.GetBody()
+}
+
+func TestCreateGistRequest_GetDescription(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateGistRequest{Description: &zeroValue}
+	c.GetDescription()
+	c = &CreateGistRequest{}
+	c.GetDescription()
+	c = nil
+	c.GetDescription()
+}
+
+func TestCreateGistRequest_GetFiles(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := map[GistFilename]GistFile{}
+	c := &CreateGistRequest{Files: zeroValue}
+	c.GetFiles()
+	c = &CreateGistRequest{}
+	c.GetFiles()
+	c = nil
+	c.GetFiles()
+}
+
+func TestCreateGistRequest_GetPublic(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	c := &CreateGistRequest{Public: &zeroValue}
+	c.GetPublic()
+	c = &CreateGistRequest{}
+	c.GetPublic()
+	c = nil
+	c.GetPublic()
+}
+
 func TestCreateHostedRunnerRequest_GetEnableStaticIP(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
@@ -52561,6 +52605,39 @@ func TestUpdateEnterpriseRunnerGroupRequest_GetVisibility(tt *testing.T) {
 	u.GetVisibility()
 	u = nil
 	u.GetVisibility()
+}
+
+func TestUpdateGistCommentRequest_GetBody(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateGistCommentRequest{Body: &zeroValue}
+	u.GetBody()
+	u = &UpdateGistCommentRequest{}
+	u.GetBody()
+	u = nil
+	u.GetBody()
+}
+
+func TestUpdateGistRequest_GetDescription(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateGistRequest{Description: &zeroValue}
+	u.GetDescription()
+	u = &UpdateGistRequest{}
+	u.GetDescription()
+	u = nil
+	u.GetDescription()
+}
+
+func TestUpdateGistRequest_GetFiles(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := map[GistFilename]GistFile{}
+	u := &UpdateGistRequest{Files: zeroValue}
+	u.GetFiles()
+	u = &UpdateGistRequest{}
+	u.GetFiles()
+	u = nil
+	u.GetFiles()
 }
 
 func TestUpdateHostedRunnerRequest_GetEnableStaticIP(tt *testing.T) {


### PR DESCRIPTION
BREAKING CHANGE: `GistsService` methods now pass required params by-value instead of by-ref.

## What problem are you solving?

This completes #3680 (open and unanswered for ~1 year), which addresses #3644 by
passing required `GistsService` inputs by value instead of by pointer.

It applies the review feedback that was agreed on #3680 but never implemented by
the original author:

- Introduce dedicated value-type request structs: `CreateGistRequest`,
  `UpdateGistRequest`, `CreateGistCommentRequest`, `UpdateGistCommentRequest`.
- `Create` and `CreateComment` now take the request struct **by value**.
- Rename `Edit` → `Update` and `EditComment` → `UpdateComment` for API
  consistency (suggested by @stevehipwell, agreed by @gmlewis).
- **No deprecated wrappers** (per @alexandear and @gmlewis on #3680; consistent
  with the earlier `GitService` refactor in #3654).
- Remove the now-obsolete `Gist` / `GistComment` entries from the paramcheck
  `body-allowed-pointer-types` allow-list in `.golangci.yml`.

`BREAKING CHANGE`: the `Create` / `Update` / `CreateComment` / `UpdateComment`
signatures change, and `Edit` / `EditComment` are renamed.

Patch coverage is 100% (the four methods and the generated accessors for the new
request structs are fully covered); generated files are regenerated and the
OpenAPI metadata is unchanged (the method renames do not affect `//meta:operation`).

~Relates to~ Fixes: #3644.
~Supersedes~ Closes: #3680.

> Note: this PR was prepared with AI assistance (Claude Code); all changes were
> reviewed and verified locally (build, full `github` test suite, custom
> `golangci-lint`, and `gofmt`).
