### PR TITLE
refactor!: Update teams create & update patterns

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11894,6 +11894,78 @@ func (c *CreateTag) GetType() string {
 	return c.Type
 }
 
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (c *CreateTeamRequest) GetDescription() string {
+	if c == nil || c.Description == nil {
+		return ""
+	}
+	return *c.Description
+}
+
+// GetMaintainers returns the Maintainers slice if it's non-nil, nil otherwise.
+func (c *CreateTeamRequest) GetMaintainers() []string {
+	if c == nil || c.Maintainers == nil {
+		return nil
+	}
+	return c.Maintainers
+}
+
+// GetName returns the Name field.
+func (c *CreateTeamRequest) GetName() string {
+	if c == nil {
+		return ""
+	}
+	return c.Name
+}
+
+// GetNotificationSetting returns the NotificationSetting field if it's non-nil, zero value otherwise.
+func (c *CreateTeamRequest) GetNotificationSetting() string {
+	if c == nil || c.NotificationSetting == nil {
+		return ""
+	}
+	return *c.NotificationSetting
+}
+
+// GetParentTeamID returns the ParentTeamID field if it's non-nil, zero value otherwise.
+func (c *CreateTeamRequest) GetParentTeamID() int64 {
+	if c == nil || c.ParentTeamID == nil {
+		return 0
+	}
+	return *c.ParentTeamID
+}
+
+// GetParentTeamSlug returns the ParentTeamSlug field if it's non-nil, zero value otherwise.
+func (c *CreateTeamRequest) GetParentTeamSlug() string {
+	if c == nil || c.ParentTeamSlug == nil {
+		return ""
+	}
+	return *c.ParentTeamSlug
+}
+
+// GetPermission returns the Permission field if it's non-nil, zero value otherwise.
+func (c *CreateTeamRequest) GetPermission() string {
+	if c == nil || c.Permission == nil {
+		return ""
+	}
+	return *c.Permission
+}
+
+// GetPrivacy returns the Privacy field if it's non-nil, zero value otherwise.
+func (c *CreateTeamRequest) GetPrivacy() string {
+	if c == nil || c.Privacy == nil {
+		return ""
+	}
+	return *c.Privacy
+}
+
+// GetRepoNames returns the RepoNames slice if it's non-nil, nil otherwise.
+func (c *CreateTeamRequest) GetRepoNames() []string {
+	if c == nil || c.RepoNames == nil {
+		return nil
+	}
+	return c.RepoNames
+}
+
 // GetCanAdminsBypass returns the CanAdminsBypass field if it's non-nil, zero value otherwise.
 func (c *CreateUpdateEnvironment) GetCanAdminsBypass() bool {
 	if c == nil || c.CanAdminsBypass == nil {
@@ -25116,78 +25188,6 @@ func (n *NetworkSettingsResource) GetSubnetID() string {
 		return ""
 	}
 	return *n.SubnetID
-}
-
-// GetDescription returns the Description field if it's non-nil, zero value otherwise.
-func (n *NewTeam) GetDescription() string {
-	if n == nil || n.Description == nil {
-		return ""
-	}
-	return *n.Description
-}
-
-// GetLDAPDN returns the LDAPDN field if it's non-nil, zero value otherwise.
-func (n *NewTeam) GetLDAPDN() string {
-	if n == nil || n.LDAPDN == nil {
-		return ""
-	}
-	return *n.LDAPDN
-}
-
-// GetMaintainers returns the Maintainers slice if it's non-nil, nil otherwise.
-func (n *NewTeam) GetMaintainers() []string {
-	if n == nil || n.Maintainers == nil {
-		return nil
-	}
-	return n.Maintainers
-}
-
-// GetName returns the Name field.
-func (n *NewTeam) GetName() string {
-	if n == nil {
-		return ""
-	}
-	return n.Name
-}
-
-// GetNotificationSetting returns the NotificationSetting field if it's non-nil, zero value otherwise.
-func (n *NewTeam) GetNotificationSetting() string {
-	if n == nil || n.NotificationSetting == nil {
-		return ""
-	}
-	return *n.NotificationSetting
-}
-
-// GetParentTeamID returns the ParentTeamID field if it's non-nil, zero value otherwise.
-func (n *NewTeam) GetParentTeamID() int64 {
-	if n == nil || n.ParentTeamID == nil {
-		return 0
-	}
-	return *n.ParentTeamID
-}
-
-// GetPermission returns the Permission field if it's non-nil, zero value otherwise.
-func (n *NewTeam) GetPermission() string {
-	if n == nil || n.Permission == nil {
-		return ""
-	}
-	return *n.Permission
-}
-
-// GetPrivacy returns the Privacy field if it's non-nil, zero value otherwise.
-func (n *NewTeam) GetPrivacy() string {
-	if n == nil || n.Privacy == nil {
-		return ""
-	}
-	return *n.Privacy
-}
-
-// GetRepoNames returns the RepoNames slice if it's non-nil, nil otherwise.
-func (n *NewTeam) GetRepoNames() []string {
-	if n == nil || n.RepoNames == nil {
-		return nil
-	}
-	return n.RepoNames
 }
 
 // GetClusterRoles returns the ClusterRoles slice if it's non-nil, nil otherwise.
@@ -43916,6 +43916,70 @@ func (u *UpdateTeamLDAPMappingRequest) GetLDAPDN() string {
 		return ""
 	}
 	return u.LDAPDN
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (u *UpdateTeamRequest) GetDescription() string {
+	if u == nil || u.Description == nil {
+		return ""
+	}
+	return *u.Description
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (u *UpdateTeamRequest) GetName() string {
+	if u == nil || u.Name == nil {
+		return ""
+	}
+	return *u.Name
+}
+
+// GetNotificationSetting returns the NotificationSetting field if it's non-nil, zero value otherwise.
+func (u *UpdateTeamRequest) GetNotificationSetting() string {
+	if u == nil || u.NotificationSetting == nil {
+		return ""
+	}
+	return *u.NotificationSetting
+}
+
+// GetParentTeamID returns the ParentTeamID field if it's non-nil, zero value otherwise.
+func (u *UpdateTeamRequest) GetParentTeamID() int64 {
+	if u == nil || u.ParentTeamID == nil {
+		return 0
+	}
+	return *u.ParentTeamID
+}
+
+// GetParentTeamSlug returns the ParentTeamSlug field if it's non-nil, zero value otherwise.
+func (u *UpdateTeamRequest) GetParentTeamSlug() string {
+	if u == nil || u.ParentTeamSlug == nil {
+		return ""
+	}
+	return *u.ParentTeamSlug
+}
+
+// GetPermission returns the Permission field if it's non-nil, zero value otherwise.
+func (u *UpdateTeamRequest) GetPermission() string {
+	if u == nil || u.Permission == nil {
+		return ""
+	}
+	return *u.Permission
+}
+
+// GetPrivacy returns the Privacy field if it's non-nil, zero value otherwise.
+func (u *UpdateTeamRequest) GetPrivacy() string {
+	if u == nil || u.Privacy == nil {
+		return ""
+	}
+	return *u.Privacy
+}
+
+// GetRemoveParentTeam returns the RemoveParentTeam field.
+func (u *UpdateTeamRequest) GetRemoveParentTeam() bool {
+	if u == nil {
+		return false
+	}
+	return u.RemoveParentTeam
 }
 
 // GetLDAPDN returns the LDAPDN field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -15075,6 +15075,102 @@ func TestCreateTag_GetType(tt *testing.T) {
 	c.GetType()
 }
 
+func TestCreateTeamRequest_GetDescription(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateTeamRequest{Description: &zeroValue}
+	c.GetDescription()
+	c = &CreateTeamRequest{}
+	c.GetDescription()
+	c = nil
+	c.GetDescription()
+}
+
+func TestCreateTeamRequest_GetMaintainers(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []string{}
+	c := &CreateTeamRequest{Maintainers: zeroValue}
+	c.GetMaintainers()
+	c = &CreateTeamRequest{}
+	c.GetMaintainers()
+	c = nil
+	c.GetMaintainers()
+}
+
+func TestCreateTeamRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateTeamRequest{}
+	c.GetName()
+	c = nil
+	c.GetName()
+}
+
+func TestCreateTeamRequest_GetNotificationSetting(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateTeamRequest{NotificationSetting: &zeroValue}
+	c.GetNotificationSetting()
+	c = &CreateTeamRequest{}
+	c.GetNotificationSetting()
+	c = nil
+	c.GetNotificationSetting()
+}
+
+func TestCreateTeamRequest_GetParentTeamID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int64
+	c := &CreateTeamRequest{ParentTeamID: &zeroValue}
+	c.GetParentTeamID()
+	c = &CreateTeamRequest{}
+	c.GetParentTeamID()
+	c = nil
+	c.GetParentTeamID()
+}
+
+func TestCreateTeamRequest_GetParentTeamSlug(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateTeamRequest{ParentTeamSlug: &zeroValue}
+	c.GetParentTeamSlug()
+	c = &CreateTeamRequest{}
+	c.GetParentTeamSlug()
+	c = nil
+	c.GetParentTeamSlug()
+}
+
+func TestCreateTeamRequest_GetPermission(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateTeamRequest{Permission: &zeroValue}
+	c.GetPermission()
+	c = &CreateTeamRequest{}
+	c.GetPermission()
+	c = nil
+	c.GetPermission()
+}
+
+func TestCreateTeamRequest_GetPrivacy(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateTeamRequest{Privacy: &zeroValue}
+	c.GetPrivacy()
+	c = &CreateTeamRequest{}
+	c.GetPrivacy()
+	c = nil
+	c.GetPrivacy()
+}
+
+func TestCreateTeamRequest_GetRepoNames(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []string{}
+	c := &CreateTeamRequest{RepoNames: zeroValue}
+	c.GetRepoNames()
+	c = &CreateTeamRequest{}
+	c.GetRepoNames()
+	c = nil
+	c.GetRepoNames()
+}
+
 func TestCreateUpdateEnvironment_GetCanAdminsBypass(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
@@ -31486,102 +31582,6 @@ func TestNetworkSettingsResource_GetSubnetID(tt *testing.T) {
 	n.GetSubnetID()
 	n = nil
 	n.GetSubnetID()
-}
-
-func TestNewTeam_GetDescription(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	n := &NewTeam{Description: &zeroValue}
-	n.GetDescription()
-	n = &NewTeam{}
-	n.GetDescription()
-	n = nil
-	n.GetDescription()
-}
-
-func TestNewTeam_GetLDAPDN(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	n := &NewTeam{LDAPDN: &zeroValue}
-	n.GetLDAPDN()
-	n = &NewTeam{}
-	n.GetLDAPDN()
-	n = nil
-	n.GetLDAPDN()
-}
-
-func TestNewTeam_GetMaintainers(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := []string{}
-	n := &NewTeam{Maintainers: zeroValue}
-	n.GetMaintainers()
-	n = &NewTeam{}
-	n.GetMaintainers()
-	n = nil
-	n.GetMaintainers()
-}
-
-func TestNewTeam_GetName(tt *testing.T) {
-	tt.Parallel()
-	n := &NewTeam{}
-	n.GetName()
-	n = nil
-	n.GetName()
-}
-
-func TestNewTeam_GetNotificationSetting(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	n := &NewTeam{NotificationSetting: &zeroValue}
-	n.GetNotificationSetting()
-	n = &NewTeam{}
-	n.GetNotificationSetting()
-	n = nil
-	n.GetNotificationSetting()
-}
-
-func TestNewTeam_GetParentTeamID(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue int64
-	n := &NewTeam{ParentTeamID: &zeroValue}
-	n.GetParentTeamID()
-	n = &NewTeam{}
-	n.GetParentTeamID()
-	n = nil
-	n.GetParentTeamID()
-}
-
-func TestNewTeam_GetPermission(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	n := &NewTeam{Permission: &zeroValue}
-	n.GetPermission()
-	n = &NewTeam{}
-	n.GetPermission()
-	n = nil
-	n.GetPermission()
-}
-
-func TestNewTeam_GetPrivacy(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	n := &NewTeam{Privacy: &zeroValue}
-	n.GetPrivacy()
-	n = &NewTeam{}
-	n.GetPrivacy()
-	n = nil
-	n.GetPrivacy()
-}
-
-func TestNewTeam_GetRepoNames(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := []string{}
-	n := &NewTeam{RepoNames: zeroValue}
-	n.GetRepoNames()
-	n = &NewTeam{}
-	n.GetRepoNames()
-	n = nil
-	n.GetRepoNames()
 }
 
 func TestNodeDetails_GetClusterRoles(tt *testing.T) {
@@ -55038,6 +55038,91 @@ func TestUpdateTeamLDAPMappingRequest_GetLDAPDN(tt *testing.T) {
 	u.GetLDAPDN()
 	u = nil
 	u.GetLDAPDN()
+}
+
+func TestUpdateTeamRequest_GetDescription(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateTeamRequest{Description: &zeroValue}
+	u.GetDescription()
+	u = &UpdateTeamRequest{}
+	u.GetDescription()
+	u = nil
+	u.GetDescription()
+}
+
+func TestUpdateTeamRequest_GetName(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateTeamRequest{Name: &zeroValue}
+	u.GetName()
+	u = &UpdateTeamRequest{}
+	u.GetName()
+	u = nil
+	u.GetName()
+}
+
+func TestUpdateTeamRequest_GetNotificationSetting(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateTeamRequest{NotificationSetting: &zeroValue}
+	u.GetNotificationSetting()
+	u = &UpdateTeamRequest{}
+	u.GetNotificationSetting()
+	u = nil
+	u.GetNotificationSetting()
+}
+
+func TestUpdateTeamRequest_GetParentTeamID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int64
+	u := &UpdateTeamRequest{ParentTeamID: &zeroValue}
+	u.GetParentTeamID()
+	u = &UpdateTeamRequest{}
+	u.GetParentTeamID()
+	u = nil
+	u.GetParentTeamID()
+}
+
+func TestUpdateTeamRequest_GetParentTeamSlug(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateTeamRequest{ParentTeamSlug: &zeroValue}
+	u.GetParentTeamSlug()
+	u = &UpdateTeamRequest{}
+	u.GetParentTeamSlug()
+	u = nil
+	u.GetParentTeamSlug()
+}
+
+func TestUpdateTeamRequest_GetPermission(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateTeamRequest{Permission: &zeroValue}
+	u.GetPermission()
+	u = &UpdateTeamRequest{}
+	u.GetPermission()
+	u = nil
+	u.GetPermission()
+}
+
+func TestUpdateTeamRequest_GetPrivacy(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateTeamRequest{Privacy: &zeroValue}
+	u.GetPrivacy()
+	u = &UpdateTeamRequest{}
+	u.GetPrivacy()
+	u = nil
+	u.GetPrivacy()
+}
+
+func TestUpdateTeamRequest_GetRemoveParentTeam(tt *testing.T) {
+	tt.Parallel()
+	u := &UpdateTeamRequest{}
+	u.GetRemoveParentTeam()
+	u = nil
+	u.GetRemoveParentTeam()
 }
 
 func TestUpdateUserLDAPMappingRequest_GetLDAPDN(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -508,6 +508,25 @@ func TestContributorStats_String(t *testing.T) {
 	}
 }
 
+func TestCreateTeamRequest_String(t *testing.T) {
+	t.Parallel()
+	v := CreateTeamRequest{
+		Name:                "",
+		Description:         Ptr(""),
+		Maintainers:         []string{""},
+		RepoNames:           []string{""},
+		Privacy:             Ptr(""),
+		NotificationSetting: Ptr(""),
+		Permission:          Ptr(""),
+		ParentTeamID:        Ptr(int64(0)),
+		ParentTeamSlug:      Ptr(""),
+	}
+	want := `github.CreateTeamRequest{Name:"", Description:"", Maintainers:[""], RepoNames:[""], Privacy:"", NotificationSetting:"", Permission:"", ParentTeamID:0, ParentTeamSlug:""}`
+	if got := v.String(); got != want {
+		t.Errorf("CreateTeamRequest.String = %v, want %v", got, want)
+	}
+}
+
 func TestDependabotSecurityUpdates_String(t *testing.T) {
 	t.Parallel()
 	v := DependabotSecurityUpdates{
@@ -1170,25 +1189,6 @@ func TestMilestoneStats_String(t *testing.T) {
 	want := `github.MilestoneStats{TotalMilestones:0, OpenMilestones:0, ClosedMilestones:0}`
 	if got := v.String(); got != want {
 		t.Errorf("MilestoneStats.String = %v, want %v", got, want)
-	}
-}
-
-func TestNewTeam_String(t *testing.T) {
-	t.Parallel()
-	v := NewTeam{
-		Name:                "",
-		Description:         Ptr(""),
-		Maintainers:         []string{""},
-		RepoNames:           []string{""},
-		ParentTeamID:        Ptr(int64(0)),
-		NotificationSetting: Ptr(""),
-		Permission:          Ptr(""),
-		Privacy:             Ptr(""),
-		LDAPDN:              Ptr(""),
-	}
-	want := `github.NewTeam{Name:"", Description:"", Maintainers:[""], RepoNames:[""], ParentTeamID:0, NotificationSetting:"", Permission:"", Privacy:"", LDAPDN:""}`
-	if got := v.String(); got != want {
-		t.Errorf("NewTeam.String = %v, want %v", got, want)
 	}
 }
 
@@ -2393,6 +2393,24 @@ func TestTreeEntry_String(t *testing.T) {
 	want := `github.TreeEntry{SHA:"", Path:"", Mode:"", Type:"", Size:0, Content:"", URL:""}`
 	if got := v.String(); got != want {
 		t.Errorf("TreeEntry.String = %v, want %v", got, want)
+	}
+}
+
+func TestUpdateTeamRequest_String(t *testing.T) {
+	t.Parallel()
+	v := UpdateTeamRequest{
+		Name:                Ptr(""),
+		Description:         Ptr(""),
+		Privacy:             Ptr(""),
+		NotificationSetting: Ptr(""),
+		Permission:          Ptr(""),
+		ParentTeamID:        Ptr(int64(0)),
+		ParentTeamSlug:      Ptr(""),
+		RemoveParentTeam:    false,
+	}
+	want := `github.UpdateTeamRequest{Name:"", Description:"", Privacy:"", NotificationSetting:"", Permission:"", ParentTeamID:0, ParentTeamSlug:"", RemoveParentTeam:false}`
+	if got := v.String(); got != want {
+		t.Errorf("UpdateTeamRequest.String = %v, want %v", got, want)
 	}
 }
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -221,7 +221,7 @@ func testPlainBody(t *testing.T, r *http.Request, want string) {
 	}
 }
 
-func testJSONBody[T any](t *testing.T, r *http.Request, want T) {
+func testJSONBody[T any](t *testing.T, r *http.Request, want T, opts ...cmp.Option) {
 	t.Helper()
 	b, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -234,7 +234,7 @@ func testJSONBody[T any](t *testing.T, r *http.Request, want T) {
 		t.Errorf("Error unmarshaling request body JSON: %v", err)
 	}
 
-	if diff := cmp.Diff(want, got); diff != "" {
+	if diff := cmp.Diff(want, got, opts...); diff != "" {
 		t.Errorf("request JSON body mismatch (-want +got):\n%v", diff)
 	}
 }

--- a/github/teams.go
+++ b/github/teams.go
@@ -267,6 +267,7 @@ func (r UpdateTeamRequest) String() string {
 	return Stringify(r)
 }
 
+// MarshalJSON implements the json.Marshaler interface.
 func (r UpdateTeamRequest) MarshalJSON() ([]byte, error) {
 	type alias UpdateTeamRequest
 	if !r.RemoveParentTeam {

--- a/github/teams.go
+++ b/github/teams.go
@@ -7,6 +7,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
@@ -266,35 +267,18 @@ func (r UpdateTeamRequest) String() string {
 	return Stringify(r)
 }
 
-func (r UpdateTeamRequest) body() any {
+func (r UpdateTeamRequest) MarshalJSON() ([]byte, error) {
+	type alias UpdateTeamRequest
 	if !r.RemoveParentTeam {
-		return r
+		return json.Marshal(alias(r))
 	}
-
-	return updateTeamRequestNoParent{
-		Name:                r.Name,
-		Description:         r.Description,
-		Privacy:             r.Privacy,
-		NotificationSetting: r.NotificationSetting,
-		Permission:          r.Permission,
-		ParentTeamID:        nil,
-		ParentTeamSlug:      nil,
-	}
-}
-
-// updateTeamRequestNoParent represents a team to be updated with the parent removed.
-type updateTeamRequestNoParent struct {
-	Name                *string `json:"name"`
-	Description         *string `json:"description,omitempty"`
-	Privacy             *string `json:"privacy,omitempty"`
-	NotificationSetting *string `json:"notification_setting,omitempty"`
-	Permission          *string `json:"permission,omitempty"`
-	ParentTeamID        *int64  `json:"parent_team_id"`
-	ParentTeamSlug      *string `json:"parent_team_slug"`
-}
-
-func (r updateTeamRequestNoParent) String() string {
-	return Stringify(r)
+	return json.Marshal(&struct {
+		alias
+		ParentTeamID   *int64  `json:"parent_team_id"`
+		ParentTeamSlug *string `json:"parent_team_slug"`
+	}{
+		alias: alias(r),
+	})
 }
 
 // UpdateTeamByID updates a team, given an organization ID, selected by ID.
@@ -304,7 +288,7 @@ func (r updateTeamRequestNoParent) String() string {
 //meta:operation PATCH /organizations/{organization_id}/team/{team_id}
 func (s *TeamsService) UpdateTeamByID(ctx context.Context, orgID, teamID int64, body UpdateTeamRequest) (*Team, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v", orgID, teamID)
-	req, err := s.client.NewRequest(ctx, "PATCH", u, body.body())
+	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -325,7 +309,7 @@ func (s *TeamsService) UpdateTeamByID(ctx context.Context, orgID, teamID int64, 
 //meta:operation PATCH /orgs/{org}/teams/{team_slug}
 func (s *TeamsService) UpdateTeamBySlug(ctx context.Context, org, slug string, body UpdateTeamRequest) (*Team, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v", org, slug)
-	req, err := s.client.NewRequest(ctx, "PATCH", u, body.body())
+	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/teams.go
+++ b/github/teams.go
@@ -8,7 +8,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"net/http"
 )
 
 // TeamsService provides access to the team-related functions
@@ -163,13 +162,26 @@ func (s *TeamsService) GetTeamBySlug(ctx context.Context, org, slug string) (*Te
 	return t, resp, nil
 }
 
-// NewTeam represents a team to be created or modified.
-type NewTeam struct {
-	Name         string   `json:"name"` // Name of the team. (Required.)
-	Description  *string  `json:"description,omitempty"`
-	Maintainers  []string `json:"maintainers,omitempty"`
-	RepoNames    []string `json:"repo_names,omitempty"`
-	ParentTeamID *int64   `json:"parent_team_id,omitempty"`
+// CreateTeamRequest represents a team to be created.
+type CreateTeamRequest struct {
+	// The name of the team (required).
+	Name string `json:"name"`
+
+	// The description of the team.
+	Description *string `json:"description,omitempty"`
+
+	// List GitHub usernames for organization members who will become team maintainers.
+	Maintainers []string `json:"maintainers,omitempty"`
+
+	// The full name (e.g., "organization-name/repository-name") of repositories to add the team to.
+	RepoNames []string `json:"repo_names,omitempty"`
+
+	// Privacy identifies the level of privacy this team should have.
+	// Possible values are:
+	//     secret - only visible to organization owners and members of this team
+	//     closed - visible to all members of this organization
+	// Default is "secret".
+	Privacy *string `json:"privacy,omitempty"`
 
 	// NotificationSetting can be one of: "notifications_enabled", "notifications_disabled".
 	NotificationSetting *string `json:"notification_setting,omitempty"`
@@ -181,20 +193,16 @@ type NewTeam struct {
 	// specifying a permission value when calling AddTeamRepo.
 	Permission *string `json:"permission,omitempty"`
 
-	// Privacy identifies the level of privacy this team should have.
-	// Possible values are:
-	//     secret - only visible to organization owners and members of this team
-	//     closed - visible to all members of this organization
-	// Default is "secret".
-	Privacy *string `json:"privacy,omitempty"`
+	// The ID of a team to set as the parent team.
+	ParentTeamID *int64 `json:"parent_team_id,omitempty"`
 
-	// LDAPDN may be used in GitHub Enterprise when the team membership
-	// is synchronized with LDAP.
-	LDAPDN *string `json:"ldap_dn,omitempty"`
+	// The slug of a team to set as the parent team.
+	// Ignored when ParentTeamID is also provided.
+	ParentTeamSlug *string `json:"parent_team_slug,omitempty"`
 }
 
-func (s NewTeam) String() string {
-	return Stringify(s)
+func (r CreateTeamRequest) String() string {
+	return Stringify(r)
 }
 
 // CreateTeam creates a new team within an organization.
@@ -202,7 +210,7 @@ func (s NewTeam) String() string {
 // GitHub API docs: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#create-a-team
 //
 //meta:operation POST /orgs/{org}/teams
-func (s *TeamsService) CreateTeam(ctx context.Context, org string, body NewTeam) (*Team, *Response, error) {
+func (s *TeamsService) CreateTeam(ctx context.Context, org string, body CreateTeamRequest) (*Team, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams", org)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
@@ -218,51 +226,85 @@ func (s *TeamsService) CreateTeam(ctx context.Context, org string, body NewTeam)
 	return t, resp, nil
 }
 
-// newTeamNoParent is the same as NewTeam but ensures that the
-// "parent_team_id" field will be null. It is for internal use
-// only and should not be exported.
-type newTeamNoParent struct {
-	Name                string   `json:"name"`
-	Description         *string  `json:"description,omitempty"`
-	Maintainers         []string `json:"maintainers,omitempty"`
-	RepoNames           []string `json:"repo_names,omitempty"`
-	ParentTeamID        *int64   `json:"parent_team_id"` // This will be "null"
-	NotificationSetting *string  `json:"notification_setting,omitempty"`
-	Privacy             *string  `json:"privacy,omitempty"`
-	LDAPDN              *string  `json:"ldap_dn,omitempty"`
+// UpdateTeamRequest represents a team to be updated.
+type UpdateTeamRequest struct {
+	// The name of the team (required).
+	Name *string `json:"name"`
+
+	// The description of the team.
+	Description *string `json:"description,omitempty"`
+
+	// Privacy identifies the level of privacy this team should have.
+	// Possible values are:
+	//     secret - only visible to organization owners and members of this team
+	//     closed - visible to all members of this organization
+	// Default is "secret".
+	Privacy *string `json:"privacy,omitempty"`
+
+	// NotificationSetting can be one of: "notifications_enabled", "notifications_disabled".
+	NotificationSetting *string `json:"notification_setting,omitempty"`
+
+	// Deprecated: Permission is deprecated when creating or editing a team in an org
+	// using the new GitHub permission model. It no longer identifies the
+	// permission a team has on its repos, but only specifies the default
+	// permission a repo is initially added with. Avoid confusion by
+	// specifying a permission value when calling AddTeamRepo.
+	Permission *string `json:"permission,omitempty"`
+
+	// The ID of a team to set as the parent team.
+	ParentTeamID *int64 `json:"parent_team_id,omitempty"`
+
+	// The slug of a team to set as the parent team.
+	// Ignored when ParentTeamID is also provided.
+	ParentTeamSlug *string `json:"parent_team_slug,omitempty"`
+
+	// If set to true, the parent team will be removed from the team.
+	RemoveParentTeam bool `json:"-"`
 }
 
-// copyNewTeamWithoutParent is used to set the "parent_team_id"
-// field to "null" after copying the other fields from a NewTeam.
-// It is for internal use only and should not be exported.
-func copyNewTeamWithoutParent(team *NewTeam) *newTeamNoParent {
-	return &newTeamNoParent{
-		Name:                team.Name,
-		Description:         team.Description,
-		Maintainers:         team.Maintainers,
-		RepoNames:           team.RepoNames,
-		NotificationSetting: team.NotificationSetting,
-		Privacy:             team.Privacy,
-		LDAPDN:              team.LDAPDN,
+func (r UpdateTeamRequest) String() string {
+	return Stringify(r)
+}
+
+func (r UpdateTeamRequest) body() any {
+	if !r.RemoveParentTeam {
+		return r
+	}
+
+	return updateTeamRequestNoParent{
+		Name:                r.Name,
+		Description:         r.Description,
+		Privacy:             r.Privacy,
+		NotificationSetting: r.NotificationSetting,
+		Permission:          r.Permission,
+		ParentTeamID:        nil,
+		ParentTeamSlug:      nil,
 	}
 }
 
-// EditTeamByID edits a team, given an organization ID, selected by ID.
+// updateTeamRequestNoParent represents a team to be updated with the parent removed.
+type updateTeamRequestNoParent struct {
+	Name                *string `json:"name"`
+	Description         *string `json:"description,omitempty"`
+	Privacy             *string `json:"privacy,omitempty"`
+	NotificationSetting *string `json:"notification_setting,omitempty"`
+	Permission          *string `json:"permission,omitempty"`
+	ParentTeamID        *int64  `json:"parent_team_id"`
+	ParentTeamSlug      *string `json:"parent_team_slug"`
+}
+
+func (r updateTeamRequestNoParent) String() string {
+	return Stringify(r)
+}
+
+// UpdateTeamByID updates a team, given an organization ID, selected by ID.
 //
 // GitHub API docs: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#update-a-team
 //
 //meta:operation PATCH /organizations/{organization_id}/team/{team_id}
-func (s *TeamsService) EditTeamByID(ctx context.Context, orgID, teamID int64, body NewTeam, removeParent bool) (*Team, *Response, error) {
+func (s *TeamsService) UpdateTeamByID(ctx context.Context, orgID, teamID int64, body UpdateTeamRequest) (*Team, *Response, error) {
 	u := fmt.Sprintf("organizations/%v/team/%v", orgID, teamID)
-
-	var req *http.Request
-	var err error
-	if removeParent {
-		teamRemoveParent := copyNewTeamWithoutParent(&body)
-		req, err = s.client.NewRequest(ctx, "PATCH", u, teamRemoveParent)
-	} else {
-		req, err = s.client.NewRequest(ctx, "PATCH", u, body)
-	}
+	req, err := s.client.NewRequest(ctx, "PATCH", u, body.body())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -276,22 +318,14 @@ func (s *TeamsService) EditTeamByID(ctx context.Context, orgID, teamID int64, bo
 	return t, resp, nil
 }
 
-// EditTeamBySlug edits a team, given an organization name, by slug.
+// UpdateTeamBySlug updates a team, given an organization name, by slug.
 //
 // GitHub API docs: https://docs.github.com/rest/teams/teams?apiVersion=2022-11-28#update-a-team
 //
 //meta:operation PATCH /orgs/{org}/teams/{team_slug}
-func (s *TeamsService) EditTeamBySlug(ctx context.Context, org, slug string, body NewTeam, removeParent bool) (*Team, *Response, error) {
+func (s *TeamsService) UpdateTeamBySlug(ctx context.Context, org, slug string, body UpdateTeamRequest) (*Team, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/teams/%v", org, slug)
-
-	var req *http.Request
-	var err error
-	if removeParent {
-		teamRemoveParent := copyNewTeamWithoutParent(&body)
-		req, err = s.client.NewRequest(ctx, "PATCH", u, teamRemoveParent)
-	} else {
-		req, err = s.client.NewRequest(ctx, "PATCH", u, body)
-	}
+	req, err := s.client.NewRequest(ctx, "PATCH", u, body.body())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -186,7 +186,7 @@ func TestTeamsService_CreateTeam(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := NewTeam{Name: "n", Privacy: Ptr("closed"), RepoNames: []string{"r"}}
+	input := CreateTeamRequest{Name: "n", Privacy: Ptr("closed"), RepoNames: []string{"r"}}
 
 	mux.HandleFunc("/orgs/o/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -225,15 +225,15 @@ func TestTeamsService_CreateTeam_invalidOrg(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Teams.CreateTeam(ctx, "%", NewTeam{})
+	_, _, err := client.Teams.CreateTeam(ctx, "%", CreateTeamRequest{})
 	testURLParseError(t, err)
 }
 
-func TestTeamsService_EditTeamByID(t *testing.T) {
+func TestTeamsService_UpdateTeamByID(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := NewTeam{Name: "n", Privacy: Ptr("closed")}
+	input := UpdateTeamRequest{Name: Ptr("n"), Privacy: Ptr("closed")}
 
 	mux.HandleFunc("/organizations/1/team/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -242,24 +242,24 @@ func TestTeamsService_EditTeamByID(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	team, _, err := client.Teams.EditTeamByID(ctx, 1, 1, input, false)
+	team, _, err := client.Teams.UpdateTeamByID(ctx, 1, 1, input)
 	if err != nil {
-		t.Errorf("Teams.EditTeamByID returned error: %v", err)
+		t.Errorf("Teams.UpdateTeamByID returned error: %v", err)
 	}
 
 	want := &Team{ID: Ptr(int64(1))}
 	if !cmp.Equal(team, want) {
-		t.Errorf("Teams.EditTeamByID returned %+v, want %+v", team, want)
+		t.Errorf("Teams.UpdateTeamByID returned %+v, want %+v", team, want)
 	}
 
-	const methodName = "EditTeamByID"
+	const methodName = "UpdateTeamByID"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Teams.EditTeamByID(ctx, -1, -1, input, false)
+		_, _, err = client.Teams.UpdateTeamByID(ctx, -1, -1, input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Teams.EditTeamByID(ctx, 1, 1, input, false)
+		got, resp, err := client.Teams.UpdateTeamByID(ctx, 1, 1, input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -267,36 +267,36 @@ func TestTeamsService_EditTeamByID(t *testing.T) {
 	})
 }
 
-func TestTeamsService_EditTeamByID_RemoveParent(t *testing.T) {
+func TestTeamsService_UpdateTeamByID_RemoveParent(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := NewTeam{Name: "n", NotificationSetting: Ptr("notifications_enabled"), Privacy: Ptr("closed")}
+	input := UpdateTeamRequest{Name: Ptr("n"), NotificationSetting: Ptr("notifications_enabled"), Privacy: Ptr("closed"), RemoveParentTeam: true}
 
 	mux.HandleFunc("/organizations/1/team/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testJSONBody(t, r, input)
+		testJSONBody(t, r, input.body().(updateTeamRequestNoParent))
 
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
 	ctx := t.Context()
-	team, _, err := client.Teams.EditTeamByID(ctx, 1, 1, input, true)
+	team, _, err := client.Teams.UpdateTeamByID(ctx, 1, 1, input)
 	if err != nil {
-		t.Errorf("Teams.EditTeamByID returned error: %v", err)
+		t.Errorf("Teams.UpdateTeamByID returned error: %v", err)
 	}
 
 	want := &Team{ID: Ptr(int64(1))}
 	if !cmp.Equal(team, want) {
-		t.Errorf("Teams.EditTeamByID returned %+v, want %+v", team, want)
+		t.Errorf("Teams.UpdateTeamByID returned %+v, want %+v", team, want)
 	}
 }
 
-func TestTeamsService_EditTeamBySlug(t *testing.T) {
+func TestTeamsService_UpdateTeamBySlug(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := NewTeam{Name: "n", Privacy: Ptr("closed")}
+	input := UpdateTeamRequest{Name: Ptr("n"), Privacy: Ptr("closed")}
 
 	mux.HandleFunc("/orgs/o/teams/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -305,24 +305,24 @@ func TestTeamsService_EditTeamBySlug(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	team, _, err := client.Teams.EditTeamBySlug(ctx, "o", "s", input, false)
+	team, _, err := client.Teams.UpdateTeamBySlug(ctx, "o", "s", input)
 	if err != nil {
-		t.Errorf("Teams.EditTeamBySlug returned error: %v", err)
+		t.Errorf("Teams.UpdateTeamBySlug returned error: %v", err)
 	}
 
 	want := &Team{ID: Ptr(int64(1))}
 	if !cmp.Equal(team, want) {
-		t.Errorf("Teams.EditTeamBySlug returned %+v, want %+v", team, want)
+		t.Errorf("Teams.UpdateTeamBySlug returned %+v, want %+v", team, want)
 	}
 
-	const methodName = "EditTeamBySlug"
+	const methodName = "UpdateTeamBySlug"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Teams.EditTeamBySlug(ctx, "\n", "\n", input, false)
+		_, _, err = client.Teams.UpdateTeamBySlug(ctx, "\n", "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Teams.EditTeamBySlug(ctx, "o", "s", input, false)
+		got, resp, err := client.Teams.UpdateTeamBySlug(ctx, "o", "s", input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}
@@ -330,28 +330,28 @@ func TestTeamsService_EditTeamBySlug(t *testing.T) {
 	})
 }
 
-func TestTeamsService_EditTeamBySlug_RemoveParent(t *testing.T) {
+func TestTeamsService_UpdateTeamBySlug_RemoveParent(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := NewTeam{Name: "n", NotificationSetting: Ptr("notifications_disabled"), Privacy: Ptr("closed")}
+	input := UpdateTeamRequest{Name: Ptr("n"), NotificationSetting: Ptr("notifications_disabled"), Privacy: Ptr("closed"), RemoveParentTeam: true}
 
 	mux.HandleFunc("/orgs/o/teams/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testJSONBody(t, r, input)
+		testJSONBody(t, r, input.body().(updateTeamRequestNoParent))
 
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
 	ctx := t.Context()
-	team, _, err := client.Teams.EditTeamBySlug(ctx, "o", "s", input, true)
+	team, _, err := client.Teams.UpdateTeamBySlug(ctx, "o", "s", input)
 	if err != nil {
-		t.Errorf("Teams.EditTeamBySlug returned error: %v", err)
+		t.Errorf("Teams.UpdateTeamBySlug returned error: %v", err)
 	}
 
 	want := &Team{ID: Ptr(int64(1))}
 	if !cmp.Equal(team, want) {
-		t.Errorf("Teams.EditTeamBySlug returned %+v, want %+v", team, want)
+		t.Errorf("Teams.UpdateTeamBySlug returned %+v, want %+v", team, want)
 	}
 }
 

--- a/github/teams_test.go
+++ b/github/teams_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestTeamsService_ListTeams(t *testing.T) {
@@ -275,7 +276,7 @@ func TestTeamsService_UpdateTeamByID_RemoveParent(t *testing.T) {
 
 	mux.HandleFunc("/organizations/1/team/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testJSONBody(t, r, input.body().(updateTeamRequestNoParent))
+		testJSONBody(t, r, input, cmpopts.IgnoreFields(UpdateTeamRequest{}, "RemoveParentTeam"))
 
 		fmt.Fprint(w, `{"id":1}`)
 	})
@@ -338,7 +339,7 @@ func TestTeamsService_UpdateTeamBySlug_RemoveParent(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/teams/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testJSONBody(t, r, input.body().(updateTeamRequestNoParent))
+		testJSONBody(t, r, input, cmpopts.IgnoreFields(UpdateTeamRequest{}, "RemoveParentTeam"))
 
 		fmt.Fprint(w, `{"id":1}`)
 	})


### PR DESCRIPTION
BREAKING CHANGE: `CreateTeam` and `UpdateTeamBy*` now take new body params by value.

This PR updates the teams create and update patterns to use the new request naming with seperate requests for create and update and adds support for linking parent teams by slug.

On the create path we've added the new `ParentTeamSlug` field and removed the unsupported `LDAPDN` field. On the update path we've removed added the new `ParentTeamSlug` field and a `RemoveParentTeam` field to replace the boolean in the method signature, as well as making `Name` optional and removing the unsupported `Maintainers`, `RepoNames` & `LDAPDN` fields.