### PR TITLE
fix: Treat `BusinessTeam` as a regular `Team` for Environment reviewers

### DIFF
--- a/github/repos_environments.go
+++ b/github/repos_environments.go
@@ -101,10 +101,17 @@ func (r *RequiredReviewer) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		r.Reviewer = reviewer.Reviewer
+	case "BusinessTeam": // BusinessTeam is the type returned for Enterprise Teams, but we will treat it as a Team type
+		reviewer.Reviewer = &Team{}
+		if err := json.Unmarshal(data, &reviewer); err != nil {
+			return err
+		}
+		r.Type = Ptr("Team") // Change the type to "Team" for compatibility
+		r.Reviewer = reviewer.Reviewer
 	default:
 		r.Type = nil
 		r.Reviewer = nil
-		return fmt.Errorf("reviewer.Type is %T, not a string of 'User' or 'Team', unable to unmarshal", reviewer.Type)
+		return fmt.Errorf("reviewer.Type is %T, not a string of 'User', 'Team' or 'BusinessTeam', unable to unmarshal", reviewer.Type)
 	}
 
 	return nil

--- a/github/repos_environments_test.go
+++ b/github/repos_environments_test.go
@@ -31,6 +31,11 @@ func TestRequiredReviewer_UnmarshalJSON(t *testing.T) {
 			wantRule:  []*RequiredReviewer{{Type: Ptr("Team"), Reviewer: &Team{ID: Ptr(int64(1)), Name: Ptr("Justice League")}}},
 			wantError: false,
 		},
+		"Enterprise Team Reviewer": {
+			data:      []byte(`[{"type": "BusinessTeam", "reviewer": {"id": 1, "name": "Justice League"}}]`),
+			wantRule:  []*RequiredReviewer{{Type: Ptr("Team"), Reviewer: &Team{ID: Ptr(int64(1)), Name: Ptr("Justice League")}}},
+			wantError: false,
+		},
 		"Both Types Reviewer": {
 			data:      []byte(`[{"type": "User", "reviewer": {"id": 1,"login": "octocat"}},{"type": "Team", "reviewer": {"id": 1, "name": "Justice League"}}]`),
 			wantRule:  []*RequiredReviewer{{Type: Ptr("User"), Reviewer: &User{ID: Ptr(int64(1)), Login: Ptr("octocat")}}, {Type: Ptr("Team"), Reviewer: &Team{ID: Ptr(int64(1)), Name: Ptr("Justice League")}}},

--- a/github/repos_environments_test.go
+++ b/github/repos_environments_test.go
@@ -76,6 +76,11 @@ func TestRequiredReviewer_UnmarshalJSON(t *testing.T) {
 			wantRule:  []*RequiredReviewer{{Type: Ptr("Team"), Reviewer: nil}},
 			wantError: true,
 		},
+		"Wrong ID Type in Enterprise Team Object": {
+			data:      []byte(`[{"type": "BusinessTeam", "reviewer": {"id": "string"}}]`),
+			wantRule:  []*RequiredReviewer{{Type: Ptr("BusinessTeam"), Reviewer: nil}},
+			wantError: true,
+		},
 		"Wrong Type of Reviewer": {
 			data:      []byte(`[{"type": "Cat", "reviewer": {"id": 1,"login": "octocat"}}]`),
 			wantRule:  []*RequiredReviewer{{Type: nil, Reviewer: nil}},


### PR DESCRIPTION
It is now supported to use Enterprise Teams as reviewers for Environments, however the type returned by the API has changed, so that instead of Team, it is now BusinessTeam. Sample JSON below:


```json
{
  "reviewers": [
    {
      "type": "BusinessTeam",
      "reviewer": {
        "name": "Name",
        "id": 123456,
        "node_id": "ET_xyz123456",
        "slug": "ent:xyz123",
        "description": "",
        "privacy": "closed",
        "notification_setting": "notifications_enabled",
        "url": "https://api.github.com/enterprises/xyz/teams/123456",
        "html_url": "https://github.com/enterprises/xyz/teams/ent:desktop",
        "members_url": "https://api.github.com/enterprises/xyz/teams/123456/memberships{/member}",
        "repositories_url": "https://api.github.com/enterprises/xyz/teams/123456/repos",
        "type": "enterprise",
        "enterprise_id": 123,
        "permission": "pull",
        "parent": null
      }
    }
  ]
}
```

Prior to this PR this leads to an unmarshaling error if an enterprise team is included as a reviewer in any environment that the library tries to read.

Whilst there are some differences between a BusinessTeam and a Team such as enterprise_id instead of organization_id, a quick workaround is to treat both types as a Team given there is sufficient overlap which allows consumers such as the Terraform provider to be able to work without any breaking changes.

Fixes #4457 