### PR TITLE
feat!: Refactor actions variables to pass request by value

### DIFF
--- a/github/actions_variables.go
+++ b/github/actions_variables.go
@@ -11,20 +11,36 @@ import (
 	"fmt"
 )
 
-// OrgActionsVariableRequest represents a request to create or update an
+// OrgActionsVariableCreateRequest represents a request to create an
 // organization variable.
-type OrgActionsVariableRequest struct {
+type OrgActionsVariableCreateRequest struct {
 	Name                  string  `json:"name"`
 	Value                 string  `json:"value"`
 	Visibility            string  `json:"visibility"`
 	SelectedRepositoryIDs []int64 `json:"selected_repository_ids,omitzero"`
 }
 
-// ActionsVariableRequest represents a request to create or update a variable
+// OrgActionsVariableUpdateRequest represents a request to update an
+// organization variable.
+type OrgActionsVariableUpdateRequest struct {
+	Name                  string  `json:"name,omitempty"`
+	Value                 string  `json:"value,omitempty"`
+	Visibility            string  `json:"visibility,omitempty"`
+	SelectedRepositoryIDs []int64 `json:"selected_repository_ids,omitzero"`
+}
+
+// ActionsVariableCreateRequest represents a request to create a variable
 // for a repository or repository environment variable.
-type ActionsVariableRequest struct {
+type ActionsVariableCreateRequest struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
+}
+
+// ActionsVariableUpdateRequest represents a request to update a variable
+// for a repository or repository environment variable.
+type ActionsVariableUpdateRequest struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 // ActionsVariable represents a repository action variable.
@@ -220,7 +236,7 @@ func (s *ActionsService) GetEnvVariable(ctx context.Context, owner, repo, env, v
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#create-a-repository-variable
 //
 //meta:operation POST /repos/{owner}/{repo}/actions/variables
-func (s *ActionsService) CreateRepoVariable(ctx context.Context, owner, repo string, body ActionsVariableRequest) (*Response, error) {
+func (s *ActionsService) CreateRepoVariable(ctx context.Context, owner, repo string, body ActionsVariableCreateRequest) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/variables", owner, repo)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
@@ -236,7 +252,7 @@ func (s *ActionsService) CreateRepoVariable(ctx context.Context, owner, repo str
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#create-an-organization-variable
 //
 //meta:operation POST /orgs/{org}/actions/variables
-func (s *ActionsService) CreateOrgVariable(ctx context.Context, org string, body OrgActionsVariableRequest) (*Response, error) {
+func (s *ActionsService) CreateOrgVariable(ctx context.Context, org string, body OrgActionsVariableCreateRequest) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/variables", org)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
@@ -252,7 +268,7 @@ func (s *ActionsService) CreateOrgVariable(ctx context.Context, org string, body
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#create-an-environment-variable
 //
 //meta:operation POST /repos/{owner}/{repo}/environments/{environment_name}/variables
-func (s *ActionsService) CreateEnvVariable(ctx context.Context, owner, repo, env string, body ActionsVariableRequest) (*Response, error) {
+func (s *ActionsService) CreateEnvVariable(ctx context.Context, owner, repo, env string, body ActionsVariableCreateRequest) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/variables", owner, repo, env)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
@@ -267,7 +283,7 @@ func (s *ActionsService) CreateEnvVariable(ctx context.Context, owner, repo, env
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#update-a-repository-variable
 //
 //meta:operation PATCH /repos/{owner}/{repo}/actions/variables/{name}
-func (s *ActionsService) UpdateRepoVariable(ctx context.Context, owner, repo, name string, body ActionsVariableRequest) (*Response, error) {
+func (s *ActionsService) UpdateRepoVariable(ctx context.Context, owner, repo, name string, body ActionsVariableUpdateRequest) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/variables/%v", owner, repo, name)
 
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
@@ -283,7 +299,7 @@ func (s *ActionsService) UpdateRepoVariable(ctx context.Context, owner, repo, na
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#update-an-organization-variable
 //
 //meta:operation PATCH /orgs/{org}/actions/variables/{name}
-func (s *ActionsService) UpdateOrgVariable(ctx context.Context, org, name string, body OrgActionsVariableRequest) (*Response, error) {
+func (s *ActionsService) UpdateOrgVariable(ctx context.Context, org, name string, body OrgActionsVariableUpdateRequest) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/variables/%v", org, name)
 
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
@@ -299,7 +315,7 @@ func (s *ActionsService) UpdateOrgVariable(ctx context.Context, org, name string
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#update-an-environment-variable
 //
 //meta:operation PATCH /repos/{owner}/{repo}/environments/{environment_name}/variables/{name}
-func (s *ActionsService) UpdateEnvVariable(ctx context.Context, owner, repo, env, name string, body ActionsVariableRequest) (*Response, error) {
+func (s *ActionsService) UpdateEnvVariable(ctx context.Context, owner, repo, env, name string, body ActionsVariableUpdateRequest) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/variables/%v", owner, repo, env, name)
 
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)

--- a/github/actions_variables.go
+++ b/github/actions_variables.go
@@ -11,17 +11,32 @@ import (
 	"fmt"
 )
 
+// OrgActionsVariableRequest represents a request to create or update an
+// organization variable.
+type OrgActionsVariableRequest struct {
+	Name                  string  `json:"name"`
+	Value                 string  `json:"value"`
+	Visibility            string  `json:"visibility"`
+	SelectedRepositoryIDs []int64 `json:"selected_repository_ids,omitzero"`
+}
+
+// ActionsVariableRequest represents a request to create or update a variable
+// for a repository or repository environment variable.
+type ActionsVariableRequest struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
 // ActionsVariable represents a repository action variable.
 type ActionsVariable struct {
-	Name       string     `json:"name"`
-	Value      string     `json:"value"`
-	CreatedAt  *Timestamp `json:"created_at,omitempty"`
-	UpdatedAt  *Timestamp `json:"updated_at,omitempty"`
-	Visibility *string    `json:"visibility,omitempty"`
+	Name      string     `json:"name"`
+	Value     string     `json:"value"`
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
+
 	// Used by ListOrgVariables and GetOrgVariables
+	Visibility              *string `json:"visibility,omitempty"`
 	SelectedRepositoriesURL *string `json:"selected_repositories_url,omitempty"`
-	// Used by UpdateOrgVariable and CreateOrgVariable
-	SelectedRepositoryIDs *SelectedRepoIDs `json:"selected_repository_ids,omitempty"`
 }
 
 // ActionsVariables represents one item from the ListVariables response.
@@ -30,8 +45,14 @@ type ActionsVariables struct {
 	Variables  []*ActionsVariable `json:"variables"`
 }
 
-func (s *ActionsService) listVariables(ctx context.Context, url string, opts *ListOptions) (*ActionsVariables, *Response, error) {
-	u, err := addOptions(url, opts)
+// ListRepoVariables lists all variables available in a repository.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#list-repository-variables
+//
+//meta:operation GET /repos/{owner}/{repo}/actions/variables
+func (s *ActionsService) ListRepoVariables(ctx context.Context, owner, repo string, opts *ListOptions) (*ActionsVariables, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/variables", owner, repo)
+	u, err := addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -50,24 +71,30 @@ func (s *ActionsService) listVariables(ctx context.Context, url string, opts *Li
 	return variables, resp, nil
 }
 
-// ListRepoVariables lists all variables available in a repository.
-//
-// GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#list-repository-variables
-//
-//meta:operation GET /repos/{owner}/{repo}/actions/variables
-func (s *ActionsService) ListRepoVariables(ctx context.Context, owner, repo string, opts *ListOptions) (*ActionsVariables, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/variables", owner, repo)
-	return s.listVariables(ctx, url, opts)
-}
-
 // ListRepoOrgVariables lists all organization variables available in a repository.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#list-repository-organization-variables
 //
 //meta:operation GET /repos/{owner}/{repo}/actions/organization-variables
 func (s *ActionsService) ListRepoOrgVariables(ctx context.Context, owner, repo string, opts *ListOptions) (*ActionsVariables, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/organization-variables", owner, repo)
-	return s.listVariables(ctx, url, opts)
+	u := fmt.Sprintf("repos/%v/%v/actions/organization-variables", owner, repo)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var variables *ActionsVariables
+	resp, err := s.client.Do(req, &variables)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return variables, resp, nil
 }
 
 // ListOrgVariables lists all variables available in an organization.
@@ -76,8 +103,24 @@ func (s *ActionsService) ListRepoOrgVariables(ctx context.Context, owner, repo s
 //
 //meta:operation GET /orgs/{org}/actions/variables
 func (s *ActionsService) ListOrgVariables(ctx context.Context, org string, opts *ListOptions) (*ActionsVariables, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/variables", org)
-	return s.listVariables(ctx, url, opts)
+	u := fmt.Sprintf("orgs/%v/actions/variables", org)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var variables *ActionsVariables
+	resp, err := s.client.Do(req, &variables)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return variables, resp, nil
 }
 
 // ListEnvVariables lists all variables available in an environment.
@@ -86,12 +129,35 @@ func (s *ActionsService) ListOrgVariables(ctx context.Context, org string, opts 
 //
 //meta:operation GET /repos/{owner}/{repo}/environments/{environment_name}/variables
 func (s *ActionsService) ListEnvVariables(ctx context.Context, owner, repo, env string, opts *ListOptions) (*ActionsVariables, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/environments/%v/variables", owner, repo, env)
-	return s.listVariables(ctx, url, opts)
+	u := fmt.Sprintf("repos/%v/%v/environments/%v/variables", owner, repo, env)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var variables *ActionsVariables
+	resp, err := s.client.Do(req, &variables)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return variables, resp, nil
 }
 
-func (s *ActionsService) getVariable(ctx context.Context, url string) (*ActionsVariable, *Response, error) {
-	req, err := s.client.NewRequest(ctx, "GET", url, nil)
+// GetRepoVariable gets a single repository variable.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#get-a-repository-variable
+//
+//meta:operation GET /repos/{owner}/{repo}/actions/variables/{name}
+func (s *ActionsService) GetRepoVariable(ctx context.Context, owner, repo, name string) (*ActionsVariable, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/variables/%v", owner, repo, name)
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -105,24 +171,26 @@ func (s *ActionsService) getVariable(ctx context.Context, url string) (*ActionsV
 	return variable, resp, nil
 }
 
-// GetRepoVariable gets a single repository variable.
-//
-// GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#get-a-repository-variable
-//
-//meta:operation GET /repos/{owner}/{repo}/actions/variables/{name}
-func (s *ActionsService) GetRepoVariable(ctx context.Context, owner, repo, name string) (*ActionsVariable, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/variables/%v", owner, repo, name)
-	return s.getVariable(ctx, url)
-}
-
 // GetOrgVariable gets a single organization variable.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#get-an-organization-variable
 //
 //meta:operation GET /orgs/{org}/actions/variables/{name}
 func (s *ActionsService) GetOrgVariable(ctx context.Context, org, name string) (*ActionsVariable, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/variables/%v", org, name)
-	return s.getVariable(ctx, url)
+	u := fmt.Sprintf("orgs/%v/actions/variables/%v", org, name)
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var variable *ActionsVariable
+	resp, err := s.client.Do(req, &variable)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return variable, resp, nil
 }
 
 // GetEnvVariable gets a single environment variable.
@@ -131,16 +199,20 @@ func (s *ActionsService) GetOrgVariable(ctx context.Context, org, name string) (
 //
 //meta:operation GET /repos/{owner}/{repo}/environments/{environment_name}/variables/{name}
 func (s *ActionsService) GetEnvVariable(ctx context.Context, owner, repo, env, variableName string) (*ActionsVariable, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/environments/%v/variables/%v", owner, repo, env, variableName)
-	return s.getVariable(ctx, url)
-}
+	u := fmt.Sprintf("repos/%v/%v/environments/%v/variables/%v", owner, repo, env, variableName)
 
-func (s *ActionsService) postVariable(ctx context.Context, url string, body *ActionsVariable) (*Response, error) {
-	req, err := s.client.NewRequest(ctx, "POST", url, body)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return s.client.Do(req, nil)
+
+	var variable *ActionsVariable
+	resp, err := s.client.Do(req, &variable)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return variable, resp, nil
 }
 
 // CreateRepoVariable creates a repository variable.
@@ -148,9 +220,15 @@ func (s *ActionsService) postVariable(ctx context.Context, url string, body *Act
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#create-a-repository-variable
 //
 //meta:operation POST /repos/{owner}/{repo}/actions/variables
-func (s *ActionsService) CreateRepoVariable(ctx context.Context, owner, repo string, body *ActionsVariable) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/variables", owner, repo)
-	return s.postVariable(ctx, url, body)
+func (s *ActionsService) CreateRepoVariable(ctx context.Context, owner, repo string, body ActionsVariableRequest) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/variables", owner, repo)
+
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }
 
 // CreateOrgVariable creates an organization variable.
@@ -158,9 +236,15 @@ func (s *ActionsService) CreateRepoVariable(ctx context.Context, owner, repo str
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#create-an-organization-variable
 //
 //meta:operation POST /orgs/{org}/actions/variables
-func (s *ActionsService) CreateOrgVariable(ctx context.Context, org string, body *ActionsVariable) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/variables", org)
-	return s.postVariable(ctx, url, body)
+func (s *ActionsService) CreateOrgVariable(ctx context.Context, org string, body OrgActionsVariableRequest) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/variables", org)
+
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }
 
 // CreateEnvVariable creates an environment variable.
@@ -168,13 +252,10 @@ func (s *ActionsService) CreateOrgVariable(ctx context.Context, org string, body
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#create-an-environment-variable
 //
 //meta:operation POST /repos/{owner}/{repo}/environments/{environment_name}/variables
-func (s *ActionsService) CreateEnvVariable(ctx context.Context, owner, repo, env string, body *ActionsVariable) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/environments/%v/variables", owner, repo, env)
-	return s.postVariable(ctx, url, body)
-}
+func (s *ActionsService) CreateEnvVariable(ctx context.Context, owner, repo, env string, body ActionsVariableRequest) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/environments/%v/variables", owner, repo, env)
 
-func (s *ActionsService) patchVariable(ctx context.Context, url string, body *ActionsVariable) (*Response, error) {
-	req, err := s.client.NewRequest(ctx, "PATCH", url, body)
+	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
 		return nil, err
 	}
@@ -186,13 +267,15 @@ func (s *ActionsService) patchVariable(ctx context.Context, url string, body *Ac
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#update-a-repository-variable
 //
 //meta:operation PATCH /repos/{owner}/{repo}/actions/variables/{name}
-func (s *ActionsService) UpdateRepoVariable(ctx context.Context, owner, repo string, variable *ActionsVariable) (*Response, error) {
-	if variable == nil {
-		return nil, errors.New("variable must be provided")
+func (s *ActionsService) UpdateRepoVariable(ctx context.Context, owner, repo, name string, body ActionsVariableRequest) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/actions/variables/%v", owner, repo, name)
+
+	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
+	if err != nil {
+		return nil, err
 	}
 
-	url := fmt.Sprintf("repos/%v/%v/actions/variables/%v", owner, repo, variable.Name)
-	return s.patchVariable(ctx, url, variable)
+	return s.client.Do(req, nil)
 }
 
 // UpdateOrgVariable updates an organization variable.
@@ -200,13 +283,15 @@ func (s *ActionsService) UpdateRepoVariable(ctx context.Context, owner, repo str
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#update-an-organization-variable
 //
 //meta:operation PATCH /orgs/{org}/actions/variables/{name}
-func (s *ActionsService) UpdateOrgVariable(ctx context.Context, org string, variable *ActionsVariable) (*Response, error) {
-	if variable == nil {
-		return nil, errors.New("variable must be provided")
+func (s *ActionsService) UpdateOrgVariable(ctx context.Context, org, name string, body OrgActionsVariableRequest) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/variables/%v", org, name)
+
+	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
+	if err != nil {
+		return nil, err
 	}
 
-	url := fmt.Sprintf("orgs/%v/actions/variables/%v", org, variable.Name)
-	return s.patchVariable(ctx, url, variable)
+	return s.client.Do(req, nil)
 }
 
 // UpdateEnvVariable updates an environment variable.
@@ -214,17 +299,10 @@ func (s *ActionsService) UpdateOrgVariable(ctx context.Context, org string, vari
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#update-an-environment-variable
 //
 //meta:operation PATCH /repos/{owner}/{repo}/environments/{environment_name}/variables/{name}
-func (s *ActionsService) UpdateEnvVariable(ctx context.Context, owner, repo, env string, variable *ActionsVariable) (*Response, error) {
-	if variable == nil {
-		return nil, errors.New("variable must be provided")
-	}
+func (s *ActionsService) UpdateEnvVariable(ctx context.Context, owner, repo, env, name string, body ActionsVariableRequest) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/environments/%v/variables/%v", owner, repo, env, name)
 
-	url := fmt.Sprintf("repos/%v/%v/environments/%v/variables/%v", owner, repo, env, variable.Name)
-	return s.patchVariable(ctx, url, variable)
-}
-
-func (s *ActionsService) deleteVariable(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
+	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {
 		return nil, err
 	}
@@ -238,8 +316,14 @@ func (s *ActionsService) deleteVariable(ctx context.Context, url string) (*Respo
 //
 //meta:operation DELETE /repos/{owner}/{repo}/actions/variables/{name}
 func (s *ActionsService) DeleteRepoVariable(ctx context.Context, owner, repo, name string) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/actions/variables/%v", owner, repo, name)
-	return s.deleteVariable(ctx, url)
+	u := fmt.Sprintf("repos/%v/%v/actions/variables/%v", owner, repo, name)
+
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }
 
 // DeleteOrgVariable deletes a variable in an organization.
@@ -248,8 +332,14 @@ func (s *ActionsService) DeleteRepoVariable(ctx context.Context, owner, repo, na
 //
 //meta:operation DELETE /orgs/{org}/actions/variables/{name}
 func (s *ActionsService) DeleteOrgVariable(ctx context.Context, org, name string) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/variables/%v", org, name)
-	return s.deleteVariable(ctx, url)
+	u := fmt.Sprintf("orgs/%v/actions/variables/%v", org, name)
+
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }
 
 // DeleteEnvVariable deletes a variable in an environment.
@@ -258,12 +348,25 @@ func (s *ActionsService) DeleteOrgVariable(ctx context.Context, org, name string
 //
 //meta:operation DELETE /repos/{owner}/{repo}/environments/{environment_name}/variables/{name}
 func (s *ActionsService) DeleteEnvVariable(ctx context.Context, owner, repo, env, variableName string) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/environments/%v/variables/%v", owner, repo, env, variableName)
-	return s.deleteVariable(ctx, url)
+	u := fmt.Sprintf("repos/%v/%v/environments/%v/variables/%v", owner, repo, env, variableName)
+
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }
 
-func (s *ActionsService) listSelectedReposForVariable(ctx context.Context, url string, opts *ListOptions) (*SelectedReposList, *Response, error) {
-	u, err := addOptions(url, opts)
+// ListSelectedReposForOrgVariable lists all repositories that have access to a variable.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#list-selected-repositories-for-an-organization-variable
+//
+//meta:operation GET /orgs/{org}/actions/variables/{name}/repositories
+func (s *ActionsService) ListSelectedReposForOrgVariable(ctx context.Context, org, name string, opts *ListOptions) (*SelectedReposList, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories", org, name)
+
+	u, err := addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -282,41 +385,19 @@ func (s *ActionsService) listSelectedReposForVariable(ctx context.Context, url s
 	return result, resp, nil
 }
 
-// ListSelectedReposForOrgVariable lists all repositories that have access to a variable.
-//
-// GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#list-selected-repositories-for-an-organization-variable
-//
-//meta:operation GET /orgs/{org}/actions/variables/{name}/repositories
-func (s *ActionsService) ListSelectedReposForOrgVariable(ctx context.Context, org, name string, opts *ListOptions) (*SelectedReposList, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories", org, name)
-	return s.listSelectedReposForVariable(ctx, url, opts)
-}
-
-func (s *ActionsService) setSelectedReposForVariable(ctx context.Context, url string, ids SelectedRepoIDs) (*Response, error) {
-	type repoIDs struct {
-		SelectedIDs SelectedRepoIDs `json:"selected_repository_ids"`
-	}
-
-	req, err := s.client.NewRequest(ctx, "PUT", url, repoIDs{SelectedIDs: ids})
-	if err != nil {
-		return nil, err
-	}
-
-	return s.client.Do(req, nil)
-}
-
 // SetSelectedReposForOrgVariable sets the repositories that have access to a variable.
 //
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#set-selected-repositories-for-an-organization-variable
 //
 //meta:operation PUT /orgs/{org}/actions/variables/{name}/repositories
-func (s *ActionsService) SetSelectedReposForOrgVariable(ctx context.Context, org, name string, ids SelectedRepoIDs) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories", org, name)
-	return s.setSelectedReposForVariable(ctx, url, ids)
-}
+func (s *ActionsService) SetSelectedReposForOrgVariable(ctx context.Context, org, name string, ids []int64) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories", org, name)
 
-func (s *ActionsService) addSelectedRepoToVariable(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest(ctx, "PUT", url, nil)
+	type repoIDs struct {
+		SelectedIDs []int64 `json:"selected_repository_ids"`
+	}
+
+	req, err := s.client.NewRequest(ctx, "PUT", u, repoIDs{SelectedIDs: ids})
 	if err != nil {
 		return nil, err
 	}
@@ -337,12 +418,8 @@ func (s *ActionsService) AddSelectedRepoToOrgVariable(ctx context.Context, org, 
 		return nil, errors.New("id must be provided")
 	}
 
-	url := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories/%v", org, name, *repo.ID)
-	return s.addSelectedRepoToVariable(ctx, url)
-}
-
-func (s *ActionsService) removeSelectedRepoFromVariable(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
+	u := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories/%v", org, name, *repo.ID)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -363,6 +440,12 @@ func (s *ActionsService) RemoveSelectedRepoFromOrgVariable(ctx context.Context, 
 		return nil, errors.New("id must be provided")
 	}
 
-	url := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories/%v", org, name, *repo.ID)
-	return s.removeSelectedRepoFromVariable(ctx, url)
+	u := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories/%v", org, name, *repo.ID)
+
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }

--- a/github/actions_variables.go
+++ b/github/actions_variables.go
@@ -23,9 +23,9 @@ type OrgActionsVariableCreateRequest struct {
 // OrgActionsVariableUpdateRequest represents a request to update an
 // organization variable.
 type OrgActionsVariableUpdateRequest struct {
-	Name                  string  `json:"name,omitempty"`
-	Value                 string  `json:"value,omitempty"`
-	Visibility            string  `json:"visibility,omitempty"`
+	Name                  *string `json:"name,omitempty"`
+	Value                 *string `json:"value,omitempty"`
+	Visibility            *string `json:"visibility,omitempty"`
 	SelectedRepositoryIDs []int64 `json:"selected_repository_ids,omitzero"`
 }
 
@@ -39,8 +39,8 @@ type ActionsVariableCreateRequest struct {
 // ActionsVariableUpdateRequest represents a request to update a variable
 // for a repository or repository environment variable.
 type ActionsVariableUpdateRequest struct {
-	Name  string `json:"name,omitempty"`
-	Value string `json:"value,omitempty"`
+	Name  *string `json:"name,omitempty"`
+	Value *string `json:"value,omitempty"`
 }
 
 // ActionsVariable represents a repository action variable.

--- a/github/actions_variables_test.go
+++ b/github/actions_variables_test.go
@@ -176,9 +176,10 @@ func TestActionsService_UpdateRepoVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
+	name := "NAME"
 	input := ActionsVariableUpdateRequest{
-		Name:  "NAME",
-		Value: "VALUE",
+		Name:  Ptr(name),
+		Value: Ptr("VALUE"),
 	}
 
 	mux.HandleFunc("/repos/o/r/actions/variables/NAME", func(w http.ResponseWriter, r *http.Request) {
@@ -189,7 +190,7 @@ func TestActionsService_UpdateRepoVariable(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	_, err := client.Actions.UpdateRepoVariable(ctx, "o", "r", input.Name, input)
+	_, err := client.Actions.UpdateRepoVariable(ctx, "o", "r", name, input)
 	if err != nil {
 		t.Errorf("Actions.UpdateRepoVariable returned error: %v", err)
 	}
@@ -201,7 +202,7 @@ func TestActionsService_UpdateRepoVariable(t *testing.T) {
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.UpdateRepoVariable(ctx, "o", "r", input.Name, input)
+		return client.Actions.UpdateRepoVariable(ctx, "o", "r", name, input)
 	})
 }
 
@@ -355,10 +356,11 @@ func TestActionsService_UpdateOrgVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
+	name := "NAME"
 	input := OrgActionsVariableUpdateRequest{
-		Name:                  "NAME",
-		Value:                 "VALUE",
-		Visibility:            "selected",
+		Name:                  Ptr(name),
+		Value:                 Ptr("VALUE"),
+		Visibility:            Ptr("selected"),
 		SelectedRepositoryIDs: []int64{1296269, 1269280},
 	}
 
@@ -370,7 +372,7 @@ func TestActionsService_UpdateOrgVariable(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	_, err := client.Actions.UpdateOrgVariable(ctx, "o", input.Name, input)
+	_, err := client.Actions.UpdateOrgVariable(ctx, "o", name, input)
 	if err != nil {
 		t.Errorf("Actions.UpdateOrgVariable returned error: %v", err)
 	}
@@ -382,7 +384,7 @@ func TestActionsService_UpdateOrgVariable(t *testing.T) {
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.UpdateOrgVariable(ctx, "o", input.Name, input)
+		return client.Actions.UpdateOrgVariable(ctx, "o", name, input)
 	})
 }
 
@@ -600,19 +602,19 @@ func TestActionsService_GetEnvVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/environments/e/variables/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"name":"variable","value":"VAR","created_at":`+refTimeStr(1136178000)+`,"updated_at":`+refTimeStr(1136178001)+`}`)
+		fmt.Fprint(w, `{"name":"NAME","value":"VAR","created_at":`+refTimeStr(1136178000)+`,"updated_at":`+refTimeStr(1136178001)+`}`)
 	})
 
 	ctx := t.Context()
-	variable, _, err := client.Actions.GetEnvVariable(ctx, "o", "r", "e", "variable")
+	variable, _, err := client.Actions.GetEnvVariable(ctx, "o", "r", "e", "NAME")
 	if err != nil {
 		t.Errorf("Actions.GetEnvVariable returned error: %v", err)
 	}
 
 	want := &ActionsVariable{
-		Name:      "variable",
+		Name:      "NAME",
 		Value:     "VAR",
 		CreatedAt: refTimestamp(1136178000),
 		UpdatedAt: refTimestamp(1136178001),
@@ -628,7 +630,7 @@ func TestActionsService_GetEnvVariable(t *testing.T) {
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.GetEnvVariable(ctx, "o", "r", "e", "variable")
+		got, resp, err := client.Actions.GetEnvVariable(ctx, "o", "r", "e", "NAME")
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -641,7 +643,7 @@ func TestActionsService_CreateEnvVariable(t *testing.T) {
 	client, mux, _ := setup(t)
 
 	input := ActionsVariableCreateRequest{
-		Name:  "variable",
+		Name:  "NAME",
 		Value: "VAR",
 	}
 
@@ -673,12 +675,13 @@ func TestActionsService_UpdateEnvVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
+	name := "NAME"
 	input := ActionsVariableUpdateRequest{
-		Name:  "variable",
-		Value: "VAR",
+		Name:  Ptr(name),
+		Value: Ptr("VAR"),
 	}
 
-	mux.HandleFunc("/repos/o/r/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/environments/e/variables/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
 		testHeader(t, r, "Content-Type", "application/json")
 		testJSONBody(t, r, input)
@@ -686,7 +689,7 @@ func TestActionsService_UpdateEnvVariable(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	_, err := client.Actions.UpdateEnvVariable(ctx, "o", "r", "e", input.Name, input)
+	_, err := client.Actions.UpdateEnvVariable(ctx, "o", "r", "e", name, input)
 	if err != nil {
 		t.Errorf("Actions.UpdateEnvVariable returned error: %v", err)
 	}
@@ -698,7 +701,7 @@ func TestActionsService_UpdateEnvVariable(t *testing.T) {
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.UpdateEnvVariable(ctx, "o", "r", "e", input.Name, input)
+		return client.Actions.UpdateEnvVariable(ctx, "o", "r", "e", name, input)
 	})
 }
 
@@ -706,12 +709,12 @@ func TestActionsService_DeleteEnvVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/o/r/environments/e/variables/variable", func(_ http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/environments/e/variables/NAME", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
 	ctx := t.Context()
-	_, err := client.Actions.DeleteEnvVariable(ctx, "o", "r", "e", "variable")
+	_, err := client.Actions.DeleteEnvVariable(ctx, "o", "r", "e", "NAME")
 	if err != nil {
 		t.Errorf("Actions.DeleteEnvVariable returned error: %v", err)
 	}
@@ -723,6 +726,6 @@ func TestActionsService_DeleteEnvVariable(t *testing.T) {
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.DeleteEnvVariable(ctx, "o", "r", "e", "variable")
+		return client.Actions.DeleteEnvVariable(ctx, "o", "r", "e", "NAME")
 	})
 }

--- a/github/actions_variables_test.go
+++ b/github/actions_variables_test.go
@@ -178,7 +178,7 @@ func TestActionsService_UpdateRepoVariable(t *testing.T) {
 
 	name := "NAME"
 	input := ActionsVariableUpdateRequest{
-		Name:  Ptr(name),
+		Name:  &name,
 		Value: Ptr("VALUE"),
 	}
 
@@ -358,7 +358,7 @@ func TestActionsService_UpdateOrgVariable(t *testing.T) {
 
 	name := "NAME"
 	input := OrgActionsVariableUpdateRequest{
-		Name:                  Ptr(name),
+		Name:                  &name,
 		Value:                 Ptr("VALUE"),
 		Visibility:            Ptr("selected"),
 		SelectedRepositoryIDs: []int64{1296269, 1269280},
@@ -677,7 +677,7 @@ func TestActionsService_UpdateEnvVariable(t *testing.T) {
 
 	name := "NAME"
 	input := ActionsVariableUpdateRequest{
-		Name:  Ptr(name),
+		Name:  &name,
 		Value: Ptr("VAR"),
 	}
 

--- a/github/actions_variables_test.go
+++ b/github/actions_variables_test.go
@@ -143,7 +143,7 @@ func TestActionsService_CreateRepoVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := ActionsVariableRequest{
+	input := ActionsVariableCreateRequest{
 		Name:  "NAME",
 		Value: "VALUE",
 	}
@@ -176,7 +176,7 @@ func TestActionsService_UpdateRepoVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := ActionsVariableRequest{
+	input := ActionsVariableUpdateRequest{
 		Name:  "NAME",
 		Value: "VALUE",
 	}
@@ -320,7 +320,7 @@ func TestActionsService_CreateOrgVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := OrgActionsVariableRequest{
+	input := OrgActionsVariableCreateRequest{
 		Name:                  "NAME",
 		Value:                 "VALUE",
 		Visibility:            "selected",
@@ -355,7 +355,7 @@ func TestActionsService_UpdateOrgVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := OrgActionsVariableRequest{
+	input := OrgActionsVariableUpdateRequest{
 		Name:                  "NAME",
 		Value:                 "VALUE",
 		Visibility:            "selected",
@@ -640,7 +640,7 @@ func TestActionsService_CreateEnvVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := ActionsVariableRequest{
+	input := ActionsVariableCreateRequest{
 		Name:  "variable",
 		Value: "VAR",
 	}
@@ -673,7 +673,7 @@ func TestActionsService_UpdateEnvVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := ActionsVariableRequest{
+	input := ActionsVariableUpdateRequest{
 		Name:  "variable",
 		Value: "VAR",
 	}

--- a/github/actions_variables_test.go
+++ b/github/actions_variables_test.go
@@ -143,7 +143,7 @@ func TestActionsService_CreateRepoVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &ActionsVariable{
+	input := ActionsVariableRequest{
 		Name:  "NAME",
 		Value: "VALUE",
 	}
@@ -176,7 +176,7 @@ func TestActionsService_UpdateRepoVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &ActionsVariable{
+	input := ActionsVariableRequest{
 		Name:  "NAME",
 		Value: "VALUE",
 	}
@@ -189,23 +189,19 @@ func TestActionsService_UpdateRepoVariable(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	_, err := client.Actions.UpdateRepoVariable(ctx, "o", "r", input)
+	_, err := client.Actions.UpdateRepoVariable(ctx, "o", "r", input.Name, input)
 	if err != nil {
 		t.Errorf("Actions.UpdateRepoVariable returned error: %v", err)
 	}
 
 	const methodName = "UpdateRepoVariable"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.UpdateRepoVariable(ctx, "o", "r", nil)
-		return err
-	})
-	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.UpdateRepoVariable(ctx, "\n", "\n", input)
+		_, err = client.Actions.UpdateRepoVariable(ctx, "\n", "\n", "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.UpdateRepoVariable(ctx, "o", "r", input)
+		return client.Actions.UpdateRepoVariable(ctx, "o", "r", input.Name, input)
 	})
 }
 
@@ -324,11 +320,11 @@ func TestActionsService_CreateOrgVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &ActionsVariable{
+	input := OrgActionsVariableRequest{
 		Name:                  "NAME",
 		Value:                 "VALUE",
-		Visibility:            Ptr("selected"),
-		SelectedRepositoryIDs: &SelectedRepoIDs{1296269, 1269280},
+		Visibility:            "selected",
+		SelectedRepositoryIDs: []int64{1296269, 1269280},
 	}
 
 	mux.HandleFunc("/orgs/o/actions/variables", func(w http.ResponseWriter, r *http.Request) {
@@ -359,11 +355,11 @@ func TestActionsService_UpdateOrgVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &ActionsVariable{
+	input := OrgActionsVariableRequest{
 		Name:                  "NAME",
 		Value:                 "VALUE",
-		Visibility:            Ptr("selected"),
-		SelectedRepositoryIDs: &SelectedRepoIDs{1296269, 1269280},
+		Visibility:            "selected",
+		SelectedRepositoryIDs: []int64{1296269, 1269280},
 	}
 
 	mux.HandleFunc("/orgs/o/actions/variables/NAME", func(w http.ResponseWriter, r *http.Request) {
@@ -374,23 +370,19 @@ func TestActionsService_UpdateOrgVariable(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	_, err := client.Actions.UpdateOrgVariable(ctx, "o", input)
+	_, err := client.Actions.UpdateOrgVariable(ctx, "o", input.Name, input)
 	if err != nil {
 		t.Errorf("Actions.UpdateOrgVariable returned error: %v", err)
 	}
 
 	const methodName = "UpdateOrgVariable"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.UpdateOrgVariable(ctx, "o", nil)
-		return err
-	})
-	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.UpdateOrgVariable(ctx, "\n", input)
+		_, err = client.Actions.UpdateOrgVariable(ctx, "\n", "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.UpdateOrgVariable(ctx, "o", input)
+		return client.Actions.UpdateOrgVariable(ctx, "o", input.Name, input)
 	})
 }
 
@@ -439,13 +431,13 @@ func TestActionsService_SetSelectedReposForOrgVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := SelectedRepoIDs{64780797}
+	input := []int64{64780797}
 
 	mux.HandleFunc("/orgs/o/actions/variables/NAME/repositories", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
 		testJSONBody(t, r, struct {
-			SelectedIDs SelectedRepoIDs `json:"selected_repository_ids"`
+			SelectedIDs []int64 `json:"selected_repository_ids"`
 		}{
 			SelectedIDs: input,
 		})
@@ -565,7 +557,7 @@ func TestActionsService_ListEnvVariables(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/usr/1/environments/e/variables", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/environments/e/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"per_page": "2", "page": "2"})
 		fmt.Fprint(w, `{"total_count":4,"variables":[{"name":"A","value":"AA","created_at":`+refTimeStr(1136178000)+`,"updated_at":`+refTimeStr(1136178001)+`},{"name":"B","value":"BB","created_at":`+refTimeStr(1136178002)+`,"updated_at":`+refTimeStr(1136178003)+`}]}`)
@@ -573,7 +565,7 @@ func TestActionsService_ListEnvVariables(t *testing.T) {
 
 	opts := &ListOptions{Page: 2, PerPage: 2}
 	ctx := t.Context()
-	variables, _, err := client.Actions.ListEnvVariables(ctx, "usr", "1", "e", opts)
+	variables, _, err := client.Actions.ListEnvVariables(ctx, "o", "r", "e", opts)
 	if err != nil {
 		t.Errorf("Actions.ListEnvVariables returned error: %v", err)
 	}
@@ -591,12 +583,12 @@ func TestActionsService_ListEnvVariables(t *testing.T) {
 
 	const methodName = "ListEnvVariables"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.ListEnvVariables(ctx, "usr", "0", "\n", opts)
+		_, _, err = client.Actions.ListEnvVariables(ctx, "\n", "\n", "\n", opts)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.ListEnvVariables(ctx, "usr", "1", "e", opts)
+		got, resp, err := client.Actions.ListEnvVariables(ctx, "o", "r", "e", opts)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -608,13 +600,13 @@ func TestActionsService_GetEnvVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/usr/1/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"name":"variable","value":"VAR","created_at":`+refTimeStr(1136178000)+`,"updated_at":`+refTimeStr(1136178001)+`}`)
 	})
 
 	ctx := t.Context()
-	variable, _, err := client.Actions.GetEnvVariable(ctx, "usr", "1", "e", "variable")
+	variable, _, err := client.Actions.GetEnvVariable(ctx, "o", "r", "e", "variable")
 	if err != nil {
 		t.Errorf("Actions.GetEnvVariable returned error: %v", err)
 	}
@@ -631,12 +623,12 @@ func TestActionsService_GetEnvVariable(t *testing.T) {
 
 	const methodName = "GetEnvVariable"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Actions.GetEnvVariable(ctx, "usr", "0", "\n", "\n")
+		_, _, err = client.Actions.GetEnvVariable(ctx, "\n", "\n", "\n", "\n")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Actions.GetEnvVariable(ctx, "usr", "1", "e", "variable")
+		got, resp, err := client.Actions.GetEnvVariable(ctx, "o", "r", "e", "variable")
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -648,12 +640,12 @@ func TestActionsService_CreateEnvVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &ActionsVariable{
+	input := ActionsVariableRequest{
 		Name:  "variable",
 		Value: "VAR",
 	}
 
-	mux.HandleFunc("/repos/usr/1/environments/e/variables", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/environments/e/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testHeader(t, r, "Content-Type", "application/json")
 		testJSONBody(t, r, input)
@@ -661,19 +653,19 @@ func TestActionsService_CreateEnvVariable(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	_, err := client.Actions.CreateEnvVariable(ctx, "usr", "1", "e", input)
+	_, err := client.Actions.CreateEnvVariable(ctx, "o", "r", "e", input)
 	if err != nil {
 		t.Errorf("Actions.CreateEnvVariable returned error: %v", err)
 	}
 
 	const methodName = "CreateEnvVariable"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.CreateEnvVariable(ctx, "usr", "0", "\n", input)
+		_, err = client.Actions.CreateEnvVariable(ctx, "\n", "\n", "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.CreateEnvVariable(ctx, "usr", "1", "e", input)
+		return client.Actions.CreateEnvVariable(ctx, "o", "r", "e", input)
 	})
 }
 
@@ -681,12 +673,12 @@ func TestActionsService_UpdateEnvVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &ActionsVariable{
+	input := ActionsVariableRequest{
 		Name:  "variable",
 		Value: "VAR",
 	}
 
-	mux.HandleFunc("/repos/usr/1/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/environments/e/variables/variable", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
 		testHeader(t, r, "Content-Type", "application/json")
 		testJSONBody(t, r, input)
@@ -694,23 +686,19 @@ func TestActionsService_UpdateEnvVariable(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	_, err := client.Actions.UpdateEnvVariable(ctx, "usr", "1", "e", input)
+	_, err := client.Actions.UpdateEnvVariable(ctx, "o", "r", "e", input.Name, input)
 	if err != nil {
 		t.Errorf("Actions.UpdateEnvVariable returned error: %v", err)
 	}
 
 	const methodName = "UpdateEnvVariable"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.UpdateEnvVariable(ctx, "usr", "1", "e", nil)
-		return err
-	})
-	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.UpdateEnvVariable(ctx, "usr", "1", "\n", input)
+		_, err = client.Actions.UpdateEnvVariable(ctx, "\n", "\n", "\n", "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.UpdateEnvVariable(ctx, "usr", "1", "e", input)
+		return client.Actions.UpdateEnvVariable(ctx, "o", "r", "e", input.Name, input)
 	})
 }
 
@@ -718,23 +706,23 @@ func TestActionsService_DeleteEnvVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/repos/usr/1/environments/e/variables/variable", func(_ http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r/environments/e/variables/variable", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
 	ctx := t.Context()
-	_, err := client.Actions.DeleteEnvVariable(ctx, "usr", "1", "e", "variable")
+	_, err := client.Actions.DeleteEnvVariable(ctx, "o", "r", "e", "variable")
 	if err != nil {
 		t.Errorf("Actions.DeleteEnvVariable returned error: %v", err)
 	}
 
 	const methodName = "DeleteEnvVariable"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.DeleteEnvVariable(ctx, "usr", "0", "\n", "\n")
+		_, err = client.Actions.DeleteEnvVariable(ctx, "\n", "\n", "\n", "\n")
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.DeleteEnvVariable(ctx, "usr", "1", "r", "variable")
+		return client.Actions.DeleteEnvVariable(ctx, "o", "r", "e", "variable")
 	})
 }

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -510,20 +510,20 @@ func (a *ActionsVariables) GetVariables() []*ActionsVariable {
 	return a.Variables
 }
 
-// GetName returns the Name field.
+// GetName returns the Name field if it's non-nil, zero value otherwise.
 func (a *ActionsVariableUpdateRequest) GetName() string {
-	if a == nil {
+	if a == nil || a.Name == nil {
 		return ""
 	}
-	return a.Name
+	return *a.Name
 }
 
-// GetValue returns the Value field.
+// GetValue returns the Value field if it's non-nil, zero value otherwise.
 func (a *ActionsVariableUpdateRequest) GetValue() string {
-	if a == nil {
+	if a == nil || a.Value == nil {
 		return ""
 	}
-	return a.Value
+	return *a.Value
 }
 
 // GetMaximumAdvancedSecurityCommitters returns the MaximumAdvancedSecurityCommitters field if it's non-nil, zero value otherwise.
@@ -25158,12 +25158,12 @@ func (o *OrgActionsVariableCreateRequest) GetVisibility() string {
 	return o.Visibility
 }
 
-// GetName returns the Name field.
+// GetName returns the Name field if it's non-nil, zero value otherwise.
 func (o *OrgActionsVariableUpdateRequest) GetName() string {
-	if o == nil {
+	if o == nil || o.Name == nil {
 		return ""
 	}
-	return o.Name
+	return *o.Name
 }
 
 // GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
@@ -25174,20 +25174,20 @@ func (o *OrgActionsVariableUpdateRequest) GetSelectedRepositoryIDs() []int64 {
 	return o.SelectedRepositoryIDs
 }
 
-// GetValue returns the Value field.
+// GetValue returns the Value field if it's non-nil, zero value otherwise.
 func (o *OrgActionsVariableUpdateRequest) GetValue() string {
-	if o == nil {
+	if o == nil || o.Value == nil {
 		return ""
 	}
-	return o.Value
+	return *o.Value
 }
 
-// GetVisibility returns the Visibility field.
+// GetVisibility returns the Visibility field if it's non-nil, zero value otherwise.
 func (o *OrgActionsVariableUpdateRequest) GetVisibility() string {
-	if o == nil {
+	if o == nil || o.Visibility == nil {
 		return ""
 	}
-	return o.Visibility
+	return *o.Visibility
 }
 
 // GetAdvancedSecurityEnabledForNewRepos returns the AdvancedSecurityEnabledForNewRepos field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -454,14 +454,6 @@ func (a *ActionsVariable) GetSelectedRepositoriesURL() string {
 	return *a.SelectedRepositoriesURL
 }
 
-// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs field.
-func (a *ActionsVariable) GetSelectedRepositoryIDs() *SelectedRepoIDs {
-	if a == nil {
-		return nil
-	}
-	return a.SelectedRepositoryIDs
-}
-
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (a *ActionsVariable) GetUpdatedAt() Timestamp {
 	if a == nil || a.UpdatedAt == nil {
@@ -484,6 +476,22 @@ func (a *ActionsVariable) GetVisibility() string {
 		return ""
 	}
 	return *a.Visibility
+}
+
+// GetName returns the Name field.
+func (a *ActionsVariableRequest) GetName() string {
+	if a == nil {
+		return ""
+	}
+	return a.Name
+}
+
+// GetValue returns the Value field.
+func (a *ActionsVariableRequest) GetValue() string {
+	if a == nil {
+		return ""
+	}
+	return a.Value
 }
 
 // GetTotalCount returns the TotalCount field.
@@ -25100,6 +25108,38 @@ func (o *OIDCSubjectClaimCustomTemplate) GetUseDefault() bool {
 		return false
 	}
 	return *o.UseDefault
+}
+
+// GetName returns the Name field.
+func (o *OrgActionsVariableRequest) GetName() string {
+	if o == nil {
+		return ""
+	}
+	return o.Name
+}
+
+// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
+func (o *OrgActionsVariableRequest) GetSelectedRepositoryIDs() []int64 {
+	if o == nil || o.SelectedRepositoryIDs == nil {
+		return nil
+	}
+	return o.SelectedRepositoryIDs
+}
+
+// GetValue returns the Value field.
+func (o *OrgActionsVariableRequest) GetValue() string {
+	if o == nil {
+		return ""
+	}
+	return o.Value
+}
+
+// GetVisibility returns the Visibility field.
+func (o *OrgActionsVariableRequest) GetVisibility() string {
+	if o == nil {
+		return ""
+	}
+	return o.Visibility
 }
 
 // GetAdvancedSecurityEnabledForNewRepos returns the AdvancedSecurityEnabledForNewRepos field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -479,7 +479,7 @@ func (a *ActionsVariable) GetVisibility() string {
 }
 
 // GetName returns the Name field.
-func (a *ActionsVariableRequest) GetName() string {
+func (a *ActionsVariableCreateRequest) GetName() string {
 	if a == nil {
 		return ""
 	}
@@ -487,7 +487,7 @@ func (a *ActionsVariableRequest) GetName() string {
 }
 
 // GetValue returns the Value field.
-func (a *ActionsVariableRequest) GetValue() string {
+func (a *ActionsVariableCreateRequest) GetValue() string {
 	if a == nil {
 		return ""
 	}
@@ -508,6 +508,22 @@ func (a *ActionsVariables) GetVariables() []*ActionsVariable {
 		return nil
 	}
 	return a.Variables
+}
+
+// GetName returns the Name field.
+func (a *ActionsVariableUpdateRequest) GetName() string {
+	if a == nil {
+		return ""
+	}
+	return a.Name
+}
+
+// GetValue returns the Value field.
+func (a *ActionsVariableUpdateRequest) GetValue() string {
+	if a == nil {
+		return ""
+	}
+	return a.Value
 }
 
 // GetMaximumAdvancedSecurityCommitters returns the MaximumAdvancedSecurityCommitters field if it's non-nil, zero value otherwise.
@@ -25111,7 +25127,7 @@ func (o *OIDCSubjectClaimCustomTemplate) GetUseDefault() bool {
 }
 
 // GetName returns the Name field.
-func (o *OrgActionsVariableRequest) GetName() string {
+func (o *OrgActionsVariableCreateRequest) GetName() string {
 	if o == nil {
 		return ""
 	}
@@ -25119,7 +25135,7 @@ func (o *OrgActionsVariableRequest) GetName() string {
 }
 
 // GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
-func (o *OrgActionsVariableRequest) GetSelectedRepositoryIDs() []int64 {
+func (o *OrgActionsVariableCreateRequest) GetSelectedRepositoryIDs() []int64 {
 	if o == nil || o.SelectedRepositoryIDs == nil {
 		return nil
 	}
@@ -25127,7 +25143,7 @@ func (o *OrgActionsVariableRequest) GetSelectedRepositoryIDs() []int64 {
 }
 
 // GetValue returns the Value field.
-func (o *OrgActionsVariableRequest) GetValue() string {
+func (o *OrgActionsVariableCreateRequest) GetValue() string {
 	if o == nil {
 		return ""
 	}
@@ -25135,7 +25151,39 @@ func (o *OrgActionsVariableRequest) GetValue() string {
 }
 
 // GetVisibility returns the Visibility field.
-func (o *OrgActionsVariableRequest) GetVisibility() string {
+func (o *OrgActionsVariableCreateRequest) GetVisibility() string {
+	if o == nil {
+		return ""
+	}
+	return o.Visibility
+}
+
+// GetName returns the Name field.
+func (o *OrgActionsVariableUpdateRequest) GetName() string {
+	if o == nil {
+		return ""
+	}
+	return o.Name
+}
+
+// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
+func (o *OrgActionsVariableUpdateRequest) GetSelectedRepositoryIDs() []int64 {
+	if o == nil || o.SelectedRepositoryIDs == nil {
+		return nil
+	}
+	return o.SelectedRepositoryIDs
+}
+
+// GetValue returns the Value field.
+func (o *OrgActionsVariableUpdateRequest) GetValue() string {
+	if o == nil {
+		return ""
+	}
+	return o.Value
+}
+
+// GetVisibility returns the Visibility field.
+func (o *OrgActionsVariableUpdateRequest) GetVisibility() string {
 	if o == nil {
 		return ""
 	}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -578,14 +578,6 @@ func TestActionsVariable_GetSelectedRepositoriesURL(tt *testing.T) {
 	a.GetSelectedRepositoriesURL()
 }
 
-func TestActionsVariable_GetSelectedRepositoryIDs(tt *testing.T) {
-	tt.Parallel()
-	a := &ActionsVariable{}
-	a.GetSelectedRepositoryIDs()
-	a = nil
-	a.GetSelectedRepositoryIDs()
-}
-
 func TestActionsVariable_GetUpdatedAt(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp
@@ -614,6 +606,22 @@ func TestActionsVariable_GetVisibility(tt *testing.T) {
 	a.GetVisibility()
 	a = nil
 	a.GetVisibility()
+}
+
+func TestActionsVariableRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	a := &ActionsVariableRequest{}
+	a.GetName()
+	a = nil
+	a.GetName()
+}
+
+func TestActionsVariableRequest_GetValue(tt *testing.T) {
+	tt.Parallel()
+	a := &ActionsVariableRequest{}
+	a.GetValue()
+	a = nil
+	a.GetValue()
 }
 
 func TestActionsVariables_GetTotalCount(tt *testing.T) {
@@ -31512,6 +31520,41 @@ func TestOIDCSubjectClaimCustomTemplate_GetUseDefault(tt *testing.T) {
 	o.GetUseDefault()
 	o = nil
 	o.GetUseDefault()
+}
+
+func TestOrgActionsVariableRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	o := &OrgActionsVariableRequest{}
+	o.GetName()
+	o = nil
+	o.GetName()
+}
+
+func TestOrgActionsVariableRequest_GetSelectedRepositoryIDs(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []int64{}
+	o := &OrgActionsVariableRequest{SelectedRepositoryIDs: zeroValue}
+	o.GetSelectedRepositoryIDs()
+	o = &OrgActionsVariableRequest{}
+	o.GetSelectedRepositoryIDs()
+	o = nil
+	o.GetSelectedRepositoryIDs()
+}
+
+func TestOrgActionsVariableRequest_GetValue(tt *testing.T) {
+	tt.Parallel()
+	o := &OrgActionsVariableRequest{}
+	o.GetValue()
+	o = nil
+	o.GetValue()
+}
+
+func TestOrgActionsVariableRequest_GetVisibility(tt *testing.T) {
+	tt.Parallel()
+	o := &OrgActionsVariableRequest{}
+	o.GetVisibility()
+	o = nil
+	o.GetVisibility()
 }
 
 func TestOrganization_GetAdvancedSecurityEnabledForNewRepos(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -645,7 +645,10 @@ func TestActionsVariables_GetVariables(tt *testing.T) {
 
 func TestActionsVariableUpdateRequest_GetName(tt *testing.T) {
 	tt.Parallel()
-	a := &ActionsVariableUpdateRequest{}
+	var zeroValue string
+	a := &ActionsVariableUpdateRequest{Name: &zeroValue}
+	a.GetName()
+	a = &ActionsVariableUpdateRequest{}
 	a.GetName()
 	a = nil
 	a.GetName()
@@ -653,7 +656,10 @@ func TestActionsVariableUpdateRequest_GetName(tt *testing.T) {
 
 func TestActionsVariableUpdateRequest_GetValue(tt *testing.T) {
 	tt.Parallel()
-	a := &ActionsVariableUpdateRequest{}
+	var zeroValue string
+	a := &ActionsVariableUpdateRequest{Value: &zeroValue}
+	a.GetValue()
+	a = &ActionsVariableUpdateRequest{}
 	a.GetValue()
 	a = nil
 	a.GetValue()
@@ -31575,7 +31581,10 @@ func TestOrgActionsVariableCreateRequest_GetVisibility(tt *testing.T) {
 
 func TestOrgActionsVariableUpdateRequest_GetName(tt *testing.T) {
 	tt.Parallel()
-	o := &OrgActionsVariableUpdateRequest{}
+	var zeroValue string
+	o := &OrgActionsVariableUpdateRequest{Name: &zeroValue}
+	o.GetName()
+	o = &OrgActionsVariableUpdateRequest{}
 	o.GetName()
 	o = nil
 	o.GetName()
@@ -31594,7 +31603,10 @@ func TestOrgActionsVariableUpdateRequest_GetSelectedRepositoryIDs(tt *testing.T)
 
 func TestOrgActionsVariableUpdateRequest_GetValue(tt *testing.T) {
 	tt.Parallel()
-	o := &OrgActionsVariableUpdateRequest{}
+	var zeroValue string
+	o := &OrgActionsVariableUpdateRequest{Value: &zeroValue}
+	o.GetValue()
+	o = &OrgActionsVariableUpdateRequest{}
 	o.GetValue()
 	o = nil
 	o.GetValue()
@@ -31602,7 +31614,10 @@ func TestOrgActionsVariableUpdateRequest_GetValue(tt *testing.T) {
 
 func TestOrgActionsVariableUpdateRequest_GetVisibility(tt *testing.T) {
 	tt.Parallel()
-	o := &OrgActionsVariableUpdateRequest{}
+	var zeroValue string
+	o := &OrgActionsVariableUpdateRequest{Visibility: &zeroValue}
+	o.GetVisibility()
+	o = &OrgActionsVariableUpdateRequest{}
 	o.GetVisibility()
 	o = nil
 	o.GetVisibility()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -608,17 +608,17 @@ func TestActionsVariable_GetVisibility(tt *testing.T) {
 	a.GetVisibility()
 }
 
-func TestActionsVariableRequest_GetName(tt *testing.T) {
+func TestActionsVariableCreateRequest_GetName(tt *testing.T) {
 	tt.Parallel()
-	a := &ActionsVariableRequest{}
+	a := &ActionsVariableCreateRequest{}
 	a.GetName()
 	a = nil
 	a.GetName()
 }
 
-func TestActionsVariableRequest_GetValue(tt *testing.T) {
+func TestActionsVariableCreateRequest_GetValue(tt *testing.T) {
 	tt.Parallel()
-	a := &ActionsVariableRequest{}
+	a := &ActionsVariableCreateRequest{}
 	a.GetValue()
 	a = nil
 	a.GetValue()
@@ -641,6 +641,22 @@ func TestActionsVariables_GetVariables(tt *testing.T) {
 	a.GetVariables()
 	a = nil
 	a.GetVariables()
+}
+
+func TestActionsVariableUpdateRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	a := &ActionsVariableUpdateRequest{}
+	a.GetName()
+	a = nil
+	a.GetName()
+}
+
+func TestActionsVariableUpdateRequest_GetValue(tt *testing.T) {
+	tt.Parallel()
+	a := &ActionsVariableUpdateRequest{}
+	a.GetValue()
+	a = nil
+	a.GetValue()
 }
 
 func TestActiveCommitters_GetMaximumAdvancedSecurityCommitters(tt *testing.T) {
@@ -31522,36 +31538,71 @@ func TestOIDCSubjectClaimCustomTemplate_GetUseDefault(tt *testing.T) {
 	o.GetUseDefault()
 }
 
-func TestOrgActionsVariableRequest_GetName(tt *testing.T) {
+func TestOrgActionsVariableCreateRequest_GetName(tt *testing.T) {
 	tt.Parallel()
-	o := &OrgActionsVariableRequest{}
+	o := &OrgActionsVariableCreateRequest{}
 	o.GetName()
 	o = nil
 	o.GetName()
 }
 
-func TestOrgActionsVariableRequest_GetSelectedRepositoryIDs(tt *testing.T) {
+func TestOrgActionsVariableCreateRequest_GetSelectedRepositoryIDs(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []int64{}
-	o := &OrgActionsVariableRequest{SelectedRepositoryIDs: zeroValue}
+	o := &OrgActionsVariableCreateRequest{SelectedRepositoryIDs: zeroValue}
 	o.GetSelectedRepositoryIDs()
-	o = &OrgActionsVariableRequest{}
+	o = &OrgActionsVariableCreateRequest{}
 	o.GetSelectedRepositoryIDs()
 	o = nil
 	o.GetSelectedRepositoryIDs()
 }
 
-func TestOrgActionsVariableRequest_GetValue(tt *testing.T) {
+func TestOrgActionsVariableCreateRequest_GetValue(tt *testing.T) {
 	tt.Parallel()
-	o := &OrgActionsVariableRequest{}
+	o := &OrgActionsVariableCreateRequest{}
 	o.GetValue()
 	o = nil
 	o.GetValue()
 }
 
-func TestOrgActionsVariableRequest_GetVisibility(tt *testing.T) {
+func TestOrgActionsVariableCreateRequest_GetVisibility(tt *testing.T) {
 	tt.Parallel()
-	o := &OrgActionsVariableRequest{}
+	o := &OrgActionsVariableCreateRequest{}
+	o.GetVisibility()
+	o = nil
+	o.GetVisibility()
+}
+
+func TestOrgActionsVariableUpdateRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	o := &OrgActionsVariableUpdateRequest{}
+	o.GetName()
+	o = nil
+	o.GetName()
+}
+
+func TestOrgActionsVariableUpdateRequest_GetSelectedRepositoryIDs(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []int64{}
+	o := &OrgActionsVariableUpdateRequest{SelectedRepositoryIDs: zeroValue}
+	o.GetSelectedRepositoryIDs()
+	o = &OrgActionsVariableUpdateRequest{}
+	o.GetSelectedRepositoryIDs()
+	o = nil
+	o.GetSelectedRepositoryIDs()
+}
+
+func TestOrgActionsVariableUpdateRequest_GetValue(tt *testing.T) {
+	tt.Parallel()
+	o := &OrgActionsVariableUpdateRequest{}
+	o.GetValue()
+	o = nil
+	o.GetValue()
+}
+
+func TestOrgActionsVariableUpdateRequest_GetVisibility(tt *testing.T) {
+	tt.Parallel()
+	o := &OrgActionsVariableUpdateRequest{}
 	o.GetVisibility()
 	o = nil
 	o.GetVisibility()


### PR DESCRIPTION
BREAKING CHANGE: `ActionsService` methods involving variables have new params and return values.

This PR updates the actions variable create & update functions to use a value parameter (see https://github.com/google/go-github/issues/3644). This aligns actions variables with the changes made to actions secrets in #4335.