### PR TITLE
feat!: Refactor dependabot secrets to pass request by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -411,8 +411,6 @@ linters:
             - CreateTag.Object # TODO: Git
             - CreateTag.Tag # TODO: Git
             - CreateTag.Type # TODO: Git
-            - DependabotEncryptedSecret.SelectedRepositoryIDs # TODO: Dependabot
-            - DependabotEncryptedSecret.Visibility # TODO: Dependabot
             - DeploymentRequest.RequiredContexts # TODO: Deployments
             - DismissalRestrictionsRequest.Apps # TODO: Repositories
             - DismissalRestrictionsRequest.Teams # TODO: Repositories

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,7 +64,7 @@ linters:
     goheader:
       values:
         regexp:
-          CopyrightDate: "Copyright \\d{4} "
+          CopyrightDate: 'Copyright \d{4} '
       template: |-
         {{CopyrightDate}}The go-github AUTHORS. All rights reserved.
 
@@ -521,16 +521,16 @@ linters:
       # Allow fmt.Print in examples, internal tools, and tests.
       - linters: [forbidigo]
         path: ^(example|tools|test|scrape)\/
-        text: "fmt\\.Print"
+        text: 'fmt\.Print'
 
       # We need to pass nil Context in order to test DoBare erroring on nil ctx.
       - linters: [staticcheck]
         path: _test\.go
-        text: "SA1012: do not pass a nil Context"
+        text: 'SA1012: do not pass a nil Context'
 
       # We need to use sha1 for validating signatures
       - linters: [gosec]
-        text: "G505: Blocklisted import crypto/sha1: weak cryptographic primitive"
+        text: 'G505: Blocklisted import crypto/sha1: weak cryptographic primitive'
 
       # This is adapted from golangci-lint's default exclusions. It disables linting for error checks on
       # os.RemoveAll, fmt.Fprint*, fmt.Scanf, and any function ending in "Close".
@@ -540,7 +540,7 @@ linters:
       # We don't care about gosec issues in examples or internal tools.
       - linters: [gosec]
         path: ^(example|tools)\/
-        text: "(G304|G703|G705|G706)"
+        text: '(G304|G703|G705|G706)'
 
       # We don't run parallel integration tests
       - linters: [paralleltest, tparallel]

--- a/github/actions_secrets.go
+++ b/github/actions_secrets.go
@@ -296,13 +296,13 @@ type EncryptedSecret struct {
 	SelectedRepositoryIDs SelectedRepoIDs `json:"selected_repository_ids,omitempty"`
 }
 
-// OrgSecretRequest represents a request to create or update a secret for an
+// SecretOrgRequest represents a request to create or update a secret for an
 // organization.
 //
 // The value of EncryptedValue must be your secret, encrypted with
 // LibSodium (see documentation here: https://libsodium.gitbook.io/doc/bindings_for_other_languages)
 // using the public key retrieved using the GetPublicKey method.
