### PR TITLE
refactor!: Pass `CreateJITConfigRequest` by value and rename `Generate*JITConfig` to `Create*JITConfig`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -228,7 +228,6 @@ linters:
             - EncryptedSecret
             - EnterpriseSecurityAnalysisSettings
             - ExternalGroup
-            - GenerateJITConfigRequest
             - Hook
             - HookConfig
             - ImpersonateUserOptions

--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -41,8 +41,8 @@ func (s *ActionsService) ListRunnerApplicationDownloads(ctx context.Context, own
 	return rads, resp, nil
 }
 
-// GenerateJITConfigRequest specifies body parameters to GenerateOrgJITConfig, GenerateRepoJITConfig, and GenerateEnterpriseJITConfig.
-type GenerateJITConfigRequest struct {
+// CreateJITConfigRequest specifies body parameters to CreateOrgJITConfig, CreateRepoJITConfig, and CreateJITConfig.
+type CreateJITConfigRequest struct {
 	Name          string  `json:"name"`
 	RunnerGroupID int64   `json:"runner_group_id"`
 	WorkFolder    *string `json:"work_folder,omitempty"`
@@ -58,12 +58,12 @@ type JITRunnerConfig struct {
 	EncodedJITConfig *string `json:"encoded_jit_config,omitempty"`
 }
 
-// GenerateOrgJITConfig generate a just-in-time configuration for an organization.
+// CreateOrgJITConfig creates a just-in-time configuration for an organization.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-configuration-for-a-just-in-time-runner-for-an-organization
 //
 //meta:operation POST /orgs/{org}/actions/runners/generate-jitconfig
-func (s *ActionsService) GenerateOrgJITConfig(ctx context.Context, org string, body GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
+func (s *ActionsService) CreateOrgJITConfig(ctx context.Context, org string, body CreateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runners/generate-jitconfig", org)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
@@ -79,12 +79,12 @@ func (s *ActionsService) GenerateOrgJITConfig(ctx context.Context, org string, b
 	return jitConfig, resp, nil
 }
 
-// GenerateRepoJITConfig generates a just-in-time configuration for a repository.
+// CreateRepoJITConfig creates a just-in-time configuration for a repository.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-configuration-for-a-just-in-time-runner-for-a-repository
 //
 //meta:operation POST /repos/{owner}/{repo}/actions/runners/generate-jitconfig
-func (s *ActionsService) GenerateRepoJITConfig(ctx context.Context, owner, repo string, body GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
+func (s *ActionsService) CreateRepoJITConfig(ctx context.Context, owner, repo string, body CreateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners/generate-jitconfig", owner, repo)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {

--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -41,7 +41,7 @@ func (s *ActionsService) ListRunnerApplicationDownloads(ctx context.Context, own
 	return rads, resp, nil
 }
 
-// GenerateJITConfigRequest specifies body parameters to GenerateRepoJITConfig.
+// GenerateJITConfigRequest specifies body parameters to GenerateOrgJITConfig, GenerateRepoJITConfig, and GenerateEnterpriseJITConfig.
 type GenerateJITConfigRequest struct {
 	Name          string  `json:"name"`
 	RunnerGroupID int64   `json:"runner_group_id"`
@@ -63,7 +63,7 @@ type JITRunnerConfig struct {
 // GitHub API docs: https://docs.github.com/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-configuration-for-a-just-in-time-runner-for-an-organization
 //
 //meta:operation POST /orgs/{org}/actions/runners/generate-jitconfig
-func (s *ActionsService) GenerateOrgJITConfig(ctx context.Context, org string, body *GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
+func (s *ActionsService) GenerateOrgJITConfig(ctx context.Context, org string, body GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/runners/generate-jitconfig", org)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
@@ -84,7 +84,7 @@ func (s *ActionsService) GenerateOrgJITConfig(ctx context.Context, org string, b
 // GitHub API docs: https://docs.github.com/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-configuration-for-a-just-in-time-runner-for-a-repository
 //
 //meta:operation POST /repos/{owner}/{repo}/actions/runners/generate-jitconfig
-func (s *ActionsService) GenerateRepoJITConfig(ctx context.Context, owner, repo string, body *GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
+func (s *ActionsService) GenerateRepoJITConfig(ctx context.Context, owner, repo string, body GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runners/generate-jitconfig", owner, repo)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {

--- a/github/actions_runners.go
+++ b/github/actions_runners.go
@@ -130,12 +130,15 @@ func (s *ActionsService) CreateRegistrationToken(ctx context.Context, owner, rep
 
 // Runner represents a self-hosted runner registered with a repository.
 type Runner struct {
-	ID     *int64          `json:"id,omitempty"`
-	Name   *string         `json:"name,omitempty"`
-	OS     *string         `json:"os,omitempty"`
-	Status *string         `json:"status,omitempty"`
-	Busy   *bool           `json:"busy,omitempty"`
-	Labels []*RunnerLabels `json:"labels,omitempty"`
+	ID            *int64          `json:"id,omitempty"`
+	RunnerGroupID *int64          `json:"runner_group_id,omitempty"`
+	Name          *string         `json:"name,omitempty"`
+	OS            *string         `json:"os,omitempty"`
+	Status        *string         `json:"status,omitempty"`
+	Busy          *bool           `json:"busy,omitempty"`
+	Labels        []*RunnerLabels `json:"labels,omitempty"`
+	Ephemeral     *bool           `json:"ephemeral,omitempty"`
+	Version       *string         `json:"version,omitempty"`
 }
 
 // RunnerLabels represents a collection of labels attached to each runner.

--- a/github/actions_runners_test.go
+++ b/github/actions_runners_test.go
@@ -54,11 +54,11 @@ func TestActionsService_ListRunnerApplicationDownloads(t *testing.T) {
 	})
 }
 
-func TestActionsService_GenerateOrgJITConfig(t *testing.T) {
+func TestActionsService_CreateOrgJITConfig(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := GenerateJITConfigRequest{Name: "test", RunnerGroupID: 1, Labels: []string{"one", "two"}}
+	input := CreateJITConfigRequest{Name: "test", RunnerGroupID: 1, Labels: []string{"one", "two"}}
 
 	mux.HandleFunc("/orgs/o/actions/runners/generate-jitconfig", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -67,24 +67,24 @@ func TestActionsService_GenerateOrgJITConfig(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	jitConfig, _, err := client.Actions.GenerateOrgJITConfig(ctx, "o", input)
+	jitConfig, _, err := client.Actions.CreateOrgJITConfig(ctx, "o", input)
 	if err != nil {
-		t.Errorf("Actions.GenerateOrgJITConfig returned error: %v", err)
+		t.Errorf("Actions.CreateOrgJITConfig returned error: %v", err)
 	}
 
 	want := &JITRunnerConfig{EncodedJITConfig: Ptr("foo")}
 	if !cmp.Equal(jitConfig, want) {
-		t.Errorf("Actions.GenerateOrgJITConfig returned %+v, want %+v", jitConfig, want)
+		t.Errorf("Actions.CreateOrgJITConfig returned %+v, want %+v", jitConfig, want)
 	}
 
-	const methodName = "GenerateOrgJITConfig"
+	const methodName = "CreateOrgJITConfig"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.GenerateOrgJITConfig(ctx, "\n", input)
+		_, _, err = client.Actions.CreateOrgJITConfig(ctx, "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.GenerateOrgJITConfig(ctx, "o", input)
+		got, resp, err := client.Actions.CreateOrgJITConfig(ctx, "o", input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -92,11 +92,11 @@ func TestActionsService_GenerateOrgJITConfig(t *testing.T) {
 	})
 }
 
-func TestActionsService_GenerateRepoJITConfig(t *testing.T) {
+func TestActionsService_CreateRepoJITConfig(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := GenerateJITConfigRequest{Name: "test", RunnerGroupID: 1, Labels: []string{"one", "two"}}
+	input := CreateJITConfigRequest{Name: "test", RunnerGroupID: 1, Labels: []string{"one", "two"}}
 
 	mux.HandleFunc("/repos/o/r/actions/runners/generate-jitconfig", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -105,24 +105,24 @@ func TestActionsService_GenerateRepoJITConfig(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	jitConfig, _, err := client.Actions.GenerateRepoJITConfig(ctx, "o", "r", input)
+	jitConfig, _, err := client.Actions.CreateRepoJITConfig(ctx, "o", "r", input)
 	if err != nil {
-		t.Errorf("Actions.GenerateRepoJITConfig returned error: %v", err)
+		t.Errorf("Actions.CreateRepoJITConfig returned error: %v", err)
 	}
 
 	want := &JITRunnerConfig{EncodedJITConfig: Ptr("foo")}
 	if !cmp.Equal(jitConfig, want) {
-		t.Errorf("Actions.GenerateRepoJITConfig returned %+v, want %+v", jitConfig, want)
+		t.Errorf("Actions.CreateRepoJITConfig returned %+v, want %+v", jitConfig, want)
 	}
 
-	const methodName = "GenerateRepoJITConfig"
+	const methodName = "CreateRepoJITConfig"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.GenerateRepoJITConfig(ctx, "\n", "\n", input)
+		_, _, err = client.Actions.CreateRepoJITConfig(ctx, "\n", "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.GenerateRepoJITConfig(ctx, "o", "r", input)
+		got, resp, err := client.Actions.CreateRepoJITConfig(ctx, "o", "r", input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/github/actions_runners_test.go
+++ b/github/actions_runners_test.go
@@ -58,7 +58,7 @@ func TestActionsService_GenerateOrgJITConfig(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &GenerateJITConfigRequest{Name: "test", RunnerGroupID: 1, Labels: []string{"one", "two"}}
+	input := GenerateJITConfigRequest{Name: "test", RunnerGroupID: 1, Labels: []string{"one", "two"}}
 
 	mux.HandleFunc("/orgs/o/actions/runners/generate-jitconfig", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -96,7 +96,7 @@ func TestActionsService_GenerateRepoJITConfig(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &GenerateJITConfigRequest{Name: "test", RunnerGroupID: 1, Labels: []string{"one", "two"}}
+	input := GenerateJITConfigRequest{Name: "test", RunnerGroupID: 1, Labels: []string{"one", "two"}}
 
 	mux.HandleFunc("/repos/o/r/actions/runners/generate-jitconfig", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/github/enterprise_actions_runners.go
+++ b/github/enterprise_actions_runners.go
@@ -36,7 +36,7 @@ func (s *EnterpriseService) ListRunnerApplicationDownloads(ctx context.Context, 
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-configuration-for-a-just-in-time-runner-for-an-enterprise
 //
 //meta:operation POST /enterprises/{enterprise}/actions/runners/generate-jitconfig
-func (s *EnterpriseService) GenerateEnterpriseJITConfig(ctx context.Context, enterprise string, body *GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
+func (s *EnterpriseService) GenerateEnterpriseJITConfig(ctx context.Context, enterprise string, body GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runners/generate-jitconfig", enterprise)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)

--- a/github/enterprise_actions_runners.go
+++ b/github/enterprise_actions_runners.go
@@ -31,12 +31,12 @@ func (s *EnterpriseService) ListRunnerApplicationDownloads(ctx context.Context, 
 	return rads, resp, nil
 }
 
-// GenerateEnterpriseJITConfig generates a just-in-time configuration for an enterprise.
+// CreateJITConfig creates a just-in-time configuration for an enterprise.
 //
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-configuration-for-a-just-in-time-runner-for-an-enterprise
 //
 //meta:operation POST /enterprises/{enterprise}/actions/runners/generate-jitconfig
-func (s *EnterpriseService) GenerateEnterpriseJITConfig(ctx context.Context, enterprise string, body GenerateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
+func (s *EnterpriseService) CreateJITConfig(ctx context.Context, enterprise string, body CreateJITConfigRequest) (*JITRunnerConfig, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/runners/generate-jitconfig", enterprise)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)

--- a/github/enterprise_actions_runners_test.go
+++ b/github/enterprise_actions_runners_test.go
@@ -17,7 +17,7 @@ func TestEnterpriseService_GenerateEnterpriseJITConfig(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &GenerateJITConfigRequest{Name: "test", RunnerGroupID: 1, Labels: []string{"one", "two"}}
+	input := GenerateJITConfigRequest{Name: "test", RunnerGroupID: 1, Labels: []string{"one", "two"}}
 
 	mux.HandleFunc("/enterprises/o/actions/runners/generate-jitconfig", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/github/enterprise_actions_runners_test.go
+++ b/github/enterprise_actions_runners_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestEnterpriseService_GenerateEnterpriseJITConfig(t *testing.T) {
+func TestEnterpriseService_CreateJITConfig(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := GenerateJITConfigRequest{Name: "test", RunnerGroupID: 1, Labels: []string{"one", "two"}}
+	input := CreateJITConfigRequest{Name: "test", RunnerGroupID: 1, Labels: []string{"one", "two"}}
 
 	mux.HandleFunc("/enterprises/o/actions/runners/generate-jitconfig", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -26,24 +26,24 @@ func TestEnterpriseService_GenerateEnterpriseJITConfig(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	jitConfig, _, err := client.Enterprise.GenerateEnterpriseJITConfig(ctx, "o", input)
+	jitConfig, _, err := client.Enterprise.CreateJITConfig(ctx, "o", input)
 	if err != nil {
-		t.Errorf("Enterprise.GenerateEnterpriseJITConfig returned error: %v", err)
+		t.Errorf("Enterprise.CreateJITConfig returned error: %v", err)
 	}
 
 	want := &JITRunnerConfig{EncodedJITConfig: Ptr("foo")}
 	if !cmp.Equal(jitConfig, want) {
-		t.Errorf("Enterprise.GenerateEnterpriseJITConfig returned %+v, want %+v", jitConfig, want)
+		t.Errorf("Enterprise.CreateJITConfig returned %+v, want %+v", jitConfig, want)
 	}
 
-	const methodName = "GenerateEnterpriseJITConfig"
+	const methodName = "CreateJITConfig"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Enterprise.GenerateEnterpriseJITConfig(ctx, "\n", input)
+		_, _, err = client.Enterprise.CreateJITConfig(ctx, "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Enterprise.GenerateEnterpriseJITConfig(ctx, "o", input)
+		got, resp, err := client.Enterprise.CreateJITConfig(ctx, "o", input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -37070,6 +37070,14 @@ func (r *Runner) GetBusy() bool {
 	return *r.Busy
 }
 
+// GetEphemeral returns the Ephemeral field if it's non-nil, zero value otherwise.
+func (r *Runner) GetEphemeral() bool {
+	if r == nil || r.Ephemeral == nil {
+		return false
+	}
+	return *r.Ephemeral
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (r *Runner) GetID() int64 {
 	if r == nil || r.ID == nil {
@@ -37102,12 +37110,28 @@ func (r *Runner) GetOS() string {
 	return *r.OS
 }
 
+// GetRunnerGroupID returns the RunnerGroupID field if it's non-nil, zero value otherwise.
+func (r *Runner) GetRunnerGroupID() int64 {
+	if r == nil || r.RunnerGroupID == nil {
+		return 0
+	}
+	return *r.RunnerGroupID
+}
+
 // GetStatus returns the Status field if it's non-nil, zero value otherwise.
 func (r *Runner) GetStatus() string {
 	if r == nil || r.Status == nil {
 		return ""
 	}
 	return *r.Status
+}
+
+// GetVersion returns the Version field if it's non-nil, zero value otherwise.
+func (r *Runner) GetVersion() string {
+	if r == nil || r.Version == nil {
+		return ""
+	}
+	return *r.Version
 }
 
 // GetArchitecture returns the Architecture field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11014,6 +11014,38 @@ func (c *CreateHostedRunnerRequest) GetSize() string {
 	return c.Size
 }
 
+// GetLabels returns the Labels slice if it's non-nil, nil otherwise.
+func (c *CreateJITConfigRequest) GetLabels() []string {
+	if c == nil || c.Labels == nil {
+		return nil
+	}
+	return c.Labels
+}
+
+// GetName returns the Name field.
+func (c *CreateJITConfigRequest) GetName() string {
+	if c == nil {
+		return ""
+	}
+	return c.Name
+}
+
+// GetRunnerGroupID returns the RunnerGroupID field.
+func (c *CreateJITConfigRequest) GetRunnerGroupID() int64 {
+	if c == nil {
+		return 0
+	}
+	return c.RunnerGroupID
+}
+
+// GetWorkFolder returns the WorkFolder field if it's non-nil, zero value otherwise.
+func (c *CreateJITConfigRequest) GetWorkFolder() string {
+	if c == nil || c.WorkFolder == nil {
+		return ""
+	}
+	return *c.WorkFolder
+}
+
 // GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.
 func (c *CreateOrganizationPrivateRegistry) GetAccountID() string {
 	if c == nil || c.AccountID == nil {
@@ -16668,38 +16700,6 @@ func (f *ForkEvent) GetSender() *User {
 		return nil
 	}
 	return f.Sender
-}
-
-// GetLabels returns the Labels slice if it's non-nil, nil otherwise.
-func (g *GenerateJITConfigRequest) GetLabels() []string {
-	if g == nil || g.Labels == nil {
-		return nil
-	}
-	return g.Labels
-}
-
-// GetName returns the Name field.
-func (g *GenerateJITConfigRequest) GetName() string {
-	if g == nil {
-		return ""
-	}
-	return g.Name
-}
-
-// GetRunnerGroupID returns the RunnerGroupID field.
-func (g *GenerateJITConfigRequest) GetRunnerGroupID() int64 {
-	if g == nil {
-		return 0
-	}
-	return g.RunnerGroupID
-}
-
-// GetWorkFolder returns the WorkFolder field if it's non-nil, zero value otherwise.
-func (g *GenerateJITConfigRequest) GetWorkFolder() string {
-	if g == nil || g.WorkFolder == nil {
-		return ""
-	}
-	return *g.WorkFolder
 }
 
 // GetConfigurationFilePath returns the ConfigurationFilePath field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -13970,6 +13970,44 @@ func TestCreateHostedRunnerRequest_GetSize(tt *testing.T) {
 	c.GetSize()
 }
 
+func TestCreateJITConfigRequest_GetLabels(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []string{}
+	c := &CreateJITConfigRequest{Labels: zeroValue}
+	c.GetLabels()
+	c = &CreateJITConfigRequest{}
+	c.GetLabels()
+	c = nil
+	c.GetLabels()
+}
+
+func TestCreateJITConfigRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateJITConfigRequest{}
+	c.GetName()
+	c = nil
+	c.GetName()
+}
+
+func TestCreateJITConfigRequest_GetRunnerGroupID(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateJITConfigRequest{}
+	c.GetRunnerGroupID()
+	c = nil
+	c.GetRunnerGroupID()
+}
+
+func TestCreateJITConfigRequest_GetWorkFolder(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateJITConfigRequest{WorkFolder: &zeroValue}
+	c.GetWorkFolder()
+	c = &CreateJITConfigRequest{}
+	c.GetWorkFolder()
+	c = nil
+	c.GetWorkFolder()
+}
+
 func TestCreateOrganizationPrivateRegistry_GetAccountID(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -20953,44 +20991,6 @@ func TestForkEvent_GetSender(tt *testing.T) {
 	f.GetSender()
 	f = nil
 	f.GetSender()
-}
-
-func TestGenerateJITConfigRequest_GetLabels(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := []string{}
-	g := &GenerateJITConfigRequest{Labels: zeroValue}
-	g.GetLabels()
-	g = &GenerateJITConfigRequest{}
-	g.GetLabels()
-	g = nil
-	g.GetLabels()
-}
-
-func TestGenerateJITConfigRequest_GetName(tt *testing.T) {
-	tt.Parallel()
-	g := &GenerateJITConfigRequest{}
-	g.GetName()
-	g = nil
-	g.GetName()
-}
-
-func TestGenerateJITConfigRequest_GetRunnerGroupID(tt *testing.T) {
-	tt.Parallel()
-	g := &GenerateJITConfigRequest{}
-	g.GetRunnerGroupID()
-	g = nil
-	g.GetRunnerGroupID()
-}
-
-func TestGenerateJITConfigRequest_GetWorkFolder(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	g := &GenerateJITConfigRequest{WorkFolder: &zeroValue}
-	g.GetWorkFolder()
-	g = &GenerateJITConfigRequest{}
-	g.GetWorkFolder()
-	g = nil
-	g.GetWorkFolder()
 }
 
 func TestGenerateNotesRequest_GetConfigurationFilePath(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -46452,6 +46452,17 @@ func TestRunner_GetBusy(tt *testing.T) {
 	r.GetBusy()
 }
 
+func TestRunner_GetEphemeral(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	r := &Runner{Ephemeral: &zeroValue}
+	r.GetEphemeral()
+	r = &Runner{}
+	r.GetEphemeral()
+	r = nil
+	r.GetEphemeral()
+}
+
 func TestRunner_GetID(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int64
@@ -46496,6 +46507,17 @@ func TestRunner_GetOS(tt *testing.T) {
 	r.GetOS()
 }
 
+func TestRunner_GetRunnerGroupID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int64
+	r := &Runner{RunnerGroupID: &zeroValue}
+	r.GetRunnerGroupID()
+	r = &Runner{}
+	r.GetRunnerGroupID()
+	r = nil
+	r.GetRunnerGroupID()
+}
+
 func TestRunner_GetStatus(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -46505,6 +46527,17 @@ func TestRunner_GetStatus(tt *testing.T) {
 	r.GetStatus()
 	r = nil
 	r.GetStatus()
+}
+
+func TestRunner_GetVersion(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	r := &Runner{Version: &zeroValue}
+	r.GetVersion()
+	r = &Runner{}
+	r.GetVersion()
+	r = nil
+	r.GetVersion()
 }
 
 func TestRunnerApplicationDownload_GetArchitecture(tt *testing.T) {


### PR DESCRIPTION
BREAKING CHANGE: the JIT config methods are renamed from `Generate*JITConfig` to `Create*JITConfig`, and they now take `CreateJITConfigRequest` (renamed from `GenerateJITConfigRequest`) by value instead of by pointer.

Towards #3644.

Continues the value-parameter conversion from the merged #3654, #3794, #4320, #4329 and #4336.

### Changes
- **Pass the request by value:** `CreateOrgJITConfig` / `CreateRepoJITConfig` (`actions_runners.go`) and `(*EnterpriseService).CreateJITConfig` (`enterprise_actions_runners.go`) now take `CreateJITConfigRequest` by value. All three methods share the same request type, so they are converted together (otherwise the `paramcheck` allow-list entry could not be removed). The type is removed from the `paramcheck` `body-allowed-pointer-types` allow-list in `.golangci.yml`.
- **Rename `Generate*JITConfig` -> `Create*JITConfig`** (methods) and `GenerateJITConfigRequest` -> `CreateJITConfigRequest`, to match the API docs operation name ("Create configuration for a just-in-time runner"). On `EnterpriseService` the method is just `CreateJITConfig` (the redundant `Enterprise` is dropped, consistent with the other `EnterpriseService` runner methods). The `generate-jitconfig` URL path is unchanged.
- **Add missing `Runner` fields:** `runner_group_id`, `ephemeral`, and `version` to the `Runner` response struct to match the self-hosted runner schema (these are returned by `JITRunnerConfig` and by the runner list/get endpoints). All optional, so non-breaking; accessors regenerated.

### Breaking changes
- `GenerateOrgJITConfig` / `GenerateRepoJITConfig` renamed to `CreateOrgJITConfig` / `CreateRepoJITConfig`; `GenerateEnterpriseJITConfig` renamed to `CreateJITConfig` (on `EnterpriseService`).
- They now take `CreateJITConfigRequest` (renamed from `GenerateJITConfigRequest`) by value instead of `*GenerateJITConfigRequest`.
