### PR TITLE
feat: Add GitHub App Enterprise perm scope

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -107,7 +107,7 @@ type InstallationPermissions struct {
 	EnterpriseCustomPropertiesForOrgs       *string `json:"enterprise_custom_properties_for_organizations,omitempty"`
 	EnterpriseOrganizations                 *string `json:"enterprise_organizations,omitempty"`
 	EnterpriseOrganizationInstallations     *string `json:"enterprise_organization_installations,omitempty"`
-	EnterpriseOrgInstallationRepositories   *string `json:"enterprise_organization_installation_repositories,omitempty"`
+	EnterpriseOrgInstallationRepos          *string `json:"enterprise_organization_installation_repositories,omitempty"`
 	EnterprisePeople                        *string `json:"enterprise_people,omitempty"`
 	EnterpriseSSO                           *string `json:"enterprise_sso,omitempty"`
 	EnterpriseTeams                         *string `json:"enterprise_teams,omitempty"`

--- a/github/apps.go
+++ b/github/apps.go
@@ -98,6 +98,19 @@ type InstallationPermissions struct {
 	Deployments                             *string `json:"deployments,omitempty"`
 	Discussions                             *string `json:"discussions,omitempty"`
 	Emails                                  *string `json:"emails,omitempty"`
+	EnterpriseAIControls                    *string `json:"enterprise_ai_controls,omitempty"`
+	EnterpriseCopilotMetrics                *string `json:"enterprise_copilot_metrics,omitempty"`
+	EnterpriseCredentials                   *string `json:"enterprise_credentials,omitempty"`
+	EnterpriseCustomEnterpriseRoles         *string `json:"enterprise_custom_enterprise_roles,omitempty"`
+	EnterpriseCustomOrgRoles                *string `json:"enterprise_custom_org_roles,omitempty"`
+	EnterpriseCustomProperties              *string `json:"enterprise_custom_properties,omitempty"`
+	EnterpriseCustomPropertiesForOrgs       *string `json:"enterprise_custom_properties_for_organizations,omitempty"`
+	EnterpriseOrganizations                 *string `json:"enterprise_organizations,omitempty"`
+	EnterpriseOrganizationInstallations     *string `json:"enterprise_organization_installations,omitempty"`
+	EnterpriseOrgInstallationRepositories   *string `json:"enterprise_organization_installation_repositories,omitempty"`
+	EnterprisePeople                        *string `json:"enterprise_people,omitempty"`
+	EnterpriseSSO                           *string `json:"enterprise_sso,omitempty"`
+	EnterpriseTeams                         *string `json:"enterprise_teams,omitempty"`
 	Environments                            *string `json:"environments,omitempty"`
 	Followers                               *string `json:"followers,omitempty"`
 	Gists                                   *string `json:"gists,omitempty"`

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -19182,12 +19182,12 @@ func (i *InstallationPermissions) GetEnterpriseOrganizations() string {
 	return *i.EnterpriseOrganizations
 }
 
-// GetEnterpriseOrgInstallationRepositories returns the EnterpriseOrgInstallationRepositories field if it's non-nil, zero value otherwise.
-func (i *InstallationPermissions) GetEnterpriseOrgInstallationRepositories() string {
-	if i == nil || i.EnterpriseOrgInstallationRepositories == nil {
+// GetEnterpriseOrgInstallationRepos returns the EnterpriseOrgInstallationRepos field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetEnterpriseOrgInstallationRepos() string {
+	if i == nil || i.EnterpriseOrgInstallationRepos == nil {
 		return ""
 	}
-	return *i.EnterpriseOrgInstallationRepositories
+	return *i.EnterpriseOrgInstallationRepos
 }
 
 // GetEnterprisePeople returns the EnterprisePeople field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -19110,6 +19110,110 @@ func (i *InstallationPermissions) GetEmails() string {
 	return *i.Emails
 }
 
+// GetEnterpriseAIControls returns the EnterpriseAIControls field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetEnterpriseAIControls() string {
+	if i == nil || i.EnterpriseAIControls == nil {
+		return ""
+	}
+	return *i.EnterpriseAIControls
+}
+
+// GetEnterpriseCopilotMetrics returns the EnterpriseCopilotMetrics field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetEnterpriseCopilotMetrics() string {
+	if i == nil || i.EnterpriseCopilotMetrics == nil {
+		return ""
+	}
+	return *i.EnterpriseCopilotMetrics
+}
+
+// GetEnterpriseCredentials returns the EnterpriseCredentials field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetEnterpriseCredentials() string {
+	if i == nil || i.EnterpriseCredentials == nil {
+		return ""
+	}
+	return *i.EnterpriseCredentials
+}
+
+// GetEnterpriseCustomEnterpriseRoles returns the EnterpriseCustomEnterpriseRoles field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetEnterpriseCustomEnterpriseRoles() string {
+	if i == nil || i.EnterpriseCustomEnterpriseRoles == nil {
+		return ""
+	}
+	return *i.EnterpriseCustomEnterpriseRoles
+}
+
+// GetEnterpriseCustomOrgRoles returns the EnterpriseCustomOrgRoles field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetEnterpriseCustomOrgRoles() string {
+	if i == nil || i.EnterpriseCustomOrgRoles == nil {
+		return ""
+	}
+	return *i.EnterpriseCustomOrgRoles
+}
+
+// GetEnterpriseCustomProperties returns the EnterpriseCustomProperties field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetEnterpriseCustomProperties() string {
+	if i == nil || i.EnterpriseCustomProperties == nil {
+		return ""
+	}
+	return *i.EnterpriseCustomProperties
+}
+
+// GetEnterpriseCustomPropertiesForOrgs returns the EnterpriseCustomPropertiesForOrgs field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetEnterpriseCustomPropertiesForOrgs() string {
+	if i == nil || i.EnterpriseCustomPropertiesForOrgs == nil {
+		return ""
+	}
+	return *i.EnterpriseCustomPropertiesForOrgs
+}
+
+// GetEnterpriseOrganizationInstallations returns the EnterpriseOrganizationInstallations field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetEnterpriseOrganizationInstallations() string {
+	if i == nil || i.EnterpriseOrganizationInstallations == nil {
+		return ""
+	}
+	return *i.EnterpriseOrganizationInstallations
+}
+
+// GetEnterpriseOrganizations returns the EnterpriseOrganizations field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetEnterpriseOrganizations() string {
+	if i == nil || i.EnterpriseOrganizations == nil {
+		return ""
+	}
+	return *i.EnterpriseOrganizations
+}
+
+// GetEnterpriseOrgInstallationRepositories returns the EnterpriseOrgInstallationRepositories field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetEnterpriseOrgInstallationRepositories() string {
+	if i == nil || i.EnterpriseOrgInstallationRepositories == nil {
+		return ""
+	}
+	return *i.EnterpriseOrgInstallationRepositories
+}
+
+// GetEnterprisePeople returns the EnterprisePeople field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetEnterprisePeople() string {
+	if i == nil || i.EnterprisePeople == nil {
+		return ""
+	}
+	return *i.EnterprisePeople
+}
+
+// GetEnterpriseSSO returns the EnterpriseSSO field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetEnterpriseSSO() string {
+	if i == nil || i.EnterpriseSSO == nil {
+		return ""
+	}
+	return *i.EnterpriseSSO
+}
+
+// GetEnterpriseTeams returns the EnterpriseTeams field if it's non-nil, zero value otherwise.
+func (i *InstallationPermissions) GetEnterpriseTeams() string {
+	if i == nil || i.EnterpriseTeams == nil {
+		return ""
+	}
+	return *i.EnterpriseTeams
+}
+
 // GetEnvironments returns the Environments field if it's non-nil, zero value otherwise.
 func (i *InstallationPermissions) GetEnvironments() string {
 	if i == nil || i.Environments == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -24154,15 +24154,15 @@ func TestInstallationPermissions_GetEnterpriseOrganizations(tt *testing.T) {
 	i.GetEnterpriseOrganizations()
 }
 
-func TestInstallationPermissions_GetEnterpriseOrgInstallationRepositories(tt *testing.T) {
+func TestInstallationPermissions_GetEnterpriseOrgInstallationRepos(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
-	i := &InstallationPermissions{EnterpriseOrgInstallationRepositories: &zeroValue}
-	i.GetEnterpriseOrgInstallationRepositories()
+	i := &InstallationPermissions{EnterpriseOrgInstallationRepos: &zeroValue}
+	i.GetEnterpriseOrgInstallationRepos()
 	i = &InstallationPermissions{}
-	i.GetEnterpriseOrgInstallationRepositories()
+	i.GetEnterpriseOrgInstallationRepos()
 	i = nil
-	i.GetEnterpriseOrgInstallationRepositories()
+	i.GetEnterpriseOrgInstallationRepos()
 }
 
 func TestInstallationPermissions_GetEnterprisePeople(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -24055,6 +24055,149 @@ func TestInstallationPermissions_GetEmails(tt *testing.T) {
 	i.GetEmails()
 }
 
+func TestInstallationPermissions_GetEnterpriseAIControls(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &InstallationPermissions{EnterpriseAIControls: &zeroValue}
+	i.GetEnterpriseAIControls()
+	i = &InstallationPermissions{}
+	i.GetEnterpriseAIControls()
+	i = nil
+	i.GetEnterpriseAIControls()
+}
+
+func TestInstallationPermissions_GetEnterpriseCopilotMetrics(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &InstallationPermissions{EnterpriseCopilotMetrics: &zeroValue}
+	i.GetEnterpriseCopilotMetrics()
+	i = &InstallationPermissions{}
+	i.GetEnterpriseCopilotMetrics()
+	i = nil
+	i.GetEnterpriseCopilotMetrics()
+}
+
+func TestInstallationPermissions_GetEnterpriseCredentials(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &InstallationPermissions{EnterpriseCredentials: &zeroValue}
+	i.GetEnterpriseCredentials()
+	i = &InstallationPermissions{}
+	i.GetEnterpriseCredentials()
+	i = nil
+	i.GetEnterpriseCredentials()
+}
+
+func TestInstallationPermissions_GetEnterpriseCustomEnterpriseRoles(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &InstallationPermissions{EnterpriseCustomEnterpriseRoles: &zeroValue}
+	i.GetEnterpriseCustomEnterpriseRoles()
+	i = &InstallationPermissions{}
+	i.GetEnterpriseCustomEnterpriseRoles()
+	i = nil
+	i.GetEnterpriseCustomEnterpriseRoles()
+}
+
+func TestInstallationPermissions_GetEnterpriseCustomOrgRoles(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &InstallationPermissions{EnterpriseCustomOrgRoles: &zeroValue}
+	i.GetEnterpriseCustomOrgRoles()
+	i = &InstallationPermissions{}
+	i.GetEnterpriseCustomOrgRoles()
+	i = nil
+	i.GetEnterpriseCustomOrgRoles()
+}
+
+func TestInstallationPermissions_GetEnterpriseCustomProperties(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &InstallationPermissions{EnterpriseCustomProperties: &zeroValue}
+	i.GetEnterpriseCustomProperties()
+	i = &InstallationPermissions{}
+	i.GetEnterpriseCustomProperties()
+	i = nil
+	i.GetEnterpriseCustomProperties()
+}
+
+func TestInstallationPermissions_GetEnterpriseCustomPropertiesForOrgs(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &InstallationPermissions{EnterpriseCustomPropertiesForOrgs: &zeroValue}
+	i.GetEnterpriseCustomPropertiesForOrgs()
+	i = &InstallationPermissions{}
+	i.GetEnterpriseCustomPropertiesForOrgs()
+	i = nil
+	i.GetEnterpriseCustomPropertiesForOrgs()
+}
+
+func TestInstallationPermissions_GetEnterpriseOrganizationInstallations(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &InstallationPermissions{EnterpriseOrganizationInstallations: &zeroValue}
+	i.GetEnterpriseOrganizationInstallations()
+	i = &InstallationPermissions{}
+	i.GetEnterpriseOrganizationInstallations()
+	i = nil
+	i.GetEnterpriseOrganizationInstallations()
+}
+
+func TestInstallationPermissions_GetEnterpriseOrganizations(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &InstallationPermissions{EnterpriseOrganizations: &zeroValue}
+	i.GetEnterpriseOrganizations()
+	i = &InstallationPermissions{}
+	i.GetEnterpriseOrganizations()
+	i = nil
+	i.GetEnterpriseOrganizations()
+}
+
+func TestInstallationPermissions_GetEnterpriseOrgInstallationRepositories(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &InstallationPermissions{EnterpriseOrgInstallationRepositories: &zeroValue}
+	i.GetEnterpriseOrgInstallationRepositories()
+	i = &InstallationPermissions{}
+	i.GetEnterpriseOrgInstallationRepositories()
+	i = nil
+	i.GetEnterpriseOrgInstallationRepositories()
+}
+
+func TestInstallationPermissions_GetEnterprisePeople(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &InstallationPermissions{EnterprisePeople: &zeroValue}
+	i.GetEnterprisePeople()
+	i = &InstallationPermissions{}
+	i.GetEnterprisePeople()
+	i = nil
+	i.GetEnterprisePeople()
+}
+
+func TestInstallationPermissions_GetEnterpriseSSO(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &InstallationPermissions{EnterpriseSSO: &zeroValue}
+	i.GetEnterpriseSSO()
+	i = &InstallationPermissions{}
+	i.GetEnterpriseSSO()
+	i = nil
+	i.GetEnterpriseSSO()
+}
+
+func TestInstallationPermissions_GetEnterpriseTeams(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &InstallationPermissions{EnterpriseTeams: &zeroValue}
+	i.GetEnterpriseTeams()
+	i = &InstallationPermissions{}
+	i.GetEnterpriseTeams()
+	i = nil
+	i.GetEnterpriseTeams()
+}
+
 func TestInstallationPermissions_GetEnvironments(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/tools/structfield/structfield.go
+++ b/tools/structfield/structfield.go
@@ -410,7 +410,7 @@ func tagNameToPascal(tagName string) (want, alternate string) {
 
 // Common Go initialisms that should be all caps.
 var initialisms = map[string]bool{
-	"API": true, "ASCII": true, "AWS": true,
+	"AI": true, "API": true, "ASCII": true, "AWS": true,
 	"CAA": true, "CAS": true, "CLI": true, "CNAME": true, "CPU": true,
 	"CSS": true, "CWE": true, "CVE": true, "CVSS": true,
 	"DN": true, "DNS": true,


### PR DESCRIPTION
This pull request adds support for several new [enterprise-related permission fields](https://github.blog/changelog/2025-03-10-enterprise-owned-github-apps-are-now-generally-available/) to the `InstallationPermissions` struct, along with corresponding accessor methods and unit tests. These changes enhance the codebase to handle a wider range of GitHub App installation permissions, particularly for enterprise features.

Creating a installation token yields this output when enterprise-scope permissions are used:
```json
{
  "token": "ghs_etcetc",
  "expires_at": "2026-06-30T14:28:23Z",
  "permissions": {
    "enterprise_ai_controls": "read",
    "enterprise_copilot_metrics": "read",
    "enterprise_credentials": "read",
    "enterprise_custom_enterprise_roles": "read",
    "enterprise_custom_org_roles": "read",
    "enterprise_custom_properties": "read",
    "enterprise_custom_properties_for_organizations": "read",
    "enterprise_organizations": "write",
    "enterprise_organization_installations": "read",
    "enterprise_organization_installation_repositories": "read",
    "enterprise_people": "read",
    "enterprise_sso": "read",
    "enterprise_teams": "read"
  },
  "repository_selection": "selected"
}
```

Previously, these information were omitted when `go-github` is in used.

**Enterprise permissions support:**

* Added new fields to the `InstallationPermissions` struct for various enterprise-related permissions, such as `EnterpriseAIControls`, `EnterpriseCopilotMetrics`, `EnterpriseCredentials`, and others. (`github/apps.go`)
* Implemented getter methods for each new enterprise permission field to safely retrieve their values. (`github/github-accessors.go`)

**Testing:**

* Added unit tests for each new getter method to ensure correct behavior when fields are set, unset, or the struct is nil. (`github/github-accessors_test.go`)