### PR TITLE
refactor!: Pass `DeploymentRequest` and `DeploymentStatusRequest` by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -411,7 +411,6 @@ linters:
             - CreateTag.Type # TODO: Git
             - DependabotEncryptedSecret.SelectedRepositoryIDs # TODO: Dependabot
             - DependabotEncryptedSecret.Visibility # TODO: Dependabot
-            - DeploymentRequest.RequiredContexts # TODO: Deployments
             - DismissalRestrictionsRequest.Apps # TODO: Repositories
             - DismissalRestrictionsRequest.Teams # TODO: Repositories
             - DismissalRestrictionsRequest.Users # TODO: Repositories

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -223,8 +223,6 @@ linters:
             - DependabotEncryptedSecret
             - DependencyGraphSnapshot
             - DeploymentBranchPolicyRequest
-            - DeploymentRequest
-            - DeploymentStatusRequest
             - EncryptedSecret
             - EnterpriseSecurityAnalysisSettings
             - ExternalGroup

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -13390,12 +13390,12 @@ func (d *DeploymentRequest) GetProductionEnvironment() bool {
 	return *d.ProductionEnvironment
 }
 
-// GetRef returns the Ref field if it's non-nil, zero value otherwise.
+// GetRef returns the Ref field.
 func (d *DeploymentRequest) GetRef() string {
-	if d == nil || d.Ref == nil {
+	if d == nil {
 		return ""
 	}
-	return *d.Ref
+	return d.Ref
 }
 
 // GetRequiredContexts returns the RequiredContexts field if it's non-nil, zero value otherwise.
@@ -13782,12 +13782,12 @@ func (d *DeploymentStatusRequest) GetLogURL() string {
 	return *d.LogURL
 }
 
-// GetState returns the State field if it's non-nil, zero value otherwise.
+// GetState returns the State field.
 func (d *DeploymentStatusRequest) GetState() string {
-	if d == nil || d.State == nil {
+	if d == nil {
 		return ""
 	}
-	return *d.State
+	return d.State
 }
 
 // GetDisplayName returns the DisplayName field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -13398,12 +13398,12 @@ func (d *DeploymentRequest) GetRef() string {
 	return d.Ref
 }
 
-// GetRequiredContexts returns the RequiredContexts field if it's non-nil, zero value otherwise.
+// GetRequiredContexts returns the RequiredContexts slice if it's non-nil, nil otherwise.
 func (d *DeploymentRequest) GetRequiredContexts() []string {
 	if d == nil || d.RequiredContexts == nil {
 		return nil
 	}
-	return *d.RequiredContexts
+	return d.RequiredContexts
 }
 
 // GetTask returns the Task field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -13790,6 +13790,14 @@ func (d *DeploymentStatusRequest) GetState() string {
 	return d.State
 }
 
