### PR TITLE
refactor!: Rename `AutolinkOptions` to `CreateAutolinkRequest`, `AddAutolink` to `CreateAutolink`, and pass the body by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -206,7 +206,6 @@ linters:
             - ActionsVariable
             - AddProjectItemOptions
             - AuthorizationRequest
-            - AutolinkOptions
             - CodeScanningAlertState
             - CodespaceCreateForUserOptions
             - ConfigApplyOptions
@@ -276,7 +275,6 @@ linters:
           # TODO: fix and remove these exceptions.
           body-allowed-wrong-names:
             - AddProjectItemOptions
-            - AutolinkOptions
             - CheckSuitePreferenceOptions
             - CodespaceCreateForUserOptions
             - ConfigApplyOptions

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -2862,30 +2862,6 @@ func (a *Autolink) GetURLTemplate() string {
 	return *a.URLTemplate
 }
 
-// GetIsAlphanumeric returns the IsAlphanumeric field if it's non-nil, zero value otherwise.
-func (a *AutolinkOptions) GetIsAlphanumeric() bool {
-	if a == nil || a.IsAlphanumeric == nil {
-		return false
-	}
-	return *a.IsAlphanumeric
-}
-
-// GetKeyPrefix returns the KeyPrefix field if it's non-nil, zero value otherwise.
-func (a *AutolinkOptions) GetKeyPrefix() string {
-	if a == nil || a.KeyPrefix == nil {
-		return ""
-	}
-	return *a.KeyPrefix
-}
-
-// GetURLTemplate returns the URLTemplate field if it's non-nil, zero value otherwise.
-func (a *AutolinkOptions) GetURLTemplate() string {
-	if a == nil || a.URLTemplate == nil {
-		return ""
-	}
-	return *a.URLTemplate
-}
-
 // GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
 func (a *AutomatedSecurityFixes) GetEnabled() bool {
 	if a == nil || a.Enabled == nil {
@@ -10692,6 +10668,30 @@ func (c *CreateArtifactStorageRequest) GetVersion() string {
 		return ""
 	}
 	return *c.Version
+}
+
+// GetIsAlphanumeric returns the IsAlphanumeric field if it's non-nil, zero value otherwise.
+func (c *CreateAutolinkRequest) GetIsAlphanumeric() bool {
+	if c == nil || c.IsAlphanumeric == nil {
+		return false
+	}
+	return *c.IsAlphanumeric
+}
+
+// GetKeyPrefix returns the KeyPrefix field.
+func (c *CreateAutolinkRequest) GetKeyPrefix() string {
+	if c == nil {
+		return ""
+	}
+	return c.KeyPrefix
+}
+
+// GetURLTemplate returns the URLTemplate field.
+func (c *CreateAutolinkRequest) GetURLTemplate() string {
+	if c == nil {
+		return ""
+	}
+	return c.URLTemplate
 }
 
 // GetActions returns the Actions slice if it's non-nil, nil otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -3649,39 +3649,6 @@ func TestAutolink_GetURLTemplate(tt *testing.T) {
 	a.GetURLTemplate()
 }
 
