### PR TITLE
refactor!: Split `RepositoryComment` request bodies and pass by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -236,7 +236,6 @@ linters:
             - PullRequestReviewsEnforcementUpdate
             - Repository
             - RepositoryAddCollaboratorOptions
-            - RepositoryComment
             - RepositoryContentFileOptions
             - RepositoryCreateForkOptions
             - RequiredStatusChecksRequest

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11582,6 +11582,38 @@ func (c *CreateCodespaceOptions) GetWorkingDirectory() string {
 	return *c.WorkingDirectory
 }
 
+// GetBody returns the Body field.
+func (c *CreateCommitCommentRequest) GetBody() string {
+	if c == nil {
+		return ""
+	}
+	return c.Body
+}
+
+// GetLine returns the Line field if it's non-nil, zero value otherwise.
+func (c *CreateCommitCommentRequest) GetLine() int {
+	if c == nil || c.Line == nil {
+		return 0
+	}
+	return *c.Line
+}
+
+// GetPath returns the Path field if it's non-nil, zero value otherwise.
+func (c *CreateCommitCommentRequest) GetPath() string {
+	if c == nil || c.Path == nil {
+		return ""
+	}
+	return *c.Path
+}
+
+// GetPosition returns the Position field if it's non-nil, zero value otherwise.
+func (c *CreateCommitCommentRequest) GetPosition() int {
+	if c == nil || c.Position == nil {
+		return 0
+	}
+	return *c.Position
+}
+
 // GetSigner returns the Signer field.
 func (c *CreateCommitOptions) GetSigner() MessageSigner {
 	if c == nil {
@@ -44044,6 +44076,14 @@ func (u *UpdateCodespaceOptions) GetRecentFolders() []string {
 		return nil
 	}
 	return u.RecentFolders
+}
+
+// GetBody returns the Body field.
+func (u *UpdateCommitCommentRequest) GetBody() string {
+	if u == nil {
+		return ""
+	}
+	return u.Body
 }
 
 // GetGroupID returns the GroupID field.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -35870,6 +35870,14 @@ func (r *RepositoryCodeSecurityConfiguration) GetState() string {
 	return *r.State
 }
 
+// GetAuthorAssociation returns the AuthorAssociation field if it's non-nil, zero value otherwise.
+func (r *RepositoryComment) GetAuthorAssociation() string {
+	if r == nil || r.AuthorAssociation == nil {
+		return ""
+	}
+	return *r.AuthorAssociation
+}
+
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
 func (r *RepositoryComment) GetBody() string {
 	if r == nil || r.Body == nil {
@@ -35908,6 +35916,14 @@ func (r *RepositoryComment) GetID() int64 {
 		return 0
 	}
 	return *r.ID
+}
+
+// GetLine returns the Line field if it's non-nil, zero value otherwise.
+func (r *RepositoryComment) GetLine() int {
+	if r == nil || r.Line == nil {
+		return 0
+	}
+	return *r.Line
 }
 
 // GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -45012,6 +45012,17 @@ func TestRepositoryCodeSecurityConfiguration_GetState(tt *testing.T) {
 	r.GetState()
 }
 
