### PR TITLE
refactor!: Pass `UpdateConnectedExternalGroup` request body by value via new `UpdateConnectedExternalGroupRequest`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -222,7 +222,6 @@ linters:
             - DependencyGraphSnapshot
             - EncryptedSecret
             - EnterpriseSecurityAnalysisSettings
-            - ExternalGroup
             - Hook
             - ImpersonateUserOptions
             - Import

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -43062,6 +43062,14 @@ func (u *UpdateCodespaceOptions) GetRecentFolders() []string {
 	return u.RecentFolders
 }
 
+// GetGroupID returns the GroupID field.
+func (u *UpdateConnectedExternalGroupRequest) GetGroupID() int64 {
+	if u == nil {
+		return 0
+	}
+	return u.GroupID
+}
+
 // GetBaseRole returns the BaseRole field if it's non-nil, zero value otherwise.
 func (u *UpdateCustomOrgRoleRequest) GetBaseRole() string {
 	if u == nil || u.BaseRole == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -53905,6 +53905,14 @@ func TestUpdateCodespaceOptions_GetRecentFolders(tt *testing.T) {
 	u.GetRecentFolders()
 }
 
+func TestUpdateConnectedExternalGroupRequest_GetGroupID(tt *testing.T) {
+	tt.Parallel()
+	u := &UpdateConnectedExternalGroupRequest{}
+	u.GetGroupID()
+	u = nil
+	u.GetGroupID()
+}
+
 func TestUpdateCustomOrgRoleRequest_GetBaseRole(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/teams.go
+++ b/github/teams.go
@@ -974,6 +974,12 @@ type ExternalGroupList struct {
 	Groups []*ExternalGroup `json:"groups"`
 }
 
+// UpdateConnectedExternalGroupRequest represents a request to update the connection
+// between an external group and a team.
+type UpdateConnectedExternalGroupRequest struct {
+	GroupID int64 `json:"group_id"`
+}
+
 // GetExternalGroup fetches an external group.
 //
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/teams/external-groups?apiVersion=2022-11-28#get-an-external-group
@@ -1056,7 +1062,7 @@ func (s *TeamsService) ListExternalGroupsForTeamBySlug(ctx context.Context, org,
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/teams/external-groups?apiVersion=2022-11-28#update-the-connection-between-an-external-group-and-a-team
 //
 //meta:operation PATCH /orgs/{org}/teams/{team_slug}/external-groups
-func (s *TeamsService) UpdateConnectedExternalGroup(ctx context.Context, org, slug string, body *ExternalGroup) (*ExternalGroup, *Response, error) {
+func (s *TeamsService) UpdateConnectedExternalGroup(ctx context.Context, org, slug string, body UpdateConnectedExternalGroupRequest) (*ExternalGroup, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v/external-groups", org, slug)
 
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -1802,8 +1802,8 @@ func TestTeamsService_UpdateConnectedExternalGroup(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	body := &ExternalGroup{
-		GroupID: Ptr(int64(123)),
+	body := UpdateConnectedExternalGroupRequest{
+		GroupID: 123,
 	}
 	externalGroup, _, err := client.Teams.UpdateConnectedExternalGroup(ctx, "o", "t", body)
 	if err != nil {
@@ -1868,8 +1868,8 @@ func TestTeamsService_UpdateConnectedExternalGroup_notFound(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	body := &ExternalGroup{
-		GroupID: Ptr(int64(123)),
+	body := UpdateConnectedExternalGroupRequest{
+		GroupID: 123,
 	}
 	eg, resp, err := client.Teams.UpdateConnectedExternalGroup(ctx, "o", "t", body)
 	if err == nil {


### PR DESCRIPTION
Continues the request-body-by-value work in #3644, this time for `TeamsService.UpdateConnectedExternalGroup`.

The method reused the `ExternalGroup` **response** type as its request body, but per the [docs](https://docs.github.com/en/enterprise-cloud@latest/rest/teams/external-groups?apiVersion=2022-11-28#update-the-connection-between-an-external-group-and-a-team) the endpoint accepts exactly one body parameter, `group_id`, and it's required. The other four fields (`group_name`, `updated_at`, `teams`, `members`) are response-only and are ignored by the server, so the signature didn't tell callers what to fill in. The existing test shows this: it builds the request with only `GroupID` set, while the response expectation populates all five fields.

So this adds a dedicated request type, following the same approach as `PullRequestSubmitReviewRequest` in #4406:

```go
type UpdateConnectedExternalGroupRequest struct {
	GroupID int64 `json:"group_id"`
}
```

`GroupID` is a non-pointer `int64` since it's required, the body is passed by value, and the type is removed from the `body-allowed-pointer-types` allowlist.

Notes:

- `ExternalGroup` is unchanged — it stays the response type for `GetExternalGroup`, `ListExternalGroups`, `ExternalGroupList` and the iterator, so its fields keep their pointer semantics.
- The method verb `Update` already matches the docs operation name, so no rename.

Verified with `go build ./...`, `go vet -tags integration ./test/integration/`, `gofmt`, the full `./github/` test suite (`UpdateConnectedExternalGroup` and the generated `GetGroupID` at 100%), and `custom-gcl` (no `paramcheck` findings after removing the allowlist entry).

Updates #3644

BREAKING CHANGE: TeamsService.UpdateConnectedExternalGroup now takes a new UpdateConnectedExternalGroupRequest (with non-pointer GroupID) by value instead of *ExternalGroup.

cc @jvm986 — flagging for #3644 coordination; this is in the `teams` service, so it shouldn't overlap with the `Issues` work.
