### PR TITLE
docs: Deprecate singular assignee fields

### DIFF
--- a/github/issues.go
+++ b/github/issues.go
@@ -54,9 +54,11 @@ type Issue struct {
 	// Deprecated: GitHub will remove this field from Events API payloads on October 7, 2025.
 	// Use the Issues REST API endpoint to retrieve this information.
 	// See: https://docs.github.com/rest/issues/issues?apiVersion=2022-11-28#get-an-issue
-	AuthorAssociation        *string                   `json:"author_association,omitempty"`
-	User                     *User                     `json:"user,omitempty"`
-	Labels                   []*Label                  `json:"labels,omitempty"`
+	AuthorAssociation *string  `json:"author_association,omitempty"`
+	User              *User    `json:"user,omitempty"`
+	Labels            []*Label `json:"labels,omitempty"`
+	// Deprecated: GitHub REST API version 2026-03-10 removed the singular assignee field.
+	// Use Assignees instead.
 	Assignee                 *User                     `json:"assignee,omitempty"`
 	Comments                 *int                      `json:"comments,omitempty"`
 	ClosedAt                 *Timestamp                `json:"closed_at,omitempty"`

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -51,9 +51,11 @@ type PullRequest struct {
 	CommentsURL       *string    `json:"comments_url,omitempty"`
 	ReviewCommentsURL *string    `json:"review_comments_url,omitempty"`
 	ReviewCommentURL  *string    `json:"review_comment_url,omitempty"`
-	Assignee          *User      `json:"assignee,omitempty"`
-	Assignees         []*User    `json:"assignees,omitempty"`
-	Milestone         *Milestone `json:"milestone,omitempty"`
+	// Deprecated: GitHub REST API version 2026-03-10 removed the singular assignee field.
+	// Use Assignees instead.
+	Assignee  *User      `json:"assignee,omitempty"`
+	Assignees []*User    `json:"assignees,omitempty"`
+	Milestone *Milestone `json:"milestone,omitempty"`
 	// AuthorAssociation is the pull request author's relationship to the repository.
 	// Possible values are "COLLABORATOR", "CONTRIBUTOR", "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "MEMBER", "OWNER", or "NONE".
 	//


### PR DESCRIPTION
AI-generated contribution. I am the human operator responsible for follow-up with maintainers. Please feel free to close this PR or request any changes.

Mark `Issue.Assignee` and `PullRequest.Assignee` deprecated in favor of `Assignees`.

GitHub REST API version 2026-03-10 removed the singular response field. The fields remain in go-github for older GitHub Enterprise Server compatibility, following the guidance from #4098, so this does not change wire behavior.

Ref #4077.

Tests:
- `script/fmt.sh`
- `go test ./github`
- `script/test.sh`
- `script/lint.sh`

AI-assisted contribution: ChatGPT helped identify and scope the #4077 migration item and draft the deprecation comments. I reviewed the final diff and ran the checks above on the submitted commit.