### PR TITLE
feat: Add user team membership fields

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -43158,6 +43158,14 @@ func (u *User) GetID() int64 {
 	return *u.ID
 }
 
+// GetInherited returns the Inherited field if it's non-nil, zero value otherwise.
+func (u *User) GetInherited() bool {
+	if u == nil || u.Inherited == nil {
+		return false
+	}
+	return *u.Inherited
+}
+
 // GetInheritedFrom returns the InheritedFrom slice if it's non-nil, nil otherwise.
 func (u *User) GetInheritedFrom() []*Team {
 	if u == nil || u.InheritedFrom == nil {
@@ -43284,6 +43292,14 @@ func (u *User) GetReposURL() string {
 		return ""
 	}
 	return *u.ReposURL
+}
+
+// GetRole returns the Role field if it's non-nil, zero value otherwise.
+func (u *User) GetRole() string {
+	if u == nil || u.Role == nil {
+		return ""
+	}
+	return *u.Role
 }
 
 // GetRoleName returns the RoleName field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -54148,6 +54148,17 @@ func TestUser_GetID(tt *testing.T) {
 	u.GetID()
 }
 
+func TestUser_GetInherited(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	u := &User{Inherited: &zeroValue}
+	u.GetInherited()
+	u = &User{}
+	u.GetInherited()
+	u = nil
+	u.GetInherited()
+}
+
 func TestUser_GetInheritedFrom(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []*Team{}
@@ -54316,6 +54327,17 @@ func TestUser_GetReposURL(tt *testing.T) {
 	u.GetReposURL()
 	u = nil
 	u.GetReposURL()
+}
+
+func TestUser_GetRole(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &User{Role: &zeroValue}
+	u.GetRole()
+	u = &User{}
+	u.GetRole()
+	u = nil
+	u.GetRole()
 }
 
 func TestUser_GetRoleName(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -2444,8 +2444,10 @@ func TestUser_String(t *testing.T) {
 		Permissions:             &RepositoryPermissions{},
 		RoleName:                Ptr(""),
 		Assignment:              Ptr(""),
+		Role:                    Ptr(""),
+		Inherited:               Ptr(false),
 	}
-	want := `github.User{Login:"", ID:0, UserViewType:"", NodeID:"", AvatarURL:"", HTMLURL:"", GravatarID:"", Name:"", Company:"", Blog:"", Location:"", Email:"", NotificationEmail:"", Hireable:false, Bio:"", TwitterUsername:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, SuspendedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Type:"", SiteAdmin:false, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, TwoFactorAuthentication:false, Plan:github.Plan{}, BusinessPlus:false, LdapDn:"", URL:"", EventsURL:"", FollowingURL:"", FollowersURL:"", GistsURL:"", OrganizationsURL:"", ReceivedEventsURL:"", ReposURL:"", StarredURL:"", SubscriptionsURL:"", Permissions:github.RepositoryPermissions{}, RoleName:"", Assignment:""}`
+	want := `github.User{Login:"", ID:0, UserViewType:"", NodeID:"", AvatarURL:"", HTMLURL:"", GravatarID:"", Name:"", Company:"", Blog:"", Location:"", Email:"", NotificationEmail:"", Hireable:false, Bio:"", TwitterUsername:"", PublicRepos:0, PublicGists:0, Followers:0, Following:0, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, SuspendedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Type:"", SiteAdmin:false, TotalPrivateRepos:0, OwnedPrivateRepos:0, PrivateGists:0, DiskUsage:0, Collaborators:0, TwoFactorAuthentication:false, Plan:github.Plan{}, BusinessPlus:false, LdapDn:"", URL:"", EventsURL:"", FollowingURL:"", FollowersURL:"", GistsURL:"", OrganizationsURL:"", ReceivedEventsURL:"", ReposURL:"", StarredURL:"", SubscriptionsURL:"", Permissions:github.RepositoryPermissions{}, RoleName:"", Assignment:"", Role:"", Inherited:false}`
 	if got := v.String(); got != want {
 		t.Errorf("User.String = %v, want %v", got, want)
 	}

--- a/github/users.go
+++ b/github/users.go
@@ -69,10 +69,14 @@ type User struct {
 	// See: search.go and https://docs.github.com/rest/search?apiVersion=2022-11-28#text-match-metadata
 	TextMatches []*TextMatch `json:"text_matches,omitempty"`
 
-	// Permissions and RoleName identify the permissions and role that a user has on a given
-	// repository. These are only populated when calling Repositories.ListCollaborators.
+	// Permissions identify the permissions that a user has on a given
+	// repository.
+	// This is only populated when calling [RepositoriesService.ListCollaborators].
 	Permissions *RepositoryPermissions `json:"permissions,omitempty"`
-	RoleName    *string                `json:"role_name,omitempty"`
+
+	// RoleName identifies the role that a user has on a given repository.
+	// This is only populated when calling [RepositoriesService.ListCollaborators].
+	RoleName *string `json:"role_name,omitempty"`
 
 	// Assignment identifies how a user was assigned to an organization role. Its
 	// possible values are: "direct", "indirect", "mixed". This is only populated when
@@ -81,6 +85,20 @@ type User struct {
 	// InheritedFrom identifies the team that a user inherited their organization role
 	// from. This is only populated when calling the ListUsersAssignedToOrgRole method.
 	InheritedFrom []*Team `json:"inherited_from,omitempty"`
+
+	// Role identifies the role that a user has on a given team.
+	// Its possible values are: "member", "maintainer".
+	// This is only populated when calling the
+	// [TeamsService.ListTeamMembersBySlug] or [TeamsService.ListTeamMembersByID]
+	// methods.
+	Role *string `json:"role,omitempty"`
+
+	// Inherited identifies whether a user inherited their team role from a child
+	// team.
+	// This is only populated when calling the
+	// [TeamsService.ListTeamMembersBySlug] or [TeamsService.ListTeamMembersByID]
+	// methods.
+	Inherited *bool `json:"inherited,omitempty"`
 }
 
 func (u User) String() string {


### PR DESCRIPTION
This PR adds support for the new `role` & `inherited` fields returned when getting team members.