### PR TITLE
refactor!: Pass `OIDCSubjectClaimCustomTemplate` by value in the OIDC subject-claim Set methods

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -243,7 +243,6 @@ linters:
             - MaintenanceOptions
             - Milestone
             - NewPullRequest
-            - OIDCSubjectClaimCustomTemplate
             - Organization
             - PagesUpdate
             - PagesUpdateWithoutCNAME

--- a/github/actions_oidc.go
+++ b/github/actions_oidc.go
@@ -56,7 +56,7 @@ func (s *ActionsService) getOIDCSubjectClaimCustomTemplate(ctx context.Context, 
 // GitHub API docs: https://docs.github.com/rest/actions/oidc?apiVersion=2022-11-28#set-the-customization-template-for-an-oidc-subject-claim-for-an-organization
 //
 //meta:operation PUT /orgs/{org}/actions/oidc/customization/sub
-func (s *ActionsService) SetOrgOIDCSubjectClaimCustomTemplate(ctx context.Context, org string, body *OIDCSubjectClaimCustomTemplate) (*Response, error) {
+func (s *ActionsService) SetOrgOIDCSubjectClaimCustomTemplate(ctx context.Context, org string, body OIDCSubjectClaimCustomTemplate) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/oidc/customization/sub", org)
 	return s.setOIDCSubjectClaimCustomTemplate(ctx, u, body)
 }
@@ -66,12 +66,12 @@ func (s *ActionsService) SetOrgOIDCSubjectClaimCustomTemplate(ctx context.Contex
 // GitHub API docs: https://docs.github.com/rest/actions/oidc?apiVersion=2022-11-28#set-the-customization-template-for-an-oidc-subject-claim-for-a-repository
 //
 //meta:operation PUT /repos/{owner}/{repo}/actions/oidc/customization/sub
-func (s *ActionsService) SetRepoOIDCSubjectClaimCustomTemplate(ctx context.Context, owner, repo string, template *OIDCSubjectClaimCustomTemplate) (*Response, error) {
+func (s *ActionsService) SetRepoOIDCSubjectClaimCustomTemplate(ctx context.Context, owner, repo string, body OIDCSubjectClaimCustomTemplate) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/oidc/customization/sub", owner, repo)
-	return s.setOIDCSubjectClaimCustomTemplate(ctx, u, template)
+	return s.setOIDCSubjectClaimCustomTemplate(ctx, u, body)
 }
 
-func (s *ActionsService) setOIDCSubjectClaimCustomTemplate(ctx context.Context, url string, body *OIDCSubjectClaimCustomTemplate) (*Response, error) {
+func (s *ActionsService) setOIDCSubjectClaimCustomTemplate(ctx context.Context, url string, body OIDCSubjectClaimCustomTemplate) (*Response, error) {
 	req, err := s.client.NewRequest(ctx, "PUT", url, body)
 	if err != nil {
 		return nil, err

--- a/github/actions_oidc.go
+++ b/github/actions_oidc.go
@@ -12,8 +12,10 @@ import (
 
 // OIDCSubjectClaimCustomTemplate represents an OIDC subject claim customization template.
 type OIDCSubjectClaimCustomTemplate struct {
-	UseDefault       *bool    `json:"use_default,omitempty"`
-	IncludeClaimKeys []string `json:"include_claim_keys,omitempty"`
+	UseDefault          *bool    `json:"use_default,omitempty"`
+	IncludeClaimKeys    []string `json:"include_claim_keys,omitempty"`
+	UseImmutableSubject *bool    `json:"use_immutable_subject,omitempty"`
+	SubClaimPrefix      *string  `json:"sub_claim_prefix,omitempty"`
 }
 
 // GetOrgOIDCSubjectClaimCustomTemplate gets the subject claim customization template for an organization.

--- a/github/actions_oidc_test.go
+++ b/github/actions_oidc_test.go
@@ -87,7 +87,7 @@ func TestActionsService_SetOrgOIDCSubjectClaimCustomTemplate(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &OIDCSubjectClaimCustomTemplate{
+	input := OIDCSubjectClaimCustomTemplate{
 		IncludeClaimKeys: []string{"repo", "context"},
 	}
 
@@ -120,7 +120,7 @@ func TestActionsService_SetRepoOIDCSubjectClaimCustomTemplate(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &OIDCSubjectClaimCustomTemplate{
+	input := OIDCSubjectClaimCustomTemplate{
 		UseDefault:       Ptr(false),
 		IncludeClaimKeys: []string{"repo", "context"},
 	}
@@ -154,7 +154,7 @@ func TestActionsService_SetRepoOIDCSubjectClaimCustomTemplateToDefault(t *testin
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &OIDCSubjectClaimCustomTemplate{
+	input := OIDCSubjectClaimCustomTemplate{
 		UseDefault: Ptr(true),
 	}
 

--- a/github/actions_oidc_test.go
+++ b/github/actions_oidc_test.go
@@ -19,7 +19,7 @@ func TestActionsService_GetOrgOIDCSubjectClaimCustomTemplate(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/actions/oidc/customization/sub", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"include_claim_keys":["repo","context"]}`)
+		fmt.Fprint(w, `{"include_claim_keys":["repo","context"],"use_immutable_subject":true}`)
 	})
 
 	ctx := t.Context()
@@ -28,7 +28,7 @@ func TestActionsService_GetOrgOIDCSubjectClaimCustomTemplate(t *testing.T) {
 		t.Errorf("Actions.GetOrgOIDCSubjectClaimCustomTemplate returned error: %v", err)
 	}
 
-	want := &OIDCSubjectClaimCustomTemplate{IncludeClaimKeys: []string{"repo", "context"}}
+	want := &OIDCSubjectClaimCustomTemplate{IncludeClaimKeys: []string{"repo", "context"}, UseImmutableSubject: Ptr(true)}
 	if !cmp.Equal(template, want) {
 		t.Errorf("Actions.GetOrgOIDCSubjectClaimCustomTemplate returned %+v, want %+v", template, want)
 	}
@@ -54,7 +54,7 @@ func TestActionsService_GetRepoOIDCSubjectClaimCustomTemplate(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/actions/oidc/customization/sub", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"use_default":false,"include_claim_keys":["repo","context"]}`)
+		fmt.Fprint(w, `{"use_default":false,"include_claim_keys":["repo","context"],"use_immutable_subject":true,"sub_claim_prefix":"repo:o/r"}`)
 	})
 
 	ctx := t.Context()
@@ -63,7 +63,7 @@ func TestActionsService_GetRepoOIDCSubjectClaimCustomTemplate(t *testing.T) {
 		t.Errorf("Actions.GetRepoOIDCSubjectClaimCustomTemplate returned error: %v", err)
 	}
 
-	want := &OIDCSubjectClaimCustomTemplate{UseDefault: Ptr(false), IncludeClaimKeys: []string{"repo", "context"}}
+	want := &OIDCSubjectClaimCustomTemplate{UseDefault: Ptr(false), IncludeClaimKeys: []string{"repo", "context"}, UseImmutableSubject: Ptr(true), SubClaimPrefix: Ptr("repo:o/r")}
 	if !cmp.Equal(template, want) {
 		t.Errorf("Actions.GetRepoOIDCSubjectClaimCustomTemplate returned %+v, want %+v", template, want)
 	}
@@ -88,7 +88,8 @@ func TestActionsService_SetOrgOIDCSubjectClaimCustomTemplate(t *testing.T) {
 	client, mux, _ := setup(t)
 
 	input := OIDCSubjectClaimCustomTemplate{
-		IncludeClaimKeys: []string{"repo", "context"},
+		IncludeClaimKeys:    []string{"repo", "context"},
+		UseImmutableSubject: Ptr(true),
 	}
 
 	mux.HandleFunc("/orgs/o/actions/oidc/customization/sub", func(w http.ResponseWriter, r *http.Request) {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -25118,12 +25118,28 @@ func (o *OIDCSubjectClaimCustomTemplate) GetIncludeClaimKeys() []string {
 	return o.IncludeClaimKeys
 }
 
+// GetSubClaimPrefix returns the SubClaimPrefix field if it's non-nil, zero value otherwise.
+func (o *OIDCSubjectClaimCustomTemplate) GetSubClaimPrefix() string {
+	if o == nil || o.SubClaimPrefix == nil {
+		return ""
+	}
+	return *o.SubClaimPrefix
+}
+
 // GetUseDefault returns the UseDefault field if it's non-nil, zero value otherwise.
 func (o *OIDCSubjectClaimCustomTemplate) GetUseDefault() bool {
 	if o == nil || o.UseDefault == nil {
 		return false
 	}
 	return *o.UseDefault
+}
+
+// GetUseImmutableSubject returns the UseImmutableSubject field if it's non-nil, zero value otherwise.
+func (o *OIDCSubjectClaimCustomTemplate) GetUseImmutableSubject() bool {
+	if o == nil || o.UseImmutableSubject == nil {
+		return false
+	}
+	return *o.UseImmutableSubject
 }
 
 // GetName returns the Name field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -31533,6 +31533,17 @@ func TestOIDCSubjectClaimCustomTemplate_GetIncludeClaimKeys(tt *testing.T) {
 	o.GetIncludeClaimKeys()
 }
 
+func TestOIDCSubjectClaimCustomTemplate_GetSubClaimPrefix(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	o := &OIDCSubjectClaimCustomTemplate{SubClaimPrefix: &zeroValue}
+	o.GetSubClaimPrefix()
+	o = &OIDCSubjectClaimCustomTemplate{}
+	o.GetSubClaimPrefix()
+	o = nil
+	o.GetSubClaimPrefix()
+}
+
 func TestOIDCSubjectClaimCustomTemplate_GetUseDefault(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
@@ -31542,6 +31553,17 @@ func TestOIDCSubjectClaimCustomTemplate_GetUseDefault(tt *testing.T) {
 	o.GetUseDefault()
 	o = nil
 	o.GetUseDefault()
+}
+
+func TestOIDCSubjectClaimCustomTemplate_GetUseImmutableSubject(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	o := &OIDCSubjectClaimCustomTemplate{UseImmutableSubject: &zeroValue}
+	o.GetUseImmutableSubject()
+	o = &OIDCSubjectClaimCustomTemplate{}
+	o.GetUseImmutableSubject()
+	o = nil
+	o.GetUseImmutableSubject()
 }
 
 func TestOrgActionsVariableCreateRequest_GetName(tt *testing.T) {


### PR DESCRIPTION
BREAKING CHANGE: `SetOrgOIDCSubjectClaimCustomTemplate` and `SetRepoOIDCSubjectClaimCustomTemplate` now take their `body` params by value.

This continues the #3644 value-parameter refactor for the Actions OIDC subject-claim customization methods.

## Pass the request body by value (refactor!)

- `Actions.SetOrgOIDCSubjectClaimCustomTemplate` and `Actions.SetRepoOIDCSubjectClaimCustomTemplate` now take `OIDCSubjectClaimCustomTemplate` by value instead of by pointer, along with the shared `setOIDCSubjectClaimCustomTemplate` helper.
- Renamed the `SetRepoOIDCSubjectClaimCustomTemplate` body parameter from `template` to `body`.
- Removed `OIDCSubjectClaimCustomTemplate` from the `paramcheck` `body-allowed-pointer-types` allowlist in `.golangci.yml`.

The type stays shared between the `Get*` (response) and `Set*` (request) methods, matching existing by-value shared types such as `RepositoryRuleset` and `CodeSecurityConfiguration`.

## Add two missing OpenAPI fields (feat)

- `UseImmutableSubject` (`use_immutable_subject`) — present in both the org and repo request bodies and responses.
- `SubClaimPrefix` (`sub_claim_prefix`) — returned by the repository-level GET response.

Both are optional, so this part is non-breaking. Accessors regenerated.

Towards #3644
