### PR TITLE
refactor!: Rename `ImpersonateUserOptions` to `CreateUserImpersonationRequest` and pass by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -223,7 +223,6 @@ linters:
             - EncryptedSecret
             - EnterpriseSecurityAnalysisSettings
             - Hook
-            - ImpersonateUserOptions
             - Import
             - InstallationTokenListRepoOptions
             - InstallationTokenOptions
@@ -274,7 +273,6 @@ linters:
             - CreateCodespaceOptions
             - CreateOrUpdateIssueTypesOptions
             - CreateOrgInvitationOptions
-            - ImpersonateUserOptions
             - InstallationTokenListRepoOptions
             - InstallationTokenOptions
             - LockIssueOptions

--- a/github/admin_users.go
+++ b/github/admin_users.go
@@ -61,9 +61,10 @@ func (s *AdminService) DeleteUser(ctx context.Context, username string) (*Respon
 	return resp, nil
 }
 
-// ImpersonateUserOptions represents the scoping for the OAuth token.
-type ImpersonateUserOptions struct {
-	Scopes []string `json:"scopes,omitempty"`
+// CreateUserImpersonationRequest represents the scoping for the OAuth token.
+// Note that `Scopes` is a required field.
+type CreateUserImpersonationRequest struct {
+	Scopes []string `json:"scopes"`
 }
 
 // OAuthAPP represents the GitHub Site Administrator OAuth app.
@@ -98,7 +99,7 @@ type UserAuthorization struct {
 // GitHub API docs: https://docs.github.com/enterprise-server@3.21/rest/enterprise-admin/users#create-an-impersonation-oauth-token
 //
 //meta:operation POST /admin/users/{username}/authorizations
-func (s *AdminService) CreateUserImpersonation(ctx context.Context, username string, body *ImpersonateUserOptions) (*UserAuthorization, *Response, error) {
+func (s *AdminService) CreateUserImpersonation(ctx context.Context, username string, body CreateUserImpersonationRequest) (*UserAuthorization, *Response, error) {
 	u := fmt.Sprintf("admin/users/%v/authorizations", username)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)

--- a/github/admin_users_test.go
+++ b/github/admin_users_test.go
@@ -75,11 +75,11 @@ func TestUserImpersonation_Create(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	opt := &ImpersonateUserOptions{Scopes: []string{"repo"}}
+	body := CreateUserImpersonationRequest{Scopes: []string{"repo"}}
 
 	mux.HandleFunc("/admin/users/github/authorizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testJSONBody(t, r, opt)
+		testJSONBody(t, r, body)
 		fmt.Fprint(w, `{"id": 1234,
 		"url": "https://example.com/authorizations",
 		"app": {
@@ -101,7 +101,7 @@ func TestUserImpersonation_Create(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	auth, _, err := client.Admin.CreateUserImpersonation(ctx, "github", opt)
+	auth, _, err := client.Admin.CreateUserImpersonation(ctx, "github", body)
 	if err != nil {
 		t.Errorf("Admin.CreateUserImpersonation returned error: %v", err)
 	}
@@ -130,12 +130,12 @@ func TestUserImpersonation_Create(t *testing.T) {
 
 	const methodName = "CreateUserImpersonation"
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.Admin.CreateUserImpersonation(ctx, "\n", opt)
+		_, _, err = client.Admin.CreateUserImpersonation(ctx, "\n", body)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Admin.CreateUserImpersonation(ctx, "github", opt)
+		got, resp, err := client.Admin.CreateUserImpersonation(ctx, "github", body)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -12006,6 +12006,14 @@ func (c *CreateUpdateEnvironment) GetWaitTimer() int {
 	return *c.WaitTimer
 }
 
+// GetScopes returns the Scopes slice if it's non-nil, nil otherwise.
+func (c *CreateUserImpersonationRequest) GetScopes() []string {
+	if c == nil || c.Scopes == nil {
+		return nil
+	}
+	return c.Scopes
+}
+
 // GetEmail returns the Email field if it's non-nil, zero value otherwise.
 func (c *CreateUserRequest) GetEmail() string {
 	if c == nil || c.Email == nil {
@@ -18900,14 +18908,6 @@ func (i *ImmutableReleaseSettings) GetSelectedRepositoriesURL() string {
 		return ""
 	}
 	return *i.SelectedRepositoriesURL
-}
-
-// GetScopes returns the Scopes slice if it's non-nil, nil otherwise.
-func (i *ImpersonateUserOptions) GetScopes() []string {
-	if i == nil || i.Scopes == nil {
-		return nil
-	}
-	return i.Scopes
 }
 
 // GetAuthorsCount returns the AuthorsCount field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -15223,6 +15223,17 @@ func TestCreateUpdateEnvironment_GetWaitTimer(tt *testing.T) {
 	c.GetWaitTimer()
 }
 
+func TestCreateUserImpersonationRequest_GetScopes(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []string{}
+	c := &CreateUserImpersonationRequest{Scopes: zeroValue}
+	c.GetScopes()
+	c = &CreateUserImpersonationRequest{}
+	c.GetScopes()
+	c = nil
+	c.GetScopes()
+}
+
 func TestCreateUserRequest_GetEmail(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -23755,17 +23766,6 @@ func TestImmutableReleaseSettings_GetSelectedRepositoriesURL(tt *testing.T) {
 	i.GetSelectedRepositoriesURL()
 	i = nil
 	i.GetSelectedRepositoriesURL()
-}
-
-func TestImpersonateUserOptions_GetScopes(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := []string{}
-	i := &ImpersonateUserOptions{Scopes: zeroValue}
-	i.GetScopes()
-	i = &ImpersonateUserOptions{}
-	i.GetScopes()
-	i = nil
-	i.GetScopes()
 }
 
 func TestImport_GetAuthorsCount(tt *testing.T) {


### PR DESCRIPTION
Continues the request-body-by-value work in #3644, this time for `AdminService.CreateUserImpersonation`.
The type had an `Options` suffix despite being a POST body, and was passed by pointer even though its only parameter, `scopes`, is [required](https://docs.github.com/en/enterprise-server@3.21/rest/enterprise-admin/users?apiVersion=2022-11-28#create-an-impersonation-oauth-token). It's renamed after the operation, passed by value, and `Scopes` drops `omitempty`. Removed from both `paramcheck` allowlists (`body-allowed-pointer-types` and `body-allowed-wrong-names`).

BREAKING CHANGE: `AdminService.CreateUserImpersonation` now takes a new `CreateUserImpersonationRequest` (with non-pointer Scopes) by value instead of `*ImpersonateUserOptions`.

cc @JamBalaya56562  @ManavSharma142 @stevehipwell