### PR TITLE
feat: Add `search_type` support to issue search

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -21534,6 +21534,14 @@ func (i *IssuesSearchResult) GetIssues() []*Issue {
 	return i.Issues
 }
 
+// GetSearchType returns the SearchType field if it's non-nil, zero value otherwise.
+func (i *IssuesSearchResult) GetSearchType() string {
+	if i == nil || i.SearchType == nil {
+		return ""
+	}
+	return *i.SearchType
+}
+
 // GetTotal returns the Total field if it's non-nil, zero value otherwise.
 func (i *IssuesSearchResult) GetTotal() int {
 	if i == nil || i.Total == nil {
@@ -38804,6 +38812,14 @@ func (s *SearchOptions) GetOrder() string {
 		return ""
 	}
 	return s.Order
+}
+
+// GetSearchType returns the SearchType field.
+func (s *SearchOptions) GetSearchType() string {
+	if s == nil {
+		return ""
+	}
+	return s.SearchType
 }
 
 // GetSort returns the Sort field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -27079,6 +27079,17 @@ func TestIssuesSearchResult_GetIssues(tt *testing.T) {
 	i.GetIssues()
 }
 
+func TestIssuesSearchResult_GetSearchType(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	i := &IssuesSearchResult{SearchType: &zeroValue}
+	i.GetSearchType()
+	i = &IssuesSearchResult{}
+	i.GetSearchType()
+	i = nil
+	i.GetSearchType()
+}
+
 func TestIssuesSearchResult_GetTotal(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int
@@ -48621,6 +48632,14 @@ func TestSearchOptions_GetOrder(tt *testing.T) {
 	s.GetOrder()
 	s = nil
 	s.GetOrder()
+}
+
+func TestSearchOptions_GetSearchType(tt *testing.T) {
+	tt.Parallel()
+	s := &SearchOptions{}
+	s.GetSearchType()
+	s = nil
+	s.GetSearchType()
 }
 
 func TestSearchOptions_GetSort(tt *testing.T) {

--- a/github/search.go
+++ b/github/search.go
@@ -57,6 +57,10 @@ type SearchOptions struct {
 	// Whether to enable advanced search for issues
 	AdvancedSearch *bool `url:"advanced_search,omitempty"`
 
+	// The type of search to perform on issues. Possible values are:
+	// semantic, hybrid. Default is lexical search.
+	SearchType string `url:"search_type,omitempty"`
+
 	ListOptions
 }
 
@@ -167,6 +171,7 @@ func (s *SearchService) Commits(ctx context.Context, query string, opts *SearchO
 type IssuesSearchResult struct {
 	Total             *int     `json:"total_count,omitempty"`
 	IncompleteResults *bool    `json:"incomplete_results,omitempty"`
+	SearchType        *string  `json:"search_type,omitempty"`
 	Issues            []*Issue `json:"items,omitempty"`
 }
 

--- a/github/search_test.go
+++ b/github/search_test.go
@@ -332,6 +332,42 @@ func TestSearchService_Issues_advancedSearch(t *testing.T) {
 	}
 }
 
+func TestSearchService_Issues_searchType(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"q":           "blah",
+			"sort":        "forks",
+			"order":       "desc",
+			"page":        "2",
+			"per_page":    "2",
+			"search_type": "hybrid",
+		})
+
+		fmt.Fprint(w, `{"total_count": 4, "incomplete_results": true, "search_type": "hybrid", "items": [{"number":1},{"number":2}]}`)
+	})
+
+	opts := &SearchOptions{Sort: "forks", Order: "desc", ListOptions: ListOptions{Page: 2, PerPage: 2}, SearchType: "hybrid"}
+	ctx := t.Context()
+	result, _, err := client.Search.Issues(ctx, "blah", opts)
+	if err != nil {
+		t.Errorf("Search.Issues_searchType returned error: %v", err)
+	}
+
+	want := &IssuesSearchResult{
+		Total:             Ptr(4),
+		IncompleteResults: Ptr(true),
+		SearchType:        Ptr("hybrid"),
+		Issues:            []*Issue{{Number: Ptr(1)}, {Number: Ptr(2)}},
+	}
+	if !cmp.Equal(result, want) {
+		t.Errorf("Search.Issues_searchType returned %+v, want %+v", result, want)
+	}
+}
+
 func TestSearchService_Issues_coverage(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)


### PR DESCRIPTION
Fixes #4415 

The [search issues and pull requests](https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-issues-and-pull-requests) endpoint supports a `search_type` query parameter (`semantic` or `hybrid`, defaulting to lexical), and returns the type that actually ran in the response body. Neither is currently exposed, so `Search.Issues` can only do lexical search, and callers can't tell when the API has fallen back to lexical for an ineligible query.

Adds `SearchType` to `SearchOptions` (mirroring `AdvancedSearch`) and to `IssuesSearchResult`.

I'm updating the [GitHub MCP server](https://github.com/github/github-mcp-server)'s `search_issues` tool to support semantic search, and we'd like to use these rather than wrapping the HTTP transport to rewrite the query string and re-parse the response body.