### PR TITLE
chore: Update SecurityAdvisory structs with new fields

### DIFF
--- a/github/dependabot_alerts.go
+++ b/github/dependabot_alerts.go
@@ -23,6 +23,13 @@ type AdvisoryCVSS struct {
 	VectorString *string  `json:"vector_string,omitempty"`
 }
 
+// AdvisoryCVSSSeverities represents the advisory pertaining to the Common Vulnerability Scoring System
+// for each supported CVSS version.
+type AdvisoryCVSSSeverities struct {
+	CVSSV3 *AdvisoryCVSS `json:"cvss_v3,omitempty"`
+	CVSSV4 *AdvisoryCVSS `json:"cvss_v4,omitempty"`
+}
+
 // AdvisoryCWEs represent the advisory pertaining to Common Weakness Enumeration.
 type AdvisoryCWEs struct {
 	CWEID *string `json:"cwe_id,omitempty"`
@@ -46,7 +53,9 @@ type DependabotSecurityAdvisory struct {
 	Description     *string                  `json:"description,omitempty"`
 	Vulnerabilities []*AdvisoryVulnerability `json:"vulnerabilities,omitempty"`
 	Severity        *string                  `json:"severity,omitempty"`
+	Classification  *string                  `json:"classification,omitempty"`
 	CVSS            *AdvisoryCVSS            `json:"cvss,omitempty"`
+	CVSSSeverities  *AdvisoryCVSSSeverities  `json:"cvss_severities,omitempty"`
 	CWEs            []*AdvisoryCWEs          `json:"cwes,omitempty"`
 	EPSS            *AdvisoryEPSS            `json:"epss,omitempty"`
 	Identifiers     []*AdvisoryIdentifier    `json:"identifiers,omitempty"`

--- a/github/event_types.go
+++ b/github/event_types.go
@@ -1887,6 +1887,7 @@ type WorkflowRunEvent struct {
 // GitHub API docs: https://docs.github.com/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#security_advisory
 type SecurityAdvisory struct {
 	CVSS               *AdvisoryCVSS                 `json:"cvss,omitempty"`
+	CVSSSeverities     *AdvisoryCVSSSeverities       `json:"cvss_severities,omitempty"`
 	CWEs               []*AdvisoryCWEs               `json:"cwes,omitempty"`
 	GHSAID             *string                       `json:"ghsa_id,omitempty"`
 	Summary            *string                       `json:"summary,omitempty"`

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -886,6 +886,22 @@ func (a *AdvisoryCVSS) GetVectorString() string {
 	return *a.VectorString
 }
 
+// GetCVSSV3 returns the CVSSV3 field.
+func (a *AdvisoryCVSSSeverities) GetCVSSV3() *AdvisoryCVSS {
+	if a == nil {
+		return nil
+	}
+	return a.CVSSV3
+}
+
+// GetCVSSV4 returns the CVSSV4 field.
+func (a *AdvisoryCVSSSeverities) GetCVSSV4() *AdvisoryCVSS {
+	if a == nil {
+		return nil
+	}
+	return a.CVSSV4
+}
+
 // GetCWEID returns the CWEID field if it's non-nil, zero value otherwise.
 func (a *AdvisoryCWEs) GetCWEID() string {
 	if a == nil || a.CWEID == nil {
@@ -12910,6 +12926,14 @@ func (d *DependabotAlertState) GetState() string {
 	return d.State
 }
 
+// GetClassification returns the Classification field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetClassification() string {
+	if d == nil || d.Classification == nil {
+		return ""
+	}
+	return *d.Classification
+}
+
 // GetCVEID returns the CVEID field if it's non-nil, zero value otherwise.
 func (d *DependabotSecurityAdvisory) GetCVEID() string {
 	if d == nil || d.CVEID == nil {
@@ -12924,6 +12948,14 @@ func (d *DependabotSecurityAdvisory) GetCVSS() *AdvisoryCVSS {
 		return nil
 	}
 	return d.CVSS
+}
+
+// GetCVSSSeverities returns the CVSSSeverities field.
+func (d *DependabotSecurityAdvisory) GetCVSSSeverities() *AdvisoryCVSSSeverities {
+	if d == nil {
+		return nil
+	}
+	return d.CVSSSeverities
 }
 
 // GetCWEs returns the CWEs slice if it's non-nil, nil otherwise.
@@ -40100,6 +40132,14 @@ func (s *SecurityAdvisory) GetCVSS() *AdvisoryCVSS {
 		return nil
 	}
 	return s.CVSS
+}
+
+// GetCVSSSeverities returns the CVSSSeverities field.
+func (s *SecurityAdvisory) GetCVSSSeverities() *AdvisoryCVSSSeverities {
+	if s == nil {
+		return nil
+	}
+	return s.CVSSSeverities
 }
 
 // GetCWEIDs returns the CWEIDs slice if it's non-nil, nil otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -1097,6 +1097,22 @@ func TestAdvisoryCVSS_GetVectorString(tt *testing.T) {
 	a.GetVectorString()
 }
 
+func TestAdvisoryCVSSSeverities_GetCVSSV3(tt *testing.T) {
+	tt.Parallel()
+	a := &AdvisoryCVSSSeverities{}
+	a.GetCVSSV3()
+	a = nil
+	a.GetCVSSV3()
+}
+
+func TestAdvisoryCVSSSeverities_GetCVSSV4(tt *testing.T) {
+	tt.Parallel()
+	a := &AdvisoryCVSSSeverities{}
+	a.GetCVSSV4()
+	a = nil
+	a.GetCVSSV4()
+}
+
 func TestAdvisoryCWEs_GetCWEID(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -16346,6 +16362,17 @@ func TestDependabotAlertState_GetState(tt *testing.T) {
 	d.GetState()
 }
 
+func TestDependabotSecurityAdvisory_GetClassification(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	d := &DependabotSecurityAdvisory{Classification: &zeroValue}
+	d.GetClassification()
+	d = &DependabotSecurityAdvisory{}
+	d.GetClassification()
+	d = nil
+	d.GetClassification()
+}
+
 func TestDependabotSecurityAdvisory_GetCVEID(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -16363,6 +16390,14 @@ func TestDependabotSecurityAdvisory_GetCVSS(tt *testing.T) {
 	d.GetCVSS()
 	d = nil
 	d.GetCVSS()
+}
+
+func TestDependabotSecurityAdvisory_GetCVSSSeverities(tt *testing.T) {
+	tt.Parallel()
+	d := &DependabotSecurityAdvisory{}
+	d.GetCVSSSeverities()
+	d = nil
+	d.GetCVSSSeverities()
 }
 
 func TestDependabotSecurityAdvisory_GetCWEs(tt *testing.T) {
@@ -50214,6 +50249,14 @@ func TestSecurityAdvisory_GetCVSS(tt *testing.T) {
 	s.GetCVSS()
 	s = nil
 	s.GetCVSS()
+}
+
+func TestSecurityAdvisory_GetCVSSSeverities(tt *testing.T) {
+	tt.Parallel()
+	s := &SecurityAdvisory{}
+	s.GetCVSSSeverities()
+	s = nil
+	s.GetCVSSSeverities()
 }
 
 func TestSecurityAdvisory_GetCWEIDs(tt *testing.T) {

--- a/github/security_advisories_test.go
+++ b/github/security_advisories_test.go
@@ -793,6 +793,10 @@ func TestListGlobalSecurityAdvisories(t *testing.T) {
 					"vector_string": "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:C/C:H/I:H/A:H",
 					"score": 7.6
 				},
+				"cvss_severities": {
+					"cvss_v3": {"vector_string": "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:C/C:H/I:H/A:H", "score": 7.6},
+					"cvss_v4": {"vector_string": "CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N", "score": 8.7}
+				},
 				"cwes": [
 					{
 						"cwe_id": "CWE-400",
@@ -863,6 +867,16 @@ func TestListGlobalSecurityAdvisories(t *testing.T) {
 				CVSS: &AdvisoryCVSS{
 					VectorString: Ptr("CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:C/C:H/I:H/A:H"),
 					Score:        Ptr(7.6),
+				},
+				CVSSSeverities: &AdvisoryCVSSSeverities{
+					CVSSV3: &AdvisoryCVSS{
+						VectorString: Ptr("CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:C/C:H/I:H/A:H"),
+						Score:        Ptr(7.6),
+					},
+					CVSSV4: &AdvisoryCVSS{
+						VectorString: Ptr("CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"),
+						Score:        Ptr(8.7),
+					},
 				},
 				CWEs: []*AdvisoryCWEs{
 					{
@@ -977,6 +991,10 @@ func TestGetGlobalSecurityAdvisories(t *testing.T) {
 				"vector_string": "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:C/C:H/I:H/A:H",
 				"score": 7.6
 			},
+			"cvss_severities": {
+				"cvss_v3": {"vector_string": "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:C/C:H/I:H/A:H", "score": 7.6},
+				"cvss_v4": {"vector_string": "CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N", "score": 8.7}
+			},
 			"cwes": [
 				{
 					"cwe_id": "CWE-400",
@@ -1043,6 +1061,16 @@ func TestGetGlobalSecurityAdvisories(t *testing.T) {
 			CVSS: &AdvisoryCVSS{
 				VectorString: Ptr("CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:C/C:H/I:H/A:H"),
 				Score:        Ptr(7.6),
+			},
+			CVSSSeverities: &AdvisoryCVSSSeverities{
+				CVSSV3: &AdvisoryCVSS{
+					VectorString: Ptr("CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:C/C:H/I:H/A:H"),
+					Score:        Ptr(7.6),
+				},
+				CVSSV4: &AdvisoryCVSS{
+					VectorString: Ptr("CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"),
+					Score:        Ptr(8.7),
+				},
 			},
 			CWEs: []*AdvisoryCWEs{
 				{


### PR DESCRIPTION
SecurityAdvisory now has CVSSSeverities (mentioned in #4077), see https://docs.github.com/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#security_advisory

DependabotSecurityAdvisory also has CVSSSeverities and also Classification, see
https://docs.github.com/en/webhooks/webhook-events-and-payloads#dependabot_alert