### PR TITLE
refactor!: Pass LDAP mapping request bodies by value via new `UpdateUserLDAPMappingRequest` and `UpdateTeamLDAPMappingRequest`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -258,13 +258,11 @@ linters:
             - Subscription
             - TeamAddTeamMembershipOptions
             - TeamAddTeamRepoOptions
-            - TeamLDAPMapping
             - TeamProjectOptions
             - UpdateCodespaceOptions
             - UpdateDefaultSetupConfigurationOptions
             - UpdateProjectItemOptions
             - User
-            - UserLDAPMapping
             - UserSuspendOptions
             - WorkflowsPermissionsOpt
           # Body type names exempt from the "Options" suffix rule.

--- a/github/admin.go
+++ b/github/admin.go
@@ -36,6 +36,12 @@ func (m TeamLDAPMapping) String() string {
 	return Stringify(m)
 }
 
+// UpdateTeamLDAPMappingRequest represents a request to update the mapping
+// between a GitHub team and an LDAP group.
+type UpdateTeamLDAPMappingRequest struct {
+	LDAPDN string `json:"ldap_dn"`
+}
+
 // UserLDAPMapping represents the mapping between a GitHub user and an LDAP user.
 type UserLDAPMapping struct {
 	ID         *int64  `json:"id,omitempty"`
@@ -62,6 +68,12 @@ func (m UserLDAPMapping) String() string {
 	return Stringify(m)
 }
 
+// UpdateUserLDAPMappingRequest represents a request to update the mapping
+// between a GitHub user and an LDAP user.
+type UpdateUserLDAPMappingRequest struct {
+	LDAPDN string `json:"ldap_dn"`
+}
+
 // Enterprise represents the GitHub enterprise profile.
 type Enterprise struct {
 	ID          *int       `json:"id,omitempty"`
@@ -85,7 +97,7 @@ func (m Enterprise) String() string {
 // GitHub API docs: https://docs.github.com/enterprise-server@3.21/rest/enterprise-admin/ldap#update-ldap-mapping-for-a-user
 //
 //meta:operation PATCH /admin/ldap/users/{username}/mapping
-func (s *AdminService) UpdateUserLDAPMapping(ctx context.Context, user string, body *UserLDAPMapping) (*UserLDAPMapping, *Response, error) {
+func (s *AdminService) UpdateUserLDAPMapping(ctx context.Context, user string, body UpdateUserLDAPMappingRequest) (*UserLDAPMapping, *Response, error) {
 	u := fmt.Sprintf("admin/ldap/users/%v/mapping", user)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {
@@ -106,8 +118,8 @@ func (s *AdminService) UpdateUserLDAPMapping(ctx context.Context, user string, b
 // GitHub API docs: https://docs.github.com/enterprise-server@3.21/rest/enterprise-admin/ldap#update-ldap-mapping-for-a-team
 //
 //meta:operation PATCH /admin/ldap/teams/{team_id}/mapping
-func (s *AdminService) UpdateTeamLDAPMapping(ctx context.Context, team int64, body *TeamLDAPMapping) (*TeamLDAPMapping, *Response, error) {
-	u := fmt.Sprintf("admin/ldap/teams/%v/mapping", team)
+func (s *AdminService) UpdateTeamLDAPMapping(ctx context.Context, teamID int64, body UpdateTeamLDAPMappingRequest) (*TeamLDAPMapping, *Response, error) {
+	u := fmt.Sprintf("admin/ldap/teams/%v/mapping", teamID)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {
 		return nil, nil, err

--- a/github/admin_test.go
+++ b/github/admin_test.go
@@ -17,8 +17,8 @@ func TestAdminService_UpdateUserLDAPMapping(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &UserLDAPMapping{
-		LDAPDN: Ptr("uid=asdf,ou=users,dc=github,dc=com"),
+	input := UpdateUserLDAPMappingRequest{
+		LDAPDN: "uid=asdf,ou=users,dc=github,dc=com",
 	}
 
 	mux.HandleFunc("/admin/ldap/users/u/mapping", func(w http.ResponseWriter, r *http.Request) {
@@ -60,8 +60,8 @@ func TestAdminService_UpdateTeamLDAPMapping(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &TeamLDAPMapping{
-		LDAPDN: Ptr("cn=Enterprise Ops,ou=teams,dc=github,dc=com"),
+	input := UpdateTeamLDAPMappingRequest{
+		LDAPDN: "cn=Enterprise Ops,ou=teams,dc=github,dc=com",
 	}
 
 	mux.HandleFunc("/admin/ldap/teams/1/mapping", func(w http.ResponseWriter, r *http.Request) {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -43838,6 +43838,22 @@ func (u *UpdateRunnerGroupRequest) GetVisibility() string {
 	return *u.Visibility
 }
 
+// GetLDAPDN returns the LDAPDN field.
+func (u *UpdateTeamLDAPMappingRequest) GetLDAPDN() string {
+	if u == nil {
+		return ""
+	}
+	return u.LDAPDN
+}
+
+// GetLDAPDN returns the LDAPDN field.
+func (u *UpdateUserLDAPMappingRequest) GetLDAPDN() string {
+	if u == nil {
+		return ""
+	}
+	return u.LDAPDN
+}
+
 // GetLicense returns the License field.
 func (u *UploadLicenseOptions) GetLicense() string {
 	if u == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -54936,6 +54936,22 @@ func TestUpdateRunnerGroupRequest_GetVisibility(tt *testing.T) {
 	u.GetVisibility()
 }
 
+func TestUpdateTeamLDAPMappingRequest_GetLDAPDN(tt *testing.T) {
+	tt.Parallel()
+	u := &UpdateTeamLDAPMappingRequest{}
+	u.GetLDAPDN()
+	u = nil
+	u.GetLDAPDN()
+}
+
+func TestUpdateUserLDAPMappingRequest_GetLDAPDN(tt *testing.T) {
+	tt.Parallel()
+	u := &UpdateUserLDAPMappingRequest{}
+	u.GetLDAPDN()
+	u = nil
+	u.GetLDAPDN()
+}
+
 func TestUploadLicenseOptions_GetLicense(tt *testing.T) {
 	tt.Parallel()
 	u := &UploadLicenseOptions{}


### PR DESCRIPTION
Continues the request-body-by-value work in #3644, this time for the two LDAP mapping endpoints on `AdminService`.

Both methods reused their **response** types as request bodies, but per the [GHES docs](https://docs.github.com/en/enterprise-server@3.21/rest/enterprise-admin/ldap?apiVersion=2022-11-28) each endpoint accepts exactly one body parameter, `ldap_dn`, and it's required:

- `UpdateUserLDAPMapping` took `*UserLDAPMapping` — 17 all-pointer fields, most of them server-generated (`avatar_url`, `events_url`, …).
- `UpdateTeamLDAPMapping` took `*TeamLDAPMapping` — 10 all-pointer fields, same story.

The existing tests show this: both build the request with only `LDAPDN` set, while the response expectations populate more fields. So this adds dedicated request types, following the same approach as `PullRequestSubmitReviewRequest` (#4406) and `UpdateConnectedExternalGroupRequest` (#4425):

```go
type UpdateUserLDAPMappingRequest struct {
	LDAPDN string `json:"ldap_dn"`
}

type UpdateTeamLDAPMappingRequest struct {
	LDAPDN string `json:"ldap_dn"`
}
```

`LDAPDN` is a non-pointer `string` since it's required, both bodies are passed by value, and both old entries are removed from the `body-allowed-pointer-types` allowlist. The two methods live in the same file and follow the identical pattern, so they're converted together.

Notes:

- `UserLDAPMapping` and `TeamLDAPMapping` are unchanged — they stay the response types, so their fields keep pointer semantics.
- The method verbs already match the docs operation names ("Update LDAP mapping for a user/team"), so no method rename.
- The `team int64` parameter is renamed to `teamID` for clarity (non-breaking).

Verified with `go build ./...`, `go vet -tags integration ./test/integration/`, `gofmt`, the full `./github/` test suite (both methods and the generated `GetLDAPDN` accessors at 100%), and `custom-gcl` (no `paramcheck` findings after removing the allowlist entries).

Updates #3644

BREAKING CHANGE: AdminService.UpdateUserLDAPMapping and UpdateTeamLDAPMapping now take new UpdateUserLDAPMappingRequest and UpdateTeamLDAPMappingRequest (with non-pointer LDAPDN) by value instead of *UserLDAPMapping and *TeamLDAPMapping.

cc @jvm986 — flagging for #3644 coordination; this is in the `admin` service, so it shouldn't overlap with the `Issues` work.
