### PR TITLE
refactor!: Pass `PendingDeploymentsRequest` and `ReviewCustomDeploymentProtectionRuleRequest` by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -233,7 +233,6 @@ linters:
             - Organization
             - PagesUpdate
             - PagesUpdateWithoutCNAME
-            - PendingDeploymentsRequest
             - ProtectionRequest
             - PublishCodespaceOptions
             - PullRequestBranchUpdateOptions
@@ -246,7 +245,6 @@ linters:
             - RepositoryContentFileOptions
             - RepositoryCreateForkOptions
             - RequiredStatusChecksRequest
-            - ReviewCustomDeploymentProtectionRuleRequest
             - SCIMUserAttributes
             - SecretScanningAlertUpdateOptions
             - SecretScanningPatternConfigsUpdateOptions

--- a/github/actions_workflow_runs.go
+++ b/github/actions_workflow_runs.go
@@ -511,7 +511,7 @@ func (s *ActionsService) GetPendingDeployments(ctx context.Context, owner, repo 
 // GitHub API docs: https://docs.github.com/rest/actions/workflow-runs?apiVersion=2022-11-28#review-pending-deployments-for-a-workflow-run
 //
 //meta:operation POST /repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments
-func (s *ActionsService) PendingDeployments(ctx context.Context, owner, repo string, runID int64, body *PendingDeploymentsRequest) ([]*Deployment, *Response, error) {
+func (s *ActionsService) PendingDeployments(ctx context.Context, owner, repo string, runID int64, body PendingDeploymentsRequest) ([]*Deployment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/pending_deployments", owner, repo, runID)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
@@ -534,7 +534,7 @@ func (s *ActionsService) PendingDeployments(ctx context.Context, owner, repo str
 // GitHub API docs: https://docs.github.com/rest/actions/workflow-runs?apiVersion=2022-11-28#review-custom-deployment-protection-rules-for-a-workflow-run
 //
 //meta:operation POST /repos/{owner}/{repo}/actions/runs/{run_id}/deployment_protection_rule
-func (s *ActionsService) ReviewCustomDeploymentProtectionRule(ctx context.Context, owner, repo string, runID int64, body *ReviewCustomDeploymentProtectionRuleRequest) (*Response, error) {
+func (s *ActionsService) ReviewCustomDeploymentProtectionRule(ctx context.Context, owner, repo string, runID int64, body ReviewCustomDeploymentProtectionRuleRequest) (*Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/actions/runs/%v/deployment_protection_rule", owner, repo, runID)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)

--- a/github/actions_workflow_runs_test.go
+++ b/github/actions_workflow_runs_test.go
@@ -811,18 +811,18 @@ func TestActionsService_ReviewCustomDeploymentProtectionRule(t *testing.T) {
 	}
 
 	ctx := t.Context()
-	if _, err := client.Actions.ReviewCustomDeploymentProtectionRule(ctx, "o", "r", 9444496, &request); err != nil {
+	if _, err := client.Actions.ReviewCustomDeploymentProtectionRule(ctx, "o", "r", 9444496, request); err != nil {
 		t.Errorf("ReviewCustomDeploymentProtectionRule returned error: %v", err)
 	}
 
 	const methodName = "ReviewCustomDeploymentProtectionRule"
 	testBadOptions(t, methodName, func() (err error) {
-		_, err = client.Actions.ReviewCustomDeploymentProtectionRule(ctx, "\n", "\n", 9444496, &request)
+		_, err = client.Actions.ReviewCustomDeploymentProtectionRule(ctx, "\n", "\n", 9444496, request)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		return client.Actions.ReviewCustomDeploymentProtectionRule(ctx, "o", "r", 9444496, &request)
+		return client.Actions.ReviewCustomDeploymentProtectionRule(ctx, "o", "r", 9444496, request)
 	})
 }
 
@@ -898,7 +898,7 @@ func TestActionsService_PendingDeployments(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &PendingDeploymentsRequest{EnvironmentIDs: []int64{3, 4}, State: "approved", Comment: ""}
+	input := PendingDeploymentsRequest{EnvironmentIDs: []int64{3, 4}, State: "approved", Comment: ""}
 
 	mux.HandleFunc("/repos/o/r/actions/runs/399444496/pending_deployments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")


### PR DESCRIPTION
Continues the request-body-by-value work in #3644, this time for the two deployment-review endpoints on `ActionsService`.

`PendingDeploymentsRequest` and `ReviewCustomDeploymentProtectionRuleRequest` were already correctly shaped — every field is a required non-pointer with no `omitempty`, and both already use the `Request` suffix — so the pointer parameter was the only defect. Both are now passed by value and removed from the `body-allowed-pointer-types` allowlist; no type or field changes.

BREAKING CHANGE: `ActionsService.PendingDeployments` and `ActionsService.ReviewCustomDeploymentProtectionRule` now take `PendingDeploymentsRequest` and `ReviewCustomDeploymentProtectionRuleRequest` by value instead of by pointer.

cc @JamBalaya56562 @ManavSharma142 @stevehipwell