### PR TITLE
feat: Add Copilot repository daily metrics report endpoints

### DIFF
--- a/github/copilot.go
+++ b/github/copilot.go
@@ -879,11 +879,70 @@ func (s *CopilotService) GetOrganizationUsersMetricsReport(ctx context.Context, 
 	return report, resp, nil
 }
 
+// GetEnterpriseRepositoriesDailyMetricsReport gets a report containing Copilot
+// repository-level pull request metrics for a single day for an enterprise.
+//
+// Use DownloadRepositoryDailyMetrics to decode the payloads served at the returned download links.
+//
+// GitHub API docs: https://docs.github.com/rest/copilot/copilot-usage-metrics?apiVersion=2022-11-28#get-copilot-enterprise-repository-report-for-a-specific-day
+//
+//meta:operation GET /enterprises/{enterprise}/copilot/metrics/reports/repos-1-day
+func (s *CopilotService) GetEnterpriseRepositoriesDailyMetricsReport(ctx context.Context, enterprise string, opts *CopilotMetricsReportOptions) (*CopilotDailyMetricsReport, *Response, error) {
+	u := fmt.Sprintf("enterprises/%v/copilot/metrics/reports/repos-1-day", enterprise)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var report *CopilotDailyMetricsReport
+	resp, err := s.client.Do(req, &report)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return report, resp, nil
+}
+
+// GetOrganizationRepositoriesDailyMetricsReport gets a report containing Copilot
+// repository-level pull request metrics for a single day for an organization.
+//
+// Use DownloadRepositoryDailyMetrics to decode the payloads served at the returned download links.
+//
+// GitHub API docs: https://docs.github.com/rest/copilot/copilot-usage-metrics?apiVersion=2022-11-28#get-copilot-organization-repository-report-for-a-specific-day
+//
+//meta:operation GET /orgs/{org}/copilot/metrics/reports/repos-1-day
+func (s *CopilotService) GetOrganizationRepositoriesDailyMetricsReport(ctx context.Context, org string, opts *CopilotMetricsReportOptions) (*CopilotDailyMetricsReport, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/copilot/metrics/reports/repos-1-day", org)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var report *CopilotDailyMetricsReport
+	resp, err := s.client.Do(req, &report)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return report, resp, nil
+}
+
 // DownloadCopilotMetrics downloads a Copilot metrics report from the provided download link
 // and decodes it as a []*CopilotMetrics.
 //
 // Deprecated: Use DownloadDailyMetrics,
-// DownloadPeriodicMetrics, DownloadUserDailyMetrics, DownloadUserPeriodicMetrics instead.
+// DownloadPeriodicMetrics, DownloadUserDailyMetrics, DownloadUserPeriodicMetrics,
+// DownloadRepositoryDailyMetrics instead.
 // The payloads served at the download links returned by the new
 // Get*MetricsReport endpoints on GitHub.com do not match the CopilotMetrics shape
 // (see https://github.com/google/go-github/issues/4136).
@@ -909,22 +968,48 @@ func (s *CopilotService) DownloadCopilotMetrics(ctx context.Context, url string)
 	return metrics, resp, nil
 }
 
