### PR TITLE
refactor!: Pass release-notes and asset params by value and rename `EditReleaseAsset` to `UpdateReleaseAsset`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -229,7 +229,6 @@ linters:
             - EnterpriseSecurityAnalysisSettings
             - ExternalGroup
             - GenerateJITConfigRequest
-            - GenerateNotesOptions
             - Hook
             - HookConfig
             - ImpersonateUserOptions
@@ -258,7 +257,6 @@ linters:
             - PullRequestReviewDismissalRequest
             - PullRequestReviewRequest
             - PullRequestReviewsEnforcementUpdate
-            - ReleaseAsset
             - RepoMergeUpstreamRequest
             - Repository
             - RepositoryAddCollaboratorOptions
@@ -300,7 +298,6 @@ linters:
             - CreateOrUpdateCustomRepoRoleOptions
             - CreateOrUpdateIssueTypesOptions
             - CreateOrgInvitationOptions
-            - GenerateNotesOptions
             - ImpersonateUserOptions
             - InstallationTokenListRepoOptions
             - InstallationTokenOptions

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -16703,7 +16703,7 @@ func (g *GenerateJITConfigRequest) GetWorkFolder() string {
 }
 
 // GetConfigurationFilePath returns the ConfigurationFilePath field if it's non-nil, zero value otherwise.