-func TestAutolinkOptions_GetIsAlphanumeric(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue bool
-	a := &AutolinkOptions{IsAlphanumeric: &zeroValue}
-	a.GetIsAlphanumeric()
-	a = &AutolinkOptions{}
-	a.GetIsAlphanumeric()
-	a = nil
-	a.GetIsAlphanumeric()
-}
-
-func TestAutolinkOptions_GetKeyPrefix(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	a := &AutolinkOptions{KeyPrefix: &zeroValue}
-	a.GetKeyPrefix()
-	a = &AutolinkOptions{}
-	a.GetKeyPrefix()
-	a = nil
-	a.GetKeyPrefix()
-}
-
-func TestAutolinkOptions_GetURLTemplate(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	a := &AutolinkOptions{URLTemplate: &zeroValue}
-	a.GetURLTemplate()
-	a = &AutolinkOptions{}
-	a.GetURLTemplate()
-	a = nil
-	a.GetURLTemplate()
-}
-
 func TestAutomatedSecurityFixes_GetEnabled(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
@@ -13561,6 +13528,33 @@ func TestCreateArtifactStorageRequest_GetVersion(tt *testing.T) {
 	c.GetVersion()
 	c = nil
 	c.GetVersion()
+}
+
+func TestCreateAutolinkRequest_GetIsAlphanumeric(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	c := &CreateAutolinkRequest{IsAlphanumeric: &zeroValue}
+	c.GetIsAlphanumeric()
+	c = &CreateAutolinkRequest{}
+	c.GetIsAlphanumeric()
+	c = nil
+	c.GetIsAlphanumeric()
+}
+
+func TestCreateAutolinkRequest_GetKeyPrefix(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateAutolinkRequest{}
+	c.GetKeyPrefix()
+	c = nil
+	c.GetKeyPrefix()
+}
+
+func TestCreateAutolinkRequest_GetURLTemplate(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateAutolinkRequest{}
+	c.GetURLTemplate()
+	c = nil
+	c.GetURLTemplate()
 }
 
 func TestCreateCheckRunOptions_GetActions(tt *testing.T) {

--- a/github/repos_autolinks.go
+++ b/github/repos_autolinks.go
@@ -10,11 +10,11 @@ import (
 	"fmt"
 )
 
-// AutolinkOptions specifies parameters for RepositoriesService.AddAutolink method.
-type AutolinkOptions struct {
-	KeyPrefix      *string `json:"key_prefix,omitempty"`
-	URLTemplate    *string `json:"url_template,omitempty"`
-	IsAlphanumeric *bool   `json:"is_alphanumeric,omitempty"`
+// CreateAutolinkRequest specifies parameters for RepositoriesService.CreateAutolink method.
+type CreateAutolinkRequest struct {
+	KeyPrefix      string `json:"key_prefix"`
+	URLTemplate    string `json:"url_template"`
+	IsAlphanumeric *bool  `json:"is_alphanumeric,omitempty"`
 }
 
 // Autolink represents autolinks to external resources like Jira issues and Zendesk tickets.
@@ -48,13 +48,13 @@ func (s *RepositoriesService) ListAutolinks(ctx context.Context, owner, repo str
 	return autolinks, resp, nil
 }
 
-// AddAutolink creates an autolink reference for a repository.
+// CreateAutolink creates an autolink reference for a repository.
 // Users with admin access to the repository can create an autolink.
 //
 // GitHub API docs: https://docs.github.com/rest/repos/autolinks?apiVersion=2022-11-28#create-an-autolink-reference-for-a-repository
 //
 //meta:operation POST /repos/{owner}/{repo}/autolinks
-func (s *RepositoriesService) AddAutolink(ctx context.Context, owner, repo string, body *AutolinkOptions) (*Autolink, *Response, error) {
+func (s *RepositoriesService) CreateAutolink(ctx context.Context, owner, repo string, body CreateAutolinkRequest) (*Autolink, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/autolinks", owner, repo)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {

--- a/github/repos_autolinks_test.go
+++ b/github/repos_autolinks_test.go
@@ -52,18 +52,18 @@ func TestRepositoriesService_ListAutolinks(t *testing.T) {
 	})
 }
 
-func TestRepositoriesService_AddAutolink(t *testing.T) {
+func TestRepositoriesService_CreateAutolink(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	opt := &AutolinkOptions{
-		KeyPrefix:      Ptr("TICKET-"),
-		URLTemplate:    Ptr("https://example.com/TICKET?query=<num>"),
+	body := CreateAutolinkRequest{
+		KeyPrefix:      "TICKET-",
+		URLTemplate:    "https://example.com/TICKET?query=<num>",
 		IsAlphanumeric: Ptr(true),
 	}
 	mux.HandleFunc("/repos/o/r/autolinks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testJSONBody(t, r, opt)
+		testJSONBody(t, r, body)
 		w.WriteHeader(http.StatusOK)
 		assertWrite(t, w, []byte(`
 			{
@@ -74,9 +74,9 @@ func TestRepositoriesService_AddAutolink(t *testing.T) {
 		`))
 	})
 	ctx := t.Context()
-	autolink, _, err := client.Repositories.AddAutolink(ctx, "o", "r", opt)
+	autolink, _, err := client.Repositories.CreateAutolink(ctx, "o", "r", body)
 	if err != nil {
-		t.Errorf("Repositories.AddAutolink returned error: %v", err)
+		t.Errorf("Repositories.CreateAutolink returned error: %v", err)
 	}
 	want := &Autolink{
 		KeyPrefix:      Ptr("TICKET-"),
@@ -85,17 +85,17 @@ func TestRepositoriesService_AddAutolink(t *testing.T) {
 	}
 
 	if !cmp.Equal(autolink, want) {
-		t.Errorf("AddAutolink returned %+v, want %+v", autolink, want)
+		t.Errorf("CreateAutolink returned %+v, want %+v", autolink, want)
 	}
 
-	const methodName = "AddAutolink"
+	const methodName = "CreateAutolink"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Repositories.AddAutolink(ctx, "\n", "\n", opt)
+		_, _, err = client.Repositories.CreateAutolink(ctx, "\n", "\n", body)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Repositories.AddAutolink(ctx, "o", "r", opt)
+		got, resp, err := client.Repositories.CreateAutolink(ctx, "o", "r", body)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -189,21 +189,21 @@ func TestRepositories_Autolinks(t *testing.T) {
 
 	repo := createRandomTestRepository(t, "", true)
 
-	opts := &github.AutolinkOptions{
-		KeyPrefix:      github.Ptr("TICKET-"),
-		URLTemplate:    github.Ptr("https://example.com/TICKET?query=<num>"),
+	body := github.CreateAutolinkRequest{
+		KeyPrefix:      "TICKET-",
+		URLTemplate:    "https://example.com/TICKET?query=<num>",
 		IsAlphanumeric: github.Ptr(false),
 	}
 
-	actionlink, _, err := client.Repositories.AddAutolink(t.Context(), *repo.Owner.Login, *repo.Name, opts)
+	actionlink, _, err := client.Repositories.CreateAutolink(t.Context(), *repo.Owner.Login, *repo.Name, body)
 	if err != nil {
-		t.Fatalf("Repositories.AddAutolink() returned error: %v", err)
+		t.Fatalf("Repositories.CreateAutolink() returned error: %v", err)
 	}
 
-	if !cmp.Equal(actionlink.KeyPrefix, opts.KeyPrefix) ||
-		!cmp.Equal(actionlink.URLTemplate, opts.URLTemplate) ||
-		!cmp.Equal(actionlink.IsAlphanumeric, opts.IsAlphanumeric) {
-		t.Errorf("Repositories.AddAutolink() returned %+v, want %+v", actionlink, opts)
+	if !cmp.Equal(actionlink.GetKeyPrefix(), body.KeyPrefix) ||
+		!cmp.Equal(actionlink.GetURLTemplate(), body.URLTemplate) ||
+		!cmp.Equal(actionlink.IsAlphanumeric, body.IsAlphanumeric) {
+		t.Errorf("Repositories.CreateAutolink() returned %+v, want %+v", actionlink, body)
 	}
 
 	_, err = client.Repositories.Delete(t.Context(), *repo.Owner.Login, *repo.Name)


### PR DESCRIPTION
Continues the request-body-by-value work in #3644, this time for `RepositoriesService.AddAutolink`.

### What changed

- `AutolinkOptions` is renamed to `CreateAutolinkRequest`, following the `...Request` convention for request bodies. The old name was in the `body-allowed-wrong-names` allowlist.
- `AddAutolink` is renamed to `CreateAutolink` to match the docs operation name, [Create an autolink reference for a repository](https://docs.github.com/rest/repos/autolinks?apiVersion=2022-11-28#create-an-autolink-reference-for-a-repository). The doc comment already read "creates an autolink reference".
- The request body is now passed by value, and both `AutolinkOptions` entries are removed from the `.golangci.yml` allowlists.
- `key_prefix` and `url_template` are required by the API, so `KeyPrefix` and `URLTemplate` become non-pointer `string` without `omitempty`. `is_alphanumeric` is optional (it defaults to `true`), so `IsAlphanumeric` stays `*bool`.

### Notes

- The request schema has exactly these three properties, so nothing was missing from the Go struct and no field needed to be added.
- The response type `Autolink` is a separate struct and is unchanged — this is a request-only type, so there is no create/update split to consider.
- `test/integration/repos_test.go` builds under the root module with `-tags integration`, so it is updated too. Its comparison needed a small fix rather than a mechanical rename: it compared `actionlink.KeyPrefix` (`*string`) against the request field, which is now a `string`, so it goes through `GetKeyPrefix()`/`GetURLTemplate()` instead.

Verified with `go build ./...`, `go vet -tags integration ./test/integration/`, `gofmt`, the full `./github/` test suite (`CreateAutolink` and the regenerated accessors at 100%), and `custom-gcl` (no `paramcheck` findings after removing the allowlist entries).

Updates #3644

BREAKING CHANGE: AutolinkOptions is renamed to CreateAutolinkRequest with non-pointer KeyPrefix and URLTemplate; RepositoriesService.AddAutolink is renamed to CreateAutolink and now takes the request body by value.

cc @jvm986 — flagging for #3644 coordination; this one is in the `repos` service, so it shouldn't overlap with the `Issues` work.