+// GetTargetURL returns the TargetURL field if it's non-nil, zero value otherwise.
+func (d *DeploymentStatusRequest) GetTargetURL() string {
+	if d == nil || d.TargetURL == nil {
+		return ""
+	}
+	return *d.TargetURL
+}
+
 // GetDisplayName returns the DisplayName field if it's non-nil, zero value otherwise.
 func (d *DevContainer) GetDisplayName() string {
 	if d == nil || d.DisplayName == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -16957,10 +16957,7 @@ func TestDeploymentRequest_GetProductionEnvironment(tt *testing.T) {
 
 func TestDeploymentRequest_GetRef(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	d := &DeploymentRequest{Ref: &zeroValue}
-	d.GetRef()
-	d = &DeploymentRequest{}
+	d := &DeploymentRequest{}
 	d.GetRef()
 	d = nil
 	d.GetRef()
@@ -17436,10 +17433,7 @@ func TestDeploymentStatusRequest_GetLogURL(tt *testing.T) {
 
 func TestDeploymentStatusRequest_GetState(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	d := &DeploymentStatusRequest{State: &zeroValue}
-	d.GetState()
-	d = &DeploymentStatusRequest{}
+	d := &DeploymentStatusRequest{}
 	d.GetState()
 	d = nil
 	d.GetState()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -17439,6 +17439,17 @@ func TestDeploymentStatusRequest_GetState(tt *testing.T) {
 	d.GetState()
 }
 
+func TestDeploymentStatusRequest_GetTargetURL(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	d := &DeploymentStatusRequest{TargetURL: &zeroValue}
+	d.GetTargetURL()
+	d = &DeploymentStatusRequest{}
+	d.GetTargetURL()
+	d = nil
+	d.GetTargetURL()
+}
+
 func TestDevContainer_GetDisplayName(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -16965,8 +16965,8 @@ func TestDeploymentRequest_GetRef(tt *testing.T) {
 
 func TestDeploymentRequest_GetRequiredContexts(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue []string
-	d := &DeploymentRequest{RequiredContexts: &zeroValue}
+	zeroValue := []string{}
+	d := &DeploymentRequest{RequiredContexts: zeroValue}
 	d.GetRequiredContexts()
 	d = &DeploymentRequest{}
 	d.GetRequiredContexts()

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -32,15 +32,17 @@ type Deployment struct {
 
 // DeploymentRequest represents a deployment request.
 type DeploymentRequest struct {
-	Ref                   string    `json:"ref"`
-	Task                  *string   `json:"task,omitempty"`
-	AutoMerge             *bool     `json:"auto_merge,omitempty"`
-	RequiredContexts      *[]string `json:"required_contexts,omitempty"`
-	Payload               any       `json:"payload,omitempty"`
-	Environment           *string   `json:"environment,omitempty"`
-	Description           *string   `json:"description,omitempty"`
-	TransientEnvironment  *bool     `json:"transient_environment,omitempty"`
-	ProductionEnvironment *bool     `json:"production_environment,omitempty"`
+	Ref       string  `json:"ref"`
+	Task      *string `json:"task,omitempty"`
+	AutoMerge *bool   `json:"auto_merge,omitempty"`
+	// RequiredContexts is the status contexts to verify against commit status checks.
+	// If nil, all unique contexts are verified; an empty slice bypasses checking entirely.
+	RequiredContexts      []string `json:"required_contexts,omitzero"`
+	Payload               any      `json:"payload,omitempty"`
+	Environment           *string  `json:"environment,omitempty"`
+	Description           *string  `json:"description,omitempty"`
+	TransientEnvironment  *bool    `json:"transient_environment,omitempty"`
+	ProductionEnvironment *bool    `json:"production_environment,omitempty"`
 }
 
 // DeploymentsListOptions specifies the optional parameters to the
@@ -242,8 +244,8 @@ func (s *RepositoriesService) GetDeploymentStatus(ctx context.Context, owner, re
 // GitHub API docs: https://docs.github.com/rest/deployments/statuses?apiVersion=2022-11-28#create-a-deployment-status
 //
 //meta:operation POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses
-func (s *RepositoriesService) CreateDeploymentStatus(ctx context.Context, owner, repo string, deployment int64, body DeploymentStatusRequest) (*DeploymentStatus, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/deployments/%v/statuses", owner, repo, deployment)
+func (s *RepositoriesService) CreateDeploymentStatus(ctx context.Context, owner, repo string, deploymentID int64, body DeploymentStatusRequest) (*DeploymentStatus, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/deployments/%v/statuses", owner, repo, deploymentID)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -172,7 +172,10 @@ type DeploymentStatus struct {
 
 // DeploymentStatusRequest represents a deployment status request.
 type DeploymentStatusRequest struct {
-	State          string  `json:"state"`
+	State string `json:"state"`
+	// TargetURL is the target URL to associate with this status.
+	// It's recommended to use LogURL instead, which replaces TargetURL.
+	TargetURL      *string `json:"target_url,omitempty"`
 	LogURL         *string `json:"log_url,omitempty"`
 	Description    *string `json:"description,omitempty"`
 	Environment    *string `json:"environment,omitempty"`

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -32,7 +32,7 @@ type Deployment struct {
 
 // DeploymentRequest represents a deployment request.
 type DeploymentRequest struct {
-	Ref                   *string   `json:"ref,omitempty"`
+	Ref                   string    `json:"ref"`
 	Task                  *string   `json:"task,omitempty"`
 	AutoMerge             *bool     `json:"auto_merge,omitempty"`
 	RequiredContexts      *[]string `json:"required_contexts,omitempty"`
@@ -114,7 +114,7 @@ func (s *RepositoriesService) GetDeployment(ctx context.Context, owner, repo str
 // GitHub API docs: https://docs.github.com/rest/deployments/deployments?apiVersion=2022-11-28#create-a-deployment
 //
 //meta:operation POST /repos/{owner}/{repo}/deployments
-func (s *RepositoriesService) CreateDeployment(ctx context.Context, owner, repo string, body *DeploymentRequest) (*Deployment, *Response, error) {
+func (s *RepositoriesService) CreateDeployment(ctx context.Context, owner, repo string, body DeploymentRequest) (*Deployment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/deployments", owner, repo)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
@@ -170,9 +170,9 @@ type DeploymentStatus struct {
 	URL            *string    `json:"url,omitempty"`
 }
 
-// DeploymentStatusRequest represents a deployment request.
+// DeploymentStatusRequest represents a deployment status request.
 type DeploymentStatusRequest struct {
-	State          *string `json:"state,omitempty"`
+	State          string  `json:"state"`
 	LogURL         *string `json:"log_url,omitempty"`
 	Description    *string `json:"description,omitempty"`
 	Environment    *string `json:"environment,omitempty"`
@@ -239,7 +239,7 @@ func (s *RepositoriesService) GetDeploymentStatus(ctx context.Context, owner, re
 // GitHub API docs: https://docs.github.com/rest/deployments/statuses?apiVersion=2022-11-28#create-a-deployment-status
 //
 //meta:operation POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses
-func (s *RepositoriesService) CreateDeploymentStatus(ctx context.Context, owner, repo string, deployment int64, body *DeploymentStatusRequest) (*DeploymentStatus, *Response, error) {
+func (s *RepositoriesService) CreateDeploymentStatus(ctx context.Context, owner, repo string, deployment int64, body DeploymentStatusRequest) (*DeploymentStatus, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/deployments/%v/statuses", owner, repo, deployment)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)

--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -32,11 +32,9 @@ type Deployment struct {
 
 // DeploymentRequest represents a deployment request.
 type DeploymentRequest struct {
-	Ref       string  `json:"ref"`
-	Task      *string `json:"task,omitempty"`
-	AutoMerge *bool   `json:"auto_merge,omitempty"`
-	// RequiredContexts is the status contexts to verify against commit status checks.
-	// If nil, all unique contexts are verified; an empty slice bypasses checking entirely.
+	Ref                   string   `json:"ref"`
+	Task                  *string  `json:"task,omitempty"`
+	AutoMerge             *bool    `json:"auto_merge,omitempty"`
 	RequiredContexts      []string `json:"required_contexts,omitzero"`
 	Payload               any      `json:"payload,omitempty"`
 	Environment           *string  `json:"environment,omitempty"`

--- a/github/repos_deployments_test.go
+++ b/github/repos_deployments_test.go
@@ -91,7 +91,7 @@ func TestRepositoriesService_CreateDeployment(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &DeploymentRequest{Ref: Ptr("1111"), Task: Ptr("deploy"), TransientEnvironment: Ptr(true)}
+	input := DeploymentRequest{Ref: "1111", Task: Ptr("deploy"), TransientEnvironment: Ptr(true)}
 
 	mux.HandleFunc("/repos/o/r/deployments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -244,7 +244,7 @@ func TestRepositoriesService_CreateDeploymentStatus(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &DeploymentStatusRequest{State: Ptr("inactive"), Description: Ptr("deploy"), AutoInactive: Ptr(false)}
+	input := DeploymentStatusRequest{State: "inactive", Description: Ptr("deploy"), AutoInactive: Ptr(false)}
 
 	mux.HandleFunc("/repos/o/r/deployments/1/statuses", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")


### PR DESCRIPTION
This is a follow-up to #3644, converting `repos_deployments.go` to the established value-parameter pattern:

- `CreateDeployment` and `CreateDeploymentStatus` now take their request bodies (`DeploymentRequest`, `DeploymentStatusRequest`) by value instead of by pointer.
- The schema-required fields are now non-pointers with `omitempty` removed: `DeploymentRequest.Ref` (`ref` is required by the create-a-deployment request schema) and `DeploymentStatusRequest.State` (`state` is required by the create-a-deployment-status request schema).
- Both types are removed from the paramcheck allowlist in `.golangci.yml` (`custom-gcl run ./...` reports 0 issues).
- A second commit adds the missing optional `TargetURL` field to `DeploymentStatusRequest` (`target_url` is present in the OpenAPI request schema; the API docs recommend `log_url`, which replaces it).

Both method names already match the GitHub docs operation names ("Create a deployment", "Create a deployment status"), so no renames are needed.

Updates #3644.

BREAKING CHANGE: `CreateDeployment` and `CreateDeploymentStatus` now take `DeploymentRequest` and `DeploymentStatusRequest` by value instead of by pointer; the required fields `DeploymentRequest.Ref` and `DeploymentStatusRequest.State` are now `string` instead of `*string`, and `DeploymentRequest.RequiredContexts` is now `[]string` instead of `*[]string`.
