### PR TITLE
chore: Bump golang-ci-lint version to v2.13.1

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,4 +1,4 @@
-version: v2.12.2 # this is the version of golangci-lint
+version: v2.13.1 # this is the version of golangci-lint
 plugins:
   - module: "github.com/google/go-github/v90/tools/extraneousnew"
     path: ./tools/extraneousnew

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -30,7 +30,7 @@ jobs:
         cache-dependency-path: "**/go.sum"
     - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
       with:
-        version: v2.12.2 # sync with version in .custom-gcl.yml
+        version: v2.13.1 # sync with version in .custom-gcl.yml
         experimental: "automatic-module-directories,no-run-logs-group"
 
   check-openapi:

--- a/example/newfilewithappauth/main.go
+++ b/example/newfilewithappauth/main.go
@@ -57,7 +57,8 @@ func main() {
 	token, _, err := client.Apps.CreateInstallationToken(
 		context.Background(),
 		installID,
-		&github.InstallationTokenOptions{})
+		&github.InstallationTokenOptions{},
+	)
 	if err != nil {
 		log.Fatalf("failed to create installation token: %v", err)
 	}
@@ -76,7 +77,8 @@ func main() {
 			Content: []byte("foo"),
 			Message: github.Ptr("sample commit"),
 			SHA:     nil,
-		})
+		},
+	)
 	if err != nil {
 		log.Fatalf("failed to create new file: %v", err)
 	}

--- a/github/github.go
+++ b/github/github.go
@@ -1577,7 +1577,7 @@ func (r *ErrorResponse) Is(target error) bool {
 			return false
 		}
 		if r.Block.CreatedAt != nil && v.Block.CreatedAt != nil {
-			if *(r.Block.CreatedAt) != *(v.Block.CreatedAt) {
+			if *r.Block.CreatedAt != *v.Block.CreatedAt {
 				return false
 			}
 		}

--- a/github/projects_test.go
+++ b/github/projects_test.go
@@ -231,7 +231,7 @@ func TestProjectsService_ListOrganizationProjectFields(t *testing.T) {
 		return resp, err
 	})
 	ctxBypass := context.WithValue(ctx, BypassRateLimitCheck, true)
-	if _, _, err = client.Projects.ListOrganizationProjectFields(ctxBypass, "o", 1, &ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{Before: ("b"), After: ("a")}}); err != nil {
+	if _, _, err = client.Projects.ListOrganizationProjectFields(ctxBypass, "o", 1, &ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{Before: "b", After: "a"}}); err != nil {
 		t.Fatalf("unexpected error when both before/after set: %v", err)
 	}
 }
