### PR TITLE
fix: treat 202 Accepted as success in MergeAsync

### DIFF
--- a/github/pulls.go
+++ b/github/pulls.go
@@ -8,6 +8,7 @@ package github
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 )
@@ -606,7 +607,15 @@ func (s *PullRequestsService) MergeAsync(ctx context.Context, owner, repo string
 	var result *PullRequestMergeAsyncResult
 	resp, err := s.client.Do(req, &result)
 	if err != nil {
-		return nil, resp, err
+		var acceptedError *AcceptedError
+		if !errors.As(err, &acceptedError) {
+			return nil, resp, err
+		}
+		// 202 Accepted is the success response here, so decode the payload
+		// instead of returning the AcceptedError.
+		if err := json.Unmarshal(acceptedError.Raw, &result); err != nil {
+			return nil, resp, err
+		}
 	}
 
 	return result, resp, nil

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -768,6 +768,7 @@ func TestPullRequestsService_MergeAsync(t *testing.T) {
 	mux.HandleFunc("/repos/o/r/pulls/1/merge-async", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testJSONBody(t, r, request)
+		w.WriteHeader(http.StatusAccepted)
 		fmt.Fprint(w, `
 			{
 			  "status": "pending",


### PR DESCRIPTION
MergeAsync trips over the one response this endpoint actually returns: GitHub answers 202 Accepted once the merge request is enqueued, but Client.Do turns every 202 into an *AcceptedError. So MergeAsync errored out with a nil result on the happy path, and callers never got the uuid they need to pass to GetMergeAsyncResult.

The fix decodes the 202 payload into the result and returns it without an error, using the same approach as UploadSarif. I also made the existing MergeAsync test write a real 202 instead of the default 200 - the mock status was why this never surfaced. The test fails without the code change and passes with it.