### PR TITLE
feat: Add `MetaService.ListAPIVersions`

### DIFF
--- a/github/meta.go
+++ b/github/meta.go
@@ -139,6 +139,27 @@ func (c *Client) APIMeta(ctx context.Context) (*APIMeta, *Response, error) {
 	return c.Meta.Get(ctx)
 }
 
+// ListAPIVersions returns the API versions supported by the GitHub REST API,
+// as dates in the YYYY-MM-DD format.
+//
+// GitHub API docs: https://docs.github.com/rest/meta/meta?apiVersion=2022-11-28#get-all-api-versions
+//
+//meta:operation GET /versions
+func (s *MetaService) ListAPIVersions(ctx context.Context) ([]string, *Response, error) {
+	req, err := s.client.NewRequest(ctx, "GET", "versions", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var versions []string
+	resp, err := s.client.Do(req, &versions)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return versions, resp, nil
+}
+
 // Octocat returns an ASCII art octocat with the specified message in a speech
 // bubble. If message is empty, a random zen phrase is used.
 //

--- a/github/meta_test.go
+++ b/github/meta_test.go
@@ -80,6 +80,36 @@ func TestMetaService_Get(t *testing.T) {
 	})
 }
 
+func TestMetaService_ListAPIVersions(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/versions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `["2021-01-01","2022-11-28"]`)
+	})
+
+	ctx := t.Context()
+	versions, _, err := client.Meta.ListAPIVersions(ctx)
+	if err != nil {
+		t.Errorf("ListAPIVersions returned error: %v", err)
+	}
+
+	want := []string{"2021-01-01", "2022-11-28"}
+	if !cmp.Equal(want, versions) {
+		t.Errorf("ListAPIVersions returned %+v, want %+v", versions, want)
+	}
+
+	const methodName = "ListAPIVersions"
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Meta.ListAPIVersions(ctx)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
 func TestMetaService_Octocat(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)


### PR DESCRIPTION
Fixes #4420

Adds `MetaService.ListAPIVersions` for `GET /versions`, operation `meta/get-all-versions`.

The 200 response schema is an array of `string` with `format: date`, so the method returns `[]string` and no new type is introduced. `GitignoresService.List` has the same signature for the same kind of operation.

Named `ListAPIVersions` rather than `Get...` because the repo uses `List` for operations returning multiple resources, and `MetaService` holds several unrelated resources so a bare `List` would be ambiguous.

The operation is already in `openapi_operations.yaml`, so `go generate ./...` produces no changes.
