### PR TITLE
chore: Validate metadata

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -426,6 +426,8 @@ func (s *AppsService) CreateInstallationTokenListRepos(ctx context.Context, id i
 
 // CreateAttachment creates a new attachment on user comment containing a url.
 //
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.3/rest/reference/apps#create-a-content-attachment
 //
 //meta:operation POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments

--- a/github/reactions.go
+++ b/github/reactions.go
@@ -429,6 +429,8 @@ func (s *ReactionsService) CreateTeamDiscussionReaction(ctx context.Context, tea
 
 // DeleteTeamDiscussionReaction deletes the reaction to a team discussion.
 //
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/reactions/reactions#delete-team-discussion-reaction
 //
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}
@@ -439,6 +441,8 @@ func (s *ReactionsService) DeleteTeamDiscussionReaction(ctx context.Context, org
 }
 
 // DeleteTeamDiscussionReactionByOrgIDAndTeamID deletes the reaction to a team discussion by organization ID and team ID.
+//
+// Deprecated: This endpoint has been deprecated by GitHub.
 //
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/reactions/reactions#create-reaction-for-a-team-discussion
 //
@@ -508,6 +512,8 @@ func (s *ReactionsService) CreateTeamDiscussionCommentReaction(ctx context.Conte
 
 // DeleteTeamDiscussionCommentReaction deletes the reaction to a team discussion comment.
 //
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/reactions/reactions#delete-team-discussion-comment-reaction
 //
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}
@@ -518,6 +524,8 @@ func (s *ReactionsService) DeleteTeamDiscussionCommentReaction(ctx context.Conte
 }
 
 // DeleteTeamDiscussionCommentReactionByOrgIDAndTeamID deletes the reaction to a team discussion comment by organization ID and team ID.
+//
+// Deprecated: This endpoint has been deprecated by GitHub.
 //
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/reactions/reactions#create-reaction-for-a-team-discussion-comment
 //

--- a/github/teams.go
+++ b/github/teams.go
@@ -123,11 +123,9 @@ func (s *TeamsService) ListTeams(ctx context.Context, org string, opts *ListOpti
 
 // GetTeamByID fetches a team, given a specified organization ID, by ID.
 //
-// Deprecated: Use GetTeamBySlug instead.
-//
 // GitHub API docs: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name
 //
-//meta:operation GET /orgs/{org}/teams/{team_slug}
+//meta:operation GET /organizations/{organization_id}/team/{team_id}
 func (s *TeamsService) GetTeamByID(ctx context.Context, orgID, teamID int64) (*Team, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v", orgID, teamID)
 	req, err := s.client.NewRequest(ctx, "GET", u, nil)
@@ -251,11 +249,9 @@ func copyNewTeamWithoutParent(team *NewTeam) *newTeamNoParent {
 
 // EditTeamByID edits a team, given an organization ID, selected by ID.
 //
-// Deprecated: Use EditTeamBySlug instead.
-//
 // GitHub API docs: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#update-a-team
 //
-//meta:operation PATCH /orgs/{org}/teams/{team_slug}
+//meta:operation PATCH /organizations/{organization_id}/team/{team_id}
 func (s *TeamsService) EditTeamByID(ctx context.Context, orgID, teamID int64, body NewTeam, removeParent bool) (*Team, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v", orgID, teamID)
 
@@ -311,11 +307,9 @@ func (s *TeamsService) EditTeamBySlug(ctx context.Context, org, slug string, bod
 
 // DeleteTeamByID deletes a team referenced by ID.
 //
-// Deprecated: Use DeleteTeamBySlug instead.
-//
 // GitHub API docs: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#delete-a-team
 //
-//meta:operation DELETE /orgs/{org}/teams/{team_slug}
+//meta:operation DELETE /organizations/{organization_id}/team/{team_id}
 func (s *TeamsService) DeleteTeamByID(ctx context.Context, orgID, teamID int64) (*Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v", orgID, teamID)
 	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
@@ -343,11 +337,9 @@ func (s *TeamsService) DeleteTeamBySlug(ctx context.Context, org, slug string) (
 
 // ListChildTeamsByParentID lists child teams for a parent team given parent ID.
 //
-// Deprecated: Use ListChildTeamsByParentSlug instead.
-//
 // GitHub API docs: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#list-child-teams
 //
-//meta:operation GET /orgs/{org}/teams/{team_slug}/teams
+//meta:operation GET /organizations/{organization_id}/team/{team_id}/teams
 func (s *TeamsService) ListChildTeamsByParentID(ctx context.Context, orgID, teamID int64, opts *ListOptions) ([]*Team, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/teams", orgID, teamID)
 	u, err := addOptions(u, opts)
@@ -397,11 +389,9 @@ func (s *TeamsService) ListChildTeamsByParentSlug(ctx context.Context, org, slug
 
 // ListTeamReposByID lists the repositories given a team ID that the specified team has access to.
 //
-// Deprecated: Use ListTeamReposBySlug instead.
-//
 // GitHub API docs: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#list-team-repositories
 //
-//meta:operation GET /orgs/{org}/teams/{team_slug}/repos
+//meta:operation GET /organizations/{organization_id}/team/{team_id}/repos
 func (s *TeamsService) ListTeamReposByID(ctx context.Context, orgID, teamID int64, opts *ListOptions) ([]*Repository, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/repos", orgID, teamID)
 	u, err := addOptions(u, opts)
@@ -457,11 +447,9 @@ func (s *TeamsService) ListTeamReposBySlug(ctx context.Context, org, slug string
 // repository is managed by team, a Repository is returned which includes the
 // permissions team has for that repo.
 //
-// Deprecated: Use IsTeamRepoBySlug instead.
-//
 // GitHub API docs: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#check-team-permissions-for-a-repository
 //
-//meta:operation GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
+//meta:operation GET /organizations/{organization_id}/team/{team_id}/repos/{owner}/{repo}
 func (s *TeamsService) IsTeamRepoByID(ctx context.Context, orgID, teamID int64, owner, repo string) (*Repository, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/repos/%v/%v", orgID, teamID, owner, repo)
 	req, err := s.client.NewRequest(ctx, "GET", u, nil)
@@ -524,11 +512,9 @@ type TeamAddTeamRepoOptions struct {
 // The specified repository must be owned by the organization to which the team
 // belongs, or a direct fork of a repository owned by the organization.
 //
-// Deprecated: Use AddTeamRepoBySlug instead.
-//
 // GitHub API docs: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#add-or-update-team-repository-permissions
 //
-//meta:operation PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
+//meta:operation PUT /organizations/{organization_id}/team/{team_id}/repos/{owner}/{repo}
 func (s *TeamsService) AddTeamRepoByID(ctx context.Context, orgID, teamID int64, owner, repo string, body *TeamAddTeamRepoOptions) (*Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/repos/%v/%v", orgID, teamID, owner, repo)
 	req, err := s.client.NewRequest(ctx, "PUT", u, body)
@@ -560,11 +546,9 @@ func (s *TeamsService) AddTeamRepoBySlug(ctx context.Context, org, slug, owner, 
 // team given the team ID. Note that this does not delete the repository, it
 // just removes it from the team.
 //
-// Deprecated: Use RemoveTeamRepoBySlug instead.
-//
 // GitHub API docs: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#remove-a-repository-from-a-team
 //
-//meta:operation DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}
+//meta:operation DELETE /organizations/{organization_id}/team/{team_id}/repos/{owner}/{repo}
 func (s *TeamsService) RemoveTeamRepoByID(ctx context.Context, orgID, teamID int64, owner, repo string) (*Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/repos/%v/%v", orgID, teamID, owner, repo)
 	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
@@ -620,11 +604,11 @@ func (s *TeamsService) ListUserTeams(ctx context.Context, opts *ListOptions) ([]
 
 // ListTeamProjectsByID lists the organization projects for a team given the team ID.
 //
-// Deprecated: Use ListTeamProjectsBySlug instead.
+// Deprecated: This endpoint has been deprecated by GitHub.
 //
 // GitHub API docs: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#list-team-projects
 //
-//meta:operation GET /orgs/{org}/teams/{team_slug}/projects
+//meta:operation GET /organizations/{organization_id}/team/{team_id}/projects
 func (s *TeamsService) ListTeamProjectsByID(ctx context.Context, orgID, teamID int64) ([]*ProjectV2, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/projects", orgID, teamID)
 
@@ -673,11 +657,11 @@ func (s *TeamsService) ListTeamProjectsBySlug(ctx context.Context, org, slug str
 // ReviewTeamProjectsByID checks whether a team, given its ID, has read, write, or admin
 // permissions for an organization project.
 //
-// Deprecated: Use ReviewTeamProjectsBySlug instead.
+// Deprecated: This endpoint has been deprecated by GitHub.
 //
 // GitHub API docs: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#check-team-permissions-for-a-project
 //
-//meta:operation GET /orgs/{org}/teams/{team_slug}/projects/{project_id}
+//meta:operation GET /organizations/{organization_id}/team/{team_id}/projects/{project_id}
 func (s *TeamsService) ReviewTeamProjectsByID(ctx context.Context, orgID, teamID, projectID int64) (*ProjectV2, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/projects/%v", orgID, teamID, projectID)
 	req, err := s.client.NewRequest(ctx, "GET", u, nil)
@@ -738,11 +722,11 @@ type TeamProjectOptions struct {
 // To add a project to a team or update the team's permission on a project, the
 // authenticated user must have admin permissions for the project.
 //
-// Deprecated: Use AddTeamProjectBySlug instead.
+// Deprecated: This endpoint has been deprecated by GitHub.
 //
 // GitHub API docs: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#add-or-update-team-project-permissions
 //
-//meta:operation PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}
+//meta:operation PUT /organizations/{organization_id}/team/{team_id}/projects/{project_id}
 func (s *TeamsService) AddTeamProjectByID(ctx context.Context, orgID, teamID, projectID int64, body *TeamProjectOptions) (*Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/projects/%v", orgID, teamID, projectID)
 	req, err := s.client.NewRequest(ctx, "PUT", u, body)
@@ -783,11 +767,11 @@ func (s *TeamsService) AddTeamProjectBySlug(ctx context.Context, org, slug strin
 // or project.
 // Note: This endpoint removes the project from the team, but does not delete it.
 //
-// Deprecated: Use RemoveTeamProjectBySlug instead.
+// Deprecated: This endpoint has been deprecated by GitHub.
 //
 // GitHub API docs: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#remove-a-project-from-a-team
 //
-//meta:operation DELETE /orgs/{org}/teams/{team_slug}/projects/{project_id}
+//meta:operation DELETE /organizations/{organization_id}/team/{team_id}/projects/{project_id}
 func (s *TeamsService) RemoveTeamProjectByID(ctx context.Context, orgID, teamID, projectID int64) (*Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/projects/%v", orgID, teamID, projectID)
 	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
@@ -873,11 +857,9 @@ func (s *TeamsService) ListIDPGroupsInOrganization(ctx context.Context, org stri
 // ListIDPGroupsForTeamByID lists IDP groups connected to a team on GitHub
 // given organization and team IDs.
 //
-// Deprecated: Use ListIDPGroupsForTeamBySlug instead.
-//
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/teams/team-sync?apiVersion=2022-11-28#list-idp-groups-for-a-team
 //
-//meta:operation GET /orgs/{org}/teams/{team_slug}/team-sync/group-mappings
+//meta:operation GET /organizations/{organization_id}/team/{team_id}/team-sync/group-mappings
 func (s *TeamsService) ListIDPGroupsForTeamByID(ctx context.Context, orgID, teamID int64) (*IDPGroupList, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/team-sync/group-mappings", orgID, teamID)
 
@@ -921,11 +903,9 @@ func (s *TeamsService) ListIDPGroupsForTeamBySlug(ctx context.Context, org, slug
 // CreateOrUpdateIDPGroupConnectionsByID creates, updates, or removes a connection
 // between a team and an IDP group given organization and team IDs.
 //
-// Deprecated: Use CreateOrUpdateIDPGroupConnectionsBySlug instead.
-//
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/teams/team-sync?apiVersion=2022-11-28#create-or-update-idp-group-connections
 //
-//meta:operation PATCH /orgs/{org}/teams/{team_slug}/team-sync/group-mappings
+//meta:operation PATCH /organizations/{organization_id}/team/{team_id}/team-sync/group-mappings
 func (s *TeamsService) CreateOrUpdateIDPGroupConnectionsByID(ctx context.Context, orgID, teamID int64, body IDPGroupList) (*IDPGroupList, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/team-sync/group-mappings", orgID, teamID)
 

--- a/github/teams_discussion_comments.go
+++ b/github/teams_discussion_comments.go
@@ -43,6 +43,8 @@ type DiscussionCommentListOptions struct {
 // ListCommentsByID lists all comments on a team discussion by team ID.
 // Authenticated user must grant read:discussion scope.
 //
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussion-comments#list-discussion-comments
 //
 //meta:operation GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments
@@ -69,6 +71,8 @@ func (s *TeamsService) ListCommentsByID(ctx context.Context, orgID, teamID int64
 
 // ListCommentsBySlug lists all comments on a team discussion by team slug.
 // Authenticated user must grant read:discussion scope.
+//
+// Deprecated: This endpoint has been deprecated by GitHub.
 //
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussion-comments#list-discussion-comments
 //
@@ -97,6 +101,8 @@ func (s *TeamsService) ListCommentsBySlug(ctx context.Context, org, slug string,
 // GetCommentByID gets a specific comment on a team discussion by team ID.
 // Authenticated user must grant read:discussion scope.
 //
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussion-comments#get-a-discussion-comment
 //
 //meta:operation GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
@@ -118,6 +124,8 @@ func (s *TeamsService) GetCommentByID(ctx context.Context, orgID, teamID int64, 
 
 // GetCommentBySlug gets a specific comment on a team discussion by team slug.
 // Authenticated user must grant read:discussion scope.
+//
+// Deprecated: This endpoint has been deprecated by GitHub.
 //
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussion-comments#get-a-discussion-comment
 //
@@ -142,6 +150,8 @@ func (s *TeamsService) GetCommentBySlug(ctx context.Context, org, slug string, d
 // CreateCommentByID creates a new comment on a team discussion by team ID.
 // Authenticated user must grant write:discussion scope.
 //
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussion-comments#create-a-discussion-comment
 //
 //meta:operation POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments
@@ -163,6 +173,8 @@ func (s *TeamsService) CreateCommentByID(ctx context.Context, orgID, teamID int6
 
 // CreateCommentBySlug creates a new comment on a team discussion by team slug.
 // Authenticated user must grant write:discussion scope.
+//
+// Deprecated: This endpoint has been deprecated by GitHub.
 //
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussion-comments#create-a-discussion-comment
 //
@@ -187,6 +199,8 @@ func (s *TeamsService) CreateCommentBySlug(ctx context.Context, org, slug string
 // Authenticated user must grant write:discussion scope.
 // User is allowed to edit body of a comment only.
 //
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussion-comments#update-a-discussion-comment
 //
 //meta:operation PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
@@ -210,6 +224,8 @@ func (s *TeamsService) EditCommentByID(ctx context.Context, orgID, teamID int64,
 // Authenticated user must grant write:discussion scope.
 // User is allowed to edit body of a comment only.
 //
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussion-comments#update-a-discussion-comment
 //
 //meta:operation PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
@@ -232,6 +248,8 @@ func (s *TeamsService) EditCommentBySlug(ctx context.Context, org, slug string, 
 // DeleteCommentByID deletes a comment on a team discussion by team ID.
 // Authenticated user must grant write:discussion scope.
 //
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussion-comments#delete-a-discussion-comment
 //
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
@@ -247,6 +265,8 @@ func (s *TeamsService) DeleteCommentByID(ctx context.Context, orgID, teamID int6
 
 // DeleteCommentBySlug deletes a comment on a team discussion by team slug.
 // Authenticated user must grant write:discussion scope.
+//
+// Deprecated: This endpoint has been deprecated by GitHub.
 //
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussion-comments#delete-a-discussion-comment
 //

--- a/github/teams_discussions.go
+++ b/github/teams_discussions.go
@@ -49,6 +49,8 @@ type DiscussionListOptions struct {
 // ListDiscussionsByID lists all discussions on team's page given Organization and Team ID.
 // Authenticated user must grant read:discussion scope.
 //
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussions#list-discussions
 //
 //meta:operation GET /orgs/{org}/teams/{team_slug}/discussions
@@ -75,6 +77,8 @@ func (s *TeamsService) ListDiscussionsByID(ctx context.Context, orgID, teamID in
 
 // ListDiscussionsBySlug lists all discussions on team's page given Organization name and Team's slug.
 // Authenticated user must grant read:discussion scope.
+//
+// Deprecated: This endpoint has been deprecated by GitHub.
 //
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussions#list-discussions
 //
@@ -103,6 +107,8 @@ func (s *TeamsService) ListDiscussionsBySlug(ctx context.Context, org, slug stri
 // GetDiscussionByID gets a specific discussion on a team's page given Organization and Team ID.
 // Authenticated user must grant read:discussion scope.
 //
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussions#get-a-discussion
 //
 //meta:operation GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
@@ -124,6 +130,8 @@ func (s *TeamsService) GetDiscussionByID(ctx context.Context, orgID, teamID int6
 
 // GetDiscussionBySlug gets a specific discussion on a team's page given Organization name and Team's slug.
 // Authenticated user must grant read:discussion scope.
+//
+// Deprecated: This endpoint has been deprecated by GitHub.
 //
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussions#get-a-discussion
 //
@@ -147,6 +155,8 @@ func (s *TeamsService) GetDiscussionBySlug(ctx context.Context, org, slug string
 // CreateDiscussionByID creates a new discussion post on a team's page given Organization and Team ID.
 // Authenticated user must grant write:discussion scope.
 //
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussions#create-a-discussion
 //
 //meta:operation POST /orgs/{org}/teams/{team_slug}/discussions
@@ -168,6 +178,8 @@ func (s *TeamsService) CreateDiscussionByID(ctx context.Context, orgID, teamID i
 
 // CreateDiscussionBySlug creates a new discussion post on a team's page given Organization name and Team's slug.
 // Authenticated user must grant write:discussion scope.
+//
+// Deprecated: This endpoint has been deprecated by GitHub.
 //
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussions#create-a-discussion
 //
@@ -192,6 +204,8 @@ func (s *TeamsService) CreateDiscussionBySlug(ctx context.Context, org, slug str
 // Authenticated user must grant write:discussion scope.
 // User is allowed to change Title and Body of a discussion only.
 //
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussions#update-a-discussion
 //
 //meta:operation PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
@@ -215,6 +229,8 @@ func (s *TeamsService) EditDiscussionByID(ctx context.Context, orgID, teamID int
 // Authenticated user must grant write:discussion scope.
 // User is allowed to change Title and Body of a discussion only.
 //
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussions#update-a-discussion
 //
 //meta:operation PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
@@ -237,6 +253,8 @@ func (s *TeamsService) EditDiscussionBySlug(ctx context.Context, org, slug strin
 // DeleteDiscussionByID deletes a discussion from team's page given Organization and Team ID.
 // Authenticated user must grant write:discussion scope.
 //
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussions#delete-a-discussion
 //
 //meta:operation DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
@@ -252,6 +270,8 @@ func (s *TeamsService) DeleteDiscussionByID(ctx context.Context, orgID, teamID i
 
 // DeleteDiscussionBySlug deletes a discussion from team's page given Organization name and Team's slug.
 // Authenticated user must grant write:discussion scope.
+//
+// Deprecated: This endpoint has been deprecated by GitHub.
 //
 // GitHub API docs: https://docs.github.com/enterprise-server@3.13/rest/teams/discussions#delete-a-discussion
 //

--- a/github/teams_members.go
+++ b/github/teams_members.go
@@ -25,7 +25,7 @@ type TeamListTeamMembersOptions struct {
 //
 // GitHub API docs: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#list-team-members
 //
-//meta:operation GET /orgs/{org}/teams/{team_slug}/members
+//meta:operation GET /organizations/{organization_id}/team/{team_id}/members
 func (s *TeamsService) ListTeamMembersByID(ctx context.Context, orgID, teamID int64, opts *TeamListTeamMembersOptions) ([]*User, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/members", orgID, teamID)
 	u, err := addOptions(u, opts)
@@ -77,9 +77,9 @@ func (s *TeamsService) ListTeamMembersBySlug(ctx context.Context, org, slug stri
 // GetTeamMembershipByID returns the membership status for a user in a team, given a specified
 // organization ID, by team ID.
 //
-// GitHub API docs: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#list-team-members
+// GitHub API docs: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#get-team-membership-for-a-user
 //
-//meta:operation GET /orgs/{org}/teams/{team_slug}/members
+//meta:operation GET /organizations/{organization_id}/team/{team_id}/memberships/{username}
 func (s *TeamsService) GetTeamMembershipByID(ctx context.Context, orgID, teamID int64, user string) (*Membership, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/memberships/%v", orgID, teamID, user)
 	req, err := s.client.NewRequest(ctx, "GET", u, nil)
@@ -137,7 +137,7 @@ type TeamAddTeamMembershipOptions struct {
 //
 // GitHub API docs: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#add-or-update-team-membership-for-a-user
 //
-//meta:operation PUT /orgs/{org}/teams/{team_slug}/memberships/{username}
+//meta:operation PUT /organizations/{organization_id}/team/{team_id}/memberships/{username}
 func (s *TeamsService) AddTeamMembershipByID(ctx context.Context, orgID, teamID int64, user string, body *TeamAddTeamMembershipOptions) (*Membership, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/memberships/%v", orgID, teamID, user)
 	req, err := s.client.NewRequest(ctx, "PUT", u, body)
@@ -181,7 +181,7 @@ func (s *TeamsService) AddTeamMembershipBySlug(ctx context.Context, org, slug, u
 //
 // GitHub API docs: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#remove-team-membership-for-a-user
 //
-//meta:operation DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}
+//meta:operation DELETE /organizations/{organization_id}/team/{team_id}/memberships/{username}
 func (s *TeamsService) RemoveTeamMembershipByID(ctx context.Context, orgID, teamID int64, user string) (*Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/memberships/%v", orgID, teamID, user)
 	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
@@ -213,7 +213,7 @@ func (s *TeamsService) RemoveTeamMembershipBySlug(ctx context.Context, org, slug
 //
 // GitHub API docs: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#list-pending-team-invitations
 //
-//meta:operation GET /orgs/{org}/teams/{team_slug}/invitations
+//meta:operation GET /organizations/{organization_id}/team/{team_id}/invitations
 func (s *TeamsService) ListPendingTeamInvitationsByID(ctx context.Context, orgID, teamID int64, opts *ListOptions) ([]*Invitation, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v/invitations", orgID, teamID)
 	u, err := addOptions(u, opts)

--- a/openapi_operations.yaml
+++ b/openapi_operations.yaml
@@ -8,6 +8,48 @@ operations:
   - name: POST /hub
     documentation_url: https://docs.github.com/webhooks/about-webhooks-for-repositories#pubsubhubbub
   - name: GET /organizations/{organization_id}
+  - name: DELETE /organizations/{organization_id}/team/{team_id}
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#delete-a-team
+  - name: GET /organizations/{organization_id}/team/{team_id}
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name
+  - name: PATCH /organizations/{organization_id}/team/{team_id}
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#update-a-team
+  - name: GET /organizations/{organization_id}/team/{team_id}/invitations
+    documentation_url: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#list-pending-team-invitations
+  - name: GET /organizations/{organization_id}/team/{team_id}/members
+    documentation_url: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#list-team-members
+  - name: DELETE /organizations/{organization_id}/team/{team_id}/memberships/{username}
+    documentation_url: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#remove-team-membership-for-a-user
+  - name: GET /organizations/{organization_id}/team/{team_id}/memberships/{username}
+    documentation_url: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#get-team-membership-for-a-user
+  - name: PUT /organizations/{organization_id}/team/{team_id}/memberships/{username}
+    documentation_url: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#add-or-update-team-membership-for-a-user
+  - name: GET /organizations/{organization_id}/team/{team_id}/projects
+    documentation_url: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#list-team-projects
+    deprecated: true
+  - name: DELETE /organizations/{organization_id}/team/{team_id}/projects/{project_id}
+    documentation_url: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#remove-a-project-from-a-team
+    deprecated: true
+  - name: GET /organizations/{organization_id}/team/{team_id}/projects/{project_id}
+    documentation_url: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#check-team-permissions-for-a-project
+    deprecated: true
+  - name: PUT /organizations/{organization_id}/team/{team_id}/projects/{project_id}
+    documentation_url: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#add-or-update-team-project-permissions
+    deprecated: true
+  - name: GET /organizations/{organization_id}/team/{team_id}/repos
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#list-team-repositories
+  - name: DELETE /organizations/{organization_id}/team/{team_id}/repos/{owner}/{repo}
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#remove-a-repository-from-a-team
+  - name: GET /organizations/{organization_id}/team/{team_id}/repos/{owner}/{repo}
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#check-team-permissions-for-a-repository
+  - name: PUT /organizations/{organization_id}/team/{team_id}/repos/{owner}/{repo}
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#add-or-update-team-repository-permissions
+  - name: GET /organizations/{organization_id}/team/{team_id}/team-sync/group-mappings
+    documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/teams/team-sync?apiVersion=2022-11-28#list-idp-groups-for-a-team
+  - name: PATCH /organizations/{organization_id}/team/{team_id}/team-sync/group-mappings
+    documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/teams/team-sync?apiVersion=2022-11-28#create-or-update-idp-group-connections
+  - name: GET /organizations/{organization_id}/team/{team_id}/teams
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#list-child-teams
   - name: GET /orgs/{org}/copilot/metrics
     documentation_url: https://docs.github.com/rest/copilot/copilot-metrics?apiVersion=2022-11-28#get-copilot-metrics-for-an-organization
     deprecated: true
@@ -22,48 +64,6 @@ operations:
     documentation_url: https://gist.github.com/jonmagic/5282384165e0f86ef105#import-status-request
   - name: GET /repositories/{repository_id}
   - name: GET /repositories/{repository_id}/installation
-  - name: GET /organizations/{organization_id}/team/{team_id}
-    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name
-  - name: PATCH /organizations/{organization_id}/team/{team_id}
-    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#update-a-team
-  - name: DELETE /organizations/{organization_id}/team/{team_id}
-    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#delete-a-team
-  - name: GET /organizations/{organization_id}/team/{team_id}/teams
-    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#list-child-teams
-  - name: GET /organizations/{organization_id}/team/{team_id}/repos
-    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#list-team-repositories
-  - name: GET /organizations/{organization_id}/team/{team_id}/repos/{owner}/{repo}
-    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#check-team-permissions-for-a-repository
-  - name: PUT /organizations/{organization_id}/team/{team_id}/repos/{owner}/{repo}
-    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#add-or-update-team-repository-permissions
-  - name: DELETE /organizations/{organization_id}/team/{team_id}/repos/{owner}/{repo}
-    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#remove-a-repository-from-a-team
-  - name: GET /organizations/{organization_id}/team/{team_id}/projects
-    documentation_url: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#list-team-projects
-    deprecated: true
-  - name: GET /organizations/{organization_id}/team/{team_id}/projects/{project_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#check-team-permissions-for-a-project
-    deprecated: true
-  - name: PUT /organizations/{organization_id}/team/{team_id}/projects/{project_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#add-or-update-team-project-permissions
-    deprecated: true
-  - name: DELETE /organizations/{organization_id}/team/{team_id}/projects/{project_id}
-    documentation_url: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#remove-a-project-from-a-team
-    deprecated: true
-  - name: GET /organizations/{organization_id}/team/{team_id}/team-sync/group-mappings
-    documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/teams/team-sync?apiVersion=2022-11-28#list-idp-groups-for-a-team
-  - name: PATCH /organizations/{organization_id}/team/{team_id}/team-sync/group-mappings
-    documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/teams/team-sync?apiVersion=2022-11-28#create-or-update-idp-group-connections
-  - name: GET /organizations/{organization_id}/team/{team_id}/members
-    documentation_url: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#list-team-members
-  - name: GET /organizations/{organization_id}/team/{team_id}/memberships/{username}
-    documentation_url: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#get-team-membership-for-a-user
-  - name: PUT /organizations/{organization_id}/team/{team_id}/memberships/{username}
-    documentation_url: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#add-or-update-team-membership-for-a-user
-  - name: DELETE /organizations/{organization_id}/team/{team_id}/memberships/{username}
-    documentation_url: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#remove-team-membership-for-a-user
-  - name: GET /organizations/{organization_id}/team/{team_id}/invitations
-    documentation_url: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#list-pending-team-invitations
 operation_overrides:
   - name: GET /meta
     documentation_url: https://docs.github.com/rest/meta/meta#get-github-meta-information
@@ -93,7 +93,7 @@ operation_overrides:
     documentation_url: https://docs.github.com/rest/pages/pages#request-a-github-pages-build
   - name: GET /repos/{owner}/{repo}/pages/builds/{build_id}
     documentation_url: https://docs.github.com/rest/pages/pages#get-github-pages-build
-openapi_commit: 3e08e45a052d4b8fe77fb5838c28652af9e89ecf
+openapi_commit: a70b6c5b86500ea35cb362ba0cbc940a7bb2155e
 openapi_operations:
   - name: GET /
     documentation_url: https://docs.github.com/rest/meta/meta#github-api-root
@@ -1181,8 +1181,16 @@ openapi_operations:
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json
+  - name: GET /enterprises/{enterprise}/copilot/usage-records
+    documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics#get-copilot-usage-records-for-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
   - name: POST /enterprises/{enterprise}/credential-authorizations/revoke-all
     documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/credential-authorizations#revoke-all-credential-authorizations-for-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: POST /enterprises/{enterprise}/credential-authorizations/{username}/revoke
+    documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/credential-authorizations#revoke-credential-authorizations-for-a-user-in-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
   - name: GET /enterprises/{enterprise}/dependabot/alerts

--- a/openapi_operations.yaml
+++ b/openapi_operations.yaml
@@ -22,6 +22,48 @@ operations:
     documentation_url: https://gist.github.com/jonmagic/5282384165e0f86ef105#import-status-request
   - name: GET /repositories/{repository_id}
   - name: GET /repositories/{repository_id}/installation
+  - name: GET /organizations/{organization_id}/team/{team_id}
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name
+  - name: PATCH /organizations/{organization_id}/team/{team_id}
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#update-a-team
+  - name: DELETE /organizations/{organization_id}/team/{team_id}
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#delete-a-team
+  - name: GET /organizations/{organization_id}/team/{team_id}/teams
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#list-child-teams
+  - name: GET /organizations/{organization_id}/team/{team_id}/repos
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#list-team-repositories
+  - name: GET /organizations/{organization_id}/team/{team_id}/repos/{owner}/{repo}
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#check-team-permissions-for-a-repository
+  - name: PUT /organizations/{organization_id}/team/{team_id}/repos/{owner}/{repo}
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#add-or-update-team-repository-permissions
+  - name: DELETE /organizations/{organization_id}/team/{team_id}/repos/{owner}/{repo}
+    documentation_url: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#remove-a-repository-from-a-team
+  - name: GET /organizations/{organization_id}/team/{team_id}/projects
+    documentation_url: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#list-team-projects
+    deprecated: true
+  - name: GET /organizations/{organization_id}/team/{team_id}/projects/{project_id}
+    documentation_url: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#check-team-permissions-for-a-project
+    deprecated: true
+  - name: PUT /organizations/{organization_id}/team/{team_id}/projects/{project_id}
+    documentation_url: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#add-or-update-team-project-permissions
+    deprecated: true
+  - name: DELETE /organizations/{organization_id}/team/{team_id}/projects/{project_id}
+    documentation_url: https://docs.github.com/enterprise-server@3.16/rest/teams/teams#remove-a-project-from-a-team
+    deprecated: true
+  - name: GET /organizations/{organization_id}/team/{team_id}/team-sync/group-mappings
+    documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/teams/team-sync?apiVersion=2022-11-28#list-idp-groups-for-a-team
+  - name: PATCH /organizations/{organization_id}/team/{team_id}/team-sync/group-mappings
+    documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/teams/team-sync?apiVersion=2022-11-28#create-or-update-idp-group-connections
+  - name: GET /organizations/{organization_id}/team/{team_id}/members
+    documentation_url: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#list-team-members
+  - name: GET /organizations/{organization_id}/team/{team_id}/memberships/{username}
+    documentation_url: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#get-team-membership-for-a-user
+  - name: PUT /organizations/{organization_id}/team/{team_id}/memberships/{username}
+    documentation_url: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#add-or-update-team-membership-for-a-user
+  - name: DELETE /organizations/{organization_id}/team/{team_id}/memberships/{username}
+    documentation_url: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#remove-team-membership-for-a-user
+  - name: GET /organizations/{organization_id}/team/{team_id}/invitations
+    documentation_url: https://docs.github.com/rest/teams/members?apiVersion=2022-11-28#list-pending-team-invitations
 operation_overrides:
   - name: GET /meta
     documentation_url: https://docs.github.com/rest/meta/meta#get-github-meta-information
@@ -4129,66 +4171,82 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/teams/discussions#list-discussions
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: POST /orgs/{org}/teams/{team_slug}/discussions
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/teams/discussions#create-a-discussion
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/teams/discussions#delete-a-discussion
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/teams/discussions#get-a-discussion
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/teams/discussions#update-a-discussion
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/teams/discussion-comments#list-discussion-comments
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/teams/discussion-comments#create-a-discussion-comment
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/teams/discussion-comments#delete-a-discussion-comment
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/teams/discussion-comments#get-a-discussion-comment
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/teams/discussion-comments#update-a-discussion-comment
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/reactions/reactions#list-reactions-for-a-team-discussion-comment
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/reactions/reactions#create-reaction-for-a-team-discussion-comment
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/reactions/reactions#delete-team-discussion-comment-reaction
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/reactions/reactions#list-reactions-for-a-team-discussion
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/reactions/reactions#create-reaction-for-a-team-discussion
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}
     documentation_url: https://docs.github.com/enterprise-server@3.13/rest/reactions/reactions#delete-team-discussion-reaction
     openapi_files:
       - descriptions/ghes-3.13/ghes-3.13.json
+    deprecated: true
   - name: DELETE /orgs/{org}/teams/{team_slug}/external-groups
     documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/teams/external-groups#remove-the-connection-between-an-external-group-and-a-team
     openapi_files:
@@ -5705,6 +5763,7 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-server@3.3/rest/reference/apps#create-a-content-attachment
     openapi_files:
       - descriptions/ghes-3.3/ghes-3.3.json
+    deprecated: true
   - name: DELETE /repos/{owner}/{repo}/contents/{path}
     documentation_url: https://docs.github.com/rest/repos/contents#delete-a-file
     openapi_files:
@@ -6805,6 +6864,7 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/pages/pages#create-a-github-pages-deployment
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: POST /repos/{owner}/{repo}/pages/deployments
     documentation_url: https://docs.github.com/rest/pages/pages#create-a-github-pages-deployment
     openapi_files:
@@ -7486,70 +7546,87 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/actions/secrets#list-environment-secrets
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: GET /repositories/{repository_id}/environments/{environment_name}/secrets/public-key
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/actions/secrets#get-an-environment-public-key
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: DELETE /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/actions/secrets#delete-an-environment-secret
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: GET /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/actions/secrets#get-an-environment-secret
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: PUT /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/actions/secrets#create-or-update-an-environment-secret
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: GET /scim/v2/Groups
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#list-provisioned-scim-groups-for-an-enterprise
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: POST /scim/v2/Groups
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#provision-a-scim-enterprise-group
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: DELETE /scim/v2/Groups/{scim_group_id}
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#delete-a-scim-group-from-an-enterprise
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: GET /scim/v2/Groups/{scim_group_id}
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-group
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: PATCH /scim/v2/Groups/{scim_group_id}
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#update-an-attribute-for-a-scim-enterprise-group
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: PUT /scim/v2/Groups/{scim_group_id}
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#set-scim-information-for-a-provisioned-enterprise-group
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: GET /scim/v2/Users
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#list-scim-provisioned-identities-for-an-enterprise
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: POST /scim/v2/Users
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#provision-a-scim-enterprise-user
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: DELETE /scim/v2/Users/{scim_user_id}
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#delete-a-scim-user-from-an-enterprise
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: GET /scim/v2/Users/{scim_user_id}
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-user
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: PATCH /scim/v2/Users/{scim_user_id}
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#update-an-attribute-for-a-scim-enterprise-user
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: PUT /scim/v2/Users/{scim_user_id}
     documentation_url: https://docs.github.com/enterprise-server@3.7/rest/enterprise-admin/scim#set-scim-information-for-a-provisioned-enterprise-user
     openapi_files:
       - descriptions/ghes-3.7/ghes-3.7.json
+    deprecated: true
   - name: GET /scim/v2/enterprises/{enterprise}/Groups
     documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/scim#list-provisioned-scim-groups-for-an-enterprise
     openapi_files:
@@ -7680,46 +7757,57 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-server@3.14/rest/enterprise-admin/management-console#get-the-configuration-status
     openapi_files:
       - descriptions/ghes-3.14/ghes-3.14.json
+    deprecated: true
   - name: POST /setup/api/configure
     documentation_url: https://docs.github.com/enterprise-server@3.14/rest/enterprise-admin/management-console#start-a-configuration-process
     openapi_files:
       - descriptions/ghes-3.14/ghes-3.14.json
+    deprecated: true
   - name: GET /setup/api/maintenance
     documentation_url: https://docs.github.com/enterprise-server@3.14/rest/enterprise-admin/management-console#get-the-maintenance-status
     openapi_files:
       - descriptions/ghes-3.14/ghes-3.14.json
+    deprecated: true
   - name: POST /setup/api/maintenance
     documentation_url: https://docs.github.com/enterprise-server@3.14/rest/enterprise-admin/management-console#enable-or-disable-maintenance-mode
     openapi_files:
       - descriptions/ghes-3.14/ghes-3.14.json
+    deprecated: true
   - name: GET /setup/api/settings
     documentation_url: https://docs.github.com/enterprise-server@3.14/rest/enterprise-admin/management-console#get-settings
     openapi_files:
       - descriptions/ghes-3.14/ghes-3.14.json
+    deprecated: true
   - name: PUT /setup/api/settings
     documentation_url: https://docs.github.com/enterprise-server@3.14/rest/enterprise-admin/management-console#set-settings
     openapi_files:
       - descriptions/ghes-3.14/ghes-3.14.json
+    deprecated: true
   - name: DELETE /setup/api/settings/authorized-keys
     documentation_url: https://docs.github.com/enterprise-server@3.14/rest/enterprise-admin/management-console#remove-an-authorized-ssh-key
     openapi_files:
       - descriptions/ghes-3.14/ghes-3.14.json
+    deprecated: true
   - name: GET /setup/api/settings/authorized-keys
     documentation_url: https://docs.github.com/enterprise-server@3.14/rest/enterprise-admin/management-console#get-all-authorized-ssh-keys
     openapi_files:
       - descriptions/ghes-3.14/ghes-3.14.json
+    deprecated: true
   - name: POST /setup/api/settings/authorized-keys
     documentation_url: https://docs.github.com/enterprise-server@3.14/rest/enterprise-admin/management-console#add-an-authorized-ssh-key
     openapi_files:
       - descriptions/ghes-3.14/ghes-3.14.json
+    deprecated: true
   - name: POST /setup/api/start
     documentation_url: https://docs.github.com/enterprise-server@3.14/rest/enterprise-admin/management-console#create-a-github-license
     openapi_files:
       - descriptions/ghes-3.14/ghes-3.14.json
+    deprecated: true
   - name: POST /setup/api/upgrade
     documentation_url: https://docs.github.com/enterprise-server@3.14/rest/enterprise-admin/management-console#upgrade-a-license
     openapi_files:
       - descriptions/ghes-3.14/ghes-3.14.json
+    deprecated: true
   - name: DELETE /teams/{team_id}
     documentation_url: https://docs.github.com/rest/teams/teams#delete-a-team-legacy
     openapi_files:

--- a/tools/metadata/openapi.go
+++ b/tools/metadata/openapi.go
@@ -58,8 +58,7 @@ func getOpsFromGithub(ctx context.Context, client *github.Client, gitRef string)
 }
 
 func deprecateOperations(descs []*openapiFile, ops []*operation) {
-	ghesLatestMajor := 0
-	ghesLatestMinor := 0
+	var ghesLatestMajor, ghesLatestMinor int
 
 	for _, desc := range descs {
 		if strings.Contains(desc.filename, "/ghes") {
@@ -77,7 +76,7 @@ func deprecateOperations(descs []*openapiFile, ops []*operation) {
 			continue
 		}
 
-		latest := false
+		var latest bool
 		for _, f := range op.OpenAPIFiles {
 			if strings.Contains(f, "/api.github.com") {
 				latest = true

--- a/tools/metadata/openapi.go
+++ b/tools/metadata/openapi.go
@@ -70,7 +70,7 @@ func deprecateOperations(descs []*openapiFile, ops []*operation) {
 		}
 	}
 
-	ghesLatest := fmt.Sprintf("/ghes-%d.%d", ghesLatestMajor, ghesLatestMinor)
+	ghesLatest := fmt.Sprintf("/ghes-%v.%v", ghesLatestMajor, ghesLatestMinor)
 
 	for _, op := range ops {
 		if op.Deprecated {

--- a/tools/metadata/openapi.go
+++ b/tools/metadata/openapi.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/go-github/v88/github"
@@ -51,8 +52,51 @@ func getOpsFromGithub(ctx context.Context, client *github.Client, gitRef string)
 			}
 		}
 	}
+	deprecateOperations(descs, ops)
 	sortOperations(ops)
 	return ops, nil
+}
+
+func deprecateOperations(descs []*openapiFile, ops []*operation) {
+	ghesLatestMajor := 0
+	ghesLatestMinor := 0
+
+	for _, desc := range descs {
+		if strings.Contains(desc.filename, "/ghes") {
+			if desc.releaseMajor > ghesLatestMajor || (desc.releaseMajor == ghesLatestMajor && desc.releaseMinor > ghesLatestMinor) {
+				ghesLatestMajor = desc.releaseMajor
+				ghesLatestMinor = desc.releaseMinor
+			}
+		}
+	}
+
+	ghesLatest := fmt.Sprintf("/ghes-%d.%d", ghesLatestMajor, ghesLatestMinor)
+
+	for _, op := range ops {
+		if op.Deprecated {
+			continue
+		}
+
+		latest := false
+		for _, f := range op.OpenAPIFiles {
+			if strings.Contains(f, "/api.github.com") {
+				latest = true
+				break
+			}
+			if strings.Contains(f, "/ghec") {
+				latest = true
+				break
+			}
+			if strings.Contains(f, ghesLatest) {
+				latest = true
+				break
+			}
+		}
+
+		if !latest {
+			op.Deprecated = true
+		}
+	}
 }
 
 func (o *openapiFile) loadDescription(ctx context.Context, client *github.Client, gitRef string) error {


### PR DESCRIPTION
This PR updates the metadata to deprecate endpoints that are no longer present in any of the most recent API schemas (github.com, GHEC, or GHES). To do this I've updated the metadata tool.

I also added missing API endpoints and corrected the documentation to match these, this includes un-deprecating team ID based endpoints that were confused with the deprecated `/teams/` APIs.

Related to #4334