### PR TITLE
refactor!: Pass `RepositoryMergeRequest` and `RepoMergeUpstreamRequest` by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -258,7 +258,6 @@ linters:
             - RepositoryComment
             - RepositoryContentFileOptions
             - RepositoryCreateForkOptions
-            - RepositoryMergeRequest
             - RequiredStatusChecksRequest
             - ReviewCustomDeploymentProtectionRuleRequest
             - SCIMUserAttributes

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -252,7 +252,6 @@ linters:
             - PullRequestReviewDismissalRequest
             - PullRequestReviewRequest
             - PullRequestReviewsEnforcementUpdate
-            - RepoMergeUpstreamRequest
             - Repository
             - RepositoryAddCollaboratorOptions
             - RepositoryComment

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -35238,12 +35238,12 @@ func (r *RepositoryListRulesetsOptions) GetIncludesParents() bool {
 	return *r.IncludesParents
 }
 
-// GetBase returns the Base field if it's non-nil, zero value otherwise.
+// GetBase returns the Base field.
 func (r *RepositoryMergeRequest) GetBase() string {
-	if r == nil || r.Base == nil {
+	if r == nil {
 		return ""
 	}
-	return *r.Base
+	return r.Base
 }
 
 // GetCommitMessage returns the CommitMessage field if it's non-nil, zero value otherwise.
@@ -35254,12 +35254,12 @@ func (r *RepositoryMergeRequest) GetCommitMessage() string {
 	return *r.CommitMessage
 }
 
-// GetHead returns the Head field if it's non-nil, zero value otherwise.
+// GetHead returns the Head field.
 func (r *RepositoryMergeRequest) GetHead() string {
-	if r == nil || r.Head == nil {
+	if r == nil {
 		return ""
 	}
-	return *r.Head
+	return r.Head
 }
 
 // GetAll returns the All slice if it's non-nil, nil otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -33198,12 +33198,12 @@ func (r *RepoImmutableReleasesStatus) GetEnforcedByOwner() bool {
 	return *r.EnforcedByOwner
 }
 
-// GetBranch returns the Branch field if it's non-nil, zero value otherwise.
+// GetBranch returns the Branch field.
 func (r *RepoMergeUpstreamRequest) GetBranch() string {
-	if r == nil || r.Branch == nil {
+	if r == nil {
 		return ""
 	}
-	return *r.Branch
+	return r.Branch
 }
 
 // GetBaseBranch returns the BaseBranch field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -41712,10 +41712,7 @@ func TestRepoImmutableReleasesStatus_GetEnforcedByOwner(tt *testing.T) {
 
 func TestRepoMergeUpstreamRequest_GetBranch(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	r := &RepoMergeUpstreamRequest{Branch: &zeroValue}
-	r.GetBranch()
-	r = &RepoMergeUpstreamRequest{}
+	r := &RepoMergeUpstreamRequest{}
 	r.GetBranch()
 	r = nil
 	r.GetBranch()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -44310,10 +44310,7 @@ func TestRepositoryListRulesetsOptions_GetIncludesParents(tt *testing.T) {
 
 func TestRepositoryMergeRequest_GetBase(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	r := &RepositoryMergeRequest{Base: &zeroValue}
-	r.GetBase()
-	r = &RepositoryMergeRequest{}
+	r := &RepositoryMergeRequest{}
 	r.GetBase()
 	r = nil
 	r.GetBase()
@@ -44332,10 +44329,7 @@ func TestRepositoryMergeRequest_GetCommitMessage(tt *testing.T) {
 
 func TestRepositoryMergeRequest_GetHead(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	r := &RepositoryMergeRequest{Head: &zeroValue}
-	r.GetHead()
-	r = &RepositoryMergeRequest{}
+	r := &RepositoryMergeRequest{}
 	r.GetHead()
 	r = nil
 	r.GetHead()

--- a/github/repos_merging.go
+++ b/github/repos_merging.go
@@ -21,7 +21,7 @@ type RepositoryMergeRequest struct {
 // RepoMergeUpstreamRequest represents a request to sync a branch of
 // a forked repository to keep it up-to-date with the upstream repository.
 type RepoMergeUpstreamRequest struct {
-	Branch *string `json:"branch,omitempty"`
+	Branch string `json:"branch"`
 }
 
 // RepoMergeUpstreamResult represents the result of syncing a branch of
@@ -59,7 +59,7 @@ func (s *RepositoriesService) Merge(ctx context.Context, owner, repo string, bod
 // GitHub API docs: https://docs.github.com/rest/branches/branches?apiVersion=2022-11-28#sync-a-fork-branch-with-the-upstream-repository
 //
 //meta:operation POST /repos/{owner}/{repo}/merge-upstream
-func (s *RepositoriesService) MergeUpstream(ctx context.Context, owner, repo string, body *RepoMergeUpstreamRequest) (*RepoMergeUpstreamResult, *Response, error) {
+func (s *RepositoriesService) MergeUpstream(ctx context.Context, owner, repo string, body RepoMergeUpstreamRequest) (*RepoMergeUpstreamResult, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/merge-upstream", owner, repo)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {

--- a/github/repos_merging.go
+++ b/github/repos_merging.go
@@ -13,8 +13,8 @@ import (
 // RepositoryMergeRequest represents a request to merge a branch in a
 // repository.
 type RepositoryMergeRequest struct {
-	Base          *string `json:"base,omitempty"`
-	Head          *string `json:"head,omitempty"`
+	Base          string  `json:"base"`
+	Head          string  `json:"head"`
 	CommitMessage *string `json:"commit_message,omitempty"`
 }
 
@@ -37,7 +37,7 @@ type RepoMergeUpstreamResult struct {
 // GitHub API docs: https://docs.github.com/rest/branches/branches?apiVersion=2022-11-28#merge-a-branch
 //
 //meta:operation POST /repos/{owner}/{repo}/merges
-func (s *RepositoriesService) Merge(ctx context.Context, owner, repo string, body *RepositoryMergeRequest) (*RepositoryCommit, *Response, error) {
+func (s *RepositoriesService) Merge(ctx context.Context, owner, repo string, body RepositoryMergeRequest) (*RepositoryCommit, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/merges", owner, repo)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {

--- a/github/repos_merging_test.go
+++ b/github/repos_merging_test.go
@@ -17,9 +17,9 @@ func TestRepositoriesService_Merge(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &RepositoryMergeRequest{
-		Base:          Ptr("b"),
-		Head:          Ptr("h"),
+	input := RepositoryMergeRequest{
+		Base:          "b",
+		Head:          "h",
 		CommitMessage: Ptr("c"),
 	}
 

--- a/github/repos_merging_test.go
+++ b/github/repos_merging_test.go
@@ -59,8 +59,8 @@ func TestRepositoriesService_MergeUpstream(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &RepoMergeUpstreamRequest{
-		Branch: Ptr("b"),
+	input := RepoMergeUpstreamRequest{
+		Branch: "b",
 	}
 
 	mux.HandleFunc("/repos/o/r/merge-upstream", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
BREAKING CHANGE: `RepositoriesService.Merge` and `RepositoriesService.MergeUpstream` now pass `body` by value and required struct fields are now values.

This continues the #3644 value-parameter refactor for the two request bodies in `github/repos_merging.go`.

## `Repositories.Merge` (`POST /repos/{owner}/{repo}/merges`)

- `Merge` now takes `RepositoryMergeRequest` by value.
- The schema-required `Base` and `Head` become non-pointer `string` (dropping `omitempty`); the optional `CommitMessage` stays `*string` with `omitempty`. Matches the OpenAPI schema 1:1 (`required: [base, head]`).

## `Repositories.MergeUpstream` (`POST /repos/{owner}/{repo}/merge-upstream`)

- `MergeUpstream` now takes `RepoMergeUpstreamRequest` by value.
- The schema-required `Branch` becomes a non-pointer `string` (`required: [branch]`).

Both types were removed from the `paramcheck` `body-allowed-pointer-types` allowlist in `.golangci.yml`, and accessors were regenerated.

Towards #3644
