### PR TITLE
feat: Add Copilot app metrics to usage metrics structs

### DIFF
--- a/github/copilot.go
+++ b/github/copilot.go
@@ -1008,6 +1008,25 @@ type CopilotMetricsCLI struct {
 	LastKnownCLIVersion *CopilotMetricsCLIVersion    `json:"last_known_cli_version,omitempty"`
 }
 
+// CopilotMetricsCopilotAppTokenUsage represents Copilot app token totals in a metrics report.
+type CopilotMetricsCopilotAppTokenUsage struct {
+	AvgTokensPerRequest *float64 `json:"avg_tokens_per_request,omitempty"`
+	OutputTokensSum     *int     `json:"output_tokens_sum,omitempty"`
+	PromptTokensSum     *int     `json:"prompt_tokens_sum,omitempty"`
+}
+
+// CopilotMetricsCopilotApp represents Copilot app totals in a metrics report.
+//
+// Unlike totals_by_cli, there is no last_known_app_version field.
+//
+// GitHub API docs: https://docs.github.com/en/copilot/reference/copilot-usage-metrics/copilot-usage-metrics#copilot-app-metrics-fields
+type CopilotMetricsCopilotApp struct {
+	SessionCount *int                                `json:"session_count,omitempty"`
+	RequestCount *int                                `json:"request_count,omitempty"`
+	PromptCount  *int                                `json:"prompt_count,omitempty"`
+	TokenUsage   *CopilotMetricsCopilotAppTokenUsage `json:"token_usage,omitempty"`
+}
+
 // CopilotMetricsThirdPartyAgent represents per-agent app totals in a Copilot usage metrics report.
 //
 // AgentID is the stable grouping key. AgentName is for display and can change.
