### PR TITLE
feat: Add Copilot 3rd-party agent metrics

### DIFF
--- a/github/copilot.go
+++ b/github/copilot.go
@@ -1008,6 +1008,22 @@ type CopilotMetricsCLI struct {
 	LastKnownCLIVersion *CopilotMetricsCLIVersion    `json:"last_known_cli_version,omitempty"`
 }
 
+// CopilotMetricsThirdPartyAgent represents per-agent app totals in a Copilot usage metrics report.
+//
+// AgentID is the stable grouping key. AgentName is for display and can change.
+// UserInitiatedInteractionCount is agent-app job starts; it is not the same as
+// the top-level user_initiated_interaction_count on the parent metrics object.
+// SessionCount is included on aggregated enterprise and organization reports
+// and omitted from per-user reports.
+//
+// GitHub API docs: https://docs.github.com/en/copilot/reference/copilot-usage-metrics/copilot-usage-metrics#agent-apps-metrics-fields
+type CopilotMetricsThirdPartyAgent struct {
+	AgentName                     string `json:"agent_name"`
+	AgentID                       string `json:"agent_id"`
+	UserInitiatedInteractionCount *int   `json:"user_initiated_interaction_count,omitempty"`
+	SessionCount                  *int   `json:"session_count,omitempty"`
+}
+
 // CopilotDailyMetrics represents the payload downloaded from a 1-day Copilot usage metrics report.
 type CopilotDailyMetrics struct {
 	Day                                 string  `json:"day"`
@@ -1032,6 +1048,7 @@ type CopilotDailyMetrics struct {
 	TotalsByLanguageModel       []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
 	TotalsByModelFeature        []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
 	TotalsByCLI                 *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
+	TotalsBy3rdPartyAgent       []*CopilotMetricsThirdPartyAgent `json:"totals_by_3rd_party_agent,omitempty"`
 	LOCSuggestedToAddSum        *int                             `json:"loc_suggested_to_add_sum,omitempty"`
 	LOCSuggestedToDeleteSum     *int                             `json:"loc_suggested_to_delete_sum,omitempty"`
 	LOCAddedSum                 *int                             `json:"loc_added_sum,omitempty"`
@@ -1092,6 +1109,7 @@ type CopilotUserDailyMetrics struct {
 	TotalsByLanguageModel        []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
 	TotalsByModelFeature         []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
 	TotalsByCLI                  *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
+	TotalsBy3rdPartyAgent        []*CopilotMetricsThirdPartyAgent `json:"totals_by_3rd_party_agent,omitempty"`
 	UsedAgent                    *bool                            `json:"used_agent,omitempty"`
 	UsedChat                     *bool                            `json:"used_chat,omitempty"`
 	UsedCLI                      *bool                            `json:"used_cli,omitempty"`
@@ -1125,6 +1143,7 @@ type CopilotUserPeriodicMetrics struct {
 	TotalsByLanguageModel        []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
 	TotalsByModelFeature         []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
 	TotalsByCLI                  *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
+	TotalsBy3rdPartyAgent        []*CopilotMetricsThirdPartyAgent `json:"totals_by_3rd_party_agent,omitempty"`
 	UsedAgent                    *bool                            `json:"used_agent,omitempty"`
 	UsedChat                     *bool                            `json:"used_chat,omitempty"`
 	UsedCLI                      *bool                            `json:"used_cli,omitempty"`

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -3064,6 +3064,14 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 					"prompt_tokens_sum": 9494
 				}
 			},
+			"totals_by_3rd_party_agent": [
+				{
+					"agent_name": "Claude",
+					"agent_id": "claude",
+					"user_initiated_interaction_count": 8,
+					"session_count": 3
+				}
+			],
 			"loc_added_sum": 100,
 			"pull_requests": {
 				"total_reviewed": 1,
@@ -3119,6 +3127,14 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 				AvgTokensPerRequest: Ptr(4123.5),
 				OutputTokensSum:     Ptr(7000),
 				PromptTokensSum:     Ptr(9494),
+			},
+		},
+		TotalsBy3rdPartyAgent: []*CopilotMetricsThirdPartyAgent{
+			{
+				AgentName:                     "Claude",
+				AgentID:                       "claude",
+				UserInitiatedInteractionCount: Ptr(8),
+				SessionCount:                  Ptr(3),
 			},
 		},
 		LOCAddedSum: Ptr(100),
@@ -3268,7 +3284,7 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 
 	mux.HandleFunc("/path/to/users-daily", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"user_id":1,"user_login":"alice","day":"2026-04-01","user_initiated_interaction_count":5,"chat_panel_edit_mode":2,"used_chat":true,"used_cli":true,"used_copilot_code_review_active":true,"totals_by_cli":{"session_count":2,"request_count":2,"prompt_count":1,"last_known_cli_version":{"sampled_at":`+refTimeStr(1136178000)+`,"cli_version":"1.0.8"}},"totals_by_ide":[{"ide":"vscode","user_initiated_interaction_count":5,"last_known_plugin_version":{"sampled_at":`+refTimeStr(1136178001)+`,"plugin":"copilot","plugin_version":"1.0.0"},"last_known_ide_version":{"sampled_at":`+refTimeStr(1136178002)+`,"ide_version":"1.90"}}]}
+		fmt.Fprint(w, `{"user_id":1,"user_login":"alice","day":"2026-04-01","user_initiated_interaction_count":5,"chat_panel_edit_mode":2,"used_chat":true,"used_cli":true,"used_copilot_code_review_active":true,"totals_by_cli":{"session_count":2,"request_count":2,"prompt_count":1,"last_known_cli_version":{"sampled_at":`+refTimeStr(1136178000)+`,"cli_version":"1.0.8"}},"totals_by_ide":[{"ide":"vscode","user_initiated_interaction_count":5,"last_known_plugin_version":{"sampled_at":`+refTimeStr(1136178001)+`,"plugin":"copilot","plugin_version":"1.0.0"},"last_known_ide_version":{"sampled_at":`+refTimeStr(1136178002)+`,"ide_version":"1.90"}}],"totals_by_3rd_party_agent":[{"agent_name":"Claude","agent_id":"claude","user_initiated_interaction_count":2}]}
 {"user_id":2,"user_login":"bob","day":"2026-04-01","used_agent":true,"used_copilot_code_review_passive":true}
 `)
 	})
