### PR TITLE
refactor!: Rename `UsersService.Edit` to `Update`, introduce `UserUpdateRequest`, and pass request by value

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -44902,6 +44902,70 @@ func (u *UserSuspendOptions) GetReason() string {
 	return *u.Reason
 }
 
+// GetBio returns the Bio field if it's non-nil, zero value otherwise.
+func (u *UserUpdateRequest) GetBio() string {
+	if u == nil || u.Bio == nil {
+		return ""
+	}
+	return *u.Bio
+}
+
+// GetBlog returns the Blog field if it's non-nil, zero value otherwise.
+func (u *UserUpdateRequest) GetBlog() string {
+	if u == nil || u.Blog == nil {
+		return ""
+	}
+	return *u.Blog
+}
+
+// GetCompany returns the Company field if it's non-nil, zero value otherwise.
+func (u *UserUpdateRequest) GetCompany() string {
+	if u == nil || u.Company == nil {
+		return ""
+	}
+	return *u.Company
+}
+
+// GetEmail returns the Email field if it's non-nil, zero value otherwise.
+func (u *UserUpdateRequest) GetEmail() string {
+	if u == nil || u.Email == nil {
+		return ""
+	}
+	return *u.Email
+}
+
+// GetHireable returns the Hireable field if it's non-nil, zero value otherwise.
+func (u *UserUpdateRequest) GetHireable() bool {
+	if u == nil || u.Hireable == nil {
+		return false
+	}
+	return *u.Hireable
+}
+
+// GetLocation returns the Location field if it's non-nil, zero value otherwise.
+func (u *UserUpdateRequest) GetLocation() string {
+	if u == nil || u.Location == nil {
+		return ""
+	}
+	return *u.Location
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (u *UserUpdateRequest) GetName() string {
+	if u == nil || u.Name == nil {
+		return ""
+	}
+	return *u.Name
+}
+
+// GetTwitterUsername returns the TwitterUsername field if it's non-nil, zero value otherwise.
+func (u *UserUpdateRequest) GetTwitterUsername() string {
+	if u == nil || u.TwitterUsername == nil {
+		return ""
+	}
+	return *u.TwitterUsername
+}
+
 // GetEcosystem returns the Ecosystem field if it's non-nil, zero value otherwise.
 func (v *VulnerabilityPackage) GetEcosystem() string {
 	if v == nil || v.Ecosystem == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -56321,6 +56321,94 @@ func TestUserSuspendOptions_GetReason(tt *testing.T) {
 	u.GetReason()
 }
 
+func TestUserUpdateRequest_GetBio(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UserUpdateRequest{Bio: &zeroValue}
+	u.GetBio()
+	u = &UserUpdateRequest{}
+	u.GetBio()
+	u = nil
+	u.GetBio()
+}
+
+func TestUserUpdateRequest_GetBlog(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UserUpdateRequest{Blog: &zeroValue}
+	u.GetBlog()
+	u = &UserUpdateRequest{}
+	u.GetBlog()
+	u = nil
+	u.GetBlog()
+}
+
+func TestUserUpdateRequest_GetCompany(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UserUpdateRequest{Company: &zeroValue}
+	u.GetCompany()
+	u = &UserUpdateRequest{}
+	u.GetCompany()
+	u = nil
+	u.GetCompany()
+}
+
+func TestUserUpdateRequest_GetEmail(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UserUpdateRequest{Email: &zeroValue}
+	u.GetEmail()
+	u = &UserUpdateRequest{}
+	u.GetEmail()
+	u = nil
+	u.GetEmail()
+}
+
+func TestUserUpdateRequest_GetHireable(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	u := &UserUpdateRequest{Hireable: &zeroValue}
+	u.GetHireable()
+	u = &UserUpdateRequest{}
+	u.GetHireable()
+	u = nil
+	u.GetHireable()
+}
+
+func TestUserUpdateRequest_GetLocation(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UserUpdateRequest{Location: &zeroValue}
+	u.GetLocation()
+	u = &UserUpdateRequest{}
+	u.GetLocation()
+	u = nil
+	u.GetLocation()
+}
+
+func TestUserUpdateRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UserUpdateRequest{Name: &zeroValue}
+	u.GetName()
+	u = &UserUpdateRequest{}
+	u.GetName()
+	u = nil
+	u.GetName()
+}
+
+func TestUserUpdateRequest_GetTwitterUsername(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UserUpdateRequest{TwitterUsername: &zeroValue}
+	u.GetTwitterUsername()
+	u = &UserUpdateRequest{}
+	u.GetTwitterUsername()
+	u = nil
+	u.GetTwitterUsername()
+}
+
 func TestVulnerabilityPackage_GetEcosystem(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/users.go
+++ b/github/users.go
@@ -101,6 +101,18 @@ type User struct {
 	Inherited *bool `json:"inherited,omitempty"`
 }
 
+// UserUpdateRequest represents the request body for updating a user.
+type UserUpdateRequest struct {
+    Name              *string `json:"name,omitempty"`
+    Email             *string `json:"email,omitempty"`
+    Blog              *string `json:"blog,omitempty"`
+    TwitterUsername   *string `json:"twitter_username,omitempty"`
+    Company           *string `json:"company,omitempty"`
+    Location          *string `json:"location,omitempty"`
+    Hireable          *bool   `json:"hireable,omitempty"`
+    Bio               *string `json:"bio,omitempty"`
+}
+
 func (u User) String() string {
 	return Stringify(u)
 }
@@ -161,7 +173,7 @@ func (s *UsersService) GetByID(ctx context.Context, id int64) (*User, *Response,
 // GitHub API docs: https://docs.github.com/rest/users/users?apiVersion=2022-11-28#update-the-authenticated-user
 //
 //meta:operation PATCH /user
-func (s *UsersService) Update(ctx context.Context, body User) (*User, *Response, error) {
+func (s *UsersService) Update(ctx context.Context, body UserUpdateRequest) (*User, *Response, error) {
 	u := "user"
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/users.go
+++ b/github/users.go
@@ -103,14 +103,14 @@ type User struct {
 
 // UserUpdateRequest represents the request body for updating a user.
 type UserUpdateRequest struct {
-    Name              *string `json:"name,omitempty"`
-    Email             *string `json:"email,omitempty"`
-    Blog              *string `json:"blog,omitempty"`
-    TwitterUsername   *string `json:"twitter_username,omitempty"`
-    Company           *string `json:"company,omitempty"`
-    Location          *string `json:"location,omitempty"`
-    Hireable          *bool   `json:"hireable,omitempty"`
-    Bio               *string `json:"bio,omitempty"`
+	Name            *string `json:"name,omitempty"`
+	Email           *string `json:"email,omitempty"`
+	Blog            *string `json:"blog,omitempty"`
+	TwitterUsername *string `json:"twitter_username,omitempty"`
+	Company         *string `json:"company,omitempty"`
+	Location        *string `json:"location,omitempty"`
+	Hireable        *bool   `json:"hireable,omitempty"`
+	Bio             *string `json:"bio,omitempty"`
 }
 
 func (u User) String() string {

--- a/github/users.go
+++ b/github/users.go
@@ -161,7 +161,7 @@ func (s *UsersService) GetByID(ctx context.Context, id int64) (*User, *Response,
 // GitHub API docs: https://docs.github.com/rest/users/users?apiVersion=2022-11-28#update-the-authenticated-user
 //
 //meta:operation PATCH /user
-func (s *UsersService) Edit(ctx context.Context, body *User) (*User, *Response, error) {
+func (s *UsersService) Update(ctx context.Context, body User) (*User, *Response, error) {
 	u := "user"
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/users.go
+++ b/github/users.go
@@ -168,7 +168,7 @@ func (s *UsersService) GetByID(ctx context.Context, id int64) (*User, *Response,
 	return user, resp, nil
 }
 
-// Edit the authenticated user.
+// Update the authenticated user.
 //
 // GitHub API docs: https://docs.github.com/rest/users/users?apiVersion=2022-11-28#update-the-authenticated-user
 //

--- a/github/users_test.go
+++ b/github/users_test.go
@@ -117,7 +117,7 @@ func TestUsersService_Update(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := User{Name: Ptr("n")}
+	input := UserUpdateRequest{Name: Ptr("n")}
 
 	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")

--- a/github/users_test.go
+++ b/github/users_test.go
@@ -113,11 +113,11 @@ func TestUsersService_GetByID(t *testing.T) {
 	})
 }
 
-func TestUsersService_Edit(t *testing.T) {
+func TestUsersService_Update(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &User{Name: Ptr("n")}
+	input := User{Name: Ptr("n")}
 
 	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -126,7 +126,7 @@ func TestUsersService_Edit(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	user, _, err := client.Users.Edit(ctx, input)
+	user, _, err := client.Users.Update(ctx, input)
 	if err != nil {
 		t.Errorf("Users.Edit returned error: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestUsersService_Edit(t *testing.T) {
 
 	const methodName = "Edit"
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Users.Edit(ctx, input)
+		got, resp, err := client.Users.Update(ctx, input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/github/users_test.go
+++ b/github/users_test.go
@@ -128,15 +128,15 @@ func TestUsersService_Update(t *testing.T) {
 	ctx := t.Context()
 	user, _, err := client.Users.Update(ctx, input)
 	if err != nil {
-		t.Errorf("Users.Edit returned error: %v", err)
+		t.Errorf("Users.Update returned error: %v", err)
 	}
 
 	want := &User{ID: Ptr(int64(1))}
 	if !cmp.Equal(user, want) {
-		t.Errorf("Users.Edit returned %+v, want %+v", user, want)
+		t.Errorf("Users.Update returned %+v, want %+v", user, want)
 	}
 
-	const methodName = "Edit"
+	const methodName = "Update"
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
 		got, resp, err := client.Users.Update(ctx, input)
 		if got != nil {

--- a/test/integration/users_test.go
+++ b/test/integration/users_test.go
@@ -67,7 +67,7 @@ func TestUsers_Update(t *testing.T) {
 	testLoc := fmt.Sprintf("test-%v", rand.Int())
 	u.Location = &testLoc
 
-	_, _, err = client.Users.Edit(t.Context(), u)
+	_, _, err = client.Users.Update(t.Context(), u)
 	if err != nil {
 		t.Fatalf("Users.Update returned error: %v", err)
 	}
@@ -84,9 +84,9 @@ func TestUsers_Update(t *testing.T) {
 
 	// set location back to the original value
 	u.Location = &location
-	_, _, err = client.Users.Edit(t.Context(), u)
+	_, _, err = client.Users.Update(t.Context(), u)
 	if err != nil {
-		t.Fatalf("Users.Edit returned error: %v", err)
+		t.Fatalf("Users.Update returned error: %v", err)
 	}
 }
 

--- a/test/integration/users_test.go
+++ b/test/integration/users_test.go
@@ -65,9 +65,8 @@ func TestUsers_Update(t *testing.T) {
 
 	// update location to test value
 	testLoc := fmt.Sprintf("test-%v", rand.Int())
-	u.Location = &testLoc
 
-	_, _, err = client.Users.Update(t.Context(), u)
+	_, _, err = client.Users.Update(t.Context(), github.UserUpdateRequest{Location: &testLoc})
 	if err != nil {
 		t.Fatalf("Users.Update returned error: %v", err)
 	}
@@ -83,8 +82,7 @@ func TestUsers_Update(t *testing.T) {
 	}
 
 	// set location back to the original value
-	u.Location = &location
-	_, _, err = client.Users.Update(t.Context(), u)
+	_, _, err = client.Users.Update(t.Context(), github.UserUpdateRequest{Location: &location})
 	if err != nil {
 		t.Fatalf("Users.Update returned error: %v", err)
 	}


### PR DESCRIPTION
BREAKING CHANGE: `UsersService.Edit` is now `Update` and uses a new `UserUpdateRequest` body value.

Relates to: #3644.

Rename UsersService.Edit to Update for consistency with GitHub API naming.
Introduce a dedicated UserUpdateRequest type containing only fields accepted by the update endpoint, and pass it by value instead of a pointer.