### PR TITLE
feat: Add Copilot AI credits and adoption phase metrics

### DIFF
--- a/github/copilot.go
+++ b/github/copilot.go
@@ -1024,6 +1024,44 @@ type CopilotMetricsThirdPartyAgent struct {
 	SessionCount                  *int   `json:"session_count,omitempty"`
 }
 
+// CopilotMetricsAIAdoptionPhase represents a user's AI adoption phase classification
+// in a Copilot usage metrics report.
+//
+// Phase assignment uses a trailing 28-day engagement window and may change day to day.
+// Version identifies the classification model (for example, "v1").
+//
+// GitHub API docs: https://docs.github.com/en/copilot/reference/copilot-usage-metrics/copilot-usage-metrics#ai-adoption-phase-fields
+type CopilotMetricsAIAdoptionPhase struct {
+	PhaseNumber int    `json:"phase_number"`
+	Phase       string `json:"phase"`
+	Version     string `json:"version"`
+}
+
+// CopilotMetricsAIAdoptionPhaseTotals represents aggregated per-phase averages in an
+// enterprise or organization Copilot usage metrics report.
+//
+// Aggregated metrics report the average per user within each phase rather than the sum,
+// except TotalEngagedUsers and TotalPullRequestsMerged.
+//
+// GitHub API docs: https://docs.github.com/en/copilot/reference/copilot-usage-metrics/copilot-usage-metrics#ai-adoption-phase-fields
+type CopilotMetricsAIAdoptionPhaseTotals struct {
+	Phase                               string   `json:"phase"`
+	PhaseNumber                         int      `json:"phase_number"`
+	TotalEngagedUsers                   *int     `json:"total_engaged_users,omitempty"`
+	AvgUserInitiatedInteractions        *float64 `json:"avg_user_initiated_interactions,omitempty"`
+	AvgCodeGenerationActivities         *float64 `json:"avg_code_generation_activities,omitempty"`
+	AvgCodeAcceptanceActivities         *float64 `json:"avg_code_acceptance_activities,omitempty"`
+	AvgLOCAdded                         *float64 `json:"avg_loc_added,omitempty"`
+	AvgLOCDeleted                       *float64 `json:"avg_loc_deleted,omitempty"`
+	AvgPullRequestsReviewed             *float64 `json:"avg_pull_requests_reviewed,omitempty"`
+	AvgPullRequestsCreated              *float64 `json:"avg_pull_requests_created,omitempty"`
+	AvgPullRequestsMerged               *float64 `json:"avg_pull_requests_merged,omitempty"`
+	TotalPullRequestsMerged             *int     `json:"total_pull_requests_merged,omitempty"`
+	AvgPullRequestsMedianMinutesToMerge *float64 `json:"avg_pull_requests_median_minutes_to_merge,omitempty"`
+	AvgPullRequestsMinutesToReview      *float64 `json:"avg_pull_requests_minutes_to_review,omitempty"`
+	AvgPullRequestsReviewCycles         *float64 `json:"avg_pull_requests_review_cycles,omitempty"`
+}
+
 // CopilotDailyMetrics represents the payload downloaded from a 1-day Copilot usage metrics report.
 type CopilotDailyMetrics struct {
 	Day                                 string  `json:"day"`
@@ -1040,20 +1078,21 @@ type CopilotDailyMetrics struct {
 	MonthlyActiveCopilotCloudAgentUsers *int    `json:"monthly_active_copilot_cloud_agent_users,omitempty"`
 	UserInitiatedInteractionCount       *int    `json:"user_initiated_interaction_count,omitempty"`
 	CopilotMetricsChatPanel
-	CodeGenerationActivityCount *int                             `json:"code_generation_activity_count,omitempty"`
-	CodeAcceptanceActivityCount *int                             `json:"code_acceptance_activity_count,omitempty"`
-	TotalsByIDE                 []*CopilotMetricsIDE             `json:"totals_by_ide,omitempty"`
-	TotalsByFeature             []*CopilotMetricsFeature         `json:"totals_by_feature,omitempty"`
-	TotalsByLanguageFeature     []*CopilotMetricsLanguageFeature `json:"totals_by_language_feature,omitempty"`
-	TotalsByLanguageModel       []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
-	TotalsByModelFeature        []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
-	TotalsByCLI                 *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
-	TotalsBy3rdPartyAgent       []*CopilotMetricsThirdPartyAgent `json:"totals_by_3rd_party_agent,omitempty"`
-	LOCSuggestedToAddSum        *int                             `json:"loc_suggested_to_add_sum,omitempty"`
-	LOCSuggestedToDeleteSum     *int                             `json:"loc_suggested_to_delete_sum,omitempty"`
-	LOCAddedSum                 *int                             `json:"loc_added_sum,omitempty"`
-	LOCDeletedSum               *int                             `json:"loc_deleted_sum,omitempty"`
-	PullRequests                *CopilotMetricsPullRequests      `json:"pull_requests,omitempty"`
+	CodeGenerationActivityCount *int                                   `json:"code_generation_activity_count,omitempty"`
+	CodeAcceptanceActivityCount *int                                   `json:"code_acceptance_activity_count,omitempty"`
+	TotalsByIDE                 []*CopilotMetricsIDE                   `json:"totals_by_ide,omitempty"`
+	TotalsByFeature             []*CopilotMetricsFeature               `json:"totals_by_feature,omitempty"`
+	TotalsByLanguageFeature     []*CopilotMetricsLanguageFeature       `json:"totals_by_language_feature,omitempty"`
+	TotalsByLanguageModel       []*CopilotMetricsLanguageModel         `json:"totals_by_language_model,omitempty"`
+	TotalsByModelFeature        []*CopilotMetricsModelFeature          `json:"totals_by_model_feature,omitempty"`
+	TotalsByCLI                 *CopilotMetricsCLI                     `json:"totals_by_cli,omitempty"`
+	TotalsBy3rdPartyAgent       []*CopilotMetricsThirdPartyAgent       `json:"totals_by_3rd_party_agent,omitempty"`
+	TotalsByAIAdoptionPhase     []*CopilotMetricsAIAdoptionPhaseTotals `json:"totals_by_ai_adoption_phase,omitempty"`
+	LOCSuggestedToAddSum        *int                                   `json:"loc_suggested_to_add_sum,omitempty"`
+	LOCSuggestedToDeleteSum     *int                                   `json:"loc_suggested_to_delete_sum,omitempty"`
+	LOCAddedSum                 *int                                   `json:"loc_added_sum,omitempty"`
+	LOCDeletedSum               *int                                   `json:"loc_deleted_sum,omitempty"`
+	PullRequests                *CopilotMetricsPullRequests            `json:"pull_requests,omitempty"`
 }
 
 // CopilotPeriodicMetrics represents the payload downloaded from a multi-day (e.g. 28-day rolling)
@@ -1094,12 +1133,13 @@ type CopilotUserMetricsIDE struct {
 // CopilotUserDailyMetrics represents a single user's per-day Copilot usage metrics record from a
 // 1-day user metrics report. User metrics reports are served as newline-delimited JSON.
 type CopilotUserDailyMetrics struct {
-	UserID                        int     `json:"user_id"`
-	UserLogin                     string  `json:"user_login"`
-	Day                           string  `json:"day"`
-	OrganizationID                *string `json:"organization_id,omitempty"`
-	EnterpriseID                  *string `json:"enterprise_id,omitempty"`
-	UserInitiatedInteractionCount *int    `json:"user_initiated_interaction_count,omitempty"`
+	UserID                        int      `json:"user_id"`
+	UserLogin                     string   `json:"user_login"`
+	Day                           string   `json:"day"`
+	OrganizationID                *string  `json:"organization_id,omitempty"`
+	EnterpriseID                  *string  `json:"enterprise_id,omitempty"`
+	AICreditsUsed                 *float64 `json:"ai_credits_used,omitempty"`
+	UserInitiatedInteractionCount *int     `json:"user_initiated_interaction_count,omitempty"`
 	CopilotMetricsChatPanel
 	CodeGenerationActivityCount  *int                             `json:"code_generation_activity_count,omitempty"`
 	CodeAcceptanceActivityCount  *int                             `json:"code_acceptance_activity_count,omitempty"`
@@ -1110,6 +1150,7 @@ type CopilotUserDailyMetrics struct {
 	TotalsByModelFeature         []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
 	TotalsByCLI                  *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
 	TotalsBy3rdPartyAgent        []*CopilotMetricsThirdPartyAgent `json:"totals_by_3rd_party_agent,omitempty"`
+	AIAdoptionPhase              *CopilotMetricsAIAdoptionPhase   `json:"ai_adoption_phase,omitempty"`
 	UsedAgent                    *bool                            `json:"used_agent,omitempty"`
 	UsedChat                     *bool                            `json:"used_chat,omitempty"`
 	UsedCLI                      *bool                            `json:"used_cli,omitempty"`
@@ -1126,14 +1167,15 @@ type CopilotUserDailyMetrics struct {
 // multi-day (e.g. 28-day rolling) user metrics report. User metrics reports are served as
 // newline-delimited JSON.
 type CopilotUserPeriodicMetrics struct {
-	ReportStartDay                string  `json:"report_start_day"`
-	ReportEndDay                  string  `json:"report_end_day"`
-	Day                           string  `json:"day"`
-	OrganizationID                *string `json:"organization_id,omitempty"`
-	EnterpriseID                  *string `json:"enterprise_id,omitempty"`
-	UserID                        int     `json:"user_id"`
-	UserLogin                     string  `json:"user_login"`
-	UserInitiatedInteractionCount *int    `json:"user_initiated_interaction_count,omitempty"`
+	ReportStartDay                string   `json:"report_start_day"`
+	ReportEndDay                  string   `json:"report_end_day"`
+	Day                           string   `json:"day"`
+	OrganizationID                *string  `json:"organization_id,omitempty"`
+	EnterpriseID                  *string  `json:"enterprise_id,omitempty"`
+	UserID                        int      `json:"user_id"`
+	UserLogin                     string   `json:"user_login"`
+	AICreditsUsed                 *float64 `json:"ai_credits_used,omitempty"`
+	UserInitiatedInteractionCount *int     `json:"user_initiated_interaction_count,omitempty"`
 	CopilotMetricsChatPanel
 	CodeGenerationActivityCount  *int                             `json:"code_generation_activity_count,omitempty"`
 	CodeAcceptanceActivityCount  *int                             `json:"code_acceptance_activity_count,omitempty"`
@@ -1144,6 +1186,7 @@ type CopilotUserPeriodicMetrics struct {
 	TotalsByModelFeature         []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
 	TotalsByCLI                  *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
 	TotalsBy3rdPartyAgent        []*CopilotMetricsThirdPartyAgent `json:"totals_by_3rd_party_agent,omitempty"`
+	AIAdoptionPhase              *CopilotMetricsAIAdoptionPhase   `json:"ai_adoption_phase,omitempty"`
 	UsedAgent                    *bool                            `json:"used_agent,omitempty"`
 	UsedChat                     *bool                            `json:"used_chat,omitempty"`
 	UsedCLI                      *bool                            `json:"used_cli,omitempty"`

--- a/github/copilot.go
+++ b/github/copilot.go
@@ -1045,21 +1045,21 @@ type CopilotMetricsAIAdoptionPhase struct {
 //
 // GitHub API docs: https://docs.github.com/en/copilot/reference/copilot-usage-metrics/copilot-usage-metrics#ai-adoption-phase-fields
 type CopilotMetricsAIAdoptionPhaseTotals struct {
-	Phase                               string   `json:"phase"`
-	PhaseNumber                         int      `json:"phase_number"`
-	TotalEngagedUsers                   *int     `json:"total_engaged_users,omitempty"`
-	AvgUserInitiatedInteractions        *float64 `json:"avg_user_initiated_interactions,omitempty"`
-	AvgCodeGenerationActivities         *float64 `json:"avg_code_generation_activities,omitempty"`
-	AvgCodeAcceptanceActivities         *float64 `json:"avg_code_acceptance_activities,omitempty"`
-	AvgLOCAdded                         *float64 `json:"avg_loc_added,omitempty"`
-	AvgLOCDeleted                       *float64 `json:"avg_loc_deleted,omitempty"`
-	AvgPullRequestsReviewed             *float64 `json:"avg_pull_requests_reviewed,omitempty"`
-	AvgPullRequestsCreated              *float64 `json:"avg_pull_requests_created,omitempty"`
-	AvgPullRequestsMerged               *float64 `json:"avg_pull_requests_merged,omitempty"`
-	TotalPullRequestsMerged             *int     `json:"total_pull_requests_merged,omitempty"`
-	AvgPullRequestsMedianMinutesToMerge *float64 `json:"avg_pull_requests_median_minutes_to_merge,omitempty"`
-	AvgPullRequestsMinutesToReview      *float64 `json:"avg_pull_requests_minutes_to_review,omitempty"`
-	AvgPullRequestsReviewCycles         *float64 `json:"avg_pull_requests_review_cycles,omitempty"`
+	Phase                               string  `json:"phase"`
+	PhaseNumber                         int     `json:"phase_number"`
+	TotalEngagedUsers                   int     `json:"total_engaged_users"`
+	AvgUserInitiatedInteractions        float64 `json:"avg_user_initiated_interactions"`
+	AvgCodeGenerationActivities         float64 `json:"avg_code_generation_activities"`
+	AvgCodeAcceptanceActivities         float64 `json:"avg_code_acceptance_activities"`
+	AvgLOCAdded                         float64 `json:"avg_loc_added"`
+	AvgLOCDeleted                       float64 `json:"avg_loc_deleted"`
+	AvgPullRequestsReviewed             float64 `json:"avg_pull_requests_reviewed"`
+	AvgPullRequestsCreated              float64 `json:"avg_pull_requests_created"`
+	AvgPullRequestsMerged               float64 `json:"avg_pull_requests_merged"`
+	TotalPullRequestsMerged             int     `json:"total_pull_requests_merged"`
+	AvgPullRequestsMedianMinutesToMerge float64 `json:"avg_pull_requests_median_minutes_to_merge"`
+	AvgPullRequestsMinutesToReview      float64 `json:"avg_pull_requests_minutes_to_review"`
+	AvgPullRequestsReviewCycles         float64 `json:"avg_pull_requests_review_cycles"`
 }
 
 // CopilotDailyMetrics represents the payload downloaded from a 1-day Copilot usage metrics report.

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -3072,6 +3072,25 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 					"session_count": 3
 				}
 			],
+			"totals_by_ai_adoption_phase": [
+				{
+					"phase": "Phase 1",
+					"phase_number": 1,
+					"total_engaged_users": 4,
+					"avg_user_initiated_interactions": 1.5,
+					"avg_code_generation_activities": 2.0,
+					"avg_code_acceptance_activities": 1.0,
+					"avg_loc_added": 22.0,
+					"avg_loc_deleted": 0.0,
+					"avg_pull_requests_reviewed": 0.5,
+					"avg_pull_requests_created": 1.0,
+					"avg_pull_requests_merged": 1.0,
+					"total_pull_requests_merged": 4,
+					"avg_pull_requests_median_minutes_to_merge": 2.5,
+					"avg_pull_requests_minutes_to_review": 1.5,
+					"avg_pull_requests_review_cycles": 1.0
+				}
+			],
 			"loc_added_sum": 100,
 			"pull_requests": {
 				"total_reviewed": 1,
@@ -3135,6 +3154,25 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 				AgentID:                       "claude",
 				UserInitiatedInteractionCount: Ptr(8),
 				SessionCount:                  Ptr(3),
+			},
+		},
+		TotalsByAIAdoptionPhase: []*CopilotMetricsAIAdoptionPhaseTotals{
+			{
+				Phase:                               "Phase 1",
+				PhaseNumber:                         1,
+				TotalEngagedUsers:                   Ptr(4),
+				AvgUserInitiatedInteractions:        Ptr(1.5),
+				AvgCodeGenerationActivities:         Ptr(2.0),
+				AvgCodeAcceptanceActivities:         Ptr(1.0),
+				AvgLOCAdded:                         Ptr(22.0),
+				AvgLOCDeleted:                       Ptr(0.0),
+				AvgPullRequestsReviewed:             Ptr(0.5),
+				AvgPullRequestsCreated:              Ptr(1.0),
+				AvgPullRequestsMerged:               Ptr(1.0),
+				TotalPullRequestsMerged:             Ptr(4),
+				AvgPullRequestsMedianMinutesToMerge: Ptr(2.5),
+				AvgPullRequestsMinutesToReview:      Ptr(1.5),
+				AvgPullRequestsReviewCycles:         Ptr(1.0),
 			},
 		},
 		LOCAddedSum: Ptr(100),
@@ -3284,7 +3322,7 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 
 	mux.HandleFunc("/path/to/users-daily", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"user_id":1,"user_login":"alice","day":"2026-04-01","user_initiated_interaction_count":5,"chat_panel_edit_mode":2,"used_chat":true,"used_cli":true,"used_copilot_code_review_active":true,"totals_by_cli":{"session_count":2,"request_count":2,"prompt_count":1,"last_known_cli_version":{"sampled_at":`+refTimeStr(1136178000)+`,"cli_version":"1.0.8"}},"totals_by_ide":[{"ide":"vscode","user_initiated_interaction_count":5,"last_known_plugin_version":{"sampled_at":`+refTimeStr(1136178001)+`,"plugin":"copilot","plugin_version":"1.0.0"},"last_known_ide_version":{"sampled_at":`+refTimeStr(1136178002)+`,"ide_version":"1.90"}}],"totals_by_3rd_party_agent":[{"agent_name":"Claude","agent_id":"claude","user_initiated_interaction_count":2}]}
+		fmt.Fprint(w, `{"user_id":1,"user_login":"alice","day":"2026-04-01","ai_credits_used":12.5,"user_initiated_interaction_count":5,"chat_panel_edit_mode":2,"used_chat":true,"used_cli":true,"used_copilot_code_review_active":true,"ai_adoption_phase":{"phase":"Phase 2","phase_number":2,"version":"v1"},"totals_by_cli":{"session_count":2,"request_count":2,"prompt_count":1,"last_known_cli_version":{"sampled_at":`+refTimeStr(1136178000)+`,"cli_version":"1.0.8"}},"totals_by_ide":[{"ide":"vscode","user_initiated_interaction_count":5,"last_known_plugin_version":{"sampled_at":`+refTimeStr(1136178001)+`,"plugin":"copilot","plugin_version":"1.0.0"},"last_known_ide_version":{"sampled_at":`+refTimeStr(1136178002)+`,"ide_version":"1.90"}}],"totals_by_3rd_party_agent":[{"agent_name":"Claude","agent_id":"claude","user_initiated_interaction_count":2}]}
 {"user_id":2,"user_login":"bob","day":"2026-04-01","used_agent":true,"used_copilot_code_review_passive":true}
 `)
 	})
@@ -3304,6 +3342,7 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 			UserID:                        1,
 			UserLogin:                     "alice",
 			Day:                           "2026-04-01",
+			AICreditsUsed:                 Ptr(12.5),
 			UserInitiatedInteractionCount: Ptr(5),
 			CopilotMetricsChatPanel: CopilotMetricsChatPanel{
 				ChatPanelEditMode: Ptr(2),
@@ -3311,6 +3350,11 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 			UsedChat:                    Ptr(true),
 			UsedCLI:                     Ptr(true),
 			UsedCopilotCodeReviewActive: Ptr(true),
+			AIAdoptionPhase: &CopilotMetricsAIAdoptionPhase{
+				Phase:       "Phase 2",
+				PhaseNumber: 2,
+				Version:     "v1",
+			},
 			TotalsByCLI: &CopilotMetricsCLI{
 				SessionCount: Ptr(2),
 				RequestCount: Ptr(2),
@@ -3398,7 +3442,7 @@ func TestCopilotService_DownloadUserPeriodicMetrics(t *testing.T) {
 
 	mux.HandleFunc("/path/to/users-periodic", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"report_start_day":"2026-03-05","report_end_day":"2026-04-01","day":"2026-03-05","user_id":1,"user_login":"alice","user_initiated_interaction_count":3,"used_copilot_code_review_active":true}
+		fmt.Fprint(w, `{"report_start_day":"2026-03-05","report_end_day":"2026-04-01","day":"2026-03-05","user_id":1,"user_login":"alice","ai_credits_used":3.25,"user_initiated_interaction_count":3,"used_copilot_code_review_active":true,"ai_adoption_phase":{"phase":"Phase 1","phase_number":1,"version":"v1"}}
 {"report_start_day":"2026-03-05","report_end_day":"2026-04-01","day":"2026-03-06","user_id":1,"user_login":"alice","used_cli":true,"used_copilot_code_review_passive":true,"used_copilot_coding_agent":true,"totals_by_cli":{"session_count":1,"request_count":3,"prompt_count":2,"token_usage":{"avg_tokens_per_request":1200.5,"output_tokens_sum":2400,"prompt_tokens_sum":1201}}}
 `)
 	})
@@ -3420,8 +3464,14 @@ func TestCopilotService_DownloadUserPeriodicMetrics(t *testing.T) {
 			Day:                           "2026-03-05",
 			UserID:                        1,
 			UserLogin:                     "alice",
+			AICreditsUsed:                 Ptr(3.25),
 			UserInitiatedInteractionCount: Ptr(3),
 			UsedCopilotCodeReviewActive:   Ptr(true),
+			AIAdoptionPhase: &CopilotMetricsAIAdoptionPhase{
+				Phase:       "Phase 1",
+				PhaseNumber: 1,
+				Version:     "v1",
+			},
 		},
 		{
 			ReportStartDay:               "2026-03-05",

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -3160,19 +3160,19 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 			{
 				Phase:                               "Phase 1",
 				PhaseNumber:                         1,
-				TotalEngagedUsers:                   Ptr(4),
-				AvgUserInitiatedInteractions:        Ptr(1.5),
-				AvgCodeGenerationActivities:         Ptr(2.0),
-				AvgCodeAcceptanceActivities:         Ptr(1.0),
-				AvgLOCAdded:                         Ptr(22.0),
-				AvgLOCDeleted:                       Ptr(0.0),
-				AvgPullRequestsReviewed:             Ptr(0.5),
-				AvgPullRequestsCreated:              Ptr(1.0),
-				AvgPullRequestsMerged:               Ptr(1.0),
-				TotalPullRequestsMerged:             Ptr(4),
-				AvgPullRequestsMedianMinutesToMerge: Ptr(2.5),
-				AvgPullRequestsMinutesToReview:      Ptr(1.5),
-				AvgPullRequestsReviewCycles:         Ptr(1.0),
+				TotalEngagedUsers:                   4,
+				AvgUserInitiatedInteractions:        1.5,
+				AvgCodeGenerationActivities:         2.0,
+				AvgCodeAcceptanceActivities:         1.0,
+				AvgLOCAdded:                         22.0,
+				AvgLOCDeleted:                       0.0,
+				AvgPullRequestsReviewed:             0.5,
+				AvgPullRequestsCreated:              1.0,
+				AvgPullRequestsMerged:               1.0,
+				TotalPullRequestsMerged:             4,
+				AvgPullRequestsMedianMinutesToMerge: 2.5,
+				AvgPullRequestsMinutesToReview:      1.5,
+				AvgPullRequestsReviewCycles:         1.0,
 			},
 		},
 		LOCAddedSum: Ptr(100),
@@ -3322,7 +3322,7 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 
 	mux.HandleFunc("/path/to/users-daily", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"user_id":1,"user_login":"alice","day":"2026-04-01","ai_credits_used":12.5,"user_initiated_interaction_count":5,"chat_panel_edit_mode":2,"used_chat":true,"used_cli":true,"used_copilot_code_review_active":true,"ai_adoption_phase":{"phase":"Phase 2","phase_number":2,"version":"v1"},"totals_by_cli":{"session_count":2,"request_count":2,"prompt_count":1,"last_known_cli_version":{"sampled_at":`+refTimeStr(1136178000)+`,"cli_version":"1.0.8"}},"totals_by_ide":[{"ide":"vscode","user_initiated_interaction_count":5,"last_known_plugin_version":{"sampled_at":`+refTimeStr(1136178001)+`,"plugin":"copilot","plugin_version":"1.0.0"},"last_known_ide_version":{"sampled_at":`+refTimeStr(1136178002)+`,"ide_version":"1.90"}}],"totals_by_3rd_party_agent":[{"agent_name":"Claude","agent_id":"claude","user_initiated_interaction_count":2}]}
+		fmt.Fprint(w, `{"user_id":1,"user_login":"alice","day":"2026-04-01","ai_credits_used":12.5,"user_initiated_interaction_count":5,"chat_panel_edit_mode":2,"used_chat":true,"used_cli":true,"used_copilot_code_review_active":true,"ai_adoption_phase":{"phase":"Phase 2","phase_number":2,"version":"v1"},"totals_by_cli":{"session_count":2,"request_count":2,"prompt_count":1,"last_known_cli_version":{"sampled_at":`+referenceTimeStr+`,"cli_version":"1.0.8"}},"totals_by_ide":[{"ide":"vscode","user_initiated_interaction_count":5,"last_known_plugin_version":{"sampled_at":`+referenceTimeStr+`,"plugin":"copilot","plugin_version":"1.0.0"},"last_known_ide_version":{"sampled_at":`+referenceTimeStr+`,"ide_version":"1.90"}}],"totals_by_3rd_party_agent":[{"agent_name":"Claude","agent_id":"claude","user_initiated_interaction_count":2}]}
 {"user_id":2,"user_login":"bob","day":"2026-04-01","used_agent":true,"used_copilot_code_review_passive":true}
 `)
 	})
@@ -3360,7 +3360,7 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 				RequestCount: Ptr(2),
 				PromptCount:  Ptr(1),
 				LastKnownCLIVersion: &CopilotMetricsCLIVersion{
-					SampledAt:  refTimestamp(1136178000),
+					SampledAt:  &referenceTimestamp,
 					CLIVersion: "1.0.8",
 				},
 			},
@@ -3369,12 +3369,12 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 					IDE:                           "vscode",
 					UserInitiatedInteractionCount: Ptr(5),
 					LastKnownPluginVersion: &CopilotUserMetricsPluginVersion{
-						SampledAt:     refTimestamp(1136178001),
+						SampledAt:     &referenceTimestamp,
 						Plugin:        "copilot",
 						PluginVersion: "1.0.0",
 					},
 					LastKnownIDEVersion: &CopilotUserMetricsIDEVersion{
-						SampledAt:  refTimestamp(1136178002),
+						SampledAt:  &referenceTimestamp,
 						IDEVersion: "1.90",
 					},
 				},

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9238,6 +9238,14 @@ func (c *CopilotDailyMetrics) GetTotalsBy3rdPartyAgent() []*CopilotMetricsThirdP
 	return c.TotalsBy3rdPartyAgent
 }
 
