### PR TITLE
chore: Remove stale `User` entry from the paramcheck allowlist

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -261,7 +261,6 @@ linters:
             - UpdateCodespaceOptions
             - UpdateDefaultSetupConfigurationOptions
             - UpdateProjectItemOptions
-            - User
             - UserSuspendOptions
             - WorkflowsPermissionsOpt
           # Body type names exempt from the "Options" suffix rule.


### PR DESCRIPTION
Follow-up to #4433.

That PR converted `UsersService.Update` to take the new `UserUpdateRequest` by value, which was the only place `User` was used as a request body. The corresponding `User` entry in the `paramcheck` `body-allowed-pointer-types` allowlist (whose header says "TODO: fix and remove these exceptions") became dead but wasn't removed.

This removes the entry. Verified that `custom-gcl` reports no `paramcheck` findings with the exception gone, confirming nothing still passes `*User` as a request body. For reference, `UserUpdateRequest` itself matches the [documented `PATCH /user` schema](https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#update-the-authenticated-user) exactly (all eight parameters optional), so no further follow-up is needed there.

Updates #3644
