### PR TITLE
fix: Allow removing runner group networks

### DIFF
--- a/github/actions_runner_groups.go
+++ b/github/actions_runner_groups.go
@@ -7,6 +7,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
@@ -59,6 +60,24 @@ type UpdateRunnerGroupRequest struct {
 	RestrictedToWorkflows    *bool    `json:"restricted_to_workflows,omitempty"`
 	SelectedWorkflows        []string `json:"selected_workflows,omitempty"`
 	NetworkConfigurationID   *string  `json:"network_configuration_id,omitempty"`
+
+	// If true, the network configuration is removed by sending null.
+	// This takes precedence over NetworkConfigurationID.
+	RemoveNetworkConfiguration bool `json:"-"`
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (r UpdateRunnerGroupRequest) MarshalJSON() ([]byte, error) {
+	type alias UpdateRunnerGroupRequest
+	if !r.RemoveNetworkConfiguration {
+		return json.Marshal(alias(r))
+	}
+	return json.Marshal(&struct {
+		alias
+		NetworkConfigurationID *string `json:"network_configuration_id"`
+	}{
+		alias: alias(r),
+	})
 }
 
 // SetRepoAccessRunnerGroupRequest represents a request to replace the list of repositories

--- a/github/actions_runner_groups_test.go
+++ b/github/actions_runner_groups_test.go
@@ -6,6 +6,7 @@
 package github
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -287,6 +288,93 @@ func TestActionsService_UpdateOrganizationRunnerGroup(t *testing.T) {
 		}
 		return resp, err
 	})
