### PR TITLE
feat: Add `Stack` field to `PullRequest` for stacked pull requests

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -32030,20 +32030,20 @@ func (p *PullRequestStack) GetSize() int {
 	return *p.Size
 }
 
-// GetRef returns the Ref field if it's non-nil, zero value otherwise.
+// GetRef returns the Ref field.
 func (p *PullRequestStackBase) GetRef() string {
-	if p == nil || p.Ref == nil {
+	if p == nil {
 		return ""
 	}
-	return *p.Ref
+	return p.Ref
 }
 
-// GetSHA returns the SHA field if it's non-nil, zero value otherwise.
+// GetSHA returns the SHA field.
 func (p *PullRequestStackBase) GetSHA() string {
-	if p == nil || p.SHA == nil {
+	if p == nil {
 		return ""
 	}
-	return *p.SHA
+	return p.SHA
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -30822,6 +30822,14 @@ func (p *PullRequest) GetReviewCommentURL() string {
 	return *p.ReviewCommentURL
 }
 
+// GetStack returns the Stack field.
+func (p *PullRequest) GetStack() *PullRequestStack {
+	if p == nil {
+		return nil
+	}
+	return p.Stack
+}
+
 // GetState returns the State field if it's non-nil, zero value otherwise.
 func (p *PullRequest) GetState() string {
 	if p == nil || p.State == nil {
@@ -31980,6 +31988,46 @@ func (p *PullRequestRuleParameters) GetRequireLastPushApproval() bool {
 		return false
 	}
 	return p.RequireLastPushApproval
+}
+
+// GetBase returns the Base field.
+func (p *PullRequestStack) GetBase() *PullRequestBranch {
+	if p == nil {
+		return nil
+	}
+	return p.Base
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (p *PullRequestStack) GetID() int64 {
+	if p == nil || p.ID == nil {
+		return 0
+	}
+	return *p.ID
+}
+
+// GetNumber returns the Number field if it's non-nil, zero value otherwise.
+func (p *PullRequestStack) GetNumber() int {
+	if p == nil || p.Number == nil {
+		return 0
+	}
+	return *p.Number
+}
+
+// GetPosition returns the Position field if it's non-nil, zero value otherwise.
+func (p *PullRequestStack) GetPosition() int {
+	if p == nil || p.Position == nil {
+		return 0
+	}
+	return *p.Position
+}
+
+// GetSize returns the Size field if it's non-nil, zero value otherwise.
+func (p *PullRequestStack) GetSize() int {
+	if p == nil || p.Size == nil {
+		return 0
+	}
+	return *p.Size
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -31991,7 +31991,7 @@ func (p *PullRequestRuleParameters) GetRequireLastPushApproval() bool {
 }
 
 // GetBase returns the Base field.
-func (p *PullRequestStack) GetBase() *PullRequestBranch {
+func (p *PullRequestStack) GetBase() *PullRequestStackBase {
 	if p == nil {
 		return nil
 	}
@@ -32028,6 +32028,22 @@ func (p *PullRequestStack) GetSize() int {
 		return 0
 	}
 	return *p.Size
+}
+
+// GetRef returns the Ref field if it's non-nil, zero value otherwise.
+func (p *PullRequestStackBase) GetRef() string {
+	if p == nil || p.Ref == nil {
+		return ""
+	}
+	return *p.Ref
+}
+
+// GetSHA returns the SHA field if it's non-nil, zero value otherwise.
+func (p *PullRequestStackBase) GetSHA() string {
+	if p == nil || p.SHA == nil {
+		return ""
+	}
+	return *p.SHA
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -40184,10 +40184,7 @@ func TestPullRequestStack_GetSize(tt *testing.T) {
 
 func TestPullRequestStackBase_GetRef(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	p := &PullRequestStackBase{Ref: &zeroValue}
-	p.GetRef()
-	p = &PullRequestStackBase{}
+	p := &PullRequestStackBase{}
 	p.GetRef()
 	p = nil
 	p.GetRef()
@@ -40195,10 +40192,7 @@ func TestPullRequestStackBase_GetRef(tt *testing.T) {
 
 func TestPullRequestStackBase_GetSHA(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	p := &PullRequestStackBase{SHA: &zeroValue}
-	p.GetSHA()
-	p = &PullRequestStackBase{}
+	p := &PullRequestStackBase{}
 	p.GetSHA()
 	p = nil
 	p.GetSHA()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -40182,6 +40182,28 @@ func TestPullRequestStack_GetSize(tt *testing.T) {
 	p.GetSize()
 }
 
+func TestPullRequestStackBase_GetRef(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PullRequestStackBase{Ref: &zeroValue}
+	p.GetRef()
+	p = &PullRequestStackBase{}
+	p.GetRef()
+	p = nil
+	p.GetRef()
+}
+
+func TestPullRequestStackBase_GetSHA(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	p := &PullRequestStackBase{SHA: &zeroValue}
+	p.GetSHA()
+	p = &PullRequestStackBase{}
+	p.GetSHA()
+	p = nil
+	p.GetSHA()
+}
+
 func TestPullRequestTargetEvent_GetAction(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -38734,6 +38734,14 @@ func TestPullRequest_GetReviewCommentURL(tt *testing.T) {
 	p.GetReviewCommentURL()
 }
 
+func TestPullRequest_GetStack(tt *testing.T) {
+	tt.Parallel()
+	p := &PullRequest{}
+	p.GetStack()
+	p = nil
+	p.GetStack()
+}
+
 func TestPullRequest_GetState(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -40120,6 +40128,58 @@ func TestPullRequestRuleParameters_GetRequireLastPushApproval(tt *testing.T) {
 	p.GetRequireLastPushApproval()
 	p = nil
 	p.GetRequireLastPushApproval()
+}
+
+func TestPullRequestStack_GetBase(tt *testing.T) {
+	tt.Parallel()
+	p := &PullRequestStack{}
+	p.GetBase()
+	p = nil
+	p.GetBase()
+}
+
+func TestPullRequestStack_GetID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int64
+	p := &PullRequestStack{ID: &zeroValue}
+	p.GetID()
+	p = &PullRequestStack{}
+	p.GetID()
+	p = nil
+	p.GetID()
+}
+
+func TestPullRequestStack_GetNumber(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	p := &PullRequestStack{Number: &zeroValue}
+	p.GetNumber()
+	p = &PullRequestStack{}
+	p.GetNumber()
+	p = nil
+	p.GetNumber()
+}
+
+func TestPullRequestStack_GetPosition(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	p := &PullRequestStack{Position: &zeroValue}
+	p.GetPosition()
+	p = &PullRequestStack{}
+	p.GetPosition()
+	p = nil
+	p.GetPosition()
+}
+
+func TestPullRequestStack_GetSize(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	p := &PullRequestStack{Size: &zeroValue}
+	p.GetSize()
+	p = &PullRequestStack{}
+	p.GetSize()
+	p = nil
+	p.GetSize()
 }
 
 func TestPullRequestTargetEvent_GetAction(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1661,9 +1661,10 @@ func TestPullRequest_String(t *testing.T) {
 		Links:               &PRLinks{},
 		Head:                &PullRequestBranch{},
 		Base:                &PullRequestBranch{},
+		Stack:               &PullRequestStack{},
 		ActiveLockReason:    Ptr(""),
 	}
-	want := `github.PullRequest{ID:0, Number:0, State:"", Locked:false, Title:"", Body:"", CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, ClosedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, MergedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, User:github.User{}, Draft:false, URL:"", HTMLURL:"", IssueURL:"", StatusesURL:"", DiffURL:"", PatchURL:"", CommitsURL:"", CommentsURL:"", ReviewCommentsURL:"", ReviewCommentURL:"", Assignee:github.User{}, Milestone:github.Milestone{}, AuthorAssociation:"", NodeID:"", AutoMerge:github.PullRequestAutoMerge{}, Merged:false, Mergeable:false, MergeableState:"", Rebaseable:false, MergedBy:github.User{}, MergeCommitSHA:"", Comments:0, Commits:0, Additions:0, Deletions:0, ChangedFiles:0, MaintainerCanModify:false, ReviewComments:0, Links:github.PRLinks{}, Head:github.PullRequestBranch{}, Base:github.PullRequestBranch{}, ActiveLockReason:""}`
+	want := `github.PullRequest{ID:0, Number:0, State:"", Locked:false, Title:"", Body:"", CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, ClosedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, MergedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, User:github.User{}, Draft:false, URL:"", HTMLURL:"", IssueURL:"", StatusesURL:"", DiffURL:"", PatchURL:"", CommitsURL:"", CommentsURL:"", ReviewCommentsURL:"", ReviewCommentURL:"", Assignee:github.User{}, Milestone:github.Milestone{}, AuthorAssociation:"", NodeID:"", AutoMerge:github.PullRequestAutoMerge{}, Merged:false, Mergeable:false, MergeableState:"", Rebaseable:false, MergedBy:github.User{}, MergeCommitSHA:"", Comments:0, Commits:0, Additions:0, Deletions:0, ChangedFiles:0, MaintainerCanModify:false, ReviewComments:0, Links:github.PRLinks{}, Head:github.PullRequestBranch{}, Base:github.PullRequestBranch{}, Stack:github.PullRequestStack{}, ActiveLockReason:""}`
 	if got := v.String(); got != want {
 		t.Errorf("PullRequest.String = %v, want %v", got, want)
 	}

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -87,6 +87,7 @@ type PullRequest struct {
 	Links *PRLinks           `json:"_links,omitempty"`
 	Head  *PullRequestBranch `json:"head,omitempty"`
 	Base  *PullRequestBranch `json:"base,omitempty"`
+	Stack *PullRequestStack  `json:"stack,omitempty"`
 
 	// ActiveLockReason is populated only when LockReason is provided while locking the pull request.
 	// Possible values are: "off-topic", "too heated", "resolved", and "spam".
@@ -121,6 +122,18 @@ type PullRequestBranch struct {
 	SHA   *string     `json:"sha,omitempty"`
 	Repo  *Repository `json:"repo,omitempty"`
 	User  *User       `json:"user,omitempty"`
+}
+
+// PullRequestStack represents the stack a pull request belongs to, in
+// repositories that use stacked pull requests. Base reports the branch the
+// entire stack ultimately targets, which can differ from the pull request's own
+// Base branch (the branch below it in the stack).
+type PullRequestStack struct {
+	ID       *int64             `json:"id,omitempty"`
+	Number   *int               `json:"number,omitempty"`
+	Base     *PullRequestBranch `json:"base,omitempty"`
+	Size     *int               `json:"size,omitempty"`
+	Position *int               `json:"position,omitempty"`
 }
 
 // PullRequestListOptions specifies the optional parameters to the

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -130,7 +130,7 @@ type PullRequestBranch struct {
 // Base branch (the branch below it in the stack).
 type PullRequestStack struct {
 	// Base is the base of the stack: the branch the entire stack ultimately targets.
-	Base *PullRequestStackBase `json:"base,omitempty"`
+	Base *PullRequestStackBase `json:"base"`
 	// Size is the total number of pull requests in the stack.
 	Size *int `json:"size,omitempty"`
 	// Position is the one-based position of this pull request within the stack,
@@ -145,8 +145,8 @@ type PullRequestStack struct {
 // PullRequestStackBase represents the base of a stacked pull request's stack:
 // the branch the entire stack ultimately targets.
 type PullRequestStackBase struct {
-	Ref *string `json:"ref,omitempty"`
-	SHA *string `json:"sha,omitempty"`
+	Ref string `json:"ref"`
+	SHA string `json:"sha"`
 }
 
 // PullRequestListOptions specifies the optional parameters to the

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -129,11 +129,24 @@ type PullRequestBranch struct {
 // entire stack ultimately targets, which can differ from the pull request's own
 // Base branch (the branch below it in the stack).
 type PullRequestStack struct {
-	ID       *int64             `json:"id,omitempty"`
-	Number   *int               `json:"number,omitempty"`
-	Base     *PullRequestBranch `json:"base,omitempty"`
-	Size     *int               `json:"size,omitempty"`
-	Position *int               `json:"position,omitempty"`
+	// Base is the base of the stack: the branch the entire stack ultimately targets.
+	Base *PullRequestStackBase `json:"base,omitempty"`
+	// Size is the total number of pull requests in the stack.
+	Size *int `json:"size,omitempty"`
+	// Position is the one-based position of this pull request within the stack,
+	// where 1 is the bottom of the stack.
+	Position *int `json:"position,omitempty"`
+	// ID is the ID of the stack that this pull request belongs to.
+	ID *int64 `json:"id,omitempty"`
+	// Number is the number of the stack that this pull request belongs to.
+	Number *int `json:"number,omitempty"`
+}
+
+// PullRequestStackBase represents the base of a stacked pull request's stack:
+// the branch the entire stack ultimately targets.
+type PullRequestStackBase struct {
+	Ref *string `json:"ref,omitempty"`
+	SHA *string `json:"sha,omitempty"`
 }
 
 // PullRequestListOptions specifies the optional parameters to the


### PR DESCRIPTION
GitHub's REST API and `pull_request` webhook payloads now include a `stack`
object on pull requests that belong to a stack (stacked pull requests). It
reports the branch the whole stack ultimately targets, which can differ from the
PR's own base branch. go-github didn't expose it.

This adds `PullRequest.Stack` and a `PullRequestStack` type
(`id`, `number`, `base`, `size`, `position`). Because webhook events reuse the
`PullRequest` struct (`PullRequestEvent.PullRequest`), the field is available for
both REST responses and incoming `pull_request` webhooks.

Accessors and stringify tests were regenerated via `go generate ./...`.

Ref: pull request schema in the REST API docs
(https://docs.github.com/en/rest/pulls/pulls), which documents the `stack`
object.