### PR TITLE
refactor!: Pass `HookConfig` by value and rename `EditHookConfiguration` to `UpdateHookConfiguration`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -229,7 +229,6 @@ linters:
             - EnterpriseSecurityAnalysisSettings
             - ExternalGroup
             - Hook
-            - HookConfig
             - ImpersonateUserOptions
             - Import
             - InstallationTokenListRepoOptions

--- a/github/apps_hooks.go
+++ b/github/apps_hooks.go
@@ -36,7 +36,7 @@ func (s *AppsService) GetHookConfig(ctx context.Context) (*HookConfig, *Response
 // GitHub API docs: https://docs.github.com/rest/apps/webhooks?apiVersion=2022-11-28#update-a-webhook-configuration-for-an-app
 //
 //meta:operation PATCH /app/hook/config
-func (s *AppsService) UpdateHookConfig(ctx context.Context, body *HookConfig) (*HookConfig, *Response, error) {
+func (s *AppsService) UpdateHookConfig(ctx context.Context, body HookConfig) (*HookConfig, *Response, error) {
 	req, err := s.client.NewRequest(ctx, "PATCH", "app/hook/config", body)
 	if err != nil {
 		return nil, nil, err

--- a/github/apps_hooks_test.go
+++ b/github/apps_hooks_test.go
@@ -57,7 +57,7 @@ func TestAppsService_UpdateHookConfig(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &HookConfig{
+	input := HookConfig{
 		ContentType: Ptr("json"),
 		InsecureSSL: Ptr("1"),
 		Secret:      Ptr("s"),

--- a/github/orgs_hooks_configuration.go
+++ b/github/orgs_hooks_configuration.go
@@ -31,12 +31,12 @@ func (s *OrganizationsService) GetHookConfiguration(ctx context.Context, org str
 	return config, resp, nil
 }
 
-// EditHookConfiguration updates the configuration for the specified organization webhook.
+// UpdateHookConfiguration updates the configuration for the specified organization webhook.
 //
 // GitHub API docs: https://docs.github.com/rest/orgs/webhooks?apiVersion=2022-11-28#update-a-webhook-configuration-for-an-organization
 //
 //meta:operation PATCH /orgs/{org}/hooks/{hook_id}/config
-func (s *OrganizationsService) EditHookConfiguration(ctx context.Context, org string, id int64, body HookConfig) (*HookConfig, *Response, error) {
+func (s *OrganizationsService) UpdateHookConfiguration(ctx context.Context, org string, id int64, body HookConfig) (*HookConfig, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/hooks/%v/config", org, id)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/orgs_hooks_configuration.go
+++ b/github/orgs_hooks_configuration.go
@@ -36,7 +36,7 @@ func (s *OrganizationsService) GetHookConfiguration(ctx context.Context, org str
 // GitHub API docs: https://docs.github.com/rest/orgs/webhooks?apiVersion=2022-11-28#update-a-webhook-configuration-for-an-organization
 //
 //meta:operation PATCH /orgs/{org}/hooks/{hook_id}/config
-func (s *OrganizationsService) EditHookConfiguration(ctx context.Context, org string, id int64, body *HookConfig) (*HookConfig, *Response, error) {
+func (s *OrganizationsService) EditHookConfiguration(ctx context.Context, org string, id int64, body HookConfig) (*HookConfig, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/hooks/%v/config", org, id)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/orgs_hooks_configuration_test.go
+++ b/github/orgs_hooks_configuration_test.go
@@ -66,7 +66,7 @@ func TestOrganizationsService_EditHookConfiguration(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &HookConfig{}
+	input := HookConfig{}
 
 	mux.HandleFunc("/orgs/o/hooks/1/config", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -110,6 +110,6 @@ func TestOrganizationsService_EditHookConfiguration_invalidOrg(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Organizations.EditHookConfiguration(ctx, "%", 1, nil)
+	_, _, err := client.Organizations.EditHookConfiguration(ctx, "%", 1, HookConfig{})
 	testURLParseError(t, err)
 }

--- a/github/orgs_hooks_configuration_test.go
+++ b/github/orgs_hooks_configuration_test.go
@@ -62,7 +62,7 @@ func TestOrganizationsService_GetHookConfiguration_invalidOrg(t *testing.T) {
 	testURLParseError(t, err)
 }
 
-func TestOrganizationsService_EditHookConfiguration(t *testing.T) {
+func TestOrganizationsService_UpdateHookConfiguration(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -75,9 +75,9 @@ func TestOrganizationsService_EditHookConfiguration(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	config, _, err := client.Organizations.EditHookConfiguration(ctx, "o", 1, input)
+	config, _, err := client.Organizations.UpdateHookConfiguration(ctx, "o", 1, input)
 	if err != nil {
-		t.Errorf("Organizations.EditHookConfiguration returned error: %v", err)
+		t.Errorf("Organizations.UpdateHookConfiguration returned error: %v", err)
 	}
 
 	want := &HookConfig{
@@ -87,17 +87,17 @@ func TestOrganizationsService_EditHookConfiguration(t *testing.T) {
 		URL:         Ptr("https://example.com/webhook"),
 	}
 	if !cmp.Equal(config, want) {
-		t.Errorf("Organizations.EditHookConfiguration returned %+v, want %+v", config, want)
+		t.Errorf("Organizations.UpdateHookConfiguration returned %+v, want %+v", config, want)
 	}
 
-	const methodName = "EditHookConfiguration"
+	const methodName = "UpdateHookConfiguration"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Organizations.EditHookConfiguration(ctx, "\n", -1, input)
+		_, _, err = client.Organizations.UpdateHookConfiguration(ctx, "\n", -1, input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Organizations.EditHookConfiguration(ctx, "o", 1, input)
+		got, resp, err := client.Organizations.UpdateHookConfiguration(ctx, "o", 1, input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -105,11 +105,11 @@ func TestOrganizationsService_EditHookConfiguration(t *testing.T) {
 	})
 }
 
-func TestOrganizationsService_EditHookConfiguration_invalidOrg(t *testing.T) {
+func TestOrganizationsService_UpdateHookConfiguration_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Organizations.EditHookConfiguration(ctx, "%", 1, HookConfig{})
+	_, _, err := client.Organizations.UpdateHookConfiguration(ctx, "%", 1, HookConfig{})
 	testURLParseError(t, err)
 }

--- a/github/repos_hooks_configuration.go
+++ b/github/repos_hooks_configuration.go
@@ -46,12 +46,12 @@ func (s *RepositoriesService) GetHookConfiguration(ctx context.Context, owner, r
 	return config, resp, nil
 }
 
-// EditHookConfiguration updates the configuration for the specified repository webhook.
+// UpdateHookConfiguration updates the configuration for the specified repository webhook.
 //
 // GitHub API docs: https://docs.github.com/rest/repos/webhooks?apiVersion=2022-11-28#update-a-webhook-configuration-for-a-repository
 //
 //meta:operation PATCH /repos/{owner}/{repo}/hooks/{hook_id}/config
-func (s *RepositoriesService) EditHookConfiguration(ctx context.Context, owner, repo string, id int64, body HookConfig) (*HookConfig, *Response, error) {
+func (s *RepositoriesService) UpdateHookConfiguration(ctx context.Context, owner, repo string, id int64, body HookConfig) (*HookConfig, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/hooks/%v/config", owner, repo, id)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/repos_hooks_configuration.go
+++ b/github/repos_hooks_configuration.go
@@ -51,7 +51,7 @@ func (s *RepositoriesService) GetHookConfiguration(ctx context.Context, owner, r
 // GitHub API docs: https://docs.github.com/rest/repos/webhooks?apiVersion=2022-11-28#update-a-webhook-configuration-for-a-repository
 //
 //meta:operation PATCH /repos/{owner}/{repo}/hooks/{hook_id}/config
-func (s *RepositoriesService) EditHookConfiguration(ctx context.Context, owner, repo string, id int64, body *HookConfig) (*HookConfig, *Response, error) {
+func (s *RepositoriesService) EditHookConfiguration(ctx context.Context, owner, repo string, id int64, body HookConfig) (*HookConfig, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/hooks/%v/config", owner, repo, id)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/repos_hooks_configuration_test.go
+++ b/github/repos_hooks_configuration_test.go
@@ -66,7 +66,7 @@ func TestRepositoriesService_EditHookConfiguration(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &HookConfig{}
+	input := HookConfig{}
 
 	mux.HandleFunc("/repos/o/r/hooks/1/config", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -110,6 +110,6 @@ func TestRepositoriesService_EditHookConfiguration_invalidOrg(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Repositories.EditHookConfiguration(ctx, "%", "%", 1, nil)
+	_, _, err := client.Repositories.EditHookConfiguration(ctx, "%", "%", 1, HookConfig{})
 	testURLParseError(t, err)
 }

--- a/github/repos_hooks_configuration_test.go
+++ b/github/repos_hooks_configuration_test.go
@@ -62,7 +62,7 @@ func TestRepositoriesService_GetHookConfiguration_invalidOrg(t *testing.T) {
 	testURLParseError(t, err)
 }
 
-func TestRepositoriesService_EditHookConfiguration(t *testing.T) {
+func TestRepositoriesService_UpdateHookConfiguration(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -75,9 +75,9 @@ func TestRepositoriesService_EditHookConfiguration(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	config, _, err := client.Repositories.EditHookConfiguration(ctx, "o", "r", 1, input)
+	config, _, err := client.Repositories.UpdateHookConfiguration(ctx, "o", "r", 1, input)
 	if err != nil {
-		t.Errorf("Repositories.EditHookConfiguration returned error: %v", err)
+		t.Errorf("Repositories.UpdateHookConfiguration returned error: %v", err)
 	}
 
 	want := &HookConfig{
@@ -87,17 +87,17 @@ func TestRepositoriesService_EditHookConfiguration(t *testing.T) {
 		URL:         Ptr("https://example.com/webhook"),
 	}
 	if !cmp.Equal(config, want) {
-		t.Errorf("Repositories.EditHookConfiguration returned %+v, want %+v", config, want)
+		t.Errorf("Repositories.UpdateHookConfiguration returned %+v, want %+v", config, want)
 	}
 
-	const methodName = "EditHookConfiguration"
+	const methodName = "UpdateHookConfiguration"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Repositories.EditHookConfiguration(ctx, "\n", "\n", -1, input)
+		_, _, err = client.Repositories.UpdateHookConfiguration(ctx, "\n", "\n", -1, input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.EditHookConfiguration(ctx, "o", "r", 1, input)
+		got, resp, err := client.Repositories.UpdateHookConfiguration(ctx, "o", "r", 1, input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -105,11 +105,11 @@ func TestRepositoriesService_EditHookConfiguration(t *testing.T) {
 	})
 }
 
-func TestRepositoriesService_EditHookConfiguration_invalidOrg(t *testing.T) {
+func TestRepositoriesService_UpdateHookConfiguration_invalidOrg(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Repositories.EditHookConfiguration(ctx, "%", "%", 1, HookConfig{})
+	_, _, err := client.Repositories.UpdateHookConfiguration(ctx, "%", "%", 1, HookConfig{})
 	testURLParseError(t, err)
 }


### PR DESCRIPTION
Part of #3644.

Two related changes to the webhook-configuration methods:

**1. Pass `HookConfig` by value.** `HookConfig` is shared as the PATCH request body by three methods, so `paramcheck` flags them together and they must be converted in a single PR:

- `RepositoriesService.UpdateHookConfiguration`
- `OrganizationsService.UpdateHookConfiguration`
- `AppsService.UpdateHookConfig`

Each method's `body` parameter changes from `*HookConfig` to `HookConfig`, and `HookConfig` is removed from the `paramcheck` `body-allowed-pointer-types` allow-list in `.golangci.yml`.

**2. Rename `EditHookConfiguration` to `UpdateHookConfiguration`** (on `RepositoriesService` and `OrganizationsService`). The GitHub API docs name this operation "Update a webhook configuration for a repository/organization", and `AppsService.UpdateHookConfig` already uses the "Update" verb. This is consistent with the method naming used elsewhere in the #3644 refactor (e.g. `EditRelease` → `UpdateRelease`).

The `HookConfig` struct is unchanged (all four fields are optional), so no generated accessors change. Cross-checked against the GitHub webhook-config schema — its only fields are `url`, `content_type`, `secret`, `insecure_ssl`, all already present.

BREAKING CHANGE: `EditHookConfiguration` is renamed to `UpdateHookConfiguration` on `RepositoriesService` and `OrganizationsService`; these methods and `AppsService.UpdateHookConfig` now take `HookConfig` by value instead of by pointer.
