### PR TITLE
refactor!: Pass `TemplateRepoRequest` by value in `Repositories.CreateFromTemplate`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -269,7 +269,6 @@ linters:
             - TeamAddTeamRepoOptions
             - TeamLDAPMapping
             - TeamProjectOptions
-            - TemplateRepoRequest
             - UpdateCodespaceOptions
             - UpdateDefaultSetupConfigurationOptions
             - UpdateProjectItemOptions

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -41494,12 +41494,12 @@ func (t *TemplateRepoRequest) GetIncludeAllBranches() bool {
 	return *t.IncludeAllBranches
 }
 
-// GetName returns the Name field if it's non-nil, zero value otherwise.
+// GetName returns the Name field.
 func (t *TemplateRepoRequest) GetName() string {
-	if t == nil || t.Name == nil {
+	if t == nil {
 		return ""
 	}
-	return *t.Name
+	return t.Name
 }
 
 // GetOwner returns the Owner field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -52006,10 +52006,7 @@ func TestTemplateRepoRequest_GetIncludeAllBranches(tt *testing.T) {
 
 func TestTemplateRepoRequest_GetName(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	t := &TemplateRepoRequest{Name: &zeroValue}
-	t.GetName()
-	t = &TemplateRepoRequest{}
+	t := &TemplateRepoRequest{}
 	t.GetName()
 	t = nil
 	t.GetName()

--- a/github/repos.go
+++ b/github/repos.go
@@ -620,13 +620,11 @@ func (s *RepositoriesService) Create(ctx context.Context, org string, repo *Repo
 
 // TemplateRepoRequest represents a request to create a repository from a template.
 type TemplateRepoRequest struct {
-	// Name is required when creating a repo.
-	Name        string  `json:"name"`
-	Owner       *string `json:"owner,omitempty"`
-	Description *string `json:"description,omitempty"`
-
-	IncludeAllBranches *bool `json:"include_all_branches,omitempty"`
-	Private            *bool `json:"private,omitempty"`
+	Name               string  `json:"name"`
+	Owner              *string `json:"owner,omitempty"`
+	Description        *string `json:"description,omitempty"`
+	IncludeAllBranches *bool   `json:"include_all_branches,omitempty"`
+	Private            *bool   `json:"private,omitempty"`
 }
 
 // CreateFromTemplate generates a repository from a template.

--- a/github/repos.go
+++ b/github/repos.go
@@ -621,7 +621,7 @@ func (s *RepositoriesService) Create(ctx context.Context, org string, repo *Repo
 // TemplateRepoRequest represents a request to create a repository from a template.
 type TemplateRepoRequest struct {
 	// Name is required when creating a repo.
-	Name        *string `json:"name,omitempty"`
+	Name        string  `json:"name"`
 	Owner       *string `json:"owner,omitempty"`
 	Description *string `json:"description,omitempty"`
 
@@ -634,7 +634,7 @@ type TemplateRepoRequest struct {
 // GitHub API docs: https://docs.github.com/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-using-a-template
 //
 //meta:operation POST /repos/{template_owner}/{template_repo}/generate
-func (s *RepositoriesService) CreateFromTemplate(ctx context.Context, templateOwner, templateRepo string, body *TemplateRepoRequest) (*Repository, *Response, error) {
+func (s *RepositoriesService) CreateFromTemplate(ctx context.Context, templateOwner, templateRepo string, body TemplateRepoRequest) (*Repository, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/generate", templateOwner, templateRepo)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)

--- a/github/repos_test.go
+++ b/github/repos_test.go
@@ -341,8 +341,8 @@ func TestRepositoriesService_CreateFromTemplate(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	templateRepoReq := &TemplateRepoRequest{
-		Name: Ptr("n"),
+	templateRepoReq := TemplateRepoRequest{
+		Name: "n",
 	}
 
 	mux.HandleFunc("/repos/to/tr/generate", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
BREAKING CHANGE: `RepositoriesService.CreateFromTemplate` now passes `body` by value and `Name` is now required and passed by value.

Towards #3644.

`Repositories.CreateFromTemplate` now takes its `TemplateRepoRequest` body by value instead of by pointer, and the required `name` property becomes a non-pointer `string` (its `omitempty` is dropped), so the required body is enforced at compile time.

The OpenAPI schema for `POST /repos/{template_owner}/{template_repo}/generate` lists `name` as the only required property, and its properties (`owner`, `name`, `description`, `include_all_branches`, `private`) map 1:1 to the struct — no fields are missing, so nothing is added.

`TemplateRepoRequest` is removed from the `paramcheck` `body-allowed-pointer-types` allowlist in `.golangci.yml`, and the generated accessors are regenerated (`GetName` now returns the value directly).
