### PR TITLE
refactor!: Rename `PullRequestReviewDismissalRequest` to `PullRequestDismissReviewRequest`, add `PullRequestSubmitReviewRequest`, and pass review request bodies by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -243,7 +243,6 @@ linters:
             - PublishCodespaceOptions
             - PullRequestBranchUpdateOptions
             - PullRequestComment
-            - PullRequestReviewDismissalRequest
             - PullRequestReviewRequest
             - PullRequestReviewsEnforcementUpdate
             - Repository

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -31558,12 +31558,12 @@ func (p *PullRequestReviewCommentEvent) GetSender() *User {
 	return p.Sender
 }
 
-// GetMessage returns the Message field if it's non-nil, zero value otherwise.
+// GetMessage returns the Message field.
 func (p *PullRequestReviewDismissalRequest) GetMessage() string {
-	if p == nil || p.Message == nil {
+	if p == nil {
 		return ""
 	}
-	return *p.Message
+	return p.Message
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -31126,6 +31126,14 @@ func (p *PullRequestComment) GetUser() *User {
 	return p.User
 }
 
+// GetEvent returns the Event field if it's non-nil, zero value otherwise.
+func (p *PullRequestDismissReviewRequest) GetEvent() string {
+	if p == nil || p.Event == nil {
+		return ""
+	}
+	return *p.Event
+}
+
 // GetMessage returns the Message field.
 func (p *PullRequestDismissReviewRequest) GetMessage() string {
 	if p == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -31934,6 +31934,22 @@ func (p *PullRequestRuleParameters) GetRequireLastPushApproval() bool {
 	return p.RequireLastPushApproval
 }
 
+// GetBody returns the Body field if it's non-nil, zero value otherwise.
+func (p *PullRequestSubmitReviewRequest) GetBody() string {
+	if p == nil || p.Body == nil {
+		return ""
+	}
+	return *p.Body
+}
+
+// GetEvent returns the Event field.
+func (p *PullRequestSubmitReviewRequest) GetEvent() string {
+	if p == nil {
+		return ""
+	}
+	return p.Event
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (p *PullRequestTargetEvent) GetAction() string {
 	if p == nil || p.Action == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -31126,6 +31126,14 @@ func (p *PullRequestComment) GetUser() *User {
 	return p.User
 }
 
+// GetMessage returns the Message field.
+func (p *PullRequestDismissReviewRequest) GetMessage() string {
+	if p == nil {
+		return ""
+	}
+	return p.Message
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (p *PullRequestEvent) GetAction() string {
 	if p == nil || p.Action == nil {
@@ -31556,14 +31564,6 @@ func (p *PullRequestReviewCommentEvent) GetSender() *User {
 		return nil
 	}
 	return p.Sender
-}
-
-// GetMessage returns the Message field.
-func (p *PullRequestReviewDismissalRequest) GetMessage() string {
-	if p == nil {
-		return ""
-	}
-	return p.Message
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -39649,10 +39649,7 @@ func TestPullRequestReviewCommentEvent_GetSender(tt *testing.T) {
 
 func TestPullRequestReviewDismissalRequest_GetMessage(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	p := &PullRequestReviewDismissalRequest{Message: &zeroValue}
-	p.GetMessage()
-	p = &PullRequestReviewDismissalRequest{}
+	p := &PullRequestReviewDismissalRequest{}
 	p.GetMessage()
 	p = nil
 	p.GetMessage()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -39146,6 +39146,17 @@ func TestPullRequestComment_GetUser(tt *testing.T) {
 	p.GetUser()
 }
 
+func TestPullRequestDismissReviewRequest_GetEvent(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PullRequestDismissReviewRequest{Event: &zeroValue}
+	p.GetEvent()
+	p = &PullRequestDismissReviewRequest{}
+	p.GetEvent()
+	p = nil
+	p.GetEvent()
+}
+
 func TestPullRequestDismissReviewRequest_GetMessage(tt *testing.T) {
 	tt.Parallel()
 	p := &PullRequestDismissReviewRequest{}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -40068,6 +40068,25 @@ func TestPullRequestRuleParameters_GetRequireLastPushApproval(tt *testing.T) {
 	p.GetRequireLastPushApproval()
 }
 
+func TestPullRequestSubmitReviewRequest_GetBody(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PullRequestSubmitReviewRequest{Body: &zeroValue}
+	p.GetBody()
+	p = &PullRequestSubmitReviewRequest{}
+	p.GetBody()
+	p = nil
+	p.GetBody()
+}
+
+func TestPullRequestSubmitReviewRequest_GetEvent(tt *testing.T) {
+	tt.Parallel()
+	p := &PullRequestSubmitReviewRequest{}
+	p.GetEvent()
+	p = nil
+	p.GetEvent()
+}
+
 func TestPullRequestTargetEvent_GetAction(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -39146,6 +39146,14 @@ func TestPullRequestComment_GetUser(tt *testing.T) {
 	p.GetUser()
 }
 
+func TestPullRequestDismissReviewRequest_GetMessage(tt *testing.T) {
+	tt.Parallel()
+	p := &PullRequestDismissReviewRequest{}
+	p.GetMessage()
+	p = nil
+	p.GetMessage()
+}
+
 func TestPullRequestEvent_GetAction(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -39645,14 +39653,6 @@ func TestPullRequestReviewCommentEvent_GetSender(tt *testing.T) {
 	p.GetSender()
 	p = nil
 	p.GetSender()
-}
-
-func TestPullRequestReviewDismissalRequest_GetMessage(tt *testing.T) {
-	tt.Parallel()
-	p := &PullRequestReviewDismissalRequest{}
-	p.GetMessage()
-	p = nil
-	p.GetMessage()
 }
 
 func TestPullRequestReviewEvent_GetAction(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1728,7 +1728,7 @@ func TestPullRequestReview_String(t *testing.T) {
 func TestPullRequestReviewDismissalRequest_String(t *testing.T) {
 	t.Parallel()
 	v := PullRequestReviewDismissalRequest{
-		Message: Ptr(""),
+		Message: "",
 	}
 	want := `github.PullRequestReviewDismissalRequest{Message:""}`
 	if got := v.String(); got != want {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1709,8 +1709,9 @@ func TestPullRequestDismissReviewRequest_String(t *testing.T) {
 	t.Parallel()
 	v := PullRequestDismissReviewRequest{
 		Message: "",
+		Event:   Ptr(""),
 	}
-	want := `github.PullRequestDismissReviewRequest{Message:""}`
+	want := `github.PullRequestDismissReviewRequest{Message:"", Event:""}`
 	if got := v.String(); got != want {
 		t.Errorf("PullRequestDismissReviewRequest.String = %v, want %v", got, want)
 	}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1705,6 +1705,17 @@ func TestPullRequestComment_String(t *testing.T) {
 	}
 }
 
+func TestPullRequestDismissReviewRequest_String(t *testing.T) {
+	t.Parallel()
+	v := PullRequestDismissReviewRequest{
+		Message: "",
+	}
+	want := `github.PullRequestDismissReviewRequest{Message:""}`
+	if got := v.String(); got != want {
+		t.Errorf("PullRequestDismissReviewRequest.String = %v, want %v", got, want)
+	}
+}
+
 func TestPullRequestReview_String(t *testing.T) {
 	t.Parallel()
 	v := PullRequestReview{
@@ -1722,17 +1733,6 @@ func TestPullRequestReview_String(t *testing.T) {
 	want := `github.PullRequestReview{ID:0, NodeID:"", User:github.User{}, Body:"", SubmittedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, CommitID:"", HTMLURL:"", PullRequestURL:"", State:"", AuthorAssociation:""}`
 	if got := v.String(); got != want {
 		t.Errorf("PullRequestReview.String = %v, want %v", got, want)
-	}
-}
-
-func TestPullRequestReviewDismissalRequest_String(t *testing.T) {
-	t.Parallel()
-	v := PullRequestReviewDismissalRequest{
-		Message: "",
-	}
-	want := `github.PullRequestReviewDismissalRequest{Message:""}`
-	if got := v.String(); got != want {
-		t.Errorf("PullRequestReviewDismissalRequest.String = %v, want %v", got, want)
 	}
 }
 

--- a/github/pulls_reviews.go
+++ b/github/pulls_reviews.go
@@ -95,7 +95,7 @@ func (r *PullRequestReviewRequest) isComfortFadePreview() (bool, error) {
 
 // PullRequestReviewDismissalRequest represents a request to dismiss a review.
 type PullRequestReviewDismissalRequest struct {
-	Message *string `json:"message,omitempty"`
+	Message string `json:"message"`
 }
 
 func (r PullRequestReviewDismissalRequest) String() string {
@@ -315,7 +315,7 @@ func (s *PullRequestsService) SubmitReview(ctx context.Context, owner, repo stri
 // GitHub API docs: https://docs.github.com/rest/pulls/reviews?apiVersion=2022-11-28#dismiss-a-review-for-a-pull-request
 //
 //meta:operation PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals
-func (s *PullRequestsService) DismissReview(ctx context.Context, owner, repo string, number int, reviewID int64, body *PullRequestReviewDismissalRequest) (*PullRequestReview, *Response, error) {
+func (s *PullRequestsService) DismissReview(ctx context.Context, owner, repo string, number int, reviewID int64, body PullRequestReviewDismissalRequest) (*PullRequestReview, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/reviews/%v/dismissals", owner, repo, number, reviewID)
 
 	req, err := s.client.NewRequest(ctx, "PUT", u, body)

--- a/github/pulls_reviews.go
+++ b/github/pulls_reviews.go
@@ -95,7 +95,8 @@ func (r *PullRequestReviewRequest) isComfortFadePreview() (bool, error) {
 
 // PullRequestDismissReviewRequest represents a request to dismiss a review.
 type PullRequestDismissReviewRequest struct {
-	Message string `json:"message"`
+	Message string  `json:"message"`
+	Event   *string `json:"event,omitempty"`
 }
 
 func (r PullRequestDismissReviewRequest) String() string {

--- a/github/pulls_reviews.go
+++ b/github/pulls_reviews.go
@@ -93,12 +93,12 @@ func (r *PullRequestReviewRequest) isComfortFadePreview() (bool, error) {
 	return false, nil
 }
 
-// PullRequestReviewDismissalRequest represents a request to dismiss a review.
-type PullRequestReviewDismissalRequest struct {
+// PullRequestDismissReviewRequest represents a request to dismiss a review.
+type PullRequestDismissReviewRequest struct {
 	Message string `json:"message"`
 }
 
-func (r PullRequestReviewDismissalRequest) String() string {
+func (r PullRequestDismissReviewRequest) String() string {
 	return Stringify(r)
 }
 
@@ -315,7 +315,7 @@ func (s *PullRequestsService) SubmitReview(ctx context.Context, owner, repo stri
 // GitHub API docs: https://docs.github.com/rest/pulls/reviews?apiVersion=2022-11-28#dismiss-a-review-for-a-pull-request
 //
 //meta:operation PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals
-func (s *PullRequestsService) DismissReview(ctx context.Context, owner, repo string, number int, reviewID int64, body PullRequestReviewDismissalRequest) (*PullRequestReview, *Response, error) {
+func (s *PullRequestsService) DismissReview(ctx context.Context, owner, repo string, number int, reviewID int64, body PullRequestDismissReviewRequest) (*PullRequestReview, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/reviews/%v/dismissals", owner, repo, number, reviewID)
 
 	req, err := s.client.NewRequest(ctx, "PUT", u, body)

--- a/github/pulls_reviews.go
+++ b/github/pulls_reviews.go
@@ -103,6 +103,12 @@ func (r PullRequestDismissReviewRequest) String() string {
 	return Stringify(r)
 }
 
+// PullRequestSubmitReviewRequest represents a request to submit a review.
+type PullRequestSubmitReviewRequest struct {
+	Body  *string `json:"body,omitempty"`
+	Event string  `json:"event"`
+}
+
 // ListReviews lists all reviews on the specified pull request.
 //
 // GitHub API docs: https://docs.github.com/rest/pulls/reviews?apiVersion=2022-11-28#list-reviews-for-a-pull-request
@@ -294,7 +300,7 @@ func (s *PullRequestsService) UpdateReview(ctx context.Context, owner, repo stri
 // GitHub API docs: https://docs.github.com/rest/pulls/reviews?apiVersion=2022-11-28#submit-a-review-for-a-pull-request
 //
 //meta:operation POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events
-func (s *PullRequestsService) SubmitReview(ctx context.Context, owner, repo string, number int, reviewID int64, body *PullRequestReviewRequest) (*PullRequestReview, *Response, error) {
+func (s *PullRequestsService) SubmitReview(ctx context.Context, owner, repo string, number int, reviewID int64, body PullRequestSubmitReviewRequest) (*PullRequestReview, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%v/reviews/%v/events", owner, repo, number, reviewID)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)

--- a/github/pulls_reviews_test.go
+++ b/github/pulls_reviews_test.go
@@ -562,7 +562,7 @@ func TestPullRequestsService_DismissReview(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &PullRequestReviewDismissalRequest{Message: Ptr("m")}
+	input := PullRequestReviewDismissalRequest{Message: "m"}
 
 	mux.HandleFunc("/repos/o/r/pulls/1/reviews/1/dismissals", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -601,6 +601,6 @@ func TestPullRequestsService_DismissReview_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.PullRequests.DismissReview(ctx, "%", "r", 1, 1, &PullRequestReviewDismissalRequest{})
+	_, _, err := client.PullRequests.DismissReview(ctx, "%", "r", 1, 1, PullRequestReviewDismissalRequest{})
 	testURLParseError(t, err)
 }

--- a/github/pulls_reviews_test.go
+++ b/github/pulls_reviews_test.go
@@ -562,7 +562,7 @@ func TestPullRequestsService_DismissReview(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := PullRequestReviewDismissalRequest{Message: "m"}
+	input := PullRequestDismissReviewRequest{Message: "m"}
 
 	mux.HandleFunc("/repos/o/r/pulls/1/reviews/1/dismissals", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -601,6 +601,6 @@ func TestPullRequestsService_DismissReview_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.PullRequests.DismissReview(ctx, "%", "r", 1, 1, PullRequestReviewDismissalRequest{})
+	_, _, err := client.PullRequests.DismissReview(ctx, "%", "r", 1, 1, PullRequestDismissReviewRequest{})
 	testURLParseError(t, err)
 }

--- a/github/pulls_reviews_test.go
+++ b/github/pulls_reviews_test.go
@@ -562,7 +562,7 @@ func TestPullRequestsService_DismissReview(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := PullRequestDismissReviewRequest{Message: "m"}
+	input := PullRequestDismissReviewRequest{Message: "m", Event: Ptr("DISMISS")}
 
 	mux.HandleFunc("/repos/o/r/pulls/1/reviews/1/dismissals", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")

--- a/github/pulls_reviews_test.go
+++ b/github/pulls_reviews_test.go
@@ -512,9 +512,9 @@ func TestPullRequestsService_SubmitReview(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &PullRequestReviewRequest{
+	input := PullRequestSubmitReviewRequest{
 		Body:  Ptr("b"),
-		Event: Ptr("APPROVE"),
+		Event: "APPROVE",
 	}
 
 	mux.HandleFunc("/repos/o/r/pulls/1/reviews/1/events", func(w http.ResponseWriter, r *http.Request) {
@@ -554,7 +554,7 @@ func TestPullRequestsService_SubmitReview_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.PullRequests.SubmitReview(ctx, "%", "r", 1, 1, &PullRequestReviewRequest{})
+	_, _, err := client.PullRequests.SubmitReview(ctx, "%", "r", 1, 1, PullRequestSubmitReviewRequest{})
 	testURLParseError(t, err)
 }
 

--- a/github/strings_test.go
+++ b/github/strings_test.go
@@ -202,7 +202,7 @@ func TestString(t *testing.T) {
 		{PullRequestReview{ID: Ptr(int64(1))}, `github.PullRequestReview{ID:1}`},
 		{DraftReviewComment{Position: Ptr(1)}, `github.DraftReviewComment{Position:1}`},
 		{PullRequestReviewRequest{Body: Ptr("r")}, `github.PullRequestReviewRequest{Body:"r"}`},
-		{PullRequestReviewDismissalRequest{Message: Ptr("r")}, `github.PullRequestReviewDismissalRequest{Message:"r"}`},
+		{PullRequestReviewDismissalRequest{Message: "r"}, `github.PullRequestReviewDismissalRequest{Message:"r"}`},
 		{HeadCommit{SHA: Ptr("s")}, `github.HeadCommit{SHA:"s"}`},
 		{PushEvent{PushID: Ptr(int64(1))}, `github.PushEvent{PushID:1}`},
 		{Reference{Ref: Ptr("r")}, `github.Reference{Ref:"r"}`},

--- a/github/strings_test.go
+++ b/github/strings_test.go
@@ -202,7 +202,7 @@ func TestString(t *testing.T) {
 		{PullRequestReview{ID: Ptr(int64(1))}, `github.PullRequestReview{ID:1}`},
 		{DraftReviewComment{Position: Ptr(1)}, `github.DraftReviewComment{Position:1}`},
 		{PullRequestReviewRequest{Body: Ptr("r")}, `github.PullRequestReviewRequest{Body:"r"}`},
-		{PullRequestReviewDismissalRequest{Message: "r"}, `github.PullRequestReviewDismissalRequest{Message:"r"}`},
+		{PullRequestDismissReviewRequest{Message: "r"}, `github.PullRequestDismissReviewRequest{Message:"r"}`},
 		{HeadCommit{SHA: Ptr("s")}, `github.HeadCommit{SHA:"s"}`},
 		{PushEvent{PushID: Ptr(int64(1))}, `github.PushEvent{PushID:1}`},
 		{Reference{Ref: Ptr("r")}, `github.Reference{Ref:"r"}`},


### PR DESCRIPTION
Continues the request-body-by-value work in #3644, for the review dismissal and submission endpoints on `PullRequestsService`.

### Dismiss a review

- `message` is [required](https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#dismiss-a-review-for-a-pull-request), so `Message` becomes a non-pointer `string` (no `omitempty`), and `DismissReview` takes the body by value. The type is removed from the `body-allowed-pointer-types` allowlist.
- Per review: the type is renamed to `PullRequestDismissReviewRequest` to match the method name, and the previously unmodeled optional `event` parameter is added as `Event *string`.

### Submit a review

Per review, `SubmitReview` no longer reuses `*PullRequestReviewRequest` — whose `node_id`, `commit_id` and `comments` fields aren't part of the [submit-a-review schema](https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#submit-a-review-for-a-pull-request) — and instead takes a new `PullRequestSubmitReviewRequest` by value, modeling that schema exactly: `Event` is required (non-pointer `string`), `Body` is optional (`*string`). `CreateReview` keeps the shared `PullRequestReviewRequest`, so its allowlist entry remains.

Verified with `go build ./...`, `go vet -tags integration ./test/integration/`, `gofmt`, the full `./github/` test suite, and `custom-gcl` (no `paramcheck` findings).

Updates #3644

BREAKING CHANGE: PullRequestReviewDismissalRequest is renamed to PullRequestDismissReviewRequest with non-pointer Message; PullRequestsService.DismissReview takes it by value; PullRequestsService.SubmitReview now takes a new PullRequestSubmitReviewRequest (non-pointer Event) by value instead of *PullRequestReviewRequest.

cc @jvm986 — flagging for #3644 coordination; this is in the `pulls` service, so it shouldn't overlap with the `Issues` work.
