### PR TITLE
feat: Add `image_gen` to `HostedRunner` and `UpdateHostedRunnerRequest`

### DIFF
--- a/github/actions_hosted_runners.go
+++ b/github/actions_hosted_runners.go
@@ -38,6 +38,7 @@ type HostedRunner struct {
 	MaximumRunners     *int64                   `json:"maximum_runners,omitempty"`
 	PublicIPEnabled    *bool                    `json:"public_ip_enabled,omitempty"`
 	PublicIPs          []*HostedRunnerPublicIP  `json:"public_ips,omitempty"`
+	ImageGen           *bool                    `json:"image_gen,omitempty"`
 	LastActiveOn       *Timestamp               `json:"last_active_on,omitempty"`
 }
 
@@ -112,6 +113,7 @@ type UpdateHostedRunnerRequest struct {
 	Size           *string `json:"size,omitempty"`
 	ImageID        *string `json:"image_id,omitempty"`
 	ImageVersion   *string `json:"image_version,omitempty"`
+	ImageGen       *bool   `json:"image_gen,omitempty"`
 }
 
 // validateCreateHostedRunnerRequest validates the provided CreateHostedRunnerRequest to ensure

--- a/github/actions_hosted_runners_test.go
+++ b/github/actions_hosted_runners_test.go
@@ -1159,3 +1159,75 @@ func TestActionsService_DeleteHostedRunnerCustomImageVersion(t *testing.T) {
 		return client.Actions.DeleteHostedRunnerCustomImageVersion(ctx, "o", 1, "1.0.0")
 	})
 }
+
+func TestHostedRunner_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &HostedRunner{}, "{}")
+
+	u := &HostedRunner{
+		ID:            new(int64(5)),
+		Name:          new("My hosted ubuntu runner"),
+		RunnerGroupID: new(int64(2)),
+		Platform:      new("linux-x64"),
+		ImageDetails: &HostedRunnerImageDetail{
+			ID:          new("ubuntu-20.04"),
+			SizeGB:      new(int64(86)),
+			DisplayName: new("20.04"),
+			Source:      new("github"),
+			Version:     new("latest"),
+		},
+		MachineSizeDetails: &HostedRunnerMachineSpec{ID: "4-core", CPUCores: 4, MemoryGB: 16, StorageGB: 150},
+		Status:             new("Ready"),
+		MaximumRunners:     new(int64(10)),
+		PublicIPEnabled:    new(true),
+		PublicIPs:          []*HostedRunnerPublicIP{{Enabled: true, Prefix: "20.80.208.150", Length: 31}},
+		ImageGen:           new(true),
+		LastActiveOn:       &Timestamp{referenceTime},
+	}
+
+	want := `{
+		"id": 5,
+		"name": "My hosted ubuntu runner",
+		"runner_group_id": 2,
+		"platform": "linux-x64",
+		"image_details": {"id": "ubuntu-20.04", "size_gb": 86, "display_name": "20.04", "source": "github", "version": "latest"},
+		"machine_size_details": {"id": "4-core", "cpu_cores": 4, "memory_gb": 16, "storage_gb": 150},
+		"status": "Ready",
+		"maximum_runners": 10,
+		"public_ip_enabled": true,
+		"public_ips": [{"enabled": true, "prefix": "20.80.208.150", "length": 31}],
+		"image_gen": true,
+		"last_active_on": ` + referenceTimeStr + `
+	}`
+
+	testJSONMarshal(t, u, want)
+}
+
+func TestUpdateHostedRunnerRequest_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &UpdateHostedRunnerRequest{}, "{}")
+
+	u := &UpdateHostedRunnerRequest{
+		Name:           new("My hosted ubuntu runner"),
+		RunnerGroupID:  new(int64(2)),
+		MaximumRunners: new(int64(10)),
+		EnableStaticIP: new(true),
+		Size:           new("4-core"),
+		ImageID:        new("ubuntu-20.04"),
+		ImageVersion:   new("latest"),
+		ImageGen:       new(true),
+	}
+
+	want := `{
+		"name": "My hosted ubuntu runner",
+		"runner_group_id": 2,
+		"maximum_runners": 10,
+		"enable_static_ip": true,
+		"size": "4-core",
+		"image_id": "ubuntu-20.04",
+		"image_version": "latest",
+		"image_gen": true
+	}`
+
+	testJSONMarshal(t, u, want)
+}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -19614,6 +19614,14 @@ func (h *HostedRunner) GetImageDetails() *HostedRunnerImageDetail {
 	return h.ImageDetails
 }
 