+// CopilotMetricsCopilotSuggestionByCommentType represents Copilot code review suggestion
+// counts broken down by comment type in a pull_requests object.
+//
+// GitHub API docs: https://docs.github.com/en/copilot/reference/copilot-usage-metrics/copilot-usage-metrics#pull-request-activity-fields
+type CopilotMetricsCopilotSuggestionByCommentType struct {
+	CommentType                    string `json:"comment_type"`
+	TotalCopilotSuggestions        *int   `json:"total_copilot_suggestions,omitempty"`
+	TotalCopilotAppliedSuggestions *int   `json:"total_copilot_applied_suggestions,omitempty"`
+}
+
 // CopilotMetricsPullRequests represents pull request totals in a Copilot metrics report.
 type CopilotMetricsPullRequests struct {
-	TotalReviewed                       *int     `json:"total_reviewed,omitempty"`
-	TotalCreated                        *int     `json:"total_created,omitempty"`
-	TotalCreatedByCopilot               *int     `json:"total_created_by_copilot,omitempty"`
-	TotalReviewedByCopilot              *int     `json:"total_reviewed_by_copilot,omitempty"`
-	TotalMerged                         *int     `json:"total_merged,omitempty"`
-	MedianMinutesToMerge                *float64 `json:"median_minutes_to_merge,omitempty"`
-	TotalSuggestions                    *int     `json:"total_suggestions,omitempty"`
-	TotalAppliedSuggestions             *int     `json:"total_applied_suggestions,omitempty"`
-	TotalMergedCreatedByCopilot         *int     `json:"total_merged_created_by_copilot,omitempty"`
-	MedianMinutesToMergeCopilotAuthored *float64 `json:"median_minutes_to_merge_copilot_authored,omitempty"`
-	TotalCopilotSuggestions             *int     `json:"total_copilot_suggestions,omitempty"`
-	TotalCopilotAppliedSuggestions      *int     `json:"total_copilot_applied_suggestions,omitempty"`
-	MedianMinutesToMergeCopilotReviewed *float64 `json:"median_minutes_to_merge_copilot_reviewed,omitempty"`
-	TotalMergedReviewedByCopilot        *int     `json:"total_merged_reviewed_by_copilot,omitempty"`
+	TotalReviewed                       *int                                            `json:"total_reviewed,omitempty"`
+	TotalCreated                        *int                                            `json:"total_created,omitempty"`
+	TotalCreatedByCopilot               *int                                            `json:"total_created_by_copilot,omitempty"`
+	TotalReviewedByCopilot              *int                                            `json:"total_reviewed_by_copilot,omitempty"`
+	TotalMerged                         *int                                            `json:"total_merged,omitempty"`
+	MedianMinutesToMerge                *float64                                        `json:"median_minutes_to_merge,omitempty"`
+	TotalSuggestions                    *int                                            `json:"total_suggestions,omitempty"`
+	TotalAppliedSuggestions             *int                                            `json:"total_applied_suggestions,omitempty"`
+	TotalMergedCreatedByCopilot         *int                                            `json:"total_merged_created_by_copilot,omitempty"`
+	MedianMinutesToMergeCopilotAuthored *float64                                        `json:"median_minutes_to_merge_copilot_authored,omitempty"`
+	TotalCopilotSuggestions             *int                                            `json:"total_copilot_suggestions,omitempty"`
+	TotalCopilotAppliedSuggestions      *int                                            `json:"total_copilot_applied_suggestions,omitempty"`
+	MedianMinutesToMergeCopilotReviewed *float64                                        `json:"median_minutes_to_merge_copilot_reviewed,omitempty"`
+	TotalMergedReviewedByCopilot        *int                                            `json:"total_merged_reviewed_by_copilot,omitempty"`
+	CopilotSuggestionsByCommentType     []*CopilotMetricsCopilotSuggestionByCommentType `json:"copilot_suggestions_by_comment_type,omitempty"`
+}
+
+// CopilotRepositoryDailyMetrics represents a single repository's per-day Copilot pull request
+// metrics record from a repos-1-day report. Repository reports are served as newline-delimited JSON.
+//
+// GitHub API docs: https://docs.github.com/en/copilot/reference/copilot-usage-metrics/copilot-usage-metrics#repository-level-fields-api-only
+type CopilotRepositoryDailyMetrics struct {
+	Day            string                      `json:"day"`
+	EnterpriseID   *string                     `json:"enterprise_id,omitempty"`
+	OrganizationID *string                     `json:"organization_id,omitempty"`
+	RepoID         int64                       `json:"repo_id"`
+	RepoOwnerName  string                      `json:"repo_owner_name"`
+	RepoName       string                      `json:"repo_name"`
+	RepoVisibility string                      `json:"repo_visibility"`
+	PullRequests   *CopilotMetricsPullRequests `json:"pull_requests,omitempty"`
 }
 
 // CopilotMetricsCodeActivity captures the code-generation activity counts and lines-of-code (LOC)
