### PR TITLE
refactor!: Pass `CreateDeploymentBranchPolicyRequest` and `UpdateDeploymentBranchPolicyRequest` by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -222,7 +222,6 @@ linters:
             - DependabotAlertState
             - DependabotEncryptedSecret
             - DependencyGraphSnapshot
-            - DeploymentBranchPolicyRequest
             - EncryptedSecret
             - EnterpriseSecurityAnalysisSettings
             - ExternalGroup

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -13206,12 +13206,12 @@ func (d *DeploymentBranchPolicy) GetType() string {
 	return *d.Type
 }
 
-// GetName returns the Name field if it's non-nil, zero value otherwise.
+// GetName returns the Name field.
 func (d *DeploymentBranchPolicyRequest) GetName() string {
-	if d == nil || d.Name == nil {
+	if d == nil {
 		return ""
 	}
-	return *d.Name
+	return d.Name
 }
 
 // GetType returns the Type field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -10878,6 +10878,22 @@ func (c *CreateCustomOrgRoleRequest) GetPermissions() []string {
 	return c.Permissions
 }
 
+// GetName returns the Name field.
+func (c *CreateDeploymentBranchPolicyRequest) GetName() string {
+	if c == nil {
+		return ""
+	}
+	return c.Name
+}
+
+// GetType returns the Type field if it's non-nil, zero value otherwise.
+func (c *CreateDeploymentBranchPolicyRequest) GetType() string {
+	if c == nil || c.Type == nil {
+		return ""
+	}
+	return *c.Type
+}
+
 // GetAllowsPublicRepositories returns the AllowsPublicRepositories field if it's non-nil, zero value otherwise.
 func (c *CreateEnterpriseRunnerGroupRequest) GetAllowsPublicRepositories() bool {
 	if c == nil || c.AllowsPublicRepositories == nil {
@@ -13200,22 +13216,6 @@ func (d *DeploymentBranchPolicy) GetNodeID() string {
 
 // GetType returns the Type field if it's non-nil, zero value otherwise.
 func (d *DeploymentBranchPolicy) GetType() string {
-	if d == nil || d.Type == nil {
-		return ""
-	}
-	return *d.Type
-}
-
-// GetName returns the Name field.
-func (d *DeploymentBranchPolicyRequest) GetName() string {
-	if d == nil {
-		return ""
-	}
-	return d.Name
-}
-
-// GetType returns the Type field if it's non-nil, zero value otherwise.
-func (d *DeploymentBranchPolicyRequest) GetType() string {
 	if d == nil || d.Type == nil {
 		return ""
 	}
@@ -42380,6 +42380,14 @@ func (u *UpdateDefaultSetupConfigurationResponse) GetRunURL() string {
 		return ""
 	}
 	return *u.RunURL
+}
+
+// GetName returns the Name field.
+func (u *UpdateDeploymentBranchPolicyRequest) GetName() string {
+	if u == nil {
+		return ""
+	}
+	return u.Name
 }
 
 // GetAllowsPublicRepositories returns the AllowsPublicRepositories field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -16749,10 +16749,7 @@ func TestDeploymentBranchPolicy_GetType(tt *testing.T) {
 
 func TestDeploymentBranchPolicyRequest_GetName(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	d := &DeploymentBranchPolicyRequest{Name: &zeroValue}
-	d.GetName()
-	d = &DeploymentBranchPolicyRequest{}
+	d := &DeploymentBranchPolicyRequest{}
 	d.GetName()
 	d = nil
 	d.GetName()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -13801,6 +13801,25 @@ func TestCreateCustomOrgRoleRequest_GetPermissions(tt *testing.T) {
 	c.GetPermissions()
 }
 
+func TestCreateDeploymentBranchPolicyRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateDeploymentBranchPolicyRequest{}
+	c.GetName()
+	c = nil
+	c.GetName()
+}
+
+func TestCreateDeploymentBranchPolicyRequest_GetType(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateDeploymentBranchPolicyRequest{Type: &zeroValue}
+	c.GetType()
+	c = &CreateDeploymentBranchPolicyRequest{}
+	c.GetType()
+	c = nil
+	c.GetType()
+}
+
 func TestCreateEnterpriseRunnerGroupRequest_GetAllowsPublicRepositories(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
@@ -16742,25 +16761,6 @@ func TestDeploymentBranchPolicy_GetType(tt *testing.T) {
 	d := &DeploymentBranchPolicy{Type: &zeroValue}
 	d.GetType()
 	d = &DeploymentBranchPolicy{}
-	d.GetType()
-	d = nil
-	d.GetType()
-}
-
-func TestDeploymentBranchPolicyRequest_GetName(tt *testing.T) {
-	tt.Parallel()
-	d := &DeploymentBranchPolicyRequest{}
-	d.GetName()
-	d = nil
-	d.GetName()
-}
-
-func TestDeploymentBranchPolicyRequest_GetType(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	d := &DeploymentBranchPolicyRequest{Type: &zeroValue}
-	d.GetType()
-	d = &DeploymentBranchPolicyRequest{}
 	d.GetType()
 	d = nil
 	d.GetType()
@@ -53139,6 +53139,14 @@ func TestUpdateDefaultSetupConfigurationResponse_GetRunURL(tt *testing.T) {
 	u.GetRunURL()
 	u = nil
 	u.GetRunURL()
+}
+
+func TestUpdateDeploymentBranchPolicyRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	u := &UpdateDeploymentBranchPolicyRequest{}
+	u.GetName()
+	u = nil
+	u.GetName()
 }
 
 func TestUpdateEnterpriseRunnerGroupRequest_GetAllowsPublicRepositories(tt *testing.T) {

--- a/github/repos_deployment_branch_policies.go
+++ b/github/repos_deployment_branch_policies.go
@@ -24,10 +24,15 @@ type DeploymentBranchPolicyResponse struct {
 	BranchPolicies []*DeploymentBranchPolicy `json:"branch_policies,omitempty"`
 }
 
-// DeploymentBranchPolicyRequest represents a deployment branch policy request.
-type DeploymentBranchPolicyRequest struct {
+// CreateDeploymentBranchPolicyRequest represents a request to create a deployment branch policy.
+type CreateDeploymentBranchPolicyRequest struct {
 	Name string  `json:"name"`
 	Type *string `json:"type,omitempty"`
+}
+
+// UpdateDeploymentBranchPolicyRequest represents a request to update a deployment branch policy.
+type UpdateDeploymentBranchPolicyRequest struct {
+	Name string `json:"name"`
 }
 
 // ListDeploymentBranchPolicies lists the deployment branch policies for an environment.
@@ -83,7 +88,7 @@ func (s *RepositoriesService) GetDeploymentBranchPolicy(ctx context.Context, own
 // GitHub API docs: https://docs.github.com/rest/deployments/branch-policies?apiVersion=2022-11-28#create-a-deployment-branch-policy
 //
 //meta:operation POST /repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies
-func (s *RepositoriesService) CreateDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, body DeploymentBranchPolicyRequest) (*DeploymentBranchPolicy, *Response, error) {
+func (s *RepositoriesService) CreateDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, body CreateDeploymentBranchPolicyRequest) (*DeploymentBranchPolicy, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment-branch-policies", owner, repo, environment)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
@@ -105,7 +110,7 @@ func (s *RepositoriesService) CreateDeploymentBranchPolicy(ctx context.Context, 
 // GitHub API docs: https://docs.github.com/rest/deployments/branch-policies?apiVersion=2022-11-28#update-a-deployment-branch-policy
 //
 //meta:operation PUT /repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies/{branch_policy_id}
-func (s *RepositoriesService) UpdateDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, branchPolicyID int64, body DeploymentBranchPolicyRequest) (*DeploymentBranchPolicy, *Response, error) {
+func (s *RepositoriesService) UpdateDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, branchPolicyID int64, body UpdateDeploymentBranchPolicyRequest) (*DeploymentBranchPolicy, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment-branch-policies/%v", owner, repo, environment, branchPolicyID)
 
 	req, err := s.client.NewRequest(ctx, "PUT", u, body)

--- a/github/repos_deployment_branch_policies.go
+++ b/github/repos_deployment_branch_policies.go
@@ -26,7 +26,7 @@ type DeploymentBranchPolicyResponse struct {
 
 // DeploymentBranchPolicyRequest represents a deployment branch policy request.
 type DeploymentBranchPolicyRequest struct {
-	Name *string `json:"name,omitempty"`
+	Name string  `json:"name"`
 	Type *string `json:"type,omitempty"`
 }
 
@@ -83,7 +83,7 @@ func (s *RepositoriesService) GetDeploymentBranchPolicy(ctx context.Context, own
 // GitHub API docs: https://docs.github.com/rest/deployments/branch-policies?apiVersion=2022-11-28#create-a-deployment-branch-policy
 //
 //meta:operation POST /repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies
-func (s *RepositoriesService) CreateDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, body *DeploymentBranchPolicyRequest) (*DeploymentBranchPolicy, *Response, error) {
+func (s *RepositoriesService) CreateDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, body DeploymentBranchPolicyRequest) (*DeploymentBranchPolicy, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment-branch-policies", owner, repo, environment)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
@@ -105,7 +105,7 @@ func (s *RepositoriesService) CreateDeploymentBranchPolicy(ctx context.Context, 
 // GitHub API docs: https://docs.github.com/rest/deployments/branch-policies?apiVersion=2022-11-28#update-a-deployment-branch-policy
 //
 //meta:operation PUT /repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies/{branch_policy_id}
-func (s *RepositoriesService) UpdateDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, branchPolicyID int64, body *DeploymentBranchPolicyRequest) (*DeploymentBranchPolicy, *Response, error) {
+func (s *RepositoriesService) UpdateDeploymentBranchPolicy(ctx context.Context, owner, repo, environment string, branchPolicyID int64, body DeploymentBranchPolicyRequest) (*DeploymentBranchPolicy, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/environments/%v/deployment-branch-policies/%v", owner, repo, environment, branchPolicyID)
 
 	req, err := s.client.NewRequest(ctx, "PUT", u, body)

--- a/github/repos_deployment_branch_policies_test.go
+++ b/github/repos_deployment_branch_policies_test.go
@@ -97,7 +97,7 @@ func TestRepositoriesService_CreateDeploymentBranchPolicy(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	got, _, err := client.Repositories.CreateDeploymentBranchPolicy(ctx, "o", "r", "e", DeploymentBranchPolicyRequest{Name: "n", Type: Ptr("branch")})
+	got, _, err := client.Repositories.CreateDeploymentBranchPolicy(ctx, "o", "r", "e", CreateDeploymentBranchPolicyRequest{Name: "n", Type: Ptr("branch")})
 	if err != nil {
 		t.Errorf("Repositories.CreateDeploymentBranchPolicy returned error: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestRepositoriesService_CreateDeploymentBranchPolicy(t *testing.T) {
 
 	const methodName = "CreateDeploymentBranchPolicy"
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.CreateDeploymentBranchPolicy(ctx, "o", "r", "e", DeploymentBranchPolicyRequest{Name: "n"})
+		got, resp, err := client.Repositories.CreateDeploymentBranchPolicy(ctx, "o", "r", "e", CreateDeploymentBranchPolicyRequest{Name: "n"})
 		if got != nil {
 			t.Errorf("got non-nil Repositories.CreateDeploymentBranchPolicy response: %+v", got)
 		}
@@ -127,7 +127,7 @@ func TestRepositoriesService_UpdateDeploymentBranchPolicy(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	got, _, err := client.Repositories.UpdateDeploymentBranchPolicy(ctx, "o", "r", "e", 1, DeploymentBranchPolicyRequest{Name: "n"})
+	got, _, err := client.Repositories.UpdateDeploymentBranchPolicy(ctx, "o", "r", "e", 1, UpdateDeploymentBranchPolicyRequest{Name: "n"})
 	if err != nil {
 		t.Errorf("Repositories.UpdateDeploymentBranchPolicy returned error: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestRepositoriesService_UpdateDeploymentBranchPolicy(t *testing.T) {
 
 	const methodName = "UpdateDeploymentBranchPolicy"
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.UpdateDeploymentBranchPolicy(ctx, "o", "r", "e", 1, DeploymentBranchPolicyRequest{Name: "n"})
+		got, resp, err := client.Repositories.UpdateDeploymentBranchPolicy(ctx, "o", "r", "e", 1, UpdateDeploymentBranchPolicyRequest{Name: "n"})
 		if got != nil {
 			t.Errorf("got non-nil Repositories.UpdateDeploymentBranchPolicy response: %+v", got)
 		}

--- a/github/repos_deployment_branch_policies_test.go
+++ b/github/repos_deployment_branch_policies_test.go
@@ -97,7 +97,7 @@ func TestRepositoriesService_CreateDeploymentBranchPolicy(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	got, _, err := client.Repositories.CreateDeploymentBranchPolicy(ctx, "o", "r", "e", &DeploymentBranchPolicyRequest{Name: Ptr("n"), Type: Ptr("branch")})
+	got, _, err := client.Repositories.CreateDeploymentBranchPolicy(ctx, "o", "r", "e", DeploymentBranchPolicyRequest{Name: "n", Type: Ptr("branch")})
 	if err != nil {
 		t.Errorf("Repositories.CreateDeploymentBranchPolicy returned error: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestRepositoriesService_CreateDeploymentBranchPolicy(t *testing.T) {
 
 	const methodName = "CreateDeploymentBranchPolicy"
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.CreateDeploymentBranchPolicy(ctx, "o", "r", "e", &DeploymentBranchPolicyRequest{Name: Ptr("n")})
+		got, resp, err := client.Repositories.CreateDeploymentBranchPolicy(ctx, "o", "r", "e", DeploymentBranchPolicyRequest{Name: "n"})
 		if got != nil {
 			t.Errorf("got non-nil Repositories.CreateDeploymentBranchPolicy response: %+v", got)
 		}
@@ -127,7 +127,7 @@ func TestRepositoriesService_UpdateDeploymentBranchPolicy(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	got, _, err := client.Repositories.UpdateDeploymentBranchPolicy(ctx, "o", "r", "e", 1, &DeploymentBranchPolicyRequest{Name: Ptr("n")})
+	got, _, err := client.Repositories.UpdateDeploymentBranchPolicy(ctx, "o", "r", "e", 1, DeploymentBranchPolicyRequest{Name: "n"})
 	if err != nil {
 		t.Errorf("Repositories.UpdateDeploymentBranchPolicy returned error: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestRepositoriesService_UpdateDeploymentBranchPolicy(t *testing.T) {
 
 	const methodName = "UpdateDeploymentBranchPolicy"
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.UpdateDeploymentBranchPolicy(ctx, "o", "r", "e", 1, &DeploymentBranchPolicyRequest{Name: Ptr("n")})
+		got, resp, err := client.Repositories.UpdateDeploymentBranchPolicy(ctx, "o", "r", "e", 1, DeploymentBranchPolicyRequest{Name: "n"})
 		if got != nil {
 			t.Errorf("got non-nil Repositories.UpdateDeploymentBranchPolicy response: %+v", got)
 		}


### PR DESCRIPTION
BREAKING CHANGE: `RepositoriesService.CreateDeploymentBranchPolicy` and `UpdateDeploymentBranchPolicy` now take `body` by value and the required `Name` field is of type `string`.

Towards #3644.

The create and update operations use different request schemas, so this replaces the shared `DeploymentBranchPolicyRequest` with two dedicated request types, both passed by value instead of by pointer:

| Method | Schema | `required` | Properties |
| --- | --- | --- | --- |
| `CreateDeploymentBranchPolicy` (POST) | `deployment-branch-policy-name-pattern-with-type` | `[name]` | `name`, `type` |
| `UpdateDeploymentBranchPolicy` (PUT) | `deployment-branch-policy-name-pattern` | `[name]` | `name` |

`CreateDeploymentBranchPolicyRequest` has a required non-pointer `Name` and an optional `Type`; `UpdateDeploymentBranchPolicyRequest` has only the required non-pointer `Name`, so the update method no longer exposes a `type` field the endpoint does not accept.

`DeploymentBranchPolicyRequest` is removed from the `paramcheck` `body-allowed-pointer-types` allowlist in `.golangci.yml`, and the generated accessors are regenerated (`GetName` returns the value directly).
