### PR TITLE
feat: Add GetOrganizationUsageSummary and GetUserUsageSummary to BillingService

### DIFF
--- a/github/billing.go
+++ b/github/billing.go
@@ -456,3 +456,98 @@ func (s *BillingService) GetUserAICreditUsage(ctx context.Context, username stri
 
 	return aiCreditUsage, resp, nil
 }
+
+// UsageSummaryOptions specifies optional parameters for the
+// BillingService.GetOrganizationUsageSummary and BillingService.GetUserUsageSummary methods.
+type UsageSummaryOptions struct {
+	Year       int    `url:"year,omitempty"`
+	Month      int    `url:"month,omitempty"`
+	Day        int    `url:"day,omitempty"`
+	Repository string `url:"repository,omitempty"`
+	Product    string `url:"product,omitempty"`
+	SKU        string `url:"sku,omitempty"`
+}
+
+// UsageSummaryTimePeriod represents a time period for billing usage summary reports.
+type UsageSummaryTimePeriod struct {
+	Year  int  `json:"year"`
+	Month *int `json:"month,omitempty"`
+	Day   *int `json:"day,omitempty"`
+}
+
+// UsageSummaryItem represents a single usage line item in a billing usage summary report.
+type UsageSummaryItem struct {
+	Product          string  `json:"product"`
+	SKU              string  `json:"sku"`
+	UnitType         string  `json:"unitType"`
+	PricePerUnit     float64 `json:"pricePerUnit"`
+	GrossQuantity    float64 `json:"grossQuantity"`
+	GrossAmount      float64 `json:"grossAmount"`
+	DiscountQuantity float64 `json:"discountQuantity"`
+	DiscountAmount   float64 `json:"discountAmount"`
+	NetQuantity      float64 `json:"netQuantity"`
+	NetAmount        float64 `json:"netAmount"`
+}
+
+// UsageSummaryReport represents the billing usage summary report response.
+type UsageSummaryReport struct {
+	TimePeriod   UsageSummaryTimePeriod `json:"timePeriod"`
+	Organization *string                `json:"organization,omitempty"`
+	User         *string                `json:"user,omitempty"`
+	Repository   *string                `json:"repository,omitempty"`
+	Product      *string                `json:"product,omitempty"`
+	SKU          *string                `json:"sku,omitempty"`
+	UsageItems   []*UsageSummaryItem    `json:"usageItems"`
+}
+
+// GetOrganizationUsageSummary returns a summary report of usage for an organization.
+//
+// GitHub API docs: https://docs.github.com/rest/billing/usage?apiVersion=2022-11-28#get-billing-usage-summary-for-an-organization
+//
+//meta:operation GET /organizations/{org}/settings/billing/usage/summary
+func (s *BillingService) GetOrganizationUsageSummary(ctx context.Context, org string, opts *UsageSummaryOptions) (*UsageSummaryReport, *Response, error) {
+	u := fmt.Sprintf("organizations/%v/settings/billing/usage/summary", org)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var report *UsageSummaryReport
+	resp, err := s.client.Do(req, &report)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return report, resp, nil
+}
+
+// GetUserUsageSummary returns a summary report of usage for a user.
+//
+// GitHub API docs: https://docs.github.com/rest/billing/usage?apiVersion=2022-11-28#get-billing-usage-summary-for-a-user
+//
+//meta:operation GET /users/{username}/settings/billing/usage/summary
+func (s *BillingService) GetUserUsageSummary(ctx context.Context, user string, opts *UsageSummaryOptions) (*UsageSummaryReport, *Response, error) {
+	u := fmt.Sprintf("users/%v/settings/billing/usage/summary", user)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var report *UsageSummaryReport
+	resp, err := s.client.Do(req, &report)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return report, resp, nil
+}

--- a/github/billing_test.go
+++ b/github/billing_test.go
@@ -1052,3 +1052,219 @@ func TestBillingService_GetUserAICreditUsage_FloatQuantities(t *testing.T) {
 		t.Errorf("Billing.GetUserAICreditUsage returned %+v, want %+v", report, want)
 	}
 }