-func (g *GenerateNotesOptions) GetConfigurationFilePath() string {
+func (g *GenerateNotesRequest) GetConfigurationFilePath() string {
 	if g == nil || g.ConfigurationFilePath == nil {
 		return ""
 	}
@@ -16711,7 +16711,7 @@ func (g *GenerateNotesOptions) GetConfigurationFilePath() string {
 }
 
 // GetPreviousTagName returns the PreviousTagName field if it's non-nil, zero value otherwise.
-func (g *GenerateNotesOptions) GetPreviousTagName() string {
+func (g *GenerateNotesRequest) GetPreviousTagName() string {
 	if g == nil || g.PreviousTagName == nil {
 		return ""
 	}
@@ -16719,7 +16719,7 @@ func (g *GenerateNotesOptions) GetPreviousTagName() string {
 }
 
 // GetTagName returns the TagName field.
-func (g *GenerateNotesOptions) GetTagName() string {
+func (g *GenerateNotesRequest) GetTagName() string {
 	if g == nil {
 		return ""
 	}
@@ -16727,7 +16727,7 @@ func (g *GenerateNotesOptions) GetTagName() string {
 }
 
 // GetTargetCommitish returns the TargetCommitish field if it's non-nil, zero value otherwise.
-func (g *GenerateNotesOptions) GetTargetCommitish() string {
+func (g *GenerateNotesRequest) GetTargetCommitish() string {
 	if g == nil || g.TargetCommitish == nil {
 		return ""
 	}
@@ -42524,6 +42524,30 @@ func (u *UpdateRef) GetSHA() string {
 		return ""
 	}
 	return u.SHA
+}
+
+// GetLabel returns the Label field if it's non-nil, zero value otherwise.
+func (u *UpdateReleaseAssetRequest) GetLabel() string {
+	if u == nil || u.Label == nil {
+		return ""
+	}
+	return *u.Label
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (u *UpdateReleaseAssetRequest) GetName() string {
+	if u == nil || u.Name == nil {
+		return ""
+	}
+	return *u.Name
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (u *UpdateReleaseAssetRequest) GetState() string {
+	if u == nil || u.State == nil {
+		return ""
+	}
+	return *u.State
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -20993,42 +20993,42 @@ func TestGenerateJITConfigRequest_GetWorkFolder(tt *testing.T) {
 	g.GetWorkFolder()
 }
 
-func TestGenerateNotesOptions_GetConfigurationFilePath(tt *testing.T) {
+func TestGenerateNotesRequest_GetConfigurationFilePath(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
-	g := &GenerateNotesOptions{ConfigurationFilePath: &zeroValue}
+	g := &GenerateNotesRequest{ConfigurationFilePath: &zeroValue}
 	g.GetConfigurationFilePath()
-	g = &GenerateNotesOptions{}
+	g = &GenerateNotesRequest{}
 	g.GetConfigurationFilePath()
 	g = nil
 	g.GetConfigurationFilePath()
 }
 
-func TestGenerateNotesOptions_GetPreviousTagName(tt *testing.T) {
+func TestGenerateNotesRequest_GetPreviousTagName(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
-	g := &GenerateNotesOptions{PreviousTagName: &zeroValue}
+	g := &GenerateNotesRequest{PreviousTagName: &zeroValue}
 	g.GetPreviousTagName()
-	g = &GenerateNotesOptions{}
+	g = &GenerateNotesRequest{}
 	g.GetPreviousTagName()
 	g = nil
 	g.GetPreviousTagName()
 }
 
-func TestGenerateNotesOptions_GetTagName(tt *testing.T) {
+func TestGenerateNotesRequest_GetTagName(tt *testing.T) {
 	tt.Parallel()
-	g := &GenerateNotesOptions{}
+	g := &GenerateNotesRequest{}
 	g.GetTagName()
 	g = nil
 	g.GetTagName()
 }
 
-func TestGenerateNotesOptions_GetTargetCommitish(tt *testing.T) {
+func TestGenerateNotesRequest_GetTargetCommitish(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
-	g := &GenerateNotesOptions{TargetCommitish: &zeroValue}
+	g := &GenerateNotesRequest{TargetCommitish: &zeroValue}
 	g.GetTargetCommitish()
-	g = &GenerateNotesOptions{}
+	g = &GenerateNotesRequest{}
 	g.GetTargetCommitish()
 	g = nil
 	g.GetTargetCommitish()
@@ -53346,6 +53346,39 @@ func TestUpdateRef_GetSHA(tt *testing.T) {
 	u.GetSHA()
 	u = nil
 	u.GetSHA()
+}
+
+func TestUpdateReleaseAssetRequest_GetLabel(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateReleaseAssetRequest{Label: &zeroValue}
+	u.GetLabel()
+	u = &UpdateReleaseAssetRequest{}
+	u.GetLabel()
+	u = nil
+	u.GetLabel()
+}
+
+func TestUpdateReleaseAssetRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateReleaseAssetRequest{Name: &zeroValue}
+	u.GetName()
+	u = &UpdateReleaseAssetRequest{}
+	u.GetName()
+	u = nil
+	u.GetName()
+}
+
+func TestUpdateReleaseAssetRequest_GetState(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateReleaseAssetRequest{State: &zeroValue}
+	u.GetState()
+	u = &UpdateReleaseAssetRequest{}
+	u.GetState()
+	u = nil
+	u.GetState()
 }
 
 func TestUpdateReleaseRequest_GetBody(tt *testing.T) {

--- a/github/repos_releases.go
+++ b/github/repos_releases.go
@@ -56,8 +56,8 @@ type RepositoryReleaseNotes struct {
 	Body string `json:"body"`
 }
 
-// GenerateNotesOptions represents the options to generate release notes.
-type GenerateNotesOptions struct {
+// GenerateNotesRequest represents the request to generate release notes.
+type GenerateNotesRequest struct {
 	TagName               string  `json:"tag_name"`
 	PreviousTagName       *string `json:"previous_tag_name,omitempty"`
 	TargetCommitish       *string `json:"target_commitish,omitempty"`
@@ -80,6 +80,13 @@ type ReleaseAsset struct {
 	Uploader           *User      `json:"uploader,omitempty"`
 	NodeID             *string    `json:"node_id,omitempty"`
 	Digest             *string    `json:"digest,omitempty"`
+}
+
+// UpdateReleaseAssetRequest represents the request to update a release asset.
+type UpdateReleaseAssetRequest struct {
+	Name  *string `json:"name,omitempty"`
+	Label *string `json:"label,omitempty"`
+	State *string `json:"state,omitempty"`
 }
 
 func (r ReleaseAsset) String() string {
@@ -146,7 +153,7 @@ func (s *RepositoriesService) GetReleaseByTag(ctx context.Context, owner, repo, 
 // GitHub API docs: https://docs.github.com/rest/releases/releases?apiVersion=2022-11-28#generate-release-notes-content-for-a-release
 //
 //meta:operation POST /repos/{owner}/{repo}/releases/generate-notes
-func (s *RepositoriesService) GenerateReleaseNotes(ctx context.Context, owner, repo string, body *GenerateNotesOptions) (*RepositoryReleaseNotes, *Response, error) {
+func (s *RepositoriesService) GenerateReleaseNotes(ctx context.Context, owner, repo string, body GenerateNotesRequest) (*RepositoryReleaseNotes, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/releases/generate-notes", owner, repo)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
@@ -375,12 +382,12 @@ func (s *RepositoriesService) downloadReleaseAssetFromURL(ctx context.Context, f
 	return resp.Body, nil
 }
 
-// EditReleaseAsset edits a repository release asset.
+// UpdateReleaseAsset updates a repository release asset.
 //
 // GitHub API docs: https://docs.github.com/rest/releases/assets?apiVersion=2022-11-28#update-a-release-asset
 //
 //meta:operation PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}
-func (s *RepositoriesService) EditReleaseAsset(ctx context.Context, owner, repo string, id int64, body *ReleaseAsset) (*ReleaseAsset, *Response, error) {
+func (s *RepositoriesService) UpdateReleaseAsset(ctx context.Context, owner, repo string, id int64, body UpdateReleaseAssetRequest) (*ReleaseAsset, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/releases/assets/%v", owner, repo, id)
 
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)

--- a/github/repos_releases_test.go
+++ b/github/repos_releases_test.go
@@ -56,18 +56,18 @@ func TestRepositoriesService_GenerateReleaseNotes(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	opt := &GenerateNotesOptions{
+	body := GenerateNotesRequest{
 		TagName: "v1.0.0",
 	}
 
 	mux.HandleFunc("/repos/o/r/releases/generate-notes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testJSONBody(t, r, opt)
+		testJSONBody(t, r, body)
 		fmt.Fprint(w, `{"name":"v1.0.0","body":"**Full Changelog**: https://github.com/o/r/compare/v0.9.0...v1.0.0"}`)
 	})
 
 	ctx := t.Context()
-	releases, _, err := client.Repositories.GenerateReleaseNotes(ctx, "o", "r", opt)
+	releases, _, err := client.Repositories.GenerateReleaseNotes(ctx, "o", "r", body)
 	if err != nil {
 		t.Errorf("Repositories.GenerateReleaseNotes returned error: %v", err)
 	}
@@ -81,12 +81,12 @@ func TestRepositoriesService_GenerateReleaseNotes(t *testing.T) {
 
 	const methodName = "GenerateReleaseNotes"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Repositories.GenerateReleaseNotes(ctx, "\n", "\n", opt)
+		_, _, err = client.Repositories.GenerateReleaseNotes(ctx, "\n", "\n", body)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.GenerateReleaseNotes(ctx, "o", "r", opt)
+		got, resp, err := client.Repositories.GenerateReleaseNotes(ctx, "o", "r", body)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -564,11 +564,11 @@ func TestRepositoriesService_DownloadReleaseAsset_APIError(t *testing.T) {
 	}
 }
 
-func TestRepositoriesService_EditReleaseAsset(t *testing.T) {
+func TestRepositoriesService_UpdateReleaseAsset(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &ReleaseAsset{Name: Ptr("n")}
+	input := UpdateReleaseAssetRequest{Name: Ptr("n")}
 
 	mux.HandleFunc("/repos/o/r/releases/assets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -577,23 +577,23 @@ func TestRepositoriesService_EditReleaseAsset(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	asset, _, err := client.Repositories.EditReleaseAsset(ctx, "o", "r", 1, input)
+	asset, _, err := client.Repositories.UpdateReleaseAsset(ctx, "o", "r", 1, input)
 	if err != nil {
-		t.Errorf("Repositories.EditReleaseAsset returned error: %v", err)
+		t.Errorf("Repositories.UpdateReleaseAsset returned error: %v", err)
 	}
 	want := &ReleaseAsset{ID: Ptr(int64(1))}
 	if !cmp.Equal(asset, want) {
-		t.Errorf("Repositories.EditReleaseAsset returned = %+v, want %+v", asset, want)
+		t.Errorf("Repositories.UpdateReleaseAsset returned = %+v, want %+v", asset, want)
 	}
 
-	const methodName = "EditReleaseAsset"
+	const methodName = "UpdateReleaseAsset"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Repositories.EditReleaseAsset(ctx, "\n", "\n", 1, input)
+		_, _, err = client.Repositories.UpdateReleaseAsset(ctx, "\n", "\n", 1, input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.EditReleaseAsset(ctx, "o", "r", 1, input)
+		got, resp, err := client.Repositories.UpdateReleaseAsset(ctx, "o", "r", 1, input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}


### PR DESCRIPTION
BREAKING CHANGE: `GenerateReleaseNotes` now takes `GenerateNotesRequest` by value (renamed from `GenerateNotesOptions`); `EditReleaseAsset` is renamed to `UpdateReleaseAsset` and takes `UpdateReleaseAssetRequest` by value.

Towards #3644.

Finishes the value-parameter conversion of `repos_releases.go`, picking up the follow-up explicitly called out in #4329 (which converted `CreateRelease`/`UpdateRelease` and noted that `EditReleaseAsset`/`GenerateReleaseNotes` were left for later because they also involve allow-list and type-name changes). Continues the pattern from the merged #3654, #3794, #4320 and #4329.

### Changes
- `GenerateReleaseNotes(ctx, owner, repo string, body *GenerateNotesOptions)` -> `body GenerateNotesRequest`. The type is renamed `GenerateNotesOptions` -> `GenerateNotesRequest` (`Options` -> `Request` suffix). `tag_name` stays required (non-pointer) per the API schema; the other fields stay optional.
- `EditReleaseAsset(ctx, owner, repo string, id int64, body *ReleaseAsset)` -> `UpdateReleaseAsset(..., body UpdateReleaseAssetRequest)`. A dedicated `UpdateReleaseAssetRequest` is introduced (`name`, `label`, `state` — the documented request fields, all optional per the API schema) instead of reusing the `ReleaseAsset` response struct as the request body.
- Dropped `GenerateNotesOptions` and `ReleaseAsset` from the `paramcheck` `body-allowed-pointer-types` / `body-allowed-wrong-names` allow-lists in `.golangci.yml`.
- No deprecated wrappers are added (clean break), consistent with #4320/#4329.
- Generated accessors regenerated accordingly.

### Breaking changes
- `GenerateReleaseNotes` now takes `GenerateNotesRequest` by value; `GenerateNotesOptions` is renamed to `GenerateNotesRequest`.
- `EditReleaseAsset` is renamed to `UpdateReleaseAsset` and takes `UpdateReleaseAssetRequest` by value (instead of `*ReleaseAsset`).
