### PR TITLE
feat: Add Copilot code review active user counts to metrics structs

### DIFF
--- a/github/copilot.go
+++ b/github/copilot.go
@@ -1064,19 +1064,25 @@ type CopilotMetricsAIAdoptionPhaseTotals struct {
 
 // CopilotDailyMetrics represents the payload downloaded from a 1-day Copilot usage metrics report.
 type CopilotDailyMetrics struct {
-	Day                                 string  `json:"day"`
-	OrganizationID                      *string `json:"organization_id,omitempty"`
-	EnterpriseID                        *string `json:"enterprise_id,omitempty"`
-	DailyActiveCLIUsers                 *int    `json:"daily_active_cli_users,omitempty"`
-	DailyActiveUsers                    *int    `json:"daily_active_users,omitempty"`
-	DailyActiveCopilotCloudAgentUsers   *int    `json:"daily_active_copilot_cloud_agent_users,omitempty"`
-	WeeklyActiveUsers                   *int    `json:"weekly_active_users,omitempty"`
-	WeeklyActiveCopilotCloudAgentUsers  *int    `json:"weekly_active_copilot_cloud_agent_users,omitempty"`
-	MonthlyActiveUsers                  *int    `json:"monthly_active_users,omitempty"`
-	MonthlyActiveChatUsers              *int    `json:"monthly_active_chat_users,omitempty"`
-	MonthlyActiveAgentUsers             *int    `json:"monthly_active_agent_users,omitempty"`
-	MonthlyActiveCopilotCloudAgentUsers *int    `json:"monthly_active_copilot_cloud_agent_users,omitempty"`
-	UserInitiatedInteractionCount       *int    `json:"user_initiated_interaction_count,omitempty"`
+	Day                                  string  `json:"day"`
+	OrganizationID                       *string `json:"organization_id,omitempty"`
+	EnterpriseID                         *string `json:"enterprise_id,omitempty"`
+	DailyActiveCLIUsers                  *int    `json:"daily_active_cli_users,omitempty"`
+	DailyActiveUsers                     *int    `json:"daily_active_users,omitempty"`
+	DailyActiveCopilotCloudAgentUsers    *int    `json:"daily_active_copilot_cloud_agent_users,omitempty"`
+	WeeklyActiveUsers                    *int    `json:"weekly_active_users,omitempty"`
+	WeeklyActiveCopilotCloudAgentUsers   *int    `json:"weekly_active_copilot_cloud_agent_users,omitempty"`
+	MonthlyActiveUsers                   *int    `json:"monthly_active_users,omitempty"`
+	MonthlyActiveChatUsers               *int    `json:"monthly_active_chat_users,omitempty"`
+	MonthlyActiveAgentUsers              *int    `json:"monthly_active_agent_users,omitempty"`
+	MonthlyActiveCopilotCloudAgentUsers  *int    `json:"monthly_active_copilot_cloud_agent_users,omitempty"`
+	DailyActiveCopilotCodeReviewUsers    *int    `json:"daily_active_copilot_code_review_users,omitempty"`
+	WeeklyActiveCopilotCodeReviewUsers   *int    `json:"weekly_active_copilot_code_review_users,omitempty"`
+	MonthlyActiveCopilotCodeReviewUsers  *int    `json:"monthly_active_copilot_code_review_users,omitempty"`
+	DailyPassiveCopilotCodeReviewUsers   *int    `json:"daily_passive_copilot_code_review_users,omitempty"`
+	WeeklyPassiveCopilotCodeReviewUsers  *int    `json:"weekly_passive_copilot_code_review_users,omitempty"`
+	MonthlyPassiveCopilotCodeReviewUsers *int    `json:"monthly_passive_copilot_code_review_users,omitempty"`
+	UserInitiatedInteractionCount        *int    `json:"user_initiated_interaction_count,omitempty"`
 	CopilotMetricsChatPanel
 	CodeGenerationActivityCount *int                                   `json:"code_generation_activity_count,omitempty"`
 	CodeAcceptanceActivityCount *int                                   `json:"code_acceptance_activity_count,omitempty"`

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -3035,8 +3035,14 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 			"organization_id": "123",
 			"daily_active_cli_users": 2,
 			"daily_active_users": 10,
+			"daily_active_copilot_code_review_users": 3,
+			"daily_passive_copilot_code_review_users": 1,
 			"weekly_active_users": 20,
+			"weekly_active_copilot_code_review_users": 8,
+			"weekly_passive_copilot_code_review_users": 2,
 			"monthly_active_users": 30,
+			"monthly_active_copilot_code_review_users": 15,
+			"monthly_passive_copilot_code_review_users": 4,
 			"chat_panel_ask_mode": 4,
 			"totals_by_ide": [
 				{"ide": "vscode", "user_initiated_interaction_count": 5, "loc_added_sum": 100}
@@ -3113,12 +3119,18 @@ func TestCopilotService_DownloadDailyMetrics(t *testing.T) {
 	}
 
 	want := &CopilotDailyMetrics{
-		Day:                 "2026-04-01",
-		OrganizationID:      new("123"),
-		DailyActiveCLIUsers: new(2),
-		DailyActiveUsers:    new(10),
-		WeeklyActiveUsers:   new(20),
-		MonthlyActiveUsers:  new(30),
+		Day:                                  "2026-04-01",
+		OrganizationID:                       new("123"),
+		DailyActiveCLIUsers:                  new(2),
+		DailyActiveUsers:                     new(10),
+		DailyActiveCopilotCodeReviewUsers:    new(3),
+		DailyPassiveCopilotCodeReviewUsers:   new(1),
+		WeeklyActiveUsers:                    new(20),
+		WeeklyActiveCopilotCodeReviewUsers:   new(8),
+		WeeklyPassiveCopilotCodeReviewUsers:  new(2),
+		MonthlyActiveUsers:                   new(30),
+		MonthlyActiveCopilotCodeReviewUsers:  new(15),
+		MonthlyPassiveCopilotCodeReviewUsers: new(4),
 		CopilotMetricsChatPanel: CopilotMetricsChatPanel{
 			ChatPanelAskMode: new(4),
 		},
@@ -3260,6 +3272,10 @@ func TestCopilotService_DownloadPeriodicMetrics(t *testing.T) {
 					"day": "2026-03-05",
 					"daily_active_cli_users": 2,
 					"daily_active_users": 5,
+					"daily_active_copilot_code_review_users": 2,
+					"daily_passive_copilot_code_review_users": 1,
+					"weekly_active_copilot_code_review_users": 6,
+					"monthly_active_copilot_code_review_users": 12,
 					"totals_by_cli": {
 						"session_count": 1,
 						"request_count": 2,
@@ -3298,9 +3314,13 @@ func TestCopilotService_DownloadPeriodicMetrics(t *testing.T) {
 		CreatedAt:      refTimestamp(1136178000),
 		DayTotals: []*CopilotDailyMetrics{
 			{
-				Day:                 "2026-03-05",
-				DailyActiveCLIUsers: new(2),
-				DailyActiveUsers:    new(5),
+				Day:                                 "2026-03-05",
+				DailyActiveCLIUsers:                 new(2),
+				DailyActiveUsers:                    new(5),
+				DailyActiveCopilotCodeReviewUsers:   new(2),
+				DailyPassiveCopilotCodeReviewUsers:  new(1),
+				WeeklyActiveCopilotCodeReviewUsers:  new(6),
+				MonthlyActiveCopilotCodeReviewUsers: new(12),
 				TotalsByCLI: &CopilotMetricsCLI{
 					SessionCount: new(1),
 					RequestCount: new(2),

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -9126,12 +9126,28 @@ func (c *CopilotDailyMetrics) GetDailyActiveCopilotCloudAgentUsers() int {
 	return *c.DailyActiveCopilotCloudAgentUsers
 }
 
+// GetDailyActiveCopilotCodeReviewUsers returns the DailyActiveCopilotCodeReviewUsers field if it's non-nil, zero value otherwise.
+func (c *CopilotDailyMetrics) GetDailyActiveCopilotCodeReviewUsers() int {
+	if c == nil || c.DailyActiveCopilotCodeReviewUsers == nil {
+		return 0
+	}
+	return *c.DailyActiveCopilotCodeReviewUsers
+}
+
 // GetDailyActiveUsers returns the DailyActiveUsers field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetDailyActiveUsers() int {
 	if c == nil || c.DailyActiveUsers == nil {
 		return 0
 	}
 	return *c.DailyActiveUsers
+}
+
+// GetDailyPassiveCopilotCodeReviewUsers returns the DailyPassiveCopilotCodeReviewUsers field if it's non-nil, zero value otherwise.
+func (c *CopilotDailyMetrics) GetDailyPassiveCopilotCodeReviewUsers() int {
+	if c == nil || c.DailyPassiveCopilotCodeReviewUsers == nil {
+		return 0
+	}
+	return *c.DailyPassiveCopilotCodeReviewUsers
 }
 
 // GetDay returns the Day field.
@@ -9206,12 +9222,28 @@ func (c *CopilotDailyMetrics) GetMonthlyActiveCopilotCloudAgentUsers() int {
 	return *c.MonthlyActiveCopilotCloudAgentUsers
 }
 
+// GetMonthlyActiveCopilotCodeReviewUsers returns the MonthlyActiveCopilotCodeReviewUsers field if it's non-nil, zero value otherwise.
+func (c *CopilotDailyMetrics) GetMonthlyActiveCopilotCodeReviewUsers() int {
+	if c == nil || c.MonthlyActiveCopilotCodeReviewUsers == nil {
+		return 0
+	}
+	return *c.MonthlyActiveCopilotCodeReviewUsers
+}
+
 // GetMonthlyActiveUsers returns the MonthlyActiveUsers field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetMonthlyActiveUsers() int {
 	if c == nil || c.MonthlyActiveUsers == nil {
 		return 0
 	}
 	return *c.MonthlyActiveUsers
+}
+
+// GetMonthlyPassiveCopilotCodeReviewUsers returns the MonthlyPassiveCopilotCodeReviewUsers field if it's non-nil, zero value otherwise.
+func (c *CopilotDailyMetrics) GetMonthlyPassiveCopilotCodeReviewUsers() int {
+	if c == nil || c.MonthlyPassiveCopilotCodeReviewUsers == nil {
+		return 0
+	}
+	return *c.MonthlyPassiveCopilotCodeReviewUsers
 }
 
 // GetOrganizationID returns the OrganizationID field if it's non-nil, zero value otherwise.
@@ -9310,12 +9342,28 @@ func (c *CopilotDailyMetrics) GetWeeklyActiveCopilotCloudAgentUsers() int {
 	return *c.WeeklyActiveCopilotCloudAgentUsers
 }
 
+// GetWeeklyActiveCopilotCodeReviewUsers returns the WeeklyActiveCopilotCodeReviewUsers field if it's non-nil, zero value otherwise.
+func (c *CopilotDailyMetrics) GetWeeklyActiveCopilotCodeReviewUsers() int {
+	if c == nil || c.WeeklyActiveCopilotCodeReviewUsers == nil {
+		return 0
+	}
+	return *c.WeeklyActiveCopilotCodeReviewUsers
+}
+
 // GetWeeklyActiveUsers returns the WeeklyActiveUsers field if it's non-nil, zero value otherwise.
 func (c *CopilotDailyMetrics) GetWeeklyActiveUsers() int {
 	if c == nil || c.WeeklyActiveUsers == nil {
 		return 0
 	}
 	return *c.WeeklyActiveUsers
+}
+
+// GetWeeklyPassiveCopilotCodeReviewUsers returns the WeeklyPassiveCopilotCodeReviewUsers field if it's non-nil, zero value otherwise.
+func (c *CopilotDailyMetrics) GetWeeklyPassiveCopilotCodeReviewUsers() int {
+	if c == nil || c.WeeklyPassiveCopilotCodeReviewUsers == nil {
+		return 0
+	}
+	return *c.WeeklyPassiveCopilotCodeReviewUsers
 }
 
 // GetDownloadLinks returns the DownloadLinks slice if it's non-nil, nil otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -11644,6 +11644,17 @@ func TestCopilotDailyMetrics_GetDailyActiveCopilotCloudAgentUsers(tt *testing.T)
 	c.GetDailyActiveCopilotCloudAgentUsers()
 }
 
+func TestCopilotDailyMetrics_GetDailyActiveCopilotCodeReviewUsers(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotDailyMetrics{DailyActiveCopilotCodeReviewUsers: &zeroValue}
+	c.GetDailyActiveCopilotCodeReviewUsers()
+	c = &CopilotDailyMetrics{}
+	c.GetDailyActiveCopilotCodeReviewUsers()
+	c = nil
+	c.GetDailyActiveCopilotCodeReviewUsers()
+}
+
 func TestCopilotDailyMetrics_GetDailyActiveUsers(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int
@@ -11653,6 +11664,17 @@ func TestCopilotDailyMetrics_GetDailyActiveUsers(tt *testing.T) {
 	c.GetDailyActiveUsers()
 	c = nil
 	c.GetDailyActiveUsers()
+}
+
+func TestCopilotDailyMetrics_GetDailyPassiveCopilotCodeReviewUsers(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotDailyMetrics{DailyPassiveCopilotCodeReviewUsers: &zeroValue}
+	c.GetDailyPassiveCopilotCodeReviewUsers()
+	c = &CopilotDailyMetrics{}
+	c.GetDailyPassiveCopilotCodeReviewUsers()
+	c = nil
+	c.GetDailyPassiveCopilotCodeReviewUsers()
 }
 
 func TestCopilotDailyMetrics_GetDay(tt *testing.T) {
@@ -11751,6 +11773,17 @@ func TestCopilotDailyMetrics_GetMonthlyActiveCopilotCloudAgentUsers(tt *testing.
 	c.GetMonthlyActiveCopilotCloudAgentUsers()
 }
 
+func TestCopilotDailyMetrics_GetMonthlyActiveCopilotCodeReviewUsers(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotDailyMetrics{MonthlyActiveCopilotCodeReviewUsers: &zeroValue}
+	c.GetMonthlyActiveCopilotCodeReviewUsers()
+	c = &CopilotDailyMetrics{}
+	c.GetMonthlyActiveCopilotCodeReviewUsers()
+	c = nil
+	c.GetMonthlyActiveCopilotCodeReviewUsers()
+}
+
 func TestCopilotDailyMetrics_GetMonthlyActiveUsers(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int
@@ -11760,6 +11793,17 @@ func TestCopilotDailyMetrics_GetMonthlyActiveUsers(tt *testing.T) {
 	c.GetMonthlyActiveUsers()
 	c = nil
 	c.GetMonthlyActiveUsers()
+}
+
+func TestCopilotDailyMetrics_GetMonthlyPassiveCopilotCodeReviewUsers(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotDailyMetrics{MonthlyPassiveCopilotCodeReviewUsers: &zeroValue}
+	c.GetMonthlyPassiveCopilotCodeReviewUsers()
+	c = &CopilotDailyMetrics{}
+	c.GetMonthlyPassiveCopilotCodeReviewUsers()
+	c = nil
+	c.GetMonthlyPassiveCopilotCodeReviewUsers()
 }
 
 func TestCopilotDailyMetrics_GetOrganizationID(tt *testing.T) {
@@ -11888,6 +11932,17 @@ func TestCopilotDailyMetrics_GetWeeklyActiveCopilotCloudAgentUsers(tt *testing.T
 	c.GetWeeklyActiveCopilotCloudAgentUsers()
 }
 
+func TestCopilotDailyMetrics_GetWeeklyActiveCopilotCodeReviewUsers(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotDailyMetrics{WeeklyActiveCopilotCodeReviewUsers: &zeroValue}
+	c.GetWeeklyActiveCopilotCodeReviewUsers()
+	c = &CopilotDailyMetrics{}
+	c.GetWeeklyActiveCopilotCodeReviewUsers()
+	c = nil
+	c.GetWeeklyActiveCopilotCodeReviewUsers()
+}
+
 func TestCopilotDailyMetrics_GetWeeklyActiveUsers(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int
@@ -11897,6 +11952,17 @@ func TestCopilotDailyMetrics_GetWeeklyActiveUsers(tt *testing.T) {
 	c.GetWeeklyActiveUsers()
 	c = nil
 	c.GetWeeklyActiveUsers()
+}
+
+func TestCopilotDailyMetrics_GetWeeklyPassiveCopilotCodeReviewUsers(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotDailyMetrics{WeeklyPassiveCopilotCodeReviewUsers: &zeroValue}
+	c.GetWeeklyPassiveCopilotCodeReviewUsers()
+	c = &CopilotDailyMetrics{}
+	c.GetWeeklyPassiveCopilotCodeReviewUsers()
+	c = nil
+	c.GetWeeklyPassiveCopilotCodeReviewUsers()
 }
 
 func TestCopilotDailyMetricsReport_GetDownloadLinks(tt *testing.T) {


### PR DESCRIPTION
Fixes #4489

Adds active and passive Copilot code review user counts to aggregated
Copilot usage metrics reports.

Docs: https://docs.github.com/en/copilot/reference/copilot-usage-metrics/copilot-usage-metrics

## Test plan
- [x] `go test ./github/... -run Copilot`
- [x] `./script/generate.sh`