+}
+
+func TestActionsService_UpdateOrganizationRunnerGroup_NetworkConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body UpdateRunnerGroupRequest
+		want string
+	}{
+		{
+			name: "omitted",
+			body: UpdateRunnerGroupRequest{},
+			want: `{}`,
+		},
+		{
+			name: "set",
+			body: UpdateRunnerGroupRequest{NetworkConfigurationID: new("network-id")},
+			want: `{"network_configuration_id":"network-id"}`,
+		},
+		{
+			name: "empty string",
+			body: UpdateRunnerGroupRequest{NetworkConfigurationID: new("")},
+			want: `{"network_configuration_id":""}`,
+		},
+		{
+			name: "rename only",
+			body: UpdateRunnerGroupRequest{Name: new("renamed")},
+			want: `{"name":"renamed"}`,
+		},
+		{
+			name: "remove",
+			body: UpdateRunnerGroupRequest{RemoveNetworkConfiguration: true},
+			want: `{"network_configuration_id":null}`,
+		},
+		{
+			name: "remove overrides ID",
+			body: UpdateRunnerGroupRequest{
+				NetworkConfigurationID:     new("network-id"),
+				RemoveNetworkConfiguration: true,
+			},
+			want: `{"network_configuration_id":null}`,
+		},
+		{
+			name: "remove with other fields",
+			body: UpdateRunnerGroupRequest{
+				Name:                       new("renamed"),
+				Visibility:                 new("selected"),
+				AllowsPublicRepositories:   new(false),
+				RestrictedToWorkflows:      new(true),
+				SelectedWorkflows:          []string{"o/r/.github/workflows/build.yml@refs/heads/main"},
+				RemoveNetworkConfiguration: true,
+			},
+			want: `{"name":"renamed","visibility":"selected","allows_public_repositories":false,"restricted_to_workflows":true,"selected_workflows":["o/r/.github/workflows/build.yml@refs/heads/main"],"network_configuration_id":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			before := Stringify(tt.body)
+			testJSONMarshalOnly(t, tt.body, tt.want)
+			testJSONMarshalOnly(t, &tt.body, tt.want)
+			if got := Stringify(tt.body); got != before {
+				t.Errorf("json.Marshal changed request to %v, want %v", got, before)
+			}
+
+			var want map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(tt.want), &want); err != nil {
+				t.Fatalf("json.Unmarshal returned error: %v", err)
+			}
+
+			client, mux, _ := setup(t)
+			mux.HandleFunc("/orgs/o/actions/runner-groups/2", func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "PATCH")
+				testJSONBody(t, r, want)
+				fmt.Fprint(w, `{"id":2}`)
+			})
+
+			if _, _, err := client.Actions.UpdateOrganizationRunnerGroup(t.Context(), "o", 2, tt.body); err != nil {
+				t.Fatalf("Actions.UpdateOrganizationRunnerGroup returned error: %v", err)
+			}
+			if got := Stringify(tt.body); got != before {
+				t.Errorf("Actions.UpdateOrganizationRunnerGroup changed request to %v, want %v", got, before)
+			}
+		})
+	}
 }
 
 func TestActionsService_ListRepositoryAccessRunnerGroup(t *testing.T) {

--- a/github/enterprise_actions_runner_groups.go
+++ b/github/enterprise_actions_runner_groups.go
@@ -7,6 +7,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
@@ -65,6 +66,24 @@ type UpdateEnterpriseRunnerGroupRequest struct {
 	RestrictedToWorkflows    *bool    `json:"restricted_to_workflows,omitempty"`
 	SelectedWorkflows        []string `json:"selected_workflows,omitempty"`
 	NetworkConfigurationID   *string  `json:"network_configuration_id,omitempty"`
+
+	// If true, the network configuration is removed by sending null.
+	// This takes precedence over NetworkConfigurationID.
+	RemoveNetworkConfiguration bool `json:"-"`
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (r UpdateEnterpriseRunnerGroupRequest) MarshalJSON() ([]byte, error) {
+	type alias UpdateEnterpriseRunnerGroupRequest
+	if !r.RemoveNetworkConfiguration {
+		return json.Marshal(alias(r))
+	}
+	return json.Marshal(&struct {
+		alias
+		NetworkConfigurationID *string `json:"network_configuration_id"`
+	}{
+		alias: alias(r),
+	})
 }
 
 // SetOrgAccessRunnerGroupRequest represents a request to replace the list of organizations

--- a/github/enterprise_actions_runner_groups_test.go
+++ b/github/enterprise_actions_runner_groups_test.go
@@ -6,6 +6,7 @@
 package github
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -279,6 +280,93 @@ func TestEnterpriseService_UpdateEnterpriseRunnerGroup(t *testing.T) {
 		}
 		return resp, err
 	})
+}
+
+func TestEnterpriseService_UpdateEnterpriseRunnerGroup_NetworkConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body UpdateEnterpriseRunnerGroupRequest
+		want string
+	}{
+		{
+			name: "omitted",
+			body: UpdateEnterpriseRunnerGroupRequest{},
+			want: `{}`,
+		},
+		{
+			name: "set",
+			body: UpdateEnterpriseRunnerGroupRequest{NetworkConfigurationID: new("network-id")},
+			want: `{"network_configuration_id":"network-id"}`,
+		},
+		{
+			name: "empty string",
+			body: UpdateEnterpriseRunnerGroupRequest{NetworkConfigurationID: new("")},
+			want: `{"network_configuration_id":""}`,
+		},
+		{
+			name: "rename only",
+			body: UpdateEnterpriseRunnerGroupRequest{Name: new("renamed")},
+			want: `{"name":"renamed"}`,
+		},
+		{
+			name: "remove",
+			body: UpdateEnterpriseRunnerGroupRequest{RemoveNetworkConfiguration: true},
+			want: `{"network_configuration_id":null}`,
+		},
+		{
+			name: "remove overrides ID",
+			body: UpdateEnterpriseRunnerGroupRequest{
+				NetworkConfigurationID:     new("network-id"),
+				RemoveNetworkConfiguration: true,
+			},
+			want: `{"network_configuration_id":null}`,
+		},
+		{
+			name: "remove with other fields",
+			body: UpdateEnterpriseRunnerGroupRequest{
+				Name:                       new("renamed"),
+				Visibility:                 new("selected"),
+				AllowsPublicRepositories:   new(false),
+				RestrictedToWorkflows:      new(true),
+				SelectedWorkflows:          []string{"o/r/.github/workflows/build.yml@refs/heads/main"},
+				RemoveNetworkConfiguration: true,
+			},
+			want: `{"name":"renamed","visibility":"selected","allows_public_repositories":false,"restricted_to_workflows":true,"selected_workflows":["o/r/.github/workflows/build.yml@refs/heads/main"],"network_configuration_id":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			before := Stringify(tt.body)
+			testJSONMarshalOnly(t, tt.body, tt.want)
+			testJSONMarshalOnly(t, &tt.body, tt.want)
+			if got := Stringify(tt.body); got != before {
+				t.Errorf("json.Marshal changed request to %v, want %v", got, before)
+			}
+
+			var want map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(tt.want), &want); err != nil {
+				t.Fatalf("json.Unmarshal returned error: %v", err)
+			}
+
+			client, mux, _ := setup(t)
+			mux.HandleFunc("/enterprises/o/actions/runner-groups/2", func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "PATCH")
+				testJSONBody(t, r, want)
+				fmt.Fprint(w, `{"id":2}`)
+			})
+
+			if _, _, err := client.Enterprise.UpdateEnterpriseRunnerGroup(t.Context(), "o", 2, tt.body); err != nil {
+				t.Fatalf("Enterprise.UpdateEnterpriseRunnerGroup returned error: %v", err)
+			}
+			if got := Stringify(tt.body); got != before {
+				t.Errorf("Enterprise.UpdateEnterpriseRunnerGroup changed request to %v, want %v", got, before)
+			}
+		})
+	}
 }
 
 func TestEnterpriseService_ListOrganizationAccessRunnerGroup(t *testing.T) {

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -45094,6 +45094,14 @@ func (u *UpdateEnterpriseRunnerGroupRequest) GetNetworkConfigurationID() string 
 	return *u.NetworkConfigurationID
 }
 