@@ -1068,6 +1087,7 @@ type CopilotDailyMetrics struct {
 	OrganizationID                      *string `json:"organization_id,omitempty"`
 	EnterpriseID                        *string `json:"enterprise_id,omitempty"`
 	DailyActiveCLIUsers                 *int    `json:"daily_active_cli_users,omitempty"`
+	DailyActiveCopilotAppUsers          *int    `json:"daily_active_copilot_app_users,omitempty"`
 	DailyActiveUsers                    *int    `json:"daily_active_users,omitempty"`
 	DailyActiveCopilotCloudAgentUsers   *int    `json:"daily_active_copilot_cloud_agent_users,omitempty"`
 	WeeklyActiveUsers                   *int    `json:"weekly_active_users,omitempty"`
@@ -1086,6 +1106,7 @@ type CopilotDailyMetrics struct {
 	TotalsByLanguageModel       []*CopilotMetricsLanguageModel         `json:"totals_by_language_model,omitempty"`
 	TotalsByModelFeature        []*CopilotMetricsModelFeature          `json:"totals_by_model_feature,omitempty"`
 	TotalsByCLI                 *CopilotMetricsCLI                     `json:"totals_by_cli,omitempty"`
+	TotalsByCopilotApp          *CopilotMetricsCopilotApp              `json:"totals_by_copilot_app,omitempty"`
 	TotalsBy3rdPartyAgent       []*CopilotMetricsThirdPartyAgent       `json:"totals_by_3rd_party_agent,omitempty"`
 	TotalsByAIAdoptionPhase     []*CopilotMetricsAIAdoptionPhaseTotals `json:"totals_by_ai_adoption_phase,omitempty"`
 	LOCSuggestedToAddSum        *int                                   `json:"loc_suggested_to_add_sum,omitempty"`
@@ -1149,11 +1170,14 @@ type CopilotUserDailyMetrics struct {
 	TotalsByLanguageModel        []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
 	TotalsByModelFeature         []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
 	TotalsByCLI                  *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
+	TotalsByCopilotApp           *CopilotMetricsCopilotApp        `json:"totals_by_copilot_app,omitempty"`
 	TotalsBy3rdPartyAgent        []*CopilotMetricsThirdPartyAgent `json:"totals_by_3rd_party_agent,omitempty"`
 	AIAdoptionPhase              *CopilotMetricsAIAdoptionPhase   `json:"ai_adoption_phase,omitempty"`
 	UsedAgent                    *bool                            `json:"used_agent,omitempty"`
 	UsedChat                     *bool                            `json:"used_chat,omitempty"`
 	UsedCLI                      *bool                            `json:"used_cli,omitempty"`
+	UsedCopilotApp               *bool                            `json:"used_copilot_app,omitempty"`
+	UsedCopilotCloudAgent        *bool                            `json:"used_copilot_cloud_agent,omitempty"`
 	UsedCopilotCodeReviewActive  *bool                            `json:"used_copilot_code_review_active,omitempty"`
 	UsedCopilotCodeReviewPassive *bool                            `json:"used_copilot_code_review_passive,omitempty"`
 	UsedCopilotCodingAgent       *bool                            `json:"used_copilot_coding_agent,omitempty"`
@@ -1185,11 +1209,14 @@ type CopilotUserPeriodicMetrics struct {
 	TotalsByLanguageModel        []*CopilotMetricsLanguageModel   `json:"totals_by_language_model,omitempty"`
 	TotalsByModelFeature         []*CopilotMetricsModelFeature    `json:"totals_by_model_feature,omitempty"`
 	TotalsByCLI                  *CopilotMetricsCLI               `json:"totals_by_cli,omitempty"`
+	TotalsByCopilotApp           *CopilotMetricsCopilotApp        `json:"totals_by_copilot_app,omitempty"`
 	TotalsBy3rdPartyAgent        []*CopilotMetricsThirdPartyAgent `json:"totals_by_3rd_party_agent,omitempty"`
 	AIAdoptionPhase              *CopilotMetricsAIAdoptionPhase   `json:"ai_adoption_phase,omitempty"`
 	UsedAgent                    *bool                            `json:"used_agent,omitempty"`
 	UsedChat                     *bool                            `json:"used_chat,omitempty"`
 	UsedCLI                      *bool                            `json:"used_cli,omitempty"`
+	UsedCopilotApp               *bool                            `json:"used_copilot_app,omitempty"`
+	UsedCopilotCloudAgent        *bool                            `json:"used_copilot_cloud_agent,omitempty"`
 	UsedCopilotCodeReviewActive  *bool                            `json:"used_copilot_code_review_active,omitempty"`
 	UsedCopilotCodeReviewPassive *bool                            `json:"used_copilot_code_review_passive,omitempty"`
 	UsedCopilotCodingAgent       *bool                            `json:"used_copilot_coding_agent,omitempty"`

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -3034,6 +3034,7 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 			"day": "2026-04-01",
 			"organization_id": "123",
 			"daily_active_cli_users": 2,
+			"daily_active_copilot_app_users": 1,
 			"daily_active_users": 10,
 			"weekly_active_users": 20,
 			"monthly_active_users": 30,
@@ -3062,6 +3063,16 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 					"avg_tokens_per_request": 4123.5,
 					"output_tokens_sum": 7000,
 					"prompt_tokens_sum": 9494
+				}
+			},
+			"totals_by_copilot_app": {
+				"session_count": 2,
+				"request_count": 6,
+				"prompt_count": 3,
+				"token_usage": {
+					"avg_tokens_per_request": 150.0,
+					"output_tokens_sum": 600,
+					"prompt_tokens_sum": 300
 				}
 			},
 			"totals_by_3rd_party_agent": [
@@ -3113,12 +3124,13 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 	}
 
 	want := &CopilotDailyMetrics{
-		Day:                 "2026-04-01",
-		OrganizationID:      new("123"),
-		DailyActiveCLIUsers: new(2),
-		DailyActiveUsers:    new(10),
-		WeeklyActiveUsers:   new(20),
-		MonthlyActiveUsers:  new(30),
+		Day:                        "2026-04-01",
+		OrganizationID:             new("123"),
+		DailyActiveCLIUsers:        new(2),
+		DailyActiveCopilotAppUsers: new(1),
+		DailyActiveUsers:           new(10),
+		WeeklyActiveUsers:          new(20),
+		MonthlyActiveUsers:         new(30),
 		CopilotMetricsChatPanel: CopilotMetricsChatPanel{
 			ChatPanelAskMode: new(4),
 		},
@@ -3146,6 +3158,16 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 				AvgTokensPerRequest: new(4123.5),
 				OutputTokensSum:     new(7000),
 				PromptTokensSum:     new(9494),
+			},
+		},
+		TotalsByCopilotApp: &CopilotMetricsCopilotApp{
+			SessionCount: new(2),
+			RequestCount: new(6),
+			PromptCount:  new(3),
+			TokenUsage: &CopilotMetricsCopilotAppTokenUsage{
+				AvgTokensPerRequest: new(150.0),
+				OutputTokensSum:     new(600),
+				PromptTokensSum:     new(300),
 			},
 		},
 		TotalsBy3rdPartyAgent: []*CopilotMetricsThirdPartyAgent{
@@ -3259,6 +3281,7 @@ func TestCopilotService_DownloadPeriodicMetrics(t *testing.T) {
 				{
 					"day": "2026-03-05",
 					"daily_active_cli_users": 2,
+					"daily_active_copilot_app_users": 1,
 					"daily_active_users": 5,
 					"totals_by_cli": {
 						"session_count": 1,
@@ -3268,6 +3291,16 @@ func TestCopilotService_DownloadPeriodicMetrics(t *testing.T) {
 							"avg_tokens_per_request": 4000.0,
 							"output_tokens_sum": 5000,
 							"prompt_tokens_sum": 3000
+						}
+					},
+					"totals_by_copilot_app": {
+						"session_count": 1,
+						"request_count": 2,
+						"prompt_count": 1,
+						"token_usage": {
+							"avg_tokens_per_request": 800.0,
+							"output_tokens_sum": 400,
+							"prompt_tokens_sum": 400
 						}
 					},
 					"pull_requests": {
@@ -3298,9 +3331,10 @@ func TestCopilotService_DownloadPeriodicMetrics(t *testing.T) {
 		CreatedAt:      refTimestamp(1136178000),
 		DayTotals: []*CopilotDailyMetrics{
 			{
-				Day:                 "2026-03-05",
-				DailyActiveCLIUsers: new(2),
-				DailyActiveUsers:    new(5),
+				Day:                        "2026-03-05",
+				DailyActiveCLIUsers:        new(2),
+				DailyActiveCopilotAppUsers: new(1),
+				DailyActiveUsers:           new(5),
 				TotalsByCLI: &CopilotMetricsCLI{
 					SessionCount: new(1),
 					RequestCount: new(2),
@@ -3309,6 +3343,16 @@ func TestCopilotService_DownloadPeriodicMetrics(t *testing.T) {
 						AvgTokensPerRequest: new(4000.0),
 						OutputTokensSum:     new(5000),
 						PromptTokensSum:     new(3000),
+					},
+				},
+				TotalsByCopilotApp: &CopilotMetricsCopilotApp{
+					SessionCount: new(1),
+					RequestCount: new(2),
+					PromptCount:  new(1),
+					TokenUsage: &CopilotMetricsCopilotAppTokenUsage{
+						AvgTokensPerRequest: new(800.0),
+						OutputTokensSum:     new(400),
+						PromptTokensSum:     new(400),
 					},
 				},
 				PullRequests: &CopilotMetricsPullRequests{
@@ -3354,7 +3398,7 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 
 	mux.HandleFunc("/path/to/users-daily", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"user_id":1,"user_login":"alice","day":"2026-04-01","ai_credits_used":12.5,"user_initiated_interaction_count":5,"chat_panel_edit_mode":2,"used_chat":true,"used_cli":true,"used_copilot_code_review_active":true,"ai_adoption_phase":{"phase":"Phase 2","phase_number":2,"version":"v1"},"totals_by_cli":{"session_count":2,"request_count":2,"prompt_count":1,"last_known_cli_version":{"sampled_at":`+referenceTimeStr+`,"cli_version":"1.0.8"}},"totals_by_ide":[{"ide":"vscode","user_initiated_interaction_count":5,"last_known_plugin_version":{"sampled_at":`+referenceTimeStr+`,"plugin":"copilot","plugin_version":"1.0.0"},"last_known_ide_version":{"sampled_at":`+referenceTimeStr+`,"ide_version":"1.90"}}],"totals_by_3rd_party_agent":[{"agent_name":"Claude","agent_id":"claude","user_initiated_interaction_count":2}]}
+		fmt.Fprint(w, `{"user_id":1,"user_login":"alice","day":"2026-04-01","ai_credits_used":12.5,"user_initiated_interaction_count":5,"chat_panel_edit_mode":2,"used_chat":true,"used_cli":true,"used_copilot_app":true,"used_copilot_cloud_agent":false,"used_copilot_coding_agent":false,"used_copilot_code_review_active":true,"ai_adoption_phase":{"phase":"Phase 2","phase_number":2,"version":"v1"},"totals_by_cli":{"session_count":2,"request_count":2,"prompt_count":1,"last_known_cli_version":{"sampled_at":`+referenceTimeStr+`,"cli_version":"1.0.8"}},"totals_by_copilot_app":{"session_count":1,"request_count":4,"prompt_count":2,"token_usage":{"avg_tokens_per_request":150.0,"output_tokens_sum":100,"prompt_tokens_sum":50}},"totals_by_ide":[{"ide":"vscode","user_initiated_interaction_count":5,"last_known_plugin_version":{"sampled_at":`+referenceTimeStr+`,"plugin":"copilot","plugin_version":"1.0.0"},"last_known_ide_version":{"sampled_at":`+referenceTimeStr+`,"ide_version":"1.90"}}],"totals_by_3rd_party_agent":[{"agent_name":"Claude","agent_id":"claude","user_initiated_interaction_count":2}]}
 {"user_id":2,"user_login":"bob","day":"2026-04-01","used_agent":true,"used_copilot_code_review_passive":true}
 `)
 	})
@@ -3381,6 +3425,9 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 			},
 			UsedChat:                    new(true),
 			UsedCLI:                     new(true),
+			UsedCopilotApp:              new(true),
+			UsedCopilotCloudAgent:       new(false),
+			UsedCopilotCodingAgent:      new(false),
 			UsedCopilotCodeReviewActive: new(true),
 			AIAdoptionPhase: &CopilotMetricsAIAdoptionPhase{
 				Phase:       "Phase 2",
@@ -3394,6 +3441,16 @@ func TestCopilotService_DownloadUserDailyMetrics(t *testing.T) {
 				LastKnownCLIVersion: &CopilotMetricsCLIVersion{
 					SampledAt:  &referenceTimestamp,
 					CLIVersion: "1.0.8",
+				},
+			},
+			TotalsByCopilotApp: &CopilotMetricsCopilotApp{
+				SessionCount: new(1),
+				RequestCount: new(4),
+				PromptCount:  new(2),
+				TokenUsage: &CopilotMetricsCopilotAppTokenUsage{
+					AvgTokensPerRequest: new(150.0),
+					OutputTokensSum:     new(100),
+					PromptTokensSum:     new(50),
 				},
 			},
 			TotalsByIDE: []*CopilotUserMetricsIDE{
@@ -3475,7 +3532,7 @@ func TestCopilotService_DownloadUserPeriodicMetrics(t *testing.T) {
 	mux.HandleFunc("/path/to/users-periodic", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"report_start_day":"2026-03-05","report_end_day":"2026-04-01","day":"2026-03-05","user_id":1,"user_login":"alice","ai_credits_used":3.25,"user_initiated_interaction_count":3,"used_copilot_code_review_active":true,"ai_adoption_phase":{"phase":"Phase 1","phase_number":1,"version":"v1"}}
-{"report_start_day":"2026-03-05","report_end_day":"2026-04-01","day":"2026-03-06","user_id":1,"user_login":"alice","used_cli":true,"used_copilot_code_review_passive":true,"used_copilot_coding_agent":true,"totals_by_cli":{"session_count":1,"request_count":3,"prompt_count":2,"token_usage":{"avg_tokens_per_request":1200.5,"output_tokens_sum":2400,"prompt_tokens_sum":1201}}}
+{"report_start_day":"2026-03-05","report_end_day":"2026-04-01","day":"2026-03-06","user_id":1,"user_login":"alice","used_cli":true,"used_copilot_app":true,"used_copilot_cloud_agent":true,"used_copilot_coding_agent":true,"used_copilot_code_review_passive":true,"totals_by_cli":{"session_count":1,"request_count":3,"prompt_count":2,"token_usage":{"avg_tokens_per_request":1200.5,"output_tokens_sum":2400,"prompt_tokens_sum":1201}},"totals_by_copilot_app":{"session_count":2,"request_count":5,"prompt_count":3,"token_usage":{"avg_tokens_per_request":900.0,"output_tokens_sum":1500,"prompt_tokens_sum":1500}}}
 `)
 	})
 
@@ -3512,6 +3569,8 @@ func TestCopilotService_DownloadUserPeriodicMetrics(t *testing.T) {
 			UserID:                       1,
 			UserLogin:                    "alice",
 			UsedCLI:                      new(true),
+			UsedCopilotApp:               new(true),
+			UsedCopilotCloudAgent:        new(true),
 			UsedCopilotCodeReviewPassive: new(true),
 			UsedCopilotCodingAgent:       new(true),
 			TotalsByCLI: &CopilotMetricsCLI{
@@ -3522,6 +3581,16 @@ func TestCopilotService_DownloadUserPeriodicMetrics(t *testing.T) {
 					AvgTokensPerRequest: new(1200.5),
 					OutputTokensSum:     new(2400),
 					PromptTokensSum:     new(1201),
+				},
+			},
+			TotalsByCopilotApp: &CopilotMetricsCopilotApp{
+				SessionCount: new(2),
+				RequestCount: new(5),
+				PromptCount:  new(3),
+				TokenUsage: &CopilotMetricsCopilotAppTokenUsage{
+					AvgTokensPerRequest: new(900.0),
+					OutputTokensSum:     new(1500),
+					PromptTokensSum:     new(1500),
 				},
 			},
 		},

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9118,6 +9118,14 @@ func (c *CopilotDailyMetrics) GetDailyActiveCLIUsers() int {
 	return *c.DailyActiveCLIUsers
 }
 
+// GetDailyActiveCopilotAppUsers returns the DailyActiveCopilotAppUsers field if it's non-nil, zero value otherwise.
+func (c *CopilotDailyMetrics) GetDailyActiveCopilotAppUsers() int {
+	if c == nil || c.DailyActiveCopilotAppUsers == nil {
+		return 0
+	}
+	return *c.DailyActiveCopilotAppUsers
+}
+
 // GetDailyActiveCopilotCloudAgentUsers returns the DailyActiveCopilotCloudAgentUsers field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetDailyActiveCopilotCloudAgentUsers() int {
 	if c == nil || c.DailyActiveCopilotCloudAgentUsers == nil {
@@ -9252,6 +9260,14 @@ func (c *CopilotDailyMetrics) GetTotalsByCLI() *CopilotMetricsCLI {
 		return nil
 	}
 	return c.TotalsByCLI
+}
+
+// GetTotalsByCopilotApp returns the TotalsByCopilotApp field.
+func (c *CopilotDailyMetrics) GetTotalsByCopilotApp() *CopilotMetricsCopilotApp {
+	if c == nil {
+		return nil
+	}
+	return c.TotalsByCopilotApp
 }
 
 // GetTotalsByFeature returns the TotalsByFeature slice if it's non-nil, nil otherwise.
@@ -10086,6 +10102,62 @@ func (c *CopilotMetricsCodeActivity) GetLOCSuggestedToDeleteSum() int {
 	return *c.LOCSuggestedToDeleteSum
 }
 
+// GetPromptCount returns the PromptCount field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsCopilotApp) GetPromptCount() int {
+	if c == nil || c.PromptCount == nil {
+		return 0
+	}
+	return *c.PromptCount
+}
+
+// GetRequestCount returns the RequestCount field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsCopilotApp) GetRequestCount() int {
+	if c == nil || c.RequestCount == nil {
+		return 0
+	}
+	return *c.RequestCount
+}
+
+// GetSessionCount returns the SessionCount field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsCopilotApp) GetSessionCount() int {
+	if c == nil || c.SessionCount == nil {
+		return 0
+	}
+	return *c.SessionCount
+}
+
+// GetTokenUsage returns the TokenUsage field.
+func (c *CopilotMetricsCopilotApp) GetTokenUsage() *CopilotMetricsCopilotAppTokenUsage {
+	if c == nil {
+		return nil
+	}
+	return c.TokenUsage
+}
+
+// GetAvgTokensPerRequest returns the AvgTokensPerRequest field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsCopilotAppTokenUsage) GetAvgTokensPerRequest() float64 {
+	if c == nil || c.AvgTokensPerRequest == nil {
+		return 0
+	}
+	return *c.AvgTokensPerRequest
+}
+
+// GetOutputTokensSum returns the OutputTokensSum field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsCopilotAppTokenUsage) GetOutputTokensSum() int {
+	if c == nil || c.OutputTokensSum == nil {
+		return 0
+	}
+	return *c.OutputTokensSum
+}
+
+// GetPromptTokensSum returns the PromptTokensSum field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsCopilotAppTokenUsage) GetPromptTokensSum() int {
+	if c == nil || c.PromptTokensSum == nil {
+		return 0
+	}
+	return *c.PromptTokensSum
+}
+
 // GetFeature returns the Feature field.
 func (c *CopilotMetricsFeature) GetFeature() string {
 	if c == nil {
@@ -10662,6 +10734,14 @@ func (c *CopilotUserDailyMetrics) GetTotalsByCLI() *CopilotMetricsCLI {
 	return c.TotalsByCLI
 }
 
+// GetTotalsByCopilotApp returns the TotalsByCopilotApp field.
+func (c *CopilotUserDailyMetrics) GetTotalsByCopilotApp() *CopilotMetricsCopilotApp {
+	if c == nil {
+		return nil
+	}
+	return c.TotalsByCopilotApp
+}
+
 // GetTotalsByFeature returns the TotalsByFeature slice if it's non-nil, nil otherwise.
 func (c *CopilotUserDailyMetrics) GetTotalsByFeature() []*CopilotMetricsFeature {
 	if c == nil || c.TotalsByFeature == nil {
@@ -10724,6 +10804,22 @@ func (c *CopilotUserDailyMetrics) GetUsedCLI() bool {
 		return false
 	}
 	return *c.UsedCLI
+}
+
+// GetUsedCopilotApp returns the UsedCopilotApp field if it's non-nil, zero value otherwise.
+func (c *CopilotUserDailyMetrics) GetUsedCopilotApp() bool {
+	if c == nil || c.UsedCopilotApp == nil {
+		return false
+	}
+	return *c.UsedCopilotApp
+}
+
+// GetUsedCopilotCloudAgent returns the UsedCopilotCloudAgent field if it's non-nil, zero value otherwise.
+func (c *CopilotUserDailyMetrics) GetUsedCopilotCloudAgent() bool {
+	if c == nil || c.UsedCopilotCloudAgent == nil {
+		return false
+	}
+	return *c.UsedCopilotCloudAgent
 }
 
 // GetUsedCopilotCodeReviewActive returns the UsedCopilotCodeReviewActive field if it's non-nil, zero value otherwise.
@@ -10966,6 +11062,14 @@ func (c *CopilotUserPeriodicMetrics) GetTotalsByCLI() *CopilotMetricsCLI {
 	return c.TotalsByCLI
 }
 
+// GetTotalsByCopilotApp returns the TotalsByCopilotApp field.
+func (c *CopilotUserPeriodicMetrics) GetTotalsByCopilotApp() *CopilotMetricsCopilotApp {
+	if c == nil {
+		return nil
+	}
+	return c.TotalsByCopilotApp
+}
+
 // GetTotalsByFeature returns the TotalsByFeature slice if it's non-nil, nil otherwise.
 func (c *CopilotUserPeriodicMetrics) GetTotalsByFeature() []*CopilotMetricsFeature {
 	if c == nil || c.TotalsByFeature == nil {
@@ -11028,6 +11132,22 @@ func (c *CopilotUserPeriodicMetrics) GetUsedCLI() bool {
 		return false
 	}
 	return *c.UsedCLI
+}
+
+// GetUsedCopilotApp returns the UsedCopilotApp field if it's non-nil, zero value otherwise.
+func (c *CopilotUserPeriodicMetrics) GetUsedCopilotApp() bool {
+	if c == nil || c.UsedCopilotApp == nil {
+		return false
+	}
+	return *c.UsedCopilotApp
+}
+
+// GetUsedCopilotCloudAgent returns the UsedCopilotCloudAgent field if it's non-nil, zero value otherwise.
+func (c *CopilotUserPeriodicMetrics) GetUsedCopilotCloudAgent() bool {
+	if c == nil || c.UsedCopilotCloudAgent == nil {
+		return false
+	}
+	return *c.UsedCopilotCloudAgent
 }
 
 // GetUsedCopilotCodeReviewActive returns the UsedCopilotCodeReviewActive field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11633,6 +11633,17 @@ func TestCopilotDailyMetrics_GetDailyActiveCLIUsers(tt *testing.T) {
 	c.GetDailyActiveCLIUsers()
 }
 
+func TestCopilotDailyMetrics_GetDailyActiveCopilotAppUsers(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotDailyMetrics{DailyActiveCopilotAppUsers: &zeroValue}
+	c.GetDailyActiveCopilotAppUsers()
+	c = &CopilotDailyMetrics{}
+	c.GetDailyActiveCopilotAppUsers()
+	c = nil
+	c.GetDailyActiveCopilotAppUsers()
+}
+
 func TestCopilotDailyMetrics_GetDailyActiveCopilotCloudAgentUsers(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int
@@ -11809,6 +11820,14 @@ func TestCopilotDailyMetrics_GetTotalsByCLI(tt *testing.T) {
 	c.GetTotalsByCLI()
 	c = nil
 	c.GetTotalsByCLI()
+}
+
+func TestCopilotDailyMetrics_GetTotalsByCopilotApp(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotDailyMetrics{}
+	c.GetTotalsByCopilotApp()
+	c = nil
+	c.GetTotalsByCopilotApp()
 }
 
 func TestCopilotDailyMetrics_GetTotalsByFeature(tt *testing.T) {
@@ -12769,6 +12788,80 @@ func TestCopilotMetricsCodeActivity_GetLOCSuggestedToDeleteSum(tt *testing.T) {
 	c.GetLOCSuggestedToDeleteSum()
 }
 
+func TestCopilotMetricsCopilotApp_GetPromptCount(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsCopilotApp{PromptCount: &zeroValue}
+	c.GetPromptCount()
+	c = &CopilotMetricsCopilotApp{}
+	c.GetPromptCount()
+	c = nil
+	c.GetPromptCount()
+}
+
+func TestCopilotMetricsCopilotApp_GetRequestCount(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsCopilotApp{RequestCount: &zeroValue}
+	c.GetRequestCount()
+	c = &CopilotMetricsCopilotApp{}
+	c.GetRequestCount()
+	c = nil
+	c.GetRequestCount()
+}
+
+func TestCopilotMetricsCopilotApp_GetSessionCount(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsCopilotApp{SessionCount: &zeroValue}
+	c.GetSessionCount()
+	c = &CopilotMetricsCopilotApp{}
+	c.GetSessionCount()
+	c = nil
+	c.GetSessionCount()
+}
+
+func TestCopilotMetricsCopilotApp_GetTokenUsage(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsCopilotApp{}
+	c.GetTokenUsage()
+	c = nil
+	c.GetTokenUsage()
+}
+
+func TestCopilotMetricsCopilotAppTokenUsage_GetAvgTokensPerRequest(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue float64
+	c := &CopilotMetricsCopilotAppTokenUsage{AvgTokensPerRequest: &zeroValue}
+	c.GetAvgTokensPerRequest()
+	c = &CopilotMetricsCopilotAppTokenUsage{}
+	c.GetAvgTokensPerRequest()
+	c = nil
+	c.GetAvgTokensPerRequest()
+}
+
+func TestCopilotMetricsCopilotAppTokenUsage_GetOutputTokensSum(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsCopilotAppTokenUsage{OutputTokensSum: &zeroValue}
+	c.GetOutputTokensSum()
+	c = &CopilotMetricsCopilotAppTokenUsage{}
+	c.GetOutputTokensSum()
+	c = nil
+	c.GetOutputTokensSum()
+}
+
+func TestCopilotMetricsCopilotAppTokenUsage_GetPromptTokensSum(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsCopilotAppTokenUsage{PromptTokensSum: &zeroValue}
+	c.GetPromptTokensSum()
+	c = &CopilotMetricsCopilotAppTokenUsage{}
+	c.GetPromptTokensSum()
+	c = nil
+	c.GetPromptTokensSum()
+}
+
 func TestCopilotMetricsFeature_GetFeature(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotMetricsFeature{}
@@ -13471,6 +13564,14 @@ func TestCopilotUserDailyMetrics_GetTotalsByCLI(tt *testing.T) {
 	c.GetTotalsByCLI()
 }
 
+func TestCopilotUserDailyMetrics_GetTotalsByCopilotApp(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserDailyMetrics{}
+	c.GetTotalsByCopilotApp()
+	c = nil
+	c.GetTotalsByCopilotApp()
+}
+
 func TestCopilotUserDailyMetrics_GetTotalsByFeature(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []*CopilotMetricsFeature{}
@@ -13557,6 +13658,28 @@ func TestCopilotUserDailyMetrics_GetUsedCLI(tt *testing.T) {
 	c.GetUsedCLI()
 	c = nil
 	c.GetUsedCLI()
+}
+
+func TestCopilotUserDailyMetrics_GetUsedCopilotApp(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	c := &CopilotUserDailyMetrics{UsedCopilotApp: &zeroValue}
+	c.GetUsedCopilotApp()
+	c = &CopilotUserDailyMetrics{}
+	c.GetUsedCopilotApp()
+	c = nil
+	c.GetUsedCopilotApp()
+}
+
+func TestCopilotUserDailyMetrics_GetUsedCopilotCloudAgent(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	c := &CopilotUserDailyMetrics{UsedCopilotCloudAgent: &zeroValue}
+	c.GetUsedCopilotCloudAgent()
+	c = &CopilotUserDailyMetrics{}
+	c.GetUsedCopilotCloudAgent()
+	c = nil
+	c.GetUsedCopilotCloudAgent()
 }
 
 func TestCopilotUserDailyMetrics_GetUsedCopilotCodeReviewActive(tt *testing.T) {
@@ -13850,6 +13973,14 @@ func TestCopilotUserPeriodicMetrics_GetTotalsByCLI(tt *testing.T) {
 	c.GetTotalsByCLI()
 }
 
+func TestCopilotUserPeriodicMetrics_GetTotalsByCopilotApp(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotUserPeriodicMetrics{}
+	c.GetTotalsByCopilotApp()
+	c = nil
+	c.GetTotalsByCopilotApp()
+}
+
 func TestCopilotUserPeriodicMetrics_GetTotalsByFeature(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []*CopilotMetricsFeature{}
@@ -13936,6 +14067,28 @@ func TestCopilotUserPeriodicMetrics_GetUsedCLI(tt *testing.T) {
 	c.GetUsedCLI()
 	c = nil
 	c.GetUsedCLI()
+}
+
+func TestCopilotUserPeriodicMetrics_GetUsedCopilotApp(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	c := &CopilotUserPeriodicMetrics{UsedCopilotApp: &zeroValue}
+	c.GetUsedCopilotApp()
+	c = &CopilotUserPeriodicMetrics{}
+	c.GetUsedCopilotApp()
+	c = nil
+	c.GetUsedCopilotApp()
+}
+
+func TestCopilotUserPeriodicMetrics_GetUsedCopilotCloudAgent(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	c := &CopilotUserPeriodicMetrics{UsedCopilotCloudAgent: &zeroValue}
+	c.GetUsedCopilotCloudAgent()
+	c = &CopilotUserPeriodicMetrics{}
+	c.GetUsedCopilotCloudAgent()
+	c = nil
+	c.GetUsedCopilotCloudAgent()
 }
 
 func TestCopilotUserPeriodicMetrics_GetUsedCopilotCodeReviewActive(tt *testing.T) {


### PR DESCRIPTION
Fixes #4487

Adds support for Copilot app usage metrics fields documented at:
https://docs.github.com/en/copilot/reference/copilot-usage-metrics/copilot-usage-metrics

## Test plan
- [x] `go test ./github/... -run Copilot`
- [x] `./script/generate.sh`