### PR TITLE
feat: Add `DeleteCodeQLDatabase` for code scanning

### DIFF
--- a/github/code_scanning.go
+++ b/github/code_scanning.go
@@ -596,6 +596,25 @@ func (s *CodeScanningService) GetCodeQLDatabase(ctx context.Context, owner, repo
 	return codeqlDatabase, resp, nil
 }
 
+// DeleteCodeQLDatabase deletes a CodeQL database for a language in a repository.
+//
+// You must use an access token with the repo scope to use this
+// endpoint with private repos or the public_repo scope for public repos.
+//
+// GitHub API docs: https://docs.github.com/rest/code-scanning/code-scanning?apiVersion=2022-11-28#delete-a-codeql-database
+//
+//meta:operation DELETE /repos/{owner}/{repo}/code-scanning/codeql/databases/{language}
+func (s *CodeScanningService) DeleteCodeQLDatabase(ctx context.Context, owner, repo, language string) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/code-scanning/codeql/databases/%v", owner, repo, language)
+
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // DefaultSetupConfiguration represents a code scanning default setup configuration.
 type DefaultSetupConfiguration struct {
 	State      *string    `json:"state,omitempty"`

--- a/github/code_scanning_test.go
+++ b/github/code_scanning_test.go
@@ -1393,6 +1393,32 @@ func TestCodeScanningService_GetCodeQLDatabase(t *testing.T) {
 	})
 }
 
+func TestCodeScanningService_DeleteCodeQLDatabase(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/repos/o/r/code-scanning/codeql/databases/lang", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := t.Context()
+	_, err := client.CodeScanning.DeleteCodeQLDatabase(ctx, "o", "r", "lang")
+	if err != nil {
+		t.Errorf("CodeScanning.DeleteCodeQLDatabase returned error: %v", err)
+	}
+
+	const methodName = "DeleteCodeQLDatabase"
+	testBadOptions(t, methodName, func() (err error) {
+		_, err = client.CodeScanning.DeleteCodeQLDatabase(ctx, "\n", "\n", "\n")
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		return client.CodeScanning.DeleteCodeQLDatabase(ctx, "o", "r", "lang")
+	})
+}
+
 func TestCodeScanningService_GetDefaultSetupConfiguration(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)


### PR DESCRIPTION
Fixes #4419

Adds `CodeScanningService.DeleteCodeQLDatabase` for `DELETE /repos/{owner}/{repo}/code-scanning/codeql/databases/{language}`.

The endpoint returns 204 with no body, so the method returns `(*Response, error)` and passes `nil` to `Do`, matching `RepositoriesService.DeleteHook`.

The operation is already present in `openapi_operations.yaml`, so `go generate ./...` produces no changes.

One thing worth flagging for a follow up: the scope sentences on the neighboring `ListCodeQLDatabases` and `GetCodeQLDatabase` say `security_events`, but the current OpenAPI description for all three of these operations says `repo` or `public_repo`. I left those two alone to keep this PR to a single endpoint.