-type OrgSecretRequest struct {
+type SecretOrgRequest struct {
 	KeyID                 string  `json:"key_id"`
 	EncryptedValue        string  `json:"encrypted_value"`
 	Visibility            string  `json:"visibility"`
@@ -341,7 +341,7 @@ func (s *ActionsService) CreateOrUpdateRepoSecret(ctx context.Context, owner, re
 // GitHub API docs: https://docs.github.com/rest/actions/secrets?apiVersion=2022-11-28#create-or-update-an-organization-secret
 //
 //meta:operation PUT /orgs/{org}/actions/secrets/{secret_name}
-func (s *ActionsService) CreateOrUpdateOrgSecret(ctx context.Context, org, name string, body OrgSecretRequest) (*Response, error) {
+func (s *ActionsService) CreateOrUpdateOrgSecret(ctx context.Context, org, name string, body SecretOrgRequest) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/secrets/%v", org, name)
 
 	req, err := s.client.NewRequest(ctx, "PUT", u, body)

--- a/github/actions_secrets_test.go
+++ b/github/actions_secrets_test.go
@@ -472,7 +472,7 @@ func TestActionsService_CreateOrUpdateOrgSecret(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := OrgSecretRequest{
+	input := SecretOrgRequest{
 		KeyID:                 "1234",
 		EncryptedValue:        "QIv=",
 		Visibility:            "selected",
@@ -482,7 +482,7 @@ func TestActionsService_CreateOrUpdateOrgSecret(t *testing.T) {
 	mux.HandleFunc("/orgs/o/actions/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
-		want := OrgSecretRequest{
+		want := SecretOrgRequest{
 			KeyID:                 "1234",
 			EncryptedValue:        "QIv=",
 			Visibility:            "selected",

--- a/github/actions_variables.go
+++ b/github/actions_variables.go
@@ -11,34 +11,34 @@ import (
 	"fmt"
 )
 
-// OrgActionsVariableCreateRequest represents a request to create an
+// ActionsCreateOrgVariableRequest represents a request to create an
 // organization variable.
-type OrgActionsVariableCreateRequest struct {
+type ActionsCreateOrgVariableRequest struct {
 	Name                  string  `json:"name"`
 	Value                 string  `json:"value"`
 	Visibility            string  `json:"visibility"`
 	SelectedRepositoryIDs []int64 `json:"selected_repository_ids,omitzero"`
 }
 
-// OrgActionsVariableUpdateRequest represents a request to update an
+// ActionsUpdateOrgVariableRequest represents a request to update an
 // organization variable.
-type OrgActionsVariableUpdateRequest struct {
+type ActionsUpdateOrgVariableRequest struct {
 	Name                  *string `json:"name,omitempty"`
 	Value                 *string `json:"value,omitempty"`
 	Visibility            *string `json:"visibility,omitempty"`
 	SelectedRepositoryIDs []int64 `json:"selected_repository_ids,omitzero"`
 }
 
-// ActionsVariableCreateRequest represents a request to create a variable
+// ActionsCreateVariableRequest represents a request to create a variable
 // for a repository or repository environment variable.
-type ActionsVariableCreateRequest struct {
+type ActionsCreateVariableRequest struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
 }
 
-// ActionsVariableUpdateRequest represents a request to update a variable
+// ActionsUpdateVariableRequest represents a request to update a variable
 // for a repository or repository environment variable.
-type ActionsVariableUpdateRequest struct {
+type ActionsUpdateVariableRequest struct {
 	Name  *string `json:"name,omitempty"`
 	Value *string `json:"value,omitempty"`
 }
@@ -236,7 +236,7 @@ func (s *ActionsService) GetEnvVariable(ctx context.Context, owner, repo, env, v
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#create-a-repository-variable
 //
 //meta:operation POST /repos/{owner}/{repo}/actions/variables
-func (s *ActionsService) CreateRepoVariable(ctx context.Context, owner, repo string, body ActionsVariableCreateRequest) (*Response, error) {
+func (s *ActionsService) CreateRepoVariable(ctx context.Context, owner, repo string, body ActionsCreateVariableRequest) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/variables", owner, repo)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
@@ -252,7 +252,7 @@ func (s *ActionsService) CreateRepoVariable(ctx context.Context, owner, repo str
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#create-an-organization-variable
 //
 //meta:operation POST /orgs/{org}/actions/variables
-func (s *ActionsService) CreateOrgVariable(ctx context.Context, org string, body OrgActionsVariableCreateRequest) (*Response, error) {
+func (s *ActionsService) CreateOrgVariable(ctx context.Context, org string, body ActionsCreateOrgVariableRequest) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/variables", org)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
@@ -268,7 +268,7 @@ func (s *ActionsService) CreateOrgVariable(ctx context.Context, org string, body
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#create-an-environment-variable
 //
 //meta:operation POST /repos/{owner}/{repo}/environments/{environment_name}/variables
-func (s *ActionsService) CreateEnvVariable(ctx context.Context, owner, repo, env string, body ActionsVariableCreateRequest) (*Response, error) {
+func (s *ActionsService) CreateEnvVariable(ctx context.Context, owner, repo, env string, body ActionsCreateVariableRequest) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/variables", owner, repo, env)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
@@ -283,7 +283,7 @@ func (s *ActionsService) CreateEnvVariable(ctx context.Context, owner, repo, env
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#update-a-repository-variable
 //
 //meta:operation PATCH /repos/{owner}/{repo}/actions/variables/{name}
-func (s *ActionsService) UpdateRepoVariable(ctx context.Context, owner, repo, name string, body ActionsVariableUpdateRequest) (*Response, error) {
+func (s *ActionsService) UpdateRepoVariable(ctx context.Context, owner, repo, name string, body ActionsUpdateVariableRequest) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/variables/%v", owner, repo, name)
 
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
@@ -299,7 +299,7 @@ func (s *ActionsService) UpdateRepoVariable(ctx context.Context, owner, repo, na
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#update-an-organization-variable
 //
 //meta:operation PATCH /orgs/{org}/actions/variables/{name}
-func (s *ActionsService) UpdateOrgVariable(ctx context.Context, org, name string, body OrgActionsVariableUpdateRequest) (*Response, error) {
+func (s *ActionsService) UpdateOrgVariable(ctx context.Context, org, name string, body ActionsUpdateOrgVariableRequest) (*Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/variables/%v", org, name)
 
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
@@ -315,7 +315,7 @@ func (s *ActionsService) UpdateOrgVariable(ctx context.Context, org, name string
 // GitHub API docs: https://docs.github.com/rest/actions/variables?apiVersion=2022-11-28#update-an-environment-variable
 //
 //meta:operation PATCH /repos/{owner}/{repo}/environments/{environment_name}/variables/{name}
-func (s *ActionsService) UpdateEnvVariable(ctx context.Context, owner, repo, env, name string, body ActionsVariableUpdateRequest) (*Response, error) {
+func (s *ActionsService) UpdateEnvVariable(ctx context.Context, owner, repo, env, name string, body ActionsUpdateVariableRequest) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/variables/%v", owner, repo, env, name)
 
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)

--- a/github/actions_variables_test.go
+++ b/github/actions_variables_test.go
@@ -143,7 +143,7 @@ func TestActionsService_CreateRepoVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := ActionsVariableCreateRequest{
+	input := ActionsCreateVariableRequest{
 		Name:  "NAME",
 		Value: "VALUE",
 	}
@@ -177,7 +177,7 @@ func TestActionsService_UpdateRepoVariable(t *testing.T) {
 	client, mux, _ := setup(t)
 
 	name := "NAME"
-	input := ActionsVariableUpdateRequest{
+	input := ActionsUpdateVariableRequest{
 		Name:  &name,
 		Value: Ptr("VALUE"),
 	}
@@ -321,7 +321,7 @@ func TestActionsService_CreateOrgVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := OrgActionsVariableCreateRequest{
+	input := ActionsCreateOrgVariableRequest{
 		Name:                  "NAME",
 		Value:                 "VALUE",
 		Visibility:            "selected",
@@ -357,7 +357,7 @@ func TestActionsService_UpdateOrgVariable(t *testing.T) {
 	client, mux, _ := setup(t)
 
 	name := "NAME"
-	input := OrgActionsVariableUpdateRequest{
+	input := ActionsUpdateOrgVariableRequest{
 		Name:                  &name,
 		Value:                 Ptr("VALUE"),
 		Visibility:            Ptr("selected"),
@@ -642,7 +642,7 @@ func TestActionsService_CreateEnvVariable(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := ActionsVariableCreateRequest{
+	input := ActionsCreateVariableRequest{
 		Name:  "NAME",
 		Value: "VAR",
 	}
@@ -676,7 +676,7 @@ func TestActionsService_UpdateEnvVariable(t *testing.T) {
 	client, mux, _ := setup(t)
 
 	name := "NAME"
-	input := ActionsVariableUpdateRequest{
+	input := ActionsUpdateVariableRequest{
 		Name:  &name,
 		Value: Ptr("VAR"),
 	}

--- a/github/dependabot_secrets.go
+++ b/github/dependabot_secrets.go
@@ -7,12 +7,18 @@ package github
 
 import (
 	"context"
-	"errors"
 	"fmt"
 )
 
-func (s *DependabotService) getPublicKey(ctx context.Context, url string) (*PublicKey, *Response, error) {
-	req, err := s.client.NewRequest(ctx, "GET", url, nil)
+// GetRepoPublicKey gets a public key that should be used for Dependabot secret encryption.
+//
+// GitHub API docs: https://docs.github.com/rest/dependabot/secrets?apiVersion=2022-11-28#get-a-repository-public-key
+//
+//meta:operation GET /repos/{owner}/{repo}/dependabot/secrets/public-key
+func (s *DependabotService) GetRepoPublicKey(ctx context.Context, owner, repo string) (*PublicKey, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/dependabot/secrets/public-key", owner, repo)
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -26,28 +32,37 @@ func (s *DependabotService) getPublicKey(ctx context.Context, url string) (*Publ
 	return pubKey, resp, nil
 }
 
-// GetRepoPublicKey gets a public key that should be used for Dependabot secret encryption.
-//
-// GitHub API docs: https://docs.github.com/rest/dependabot/secrets?apiVersion=2022-11-28#get-a-repository-public-key
-//
-//meta:operation GET /repos/{owner}/{repo}/dependabot/secrets/public-key
-func (s *DependabotService) GetRepoPublicKey(ctx context.Context, owner, repo string) (*PublicKey, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/dependabot/secrets/public-key", owner, repo)
-	return s.getPublicKey(ctx, url)
-}
-
 // GetOrgPublicKey gets a public key that should be used for Dependabot secret encryption.
 //
 // GitHub API docs: https://docs.github.com/rest/dependabot/secrets?apiVersion=2022-11-28#get-an-organization-public-key
 //
 //meta:operation GET /orgs/{org}/dependabot/secrets/public-key
 func (s *DependabotService) GetOrgPublicKey(ctx context.Context, org string) (*PublicKey, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/public-key", org)
-	return s.getPublicKey(ctx, url)
+	u := fmt.Sprintf("orgs/%v/dependabot/secrets/public-key", org)
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var pubKey *PublicKey
+	resp, err := s.client.Do(req, &pubKey)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pubKey, resp, nil
 }
 
-func (s *DependabotService) listSecrets(ctx context.Context, url string, opts *ListOptions) (*Secrets, *Response, error) {
-	u, err := addOptions(url, opts)
+// ListRepoSecrets lists all Dependabot secrets available in a repository
+// without revealing their encrypted values.
+//
+// GitHub API docs: https://docs.github.com/rest/dependabot/secrets?apiVersion=2022-11-28#list-repository-secrets
+//
+//meta:operation GET /repos/{owner}/{repo}/dependabot/secrets
+func (s *DependabotService) ListRepoSecrets(ctx context.Context, owner, repo string, opts *ListOptions) (*Secrets, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/dependabot/secrets", owner, repo)
+	u, err := addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -66,17 +81,6 @@ func (s *DependabotService) listSecrets(ctx context.Context, url string, opts *L
 	return secrets, resp, nil
 }
 
-// ListRepoSecrets lists all Dependabot secrets available in a repository
-// without revealing their encrypted values.
-//
-// GitHub API docs: https://docs.github.com/rest/dependabot/secrets?apiVersion=2022-11-28#list-repository-secrets
-//
-//meta:operation GET /repos/{owner}/{repo}/dependabot/secrets
-func (s *DependabotService) ListRepoSecrets(ctx context.Context, owner, repo string, opts *ListOptions) (*Secrets, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/dependabot/secrets", owner, repo)
-	return s.listSecrets(ctx, url, opts)
-}
-
 // ListOrgSecrets lists all Dependabot secrets available in an organization
 // without revealing their encrypted values.
 //
@@ -84,12 +88,35 @@ func (s *DependabotService) ListRepoSecrets(ctx context.Context, owner, repo str
 //
 //meta:operation GET /orgs/{org}/dependabot/secrets
 func (s *DependabotService) ListOrgSecrets(ctx context.Context, org string, opts *ListOptions) (*Secrets, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets", org)
-	return s.listSecrets(ctx, url, opts)
+	u := fmt.Sprintf("orgs/%v/dependabot/secrets", org)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var secrets *Secrets
+	resp, err := s.client.Do(req, &secrets)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return secrets, resp, nil
 }
 
-func (s *DependabotService) getSecret(ctx context.Context, url string) (*Secret, *Response, error) {
-	req, err := s.client.NewRequest(ctx, "GET", url, nil)
+// GetRepoSecret gets a single repository Dependabot secret without revealing its encrypted value.
+//
+// GitHub API docs: https://docs.github.com/rest/dependabot/secrets?apiVersion=2022-11-28#get-a-repository-secret
+//
+//meta:operation GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name}
+func (s *DependabotService) GetRepoSecret(ctx context.Context, owner, repo, name string) (*Secret, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/dependabot/secrets/%v", owner, repo, name)
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -103,46 +130,26 @@ func (s *DependabotService) getSecret(ctx context.Context, url string) (*Secret,
 	return secret, resp, nil
 }
 
-// GetRepoSecret gets a single repository Dependabot secret without revealing its encrypted value.
-//
-// GitHub API docs: https://docs.github.com/rest/dependabot/secrets?apiVersion=2022-11-28#get-a-repository-secret
-//
-//meta:operation GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name}
-func (s *DependabotService) GetRepoSecret(ctx context.Context, owner, repo, name string) (*Secret, *Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/dependabot/secrets/%v", owner, repo, name)
-	return s.getSecret(ctx, url)
-}
-
 // GetOrgSecret gets a single organization Dependabot secret without revealing its encrypted value.
 //
 // GitHub API docs: https://docs.github.com/rest/dependabot/secrets?apiVersion=2022-11-28#get-an-organization-secret
 //
 //meta:operation GET /orgs/{org}/dependabot/secrets/{secret_name}
 func (s *DependabotService) GetOrgSecret(ctx context.Context, org, name string) (*Secret, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v", org, name)
-	return s.getSecret(ctx, url)
-}
+	u := fmt.Sprintf("orgs/%v/dependabot/secrets/%v", org, name)
 
-// DependabotEncryptedSecret represents a secret that is encrypted using a public key for Dependabot.
-//
-// The value of EncryptedValue must be your secret, encrypted with
-// LibSodium (see documentation here: https://libsodium.gitbook.io/doc/bindings_for_other_languages)
-// using the public key retrieved using the GetPublicKey method.
-type DependabotEncryptedSecret struct {
-	Name                  string                           `json:"-"`
-	KeyID                 string                           `json:"key_id"`
-	EncryptedValue        string                           `json:"encrypted_value"`
-	Visibility            string                           `json:"visibility,omitempty"`
-	SelectedRepositoryIDs DependabotSecretsSelectedRepoIDs `json:"selected_repository_ids,omitempty"`
-}
-
-func (s *DependabotService) putSecret(ctx context.Context, url string, body *DependabotEncryptedSecret) (*Response, error) {
-	req, err := s.client.NewRequest(ctx, "PUT", url, body)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return s.client.Do(req, nil)
+	var secret *Secret
+	resp, err := s.client.Do(req, &secret)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return secret, resp, nil
 }
 
 // CreateOrUpdateRepoSecret creates or updates a repository Dependabot secret with an encrypted value.
@@ -150,39 +157,10 @@ func (s *DependabotService) putSecret(ctx context.Context, url string, body *Dep
 // GitHub API docs: https://docs.github.com/rest/dependabot/secrets?apiVersion=2022-11-28#create-or-update-a-repository-secret
 //
 //meta:operation PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name}
-func (s *DependabotService) CreateOrUpdateRepoSecret(ctx context.Context, owner, repo string, eSecret *DependabotEncryptedSecret) (*Response, error) {
-	if eSecret == nil {
-		return nil, errors.New("dependabot encrypted secret must be provided")
-	}
+func (s *DependabotService) CreateOrUpdateRepoSecret(ctx context.Context, owner, repo, name string, body SecretRequest) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/dependabot/secrets/%v", owner, repo, name)
 
-	url := fmt.Sprintf("repos/%v/%v/dependabot/secrets/%v", owner, repo, eSecret.Name)
-	return s.putSecret(ctx, url, eSecret)
-}
-
-// CreateOrUpdateOrgSecret creates or updates an organization Dependabot secret with an encrypted value.
-//
-// GitHub API docs: https://docs.github.com/rest/dependabot/secrets?apiVersion=2022-11-28#create-or-update-an-organization-secret
-//
-//meta:operation PUT /orgs/{org}/dependabot/secrets/{secret_name}
-func (s *DependabotService) CreateOrUpdateOrgSecret(ctx context.Context, org string, eSecret *DependabotEncryptedSecret) (*Response, error) {
-	if eSecret == nil {
-		return nil, errors.New("dependabot encrypted secret must be provided")
-	}
-
-	repoIDs := make([]string, len(eSecret.SelectedRepositoryIDs))
-	for i, secret := range eSecret.SelectedRepositoryIDs {
-		repoIDs[i] = fmt.Sprintf("%v", secret)
-	}
-	params := struct {
-		*DependabotEncryptedSecret
-		SelectedRepositoryIDs []string `json:"selected_repository_ids,omitempty"`
-	}{
-		DependabotEncryptedSecret: eSecret,
-		SelectedRepositoryIDs:     repoIDs,
-	}
-
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v", org, eSecret.Name)
-	req, err := s.client.NewRequest(ctx, "PUT", url, params)
+	req, err := s.client.NewRequest(ctx, "PUT", u, body)
 	if err != nil {
 		return nil, err
 	}
@@ -190,8 +168,31 @@ func (s *DependabotService) CreateOrUpdateOrgSecret(ctx context.Context, org str
 	return s.client.Do(req, nil)
 }
 
-func (s *DependabotService) deleteSecret(ctx context.Context, url string) (*Response, error) {
-	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
+// CreateOrUpdateOrgSecret creates or updates an organization Dependabot secret with an encrypted value.
+//
+// GitHub API docs: https://docs.github.com/rest/dependabot/secrets?apiVersion=2022-11-28#create-or-update-an-organization-secret
+//
+//meta:operation PUT /orgs/{org}/dependabot/secrets/{secret_name}
+func (s *DependabotService) CreateOrUpdateOrgSecret(ctx context.Context, org, name string, body SecretOrgRequest) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/dependabot/secrets/%v", org, name)
+
+	var bodyOverride any = body
+	if len(body.SelectedRepositoryIDs) > 0 {
+		repoIDs := make([]string, len(body.SelectedRepositoryIDs))
+		for i, id := range body.SelectedRepositoryIDs {
+			repoIDs[i] = fmt.Sprintf("%v", id)
+		}
+
+		bodyOverride = struct {
+			SecretOrgRequest
+			SelectedRepositoryIDs []string `json:"selected_repository_ids,omitzero"`
+		}{
+			SecretOrgRequest:      body,
+			SelectedRepositoryIDs: repoIDs,
+		}
+	}
+
+	req, err := s.client.NewRequest(ctx, "PUT", u, bodyOverride)
 	if err != nil {
 		return nil, err
 	}
@@ -205,8 +206,14 @@ func (s *DependabotService) deleteSecret(ctx context.Context, url string) (*Resp
 //
 //meta:operation DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name}
 func (s *DependabotService) DeleteRepoSecret(ctx context.Context, owner, repo, name string) (*Response, error) {
-	url := fmt.Sprintf("repos/%v/%v/dependabot/secrets/%v", owner, repo, name)
-	return s.deleteSecret(ctx, url)
+	u := fmt.Sprintf("repos/%v/%v/dependabot/secrets/%v", owner, repo, name)
+
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }
 
 // DeleteOrgSecret deletes a Dependabot secret in an organization using the secret name.
@@ -215,8 +222,14 @@ func (s *DependabotService) DeleteRepoSecret(ctx context.Context, owner, repo, n
 //
 //meta:operation DELETE /orgs/{org}/dependabot/secrets/{secret_name}
 func (s *DependabotService) DeleteOrgSecret(ctx context.Context, org, name string) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v", org, name)
-	return s.deleteSecret(ctx, url)
+	u := fmt.Sprintf("orgs/%v/dependabot/secrets/%v", org, name)
+
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }
 
 // ListSelectedReposForOrgSecret lists all repositories that have access to a Dependabot secret.
@@ -225,8 +238,8 @@ func (s *DependabotService) DeleteOrgSecret(ctx context.Context, org, name strin
 //
 //meta:operation GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories
 func (s *DependabotService) ListSelectedReposForOrgSecret(ctx context.Context, org, name string, opts *ListOptions) (*SelectedReposList, *Response, error) {
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v/repositories", org, name)
-	u, err := addOptions(url, opts)
+	u := fmt.Sprintf("orgs/%v/dependabot/secrets/%v/repositories", org, name)
+	u, err := addOptions(u, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -245,21 +258,19 @@ func (s *DependabotService) ListSelectedReposForOrgSecret(ctx context.Context, o
 	return result, resp, nil
 }
 
-// DependabotSecretsSelectedRepoIDs are the repository IDs that have access to the dependabot secrets.
-type DependabotSecretsSelectedRepoIDs []int64
-
 // SetSelectedReposForOrgSecret sets the repositories that have access to a Dependabot secret.
 //
 // GitHub API docs: https://docs.github.com/rest/dependabot/secrets?apiVersion=2022-11-28#set-selected-repositories-for-an-organization-secret
 //
 //meta:operation PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories
-func (s *DependabotService) SetSelectedReposForOrgSecret(ctx context.Context, org, name string, ids DependabotSecretsSelectedRepoIDs) (*Response, error) {
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v/repositories", org, name)
+func (s *DependabotService) SetSelectedReposForOrgSecret(ctx context.Context, org, name string, ids []int64) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/dependabot/secrets/%v/repositories", org, name)
+
 	type repoIDs struct {
-		SelectedIDs DependabotSecretsSelectedRepoIDs `json:"selected_repository_ids"`
+		SelectedIDs []int64 `json:"selected_repository_ids"`
 	}
 
-	req, err := s.client.NewRequest(ctx, "PUT", url, repoIDs{SelectedIDs: ids})
+	req, err := s.client.NewRequest(ctx, "PUT", u, repoIDs{SelectedIDs: ids})
 	if err != nil {
 		return nil, err
 	}
@@ -272,16 +283,10 @@ func (s *DependabotService) SetSelectedReposForOrgSecret(ctx context.Context, or
 // GitHub API docs: https://docs.github.com/rest/dependabot/secrets?apiVersion=2022-11-28#add-selected-repository-to-an-organization-secret
 //
 //meta:operation PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}
-func (s *DependabotService) AddSelectedRepoToOrgSecret(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
-	if repo == nil {
-		return nil, errors.New("repository must be provided")
-	}
-	if repo.ID == nil {
-		return nil, errors.New("id must be provided")
-	}
+func (s *DependabotService) AddSelectedRepoToOrgSecret(ctx context.Context, org, name string, repoID int64) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/dependabot/secrets/%v/repositories/%v", org, name, repoID)
 
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v/repositories/%v", org, name, *repo.ID)
-	req, err := s.client.NewRequest(ctx, "PUT", url, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -294,16 +299,10 @@ func (s *DependabotService) AddSelectedRepoToOrgSecret(ctx context.Context, org,
 // GitHub API docs: https://docs.github.com/rest/dependabot/secrets?apiVersion=2022-11-28#remove-selected-repository-from-an-organization-secret
 //
 //meta:operation DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}
-func (s *DependabotService) RemoveSelectedRepoFromOrgSecret(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
-	if repo == nil {
-		return nil, errors.New("repository must be provided")
-	}
-	if repo.ID == nil {
-		return nil, errors.New("id must be provided")
-	}
+func (s *DependabotService) RemoveSelectedRepoFromOrgSecret(ctx context.Context, org, name string, repoID int64) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/dependabot/secrets/%v/repositories/%v", org, name, repoID)
 
-	url := fmt.Sprintf("orgs/%v/dependabot/secrets/%v/repositories/%v", org, name, *repo.ID)
-	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/github/dependabot_secrets_test.go
+++ b/github/dependabot_secrets_test.go
@@ -169,8 +169,7 @@ func TestDependabotService_CreateOrUpdateRepoSecret(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &DependabotEncryptedSecret{
-		Name:           "NAME",
+	input := SecretRequest{
 		EncryptedValue: "QIv=",
 		KeyID:          "1234",
 	}
@@ -178,7 +177,7 @@ func TestDependabotService_CreateOrUpdateRepoSecret(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/dependabot/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
-		want := DependabotEncryptedSecret{
+		want := SecretRequest{
 			EncryptedValue: input.EncryptedValue,
 			KeyID:          input.KeyID,
 		}
@@ -187,23 +186,19 @@ func TestDependabotService_CreateOrUpdateRepoSecret(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	_, err := client.Dependabot.CreateOrUpdateRepoSecret(ctx, "o", "r", input)
+	_, err := client.Dependabot.CreateOrUpdateRepoSecret(ctx, "o", "r", "NAME", input)
 	if err != nil {
 		t.Errorf("Dependabot.CreateOrUpdateRepoSecret returned error: %v", err)
 	}
 
 	const methodName = "CreateOrUpdateRepoSecret"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Dependabot.CreateOrUpdateRepoSecret(ctx, "o", "r", nil)
-		return err
-	})
-	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Dependabot.CreateOrUpdateRepoSecret(ctx, "\n", "\n", input)
+		_, err = client.Dependabot.CreateOrUpdateRepoSecret(ctx, "\n", "\n", "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Dependabot.CreateOrUpdateRepoSecret(ctx, "o", "r", input)
+		return client.Dependabot.CreateOrUpdateRepoSecret(ctx, "o", "r", "NAME", input)
 	})
 }
 
@@ -356,50 +351,45 @@ func TestDependabotService_CreateOrUpdateOrgSecret(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &DependabotEncryptedSecret{
-		Name:                  "NAME",
+	input := SecretOrgRequest{
 		EncryptedValue:        "QIv=",
 		KeyID:                 "1234",
 		Visibility:            "selected",
-		SelectedRepositoryIDs: DependabotSecretsSelectedRepoIDs{1296269, 1269280},
+		SelectedRepositoryIDs: []int64{1296269, 1269280},
 	}
 
 	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
-		want := DependabotEncryptedSecret{
+		want := SecretOrgRequest{
 			EncryptedValue: input.EncryptedValue,
 			KeyID:          input.KeyID,
 			Visibility:     input.Visibility,
 		}
 		testJSONBody(t, r, struct {
-			*DependabotEncryptedSecret
+			SecretOrgRequest
 			SelectedRepositoryIDs []string `json:"selected_repository_ids,omitempty"`
 		}{
-			DependabotEncryptedSecret: &want,
-			SelectedRepositoryIDs:     []string{"1296269", "1269280"},
+			SecretOrgRequest:      want,
+			SelectedRepositoryIDs: []string{"1296269", "1269280"},
 		})
 		w.WriteHeader(http.StatusCreated)
 	})
 
 	ctx := t.Context()
-	_, err := client.Dependabot.CreateOrUpdateOrgSecret(ctx, "o", input)
+	_, err := client.Dependabot.CreateOrUpdateOrgSecret(ctx, "o", "NAME", input)
 	if err != nil {
 		t.Errorf("Dependabot.CreateOrUpdateOrgSecret returned error: %v", err)
 	}
 
 	const methodName = "CreateOrUpdateOrgSecret"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Dependabot.CreateOrUpdateOrgSecret(ctx, "o", nil)
-		return err
-	})
-	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Dependabot.CreateOrUpdateOrgSecret(ctx, "\n", input)
+		_, err = client.Dependabot.CreateOrUpdateOrgSecret(ctx, "\n", "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Dependabot.CreateOrUpdateOrgSecret(ctx, "o", input)
+		return client.Dependabot.CreateOrUpdateOrgSecret(ctx, "o", "NAME", input)
 	})
 }
 
@@ -448,13 +438,13 @@ func TestDependabotService_SetSelectedReposForOrgSecret(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := DependabotSecretsSelectedRepoIDs{64780797}
+	input := []int64{64780797}
 
 	mux.HandleFunc("/orgs/o/dependabot/secrets/NAME/repositories", func(_ http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Content-Type", "application/json")
 		testJSONBody(t, r, struct {
-			SelectedIDs DependabotSecretsSelectedRepoIDs `json:"selected_repository_ids"`
+			SelectedIDs []int64 `json:"selected_repository_ids"`
 		}{
 			SelectedIDs: input,
 		})
@@ -485,29 +475,25 @@ func TestDependabotService_AddSelectedRepoToOrgSecret(t *testing.T) {
 		testMethod(t, r, "PUT")
 	})
 
-	repo := &Repository{ID: Ptr(int64(1234))}
+	repoID := int64(1234)
 	ctx := t.Context()
-	_, err := client.Dependabot.AddSelectedRepoToOrgSecret(ctx, "o", "NAME", repo)
+	_, err := client.Dependabot.AddSelectedRepoToOrgSecret(ctx, "o", "NAME", repoID)
 	if err != nil {
 		t.Errorf("Dependabot.AddSelectedRepoToOrgSecret returned error: %v", err)
 	}
 
 	const methodName = "AddSelectedRepoToOrgSecret"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Dependabot.AddSelectedRepoToOrgSecret(ctx, "o", "NAME", nil)
+		_, err = client.Dependabot.AddSelectedRepoToOrgSecret(ctx, "o", "NAME", 0)
 		return err
 	})
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Dependabot.AddSelectedRepoToOrgSecret(ctx, "o", "NAME", &Repository{ID: nil})
-		return err
-	})
-	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Dependabot.AddSelectedRepoToOrgSecret(ctx, "\n", "\n", repo)
+		_, err = client.Dependabot.AddSelectedRepoToOrgSecret(ctx, "\n", "\n", repoID)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Dependabot.AddSelectedRepoToOrgSecret(ctx, "o", "NAME", repo)
+		return client.Dependabot.AddSelectedRepoToOrgSecret(ctx, "o", "NAME", repoID)
 	})
 }
 
@@ -519,29 +505,25 @@ func TestDependabotService_RemoveSelectedRepoFromOrgSecret(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	repo := &Repository{ID: Ptr(int64(1234))}
+	repoID := int64(1234)
 	ctx := t.Context()
-	_, err := client.Dependabot.RemoveSelectedRepoFromOrgSecret(ctx, "o", "NAME", repo)
+	_, err := client.Dependabot.RemoveSelectedRepoFromOrgSecret(ctx, "o", "NAME", repoID)
 	if err != nil {
 		t.Errorf("Dependabot.RemoveSelectedRepoFromOrgSecret returned error: %v", err)
 	}
 
 	const methodName = "RemoveSelectedRepoFromOrgSecret"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Dependabot.RemoveSelectedRepoFromOrgSecret(ctx, "o", "NAME", nil)
+		_, err = client.Dependabot.RemoveSelectedRepoFromOrgSecret(ctx, "o", "NAME", 0)
 		return err
 	})
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Dependabot.RemoveSelectedRepoFromOrgSecret(ctx, "o", "NAME", &Repository{ID: nil})
-		return err
-	})
-	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Dependabot.RemoveSelectedRepoFromOrgSecret(ctx, "\n", "\n", repo)
+		_, err = client.Dependabot.RemoveSelectedRepoFromOrgSecret(ctx, "\n", "\n", repoID)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Dependabot.RemoveSelectedRepoFromOrgSecret(ctx, "o", "NAME", repo)
+		return client.Dependabot.RemoveSelectedRepoFromOrgSecret(ctx, "o", "NAME", repoID)
 	})
 }
 

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -294,6 +294,54 @@ func (a *ActionsCacheUsageList) GetTotalCount() int {
 	return a.TotalCount
 }
 
+// GetName returns the Name field.
+func (a *ActionsCreateOrgVariableRequest) GetName() string {
+	if a == nil {
+		return ""
+	}
+	return a.Name
+}
+
+// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
+func (a *ActionsCreateOrgVariableRequest) GetSelectedRepositoryIDs() []int64 {
+	if a == nil || a.SelectedRepositoryIDs == nil {
+		return nil
+	}
+	return a.SelectedRepositoryIDs
+}
+
+// GetValue returns the Value field.
+func (a *ActionsCreateOrgVariableRequest) GetValue() string {
+	if a == nil {
+		return ""
+	}
+	return a.Value
+}
+
+// GetVisibility returns the Visibility field.
+func (a *ActionsCreateOrgVariableRequest) GetVisibility() string {
+	if a == nil {
+		return ""
+	}
+	return a.Visibility
+}
+
+// GetName returns the Name field.
+func (a *ActionsCreateVariableRequest) GetName() string {
+	if a == nil {
+		return ""
+	}
+	return a.Name
+}
+
+// GetValue returns the Value field.
+func (a *ActionsCreateVariableRequest) GetValue() string {
+	if a == nil {
+		return ""
+	}
+	return a.Value
+}
+
 // GetOrganizations returns the Organizations slice if it's non-nil, nil otherwise.
 func (a *ActionsEnabledOnEnterpriseRepos) GetOrganizations() []*Organization {
 	if a == nil || a.Organizations == nil {
@@ -430,6 +478,54 @@ func (a *ActionsPermissionsRepository) GetSHAPinningRequired() bool {
 	return *a.SHAPinningRequired
 }
 
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (a *ActionsUpdateOrgVariableRequest) GetName() string {
+	if a == nil || a.Name == nil {
+		return ""
+	}
+	return *a.Name
+}
+
+// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
+func (a *ActionsUpdateOrgVariableRequest) GetSelectedRepositoryIDs() []int64 {
+	if a == nil || a.SelectedRepositoryIDs == nil {
+		return nil
+	}
+	return a.SelectedRepositoryIDs
+}
+
+// GetValue returns the Value field if it's non-nil, zero value otherwise.
+func (a *ActionsUpdateOrgVariableRequest) GetValue() string {
+	if a == nil || a.Value == nil {
+		return ""
+	}
+	return *a.Value
+}
+
+// GetVisibility returns the Visibility field if it's non-nil, zero value otherwise.
+func (a *ActionsUpdateOrgVariableRequest) GetVisibility() string {
+	if a == nil || a.Visibility == nil {
+		return ""
+	}
+	return *a.Visibility
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (a *ActionsUpdateVariableRequest) GetName() string {
+	if a == nil || a.Name == nil {
+		return ""
+	}
+	return *a.Name
+}
+
+// GetValue returns the Value field if it's non-nil, zero value otherwise.
+func (a *ActionsUpdateVariableRequest) GetValue() string {
+	if a == nil || a.Value == nil {
+		return ""
+	}
+	return *a.Value
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (a *ActionsVariable) GetCreatedAt() Timestamp {
 	if a == nil || a.CreatedAt == nil {
@@ -478,22 +574,6 @@ func (a *ActionsVariable) GetVisibility() string {
 	return *a.Visibility
 }
 
-// GetName returns the Name field.
-func (a *ActionsVariableCreateRequest) GetName() string {
-	if a == nil {
-		return ""
-	}
-	return a.Name
-}
-
-// GetValue returns the Value field.
-func (a *ActionsVariableCreateRequest) GetValue() string {
-	if a == nil {
-		return ""
-	}
-	return a.Value
-}
-
 // GetTotalCount returns the TotalCount field.
 func (a *ActionsVariables) GetTotalCount() int {
 	if a == nil {
@@ -508,22 +588,6 @@ func (a *ActionsVariables) GetVariables() []*ActionsVariable {
 		return nil
 	}
 	return a.Variables
-}
-
-// GetName returns the Name field if it's non-nil, zero value otherwise.
-func (a *ActionsVariableUpdateRequest) GetName() string {
-	if a == nil || a.Name == nil {
-		return ""
-	}
-	return *a.Name
-}
-
-// GetValue returns the Value field if it's non-nil, zero value otherwise.
-func (a *ActionsVariableUpdateRequest) GetValue() string {
-	if a == nil || a.Value == nil {
-		return ""
-	}
-	return *a.Value
 }
 
 // GetMaximumAdvancedSecurityCommitters returns the MaximumAdvancedSecurityCommitters field if it's non-nil, zero value otherwise.
@@ -12588,46 +12652,6 @@ func (d *DependabotAlertState) GetState() string {
 		return ""
 	}
 	return d.State
-}
-
-// GetEncryptedValue returns the EncryptedValue field.
-func (d *DependabotEncryptedSecret) GetEncryptedValue() string {
-	if d == nil {
-		return ""
-	}
-	return d.EncryptedValue
-}
-
-// GetKeyID returns the KeyID field.
-func (d *DependabotEncryptedSecret) GetKeyID() string {
-	if d == nil {
-		return ""
-	}
-	return d.KeyID
-}
-
-// GetName returns the Name field.
-func (d *DependabotEncryptedSecret) GetName() string {
-	if d == nil {
-		return ""
-	}
-	return d.Name
-}
-
-// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs field.
-func (d *DependabotEncryptedSecret) GetSelectedRepositoryIDs() DependabotSecretsSelectedRepoIDs {
-	if d == nil {
-		return nil
-	}
-	return d.SelectedRepositoryIDs
-}
-
-// GetVisibility returns the Visibility field.
-func (d *DependabotEncryptedSecret) GetVisibility() string {
-	if d == nil {
-		return ""
-	}
-	return d.Visibility
 }
 
 // GetCVEID returns the CVEID field if it's non-nil, zero value otherwise.
@@ -25142,70 +25166,6 @@ func (o *OIDCSubjectClaimCustomTemplate) GetUseImmutableSubject() bool {
 	return *o.UseImmutableSubject
 }
 
-// GetName returns the Name field.
-func (o *OrgActionsVariableCreateRequest) GetName() string {
-	if o == nil {
-		return ""
-	}
-	return o.Name
-}
-
-// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
-func (o *OrgActionsVariableCreateRequest) GetSelectedRepositoryIDs() []int64 {
-	if o == nil || o.SelectedRepositoryIDs == nil {
-		return nil
-	}
-	return o.SelectedRepositoryIDs
-}
-
-// GetValue returns the Value field.
-func (o *OrgActionsVariableCreateRequest) GetValue() string {
-	if o == nil {
-		return ""
-	}
-	return o.Value
-}
-
-// GetVisibility returns the Visibility field.
-func (o *OrgActionsVariableCreateRequest) GetVisibility() string {
-	if o == nil {
-		return ""
-	}
-	return o.Visibility
-}
-
-// GetName returns the Name field if it's non-nil, zero value otherwise.
-func (o *OrgActionsVariableUpdateRequest) GetName() string {
-	if o == nil || o.Name == nil {
-		return ""
-	}
-	return *o.Name
-}
-
-// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
-func (o *OrgActionsVariableUpdateRequest) GetSelectedRepositoryIDs() []int64 {
-	if o == nil || o.SelectedRepositoryIDs == nil {
-		return nil
-	}
-	return o.SelectedRepositoryIDs
-}
-
-// GetValue returns the Value field if it's non-nil, zero value otherwise.
-func (o *OrgActionsVariableUpdateRequest) GetValue() string {
-	if o == nil || o.Value == nil {
-		return ""
-	}
-	return *o.Value
-}
-
-// GetVisibility returns the Visibility field if it's non-nil, zero value otherwise.
-func (o *OrgActionsVariableUpdateRequest) GetVisibility() string {
-	if o == nil || o.Visibility == nil {
-		return ""
-	}
-	return *o.Visibility
-}
-
 // GetAdvancedSecurityEnabledForNewRepos returns the AdvancedSecurityEnabledForNewRepos field if it's non-nil, zero value otherwise.
 func (o *Organization) GetAdvancedSecurityEnabledForNewRepos() bool {
 	if o == nil || o.AdvancedSecurityEnabledForNewRepos == nil {
@@ -25932,38 +25892,6 @@ func (o *OrgBlockEvent) GetSender() *User {
 		return nil
 	}
 	return o.Sender
-}
-
-// GetEncryptedValue returns the EncryptedValue field.
-func (o *OrgSecretRequest) GetEncryptedValue() string {
-	if o == nil {
-		return ""
-	}
-	return o.EncryptedValue
-}
-
-// GetKeyID returns the KeyID field.
-func (o *OrgSecretRequest) GetKeyID() string {
-	if o == nil {
-		return ""
-	}
-	return o.KeyID
-}
-
-// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
-func (o *OrgSecretRequest) GetSelectedRepositoryIDs() []int64 {
-	if o == nil || o.SelectedRepositoryIDs == nil {
-		return nil
-	}
-	return o.SelectedRepositoryIDs
-}
-
-// GetVisibility returns the Visibility field.
-func (o *OrgSecretRequest) GetVisibility() string {
-	if o == nil {
-		return ""
-	}
-	return o.Visibility
 }
 
 // GetDisabledOrgs returns the DisabledOrgs field if it's non-nil, zero value otherwise.
@@ -38504,6 +38432,38 @@ func (s *Secret) GetUpdatedAt() Timestamp {
 
 // GetVisibility returns the Visibility field.
 func (s *Secret) GetVisibility() string {
+	if s == nil {
+		return ""
+	}
+	return s.Visibility
+}
+
+// GetEncryptedValue returns the EncryptedValue field.
+func (s *SecretOrgRequest) GetEncryptedValue() string {
+	if s == nil {
+		return ""
+	}
+	return s.EncryptedValue
+}
+
+// GetKeyID returns the KeyID field.
+func (s *SecretOrgRequest) GetKeyID() string {
+	if s == nil {
+		return ""
+	}
+	return s.KeyID
+}
+
+// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs slice if it's non-nil, nil otherwise.
+func (s *SecretOrgRequest) GetSelectedRepositoryIDs() []int64 {
+	if s == nil || s.SelectedRepositoryIDs == nil {
+		return nil
+	}
+	return s.SelectedRepositoryIDs
+}
+
+// GetVisibility returns the Visibility field.
+func (s *SecretOrgRequest) GetVisibility() string {
 	if s == nil {
 		return ""
 	}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -367,6 +367,57 @@ func TestActionsCacheUsageList_GetTotalCount(tt *testing.T) {
 	a.GetTotalCount()
 }
 
+func TestActionsCreateOrgVariableRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	a := &ActionsCreateOrgVariableRequest{}
+	a.GetName()
+	a = nil
+	a.GetName()
+}
+
+func TestActionsCreateOrgVariableRequest_GetSelectedRepositoryIDs(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []int64{}
+	a := &ActionsCreateOrgVariableRequest{SelectedRepositoryIDs: zeroValue}
+	a.GetSelectedRepositoryIDs()
+	a = &ActionsCreateOrgVariableRequest{}
+	a.GetSelectedRepositoryIDs()
+	a = nil
+	a.GetSelectedRepositoryIDs()
+}
+
+func TestActionsCreateOrgVariableRequest_GetValue(tt *testing.T) {
+	tt.Parallel()
+	a := &ActionsCreateOrgVariableRequest{}
+	a.GetValue()
+	a = nil
+	a.GetValue()
+}
+
+func TestActionsCreateOrgVariableRequest_GetVisibility(tt *testing.T) {
+	tt.Parallel()
+	a := &ActionsCreateOrgVariableRequest{}
+	a.GetVisibility()
+	a = nil
+	a.GetVisibility()
+}
+
+func TestActionsCreateVariableRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	a := &ActionsCreateVariableRequest{}
+	a.GetName()
+	a = nil
+	a.GetName()
+}
+
+func TestActionsCreateVariableRequest_GetValue(tt *testing.T) {
+	tt.Parallel()
+	a := &ActionsCreateVariableRequest{}
+	a.GetValue()
+	a = nil
+	a.GetValue()
+}
+
 func TestActionsEnabledOnEnterpriseRepos_GetOrganizations(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []*Organization{}
@@ -548,6 +599,72 @@ func TestActionsPermissionsRepository_GetSHAPinningRequired(tt *testing.T) {
 	a.GetSHAPinningRequired()
 }
 
+func TestActionsUpdateOrgVariableRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	a := &ActionsUpdateOrgVariableRequest{Name: &zeroValue}
+	a.GetName()
+	a = &ActionsUpdateOrgVariableRequest{}
+	a.GetName()
+	a = nil
+	a.GetName()
+}
+
+func TestActionsUpdateOrgVariableRequest_GetSelectedRepositoryIDs(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []int64{}
+	a := &ActionsUpdateOrgVariableRequest{SelectedRepositoryIDs: zeroValue}
+	a.GetSelectedRepositoryIDs()
+	a = &ActionsUpdateOrgVariableRequest{}
+	a.GetSelectedRepositoryIDs()
+	a = nil
+	a.GetSelectedRepositoryIDs()
+}
+
+func TestActionsUpdateOrgVariableRequest_GetValue(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	a := &ActionsUpdateOrgVariableRequest{Value: &zeroValue}
+	a.GetValue()
+	a = &ActionsUpdateOrgVariableRequest{}
+	a.GetValue()
+	a = nil
+	a.GetValue()
+}
+
+func TestActionsUpdateOrgVariableRequest_GetVisibility(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	a := &ActionsUpdateOrgVariableRequest{Visibility: &zeroValue}
+	a.GetVisibility()
+	a = &ActionsUpdateOrgVariableRequest{}
+	a.GetVisibility()
+	a = nil
+	a.GetVisibility()
+}
+
+func TestActionsUpdateVariableRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	a := &ActionsUpdateVariableRequest{Name: &zeroValue}
+	a.GetName()
+	a = &ActionsUpdateVariableRequest{}
+	a.GetName()
+	a = nil
+	a.GetName()
+}
+
+func TestActionsUpdateVariableRequest_GetValue(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	a := &ActionsUpdateVariableRequest{Value: &zeroValue}
+	a.GetValue()
+	a = &ActionsUpdateVariableRequest{}
+	a.GetValue()
+	a = nil
+	a.GetValue()
+}
+
 func TestActionsVariable_GetCreatedAt(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp
@@ -608,22 +725,6 @@ func TestActionsVariable_GetVisibility(tt *testing.T) {
 	a.GetVisibility()
 }
 
-func TestActionsVariableCreateRequest_GetName(tt *testing.T) {
-	tt.Parallel()
-	a := &ActionsVariableCreateRequest{}
-	a.GetName()
-	a = nil
-	a.GetName()
-}
-
-func TestActionsVariableCreateRequest_GetValue(tt *testing.T) {
-	tt.Parallel()
-	a := &ActionsVariableCreateRequest{}
-	a.GetValue()
-	a = nil
-	a.GetValue()
-}
-
 func TestActionsVariables_GetTotalCount(tt *testing.T) {
 	tt.Parallel()
 	a := &ActionsVariables{}
@@ -641,28 +742,6 @@ func TestActionsVariables_GetVariables(tt *testing.T) {
 	a.GetVariables()
 	a = nil
 	a.GetVariables()
-}
-
-func TestActionsVariableUpdateRequest_GetName(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	a := &ActionsVariableUpdateRequest{Name: &zeroValue}
-	a.GetName()
-	a = &ActionsVariableUpdateRequest{}
-	a.GetName()
-	a = nil
-	a.GetName()
-}
-
-func TestActionsVariableUpdateRequest_GetValue(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	a := &ActionsVariableUpdateRequest{Value: &zeroValue}
-	a.GetValue()
-	a = &ActionsVariableUpdateRequest{}
-	a.GetValue()
-	a = nil
-	a.GetValue()
 }
 
 func TestActiveCommitters_GetMaximumAdvancedSecurityCommitters(tt *testing.T) {
@@ -15952,46 +16031,6 @@ func TestDependabotAlertState_GetState(tt *testing.T) {
 	d.GetState()
 	d = nil
 	d.GetState()
-}
-
-func TestDependabotEncryptedSecret_GetEncryptedValue(tt *testing.T) {
-	tt.Parallel()
-	d := &DependabotEncryptedSecret{}
-	d.GetEncryptedValue()
-	d = nil
-	d.GetEncryptedValue()
-}
-
-func TestDependabotEncryptedSecret_GetKeyID(tt *testing.T) {
-	tt.Parallel()
-	d := &DependabotEncryptedSecret{}
-	d.GetKeyID()
-	d = nil
-	d.GetKeyID()
-}
-
-func TestDependabotEncryptedSecret_GetName(tt *testing.T) {
-	tt.Parallel()
-	d := &DependabotEncryptedSecret{}
-	d.GetName()
-	d = nil
-	d.GetName()
-}
-
-func TestDependabotEncryptedSecret_GetSelectedRepositoryIDs(tt *testing.T) {
-	tt.Parallel()
-	d := &DependabotEncryptedSecret{}
-	d.GetSelectedRepositoryIDs()
-	d = nil
-	d.GetSelectedRepositoryIDs()
-}
-
-func TestDependabotEncryptedSecret_GetVisibility(tt *testing.T) {
-	tt.Parallel()
-	d := &DependabotEncryptedSecret{}
-	d.GetVisibility()
-	d = nil
-	d.GetVisibility()
 }
 
 func TestDependabotSecurityAdvisory_GetCVEID(tt *testing.T) {
@@ -31566,85 +31605,6 @@ func TestOIDCSubjectClaimCustomTemplate_GetUseImmutableSubject(tt *testing.T) {
 	o.GetUseImmutableSubject()
 }
 
-func TestOrgActionsVariableCreateRequest_GetName(tt *testing.T) {
-	tt.Parallel()
-	o := &OrgActionsVariableCreateRequest{}
-	o.GetName()
-	o = nil
-	o.GetName()
-}
-
-func TestOrgActionsVariableCreateRequest_GetSelectedRepositoryIDs(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := []int64{}
-	o := &OrgActionsVariableCreateRequest{SelectedRepositoryIDs: zeroValue}
-	o.GetSelectedRepositoryIDs()
-	o = &OrgActionsVariableCreateRequest{}
-	o.GetSelectedRepositoryIDs()
-	o = nil
-	o.GetSelectedRepositoryIDs()
-}
-
-func TestOrgActionsVariableCreateRequest_GetValue(tt *testing.T) {
-	tt.Parallel()
-	o := &OrgActionsVariableCreateRequest{}
-	o.GetValue()
-	o = nil
-	o.GetValue()
-}
-
-func TestOrgActionsVariableCreateRequest_GetVisibility(tt *testing.T) {
-	tt.Parallel()
-	o := &OrgActionsVariableCreateRequest{}
-	o.GetVisibility()
-	o = nil
-	o.GetVisibility()
-}
-
-func TestOrgActionsVariableUpdateRequest_GetName(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	o := &OrgActionsVariableUpdateRequest{Name: &zeroValue}
-	o.GetName()
-	o = &OrgActionsVariableUpdateRequest{}
-	o.GetName()
-	o = nil
-	o.GetName()
-}
-
-func TestOrgActionsVariableUpdateRequest_GetSelectedRepositoryIDs(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := []int64{}
-	o := &OrgActionsVariableUpdateRequest{SelectedRepositoryIDs: zeroValue}
-	o.GetSelectedRepositoryIDs()
-	o = &OrgActionsVariableUpdateRequest{}
-	o.GetSelectedRepositoryIDs()
-	o = nil
-	o.GetSelectedRepositoryIDs()
-}
-
-func TestOrgActionsVariableUpdateRequest_GetValue(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	o := &OrgActionsVariableUpdateRequest{Value: &zeroValue}
-	o.GetValue()
-	o = &OrgActionsVariableUpdateRequest{}
-	o.GetValue()
-	o = nil
-	o.GetValue()
-}
-
-func TestOrgActionsVariableUpdateRequest_GetVisibility(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	o := &OrgActionsVariableUpdateRequest{Visibility: &zeroValue}
-	o.GetVisibility()
-	o = &OrgActionsVariableUpdateRequest{}
-	o.GetVisibility()
-	o = nil
-	o.GetVisibility()
-}
-
 func TestOrganization_GetAdvancedSecurityEnabledForNewRepos(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
@@ -32602,41 +32562,6 @@ func TestOrgBlockEvent_GetSender(tt *testing.T) {
 	o.GetSender()
 	o = nil
 	o.GetSender()
-}
-
-func TestOrgSecretRequest_GetEncryptedValue(tt *testing.T) {
-	tt.Parallel()
-	o := &OrgSecretRequest{}
-	o.GetEncryptedValue()
-	o = nil
-	o.GetEncryptedValue()
-}
-
-func TestOrgSecretRequest_GetKeyID(tt *testing.T) {
-	tt.Parallel()
-	o := &OrgSecretRequest{}
-	o.GetKeyID()
-	o = nil
-	o.GetKeyID()
-}
-
-func TestOrgSecretRequest_GetSelectedRepositoryIDs(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := []int64{}
-	o := &OrgSecretRequest{SelectedRepositoryIDs: zeroValue}
-	o.GetSelectedRepositoryIDs()
-	o = &OrgSecretRequest{}
-	o.GetSelectedRepositoryIDs()
-	o = nil
-	o.GetSelectedRepositoryIDs()
-}
-
-func TestOrgSecretRequest_GetVisibility(tt *testing.T) {
-	tt.Parallel()
-	o := &OrgSecretRequest{}
-	o.GetVisibility()
-	o = nil
-	o.GetVisibility()
 }
 
 func TestOrgStats_GetDisabledOrgs(tt *testing.T) {
@@ -48280,6 +48205,41 @@ func TestSecret_GetUpdatedAt(tt *testing.T) {
 func TestSecret_GetVisibility(tt *testing.T) {
 	tt.Parallel()
 	s := &Secret{}
+	s.GetVisibility()
+	s = nil
+	s.GetVisibility()
+}
+
+func TestSecretOrgRequest_GetEncryptedValue(tt *testing.T) {
+	tt.Parallel()
+	s := &SecretOrgRequest{}
+	s.GetEncryptedValue()
+	s = nil
+	s.GetEncryptedValue()
+}
+
+func TestSecretOrgRequest_GetKeyID(tt *testing.T) {
+	tt.Parallel()
+	s := &SecretOrgRequest{}
+	s.GetKeyID()
+	s = nil
+	s.GetKeyID()
+}
+
+func TestSecretOrgRequest_GetSelectedRepositoryIDs(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []int64{}
+	s := &SecretOrgRequest{SelectedRepositoryIDs: zeroValue}
+	s.GetSelectedRepositoryIDs()
+	s = &SecretOrgRequest{}
+	s.GetSelectedRepositoryIDs()
+	s = nil
+	s.GetSelectedRepositoryIDs()
+}
+
+func TestSecretOrgRequest_GetVisibility(tt *testing.T) {
+	tt.Parallel()
+	s := &SecretOrgRequest{}
 	s.GetVisibility()
 	s = nil
 	s.GetVisibility()


### PR DESCRIPTION
BREAKING CHANGE: `DependabotService` methods involving secrets have new params and return values.

This PR updates the Dependabot secret update/create functions to use a value parameter (see https://github.com/google/go-github/issues/3644). This aligns Dependabot secrets with the changes made to actions secrets (https://github.com/google/go-github/pull/4335) & actions variables (https://github.com/google/go-github/pull/4346). It also aligns the names of the actions secret and variable request types.