### PR TITLE
chore: Bump version of go-github to v90.0.0

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,14 +1,14 @@
 version: v2.12.2 # this is the version of golangci-lint
 plugins:
-  - module: "github.com/google/go-github/v89/tools/extraneousnew"
+  - module: "github.com/google/go-github/v90/tools/extraneousnew"
     path: ./tools/extraneousnew
-  - module: "github.com/google/go-github/v89/tools/fmtpercentv"
+  - module: "github.com/google/go-github/v90/tools/fmtpercentv"
     path: ./tools/fmtpercentv
-  - module: "github.com/google/go-github/v89/tools/paramcheck"
+  - module: "github.com/google/go-github/v90/tools/paramcheck"
     path: ./tools/paramcheck
-  - module: "github.com/google/go-github/v89/tools/redundantptr"
+  - module: "github.com/google/go-github/v90/tools/redundantptr"
     path: ./tools/redundantptr
-  - module: "github.com/google/go-github/v89/tools/sliceofpointers"
+  - module: "github.com/google/go-github/v90/tools/sliceofpointers"
     path: ./tools/sliceofpointers
-  - module: "github.com/google/go-github/v89/tools/structfield"
+  - module: "github.com/google/go-github/v90/tools/structfield"
     path: ./tools/structfield

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -186,7 +186,7 @@ linters:
       extraneousnew:
         type: module
         description: Reports problematic usage of 'new' or '&SomeStruct{}' when a more idiomatic 'var' pointer would be more appropriate.
-        original-url: github.com/google/go-github/v89/tools/extraneousnew
+        original-url: github.com/google/go-github/v90/tools/extraneousnew
         settings:
           ignored-methods:
             - RateLimitService.Get
@@ -194,11 +194,11 @@ linters:
       fmtpercentv:
         type: module
         description: Reports usage of %d or %s in format strings.
-        original-url: github.com/google/go-github/v89/tools/fmtpercentv
+        original-url: github.com/google/go-github/v90/tools/fmtpercentv
       paramcheck:
         type: module
         description: Reports parameter naming and type convention issues.
-        original-url: github.com/google/go-github/v89/tools/paramcheck
+        original-url: github.com/google/go-github/v90/tools/paramcheck
         settings:
           # Body type names exempt from the "pass by value, not by pointer" rule.
           # TODO: fix and remove these exceptions.
@@ -302,15 +302,15 @@ linters:
       redundantptr:
         type: module
         description: Reports github.Ptr(x) calls that can be replaced with &x.
-        original-url: github.com/google/go-github/v89/tools/redundantptr
+        original-url: github.com/google/go-github/v90/tools/redundantptr
       sliceofpointers:
         type: module
         description: Reports usage of []*string and slices of structs without pointers.
-        original-url: github.com/google/go-github/v89/tools/sliceofpointers
+        original-url: github.com/google/go-github/v90/tools/sliceofpointers
       structfield:
         type: module
         description: Reports mismatches between Go field and JSON, URL tag names and types.