+// GetTotalsByAIAdoptionPhase returns the TotalsByAIAdoptionPhase slice if it's non-nil, nil otherwise.
+func (c *CopilotDailyMetrics) GetTotalsByAIAdoptionPhase() []*CopilotMetricsAIAdoptionPhaseTotals {
+	if c == nil || c.TotalsByAIAdoptionPhase == nil {
+		return nil
+	}
+	return c.TotalsByAIAdoptionPhase
+}
+
 // GetTotalsByCLI returns the TotalsByCLI field.
 func (c *CopilotDailyMetrics) GetTotalsByCLI() *CopilotMetricsCLI {
 	if c == nil {
@@ -9764,6 +9772,150 @@ func (c *CopilotMetrics) GetTotalEngagedUsers() int {
 		return 0
 	}
 	return *c.TotalEngagedUsers
+}
+
+// GetPhase returns the Phase field.
+func (c *CopilotMetricsAIAdoptionPhase) GetPhase() string {
+	if c == nil {
+		return ""
+	}
+	return c.Phase
+}
+
+// GetPhaseNumber returns the PhaseNumber field.
+func (c *CopilotMetricsAIAdoptionPhase) GetPhaseNumber() int {
+	if c == nil {
+		return 0
+	}
+	return c.PhaseNumber
+}
+
+// GetVersion returns the Version field.
+func (c *CopilotMetricsAIAdoptionPhase) GetVersion() string {
+	if c == nil {
+		return ""
+	}
+	return c.Version
+}
+
+// GetAvgCodeAcceptanceActivities returns the AvgCodeAcceptanceActivities field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgCodeAcceptanceActivities() float64 {
+	if c == nil || c.AvgCodeAcceptanceActivities == nil {
+		return 0
+	}
+	return *c.AvgCodeAcceptanceActivities
+}
+
+// GetAvgCodeGenerationActivities returns the AvgCodeGenerationActivities field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgCodeGenerationActivities() float64 {
+	if c == nil || c.AvgCodeGenerationActivities == nil {
+		return 0
+	}
+	return *c.AvgCodeGenerationActivities
+}
+
+// GetAvgLOCAdded returns the AvgLOCAdded field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgLOCAdded() float64 {
+	if c == nil || c.AvgLOCAdded == nil {
+		return 0
+	}
+	return *c.AvgLOCAdded
+}
+
+// GetAvgLOCDeleted returns the AvgLOCDeleted field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgLOCDeleted() float64 {
+	if c == nil || c.AvgLOCDeleted == nil {
+		return 0
+	}
+	return *c.AvgLOCDeleted
+}
+
+// GetAvgPullRequestsCreated returns the AvgPullRequestsCreated field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgPullRequestsCreated() float64 {
+	if c == nil || c.AvgPullRequestsCreated == nil {
+		return 0
+	}
+	return *c.AvgPullRequestsCreated
+}
+
+// GetAvgPullRequestsMedianMinutesToMerge returns the AvgPullRequestsMedianMinutesToMerge field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgPullRequestsMedianMinutesToMerge() float64 {
+	if c == nil || c.AvgPullRequestsMedianMinutesToMerge == nil {
+		return 0
+	}
+	return *c.AvgPullRequestsMedianMinutesToMerge
+}
+
+// GetAvgPullRequestsMerged returns the AvgPullRequestsMerged field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgPullRequestsMerged() float64 {
+	if c == nil || c.AvgPullRequestsMerged == nil {
+		return 0
+	}
+	return *c.AvgPullRequestsMerged
+}
+
+// GetAvgPullRequestsMinutesToReview returns the AvgPullRequestsMinutesToReview field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgPullRequestsMinutesToReview() float64 {
+	if c == nil || c.AvgPullRequestsMinutesToReview == nil {
+		return 0
+	}
+	return *c.AvgPullRequestsMinutesToReview
+}
+
+// GetAvgPullRequestsReviewCycles returns the AvgPullRequestsReviewCycles field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgPullRequestsReviewCycles() float64 {
+	if c == nil || c.AvgPullRequestsReviewCycles == nil {
+		return 0
+	}
+	return *c.AvgPullRequestsReviewCycles
+}
+
+// GetAvgPullRequestsReviewed returns the AvgPullRequestsReviewed field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgPullRequestsReviewed() float64 {
+	if c == nil || c.AvgPullRequestsReviewed == nil {
+		return 0
+	}
+	return *c.AvgPullRequestsReviewed
+}
+
+// GetAvgUserInitiatedInteractions returns the AvgUserInitiatedInteractions field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgUserInitiatedInteractions() float64 {
+	if c == nil || c.AvgUserInitiatedInteractions == nil {
+		return 0
+	}
+	return *c.AvgUserInitiatedInteractions
+}
+
+// GetPhase returns the Phase field.
+func (c *CopilotMetricsAIAdoptionPhaseTotals) GetPhase() string {
+	if c == nil {
+		return ""
+	}
+	return c.Phase
+}
+
+// GetPhaseNumber returns the PhaseNumber field.
+func (c *CopilotMetricsAIAdoptionPhaseTotals) GetPhaseNumber() int {
+	if c == nil {
+		return 0
+	}
+	return c.PhaseNumber
+}
+
+// GetTotalEngagedUsers returns the TotalEngagedUsers field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsAIAdoptionPhaseTotals) GetTotalEngagedUsers() int {
+	if c == nil || c.TotalEngagedUsers == nil {
+		return 0
+	}
+	return *c.TotalEngagedUsers
+}
+
+// GetTotalPullRequestsMerged returns the TotalPullRequestsMerged field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsAIAdoptionPhaseTotals) GetTotalPullRequestsMerged() int {
+	if c == nil || c.TotalPullRequestsMerged == nil {
+		return 0
+	}
+	return *c.TotalPullRequestsMerged
 }
 
 // GetChatPanelAgentMode returns the ChatPanelAgentMode field if it's non-nil, zero value otherwise.
