### PR TITLE
refactor!: Split `IssueRequest` into `CreateIssueRequest` & `UpdateIssueRequest` and pass by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -232,7 +232,6 @@ linters:
             - InstallationTokenOptions
             - IssueComment
             - IssueImportRequest
-            - IssueRequest
             - Key
             - Label
             - LockIssueOptions

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -420,8 +420,6 @@ linters:
             - IssueListByRepoOptions.Since # TODO: Issues
             - IssueListCommentsOptions.Direction
             - IssueListCommentsOptions.Sort
-            - IssueRequest.Assignees # TODO: Issues
-            - IssueRequest.Labels # TODO: Issues
             - License.Conditions # TODO: Licenses
             - License.Limitations # TODO: Licenses
             - License.Permissions # TODO: Licenses

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -21358,6 +21358,14 @@ func (i *IssueRequest) GetBody() string {
 	return *i.Body
 }
 
+// GetDuplicateIssueID returns the DuplicateIssueID field if it's non-nil, zero value otherwise.
+func (i *IssueRequest) GetDuplicateIssueID() int {
+	if i == nil || i.DuplicateIssueID == nil {
+		return 0
+	}
+	return *i.DuplicateIssueID
+}
+
 // GetIssueFieldValues returns the IssueFieldValues slice if it's non-nil, nil otherwise.
 func (i *IssueRequest) GetIssueFieldValues() []*IssueRequestFieldValue {
 	if i == nil || i.IssueFieldValues == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11118,6 +11118,70 @@ func (c *CreateHostedRunnerRequest) GetSize() string {
 	return c.Size
 }
 
+// GetAssignee returns the Assignee field if it's non-nil, zero value otherwise.
+func (c *CreateIssueRequest) GetAssignee() string {
+	if c == nil || c.Assignee == nil {
+		return ""
+	}
+	return *c.Assignee
+}
+
+// GetAssignees returns the Assignees slice if it's non-nil, nil otherwise.
+func (c *CreateIssueRequest) GetAssignees() []string {
+	if c == nil || c.Assignees == nil {
+		return nil
+	}
+	return c.Assignees
+}
+
+// GetBody returns the Body field if it's non-nil, zero value otherwise.
+func (c *CreateIssueRequest) GetBody() string {
+	if c == nil || c.Body == nil {
+		return ""
+	}
+	return *c.Body
+}
+
+// GetIssueFieldValues returns the IssueFieldValues slice if it's non-nil, nil otherwise.
+func (c *CreateIssueRequest) GetIssueFieldValues() []*IssueRequestFieldValue {
+	if c == nil || c.IssueFieldValues == nil {
+		return nil
+	}
+	return c.IssueFieldValues
+}
+
+// GetLabels returns the Labels slice if it's non-nil, nil otherwise.
+func (c *CreateIssueRequest) GetLabels() []string {
+	if c == nil || c.Labels == nil {
+		return nil
+	}
+	return c.Labels
+}
+
+// GetMilestone returns the Milestone field if it's non-nil, zero value otherwise.
+func (c *CreateIssueRequest) GetMilestone() int {
+	if c == nil || c.Milestone == nil {
+		return 0
+	}
+	return *c.Milestone
+}
+
+// GetTitle returns the Title field.
+func (c *CreateIssueRequest) GetTitle() string {
+	if c == nil {
+		return ""
+	}
+	return c.Title
+}
+
+// GetType returns the Type field if it's non-nil, zero value otherwise.
+func (c *CreateIssueRequest) GetType() string {
+	if c == nil || c.Type == nil {
+		return ""
+	}
+	return *c.Type
+}
+
 // GetLabels returns the Labels slice if it's non-nil, nil otherwise.
 func (c *CreateJITConfigRequest) GetLabels() []string {
 	if c == nil || c.Labels == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -21398,94 +21398,6 @@ func (i *IssueListCommentsOptions) GetSort() string {
 	return *i.Sort
 }
 
-// GetAssignee returns the Assignee field if it's non-nil, zero value otherwise.
-func (i *IssueRequest) GetAssignee() string {
-	if i == nil || i.Assignee == nil {
-		return ""
-	}
-	return *i.Assignee
-}
-
-// GetAssignees returns the Assignees slice if it's non-nil, nil otherwise.
-func (i *IssueRequest) GetAssignees() []string {
-	if i == nil || i.Assignees == nil {
-		return nil
-	}
-	return i.Assignees
-}
-
-// GetBody returns the Body field if it's non-nil, zero value otherwise.
-func (i *IssueRequest) GetBody() string {
-	if i == nil || i.Body == nil {
-		return ""
-	}
-	return *i.Body
-}
-
-// GetDuplicateIssueID returns the DuplicateIssueID field if it's non-nil, zero value otherwise.
-func (i *IssueRequest) GetDuplicateIssueID() int {
-	if i == nil || i.DuplicateIssueID == nil {
-		return 0
-	}
-	return *i.DuplicateIssueID
-}
-
-// GetIssueFieldValues returns the IssueFieldValues slice if it's non-nil, nil otherwise.
-func (i *IssueRequest) GetIssueFieldValues() []*IssueRequestFieldValue {
-	if i == nil || i.IssueFieldValues == nil {
-		return nil
-	}
-	return i.IssueFieldValues
-}
-
-// GetLabels returns the Labels slice if it's non-nil, nil otherwise.
-func (i *IssueRequest) GetLabels() []string {
-	if i == nil || i.Labels == nil {
-		return nil
-	}
-	return i.Labels
-}
-
-// GetMilestone returns the Milestone field if it's non-nil, zero value otherwise.
-func (i *IssueRequest) GetMilestone() int {
-	if i == nil || i.Milestone == nil {
-		return 0
-	}
-	return *i.Milestone
-}
-
-// GetState returns the State field if it's non-nil, zero value otherwise.
-func (i *IssueRequest) GetState() string {
-	if i == nil || i.State == nil {
-		return ""
-	}
-	return *i.State
-}
-
-// GetStateReason returns the StateReason field if it's non-nil, zero value otherwise.
-func (i *IssueRequest) GetStateReason() string {
-	if i == nil || i.StateReason == nil {
-		return ""
-	}
-	return *i.StateReason
-}
-
-// GetTitle returns the Title field if it's non-nil, zero value otherwise.
-func (i *IssueRequest) GetTitle() string {
-	if i == nil || i.Title == nil {
-		return ""
-	}
-	return *i.Title
-}
-
-// GetType returns the Type field if it's non-nil, zero value otherwise.
-func (i *IssueRequest) GetType() string {
-	if i == nil || i.Type == nil {
-		return ""
-	}
-	return *i.Type
-}
-
 // GetFieldID returns the FieldID field.
 func (i *IssueRequestFieldValue) GetFieldID() int64 {
 	if i == nil {
@@ -42900,6 +42812,94 @@ func (u *UpdateHostedRunnerRequest) GetSize() string {
 		return ""
 	}
 	return *u.Size
+}
+
+// GetAssignee returns the Assignee field if it's non-nil, zero value otherwise.
+func (u *UpdateIssueRequest) GetAssignee() string {
+	if u == nil || u.Assignee == nil {
+		return ""
+	}
+	return *u.Assignee
+}
+
+// GetAssignees returns the Assignees slice if it's non-nil, nil otherwise.
+func (u *UpdateIssueRequest) GetAssignees() []string {
+	if u == nil || u.Assignees == nil {
+		return nil
+	}
+	return u.Assignees
+}
+
+// GetBody returns the Body field if it's non-nil, zero value otherwise.
+func (u *UpdateIssueRequest) GetBody() string {
+	if u == nil || u.Body == nil {
+		return ""
+	}
+	return *u.Body
+}
+
+// GetDuplicateIssueID returns the DuplicateIssueID field if it's non-nil, zero value otherwise.
+func (u *UpdateIssueRequest) GetDuplicateIssueID() int {
+	if u == nil || u.DuplicateIssueID == nil {
+		return 0
+	}
+	return *u.DuplicateIssueID
+}
+
+// GetIssueFieldValues returns the IssueFieldValues slice if it's non-nil, nil otherwise.
+func (u *UpdateIssueRequest) GetIssueFieldValues() []*IssueRequestFieldValue {
+	if u == nil || u.IssueFieldValues == nil {
+		return nil
+	}
+	return u.IssueFieldValues
+}
+
+// GetLabels returns the Labels slice if it's non-nil, nil otherwise.
+func (u *UpdateIssueRequest) GetLabels() []string {
+	if u == nil || u.Labels == nil {
+		return nil
+	}
+	return u.Labels
+}
+
+// GetMilestone returns the Milestone field if it's non-nil, zero value otherwise.
+func (u *UpdateIssueRequest) GetMilestone() int {
+	if u == nil || u.Milestone == nil {
+		return 0
+	}
+	return *u.Milestone
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (u *UpdateIssueRequest) GetState() string {
+	if u == nil || u.State == nil {
+		return ""
+	}
+	return *u.State
+}
+
+// GetStateReason returns the StateReason field if it's non-nil, zero value otherwise.
+func (u *UpdateIssueRequest) GetStateReason() string {
+	if u == nil || u.StateReason == nil {
+		return ""
+	}
+	return *u.StateReason
+}
+
+// GetTitle returns the Title field if it's non-nil, zero value otherwise.
+func (u *UpdateIssueRequest) GetTitle() string {
+	if u == nil || u.Title == nil {
+		return ""
+	}
+	return *u.Title
+}
+
+// GetType returns the Type field if it's non-nil, zero value otherwise.
+func (u *UpdateIssueRequest) GetType() string {
+	if u == nil || u.Type == nil {
+		return ""
+	}
+	return *u.Type
 }
 
 // GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -21342,12 +21342,12 @@ func (i *IssueRequest) GetAssignee() string {
 	return *i.Assignee
 }
 
-// GetAssignees returns the Assignees field if it's non-nil, zero value otherwise.
+// GetAssignees returns the Assignees slice if it's non-nil, nil otherwise.
 func (i *IssueRequest) GetAssignees() []string {
 	if i == nil || i.Assignees == nil {
 		return nil
 	}
-	return *i.Assignees
+	return i.Assignees
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
@@ -21374,12 +21374,12 @@ func (i *IssueRequest) GetIssueFieldValues() []*IssueRequestFieldValue {
 	return i.IssueFieldValues
 }
 
-// GetLabels returns the Labels field if it's non-nil, zero value otherwise.
+// GetLabels returns the Labels slice if it's non-nil, nil otherwise.
 func (i *IssueRequest) GetLabels() []string {
 	if i == nil || i.Labels == nil {
 		return nil
 	}
-	return *i.Labels
+	return i.Labels
 }
 
 // GetMilestone returns the Milestone field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -26940,127 +26940,6 @@ func TestIssueListCommentsOptions_GetSort(tt *testing.T) {
 	i.GetSort()
 }
 
-func TestIssueRequest_GetAssignee(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	i := &IssueRequest{Assignee: &zeroValue}
-	i.GetAssignee()
-	i = &IssueRequest{}
-	i.GetAssignee()
-	i = nil
-	i.GetAssignee()
-}
-
-func TestIssueRequest_GetAssignees(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := []string{}
-	i := &IssueRequest{Assignees: zeroValue}
-	i.GetAssignees()
-	i = &IssueRequest{}
-	i.GetAssignees()
-	i = nil
-	i.GetAssignees()
-}
-
-func TestIssueRequest_GetBody(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	i := &IssueRequest{Body: &zeroValue}
-	i.GetBody()
-	i = &IssueRequest{}
-	i.GetBody()
-	i = nil
-	i.GetBody()
-}
-
-func TestIssueRequest_GetDuplicateIssueID(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue int
-	i := &IssueRequest{DuplicateIssueID: &zeroValue}
-	i.GetDuplicateIssueID()
-	i = &IssueRequest{}
-	i.GetDuplicateIssueID()
-	i = nil
-	i.GetDuplicateIssueID()
-}
-
-func TestIssueRequest_GetIssueFieldValues(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := []*IssueRequestFieldValue{}
-	i := &IssueRequest{IssueFieldValues: zeroValue}
-	i.GetIssueFieldValues()
-	i = &IssueRequest{}
-	i.GetIssueFieldValues()
-	i = nil
-	i.GetIssueFieldValues()
-}
-
-func TestIssueRequest_GetLabels(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := []string{}
-	i := &IssueRequest{Labels: zeroValue}
-	i.GetLabels()
-	i = &IssueRequest{}
-	i.GetLabels()
-	i = nil
-	i.GetLabels()
-}
-
-func TestIssueRequest_GetMilestone(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue int
-	i := &IssueRequest{Milestone: &zeroValue}
-	i.GetMilestone()
-	i = &IssueRequest{}
-	i.GetMilestone()
-	i = nil
-	i.GetMilestone()
-}
-
-func TestIssueRequest_GetState(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	i := &IssueRequest{State: &zeroValue}
-	i.GetState()
-	i = &IssueRequest{}
-	i.GetState()
-	i = nil
-	i.GetState()
-}
-
-func TestIssueRequest_GetStateReason(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	i := &IssueRequest{StateReason: &zeroValue}
-	i.GetStateReason()
-	i = &IssueRequest{}
-	i.GetStateReason()
-	i = nil
-	i.GetStateReason()
-}
-
-func TestIssueRequest_GetTitle(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	i := &IssueRequest{Title: &zeroValue}
-	i.GetTitle()
-	i = &IssueRequest{}
-	i.GetTitle()
-	i = nil
-	i.GetTitle()
-}
-
-func TestIssueRequest_GetType(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	i := &IssueRequest{Type: &zeroValue}
-	i.GetType()
-	i = &IssueRequest{}
-	i.GetType()
-	i = nil
-	i.GetType()
-}
-
 func TestIssueRequestFieldValue_GetFieldID(tt *testing.T) {
 	tt.Parallel()
 	i := &IssueRequestFieldValue{}
@@ -53785,6 +53664,127 @@ func TestUpdateHostedRunnerRequest_GetSize(tt *testing.T) {
 	u.GetSize()
 	u = nil
 	u.GetSize()
+}
+
+func TestUpdateIssueRequest_GetAssignee(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateIssueRequest{Assignee: &zeroValue}
+	u.GetAssignee()
+	u = &UpdateIssueRequest{}
+	u.GetAssignee()
+	u = nil
+	u.GetAssignee()
+}
+
+func TestUpdateIssueRequest_GetAssignees(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []string{}
+	u := &UpdateIssueRequest{Assignees: zeroValue}
+	u.GetAssignees()
+	u = &UpdateIssueRequest{}
+	u.GetAssignees()
+	u = nil
+	u.GetAssignees()
+}
+
+func TestUpdateIssueRequest_GetBody(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateIssueRequest{Body: &zeroValue}
+	u.GetBody()
+	u = &UpdateIssueRequest{}
+	u.GetBody()
+	u = nil
+	u.GetBody()
+}
+
+func TestUpdateIssueRequest_GetDuplicateIssueID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	u := &UpdateIssueRequest{DuplicateIssueID: &zeroValue}
+	u.GetDuplicateIssueID()
+	u = &UpdateIssueRequest{}
+	u.GetDuplicateIssueID()
+	u = nil
+	u.GetDuplicateIssueID()
+}
+
+func TestUpdateIssueRequest_GetIssueFieldValues(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*IssueRequestFieldValue{}
+	u := &UpdateIssueRequest{IssueFieldValues: zeroValue}
+	u.GetIssueFieldValues()
+	u = &UpdateIssueRequest{}
+	u.GetIssueFieldValues()
+	u = nil
+	u.GetIssueFieldValues()
+}
+
+func TestUpdateIssueRequest_GetLabels(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []string{}
+	u := &UpdateIssueRequest{Labels: zeroValue}
+	u.GetLabels()
+	u = &UpdateIssueRequest{}
+	u.GetLabels()
+	u = nil
+	u.GetLabels()
+}
+
+func TestUpdateIssueRequest_GetMilestone(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	u := &UpdateIssueRequest{Milestone: &zeroValue}
+	u.GetMilestone()
+	u = &UpdateIssueRequest{}
+	u.GetMilestone()
+	u = nil
+	u.GetMilestone()
+}
+
+func TestUpdateIssueRequest_GetState(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateIssueRequest{State: &zeroValue}
+	u.GetState()
+	u = &UpdateIssueRequest{}
+	u.GetState()
+	u = nil
+	u.GetState()
+}
+
+func TestUpdateIssueRequest_GetStateReason(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateIssueRequest{StateReason: &zeroValue}
+	u.GetStateReason()
+	u = &UpdateIssueRequest{}
+	u.GetStateReason()
+	u = nil
+	u.GetStateReason()
+}
+
+func TestUpdateIssueRequest_GetTitle(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateIssueRequest{Title: &zeroValue}
+	u.GetTitle()
+	u = &UpdateIssueRequest{}
+	u.GetTitle()
+	u = nil
+	u.GetTitle()
+}
+
+func TestUpdateIssueRequest_GetType(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateIssueRequest{Type: &zeroValue}
+	u.GetType()
+	u = &UpdateIssueRequest{}
+	u.GetType()
+	u = nil
+	u.GetType()
 }
 
 func TestUpdateOrganizationPrivateRegistry_GetAccountID(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -14098,6 +14098,91 @@ func TestCreateHostedRunnerRequest_GetSize(tt *testing.T) {
 	c.GetSize()
 }
 
+func TestCreateIssueRequest_GetAssignee(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateIssueRequest{Assignee: &zeroValue}
+	c.GetAssignee()
+	c = &CreateIssueRequest{}
+	c.GetAssignee()
+	c = nil
+	c.GetAssignee()
+}
+
+func TestCreateIssueRequest_GetAssignees(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []string{}
+	c := &CreateIssueRequest{Assignees: zeroValue}
+	c.GetAssignees()
+	c = &CreateIssueRequest{}
+	c.GetAssignees()
+	c = nil
+	c.GetAssignees()
+}
+
+func TestCreateIssueRequest_GetBody(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateIssueRequest{Body: &zeroValue}
+	c.GetBody()
+	c = &CreateIssueRequest{}
+	c.GetBody()
+	c = nil
+	c.GetBody()
+}
+
+func TestCreateIssueRequest_GetIssueFieldValues(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*IssueRequestFieldValue{}
+	c := &CreateIssueRequest{IssueFieldValues: zeroValue}
+	c.GetIssueFieldValues()
+	c = &CreateIssueRequest{}
+	c.GetIssueFieldValues()
+	c = nil
+	c.GetIssueFieldValues()
+}
+
+func TestCreateIssueRequest_GetLabels(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []string{}
+	c := &CreateIssueRequest{Labels: zeroValue}
+	c.GetLabels()
+	c = &CreateIssueRequest{}
+	c.GetLabels()
+	c = nil
+	c.GetLabels()
+}
+
+func TestCreateIssueRequest_GetMilestone(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CreateIssueRequest{Milestone: &zeroValue}
+	c.GetMilestone()
+	c = &CreateIssueRequest{}
+	c.GetMilestone()
+	c = nil
+	c.GetMilestone()
+}
+
+func TestCreateIssueRequest_GetTitle(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateIssueRequest{}
+	c.GetTitle()
+	c = nil
+	c.GetTitle()
+}
+
+func TestCreateIssueRequest_GetType(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateIssueRequest{Type: &zeroValue}
+	c.GetType()
+	c = &CreateIssueRequest{}
+	c.GetType()
+	c = nil
+	c.GetType()
+}
+
 func TestCreateJITConfigRequest_GetLabels(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []string{}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -26871,8 +26871,8 @@ func TestIssueRequest_GetAssignee(tt *testing.T) {
 
 func TestIssueRequest_GetAssignees(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue []string
-	i := &IssueRequest{Assignees: &zeroValue}
+	zeroValue := []string{}
+	i := &IssueRequest{Assignees: zeroValue}
 	i.GetAssignees()
 	i = &IssueRequest{}
 	i.GetAssignees()
@@ -26915,8 +26915,8 @@ func TestIssueRequest_GetIssueFieldValues(tt *testing.T) {
 
 func TestIssueRequest_GetLabels(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue []string
-	i := &IssueRequest{Labels: &zeroValue}
+	zeroValue := []string{}
+	i := &IssueRequest{Labels: zeroValue}
 	i.GetLabels()
 	i = &IssueRequest{}
 	i.GetLabels()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -26891,6 +26891,17 @@ func TestIssueRequest_GetBody(tt *testing.T) {
 	i.GetBody()
 }
 
+func TestIssueRequest_GetDuplicateIssueID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	i := &IssueRequest{DuplicateIssueID: &zeroValue}
+	i.GetDuplicateIssueID()
+	i = &IssueRequest{}
+	i.GetDuplicateIssueID()
+	i = nil
+	i.GetDuplicateIssueID()
+}
+
 func TestIssueRequest_GetIssueFieldValues(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []*IssueRequestFieldValue{}

--- a/github/issues.go
+++ b/github/issues.go
@@ -123,17 +123,21 @@ type CreateIssueRequest struct {
 // It is separate from Issue above because otherwise Labels
 // and Assignee fail to serialize to the correct JSON.
 type IssueRequest struct {
-	Title    *string   `json:"title,omitempty"`
-	Body     *string   `json:"body,omitempty"`
-	Labels   *[]string `json:"labels,omitempty"`
-	Assignee *string   `json:"assignee,omitempty"`
-	State    *string   `json:"state,omitempty"`
+	Title *string `json:"title,omitempty"`
+	Body  *string `json:"body,omitempty"`
+	// Labels: nil leaves existing labels unchanged; a non-nil slice replaces
+	// them, so []string{} clears all labels.
+	Labels   []string `json:"labels,omitzero"`
+	Assignee *string  `json:"assignee,omitempty"`
+	State    *string  `json:"state,omitempty"`
 	// StateReason can be `completed`, `not_planned`, `duplicate` or `reopened`.
 	StateReason *string `json:"state_reason,omitempty"`
 	// DuplicateIssueID is required when state_reason is `duplicate`.
-	DuplicateIssueID *int                      `json:"duplicate_issue_id,omitempty"`
-	Milestone        *int                      `json:"milestone,omitempty"`
-	Assignees        *[]string                 `json:"assignees,omitempty"`
+	DuplicateIssueID *int `json:"duplicate_issue_id,omitempty"`
+	Milestone        *int `json:"milestone,omitempty"`
+	// Assignees: nil leaves existing assignees unchanged; a non-nil slice
+	// replaces them, so []string{} clears all assignees.
+	Assignees        []string                  `json:"assignees,omitzero"`
 	Type             *string                   `json:"type,omitempty"`
 	IssueFieldValues []*IssueRequestFieldValue `json:"issue_field_values,omitempty"`
 }

--- a/github/issues.go
+++ b/github/issues.go
@@ -491,12 +491,12 @@ func (s *IssuesService) Create(ctx context.Context, owner, repo string, body Cre
 	return i, resp, nil
 }
 
-// Edit (update) an issue.
+// Update an issue.
 //
 // GitHub API docs: https://docs.github.com/rest/issues/issues?apiVersion=2022-11-28#update-an-issue
 //
 //meta:operation PATCH /repos/{owner}/{repo}/issues/{issue_number}
-func (s *IssuesService) Edit(ctx context.Context, owner, repo string, number int, body IssueRequest) (*Issue, *Response, error) {
+func (s *IssuesService) Update(ctx context.Context, owner, repo string, number int, body IssueRequest) (*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v", owner, repo, number)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/issues.go
+++ b/github/issues.go
@@ -108,7 +108,6 @@ func (i Issue) IsPullRequest() bool {
 // It is separate from Issue above because otherwise Labels
 // and Assignee fail to serialize to the correct JSON.
 type CreateIssueRequest struct {
-	// Title is required when creating an issue.
 	Title            string                    `json:"title"`
 	Body             *string                   `json:"body,omitempty"`
 	Labels           []string                  `json:"labels,omitempty"`
@@ -119,10 +118,10 @@ type CreateIssueRequest struct {
 	IssueFieldValues []*IssueRequestFieldValue `json:"issue_field_values,omitempty"`
 }
 
-// IssueRequest represents a request to edit an issue.
+// UpdateIssueRequest represents a request to edit an issue.
 // It is separate from Issue above because otherwise Labels
 // and Assignee fail to serialize to the correct JSON.
-type IssueRequest struct {
+type UpdateIssueRequest struct {
 	Title *string `json:"title,omitempty"`
 	Body  *string `json:"body,omitempty"`
 	// Labels: nil leaves existing labels unchanged; a non-nil slice replaces
@@ -500,7 +499,7 @@ func (s *IssuesService) Create(ctx context.Context, owner, repo string, body Cre
 // GitHub API docs: https://docs.github.com/rest/issues/issues?apiVersion=2022-11-28#update-an-issue
 //
 //meta:operation PATCH /repos/{owner}/{repo}/issues/{issue_number}
-func (s *IssuesService) Update(ctx context.Context, owner, repo string, number int, body IssueRequest) (*Issue, *Response, error) {
+func (s *IssuesService) Update(ctx context.Context, owner, repo string, number int, body UpdateIssueRequest) (*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v", owner, repo, number)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/issues.go
+++ b/github/issues.go
@@ -128,8 +128,10 @@ type IssueRequest struct {
 	Labels   *[]string `json:"labels,omitempty"`
 	Assignee *string   `json:"assignee,omitempty"`
 	State    *string   `json:"state,omitempty"`
-	// StateReason can be 'completed' or 'not_planned'.
-	StateReason      *string                   `json:"state_reason,omitempty"`
+	// StateReason can be `completed`, `not_planned`, `duplicate` or `reopened`.
+	StateReason *string `json:"state_reason,omitempty"`
+	// DuplicateIssueID is required when state_reason is `duplicate`.
+	DuplicateIssueID *int                      `json:"duplicate_issue_id,omitempty"`
 	Milestone        *int                      `json:"milestone,omitempty"`
 	Assignees        *[]string                 `json:"assignees,omitempty"`
 	Type             *string                   `json:"type,omitempty"`

--- a/github/issues.go
+++ b/github/issues.go
@@ -458,7 +458,7 @@ func (s *IssuesService) Get(ctx context.Context, owner, repo string, number int)
 // GitHub API docs: https://docs.github.com/rest/issues/issues?apiVersion=2022-11-28#create-an-issue
 //
 //meta:operation POST /repos/{owner}/{repo}/issues
-func (s *IssuesService) Create(ctx context.Context, owner, repo string, body *IssueRequest) (*Issue, *Response, error) {
+func (s *IssuesService) Create(ctx context.Context, owner, repo string, body IssueRequest) (*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues", owner, repo)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
@@ -479,7 +479,7 @@ func (s *IssuesService) Create(ctx context.Context, owner, repo string, body *Is
 // GitHub API docs: https://docs.github.com/rest/issues/issues?apiVersion=2022-11-28#update-an-issue
 //
 //meta:operation PATCH /repos/{owner}/{repo}/issues/{issue_number}
-func (s *IssuesService) Edit(ctx context.Context, owner, repo string, number int, body *IssueRequest) (*Issue, *Response, error) {
+func (s *IssuesService) Edit(ctx context.Context, owner, repo string, number int, body IssueRequest) (*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues/%v", owner, repo, number)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/issues.go
+++ b/github/issues.go
@@ -104,7 +104,22 @@ func (i Issue) IsPullRequest() bool {
 	return i.PullRequestLinks != nil
 }
 
-// IssueRequest represents a request to create/edit an issue.
+// CreateIssueRequest represents a request to create an issue.
+// It is separate from Issue above because otherwise Labels
+// and Assignee fail to serialize to the correct JSON.
+type CreateIssueRequest struct {
+	// Title is required when creating an issue.
+	Title            string                    `json:"title"`
+	Body             *string                   `json:"body,omitempty"`
+	Labels           []string                  `json:"labels,omitempty"`
+	Assignee         *string                   `json:"assignee,omitempty"`
+	Milestone        *int                      `json:"milestone,omitempty"`
+	Assignees        []string                  `json:"assignees,omitempty"`
+	Type             *string                   `json:"type,omitempty"`
+	IssueFieldValues []*IssueRequestFieldValue `json:"issue_field_values,omitempty"`
+}
+
+// IssueRequest represents a request to edit an issue.
 // It is separate from Issue above because otherwise Labels
 // and Assignee fail to serialize to the correct JSON.
 type IssueRequest struct {
@@ -458,7 +473,7 @@ func (s *IssuesService) Get(ctx context.Context, owner, repo string, number int)
 // GitHub API docs: https://docs.github.com/rest/issues/issues?apiVersion=2022-11-28#create-an-issue
 //
 //meta:operation POST /repos/{owner}/{repo}/issues
-func (s *IssuesService) Create(ctx context.Context, owner, repo string, body IssueRequest) (*Issue, *Response, error) {
+func (s *IssuesService) Create(ctx context.Context, owner, repo string, body CreateIssueRequest) (*Issue, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/issues", owner, repo)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -350,7 +350,7 @@ func TestIssuesService_Update(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := IssueRequest{Title: Ptr("t"), Type: Ptr("bug")}
+	input := UpdateIssueRequest{Title: Ptr("t"), Type: Ptr("bug")}
 
 	mux.HandleFunc("/repos/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -424,7 +424,7 @@ func TestIssuesService_Update_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Issues.Update(ctx, "%", "r", 1, IssueRequest{})
+	_, _, err := client.Issues.Update(ctx, "%", "r", 1, UpdateIssueRequest{})
 	testURLParseError(t, err)
 }
 
@@ -437,22 +437,22 @@ func TestIssueRequest_Marshal_LabelsAndAssignees(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		input IssueRequest
+		input UpdateIssueRequest
 		want  string
 	}{
 		{
 			name:  "nil labels and assignees are omitted",
-			input: IssueRequest{},
+			input: UpdateIssueRequest{},
 			want:  `{}`,
 		},
 		{
 			name:  "empty non-nil labels and assignees are sent to clear them",
-			input: IssueRequest{Labels: []string{}, Assignees: []string{}},
+			input: UpdateIssueRequest{Labels: []string{}, Assignees: []string{}},
 			want:  `{"labels":[],"assignees":[]}`,
 		},
 		{
 			name:  "populated labels and assignees are sent",
-			input: IssueRequest{Labels: []string{"bug"}, Assignees: []string{"octocat"}},
+			input: UpdateIssueRequest{Labels: []string{"bug"}, Assignees: []string{"octocat"}},
 			want:  `{"labels":["bug"],"assignees":["octocat"]}`,
 		},
 	}

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -297,7 +297,7 @@ func TestIssuesService_Create(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &IssueRequest{
+	input := IssueRequest{
 		Title:    Ptr("t"),
 		Body:     Ptr("b"),
 		Assignee: Ptr("a"),
@@ -341,7 +341,7 @@ func TestIssuesService_Create_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Issues.Create(ctx, "%", "r", nil)
+	_, _, err := client.Issues.Create(ctx, "%", "r", IssueRequest{})
 	testURLParseError(t, err)
 }
 
@@ -349,7 +349,7 @@ func TestIssuesService_Edit(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &IssueRequest{Title: Ptr("t"), Type: Ptr("bug")}
+	input := IssueRequest{Title: Ptr("t"), Type: Ptr("bug")}
 
 	mux.HandleFunc("/repos/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -423,7 +423,7 @@ func TestIssuesService_Edit_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Issues.Edit(ctx, "%", "r", 1, nil)
+	_, _, err := client.Issues.Edit(ctx, "%", "r", 1, IssueRequest{})
 	testURLParseError(t, err)
 }
 

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -6,6 +6,7 @@
 package github
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -345,7 +346,7 @@ func TestIssuesService_Create_invalidOwner(t *testing.T) {
 	testURLParseError(t, err)
 }
 
-func TestIssuesService_Edit(t *testing.T) {
+func TestIssuesService_Update(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -360,15 +361,15 @@ func TestIssuesService_Edit(t *testing.T) {
 	ctx := t.Context()
 	issue, _, err := client.Issues.Update(ctx, "o", "r", 1, input)
 	if err != nil {
-		t.Errorf("Issues.Edit returned error: %v", err)
+		t.Errorf("Issues.Update returned error: %v", err)
 	}
 
 	want := &Issue{Number: Ptr(1), Type: &IssueType{Name: Ptr("bug")}}
 	if !cmp.Equal(issue, want) {
-		t.Errorf("Issues.Edit returned %+v, want %+v", issue, want)
+		t.Errorf("Issues.Update returned %+v, want %+v", issue, want)
 	}
 
-	const methodName = "Edit"
+	const methodName = "Update"
 	testBadOptions(t, methodName, func() (err error) {
 		_, _, err = client.Issues.Update(ctx, "\n", "\n", -1, input)
 		return err
@@ -418,13 +419,57 @@ func TestIssuesService_RemoveMilestone(t *testing.T) {
 	})
 }
 
-func TestIssuesService_Edit_invalidOwner(t *testing.T) {
+func TestIssuesService_Update_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
 	_, _, err := client.Issues.Update(ctx, "%", "r", 1, IssueRequest{})
 	testURLParseError(t, err)
+}
+
+// TestIssueRequest_Marshal_LabelsAndAssignees verifies the omitzero behavior of
+// the Labels and Assignees fields: a nil slice is omitted from the request body
+// (leaving the existing values unchanged), whereas a non-nil slice — including
+// an explicit empty slice — is sent (clearing the values when empty).
+func TestIssueRequest_Marshal_LabelsAndAssignees(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input IssueRequest
+		want  string
+	}{
+		{
+			name:  "nil labels and assignees are omitted",
+			input: IssueRequest{},
+			want:  `{}`,
+		},
+		{
+			name:  "empty non-nil labels and assignees are sent to clear them",
+			input: IssueRequest{Labels: []string{}, Assignees: []string{}},
+			want:  `{"labels":[],"assignees":[]}`,
+		},
+		{
+			name:  "populated labels and assignees are sent",
+			input: IssueRequest{Labels: []string{"bug"}, Assignees: []string{"octocat"}},
+			want:  `{"labels":["bug"],"assignees":["octocat"]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b, err := json.Marshal(tt.input)
+			if err != nil {
+				t.Fatalf("json.Marshal(%#v) returned error: %v", tt.input, err)
+			}
+			if got := string(b); got != tt.want {
+				t.Errorf("json.Marshal(%#v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestIssuesService_Lock(t *testing.T) {

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -297,11 +297,11 @@ func TestIssuesService_Create(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := IssueRequest{
-		Title:    Ptr("t"),
+	input := CreateIssueRequest{
+		Title:    "t",
 		Body:     Ptr("b"),
 		Assignee: Ptr("a"),
-		Labels:   &[]string{"l1", "l2"},
+		Labels:   []string{"l1", "l2"},
 	}
 
 	mux.HandleFunc("/repos/o/r/issues", func(w http.ResponseWriter, r *http.Request) {
@@ -341,7 +341,7 @@ func TestIssuesService_Create_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Issues.Create(ctx, "%", "r", IssueRequest{})
+	_, _, err := client.Issues.Create(ctx, "%", "r", CreateIssueRequest{})
 	testURLParseError(t, err)
 }
 

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -358,7 +358,7 @@ func TestIssuesService_Edit(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	issue, _, err := client.Issues.Edit(ctx, "o", "r", 1, input)
+	issue, _, err := client.Issues.Update(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("Issues.Edit returned error: %v", err)
 	}
@@ -370,12 +370,12 @@ func TestIssuesService_Edit(t *testing.T) {
 
 	const methodName = "Edit"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Issues.Edit(ctx, "\n", "\n", -1, input)
+		_, _, err = client.Issues.Update(ctx, "\n", "\n", -1, input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Issues.Edit(ctx, "o", "r", 1, input)
+		got, resp, err := client.Issues.Update(ctx, "o", "r", 1, input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -423,7 +423,7 @@ func TestIssuesService_Edit_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Issues.Edit(ctx, "%", "r", 1, IssueRequest{})
+	_, _, err := client.Issues.Update(ctx, "%", "r", 1, IssueRequest{})
 	testURLParseError(t, err)
 }
 


### PR DESCRIPTION
BREAKING CHANGE: `IssueService.Edit` is renamed to `IssueService.Update` to match the underlying "update an issue" endpoint.

`IssuesService.Create` now takes a dedicated `CreateIssueRequest` by value (with a required non-pointer `Title`).
`IssuesService.Updated` takes `UpdateIssueRequest` by value.

Towards #3644.