### PR TITLE
refactor!: Split `CreateOrUpdateCustomRepoRoleOptions` into `CreateCustomRepoRoleRequest` and `UpdateCustomRepoRoleRequest` and pass by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -211,7 +211,6 @@ linters:
             - ConfigApplyOptions
             - ConfigSettings
             - CreateCodespaceOptions
-            - CreateOrUpdateCustomRepoRoleOptions
             - CreateOrUpdateIssueTypesOptions
             - CreateOrgInvitationOptions
             - CreateUpdateEnvironment
@@ -281,7 +280,6 @@ linters:
             - CreateCheckRunOptions
             - CreateCheckSuiteOptions
             - CreateCodespaceOptions
-            - CreateOrUpdateCustomRepoRoleOptions
             - CreateOrUpdateIssueTypesOptions
             - CreateOrgInvitationOptions
             - ImpersonateUserOptions

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -10918,6 +10918,38 @@ func (c *CreateCustomOrgRoleRequest) GetPermissions() []string {
 	return c.Permissions
 }
 
+// GetBaseRole returns the BaseRole field.
+func (c *CreateCustomRepoRoleRequest) GetBaseRole() string {
+	if c == nil {
+		return ""
+	}
+	return c.BaseRole
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (c *CreateCustomRepoRoleRequest) GetDescription() string {
+	if c == nil || c.Description == nil {
+		return ""
+	}
+	return *c.Description
+}
+
+// GetName returns the Name field.
+func (c *CreateCustomRepoRoleRequest) GetName() string {
+	if c == nil {
+		return ""
+	}
+	return c.Name
+}
+
+// GetPermissions returns the Permissions slice if it's non-nil, nil otherwise.
+func (c *CreateCustomRepoRoleRequest) GetPermissions() []string {
+	if c == nil || c.Permissions == nil {
+		return nil
+	}
+	return c.Permissions
+}
+
 // GetName returns the Name field.
 func (c *CreateDeploymentBranchPolicyRequest) GetName() string {
 	if c == nil {
@@ -11436,38 +11468,6 @@ func (c *CreateOrgInvitationOptions) GetTeamID() []int64 {
 		return nil
 	}
 	return c.TeamID
-}
-
-// GetBaseRole returns the BaseRole field if it's non-nil, zero value otherwise.
-func (c *CreateOrUpdateCustomRepoRoleOptions) GetBaseRole() string {
-	if c == nil || c.BaseRole == nil {
-		return ""
-	}
-	return *c.BaseRole
-}
-
-// GetDescription returns the Description field if it's non-nil, zero value otherwise.
-func (c *CreateOrUpdateCustomRepoRoleOptions) GetDescription() string {
-	if c == nil || c.Description == nil {
-		return ""
-	}
-	return *c.Description
-}
-
-// GetName returns the Name field if it's non-nil, zero value otherwise.
-func (c *CreateOrUpdateCustomRepoRoleOptions) GetName() string {
-	if c == nil || c.Name == nil {
-		return ""
-	}
-	return *c.Name
-}
-
-// GetPermissions returns the Permissions slice if it's non-nil, nil otherwise.
-func (c *CreateOrUpdateCustomRepoRoleOptions) GetPermissions() []string {
-	if c == nil || c.Permissions == nil {
-		return nil
-	}
-	return c.Permissions
 }
 
 // GetColor returns the Color field if it's non-nil, zero value otherwise.
@@ -42624,6 +42624,38 @@ func (u *UpdateCustomOrgRoleRequest) GetName() string {
 
 // GetPermissions returns the Permissions slice if it's non-nil, nil otherwise.
 func (u *UpdateCustomOrgRoleRequest) GetPermissions() []string {
+	if u == nil || u.Permissions == nil {
+		return nil
+	}
+	return u.Permissions
+}
+
+// GetBaseRole returns the BaseRole field if it's non-nil, zero value otherwise.
+func (u *UpdateCustomRepoRoleRequest) GetBaseRole() string {
+	if u == nil || u.BaseRole == nil {
+		return ""
+	}
+	return *u.BaseRole
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (u *UpdateCustomRepoRoleRequest) GetDescription() string {
+	if u == nil || u.Description == nil {
+		return ""
+	}
+	return *u.Description
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (u *UpdateCustomRepoRoleRequest) GetName() string {
+	if u == nil || u.Name == nil {
+		return ""
+	}
+	return *u.Name
+}
+
+// GetPermissions returns the Permissions slice if it's non-nil, nil otherwise.
+func (u *UpdateCustomRepoRoleRequest) GetPermissions() []string {
 	if u == nil || u.Permissions == nil {
 		return nil
 	}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -13847,6 +13847,44 @@ func TestCreateCustomOrgRoleRequest_GetPermissions(tt *testing.T) {
 	c.GetPermissions()
 }
 
+func TestCreateCustomRepoRoleRequest_GetBaseRole(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateCustomRepoRoleRequest{}
+	c.GetBaseRole()
+	c = nil
+	c.GetBaseRole()
+}
+
+func TestCreateCustomRepoRoleRequest_GetDescription(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateCustomRepoRoleRequest{Description: &zeroValue}
+	c.GetDescription()
+	c = &CreateCustomRepoRoleRequest{}
+	c.GetDescription()
+	c = nil
+	c.GetDescription()
+}
+
+func TestCreateCustomRepoRoleRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateCustomRepoRoleRequest{}
+	c.GetName()
+	c = nil
+	c.GetName()
+}
+
+func TestCreateCustomRepoRoleRequest_GetPermissions(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []string{}
+	c := &CreateCustomRepoRoleRequest{Permissions: zeroValue}
+	c.GetPermissions()
+	c = &CreateCustomRepoRoleRequest{}
+	c.GetPermissions()
+	c = nil
+	c.GetPermissions()
+}
+
 func TestCreateDeploymentBranchPolicyRequest_GetName(tt *testing.T) {
 	tt.Parallel()
 	c := &CreateDeploymentBranchPolicyRequest{}
@@ -14509,50 +14547,6 @@ func TestCreateOrgInvitationOptions_GetTeamID(tt *testing.T) {
 	c.GetTeamID()
 	c = nil
 	c.GetTeamID()
-}
-
-func TestCreateOrUpdateCustomRepoRoleOptions_GetBaseRole(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	c := &CreateOrUpdateCustomRepoRoleOptions{BaseRole: &zeroValue}
-	c.GetBaseRole()
-	c = &CreateOrUpdateCustomRepoRoleOptions{}
-	c.GetBaseRole()
-	c = nil
-	c.GetBaseRole()
-}
-
-func TestCreateOrUpdateCustomRepoRoleOptions_GetDescription(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	c := &CreateOrUpdateCustomRepoRoleOptions{Description: &zeroValue}
-	c.GetDescription()
-	c = &CreateOrUpdateCustomRepoRoleOptions{}
-	c.GetDescription()
-	c = nil
-	c.GetDescription()
-}
-
-func TestCreateOrUpdateCustomRepoRoleOptions_GetName(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	c := &CreateOrUpdateCustomRepoRoleOptions{Name: &zeroValue}
-	c.GetName()
-	c = &CreateOrUpdateCustomRepoRoleOptions{}
-	c.GetName()
-	c = nil
-	c.GetName()
-}
-
-func TestCreateOrUpdateCustomRepoRoleOptions_GetPermissions(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := []string{}
-	c := &CreateOrUpdateCustomRepoRoleOptions{Permissions: zeroValue}
-	c.GetPermissions()
-	c = &CreateOrUpdateCustomRepoRoleOptions{}
-	c.GetPermissions()
-	c = nil
-	c.GetPermissions()
 }
 
 func TestCreateOrUpdateIssueTypesOptions_GetColor(tt *testing.T) {
@@ -53411,6 +53405,50 @@ func TestUpdateCustomOrgRoleRequest_GetPermissions(tt *testing.T) {
 	u := &UpdateCustomOrgRoleRequest{Permissions: zeroValue}
 	u.GetPermissions()
 	u = &UpdateCustomOrgRoleRequest{}
+	u.GetPermissions()
+	u = nil
+	u.GetPermissions()
+}
+
+func TestUpdateCustomRepoRoleRequest_GetBaseRole(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateCustomRepoRoleRequest{BaseRole: &zeroValue}
+	u.GetBaseRole()
+	u = &UpdateCustomRepoRoleRequest{}
+	u.GetBaseRole()
+	u = nil
+	u.GetBaseRole()
+}
+
+func TestUpdateCustomRepoRoleRequest_GetDescription(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateCustomRepoRoleRequest{Description: &zeroValue}
+	u.GetDescription()
+	u = &UpdateCustomRepoRoleRequest{}
+	u.GetDescription()
+	u = nil
+	u.GetDescription()
+}
+
+func TestUpdateCustomRepoRoleRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateCustomRepoRoleRequest{Name: &zeroValue}
+	u.GetName()
+	u = &UpdateCustomRepoRoleRequest{}
+	u.GetName()
+	u = nil
+	u.GetName()
+}
+
+func TestUpdateCustomRepoRoleRequest_GetPermissions(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []string{}
+	u := &UpdateCustomRepoRoleRequest{Permissions: zeroValue}
+	u.GetPermissions()
+	u = &UpdateCustomRepoRoleRequest{}
 	u.GetPermissions()
 	u = nil
 	u.GetPermissions()

--- a/github/orgs_custom_repository_roles.go
+++ b/github/orgs_custom_repository_roles.go
@@ -43,7 +43,7 @@ type UpdateCustomRepoRoleRequest struct {
 	Name        *string  `json:"name,omitempty"`
 	Description *string  `json:"description,omitempty"`
 	BaseRole    *string  `json:"base_role,omitempty"`
-	Permissions []string `json:"permissions,omitempty"`
+	Permissions []string `json:"permissions,omitzero"`
 }
 
 // RepoFineGrainedPermission represents a fine-grained permission that can be used in a custom repository role.

--- a/github/orgs_custom_repository_roles.go
+++ b/github/orgs_custom_repository_roles.go
@@ -30,12 +30,20 @@ type CustomRepoRoles struct {
 	UpdatedAt   *Timestamp    `json:"updated_at,omitempty"`
 }
 
-// CreateOrUpdateCustomRepoRoleOptions represents options required to create or update a custom repository role.
-type CreateOrUpdateCustomRepoRoleOptions struct {
+// CreateCustomRepoRoleRequest represents the parameters to create a custom repository role.
+type CreateCustomRepoRoleRequest struct {
+	Name        string   `json:"name"`
+	Description *string  `json:"description,omitempty"`
+	BaseRole    string   `json:"base_role"`
+	Permissions []string `json:"permissions"`
+}
+
+// UpdateCustomRepoRoleRequest represents the parameters to update a custom repository role.
+type UpdateCustomRepoRoleRequest struct {
 	Name        *string  `json:"name,omitempty"`
 	Description *string  `json:"description,omitempty"`
 	BaseRole    *string  `json:"base_role,omitempty"`
-	Permissions []string `json:"permissions"`
+	Permissions []string `json:"permissions,omitempty"`
 }
 
 // RepoFineGrainedPermission represents a fine-grained permission that can be used in a custom repository role.
@@ -96,7 +104,7 @@ func (s *OrganizationsService) GetCustomRepoRole(ctx context.Context, org string
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/orgs/custom-roles?apiVersion=2022-11-28#create-a-custom-repository-role
 //
 //meta:operation POST /orgs/{org}/custom-repository-roles
-func (s *OrganizationsService) CreateCustomRepoRole(ctx context.Context, org string, body *CreateOrUpdateCustomRepoRoleOptions) (*CustomRepoRoles, *Response, error) {
+func (s *OrganizationsService) CreateCustomRepoRole(ctx context.Context, org string, body CreateCustomRepoRoleRequest) (*CustomRepoRoles, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/custom-repository-roles", org)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
@@ -119,7 +127,7 @@ func (s *OrganizationsService) CreateCustomRepoRole(ctx context.Context, org str
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/orgs/custom-roles?apiVersion=2022-11-28#update-a-custom-repository-role
 //
 //meta:operation PATCH /orgs/{org}/custom-repository-roles/{role_id}
-func (s *OrganizationsService) UpdateCustomRepoRole(ctx context.Context, org string, roleID int64, body *CreateOrUpdateCustomRepoRoleOptions) (*CustomRepoRoles, *Response, error) {
+func (s *OrganizationsService) UpdateCustomRepoRole(ctx context.Context, org string, roleID int64, body UpdateCustomRepoRoleRequest) (*CustomRepoRoles, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/custom-repository-roles/%v", org, roleID)
 
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)

--- a/github/orgs_custom_repository_roles_test.go
+++ b/github/orgs_custom_repository_roles_test.go
@@ -183,13 +183,13 @@ func TestOrganizationsService_CreateCustomRepoRole(t *testing.T) {
 
 	ctx := t.Context()
 
-	opts := &CreateOrUpdateCustomRepoRoleOptions{
-		Name:        Ptr("Labeler"),
+	body := CreateCustomRepoRoleRequest{
+		Name:        "Labeler",
 		Description: Ptr("A role for issue and PR labelers"),
-		BaseRole:    Ptr("read"),
+		BaseRole:    "read",
 		Permissions: []string{"add_label"},
 	}
-	apps, _, err := client.Organizations.CreateCustomRepoRole(ctx, "o", opts)
+	apps, _, err := client.Organizations.CreateCustomRepoRole(ctx, "o", body)
 	if err != nil {
 		t.Errorf("Organizations.CreateCustomRepoRole returned error: %v", err)
 	}
@@ -202,12 +202,12 @@ func TestOrganizationsService_CreateCustomRepoRole(t *testing.T) {
 
 	const methodName = "CreateCustomRepoRole"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Organizations.CreateCustomRepoRole(ctx, "\no", nil)
+		_, _, err = client.Organizations.CreateCustomRepoRole(ctx, "\no", CreateCustomRepoRoleRequest{})
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Organizations.CreateCustomRepoRole(ctx, "o", nil)
+		got, resp, err := client.Organizations.CreateCustomRepoRole(ctx, "o", CreateCustomRepoRoleRequest{})
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -226,11 +226,11 @@ func TestOrganizationsService_UpdateCustomRepoRole(t *testing.T) {
 
 	ctx := t.Context()
 
-	opts := &CreateOrUpdateCustomRepoRoleOptions{
+	body := UpdateCustomRepoRoleRequest{
 		Name:        Ptr("Updated Name"),
 		Description: Ptr("Updated Description"),
 	}
-	apps, _, err := client.Organizations.UpdateCustomRepoRole(ctx, "o", 8030, opts)
+	apps, _, err := client.Organizations.UpdateCustomRepoRole(ctx, "o", 8030, body)
 	if err != nil {
 		t.Errorf("Organizations.UpdateCustomRepoRole returned error: %v", err)
 	}
@@ -243,12 +243,12 @@ func TestOrganizationsService_UpdateCustomRepoRole(t *testing.T) {
 
 	const methodName = "UpdateCustomRepoRole"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Organizations.UpdateCustomRepoRole(ctx, "\no", 8030, nil)
+		_, _, err = client.Organizations.UpdateCustomRepoRole(ctx, "\no", 8030, UpdateCustomRepoRoleRequest{})
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Organizations.UpdateCustomRepoRole(ctx, "o", 8030, nil)
+		got, resp, err := client.Organizations.UpdateCustomRepoRole(ctx, "o", 8030, UpdateCustomRepoRoleRequest{})
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}


### PR DESCRIPTION
Continues the request-body-by-value work in #3644, this time for the custom repository role endpoints on `OrganizationsService`.

`CreateOrUpdateCustomRepoRoleOptions` was a single type shared by both the create and update methods, but the two endpoints don't share the same required fields:

| Field | Create (POST) | Update (PATCH) |
|---|---|---|
| `name` | **required** | optional |
| `base_role` | **required** | optional |
| `permissions` | **required** | optional |
| `description` | optional | optional |

So the shared type is split into two request types, matching the split done for deployment branch policies in #4382:

- **`CreateCustomRepoRoleRequest`** — `Name` and `BaseRole` become non-pointer `string` (no `omitempty`) since they're required; `Permissions` stays required; `Description` stays optional (`*string`).
- **`UpdateCustomRepoRoleRequest`** — every field is optional, so all stay pointers (with `Permissions` gaining `omitempty`).

`CreateCustomRepoRole` and `UpdateCustomRepoRole` now take their body by value, and both entries are removed from the `.golangci.yml` allowlists. The method verbs already match the docs operation names ([Create](https://docs.github.com/en/rest/orgs/custom-roles?apiVersion=2022-11-28#create-a-custom-repository-role) / [Update](https://docs.github.com/en/rest/orgs/custom-roles?apiVersion=2022-11-28#update-a-custom-repository-role)), so no method rename is needed. The response type `CustomRepoRoles` is unchanged.

Verified with `go build ./...`, `go vet -tags integration ./test/integration/`, `gofmt`, the full `./github/` test suite (both methods and the regenerated accessors at 100%), and `custom-gcl` (no `paramcheck` findings after removing the allowlist entries).

Updates #3644

BREAKING CHANGE: CreateOrUpdateCustomRepoRoleOptions is split into CreateCustomRepoRoleRequest (with non-pointer Name and BaseRole) and UpdateCustomRepoRoleRequest; OrganizationsService.CreateCustomRepoRole and UpdateCustomRepoRole now take these request types by value.

cc @jvm986 — flagging for #3644 coordination; this is in the `orgs` service, so it shouldn't overlap with the `Issues` work.