@@ -10406,6 +10558,22 @@ func (c *CopilotSeatDetails) GetUpdatedAt() Timestamp {
 	return *c.UpdatedAt
 }
 
+// GetAIAdoptionPhase returns the AIAdoptionPhase field.
+func (c *CopilotUserDailyMetrics) GetAIAdoptionPhase() *CopilotMetricsAIAdoptionPhase {
+	if c == nil {
+		return nil
+	}
+	return c.AIAdoptionPhase
+}
+
+// GetAICreditsUsed returns the AICreditsUsed field if it's non-nil, zero value otherwise.
+func (c *CopilotUserDailyMetrics) GetAICreditsUsed() float64 {
+	if c == nil || c.AICreditsUsed == nil {
+		return 0
+	}
+	return *c.AICreditsUsed
+}
+
 // GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field if it's non-nil, zero value otherwise.
 func (c *CopilotUserDailyMetrics) GetCodeAcceptanceActivityCount() int {
 	if c == nil || c.CodeAcceptanceActivityCount == nil {
@@ -10676,6 +10844,22 @@ func (c *CopilotUserMetricsPluginVersion) GetSampledAt() Timestamp {
 		return Timestamp{}
 	}
 	return *c.SampledAt
+}
+
+// GetAIAdoptionPhase returns the AIAdoptionPhase field.
+func (c *CopilotUserPeriodicMetrics) GetAIAdoptionPhase() *CopilotMetricsAIAdoptionPhase {
+	if c == nil {
+		return nil
+	}
+	return c.AIAdoptionPhase
+}
+
+// GetAICreditsUsed returns the AICreditsUsed field if it's non-nil, zero value otherwise.
+func (c *CopilotUserPeriodicMetrics) GetAICreditsUsed() float64 {
+	if c == nil || c.AICreditsUsed == nil {
+		return 0
+	}
+	return *c.AICreditsUsed
 }
 
 // GetCodeAcceptanceActivityCount returns the CodeAcceptanceActivityCount field if it's non-nil, zero value otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9798,92 +9798,92 @@ func (c *CopilotMetricsAIAdoptionPhase) GetVersion() string {
 	return c.Version
 }
 
