### PR TITLE
build: Exclude generated files from golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -557,6 +557,12 @@ linters:
       # Because fmt.Sprint(reset.Unix())) is more readable than strconv.FormatInt(reset.Unix(), 10).
       - linters: [perfsprint]
         text: fmt.Sprint.* can be replaced with faster strconv.FormatInt
+
+    # Exclude the large auto-generated files (script/generate.sh output) from linting.
+    paths:
+      - github/github-accessors.*\.go$
+      - github/github-iterators.*\.go$
+      - github/github-stringify_test\.go$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
@@ -569,3 +575,9 @@ formatters:
   settings:
     gofumpt:
       extra-rules: true
+  exclusions:
+    # Exclude the large auto-generated files (script/generate.sh output) from formatting.
+    paths:
+      - github/github-accessors.*\.go$
+      - github/github-iterators.*\.go$
+      - github/github-stringify_test\.go$


### PR DESCRIPTION
Excludes the large auto-generated files from golangci-lint's linters and formatters in `.golangci.yml`:

- `github/github-accessors.go` / `github/github-accessors_test.go`
- `github/github-iterators.go` / `github/github-iterators_test.go`
- `github/github-stringify_test.go`

They are added to `linters.exclusions.paths` and `formatters.exclusions.paths`. All carry the `// Code generated ... DO NOT EDIT.` header and are covered by `check-generated`, `go build`, and `go test`.

This did not measurably change lint/format wall-clock time:

| | linters (`run`) | formatters (`fmt`) |
| --- | --- | --- |
| before | ~15–17 s | ~6–7 s |
| after | ~16–17 s | ~6–7 s |

golangci-lint loads and type-checks whole packages, so the excluded files are still parsed; `exclusions.paths` only suppresses their reported issues/formatting (`lax` mode already suppresses generated-file issues for the linters, so the net-new effect is on the formatters).

Re #4070
