### PR TITLE
refactor!: Pass the secret scanning body types by value and rename them to `...Request`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -236,8 +236,6 @@ linters:
             - RepositoryCreateForkOptions
             - RequiredStatusChecksRequest
             - SCIMUserAttributes
-            - SecretScanningAlertUpdateOptions
-            - SecretScanningPatternConfigsUpdateOptions
             - SourceImportAuthor
             - Subscription
             - TeamAddTeamMembershipOptions
@@ -265,8 +263,6 @@ linters:
             - RepositoryAddCollaboratorOptions
             - RepositoryContentFileOptions
             - RepositoryCreateForkOptions
-            - SecretScanningAlertUpdateOptions
-            - SecretScanningPatternConfigsUpdateOptions
             - TeamAddTeamMembershipOptions
             - TeamAddTeamRepoOptions
             - TeamProjectOptions

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -41918,6 +41918,14 @@ func (s *SecretScanningAlertMetadata) GetValue() string {
 	return s.Value
 }
 
+// GetAssignee returns the Assignee field if it's non-nil, zero value otherwise.
+func (s *SecretScanningAlertUpdateOptions) GetAssignee() string {
+	if s == nil || s.Assignee == nil {
+		return ""
+	}
+	return *s.Assignee
+}
+
 // GetResolution returns the Resolution field if it's non-nil, zero value otherwise.
 func (s *SecretScanningAlertUpdateOptions) GetResolution() string {
 	if s == nil || s.Resolution == nil {
@@ -41934,12 +41942,20 @@ func (s *SecretScanningAlertUpdateOptions) GetResolutionComment() string {
 	return *s.ResolutionComment
 }
 
-// GetState returns the State field.
+// GetState returns the State field if it's non-nil, zero value otherwise.
 func (s *SecretScanningAlertUpdateOptions) GetState() string {
-	if s == nil {
+	if s == nil || s.State == nil {
 		return ""
 	}
-	return s.State
+	return *s.State
+}
+
+// GetValidity returns the Validity field if it's non-nil, zero value otherwise.
+func (s *SecretScanningAlertUpdateOptions) GetValidity() string {
+	if s == nil || s.Validity == nil {
+		return ""
+	}
+	return *s.Validity
 }
 
 // GetPatterns returns the Patterns slice if it's non-nil, nil otherwise.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -41918,46 +41918,6 @@ func (s *SecretScanningAlertMetadata) GetValue() string {
 	return s.Value
 }
 
-// GetAssignee returns the Assignee field if it's non-nil, zero value otherwise.
-func (s *SecretScanningAlertUpdateOptions) GetAssignee() string {
-	if s == nil || s.Assignee == nil {
-		return ""
-	}
-	return *s.Assignee
-}
-
-// GetResolution returns the Resolution field if it's non-nil, zero value otherwise.
-func (s *SecretScanningAlertUpdateOptions) GetResolution() string {
-	if s == nil || s.Resolution == nil {
-		return ""
-	}
-	return *s.Resolution
-}
-
-// GetResolutionComment returns the ResolutionComment field if it's non-nil, zero value otherwise.
-func (s *SecretScanningAlertUpdateOptions) GetResolutionComment() string {
-	if s == nil || s.ResolutionComment == nil {
-		return ""
-	}
-	return *s.ResolutionComment
-}
-
-// GetState returns the State field if it's non-nil, zero value otherwise.
-func (s *SecretScanningAlertUpdateOptions) GetState() string {
-	if s == nil || s.State == nil {
-		return ""
-	}
-	return *s.State
-}
-
-// GetValidity returns the Validity field if it's non-nil, zero value otherwise.
-func (s *SecretScanningAlertUpdateOptions) GetValidity() string {
-	if s == nil || s.Validity == nil {
-		return ""
-	}
-	return *s.Validity
-}
-
 // GetPatterns returns the Patterns slice if it's non-nil, nil otherwise.
 func (s *SecretScanningCreateCustomPatternsRequest) GetPatterns() []*SecretScanningCustomPatternRequest {
 	if s == nil || s.Patterns == nil {
@@ -42252,30 +42212,6 @@ func (s *SecretScanningPatternConfigsUpdate) GetPatternConfigVersion() string {
 		return ""
 	}
 	return *s.PatternConfigVersion
-}
-
-// GetCustomPatternSettings returns the CustomPatternSettings slice if it's non-nil, nil otherwise.
-func (s *SecretScanningPatternConfigsUpdateOptions) GetCustomPatternSettings() []*SecretScanningCustomPatternSetting {
-	if s == nil || s.CustomPatternSettings == nil {
-		return nil
-	}
-	return s.CustomPatternSettings
-}
-
-// GetPatternConfigVersion returns the PatternConfigVersion field if it's non-nil, zero value otherwise.
-func (s *SecretScanningPatternConfigsUpdateOptions) GetPatternConfigVersion() string {
-	if s == nil || s.PatternConfigVersion == nil {
-		return ""
-	}
-	return *s.PatternConfigVersion
-}
-
-// GetProviderPatternSettings returns the ProviderPatternSettings slice if it's non-nil, nil otherwise.
-func (s *SecretScanningPatternConfigsUpdateOptions) GetProviderPatternSettings() []*SecretScanningProviderPatternSetting {
-	if s == nil || s.ProviderPatternSettings == nil {
-		return nil
-	}
-	return s.ProviderPatternSettings
 }
 
 // GetAlertTotal returns the AlertTotal field if it's non-nil, zero value otherwise.
@@ -46324,6 +46260,70 @@ func (u *UpdateRunnerGroupRequest) GetVisibility() string {
 		return ""
 	}
 	return *u.Visibility
+}
+
+// GetAssignee returns the Assignee field if it's non-nil, zero value otherwise.
+func (u *UpdateSecretScanningAlertRequest) GetAssignee() string {
+	if u == nil || u.Assignee == nil {
+		return ""
+	}
+	return *u.Assignee
+}
+
+// GetResolution returns the Resolution field if it's non-nil, zero value otherwise.
+func (u *UpdateSecretScanningAlertRequest) GetResolution() string {
+	if u == nil || u.Resolution == nil {
+		return ""
+	}
+	return *u.Resolution
+}
+
+// GetResolutionComment returns the ResolutionComment field if it's non-nil, zero value otherwise.
+func (u *UpdateSecretScanningAlertRequest) GetResolutionComment() string {
+	if u == nil || u.ResolutionComment == nil {
+		return ""
+	}
+	return *u.ResolutionComment
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (u *UpdateSecretScanningAlertRequest) GetState() string {
+	if u == nil || u.State == nil {
+		return ""
+	}
+	return *u.State
+}
+
+// GetValidity returns the Validity field if it's non-nil, zero value otherwise.
+func (u *UpdateSecretScanningAlertRequest) GetValidity() string {
+	if u == nil || u.Validity == nil {
+		return ""
+	}
+	return *u.Validity
+}
+
+// GetCustomPatternSettings returns the CustomPatternSettings slice if it's non-nil, nil otherwise.
+func (u *UpdateSecretScanningPatternConfigsRequest) GetCustomPatternSettings() []*SecretScanningCustomPatternSetting {
+	if u == nil || u.CustomPatternSettings == nil {
+		return nil
+	}
+	return u.CustomPatternSettings
+}
+
+// GetPatternConfigVersion returns the PatternConfigVersion field if it's non-nil, zero value otherwise.
+func (u *UpdateSecretScanningPatternConfigsRequest) GetPatternConfigVersion() string {
+	if u == nil || u.PatternConfigVersion == nil {
+		return ""
+	}
+	return *u.PatternConfigVersion
+}
+
+// GetProviderPatternSettings returns the ProviderPatternSettings slice if it's non-nil, nil otherwise.
+func (u *UpdateSecretScanningPatternConfigsRequest) GetProviderPatternSettings() []*SecretScanningProviderPatternSetting {
+	if u == nil || u.ProviderPatternSettings == nil {
+		return nil
+	}
+	return u.ProviderPatternSettings
 }
 
 // GetLDAPDN returns the LDAPDN field.

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -41350,6 +41350,38 @@ func (s *SecretScanning) GetStatus() string {
 	return *s.Status
 }
 
+// GetAssignedTo returns the AssignedTo field.
+func (s *SecretScanningAlert) GetAssignedTo() *User {
+	if s == nil {
+		return nil
+	}
+	return s.AssignedTo
+}
+
+// GetClosureRequestComment returns the ClosureRequestComment field if it's non-nil, zero value otherwise.
+func (s *SecretScanningAlert) GetClosureRequestComment() string {
+	if s == nil || s.ClosureRequestComment == nil {
+		return ""
+	}
+	return *s.ClosureRequestComment
+}
+
+// GetClosureRequestReviewer returns the ClosureRequestReviewer field.
+func (s *SecretScanningAlert) GetClosureRequestReviewer() *User {
+	if s == nil {
+		return nil
+	}
+	return s.ClosureRequestReviewer
+}
+
+// GetClosureRequestReviewerComment returns the ClosureRequestReviewerComment field if it's non-nil, zero value otherwise.
+func (s *SecretScanningAlert) GetClosureRequestReviewerComment() string {
+	if s == nil || s.ClosureRequestReviewerComment == nil {
+		return ""
+	}
+	return *s.ClosureRequestReviewerComment
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (s *SecretScanningAlert) GetCreatedAt() Timestamp {
 	if s == nil || s.CreatedAt == nil {
@@ -41398,6 +41430,14 @@ func (s *SecretScanningAlert) GetLocationsURL() string {
 	return *s.LocationsURL
 }
 
+// GetMetadata returns the Metadata slice if it's non-nil, nil otherwise.
+func (s *SecretScanningAlert) GetMetadata() []*SecretScanningAlertMetadata {
+	if s == nil || s.Metadata == nil {
+		return nil
+	}
+	return s.Metadata
+}
+
 // GetMultiRepo returns the MultiRepo field if it's non-nil, zero value otherwise.
 func (s *SecretScanningAlert) GetMultiRepo() bool {
 	if s == nil || s.MultiRepo == nil {
@@ -41412,6 +41452,22 @@ func (s *SecretScanningAlert) GetNumber() int {
 		return 0
 	}
 	return *s.Number
+}
+
+// GetProvider returns the Provider field if it's non-nil, zero value otherwise.
+func (s *SecretScanningAlert) GetProvider() string {
+	if s == nil || s.Provider == nil {
+		return ""
+	}
+	return *s.Provider
+}
+
+// GetProviderSlug returns the ProviderSlug field if it's non-nil, zero value otherwise.
+func (s *SecretScanningAlert) GetProviderSlug() string {
+	if s == nil || s.ProviderSlug == nil {
+		return ""
+	}
+	return *s.ProviderSlug
 }
 
 // GetPubliclyLeaked returns the PubliclyLeaked field if it's non-nil, zero value otherwise.
@@ -41844,6 +41900,22 @@ func (s *SecretScanningAlertLocationEvent) GetSender() *User {
 		return nil
 	}
 	return s.Sender
+}
+
+// GetKey returns the Key field.
+func (s *SecretScanningAlertMetadata) GetKey() string {
+	if s == nil {
+		return ""
+	}
+	return s.Key
+}
+
+// GetValue returns the Value field.
+func (s *SecretScanningAlertMetadata) GetValue() string {
+	if s == nil {
+		return ""
+	}
+	return s.Value
 }
 
 // GetResolution returns the Resolution field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -52290,6 +52290,17 @@ func TestSecretScanningAlertMetadata_GetValue(tt *testing.T) {
 	s.GetValue()
 }
 
+func TestSecretScanningAlertUpdateOptions_GetAssignee(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	s := &SecretScanningAlertUpdateOptions{Assignee: &zeroValue}
+	s.GetAssignee()
+	s = &SecretScanningAlertUpdateOptions{}
+	s.GetAssignee()
+	s = nil
+	s.GetAssignee()
+}
+
 func TestSecretScanningAlertUpdateOptions_GetResolution(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue string
@@ -52314,10 +52325,24 @@ func TestSecretScanningAlertUpdateOptions_GetResolutionComment(tt *testing.T) {
 
 func TestSecretScanningAlertUpdateOptions_GetState(tt *testing.T) {
 	tt.Parallel()
-	s := &SecretScanningAlertUpdateOptions{}
+	var zeroValue string
+	s := &SecretScanningAlertUpdateOptions{State: &zeroValue}
+	s.GetState()
+	s = &SecretScanningAlertUpdateOptions{}
 	s.GetState()
 	s = nil
 	s.GetState()
+}
+
+func TestSecretScanningAlertUpdateOptions_GetValidity(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	s := &SecretScanningAlertUpdateOptions{Validity: &zeroValue}
+	s.GetValidity()
+	s = &SecretScanningAlertUpdateOptions{}
+	s.GetValidity()
+	s = nil
+	s.GetValidity()
 }
 
 func TestSecretScanningCreateCustomPatternsRequest_GetPatterns(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -51599,6 +51599,44 @@ func TestSecretScanning_GetStatus(tt *testing.T) {
 	s.GetStatus()
 }
 
+func TestSecretScanningAlert_GetAssignedTo(tt *testing.T) {
+	tt.Parallel()
+	s := &SecretScanningAlert{}
+	s.GetAssignedTo()
+	s = nil
+	s.GetAssignedTo()
+}
+
+func TestSecretScanningAlert_GetClosureRequestComment(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	s := &SecretScanningAlert{ClosureRequestComment: &zeroValue}
+	s.GetClosureRequestComment()
+	s = &SecretScanningAlert{}
+	s.GetClosureRequestComment()
+	s = nil
+	s.GetClosureRequestComment()
+}
+
+func TestSecretScanningAlert_GetClosureRequestReviewer(tt *testing.T) {
+	tt.Parallel()
+	s := &SecretScanningAlert{}
+	s.GetClosureRequestReviewer()
+	s = nil
+	s.GetClosureRequestReviewer()
+}
+
+func TestSecretScanningAlert_GetClosureRequestReviewerComment(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	s := &SecretScanningAlert{ClosureRequestReviewerComment: &zeroValue}
+	s.GetClosureRequestReviewerComment()
+	s = &SecretScanningAlert{}
+	s.GetClosureRequestReviewerComment()
+	s = nil
+	s.GetClosureRequestReviewerComment()
+}
+
 func TestSecretScanningAlert_GetCreatedAt(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp
@@ -51662,6 +51700,17 @@ func TestSecretScanningAlert_GetLocationsURL(tt *testing.T) {
 	s.GetLocationsURL()
 }
 
+func TestSecretScanningAlert_GetMetadata(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*SecretScanningAlertMetadata{}
+	s := &SecretScanningAlert{Metadata: zeroValue}
+	s.GetMetadata()
+	s = &SecretScanningAlert{}
+	s.GetMetadata()
+	s = nil
+	s.GetMetadata()
+}
+
 func TestSecretScanningAlert_GetMultiRepo(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue bool
@@ -51682,6 +51731,28 @@ func TestSecretScanningAlert_GetNumber(tt *testing.T) {
 	s.GetNumber()
 	s = nil
 	s.GetNumber()
+}
+
+func TestSecretScanningAlert_GetProvider(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	s := &SecretScanningAlert{Provider: &zeroValue}
+	s.GetProvider()
+	s = &SecretScanningAlert{}
+	s.GetProvider()
+	s = nil
+	s.GetProvider()
+}
+
+func TestSecretScanningAlert_GetProviderSlug(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	s := &SecretScanningAlert{ProviderSlug: &zeroValue}
+	s.GetProviderSlug()
+	s = &SecretScanningAlert{}
+	s.GetProviderSlug()
+	s = nil
+	s.GetProviderSlug()
 }
 
 func TestSecretScanningAlert_GetPubliclyLeaked(tt *testing.T) {
@@ -52201,6 +52272,22 @@ func TestSecretScanningAlertLocationEvent_GetSender(tt *testing.T) {
 	s.GetSender()
 	s = nil
 	s.GetSender()
+}
+
+func TestSecretScanningAlertMetadata_GetKey(tt *testing.T) {
+	tt.Parallel()
+	s := &SecretScanningAlertMetadata{}
+	s.GetKey()
+	s = nil
+	s.GetKey()
+}
+
+func TestSecretScanningAlertMetadata_GetValue(tt *testing.T) {
+	tt.Parallel()
+	s := &SecretScanningAlertMetadata{}
+	s.GetValue()
+	s = nil
+	s.GetValue()
 }
 
 func TestSecretScanningAlertUpdateOptions_GetResolution(tt *testing.T) {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -52290,61 +52290,6 @@ func TestSecretScanningAlertMetadata_GetValue(tt *testing.T) {
 	s.GetValue()
 }
 
-func TestSecretScanningAlertUpdateOptions_GetAssignee(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	s := &SecretScanningAlertUpdateOptions{Assignee: &zeroValue}
-	s.GetAssignee()
-	s = &SecretScanningAlertUpdateOptions{}
-	s.GetAssignee()
-	s = nil
-	s.GetAssignee()
-}
-
-func TestSecretScanningAlertUpdateOptions_GetResolution(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	s := &SecretScanningAlertUpdateOptions{Resolution: &zeroValue}
-	s.GetResolution()
-	s = &SecretScanningAlertUpdateOptions{}
-	s.GetResolution()
-	s = nil
-	s.GetResolution()
-}
-
-func TestSecretScanningAlertUpdateOptions_GetResolutionComment(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	s := &SecretScanningAlertUpdateOptions{ResolutionComment: &zeroValue}
-	s.GetResolutionComment()
-	s = &SecretScanningAlertUpdateOptions{}
-	s.GetResolutionComment()
-	s = nil
-	s.GetResolutionComment()
-}
-
-func TestSecretScanningAlertUpdateOptions_GetState(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	s := &SecretScanningAlertUpdateOptions{State: &zeroValue}
-	s.GetState()
-	s = &SecretScanningAlertUpdateOptions{}
-	s.GetState()
-	s = nil
-	s.GetState()
-}
-
-func TestSecretScanningAlertUpdateOptions_GetValidity(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	s := &SecretScanningAlertUpdateOptions{Validity: &zeroValue}
-	s.GetValidity()
-	s = &SecretScanningAlertUpdateOptions{}
-	s.GetValidity()
-	s = nil
-	s.GetValidity()
-}
-
 func TestSecretScanningCreateCustomPatternsRequest_GetPatterns(tt *testing.T) {
 	tt.Parallel()
 	zeroValue := []*SecretScanningCustomPatternRequest{}
@@ -52705,39 +52650,6 @@ func TestSecretScanningPatternConfigsUpdate_GetPatternConfigVersion(tt *testing.
 	s.GetPatternConfigVersion()
 	s = nil
 	s.GetPatternConfigVersion()
-}
-
-func TestSecretScanningPatternConfigsUpdateOptions_GetCustomPatternSettings(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := []*SecretScanningCustomPatternSetting{}
-	s := &SecretScanningPatternConfigsUpdateOptions{CustomPatternSettings: zeroValue}
-	s.GetCustomPatternSettings()
-	s = &SecretScanningPatternConfigsUpdateOptions{}
-	s.GetCustomPatternSettings()
-	s = nil
-	s.GetCustomPatternSettings()
-}
-
-func TestSecretScanningPatternConfigsUpdateOptions_GetPatternConfigVersion(tt *testing.T) {
-	tt.Parallel()
-	var zeroValue string
-	s := &SecretScanningPatternConfigsUpdateOptions{PatternConfigVersion: &zeroValue}
-	s.GetPatternConfigVersion()
-	s = &SecretScanningPatternConfigsUpdateOptions{}
-	s.GetPatternConfigVersion()
-	s = nil
-	s.GetPatternConfigVersion()
-}
-
-func TestSecretScanningPatternConfigsUpdateOptions_GetProviderPatternSettings(tt *testing.T) {
-	tt.Parallel()
-	zeroValue := []*SecretScanningProviderPatternSetting{}
-	s := &SecretScanningPatternConfigsUpdateOptions{ProviderPatternSettings: zeroValue}
-	s.GetProviderPatternSettings()
-	s = &SecretScanningPatternConfigsUpdateOptions{}
-	s.GetProviderPatternSettings()
-	s = nil
-	s.GetProviderPatternSettings()
 }
 
 func TestSecretScanningPatternOverride_GetAlertTotal(tt *testing.T) {
@@ -57890,6 +57802,94 @@ func TestUpdateRunnerGroupRequest_GetVisibility(tt *testing.T) {
 	u.GetVisibility()
 	u = nil
 	u.GetVisibility()
+}
+
+func TestUpdateSecretScanningAlertRequest_GetAssignee(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateSecretScanningAlertRequest{Assignee: &zeroValue}
+	u.GetAssignee()
+	u = &UpdateSecretScanningAlertRequest{}
+	u.GetAssignee()
+	u = nil
+	u.GetAssignee()
+}
+
+func TestUpdateSecretScanningAlertRequest_GetResolution(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateSecretScanningAlertRequest{Resolution: &zeroValue}
+	u.GetResolution()
+	u = &UpdateSecretScanningAlertRequest{}
+	u.GetResolution()
+	u = nil
+	u.GetResolution()
+}
+
+func TestUpdateSecretScanningAlertRequest_GetResolutionComment(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateSecretScanningAlertRequest{ResolutionComment: &zeroValue}
+	u.GetResolutionComment()
+	u = &UpdateSecretScanningAlertRequest{}
+	u.GetResolutionComment()
+	u = nil
+	u.GetResolutionComment()
+}
+
+func TestUpdateSecretScanningAlertRequest_GetState(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateSecretScanningAlertRequest{State: &zeroValue}
+	u.GetState()
+	u = &UpdateSecretScanningAlertRequest{}
+	u.GetState()
+	u = nil
+	u.GetState()
+}
+
+func TestUpdateSecretScanningAlertRequest_GetValidity(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateSecretScanningAlertRequest{Validity: &zeroValue}
+	u.GetValidity()
+	u = &UpdateSecretScanningAlertRequest{}
+	u.GetValidity()
+	u = nil
+	u.GetValidity()
+}
+
+func TestUpdateSecretScanningPatternConfigsRequest_GetCustomPatternSettings(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*SecretScanningCustomPatternSetting{}
+	u := &UpdateSecretScanningPatternConfigsRequest{CustomPatternSettings: zeroValue}
+	u.GetCustomPatternSettings()
+	u = &UpdateSecretScanningPatternConfigsRequest{}
+	u.GetCustomPatternSettings()
+	u = nil
+	u.GetCustomPatternSettings()
+}
+
+func TestUpdateSecretScanningPatternConfigsRequest_GetPatternConfigVersion(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	u := &UpdateSecretScanningPatternConfigsRequest{PatternConfigVersion: &zeroValue}
+	u.GetPatternConfigVersion()
+	u = &UpdateSecretScanningPatternConfigsRequest{}
+	u.GetPatternConfigVersion()
+	u = nil
+	u.GetPatternConfigVersion()
+}
+
+func TestUpdateSecretScanningPatternConfigsRequest_GetProviderPatternSettings(tt *testing.T) {
+	tt.Parallel()
+	zeroValue := []*SecretScanningProviderPatternSetting{}
+	u := &UpdateSecretScanningPatternConfigsRequest{ProviderPatternSettings: zeroValue}
+	u.GetProviderPatternSettings()
+	u = &UpdateSecretScanningPatternConfigsRequest{}
+	u.GetProviderPatternSettings()
+	u = nil
+	u.GetProviderPatternSettings()
 }
 
 func TestUpdateTeamLDAPMappingRequest_GetLDAPDN(tt *testing.T) {

--- a/github/secret_scanning.go
+++ b/github/secret_scanning.go
@@ -44,6 +44,19 @@ type SecretScanningAlert struct {
 	PushProtectionBypassRequestReviewer        *User                               `json:"push_protection_bypass_request_reviewer,omitempty"`
 	PushProtectionBypassRequestReviewerComment *string                             `json:"push_protection_bypass_request_reviewer_comment,omitempty"`
 	Validity                                   *string                             `json:"validity,omitempty"`
+	AssignedTo                                 *User                               `json:"assigned_to,omitempty"`
+	ClosureRequestComment                      *string                             `json:"closure_request_comment,omitempty"`
+	ClosureRequestReviewer                     *User                               `json:"closure_request_reviewer,omitempty"`
+	ClosureRequestReviewerComment              *string                             `json:"closure_request_reviewer_comment,omitempty"`
+	Provider                                   *string                             `json:"provider,omitempty"`
+	ProviderSlug                               *string                             `json:"provider_slug,omitempty"`
+	Metadata                                   []*SecretScanningAlertMetadata      `json:"metadata,omitempty"`
+}
+
+// SecretScanningAlertMetadata represents a metadata key/value pair associated with a secret scanning alert.
+type SecretScanningAlertMetadata struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 // SecretScanningAlertLocation represents the location for a secret scanning alert.

--- a/github/secret_scanning.go
+++ b/github/secret_scanning.go
@@ -118,8 +118,8 @@ type SecretScanningAlertListOptions struct {
 	ListOptions
 }
 
-// SecretScanningAlertUpdateOptions specifies optional parameters to the SecretScanningService.UpdateAlert method.
-type SecretScanningAlertUpdateOptions struct {
+// UpdateSecretScanningAlertRequest represents a request to update a secret scanning alert.
+type UpdateSecretScanningAlertRequest struct {
 	// State sets the state of the secret scanning alert. Can be either "open" or "resolved".
 	// You must provide resolution when you set the state to "resolved".
 	State *string `json:"state,omitempty"`
@@ -305,7 +305,7 @@ func (s *SecretScanningService) GetAlert(ctx context.Context, owner, repo string
 // GitHub API docs: https://docs.github.com/rest/secret-scanning/secret-scanning?apiVersion=2022-11-28#update-a-secret-scanning-alert
 //
 //meta:operation PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}
-func (s *SecretScanningService) UpdateAlert(ctx context.Context, owner, repo string, number int64, body *SecretScanningAlertUpdateOptions) (*SecretScanningAlert, *Response, error) {
+func (s *SecretScanningService) UpdateAlert(ctx context.Context, owner, repo string, number int64, body UpdateSecretScanningAlertRequest) (*SecretScanningAlert, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/secret-scanning/alerts/%v", owner, repo, number)
 
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)

--- a/github/secret_scanning.go
+++ b/github/secret_scanning.go
@@ -120,10 +120,9 @@ type SecretScanningAlertListOptions struct {
 
 // SecretScanningAlertUpdateOptions specifies optional parameters to the SecretScanningService.UpdateAlert method.
 type SecretScanningAlertUpdateOptions struct {
-	// State is required and sets the state of the secret scanning alert.
-	// Can be either "open" or "resolved".
+	// State sets the state of the secret scanning alert. Can be either "open" or "resolved".
 	// You must provide resolution when you set the state to "resolved".
-	State string `json:"state"`
+	State *string `json:"state,omitempty"`
 
 	// Required when the state is "resolved" and represents the reason for resolving the alert.
 	// Can be one of: "false_positive", "wont_fix", "revoked", or "used_in_tests".
@@ -131,6 +130,12 @@ type SecretScanningAlertUpdateOptions struct {
 
 	// An optional comment when closing an alert.
 	ResolutionComment *string `json:"resolution_comment,omitempty"`
+
+	// Assignee is the username of the user to assign to the alert.
+	Assignee *string `json:"assignee,omitempty"`
+
+	// Validity sets the validity of the secret scanning alert. Can be either "active" or "inactive".
+	Validity *string `json:"validity,omitempty"`
 }
 
 // PushProtectionBypassRequest represents the parameters for CreatePushProtectionBypass.

--- a/github/secret_scanning_pattern_configs.go
+++ b/github/secret_scanning_pattern_configs.go
@@ -39,10 +39,8 @@ type SecretScanningPatternConfigsUpdate struct {
 	PatternConfigVersion *string `json:"pattern_config_version,omitempty"`
 }
 
-// SecretScanningPatternConfigsUpdateOptions specifies optional parameters to
-// the SecretScanningService.UpdatePatternConfigsForEnterprise method and
-// the SecretScanningService.UpdatePatternConfigsForOrg method.
-type SecretScanningPatternConfigsUpdateOptions struct {
+// UpdateSecretScanningPatternConfigsRequest represents a request to update secret scanning pattern configurations.
+type UpdateSecretScanningPatternConfigsRequest struct {
 	// The version of the entity.
 	PatternConfigVersion *string `json:"pattern_config_version,omitempty"`
 
@@ -125,7 +123,7 @@ func (s *SecretScanningService) ListPatternConfigsForOrg(ctx context.Context, or
 // GitHub API docs: https://docs.github.com/enterprise-cloud@latest/rest/secret-scanning/push-protection?apiVersion=2022-11-28#update-enterprise-pattern-configurations
 //
 //meta:operation PATCH /enterprises/{enterprise}/secret-scanning/pattern-configurations
-func (s *SecretScanningService) UpdatePatternConfigsForEnterprise(ctx context.Context, enterprise string, body *SecretScanningPatternConfigsUpdateOptions) (*SecretScanningPatternConfigsUpdate, *Response, error) {
+func (s *SecretScanningService) UpdatePatternConfigsForEnterprise(ctx context.Context, enterprise string, body UpdateSecretScanningPatternConfigsRequest) (*SecretScanningPatternConfigsUpdate, *Response, error) {
 	u := fmt.Sprintf("enterprises/%v/secret-scanning/pattern-configurations", enterprise)
 
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)
@@ -147,7 +145,7 @@ func (s *SecretScanningService) UpdatePatternConfigsForEnterprise(ctx context.Co
 // GitHub API docs: https://docs.github.com/rest/secret-scanning/push-protection?apiVersion=2022-11-28#update-organization-pattern-configurations
 //
 //meta:operation PATCH /orgs/{org}/secret-scanning/pattern-configurations
-func (s *SecretScanningService) UpdatePatternConfigsForOrg(ctx context.Context, org string, body *SecretScanningPatternConfigsUpdateOptions) (*SecretScanningPatternConfigsUpdate, *Response, error) {
+func (s *SecretScanningService) UpdatePatternConfigsForOrg(ctx context.Context, org string, body UpdateSecretScanningPatternConfigsRequest) (*SecretScanningPatternConfigsUpdate, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/secret-scanning/pattern-configurations", org)
 
 	req, err := s.client.NewRequest(ctx, "PATCH", u, body)

--- a/github/secret_scanning_pattern_configs_test.go
+++ b/github/secret_scanning_pattern_configs_test.go
@@ -220,17 +220,7 @@ func TestSecretScanningService_UpdatePatternConfigsForEnterprise(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/enterprises/e/secret-scanning/pattern-configurations", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PATCH")
-
-		fmt.Fprint(w, `{
-			"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"
-		}`)
-	})
-
-	ctx := t.Context()
-
-	opts := &SecretScanningPatternConfigsUpdateOptions{
+	input := UpdateSecretScanningPatternConfigsRequest{
 		PatternConfigVersion: new("0ujsswThIGTUYm2K8FjOOfXtY1K"),
 		ProviderPatternSettings: []*SecretScanningProviderPatternSetting{
 			{
@@ -247,7 +237,18 @@ func TestSecretScanningService_UpdatePatternConfigsForEnterprise(t *testing.T) {
 		},
 	}
 
-	configsUpdate, _, err := client.SecretScanning.UpdatePatternConfigsForEnterprise(ctx, "e", opts)
+	mux.HandleFunc("/enterprises/e/secret-scanning/pattern-configurations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		testJSONBody(t, r, input)
+
+		fmt.Fprint(w, `{
+			"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"
+		}`)
+	})
+
+	ctx := t.Context()
+
+	configsUpdate, _, err := client.SecretScanning.UpdatePatternConfigsForEnterprise(ctx, "e", input)
 	if err != nil {
 		t.Errorf("SecretScanning.UpdatePatternConfigsForEnterprise returned error: %v", err)
 	}
@@ -263,12 +264,12 @@ func TestSecretScanningService_UpdatePatternConfigsForEnterprise(t *testing.T) {
 	const methodName = "UpdatePatternConfigsForEnterprise"
 
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.SecretScanning.UpdatePatternConfigsForEnterprise(ctx, "\n", opts)
+		_, _, err = client.SecretScanning.UpdatePatternConfigsForEnterprise(ctx, "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		_, resp, err := client.SecretScanning.UpdatePatternConfigsForEnterprise(ctx, "o", opts)
+		_, resp, err := client.SecretScanning.UpdatePatternConfigsForEnterprise(ctx, "o", input)
 		return resp, err
 	})
 }
@@ -277,17 +278,7 @@ func TestSecretScanningService_UpdatePatternConfigsForOrg(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	mux.HandleFunc("/orgs/o/secret-scanning/pattern-configurations", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PATCH")
-
-		fmt.Fprint(w, `{
-			"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"
-		}`)
-	})
-
-	ctx := t.Context()
-
-	opts := &SecretScanningPatternConfigsUpdateOptions{
+	input := UpdateSecretScanningPatternConfigsRequest{
 		PatternConfigVersion: new("0ujsswThIGTUYm2K8FjOOfXtY1K"),
 		ProviderPatternSettings: []*SecretScanningProviderPatternSetting{
 			{
@@ -304,7 +295,18 @@ func TestSecretScanningService_UpdatePatternConfigsForOrg(t *testing.T) {
 		},
 	}
 
-	configsUpdate, _, err := client.SecretScanning.UpdatePatternConfigsForOrg(ctx, "o", opts)
+	mux.HandleFunc("/orgs/o/secret-scanning/pattern-configurations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		testJSONBody(t, r, input)
+
+		fmt.Fprint(w, `{
+			"pattern_config_version": "0ujsswThIGTUYm2K8FjOOfXtY1K"
+		}`)
+	})
+
+	ctx := t.Context()
+
+	configsUpdate, _, err := client.SecretScanning.UpdatePatternConfigsForOrg(ctx, "o", input)
 	if err != nil {
 		t.Errorf("SecretScanning.UpdatePatternConfigsForOrg returned err: %v", err)
 	}
@@ -320,12 +322,12 @@ func TestSecretScanningService_UpdatePatternConfigsForOrg(t *testing.T) {
 	const methodName = "UpdatePatternConfigsForOrg"
 
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.SecretScanning.UpdatePatternConfigsForOrg(ctx, "\n", opts)
+		_, _, err = client.SecretScanning.UpdatePatternConfigsForOrg(ctx, "\n", input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		_, resp, err := client.SecretScanning.UpdatePatternConfigsForOrg(ctx, "o", opts)
+		_, resp, err := client.SecretScanning.UpdatePatternConfigsForOrg(ctx, "o", input)
 		return resp, err
 	})
 }

--- a/github/secret_scanning_test.go
+++ b/github/secret_scanning_test.go
@@ -345,11 +345,11 @@ func TestSecretScanningService_UpdateAlert(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	opts := &SecretScanningAlertUpdateOptions{State: new("resolved"), Resolution: new("used_in_tests")}
+	input := UpdateSecretScanningAlertRequest{State: new("resolved"), Resolution: new("used_in_tests")}
 
 	mux.HandleFunc("/repos/o/r/secret-scanning/alerts/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-		testJSONBody(t, r, opts)
+		testJSONBody(t, r, input)
 		fmt.Fprint(w, `{
 			"number": 1,
 			"created_at": `+refTimeStr(1136178000)+`,
@@ -372,7 +372,7 @@ func TestSecretScanningService_UpdateAlert(t *testing.T) {
 	})
 
 	ctx := t.Context()
-	alert, _, err := client.SecretScanning.UpdateAlert(ctx, "o", "r", 1, opts)
+	alert, _, err := client.SecretScanning.UpdateAlert(ctx, "o", "r", 1, input)
 	if err != nil {
 		t.Errorf("SecretScanning.UpdateAlert returned error: %v", err)
 	}
@@ -404,26 +404,26 @@ func TestSecretScanningService_UpdateAlert(t *testing.T) {
 	const methodName = "UpdateAlert"
 
 	testBadOptions(t, methodName, func() (err error) {
-		_, _, err = client.SecretScanning.UpdateAlert(ctx, "\n", "\n", 1, opts)
+		_, _, err = client.SecretScanning.UpdateAlert(ctx, "\n", "\n", 1, input)
 		return err
 	})
 
 	testNewRequestAndDoFailure(t, methodName, client, func() (*Response, error) {
-		_, resp, err := client.SecretScanning.UpdateAlert(ctx, "o", "r", 1, opts)
+		_, resp, err := client.SecretScanning.UpdateAlert(ctx, "o", "r", 1, input)
 		return resp, err
 	})
 }
 
-func TestSecretScanningAlertUpdateOptions_Marshal(t *testing.T) {
+func TestUpdateSecretScanningAlertRequest_Marshal(t *testing.T) {
 	t.Parallel()
 
-	resolveInput := SecretScanningAlertUpdateOptions{
+	resolveInput := UpdateSecretScanningAlertRequest{
 		State:      new("resolved"),
 		Resolution: new("used_in_tests"),
 	}
 	testJSONMarshal(t, resolveInput, `{"state":"resolved","resolution":"used_in_tests"}`)
 
-	assignInput := SecretScanningAlertUpdateOptions{
+	assignInput := UpdateSecretScanningAlertRequest{
 		Assignee: new("octocat"),
 	}
 	testJSONMarshal(t, assignInput, `{"assignee":"octocat"}`)

--- a/github/secret_scanning_test.go
+++ b/github/secret_scanning_test.go
@@ -362,7 +362,12 @@ func TestSecretScanningService_UpdateAlert(t *testing.T) {
 			"resolved_at": `+refTimeStr(1136178001)+`,
 			"resolved_by": null,
 			"secret_type": "mailchimp_api_key",
-			"secret": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-us2"
+			"secret": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-us2",
+			"assigned_to": {"login": "octocat"},
+			"closure_request_comment": "closure comment",
+			"provider": "Mailchimp",
+			"provider_slug": "mailchimp",
+			"metadata": [{"key": "k", "value": "v"}]
 		}`)
 	})
 
@@ -373,18 +378,23 @@ func TestSecretScanningService_UpdateAlert(t *testing.T) {
 	}
 
 	want := &SecretScanningAlert{
-		Number:            new(1),
-		CreatedAt:         refTimestamp(1136178000),
-		URL:               new("https://api.github.com/repos/o/r/secret-scanning/alerts/1"),
-		HTMLURL:           new("https://github.com/o/r/security/secret-scanning/1"),
-		LocationsURL:      new("https://api.github.com/repos/o/r/secret-scanning/alerts/1/locations"),
-		State:             new("resolved"),
-		Resolution:        new("used_in_tests"),
-		ResolutionComment: new("resolution comment"),
-		ResolvedAt:        refTimestamp(1136178001),
-		ResolvedBy:        nil,
-		SecretType:        new("mailchimp_api_key"),
-		Secret:            new("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-us2"),
+		Number:                new(1),
+		CreatedAt:             refTimestamp(1136178000),
+		URL:                   new("https://api.github.com/repos/o/r/secret-scanning/alerts/1"),
+		HTMLURL:               new("https://github.com/o/r/security/secret-scanning/1"),
+		LocationsURL:          new("https://api.github.com/repos/o/r/secret-scanning/alerts/1/locations"),
+		State:                 new("resolved"),
+		Resolution:            new("used_in_tests"),
+		ResolutionComment:     new("resolution comment"),
+		ResolvedAt:            refTimestamp(1136178001),
+		ResolvedBy:            nil,
+		SecretType:            new("mailchimp_api_key"),
+		Secret:                new("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-us2"),
+		AssignedTo:            &User{Login: new("octocat")},
+		ClosureRequestComment: new("closure comment"),
+		Provider:              new("Mailchimp"),
+		ProviderSlug:          new("mailchimp"),
+		Metadata:              []*SecretScanningAlertMetadata{{Key: "k", Value: "v"}},
 	}
 
 	if !cmp.Equal(alert, want) {

--- a/github/secret_scanning_test.go
+++ b/github/secret_scanning_test.go
@@ -345,7 +345,7 @@ func TestSecretScanningService_UpdateAlert(t *testing.T) {
 	t.Parallel()
 	client, mux, _ := setup(t)
 
-	opts := &SecretScanningAlertUpdateOptions{State: "resolved", Resolution: new("used_in_tests")}
+	opts := &SecretScanningAlertUpdateOptions{State: new("resolved"), Resolution: new("used_in_tests")}
 
 	mux.HandleFunc("/repos/o/r/secret-scanning/alerts/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
@@ -412,6 +412,21 @@ func TestSecretScanningService_UpdateAlert(t *testing.T) {
 		_, resp, err := client.SecretScanning.UpdateAlert(ctx, "o", "r", 1, opts)
 		return resp, err
 	})
+}
+
+func TestSecretScanningAlertUpdateOptions_Marshal(t *testing.T) {
+	t.Parallel()
+
+	resolveInput := SecretScanningAlertUpdateOptions{
+		State:      new("resolved"),
+		Resolution: new("used_in_tests"),
+	}
+	testJSONMarshal(t, resolveInput, `{"state":"resolved","resolution":"used_in_tests"}`)
+
+	assignInput := SecretScanningAlertUpdateOptions{
+		Assignee: new("octocat"),
+	}
+	testJSONMarshal(t, assignInput, `{"assignee":"octocat"}`)
 }
 
 func TestSecretScanningService_ListLocationsForAlert(t *testing.T) {


### PR DESCRIPTION
Updates #3644

This converts the two remaining `SecretScanningService` body types, removing 4 entries from the `paramcheck` exception lists in `.golangci.yml` (2 from `body-allowed-pointer-types` and 2 from `body-allowed-wrong-names`).

Checking the types against the OpenAPI descriptions turned up two gaps that are fixed in separate commits:

1. The request schema for `PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}` has five properties (`state`, `resolution`, `resolution_comment`, `assignee`, `validity`) with `anyOf: [{required: [state]}, {required: [assignee]}, {required: [validity]}]`. `SecretScanningAlertUpdateOptions` only had the first three and declared `State string \`json:"state"\``, so an assignee-only or validity-only update was not possible. `State` is now `*string` with `omitempty`, and `Assignee` and `Validity` are added. As elsewhere in this package (e.g. `IssueRequest.Assignee`), `omitempty` cannot express the schema's "set to `null` to clear" case; that is unchanged here.
2. The secret scanning alert response schemas have `assigned_to`, `closure_request_comment`, `closure_request_reviewer`, `closure_request_reviewer_comment`, `provider`, `provider_slug` and `metadata`, none of which were on `SecretScanningAlert`. They are added as optional fields, with a new `SecretScanningAlertMetadata` type for the `metadata` entries.

`UpdateSecretScanningPatternConfigsRequest` stays shared between `UpdatePatternConfigsForEnterprise` and `UpdatePatternConfigsForOrg`; the two request schemas are identical. The pattern configuration tests now also assert the request body, which they did not before.

BREAKING CHANGE: `SecretScanningAlertUpdateOptions` and `SecretScanningPatternConfigsUpdateOptions` are renamed to `UpdateSecretScanningAlertRequest` and `UpdateSecretScanningPatternConfigsRequest`; `SecretScanningService.UpdateAlert`, `UpdatePatternConfigsForEnterprise` and `UpdatePatternConfigsForOrg` now take them by value instead of by pointer; `UpdateSecretScanningAlertRequest.State` is now `*string`.
