### PR TITLE
chore: Mark removed billing endpoints as deprecated

### DIFF
--- a/github/billing.go
+++ b/github/billing.go
@@ -173,8 +173,11 @@ type PremiumRequestUsageReport struct {
 
 // GetOrganizationPackagesBilling returns the free and paid storage used for GitHub Packages in gigabytes for an Org.
 //
-// This endpoint appears to have disappeared from the official GitHub v3 API documentation website.
-// See https://github.com/google/go-github/issues/3894 for details.
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
+// GitHub API docs: https://docs.github.com/rest/billing/billing?apiVersion=2022-11-28#get-github-packages-billing-for-an-organization
+//
+//meta:operation GET /orgs/{org}/settings/billing/packages
 func (s *BillingService) GetOrganizationPackagesBilling(ctx context.Context, org string) (*PackagesBilling, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/settings/billing/packages", org)
 	req, err := s.client.NewRequest(ctx, "GET", u, nil)
@@ -194,8 +197,11 @@ func (s *BillingService) GetOrganizationPackagesBilling(ctx context.Context, org
 // GetOrganizationStorageBilling returns the estimated paid and estimated total storage used for GitHub Actions
 // and GitHub Packages in gigabytes for an Org.
 //
-// This endpoint appears to have disappeared from the official GitHub v3 API documentation website.
-// See https://github.com/google/go-github/issues/3894 for details.
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
+// GitHub API docs: https://docs.github.com/rest/billing/billing?apiVersion=2022-11-28#get-shared-storage-billing-for-an-organization
+//
+//meta:operation GET /orgs/{org}/settings/billing/shared-storage
 func (s *BillingService) GetOrganizationStorageBilling(ctx context.Context, org string) (*StorageBilling, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/settings/billing/shared-storage", org)
 	req, err := s.client.NewRequest(ctx, "GET", u, nil)
@@ -240,8 +246,11 @@ func (s *BillingService) GetOrganizationAdvancedSecurityActiveCommitters(ctx con
 
 // GetPackagesBilling returns the free and paid storage used for GitHub Packages in gigabytes for a user.
 //
-// This endpoint appears to have disappeared from the official GitHub v3 API documentation website.
-// See https://github.com/google/go-github/issues/3894 for details.
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
+// GitHub API docs: https://docs.github.com/rest/billing/billing?apiVersion=2022-11-28#get-github-packages-billing-for-a-user
+//
+//meta:operation GET /users/{username}/settings/billing/packages
 func (s *BillingService) GetPackagesBilling(ctx context.Context, user string) (*PackagesBilling, *Response, error) {
 	u := fmt.Sprintf("users/%v/settings/billing/packages", user)
 	req, err := s.client.NewRequest(ctx, "GET", u, nil)
@@ -261,8 +270,11 @@ func (s *BillingService) GetPackagesBilling(ctx context.Context, user string) (*
 // GetStorageBilling returns the estimated paid and estimated total storage used for GitHub Actions
 // and GitHub Packages in gigabytes for a user.
 //
-// This endpoint appears to have disappeared from the official GitHub v3 API documentation website.
-// See https://github.com/google/go-github/issues/3894 for details.
+// Deprecated: This endpoint has been deprecated by GitHub.
+//
+// GitHub API docs: https://docs.github.com/rest/billing/billing?apiVersion=2022-11-28#get-shared-storage-billing-for-a-user
+//
+//meta:operation GET /users/{username}/settings/billing/shared-storage
 func (s *BillingService) GetStorageBilling(ctx context.Context, user string) (*StorageBilling, *Response, error) {
 	u := fmt.Sprintf("users/%v/settings/billing/shared-storage", user)
 	req, err := s.client.NewRequest(ctx, "GET", u, nil)

--- a/openapi_operations.yaml
+++ b/openapi_operations.yaml
@@ -53,6 +53,12 @@ operations:
   - name: GET /orgs/{org}/copilot/metrics
     documentation_url: https://docs.github.com/rest/copilot/copilot-metrics?apiVersion=2022-11-28#get-copilot-metrics-for-an-organization
     deprecated: true
+  - name: GET /orgs/{org}/settings/billing/packages
+    documentation_url: https://docs.github.com/rest/billing/billing?apiVersion=2022-11-28#get-github-packages-billing-for-an-organization
+    deprecated: true
+  - name: GET /orgs/{org}/settings/billing/shared-storage
+    documentation_url: https://docs.github.com/rest/billing/billing?apiVersion=2022-11-28#get-shared-storage-billing-for-an-organization
+    deprecated: true
   - name: GET /orgs/{org}/team/{team_slug}/copilot/metrics
     documentation_url: https://docs.github.com/rest/copilot/copilot-metrics?apiVersion=2022-11-28#get-copilot-metrics-for-a-team
     deprecated: true
@@ -64,6 +70,12 @@ operations:
     documentation_url: https://gist.github.com/jonmagic/5282384165e0f86ef105#import-status-request
   - name: GET /repositories/{repository_id}
   - name: GET /repositories/{repository_id}/installation
+  - name: GET /users/{username}/settings/billing/packages
+    documentation_url: https://docs.github.com/rest/billing/billing?apiVersion=2022-11-28#get-github-packages-billing-for-a-user
+    deprecated: true
+  - name: GET /users/{username}/settings/billing/shared-storage
+    documentation_url: https://docs.github.com/rest/billing/billing?apiVersion=2022-11-28#get-shared-storage-billing-for-a-user
+    deprecated: true
 operation_overrides:
   - name: GET /meta
     documentation_url: https://docs.github.com/rest/meta/meta#get-github-meta-information

--- a/tools/metadata/metadata.go
+++ b/tools/metadata/metadata.go
@@ -563,15 +563,12 @@ func nodeServiceMethod(fn *ast.FuncDecl) string {
 	return serviceMethod
 }
 
-// See: https://github.com/google/go-github/issues/3894
+// skipServiceMethod lists helper methods that download from URLs returned by
+// other endpoints and therefore have no REST API operation of their own.
 var skipServiceMethod = map[string]bool{
-	"BillingService.GetOrganizationPackagesBilling": true,
-	"BillingService.GetOrganizationStorageBilling":  true,
-	"BillingService.GetPackagesBilling":             true,
-	"BillingService.GetStorageBilling":              true,
-	"CopilotService.DownloadCopilotMetrics":         true,
-	"CopilotService.DownloadDailyMetrics":           true,
-	"CopilotService.DownloadPeriodicMetrics":        true,
-	"CopilotService.DownloadUserDailyMetrics":       true,
-	"CopilotService.DownloadUserPeriodicMetrics":    true,
+	"CopilotService.DownloadCopilotMetrics":      true,
+	"CopilotService.DownloadDailyMetrics":        true,
+	"CopilotService.DownloadPeriodicMetrics":     true,
+	"CopilotService.DownloadUserDailyMetrics":    true,
+	"CopilotService.DownloadUserPeriodicMetrics": true,
 }


### PR DESCRIPTION
GitHub removed the four product-specific billing endpoints from its API and documentation ([changelog: "Product-specific billing APIs are closing down"](https://github.blog/changelog/2025-09-26-product-specific-billing-apis-are-closing-down/)):

- `GET /orgs/{org}/settings/billing/packages` (`GetOrganizationPackagesBilling`)
- `GET /orgs/{org}/settings/billing/shared-storage` (`GetOrganizationStorageBilling`)
- `GET /users/{username}/settings/billing/packages` (`GetPackagesBilling`)
- `GET /users/{username}/settings/billing/shared-storage` (`GetStorageBilling`)

This follows up on the interim fix from #3895 (which removed the `//meta:operation` annotations and excluded the methods from metadata validation via `skipServiceMethod`) by marking the methods as deprecated in code, as suggested in the issue discussion, using the metadata tooling introduced in #4358:

- Register the four endpoints in the manual `operations:` section of `openapi_operations.yaml` with `deprecated: true`, using their original documentation URLs (I verified against the `github/rest-api-description` OpenAPI descriptions that these endpoints are absent from GHES of any version and from GHEC, so unlike #4358 there is no `enterprise-server@x.y` documentation to point to).
- Restore the `//meta:operation` annotations on the four `BillingService` methods and run `script/metadata.sh update-go`, which generates the canonical `// Deprecated: This endpoint has been deprecated by GitHub.` notices and the `GitHub API docs:` links.
- Remove the four interim `skipServiceMethod` entries from `tools/metadata/metadata.go` (the Copilot download helpers remain, with a comment explaining why they are skipped).

The methods themselves are intentionally left in place; if and when to remove them entirely for GitHub Enterprise users remains a maintainer decision and is out of scope here.

Updates #3894.