### PR TITLE
refactor!: Rename `NewPullRequest` to `CreatePullRequest` and pass it by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -238,7 +238,6 @@ linters:
             - LockIssueOptions
             - MaintenanceOptions
             - Milestone
-            - NewPullRequest
             - Organization
             - PagesUpdate
             - PagesUpdateWithoutCNAME

--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -194,7 +194,7 @@ func createPR() (err error) {
 		prRepo = sourceRepo
 	}
 
-	newPR := github.NewPullRequest{
+	newPR := github.CreatePullRequest{
 		Title:               prSubject,
 		Head:                *commitBranch,
 		HeadRepo:            repoBranch,

--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -194,11 +194,11 @@ func createPR() (err error) {
 		prRepo = sourceRepo
 	}
 
-	newPR := &github.NewPullRequest{
+	newPR := github.NewPullRequest{
 		Title:               prSubject,
-		Head:                commitBranch,
+		Head:                *commitBranch,
 		HeadRepo:            repoBranch,
-		Base:                prBranch,
+		Base:                *prBranch,
 		Body:                prDescription,
 		MaintainerCanModify: github.Ptr(true),
 	}

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -135,10 +135,10 @@ func ExamplePullRequestsService_Create() {
 		log.Fatalf("Error creating GitHub client: %v", err)
 	}
 
-	newPR := &github.NewPullRequest{
+	newPR := github.NewPullRequest{
 		Title:               github.Ptr("My awesome pull request"),
-		Head:                github.Ptr("branch_to_merge"),
-		Base:                github.Ptr("master"),
+		Head:                "branch_to_merge",
+		Base:                "master",
 		Body:                github.Ptr("This is the description of the PR created with the package `github.com/google/go-github/github`"),
 		MaintainerCanModify: github.Ptr(true),
 	}

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -135,7 +135,7 @@ func ExamplePullRequestsService_Create() {
 		log.Fatalf("Error creating GitHub client: %v", err)
 	}
 
-	newPR := github.NewPullRequest{
+	newPR := github.CreatePullRequest{
 		Title:               github.Ptr("My awesome pull request"),
 		Head:                "branch_to_merge",
 		Base:                "master",

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -24886,12 +24886,12 @@ func (n *NetworkSettingsResource) GetSubnetID() string {
 	return *n.SubnetID
 }
 
-// GetBase returns the Base field if it's non-nil, zero value otherwise.
+// GetBase returns the Base field.
 func (n *NewPullRequest) GetBase() string {
-	if n == nil || n.Base == nil {
+	if n == nil {
 		return ""
 	}
-	return *n.Base
+	return n.Base
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
@@ -24910,12 +24910,12 @@ func (n *NewPullRequest) GetDraft() bool {
 	return *n.Draft
 }
 
-// GetHead returns the Head field if it's non-nil, zero value otherwise.
+// GetHead returns the Head field.
 func (n *NewPullRequest) GetHead() string {
-	if n == nil || n.Head == nil {
+	if n == nil {
 		return ""
 	}
-	return *n.Head
+	return n.Head
 }
 
 // GetHeadRepo returns the HeadRepo field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11414,6 +11414,70 @@ func (c *CreateProtectedChanges) GetFrom() bool {
 	return *c.From
 }
 
+// GetBase returns the Base field.
+func (c *CreatePullRequest) GetBase() string {
+	if c == nil {
+		return ""
+	}
+	return c.Base
+}
+
+// GetBody returns the Body field if it's non-nil, zero value otherwise.
+func (c *CreatePullRequest) GetBody() string {
+	if c == nil || c.Body == nil {
+		return ""
+	}
+	return *c.Body
+}
+
+// GetDraft returns the Draft field if it's non-nil, zero value otherwise.
+func (c *CreatePullRequest) GetDraft() bool {
+	if c == nil || c.Draft == nil {
+		return false
+	}
+	return *c.Draft
+}
+
+// GetHead returns the Head field.
+func (c *CreatePullRequest) GetHead() string {
+	if c == nil {
+		return ""
+	}
+	return c.Head
+}
+
+// GetHeadRepo returns the HeadRepo field if it's non-nil, zero value otherwise.
+func (c *CreatePullRequest) GetHeadRepo() string {
+	if c == nil || c.HeadRepo == nil {
+		return ""
+	}
+	return *c.HeadRepo
+}
+
+// GetIssue returns the Issue field if it's non-nil, zero value otherwise.
+func (c *CreatePullRequest) GetIssue() int {
+	if c == nil || c.Issue == nil {
+		return 0
+	}
+	return *c.Issue
+}
+
+// GetMaintainerCanModify returns the MaintainerCanModify field if it's non-nil, zero value otherwise.
+func (c *CreatePullRequest) GetMaintainerCanModify() bool {
+	if c == nil || c.MaintainerCanModify == nil {
+		return false
+	}
+	return *c.MaintainerCanModify
+}
+
+// GetTitle returns the Title field if it's non-nil, zero value otherwise.
+func (c *CreatePullRequest) GetTitle() string {
+	if c == nil || c.Title == nil {
+		return ""
+	}
+	return *c.Title
+}
+
 // GetRef returns the Ref field.
 func (c *CreateRef) GetRef() string {
 	if c == nil {
@@ -24884,70 +24948,6 @@ func (n *NetworkSettingsResource) GetSubnetID() string {
 		return ""
 	}
 	return *n.SubnetID
-}
-
-// GetBase returns the Base field.
-func (n *NewPullRequest) GetBase() string {
-	if n == nil {
-		return ""
-	}
-	return n.Base
-}
-
-// GetBody returns the Body field if it's non-nil, zero value otherwise.
-func (n *NewPullRequest) GetBody() string {
-	if n == nil || n.Body == nil {
-		return ""
-	}
-	return *n.Body
-}
-
-// GetDraft returns the Draft field if it's non-nil, zero value otherwise.
-func (n *NewPullRequest) GetDraft() bool {
-	if n == nil || n.Draft == nil {
-		return false
-	}
-	return *n.Draft
-}
-
-// GetHead returns the Head field.
-func (n *NewPullRequest) GetHead() string {
-	if n == nil {
-		return ""
-	}
-	return n.Head
-}
-
-// GetHeadRepo returns the HeadRepo field if it's non-nil, zero value otherwise.
-func (n *NewPullRequest) GetHeadRepo() string {
-	if n == nil || n.HeadRepo == nil {
-		return ""
-	}
-	return *n.HeadRepo
-}
-
-// GetIssue returns the Issue field if it's non-nil, zero value otherwise.
-func (n *NewPullRequest) GetIssue() int {
-	if n == nil || n.Issue == nil {
-		return 0
-	}
-	return *n.Issue
-}
-
-// GetMaintainerCanModify returns the MaintainerCanModify field if it's non-nil, zero value otherwise.
-func (n *NewPullRequest) GetMaintainerCanModify() bool {
-	if n == nil || n.MaintainerCanModify == nil {
-		return false
-	}
-	return *n.MaintainerCanModify
-}
-
-// GetTitle returns the Title field if it's non-nil, zero value otherwise.
-func (n *NewPullRequest) GetTitle() string {
-	if n == nil || n.Title == nil {
-		return ""
-	}
-	return *n.Title
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -31237,10 +31237,7 @@ func TestNetworkSettingsResource_GetSubnetID(tt *testing.T) {
 
 func TestNewPullRequest_GetBase(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	n := &NewPullRequest{Base: &zeroValue}
-	n.GetBase()
-	n = &NewPullRequest{}
+	n := &NewPullRequest{}
 	n.GetBase()
 	n = nil
 	n.GetBase()
@@ -31270,10 +31267,7 @@ func TestNewPullRequest_GetDraft(tt *testing.T) {
 
 func TestNewPullRequest_GetHead(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	n := &NewPullRequest{Head: &zeroValue}
-	n.GetHead()
-	n = &NewPullRequest{}
+	n := &NewPullRequest{}
 	n.GetHead()
 	n = nil
 	n.GetHead()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -14484,6 +14484,88 @@ func TestCreateProtectedChanges_GetFrom(tt *testing.T) {
 	c.GetFrom()
 }
 
+func TestCreatePullRequest_GetBase(tt *testing.T) {
+	tt.Parallel()
+	c := &CreatePullRequest{}
+	c.GetBase()
+	c = nil
+	c.GetBase()
+}
+
+func TestCreatePullRequest_GetBody(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreatePullRequest{Body: &zeroValue}
+	c.GetBody()
+	c = &CreatePullRequest{}
+	c.GetBody()
+	c = nil
+	c.GetBody()
+}
+
+func TestCreatePullRequest_GetDraft(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	c := &CreatePullRequest{Draft: &zeroValue}
+	c.GetDraft()
+	c = &CreatePullRequest{}
+	c.GetDraft()
+	c = nil
+	c.GetDraft()
+}
+
+func TestCreatePullRequest_GetHead(tt *testing.T) {
+	tt.Parallel()
+	c := &CreatePullRequest{}
+	c.GetHead()
+	c = nil
+	c.GetHead()
+}
+
+func TestCreatePullRequest_GetHeadRepo(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreatePullRequest{HeadRepo: &zeroValue}
+	c.GetHeadRepo()
+	c = &CreatePullRequest{}
+	c.GetHeadRepo()
+	c = nil
+	c.GetHeadRepo()
+}
+
+func TestCreatePullRequest_GetIssue(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CreatePullRequest{Issue: &zeroValue}
+	c.GetIssue()
+	c = &CreatePullRequest{}
+	c.GetIssue()
+	c = nil
+	c.GetIssue()
+}
+
+func TestCreatePullRequest_GetMaintainerCanModify(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	c := &CreatePullRequest{MaintainerCanModify: &zeroValue}
+	c.GetMaintainerCanModify()
+	c = &CreatePullRequest{}
+	c.GetMaintainerCanModify()
+	c = nil
+	c.GetMaintainerCanModify()
+}
+
+func TestCreatePullRequest_GetTitle(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreatePullRequest{Title: &zeroValue}
+	c.GetTitle()
+	c = &CreatePullRequest{}
+	c.GetTitle()
+	c = nil
+	c.GetTitle()
+}
+
 func TestCreateRef_GetRef(tt *testing.T) {
 	tt.Parallel()
 	c := &CreateRef{}
@@ -31233,88 +31315,6 @@ func TestNetworkSettingsResource_GetSubnetID(tt *testing.T) {
 	n.GetSubnetID()
 	n = nil
 	n.GetSubnetID()
-}
-
-func TestNewPullRequest_GetBase(tt *testing.T) {
-	tt.Parallel()
-	n := &NewPullRequest{}
-	n.GetBase()
-	n = nil
-	n.GetBase()
-}
-
-func TestNewPullRequest_GetBody(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	n := &NewPullRequest{Body: &zeroValue}
-	n.GetBody()
-	n = &NewPullRequest{}
-	n.GetBody()
-	n = nil
-	n.GetBody()
-}
-
-func TestNewPullRequest_GetDraft(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue bool
-	n := &NewPullRequest{Draft: &zeroValue}
-	n.GetDraft()
-	n = &NewPullRequest{}
-	n.GetDraft()
-	n = nil
-	n.GetDraft()
-}
-
-func TestNewPullRequest_GetHead(tt *testing.T) {
-	tt.Parallel()
-	n := &NewPullRequest{}
-	n.GetHead()
-	n = nil
-	n.GetHead()
-}
-
-func TestNewPullRequest_GetHeadRepo(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	n := &NewPullRequest{HeadRepo: &zeroValue}
-	n.GetHeadRepo()
-	n = &NewPullRequest{}
-	n.GetHeadRepo()
-	n = nil
-	n.GetHeadRepo()
-}
-
-func TestNewPullRequest_GetIssue(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue int
-	n := &NewPullRequest{Issue: &zeroValue}
-	n.GetIssue()
-	n = &NewPullRequest{}
-	n.GetIssue()
-	n = nil
-	n.GetIssue()
-}
-
-func TestNewPullRequest_GetMaintainerCanModify(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue bool
-	n := &NewPullRequest{MaintainerCanModify: &zeroValue}
-	n.GetMaintainerCanModify()
-	n = &NewPullRequest{}
-	n.GetMaintainerCanModify()
-	n = nil
-	n.GetMaintainerCanModify()
-}
-
-func TestNewPullRequest_GetTitle(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	n := &NewPullRequest{Title: &zeroValue}
-	n.GetTitle()
-	n = &NewPullRequest{}
-	n.GetTitle()
-	n = nil
-	n.GetTitle()
 }
 
 func TestNewTeam_GetDescription(tt *testing.T) {

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -258,8 +258,8 @@ func (s *PullRequestsService) GetRaw(ctx context.Context, owner, repo string, nu
 	return buf.String(), resp, nil
 }
 
-// NewPullRequest represents a new pull request to be created.
-type NewPullRequest struct {
+// CreatePullRequest represents a request to create a pull request.
+type CreatePullRequest struct {
 	Title *string `json:"title,omitempty"`
 	// The name of the branch where your changes are implemented. For
 	// cross-repository pull requests in the same network, namespace head with
@@ -282,7 +282,7 @@ type NewPullRequest struct {
 // GitHub API docs: https://docs.github.com/rest/pulls/pulls?apiVersion=2022-11-28#create-a-pull-request
 //
 //meta:operation POST /repos/{owner}/{repo}/pulls
-func (s *PullRequestsService) Create(ctx context.Context, owner, repo string, body NewPullRequest) (*PullRequest, *Response, error) {
+func (s *PullRequestsService) Create(ctx context.Context, owner, repo string, body CreatePullRequest) (*PullRequest, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls", owner, repo)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -264,13 +264,13 @@ type NewPullRequest struct {
 	// The name of the branch where your changes are implemented. For
 	// cross-repository pull requests in the same network, namespace head with
 	// a user like this: username:branch.
-	Head     *string `json:"head,omitempty"`
+	Head     string  `json:"head"`
 	HeadRepo *string `json:"head_repo,omitempty"`
 	// The name of the branch you want the changes pulled into. This should be
 	// an existing branch on the current repository. You cannot submit a pull
 	// request to one repository that requests a merge to a base of another
 	// repository.
-	Base                *string `json:"base,omitempty"`
+	Base                string  `json:"base"`
 	Body                *string `json:"body,omitempty"`
 	Issue               *int    `json:"issue,omitempty"`
 	MaintainerCanModify *bool   `json:"maintainer_can_modify,omitempty"`
@@ -282,7 +282,7 @@ type NewPullRequest struct {
 // GitHub API docs: https://docs.github.com/rest/pulls/pulls?apiVersion=2022-11-28#create-a-pull-request
 //
 //meta:operation POST /repos/{owner}/{repo}/pulls
-func (s *PullRequestsService) Create(ctx context.Context, owner, repo string, body *NewPullRequest) (*PullRequest, *Response, error) {
+func (s *PullRequestsService) Create(ctx context.Context, owner, repo string, body NewPullRequest) (*PullRequest, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls", owner, repo)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -355,7 +355,7 @@ func TestPullRequestsService_Create(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &NewPullRequest{Title: Ptr("t")}
+	input := NewPullRequest{Title: Ptr("t")}
 
 	mux.HandleFunc("/repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -395,7 +395,7 @@ func TestPullRequestsService_Create_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.PullRequests.Create(ctx, "%", "r", nil)
+	_, _, err := client.PullRequests.Create(ctx, "%", "r", NewPullRequest{})
 	testURLParseError(t, err)
 }
 

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -355,7 +355,7 @@ func TestPullRequestsService_Create(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := NewPullRequest{Title: Ptr("t")}
+	input := CreatePullRequest{Title: Ptr("t")}
 
 	mux.HandleFunc("/repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -395,7 +395,7 @@ func TestPullRequestsService_Create_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.PullRequests.Create(ctx, "%", "r", NewPullRequest{})
+	_, _, err := client.PullRequests.Create(ctx, "%", "r", CreatePullRequest{})
 	testURLParseError(t, err)
 }
 


### PR DESCRIPTION
BREAKING CHANGE: `NewPullRequest` is renamed to `CreatePullRequest`, `PullRequests.Create` now takes it by value, and `CreatePullRequest.Head` and `CreatePullRequest.Base` are now `string`.

Towards #3644.

`PullRequests.Create` now takes its request body by value instead of by pointer, the type is renamed from `NewPullRequest` to `CreatePullRequest` (the `New` prefix reads as a constructor function; `Create` matches the create-a-pull-request operation), and the two required properties become non-pointer strings (their `omitempty` is dropped): the OpenAPI schema for `POST /repos/{owner}/{repo}/pulls` lists `head` and `base` as `required`, so `CreatePullRequest.Head` and `CreatePullRequest.Base` are now `string`.

`title` is not in the schema's `required` list (an issue number can be supplied via `issue` instead of a title), so `Title` and the other optional fields stay pointers. The schema's eight properties map 1:1 to the struct — nothing is missing, so nothing is added.

`CreatePullRequest` is the dedicated body of that single endpoint (the response is the separate `PullRequest` type), so there is no shared-type / split concern. The type is removed from the `paramcheck` `body-allowed-pointer-types` allowlist in `.golangci.yml`, the generated accessors are regenerated (`GetHead`/`GetBase` return the value directly), and the `example/commitpr` sample and `ExampleClient_pullRequests` are updated to match.

