### PR TITLE
chore: Remove stale `paramcheck` allowlist entries

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -203,7 +203,6 @@ linters:
           # Body type names exempt from the "pass by value, not by pointer" rule.
           # TODO: fix and remove these exceptions.
           body-allowed-pointer-types:
-            - ActionsVariable
             - AddProjectItemOptions
             - AuthorizationRequest
             - CodeScanningAlertState
@@ -218,7 +217,6 @@ linters:
             - CustomDeploymentProtectionRuleRequest
             - CustomProperty
             - DependabotAlertState
-            - DependabotEncryptedSecret
             - DependencyGraphSnapshot
             - EncryptedSecret
             - EnterpriseSecurityAnalysisSettings


### PR DESCRIPTION
Follow-up to #4346 and #4348.

Those PRs converted the actions-variable and dependabot-secret request bodies to pass by value, which were the only places `ActionsVariable` and `DependabotEncryptedSecret` were used as request bodies. Their entries in the `paramcheck` `body-allowed-pointer-types` allowlist became dead but weren't removed — #4348 dropped that type's `structfield` entries but not its `paramcheck` one.