### PR TITLE
docs: Add AGENTS.md and review-feedback tip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository.
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for everything you need, in particular:
+
+- [Submitting a patch](./CONTRIBUTING.md#submitting-a-patch) - workflow and the scripts to run before submitting (`script/fmt.sh`, `script/test.sh`, `script/lint.sh`, `script/generate.sh`).
+- [Tips](./CONTRIBUTING.md#tips) - expectations for (AI-driven) PRs.
+- [Code Guidelines](./CONTRIBUTING.md#code-guidelines) - file organization, naming conventions, type conventions, JSON tags, pagination, generated code, and testing patterns.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,9 @@ tips (which are frequently ignored by AI-driven PRs):
   fail, but with the included PR changes, the new test(s) pass.
 * When possible, try to make smaller, focused PRs (which are easier to review
   and easier for others to understand).
+* When a reviewer leaves a comment on one occurrence of an issue, apply the
+  same fix to all similar occurrences throughout the entire PR - don't wait
+  for the reviewer to point out each one individually.
 
 ## Code Guidelines
 


### PR DESCRIPTION
Advise contributors to fix all similar occurrences of a reviewer's comment across the whole PR, and add `AGENTS.md` pointing agents to `CONTRIBUTING.md`.

https://agents.md/ is a simple, open format for guiding all coding agents.

Updates #3939