@@ -3317,6 +3333,13 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 						SampledAt:  refTimestamp(1136178002),
 						IDEVersion: "1.90",
 					},
+				},
+			},
+			TotalsBy3rdPartyAgent: []*CopilotMetricsThirdPartyAgent{
+				{
+					AgentName:                     "Claude",
+					AgentID:                       "claude",
+					UserInitiatedInteractionCount: Ptr(2),
 				},
 			},
 		},

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -8822,6 +8822,14 @@ func (c *CopilotDailyMetrics) GetPullRequests() *CopilotMetricsPullRequests {
 	return c.PullRequests
 }
 
+// GetTotalsBy3rdPartyAgent returns the TotalsBy3rdPartyAgent slice if it's non-nil, nil otherwise.
+func (c *CopilotDailyMetrics) GetTotalsBy3rdPartyAgent() []*CopilotMetricsThirdPartyAgent {
+	if c == nil || c.TotalsBy3rdPartyAgent == nil {
+		return nil
+	}
+	return c.TotalsBy3rdPartyAgent
+}
+
 // GetTotalsByCLI returns the TotalsByCLI field.
 func (c *CopilotDailyMetrics) GetTotalsByCLI() *CopilotMetricsCLI {
 	if c == nil {
@@ -9766,6 +9774,38 @@ func (c *CopilotMetricsReportOptions) GetDay() string {
 	return c.Day
 }
 
+// GetAgentID returns the AgentID field.
+func (c *CopilotMetricsThirdPartyAgent) GetAgentID() string {
+	if c == nil {
+		return ""
+	}
+	return c.AgentID
+}
+
+// GetAgentName returns the AgentName field.
+func (c *CopilotMetricsThirdPartyAgent) GetAgentName() string {
+	if c == nil {
+		return ""
+	}
+	return c.AgentName
+}
+
+// GetSessionCount returns the SessionCount field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsThirdPartyAgent) GetSessionCount() int {
+	if c == nil || c.SessionCount == nil {
+		return 0
+	}
+	return *c.SessionCount
+}
+
+// GetUserInitiatedInteractionCount returns the UserInitiatedInteractionCount field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsThirdPartyAgent) GetUserInitiatedInteractionCount() int {
+	if c == nil || c.UserInitiatedInteractionCount == nil {
+		return 0
+	}
+	return *c.UserInitiatedInteractionCount
+}
+
 // GetCopilotChat returns the CopilotChat field.
 func (c *CopilotOrganizationDetails) GetCopilotChat() string {
 	if c == nil {
@@ -10028,6 +10068,14 @@ func (c *CopilotUserDailyMetrics) GetOrganizationID() string {
 		return ""
 	}
 	return *c.OrganizationID
+}
+
+// GetTotalsBy3rdPartyAgent returns the TotalsBy3rdPartyAgent slice if it's non-nil, nil otherwise.
+func (c *CopilotUserDailyMetrics) GetTotalsBy3rdPartyAgent() []*CopilotMetricsThirdPartyAgent {
+	if c == nil || c.TotalsBy3rdPartyAgent == nil {
+		return nil
+	}
+	return c.TotalsBy3rdPartyAgent
 }
 
 // GetTotalsByCLI returns the TotalsByCLI field.
@@ -10308,6 +10356,14 @@ func (c *CopilotUserPeriodicMetrics) GetReportStartDay() string {
 		return ""
 	}
 	return c.ReportStartDay
+}
+
+// GetTotalsBy3rdPartyAgent returns the TotalsBy3rdPartyAgent slice if it's non-nil, nil otherwise.
+func (c *CopilotUserPeriodicMetrics) GetTotalsBy3rdPartyAgent() []*CopilotMetricsThirdPartyAgent {
+	if c == nil || c.TotalsBy3rdPartyAgent == nil {
+		return nil
+	}
+	return c.TotalsBy3rdPartyAgent
 }
 
 // GetTotalsByCLI returns the TotalsByCLI field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11280,6 +11280,17 @@ func TestCopilotDailyMetrics_GetPullRequests(tt *testing.T) {
 	c.GetPullRequests()
 }
 
