### PR TITLE
refactor!: Rename `EditMilestone` to `UpdateMilestone`, split `Milestone` request bodies into `CreateMilestoneRequest` and `UpdateMilestoneRequest`, and pass by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -232,7 +232,6 @@ linters:
             - Key
             - LockIssueOptions
             - MaintenanceOptions
-            - Milestone
             - Organization
             - PagesUpdate
             - PagesUpdateWithoutCNAME

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11326,6 +11326,38 @@ func (c *CreateJITConfigRequest) GetWorkFolder() string {
 	return *c.WorkFolder
 }
 
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (c *CreateMilestoneRequest) GetDescription() string {
+	if c == nil || c.Description == nil {
+		return ""
+	}
+	return *c.Description
+}
+
+// GetDueOn returns the DueOn field if it's non-nil, zero value otherwise.
+func (c *CreateMilestoneRequest) GetDueOn() Timestamp {
+	if c == nil || c.DueOn == nil {
+		return Timestamp{}
+	}
+	return *c.DueOn
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (c *CreateMilestoneRequest) GetState() string {
+	if c == nil || c.State == nil {
+		return ""
+	}
+	return *c.State
+}
+
+// GetTitle returns the Title field.
+func (c *CreateMilestoneRequest) GetTitle() string {
+	if c == nil {
+		return ""
+	}
+	return c.Title
+}
+
 // GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.
 func (c *CreateOrganizationPrivateRegistry) GetAccountID() string {
 	if c == nil || c.AccountID == nil {
@@ -43428,6 +43460,38 @@ func (u *UpdateIssueRequest) GetType() string {
 		return ""
 	}
 	return *u.Type
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (u *UpdateMilestoneRequest) GetDescription() string {
+	if u == nil || u.Description == nil {
+		return ""
+	}
+	return *u.Description
+}
+
+// GetDueOn returns the DueOn field if it's non-nil, zero value otherwise.
+func (u *UpdateMilestoneRequest) GetDueOn() Timestamp {
+	if u == nil || u.DueOn == nil {
+		return Timestamp{}
+	}
+	return *u.DueOn
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (u *UpdateMilestoneRequest) GetState() string {
+	if u == nil || u.State == nil {
+		return ""
+	}
+	return *u.State
+}
+
+// GetTitle returns the Title field if it's non-nil, zero value otherwise.
+func (u *UpdateMilestoneRequest) GetTitle() string {
+	if u == nil || u.Title == nil {
+		return ""
+	}
+	return *u.Title
 }
 
 // GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -14351,6 +14351,47 @@ func TestCreateJITConfigRequest_GetWorkFolder(tt *testing.T) {
 	c.GetWorkFolder()
 }
 
+func TestCreateMilestoneRequest_GetDescription(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateMilestoneRequest{Description: &zeroValue}
+	c.GetDescription()
+	c = &CreateMilestoneRequest{}
+	c.GetDescription()
+	c = nil
+	c.GetDescription()
+}
+
+func TestCreateMilestoneRequest_GetDueOn(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue Timestamp
+	c := &CreateMilestoneRequest{DueOn: &zeroValue}
+	c.GetDueOn()
+	c = &CreateMilestoneRequest{}
+	c.GetDueOn()
+	c = nil
+	c.GetDueOn()
+}
+
+func TestCreateMilestoneRequest_GetState(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateMilestoneRequest{State: &zeroValue}
+	c.GetState()
+	c = &CreateMilestoneRequest{}
+	c.GetState()
+	c = nil
+	c.GetState()
+}
+
+func TestCreateMilestoneRequest_GetTitle(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateMilestoneRequest{}
+	c.GetTitle()
+	c = nil
+	c.GetTitle()
+}
+
 func TestCreateOrganizationPrivateRegistry_GetAccountID(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -54397,6 +54438,50 @@ func TestUpdateIssueRequest_GetType(tt *testing.T) {
 	u.GetType()
 	u = nil
 	u.GetType()
+}
+
+func TestUpdateMilestoneRequest_GetDescription(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateMilestoneRequest{Description: &zeroValue}
+	u.GetDescription()
+	u = &UpdateMilestoneRequest{}
+	u.GetDescription()
+	u = nil
+	u.GetDescription()
+}
+
+func TestUpdateMilestoneRequest_GetDueOn(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue Timestamp
+	u := &UpdateMilestoneRequest{DueOn: &zeroValue}
+	u.GetDueOn()
+	u = &UpdateMilestoneRequest{}
+	u.GetDueOn()
+	u = nil
+	u.GetDueOn()
+}
+
+func TestUpdateMilestoneRequest_GetState(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateMilestoneRequest{State: &zeroValue}
+	u.GetState()
+	u = &UpdateMilestoneRequest{}
+	u.GetState()
+	u = nil
+	u.GetState()
+}
+
+func TestUpdateMilestoneRequest_GetTitle(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateMilestoneRequest{Title: &zeroValue}
+	u.GetTitle()
+	u = &UpdateMilestoneRequest{}
+	u.GetTitle()
+	u = nil
+	u.GetTitle()
 }
 
 func TestUpdateOrganizationPrivateRegistry_GetAccountID(tt *testing.T) {

--- a/github/issues_milestones.go
+++ b/github/issues_milestones.go
@@ -34,6 +34,22 @@ func (m Milestone) String() string {
 	return Stringify(m)
 }
 
+// CreateMilestoneRequest represents a request to create a milestone.
+type CreateMilestoneRequest struct {
+	Title       string     `json:"title"`
+	State       *string    `json:"state,omitempty"`
+	Description *string    `json:"description,omitempty"`
+	DueOn       *Timestamp `json:"due_on,omitempty"`
+}
+
+// UpdateMilestoneRequest represents a request to update a milestone.
+type UpdateMilestoneRequest struct {
+	Title       *string    `json:"title,omitempty"`
+	State       *string    `json:"state,omitempty"`
+	Description *string    `json:"description,omitempty"`
+	DueOn       *Timestamp `json:"due_on,omitempty"`
+}
+
 // MilestoneListOptions specifies the optional parameters to the
 // IssuesService.ListMilestones method.
 type MilestoneListOptions struct {
@@ -104,7 +120,7 @@ func (s *IssuesService) GetMilestone(ctx context.Context, owner, repo string, nu
 // GitHub API docs: https://docs.github.com/rest/issues/milestones?apiVersion=2022-11-28#create-a-milestone
 //
 //meta:operation POST /repos/{owner}/{repo}/milestones
-func (s *IssuesService) CreateMilestone(ctx context.Context, owner, repo string, body *Milestone) (*Milestone, *Response, error) {
+func (s *IssuesService) CreateMilestone(ctx context.Context, owner, repo string, body CreateMilestoneRequest) (*Milestone, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/milestones", owner, repo)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
@@ -120,12 +136,12 @@ func (s *IssuesService) CreateMilestone(ctx context.Context, owner, repo string,
 	return m, resp, nil
 }
 
-// EditMilestone edits a milestone.
+// UpdateMilestone updates a milestone.
 //
 // GitHub API docs: https://docs.github.com/rest/issues/milestones?apiVersion=2022-11-28#update-a-milestone
 //
 //meta:operation PATCH /repos/{owner}/{repo}/milestones/{milestone_number}
-func (s *IssuesService) EditMilestone(ctx context.Context, owner, repo string, number int, body *Milestone) (*Milestone, *Response, error) {
+func (s *IssuesService) UpdateMilestone(ctx context.Context, owner, repo string, number int, body UpdateMilestoneRequest) (*Milestone, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/milestones/%v", owner, repo, number)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {

--- a/github/issues_milestones_test.go
+++ b/github/issues_milestones_test.go
@@ -112,7 +112,7 @@ func TestIssuesService_CreateMilestone(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &Milestone{Title: Ptr("t")}
+	input := CreateMilestoneRequest{Title: "t"}
 
 	mux.HandleFunc("/repos/o/r/milestones", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -151,15 +151,15 @@ func TestIssuesService_CreateMilestone_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Issues.CreateMilestone(ctx, "%", "r", nil)
+	_, _, err := client.Issues.CreateMilestone(ctx, "%", "r", CreateMilestoneRequest{})
 	testURLParseError(t, err)
 }
 
-func TestIssuesService_EditMilestone(t *testing.T) {
+func TestIssuesService_UpdateMilestone(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &Milestone{Title: Ptr("t")}
+	input := UpdateMilestoneRequest{Title: Ptr("t")}
 
 	mux.HandleFunc("/repos/o/r/milestones/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -168,24 +168,24 @@ func TestIssuesService_EditMilestone(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	milestone, _, err := client.Issues.EditMilestone(ctx, "o", "r", 1, input)
+	milestone, _, err := client.Issues.UpdateMilestone(ctx, "o", "r", 1, input)
 	if err != nil {
-		t.Errorf("IssuesService.EditMilestone returned error: %v", err)
+		t.Errorf("IssuesService.UpdateMilestone returned error: %v", err)
 	}
 
 	want := &Milestone{Number: Ptr(1)}
 	if !cmp.Equal(milestone, want) {
-		t.Errorf("IssuesService.EditMilestone returned %+v, want %+v", milestone, want)
+		t.Errorf("IssuesService.UpdateMilestone returned %+v, want %+v", milestone, want)
 	}
 
-	const methodName = "EditMilestone"
+	const methodName = "UpdateMilestone"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Issues.EditMilestone(ctx, "\n", "\n", -1, input)
+		_, _, err = client.Issues.UpdateMilestone(ctx, "\n", "\n", -1, input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Issues.EditMilestone(ctx, "o", "r", 1, input)
+		got, resp, err := client.Issues.UpdateMilestone(ctx, "o", "r", 1, input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -193,12 +193,12 @@ func TestIssuesService_EditMilestone(t *testing.T) {
 	})
 }
 
-func TestIssuesService_EditMilestone_invalidOwner(t *testing.T) {
+func TestIssuesService_UpdateMilestone_invalidOwner(t *testing.T) {
 	t.Parallel()
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Issues.EditMilestone(ctx, "%", "r", 1, nil)
+	_, _, err := client.Issues.UpdateMilestone(ctx, "%", "r", 1, UpdateMilestoneRequest{})
 	testURLParseError(t, err)
 }
 


### PR DESCRIPTION
Continues the request-body-by-value work in #3644, this time for the milestone endpoints on `IssuesService`.

`CreateMilestone` and `EditMilestone` reused the 16-field `Milestone` **response** type as their request bodies, but per the [docs](https://docs.github.com/en/rest/issues/milestones?apiVersion=2022-11-28) the endpoints accept only four parameters — the other twelve fields (`url`, `number`, `creator`, `open_issues`, `created_at`, …) are server-generated. And the two schemas differ:

| Field | Create (POST) | Update (PATCH) |
|---|---|---|
| `title` | **required** | optional |
| `state` | optional | optional |
| `description` | optional | optional |
| `due_on` | optional | optional |

So this splits the request body into two dedicated types, following the same approach as #4382, #4401 and the `Issues`-service splits in #4396/#4400:

- **`CreateMilestoneRequest`** — `Title` is a non-pointer `string` (no `omitempty`) since it's required; the rest stay pointers.
- **`UpdateMilestoneRequest`** — every field is optional, so all stay pointers.

`EditMilestone` is renamed to `UpdateMilestone` to match the docs operation name, [Update a milestone](https://docs.github.com/en/rest/issues/milestones?apiVersion=2022-11-28#update-a-milestone) (same convention as `EditLabel`→`UpdateLabel` in #4400). Both methods now take their body by value, and `Milestone` is removed from the `body-allowed-pointer-types` allowlist. The `Milestone` response type itself is unchanged.

Verified with `go build ./...`, `go vet -tags integration ./test/integration/`, `gofmt`, the full `./github/` test suite (both methods and the eight generated accessors at 100%), and `custom-gcl` (no `paramcheck` findings after removing the allowlist entry).

Updates #3644

BREAKING CHANGE: IssuesService.CreateMilestone now takes a new CreateMilestoneRequest (with non-pointer Title) by value, and IssuesService.EditMilestone is renamed to UpdateMilestone and takes a new UpdateMilestoneRequest by value, instead of *Milestone.

cc @jvm986 — this one is in the `Issues` service, which you'd been working through; since it's been a couple of weeks I picked up the next item, but happy to coordinate again whenever you resume.