+
+func TestBillingService_GetOrganizationUsageSummary(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/organizations/o/settings/billing/usage/summary", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"year":       "2025",
+			"month":      "8",
+			"day":        "15",
+			"repository": "o/repo",
+			"product":    "actions",
+			"sku":        "actions_linux",
+		})
+		fmt.Fprint(w, `{
+			"timePeriod": {
+				"year": 2025,
+				"month": 8,
+				"day": 15
+			},
+			"organization": "o",
+			"repository": "o/repo",
+			"product": "actions",
+			"sku": "actions_linux",
+			"usageItems": [
+				{
+					"product": "actions",
+					"sku": "actions_linux",
+					"unitType": "minutes",
+					"pricePerUnit": 0.008,
+					"grossQuantity": 100,
+					"grossAmount": 0.8,
+					"discountQuantity": 10,
+					"discountAmount": 0.08,
+					"netQuantity": 90,
+					"netAmount": 0.72
+				}
+			]
+		}`)
+	})
+
+	ctx := t.Context()
+	opts := &UsageSummaryOptions{
+		Year:       2025,
+		Month:      8,
+		Day:        15,
+		Repository: "o/repo",
+		Product:    "actions",
+		SKU:        "actions_linux",
+	}
+	report, _, err := client.Billing.GetOrganizationUsageSummary(ctx, "o", opts)
+	if err != nil {
+		t.Fatalf("Billing.GetOrganizationUsageSummary returned error: %v", err)
+	}
+
+	want := &UsageSummaryReport{
+		TimePeriod: UsageSummaryTimePeriod{
+			Year:  2025,
+			Month: new(8),
+			Day:   new(15),
+		},
+		Organization: new("o"),
+		Repository:   new("o/repo"),
+		Product:      new("actions"),
+		SKU:          new("actions_linux"),
+		UsageItems: []*UsageSummaryItem{
+			{
+				Product:          "actions",
+				SKU:              "actions_linux",
+				UnitType:         "minutes",
+				PricePerUnit:     0.008,
+				GrossQuantity:    100.0,
+				GrossAmount:      0.8,
+				DiscountQuantity: 10.0,
+				DiscountAmount:   0.08,
+				NetQuantity:      90.0,
+				NetAmount:        0.72,
+			},
+		},
+	}
+	if !cmp.Equal(report, want) {
+		t.Errorf("Billing.GetOrganizationUsageSummary returned %+v, want %+v", report, want)
+	}
+
+	const methodName = "GetOrganizationUsageSummary"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Billing.GetOrganizationUsageSummary(ctx, "\n", opts)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Billing.GetOrganizationUsageSummary(ctx, "o", nil)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestBillingService_GetOrganizationUsageSummary_invalidOrg(t *testing.T) {
+	t.Parallel()
+	client, _, _ := setup(t)
+
+	ctx := t.Context()
+	_, _, err := client.Billing.GetOrganizationUsageSummary(ctx, "%", nil)
+	testURLParseError(t, err)
+}
+
+func TestBillingService_GetUserUsageSummary(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/users/u/settings/billing/usage/summary", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"year":       "2025",
+			"month":      "8",
+			"day":        "15",
+			"repository": "u/repo",
+			"product":    "actions",
+			"sku":        "actions_linux",
+		})
+		fmt.Fprint(w, `{
+			"timePeriod": {
+				"year": 2025,
+				"month": 8,
+				"day": 15
+			},
+			"user": "u",
+			"repository": "u/repo",
+			"product": "actions",
+			"sku": "actions_linux",
+			"usageItems": [
+				{
+					"product": "actions",
+					"sku": "actions_linux",
+					"unitType": "minutes",
+					"pricePerUnit": 0.008,
+					"grossQuantity": 100,
+					"grossAmount": 0.8,
+					"discountQuantity": 10,
+					"discountAmount": 0.08,
+					"netQuantity": 90,
+					"netAmount": 0.72
+				}
+			]
+		}`)
+	})
+
+	ctx := t.Context()
+	opts := &UsageSummaryOptions{
+		Year:       2025,
+		Month:      8,
+		Day:        15,
+		Repository: "u/repo",
+		Product:    "actions",
+		SKU:        "actions_linux",
+	}
+	report, _, err := client.Billing.GetUserUsageSummary(ctx, "u", opts)
+	if err != nil {
+		t.Fatalf("Billing.GetUserUsageSummary returned error: %v", err)
+	}
+
+	want := &UsageSummaryReport{
+		TimePeriod: UsageSummaryTimePeriod{
+			Year:  2025,
+			Month: new(8),
+			Day:   new(15),
+		},
+		User:       new("u"),
+		Repository: new("u/repo"),
+		Product:    new("actions"),
+		SKU:        new("actions_linux"),
+		UsageItems: []*UsageSummaryItem{
+			{
+				Product:          "actions",
+				SKU:              "actions_linux",
+				UnitType:         "minutes",
+				PricePerUnit:     0.008,
+				GrossQuantity:    100.0,
+				GrossAmount:      0.8,
+				DiscountQuantity: 10.0,
+				DiscountAmount:   0.08,
+				NetQuantity:      90.0,
+				NetAmount:        0.72,
+			},
+		},
+	}
+	if !cmp.Equal(report, want) {
+		t.Errorf("Billing.GetUserUsageSummary returned %+v, want %+v", report, want)
+	}
+
+	const methodName = "GetUserUsageSummary"
+	testBadOptions(t, methodName, func() (err error) {
+		_, _, err = client.Billing.GetUserUsageSummary(ctx, "\n", opts)
+		return err
+	})
+
+	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
+		got, resp, err := client.Billing.GetUserUsageSummary(ctx, "u", nil)
+		if got != nil {
+			t.Errorf("testNewRequestAndDoFailure %v = %#v, want nil", methodName, got)
+		}
+		return resp, err
+	})
+}
+
+func TestBillingService_GetUserUsageSummary_invalidUser(t *testing.T) {
+	t.Parallel()
+	client, _, _ := setup(t)
+
+	ctx := t.Context()
+	_, _, err := client.Billing.GetUserUsageSummary(ctx, "%", nil)
+	testURLParseError(t, err)
+}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -45654,6 +45654,214 @@ func (u *UsageReportOptions) GetYear() int {
 	return *u.Year
 }
 