+func TestCopilotDailyMetrics_GetTotalsBy3rdPartyAgent(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsThirdPartyAgent{}
+	c := &CopilotDailyMetrics{TotalsBy3rdPartyAgent: zeroValue}
+	c.GetTotalsBy3rdPartyAgent()
+	c = &CopilotDailyMetrics{}
+	c.GetTotalsBy3rdPartyAgent()
+	c = nil
+	c.GetTotalsBy3rdPartyAgent()
+}
+
 func TestCopilotDailyMetrics_GetTotalsByCLI(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotDailyMetrics{}
@@ -12410,6 +12421,44 @@ func TestCopilotMetricsReportOptions_GetDay(tt *testing.T) {
 	c.GetDay()
 }
 
+func TestCopilotMetricsThirdPartyAgent_GetAgentID(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsThirdPartyAgent{}
+	c.GetAgentID()
+	c = nil
+	c.GetAgentID()
+}
+
+func TestCopilotMetricsThirdPartyAgent_GetAgentName(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsThirdPartyAgent{}
+	c.GetAgentName()
+	c = nil
+	c.GetAgentName()
+}
+
+func TestCopilotMetricsThirdPartyAgent_GetSessionCount(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsThirdPartyAgent{SessionCount: &zeroValue}
+	c.GetSessionCount()
+	c = &CopilotMetricsThirdPartyAgent{}
+	c.GetSessionCount()
+	c = nil
+	c.GetSessionCount()
+}
+
+func TestCopilotMetricsThirdPartyAgent_GetUserInitiatedInteractionCount(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsThirdPartyAgent{UserInitiatedInteractionCount: &zeroValue}
+	c.GetUserInitiatedInteractionCount()
+	c = &CopilotMetricsThirdPartyAgent{}
+	c.GetUserInitiatedInteractionCount()
+	c = nil
+	c.GetUserInitiatedInteractionCount()
+}
+
 func TestCopilotOrganizationDetails_GetCopilotChat(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotOrganizationDetails{}
@@ -12726,6 +12775,17 @@ func TestCopilotUserDailyMetrics_GetOrganizationID(tt *testing.T) {
 	c.GetOrganizationID()
 	c = nil
 	c.GetOrganizationID()
+}
+
+func TestCopilotUserDailyMetrics_GetTotalsBy3rdPartyAgent(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsThirdPartyAgent{}
+	c := &CopilotUserDailyMetrics{TotalsBy3rdPartyAgent: zeroValue}
+	c.GetTotalsBy3rdPartyAgent()
+	c = &CopilotUserDailyMetrics{}
+	c.GetTotalsBy3rdPartyAgent()
+	c = nil
+	c.GetTotalsBy3rdPartyAgent()
 }
 
 func TestCopilotUserDailyMetrics_GetTotalsByCLI(tt *testing.T) {
@@ -13075,6 +13135,17 @@ func TestCopilotUserPeriodicMetrics_GetReportStartDay(tt *testing.T) {
 	c.GetReportStartDay()
 	c = nil
 	c.GetReportStartDay()
+}
+
+func TestCopilotUserPeriodicMetrics_GetTotalsBy3rdPartyAgent(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsThirdPartyAgent{}
+	c := &CopilotUserPeriodicMetrics{TotalsBy3rdPartyAgent: zeroValue}
+	c.GetTotalsBy3rdPartyAgent()
+	c = &CopilotUserPeriodicMetrics{}
+	c.GetTotalsBy3rdPartyAgent()
+	c = nil
+	c.GetTotalsBy3rdPartyAgent()
 }
 
 func TestCopilotUserPeriodicMetrics_GetTotalsByCLI(tt *testing.T) {


### PR DESCRIPTION
Adds `totals_by_3rd_party_agent` to Copilot usage metrics report structs.

GitHub changelog: https://github.blog/changelog/2026-08-07-copilot-usage-metrics-api-adds-agent-app-activity/

- New `CopilotMetricsThirdPartyAgent` type (`agent_name`, `agent_id`, `user_initiated_interaction_count`, optional `session_count`)
- Field wired on `CopilotDailyMetrics`, `CopilotUserDailyMetrics`, and `CopilotUserPeriodicMetrics`
- Tests for daily and user-daily downloads; accessors regenerated via `script/generate.sh`

Fixes #4459