+// GetImageGen returns the ImageGen field if it's non-nil, zero value otherwise.
+func (h *HostedRunner) GetImageGen() bool {
+	if h == nil || h.ImageGen == nil {
+		return false
+	}
+	return *h.ImageGen
+}
+
 // GetLastActiveOn returns the LastActiveOn field if it's non-nil, zero value otherwise.
 func (h *HostedRunner) GetLastActiveOn() Timestamp {
 	if h == nil || h.LastActiveOn == nil {
@@ -45156,6 +45164,14 @@ func (u *UpdateHostedRunnerRequest) GetEnableStaticIP() bool {
 		return false
 	}
 	return *u.EnableStaticIP
+}
+
+// GetImageGen returns the ImageGen field if it's non-nil, zero value otherwise.
+func (u *UpdateHostedRunnerRequest) GetImageGen() bool {
+	if u == nil || u.ImageGen == nil {
+		return false
+	}
+	return *u.ImageGen
 }
 
 // GetImageID returns the ImageID field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -24607,6 +24607,17 @@ func TestHostedRunner_GetImageDetails(tt *testing.T) {
 	h.GetImageDetails()
 }
 
+func TestHostedRunner_GetImageGen(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	h := &HostedRunner{ImageGen: &zeroValue}
+	h.GetImageGen()
+	h = &HostedRunner{}
+	h.GetImageGen()
+	h = nil
+	h.GetImageGen()
+}
+
 func TestHostedRunner_GetLastActiveOn(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp
@@ -56374,6 +56385,17 @@ func TestUpdateHostedRunnerRequest_GetEnableStaticIP(tt *testing.T) {
 	u.GetEnableStaticIP()
 	u = nil
 	u.GetEnableStaticIP()
+}
+
+func TestUpdateHostedRunnerRequest_GetImageGen(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	u := &UpdateHostedRunnerRequest{ImageGen: &zeroValue}
+	u.GetImageGen()
+	u = &UpdateHostedRunnerRequest{}
+	u.GetImageGen()
+	u = nil
+	u.GetImageGen()
 }
 
 func TestUpdateHostedRunnerRequest_GetImageID(tt *testing.T) {


### PR DESCRIPTION
Fixes #4532

## What

The GitHub-hosted runner API supports `image_gen` on create, update, and read (it was added for create in #3973), but go-github only models it on `CreateHostedRunnerRequest`. The field can be set at create time but never read back or patched: `HostedRunner` (the response type for `GetHostedRunner`, `CreateHostedRunner`, `UpdateHostedRunner`, `DeleteHostedRunner`, `ListHostedRunners`, and the `EnterpriseService` equivalents) and `UpdateHostedRunnerRequest` both lack it. As the issue notes, this breaks terraform-provider-github round-trips: an import records `false`, and an apply with `true` destroys and recreates the pool.

Verified against current `master` (2433615): `github/actions_hosted_runners.go` has `ImageGen` only on `CreateHostedRunnerRequest` (:103); `HostedRunner` (:30) and `UpdateHostedRunnerRequest` (:107) do not.

## Change

- `HostedRunner`: add `ImageGen *bool \`json:"image_gen,omitempty"\``
- `UpdateHostedRunnerRequest`: add `ImageGen *bool \`json:"image_gen,omitempty"\``
- `script/generate.sh` run per CONTRIBUTING - `github-accessors.go` and `github-accessors_test.go` regenerated (accessor + accessor test for both new fields; no hand-written surface beyond the two field lines)
- New round-trip marshal tests in the repo's standard `testJSONMarshal` style: `TestHostedRunner_Marshal` and `TestUpdateHostedRunnerRequest_Marshal`, each covering the empty struct and a fully populated struct including `image_gen`

## Testing

- `TestHostedRunner_Marshal`, `TestUpdateHostedRunnerRequest_Marshal`: PASS
- Existing hosted-runner tests re-run against the change (`TestActionsService_ListHostedRunners`, `TestActionsService_GetHostedRunner`, `TestActionsService_UpdateHostedRunner`, `TestActionsService_ListHostedRunnersIter`): PASS
- `gofmt -l github/`: clean
- Disclosure: the full `github` package test binary OOMs at compile time in this memory-constrained sandbox (2 GB), so the complete suite was not run locally; the targeted tests above all pass and CI will cover the rest.

> Built by breken, your AI support engineer - breken.ai - this one's on us.