-// GetAvgCodeAcceptanceActivities returns the AvgCodeAcceptanceActivities field if it's non-nil, zero value otherwise.
+// GetAvgCodeAcceptanceActivities returns the AvgCodeAcceptanceActivities field.
 func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgCodeAcceptanceActivities() float64 {
-	if c == nil || c.AvgCodeAcceptanceActivities == nil {
+	if c == nil {
 		return 0
 	}
-	return *c.AvgCodeAcceptanceActivities
+	return c.AvgCodeAcceptanceActivities
 }
 
-// GetAvgCodeGenerationActivities returns the AvgCodeGenerationActivities field if it's non-nil, zero value otherwise.
+// GetAvgCodeGenerationActivities returns the AvgCodeGenerationActivities field.
 func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgCodeGenerationActivities() float64 {
-	if c == nil || c.AvgCodeGenerationActivities == nil {
+	if c == nil {
 		return 0
 	}
-	return *c.AvgCodeGenerationActivities
+	return c.AvgCodeGenerationActivities
 }
 
-// GetAvgLOCAdded returns the AvgLOCAdded field if it's non-nil, zero value otherwise.
+// GetAvgLOCAdded returns the AvgLOCAdded field.
 func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgLOCAdded() float64 {
-	if c == nil || c.AvgLOCAdded == nil {
+	if c == nil {
 		return 0
 	}
-	return *c.AvgLOCAdded
+	return c.AvgLOCAdded
 }
 
-// GetAvgLOCDeleted returns the AvgLOCDeleted field if it's non-nil, zero value otherwise.
+// GetAvgLOCDeleted returns the AvgLOCDeleted field.
 func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgLOCDeleted() float64 {
-	if c == nil || c.AvgLOCDeleted == nil {
+	if c == nil {
 		return 0
 	}
-	return *c.AvgLOCDeleted
+	return c.AvgLOCDeleted
 }
 
-// GetAvgPullRequestsCreated returns the AvgPullRequestsCreated field if it's non-nil, zero value otherwise.
+// GetAvgPullRequestsCreated returns the AvgPullRequestsCreated field.
 func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgPullRequestsCreated() float64 {
-	if c == nil || c.AvgPullRequestsCreated == nil {
+	if c == nil {
 		return 0
 	}
-	return *c.AvgPullRequestsCreated
+	return c.AvgPullRequestsCreated
 }
 
-// GetAvgPullRequestsMedianMinutesToMerge returns the AvgPullRequestsMedianMinutesToMerge field if it's non-nil, zero value otherwise.
+// GetAvgPullRequestsMedianMinutesToMerge returns the AvgPullRequestsMedianMinutesToMerge field.
 func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgPullRequestsMedianMinutesToMerge() float64 {
-	if c == nil || c.AvgPullRequestsMedianMinutesToMerge == nil {
+	if c == nil {
 		return 0
 	}
-	return *c.AvgPullRequestsMedianMinutesToMerge
+	return c.AvgPullRequestsMedianMinutesToMerge
 }
 
-// GetAvgPullRequestsMerged returns the AvgPullRequestsMerged field if it's non-nil, zero value otherwise.
+// GetAvgPullRequestsMerged returns the AvgPullRequestsMerged field.
 func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgPullRequestsMerged() float64 {
-	if c == nil || c.AvgPullRequestsMerged == nil {
+	if c == nil {
 		return 0
 	}
-	return *c.AvgPullRequestsMerged
+	return c.AvgPullRequestsMerged
 }
 
-// GetAvgPullRequestsMinutesToReview returns the AvgPullRequestsMinutesToReview field if it's non-nil, zero value otherwise.
+// GetAvgPullRequestsMinutesToReview returns the AvgPullRequestsMinutesToReview field.
 func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgPullRequestsMinutesToReview() float64 {
-	if c == nil || c.AvgPullRequestsMinutesToReview == nil {
+	if c == nil {
 		return 0
 	}
-	return *c.AvgPullRequestsMinutesToReview
+	return c.AvgPullRequestsMinutesToReview
 }
 
-// GetAvgPullRequestsReviewCycles returns the AvgPullRequestsReviewCycles field if it's non-nil, zero value otherwise.
+// GetAvgPullRequestsReviewCycles returns the AvgPullRequestsReviewCycles field.
 func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgPullRequestsReviewCycles() float64 {
-	if c == nil || c.AvgPullRequestsReviewCycles == nil {
+	if c == nil {
 		return 0
 	}
-	return *c.AvgPullRequestsReviewCycles
+	return c.AvgPullRequestsReviewCycles
 }
 
-// GetAvgPullRequestsReviewed returns the AvgPullRequestsReviewed field if it's non-nil, zero value otherwise.
+// GetAvgPullRequestsReviewed returns the AvgPullRequestsReviewed field.
 func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgPullRequestsReviewed() float64 {
-	if c == nil || c.AvgPullRequestsReviewed == nil {
+	if c == nil {
 		return 0
 	}
-	return *c.AvgPullRequestsReviewed
+	return c.AvgPullRequestsReviewed
 }
 
-// GetAvgUserInitiatedInteractions returns the AvgUserInitiatedInteractions field if it's non-nil, zero value otherwise.
+// GetAvgUserInitiatedInteractions returns the AvgUserInitiatedInteractions field.
 func (c *CopilotMetricsAIAdoptionPhaseTotals) GetAvgUserInitiatedInteractions() float64 {
-	if c == nil || c.AvgUserInitiatedInteractions == nil {
+	if c == nil {
 		return 0
 	}
-	return *c.AvgUserInitiatedInteractions
+	return c.AvgUserInitiatedInteractions
 }
 
 // GetPhase returns the Phase field.
@@ -9902,20 +9902,20 @@ func (c *CopilotMetricsAIAdoptionPhaseTotals) GetPhaseNumber() int {
 	return c.PhaseNumber
 }
 
-// GetTotalEngagedUsers returns the TotalEngagedUsers field if it's non-nil, zero value otherwise.
+// GetTotalEngagedUsers returns the TotalEngagedUsers field.
 func (c *CopilotMetricsAIAdoptionPhaseTotals) GetTotalEngagedUsers() int {
-	if c == nil || c.TotalEngagedUsers == nil {
+	if c == nil {
 		return 0
 	}
-	return *c.TotalEngagedUsers
+	return c.TotalEngagedUsers
 }
 
-// GetTotalPullRequestsMerged returns the TotalPullRequestsMerged field if it's non-nil, zero value otherwise.
+// GetTotalPullRequestsMerged returns the TotalPullRequestsMerged field.
 func (c *CopilotMetricsAIAdoptionPhaseTotals) GetTotalPullRequestsMerged() int {
-	if c == nil || c.TotalPullRequestsMerged == nil {
+	if c == nil {
 		return 0
 	}
-	return *c.TotalPullRequestsMerged
+	return c.TotalPullRequestsMerged
 }
 
 // GetChatPanelAgentMode returns the ChatPanelAgentMode field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11792,6 +11792,17 @@ func TestCopilotDailyMetrics_GetTotalsBy3rdPartyAgent(tt *testing.T) {
 	c.GetTotalsBy3rdPartyAgent()
 }
 
+func TestCopilotDailyMetrics_GetTotalsByAIAdoptionPhase(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsAIAdoptionPhaseTotals{}
+	c := &CopilotDailyMetrics{TotalsByAIAdoptionPhase: zeroValue}
+	c.GetTotalsByAIAdoptionPhase()
+	c = &CopilotDailyMetrics{}
+	c.GetTotalsByAIAdoptionPhase()
+	c = nil
+	c.GetTotalsByAIAdoptionPhase()
+}
+
 func TestCopilotDailyMetrics_GetTotalsByCLI(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotDailyMetrics{}
@@ -12390,6 +12401,189 @@ func TestCopilotMetrics_GetTotalEngagedUsers(tt *testing.T) {
 	c.GetTotalEngagedUsers()
 	c = nil
 	c.GetTotalEngagedUsers()
+}
+
+func TestCopilotMetricsAIAdoptionPhase_GetPhase(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsAIAdoptionPhase{}
+	c.GetPhase()
+	c = nil
+	c.GetPhase()
+}
+
+func TestCopilotMetricsAIAdoptionPhase_GetPhaseNumber(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsAIAdoptionPhase{}
+	c.GetPhaseNumber()
+	c = nil
+	c.GetPhaseNumber()
+}
+
+func TestCopilotMetricsAIAdoptionPhase_GetVersion(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsAIAdoptionPhase{}
+	c.GetVersion()
+	c = nil
+	c.GetVersion()
+}
+
+func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgCodeAcceptanceActivities(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue float64
+	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgCodeAcceptanceActivities: &zeroValue}
+	c.GetAvgCodeAcceptanceActivities()
+	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c.GetAvgCodeAcceptanceActivities()
+	c = nil
+	c.GetAvgCodeAcceptanceActivities()
+}
+
+func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgCodeGenerationActivities(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue float64
+	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgCodeGenerationActivities: &zeroValue}
+	c.GetAvgCodeGenerationActivities()
+	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c.GetAvgCodeGenerationActivities()
+	c = nil
+	c.GetAvgCodeGenerationActivities()
+}
+
+func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgLOCAdded(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue float64
+	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgLOCAdded: &zeroValue}
+	c.GetAvgLOCAdded()
+	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c.GetAvgLOCAdded()
+	c = nil
+	c.GetAvgLOCAdded()
+}
+
+func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgLOCDeleted(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue float64
+	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgLOCDeleted: &zeroValue}
+	c.GetAvgLOCDeleted()
+	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c.GetAvgLOCDeleted()
+	c = nil
+	c.GetAvgLOCDeleted()
+}
+
+func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsCreated(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue float64
+	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgPullRequestsCreated: &zeroValue}
+	c.GetAvgPullRequestsCreated()
+	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c.GetAvgPullRequestsCreated()
+	c = nil
+	c.GetAvgPullRequestsCreated()
+}
+
+func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsMedianMinutesToMerge(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue float64
+	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgPullRequestsMedianMinutesToMerge: &zeroValue}
+	c.GetAvgPullRequestsMedianMinutesToMerge()
+	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c.GetAvgPullRequestsMedianMinutesToMerge()
+	c = nil
+	c.GetAvgPullRequestsMedianMinutesToMerge()
+}
+
+func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsMerged(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue float64
+	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgPullRequestsMerged: &zeroValue}
+	c.GetAvgPullRequestsMerged()
+	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c.GetAvgPullRequestsMerged()
+	c = nil
+	c.GetAvgPullRequestsMerged()
+}
+
+func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsMinutesToReview(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue float64
+	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgPullRequestsMinutesToReview: &zeroValue}
+	c.GetAvgPullRequestsMinutesToReview()
+	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c.GetAvgPullRequestsMinutesToReview()
+	c = nil
+	c.GetAvgPullRequestsMinutesToReview()
+}
+
+func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsReviewCycles(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue float64
+	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgPullRequestsReviewCycles: &zeroValue}
+	c.GetAvgPullRequestsReviewCycles()
+	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c.GetAvgPullRequestsReviewCycles()
+	c = nil
+	c.GetAvgPullRequestsReviewCycles()
+}
+
+func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsReviewed(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue float64
+	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgPullRequestsReviewed: &zeroValue}
+	c.GetAvgPullRequestsReviewed()
+	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c.GetAvgPullRequestsReviewed()
+	c = nil
+	c.GetAvgPullRequestsReviewed()
+}
+
+func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgUserInitiatedInteractions(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue float64
+	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgUserInitiatedInteractions: &zeroValue}
+	c.GetAvgUserInitiatedInteractions()
+	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c.GetAvgUserInitiatedInteractions()
+	c = nil
+	c.GetAvgUserInitiatedInteractions()
+}
+
+func TestCopilotMetricsAIAdoptionPhaseTotals_GetPhase(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsAIAdoptionPhaseTotals{}
+	c.GetPhase()
+	c = nil
+	c.GetPhase()
+}
+
+func TestCopilotMetricsAIAdoptionPhaseTotals_GetPhaseNumber(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsAIAdoptionPhaseTotals{}
+	c.GetPhaseNumber()
+	c = nil
+	c.GetPhaseNumber()
+}
+
+func TestCopilotMetricsAIAdoptionPhaseTotals_GetTotalEngagedUsers(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsAIAdoptionPhaseTotals{TotalEngagedUsers: &zeroValue}
+	c.GetTotalEngagedUsers()
+	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c.GetTotalEngagedUsers()
+	c = nil
+	c.GetTotalEngagedUsers()
+}
+
+func TestCopilotMetricsAIAdoptionPhaseTotals_GetTotalPullRequestsMerged(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsAIAdoptionPhaseTotals{TotalPullRequestsMerged: &zeroValue}
+	c.GetTotalPullRequestsMerged()
+	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c.GetTotalPullRequestsMerged()
+	c = nil
+	c.GetTotalPullRequestsMerged()
 }
 
 func TestCopilotMetricsChatPanel_GetChatPanelAgentMode(tt *testing.T) {
@@ -13182,6 +13376,25 @@ func TestCopilotSeatDetails_GetUpdatedAt(tt *testing.T) {
 	c.GetUpdatedAt()
 }
 
+func TestCopilotUserDailyMetrics_GetAIAdoptionPhase(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetAIAdoptionPhase()
+	c = nil
+	c.GetAIAdoptionPhase()
+}
+
+func TestCopilotUserDailyMetrics_GetAICreditsUsed(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue float64
+	c := &CopilotUserDailyMetrics{AICreditsUsed: &zeroValue}
+	c.GetAICreditsUsed()
+	c = &CopilotUserDailyMetrics{}
+	c.GetAICreditsUsed()
+	c = nil
+	c.GetAICreditsUsed()
+}
+
 func TestCopilotUserDailyMetrics_GetCodeAcceptanceActivityCount(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int
@@ -13524,6 +13737,25 @@ func TestCopilotUserMetricsPluginVersion_GetSampledAt(tt *testing.T) {
 	c.GetSampledAt()
 	c = nil
 	c.GetSampledAt()
+}
+
+func TestCopilotUserPeriodicMetrics_GetAIAdoptionPhase(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetAIAdoptionPhase()
+	c = nil
+	c.GetAIAdoptionPhase()
+}
+
+func TestCopilotUserPeriodicMetrics_GetAICreditsUsed(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue float64
+	c := &CopilotUserPeriodicMetrics{AICreditsUsed: &zeroValue}
+	c.GetAICreditsUsed()
+	c = &CopilotUserPeriodicMetrics{}
+	c.GetAICreditsUsed()
+	c = nil
+	c.GetAICreditsUsed()
 }
 
 func TestCopilotUserPeriodicMetrics_GetCodeAcceptanceActivityCount(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -12429,10 +12429,7 @@ func TestCopilotMetricsAIAdoptionPhase_GetVersion(tt *testing.T) {
 
 func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgCodeAcceptanceActivities(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue float64
-	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgCodeAcceptanceActivities: &zeroValue}
-	c.GetAvgCodeAcceptanceActivities()
-	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c := &CopilotMetricsAIAdoptionPhaseTotals{}
 	c.GetAvgCodeAcceptanceActivities()
 	c = nil
 	c.GetAvgCodeAcceptanceActivities()
@@ -12440,10 +12437,7 @@ func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgCodeAcceptanceActivities(tt *
 
 func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgCodeGenerationActivities(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue float64
-	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgCodeGenerationActivities: &zeroValue}
-	c.GetAvgCodeGenerationActivities()
-	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c := &CopilotMetricsAIAdoptionPhaseTotals{}
 	c.GetAvgCodeGenerationActivities()
 	c = nil
 	c.GetAvgCodeGenerationActivities()
@@ -12451,10 +12445,7 @@ func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgCodeGenerationActivities(tt *
 
 func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgLOCAdded(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue float64
-	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgLOCAdded: &zeroValue}
-	c.GetAvgLOCAdded()
-	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c := &CopilotMetricsAIAdoptionPhaseTotals{}
 	c.GetAvgLOCAdded()
 	c = nil
 	c.GetAvgLOCAdded()
@@ -12462,10 +12453,7 @@ func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgLOCAdded(tt *testing.T) {
 
 func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgLOCDeleted(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue float64
-	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgLOCDeleted: &zeroValue}
-	c.GetAvgLOCDeleted()
-	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c := &CopilotMetricsAIAdoptionPhaseTotals{}
 	c.GetAvgLOCDeleted()
 	c = nil
 	c.GetAvgLOCDeleted()
@@ -12473,10 +12461,7 @@ func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgLOCDeleted(tt *testing.T) {
 
 func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsCreated(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue float64
-	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgPullRequestsCreated: &zeroValue}
-	c.GetAvgPullRequestsCreated()
-	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c := &CopilotMetricsAIAdoptionPhaseTotals{}
 	c.GetAvgPullRequestsCreated()
 	c = nil
 	c.GetAvgPullRequestsCreated()
@@ -12484,10 +12469,7 @@ func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsCreated(tt *testi
 
 func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsMedianMinutesToMerge(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue float64
-	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgPullRequestsMedianMinutesToMerge: &zeroValue}
-	c.GetAvgPullRequestsMedianMinutesToMerge()
-	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c := &CopilotMetricsAIAdoptionPhaseTotals{}
 	c.GetAvgPullRequestsMedianMinutesToMerge()
 	c = nil
 	c.GetAvgPullRequestsMedianMinutesToMerge()
@@ -12495,10 +12477,7 @@ func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsMedianMinutesToMe
 
 func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsMerged(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue float64
-	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgPullRequestsMerged: &zeroValue}
-	c.GetAvgPullRequestsMerged()
-	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c := &CopilotMetricsAIAdoptionPhaseTotals{}
 	c.GetAvgPullRequestsMerged()
 	c = nil
 	c.GetAvgPullRequestsMerged()
@@ -12506,10 +12485,7 @@ func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsMerged(tt *testin
 
 func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsMinutesToReview(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue float64
-	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgPullRequestsMinutesToReview: &zeroValue}
-	c.GetAvgPullRequestsMinutesToReview()
-	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c := &CopilotMetricsAIAdoptionPhaseTotals{}
 	c.GetAvgPullRequestsMinutesToReview()
 	c = nil
 	c.GetAvgPullRequestsMinutesToReview()
@@ -12517,10 +12493,7 @@ func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsMinutesToReview(t
 
 func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsReviewCycles(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue float64
-	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgPullRequestsReviewCycles: &zeroValue}
-	c.GetAvgPullRequestsReviewCycles()
-	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c := &CopilotMetricsAIAdoptionPhaseTotals{}
 	c.GetAvgPullRequestsReviewCycles()
 	c = nil
 	c.GetAvgPullRequestsReviewCycles()
@@ -12528,10 +12501,7 @@ func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsReviewCycles(tt *
 
 func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsReviewed(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue float64
-	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgPullRequestsReviewed: &zeroValue}
-	c.GetAvgPullRequestsReviewed()
-	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c := &CopilotMetricsAIAdoptionPhaseTotals{}
 	c.GetAvgPullRequestsReviewed()
 	c = nil
 	c.GetAvgPullRequestsReviewed()
@@ -12539,10 +12509,7 @@ func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgPullRequestsReviewed(tt *test
 
 func TestCopilotMetricsAIAdoptionPhaseTotals_GetAvgUserInitiatedInteractions(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue float64
-	c := &CopilotMetricsAIAdoptionPhaseTotals{AvgUserInitiatedInteractions: &zeroValue}
-	c.GetAvgUserInitiatedInteractions()
-	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c := &CopilotMetricsAIAdoptionPhaseTotals{}
 	c.GetAvgUserInitiatedInteractions()
 	c = nil
 	c.GetAvgUserInitiatedInteractions()
@@ -12566,10 +12533,7 @@ func TestCopilotMetricsAIAdoptionPhaseTotals_GetPhaseNumber(tt *testing.T) {
 
 func TestCopilotMetricsAIAdoptionPhaseTotals_GetTotalEngagedUsers(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue int
-	c := &CopilotMetricsAIAdoptionPhaseTotals{TotalEngagedUsers: &zeroValue}
-	c.GetTotalEngagedUsers()
-	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c := &CopilotMetricsAIAdoptionPhaseTotals{}
 	c.GetTotalEngagedUsers()
 	c = nil
 	c.GetTotalEngagedUsers()
@@ -12577,10 +12541,7 @@ func TestCopilotMetricsAIAdoptionPhaseTotals_GetTotalEngagedUsers(tt *testing.T)
 
 func TestCopilotMetricsAIAdoptionPhaseTotals_GetTotalPullRequestsMerged(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue int
-	c := &CopilotMetricsAIAdoptionPhaseTotals{TotalPullRequestsMerged: &zeroValue}
-	c.GetTotalPullRequestsMerged()
-	c = &CopilotMetricsAIAdoptionPhaseTotals{}
+	c := &CopilotMetricsAIAdoptionPhaseTotals{}
 	c.GetTotalPullRequestsMerged()
 	c = nil
 	c.GetTotalPullRequestsMerged()


### PR DESCRIPTION
## Summary
- Add `ai_credits_used` and `ai_adoption_phase` on per-user Copilot usage metrics reports
- Add `totals_by_ai_adoption_phase` on aggregated enterprise/organization daily reports
- Download-path tests + regenerated accessors

Fixes #4479