### PR TITLE
feat: Support OIDC custom property claims for Actions

### DIFF
--- a/github/actions_oidc.go
+++ b/github/actions_oidc.go
@@ -93,8 +93,13 @@ const (
 
 // OIDCCustomPropertyClaim represents an OIDC custom property claim for GitHub Actions.
 type OIDCCustomPropertyClaim struct {
-	CustomPropertyName string          `json:"custom_property_name"`
-	InclusionSource    InclusionSource `json:"inclusion_source"`
+	CustomPropertyName string `json:"custom_property_name"`
+}
+
+// OIDCCustomPropertyClaimResponse represents the OIDC custom property claim along with the inclusion source (enterprise or organization) for GitHub Actions.
+type OIDCCustomPropertyClaimResponse struct {
+	OIDCCustomPropertyClaim
+	InclusionSource InclusionSource `json:"inclusion_source"`
 }
 
 // ListEnterpriseOIDCCustomPropertyClaims lists the custom property claims in oidc for enterprise actions.
@@ -102,7 +107,7 @@ type OIDCCustomPropertyClaim struct {
 // GitHub API docs: https://docs.github.com/rest/actions/oidc?apiVersion=2022-11-28#list-oidc-custom-property-inclusions-for-an-enterprise
 //
 //meta:operation GET /enterprises/{enterprise}/actions/oidc/customization/properties/repo
-func (s *ActionsService) ListEnterpriseOIDCCustomPropertyClaims(ctx context.Context, enterprise string) ([]*OIDCCustomPropertyClaim, *Response, error) {
+func (s *ActionsService) ListEnterpriseOIDCCustomPropertyClaims(ctx context.Context, enterprise string) ([]*OIDCCustomPropertyClaimResponse, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/actions/oidc/customization/properties/repo", enterprise)
 	return s.listOIDCCustomPropertyClaims(ctx, u)
 }
@@ -112,18 +117,18 @@ func (s *ActionsService) ListEnterpriseOIDCCustomPropertyClaims(ctx context.Cont
 // GitHub API docs: https://docs.github.com/rest/actions/oidc?apiVersion=2022-11-28#list-oidc-custom-property-inclusions-for-an-organization
 //
 //meta:operation GET /orgs/{org}/actions/oidc/customization/properties/repo
-func (s *ActionsService) ListOrgOIDCCustomPropertyClaims(ctx context.Context, org string) ([]*OIDCCustomPropertyClaim, *Response, error) {
+func (s *ActionsService) ListOrgOIDCCustomPropertyClaims(ctx context.Context, org string) ([]*OIDCCustomPropertyClaimResponse, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/actions/oidc/customization/properties/repo", org)
 	return s.listOIDCCustomPropertyClaims(ctx, u)
 }
 
-func (s *ActionsService) listOIDCCustomPropertyClaims(ctx context.Context, url string) ([]*OIDCCustomPropertyClaim, *Response, error) {
+func (s *ActionsService) listOIDCCustomPropertyClaims(ctx context.Context, url string) ([]*OIDCCustomPropertyClaimResponse, *Response, error) {
 	req, err := s.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var props []*OIDCCustomPropertyClaim
+	var props []*OIDCCustomPropertyClaimResponse
 	resp, err := s.client.Do(req, &props)
 	if err != nil {
 		return nil, resp, err

--- a/github/actions_oidc.go
+++ b/github/actions_oidc.go
@@ -81,3 +81,116 @@ func (s *ActionsService) setOIDCSubjectClaimCustomTemplate(ctx context.Context, 
 
 	return s.client.Do(req, nil)
 }
+
+// InclusionSource represents whether the custom oidc property claim was defined at the organization or enterprise level.
+type InclusionSource string
+
+// InclusionSource constants represent whether the inclusion was defined at the organization or enterprise level.
+const (
+	InclusionSourceEnterprise   InclusionSource = "enterprise"
+	InclusionSourceOrganization InclusionSource = "organization"
+)
+
+// OIDCCustomPropertyClaim represents an OIDC custom property claim for GitHub Actions.
+type OIDCCustomPropertyClaim struct {
+	CustomPropertyName *string          `json:"custom_property_name,omitempty"`
+	InclusionSource    *InclusionSource `json:"inclusion_source,omitempty"`
+}
+
+// ListEnterpriseOIDCCustomPropertyClaims lists the custom property claims in oidc for enterprise actions.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/oidc?apiVersion=2022-11-28#list-oidc-custom-property-inclusions-for-an-enterprise
+//
+//meta:operation GET /enterprises/{enterprise}/actions/oidc/customization/properties/repo
+func (s *ActionsService) ListEnterpriseOIDCCustomPropertyClaims(ctx context.Context, enterprise string) ([]*OIDCCustomPropertyClaim, *Response, error) {
+	u := fmt.Sprintf("enterprises/%v/actions/oidc/customization/properties/repo", enterprise)
+	return s.listOIDCCustomPropertyClaims(ctx, u)
+}
+
+// ListOrgOIDCCustomPropertyClaims lists the custom property claims in oidc for organization actions.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/oidc?apiVersion=2022-11-28#list-oidc-custom-property-inclusions-for-an-organization
+//
+//meta:operation GET /orgs/{org}/actions/oidc/customization/properties/repo
+func (s *ActionsService) ListOrgOIDCCustomPropertyClaims(ctx context.Context, org string) ([]*OIDCCustomPropertyClaim, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/oidc/customization/properties/repo", org)
+	return s.listOIDCCustomPropertyClaims(ctx, u)
+}
+
+func (s *ActionsService) listOIDCCustomPropertyClaims(ctx context.Context, url string) ([]*OIDCCustomPropertyClaim, *Response, error) {
+	req, err := s.client.NewRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var props []*OIDCCustomPropertyClaim
+	resp, err := s.client.Do(req, &props)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return props, resp, nil
+}
+
+// SetEnterpriseOIDCCustomPropertyClaim sets a new custom property claim in oidc for enterprise actions.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/oidc?apiVersion=2022-11-28#create-an-oidc-custom-property-inclusion-for-an-enterprise
+//
+//meta:operation POST /enterprises/{enterprise}/actions/oidc/customization/properties/repo
+func (s *ActionsService) SetEnterpriseOIDCCustomPropertyClaim(ctx context.Context, enterprise string, body OIDCCustomPropertyClaim) (*OIDCCustomPropertyClaim, *Response, error) {
+	u := fmt.Sprintf("enterprises/%v/actions/oidc/customization/properties/repo", enterprise)
+	return s.setOIDCCustomPropertyClaim(ctx, u, body)
+}
+
+// SetOrgOIDCCustomPropertyClaim sets a new custom property claim in oidc for organization actions.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/oidc?apiVersion=2022-11-28#create-an-oidc-custom-property-inclusion-for-an-organization
+//
+//meta:operation POST /orgs/{org}/actions/oidc/customization/properties/repo
+func (s *ActionsService) SetOrgOIDCCustomPropertyClaim(ctx context.Context, org string, body OIDCCustomPropertyClaim) (*OIDCCustomPropertyClaim, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/oidc/customization/properties/repo", org)
+	return s.setOIDCCustomPropertyClaim(ctx, u, body)
+}
+
+func (s *ActionsService) setOIDCCustomPropertyClaim(ctx context.Context, url string, body OIDCCustomPropertyClaim) (*OIDCCustomPropertyClaim, *Response, error) {
+	req, err := s.client.NewRequest(ctx, "POST", url, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var customProperty *OIDCCustomPropertyClaim
+	resp, err := s.client.Do(req, &customProperty)
+	if err != nil {
+		return nil, resp, err
+	}
+	return customProperty, resp, err
+}
+
+// DeleteEnterpriseOIDCCustomPropertyClaim deletes a custom property claim in oidc for enterprise actions.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/oidc?apiVersion=2022-11-28#delete-an-oidc-custom-property-inclusion-for-an-enterprise
+//
+//meta:operation DELETE /enterprises/{enterprise}/actions/oidc/customization/properties/repo/{custom_property_name}
+func (s *ActionsService) DeleteEnterpriseOIDCCustomPropertyClaim(ctx context.Context, enterprise, customProperty string) (*Response, error) {
+	u := fmt.Sprintf("enterprises/%v/actions/oidc/customization/properties/repo/%v", enterprise, customProperty)
+	return s.deleteOIDCCustomPropertyClaim(ctx, u)
+}
+
+// DeleteOrgOIDCCustomPropertyClaim deletes a custom property claim in oidc for organization actions.
+//
+// GitHub API docs: https://docs.github.com/rest/actions/oidc?apiVersion=2022-11-28#delete-an-oidc-custom-property-inclusion-for-an-organization
+//
+//meta:operation DELETE /orgs/{org}/actions/oidc/customization/properties/repo/{custom_property_name}
+func (s *ActionsService) DeleteOrgOIDCCustomPropertyClaim(ctx context.Context, enterprise, customProperty string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/actions/oidc/customization/properties/repo/%v", enterprise, customProperty)
+	return s.deleteOIDCCustomPropertyClaim(ctx, u)
+}
+
+func (s *ActionsService) deleteOIDCCustomPropertyClaim(ctx context.Context, url string) (*Response, error) {
+	req, err := s.client.NewRequest(ctx, "DELETE", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/github/actions_oidc.go
+++ b/github/actions_oidc.go
@@ -93,8 +93,8 @@ const (
 
 // OIDCCustomPropertyClaim represents an OIDC custom property claim for GitHub Actions.
 type OIDCCustomPropertyClaim struct {
-	CustomPropertyName *string          `json:"custom_property_name,omitempty"`
-	InclusionSource    *InclusionSource `json:"inclusion_source,omitempty"`
+	CustomPropertyName string          `json:"custom_property_name"`
+	InclusionSource    InclusionSource `json:"inclusion_source"`
 }
 
 // ListEnterpriseOIDCCustomPropertyClaims lists the custom property claims in oidc for enterprise actions.

--- a/github/actions_oidc_test.go
+++ b/github/actions_oidc_test.go
@@ -182,3 +182,217 @@ func TestActionsService_SetRepoOIDCSubjectClaimCustomTemplateToDefault(t *testin
 		return client.Actions.SetRepoOIDCSubjectClaimCustomTemplate(ctx, "o", "r", input)
 	})
 }
+
+func TestActionsService_ListEnterpriseOIDCCustomPropertyClaims(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/enterprises/e/actions/oidc/customization/properties/repo", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{"custom_property_name": "environment","inclusion_source": "enterprise"},{"custom_property_name": "lane","inclusion_source": "enterprise"}]`)
+	})
+
+	ctx := t.Context()
+	claims, _, err := client.Actions.ListEnterpriseOIDCCustomPropertyClaims(ctx, "e")
+	if err != nil {
+		t.Errorf("Actions.ListEnterpriseOIDCCustomPropertyClaims returned error: %v", err)
+	}
+
+	want := []*OIDCCustomPropertyClaim{
+		{CustomPropertyName: Ptr("environment"), InclusionSource: Ptr(InclusionSourceEnterprise)},
+		{CustomPropertyName: Ptr("lane"), InclusionSource: Ptr(InclusionSourceEnterprise)},
+	}
+
+	if !cmp.Equal(claims, want) {
+		t.Errorf("Actions.ListEnterpriseOIDCCustomPropertyClaims returned %+v, want %+v", claims, want)
+	}
+
+	const methodName = "ListEnterpriseOIDCCustomPropertyClaims"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.ListEnterpriseOIDCCustomPropertyClaims(ctx, "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.ListEnterpriseOIDCCustomPropertyClaims(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestActionsService_ListOrgOIDCCustomPropertyClaims(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/actions/oidc/customization/properties/repo", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{"custom_property_name": "environment","inclusion_source": "organization"},{"custom_property_name": "lane","inclusion_source": "organization"}]`)
+	})
+
+	ctx := t.Context()
+	claims, _, err := client.Actions.ListOrgOIDCCustomPropertyClaims(ctx, "o")
+	if err != nil {
+		t.Errorf("Actions.ListOrgOIDCCustomPropertyClaims returned error: %v", err)
+	}
+
+	want := []*OIDCCustomPropertyClaim{
+		{CustomPropertyName: Ptr("environment"), InclusionSource: Ptr(InclusionSourceOrganization)},
+		{CustomPropertyName: Ptr("lane"), InclusionSource: Ptr(InclusionSourceOrganization)},
+	}
+
+	if !cmp.Equal(claims, want) {
+		t.Errorf("Actions.ListOrgOIDCCustomPropertyClaims returned %+v, want %+v", claims, want)
+	}
+
+	const methodName = "ListOrgOIDCCustomPropertyClaims"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.ListOrgOIDCCustomPropertyClaims(ctx, "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.ListOrgOIDCCustomPropertyClaims(ctx, "o")
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestActionsService_SetEnterpriseOIDCCustomPropertyClaim(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	input := OIDCCustomPropertyClaim{
+		CustomPropertyName: Ptr("environment"),
+	}
+
+	mux.HandleFunc("/enterprises/e/actions/oidc/customization/properties/repo", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Content-Type", "application/json")
+		testJSONBody(t, r, input)
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"custom_property_name": "environment"}`)
+	})
+
+	ctx := t.Context()
+	property, _, err := client.Actions.SetEnterpriseOIDCCustomPropertyClaim(ctx, "e", input)
+	if err != nil {
+		t.Errorf("Actions.SetEnterpriseOIDCCustomPropertyClaim returned error: %v", err)
+	}
+
+	want := &OIDCCustomPropertyClaim{CustomPropertyName: Ptr("environment")}
+	if !cmp.Equal(property, want) {
+		t.Errorf("Actions.SetEnterpriseOIDCCustomPropertyClaim returned %+v, want %+v", property, want)
+	}
+
+	const methodName = "SetEnterpriseOIDCCustomPropertyClaim"
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.SetEnterpriseOIDCCustomPropertyClaim(ctx, "\n", input)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.SetEnterpriseOIDCCustomPropertyClaim(ctx, "e", input)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestActionsService_SetOrgOIDCCustomPropertyClaim(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	input := OIDCCustomPropertyClaim{
+		CustomPropertyName: Ptr("environment"),
+	}
+
+	mux.HandleFunc("/orgs/o/actions/oidc/customization/properties/repo", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Content-Type", "application/json")
+		testJSONBody(t, r, input)
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"custom_property_name": "environment"}`)
+	})
+
+	ctx := t.Context()
+	property, _, err := client.Actions.SetOrgOIDCCustomPropertyClaim(ctx, "o", input)
+	if err != nil {
+		t.Errorf("Actions.SetOrgOIDCCustomPropertyClaim returned error: %v", err)
+	}
+
+	want := &OIDCCustomPropertyClaim{CustomPropertyName: Ptr("environment")}
+	if !cmp.Equal(property, want) {
+		t.Errorf("Actions.SetOrgOIDCCustomPropertyClaim returned %+v, want %+v", property, want)
+	}
+
+	const methodName = "SetOrgOIDCCustomPropertyClaim"
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Actions.SetOrgOIDCCustomPropertyClaim(ctx, "\n", input)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Actions.SetOrgOIDCCustomPropertyClaim(ctx, "o", input)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestActionsService_DeleteEnterpriseOIDCCustomPropertyClaim(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/enterprises/e/actions/oidc/customization/properties/repo/environment", func(_ http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	ctx := t.Context()
+	_, err := client.Actions.DeleteEnterpriseOIDCCustomPropertyClaim(ctx, "e", "environment")
+	if err != nil {
+		t.Errorf("Actions.DeleteEnterpriseOIDCCustomPropertyClaim return error: %v", err)
+	}
+
+	const methodName = "DeleteEnterpriseOIDCCustomPropertyClaim"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.DeleteEnterpriseOIDCCustomPropertyClaim(ctx, "\n", "environment")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.DeleteEnterpriseOIDCCustomPropertyClaim(ctx, "e", "r")
+	})
+}
+
+func TestActionsService_DeleteOrgOIDCCustomPropertyClaim(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/actions/oidc/customization/properties/repo/environment", func(_ http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	ctx := t.Context()
+	_, err := client.Actions.DeleteOrgOIDCCustomPropertyClaim(ctx, "o", "environment")
+	if err != nil {
+		t.Errorf("Actions.DeleteOrgOIDCCustomPropertyClaim return error: %v", err)
+	}
+
+	const methodName = "DeleteOrgOIDCCustomPropertyClaim"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.Actions.DeleteOrgOIDCCustomPropertyClaim(ctx, "\n", "environment")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.Actions.DeleteOrgOIDCCustomPropertyClaim(ctx, "o", "r")
+	})
+}

--- a/github/actions_oidc_test.go
+++ b/github/actions_oidc_test.go
@@ -198,9 +198,9 @@ func TestActionsService_ListEnterpriseOIDCCustomPropertyClaims(t *testing.T) {
 		t.Errorf("Actions.ListEnterpriseOIDCCustomPropertyClaims returned error: %v", err)
 	}
 
-	want := []*OIDCCustomPropertyClaim{
-		{CustomPropertyName: Ptr("environment"), InclusionSource: Ptr(InclusionSourceEnterprise)},
-		{CustomPropertyName: Ptr("lane"), InclusionSource: Ptr(InclusionSourceEnterprise)},
+	want := []*OIDCCustomPropertyClaimResponse{
+		{OIDCCustomPropertyClaim: OIDCCustomPropertyClaim{"environment"}, InclusionSource: InclusionSourceEnterprise},
+		{OIDCCustomPropertyClaim: OIDCCustomPropertyClaim{"lane"}, InclusionSource: InclusionSourceEnterprise},
 	}
 
 	if !cmp.Equal(claims, want) {
@@ -237,9 +237,9 @@ func TestActionsService_ListOrgOIDCCustomPropertyClaims(t *testing.T) {
 		t.Errorf("Actions.ListOrgOIDCCustomPropertyClaims returned error: %v", err)
 	}
 
-	want := []*OIDCCustomPropertyClaim{
-		{CustomPropertyName: Ptr("environment"), InclusionSource: Ptr(InclusionSourceOrganization)},
-		{CustomPropertyName: Ptr("lane"), InclusionSource: Ptr(InclusionSourceOrganization)},
+	want := []*OIDCCustomPropertyClaimResponse{
+		{OIDCCustomPropertyClaim: OIDCCustomPropertyClaim{"environment"}, InclusionSource: InclusionSourceOrganization},
+		{OIDCCustomPropertyClaim: OIDCCustomPropertyClaim{"lane"}, InclusionSource: InclusionSourceOrganization},
 	}
 
 	if !cmp.Equal(claims, want) {
@@ -266,7 +266,7 @@ func TestActionsService_SetEnterpriseOIDCCustomPropertyClaim(t *testing.T) {
 	client, mux, _ := setup(t)
 
 	input := OIDCCustomPropertyClaim{
-		CustomPropertyName: Ptr("environment"),
+		CustomPropertyName: "environment",
 	}
 
 	mux.HandleFunc("/enterprises/e/actions/oidc/customization/properties/repo", func(w http.ResponseWriter, r *http.Request) {
@@ -283,7 +283,7 @@ func TestActionsService_SetEnterpriseOIDCCustomPropertyClaim(t *testing.T) {
 		t.Errorf("Actions.SetEnterpriseOIDCCustomPropertyClaim returned error: %v", err)
 	}
 
-	want := &OIDCCustomPropertyClaim{CustomPropertyName: Ptr("environment")}
+	want := &OIDCCustomPropertyClaim{CustomPropertyName: "environment"}
 	if !cmp.Equal(property, want) {
 		t.Errorf("Actions.SetEnterpriseOIDCCustomPropertyClaim returned %+v, want %+v", property, want)
 	}
@@ -309,7 +309,7 @@ func TestActionsService_SetOrgOIDCCustomPropertyClaim(t *testing.T) {
 	client, mux, _ := setup(t)
 
 	input := OIDCCustomPropertyClaim{
-		CustomPropertyName: Ptr("environment"),
+		CustomPropertyName: "environment",
 	}
 
 	mux.HandleFunc("/orgs/o/actions/oidc/customization/properties/repo", func(w http.ResponseWriter, r *http.Request) {
@@ -326,7 +326,7 @@ func TestActionsService_SetOrgOIDCCustomPropertyClaim(t *testing.T) {
 		t.Errorf("Actions.SetOrgOIDCCustomPropertyClaim returned error: %v", err)
 	}
 
-	want := &OIDCCustomPropertyClaim{CustomPropertyName: Ptr("environment")}
+	want := &OIDCCustomPropertyClaim{CustomPropertyName: "environment"}
 	if !cmp.Equal(property, want) {
 		t.Errorf("Actions.SetOrgOIDCCustomPropertyClaim returned %+v, want %+v", property, want)
 	}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -25342,6 +25342,22 @@ func (o *OAuthAPP) GetURL() string {
 	return *o.URL
 }
 
+// GetCustomPropertyName returns the CustomPropertyName field if it's non-nil, zero value otherwise.
+func (o *OIDCCustomPropertyClaim) GetCustomPropertyName() string {
+	if o == nil || o.CustomPropertyName == nil {
+		return ""
+	}
+	return *o.CustomPropertyName
+}
+
+// GetInclusionSource returns the InclusionSource field.
+func (o *OIDCCustomPropertyClaim) GetInclusionSource() *InclusionSource {
+	if o == nil {
+		return nil
+	}
+	return o.InclusionSource
+}
+
 // GetIncludeClaimKeys returns the IncludeClaimKeys slice if it's non-nil, nil otherwise.
 func (o *OIDCSubjectClaimCustomTemplate) GetIncludeClaimKeys() []string {
 	if o == nil || o.IncludeClaimKeys == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -25342,18 +25342,18 @@ func (o *OAuthAPP) GetURL() string {
 	return *o.URL
 }
 
-// GetCustomPropertyName returns the CustomPropertyName field if it's non-nil, zero value otherwise.
+// GetCustomPropertyName returns the CustomPropertyName field.
 func (o *OIDCCustomPropertyClaim) GetCustomPropertyName() string {
-	if o == nil || o.CustomPropertyName == nil {
+	if o == nil {
 		return ""
 	}
-	return *o.CustomPropertyName
+	return o.CustomPropertyName
 }
 
 // GetInclusionSource returns the InclusionSource field.
-func (o *OIDCCustomPropertyClaim) GetInclusionSource() *InclusionSource {
+func (o *OIDCCustomPropertyClaimResponse) GetInclusionSource() InclusionSource {
 	if o == nil {
-		return nil
+		return ""
 	}
 	return o.InclusionSource
 }

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -31784,6 +31784,25 @@ func TestOAuthAPP_GetURL(tt *testing.T) {
 	o.GetURL()
 }
 
+func TestOIDCCustomPropertyClaim_GetCustomPropertyName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	o := &OIDCCustomPropertyClaim{CustomPropertyName: &zeroValue}
+	o.GetCustomPropertyName()
+	o = &OIDCCustomPropertyClaim{}
+	o.GetCustomPropertyName()
+	o = nil
+	o.GetCustomPropertyName()
+}
+
+func TestOIDCCustomPropertyClaim_GetInclusionSource(tt *testing.T) {
+	tt.Parallel()
+	o := &OIDCCustomPropertyClaim{}
+	o.GetInclusionSource()
+	o = nil
+	o.GetInclusionSource()
+}
+
 func TestOIDCSubjectClaimCustomTemplate_GetIncludeClaimKeys(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []string{}

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -31786,18 +31786,15 @@ func TestOAuthAPP_GetURL(tt *testing.T) {
 
 func TestOIDCCustomPropertyClaim_GetCustomPropertyName(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	o := &OIDCCustomPropertyClaim{CustomPropertyName: &zeroValue}
-	o.GetCustomPropertyName()
-	o = &OIDCCustomPropertyClaim{}
+	o := &OIDCCustomPropertyClaim{}
 	o.GetCustomPropertyName()
 	o = nil
 	o.GetCustomPropertyName()
 }
 
-func TestOIDCCustomPropertyClaim_GetInclusionSource(tt *testing.T) {
+func TestOIDCCustomPropertyClaimResponse_GetInclusionSource(tt *testing.T) {
 	tt.Parallel()
-	o := &OIDCCustomPropertyClaim{}
+	o := &OIDCCustomPropertyClaimResponse{}
 	o.GetInclusionSource()
 	o = nil
 	o.GetInclusionSource()

--- a/openapi_operations.yaml
+++ b/openapi_operations.yaml
@@ -105,7 +105,7 @@ operation_overrides:
     documentation_url: https://docs.github.com/rest/pages/pages#request-a-github-pages-build
   - name: GET /repos/{owner}/{repo}/pages/builds/{build_id}
     documentation_url: https://docs.github.com/rest/pages/pages#get-github-pages-build
-openapi_commit: 03ca9c1cac754ec9b8369dc75de8a8c753c6e087
+openapi_commit: 16bc535ad66fac59d585b1516d1d52f58f787962
 openapi_operations:
   - name: GET /
     documentation_url: https://docs.github.com/rest/meta/meta#github-api-root
@@ -1212,8 +1212,16 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/credential-authorizations#revoke-all-credential-authorizations-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
+  - name: POST /enterprises/{enterprise}/credential-authorizations/revoke-credential-type
+    documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/credential-authorizations#revoke-a-single-credential-type-for-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
   - name: POST /enterprises/{enterprise}/credential-authorizations/{username}/revoke
     documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/credential-authorizations#revoke-credential-authorizations-for-a-user-in-an-enterprise
+    openapi_files:
+      - descriptions/ghec/ghec.json
+  - name: POST /enterprises/{enterprise}/credential-authorizations/{username}/revoke-credential-type
+    documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/credential-authorizations#revoke-a-single-credential-type-for-a-user-in-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
   - name: GET /enterprises/{enterprise}/dependabot/alerts
@@ -6773,6 +6781,21 @@ openapi_operations:
       - descriptions/ghec/ghec.json
   - name: PATCH /repos/{owner}/{repo}/issues/{issue_number}/sub_issues/priority
     documentation_url: https://docs.github.com/rest/issues/sub-issues#reprioritize-sub-issue
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: GET /repos/{owner}/{repo}/issues/{issue_number}/suggestions
+    documentation_url: https://docs.github.com/rest/issues/issues#list-issue-suggestions
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: POST /repos/{owner}/{repo}/issues/{issue_number}/suggestions/{suggestion_id}/approve
+    documentation_url: https://docs.github.com/rest/issues/issues#approve-an-issue-suggestion
+    openapi_files:
+      - descriptions/api.github.com/api.github.com.json
+      - descriptions/ghec/ghec.json
+  - name: POST /repos/{owner}/{repo}/issues/{issue_number}/suggestions/{suggestion_id}/dismiss
+    documentation_url: https://docs.github.com/rest/issues/issues#dismiss-an-issue-suggestion
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json

--- a/openapi_operations.yaml
+++ b/openapi_operations.yaml
@@ -105,7 +105,7 @@ operation_overrides:
     documentation_url: https://docs.github.com/rest/pages/pages#request-a-github-pages-build
   - name: GET /repos/{owner}/{repo}/pages/builds/{build_id}
     documentation_url: https://docs.github.com/rest/pages/pages#get-github-pages-build
-openapi_commit: 16bc535ad66fac59d585b1516d1d52f58f787962
+openapi_commit: 03ca9c1cac754ec9b8369dc75de8a8c753c6e087
 openapi_operations:
   - name: GET /
     documentation_url: https://docs.github.com/rest/meta/meta#github-api-root
@@ -1212,16 +1212,8 @@ openapi_operations:
     documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/credential-authorizations#revoke-all-credential-authorizations-for-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
-  - name: POST /enterprises/{enterprise}/credential-authorizations/revoke-credential-type
-    documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/credential-authorizations#revoke-a-single-credential-type-for-an-enterprise
-    openapi_files:
-      - descriptions/ghec/ghec.json
   - name: POST /enterprises/{enterprise}/credential-authorizations/{username}/revoke
     documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/credential-authorizations#revoke-credential-authorizations-for-a-user-in-an-enterprise
-    openapi_files:
-      - descriptions/ghec/ghec.json
-  - name: POST /enterprises/{enterprise}/credential-authorizations/{username}/revoke-credential-type
-    documentation_url: https://docs.github.com/enterprise-cloud@latest/rest/enterprise-admin/credential-authorizations#revoke-a-single-credential-type-for-a-user-in-an-enterprise
     openapi_files:
       - descriptions/ghec/ghec.json
   - name: GET /enterprises/{enterprise}/dependabot/alerts
@@ -6781,21 +6773,6 @@ openapi_operations:
       - descriptions/ghec/ghec.json
   - name: PATCH /repos/{owner}/{repo}/issues/{issue_number}/sub_issues/priority
     documentation_url: https://docs.github.com/rest/issues/sub-issues#reprioritize-sub-issue
-    openapi_files:
-      - descriptions/api.github.com/api.github.com.json
-      - descriptions/ghec/ghec.json
-  - name: GET /repos/{owner}/{repo}/issues/{issue_number}/suggestions
-    documentation_url: https://docs.github.com/rest/issues/issues#list-issue-suggestions
-    openapi_files:
-      - descriptions/api.github.com/api.github.com.json
-      - descriptions/ghec/ghec.json
-  - name: POST /repos/{owner}/{repo}/issues/{issue_number}/suggestions/{suggestion_id}/approve
-    documentation_url: https://docs.github.com/rest/issues/issues#approve-an-issue-suggestion
-    openapi_files:
-      - descriptions/api.github.com/api.github.com.json
-      - descriptions/ghec/ghec.json
-  - name: POST /repos/{owner}/{repo}/issues/{issue_number}/suggestions/{suggestion_id}/dismiss
-    documentation_url: https://docs.github.com/rest/issues/issues#dismiss-an-issue-suggestion
     openapi_files:
       - descriptions/api.github.com/api.github.com.json
       - descriptions/ghec/ghec.json


### PR DESCRIPTION
Adds `GET`, `POST`, `DELETE` methods for enterprises and organizations OIDC custom property claims for GitHub Actions. 

- `/enterprises/{enterprise}/actions/oidc/customization/properties/repo`
- `/orgs/{org}/actions/oidc/customization/properties/repo`

API Docs: https://docs.github.com/en/rest/actions/oidc?apiVersion=2026-03-10

closes https://github.com/google/go-github/issues/4407