+// GetDiscountAmount returns the DiscountAmount field.
+func (u *UsageSummaryItem) GetDiscountAmount() float64 {
+	if u == nil {
+		return 0
+	}
+	return u.DiscountAmount
+}
+
+// GetDiscountQuantity returns the DiscountQuantity field.
+func (u *UsageSummaryItem) GetDiscountQuantity() float64 {
+	if u == nil {
+		return 0
+	}
+	return u.DiscountQuantity
+}
+
+// GetGrossAmount returns the GrossAmount field.
+func (u *UsageSummaryItem) GetGrossAmount() float64 {
+	if u == nil {
+		return 0
+	}
+	return u.GrossAmount
+}
+
+// GetGrossQuantity returns the GrossQuantity field.
+func (u *UsageSummaryItem) GetGrossQuantity() float64 {
+	if u == nil {
+		return 0
+	}
+	return u.GrossQuantity
+}
+
+// GetNetAmount returns the NetAmount field.
+func (u *UsageSummaryItem) GetNetAmount() float64 {
+	if u == nil {
+		return 0
+	}
+	return u.NetAmount
+}
+
+// GetNetQuantity returns the NetQuantity field.
+func (u *UsageSummaryItem) GetNetQuantity() float64 {
+	if u == nil {
+		return 0
+	}
+	return u.NetQuantity
+}
+
+// GetPricePerUnit returns the PricePerUnit field.
+func (u *UsageSummaryItem) GetPricePerUnit() float64 {
+	if u == nil {
+		return 0
+	}
+	return u.PricePerUnit
+}
+
+// GetProduct returns the Product field.
+func (u *UsageSummaryItem) GetProduct() string {
+	if u == nil {
+		return ""
+	}
+	return u.Product
+}
+
+// GetSKU returns the SKU field.
+func (u *UsageSummaryItem) GetSKU() string {
+	if u == nil {
+		return ""
+	}
+	return u.SKU
+}
+
+// GetUnitType returns the UnitType field.
+func (u *UsageSummaryItem) GetUnitType() string {
+	if u == nil {
+		return ""
+	}
+	return u.UnitType
+}
+
+// GetDay returns the Day field.
+func (u *UsageSummaryOptions) GetDay() int {
+	if u == nil {
+		return 0
+	}
+	return u.Day
+}
+
+// GetMonth returns the Month field.
+func (u *UsageSummaryOptions) GetMonth() int {
+	if u == nil {
+		return 0
+	}
+	return u.Month
+}
+
+// GetProduct returns the Product field.
+func (u *UsageSummaryOptions) GetProduct() string {
+	if u == nil {
+		return ""
+	}
+	return u.Product
+}
+
+// GetRepository returns the Repository field.
+func (u *UsageSummaryOptions) GetRepository() string {
+	if u == nil {
+		return ""
+	}
+	return u.Repository
+}
+
+// GetSKU returns the SKU field.
+func (u *UsageSummaryOptions) GetSKU() string {
+	if u == nil {
+		return ""
+	}
+	return u.SKU
+}
+
+// GetYear returns the Year field.
+func (u *UsageSummaryOptions) GetYear() int {
+	if u == nil {
+		return 0
+	}
+	return u.Year
+}
+
+// GetOrganization returns the Organization field if it's non-nil, zero value otherwise.
+func (u *UsageSummaryReport) GetOrganization() string {
+	if u == nil || u.Organization == nil {
+		return ""
+	}
+	return *u.Organization
+}
+
+// GetProduct returns the Product field if it's non-nil, zero value otherwise.
+func (u *UsageSummaryReport) GetProduct() string {
+	if u == nil || u.Product == nil {
+		return ""
+	}
+	return *u.Product
+}
+
+// GetRepository returns the Repository field if it's non-nil, zero value otherwise.
+func (u *UsageSummaryReport) GetRepository() string {
+	if u == nil || u.Repository == nil {
+		return ""
+	}
+	return *u.Repository
+}
+
+// GetSKU returns the SKU field if it's non-nil, zero value otherwise.
+func (u *UsageSummaryReport) GetSKU() string {
+	if u == nil || u.SKU == nil {
+		return ""
+	}
+	return *u.SKU
+}
+
+// GetTimePeriod returns the TimePeriod field.
+func (u *UsageSummaryReport) GetTimePeriod() UsageSummaryTimePeriod {
+	if u == nil {
+		return UsageSummaryTimePeriod{}
+	}
+	return u.TimePeriod
+}
+
+// GetUsageItems returns the UsageItems slice if it's non-nil, nil otherwise.
+func (u *UsageSummaryReport) GetUsageItems() []*UsageSummaryItem {
+	if u == nil || u.UsageItems == nil {
+		return nil
+	}
+	return u.UsageItems
+}
+
+// GetUser returns the User field if it's non-nil, zero value otherwise.
+func (u *UsageSummaryReport) GetUser() string {
+	if u == nil || u.User == nil {
+		return ""
+	}
+	return *u.User
+}
+
+// GetDay returns the Day field if it's non-nil, zero value otherwise.
+func (u *UsageSummaryTimePeriod) GetDay() int {
+	if u == nil || u.Day == nil {
+		return 0
+	}
+	return *u.Day
+}
+
+// GetMonth returns the Month field if it's non-nil, zero value otherwise.
+func (u *UsageSummaryTimePeriod) GetMonth() int {
+	if u == nil || u.Month == nil {
+		return 0
+	}
+	return *u.Month
+}
+
+// GetYear returns the Year field.
+func (u *UsageSummaryTimePeriod) GetYear() int {
+	if u == nil {
+		return 0
+	}
+	return u.Year
+}
+
 // GetAssignment returns the Assignment field if it's non-nil, zero value otherwise.
 func (u *User) GetAssignment() string {
 	if u == nil || u.Assignment == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -57127,6 +57127,238 @@ func TestUsageReportOptions_GetYear(tt *testing.T) {
 	u.GetYear()
 }
 
+func TestUsageSummaryItem_GetDiscountAmount(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryItem{}
+	u.GetDiscountAmount()
+	u = nil
+	u.GetDiscountAmount()
+}
+
+func TestUsageSummaryItem_GetDiscountQuantity(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryItem{}
+	u.GetDiscountQuantity()
+	u = nil
+	u.GetDiscountQuantity()
+}
+
+func TestUsageSummaryItem_GetGrossAmount(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryItem{}
+	u.GetGrossAmount()
+	u = nil
+	u.GetGrossAmount()
+}
+
+func TestUsageSummaryItem_GetGrossQuantity(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryItem{}
+	u.GetGrossQuantity()
+	u = nil
+	u.GetGrossQuantity()
+}
+
+func TestUsageSummaryItem_GetNetAmount(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryItem{}
+	u.GetNetAmount()
+	u = nil
+	u.GetNetAmount()
+}
+
+func TestUsageSummaryItem_GetNetQuantity(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryItem{}
+	u.GetNetQuantity()
+	u = nil
+	u.GetNetQuantity()
+}
+
+func TestUsageSummaryItem_GetPricePerUnit(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryItem{}
+	u.GetPricePerUnit()
+	u = nil
+	u.GetPricePerUnit()
+}
+
+func TestUsageSummaryItem_GetProduct(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryItem{}
+	u.GetProduct()
+	u = nil
+	u.GetProduct()
+}
+
+func TestUsageSummaryItem_GetSKU(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryItem{}
+	u.GetSKU()
+	u = nil
+	u.GetSKU()
+}
+
+func TestUsageSummaryItem_GetUnitType(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryItem{}
+	u.GetUnitType()
+	u = nil
+	u.GetUnitType()
+}
+
+func TestUsageSummaryOptions_GetDay(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryOptions{}
+	u.GetDay()
+	u = nil
+	u.GetDay()
+}
+
+func TestUsageSummaryOptions_GetMonth(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryOptions{}
+	u.GetMonth()
+	u = nil
+	u.GetMonth()
+}
+
+func TestUsageSummaryOptions_GetProduct(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryOptions{}
+	u.GetProduct()
+	u = nil
+	u.GetProduct()
+}
+
+func TestUsageSummaryOptions_GetRepository(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryOptions{}
+	u.GetRepository()
+	u = nil
+	u.GetRepository()
+}
+
+func TestUsageSummaryOptions_GetSKU(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryOptions{}
+	u.GetSKU()
+	u = nil
+	u.GetSKU()
+}
+
+func TestUsageSummaryOptions_GetYear(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryOptions{}
+	u.GetYear()
+	u = nil
+	u.GetYear()
+}
+
+func TestUsageSummaryReport_GetOrganization(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UsageSummaryReport{Organization: &zeroValue}
+	u.GetOrganization()
+	u = &UsageSummaryReport{}
+	u.GetOrganization()
+	u = nil
+	u.GetOrganization()
+}
+
+func TestUsageSummaryReport_GetProduct(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UsageSummaryReport{Product: &zeroValue}
+	u.GetProduct()
+	u = &UsageSummaryReport{}
+	u.GetProduct()
+	u = nil
+	u.GetProduct()
+}
+
+func TestUsageSummaryReport_GetRepository(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UsageSummaryReport{Repository: &zeroValue}
+	u.GetRepository()
+	u = &UsageSummaryReport{}
+	u.GetRepository()
+	u = nil
+	u.GetRepository()
+}
+
+func TestUsageSummaryReport_GetSKU(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UsageSummaryReport{SKU: &zeroValue}
+	u.GetSKU()
+	u = &UsageSummaryReport{}
+	u.GetSKU()
+	u = nil
+	u.GetSKU()
+}
+
+func TestUsageSummaryReport_GetTimePeriod(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryReport{}
+	u.GetTimePeriod()
+	u = nil
+	u.GetTimePeriod()
+}
+
+func TestUsageSummaryReport_GetUsageItems(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*UsageSummaryItem{}
+	u := &UsageSummaryReport{UsageItems: zeroValue}
+	u.GetUsageItems()
+	u = &UsageSummaryReport{}
+	u.GetUsageItems()
+	u = nil
+	u.GetUsageItems()
+}
+
+func TestUsageSummaryReport_GetUser(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UsageSummaryReport{User: &zeroValue}
+	u.GetUser()
+	u = &UsageSummaryReport{}
+	u.GetUser()
+	u = nil
+	u.GetUser()
+}
+
+func TestUsageSummaryTimePeriod_GetDay(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	u := &UsageSummaryTimePeriod{Day: &zeroValue}
+	u.GetDay()
+	u = &UsageSummaryTimePeriod{}
+	u.GetDay()
+	u = nil
+	u.GetDay()
+}
+
+func TestUsageSummaryTimePeriod_GetMonth(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue int
+	u := &UsageSummaryTimePeriod{Month: &zeroValue}
+	u.GetMonth()
+	u = &UsageSummaryTimePeriod{}
+	u.GetMonth()
+	u = nil
+	u.GetMonth()
+}
+
+func TestUsageSummaryTimePeriod_GetYear(tt *testing.T) {
+	tt.Parallel()
+	u := &UsageSummaryTimePeriod{}
+	u.GetYear()
+	u = nil
+	u.GetYear()
+}
+
 func TestUser_GetAssignment(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string


### PR DESCRIPTION
### What this PR does

Implements the enhanced billing platform usage summary endpoints for organizations and users:
- `GET /organizations/{org}/settings/billing/usage/summary` via `BillingService.GetOrganizationUsageSummary`
- `GET /users/{username}/settings/billing/usage/summary` via `BillingService.GetUserUsageSummary`

These endpoints provide the organization- and user-level counterparts to `EnterpriseService.GetUsageSummary`.

### Checklist
- [x] Unit tests added covering both methods and error paths
- [x] Generated accessor methods and tests via `./script/generate.sh`
- [x] `./script/generate.sh --check` passed
- [x] `./bin/custom-gcl run ./github/...` passed with 0 issues
- [x] `./script/test.sh` passed