-        original-url: github.com/google/go-github/v89/tools/structfield
+        original-url: github.com/google/go-github/v90/tools/structfield
         settings:
           allowed-tag-names:
             - ActionsCacheUsageList.RepoCacheUsage # TODO: RepoCacheUsages ?

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-github #
 
 [![go-github release (latest SemVer)](https://img.shields.io/github/v/release/google/go-github?sort=semver)](https://github.com/google/go-github/releases)
-[![Go Reference](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/google/go-github/v89/github)
+[![Go Reference](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/google/go-github/v90/github)
 [![Test Status](https://github.com/google/go-github/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/google/go-github/actions/workflows/tests.yml)
 [![Test Coverage](https://codecov.io/gh/google/go-github/branch/master/graph/badge.svg)](https://codecov.io/gh/google/go-github)
 [![Discuss at go-github@googlegroups.com](https://img.shields.io/badge/discuss-go--github%40googlegroups.com-blue.svg)](https://groups.google.com/group/go-github)
@@ -30,7 +30,7 @@ If you're interested in using the [GraphQL API v4][], the recommended library is
 go-github is compatible with modern Go releases in module mode, with Go installed:
 
 ```bash
-go get github.com/google/go-github/v89
+go get github.com/google/go-github/v90
 ```
 
 will resolve and add the package to the current development module, along with its dependencies.
@@ -38,7 +38,7 @@ will resolve and add the package to the current development module, along with i
 Alternatively the same can be achieved if you use import in a package:
 
 ```go
-import "github.com/google/go-github/v89/github"
+import "github.com/google/go-github/v90/github"
 ```
 
 and run `go get` without parameters.
@@ -46,20 +46,20 @@ and run `go get` without parameters.
 Finally, to use the top-of-trunk version of this repo, use the following command:
 
 ```bash
-go get github.com/google/go-github/v89@master
+go get github.com/google/go-github/v90@master
 ```
 
 To discover all the changes that have occurred since a prior release, you can
 first clone the repo, then run (for example):
 
 ```bash
-go run tools/gen-release-notes/main.go --tag v89.0.0
+go run tools/gen-release-notes/main.go --tag v90.0.0
 ```
 
 ## Usage ##
 
 ```go
-import "github.com/google/go-github/v89/github"
+import "github.com/google/go-github/v90/github"
 ```
 
 Construct a new GitHub client, then use the various services on the client to
@@ -123,7 +123,7 @@ include the specified OAuth token. Therefore, authenticated clients should
 almost never be shared between different users.
 
 For API methods that require HTTP Basic Authentication, use the
-[`BasicAuthTransport`](https://pkg.go.dev/github.com/google/go-github/v89/github#BasicAuthTransport).
+[`BasicAuthTransport`](https://pkg.go.dev/github.com/google/go-github/v90/github#BasicAuthTransport).
 
 #### As a GitHub App ####
 
@@ -146,7 +146,7 @@ import (
 	"net/http"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func main() {
@@ -183,7 +183,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/jferrl/go-githubauth"
 	"golang.org/x/oauth2"
 )
@@ -465,7 +465,7 @@ For complete usage of go-github, see the full [package docs][].
 
 [GitHub API v3]: https://docs.github.com/en/rest
 [personal access token]: https://github.com/blog/1509-personal-api-tokens
-[package docs]: https://pkg.go.dev/github.com/google/go-github/v89/github
+[package docs]: https://pkg.go.dev/github.com/google/go-github/v90/github
 [GraphQL API v4]: https://developer.github.com/v4/
 [shurcooL/githubv4]: https://github.com/shurcooL/githubv4
 [GitHub webhook events]: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads
@@ -541,7 +541,7 @@ Versions prior to 48.2.0 are not listed.
 
 | go-github Version | GitHub v3 API Version |
 | ----------------- | --------------------- |
-| 89.0.0            | 2022-11-28            |
+| 90.0.0            | 2022-11-28            |
 | ...               | 2022-11-28            |
 | 48.2.0            | 2022-11-28            |
 

--- a/example/actionpermissions/main.go
+++ b/example/actionpermissions/main.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 var (

--- a/example/auditlogstream/main.go
+++ b/example/auditlogstream/main.go
@@ -37,7 +37,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/basicauth/main.go
+++ b/example/basicauth/main.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"golang.org/x/term"
 )
 

--- a/example/codespaces/newreposecretwithxcrypto/main.go
+++ b/example/codespaces/newreposecretwithxcrypto/main.go
@@ -37,7 +37,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/codespaces/newusersecretwithxcrypto/main.go
+++ b/example/codespaces/newusersecretwithxcrypto/main.go
@@ -38,7 +38,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -13,7 +13,7 @@
 //
 // Note, if you want to push a single file, you probably prefer to use the
 // content API. An example is available here:
-// https://pkg.go.dev/github.com/google/go-github/v89/github#example-RepositoriesService-CreateFile
+// https://pkg.go.dev/github.com/google/go-github/v90/github#example-RepositoriesService-CreateFile
 //
 // Note, for this to work at least 1 commit is needed, so you if you use this
 // after creating a repository you might want to make sure you set `AutoInit` to
@@ -33,7 +33,7 @@ import (
 	"time"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 var (
@@ -178,7 +178,7 @@ func pushCommit(ref *github.Reference, tree *github.Tree) (err error) {
 	return err
 }
 
-// createPR creates a pull request. Based on: https://pkg.go.dev/github.com/google/go-github/v89/github#example-PullRequestsService-Create
+// createPR creates a pull request. Based on: https://pkg.go.dev/github.com/google/go-github/v90/github#example-PullRequestsService-Create
 func createPR() (err error) {
 	if *prSubject == "" {
 		return errors.New("missing `-pr-title` flag; skipping PR creation")

--- a/example/contents/main.go
+++ b/example/contents/main.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func main() {

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v89/example
+module github.com/google/go-github/v90/example
 
 go 1.25.8
 
@@ -7,8 +7,8 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.19.0
 	github.com/gofri/go-github-pagination v1.0.1
 	github.com/gofri/go-github-ratelimit/v2 v2.0.2
-	github.com/google/go-github/otel/v89 v89.0.0
-	github.com/google/go-github/v89 v89.0.0
+	github.com/google/go-github/otel/v90 v90.0.0
+	github.com/google/go-github/v90 v90.0.0
 	github.com/sigstore/sigstore-go v1.2.2
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
@@ -91,6 +91,6 @@ require (
 )
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v89 => ../
+replace github.com/google/go-github/v90 => ../
 
-replace github.com/google/go-github/otel/v89 => ../otel
+replace github.com/google/go-github/otel/v90 => ../otel

--- a/example/listenvironments/main.go
+++ b/example/listenvironments/main.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func main() {

--- a/example/migrations/main.go
+++ b/example/migrations/main.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func fetchAllUserMigrations() ([]*github.UserMigration, error) {

--- a/example/newfilewithappauth/main.go
+++ b/example/newfilewithappauth/main.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func main() {

--- a/example/newrepo/main.go
+++ b/example/newrepo/main.go
@@ -16,7 +16,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 var (

--- a/example/newreposecretwithxcrypto/main.go
+++ b/example/newreposecretwithxcrypto/main.go
@@ -37,7 +37,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/otel/main.go
+++ b/example/otel/main.go
@@ -13,8 +13,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/otel/v89"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/otel/v90"
+	"github.com/google/go-github/v90/github"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/trace"
 )

--- a/example/ratelimit/main.go
+++ b/example/ratelimit/main.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit"
 	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit/github_primary_ratelimit"
 	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit/github_secondary_ratelimit"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func main() {

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 // Fetch all the public organizations' membership of a user.

--- a/example/tokenauth/main.go
+++ b/example/tokenauth/main.go
@@ -15,7 +15,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"golang.org/x/term"
 )
 

--- a/example/topics/main.go
+++ b/example/topics/main.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 // Fetch and lists all the public topics associated with the specified GitHub topic.

--- a/example/uploadreleaseassetfromrelease/main.go
+++ b/example/uploadreleaseassetfromrelease/main.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func main() {

--- a/example/verifyartifact/main.go
+++ b/example/verifyartifact/main.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/verify"

--- a/github/doc.go
+++ b/github/doc.go
@@ -8,7 +8,7 @@ Package github provides a client for using the GitHub API.
 
 Usage:
 
-	import "github.com/google/go-github/v89/github"
+	import "github.com/google/go-github/v90/github"
 
 Construct a new GitHub client using [NewClient], then use the various services on the client to
 access different parts of the GitHub API. For example:

--- a/github/example_iterators_test.go
+++ b/github/example_iterators_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func ExampleRepositoriesService_ListByUserIter() {

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func ExampleMarkdownService_Render() {
@@ -79,7 +79,7 @@ func ExampleRepositoriesService_CreateFile() {
 	// so you will need to modify the example to provide authentication to
 	// github.NewClient(). See the following documentation for more information
 	// on how to authenticate with the client:
-	// https://pkg.go.dev/github.com/google/go-github/v89/github#hdr-Authentication
+	// https://pkg.go.dev/github.com/google/go-github/v90/github#hdr-Authentication
 	client, err := github.NewClient()
 	if err != nil {
 		log.Fatalf("Error creating GitHub client: %v", err)
@@ -129,7 +129,7 @@ func ExamplePullRequestsService_Create() {
 	// so you will need to modify the example to provide authentication to
 	// github.NewClient(). See the following documentation for more information
 	// on how to authenticate with the client:
-	// https://pkg.go.dev/github.com/google/go-github/v89/github#hdr-Authentication
+	// https://pkg.go.dev/github.com/google/go-github/v90/github#hdr-Authentication
 	client, err := github.NewClient()
 	if err != nil {
 		log.Fatalf("Error creating GitHub client: %v", err)
@@ -160,7 +160,7 @@ func ExampleTeamsService_ListTeams() {
 	// the example to to provide authentication to github.NewClient(). See the
 	//  following documentation for more information on how to authenticate with
 	// the client:
-	// https://pkg.go.dev/github.com/google/go-github/v89/github#hdr-Authentication
+	// https://pkg.go.dev/github.com/google/go-github/v90/github#hdr-Authentication
 	client, err := github.NewClient()
 	if err != nil {
 		log.Fatalf("Error creating GitHub client: %v", err)

--- a/github/github.go
+++ b/github/github.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	Version = "v89.0.0"
+	Version = "v90.0.0"
 
 	HeaderRateLimit     = "X-Ratelimit-Limit"
 	HeaderRateRemaining = "X-Ratelimit-Remaining"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v89
+module github.com/google/go-github/v90
 
 go 1.25.0
 

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -1,9 +1,9 @@
-module github.com/google/go-github/otel/v89
+module github.com/google/go-github/otel/v90
 
 go 1.25.0
 
 require (
-	github.com/google/go-github/v89 v89.0.0
+	github.com/google/go-github/v90 v90.0.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
@@ -20,4 +20,4 @@ require (
 	golang.org/x/sys v0.45.0 // indirect
 )
 
-replace github.com/google/go-github/v89 => ../
+replace github.com/google/go-github/v90 => ../

--- a/otel/transport.go
+++ b/otel/transport.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -22,7 +22,7 @@ import (
 
 const (
 	// instrumentationName is the name of this instrumentation package.
-	instrumentationName = "github.com/google/go-github/v89/otel"
+	instrumentationName = "github.com/google/go-github/v90/otel"
 )
 
 // Transport is an http.RoundTripper that instrument requests with OpenTelemetry.

--- a/test/integration/activity_test.go
+++ b/test/integration/activity_test.go
@@ -10,7 +10,7 @@ package integration
 import (
 	"testing"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 const (

--- a/test/integration/authorizations_test.go
+++ b/test/integration/authorizations_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 const (

--- a/test/integration/github_test.go
+++ b/test/integration/github_test.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 // client is a github.Client with the default http.Client. It is authorized if auth is true.

--- a/test/integration/licences_test.go
+++ b/test/integration/licences_test.go
@@ -10,7 +10,7 @@ package integration
 import (
 	"testing"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func TestLicenses_ListIter(t *testing.T) {

--- a/test/integration/pagination_test.go
+++ b/test/integration/pagination_test.go
@@ -10,7 +10,7 @@ package integration
 import (
 	"testing"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func TestSecurityAdvisories_ListGlobalSecurityAdvisories(t *testing.T) {

--- a/test/integration/projects_test.go
+++ b/test/integration/projects_test.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 // Integration tests for Projects V2 endpoints defined in github/projects.go.

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func TestRepositories_CRUD(t *testing.T) {

--- a/test/integration/users_test.go
+++ b/test/integration/users_test.go
@@ -12,7 +12,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func TestUsers_Get(t *testing.T) {

--- a/tools/check-structfield-settings/go.mod
+++ b/tools/check-structfield-settings/go.mod
@@ -1,10 +1,10 @@
-module github.com/google/go-github/v89/tools/check-structfield-settings
+module github.com/google/go-github/v90/tools/check-structfield-settings
 
 go 1.25.0
 
 require (
 	github.com/golangci/plugin-module-register v0.1.2
-	github.com/google/go-github/v89/tools/structfield v0.0.0
+	github.com/google/go-github/v90/tools/structfield v0.0.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/tools v0.48.0
 )
@@ -15,4 +15,4 @@ require (
 )
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v89/tools/structfield v0.0.0 => ../structfield
+replace github.com/google/go-github/v90/tools/structfield v0.0.0 => ../structfield

--- a/tools/check-structfield-settings/main.go
+++ b/tools/check-structfield-settings/main.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/golangci/plugin-module-register/register"
-	"github.com/google/go-github/v89/tools/structfield"
+	"github.com/google/go-github/v90/tools/structfield"
 	"go.yaml.in/yaml/v3"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/checker"

--- a/tools/extraneousnew/go.mod
+++ b/tools/extraneousnew/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v89/tools/extraneousnew
+module github.com/google/go-github/v90/tools/extraneousnew
 
 go 1.25.0
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v1.16.0
 	github.com/getkin/kin-openapi v0.144.0
 	github.com/google/go-cmp v0.7.0
-	github.com/google/go-github/v89 v89.0.0
+	github.com/google/go-github/v90 v90.0.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.22.0
 )
@@ -23,4 +23,4 @@ require (
 )
 
 // Use version at HEAD, not the latest published.
-replace github.com/google/go-github/v89 => ../
+replace github.com/google/go-github/v90 => ../

--- a/tools/metadata/main.go
+++ b/tools/metadata/main.go
@@ -17,7 +17,7 @@ import (
 	"slices"
 
 	"github.com/alecthomas/kong"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 var helpVars = kong.Vars{

--- a/tools/metadata/main_test.go
+++ b/tools/metadata/main_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func TestUpdateGo(t *testing.T) {

--- a/tools/metadata/metadata.go
+++ b/tools/metadata/metadata.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"go.yaml.in/yaml/v3"
 )
 

--- a/tools/metadata/openapi.go
+++ b/tools/metadata/openapi.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/tools/structfield/go.mod
+++ b/tools/structfield/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v89/tools/structfield
+module github.com/google/go-github/v90/tools/structfield
 
 go 1.25.0
 


### PR DESCRIPTION
This release contains the following breaking API changes:

* #4425
  BREAKING CHANGE: `TeamsService.UpdateConnectedExternalGroup` now takes `UpdateConnectedExternalGroupRequest` (with non-pointer `GroupID`) by value.
* #4406
  BREAKING CHANGE: `PullRequestReviewDismissalRequest` is now `PullRequestDismissReviewRequest` with non-pointer `Message` and `PullRequestsService.DismissReview` takes it by value; `PullRequestsService.SubmitReview` now takes a new `PullRequestSubmitReviewRequest`.
* #4401
  BREAKING CHANGE: `CreateOrUpdateCustomRepoRoleOptions` is split into `CreateCustomRepoRoleRequest` (with non-pointer `Name` and `BaseRole`) and `UpdateCustomRepoRoleRequest`; `OrganizationsService.CreateCustomRepoRole` and `UpdateCustomRepoRole` now take these request types by value.
* #4400
  BREAKING CHANGE: `IssuesService.CreateLabel` now takes `CreateLabelRequest` by value (with required non-pointer `Name`); `IssuesService.EditLabel` renamed to `UpdateLabel`, taking an `UpdateLabelRequest` by value.
* #4399
  BREAKING CHANGE: `AutolinkOptions` is now `CreateAutolinkRequest` with non-pointer `KeyPrefix` and `URLTemplate`; `RepositoriesService.AddAutolink` is now `CreateAutolink` and passes `body` by value.
* #4396
  BREAKING CHANGE: `IssueService.Edit` is renamed to `IssueService.Update`.
* #4395
  BREAKING CHANGE: `NewPullRequest` is renamed to `CreatePullRequest`, `PullRequests.Create` now takes it by value, and `CreatePullRequest.Head` and `CreatePullRequest.Base` are now `string`.
* #4394
  BREAKING CHANGE: `CodeScanningService.UploadSarif` now takes `body` by value and its required fields are no longer pointers.
* #4382
  BREAKING CHANGE: `RepositoriesService.CreateDeploymentBranchPolicy` and `UpdateDeploymentBranchPolicy` now take `body` by value and the required `Name` field is of type `string`.
* #4378
  BREAKING CHANGE: `RepositoriesService.CreateFromTemplate` now passes `body` by value and `Name` is now required and passed by value.
* #4372
  BREAKING CHANGE: `RepositoriesService.Merge` and `RepositoriesService.MergeUpstream` now pass `body` by value and required struct fields are now values.
* #4348
  BREAKING CHANGE: `DependabotService` methods involving secrets have new params and return values.

...and the following additional changes:

* #4427
* #4426
* #4422
* #4421
* #4423
* #4424
* #4414
* #4413
* #4418
* #4411
* #4397
* #4412
* #4410
* #4405
* #4398
* #4319
* #4393
* #4380
* #4377
* #4376
* #4374
* #4371
* #4343
* #4370