### PR TITLE
refactor!: Split `Key` request bodies into `CreateDeployKeyRequest`, `CreateUserKeyRequest` and `CreateSSHSigningKeyRequest` and pass by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -227,7 +227,6 @@ linters:
             - InstallationTokenListRepoOptions
             - InstallationTokenOptions
             - IssueImportRequest
-            - Key
             - LockIssueOptions
             - MaintenanceOptions
             - Organization

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -22350,6 +22350,14 @@ func (k *Key) GetCreatedAt() Timestamp {
 	return *k.CreatedAt
 }
 
+// GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
+func (k *Key) GetEnabled() bool {
+	if k == nil || k.Enabled == nil {
+		return false
+	}
+	return *k.Enabled
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (k *Key) GetID() int64 {
 	if k == nil || k.ID == nil {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11414,6 +11414,30 @@ func (c *CreateCustomRepoRoleRequest) GetPermissions() []string {
 	return c.Permissions
 }
 
+// GetKey returns the Key field.
+func (c *CreateDeployKeyRequest) GetKey() string {
+	if c == nil {
+		return ""
+	}
+	return c.Key
+}
+
+// GetReadOnly returns the ReadOnly field if it's non-nil, zero value otherwise.
+func (c *CreateDeployKeyRequest) GetReadOnly() bool {
+	if c == nil || c.ReadOnly == nil {
+		return false
+	}
+	return *c.ReadOnly
+}
+
+// GetTitle returns the Title field if it's non-nil, zero value otherwise.
+func (c *CreateDeployKeyRequest) GetTitle() string {
+	if c == nil || c.Title == nil {
+		return ""
+	}
+	return *c.Title
+}
+
 // GetName returns the Name field.
 func (c *CreateDeploymentBranchPolicyRequest) GetName() string {
 	if c == nil {
@@ -12302,6 +12326,22 @@ func (c *CreateRunnerGroupRequest) GetVisibility() string {
 	return *c.Visibility
 }
 
+// GetKey returns the Key field.
+func (c *CreateSSHSigningKeyRequest) GetKey() string {
+	if c == nil {
+		return ""
+	}
+	return c.Key
+}
+
+// GetTitle returns the Title field if it's non-nil, zero value otherwise.
+func (c *CreateSSHSigningKeyRequest) GetTitle() string {
+	if c == nil || c.Title == nil {
+		return ""
+	}
+	return *c.Title
+}
+
 // GetMessage returns the Message field.
 func (c *CreateTag) GetMessage() string {
 	if c == nil {
@@ -12460,6 +12500,22 @@ func (c *CreateUserImpersonationRequest) GetScopes() []string {
 		return nil
 	}
 	return c.Scopes
+}
+
+// GetKey returns the Key field.
+func (c *CreateUserKeyRequest) GetKey() string {
+	if c == nil {
+		return ""
+	}
+	return c.Key
+}
+
+// GetTitle returns the Title field if it's non-nil, zero value otherwise.
+func (c *CreateUserKeyRequest) GetTitle() string {
+	if c == nil || c.Title == nil {
+		return ""
+	}
+	return *c.Title
 }
 
 // GetEmail returns the Email field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -28099,6 +28099,17 @@ func TestKey_GetCreatedAt(tt *testing.T) {
 	k.GetCreatedAt()
 }
 
+func TestKey_GetEnabled(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	k := &Key{Enabled: &zeroValue}
+	k.GetEnabled()
+	k = &Key{}
+	k.GetEnabled()
+	k = nil
+	k.GetEnabled()
+}
+
 func TestKey_GetID(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int64

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -14454,6 +14454,36 @@ func TestCreateCustomRepoRoleRequest_GetPermissions(tt *testing.T) {
 	c.GetPermissions()
 }
 
+func TestCreateDeployKeyRequest_GetKey(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateDeployKeyRequest{}
+	c.GetKey()
+	c = nil
+	c.GetKey()
+}
+
+func TestCreateDeployKeyRequest_GetReadOnly(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	c := &CreateDeployKeyRequest{ReadOnly: &zeroValue}
+	c.GetReadOnly()
+	c = &CreateDeployKeyRequest{}
+	c.GetReadOnly()
+	c = nil
+	c.GetReadOnly()
+}
+
+func TestCreateDeployKeyRequest_GetTitle(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateDeployKeyRequest{Title: &zeroValue}
+	c.GetTitle()
+	c = &CreateDeployKeyRequest{}
+	c.GetTitle()
+	c = nil
+	c.GetTitle()
+}
+
 func TestCreateDeploymentBranchPolicyRequest_GetName(tt *testing.T) {
 	tt.Parallel()
 	c := &CreateDeploymentBranchPolicyRequest{}
@@ -15588,6 +15618,25 @@ func TestCreateRunnerGroupRequest_GetVisibility(tt *testing.T) {
 	c.GetVisibility()
 }
 
+func TestCreateSSHSigningKeyRequest_GetKey(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateSSHSigningKeyRequest{}
+	c.GetKey()
+	c = nil
+	c.GetKey()
+}
+
+func TestCreateSSHSigningKeyRequest_GetTitle(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateSSHSigningKeyRequest{Title: &zeroValue}
+	c.GetTitle()
+	c = &CreateSSHSigningKeyRequest{}
+	c.GetTitle()
+	c = nil
+	c.GetTitle()
+}
+
 func TestCreateTag_GetMessage(tt *testing.T) {
 	tt.Parallel()
 	c := &CreateTag{}
@@ -15785,6 +15834,25 @@ func TestCreateUserImpersonationRequest_GetScopes(tt *testing.T) {
 	c.GetScopes()
 	c = nil
 	c.GetScopes()
+}
+
+func TestCreateUserKeyRequest_GetKey(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateUserKeyRequest{}
+	c.GetKey()
+	c = nil
+	c.GetKey()
+}
+
+func TestCreateUserKeyRequest_GetTitle(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateUserKeyRequest{Title: &zeroValue}
+	c.GetTitle()
+	c = &CreateUserKeyRequest{}
+	c.GetTitle()
+	c = nil
+	c.GetTitle()
 }
 
 func TestCreateUserRequest_GetEmail(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1044,12 +1044,13 @@ func TestKey_String(t *testing.T) {
 		URL:       Ptr(""),
 		Title:     Ptr(""),
 		ReadOnly:  Ptr(false),
+		Enabled:   Ptr(false),
 		Verified:  Ptr(false),
 		CreatedAt: &Timestamp{},
 		AddedBy:   Ptr(""),
 		LastUsed:  &Timestamp{},
 	}
-	want := `github.Key{ID:0, Key:"", URL:"", Title:"", ReadOnly:false, Verified:false, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, AddedBy:"", LastUsed:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}`
+	want := `github.Key{ID:0, Key:"", URL:"", Title:"", ReadOnly:false, Enabled:false, Verified:false, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, AddedBy:"", LastUsed:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}}`
 	if got := v.String(); got != want {
 		t.Errorf("Key.String = %v, want %v", got, want)
 	}

--- a/github/repos_keys.go
+++ b/github/repos_keys.go
@@ -60,12 +60,19 @@ func (s *RepositoriesService) GetKey(ctx context.Context, owner, repo string, id
 	return key, resp, nil
 }
 
+// CreateDeployKeyRequest represents a request to create a deploy key.
+type CreateDeployKeyRequest struct {
+	Title    *string `json:"title,omitempty"`
+	Key      string  `json:"key"`
+	ReadOnly *bool   `json:"read_only,omitempty"`
+}
+
 // CreateKey adds a deploy key for a repository.
 //
 // GitHub API docs: https://docs.github.com/rest/deploy-keys/deploy-keys?apiVersion=2022-11-28#create-a-deploy-key
 //
 //meta:operation POST /repos/{owner}/{repo}/keys
-func (s *RepositoriesService) CreateKey(ctx context.Context, owner, repo string, body *Key) (*Key, *Response, error) {
+func (s *RepositoriesService) CreateKey(ctx context.Context, owner, repo string, body CreateDeployKeyRequest) (*Key, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/keys", owner, repo)
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)

--- a/github/repos_keys_test.go
+++ b/github/repos_keys_test.go
@@ -107,7 +107,7 @@ func TestRepositoriesService_CreateKey(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &Key{Key: Ptr("k"), Title: Ptr("t")}
+	input := CreateDeployKeyRequest{Key: "k", Title: Ptr("t")}
 
 	mux.HandleFunc("/repos/o/r/keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -146,7 +146,7 @@ func TestRepositoriesService_CreateKey_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Repositories.CreateKey(ctx, "%", "%", nil)
+	_, _, err := client.Repositories.CreateKey(ctx, "%", "%", CreateDeployKeyRequest{})
 	testURLParseError(t, err)
 }
 

--- a/github/users_keys.go
+++ b/github/users_keys.go
@@ -17,6 +17,7 @@ type Key struct {
 	URL       *string    `json:"url,omitempty"`
 	Title     *string    `json:"title,omitempty"`
 	ReadOnly  *bool      `json:"read_only,omitempty"`
+	Enabled   *bool      `json:"enabled,omitempty"`
 	Verified  *bool      `json:"verified,omitempty"`
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 	AddedBy   *string    `json:"added_by,omitempty"`

--- a/github/users_keys.go
+++ b/github/users_keys.go
@@ -27,6 +27,13 @@ func (k Key) String() string {
 	return Stringify(k)
 }
 
+// CreateUserKeyRequest represents a request to create a public SSH key for the
+// authenticated user.
+type CreateUserKeyRequest struct {
+	Title *string `json:"title,omitempty"`
+	Key   string  `json:"key"`
+}
+
 // ListKeys lists the verified public keys for a user. Passing the empty
 // string will fetch keys for the authenticated user.
 //
@@ -89,7 +96,7 @@ func (s *UsersService) GetKey(ctx context.Context, id int64) (*Key, *Response, e
 // GitHub API docs: https://docs.github.com/rest/users/keys?apiVersion=2022-11-28#create-a-public-ssh-key-for-the-authenticated-user
 //
 //meta:operation POST /user/keys
-func (s *UsersService) CreateKey(ctx context.Context, body *Key) (*Key, *Response, error) {
+func (s *UsersService) CreateKey(ctx context.Context, body CreateUserKeyRequest) (*Key, *Response, error) {
 	u := "user/keys"
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)

--- a/github/users_keys_test.go
+++ b/github/users_keys_test.go
@@ -119,7 +119,7 @@ func TestUsersService_CreateKey(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &Key{Key: Ptr("k"), Title: Ptr("t")}
+	input := CreateUserKeyRequest{Key: "k", Title: Ptr("t")}
 
 	mux.HandleFunc("/user/keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/github/users_ssh_signing_keys.go
+++ b/github/users_ssh_signing_keys.go
@@ -22,6 +22,13 @@ func (k SSHSigningKey) String() string {
 	return Stringify(k)
 }
 
+// CreateSSHSigningKeyRequest represents a request to create an SSH signing key
+// for the authenticated user.
+type CreateSSHSigningKeyRequest struct {
+	Title *string `json:"title,omitempty"`
+	Key   string  `json:"key"`
+}
+
 // ListSSHSigningKeys lists the SSH signing keys for a user. Passing an empty
 // username string will fetch SSH signing keys for the authenticated user.
 //
@@ -84,7 +91,7 @@ func (s *UsersService) GetSSHSigningKey(ctx context.Context, id int64) (*SSHSign
 // GitHub API docs: https://docs.github.com/rest/users/ssh-signing-keys?apiVersion=2022-11-28#create-a-ssh-signing-key-for-the-authenticated-user
 //
 //meta:operation POST /user/ssh_signing_keys
-func (s *UsersService) CreateSSHSigningKey(ctx context.Context, body *Key) (*SSHSigningKey, *Response, error) {
+func (s *UsersService) CreateSSHSigningKey(ctx context.Context, body CreateSSHSigningKeyRequest) (*SSHSigningKey, *Response, error) {
 	u := "user/ssh_signing_keys"
 
 	req, err := s.client.NewRequest(ctx, "POST", u, body)

--- a/github/users_ssh_signing_keys_test.go
+++ b/github/users_ssh_signing_keys_test.go
@@ -119,7 +119,7 @@ func TestUsersService_CreateSSHSigningKey(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &Key{Key: Ptr("k"), Title: Ptr("t")}
+	input := CreateSSHSigningKeyRequest{Key: "k", Title: Ptr("t")}
 
 	mux.HandleFunc("/user/ssh_signing_keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -138,9 +138,9 @@ func TestUsersService_CreateSSHSigningKey(t *testing.T) {
 		t.Errorf("Users.CreateSSHSigningKey returned %+v, want %+v", key, want)
 	}
 
-	const methodName = "CreateKey"
+	const methodName = "CreateSSHSigningKey"
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		got, resp, err := client.Users.CreateKey(ctx, input)
+		got, resp, err := client.Users.CreateSSHSigningKey(ctx, input)
 		if got != nil {
 			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
 		}

--- a/test/integration/users_test.go
+++ b/test/integration/users_test.go
@@ -180,9 +180,9 @@ func TestUsers_Keys(t *testing.T) {
 	}
 
 	// Add new key
-	_, _, err = client.Users.CreateKey(t.Context(), &github.Key{
+	_, _, err = client.Users.CreateKey(t.Context(), github.CreateUserKeyRequest{
 		Title: github.Ptr("go-github test key"),
-		Key:   &key,
+		Key:   key,
 	})
 	if err != nil {
 		t.Fatalf("Users.CreateKey() returned error: %v", err)


### PR DESCRIPTION
Continues the request-body-by-value work in #3644, this time for the three key-creation endpoints that shared the `Key` **response** type as their request body.

Per the docs, each endpoint accepts only a small request schema — the other six `Key` fields (`id`, `url`, `verified`, `created_at`, `added_by`, `last_used`) are server-generated — and the schemas differ per resource:

| Method | Endpoint | `key` | `title` | `read_only` |
|---|---|---|---|---|
| `RepositoriesService.CreateKey` | [Create a deploy key](https://docs.github.com/en/rest/deploy-keys/deploy-keys?apiVersion=2022-11-28#create-a-deploy-key) | **required** | optional | optional |
| `UsersService.CreateKey` | [Create a public SSH key](https://docs.github.com/en/rest/users/keys?apiVersion=2022-11-28#create-a-public-ssh-key-for-the-authenticated-user) | **required** | optional | — |
| `UsersService.CreateSSHSigningKey` | [Create a SSH signing key](https://docs.github.com/en/rest/users/ssh-signing-keys?apiVersion=2022-11-28#create-a-ssh-signing-key-for-the-authenticated-user) | **required** | optional | — |

So this splits the body into three per-resource request types — `CreateDeployKeyRequest` (with `ReadOnly`), `CreateUserKeyRequest` and `CreateSSHSigningKeyRequest` — following the same approach as #4406/#4425/#4432/#4434/#4444. `Key` is a non-pointer `string` in all three since it's required everywhere. The methods keep their names (the `Create` verb already matches the docs, and renaming only the create methods would break consistency with the surrounding `Get`/`List`/`DeleteKey` families).

Also fixed in passing, since the signature change touches the exact lines: the failure case in `TestUsersService_CreateSSHSigningKey` had a pre-existing copy-paste bug — it called `Users.CreateKey` (a different method) with `methodName = "CreateKey"`; it now exercises `CreateSSHSigningKey` as intended.

Notes:

- The `Key` response type is unchanged — it stays the response for `ListKeys`/`GetKey`/both create methods, so its fields keep pointer semantics. `SSHSigningKey` is untouched.
- `test/integration/users_test.go` builds under the root module with `-tags integration`, so its `Users.CreateKey` call is updated too (verified with `go vet -tags integration`).

Verified with `go build ./...`, `go vet -tags integration ./test/integration/`, `gofmt`, the full `./github/` test suite (all three methods and the seven generated accessors at 100%), and `custom-gcl` (no `paramcheck` findings after removing the allowlist entry).

Updates #3644

BREAKING CHANGE: RepositoriesService.CreateKey, UsersService.CreateKey and UsersService.CreateSSHSigningKey now take new CreateDeployKeyRequest, CreateUserKeyRequest and CreateSSHSigningKeyRequest (with non-pointer Key) by value instead of *Key.

cc @jvm986 — flagging for #3644 coordination; this covers the `Key` type (repos/users key endpoints), so it doesn't overlap with #4475.