@@ -1343,6 +1428,25 @@ func (s *CopilotService) DownloadUserPeriodicMetrics(ctx context.Context, url st
 	defer resp.Body.Close()
 
 	records, err := decodeNDJSONMetrics[CopilotUserPeriodicMetrics](resp.Body)
+	if err != nil {
+		return nil, r, err
+	}
+	return records, r, nil
+}
+
+// DownloadRepositoryDailyMetrics downloads the payload of a 1-day Copilot repository metrics
+// report from a download link returned by GetEnterpriseRepositoriesDailyMetricsReport or
+// GetOrganizationRepositoriesDailyMetricsReport.
+//
+// The response is newline-delimited JSON, with one CopilotRepositoryDailyMetrics record per line.
+func (s *CopilotService) DownloadRepositoryDailyMetrics(ctx context.Context, url string) ([]*CopilotRepositoryDailyMetrics, *Response, error) {
+	resp, r, err := s.fetchMetricsReport(ctx, url)
+	if err != nil {
+		return nil, r, err
+	}
+	defer resp.Body.Close()
+
+	records, err := decodeNDJSONMetrics[CopilotRepositoryDailyMetrics](resp.Body)
 	if err != nil {
 		return nil, r, err
 	}

--- a/github/copilot_test.go
+++ b/github/copilot_test.go
@@ -2888,6 +2888,96 @@ func TestCopilotService_GetOrganizationUsersMetricsReport(t *testing.T) {
 	})
 }
 
