### PR TITLE
feat: Add ThrottledAt field to HookDelivery

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -19430,6 +19430,14 @@ func (h *HookDelivery) GetStatusCode() int {
 	return *h.StatusCode
 }
 
+// GetThrottledAt returns the ThrottledAt field if it's non-nil, zero value otherwise.
+func (h *HookDelivery) GetThrottledAt() Timestamp {
+	if h == nil || h.ThrottledAt == nil {
+		return Timestamp{}
+	}
+	return *h.ThrottledAt
+}
+
 // GetHeaders returns the Headers map if it's non-nil, an empty map otherwise.
 func (h *HookRequest) GetHeaders() map[string]string {
 	if h == nil || h.Headers == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -24414,6 +24414,17 @@ func TestHookDelivery_GetStatusCode(tt *testing.T) {
 	h.GetStatusCode()
 }
 
+func TestHookDelivery_GetThrottledAt(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue Timestamp
+	h := &HookDelivery{ThrottledAt: &zeroValue}
+	h.GetThrottledAt()
+	h = &HookDelivery{}
+	h.GetThrottledAt()
+	h = nil
+	h.GetThrottledAt()
+}
+
 func TestHookRequest_GetHeaders(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := map[string]string{}

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -849,10 +849,11 @@ func TestHookDelivery_String(t *testing.T) {
 		Action:         new(""),
 		InstallationID: new(int64(0)),
 		RepositoryID:   new(int64(0)),
+		ThrottledAt:    &Timestamp{},
 		Request:        &HookRequest{},
 		Response:       &HookResponse{},
 	}
-	want := `github.HookDelivery{ID:0, GUID:"", DeliveredAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Redelivery:false, Duration:0, Status:"", StatusCode:0, Event:"", Action:"", InstallationID:0, RepositoryID:0, Request:github.HookRequest{}, Response:github.HookResponse{}}`
+	want := `github.HookDelivery{ID:0, GUID:"", DeliveredAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Redelivery:false, Duration:0, Status:"", StatusCode:0, Event:"", Action:"", InstallationID:0, RepositoryID:0, ThrottledAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, Request:github.HookRequest{}, Response:github.HookResponse{}}`
 	if got := v.String(); got != want {
 		t.Errorf("HookDelivery.String = %v, want %v", got, want)
 	}

--- a/github/repos_hooks_deliveries.go
+++ b/github/repos_hooks_deliveries.go
@@ -29,6 +29,7 @@ type HookDelivery struct {
 	Action         *string    `json:"action,omitempty"`
 	InstallationID *int64     `json:"installation_id,omitempty"`
 	RepositoryID   *int64     `json:"repository_id,omitempty"`
+	ThrottledAt    *Timestamp `json:"throttled_at,omitempty"`
 
 	// Request is populated by GetHookDelivery.
 	Request *HookRequest `json:"request,omitempty"`

--- a/github/repos_hooks_deliveries_test.go
+++ b/github/repos_hooks_deliveries_test.go
@@ -22,7 +22,7 @@ func TestRepositoriesService_ListHookDeliveries(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/hooks/1/deliveries", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"cursor": "v1_12077215967"})
-		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
+		fmt.Fprint(w, `[{"id":1,"throttled_at":`+referenceTimeStr+`}, {"id":2}]`)
 	})
 
 	opt := &ListCursorOptions{Cursor: "v1_12077215967"}
@@ -33,7 +33,7 @@ func TestRepositoriesService_ListHookDeliveries(t *testing.T) {
 		t.Errorf("Repositories.ListHookDeliveries returned error: %v", err)
 	}
 
-	want := []*HookDelivery{{ID: new(int64(1))}, {ID: new(int64(2))}}
+	want := []*HookDelivery{{ID: new(int64(1)), ThrottledAt: &referenceTimestamp}, {ID: new(int64(2))}}
 	if d := cmp.Diff(hooks, want); d != "" {
 		t.Errorf("Repositories.ListHooks want (-), got (+):\n%v", d)
 	}
@@ -68,7 +68,7 @@ func TestRepositoriesService_GetHookDelivery(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/hooks/1/deliveries/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"id":1}`)
+		fmt.Fprint(w, `{"id":1,"throttled_at":`+referenceTimeStr+`}`)
 	})
 
 	ctx := t.Context()
@@ -77,7 +77,7 @@ func TestRepositoriesService_GetHookDelivery(t *testing.T) {
 		t.Errorf("Repositories.GetHookDelivery returned error: %v", err)
 	}
 
-	want := &HookDelivery{ID: new(int64(1))}
+	want := &HookDelivery{ID: new(int64(1)), ThrottledAt: &referenceTimestamp}
 	if !cmp.Equal(hook, want) {
 		t.Errorf("Repositories.GetHookDelivery returned %+v, want %+v", hook, want)
 	}


### PR DESCRIPTION
Adds the `throttled_at` field to `HookDelivery`. It is documented in the `hook-delivery` / `hook-delivery-item` OpenAPI schemas, and confirmed present in the live list-deliveries and get-delivery responses for a real push event on my fork; it was previously dropped on decode.

Note on verification: the drop was observed end-to-end through `ListHookDeliveries` on the live API (raw body has the key, decoded struct does not). For `GetHookDelivery` the live response also carries the key, but its value was `null` on my fork (the delivery was not throttled), so the typed path can't show a difference there; both methods decode into the same `HookDelivery` struct, and the non-null case is covered by the updated unit tests.

Updated the existing `ListHookDeliveries` and `GetHookDelivery` tests to cover the new field.

Fixes #4517

AI assistance: Claude was used to diff go-github's structs against GitHub's OpenAPI description and to draft the edits; the field was verified against the live API, and the change was applied, tested (`script/fmt.sh`, `script/test.sh`, `script/lint.sh`) and reviewed locally by me.