+// GetRemoveNetworkConfiguration returns the RemoveNetworkConfiguration field.
+func (u *UpdateEnterpriseRunnerGroupRequest) GetRemoveNetworkConfiguration() bool {
+	if u == nil {
+		return false
+	}
+	return u.RemoveNetworkConfiguration
+}
+
 // GetRestrictedToWorkflows returns the RestrictedToWorkflows field if it's non-nil, zero value otherwise.
 func (u *UpdateEnterpriseRunnerGroupRequest) GetRestrictedToWorkflows() bool {
 	if u == nil || u.RestrictedToWorkflows == nil {
@@ -45748,6 +45756,14 @@ func (u *UpdateRunnerGroupRequest) GetNetworkConfigurationID() string {
 		return ""
 	}
 	return *u.NetworkConfigurationID
+}
+
+// GetRemoveNetworkConfiguration returns the RemoveNetworkConfiguration field.
+func (u *UpdateRunnerGroupRequest) GetRemoveNetworkConfiguration() bool {
+	if u == nil {
+		return false
+	}
+	return u.RemoveNetworkConfiguration
 }
 
 // GetRestrictedToWorkflows returns the RestrictedToWorkflows field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -56291,6 +56291,14 @@ func TestUpdateEnterpriseRunnerGroupRequest_GetNetworkConfigurationID(tt *testin
 	u.GetNetworkConfigurationID()
 }
 
+func TestUpdateEnterpriseRunnerGroupRequest_GetRemoveNetworkConfiguration(tt *testing.T) {
+	tt.Parallel()
+	u := &UpdateEnterpriseRunnerGroupRequest{}
+	u.GetRemoveNetworkConfiguration()
+	u = nil
+	u.GetRemoveNetworkConfiguration()
+}
+
 func TestUpdateEnterpriseRunnerGroupRequest_GetRestrictedToWorkflows(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
@@ -57161,6 +57169,14 @@ func TestUpdateRunnerGroupRequest_GetNetworkConfigurationID(tt *testing.T) {
 	u.GetNetworkConfigurationID()
 	u = nil
 	u.GetNetworkConfigurationID()
+}
+
+func TestUpdateRunnerGroupRequest_GetRemoveNetworkConfiguration(tt *testing.T) {
+	tt.Parallel()
+	u := &UpdateRunnerGroupRequest{}
+	u.GetRemoveNetworkConfiguration()
+	u = nil
+	u.GetRemoveNetworkConfiguration()
 }
 
 func TestUpdateRunnerGroupRequest_GetRestrictedToWorkflows(tt *testing.T) {


### PR DESCRIPTION
Add `RemoveNetworkConfiguration` to organization and enterprise runner-group update requests, following [`UpdateTeamRequest.RemoveParentTeam`](github/teams.go). Setting it sends `"network_configuration_id": null` and takes precedence over a supplied ID. The value-receiver marshaler supports both values and pointers without mutation. Creates and responses are unchanged.

The Go 1.26.0 `encoding/json` repro shows that `*string` behaves identically with `omitempty` and `omitzero`: nil omits the field, `new("network-id")` sends a string, and `new("")` sends `""`. Neither tag produces JSON null. Empty-string behavior is preserved for compatibility, but empty-string detachment is unverified. Both PATCH schemas allow null: [organization](https://github.com/github/rest-api-description/blob/0a144e030abbe358000f0d32874e197b59a8f7ed/descriptions/api.github.com/api.github.com.json#L15939-L15943) and [enterprise](https://github.com/github/rest-api-description/blob/0a144e030abbe358000f0d32874e197b59a8f7ed/descriptions/ghec/ghec.json#L8154-L8158).

Regression tests cover omission, assignment, empty-string compatibility, explicit null, flag precedence, preservation of other fields, value/pointer marshaling, request immutability, and both native PATCH bodies. The null cases fail without the marshalers. On Go 1.26.0, runner-group race tests, all-module `script/test.sh` race tests, `script/fmt.sh`, `script/generate.sh`, `script/lint.sh`, and OpenAPI metadata validation pass. No live API writes were made for this revision.

This revises the earlier `omitzero` implementation and still needs maintainer agreement on explicit-null removal. Needed by integrations/terraform-provider-github#3274, which remains gated on a merged and released SDK fix.

Copilot assisted with implementation, tests, and this description.