### PR TITLE
fix: Accept 202 when deleting app installation

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -8,6 +8,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"net/http"
 )
 
 // AppsService provides access to the installation related functions
@@ -388,7 +389,11 @@ func (s *AppsService) DeleteInstallation(ctx context.Context, id int64) (*Respon
 		return nil, err
 	}
 
-	return s.client.Do(req, nil)
+	resp, err := s.client.Do(req, nil)
+	if err != nil && (resp == nil || resp.StatusCode != http.StatusAccepted) {
+		return resp, err
+	}
+	return resp, nil
 }
 
 // CreateInstallationToken creates a new installation token.

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -397,6 +397,22 @@ func TestAppsService_DeleteInstallation(t *testing.T) {
 	})
 }
 
+func TestAppsService_DeleteInstallationNoContent(t *testing.T) {
+	t.Parallel()
+	client, mux, _ := setup(t)
+
+	mux.HandleFunc("/app/installations/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := t.Context()
+	_, err := client.Apps.DeleteInstallation(ctx, 1)
+	if err != nil {
+		t.Errorf("Apps.DeleteInstallation returned error: %v", err)
+	}
+}
+
 func TestAppsService_CreateInstallationToken(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -377,7 +377,7 @@ func TestAppsService_DeleteInstallation(t *testing.T) {
 
 	mux.HandleFunc("/app/installations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusAccepted)
 	})
 
 	ctx := t.Context()


### PR DESCRIPTION
## Summary

GitHub REST API version 2026-03-10 changed `DELETE /app/installations/{installation_id}` from a `204 No Content` success response to `202 Accepted`.

`Client.Do` intentionally represents HTTP 202 as `AcceptedError`, so `AppsService.DeleteInstallation` currently returns an error for the endpoint's new successful response. This change treats 202 as success for this endpoint and updates the regression test accordingly.

This is intentionally scoped to the corresponding checkbox in #4077; other App APIs are unchanged.

## Verification

- `go test ./github -run '^TestAppsService_DeleteInstallation$'`
- `script/fmt.sh`
- `git diff --check`
- full repository CI is also running on the submitted commit

Ref #4077

AI-assisted contribution: ChatGPT helped identify the tracked migration item, inspect the 202 handling path, and draft the change. I reviewed the final diff and verification results.