### PR TITLE
fix: Stop test/fields from reporting null-valued fields as missing

### DIFF
--- a/test/fields/fields.go
+++ b/test/fields/fields.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/google/go-github/v88/github"
@@ -77,72 +78,134 @@ func main() {
 // struct fields of typ.
 func testType(urlStr string, typ any) error {
 	ctx := context.Background()
-	slice := reflect.Indirect(reflect.ValueOf(typ)).Kind() == reflect.Slice
 
 	req, err := client.NewRequest(ctx, "GET", urlStr, nil)
 	if err != nil {
 		return err
 	}
 
-	// start with a json.RawMessage so we can decode multiple ways below
 	raw := new(json.RawMessage)
 	_, err = client.Do(req, raw)
 	if err != nil {
 		return err
 	}
 
-	// unmarshal directly to a map
-	var m1 map[string]any
-	if slice {
-		var s []map[string]any
-		err = json.Unmarshal(*raw, &s)
-		if err != nil {
-			return err
-		}
-		m1 = s[0]
-	} else {
-		err = json.Unmarshal(*raw, &m1)
-		if err != nil {
-			return err
-		}
-	}
-
-	// unmarshal to typ first, then re-marshal and unmarshal to a map
-	err = json.Unmarshal(*raw, typ)
+	missing, err := missingFields(*raw, typ, *skipURLs)
 	if err != nil {
 		return err
 	}
-
-	var byt []byte
-	if slice {
-		// use first item in slice
-		v := reflect.Indirect(reflect.ValueOf(typ))
-		byt, err = json.Marshal(v.Index(0).Interface())
-		if err != nil {
-			return err
-		}
-	} else {
-		byt, err = json.Marshal(typ)
-		if err != nil {
-			return err
-		}
-	}
-
-	var m2 map[string]any
-	err = json.Unmarshal(byt, &m2)
-	if err != nil {
-		return err
-	}
-
-	// now compare the two maps
-	for k, v := range m1 {
-		if *skipURLs && strings.HasSuffix(k, "_url") {
-			continue
-		}
-		if _, ok := m2[k]; !ok {
-			fmt.Printf("%v missing field for key: %v (example value: %v)\n", reflect.TypeOf(typ), k, v)
-		}
+	for _, m := range missing {
+		fmt.Printf("%v missing field for key: %v (example value: %v)\n", reflect.TypeOf(typ), m.key, m.value)
 	}
 
 	return nil
+}
+
+// missingField is a JSON key returned by the API that has no corresponding
+// struct field in the relevant go-github type.
+type missingField struct {
+	key   string
+	value any
+}
+
+// missingFields returns, sorted by key, the JSON keys present in the API
+// response raw that have no corresponding field in typ. typ may be a pointer to
+// a struct or a pointer to a slice of structs (the element type is used, and
+// the first element of the response array is inspected).
+//
+// The expected set of struct keys is derived from the type via reflection
+// rather than by re-marshaling a decoded value. Re-marshaling drops keys for
+// any field whose value is the zero value because go-github fields use
+// ",omitempty"; a field that the API returns as null therefore decodes to a nil
+// pointer and disappears on re-marshal, which previously caused those fields to
+// be reported as missing even though they are mapped (see issue #576).
+func missingFields(raw json.RawMessage, typ any, skipURLs bool) ([]*missingField, error) {
+	v := reflect.Indirect(reflect.ValueOf(typ))
+
+	// Decode the raw response into a map of its top-level keys. For a slice
+	// response, inspect the first element.
+	var m1 map[string]any
+	if v.Kind() == reflect.Slice {
+		var s []map[string]any
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return nil, err
+		}
+		if len(s) > 0 {
+			m1 = s[0]
+		}
+	} else {
+		if err := json.Unmarshal(raw, &m1); err != nil {
+			return nil, err
+		}
+	}
+
+	t := v.Type()
+	if t.Kind() == reflect.Slice {
+		t = t.Elem()
+	}
+	want := jsonFieldNames(t)
+
+	var missing []*missingField
+	for k, val := range m1 {
+		if skipURLs && strings.HasSuffix(k, "_url") {
+			continue
+		}
+		if _, ok := want[k]; !ok {
+			missing = append(missing, &missingField{key: k, value: val})
+		}
+	}
+	slices.SortFunc(missing, func(a, b *missingField) int {
+		return strings.Compare(a.key, b.key)
+	})
+	return missing, nil
+}
+
+// jsonFieldNames returns the set of top-level JSON object keys that a value of
+// type t marshals to, following encoding/json's rules: it skips unexported
+// fields and fields tagged `json:"-"`, uses the tag name (the part before the
+// first comma) when present and otherwise the field name, and promotes the
+// fields of anonymous (embedded) structs. Unlike re-marshaling a value, this is
+// value-independent, so a ",omitempty" field is never dropped.
+func jsonFieldNames(t reflect.Type) map[string]struct{} {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	names := map[string]struct{}{}
+	if t.Kind() != reflect.Struct {
+		return names
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		name, _, _ := strings.Cut(f.Tag.Get("json"), ",")
+		if name == "-" {
+			continue
+		}
+
+		// An embedded struct without an explicit JSON name has its fields
+		// promoted to the parent's top-level keys.
+		if f.Anonymous && name == "" {
+			ft := f.Type
+			for ft.Kind() == reflect.Pointer {
+				ft = ft.Elem()
+			}
+			if ft.Kind() == reflect.Struct {
+				for k := range jsonFieldNames(ft) {
+					names[k] = struct{}{}
+				}
+				continue
+			}
+		}
+
+		if !f.IsExported() {
+			continue
+		}
+		if name == "" {
+			name = f.Name
+		}
+		names[name] = struct{}{}
+	}
+
+	return names
 }

--- a/test/fields/fields_test.go
+++ b/test/fields/fields_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+
+	"github.com/google/go-github/v88/github"
+)
+
+func TestMissingFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		raw      string
+		typ      any
+		skipURLs bool
+		want     []string
+	}{
+		{
+			// Regression test for #576: a mapped field whose API value is null
+			// must not be reported as missing. Previously the struct was
+			// re-marshaled and ",omitempty" dropped the nil milestone key.
+			name: "null-valued mapped field is not reported",
+			raw:  `{"number": 1, "milestone": null, "comments": 2}`,
+			typ:  &github.Issue{},
+			want: nil,
+		},
+		{
+			name: "genuinely unmapped field is reported",
+			raw:  `{"milestone": null, "this_field_does_not_exist": 123}`,
+			typ:  &github.Issue{},
+			want: []string{"this_field_does_not_exist"},
+		},
+		{
+			name:     "url fields are skipped when requested",
+			raw:      `{"bogus_url": "x", "another_bogus": 1}`,
+			typ:      &github.Issue{},
+			skipURLs: true,
+			want:     []string{"another_bogus"},
+		},
+		{
+			name: "slice response inspects the first element",
+			raw:  `[{"totally_bogus": true}]`,
+			typ:  &[]github.Key{},
+			want: []string{"totally_bogus"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := missingFields(json.RawMessage(tt.raw), tt.typ, tt.skipURLs)
+			if err != nil {
+				t.Fatalf("missingFields returned error: %v", err)
+			}
+
+			var keys []string
+			for _, m := range got {
+				keys = append(keys, m.key)
+			}
+			if !slices.Equal(keys, tt.want) {
+				t.Errorf("missingFields keys = %v, want %v", keys, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What problem are you solving?

Fixes #576. The `test/fields` developer utility falsely reported mapped struct fields as "missing" whenever the GitHub API returned `null` for them (e.g. `Issue.Milestone` for `"milestone": null`).

## Root cause

`testType` decoded the raw JSON into the struct and then **re-marshaled** the struct to build the set of known keys. Since every go-github field is a `,omitempty` pointer, a `null` value decodes to a nil pointer and is dropped on re-marshal, so the key was absent from the comparison set and incorrectly flagged as missing.

## Fix

Derive the expected top-level JSON keys directly from the struct type via reflection (`jsonFieldNames`), which is value-independent and therefore never drops `,omitempty` fields. The comparison is extracted into a `missingFields` function and covered by a network-free unit test (`fields_test.go`), including a regression test for the null-`milestone` case and a check that genuinely unmapped keys are still reported.

This keeps the tool's existing top-level scope; recursing into nested structs/slices is out of scope for this fix.

> Note: prepared with AI assistance (Claude Code); all changes were reviewed and verified locally (`go build`/`go test`/`go vet`/`gofmt` and the repo's custom `golangci-lint`).