@@ -274,7 +274,7 @@ func TestProjectsService_ListUserProjectFields(t *testing.T) {
 		]`)
 	})
 
-	opts := &ListProjectsOptions{Query: ("text"), ListProjectsPaginationOptions: ListProjectsPaginationOptions{After: ("2"), Before: ("1")}}
+	opts := &ListProjectsOptions{Query: "text", ListProjectsPaginationOptions: ListProjectsPaginationOptions{After: "2", Before: "1"}}
 	ctx := t.Context()
 	fields, _, err := client.Projects.ListUserProjectFields(ctx, "u", 1, opts)
 	if err != nil {
@@ -300,7 +300,7 @@ func TestProjectsService_ListUserProjectFields(t *testing.T) {
 		return resp, err
 	})
 	ctxBypass := context.WithValue(ctx, BypassRateLimitCheck, true)
-	if _, _, err = client.Projects.ListUserProjectFields(ctxBypass, "u", 1, &ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{Before: ("b"), After: ("a")}}); err != nil {
+	if _, _, err = client.Projects.ListUserProjectFields(ctxBypass, "u", 1, &ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{Before: "b", After: "a"}}); err != nil {
 		t.Fatalf("unexpected error when both before/after set: %v", err)
 	}
 }
@@ -418,7 +418,7 @@ func TestProjectsService_ListUserProjects_pagination(t *testing.T) {
 		t.Fatalf("expected resp.After=ucursor2 got %q", resp.After)
 	}
 
-	opts := &ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{After: (resp.After)}}
+	opts := &ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{After: resp.After}}
 	second, resp2, err := client.Projects.ListUserProjects(ctx, "u", opts)
 	if err != nil {
 		t.Fatalf("second page error: %v", err)
@@ -491,7 +491,7 @@ func TestProjectsService_ListOrganizationProjectFields_pagination(t *testing.T) 
 		t.Fatalf("expected resp.After=cursor2 got %q", resp.After)
 	}
 
-	opts := &ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{After: (resp.After)}}
+	opts := &ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{After: resp.After}}
 	second, resp2, err := client.Projects.ListOrganizationProjectFields(ctx, "o", 1, opts)
 	if err != nil {
 		t.Fatalf("second page error: %v", err)
@@ -537,7 +537,7 @@ func TestProjectsService_ListOrganizationProjects_pagination(t *testing.T) {
 		t.Fatalf("expected resp.After=ocursor2 got %q", resp.After)
 	}
 
-	opts := &ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{After: (resp.After)}}
+	opts := &ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{After: resp.After}}
 	second, resp2, err := client.Projects.ListOrganizationProjects(ctx, "o", opts)
 	if err != nil {
 		t.Fatalf("second page error: %v", err)
@@ -565,7 +565,7 @@ func TestProjectsService_ListOrganizationProjectItems(t *testing.T) {
 		fmt.Fprint(w, `[{"id":17,"node_id":"PVTI_node"}]`)
 	})
 
-	opts := &ListProjectItemsOptions{ListProjectsOptions: ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{After: ("2"), Before: ("1"), PerPage: (50)}, Query: ("status:open")}, Fields: []int64{10, 11}}
+	opts := &ListProjectItemsOptions{ListProjectsOptions: ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{After: "2", Before: "1", PerPage: 50}, Query: "status:open"}, Fields: []int64{10, 11}}
 	ctx := t.Context()
 	items, _, err := client.Projects.ListOrganizationProjectItems(ctx, "o", 1, opts)
 	if err != nil {
@@ -590,7 +590,7 @@ func TestProjectsService_ListOrganizationProjectItems(t *testing.T) {
 	})
 
 	ctxBypass := context.WithValue(ctx, BypassRateLimitCheck, true)
-	if _, _, err = client.Projects.ListOrganizationProjectItems(ctxBypass, "o", 1, &ListProjectItemsOptions{ListProjectsOptions: ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{Before: ("b"), After: ("a")}}}); err != nil {
+	if _, _, err = client.Projects.ListOrganizationProjectItems(ctxBypass, "o", 1, &ListProjectItemsOptions{ListProjectsOptions: ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{Before: "b", After: "a"}}}); err != nil {
 		t.Fatalf("unexpected error when both before/after set: %v", err)
 	}
 }
@@ -827,7 +827,7 @@ func TestProjectsService_ListUserProjectItems(t *testing.T) {
 		fmt.Fprint(w, `[{"id":7,"node_id":"PVTI_user"}]`)
 	})
 	ctx := t.Context()
-	items, _, err := client.Projects.ListUserProjectItems(ctx, "u", 2, &ListProjectItemsOptions{ListProjectsOptions: ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{PerPage: (20)}, Query: ("type:issue")}})
+	items, _, err := client.Projects.ListUserProjectItems(ctx, "u", 2, &ListProjectItemsOptions{ListProjectsOptions: ListProjectsOptions{ListProjectsPaginationOptions: ListProjectsPaginationOptions{PerPage: 20}, Query: "type:issue"}})
 	if err != nil {
 		t.Fatalf("ListUserProjectItems error: %v", err)
 	}

--- a/tools/metadata/main_test.go
+++ b/tools/metadata/main_test.go
@@ -78,7 +78,8 @@ func TestUpdateOpenAPI(t *testing.T) {
 							URL: "https://docs.github.com/rest/reference/a",
 						},
 					},
-				})),
+				}),
+			),
 		},
 		"ghec/ghec.json": openapi3.T{
 			Paths: openapi3.NewPaths(
@@ -88,7 +89,8 @@ func TestUpdateOpenAPI(t *testing.T) {
 							URL: "https://docs.github.com/rest/reference/a",
 						},
 					},
-				})),
+				}),
+			),
 		},
 		"ghes-3.9/ghes-3.9.json": openapi3.T{
 			Paths: openapi3.NewPaths(
@@ -98,7 +100,8 @@ func TestUpdateOpenAPI(t *testing.T) {
 							URL: "https://docs.github.com/rest/reference/a",
 						},
 					},
-				})),
+				}),
+			),
 		},
 		"ghes-3.10/ghes-3.10.json": openapi3.T{
 			Paths: openapi3.NewPaths(
@@ -108,7 +111,8 @@ func TestUpdateOpenAPI(t *testing.T) {
 							URL: "https://docs.github.com/rest/reference/a",
 						},
 					},
-				})),
+				}),
+			),
 		},
 		"ghes-2.22/ghes-2.22.json": openapi3.T{
 			Paths: openapi3.NewPaths(
@@ -118,7 +122,8 @@ func TestUpdateOpenAPI(t *testing.T) {
 							URL: "https://docs.github.com/rest/reference/a",
 						},
 					},
-				})),
+				}),
+			),
 		},
 	})
 


### PR DESCRIPTION
This should fix panics found in golang-ci-lint such as the ones here:
https://github.com/google/go-github/actions/runs/32389013094