### PR TITLE
refactor!: Rename `DependencyGraphSnapshot` to `CreateDependencyGraphSnapshotRequest` and pass by value

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -216,7 +216,6 @@ linters:
             - CustomDeploymentProtectionRuleRequest
             - CustomProperty
             - DependabotAlertState
-            - DependencyGraphSnapshot
             - EncryptedSecret
             - EnterpriseSecurityAnalysisSettings
             - Hook

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -304,7 +304,6 @@ linters:
             - CommitsSearchResult.Commits
             - CommitsSearchResult.Total
             - CreateOrgInvitationOptions.TeamID # TODO: TeamIDs
-            - DependencyGraphSnapshot.Sha # TODO: SHA
             - Discussion.DiscussionCategory # TODO: Category ?
             - EditOwner.OwnerInfo
             - EnterpriseLicensedUsers.GithubComSamlNameID # TODO: GithubComSAMLNameID

--- a/github/dependency_graph_snapshots.go
+++ b/github/dependency_graph_snapshots.go
@@ -77,7 +77,7 @@ type DependencyGraphSnapshotManifest struct {
 // GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#create-a-snapshot-of-dependencies-for-a-repository
 type DependencyGraphSnapshot struct {
 	Version   int                                         `json:"version"`
-	Sha       *string                                     `json:"sha,omitempty"`
+	SHA       *string                                     `json:"sha,omitempty"`
 	Ref       *string                                     `json:"ref,omitempty"`
 	Job       *DependencyGraphSnapshotJob                 `json:"job,omitempty"`
 	Detector  *DependencyGraphSnapshotDetector            `json:"detector,omitempty"`

--- a/github/dependency_graph_snapshots.go
+++ b/github/dependency_graph_snapshots.go
@@ -41,8 +41,8 @@ type DependencyGraphSnapshotResolvedDependency struct {
 //
 // GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#create-a-snapshot-of-dependencies-for-a-repository
 type DependencyGraphSnapshotJob struct {
-	Correlator *string `json:"correlator,omitempty"`
-	ID         *string `json:"id,omitempty"`
+	Correlator string  `json:"correlator"`
+	ID         string  `json:"id"`
 	HTMLURL    *string `json:"html_url,omitempty"`
 }
 
@@ -50,9 +50,9 @@ type DependencyGraphSnapshotJob struct {
 //
 // GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#create-a-snapshot-of-dependencies-for-a-repository
 type DependencyGraphSnapshotDetector struct {
-	Name    *string `json:"name,omitempty"`
-	Version *string `json:"version,omitempty"`
-	URL     *string `json:"url,omitempty"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	URL     string `json:"url"`
 }
 
 // DependencyGraphSnapshotManifestFile represents the file declaring the repository's dependencies.
@@ -66,22 +66,22 @@ type DependencyGraphSnapshotManifestFile struct {
 //
 // GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#create-a-snapshot-of-dependencies-for-a-repository
 type DependencyGraphSnapshotManifest struct {
-	Name     *string                                               `json:"name,omitempty"`
+	Name     string                                                `json:"name"`
 	File     *DependencyGraphSnapshotManifestFile                  `json:"file,omitempty"`
 	Metadata map[string]any                                        `json:"metadata,omitempty"`
 	Resolved map[string]*DependencyGraphSnapshotResolvedDependency `json:"resolved,omitempty"`
 }
 
-// DependencyGraphSnapshot represent a snapshot of a repository's dependencies.
+// CreateDependencyGraphSnapshotRequest represents a request to create a snapshot of a repository's dependencies.
 //
 // GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#create-a-snapshot-of-dependencies-for-a-repository
-type DependencyGraphSnapshot struct {
+type CreateDependencyGraphSnapshotRequest struct {
 	Version   int                                         `json:"version"`
-	SHA       *string                                     `json:"sha,omitempty"`
-	Ref       *string                                     `json:"ref,omitempty"`
-	Job       *DependencyGraphSnapshotJob                 `json:"job,omitempty"`
-	Detector  *DependencyGraphSnapshotDetector            `json:"detector,omitempty"`
-	Scanned   *Timestamp                                  `json:"scanned,omitempty"`
+	SHA       string                                      `json:"sha"`
+	Ref       string                                      `json:"ref"`
+	Job       DependencyGraphSnapshotJob                  `json:"job"`
+	Detector  DependencyGraphSnapshotDetector             `json:"detector"`
+	Scanned   Timestamp                                   `json:"scanned"`
 	Metadata  map[string]any                              `json:"metadata,omitempty"`
 	Manifests map[string]*DependencyGraphSnapshotManifest `json:"manifests,omitempty"`
 }
@@ -106,7 +106,7 @@ type DependencyGraphSnapshotCreationData struct {
 // GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#create-a-snapshot-of-dependencies-for-a-repository
 //
 //meta:operation POST /repos/{owner}/{repo}/dependency-graph/snapshots
-func (s *DependencyGraphService) CreateSnapshot(ctx context.Context, owner, repo string, body *DependencyGraphSnapshot) (*DependencyGraphSnapshotCreationData, *Response, error) {
+func (s *DependencyGraphService) CreateSnapshot(ctx context.Context, owner, repo string, body CreateDependencyGraphSnapshotRequest) (*DependencyGraphSnapshotCreationData, *Response, error) {
 	url := fmt.Sprintf("repos/%v/%v/dependency-graph/snapshots", owner, repo)
 
 	req, err := s.client.NewRequest(ctx, "POST", url, body)

--- a/github/dependency_graph_snapshots.go
+++ b/github/dependency_graph_snapshots.go
@@ -75,6 +75,8 @@ type DependencyGraphSnapshotManifest struct {
 // CreateDependencyGraphSnapshotRequest represents a request to create a snapshot of a repository's dependencies.
 //
 // GitHub API docs: https://docs.github.com/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#create-a-snapshot-of-dependencies-for-a-repository
+//
+//meta:schema request POST /repos/{owner}/{repo}/dependency-graph/snapshots
 type CreateDependencyGraphSnapshotRequest struct {
 	Version   int                                         `json:"version"`
 	SHA       string                                      `json:"sha"`

--- a/github/dependency_graph_snapshots_test.go
+++ b/github/dependency_graph_snapshots_test.go
@@ -17,28 +17,28 @@ func TestDependencyGraphService_CreateSnapshot(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	snapshot := &DependencyGraphSnapshot{
+	snapshot := CreateDependencyGraphSnapshotRequest{
 		Version: 0,
-		SHA:     new("ce587453ced02b1526dfb4cb910479d431683101"),
-		Ref:     new("refs/heads/main"),
-		Job: &DependencyGraphSnapshotJob{
-			Correlator: new("yourworkflowname_youractionname"),
-			ID:         new("yourrunid"),
+		SHA:     "ce587453ced02b1526dfb4cb910479d431683101",
+		Ref:     "refs/heads/main",
+		Job: DependencyGraphSnapshotJob{
+			Correlator: "yourworkflowname_youractionname",
+			ID:         "yourrunid",
 			HTMLURL:    new("https://example.com"),
 		},
-		Detector: &DependencyGraphSnapshotDetector{
-			Name:    new("octo-detector"),
-			Version: new("0.0.1"),
-			URL:     new("https://github.com/octo-org/octo-repo"),
+		Detector: DependencyGraphSnapshotDetector{
+			Name:    "octo-detector",
+			Version: "0.0.1",
+			URL:     "https://github.com/octo-org/octo-repo",
 		},
-		Scanned: &referenceTimestamp,
+		Scanned: referenceTimestamp,
 		Metadata: map[string]any{
 			"key1": "value1",
 			"key2": "value2",
 		},
 		Manifests: map[string]*DependencyGraphSnapshotManifest{
 			"package-lock.json": {
-				Name: new("package-lock.json"),
+				Name: "package-lock.json",
 				File: &DependencyGraphSnapshotManifestFile{SourceLocation: new("src/package-lock.json")},
 				Metadata: map[string]any{
 					"key1": "value1",

--- a/github/dependency_graph_snapshots_test.go
+++ b/github/dependency_graph_snapshots_test.go
@@ -19,7 +19,7 @@ func TestDependencyGraphService_CreateSnapshot(t *testing.T) {
 
 	snapshot := &DependencyGraphSnapshot{
 		Version: 0,
-		Sha:     new("ce587453ced02b1526dfb4cb910479d431683101"),
+		SHA:     new("ce587453ced02b1526dfb4cb910479d431683101"),
 		Ref:     new("refs/heads/main"),
 		Job: &DependencyGraphSnapshotJob{
 			Correlator: new("yourworkflowname_youractionname"),

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -14366,12 +14366,12 @@ func (d *DependencyGraphSnapshot) GetScanned() Timestamp {
 	return *d.Scanned
 }
 
-// GetSha returns the Sha field if it's non-nil, zero value otherwise.
-func (d *DependencyGraphSnapshot) GetSha() string {
-	if d == nil || d.Sha == nil {
+// GetSHA returns the SHA field if it's non-nil, zero value otherwise.
+func (d *DependencyGraphSnapshot) GetSHA() string {
+	if d == nil || d.SHA == nil {
 		return ""
 	}
-	return *d.Sha
+	return *d.SHA
 }
 
 // GetVersion returns the Version field.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11950,6 +11950,62 @@ func (c *CreateCustomRepoRoleRequest) GetPermissions() []string {
 	return c.Permissions
 }
 
+// GetDetector returns the Detector field.
+func (c *CreateDependencyGraphSnapshotRequest) GetDetector() DependencyGraphSnapshotDetector {
+	if c == nil {
+		return DependencyGraphSnapshotDetector{}
+	}
+	return c.Detector
+}
+
+// GetJob returns the Job field.
+func (c *CreateDependencyGraphSnapshotRequest) GetJob() DependencyGraphSnapshotJob {
+	if c == nil {
+		return DependencyGraphSnapshotJob{}
+	}
+	return c.Job
+}
+
+// GetMetadata returns the Metadata map if it's non-nil, an empty map otherwise.
+func (c *CreateDependencyGraphSnapshotRequest) GetMetadata() map[string]any {
+	if c == nil || c.Metadata == nil {
+		return map[string]any{}
+	}
+	return c.Metadata
+}
+
+// GetRef returns the Ref field.
+func (c *CreateDependencyGraphSnapshotRequest) GetRef() string {
+	if c == nil {
+		return ""
+	}
+	return c.Ref
+}
+
+// GetScanned returns the Scanned field.
+func (c *CreateDependencyGraphSnapshotRequest) GetScanned() Timestamp {
+	if c == nil {
+		return Timestamp{}
+	}
+	return c.Scanned
+}
+
+// GetSHA returns the SHA field.
+func (c *CreateDependencyGraphSnapshotRequest) GetSHA() string {
+	if c == nil {
+		return ""
+	}
+	return c.SHA
+}
+
+// GetVersion returns the Version field.
+func (c *CreateDependencyGraphSnapshotRequest) GetVersion() int {
+	if c == nil {
+		return 0
+	}
+	return c.Version
+}
+
 // GetKey returns the Key field.
 func (c *CreateDeployKeyRequest) GetKey() string {
 	if c == nil {
@@ -14326,62 +14382,6 @@ func (d *DependencyGraphAutosubmitActionOptions) GetLabeledRunners() bool {
 	return *d.LabeledRunners
 }
 
-// GetDetector returns the Detector field.
-func (d *DependencyGraphSnapshot) GetDetector() *DependencyGraphSnapshotDetector {
-	if d == nil {
-		return nil
-	}
-	return d.Detector
-}
-
-// GetJob returns the Job field.
-func (d *DependencyGraphSnapshot) GetJob() *DependencyGraphSnapshotJob {
-	if d == nil {
-		return nil
-	}
-	return d.Job
-}
-
-// GetMetadata returns the Metadata map if it's non-nil, an empty map otherwise.
-func (d *DependencyGraphSnapshot) GetMetadata() map[string]any {
-	if d == nil || d.Metadata == nil {
-		return map[string]any{}
-	}
-	return d.Metadata
-}
-
-// GetRef returns the Ref field if it's non-nil, zero value otherwise.
-func (d *DependencyGraphSnapshot) GetRef() string {
-	if d == nil || d.Ref == nil {
-		return ""
-	}
-	return *d.Ref
-}
-
-// GetScanned returns the Scanned field if it's non-nil, zero value otherwise.
-func (d *DependencyGraphSnapshot) GetScanned() Timestamp {
-	if d == nil || d.Scanned == nil {
-		return Timestamp{}
-	}
-	return *d.Scanned
-}
-
-// GetSHA returns the SHA field if it's non-nil, zero value otherwise.
-func (d *DependencyGraphSnapshot) GetSHA() string {
-	if d == nil || d.SHA == nil {
-		return ""
-	}
-	return *d.SHA
-}
-
-// GetVersion returns the Version field.
-func (d *DependencyGraphSnapshot) GetVersion() int {
-	if d == nil {
-		return 0
-	}
-	return d.Version
-}
-
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (d *DependencyGraphSnapshotCreationData) GetCreatedAt() Timestamp {
 	if d == nil || d.CreatedAt == nil {
@@ -14414,36 +14414,36 @@ func (d *DependencyGraphSnapshotCreationData) GetResult() string {
 	return *d.Result
 }
 
-// GetName returns the Name field if it's non-nil, zero value otherwise.
+// GetName returns the Name field.
 func (d *DependencyGraphSnapshotDetector) GetName() string {
-	if d == nil || d.Name == nil {
+	if d == nil {
 		return ""
 	}
-	return *d.Name
+	return d.Name
 }
 
-// GetURL returns the URL field if it's non-nil, zero value otherwise.
+// GetURL returns the URL field.
 func (d *DependencyGraphSnapshotDetector) GetURL() string {
-	if d == nil || d.URL == nil {
+	if d == nil {
 		return ""
 	}
-	return *d.URL
+	return d.URL
 }
 
-// GetVersion returns the Version field if it's non-nil, zero value otherwise.
+// GetVersion returns the Version field.
 func (d *DependencyGraphSnapshotDetector) GetVersion() string {
-	if d == nil || d.Version == nil {
+	if d == nil {
 		return ""
 	}
-	return *d.Version
+	return d.Version
 }
 
-// GetCorrelator returns the Correlator field if it's non-nil, zero value otherwise.
+// GetCorrelator returns the Correlator field.
 func (d *DependencyGraphSnapshotJob) GetCorrelator() string {
-	if d == nil || d.Correlator == nil {
+	if d == nil {
 		return ""
 	}
-	return *d.Correlator
+	return d.Correlator
 }
 
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
@@ -14454,12 +14454,12 @@ func (d *DependencyGraphSnapshotJob) GetHTMLURL() string {
 	return *d.HTMLURL
 }
 
-// GetID returns the ID field if it's non-nil, zero value otherwise.
+// GetID returns the ID field.
 func (d *DependencyGraphSnapshotJob) GetID() string {
-	if d == nil || d.ID == nil {
+	if d == nil {
 		return ""
 	}
-	return *d.ID
+	return d.ID
 }
 
 // GetFile returns the File field.
@@ -14478,12 +14478,12 @@ func (d *DependencyGraphSnapshotManifest) GetMetadata() map[string]any {
 	return d.Metadata
 }
 
-// GetName returns the Name field if it's non-nil, zero value otherwise.
+// GetName returns the Name field.
 func (d *DependencyGraphSnapshotManifest) GetName() string {
-	if d == nil || d.Name == nil {
+	if d == nil {
 		return ""
 	}
-	return *d.Name
+	return d.Name
 }
 
 // GetSourceLocation returns the SourceLocation field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -15089,6 +15089,65 @@ func TestCreateCustomRepoRoleRequest_GetPermissions(tt *testing.T) {
 	c.GetPermissions()
 }
 
+func TestCreateDependencyGraphSnapshotRequest_GetDetector(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateDependencyGraphSnapshotRequest{}
+	c.GetDetector()
+	c = nil
+	c.GetDetector()
+}
+
+func TestCreateDependencyGraphSnapshotRequest_GetJob(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateDependencyGraphSnapshotRequest{}
+	c.GetJob()
+	c = nil
+	c.GetJob()
+}
+
+func TestCreateDependencyGraphSnapshotRequest_GetMetadata(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := map[string]any{}
+	c := &CreateDependencyGraphSnapshotRequest{Metadata: zeroValue}
+	c.GetMetadata()
+	c = &CreateDependencyGraphSnapshotRequest{}
+	c.GetMetadata()
+	c = nil
+	c.GetMetadata()
+}
+
+func TestCreateDependencyGraphSnapshotRequest_GetRef(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateDependencyGraphSnapshotRequest{}
+	c.GetRef()
+	c = nil
+	c.GetRef()
+}
+
+func TestCreateDependencyGraphSnapshotRequest_GetScanned(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateDependencyGraphSnapshotRequest{}
+	c.GetScanned()
+	c = nil
+	c.GetScanned()
+}
+
+func TestCreateDependencyGraphSnapshotRequest_GetSHA(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateDependencyGraphSnapshotRequest{}
+	c.GetSHA()
+	c = nil
+	c.GetSHA()
+}
+
+func TestCreateDependencyGraphSnapshotRequest_GetVersion(tt *testing.T) {
+	tt.Parallel()
+	c := &CreateDependencyGraphSnapshotRequest{}
+	c.GetVersion()
+	c = nil
+	c.GetVersion()
+}
+
 func TestCreateDeployKeyRequest_GetKey(tt *testing.T) {
 	tt.Parallel()
 	c := &CreateDeployKeyRequest{}
@@ -18086,74 +18145,6 @@ func TestDependencyGraphAutosubmitActionOptions_GetLabeledRunners(tt *testing.T)
 	d.GetLabeledRunners()
 }
 
-func TestDependencyGraphSnapshot_GetDetector(tt *testing.T) {
-	tt.Parallel()
-	d := &DependencyGraphSnapshot{}
-	d.GetDetector()
-	d = nil
-	d.GetDetector()
-}
-
-func TestDependencyGraphSnapshot_GetJob(tt *testing.T) {
-	tt.Parallel()
-	d := &DependencyGraphSnapshot{}
-	d.GetJob()
-	d = nil
-	d.GetJob()
-}
-
-func TestDependencyGraphSnapshot_GetMetadata(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := map[string]any{}
-	d := &DependencyGraphSnapshot{Metadata: zeroValue}
-	d.GetMetadata()
-	d = &DependencyGraphSnapshot{}
-	d.GetMetadata()
-	d = nil
-	d.GetMetadata()
-}
-
-func TestDependencyGraphSnapshot_GetRef(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	d := &DependencyGraphSnapshot{Ref: &zeroValue}
-	d.GetRef()
-	d = &DependencyGraphSnapshot{}
-	d.GetRef()
-	d = nil
-	d.GetRef()
-}
-
-func TestDependencyGraphSnapshot_GetScanned(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue Timestamp
-	d := &DependencyGraphSnapshot{Scanned: &zeroValue}
-	d.GetScanned()
-	d = &DependencyGraphSnapshot{}
-	d.GetScanned()
-	d = nil
-	d.GetScanned()
-}
-
-func TestDependencyGraphSnapshot_GetSHA(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	d := &DependencyGraphSnapshot{SHA: &zeroValue}
-	d.GetSHA()
-	d = &DependencyGraphSnapshot{}
-	d.GetSHA()
-	d = nil
-	d.GetSHA()
-}
-
-func TestDependencyGraphSnapshot_GetVersion(tt *testing.T) {
-	tt.Parallel()
-	d := &DependencyGraphSnapshot{}
-	d.GetVersion()
-	d = nil
-	d.GetVersion()
-}
-
 func TestDependencyGraphSnapshotCreationData_GetCreatedAt(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp
@@ -18197,10 +18188,7 @@ func TestDependencyGraphSnapshotCreationData_GetResult(tt *testing.T) {
 
 func TestDependencyGraphSnapshotDetector_GetName(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	d := &DependencyGraphSnapshotDetector{Name: &zeroValue}
-	d.GetName()
-	d = &DependencyGraphSnapshotDetector{}
+	d := &DependencyGraphSnapshotDetector{}
 	d.GetName()
 	d = nil
 	d.GetName()
@@ -18208,10 +18196,7 @@ func TestDependencyGraphSnapshotDetector_GetName(tt *testing.T) {
 
 func TestDependencyGraphSnapshotDetector_GetURL(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	d := &DependencyGraphSnapshotDetector{URL: &zeroValue}
-	d.GetURL()
-	d = &DependencyGraphSnapshotDetector{}
+	d := &DependencyGraphSnapshotDetector{}
 	d.GetURL()
 	d = nil
 	d.GetURL()
@@ -18219,10 +18204,7 @@ func TestDependencyGraphSnapshotDetector_GetURL(tt *testing.T) {
 
 func TestDependencyGraphSnapshotDetector_GetVersion(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	d := &DependencyGraphSnapshotDetector{Version: &zeroValue}
-	d.GetVersion()
-	d = &DependencyGraphSnapshotDetector{}
+	d := &DependencyGraphSnapshotDetector{}
 	d.GetVersion()
 	d = nil
 	d.GetVersion()
@@ -18230,10 +18212,7 @@ func TestDependencyGraphSnapshotDetector_GetVersion(tt *testing.T) {
 
 func TestDependencyGraphSnapshotJob_GetCorrelator(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	d := &DependencyGraphSnapshotJob{Correlator: &zeroValue}
-	d.GetCorrelator()
-	d = &DependencyGraphSnapshotJob{}
+	d := &DependencyGraphSnapshotJob{}
 	d.GetCorrelator()
 	d = nil
 	d.GetCorrelator()
@@ -18252,10 +18231,7 @@ func TestDependencyGraphSnapshotJob_GetHTMLURL(tt *testing.T) {
 
 func TestDependencyGraphSnapshotJob_GetID(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	d := &DependencyGraphSnapshotJob{ID: &zeroValue}
-	d.GetID()
-	d = &DependencyGraphSnapshotJob{}
+	d := &DependencyGraphSnapshotJob{}
 	d.GetID()
 	d = nil
 	d.GetID()
@@ -18282,10 +18258,7 @@ func TestDependencyGraphSnapshotManifest_GetMetadata(tt *testing.T) {
 
 func TestDependencyGraphSnapshotManifest_GetName(tt *testing.T) {
 	tt.Parallel()
-	var zeroValue string
-	d := &DependencyGraphSnapshotManifest{Name: &zeroValue}
-	d.GetName()
-	d = &DependencyGraphSnapshotManifest{}
+	d := &DependencyGraphSnapshotManifest{}
 	d.GetName()
 	d = nil
 	d.GetName()

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -18135,15 +18135,15 @@ func TestDependencyGraphSnapshot_GetScanned(tt *testing.T) {
 	d.GetScanned()
 }
 
-func TestDependencyGraphSnapshot_GetSha(tt *testing.T) {
+func TestDependencyGraphSnapshot_GetSHA(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
-	d := &DependencyGraphSnapshot{Sha: &zeroValue}
-	d.GetSha()
+	d := &DependencyGraphSnapshot{SHA: &zeroValue}
+	d.GetSHA()
 	d = &DependencyGraphSnapshot{}
-	d.GetSha()
+	d.GetSHA()
 	d = nil
-	d.GetSha()
+	d.GetSHA()
 }
 
 func TestDependencyGraphSnapshot_GetVersion(tt *testing.T) {


### PR DESCRIPTION
Continues the request-body-by-value work in #3644 with `DependencyGraphService.CreateSnapshot`, whose body is the dependency submission snapshot document.

### Why this one

The [snapshot schema](https://docs.github.com/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#create-a-snapshot-of-dependencies-for-a-repository) marks six of its eight properties as required, and its nested objects have required fields of their own, yet the Go types modelled all of them as optional pointers. This is the request-body type that the `check-schema-fields` tool proposed in #4375 flagged first, so this PR fixes the real finding rather than only flipping a parameter:

| Schema | Required | Before | After |
|---|---|---|---|
| `snapshot` | `version` | `Version int` | unchanged |
| | `sha`, `ref` | `*string,omitempty` | `string` |
| | `job`, `detector` | `*DependencyGraphSnapshotJob,omitempty` / `*DependencyGraphSnapshotDetector,omitempty` | value structs |
| | `scanned` | `*Timestamp,omitempty` | `Timestamp` |
| | `metadata`, `manifests` (optional) | maps with `omitempty` | unchanged |
| `job` | `id`, `correlator` | `*string,omitempty` | `string` (`html_url` stays optional) |
| `detector` | `name`, `version`, `url` | `*string,omitempty` | `string` |
| `manifest` | `name` | `*string,omitempty` | `string` (`file`, `metadata`, `resolved` stay optional) |

Value-typed nested structs follow `CreateHostedRunnerRequest.Image HostedRunnerImage` (#4371). `Scanned Timestamp` is the first required timestamp in an exported request type; it uses a bare `json:"scanned"` tag since the API requires it on every submission.

### Commits

1. **`refactor!:` `Sha` → `SHA`** — the field was on the `structfield` allowlist as a TODO; since the type is changing incompatibly anyway, this clears that entry.
2. **`refactor!:` rename + pass by value** — `DependencyGraphSnapshot` becomes `CreateDependencyGraphSnapshotRequest` (the `Create…Request` convention used by the rest of the series; the `DependencyGraphSnapshot*` sub-types keep their names as parts of the snapshot document), `CreateSnapshot` takes it by value, the required fields above become non-pointer, and `DependencyGraphSnapshot` is removed from the `paramcheck` allowlist. The docs operation name ("Create a snapshot…") already matches the method verb, so no method rename.
3. **`docs:` `//meta:schema` annotation** — a plain comment until #4375 lands, after which `check-schema-fields` validates this body automatically. Running the tool from that branch against this PR reports `Found 0 schema field issues` / `Checked 1 annotations on 1 annotated structs` — before this change the same type produced five required-but-pointer findings.

BREAKING CHANGE: `DependencyGraphSnapshot` is renamed to `CreateDependencyGraphSnapshotRequest`, its `Sha` field to `SHA`, `DependencyGraphService.CreateSnapshot` takes it by value, and the fields the API requires (`SHA`, `Ref`, `Job`, `Detector`, `Scanned`; `DependencyGraphSnapshotJob.ID` and `Correlator`; `DependencyGraphSnapshotDetector.Name`, `Version`, and `URL`; `DependencyGraphSnapshotManifest.Name`) are no longer pointers.

Verified with `go build ./...`, `gofmt`, `go vet -tags integration ./test/integration/`, the full `./github/` test suite (`CreateSnapshot` at 100% coverage), generator idempotency, and `custom-gcl` (0 issues with the allowlist entries removed). No usages outside the `github` package.

Updates #3644.

cc @jvm986
