### PR TITLE
refactor!: Rename `EditLabel` to `UpdateLabel`, Split `Label` into `CreateLabelRequest` & `UpdateLabelRequest` and pass by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -232,7 +232,6 @@ linters:
             - IssueComment
             - IssueImportRequest
             - Key
-            - Label
             - LockIssueOptions
             - MaintenanceOptions
             - Milestone

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11254,6 +11254,30 @@ func (c *CreateJITConfigRequest) GetWorkFolder() string {
 	return *c.WorkFolder
 }
 
+// GetColor returns the Color field if it's non-nil, zero value otherwise.
+func (c *CreateLabelRequest) GetColor() string {
+	if c == nil || c.Color == nil {
+		return ""
+	}
+	return *c.Color
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (c *CreateLabelRequest) GetDescription() string {
+	if c == nil || c.Description == nil {
+		return ""
+	}
+	return *c.Description
+}
+
+// GetName returns the Name field.
+func (c *CreateLabelRequest) GetName() string {
+	if c == nil {
+		return ""
+	}
+	return c.Name
+}
+
 // GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.
 func (c *CreateOrganizationPrivateRegistry) GetAccountID() string {
 	if c == nil || c.AccountID == nil {
@@ -42900,6 +42924,30 @@ func (u *UpdateIssueRequest) GetType() string {
 		return ""
 	}
 	return *u.Type
+}
+
+// GetColor returns the Color field if it's non-nil, zero value otherwise.
+func (u *UpdateLabelRequest) GetColor() string {
+	if u == nil || u.Color == nil {
+		return ""
+	}
+	return *u.Color
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (u *UpdateLabelRequest) GetDescription() string {
+	if u == nil || u.Description == nil {
+		return ""
+	}
+	return *u.Description
+}
+
+// GetNewName returns the NewName field if it's non-nil, zero value otherwise.
+func (u *UpdateLabelRequest) GetNewName() string {
+	if u == nil || u.NewName == nil {
+		return ""
+	}
+	return *u.NewName
 }
 
 // GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11158,6 +11158,30 @@ func (c *CreateHostedRunnerRequest) GetSize() string {
 	return c.Size
 }
 
+// GetColor returns the Color field if it's non-nil, zero value otherwise.
+func (c *CreateIssueLabelRequest) GetColor() string {
+	if c == nil || c.Color == nil {
+		return ""
+	}
+	return *c.Color
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (c *CreateIssueLabelRequest) GetDescription() string {
+	if c == nil || c.Description == nil {
+		return ""
+	}
+	return *c.Description
+}
+
+// GetName returns the Name field.
+func (c *CreateIssueLabelRequest) GetName() string {
+	if c == nil {
+		return ""
+	}
+	return c.Name
+}
+
 // GetAssignee returns the Assignee field if it's non-nil, zero value otherwise.
 func (c *CreateIssueRequest) GetAssignee() string {
 	if c == nil || c.Assignee == nil {
@@ -11252,30 +11276,6 @@ func (c *CreateJITConfigRequest) GetWorkFolder() string {
 		return ""
 	}
 	return *c.WorkFolder
-}
-
-// GetColor returns the Color field if it's non-nil, zero value otherwise.
-func (c *CreateLabelRequest) GetColor() string {
-	if c == nil || c.Color == nil {
-		return ""
-	}
-	return *c.Color
-}
-
-// GetDescription returns the Description field if it's non-nil, zero value otherwise.
-func (c *CreateLabelRequest) GetDescription() string {
-	if c == nil || c.Description == nil {
-		return ""
-	}
-	return *c.Description
-}
-
-// GetName returns the Name field.
-func (c *CreateLabelRequest) GetName() string {
-	if c == nil {
-		return ""
-	}
-	return c.Name
 }
 
 // GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.
@@ -21726,20 +21726,20 @@ func (k *Key) GetVerified() bool {
 	return *k.Verified
 }
 
-// GetColor returns the Color field if it's non-nil, zero value otherwise.
+// GetColor returns the Color field.
 func (l *Label) GetColor() string {
-	if l == nil || l.Color == nil {
+	if l == nil {
 		return ""
 	}
-	return *l.Color
+	return l.Color
 }
 
-// GetDefault returns the Default field if it's non-nil, zero value otherwise.
+// GetDefault returns the Default field.
 func (l *Label) GetDefault() bool {
-	if l == nil || l.Default == nil {
+	if l == nil {
 		return false
 	}
-	return *l.Default
+	return l.Default
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
@@ -21750,36 +21750,36 @@ func (l *Label) GetDescription() string {
 	return *l.Description
 }
 
-// GetID returns the ID field if it's non-nil, zero value otherwise.
+// GetID returns the ID field.
 func (l *Label) GetID() int64 {
-	if l == nil || l.ID == nil {
+	if l == nil {
 		return 0
 	}
-	return *l.ID
+	return l.ID
 }
 
-// GetName returns the Name field if it's non-nil, zero value otherwise.
+// GetName returns the Name field.
 func (l *Label) GetName() string {
-	if l == nil || l.Name == nil {
+	if l == nil {
 		return ""
 	}
-	return *l.Name
+	return l.Name
 }
 
-// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+// GetNodeID returns the NodeID field.
 func (l *Label) GetNodeID() string {
-	if l == nil || l.NodeID == nil {
+	if l == nil {
 		return ""
 	}
-	return *l.NodeID
+	return l.NodeID
 }
 
-// GetURL returns the URL field if it's non-nil, zero value otherwise.
+// GetURL returns the URL field.
 func (l *Label) GetURL() string {
-	if l == nil || l.URL == nil {
+	if l == nil {
 		return ""
 	}
-	return *l.URL
+	return l.URL
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
@@ -42838,6 +42838,30 @@ func (u *UpdateHostedRunnerRequest) GetSize() string {
 	return *u.Size
 }
 
+// GetColor returns the Color field if it's non-nil, zero value otherwise.
+func (u *UpdateIssueLabelRequest) GetColor() string {
+	if u == nil || u.Color == nil {
+		return ""
+	}
+	return *u.Color
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (u *UpdateIssueLabelRequest) GetDescription() string {
+	if u == nil || u.Description == nil {
+		return ""
+	}
+	return *u.Description
+}
+
+// GetNewName returns the NewName field if it's non-nil, zero value otherwise.
+func (u *UpdateIssueLabelRequest) GetNewName() string {
+	if u == nil || u.NewName == nil {
+		return ""
+	}
+	return *u.NewName
+}
+
 // GetAssignee returns the Assignee field if it's non-nil, zero value otherwise.
 func (u *UpdateIssueRequest) GetAssignee() string {
 	if u == nil || u.Assignee == nil {
@@ -42924,30 +42948,6 @@ func (u *UpdateIssueRequest) GetType() string {
 		return ""
 	}
 	return *u.Type
-}
-
-// GetColor returns the Color field if it's non-nil, zero value otherwise.
-func (u *UpdateLabelRequest) GetColor() string {
-	if u == nil || u.Color == nil {
-		return ""
-	}
-	return *u.Color
-}
-
-// GetDescription returns the Description field if it's non-nil, zero value otherwise.
-func (u *UpdateLabelRequest) GetDescription() string {
-	if u == nil || u.Description == nil {
-		return ""
-	}
-	return *u.Description
-}
-
-// GetNewName returns the NewName field if it's non-nil, zero value otherwise.
-func (u *UpdateLabelRequest) GetNewName() string {
-	if u == nil || u.NewName == nil {
-		return ""
-	}
-	return *u.NewName
 }
 
 // GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -14144,6 +14144,36 @@ func TestCreateHostedRunnerRequest_GetSize(tt *testing.T) {
 	c.GetSize()
 }
 
+func TestCreateIssueLabelRequest_GetColor(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateIssueLabelRequest{Color: &zeroValue}
+	c.GetColor()
+	c = &CreateIssueLabelRequest{}
+	c.GetColor()
+	c = nil
+	c.GetColor()
+}
+
+func TestCreateIssueLabelRequest_GetDescription(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateIssueLabelRequest{Description: &zeroValue}
+	c.GetDescription()
+	c = &CreateIssueLabelRequest{}
+	c.GetDescription()
+	c = nil
+	c.GetDescription()
+}
+
+func TestCreateIssueLabelRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateIssueLabelRequest{}
+	c.GetName()
+	c = nil
+	c.GetName()
+}
+
 func TestCreateIssueRequest_GetAssignee(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -14265,36 +14295,6 @@ func TestCreateJITConfigRequest_GetWorkFolder(tt *testing.T) {
 	c.GetWorkFolder()
 	c = nil
 	c.GetWorkFolder()
-}
-
-func TestCreateLabelRequest_GetColor(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	c := &CreateLabelRequest{Color: &zeroValue}
-	c.GetColor()
-	c = &CreateLabelRequest{}
-	c.GetColor()
-	c = nil
-	c.GetColor()
-}
-
-func TestCreateLabelRequest_GetDescription(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	c := &CreateLabelRequest{Description: &zeroValue}
-	c.GetDescription()
-	c = &CreateLabelRequest{}
-	c.GetDescription()
-	c = nil
-	c.GetDescription()
-}
-
-func TestCreateLabelRequest_GetName(tt *testing.T) {
-	tt.Parallel()
-	c := &CreateLabelRequest{}
-	c.GetName()
-	c = nil
-	c.GetName()
 }
 
 func TestCreateOrganizationPrivateRegistry_GetAccountID(tt *testing.T) {
@@ -27348,10 +27348,7 @@ func TestKey_GetVerified(tt *testing.T) {
 
 func TestLabel_GetColor(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	l := &Label{Color: &zeroValue}
-	l.GetColor()
-	l = &Label{}
+	l := &Label{}
 	l.GetColor()
 	l = nil
 	l.GetColor()
@@ -27359,10 +27356,7 @@ func TestLabel_GetColor(tt *testing.T) {
 
 func TestLabel_GetDefault(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue bool
-	l := &Label{Default: &zeroValue}
-	l.GetDefault()
-	l = &Label{}
+	l := &Label{}
 	l.GetDefault()
 	l = nil
 	l.GetDefault()
@@ -27381,10 +27375,7 @@ func TestLabel_GetDescription(tt *testing.T) {
 
 func TestLabel_GetID(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue int64
-	l := &Label{ID: &zeroValue}
-	l.GetID()
-	l = &Label{}
+	l := &Label{}
 	l.GetID()
 	l = nil
 	l.GetID()
@@ -27392,10 +27383,7 @@ func TestLabel_GetID(tt *testing.T) {
 
 func TestLabel_GetName(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	l := &Label{Name: &zeroValue}
-	l.GetName()
-	l = &Label{}
+	l := &Label{}
 	l.GetName()
 	l = nil
 	l.GetName()
@@ -27403,10 +27391,7 @@ func TestLabel_GetName(tt *testing.T) {
 
 func TestLabel_GetNodeID(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	l := &Label{NodeID: &zeroValue}
-	l.GetNodeID()
-	l = &Label{}
+	l := &Label{}
 	l.GetNodeID()
 	l = nil
 	l.GetNodeID()
@@ -27414,10 +27399,7 @@ func TestLabel_GetNodeID(tt *testing.T) {
 
 func TestLabel_GetURL(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	l := &Label{URL: &zeroValue}
-	l.GetURL()
-	l = &Label{}
+	l := &Label{}
 	l.GetURL()
 	l = nil
 	l.GetURL()
@@ -53690,6 +53672,39 @@ func TestUpdateHostedRunnerRequest_GetSize(tt *testing.T) {
 	u.GetSize()
 }
 
+func TestUpdateIssueLabelRequest_GetColor(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateIssueLabelRequest{Color: &zeroValue}
+	u.GetColor()
+	u = &UpdateIssueLabelRequest{}
+	u.GetColor()
+	u = nil
+	u.GetColor()
+}
+
+func TestUpdateIssueLabelRequest_GetDescription(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateIssueLabelRequest{Description: &zeroValue}
+	u.GetDescription()
+	u = &UpdateIssueLabelRequest{}
+	u.GetDescription()
+	u = nil
+	u.GetDescription()
+}
+
+func TestUpdateIssueLabelRequest_GetNewName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateIssueLabelRequest{NewName: &zeroValue}
+	u.GetNewName()
+	u = &UpdateIssueLabelRequest{}
+	u.GetNewName()
+	u = nil
+	u.GetNewName()
+}
+
 func TestUpdateIssueRequest_GetAssignee(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -53809,39 +53824,6 @@ func TestUpdateIssueRequest_GetType(tt *testing.T) {
 	u.GetType()
 	u = nil
 	u.GetType()
-}
-
-func TestUpdateLabelRequest_GetColor(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	u := &UpdateLabelRequest{Color: &zeroValue}
-	u.GetColor()
-	u = &UpdateLabelRequest{}
-	u.GetColor()
-	u = nil
-	u.GetColor()
-}
-
-func TestUpdateLabelRequest_GetDescription(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	u := &UpdateLabelRequest{Description: &zeroValue}
-	u.GetDescription()
-	u = &UpdateLabelRequest{}
-	u.GetDescription()
-	u = nil
-	u.GetDescription()
-}
-
-func TestUpdateLabelRequest_GetNewName(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	u := &UpdateLabelRequest{NewName: &zeroValue}
-	u.GetNewName()
-	u = &UpdateLabelRequest{}
-	u.GetNewName()
-	u = nil
-	u.GetNewName()
 }
 
 func TestUpdateOrganizationPrivateRegistry_GetAccountID(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -14267,6 +14267,36 @@ func TestCreateJITConfigRequest_GetWorkFolder(tt *testing.T) {
 	c.GetWorkFolder()
 }
 
+func TestCreateLabelRequest_GetColor(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateLabelRequest{Color: &zeroValue}
+	c.GetColor()
+	c = &CreateLabelRequest{}
+	c.GetColor()
+	c = nil
+	c.GetColor()
+}
+
+func TestCreateLabelRequest_GetDescription(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateLabelRequest{Description: &zeroValue}
+	c.GetDescription()
+	c = &CreateLabelRequest{}
+	c.GetDescription()
+	c = nil
+	c.GetDescription()
+}
+
+func TestCreateLabelRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateLabelRequest{}
+	c.GetName()
+	c = nil
+	c.GetName()
+}
+
 func TestCreateOrganizationPrivateRegistry_GetAccountID(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -53779,6 +53809,39 @@ func TestUpdateIssueRequest_GetType(tt *testing.T) {
 	u.GetType()
 	u = nil
 	u.GetType()
+}
+
+func TestUpdateLabelRequest_GetColor(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateLabelRequest{Color: &zeroValue}
+	u.GetColor()
+	u = &UpdateLabelRequest{}
+	u.GetColor()
+	u = nil
+	u.GetColor()
+}
+
+func TestUpdateLabelRequest_GetDescription(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateLabelRequest{Description: &zeroValue}
+	u.GetDescription()
+	u = &UpdateLabelRequest{}
+	u.GetDescription()
+	u = nil
+	u.GetDescription()
+}
+
+func TestUpdateLabelRequest_GetNewName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateLabelRequest{NewName: &zeroValue}
+	u.GetNewName()
+	u = &UpdateLabelRequest{}
+	u.GetNewName()
+	u = nil
+	u.GetNewName()
 }
 
 func TestUpdateOrganizationPrivateRegistry_GetAccountID(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1036,13 +1036,13 @@ func TestKey_String(t *testing.T) {
 func TestLabel_String(t *testing.T) {
 	t.Parallel()
 	v := Label{
-		ID:          Ptr(int64(0)),
-		URL:         Ptr(""),
-		Name:        Ptr(""),
-		Color:       Ptr(""),
+		ID:          0,
+		URL:         "",
+		Name:        "",
+		Color:       "",
 		Description: Ptr(""),
-		Default:     Ptr(false),
-		NodeID:      Ptr(""),
+		Default:     false,
+		NodeID:      "",
 	}
 	want := `github.Label{ID:0, URL:"", Name:"", Color:"", Description:"", Default:false, NodeID:""}`
 	if got := v.String(); got != want {

--- a/github/issues_labels.go
+++ b/github/issues_labels.go
@@ -25,6 +25,20 @@ func (l Label) String() string {
 	return Stringify(l)
 }
 
+// CreateLabelRequest represents a request to create a label.
+type CreateLabelRequest struct {
+	Name        string  `json:"name"`
+	Color       *string `json:"color,omitempty"`
+	Description *string `json:"description,omitempty"`
+}
+
+// UpdateLabelRequest represents a request to update a label.
+type UpdateLabelRequest struct {
+	NewName     *string `json:"new_name,omitempty"`
+	Color       *string `json:"color,omitempty"`
+	Description *string `json:"description,omitempty"`
+}
+
 // ListLabels lists all labels for a repository.
 //
 // GitHub API docs: https://docs.github.com/rest/issues/labels?apiVersion=2022-11-28#list-labels-for-a-repository
@@ -77,7 +91,7 @@ func (s *IssuesService) GetLabel(ctx context.Context, owner, repo, name string) 
 // GitHub API docs: https://docs.github.com/rest/issues/labels?apiVersion=2022-11-28#create-a-label
 //
 //meta:operation POST /repos/{owner}/{repo}/labels
-func (s *IssuesService) CreateLabel(ctx context.Context, owner, repo string, body *Label) (*Label, *Response, error) {
+func (s *IssuesService) CreateLabel(ctx context.Context, owner, repo string, body CreateLabelRequest) (*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/labels", owner, repo)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
@@ -98,7 +112,7 @@ func (s *IssuesService) CreateLabel(ctx context.Context, owner, repo string, bod
 // GitHub API docs: https://docs.github.com/rest/issues/labels?apiVersion=2022-11-28#update-a-label
 //
 //meta:operation PATCH /repos/{owner}/{repo}/labels/{name}
-func (s *IssuesService) EditLabel(ctx context.Context, owner, repo, name string, body *Label) (*Label, *Response, error) {
+func (s *IssuesService) EditLabel(ctx context.Context, owner, repo, name string, body UpdateLabelRequest) (*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/labels/%v", owner, repo, name)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/issues_labels.go
+++ b/github/issues_labels.go
@@ -107,12 +107,12 @@ func (s *IssuesService) CreateLabel(ctx context.Context, owner, repo string, bod
 	return l, resp, nil
 }
 
-// EditLabel edits a label.
+// UpdateLabel updates a label.
 //
 // GitHub API docs: https://docs.github.com/rest/issues/labels?apiVersion=2022-11-28#update-a-label
 //
 //meta:operation PATCH /repos/{owner}/{repo}/labels/{name}
-func (s *IssuesService) EditLabel(ctx context.Context, owner, repo, name string, body UpdateLabelRequest) (*Label, *Response, error) {
+func (s *IssuesService) UpdateLabel(ctx context.Context, owner, repo, name string, body UpdateLabelRequest) (*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/labels/%v", owner, repo, name)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/issues_labels.go
+++ b/github/issues_labels.go
@@ -12,28 +12,28 @@ import (
 
 // Label represents a GitHub label on an Issue.
 type Label struct {
-	ID          *int64  `json:"id,omitempty"`
-	URL         *string `json:"url,omitempty"`
-	Name        *string `json:"name,omitempty"`
-	Color       *string `json:"color,omitempty"`
-	Description *string `json:"description,omitempty"`
-	Default     *bool   `json:"default,omitempty"`
-	NodeID      *string `json:"node_id,omitempty"`
+	ID          int64   `json:"id"`
+	URL         string  `json:"url"`
+	Name        string  `json:"name"`
+	Color       string  `json:"color"`
+	Description *string `json:"description"`
+	Default     bool    `json:"default"`
+	NodeID      string  `json:"node_id"`
 }
 
 func (l Label) String() string {
 	return Stringify(l)
 }
 
-// CreateLabelRequest represents a request to create a label.
-type CreateLabelRequest struct {
+// CreateIssueLabelRequest represents a request to create a label.
+type CreateIssueLabelRequest struct {
 	Name        string  `json:"name"`
 	Color       *string `json:"color,omitempty"`
 	Description *string `json:"description,omitempty"`
 }
 
-// UpdateLabelRequest represents a request to update a label.
-type UpdateLabelRequest struct {
+// UpdateIssueLabelRequest represents a request to update a label.
+type UpdateIssueLabelRequest struct {
 	NewName     *string `json:"new_name,omitempty"`
 	Color       *string `json:"color,omitempty"`
 	Description *string `json:"description,omitempty"`
@@ -91,7 +91,7 @@ func (s *IssuesService) GetLabel(ctx context.Context, owner, repo, name string) 
 // GitHub API docs: https://docs.github.com/rest/issues/labels?apiVersion=2022-11-28#create-a-label
 //
 //meta:operation POST /repos/{owner}/{repo}/labels
-func (s *IssuesService) CreateLabel(ctx context.Context, owner, repo string, body CreateLabelRequest) (*Label, *Response, error) {
+func (s *IssuesService) CreateLabel(ctx context.Context, owner, repo string, body CreateIssueLabelRequest) (*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/labels", owner, repo)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
@@ -112,7 +112,7 @@ func (s *IssuesService) CreateLabel(ctx context.Context, owner, repo string, bod
 // GitHub API docs: https://docs.github.com/rest/issues/labels?apiVersion=2022-11-28#update-a-label
 //
 //meta:operation PATCH /repos/{owner}/{repo}/labels/{name}
-func (s *IssuesService) UpdateLabel(ctx context.Context, owner, repo, name string, body UpdateLabelRequest) (*Label, *Response, error) {
+func (s *IssuesService) UpdateLabel(ctx context.Context, owner, repo, name string, body UpdateIssueLabelRequest) (*Label, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/labels/%v", owner, repo, name)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/issues_labels_test.go
+++ b/github/issues_labels_test.go
@@ -107,7 +107,7 @@ func TestIssuesService_CreateLabel(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &Label{Name: Ptr("n")}
+	input := CreateLabelRequest{Name: "n"}
 
 	mux.HandleFunc("/repos/o/r/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -146,7 +146,7 @@ func TestIssuesService_CreateLabel_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Issues.CreateLabel(ctx, "%", "%", nil)
+	_, _, err := client.Issues.CreateLabel(ctx, "%", "%", CreateLabelRequest{})
 	testURLParseError(t, err)
 }
 
@@ -154,11 +154,11 @@ func TestIssuesService_EditLabel(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &Label{Name: Ptr("z")}
+	input := UpdateLabelRequest{NewName: Ptr("z")}
 
 	mux.HandleFunc("/repos/o/r/labels/n", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testJSONBody(t, r, input)
+		testPlainBody(t, r, `{"new_name":"z"}`+"\n")
 		fmt.Fprint(w, `{"url":"u"}`)
 	})
 
@@ -175,7 +175,7 @@ func TestIssuesService_EditLabel(t *testing.T) {
 
 	const methodName = "EditLabel"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Issues.EditLabel(ctx, "\n", "\n", "\n", input)
+		_, _, err = client.Issues.EditLabel(ctx, "\n", "\n", "\n", UpdateLabelRequest{})
 		return err
 	})
 
@@ -193,7 +193,7 @@ func TestIssuesService_EditLabel_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Issues.EditLabel(ctx, "%", "%", "%", nil)
+	_, _, err := client.Issues.EditLabel(ctx, "%", "%", "%", UpdateLabelRequest{})
 	testURLParseError(t, err)
 }
 

--- a/github/issues_labels_test.go
+++ b/github/issues_labels_test.go
@@ -30,7 +30,7 @@ func TestIssuesService_ListLabels(t *testing.T) {
 		t.Errorf("Issues.ListLabels returned error: %v", err)
 	}
 
-	want := []*Label{{Name: Ptr("a")}, {Name: Ptr("b")}}
+	want := []*Label{{Name: "a"}, {Name: "b"}}
 	if !cmp.Equal(labels, want) {
 		t.Errorf("Issues.ListLabels returned %+v, want %+v", labels, want)
 	}
@@ -74,7 +74,7 @@ func TestIssuesService_GetLabel(t *testing.T) {
 		t.Errorf("Issues.GetLabel returned error: %v", err)
 	}
 
-	want := &Label{URL: Ptr("u"), Name: Ptr("n"), Color: Ptr("c"), Description: Ptr("d")}
+	want := &Label{URL: "u", Name: "n", Color: "c", Description: Ptr("d")}
 	if !cmp.Equal(label, want) {
 		t.Errorf("Issues.GetLabel returned %+v, want %+v", label, want)
 	}
@@ -107,7 +107,7 @@ func TestIssuesService_CreateLabel(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := CreateLabelRequest{Name: "n"}
+	input := CreateIssueLabelRequest{Name: "n"}
 
 	mux.HandleFunc("/repos/o/r/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -121,7 +121,7 @@ func TestIssuesService_CreateLabel(t *testing.T) {
 		t.Errorf("Issues.CreateLabel returned error: %v", err)
 	}
 
-	want := &Label{URL: Ptr("u")}
+	want := &Label{URL: "u"}
 	if !cmp.Equal(label, want) {
 		t.Errorf("Issues.CreateLabel returned %+v, want %+v", label, want)
 	}
@@ -146,7 +146,7 @@ func TestIssuesService_CreateLabel_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Issues.CreateLabel(ctx, "%", "%", CreateLabelRequest{})
+	_, _, err := client.Issues.CreateLabel(ctx, "%", "%", CreateIssueLabelRequest{})
 	testURLParseError(t, err)
 }
 
@@ -154,7 +154,7 @@ func TestIssuesService_UpdateLabel(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := UpdateLabelRequest{NewName: Ptr("z")}
+	input := UpdateIssueLabelRequest{NewName: Ptr("z")}
 
 	mux.HandleFunc("/repos/o/r/labels/n", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -168,14 +168,14 @@ func TestIssuesService_UpdateLabel(t *testing.T) {
 		t.Errorf("Issues.UpdateLabel returned error: %v", err)
 	}
 
-	want := &Label{URL: Ptr("u")}
+	want := &Label{URL: "u"}
 	if !cmp.Equal(label, want) {
 		t.Errorf("Issues.UpdateLabel returned %+v, want %+v", label, want)
 	}
 
 	const methodName = "UpdateLabel"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Issues.UpdateLabel(ctx, "\n", "\n", "\n", UpdateLabelRequest{})
+		_, _, err = client.Issues.UpdateLabel(ctx, "\n", "\n", "\n", UpdateIssueLabelRequest{})
 		return err
 	})
 
@@ -193,7 +193,7 @@ func TestIssuesService_UpdateLabel_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Issues.UpdateLabel(ctx, "%", "%", "%", UpdateLabelRequest{})
+	_, _, err := client.Issues.UpdateLabel(ctx, "%", "%", "%", UpdateIssueLabelRequest{})
 	testURLParseError(t, err)
 }
 
@@ -249,8 +249,8 @@ func TestIssuesService_ListLabelsByIssue(t *testing.T) {
 	}
 
 	want := []*Label{
-		{Name: Ptr("a"), ID: Ptr(int64(1))},
-		{Name: Ptr("b"), ID: Ptr(int64(2))},
+		{Name: "a", ID: 1},
+		{Name: "b", ID: 2},
 	}
 	if !cmp.Equal(labels, want) {
 		t.Errorf("Issues.ListLabelsByIssue returned %+v, want %+v", labels, want)
@@ -298,7 +298,7 @@ func TestIssuesService_AddLabelsToIssue(t *testing.T) {
 		t.Errorf("Issues.AddLabelsToIssue returned error: %v", err)
 	}
 
-	want := []*Label{{URL: Ptr("u")}}
+	want := []*Label{{URL: "u"}}
 	if !cmp.Equal(labels, want) {
 		t.Errorf("Issues.AddLabelsToIssue returned %+v, want %+v", labels, want)
 	}
@@ -379,7 +379,7 @@ func TestIssuesService_ReplaceLabelsForIssue(t *testing.T) {
 		t.Errorf("Issues.ReplaceLabelsForIssue returned error: %v", err)
 	}
 
-	want := []*Label{{URL: Ptr("u")}}
+	want := []*Label{{URL: "u"}}
 	if !cmp.Equal(labels, want) {
 		t.Errorf("Issues.ReplaceLabelsForIssue returned %+v, want %+v", labels, want)
 	}
@@ -459,7 +459,7 @@ func TestIssuesService_ListLabelsForMilestone(t *testing.T) {
 		t.Errorf("Issues.ListLabelsForMilestone returned error: %v", err)
 	}
 
-	want := []*Label{{Name: Ptr("a")}, {Name: Ptr("b")}}
+	want := []*Label{{Name: "a"}, {Name: "b"}}
 	if !cmp.Equal(labels, want) {
 		t.Errorf("Issues.ListLabelsForMilestone returned %+v, want %+v", labels, want)
 	}

--- a/github/issues_labels_test.go
+++ b/github/issues_labels_test.go
@@ -150,7 +150,7 @@ func TestIssuesService_CreateLabel_invalidOwner(t *testing.T) {
 	testURLParseError(t, err)
 }
 
-func TestIssuesService_EditLabel(t *testing.T) {
+func TestIssuesService_UpdateLabel(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
@@ -163,24 +163,24 @@ func TestIssuesService_EditLabel(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	label, _, err := client.Issues.EditLabel(ctx, "o", "r", "n", input)
+	label, _, err := client.Issues.UpdateLabel(ctx, "o", "r", "n", input)
 	if err != nil {
-		t.Errorf("Issues.EditLabel returned error: %v", err)
+		t.Errorf("Issues.UpdateLabel returned error: %v", err)
 	}
 
 	want := &Label{URL: Ptr("u")}
 	if !cmp.Equal(label, want) {
-		t.Errorf("Issues.EditLabel returned %+v, want %+v", label, want)
+		t.Errorf("Issues.UpdateLabel returned %+v, want %+v", label, want)
 	}
 
-	const methodName = "EditLabel"
+	const methodName = "UpdateLabel"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Issues.EditLabel(ctx, "\n", "\n", "\n", UpdateLabelRequest{})
+		_, _, err = client.Issues.UpdateLabel(ctx, "\n", "\n", "\n", UpdateLabelRequest{})
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Issues.EditLabel(ctx, "o", "r", "n", input)
+		got, resp, err := client.Issues.UpdateLabel(ctx, "o", "r", "n", input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -188,12 +188,12 @@ func TestIssuesService_EditLabel(t *testing.T) {
 	})
 }
 
-func TestIssuesService_EditLabel_invalidOwner(t *testing.T) {
+func TestIssuesService_UpdateLabel_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Issues.EditLabel(ctx, "%", "%", "%", UpdateLabelRequest{})
+	_, _, err := client.Issues.UpdateLabel(ctx, "%", "%", "%", UpdateLabelRequest{})
 	testURLParseError(t, err)
 }
 

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -261,9 +261,9 @@ func TestIssuesService_Get(t *testing.T) {
 		Number:            Ptr(1),
 		AuthorAssociation: Ptr("MEMBER"),
 		Labels: []*Label{{
-			URL:   Ptr("u"),
-			Name:  Ptr("n"),
-			Color: Ptr("c"),
+			URL:   "u",
+			Name:  "n",
+			Color: "c",
 		}},
 	}
 	if !cmp.Equal(issue, want) {

--- a/github/strings_test.go
+++ b/github/strings_test.go
@@ -195,7 +195,7 @@ func TestString(t *testing.T) {
 		{Issue{Number: Ptr(1)}, `github.Issue{Number:1}`},
 		{SubIssue{ID: Ptr(int64(1))}, `github.SubIssue{ID:1}`},
 		{Key{ID: Ptr(int64(1))}, `github.Key{ID:1}`},
-		{Label{ID: Ptr(int64(1)), Name: Ptr("l")}, `github.Label{ID:1, Name:"l"}`},
+		{Label{ID: 1, Name: "l"}, `github.Label{ID:1, URL:"", Name:"l", Color:"", Default:false, NodeID:""}`},
 		{Organization{ID: Ptr(int64(1))}, `github.Organization{ID:1}`},
 		{PullRequestComment{ID: Ptr(int64(1))}, `github.PullRequestComment{ID:1}`},
 		{PullRequest{Number: Ptr(1)}, `github.PullRequest{Number:1}`},


### PR DESCRIPTION
Continues the request-body-by-value work in #3644, for `IssuesService.Label`.

BREAKING CHANGE: `IssuesService.CreateLabel` now takes a `CreateLabelRequest` by value (with a required non-pointer `Name`). `IssuesService.EditLabel` renamed to `UpdateLabel`, taking an `UpdateLabelRequest` by value instead of a `*Label` (with all fields optional).

## Notes
- The update request takes `new_name`, not `name` which appears to have been a latent bug.

cc @JamBalaya56562 flagging for #3644 coordination