### PR TITLE
feat: Add ImageGen to HostedRunner and UpdateHostedRunnerRequest

### DIFF
--- a/github/actions_hosted_runners.go
+++ b/github/actions_hosted_runners.go
@@ -38,6 +38,7 @@ type HostedRunner struct {
 	MaximumRunners     *int64                   `json:"maximum_runners,omitempty"`
 	PublicIPEnabled    *bool                    `json:"public_ip_enabled,omitempty"`
 	PublicIPs          []*HostedRunnerPublicIP  `json:"public_ips,omitempty"`
+	ImageGen           *bool                    `json:"image_gen,omitempty"`
 	LastActiveOn       *Timestamp               `json:"last_active_on,omitempty"`
 }
 
@@ -112,6 +113,7 @@ type UpdateHostedRunnerRequest struct {
 	Size           *string `json:"size,omitempty"`
 	ImageID        *string `json:"image_id,omitempty"`
 	ImageVersion   *string `json:"image_version,omitempty"`
+	ImageGen       *bool   `json:"image_gen,omitempty"`
 }
 
 // validateCreateHostedRunnerRequest validates the provided CreateHostedRunnerRequest to ensure

--- a/github/actions_hosted_runners_test.go
+++ b/github/actions_hosted_runners_test.go
@@ -1159,3 +1159,75 @@ func TestActionsService_DeleteHostedRunnerCustomImageVersion(t *testing.T) {
 		return client.Actions.DeleteHostedRunnerCustomImageVersion(ctx, "o", 1, "1.0.0")
 	})
 }
+
+func TestHostedRunner_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &HostedRunner{}, "{}")
+
+	u := &HostedRunner{
+		ID:            new(int64(5)),
+		Name:          new("My hosted ubuntu runner"),
+		RunnerGroupID: new(int64(2)),
+		Platform:      new("linux-x64"),
+		ImageDetails: &HostedRunnerImageDetail{
+			ID:          new("ubuntu-20.04"),
+			SizeGB:      new(int64(86)),
+			DisplayName: new("20.04"),
+			Source:      new("github"),
+			Version:     new("latest"),
+		},
+		MachineSizeDetails: &HostedRunnerMachineSpec{ID: "4-core", CPUCores: 4, MemoryGB: 16, StorageGB: 150},
+		Status:             new("Ready"),
+		MaximumRunners:     new(int64(10)),
+		PublicIPEnabled:    new(true),
+		PublicIPs:          []*HostedRunnerPublicIP{{Enabled: true, Prefix: "20.80.208.150", Length: 31}},
+		ImageGen:           new(true),
+		LastActiveOn:       &Timestamp{referenceTime},
+	}
+
+	want := `{
+		"id": 5,
+		"name": "My hosted ubuntu runner",
+		"runner_group_id": 2,
+		"platform": "linux-x64",
+		"image_details": {"id": "ubuntu-20.04", "size_gb": 86, "display_name": "20.04", "source": "github", "version": "latest"},
+		"machine_size_details": {"id": "4-core", "cpu_cores": 4, "memory_gb": 16, "storage_gb": 150},
+		"status": "Ready",
+		"maximum_runners": 10,
+		"public_ip_enabled": true,
+		"public_ips": [{"enabled": true, "prefix": "20.80.208.150", "length": 31}],
+		"image_gen": true,
+		"last_active_on": ` + referenceTimeStr + `
+	}`
+
+	testJSONMarshal(t, u, want)
+}
+
+func TestUpdateHostedRunnerRequest_Marshal(t *testing.T) {
+	t.Parallel()
+	testJSONMarshal(t, &UpdateHostedRunnerRequest{}, "{}")
+
+	u := &UpdateHostedRunnerRequest{
+		Name:           new("My hosted ubuntu runner"),
+		RunnerGroupID:  new(int64(2)),
+		MaximumRunners: new(int64(10)),
+		EnableStaticIP: new(true),
+		Size:           new("4-core"),
+		ImageID:        new("ubuntu-20.04"),
+		ImageVersion:   new("latest"),
+		ImageGen:       new(true),
+	}
+
+	want := `{
+		"name": "My hosted ubuntu runner",
+		"runner_group_id": 2,
+		"maximum_runners": 10,
+		"enable_static_ip": true,
+		"size": "4-core",
+		"image_id": "ubuntu-20.04",
+		"image_version": "latest",
+		"image_gen": true
+	}`
+
+	testJSONMarshal(t, u, want)
+}

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -19966,6 +19966,14 @@ func (h *HostedRunner) GetImageDetails() *HostedRunnerImageDetail {
 	return h.ImageDetails
 }
 
+// GetImageGen returns the ImageGen field if it's non-nil, zero value otherwise.
+func (h *HostedRunner) GetImageGen() bool {
+	if h == nil || h.ImageGen == nil {
+		return false
+	}
+	return *h.ImageGen
+}
+
 // GetLastActiveOn returns the LastActiveOn field if it's non-nil, zero value otherwise.
 func (h *HostedRunner) GetLastActiveOn() Timestamp {
 	if h == nil || h.LastActiveOn == nil {
@@ -45580,6 +45588,14 @@ func (u *UpdateHostedRunnerRequest) GetEnableStaticIP() bool {
 		return false
 	}
 	return *u.EnableStaticIP
+}
+
+// GetImageGen returns the ImageGen field if it's non-nil, zero value otherwise.
+func (u *UpdateHostedRunnerRequest) GetImageGen() bool {
+	if u == nil || u.ImageGen == nil {
+		return false
+	}
+	return *u.ImageGen
 }
 
 // GetImageID returns the ImageID field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -25040,6 +25040,17 @@ func TestHostedRunner_GetImageDetails(tt *testing.T) {
 	h.GetImageDetails()
 }
 
+func TestHostedRunner_GetImageGen(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	h := &HostedRunner{ImageGen: &zeroValue}
+	h.GetImageGen()
+	h = &HostedRunner{}
+	h.GetImageGen()
+	h = nil
+	h.GetImageGen()
+}
+
 func TestHostedRunner_GetLastActiveOn(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue Timestamp
@@ -56903,6 +56914,17 @@ func TestUpdateHostedRunnerRequest_GetEnableStaticIP(tt *testing.T) {
 	u.GetEnableStaticIP()
 	u = nil
 	u.GetEnableStaticIP()
+}
+
+func TestUpdateHostedRunnerRequest_GetImageGen(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue bool
+	u := &UpdateHostedRunnerRequest{ImageGen: &zeroValue}
+	u.GetImageGen()
+	u = &UpdateHostedRunnerRequest{}
+	u.GetImageGen()
+	u = nil
+	u.GetImageGen()
 }
 
 func TestUpdateHostedRunnerRequest_GetImageID(tt *testing.T) {


### PR DESCRIPTION
Fixes #4532
Supersedes #4544 (blocked on unsigned CLA from bot account).

### Cause
The GitHub-hosted runner API supports `image_gen` on create, read, and update. Currently, `go-github` only includes `ImageGen` in `CreateHostedRunnerRequest`, making it impossible to read back or update the image generation configuration of runner pools.

### Solution
- Added `ImageGen *bool `json:"image_gen,omitempty"`` to `HostedRunner` and `UpdateHostedRunnerRequest`.
- Regenerated accessors in `github-accessors.go` and `github-accessors_test.go` via `go generate ./...`.
- Added unit tests `TestHostedRunner_Marshal` and `TestUpdateHostedRunnerRequest_Marshal` verifying JSON round-trip marshaling.

AI assistance: Drafted marshal tests and verified accessor generation against the OpenAPI spec.