+func TestCopilotService_GetEnterpriseRepositoriesDailyMetricsReport(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/enterprises/e/copilot/metrics/reports/repos-1-day", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"day": "2026-07-14"})
+		fmt.Fprint(w, `{
+			"download_links": ["https://example.com/repos-1.json", "https://example.com/repos-2.json"],
+			"report_day": "2026-07-14"
+		}`)
+	})
+
+	ctx := t.Context()
+	opts := &CopilotMetricsReportOptions{Day: "2026-07-14"}
+	got, _, err := client.Copilot.GetEnterpriseRepositoriesDailyMetricsReport(ctx, "e", opts)
+	if err != nil {
+		t.Errorf("Copilot.GetEnterpriseRepositoriesDailyMetricsReport returned error: %v", err)
+	}
+
+	want := &CopilotDailyMetricsReport{
+		DownloadLinks: []string{"https://example.com/repos-1.json", "https://example.com/repos-2.json"},
+		ReportDay:     "2026-07-14",
+	}
+
+	if !cmp.Equal(got, want) {
+		t.Errorf("Copilot.GetEnterpriseRepositoriesDailyMetricsReport returned %+v, want %+v", got, want)
+	}
+
+	const methodName = "GetEnterpriseRepositoriesDailyMetricsReport"
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Copilot.GetEnterpriseRepositoriesDailyMetricsReport(ctx, "\n", opts)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Copilot.GetEnterpriseRepositoriesDailyMetricsReport(ctx, "e", opts)
+		if got != nil {
+			t.Errorf("Copilot.GetEnterpriseRepositoriesDailyMetricsReport returned %+v, want nil", got)
+		}
+		return resp, err
+	})
+}
+
+func TestCopilotService_GetOrganizationRepositoriesDailyMetricsReport(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/orgs/o/copilot/metrics/reports/repos-1-day", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"day": "2026-07-14"})
+		fmt.Fprint(w, `{
+			"download_links": ["https://example.com/repos-1.json"],
+			"report_day": "2026-07-14"
+		}`)
+	})
+
+	ctx := t.Context()
+	opts := &CopilotMetricsReportOptions{Day: "2026-07-14"}
+	got, _, err := client.Copilot.GetOrganizationRepositoriesDailyMetricsReport(ctx, "o", opts)
+	if err != nil {
+		t.Errorf("Copilot.GetOrganizationRepositoriesDailyMetricsReport returned error: %v", err)
+	}
+
+	want := &CopilotDailyMetricsReport{
+		DownloadLinks: []string{"https://example.com/repos-1.json"},
+		ReportDay:     "2026-07-14",
+	}
+
+	if !cmp.Equal(got, want) {
+		t.Errorf("Copilot.GetOrganizationRepositoriesDailyMetricsReport returned %+v, want %+v", got, want)
+	}
+
+	const methodName = "GetOrganizationRepositoriesDailyMetricsReport"
+
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Copilot.GetOrganizationRepositoriesDailyMetricsReport(ctx, "\n", opts)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Copilot.GetOrganizationRepositoriesDailyMetricsReport(ctx, "o", opts)
+		if got != nil {
+			t.Errorf("Copilot.GetOrganizationRepositoriesDailyMetricsReport returned %+v, want nil", got)
+		}
+		return resp, err
+	})
+}
+
 func TestCopilotService_DownloadCopilotMetrics(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
@@ -3652,5 +3742,124 @@ func TestCopilotService_DownloadUserPeriodicMetrics(t *testing.T) {
 	})
 	if _, _, err := client.Copilot.DownloadUserPeriodicMetrics(ctx, client.baseURL.String()+"path/to/users-periodic/badjson"); err == nil {
 		t.Error("Copilot.DownloadUserPeriodicMetrics expected error for bad JSON, got none")
+	}
+}
+
+func TestCopilotService_DownloadRepositoryDailyMetrics(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/path/to/repos-daily", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"day":"2026-07-14","enterprise_id":"1001","organization_id":"2002","repo_id":900000001,"repo_owner_name":"octodemo-metrics","repo_name":"example-service-alpha","repo_visibility":"INTERNAL","pull_requests":{"total_reviewed":1,"total_created":1,"total_created_by_copilot":1,"total_reviewed_by_copilot":1,"total_merged":1,"median_minutes_to_merge":372.62,"total_suggestions":0,"total_applied_suggestions":0,"total_merged_created_by_copilot":1,"median_minutes_to_merge_copilot_authored":372.62,"total_copilot_suggestions":0,"total_copilot_applied_suggestions":0,"total_merged_reviewed_by_copilot":1,"median_minutes_to_merge_copilot_reviewed":372.62,"copilot_suggestions_by_comment_type":[]}}
+{"day":"2026-07-14","enterprise_id":"1001","organization_id":"2002","repo_id":900000003,"repo_owner_name":"octodemo-metrics","repo_name":"example-service-gamma","repo_visibility":"INTERNAL","pull_requests":{"total_reviewed":1,"total_created":0,"total_created_by_copilot":0,"total_reviewed_by_copilot":1,"total_merged":1,"median_minutes_to_merge":1020.53,"total_suggestions":0,"total_applied_suggestions":1,"total_merged_created_by_copilot":0,"total_copilot_suggestions":0,"total_copilot_applied_suggestions":1,"total_merged_reviewed_by_copilot":1,"median_minutes_to_merge_copilot_reviewed":1020.53,"copilot_suggestions_by_comment_type":[{"comment_type":"spelling","total_copilot_suggestions":0,"total_copilot_applied_suggestions":1}]}}
+`)
+	})
+
+	ctx := t.Context()
+	url := client.baseURL.String() + "path/to/repos-daily"
+	got, resp, err := client.Copilot.DownloadRepositoryDailyMetrics(ctx, url)
+	if err != nil {
+		t.Errorf("Copilot.DownloadRepositoryDailyMetrics returned error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Copilot.DownloadRepositoryDailyMetrics returned status code: %v", resp.StatusCode)
+	}
+
+	want := []*CopilotRepositoryDailyMetrics{
+		{
+			Day:            "2026-07-14",
+			EnterpriseID:   new("1001"),
+			OrganizationID: new("2002"),
+			RepoID:         900000001,
+			RepoOwnerName:  "octodemo-metrics",
+			RepoName:       "example-service-alpha",
+			RepoVisibility: "INTERNAL",
+			PullRequests: &CopilotMetricsPullRequests{
+				TotalReviewed:                       new(1),
+				TotalCreated:                        new(1),
+				TotalCreatedByCopilot:               new(1),
+				TotalReviewedByCopilot:              new(1),
+				TotalMerged:                         new(1),
+				MedianMinutesToMerge:                new(372.62),
+				TotalSuggestions:                    new(0),
+				TotalAppliedSuggestions:             new(0),
+				TotalMergedCreatedByCopilot:         new(1),
+				MedianMinutesToMergeCopilotAuthored: new(372.62),
+				TotalCopilotSuggestions:             new(0),
+				TotalCopilotAppliedSuggestions:      new(0),
+				TotalMergedReviewedByCopilot:        new(1),
+				MedianMinutesToMergeCopilotReviewed: new(372.62),
+				CopilotSuggestionsByCommentType:     []*CopilotMetricsCopilotSuggestionByCommentType{},
+			},
+		},
+		{
+			Day:            "2026-07-14",
+			EnterpriseID:   new("1001"),
+			OrganizationID: new("2002"),
+			RepoID:         900000003,
+			RepoOwnerName:  "octodemo-metrics",
+			RepoName:       "example-service-gamma",
+			RepoVisibility: "INTERNAL",
+			PullRequests: &CopilotMetricsPullRequests{
+				TotalReviewed:                       new(1),
+				TotalCreated:                        new(0),
+				TotalCreatedByCopilot:               new(0),
+				TotalReviewedByCopilot:              new(1),
+				TotalMerged:                         new(1),
+				MedianMinutesToMerge:                new(1020.53),
+				TotalSuggestions:                    new(0),
+				TotalAppliedSuggestions:             new(1),
+				TotalMergedCreatedByCopilot:         new(0),
+				TotalCopilotSuggestions:             new(0),
+				TotalCopilotAppliedSuggestions:      new(1),
+				TotalMergedReviewedByCopilot:        new(1),
+				MedianMinutesToMergeCopilotReviewed: new(1020.53),
+				CopilotSuggestionsByCommentType: []*CopilotMetricsCopilotSuggestionByCommentType{
+					{
+						CommentType:                    "spelling",
+						TotalCopilotSuggestions:        new(0),
+						TotalCopilotAppliedSuggestions: new(1),
+					},
+				},
+			},
+		},
+	}
+
+	if !cmp.Equal(got, want) {
+		t.Errorf("Copilot.DownloadRepositoryDailyMetrics returned %+v, want %+v", got, want)
+	}
+
+	mux.HandleFunc("/path/to/repos-daily/empty", func(_ http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+	})
+	gotEmpty, _, err := client.Copilot.DownloadRepositoryDailyMetrics(ctx, client.baseURL.String()+"path/to/repos-daily/empty")
+	if err != nil {
+		t.Errorf("Copilot.DownloadRepositoryDailyMetrics empty body returned error: %v", err)
+	}
+	if gotEmpty != nil {
+		t.Errorf("Copilot.DownloadRepositoryDailyMetrics empty body returned %+v, want nil", gotEmpty)
+	}
+
+	mux.HandleFunc("/path/to/repos-daily/error", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.WriteHeader(http.StatusNotFound)
+	})
+	if _, _, err := client.Copilot.DownloadRepositoryDailyMetrics(ctx, client.baseURL.String()+"path/to/repos-daily/error"); err == nil {
+		t.Error("Copilot.DownloadRepositoryDailyMetrics expected error but got none")
+	}
+	if _, _, err := client.Copilot.DownloadRepositoryDailyMetrics(ctx, "\n"); err == nil {
+		t.Error("Copilot.DownloadRepositoryDailyMetrics expected error for invalid URL, got none")
+	}
+	if _, _, err := client.Copilot.DownloadRepositoryDailyMetrics(ctx, "invalid-scheme://test"); err == nil {
+		t.Error("Copilot.DownloadRepositoryDailyMetrics expected error for invalid scheme, got none")
+	}
+
+	mux.HandleFunc("/path/to/repos-daily/badjson", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, "{\"repo_id\":1,\"day\":\"2026-07-14\"}\n{bad\n")
+	})
+	if _, _, err := client.Copilot.DownloadRepositoryDailyMetrics(ctx, client.baseURL.String()+"path/to/repos-daily/badjson"); err == nil {
+		t.Error("Copilot.DownloadRepositoryDailyMetrics expected error for bad JSON, got none")
 	}
 }

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -10206,6 +10206,30 @@ func (c *CopilotMetricsCopilotAppTokenUsage) GetPromptTokensSum() int {
 	return *c.PromptTokensSum
 }
 
+// GetCommentType returns the CommentType field.
+func (c *CopilotMetricsCopilotSuggestionByCommentType) GetCommentType() string {
+	if c == nil {
+		return ""
+	}
+	return c.CommentType
+}
+
+// GetTotalCopilotAppliedSuggestions returns the TotalCopilotAppliedSuggestions field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsCopilotSuggestionByCommentType) GetTotalCopilotAppliedSuggestions() int {
+	if c == nil || c.TotalCopilotAppliedSuggestions == nil {
+		return 0
+	}
+	return *c.TotalCopilotAppliedSuggestions
+}
+
+// GetTotalCopilotSuggestions returns the TotalCopilotSuggestions field if it's non-nil, zero value otherwise.
+func (c *CopilotMetricsCopilotSuggestionByCommentType) GetTotalCopilotSuggestions() int {
+	if c == nil || c.TotalCopilotSuggestions == nil {
+		return 0
+	}
+	return *c.TotalCopilotSuggestions
+}
+
 // GetFeature returns the Feature field.
 func (c *CopilotMetricsFeature) GetFeature() string {
 	if c == nil {
@@ -10308,6 +10332,14 @@ func (c *CopilotMetricsModelFeature) GetUserInitiatedInteractionCount() int {
 		return 0
 	}
 	return *c.UserInitiatedInteractionCount
+}
+
+// GetCopilotSuggestionsByCommentType returns the CopilotSuggestionsByCommentType slice if it's non-nil, nil otherwise.
+func (c *CopilotMetricsPullRequests) GetCopilotSuggestionsByCommentType() []*CopilotMetricsCopilotSuggestionByCommentType {
+	if c == nil || c.CopilotSuggestionsByCommentType == nil {
+		return nil
+	}
+	return c.CopilotSuggestionsByCommentType
 }
 
 // GetMedianMinutesToMerge returns the MedianMinutesToMerge field if it's non-nil, zero value otherwise.
@@ -10564,6 +10596,70 @@ func (c *CopilotPeriodicMetrics) GetReportStartDay() string {
 		return ""
 	}
 	return c.ReportStartDay
+}
+
+// GetDay returns the Day field.
+func (c *CopilotRepositoryDailyMetrics) GetDay() string {
+	if c == nil {
+		return ""
+	}
+	return c.Day
+}
+
+// GetEnterpriseID returns the EnterpriseID field if it's non-nil, zero value otherwise.
+func (c *CopilotRepositoryDailyMetrics) GetEnterpriseID() string {
+	if c == nil || c.EnterpriseID == nil {
+		return ""
+	}
+	return *c.EnterpriseID
+}
+
+// GetOrganizationID returns the OrganizationID field if it's non-nil, zero value otherwise.
+func (c *CopilotRepositoryDailyMetrics) GetOrganizationID() string {
+	if c == nil || c.OrganizationID == nil {
+		return ""
+	}
+	return *c.OrganizationID
+}
+
+// GetPullRequests returns the PullRequests field.
+func (c *CopilotRepositoryDailyMetrics) GetPullRequests() *CopilotMetricsPullRequests {
+	if c == nil {
+		return nil
+	}
+	return c.PullRequests
+}
+
+// GetRepoID returns the RepoID field.
+func (c *CopilotRepositoryDailyMetrics) GetRepoID() int64 {
+	if c == nil {
+		return 0
+	}
+	return c.RepoID
+}
+
+// GetRepoName returns the RepoName field.
+func (c *CopilotRepositoryDailyMetrics) GetRepoName() string {
+	if c == nil {
+		return ""
+	}
+	return c.RepoName
+}
+
+// GetRepoOwnerName returns the RepoOwnerName field.
+func (c *CopilotRepositoryDailyMetrics) GetRepoOwnerName() string {
+	if c == nil {
+		return ""
+	}
+	return c.RepoOwnerName
+}
+
+// GetRepoVisibility returns the RepoVisibility field.
+func (c *CopilotRepositoryDailyMetrics) GetRepoVisibility() string {
+	if c == nil {
+		return ""
+	}
+	return c.RepoVisibility
 }
 
 // GetActiveThisCycle returns the ActiveThisCycle field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -12928,6 +12928,36 @@ func TestCopilotMetricsCopilotAppTokenUsage_GetPromptTokensSum(tt *testing.T) {
 	c.GetPromptTokensSum()
 }
 
+func TestCopilotMetricsCopilotSuggestionByCommentType_GetCommentType(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotMetricsCopilotSuggestionByCommentType{}
+	c.GetCommentType()
+	c = nil
+	c.GetCommentType()
+}
+
+func TestCopilotMetricsCopilotSuggestionByCommentType_GetTotalCopilotAppliedSuggestions(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsCopilotSuggestionByCommentType{TotalCopilotAppliedSuggestions: &zeroValue}
+	c.GetTotalCopilotAppliedSuggestions()
+	c = &CopilotMetricsCopilotSuggestionByCommentType{}
+	c.GetTotalCopilotAppliedSuggestions()
+	c = nil
+	c.GetTotalCopilotAppliedSuggestions()
+}
+
+func TestCopilotMetricsCopilotSuggestionByCommentType_GetTotalCopilotSuggestions(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	c := &CopilotMetricsCopilotSuggestionByCommentType{TotalCopilotSuggestions: &zeroValue}
+	c.GetTotalCopilotSuggestions()
+	c = &CopilotMetricsCopilotSuggestionByCommentType{}
+	c.GetTotalCopilotSuggestions()
+	c = nil
+	c.GetTotalCopilotSuggestions()
+}
+
 func TestCopilotMetricsFeature_GetFeature(tt *testing.T) {
 	tt.Parallel()
 	c := &CopilotMetricsFeature{}
@@ -13045,6 +13075,17 @@ func TestCopilotMetricsModelFeature_GetUserInitiatedInteractionCount(tt *testing
 	c.GetUserInitiatedInteractionCount()
 	c = nil
 	c.GetUserInitiatedInteractionCount()
+}
+
+func TestCopilotMetricsPullRequests_GetCopilotSuggestionsByCommentType(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CopilotMetricsCopilotSuggestionByCommentType{}
+	c := &CopilotMetricsPullRequests{CopilotSuggestionsByCommentType: zeroValue}
+	c.GetCopilotSuggestionsByCommentType()
+	c = &CopilotMetricsPullRequests{}
+	c.GetCopilotSuggestionsByCommentType()
+	c = nil
+	c.GetCopilotSuggestionsByCommentType()
 }
 
 func TestCopilotMetricsPullRequests_GetMedianMinutesToMerge(tt *testing.T) {
@@ -13364,6 +13405,76 @@ func TestCopilotPeriodicMetrics_GetReportStartDay(tt *testing.T) {
 	c.GetReportStartDay()
 	c = nil
 	c.GetReportStartDay()
+}
+
+func TestCopilotRepositoryDailyMetrics_GetDay(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotRepositoryDailyMetrics{}
+	c.GetDay()
+	c = nil
+	c.GetDay()
+}
+
+func TestCopilotRepositoryDailyMetrics_GetEnterpriseID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CopilotRepositoryDailyMetrics{EnterpriseID: &zeroValue}
+	c.GetEnterpriseID()
+	c = &CopilotRepositoryDailyMetrics{}
+	c.GetEnterpriseID()
+	c = nil
+	c.GetEnterpriseID()
+}
+
+func TestCopilotRepositoryDailyMetrics_GetOrganizationID(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	c := &CopilotRepositoryDailyMetrics{OrganizationID: &zeroValue}
+	c.GetOrganizationID()
+	c = &CopilotRepositoryDailyMetrics{}
+	c.GetOrganizationID()
+	c = nil
+	c.GetOrganizationID()
+}
+
+func TestCopilotRepositoryDailyMetrics_GetPullRequests(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotRepositoryDailyMetrics{}
+	c.GetPullRequests()
+	c = nil
+	c.GetPullRequests()
+}
+
+func TestCopilotRepositoryDailyMetrics_GetRepoID(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotRepositoryDailyMetrics{}
+	c.GetRepoID()
+	c = nil
+	c.GetRepoID()
+}
+
+func TestCopilotRepositoryDailyMetrics_GetRepoName(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotRepositoryDailyMetrics{}
+	c.GetRepoName()
+	c = nil
+	c.GetRepoName()
+}
+
+func TestCopilotRepositoryDailyMetrics_GetRepoOwnerName(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotRepositoryDailyMetrics{}
+	c.GetRepoOwnerName()
+	c = nil
+	c.GetRepoOwnerName()
+}
+
+func TestCopilotRepositoryDailyMetrics_GetRepoVisibility(tt *testing.T) {
+	tt.Parallel()
+	c := &CopilotRepositoryDailyMetrics{}
+	c.GetRepoVisibility()
+	c = nil
+	c.GetRepoVisibility()
 }
 
 func TestCopilotSeatBreakdown_GetActiveThisCycle(tt *testing.T) {

--- a/tools/metadata/metadata.go
+++ b/tools/metadata/metadata.go
@@ -566,9 +566,10 @@ func nodeServiceMethod(fn *ast.FuncDecl) string {
 // skipServiceMethod lists helper methods that download from URLs returned by
 // other endpoints and therefore have no REST API operation of their own.
 var skipServiceMethod = map[string]bool{
-	"CopilotService.DownloadCopilotMetrics":      true,
-	"CopilotService.DownloadDailyMetrics":        true,
-	"CopilotService.DownloadPeriodicMetrics":     true,
-	"CopilotService.DownloadUserDailyMetrics":    true,
-	"CopilotService.DownloadUserPeriodicMetrics": true,
+	"CopilotService.DownloadCopilotMetrics":         true,
+	"CopilotService.DownloadDailyMetrics":           true,
+	"CopilotService.DownloadPeriodicMetrics":        true,
+	"CopilotService.DownloadRepositoryDailyMetrics": true,
+	"CopilotService.DownloadUserDailyMetrics":       true,
+	"CopilotService.DownloadUserPeriodicMetrics":    true,
 }


### PR DESCRIPTION
Fixes #4497

Adds Copilot `repos-1-day` report endpoints and download helper.

Docs: https://docs.github.com/en/rest/copilot/copilot-usage-metrics

## Test plan
- [x] `go test ./github/... -run Copilot`
- [x] `./script/fmt.sh`
- [x] `./script/generate.sh`