### PR TITLE
feat: Add IsEnabled field to IssueType

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -22766,6 +22766,14 @@ func (i *IssueType) GetID() int64 {
 	return *i.ID
 }
 
+// GetIsEnabled returns the IsEnabled field if it's non-nil, zero value otherwise.
+func (i *IssueType) GetIsEnabled() bool {
+	if i == nil || i.IsEnabled == nil {
+		return false
+	}
+	return *i.IsEnabled
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (i *IssueType) GetName() string {
 	if i == nil || i.Name == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -28587,6 +28587,17 @@ func TestIssueType_GetID(tt *testing.T) {
 	i.GetID()
 }
 
+func TestIssueType_GetIsEnabled(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	i := &IssueType{IsEnabled: &zeroValue}
+	i.GetIsEnabled()
+	i = &IssueType{}
+	i.GetIsEnabled()
+	i = nil
+	i.GetIsEnabled()
+}
+
 func TestIssueType_GetName(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string

--- a/github/issues.go
+++ b/github/issues.go
@@ -159,6 +159,7 @@ type IssueType struct {
 	Name        *string    `json:"name,omitempty"`
 	Description *string    `json:"description,omitempty"`
 	Color       *string    `json:"color,omitempty"`
+	IsEnabled   *bool      `json:"is_enabled,omitempty"`
 	CreatedAt   *Timestamp `json:"created_at,omitempty"`
 	UpdatedAt   *Timestamp `json:"updated_at,omitempty"`
 }

--- a/github/orgs_issue_types_test.go
+++ b/github/orgs_issue_types_test.go
@@ -25,6 +25,7 @@ func TestOrganizationsService_ListIssueTypes(t *testing.T) {
 				"node_id": "IT_kwDNAd3NAZo",
 				"name": "Task",
 				"description": "A specific piece of work",
+				"is_enabled": true,
 				"created_at": `+refTimeStr(1136178000)+`,
 				"updated_at": `+refTimeStr(1136178001)+`
 			},
@@ -33,6 +34,7 @@ func TestOrganizationsService_ListIssueTypes(t *testing.T) {
 				"node_id": "IT_kwDNAd3NAZs",
 				"name": "Bug",
 				"description": "An unexpected problem or behavior",
+				"is_enabled": false,
 				"created_at": `+refTimeStr(1136178002)+`,
 				"updated_at": `+refTimeStr(1136178003)+`
 			}
@@ -51,6 +53,7 @@ func TestOrganizationsService_ListIssueTypes(t *testing.T) {
 			NodeID:      new("IT_kwDNAd3NAZo"),
 			Name:        new("Task"),
 			Description: new("A specific piece of work"),
+			IsEnabled:   new(true),
 			CreatedAt:   refTimestamp(1136178000),
 			UpdatedAt:   refTimestamp(1136178001),
 		},
@@ -59,6 +62,7 @@ func TestOrganizationsService_ListIssueTypes(t *testing.T) {
 			NodeID:      new("IT_kwDNAd3NAZs"),
 			Name:        new("Bug"),
 			Description: new("An unexpected problem or behavior"),
+			IsEnabled:   new(false),
 			CreatedAt:   refTimestamp(1136178002),
 			UpdatedAt:   refTimestamp(1136178003),
 		},
@@ -102,6 +106,7 @@ func TestOrganizationsService_CreateIssueType(t *testing.T) {
 				"node_id": "IT_kwDNAd3NAZo",
 				"name": "Epic",
 				"description": "An issue type for a multi-week tracking of work",
+				"is_enabled": true,
 				"created_at": `+refTimeStr(1136178000)+`,
 				"updated_at": `+refTimeStr(1136178001)+`
 		}`)
@@ -117,6 +122,7 @@ func TestOrganizationsService_CreateIssueType(t *testing.T) {
 		NodeID:      new("IT_kwDNAd3NAZo"),
 		Name:        new("Epic"),
 		Description: new("An issue type for a multi-week tracking of work"),
+		IsEnabled:   new(true),
 		CreatedAt:   refTimestamp(1136178000),
 		UpdatedAt:   refTimestamp(1136178001),
 	}
@@ -160,6 +166,7 @@ func TestOrganizationsService_UpdateIssueType(t *testing.T) {
 				"node_id": "IT_kwDNAd3NAZo",
 				"name": "Epic",
 				"description": "An issue type for a multi-week tracking of work",
+				"is_enabled": true,
 				"created_at": `+refTimeStr(1136178000)+`,
 				"updated_at": `+refTimeStr(1136178001)+`
 		}`)
@@ -175,6 +182,7 @@ func TestOrganizationsService_UpdateIssueType(t *testing.T) {
 		NodeID:      new("IT_kwDNAd3NAZo"),
 		Name:        new("Epic"),
 		Description: new("An issue type for a multi-week tracking of work"),
+		IsEnabled:   new(true),
 		CreatedAt:   refTimestamp(1136178000),
 		UpdatedAt:   refTimestamp(1136178001),
 	}


### PR DESCRIPTION
Adds the `is_enabled` field to `IssueType`. GitHub returns it for issue types (see the `issue-type` OpenAPI schema), but it was previously dropped on decode. The request type `CreateOrUpdateIssueTypesOptions` already had the corresponding field.

Updated the existing `ListIssueTypes`, `CreateIssueType` and `UpdateIssueType` tests to cover the new field.

Fixes #4503

AI assistance: Claude was used to diff go-github's structs against GitHub's OpenAPI description to find the missing field and to draft the edits; the change was applied, tested (`script/fmt.sh`, `script/test.sh`, `script/lint.sh`) and reviewed locally by me.