### PR TITLE
feat: Add repository ruleset code quality support

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -3934,6 +3934,14 @@ func (b *BranchRules) GetBranchNamePattern() []*PatternBranchRule {
 	return b.BranchNamePattern
 }
 
+// GetCodeQuality returns the CodeQuality slice if it's non-nil, nil otherwise.
+func (b *BranchRules) GetCodeQuality() []*CodeQualityBranchRule {
+	if b == nil || b.CodeQuality == nil {
+		return nil
+	}
+	return b.CodeQuality
+}
+
 // GetCodeScanning returns the CodeScanning slice if it's non-nil, nil otherwise.
 func (b *BranchRules) GetCodeScanning() []*CodeScanningBranchRule {
 	if b == nil || b.CodeScanning == nil {
@@ -5334,6 +5342,14 @@ func (c *CodeQLDatabase) GetURL() string {
 	return *c.URL
 }
 
+// GetParameters returns the Parameters field.
+func (c *CodeQualityBranchRule) GetParameters() CodeQualityRuleParameters {
+	if c == nil {
+		return CodeQualityRuleParameters{}
+	}
+	return c.Parameters
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (c *CodeQualityFinding) GetCreatedAt() Timestamp {
 	if c == nil || c.CreatedAt == nil {
@@ -5492,6 +5508,14 @@ func (c *CodeQualityFindingRule) GetTitle() string {
 		return ""
 	}
 	return c.Title
+}
+
+// GetSeverity returns the Severity field.
+func (c *CodeQualityRuleParameters) GetSeverity() CodeQualitySeverity {
+	if c == nil {
+		return ""
+	}
+	return c.Severity
 }
 
 // GetLanguages returns the Languages slice if it's non-nil, nil otherwise.
@@ -38044,6 +38068,14 @@ func (r *RepositoryRulesetRules) GetBranchNamePattern() *PatternRuleParameters {
 		return nil
 	}
 	return r.BranchNamePattern
+}
+
+// GetCodeQuality returns the CodeQuality field.
+func (r *RepositoryRulesetRules) GetCodeQuality() *CodeQualityRuleParameters {
+	if r == nil {
+		return nil
+	}
+	return r.CodeQuality
 }
 
 // GetCodeScanning returns the CodeScanning field.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -4973,6 +4973,17 @@ func TestBranchRules_GetBranchNamePattern(tt *testing.T) {
 	b.GetBranchNamePattern()
 }
 
+func TestBranchRules_GetCodeQuality(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*CodeQualityBranchRule{}
+	b := &BranchRules{CodeQuality: zeroValue}
+	b.GetCodeQuality()
+	b = &BranchRules{}
+	b.GetCodeQuality()
+	b = nil
+	b.GetCodeQuality()
+}
+
 func TestBranchRules_GetCodeScanning(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []*CodeScanningBranchRule{}
@@ -6775,6 +6786,14 @@ func TestCodeQLDatabase_GetURL(tt *testing.T) {
 	c.GetURL()
 }
 
+func TestCodeQualityBranchRule_GetParameters(tt *testing.T) {
+	tt.Parallel()
+	c := &CodeQualityBranchRule{}
+	c.GetParameters()
+	c = nil
+	c.GetParameters()
+}
+
 func TestCodeQualityFinding_GetCreatedAt(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp
@@ -6951,6 +6970,14 @@ func TestCodeQualityFindingRule_GetTitle(tt *testing.T) {
 	c.GetTitle()
 	c = nil
 	c.GetTitle()
+}
+
+func TestCodeQualityRuleParameters_GetSeverity(tt *testing.T) {
+	tt.Parallel()
+	c := &CodeQualityRuleParameters{}
+	c.GetSeverity()
+	c = nil
+	c.GetSeverity()
 }
 
 func TestCodeQualitySetupConfiguration_GetLanguages(tt *testing.T) {
@@ -47630,6 +47657,14 @@ func TestRepositoryRulesetRules_GetBranchNamePattern(tt *testing.T) {
 	r.GetBranchNamePattern()
 	r = nil
 	r.GetBranchNamePattern()
+}
+
+func TestRepositoryRulesetRules_GetCodeQuality(tt *testing.T) {
+	tt.Parallel()
+	r := &RepositoryRulesetRules{}
+	r.GetCodeQuality()
+	r = nil
+	r.GetCodeQuality()
 }
 
 func TestRepositoryRulesetRules_GetCodeScanning(tt *testing.T) {

--- a/github/rules.go
+++ b/github/rules.go
@@ -73,6 +73,7 @@ const (
 	// Branch or tag target rules.
 	RulesetRuleTypeBranchNamePattern        RepositoryRuleType = "branch_name_pattern"
 	RulesetRuleTypeCodeScanning             RepositoryRuleType = "code_scanning"
+	RulesetRuleTypeCodeQuality              RepositoryRuleType = "code_quality"
 	RulesetRuleTypeCommitAuthorEmailPattern RepositoryRuleType = "commit_author_email_pattern"
 	RulesetRuleTypeCommitMessagePattern     RepositoryRuleType = "commit_message_pattern"
 	RulesetRuleTypeCommitterEmailPattern    RepositoryRuleType = "committer_email_pattern"
@@ -183,6 +184,15 @@ const (
 	CodeScanningSecurityAlertsThresholdHighOrHigher   CodeScanningSecurityAlertsThreshold = "high_or_higher"
 	CodeScanningSecurityAlertsThresholdMediumOrHigher CodeScanningSecurityAlertsThreshold = "medium_or_higher"
 	CodeScanningSecurityAlertsThresholdAll            CodeScanningSecurityAlertsThreshold = "all"
+)
+
+// CodeQualitySeverity models the minimum code quality severity that blocks a merge.
+type CodeQualitySeverity string
+
+// This is the set of GitHub code quality severity thresholds.
+const (
+	CodeQualitySeverityErrors            CodeQualitySeverity = "errors"
+	CodeQualitySeverityErrorsAndWarnings CodeQualitySeverity = "errors_and_warnings"
 )
 
 // RepositoryRuleset represents a GitHub ruleset object.
@@ -308,6 +318,7 @@ type RepositoryRulesetRules struct {
 	TagNamePattern           *PatternRuleParameters
 	Workflows                *WorkflowsRuleParameters
 	CodeScanning             *CodeScanningRuleParameters
+	CodeQuality              *CodeQualityRuleParameters
 	CopilotCodeReview        *CopilotCodeReviewRuleParameters
 
 	// Push target rules.
@@ -345,6 +356,7 @@ type BranchRules struct {
 	TagNamePattern           []*PatternBranchRule
 	Workflows                []*WorkflowsBranchRule
 	CodeScanning             []*CodeScanningBranchRule
+	CodeQuality              []*CodeQualityBranchRule
 	CopilotCodeReview        []*CopilotCodeReviewBranchRule
 
 	// Push target rules.
@@ -431,6 +443,12 @@ type WorkflowsBranchRule struct {
 type CodeScanningBranchRule struct {
 	BranchRuleMetadata
 	Parameters CodeScanningRuleParameters `json:"parameters"`
+}
+
+// CodeQualityBranchRule represents a code quality branch rule.
+type CodeQualityBranchRule struct {
+	BranchRuleMetadata
+	Parameters CodeQualityRuleParameters `json:"parameters"`
 }
 
 // CopilotCodeReviewBranchRule represents a copilot code review branch rule.
@@ -577,6 +595,11 @@ type RuleWorkflow struct {
 // CodeScanningRuleParameters represents the code scanning rule parameters.
 type CodeScanningRuleParameters struct {
 	CodeScanningTools []*RuleCodeScanningTool `json:"code_scanning_tools"`
+}
+
+// CodeQualityRuleParameters represents the code_quality rule parameters.
+type CodeQualityRuleParameters struct {
+	Severity CodeQualitySeverity `json:"severity"`
 }
 
 // CopilotCodeReviewRuleParameters represents the copilot_code_review rule parameters.
@@ -777,6 +800,14 @@ func (r RepositoryRulesetRules) MarshalJSON() ([]byte, error) {
 
 	if r.CodeScanning != nil {
 		bytes, err := marshalRepositoryRulesetRule(RulesetRuleTypeCodeScanning, r.CodeScanning)
+		if err != nil {
+			return nil, err
+		}
+		rawRules = append(rawRules, json.RawMessage(bytes))
+	}
+
+	if r.CodeQuality != nil {
+		bytes, err := marshalRepositoryRulesetRule(RulesetRuleTypeCodeQuality, r.CodeQuality)
 		if err != nil {
 			return nil, err
 		}
@@ -1022,6 +1053,14 @@ func (r *RepositoryRulesetRules) UnmarshalJSON(data []byte) error {
 					return err
 				}
 			}
+		case RulesetRuleTypeCodeQuality:
+			r.CodeQuality = &CodeQualityRuleParameters{}
+
+			if w.Parameters != nil {
+				if err := json.Unmarshal(w.Parameters, r.CodeQuality); err != nil {
+					return err
+				}
+			}
 		case RulesetRuleTypeCopilotCodeReview:
 			r.CopilotCodeReview = &CopilotCodeReviewRuleParameters{}
 
@@ -1245,6 +1284,16 @@ func (r *BranchRules) UnmarshalJSON(data []byte) error {
 			}
 
 			r.CodeScanning = append(r.CodeScanning, &CodeScanningBranchRule{BranchRuleMetadata: w.BranchRuleMetadata, Parameters: *params})
+		case RulesetRuleTypeCodeQuality:
+			params := &CodeQualityRuleParameters{}
+
+			if w.Parameters != nil {
+				if err := json.Unmarshal(w.Parameters, params); err != nil {
+					return err
+				}
+			}
+
+			r.CodeQuality = append(r.CodeQuality, &CodeQualityBranchRule{BranchRuleMetadata: w.BranchRuleMetadata, Parameters: *params})
 		case RulesetRuleTypeCopilotCodeReview:
 			params := &CopilotCodeReviewRuleParameters{}
 

--- a/github/rules_test.go
+++ b/github/rules_test.go
@@ -369,6 +369,22 @@ func TestBranchRules(t *testing.T) {
 			`[{"type":"update","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"update_allows_fetch_and_merge":true}}]`,
 		},
 		{
+			"code_quality",
+			&BranchRules{
+				CodeQuality: []*CodeQualityBranchRule{
+					{
+						BranchRuleMetadata: BranchRuleMetadata{
+							RulesetSourceType: RulesetSourceTypeRepository,
+							RulesetSource:     "test/test",
+							RulesetID:         1,
+						},
+						Parameters: CodeQualityRuleParameters{Severity: CodeQualitySeverityErrors},
+					},
+				},
+			},
+			`[{"type":"code_quality","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":{"severity":"errors"}}]`,
+		},
+		{
 			"all_rule_types_with_all_parameters",
 			&BranchRules{
 				Creation: []*BranchRuleMetadata{

--- a/github/rules_test.go
+++ b/github/rules_test.go
@@ -35,6 +35,13 @@ func TestRepositoryRulesetRules(t *testing.T) {
 			`[{"type":"required_deployments","parameters":{"required_deployment_environments":["test"]}}]`,
 		},
 		{
+			"code_quality_rule",
+			&RepositoryRulesetRules{
+				CodeQuality: &CodeQualityRuleParameters{Severity: "errors"},
+			},
+			`[{"type":"code_quality","parameters":{"severity":"errors"}}]`,
+		},
+		{
 			"all_rules_with_required_params",
 			&RepositoryRulesetRules{
 				Creation:              &EmptyRuleParameters{},

--- a/github/rules_test.go
+++ b/github/rules_test.go
@@ -316,6 +316,10 @@ func TestRepositoryRulesetRules(t *testing.T) {
 				"invalid_copilot_code_review_parameters",
 				`[{"type":"copilot_code_review","parameters":"not_an_object"}]`,
 			},
+			{
+				"invalid_code_quality_parameters",
+				`[{"type":"code_quality","parameters":"not_an_object"}]`,
+			},
 		}
 
 		for _, tt := range tests {
@@ -720,6 +724,10 @@ func TestBranchRules(t *testing.T) {
 			{
 				"invalid_copilot_code_review_parameters",
 				`[{"type":"copilot_code_review","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":"not_an_object"}]`,
+			},
+			{
+				"invalid_code_quality_parameters",
+				`[{"type":"code_quality","ruleset_source_type":"Repository","ruleset_source":"test/test","ruleset_id":1,"parameters":"not_an_object"}]`,
 			},
 		}
 


### PR DESCRIPTION
## Summary

- model the GitHub `code_quality` repository ruleset rule
- preserve its severity when marshaling and unmarshaling rulesets
- add regression coverage for round-tripping the rule

Fixes #4520

## Tests

- `go test ./github -count=1`