### PR TITLE
fix: Adjust argument index for `Fprintf` in `fmtpercentv` linter check

### DIFF
--- a/tools/fmtpercentv/fmtpercentv.go
+++ b/tools/fmtpercentv/fmtpercentv.go
@@ -77,7 +77,11 @@ func checkCallExpr(expr *ast.CallExpr, tokenPos token.Pos, pass *analysis.Pass) 
 	if fun.Sel.Name != "Sprintf" && fun.Sel.Name != "Printf" && fun.Sel.Name != "Fprintf" && fun.Sel.Name != "Errorf" {
 		return
 	}
-	fmtStrBasicLit, ok := expr.Args[0].(*ast.BasicLit)
+	argIdx := 0
+	if fun.Sel.Name == "Fprintf" {
+		argIdx = 1
+	}
+	fmtStrBasicLit, ok := expr.Args[argIdx].(*ast.BasicLit)
 	if !ok {
 		return
 	}

--- a/tools/fmtpercentv/testdata/src/has-warnings/main.go
+++ b/tools/fmtpercentv/testdata/src/has-warnings/main.go
@@ -14,4 +14,5 @@ func main() {
 	_ = fmt.Sprintf("some/%d/%s/url", 1, "yo") // want `use %v instead of %s and %d`
 	fmt.Printf("some %d", 1)                   // want `use %v instead of %d`
 	fmt.Printf("some %s", "thing")             // want `use %v instead of %s`
+	fmt.Fprintf(nil, "some %s", 1)             // want `use %v instead of %s`
 }

--- a/tools/fmtpercentv/testdata/src/has-warnings/main.go
+++ b/tools/fmtpercentv/testdata/src/has-warnings/main.go
@@ -14,5 +14,5 @@ func main() {
 	_ = fmt.Sprintf("some/%d/%s/url", 1, "yo") // want `use %v instead of %s and %d`
 	fmt.Printf("some %d", 1)                   // want `use %v instead of %d`
 	fmt.Printf("some %s", "thing")             // want `use %v instead of %s`
-	fmt.Fprintf(nil, "some %s", 1)             // want `use %v instead of %s`
+	fmt.Fprintf(nil, "some %s", "thing")       // want `use %v instead of %s`
 }

--- a/tools/fmtpercentv/testdata/src/no-warnings/main.go
+++ b/tools/fmtpercentv/testdata/src/no-warnings/main.go
@@ -11,4 +11,5 @@ func main() {
 	_ = fmt.Sprintf("some/%v/url", 1) // Should not be flagged
 	fmt.Printf("some %v", 1)          // Should not be flagged
 	fmt.Printf("some %v", "thing")    // Should not be flagged
+	fmt.Fprintf(nil, "some %v", 1)    // Should not be flagged
 }


### PR DESCRIPTION
`Fprintf` has the following signature
```go 
func Fprintf(w io.Writer, format string, a ...any) (n int, err error)
```
Previously, the linter always assumed the format string was at `expr.Args[0]`
```go
fmtStrBasicLit, ok := expr.Args[0].(*ast.BasicLit)
```

https://github.com/google/go-github/pull/4436#discussion_r3733201234