### PR TITLE
refactor!: Pass `UpdatePreReceiveHook` request body by value via new `UpdatePreReceiveHookRequest`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -237,7 +237,6 @@ linters:
             - PagesUpdate
             - PagesUpdateWithoutCNAME
             - PendingDeploymentsRequest
-            - PreReceiveHook
             - ProtectionRequest
             - PublishCodespaceOptions
             - PullRequestBranchUpdateOptions

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -43582,6 +43582,14 @@ func (u *UpdateOrganizationPrivateRegistry) GetVisibility() *PrivateRegistryVisi
 	return u.Visibility
 }
 
+// GetEnforcement returns the Enforcement field if it's non-nil, zero value otherwise.
+func (u *UpdatePreReceiveHookRequest) GetEnforcement() string {
+	if u == nil || u.Enforcement == nil {
+		return ""
+	}
+	return *u.Enforcement
+}
+
 // GetArchived returns the Archived field if it's non-nil, zero value otherwise.
 func (u *UpdateProjectItemOptions) GetArchived() bool {
 	if u == nil || u.Archived == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -54602,6 +54602,17 @@ func TestUpdateOrganizationPrivateRegistry_GetVisibility(tt *testing.T) {
 	u.GetVisibility()
 }
 
+func TestUpdatePreReceiveHookRequest_GetEnforcement(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdatePreReceiveHookRequest{Enforcement: &zeroValue}
+	u.GetEnforcement()
+	u = &UpdatePreReceiveHookRequest{}
+	u.GetEnforcement()
+	u = nil
+	u.GetEnforcement()
+}
+
 func TestUpdateProjectItemOptions_GetArchived(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool

--- a/github/repos_prereceive_hooks.go
+++ b/github/repos_prereceive_hooks.go
@@ -22,6 +22,12 @@ func (p PreReceiveHook) String() string {
 	return Stringify(p)
 }
 
+// UpdatePreReceiveHookRequest represents a request to update the enforcement
+// of a pre-receive hook for a repository.
+type UpdatePreReceiveHookRequest struct {
+	Enforcement *string `json:"enforcement,omitempty"`
+}
+
 // ListPreReceiveHooks lists all pre-receive hooks for the specified repository.
 //
 // GitHub API docs: https://docs.github.com/enterprise-server@3.21/rest/enterprise-admin/repo-pre-receive-hooks#list-pre-receive-hooks-for-a-repository
@@ -78,7 +84,7 @@ func (s *RepositoriesService) GetPreReceiveHook(ctx context.Context, owner, repo
 // GitHub API docs: https://docs.github.com/enterprise-server@3.21/rest/enterprise-admin/repo-pre-receive-hooks#update-pre-receive-hook-enforcement-for-a-repository
 //
 //meta:operation PATCH /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}
-func (s *RepositoriesService) UpdatePreReceiveHook(ctx context.Context, owner, repo string, id int64, body *PreReceiveHook) (*PreReceiveHook, *Response, error) {
+func (s *RepositoriesService) UpdatePreReceiveHook(ctx context.Context, owner, repo string, id int64, body UpdatePreReceiveHookRequest) (*PreReceiveHook, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pre-receive-hooks/%v", owner, repo, id)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/repos_prereceive_hooks_test.go
+++ b/github/repos_prereceive_hooks_test.go
@@ -110,7 +110,7 @@ func TestRepositoriesService_UpdatePreReceiveHook(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &PreReceiveHook{}
+	input := UpdatePreReceiveHookRequest{Enforcement: Ptr("enabled")}
 
 	mux.HandleFunc("/repos/o/r/pre-receive-hooks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -149,7 +149,7 @@ func TestRepositoriesService_PreReceiveHook_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Repositories.UpdatePreReceiveHook(ctx, "%", "%", 1, nil)
+	_, _, err := client.Repositories.UpdatePreReceiveHook(ctx, "%", "%", 1, UpdatePreReceiveHookRequest{})
 	testURLParseError(t, err)
 }
 


### PR DESCRIPTION
Continues the request-body-by-value work in #3644, this time for `RepositoriesService.UpdatePreReceiveHook` (GHES).

The method reused the `PreReceiveHook` **response** type as its request body, but per the [GHES docs](https://docs.github.com/en/enterprise-server@3.21/rest/enterprise-admin/repo-pre-receive-hooks?apiVersion=2022-11-28#update-pre-receive-hook-enforcement-for-a-repository) the endpoint accepts exactly one body parameter, `enforcement` — `id`, `name` and `configuration_url` are server-generated. The existing test illustrates the problem: it sent an empty `&PreReceiveHook{}` as the body, since the reused type gives no hint of what to fill in.

So this adds a dedicated request type, following the same approach as #4406, #4425 and #4432:

```go
type UpdatePreReceiveHookRequest struct {
	Enforcement *string `json:"enforcement,omitempty"`
}
```

`Enforcement` stays a pointer with `omitempty` since the docs don't mark it required. The body is passed by value, and the type's entry is removed from the `body-allowed-pointer-types` allowlist. The test now sends a meaningful body (`Enforcement: Ptr("enabled")`) instead of an empty struct.

Notes:

- `PreReceiveHook` is unchanged — it stays the response type for `ListPreReceiveHooks`, `GetPreReceiveHook` and this method, so its fields keep pointer semantics. (Its `ConfigURL` entry in the `structfield` allowlist is response-side debt and is untouched.)
- The method verb `Update` already matches the docs operation name, so no rename.

Verified with `go build ./...`, `go vet -tags integration ./test/integration/`, `gofmt`, the full `./github/` test suite (`UpdatePreReceiveHook` and the generated `GetEnforcement` at 100%), and `custom-gcl` (no `paramcheck` findings after removing the allowlist entry).

Updates #3644

BREAKING CHANGE: RepositoriesService.UpdatePreReceiveHook now takes a new UpdatePreReceiveHookRequest by value instead of *PreReceiveHook.

cc @jvm986 — flagging for #3644 coordination; this is in the `repos` service (GHES pre-receive hooks), so it doesn't overlap with the `Issues` work, nor with #4433 (`UsersService`).