+func TestRepositoryComment_GetAuthorAssociation(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	r := &RepositoryComment{AuthorAssociation: &zeroValue}
+	r.GetAuthorAssociation()
+	r = &RepositoryComment{}
+	r.GetAuthorAssociation()
+	r = nil
+	r.GetAuthorAssociation()
+}
+
 func TestRepositoryComment_GetBody(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -45065,6 +45076,17 @@ func TestRepositoryComment_GetID(tt *testing.T) {
 	r.GetID()
 	r = nil
 	r.GetID()
+}
+
+func TestRepositoryComment_GetLine(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	r := &RepositoryComment{Line: &zeroValue}
+	r.GetLine()
+	r = &RepositoryComment{}
+	r.GetLine()
+	r = nil
+	r.GetLine()
 }
 
 func TestRepositoryComment_GetNodeID(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -14631,6 +14631,47 @@ func TestCreateCodespaceOptions_GetWorkingDirectory(tt *testing.T) {
 	c.GetWorkingDirectory()
 }
 
+func TestCreateCommitCommentRequest_GetBody(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateCommitCommentRequest{}
+	c.GetBody()
+	c = nil
+	c.GetBody()
+}
+
+func TestCreateCommitCommentRequest_GetLine(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CreateCommitCommentRequest{Line: &zeroValue}
+	c.GetLine()
+	c = &CreateCommitCommentRequest{}
+	c.GetLine()
+	c = nil
+	c.GetLine()
+}
+
+func TestCreateCommitCommentRequest_GetPath(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CreateCommitCommentRequest{Path: &zeroValue}
+	c.GetPath()
+	c = &CreateCommitCommentRequest{}
+	c.GetPath()
+	c = nil
+	c.GetPath()
+}
+
+func TestCreateCommitCommentRequest_GetPosition(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CreateCommitCommentRequest{Position: &zeroValue}
+	c.GetPosition()
+	c = &CreateCommitCommentRequest{}
+	c.GetPosition()
+	c = nil
+	c.GetPosition()
+}
+
 func TestCreateCommitOptions_GetSigner(tt *testing.T) {
 	tt.Parallel()
 	c := &CreateCommitOptions{}
@@ -55073,6 +55114,14 @@ func TestUpdateCodespaceOptions_GetRecentFolders(tt *testing.T) {
 	u.GetRecentFolders()
 	u = nil
 	u.GetRecentFolders()
+}
+
+func TestUpdateCommitCommentRequest_GetBody(tt *testing.T) {
+	tt.Parallel()
+	u := &UpdateCommitCommentRequest{}
+	u.GetBody()
+	u = nil
+	u.GetBody()
 }
 
 func TestUpdateConnectedExternalGroupRequest_GetGroupID(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -2050,20 +2050,22 @@ func TestRepository_String(t *testing.T) {
 func TestRepositoryComment_String(t *testing.T) {
 	t.Parallel()
 	v := RepositoryComment{
-		HTMLURL:   new(""),
-		URL:       new(""),
-		ID:        new(int64(0)),
-		NodeID:    new(""),
-		CommitID:  new(""),
-		User:      &User{},
-		Reactions: &Reactions{},
-		CreatedAt: &Timestamp{},
-		UpdatedAt: &Timestamp{},
-		Body:      new(""),
-		Path:      new(""),
-		Position:  new(0),
+		HTMLURL:           new(""),
+		URL:               new(""),
+		ID:                new(int64(0)),
+		NodeID:            new(""),
+		CommitID:          new(""),
+		User:              &User{},
+		AuthorAssociation: new(""),
+		Reactions:         &Reactions{},
+		CreatedAt:         &Timestamp{},
+		UpdatedAt:         &Timestamp{},
+		Body:              new(""),
+		Path:              new(""),
+		Position:          new(0),
+		Line:              new(0),
 	}
-	want := `github.RepositoryComment{HTMLURL:"", URL:"", ID:0, NodeID:"", CommitID:"", User:github.User{}, Reactions:github.Reactions{}, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Body:"", Path:"", Position:0}`
+	want := `github.RepositoryComment{HTMLURL:"", URL:"", ID:0, NodeID:"", CommitID:"", User:github.User{}, AuthorAssociation:"", Reactions:github.Reactions{}, CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Body:"", Path:"", Position:0, Line:0}`
 	if got := v.String(); got != want {
 		t.Errorf("RepositoryComment.String = %v, want %v", got, want)
 	}

--- a/github/repos_comments.go
+++ b/github/repos_comments.go
@@ -21,16 +21,27 @@ type RepositoryComment struct {
 	Reactions *Reactions `json:"reactions,omitempty"`
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
-
-	// User-mutable fields
-	Body *string `json:"body"`
-	// User-initialized fields
-	Path     *string `json:"path,omitempty"`
-	Position *int    `json:"position,omitempty"`
+	Body      *string    `json:"body,omitempty"`
+	Path      *string    `json:"path,omitempty"`
+	Position  *int       `json:"position,omitempty"`
 }
 
 func (r RepositoryComment) String() string {
 	return Stringify(r)
+}
+
+// CreateCommitCommentRequest represents a request to create a commit comment.
+type CreateCommitCommentRequest struct {
+	Body     string  `json:"body"`
+	Path     *string `json:"path,omitempty"`
+	Position *int    `json:"position,omitempty"`
+	// Deprecated: Use Position instead.
+	Line *int `json:"line,omitempty"`
+}
+
+// UpdateCommitCommentRequest represents a request to update a commit comment.
+type UpdateCommitCommentRequest struct {
+	Body string `json:"body"`
 }
 
 // ListComments lists all the comments for the repository.
@@ -95,7 +106,7 @@ func (s *RepositoriesService) ListCommitComments(ctx context.Context, owner, rep
 // GitHub API docs: https://docs.github.com/rest/commits/comments?apiVersion=2022-11-28#create-a-commit-comment
 //
 //meta:operation POST /repos/{owner}/{repo}/commits/{commit_sha}/comments
-func (s *RepositoriesService) CreateComment(ctx context.Context, owner, repo, sha string, body *RepositoryComment) (*RepositoryComment, *Response, error) {
+func (s *RepositoriesService) CreateComment(ctx context.Context, owner, repo, sha string, body CreateCommitCommentRequest) (*RepositoryComment, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/commits/%v/comments", owner, repo, sha)
 	req, err := s.client.NewRequest(ctx, "POST", u, body)
 	if err != nil {
@@ -116,8 +127,8 @@ func (s *RepositoriesService) CreateComment(ctx context.Context, owner, repo, sh
 // GitHub API docs: https://docs.github.com/rest/commits/comments?apiVersion=2022-11-28#get-a-commit-comment
 //
 //meta:operation GET /repos/{owner}/{repo}/comments/{comment_id}
-func (s *RepositoriesService) GetComment(ctx context.Context, owner, repo string, id int64) (*RepositoryComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, id)
+func (s *RepositoriesService) GetComment(ctx context.Context, owner, repo string, commentID int64) (*RepositoryComment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, commentID)
 	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
@@ -139,8 +150,8 @@ func (s *RepositoriesService) GetComment(ctx context.Context, owner, repo string
 // GitHub API docs: https://docs.github.com/rest/commits/comments?apiVersion=2022-11-28#update-a-commit-comment
 //
 //meta:operation PATCH /repos/{owner}/{repo}/comments/{comment_id}
-func (s *RepositoriesService) UpdateComment(ctx context.Context, owner, repo string, id int64, body *RepositoryComment) (*RepositoryComment, *Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, id)
+func (s *RepositoriesService) UpdateComment(ctx context.Context, owner, repo string, commentID int64, body UpdateCommitCommentRequest) (*RepositoryComment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, commentID)
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
 	if err != nil {
 		return nil, nil, err
@@ -160,8 +171,8 @@ func (s *RepositoriesService) UpdateComment(ctx context.Context, owner, repo str
 // GitHub API docs: https://docs.github.com/rest/commits/comments?apiVersion=2022-11-28#delete-a-commit-comment
 //
 //meta:operation DELETE /repos/{owner}/{repo}/comments/{comment_id}
-func (s *RepositoriesService) DeleteComment(ctx context.Context, owner, repo string, id int64) (*Response, error) {
-	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, id)
+func (s *RepositoriesService) DeleteComment(ctx context.Context, owner, repo string, commentID int64) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, commentID)
 	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/github/repos_comments.go
+++ b/github/repos_comments.go
@@ -12,18 +12,20 @@ import (
 
 // RepositoryComment represents a comment for a commit, file, or line in a repository.
 type RepositoryComment struct {
-	HTMLURL   *string    `json:"html_url,omitempty"`
-	URL       *string    `json:"url,omitempty"`
-	ID        *int64     `json:"id,omitempty"`
-	NodeID    *string    `json:"node_id,omitempty"`
-	CommitID  *string    `json:"commit_id,omitempty"`
-	User      *User      `json:"user,omitempty"`
-	Reactions *Reactions `json:"reactions,omitempty"`
-	CreatedAt *Timestamp `json:"created_at,omitempty"`
-	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
-	Body      *string    `json:"body,omitempty"`
-	Path      *string    `json:"path,omitempty"`
-	Position  *int       `json:"position,omitempty"`
+	HTMLURL           *string    `json:"html_url,omitempty"`
+	URL               *string    `json:"url,omitempty"`
+	ID                *int64     `json:"id,omitempty"`
+	NodeID            *string    `json:"node_id,omitempty"`
+	CommitID          *string    `json:"commit_id,omitempty"`
+	User              *User      `json:"user,omitempty"`
+	AuthorAssociation *string    `json:"author_association,omitempty"`
+	Reactions         *Reactions `json:"reactions,omitempty"`
+	CreatedAt         *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt         *Timestamp `json:"updated_at,omitempty"`
+	Body              *string    `json:"body,omitempty"`
+	Path              *string    `json:"path,omitempty"`
+	Position          *int       `json:"position,omitempty"`
+	Line              *int       `json:"line,omitempty"`
 }
 
 func (r RepositoryComment) String() string {

--- a/github/repos_comments_test.go
+++ b/github/repos_comments_test.go
@@ -111,7 +111,7 @@ func TestRepositoriesService_CreateComment(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &RepositoryComment{Body: new("b")}
+	input := CreateCommitCommentRequest{Body: "b"}
 
 	mux.HandleFunc("/repos/o/r/commits/s/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -150,7 +150,7 @@ func TestRepositoriesService_CreateComment_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Repositories.CreateComment(ctx, "%", "%", "%", nil)
+	_, _, err := client.Repositories.CreateComment(ctx, "%", "%", "%", CreateCommitCommentRequest{})
 	testURLParseError(t, err)
 }
 
@@ -203,7 +203,7 @@ func TestRepositoriesService_UpdateComment(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	input := &RepositoryComment{Body: new("b")}
+	input := UpdateCommitCommentRequest{Body: "b"}
 
 	mux.HandleFunc("/repos/o/r/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -243,7 +243,7 @@ func TestRepositoriesService_UpdateComment_invalidOwner(t *testing.T) {
 	client, _, _ := setup(t)
 
 	ctx := t.Context()
-	_, _, err := client.Repositories.UpdateComment(ctx, "%", "%", 1, nil)
+	_, _, err := client.Repositories.UpdateComment(ctx, "%", "%", 1, UpdateCommitCommentRequest{})
 	testURLParseError(t, err)
 }
 


### PR DESCRIPTION
Continues the request-body-by-value work in #3644 — the commit-comments counterpart of #4444 (`IssueComment`, issues) and #4493 (`PullRequestComment`, pulls), completing the comment-endpoint family.

**Commit 1 (`refactor!:`)** — `RepositoriesService.CreateComment` and `UpdateComment` reused the 12-field `RepositoryComment` **response** type as their request bodies. Per the [create](https://docs.github.com/rest/commits/comments?apiVersion=2022-11-28#create-a-commit-comment) / [update](https://docs.github.com/rest/commits/comments?apiVersion=2022-11-28#update-a-commit-comment) docs the two request schemas differ, so this splits them into dedicated types (same shape as #4493):

| | `body` | `path` | `position` | `line` |
|---|---|---|---|---|
| create | **required** | optional | optional | optional (deprecated — "use position instead") |
| update | **required** | — | — | — |

```go
type CreateCommitCommentRequest struct {
	Body     string  `json:"body"`
	Path     *string `json:"path,omitempty"`
	Position *int    `json:"position,omitempty"`
	// Deprecated: Use Position instead.
	Line *int `json:"line,omitempty"`
}

type UpdateCommitCommentRequest struct {
	Body string `json:"body"`
}
```

Both methods now take these by value (`Body` required → non-pointer, no `omitempty`), and `RepositoryComment` is removed from the `paramcheck` allowlist in `.golangci.yml`. No method renames are needed — `Create`/`Update` already match the docs operation names. Alongside:

- the now-stale `// User-mutable fields` / `// User-initialized fields` markers on `RepositoryComment` are dropped and `Body`'s tag normalized to `json:"body,omitempty"`, making it a plain response type like `IssueComment` / `PullRequestComment`;
- the `{comment_id}` parameter is named `commentID` consistently across `GetComment` / `UpdateComment` / `DeleteComment` (matching the issues/pulls comment files);
- the request types also gain the deprecated `line` create parameter, which the old shared type could not send at all.

**Commit 2 (`feat:`, non-breaking)** — cross-checking the full [commit-comment response schema](https://docs.github.com/rest/commits/comments?apiVersion=2022-11-28#get-a-commit-comment) against the struct turned up two missing fields, added here with regenerated accessors: `AuthorAssociation` and `Line`.

BREAKING CHANGE: `RepositoriesService.CreateComment` now takes `CreateCommitCommentRequest` and `RepositoriesService.UpdateComment` takes `UpdateCommitCommentRequest`, both passed by value instead of `*RepositoryComment`.

Verified with `go build ./...`, `gofmt`, `go vet -tags integration ./test/integration/`, the full `./github/` test suite (all `repos_comments.go` methods at 100% coverage), generator idempotency, and `custom-gcl` (0 issues with the allowlist entry removed).

Updates #3644.

cc @jvm986
