### PR TITLE
refactor!: Pass `SarifAnalysis` by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -259,7 +259,6 @@ linters:
             - RequiredStatusChecksRequest
             - ReviewCustomDeploymentProtectionRuleRequest
             - SCIMUserAttributes
-            - SarifAnalysis
             - SecretScanningAlertUpdateOptions
             - SecretScanningPatternConfigsUpdateOptions
             - SourceImportAuthor

--- a/github/code_scanning.go
+++ b/github/code_scanning.go
@@ -215,8 +215,7 @@ type SarifAnalysis struct {
 	CheckoutURI *string    `json:"checkout_uri,omitempty"`
 	StartedAt   *Timestamp `json:"started_at,omitempty"`
 	ToolName    *string    `json:"tool_name,omitempty"`
-	// Validate indicates whether the SARIF file will be validated according to the code scanning specification.
-	Validate *bool `json:"validate,omitempty"`
+	Validate    *bool      `json:"validate,omitempty"`
 }
 
 // CodeScanningAlertState specifies the state of a code scanning alert.

--- a/github/code_scanning.go
+++ b/github/code_scanning.go
@@ -209,9 +209,9 @@ type ScanningAnalysis struct {
 //
 // GitHub API docs: https://docs.github.com/rest/code-scanning?apiVersion=2022-11-28
 type SarifAnalysis struct {
-	CommitSHA   *string    `json:"commit_sha,omitempty"`
-	Ref         *string    `json:"ref,omitempty"`
-	Sarif       *string    `json:"sarif,omitempty"`
+	CommitSHA   string     `json:"commit_sha"`
+	Ref         string     `json:"ref"`
+	Sarif       string     `json:"sarif"`
 	CheckoutURI *string    `json:"checkout_uri,omitempty"`
 	StartedAt   *Timestamp `json:"started_at,omitempty"`
 	ToolName    *string    `json:"tool_name,omitempty"`
@@ -392,7 +392,7 @@ func (s *CodeScanningService) ListAlertInstances(ctx context.Context, owner, rep
 // GitHub API docs: https://docs.github.com/rest/code-scanning/code-scanning?apiVersion=2022-11-28#upload-an-analysis-as-sarif-data
 //
 //meta:operation POST /repos/{owner}/{repo}/code-scanning/sarifs
-func (s *CodeScanningService) UploadSarif(ctx context.Context, owner, repo string, body *SarifAnalysis) (*SarifID, *Response, error) {
+func (s *CodeScanningService) UploadSarif(ctx context.Context, owner, repo string, body SarifAnalysis) (*SarifID, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/code-scanning/sarifs", owner, repo)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)

--- a/github/code_scanning.go
+++ b/github/code_scanning.go
@@ -215,6 +215,8 @@ type SarifAnalysis struct {
 	CheckoutURI *string    `json:"checkout_uri,omitempty"`
 	StartedAt   *Timestamp `json:"started_at,omitempty"`
 	ToolName    *string    `json:"tool_name,omitempty"`
+	// Validate indicates whether the SARIF file will be validated according to the code scanning specification.
+	Validate *bool `json:"validate,omitempty"`
 }
 
 // CodeScanningAlertState specifies the state of a code scanning alert.

--- a/github/code_scanning_test.go
+++ b/github/code_scanning_test.go
@@ -62,7 +62,7 @@ func TestCodeScanningService_UploadSarif(t *testing.T) {
 		URL: Ptr("https://example.com/testurl"),
 	}
 
-	sarifAnalysis := &SarifAnalysis{CommitSHA: Ptr("abc"), Ref: Ptr("ref/head/main"), Sarif: Ptr("abc"), CheckoutURI: Ptr("uri"), StartedAt: &referenceTimestamp, ToolName: Ptr("codeql-cli")}
+	sarifAnalysis := SarifAnalysis{CommitSHA: "abc", Ref: "ref/head/main", Sarif: "abc", CheckoutURI: Ptr("uri"), StartedAt: &referenceTimestamp, ToolName: Ptr("codeql-cli")}
 
 	mux.HandleFunc("/repos/o/r/code-scanning/sarifs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/github/code_scanning_test.go
+++ b/github/code_scanning_test.go
@@ -62,7 +62,7 @@ func TestCodeScanningService_UploadSarif(t *testing.T) {
 		URL: Ptr("https://example.com/testurl"),
 	}
 
-	sarifAnalysis := SarifAnalysis{CommitSHA: "abc", Ref: "ref/head/main", Sarif: "abc", CheckoutURI: Ptr("uri"), StartedAt: &referenceTimestamp, ToolName: Ptr("codeql-cli")}
+	sarifAnalysis := SarifAnalysis{CommitSHA: "abc", Ref: "ref/head/main", Sarif: "abc", CheckoutURI: Ptr("uri"), StartedAt: &referenceTimestamp, ToolName: Ptr("codeql-cli"), Validate: Ptr(true)}
 
 	mux.HandleFunc("/repos/o/r/code-scanning/sarifs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -37566,6 +37566,14 @@ func (s *SarifAnalysis) GetToolName() string {
 	return *s.ToolName
 }
 
+// GetValidate returns the Validate field if it's non-nil, zero value otherwise.
+func (s *SarifAnalysis) GetValidate() bool {
+	if s == nil || s.Validate == nil {
+		return false
+	}
+	return *s.Validate
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (s *SarifID) GetID() string {
 	if s == nil || s.ID == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -37526,28 +37526,28 @@ func (s *SarifAnalysis) GetCheckoutURI() string {
 	return *s.CheckoutURI
 }
 
-// GetCommitSHA returns the CommitSHA field if it's non-nil, zero value otherwise.
+// GetCommitSHA returns the CommitSHA field.
 func (s *SarifAnalysis) GetCommitSHA() string {
-	if s == nil || s.CommitSHA == nil {
+	if s == nil {
 		return ""
 	}
-	return *s.CommitSHA
+	return s.CommitSHA
 }
 
-// GetRef returns the Ref field if it's non-nil, zero value otherwise.
+// GetRef returns the Ref field.
 func (s *SarifAnalysis) GetRef() string {
-	if s == nil || s.Ref == nil {
+	if s == nil {
 		return ""
 	}
-	return *s.Ref
+	return s.Ref
 }
 
-// GetSarif returns the Sarif field if it's non-nil, zero value otherwise.
+// GetSarif returns the Sarif field.
 func (s *SarifAnalysis) GetSarif() string {
-	if s == nil || s.Sarif == nil {
+	if s == nil {
 		return ""
 	}
-	return *s.Sarif
+	return s.Sarif
 }
 
 // GetStartedAt returns the StartedAt field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -47104,6 +47104,17 @@ func TestSarifAnalysis_GetToolName(tt *testing.T) {
 	s.GetToolName()
 }
 
+func TestSarifAnalysis_GetValidate(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	s := &SarifAnalysis{Validate: &zeroValue}
+	s.GetValidate()
+	s = &SarifAnalysis{}
+	s.GetValidate()
+	s = nil
+	s.GetValidate()
+}
+
 func TestSarifID_GetID(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -47060,10 +47060,7 @@ func TestSarifAnalysis_GetCheckoutURI(tt *testing.T) {
 
 func TestSarifAnalysis_GetCommitSHA(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	s := &SarifAnalysis{CommitSHA: &zeroValue}
-	s.GetCommitSHA()
-	s = &SarifAnalysis{}
+	s := &SarifAnalysis{}
 	s.GetCommitSHA()
 	s = nil
 	s.GetCommitSHA()
@@ -47071,10 +47068,7 @@ func TestSarifAnalysis_GetCommitSHA(tt *testing.T) {
 
 func TestSarifAnalysis_GetRef(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	s := &SarifAnalysis{Ref: &zeroValue}
-	s.GetRef()
-	s = &SarifAnalysis{}
+	s := &SarifAnalysis{}
 	s.GetRef()
 	s = nil
 	s.GetRef()
@@ -47082,10 +47076,7 @@ func TestSarifAnalysis_GetRef(tt *testing.T) {
 
 func TestSarifAnalysis_GetSarif(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	s := &SarifAnalysis{Sarif: &zeroValue}
-	s.GetSarif()
-	s = &SarifAnalysis{}
+	s := &SarifAnalysis{}
 	s.GetSarif()
 	s = nil
 	s.GetSarif()


### PR DESCRIPTION
BREAKING CHANGE: `CodeScanningService.UploadSarif` now takes `body` by value and its required fields are no longer pointers.

Towards #3644.

This has two commits:

1. **`refactor!`** — `CodeScanning.UploadSarif` now takes its `SarifAnalysis` body by value instead of by pointer, and the three required properties become non-pointer strings (their `omitempty` is dropped). The OpenAPI schema for `POST /repos/{owner}/{repo}/code-scanning/sarifs` lists `commit_sha`, `ref`, and `sarif` as `required`, so `SarifAnalysis.CommitSHA`, `.Ref`, and `.Sarif` are now `string`. `SarifAnalysis` is removed from the `paramcheck` `body-allowed-pointer-types` allowlist in `.golangci.yml`.

2. **`feat`** — adds the optional `Validate *bool` (`validate`) property, which the same endpoint accepts but `SarifAnalysis` was missing.

`SarifAnalysis` is the dedicated body of that single endpoint (the response is a separate `SarifID`), so there is no shared-type / split concern. The generated accessors are regenerated.
